### PR TITLE
Design: content-addressed action identity + Phase 0 (ordinal-free implementationRef)

### DIFF
--- a/docs/specs/content-addressed-action-identity.md
+++ b/docs/specs/content-addressed-action-identity.md
@@ -356,11 +356,13 @@ Phased migration (op-migration playbook):
   graphs (e.g. `$opFallback` payloads); old ordinal-bearing refs will no
   longer match re-minted ones, so resolution of such stored graphs falls to
   the stringified-implementation fallback (or fails where the implementation
-  was omitted). If pre-change persisted graphs matter, register a legacy
-  alias during a transition: keep incrementing the counter and ALSO register
-  the fn under `createRef({kind, source, preview, ordinal})`. Decide based on
-  an audit of real stored data; the in-memory/identity fast paths are
-  unaffected either way.
+  was omitted). Mitigated by a transition shim (landed with Phase 0): the
+  counter keeps incrementing at the same call sites and the fn is ALSO
+  registered under the legacy `createRef({kind, source, preview, ordinal})`
+  alias, reproducing the pre-removal ordinal sequence exactly. The attached/
+  serialized ref is the content-derived one. The shim (and its test,
+  `implementation-ref.test.ts`) is removed together with `implementationRef`
+  itself in Phase 3.
 - **Phase 1 — dual-write, dual-read.** Writers emit `$implRef` (+ keep
   `implementationRef` and the conditional stringified `implementation`).
   Readers prefer `$implRef`; absent that, fall back to the legacy

--- a/docs/specs/content-addressed-action-identity.md
+++ b/docs/specs/content-addressed-action-identity.md
@@ -93,7 +93,7 @@ or stops needing identity-carry, the symbols die with it.)
 
 | # | Copy site | What it does | Verdict |
 |---|---|---|---|
-| C1 | `createPattern` (`builder/pattern.ts` ~332, 368–373): build-time serialization of `result` + every node's `module`/`inputs`/`outputs` via `toJSONWithLegacyAliases` | Produces the `Pattern` object — the durable graph representation. Writes `unsafe_originalPattern` onto every nested pattern copy (`json-utils.ts:183`) | **Copy stays** (the `Pattern` IS the serialized artifact). The *backref* is replaced by registering the copy in a side table at copy time (§ Trust). Long-term, nested trusted patterns can serialize as `$patternRef` sentinels directly once build-time refs are resolvable (see Open questions — refs aren't known until post-module-evaluation, which is why the lazy backref exists today). |
+| C1 | `createPattern` (`builder/pattern.ts` ~332, 368–373): build-time serialization of `result` + every node's `module`/`inputs`/`outputs` via `toJSONWithLegacyAliases` | Produces the `Pattern` object — the durable graph representation. Writes `unsafe_originalPattern` onto every nested pattern copy (`json-utils.ts:183`) | **Copy stays in memory; stops crossing the serialization boundary.** The in-memory graph remains the instantiation representation; `toJSON` at the storage boundary emits refs (§7). The *backref* is replaced by registering the copy in a side table at copy time (§ Trust). |
 | C2 | `moduleToJSON` pattern-type implementation (`json-utils.ts:387`, the CT-1230 workaround): sub-pattern passed as a module implementation (e.g. to `.map()`) | Serializes the nested pattern graph instead of stringifying it | **Subsumed by op-by-identity.** The op already travels as `$patternRef` + `$opFallback`; with `$opFallback` retained the embedded copy is only the fallback payload. When the fallback is dropped (Phase 4), this copy site disappears. |
 | C3 | `traverseValue` (`traverse-utils.ts:54`): copies during build traversal (`collectCellsAndNodes`, `node-utils` connect) | Preserves the backref so a traversal copy still resolves `getArtifactEntryRef` | **Copy stays; backref replaced** by side-table registration at the same line. |
 | C4 | `unwrapOneLevelAndBindtoDoc` (`pattern-binding.ts:333–340`): instantiation-time rebinding copies | Propagates backref + the `verifiedLoadId` side-table entry to the bound copy | **Copy stays; backref replaced** by side-table registration; the `verifiedLoadId` propagation is deleted outright (CFC identity no longer flows through loadIds — § CFC). |
@@ -298,6 +298,42 @@ the global `addressableByIdentity` index suffices and the pattern-scoped
 second key is dropped. `PatternManager`'s piece/meta `patternId` (URIs, meta
 cells, LRU) is unrelated and stays.
 
+### 7. Pattern JSON becomes refs; the graph representation goes internal
+
+Decision (resolves former open question 1): the serialization *boundary* emits
+`{ identity, symbol }` refs — the full node-graph JSON becomes a runtime-
+internal representation (and a debug output, e.g. `cf check --pattern-json`).
+
+The timing objection that motivated the lazy backref does not apply at the
+boundary: `createPattern` runs during module evaluation (refs not yet indexed),
+but `toJSON` runs when a value is *written to a cell* — after
+`registerEvaluatedModules` has indexed the module. So:
+
+- `Pattern.toJSON()` → `{ $patternRef: { identity, symbol } }` (plus
+  `argumentSchema`/`resultSchema` if consumers need them without resolving).
+- `moduleToJSON` for a pattern-type implementation (C2) → the same ref, not an
+  embedded graph.
+- `moduleToJSON` for javascript modules → `$implRef` (§1).
+- `Pattern.nodes` / `result` / `initial` stay as the in-memory instantiation
+  representation only; nothing outside the runner consumes them as JSON.
+
+Known things this trips (each becomes a work item):
+
+- **`$opFallback`** embeds a full serialized graph *on purpose* (eviction
+  resilience). Refs-only `toJSON` would silently turn the fallback into a ref
+  too, defeating it. Either give the fallback an explicit
+  `serializePatternGraph()` escape hatch (internal serializer, not `toJSON`),
+  or drop the fallback and solve eviction pinning first (open question 2 —
+  these two decisions are now coupled).
+- Anything that JSON-round-trips patterns and expects a graph: json-utils
+  round-trip tests, pattern-as-value deserialization in `pattern-binding`,
+  debug tooling. Deserialization of a ref requires the module to be loadable
+  by identity (in-memory, or storage-backed via the compile cache) — which is
+  the whole point, but makes by-identity load the only rehydration path.
+- Wire/IPC surfaces that today receive pattern JSON (runtime-client
+  `getPatternSources` is source-based and unaffected; audit any other
+  protocol field carrying serialized patterns).
+
 ## Persisted-data compatibility
 
 What's in stored graphs today (verified writer): `{ type: "javascript",
