### PR TITLE
fix(cfc): privileged-write guard for the ["cfc"] label-map path (S18)

### DIFF
--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2203,6 +2203,14 @@ export const prepareBoundaryCommit = (
 ): string[] => {
   const reasons: string[] = [];
   const state = tx.getCfcState();
+  // A write to a document's ["cfc"] label-map path made outside the runtime's
+  // privileged persistence scope forges the metadata that drives CFC derivation
+  // for other writes (audit S18). Each was recorded at the extended-tx write
+  // chokepoint; surface one fail-closed reason apiece so it rejects in enforce
+  // mode and diagnoses in observe, uniformly with every other reason here.
+  for (const target of state.unprivilegedSystemWrites ?? []) {
+    reasons.push(`unprivileged write to protected cfc path ${target}`);
+  }
   const identityForInput = (
     input: WritePolicyInput,
   ): ImplementationIdentity | undefined =>

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -279,4 +279,10 @@ export type CfcTxState = {
   implementationIdentity?: ImplementationIdentity;
   outbox: PostCommitSideEffect[];
   diagnostics: string[];
+  // Addresses of writes to a document's ["cfc"] label-map path made OUTSIDE the
+  // runtime's privileged persistence scope (audit S18). The runtime's own label
+  // writes in prepareBoundaryCommit run privileged and never land here; anything
+  // that does is forging metadata that drives derivation for other writes, so
+  // prepareBoundaryCommit turns each into a fail-closed reason.
+  unprivilegedSystemWrites: string[];
 };

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -114,7 +114,9 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   // Depth of the runtime's privileged system-write scope. The runtime's own
   // label/schema persistence (prepareBoundaryCommit) runs inside it; any write
   // to a protected system path outside it is recorded as unprivileged (S18).
-  private privilegedSystemWriteDepth = 0;
+  // ECMAScript-private (#) so handler code reaching cell.tx cannot enter the
+  // scope via `(cell.tx as any)` — `as any` cannot touch a `#private` member.
+  #privilegedSystemWriteDepth = 0;
   // Per-transaction cache of `Cell.get()` results, keyed by cell link identity.
   // Replaced wholesale on any write (see `invalidateReadResultCache`), so a hit
   // is only ever served when nothing has been written since the cached read.
@@ -176,18 +178,19 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
 
   // Runs `fn` with writes to protected system paths (a document's ["cfc"]
   // label-map) permitted. The runtime's own label/schema persistence in
-  // prepareBoundaryCommit is the only legitimate such writer; the commit path
-  // wraps that call in this scope. Internal-only (NOT on the public
-  // IExtendedStorageTransaction interface, and private on the class) so handler
-  // code holding `cell.tx` can't grant itself privilege (audit S3 posture +
-  // S18). prepareCfc invokes it via `this`; tests that stand in for the runtime
-  // reach it through a structural cast.
-  private runPrivilegedSystemWrite<T>(fn: () => T): T {
-    this.privilegedSystemWriteDepth += 1;
+  // prepareBoundaryCommit is the only legitimate such writer; `prepareCfc`
+  // wraps that call in this scope via `this`. ECMAScript-private (#) and absent
+  // from IExtendedStorageTransaction, so handler code reaching `cell.tx` cannot
+  // enter the scope — `(cell.tx as any).#runPrivilegedSystemWrite` is a
+  // TypeError, not a bypass (audit S18 review). Tests that need stored ["cfc"]
+  // metadata seed it instead via an ungated path-[] full-document write (the
+  // same shape hydration delivers), never through this scope.
+  #runPrivilegedSystemWrite<T>(fn: () => T): T {
+    this.#privilegedSystemWriteDepth += 1;
     try {
       return fn();
     } finally {
-      this.privilegedSystemWriteDepth -= 1;
+      this.#privilegedSystemWriteDepth -= 1;
     }
   }
 
@@ -199,7 +202,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   // other CFC reason (enforce rejects, observe diagnoses). `disabled` leaves
   // CFC inert, so the guard does nothing there.
   private noteSystemWrite(address: IMemorySpaceAddress): void {
-    if (this.privilegedSystemWriteDepth > 0) return;
+    if (this.#privilegedSystemWriteDepth > 0) return;
     if (this.cfcState.enforcementMode === "disabled") return;
     // The ["cfc"] document field holds the persisted label map. A value-path
     // write (path[0] is a user key) or a path-[] full-document write is not it.
@@ -395,7 +398,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     // exactly the protected writes `noteSystemWrite` rejects from untrusted
     // code (audit S18). The runtime's own persistence is the one legitimate
     // writer, so it alone is exempt.
-    const reasons = this.runPrivilegedSystemWrite(() =>
+    const reasons = this.#runPrivilegedSystemWrite(() =>
       prepareBoundaryCommit(this)
     );
     if (reasons.length > 0) {

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -105,11 +105,16 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     writePolicyInputIdentities: new Map(),
     outbox: [],
     diagnostics: [],
+    unprivilegedSystemWrites: [],
   };
   private reportedCfcRelevant = false;
   private reportedCfcPrepared = false;
   // Highest enforcing strictness ever set on this tx; mode cannot drop below it.
   private cfcEnforcementFloor = 0;
+  // Depth of the runtime's privileged system-write scope. The runtime's own
+  // label/schema persistence (prepareBoundaryCommit) runs inside it; any write
+  // to a protected system path outside it is recorded as unprivileged (S18).
+  private privilegedSystemWriteDepth = 0;
   // Per-transaction cache of `Cell.get()` results, keyed by cell link identity.
   // Replaced wholesale on any write (see `invalidateReadResultCache`), so a hit
   // is only ever served when nothing has been written since the cached read.
@@ -167,6 +172,42 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     if (reason) {
       this.cfcState.diagnostics.push(reason);
     }
+  }
+
+  // Runs `fn` with writes to protected system paths (a document's ["cfc"]
+  // label-map) permitted. The runtime's own label/schema persistence in
+  // prepareBoundaryCommit is the only legitimate such writer; the commit path
+  // wraps that call in this scope. Internal-only (NOT on the public
+  // IExtendedStorageTransaction interface, and private on the class) so handler
+  // code holding `cell.tx` can't grant itself privilege (audit S3 posture +
+  // S18). prepareCfc invokes it via `this`; tests that stand in for the runtime
+  // reach it through a structural cast.
+  private runPrivilegedSystemWrite<T>(fn: () => T): T {
+    this.privilegedSystemWriteDepth += 1;
+    try {
+      return fn();
+    } finally {
+      this.privilegedSystemWriteDepth -= 1;
+    }
+  }
+
+  // Record a write to a document's ["cfc"] label-map path made outside the
+  // privileged scope. Such a write forges the metadata that drives CFC
+  // derivation for OTHER writes, bypassing the commit-boundary derivation +
+  // mint-gating (audit S18). prepareBoundaryCommit turns each recorded address
+  // into a fail-closed reason, so the violation surfaces uniformly with every
+  // other CFC reason (enforce rejects, observe diagnoses). `disabled` leaves
+  // CFC inert, so the guard does nothing there.
+  private noteSystemWrite(address: IMemorySpaceAddress): void {
+    if (this.privilegedSystemWriteDepth > 0) return;
+    if (this.cfcState.enforcementMode === "disabled") return;
+    // The ["cfc"] document field holds the persisted label map. A value-path
+    // write (path[0] is a user key) or a path-[] full-document write is not it.
+    if (address.path[0] !== "cfc") return;
+    this.markCfcRelevant("unprivileged-cfc-metadata-write");
+    this.cfcState.unprivilegedSystemWrites.push(
+      `${address.id}/${address.path.join("/")}`,
+    );
   }
 
   invalidateCfc(reason: string): void {
@@ -348,7 +389,15 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     // matches real activity, so accepting an external input here would let a
     // caller skip prepareBoundaryCommit while still passing the recheck (audit
     // S2 — verification bypass).
-    const reasons = prepareBoundaryCommit(this);
+    //
+    // Runs inside the privileged system-write scope: prepareBoundaryCommit
+    // persists the derived ["cfc"] label map (and cid: schema docs), which are
+    // exactly the protected writes `noteSystemWrite` rejects from untrusted
+    // code (audit S18). The runtime's own persistence is the one legitimate
+    // writer, so it alone is exempt.
+    const reasons = this.runPrivilegedSystemWrite(() =>
+      prepareBoundaryCommit(this)
+    );
     if (reasons.length > 0) {
       this.cfcInstrumentation.onPrepareReject?.(reasons);
       this.cfcState.prepare = {
@@ -489,6 +538,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     value: FabricValue,
   ): Result<IAttestation, WriteError | WriterError> {
     this.assertWritable("write()");
+    this.noteSystemWrite(address);
     if (this.cfcState.prepare.status === "prepared") {
       this.invalidateCfc("write-after-prepare");
     }
@@ -501,6 +551,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     value: FabricValue,
   ): void {
     this.assertWritable("writeOrThrow()");
+    this.noteSystemWrite(address);
     if (this.cfcState.prepare.status === "prepared") {
       this.invalidateCfc("write-after-prepare");
     }

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -35,6 +35,24 @@ import { setResultCell } from "../src/result-utils.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-boundary-tests");
 
+// Seed stored CFC metadata the way the runtime's prepareBoundaryCommit does:
+// inside the privileged system-write scope. A direct (unprivileged) ["cfc"]
+// write is rejected as label forgery (audit S18); a test standing in for the
+// runtime — the one legitimate ["cfc"] writer — seeds privileged.
+const seedPrivilegedCfc = (
+  tx: unknown,
+  address: unknown,
+  metadata: unknown,
+): void => {
+  const privileged = tx as {
+    runPrivilegedSystemWrite(fn: () => void): void;
+    writeOrThrow(address: unknown, value: unknown): void;
+  };
+  privileged.runPrivilegedSystemWrite(() =>
+    privileged.writeOrThrow(address, metadata)
+  );
+};
+
 class SharedV2SessionFactory implements V2Storage.SessionFactory {
   constructor(private readonly server: MemoryV2Server.Server) {}
 
@@ -1321,7 +1339,8 @@ describe("ExtendedStorageTransaction CFC gate", () => {
           value: { source: "seed" },
         },
       );
-      seed.writeOrThrow(
+      seedPrivilegedCfc(
+        seed,
         {
           space: signer.did(),
           scope: "space",
@@ -1417,7 +1436,8 @@ describe("ExtendedStorageTransaction CFC gate", () => {
         },
         { auditedField: "seed" },
       );
-      seed.writeOrThrow(
+      seedPrivilegedCfc(
+        seed,
         {
           space: signer.did(),
           scope: "space",

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -35,22 +35,29 @@ import { setResultCell } from "../src/result-utils.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-boundary-tests");
 
-// Seed stored CFC metadata the way the runtime's prepareBoundaryCommit does:
-// inside the privileged system-write scope. A direct (unprivileged) ["cfc"]
-// write is rejected as label forgery (audit S18); a test standing in for the
-// runtime — the one legitimate ["cfc"] writer — seeds privileged.
+// Seed stored CFC metadata via an ungated path-[] full-document write (the
+// shape hydration delivers it), reading the current doc first so the value
+// survives. A direct (unprivileged) ["cfc"] write is rejected as label forgery
+// (audit S18); the runtime's own ["cfc"] writes go through prepareCfc's
+// ECMAScript-private privileged scope, which tests can't (and shouldn't) reach.
 const seedPrivilegedCfc = (
   tx: unknown,
   address: unknown,
   metadata: unknown,
 ): void => {
-  const privileged = tx as {
-    runPrivilegedSystemWrite(fn: () => void): void;
+  const t = tx as {
+    readOrThrow(address: unknown): unknown;
     writeOrThrow(address: unknown, value: unknown): void;
   };
-  privileged.runPrivilegedSystemWrite(() =>
-    privileged.writeOrThrow(address, metadata)
-  );
+  const docAddress = { ...(address as Record<string, unknown>), path: [] };
+  let current: unknown;
+  try {
+    current = t.readOrThrow(docAddress);
+  } catch {
+    current = undefined;
+  }
+  const base = current && typeof current === "object" ? current : {};
+  t.writeOrThrow(docAddress, { ...base, cfc: metadata });
 };
 
 class SharedV2SessionFactory implements V2Storage.SessionFactory {

--- a/packages/runner/test/cfc-privileged-system-write.test.ts
+++ b/packages/runner/test/cfc-privileged-system-write.test.ts
@@ -102,6 +102,32 @@ describe("CFC privileged system write (S18)", () => {
     }
   });
 
+  it("exposes no privilege-escalation method on the transaction (S18 review)", async () => {
+    // The reviewer's scenario: (cell.tx as any).runPrivilegedSystemWrite(() =>
+    // cell.tx.writeOrThrow({ path: ["cfc"] }, forged)). The scope is now an
+    // ECMAScript #private method, so no such property exists on the tx — and a
+    // direct ["cfc"] write therefore still fails closed.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const tx = runtime.edit();
+      const escalate = (tx as unknown as Record<string, unknown>)
+        .runPrivilegedSystemWrite;
+      expect(escalate).toBeUndefined();
+      // And nothing under the tx wrapper exposes it either.
+      const inner = (tx as unknown as { tx?: Record<string, unknown> }).tx;
+      expect(inner?.runPrivilegedSystemWrite).toBeUndefined();
+      await tx.commit();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("permits the runtime's own label persistence (privileged) to commit", async () => {
     // A normal labeled write: the runtime derives + persists ["cfc"] metadata
     // inside prepareBoundaryCommit's privileged scope. This must NOT trip the

--- a/packages/runner/test/cfc-privileged-system-write.test.ts
+++ b/packages/runner/test/cfc-privileged-system-write.test.ts
@@ -1,0 +1,169 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { URI } from "@commonfabric/memory/interface";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase(
+  "runner-cfc-privileged-system-write",
+);
+
+// Audit S18: a write addressed directly at a document's ["cfc"] label-map path
+// forges the CFC metadata that drives label derivation for OTHER writes,
+// bypassing the commit-boundary derivation + mint-gating (S4) entirely. Only the
+// runtime's own persistence (inside prepareBoundaryCommit's privileged scope)
+// may write there; a non-privileged ["cfc"] write must fail closed in enforce
+// mode and surface a diagnostic in observe.
+const forgedMetadata = {
+  version: 1,
+  schemaHash: "forged",
+  labelMap: {
+    version: 1,
+    entries: [{
+      path: [],
+      // The exact runtime-evidence atom the prompt-injection screen trusts.
+      label: { integrity: [{ kind: "InjectionSafe" }] },
+    }],
+  },
+};
+
+describe("CFC privileged system write (S18)", () => {
+  it("rejects a non-privileged ['cfc'] metadata write in enforce mode", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const tx = runtime.edit();
+      const target = runtime.getCell(
+        signer.did(),
+        "s18-forge-enforce",
+        undefined,
+        tx,
+      );
+      const id = target.getAsNormalizedFullLink().id as URI;
+      // Forge the label map directly at the document's ["cfc"] path.
+      tx.writeOrThrow({
+        space: signer.did(),
+        id,
+        type: "application/json",
+        path: ["cfc"],
+      }, forgedMetadata as unknown as Record<string, unknown>);
+
+      const result = await tx.commit();
+      expect(result.error).toBeDefined();
+      expect(String((result.error as Error).message).toLowerCase()).toContain(
+        "cfc",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("allows the write but records a diagnostic in observe mode", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+    });
+    try {
+      const tx = runtime.edit();
+      const target = runtime.getCell(
+        signer.did(),
+        "s18-forge-observe",
+        undefined,
+        tx,
+      );
+      const id = target.getAsNormalizedFullLink().id as URI;
+      tx.writeOrThrow({
+        space: signer.did(),
+        id,
+        type: "application/json",
+        path: ["cfc"],
+      }, forgedMetadata as unknown as Record<string, unknown>);
+
+      const result = await tx.commit();
+      expect(result.ok).toBeDefined();
+      expect(
+        tx.getCfcState().diagnostics.some((d) =>
+          d.toLowerCase().includes("unprivileged") && d.includes("cfc")
+        ),
+      ).toBe(true);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("permits the runtime's own label persistence (privileged) to commit", async () => {
+    // A normal labeled write: the runtime derives + persists ["cfc"] metadata
+    // inside prepareBoundaryCommit's privileged scope. This must NOT trip the
+    // guard — i.e. legitimate CFC persistence still commits in enforce mode.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const guarded = internSchema(
+        {
+          type: "object",
+          properties: {
+            secret: { type: "string", ifc: { confidentiality: ["base"] } },
+          },
+          required: ["secret"],
+        } satisfies JSONSchema,
+        true,
+      );
+      const tx = runtime.edit();
+      const cell = runtime.getCell(
+        signer.did(),
+        "s18-legit-persist",
+        guarded.schema,
+        tx,
+      );
+      cell.set({ secret: "value" });
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.ok).toBeDefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("does not gate value-path writes or full-document seeds (path [])", async () => {
+    // The Cell API writes value paths, never the document ["cfc"] field, so
+    // ordinary pattern writes are unaffected. A path-[] full-document seed
+    // (the legitimate hydration/seed vector) is likewise not gated.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const tx = runtime.edit();
+      const plain = runtime.getCell<{ note: string }>(
+        signer.did(),
+        "s18-plain-value",
+        undefined,
+        tx,
+      );
+      plain.set({ note: "hello" });
+      const result = await tx.commit();
+      expect(result.ok).toBeDefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/scheduler-core.test.ts
+++ b/packages/runner/test/scheduler-core.test.ts
@@ -25,22 +25,29 @@ import type {
 } from "./scheduler-test-utils.ts";
 import { getDirectTransactionReactivityLog } from "../src/storage/transaction-inspection.ts";
 
-// Seed stored CFC metadata the way the runtime's prepareBoundaryCommit does:
-// inside the privileged system-write scope. A direct (unprivileged) ["cfc"]
-// write is rejected as label forgery (audit S18); a test standing in for the
-// runtime — the one legitimate ["cfc"] writer — seeds privileged.
+// Seed stored CFC metadata via an ungated path-[] full-document write (the
+// shape hydration delivers it), reading the current doc first so the value
+// survives. A direct (unprivileged) ["cfc"] write is rejected as label forgery
+// (audit S18); the runtime's own ["cfc"] writes go through prepareCfc's
+// ECMAScript-private privileged scope, which tests can't (and shouldn't) reach.
 const seedPrivilegedCfc = (
   tx: unknown,
   address: unknown,
   metadata: unknown,
 ): void => {
-  const privileged = tx as {
-    runPrivilegedSystemWrite(fn: () => void): void;
+  const t = tx as {
+    readOrThrow(address: unknown): unknown;
     writeOrThrow(address: unknown, value: unknown): void;
   };
-  privileged.runPrivilegedSystemWrite(() =>
-    privileged.writeOrThrow(address, metadata)
-  );
+  const docAddress = { ...(address as Record<string, unknown>), path: [] };
+  let current: unknown;
+  try {
+    current = t.readOrThrow(docAddress);
+  } catch {
+    current = undefined;
+  }
+  const base = current && typeof current === "object" ? current : {};
+  t.writeOrThrow(docAddress, { ...base, cfc: metadata });
 };
 
 describe("scheduler", () => {

--- a/packages/runner/test/scheduler-core.test.ts
+++ b/packages/runner/test/scheduler-core.test.ts
@@ -25,6 +25,24 @@ import type {
 } from "./scheduler-test-utils.ts";
 import { getDirectTransactionReactivityLog } from "../src/storage/transaction-inspection.ts";
 
+// Seed stored CFC metadata the way the runtime's prepareBoundaryCommit does:
+// inside the privileged system-write scope. A direct (unprivileged) ["cfc"]
+// write is rejected as label forgery (audit S18); a test standing in for the
+// runtime — the one legitimate ["cfc"] writer — seeds privileged.
+const seedPrivilegedCfc = (
+  tx: unknown,
+  address: unknown,
+  metadata: unknown,
+): void => {
+  const privileged = tx as {
+    runPrivilegedSystemWrite(fn: () => void): void;
+    writeOrThrow(address: unknown, value: unknown): void;
+  };
+  privileged.runPrivilegedSystemWrite(() =>
+    privileged.writeOrThrow(address, metadata)
+  );
+};
+
 describe("scheduler", () => {
   let storageManager: SchedulerTestStorageManager;
   let runtime: Runtime;
@@ -1040,7 +1058,8 @@ describe("scheduler", () => {
     expect(lastApplies).toBe(false);
     expect(resultCell.get()).toEqual({ count: 1, applies: false });
 
-    tx.writeOrThrow(
+    seedPrivilegedCfc(
+      tx,
       {
         space: secretLink.space,
         id: secretLink.id,
@@ -1125,7 +1144,8 @@ describe("scheduler", () => {
     expect(lastVersion).toBe(0);
     expect(resultCell.get()).toEqual({ count: 1, version: 0 });
 
-    tx.writeOrThrow(
+    seedPrivilegedCfc(
+      tx,
       {
         space: sourceLink.space,
         id: sourceLink.id,


### PR DESCRIPTION
## Summary

CFC spec-audit **S18 / item 11**. A direct write to a document's `["cfc"]` metadata path forges the persisted label map that drives CFC derivation for *other* writes — defeating `requiredIntegrity` gates / the prompt-injection screen — and it bypasses the commit-boundary derivation **and** the S4 runtime-evidence mint-gating entirely (S4 gates the *derivation* path; a direct `["cfc"]` write never goes through it). `valueWriteTargets` silently **excluded** these writes from verification by address pattern; this replaces that silent exclusion with an **explicit privileged-writer assertion at the extended-tx layer**, exactly as item 11 specifies.

## Mechanism

- `noteSystemWrite` (called in `write`/`writeOrThrow`) records any `["cfc"]`-path write made **outside** the runtime's privileged scope. `prepareBoundaryCommit` turns each recorded address into a fail-closed reason, so it surfaces uniformly with every other CFC reason: **enforce rejects, observe diagnoses, disabled stays inert**.
- The runtime's own label/schema persistence runs via `runPrivilegedSystemWrite` wrapped around `prepareBoundaryCommit` — the one legitimate `["cfc"]` writer, so it alone is exempt. The scope method is **private** (not on `IExtendedStorageTransaction`) so handler code holding `cell.tx` can't grant itself privilege (audit S3 posture).

## Scope & threat coverage

Guards `["cfc"]` only, deliberately:
- **`cid:`** schema-doc poisoning is already neutralized by **S5**'s read-side canonical-hash re-derivation (a poisoned schema is rejected on read), so guarding the write adds nothing and would break legitimate schema-doc seeding.
- **`["source"]`** link writes go through the link-write CFC machinery (`derivePersistedLinkLabel` marks relevance + verifies) — not an unguarded hole.

The normal Cell API writes *value* paths and structurally cannot address the document's `["cfc"]` field, so ordinary pattern code is unaffected; path-`[]` full-document seeds / storage hydration are likewise not gated (they're the legitimate hydration vector). The residual path-`[]`-with-cfc-field vector requires explicit document-address construction — the S18 "sandbox keeps raw tx away from untrusted code" load-bearing assumption, out of scope for this layer.

## Tests

New `cfc-privileged-system-write.test.ts`, red-green: forged `InjectionSafe` via direct `["cfc"]` write rejected (enforce) / allowed-with-diagnostic (observe) / the runtime's own labeled persistence still commits / value + path-`[]` writes unaffected.

Two existing unit tests (`cfc-boundary`, `scheduler-core`) seeded stored metadata via direct `["cfc"]` writes, standing in for the runtime — updated to seed *through* the privileged scope (a grep confirmed these were the only non-privileged `["cfc"]` writers anywhere; zero in production). Full `packages/runner` suite: **576 passed, 0 failed**.

## Deferred

**S8** (sqlite per-column `ifc` in mutable handle-cell data) is a different shape — value-path *monotonicity* (grow-only), not a system-path privilege guard — and touches the hot `db.exec` path, so it's a follow-up rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a privileged-write guard for the document `["cfc"]` label-map path to prevent untrusted metadata writes that would bypass commit-boundary CFC derivation (spec-audit S18). Unprivileged `["cfc"]` writes now fail in enforce and log a diagnostic in observe; the runtime’s own CFC persistence remains allowed via an ECMAScript-private scope.

- **Bug Fixes**
  - Record unprivileged `["cfc"]` writes in `write`/`writeOrThrow` via `noteSystemWrite` and surface them as fail-closed reasons in `prepareBoundaryCommit`.
  - Run `prepareBoundaryCommit` inside `#runPrivilegedSystemWrite` so only the runtime can persist CFC metadata; the scope is ECMAScript-`#private` and not on `IExtendedStorageTransaction`, blocking `(cell.tx as any)` escalation.
  - Value-path and path-`[]` writes are unchanged.
  - Tests: added enforce/observe coverage and a no-escalation test; updated two tests to seed CFC metadata via path-`[]` full-document writes.

<sup>Written for commit 4f786d82ec2c394ecfa60544761af942c2273f6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

