### PR TITLE
refactor(home): remove stored spaceDid from favorites

### DIFF
--- a/packages/home-schemas/favorites.ts
+++ b/packages/home-schemas/favorites.ts
@@ -14,7 +14,6 @@ export const favoriteEntrySchema = {
     tag: { type: "string", default: "" },
     userTags: { type: "array", items: { type: "string" }, default: [] },
     spaceName: { type: "string" },
-    spaceDid: { type: "string" },
   },
   required: ["cell"],
 } as const satisfies JSONSchema;

--- a/packages/patterns/system/favorites-manager.tsx
+++ b/packages/patterns/system/favorites-manager.tsx
@@ -16,7 +16,6 @@ type Favorite = {
   tag: string;
   userTags: Writable<string[]>;
   spaceName?: string;
-  spaceDid?: string;
 };
 
 const onRemoveFavorite = handler<

--- a/packages/patterns/system/home-ben.tsx
+++ b/packages/patterns/system/home-ben.tsx
@@ -18,7 +18,6 @@ type Favorite = {
   tag: string;
   userTags: string[];
   spaceName?: string;
-  spaceDid?: string;
 };
 
 type JournalSnapshot = {
@@ -118,9 +117,6 @@ const addFavorite = handler<
       .asSchemaFromLinks?.()?.schema;
     if (typeof schema !== "object") schema = ""; // schema can be true or false
 
-    // Get spaceDid from the piece cell
-    const spaceDid = (piece as any)?.space as string | undefined;
-
     const schemaTag = tag || JSON.stringify(schema) || "";
 
     favorites.push({
@@ -128,7 +124,6 @@ const addFavorite = handler<
       tag: schemaTag,
       userTags: [],
       spaceName,
-      spaceDid,
     });
 
     // Add journal entry for the favorite action

--- a/packages/patterns/system/home.tsx
+++ b/packages/patterns/system/home.tsx
@@ -26,7 +26,6 @@ type Favorite = {
   tag: string;
   userTags: string[];
   spaceName?: string;
-  spaceDid?: string;
 };
 
 type JournalEntry = {
@@ -71,7 +70,6 @@ const addFavorite = handler<
       .asSchemaFromLinks?.()?.schema;
     if (typeof schema !== "object") schema = "";
 
-    const spaceDid = (piece as any)?.space as string | undefined;
     const schemaTag = tag || JSON.stringify(schema) || "";
 
     favorites.push({
@@ -79,7 +77,6 @@ const addFavorite = handler<
       tag: schemaTag,
       userTags: [],
       spaceName,
-      spaceDid,
     });
   }
 });


### PR DESCRIPTION
The spaceDid field on favorite entries was written on every favorite but never read back. Its only consumer, the Spaces tab derived from favorites, was replaced by the managed spaces list in #2926. Consumers that need a favorite's space derive it from the stored cell link via CellHandle.space().

Removing the field also removes the handler casts that captured it by reading the internal space property off the piece cell.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused spaceDid from favorite entries to simplify the schema and eliminate unsafe handler casts. Spaces are derived from the stored cell via `CellHandle.space()`, and the old Spaces tab was replaced in #2926.

- **Refactors**
  - Removed `spaceDid` from `packages/home-schemas/favorites.ts` and Favorite types in `favorites-manager.tsx`, `home.tsx`, and `home-ben.tsx`.
  - Deleted code that read `(piece as any).space` to capture `spaceDid`.

<sup>Written for commit d03e7ada350b0e05d120f4057873b17426df15f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