@@ -308,6 +344,23 @@ same (ordinal-dependent!) refs when the pattern re-evaluates.
 
 Phased migration (op-migration playbook):
 
+- **Phase 0 — drop the `ordinal` from `ensureImplementationRef` (landable
+  now).** The ordinal (`frame.generatedIdCounter++`) was a defense against the
+  same function being inline-declared twice; the builder-call-hoisting
+  transformer moves every builder call to a module-scope declaration and the
+  SES verifier enforces that shape, so under the ESM loader `(kind, src,
+  preview)` is already unique — and `src` is the canonical
+  `cf:module/<hash>/<path>:line:col`, making the ref content-derived. Removing
+  the ordinal eliminates build-order sensitivity (the same class of bug as the
+  CT-1623 reload churn). Compat caveat: refs are persisted inside serialized
+  graphs (e.g. `$opFallback` payloads); old ordinal-bearing refs will no
+  longer match re-minted ones, so resolution of such stored graphs falls to
+  the stringified-implementation fallback (or fails where the implementation
+  was omitted). If pre-change persisted graphs matter, register a legacy
+  alias during a transition: keep incrementing the counter and ALSO register
+  the fn under `createRef({kind, source, preview, ordinal})`. Decide based on
+  an audit of real stored data; the in-memory/identity fast paths are
+  unaffected either way.
 - **Phase 1 — dual-write, dual-read.** Writers emit `$implRef` (+ keep
   `implementationRef` and the conditional stringified `implementation`).
   Readers prefer `$implRef`; absent that, fall back to the legacy
@@ -362,6 +415,32 @@ canary test compiling+resolving with `$implRef` stripped.
 - `runner.ts`: `resolveJavaScriptFunction` ref path, `discoverAndCacheFunctions`,
   `verifiedLoadId` threading through `JavaScriptNodeContext`/frames.
 
