### PR TITLE
fix: address post-merge review comments from the perf PR series

### DIFF
--- a/docs/development/PERFORMANCE_PROGRAM.md
+++ b/docs/development/PERFORMANCE_PROGRAM.md
@@ -63,7 +63,8 @@ step, and we'll ratchet targets down as we improve.
 
 **What we don't have:**
 - No breakdown of "pattern load takes Xms: Y% compilation, Z% traversal, ..."
-- No profiling data from real usage
+- No profiling data from real production usage (the profiles below are from
+  the integration test flow on a dev stack)
 
 **First flow profiled:** steady-state note creation in the default-app shell
 integration test — see

--- a/packages/data-model/src/schema-utils.ts
+++ b/packages/data-model/src/schema-utils.ts
@@ -408,6 +408,16 @@ export function internPathSelector(
   if (existingRef !== undefined) {
     const existing = existingRef.deref();
     if (existing !== undefined) {
+      // Preserve the pre-cache contract for callers that keep using their
+      // input object: a mutable input is still canonicalized and frozen in
+      // place even when a structurally-equal canonical instance exists.
+      if (existing !== selector && !Object.isFrozen(selector)) {
+        if (interned !== schema) {
+          selector.schema = interned;
+        }
+        Object.freeze(path);
+        Object.freeze(selector);
+      }
       return existing;
     }
     byPath.delete(pathK);

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -320,8 +320,15 @@ describe("default-app flow test", () => {
     let cpuProfiler: CdpWorkerProfiler | undefined;
     if (CAPTURE_NOTE_CREATE_CPUPROFILE_SERIES > 0) {
       console.log("Connect CDP worker profiler...");
-      cpuProfiler = await CdpWorkerProfiler.connect(shell.wsEndpoint());
-      await cpuProfiler.waitForWorker("worker-runtime");
+      try {
+        cpuProfiler = await CdpWorkerProfiler.connect(shell.wsEndpoint());
+        await cpuProfiler.waitForWorker("worker-runtime");
+      } catch (error) {
+        // Profiling is best-effort instrumentation; never fail the test.
+        console.warn("Worker CPU profiler setup failed, disabling:", error);
+        cpuProfiler?.close();
+        cpuProfiler = undefined;
+      }
     }
 
     if (CAPTURE_HOME_LOAD_SERIES > 0) {


### PR DESCRIPTION
Three P2 review comments slipped through the shepherding of the perf series (found on a final sweep of all six PRs):

1. **[#3959](https://github.com/commontoolsinc/labs/pull/3959) / PERFORMANCE_PROGRAM.md** (cubic): the new "First flow profiled" section contradicted the adjacent stale "No profiling data from real usage" bullet. Bullet reworded to say what's actually still missing (production usage; the existing profiles are from the integration flow on a dev stack).
2. **[#3959](https://github.com/commontoolsinc/labs/pull/3959) / default-app.test.ts** (cubic): `CdpWorkerProfiler.connect`/`waitForWorker` setup wasn't wrapped, so a CDP failure could fail the test even though profiling is best-effort (start/stop were already wrapped). Now disables profiling and continues.
3. **[#3981](https://github.com/commontoolsinc/labs/pull/3981) / schema-utils.ts** (Codex): `internPathSelector`'s cache-hit path returned the canonical instance without applying the documented in-place canonicalize+freeze to the *input* selector — a contract regression for callers that keep using their input object. Restored on the hit path.

## Test plan

- [x] data-model suite green; runner trigger-index/selector-tracker/memory-v2-subscription/traverse green
- [x] `deno check`/`lint`/`fmt` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three follow-ups from the perf PR series: restores the `internPathSelector` contract, makes CPU profiler setup best‑effort in the integration test, and clarifies the performance program doc.

- **Bug Fixes**
  - Data model: On cache hit, `internPathSelector` now canonicalizes and freezes the input selector in place (and updates `schema` when needed) before returning the cached instance.
  - Integration test: Wraps `CdpWorkerProfiler.connect`/`waitForWorker` so CDP errors disable profiling and the test continues.
  - Docs: Clarifies “no profiling data” to mean “no real production profiling,” noting current profiles come from the dev integration flow.

<sup>Written for commit 9ce0600eb912cb1fbc91a4789c90721ea6a98a59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