+## Delivery
+
+- **Separate PRs per target**, independently revertible, each green before the
+  next: (1) Phase 0 ordinal removal; (2) `unsafe_parentPattern` deletion
+  (write-only today — no design dependency); (3) `noteDerivedCopy` + trust/
+  entry-ref decoupling, then `unsafe_originalPattern` deletion; (4) `$implRef`
+  dual-write + CFC provenance WeakMap; (5) pattern-scoped registry deletion;
+  (6) flips and shim removals per the phases. Action-identity `patternId`
+  rides on (5); the broader piece/root-pattern `patternId` (~300 refs across
+  shell/piece/runtime-client, wire + persisted surfaces) is a separately
+  designed follow-on — it has its own compat constraints (stored ids, IPC) and
+  must not be bundled here.
+- A note on layering (why `noteDerivedCopy` and not "just look at the
+  manager"): the copy sites live in builder-layer utilities with no
+  PatternManager handle. Either `noteDerivedCopy` lives module-level next to
+  the trust WeakSets (preferred — `valueToEntryRef` keys are globally
+  meaningful content addresses, so promoting that map toward module level is
+  safe), or the builder calls it through the ambient frame.
+- **Red-team pass** (security gate for the CFC change, PR 4): a dedicated
+  adversarial review of the verified-identity path — forged functions with
+  matching source text, `__cf_data`-shaped factories, replayed `$implRef`s
+  pointing at other modules' symbols, host-artifact escalation attempts — with
+  each attack landed as a test (extend `cfreg-security.test.ts` /
+  `esm-verifier-adversarial.test.ts`). Every fail-closed property must be
+  demonstrated, not argued.
+
 ## Test plan
 
 - Red-green per phase: serialization snapshot tests pin the `$implRef` form;
@@ -382,19 +461,13 @@ canary test compiling+resolving with `$implRef` stripped.
 
 ## Open questions
 
-1. **Build-time sentinels (C1).** Can `createPattern` serialize nested trusted
-   patterns as `$patternRef` directly instead of embedding graphs + side-table
-   carry? Requires refs at build time, but indexing happens post-evaluation.
-   Options: a deferred slot patched by `registerEvaluatedModules` (the
-   serialized graph is still in memory then), or keeping instantiation-time
-   substitution (status quo, generalized). Default: keep instantiation-time.
-2. **Eviction pinning.** `addressableByIdentity` is FIFO-bounded; the op path
+1. **Eviction pinning.** `addressableByIdentity` is FIFO-bounded; the op path
    tolerates eviction via `$opFallback`. If Phase 4 drops fallbacks, running
    patterns must pin their modules' index entries (refcount on running pieces)
    or the resolver needs a sync-safe re-evaluation path from
    `modulesByIdentity`. Decide before Phase 4; until then fallbacks cover it.
-3. **`cfc/canonical.ts` digests.** Confirm no *persisted* artifact compares
+2. **`cfc/canonical.ts` digests.** Confirm no *persisted* artifact compares
    `bundleId`s across sessions (believed session-only; verify before Phase 3).
-4. **`location`/`preview` retention.** Keep both on serialized modules for
+3. **`location`/`preview` retention.** Keep both on serialized modules for
    debugging (they're inert), or derive `location` from `$implRef` + symbol?
    Default: keep.

--- a/docs/specs/content-addressed-action-identity.md
+++ b/docs/specs/content-addressed-action-identity.md
@@ -1,0 +1,400 @@
+# Content-Addressed Action Identity
+
+Retiring `implementationRef`, the `unsafe_originalPattern`/`unsafe_parentPattern`
+backrefs, and pattern-scoped function registries in favor of `{ identity,
+symbol }` references and object-keyed (WeakMap/WeakSet) trust.
+
+## Status
+
+Design. Depends on (and assumes) the shipped state after the AMD-loader
+removal: the ESM module-record loader is the only loader, every module has a
+content-addressed identity (`cf:module/<hash>`), and every module-scope builder
+artifact (pattern / lift / handler) is addressable as `{ identity, symbol }` —
+authored exports by export name, hoisted/non-exported artifacts by their
+`__cfReg` key (see `docs/specs/module-loading.md` and the op-by-identity
+migration that introduced the `$patternRef` sentinel,
+`builtins/op-pattern-ref.ts`).
+
+## Last Updated
+
+2026-06-10
+
+## Motivation
+
+Three legacy identity mechanisms predate content addressing and now duplicate
+it badly:
+
+1. **`implementationRef`** (`builder/module.ts:ensureImplementationRef`) — an
+   opaque per-function ref minted from `{ kind, source: fn.src, preview:
+   fn.toString(), ordinal: frame.generatedIdCounter++ }`. The **ordinal makes
+   it build-order-dependent**: it is not a content address, and cross-reload
+   matching works only because pattern instantiation is deterministic. It keys
+   four string-indexed maps in the `ExecutableRegistry`, the per-runner
+   `FunctionCache`, the CFC verified-identity resolution, and rides along in
+   serialized module JSON (`moduleToJSON` spreads it via `...rest`).
+
+2. **`unsafe_originalPattern` / `unsafe_parentPattern`** (symbols in
+   `builder/types.ts`) — in-memory backrefs from serialized pattern copies to
+   the live branded original. They exist so that (a) trust-chain walks
+   (`isTrustedPattern` / `isTrustedBuilderArtifact`) can confer trust on
+   copies, and (b) `getArtifactEntryRef` can resolve a copy to the registered
+   `{ identity, symbol }`. Symbols never survive the storage round-trip, so
+   every consumer already has a backref-less path; the symbols only serve the
+   in-memory hop between build-time serialization and instantiation.
+   `unsafe_parentPattern` is **write-only today** (set in
+   `pattern-binding.ts:354`, read nowhere in `src/`) — it is already dead.
+
+3. **`patternId`-scoped function registries**
+   (`ExecutableRegistry.verifiedPatternFunctions` / `verifiedPatternLoadIds`,
+   populated by `associatePattern`) — a session-scoped secondary index so a
+   rehydrated pattern instance resolves *its* load's function objects. This
+   exists to disambiguate equal `implementationRef`s across loads — a problem
+   content addressing dissolves (below).
+
+The scheduler is already migrated: persisted observations key on the
+content-addressed `implementationHash` (`cf:module/<hash>:<line>:<col>`,
+`scheduler/action-run.ts`), with no `implementationRef` dependence.
+
+## The invariant this design stands on
+
+**Every referenced pattern/handler/lift is addressable as `{ identity, symbol }`.**
+
+- The builder-call-hoisting transformer
+  (`ts-transformers/src/transformers/builder-call-hoisting.ts`) hoists every
+  `lift(...)`/`handler(...)`/`pattern(...)` call to module scope
+  (`__cfLift_N`/`__cfHandler_N`/`__cfPattern_N`) and emits a trailing
+  `__cfReg({...})` registering every hoisted and non-exported module-scope
+  builder artifact. Exports are addressable through the module namespace.
+- `PatternManager.registerEvaluatedModules` indexes both channels into
+  `addressableByIdentity` (identity → symbol → live value, FIFO-bounded) and
+  `valueToEntryRef` (live value → `{identity, symbol}`), gated on
+  `isTrustedBuilderArtifact`.
+- Per-instance state does NOT live in function closures: handler/lift
+  implementations are module-scope functions, and instance state is bound
+  explicitly through node inputs (`$ctx`). Two `handler(...)` calls at the same
+  source location are distinct hoisted symbols, not colliding closures.
+
+**Soundness of content-addressed function resolution.** The per-module SES
+verifier rejects top-level mutable bindings (`classifyModuleItems`: "Top-level
+mutable bindings are not allowed in SES mode"). A verified module therefore has
+no module-scope mutable state, so any two evaluations of the same module
+identity produce **interchangeable** function objects. This is what makes it
+sound to resolve a serialized node's implementation from *any* live evaluation
+of that module identity — and what makes `patternId` scoping unnecessary.
+
+For artifacts with no compiled module (host functions, in-test builders), a
+synthetic-identity registration path covers the gap (§ Host and test
+artifacts).
+
+## Audit: where we make pattern copies, and whether we still need them
+
+(The `unsafe_*` symbols only exist to ride on copies; if a copy site goes away
+or stops needing identity-carry, the symbols die with it.)
+
+| # | Copy site | What it does | Verdict |
+|---|---|---|---|
+| C1 | `createPattern` (`builder/pattern.ts` ~332, 368–373): build-time serialization of `result` + every node's `module`/`inputs`/`outputs` via `toJSONWithLegacyAliases` | Produces the `Pattern` object — the durable graph representation. Writes `unsafe_originalPattern` onto every nested pattern copy (`json-utils.ts:183`) | **Copy stays** (the `Pattern` IS the serialized artifact). The *backref* is replaced by registering the copy in a side table at copy time (§ Trust). Long-term, nested trusted patterns can serialize as `$patternRef` sentinels directly once build-time refs are resolvable (see Open questions — refs aren't known until post-module-evaluation, which is why the lazy backref exists today). |
+| C2 | `moduleToJSON` pattern-type implementation (`json-utils.ts:387`, the CT-1230 workaround): sub-pattern passed as a module implementation (e.g. to `.map()`) | Serializes the nested pattern graph instead of stringifying it | **Subsumed by op-by-identity.** The op already travels as `$patternRef` + `$opFallback`; with `$opFallback` retained the embedded copy is only the fallback payload. When the fallback is dropped (Phase 4), this copy site disappears. |
+| C3 | `traverseValue` (`traverse-utils.ts:54`): copies during build traversal (`collectCellsAndNodes`, `node-utils` connect) | Preserves the backref so a traversal copy still resolves `getArtifactEntryRef` | **Copy stays; backref replaced** by side-table registration at the same line. |
+| C4 | `unwrapOneLevelAndBindtoDoc` (`pattern-binding.ts:333–340`): instantiation-time rebinding copies | Propagates backref + the `verifiedLoadId` side-table entry to the bound copy | **Copy stays; backref replaced** by side-table registration; the `verifiedLoadId` propagation is deleted outright (CFC identity no longer flows through loadIds — § CFC). |
+| C5 | `unsafe_noteParentOnPatterns` (`pattern-binding.ts:346–358`): writes `unsafe_parentPattern` | Nothing reads it | **Delete now.** Independent of the rest of this design. |
+
+Net: the copies themselves are mostly load-bearing (the serialized graph is the
+product); what dies is the *symbol-on-object identity-carry*. The replacement
+is one explicit call at each copy site:
+
+```ts
+// pattern-manager (or a small trust module):
+noteDerivedCopy(copy: object, original: object): void
+//  - if isTrustedBuilderArtifact(original): brand `copy` as derived-trusted
+//    (WeakSet add — same side-table family as brandTrustedPattern)
+//  - if valueToEntryRef.has(original): valueToEntryRef.set(copy, ref)
+```
+
+This converts the *lazy backwalk* (follow symbols at lookup time) into an
+*eager forward registration* (record at copy time). Lookup sites
+(`isTrustedPattern`, `isTrustedBuilderArtifact`, `getArtifactEntryRef`,
+`findOriginalPattern`) collapse to single WeakSet/WeakMap probes — no chain
+walks, no cycle guards, no symbol declarations on `Pattern`.
+
+Security note: the forged-value defense is unchanged in kind but simpler in
+mechanism. Today a forger cannot reference the module-private symbol; tomorrow
+there is nothing on the object at all — trust lives exclusively in runner-owned
+WeakSets keyed by object identity, which `__cf_data`-forged values can never
+enter (they are never passed to `noteDerivedCopy` with a trusted original).
+`cfreg-security.test.ts`'s string-keyed-symbol forgery tests become "no
+property on the object grants trust" tests.
+
+## Target design
+
+### 1. Serialized form: `$implRef` sentinel
+
+A JavaScript module (handler/lift) in a serialized graph carries a plain-data
+sentinel instead of `implementationRef` (+ conditionally stringified
+`implementation`):
+
+```jsonc
+{
+  "type": "javascript",
+  "wrapper": "handler",
+  "argumentSchema": { /* ... */ },
+  "resultSchema": { /* ... */ },
+  "$implRef": { "identity": "<module-hash>", "symbol": "__cfHandler_1" },
+  "preview": "function (event, ctx) { ... }",   // debug only
+  "location": "cf:module/<hash>/file.tsx:42:15" // debug only
+}
+```
+
+- `identity` — prefix-free module content hash (same namespace as
+  `$patternRef`, the compile cache, and `fn.src`).
+- `symbol` — export name or `__cfReg` key of the **factory** the builder
+  returned. The implementation function is reached as `factory.implementation`.
+- Exactly the `$patternRef` precedent; same trust gate on resolution
+  (`indexArtifact` only indexes `isTrustedBuilderArtifact` values, so whatever
+  resolves is builder-made by construction).
+- During the transition the stringified `implementation` is retained as the
+  fallback payload (mirror of `$opFallback`); see Phases for when it drops.
+
+`ensureImplementationRef` is deleted; nothing is minted at builder time. The
+sentinel is stamped where the op sentinel is stamped today: at node
+instantiation/serialization time, via `getArtifactEntryRef(factory)` —
+generalizing `substituteOpPatternRefs` from `map/filter/flatMap` ops to **every
+javascript-module node**.
+
+### 2. Resolution (runner)
+
+`resolveJavaScriptFunction(module, pattern)` becomes:
+
+1. Live module object (fresh build): `module.implementation` is the function —
+   use it (status quo; no lookup at all).
+2. Rehydrated module with `$implRef`:
+   `patternManager.artifactFromIdentitySync(identity, symbol)?.implementation`.
+   This hits whenever the owning pattern is running — its module was evaluated,
+   which is what populated the index. (Same liveness argument as ops; the
+   bounded cache's eviction risk is covered by the fallback during transition,
+   and by pinning the running pattern's modules — see Open questions.)
+3. Fallback (transition only): stringified source via `getInvocation` (SES
+   `evaluateCallback`) — runs sandboxed but **unverified**, so CFC identity is
+   `unsupported` (fail-closed), exactly as registry misses behave today.
+
+`FunctionCache` re-keys from `module.implementationRef` to the module object
+(it already takes the module; a WeakMap keyed by module object also drops the
+string indirection) — or is deleted if step 2 is cheap enough (two Map hits).
+
+### 3. CFC implementation identity
+
+Today (`cfc/implementation-identity.ts`): `kind: "verified"` is proven by
+`getVerifiedFunctionInLoad(verifiedLoadId, implementationRef) ===
+implementation` plus `isVerifiedSourceInLoad`, and reported as `{ bundleId,
+sourceFile?, bindingPath?, sourceLocation, codeHash? }`. The `bundleId` is the
+load's concatenated-script hash — load-scoped, not content-addressed.
+
+Target: registration during verified evaluation records provenance keyed by
+the **function object**:
+
+```ts
+// populated by registerEvaluatedModules / the __cfReg sink walk:
+verifiedProvenance: WeakMap<Function, {
+  identity: string;          // module content hash
+  symbol: string;            // factory's export/__cfReg key
+  bindingIdentity?: { sourceFile: string; bindingPath: string[] };
+                             // from __cfVerifiedBindingIdentity (CT-1665),
+                             // read off the factory annotation directly
+}>
+```
+
+`resolvePolicyFacingImplementationIdentity` becomes: look the *function object*
+up in `verifiedProvenance`; if present, emit
+
+```ts
+{ kind: "verified",
+  moduleIdentity,            // replaces bundleId — content-addressed, reload-stable
+  symbol,                    // replaces codeHash for module-scope artifacts
+  sourceFile?, bindingPath?, // unchanged semantics (writeAuthorizedBy)
+  sourceLocation }           // from fn.src (already canonical cf:module/<hash>/…)
+```
+
+else `unsupported` (fail-closed). The WeakMap *is* the anti-spoof check — an
+attacker-supplied function was never registered during a verified evaluation,
+so it has no entry; there is no string key to collide and no loadId to scope.
+This strictly strengthens the policy identity: `bundleId` varied per load and
+per surrounding file set; `moduleIdentity` is stable for byte-identical code.
+
+Consequences:
+- `verifiedLoadId` threading through frames / `JavaScriptNodeContext` /
+  `json-utils` (`frame.verifiedLoadId` in `moduleToJSON`'s
+  `admittedImplementation` probe) is deleted. `setVerifiedLoadId` /
+  `getVerifiedLoadId` side tables and `seedVerifiedLoadIds` /
+  `annotateVerifiedPatterns` walks are deleted (their job — marking which load
+  verified a pattern — is subsumed by `valueToEntryRef` + `verifiedProvenance`).
+- `isVerifiedSourceInLoad` / `verifiedLoadSources` / `verifiedLoadBundleIds`:
+  the source check becomes "does `fn.src`'s `cf:module/<identity>` prefix match
+  the provenance identity" — a string comparison against the WeakMap entry, no
+  per-load source sets.
+- CFC label/policy storage that embeds identities: anything persisted that
+  contains a `bundleId` is already load-scoped (unstable), so policy matching
+  re-derives per session — switching to `moduleIdentity` is
+  backward-compatible for enforcement (fail-closed on mismatch) but check
+  `cfc/canonical.ts` digests for any persisted comparisons (Phase audit item).
+
+### 4. ExecutableRegistry: what remains
+
+Deleted: `verifiedFunctions`, `verifiedFunctionIndex`,
+`verifiedFunctionLoadIds`, `verifiedBindingMetadata`,
+`verifiedPatternFunctions`, `verifiedPatternLoadIds`,
+`trustedHostFunctionIndex` + `unsafe-host:` ref minting, `beginVerifiedLoad`'s
+cross-load index repair, `captureVerifiedValue`'s whole-namespace
+`recordVerifiedFunctions` walk, `associatePattern`,
+`setVerifiedFunctionRegistrar` and the builder-time
+`registerVerifiedFunctionImplementation` channel.
+
+Remaining (likely small enough to fold into PatternManager or a `trust.ts`):
+- `verifiedProvenance` WeakMap (above) and its registration walk over
+  `exportsByIdentity` + the `__cfReg` sink (today's
+  `captureVerifiedBindingCandidates`, generalized).
+- Host trust WeakSet (below).
+
+`runner.discoverAndCacheFunctions` (prewarm walk keyed by ref) is deleted —
+prewarming by `{identity, symbol}` is a single index probe if still wanted.
+
+### 5. Host and test artifacts (the "pseudo module")
+
+Some trusted callables have no compiled module: host-provided functions
+(`runtime.unsafeTrustHostValue`, used for wish/builtin host capabilities) and
+builder artifacts constructed directly in tests.
+
+Design: a synthetic-identity registrar, one mechanism for both:
+
+```ts
+runtime.unsafe_registerHostArtifact(value: object, options: {
+  symbol: string;            // caller-chosen name
+  reason: string;            // non-empty, like UnsafeHostTrustOptions today
+}): { identity: string; symbol: string }
+// identity = `host:` + hash of (reason, symbol, monotonic nonce) — a distinct
+// namespace from cf:module hashes; never collides with compiled identities.
+```
+
+- Indexes `value` in `addressableByIdentity`/`valueToEntryRef` like any
+  artifact, so serialization and resolution are uniform (`$implRef` with a
+  `host:` identity resolves in-session only — host artifacts were never
+  resumable from storage, unchanged).
+- Trust: adds the value (and its `.implementation`) to a `hostTrusted` WeakSet;
+  execution allowed, but CFC identity stays `undefined`/`unsupported` exactly
+  as `unsafe-host:` refs behave today (`resolvePolicyFacingImplementationIdentity`
+  returns `undefined` for host artifacts — fail-closed for policy purposes).
+- Tests use the same API (possibly sugared as a `test-support` helper
+  `registerTestArtifact(value, name)`), replacing every test that today relies
+  on builder-time `implementationRef` registration outside a compiled program.
+  Tests that want **verified** (CFC-passing) artifacts compile a small
+  in-memory program — already the dominant idiom post-AMD.
+
+### 6. `patternId` scoping: deleted
+
+`verifiedPatternFunctions` existed so a pattern instance resolves the function
+objects of *its* load when the same `implementationRef` was registered by
+several loads. Under content addressing any live instance of the same module
+identity is interchangeable (no module-scope mutable state — § Invariant), so
+the global `addressableByIdentity` index suffices and the pattern-scoped
+second key is dropped. `PatternManager`'s piece/meta `patternId` (URIs, meta
+cells, LRU) is unrelated and stays.
+
+## Persisted-data compatibility
+
+What's in stored graphs today (verified writer): `{ type: "javascript",
+wrapper, schemas, implementationRef, preview, location }` — `implementation`
+omitted when the function was admitted (verified) at serialization time, else
+stringified. Resolution of old data depends on the registry repopulating the
+same (ordinal-dependent!) refs when the pattern re-evaluates.
+
+Phased migration (op-migration playbook):
+
+- **Phase 1 — dual-write, dual-read.** Writers emit `$implRef` (+ keep
+  `implementationRef` and the conditional stringified `implementation`).
+  Readers prefer `$implRef`; absent that, fall back to the legacy
+  `implementationRef` lookup (registry retained, deprecated). New CFC
+  provenance WeakMap runs in parallel; CFC resolution prefers it and falls back
+  to the loadId path. `noteDerivedCopy` lands; copy sites call it *in addition
+  to* writing the symbol.
+- **Phase 2 — legacy reads behind re-registration only.** Because a stored
+  node only resolves after its pattern's module re-evaluates (which re-runs the
+  builder and re-mints refs deterministically), the legacy path's only real
+  dependency is `ensureImplementationRef` + the global index. Keep exactly
+  that pair; delete pattern scoping, loadId threading, and the binding-metadata
+  map (provenance WeakMap covers them).
+- **Phase 3 — flip.** Writers stop emitting `implementationRef`/stringified
+  `implementation`; `unsafe_*` symbols deleted (reads first, then writes);
+  trust-chain walks become WeakSet probes; CFC loadId machinery deleted.
+  Legacy read shim retained for stored-data only.
+- **Phase 4 — drop the shim + fallbacks.** Requires either (a) accepted data
+  migration on write (graphs rewrite to `$implRef` whenever a piece is saved —
+  they do on every pattern re-instantiation, so old refs age out quickly), or
+  (b) a `COMPILE_CACHE_RUNTIME_VERSION`-style cutoff. Also the point to decide
+  whether `$opFallback`/stringified-implementation fallbacks can drop in favor
+  of storage-backed by-identity loads (`loadPatternByIdentity` covers patterns;
+  an analogous module-closure load covers handler modules — both async, so the
+  sync action path keeps the in-memory index as the primary).
+
+Rollback safety: Phases 1–2 are additive; the legacy path stays exercised by a
+canary test compiling+resolving with `$implRef` stripped.
+
+## What gets deleted (end state)
+
+- `builder/module.ts`: `ensureImplementationRef`,
+  `registerVerifiedFunctionImplementation` channel and its
+  `setVerifiedFunctionRegistrar` ambient in `function-hardening.ts`.
+- `builder/types.ts`: `unsafe_originalPattern`, `unsafe_parentPattern`, their
+  `Pattern` declarations and `index.ts` exports.
+- `json-utils.ts`: backref write (line ~183), `admittedImplementation` probe,
+  the "must carry implementationRef" throw; `moduleToJSON` emits `$implRef`.
+- `traverse-utils.ts` / `pattern-binding.ts`: backref/`verifiedLoadId`
+  propagation → `noteDerivedCopy`; `unsafe_noteParentOnPatterns` deleted.
+- `pattern-metadata.ts`: chain walks in `isTrustedPattern` /
+  `isTrustedBuilderArtifact` (brand probes remain), `setVerifiedLoadId` /
+  `getVerifiedLoadId` side tables.
+- `pattern-manager.ts`: `findOriginalPattern`, `seedVerifiedLoadIds`,
+  `patternToVerifiedLoadId`, `associateVerifiedFunctions`.
+- `harness/executable-registry.ts`: ~everything string-keyed (§4);
+  `function-cache.ts` re-keyed or deleted.
+- `cfc/implementation-identity.ts`: loadId/ref plumbing → provenance WeakMap;
+  `Harness` interface loses `getVerifiedLoadId`, `getVerifiedFunctionInLoad`,
+  `isVerifiedSourceInLoad`, `getVerifiedBundleId`, `getVerifiedBindingMetadata`,
+  `registerVerifiedFunction`, `getExecutableFunction`, `associatePattern`.
+- `runner.ts`: `resolveJavaScriptFunction` ref path, `discoverAndCacheFunctions`,
+  `verifiedLoadId` threading through `JavaScriptNodeContext`/frames.
+
+## Test plan
+
+- Red-green per phase: serialization snapshot tests pin the `$implRef` form;
+  a stored-graph fixture (captured pre-migration) pins legacy-read compat.
+- CFC: `cfc-implementation-identity.test.ts` ports to provenance-based
+  `{ kind: "verified", moduleIdentity, ... }`; spoof tests assert an
+  unregistered function (same source, constructed outside verified eval) is
+  `unsupported`.
+- Trust: `cfreg-security.test.ts` forgery suite ports from "string-keyed
+  symbol is inert" to "no own property grants trust"; derived-copy trust tests
+  go through `noteDerivedCopy`.
+- Resume: `resume-by-identity` / `by-identity-handler-exec` extended with a
+  handler-bearing piece resumed source-free, resolving through `$implRef`.
+- Host/test registrar: a piece using `unsafe_registerHostArtifact` callables
+  executes but its writes carry no verified identity (CFC fail-closed assert).
+- Multi-instance: two pieces from byte-identical programs share resolution
+  (the patternId-scoping deletion's regression guard).
+
+## Open questions
+
+1. **Build-time sentinels (C1).** Can `createPattern` serialize nested trusted
+   patterns as `$patternRef` directly instead of embedding graphs + side-table
+   carry? Requires refs at build time, but indexing happens post-evaluation.
+   Options: a deferred slot patched by `registerEvaluatedModules` (the
+   serialized graph is still in memory then), or keeping instantiation-time
+   substitution (status quo, generalized). Default: keep instantiation-time.
+2. **Eviction pinning.** `addressableByIdentity` is FIFO-bounded; the op path
+   tolerates eviction via `$opFallback`. If Phase 4 drops fallbacks, running
+   patterns must pin their modules' index entries (refcount on running pieces)
+   or the resolver needs a sync-safe re-evaluation path from
+   `modulesByIdentity`. Decide before Phase 4; until then fallbacks cover it.
+3. **`cfc/canonical.ts` digests.** Confirm no *persisted* artifact compares
+   `bundleId`s across sessions (believed session-only; verify before Phase 3).
+4. **`location`/`preview` retention.** Keep both on serialized modules for
+   debugging (they're inert), or derive `location` from `$implRef` + symbol?
+   Default: keep.

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -717,6 +717,25 @@ function ensureImplementationRef(
       preview: implementation.toString(),
     }, "verified implementation").toString();
 
+    // Transition shim: graphs persisted before the ordinal removal carry
+    // ordinal-bearing refs, and `moduleToJSON` omits the function body for
+    // admitted (verified) modules — those stored refs only resolve if a fresh
+    // evaluation re-registers the implementation under the legacy form too.
+    // Consuming the frame counter HERE (first mint per function, same call
+    // sites as before) reproduces the pre-removal ordinal sequence exactly.
+    // Removed together with `implementationRef` itself — see
+    // docs/specs/content-addressed-action-identity.md.
+    const frame = getTopFrame();
+    if (frame) {
+      const legacy = createRef({
+        kind,
+        source,
+        preview: implementation.toString(),
+        ordinal: frame.generatedIdCounter++,
+      }, "verified implementation").toString();
+      registerVerifiedFunctionImplementation(legacy, implementation);
+    }
+
     if (Object.isExtensible(implementation)) {
       Object.defineProperty(implementation, "implementationRef", {
         value: minted,

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -699,17 +699,22 @@ function ensureImplementationRef(
   implementation: (...args: any[]) => unknown,
   kind: "fn" | "handler",
 ): string {
-  const frame = getTopFrame();
   const existing = (implementation as { implementationRef?: string })
     .implementationRef;
   const implementationRef = existing ?? (() => {
+    // Purely content-derived: `src` is the canonical content-addressed source
+    // location (`cf:module/<hash>/<path>:line:col`) under the ESM loader, and
+    // the builder-call-hoisting transformer + SES verifier guarantee one
+    // builder call per module-scope declaration, so (source, preview)
+    // uniquely identifies the implementation. (An order-dependent `ordinal`
+    // used to be folded in as a defense against inline duplicate
+    // declarations, which made refs build-order-dependent.)
     const source = (implementation as { src?: string }).src ??
       implementation.name;
     const minted = createRef({
       kind,
       source,
       preview: implementation.toString(),
-      ...(frame ? { ordinal: frame.generatedIdCounter++ } : {}),
     }, "verified implementation").toString();
 
     if (Object.isExtensible(implementation)) {

--- a/packages/runner/test/implementation-ref.test.ts
+++ b/packages/runner/test/implementation-ref.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { lift } from "../src/builder/module.ts";
+import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { setVerifiedFunctionRegistrar } from "../src/sandbox/function-hardening.ts";
+
+/**
+ * `ensureImplementationRef` minting (see builder/module.ts).
+ *
+ * The attached (and serialized) ref is purely content-derived
+ * (`{kind, source, preview}`) — the build-order `ordinal` was removed
+ * (transformer hoisting + the SES verifier guarantee one builder call per
+ * module-scope declaration, so the ordinal only added build-order
+ * sensitivity).
+ *
+ * Transition shim: graphs persisted BEFORE the ordinal removal carry
+ * ordinal-bearing refs, and `moduleToJSON` omits the function body for
+ * admitted (verified) modules — so those stored refs only resolve if a fresh
+ * evaluation re-registers the implementation under the legacy ordinal form
+ * too. These tests pin that dual registration and the order-independence of
+ * the attached ref; the shim is removed together with `implementationRef`
+ * itself (docs/specs/content-addressed-action-identity.md).
+ */
+describe("ensureImplementationRef minting", () => {
+  // Source-identical but distinct function objects (same text, same (lack
+  // of) src), built fresh per call so no attached ref is carried over.
+  const makeImpl = () => (x: { value: number }) => x.value + 1;
+
+  it("attaches a content-derived ref and registers a legacy ordinal alias", () => {
+    const registered: string[] = [];
+    const restore = setVerifiedFunctionRegistrar((ref) => {
+      registered.push(ref);
+    });
+    const frame = pushFrame();
+    try {
+      const impl = makeImpl();
+      lift(impl);
+      const attached = (impl as { implementationRef?: string })
+        .implementationRef;
+      expect(typeof attached).toBe("string");
+      const distinct = new Set(registered);
+      // Dual registration: the content-derived ref (the attached one) plus
+      // exactly one legacy ordinal-bearing alias.
+      expect(distinct.size).toBe(2);
+      expect(distinct.has(attached!)).toBe(true);
+    } finally {
+      popFrame(frame);
+      restore();
+    }
+  });
+
+  it("attached ref is build-order independent; the legacy alias is not", () => {
+    const mintInFreshFrame = (counterStart: number) => {
+      const registered: string[] = [];
+      const restore = setVerifiedFunctionRegistrar((ref) => {
+        registered.push(ref);
+      });
+      const frame = pushFrame();
+      frame.generatedIdCounter = counterStart;
+      try {
+        const impl = makeImpl();
+        lift(impl);
+        const attached = (impl as { implementationRef?: string })
+          .implementationRef!;
+        const legacy = [...new Set(registered)].find((r) => r !== attached)!;
+        return { attached, legacy };
+      } finally {
+        popFrame(frame);
+        restore();
+      }
+    };
+
+    const a = mintInFreshFrame(0);
+    const b = mintInFreshFrame(7);
+    // Content-derived: identical source text mints the identical ref no
+    // matter how much of the frame's id counter prior builds consumed.
+    expect(b.attached).toBe(a.attached);
+    // The legacy alias reproduces the old ordinal-bearing form, so it DOES
+    // vary with the counter — that variance is exactly what old persisted
+    // graphs encode and what the alias re-registers.
+    expect(b.legacy).not.toBe(a.legacy);
+  });
+});


### PR DESCRIPTION
## Summary

Two things, per the design's own delivery plan:

### 1. Design doc: `docs/specs/content-addressed-action-identity.md`

The plan for retiring `implementationRef`, the `unsafe_originalPattern`/`unsafe_parentPattern` backrefs, and pattern-scoped function registries, standing on the post-AMD invariant that **every referenced pattern/handler/lift is addressable as `{identity, symbol}`** (exports by name, hoisted/non-exported artifacts by their `__cfReg` key).

Highlights:
- **Copy-site audit**: the in-memory copies (build-time graph serialization, traversal, rebinding) stay; what dies is the symbol-on-object identity-carry, replaced by one explicit `noteDerivedCopy(copy, original)` registration at each copy site — lazy backwalks become eager WeakSet/WeakMap probes. `unsafe_parentPattern` is **write-only today** (set, never read) and can be deleted immediately.
- **Serialization boundary emits refs**: `toJSON` runs at storage time (post-evaluation, refs known), so pattern JSON becomes `$patternRef`/`$implRef` sentinels and the node-graph representation goes runtime-internal (debug output via `cf check`). Known trip-points enumerated ($opFallback needs an explicit full-graph serializer or eviction pinning first).
- **CFC identity via provenance WeakMap**: function-object-keyed `{moduleIdentity, symbol, bindingIdentity}` replaces the `implementationRef`×`verifiedLoadId` registry checks; the WeakMap *is* the anti-spoof proof, and `moduleIdentity` replaces the load-scoped `bundleId` (strictly more stable). Fail-closed throughout; a dedicated red-team pass with attacks-as-tests gates that PR.
- **`patternId` scoping deleted**: sound because the SES verifier forbids module-scope mutable state, so any live evaluation of the same module identity is interchangeable. The broader cross-package piece/root `patternId` is explicitly a separately-designed follow-on.
- **Host/test artifacts**: a synthetic-identity registrar (`host:` namespace) covers trusted callables with no compiled module, doubling as the in-test affordance.
- Four-phase persisted-data migration (dual-write → scoped legacy reads → flip → shim removal), one PR per target.

### 2. Phase 0, landable now: drop the `ordinal` from `ensureImplementationRef`

The ordinal (`frame.generatedIdCounter++`) defended against the same function being inline-declared twice. The builder-call-hoisting transformer now hoists every builder call to a module-scope declaration and the SES verifier enforces that shape, so `(kind, src, preview)` is already unique — and `src` is the canonical `cf:module/<hash>/<path>:line:col`, making the ref purely content-derived. The ordinal only added build-order sensitivity (the CT-1623 reload-churn bug class).

**Caveat (documented in the doc)**: refs persisted in pre-change graphs (notably `$opFallback` payloads) carry ordinal-bearing refs that won't match re-minted ones; those resolve via the stringified-implementation fallback, which is absent for verified-omitted modules. The exposure is old data + identity-cache eviction (>1000 modules in one session) only; a legacy-alias dual-registration shim is described in the doc if we'd rather close even that window before the `$implRef` phases retire the mechanism entirely.

## Verification

- Full runner suite: **564 passed / 0 failed**.
- Identity-sensitive set run explicitly: map-op-by-identity, cfc-implementation-identity, action-fingerprint, resume-by-identity, load-by-identity, cfreg-builder-identity, cfc-nonexported-binding-identity — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Designs content‑addressed action identity and ships Phase 0 by removing the build‑order ordinal from `ensureImplementationRef` so refs are content‑derived and stable. Adds a temporary legacy ordinal‑alias registration to keep pre‑change persisted refs resolving.

- `docs/specs/content-addressed-action-identity.md` outlines replacing `implementationRef`, unsafe backrefs, and pattern‑scoped registries with `{identity, symbol}`; `$implRef` for serialized JS modules; CFC provenance via a function‑keyed WeakMap; and phased migration.

- **Refactors**
  - `packages/runner/src/builder/module.ts`: `ensureImplementationRef` now mints refs from `(kind, src, preview)` only, removing the `ordinal`, and also dual‑registers a legacy ordinal alias for back‑compat (to be removed in Phase 3).

- **Migration**
  - Old graphs with ordinal‑bearing refs continue to resolve via the dual registration; tests pin build‑order independence of the attached ref and the legacy alias behavior (`packages/runner/test/implementation-ref.test.ts`).

<sup>Written for commit b90f031de9ba05d9e85e95d975334c0a4b84af0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

### Perf-check override

Runner-noise, demonstrated across attempts of identical code: pattern-unit-4 and its lunch-poll subtest were inside threshold on attempt 1, +30% on the slow attempt-2 runner, and the targeted shard rerun (attempt 4) completed the whole job in 72s — but the perf check re-reads the attempt-2 timing artifact, so the stale measurement can't clear without a full new run. (The other attempt-2 straggler, Package Integration Tests (runner), DID clear via targeted job rerun: fresh sample 81s, mid-range of main's 76–88s.)

NEW_PERF_BASELINE: test: pattern-unit-4/pattern-unit-tests = 247s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/main.test.tsx = 22s
