### PR TITLE
fix(runner): idempotency recheck skips runs whose inputs moved externally (scrabble multi-user flake)

### DIFF
--- a/docs/development/debugging/non-idempotent-detection.md
+++ b/docs/development/debugging/non-idempotent-detection.md
@@ -99,6 +99,25 @@ A cycle means two or more actions form a loop where each one's writes trigger
 the next. Even if each action is individually idempotent, a cycle prevents the
 system from settling.
 
+### 4. Inline Recheck (`cf test`)
+
+`cf test` enables an inline mode (`runtime.enableIdempotencyCheck()`): every
+computation run is immediately followed by a second synchronous run against
+post-commit state, and differing writes fail the test at the end
+(`✗ N non-idempotent computation(s)`, listing each action and its differing
+write keys). A test pattern can opt out by returning
+`expectNonIdempotent: true` — note this *tolerates* violations, it does not
+assert one is found.
+
+Because the second run executes against the latest state, a concurrent write
+landing between the first run and the recheck (another transaction's
+commit/rollback, or a cross-runtime sync apply in multi-user tests) would make
+a pure computation look non-idempotent. The recheck guards against this: when
+writes differ, it compares both runs' read invariants and skips the report if
+an input the action did not itself write moved between the runs. Self-caused
+input moves (reading what it writes — the accumulator anti-pattern) and
+equal-input nondeterminism (timestamps, random ordering) are still reported.
+
 ## Using the Console API
 
 ### Basic Usage

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -282,11 +282,16 @@ const handlers: Record<
   health() {
     return Promise.resolve({
       runtimeErrors: [...runtimeErrors],
-      nonIdempotent: rt().getIdempotencyViolations?.()?.map((violation) =>
-        String(
-          (violation as { actionId?: string }).actionId ?? violation,
-        )
-      ) ?? [],
+      nonIdempotent: rt().getIdempotencyViolations?.()?.map((violation) => {
+        const { actionId, differingWriteKeys } = violation as {
+          actionId?: string;
+          differingWriteKeys?: string[];
+        };
+        const id = String(actionId ?? violation);
+        return differingWriteKeys?.length
+          ? `${id} (differing writes: ${differingWriteKeys.join(", ")})`
+          : id;
+      }) ?? [],
     });
   },
 

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -1422,7 +1422,12 @@ export async function runTestPattern(
 
     // Collect idempotency violations detected during normal execution
     const nonIdempotent = runtime.getIdempotencyViolations()
-      .map((r) => r.actionInfo?.patternName ?? r.actionId);
+      .map((r) => {
+        const id = r.actionInfo?.patternName ?? r.actionId;
+        return r.differingWriteKeys.length
+          ? `${id} (differing writes: ${r.differingWriteKeys.join(", ")})`
+          : id;
+      });
 
     const errorMessages = runtimeErrors.map((e) => String(e));
     return {

--- a/packages/runner/src/scheduler/diagnosis.ts
+++ b/packages/runner/src/scheduler/diagnosis.ts
@@ -194,7 +194,12 @@ function transactionReadInvariants(
   for (const space of spaces) {
     try {
       for (const detail of getTransactionReadDetails(tx, space)) {
-        invariants.set(makeAddressKey(detail.address), {
+        // makeAddressKey ignores scope; include it so same id+path reads
+        // under different cell scopes don't collide.
+        const key = `${detail.address.scope ?? ""}|${
+          makeAddressKey(detail.address)
+        }`;
+        invariants.set(key, {
           address: detail.address,
           value: detail.value,
         });

--- a/packages/runner/src/scheduler/diagnosis.ts
+++ b/packages/runner/src/scheduler/diagnosis.ts
@@ -237,7 +237,10 @@ function readInvariantMovedExternally(
     // Only reads both runs performed are comparable.
     if (!previous) continue;
     if (deepEqual(previous.value, value)) continue;
-    const coveredByOwnWrites = log.writes.some((write) =>
+    // Cover writes of EITHER run: run1's commit moving its own read is the
+    // accumulator pattern, and a write-then-read inside the recheck run is
+    // nondeterminism, not external interference — both must stay flagged.
+    const coveredByOwnWrites = [...log.writes, ...log2.writes].some((write) =>
       write.space === address.space && write.id === address.id &&
       arraysOverlap(write.path, address.path)
     );

--- a/packages/runner/src/scheduler/diagnosis.ts
+++ b/packages/runner/src/scheduler/diagnosis.ts
@@ -4,8 +4,12 @@ import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
 } from "../storage/interface.ts";
-import { getTransactionWriteDetails } from "../storage/transaction-inspection.ts";
+import {
+  getTransactionReadDetails,
+  getTransactionWriteDetails,
+} from "../storage/transaction-inspection.ts";
 import { ignoreReadForScheduling } from "../storage/reactivity-log.ts";
+import { arraysOverlap } from "../reactive-dependencies.ts";
 import type {
   CycleReport,
   NonIdempotentReport,
@@ -174,6 +178,67 @@ export function findNonIdempotentPair(
   return undefined;
 }
 
+/**
+ * Values a transaction observed for its reads (its read invariants), keyed
+ * by address. Available after commit/abort since per-document snapshots are
+ * pinned for the transaction's lifetime.
+ */
+function transactionReadInvariants(
+  tx: IExtendedStorageTransaction,
+  spaces: ReadonlySet<IMemorySpaceAddress["space"]>,
+): Map<string, { address: IMemorySpaceAddress; value: unknown }> {
+  const invariants = new Map<
+    string,
+    { address: IMemorySpaceAddress; value: unknown }
+  >();
+  for (const space of spaces) {
+    try {
+      for (const detail of getTransactionReadDetails(tx, space)) {
+        invariants.set(makeAddressKey(detail.address), {
+          address: detail.address,
+          value: detail.value,
+        });
+      }
+    } catch { /* read details unavailable — treat as no invariants */ }
+  }
+  return invariants;
+}
+
+/**
+ * Whether an input read by both runs changed value between them without the
+ * action itself having written it. That means a concurrent writer (another
+ * action's commit rollback, or a cross-runtime sync apply in multi-runtime
+ * setups) landed between the first run and the recheck — the two runs
+ * computed over different inputs, so differing writes say nothing about
+ * idempotency. Self-caused moves (the action reads what it writes, the
+ * accumulator anti-pattern) stay flagged.
+ */
+function readInvariantMovedExternally(
+  tx: IExtendedStorageTransaction,
+  tx2: IExtendedStorageTransaction,
+  log: ReactivityLog,
+  log2: ReactivityLog,
+): boolean {
+  const spaces = new Set<IMemorySpaceAddress["space"]>();
+  for (const read of log.reads) spaces.add(read.space);
+  for (const read of log2.reads) spaces.add(read.space);
+  const before = transactionReadInvariants(tx, spaces);
+  if (before.size === 0) return false;
+  const after = transactionReadInvariants(tx2, spaces);
+  for (const [key, { address, value }] of after) {
+    const previous = before.get(key);
+    // Only reads both runs performed are comparable.
+    if (!previous) continue;
+    if (deepEqual(previous.value, value)) continue;
+    const coveredByOwnWrites = log.writes.some((write) =>
+      write.space === address.space && write.id === address.id &&
+      arraysOverlap(write.path, address.path)
+    );
+    if (!coveredByOwnWrites) return true;
+  }
+  return false;
+}
+
 export function runIdempotencyRecheck(
   state: {
     readonly idempotencyViolations: NonIdempotentReport[];
@@ -207,16 +272,27 @@ export function runIdempotencyRecheck(
   const writes2 = isAsync
     ? new Map()
     : captureTransactionWrites(tx2, log2.writes);
-  tx2.abort();
 
   // Skip comparison for async actions; writes are incomplete/unreliable.
-  if (isAsync) return;
+  if (isAsync) {
+    tx2.abort();
+    return;
+  }
 
   const differingKeys = findDifferingWriteKeys(writes1, writes2, {
     keySet: "latest",
   });
 
-  if (differingKeys.length === 0) return;
+  if (differingKeys.length === 0) {
+    tx2.abort();
+    return;
+  }
+
+  // Differing writes only witness non-idempotency if both runs read the same
+  // inputs (read both journals before aborting tx2).
+  const inputsMoved = readInvariantMovedExternally(tx, tx2, log, log2);
+  tx2.abort();
+  if (inputsMoved) return;
 
   const actionId = state.getActionId(action);
   // Deduplicate: only record first violation per action.

--- a/packages/runner/src/scheduler/diagnosis.ts
+++ b/packages/runner/src/scheduler/diagnosis.ts
@@ -226,7 +226,9 @@ function readInvariantMovedExternally(
 ): boolean {
   const spaces = new Set<IMemorySpaceAddress["space"]>();
   for (const read of log.reads) spaces.add(read.space);
+  for (const read of log.shallowReads) spaces.add(read.space);
   for (const read of log2.reads) spaces.add(read.space);
+  for (const read of log2.shallowReads) spaces.add(read.space);
   const before = transactionReadInvariants(tx, spaces);
   if (before.size === 0) return false;
   const after = transactionReadInvariants(tx2, spaces);
@@ -294,7 +296,7 @@ export function runIdempotencyRecheck(
   }
 
   // Differing writes only witness non-idempotency if both runs read the same
-  // inputs (read both journals before aborting tx2).
+  // inputs (capture both runs' read invariants before aborting tx2).
   const inputsMoved = readInvariantMovedExternally(tx, tx2, log, log2);
   tx2.abort();
   if (inputsMoved) return;

--- a/packages/runner/src/scheduler/diagnosis.ts
+++ b/packages/runner/src/scheduler/diagnosis.ts
@@ -10,6 +10,7 @@ import {
 } from "../storage/transaction-inspection.ts";
 import { ignoreReadForScheduling } from "../storage/reactivity-log.ts";
 import { arraysOverlap } from "../reactive-dependencies.ts";
+import { normalizeCellScope } from "../scope.ts";
 import type {
   CycleReport,
   NonIdempotentReport,
@@ -196,7 +197,7 @@ function transactionReadInvariants(
       for (const detail of getTransactionReadDetails(tx, space)) {
         // makeAddressKey ignores scope; include it so same id+path reads
         // under different cell scopes don't collide.
-        const key = `${detail.address.scope ?? ""}|${
+        const key = `${normalizeCellScope(detail.address.scope)}|${
           makeAddressKey(detail.address)
         }`;
         invariants.set(key, {
@@ -240,8 +241,11 @@ function readInvariantMovedExternally(
     // Cover writes of EITHER run: run1's commit moving its own read is the
     // accumulator pattern, and a write-then-read inside the recheck run is
     // nondeterminism, not external interference — both must stay flagged.
+    // Scope participates in the match: different scopes are different
+    // documents, so a write in another scope cannot have moved this read.
     const coveredByOwnWrites = [...log.writes, ...log2.writes].some((write) =>
       write.space === address.space && write.id === address.id &&
+      normalizeCellScope(write.scope) === normalizeCellScope(address.scope) &&
       arraysOverlap(write.path, address.path)
     );
     if (!coveredByOwnWrites) return true;

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -582,6 +582,14 @@ export interface IStorageTransaction {
   getWriteDetails?(space: MemorySpace): Iterable<TransactionWriteDetail>;
 
   /**
+   * Optional read details for the given space: the values this transaction
+   * observed for its reads (its read invariants). Available after commit or
+   * abort, since the underlying per-document snapshots are pinned for the
+   * transaction's lifetime.
+   */
+  getReadDetails?(space: MemorySpace): Iterable<TransactionReadDetail>;
+
+  /**
    * Describes current status of the transaction. Returns a union type with
    * status field indicating the current state:
    * - `"ready"`: Transaction is being built and ready for operations
@@ -1210,6 +1218,11 @@ export interface TransactionWriteDetail {
   address: IMemorySpaceAddress;
   value?: Immutable<FabricValue>;
   previousValue?: Immutable<FabricValue>;
+}
+
+export interface TransactionReadDetail {
+  address: IMemorySpaceAddress;
+  value?: Immutable<FabricValue>;
 }
 
 export type NativeStorageCommitOperation =

--- a/packages/runner/src/storage/transaction-inspection.ts
+++ b/packages/runner/src/storage/transaction-inspection.ts
@@ -4,6 +4,7 @@ import type {
   IStorageTransaction,
   MemorySpace,
   TransactionReactivityLog,
+  TransactionReadDetail,
   TransactionWriteDetail,
 } from "./interface.ts";
 
@@ -37,6 +38,27 @@ export function getTransactionReadActivities(
       if ("read" in activity && activity.read) {
         yield activity.read;
       }
+    }
+  })();
+}
+
+export function getTransactionReadDetails(
+  tx: TxLike,
+  space: MemorySpace,
+): Iterable<TransactionReadDetail> {
+  const direct = tx.getReadDetails?.(space) ??
+    unwrap(tx).getReadDetails?.(space);
+  if (direct) {
+    return direct;
+  }
+
+  // Chronicle-style transactions record read invariants as journal history.
+  return (function* () {
+    for (const attestation of tx.journal.history(space)) {
+      yield {
+        address: { ...attestation.address, space },
+        value: attestation.value as TransactionReadDetail["value"],
+      };
     }
   })();
 }

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -36,6 +36,7 @@ import type {
   StorageTransactionRejected,
   StorageTransactionStatus,
   TransactionReactivityLog,
+  TransactionReadDetail,
   TransactionWriteDetail,
   Unit,
   URI,
@@ -897,6 +898,26 @@ export class V2StorageTransaction implements IStorageTransaction {
         continue;
       }
       yield* entry.writeDetails.values();
+    }
+  }
+
+  *getReadDetails(space: MemorySpace): Iterable<TransactionReadDetail> {
+    const branch = this.#branches.get(space);
+    if (!branch) {
+      return;
+    }
+    for (const [key, entry] of branch.docs) {
+      const frozenReads = entry.frozenReads;
+      if (!frozenReads) {
+        continue;
+      }
+      const { id, scope } = this.parseDocKey(key);
+      for (const [path, value] of frozenReads.entries()) {
+        yield {
+          address: { space, scope, id, path: [...path] },
+          value: value as TransactionReadDetail["value"],
+        };
+      }
     }
   }
 

--- a/packages/runner/test/scheduler-pull-idempotency.test.ts
+++ b/packages/runner/test/scheduler-pull-idempotency.test.ts
@@ -103,13 +103,109 @@ describe("inline idempotency check mode", () => {
     );
     expect(await output.pull()).toBe(10);
 
-    const violations = runtime.scheduler.getIdempotencyViolations()
-      .filter((r) =>
-        r.runs.some((run) =>
-          Object.keys(run.writes).some((k) => k.includes("inline-idempotent"))
-        )
-      );
-    expect(violations.length).toBe(0);
+    // Unfiltered: cell ids are cause-derived hashes, so filtering write keys
+    // by the cause string would match nothing and pass vacuously.
+    expect(runtime.scheduler.getIdempotencyViolations()).toEqual([]);
+  });
+
+  it("does not flag an idempotent computation when an external write lands between run and recheck", async () => {
+    runtime.scheduler.enableIdempotencyCheck();
+
+    const input = runtime.getCell<number>(
+      space,
+      "inline-race-input",
+      undefined,
+      tx,
+    );
+    input.set(5);
+    const output = runtime.getCell<number>(
+      space,
+      "inline-race-output",
+      undefined,
+      tx,
+    );
+    output.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    // Pure function of its input — idempotent by construction. The first run
+    // queues a microtask that writes the input through a separate
+    // transaction, modeling a cross-runtime sync apply landing between the
+    // run and its synchronous idempotency recheck (the multi-user `cf test`
+    // flake): the recheck then reads newer state than the first run did.
+    let injected = false;
+    const doubler: Action = (actionTx) => {
+      const value = input.withTx(actionTx).get() ?? 0;
+      if (!injected) {
+        injected = true;
+        Promise.resolve().then(() => {
+          const interloper = runtime.edit();
+          input.withTx(interloper).set(99);
+          interloper.commit();
+        });
+      }
+      output.withTx(actionTx).send(value * 2);
+    };
+    (
+      doubler as Action & {
+        writes: ReturnType<typeof output.getAsNormalizedFullLink>[];
+      }
+    ).writes = [output.getAsNormalizedFullLink()];
+    runtime.scheduler.subscribe(
+      doubler,
+      (tx) => {
+        input.withTx(tx).get();
+      },
+      {},
+    );
+    await output.pull();
+    await runtime.idle();
+
+    expect(runtime.scheduler.getIdempotencyViolations()).toEqual([]);
+    // The interloping write itself must still converge.
+    expect(await output.pull()).toBe(198);
+  });
+
+  it("still flags self-feedback (accumulator) computations in inline mode", async () => {
+    runtime.scheduler.enableIdempotencyCheck();
+
+    const log = runtime.getCell<number[]>(
+      space,
+      "inline-accumulator",
+      undefined,
+      tx,
+    );
+    log.set([]);
+    await tx.commit();
+    tx = runtime.edit();
+
+    // Reads what it writes — the accumulator anti-pattern. The recheck's
+    // second run sees the first run's committed write, so its inputs moved,
+    // but the move is covered by the action's own writes and must stay
+    // flagged. (Capped so the feedback loop terminates.)
+    const accumulator: Action = (actionTx) => {
+      const current = log.withTx(actionTx).get() ?? [];
+      if (current.length >= 3) return;
+      log.withTx(actionTx).set([...current, current.length]);
+    };
+    (
+      accumulator as Action & {
+        writes: ReturnType<typeof log.getAsNormalizedFullLink>[];
+      }
+    ).writes = [log.getAsNormalizedFullLink()];
+    runtime.scheduler.subscribe(
+      accumulator,
+      (tx) => {
+        log.withTx(tx).get();
+      },
+      {},
+    );
+    await log.pull();
+    await runtime.idle();
+
+    expect(
+      runtime.scheduler.getIdempotencyViolations().length,
+    ).toBeGreaterThan(0);
   });
 
   it("treats removed undefined writes as differing", () => {

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -40,6 +40,7 @@ import {
   MIN_ABSOLUTE_DELTA,
   MIN_REGRESSION_PCT,
   MIN_SAMPLES,
+  newestArtifactsByName,
   parseBaselineOverrides,
   PERF_METRICS_ARTIFACT_NAME,
   PERF_METRICS_BACKFILL_ARTIFACT_NAME,
@@ -201,9 +202,10 @@ async function main() {
   // Extract per-test metrics from JUnit artifacts
   try {
     const artifacts = await fetchArtifactsForRun(runIdNum);
-    const timingArtifacts = artifacts.filter(
+    // Newest per name: a re-run of a flagged test job must refresh its metric.
+    const timingArtifacts = newestArtifactsByName(artifacts.filter(
       (a) => a.name.startsWith("test-timing-") && !a.expired,
-    );
+    ));
     for (const artifact of timingArtifacts) {
       const suites = await downloadAndParseJUnit(artifact.id);
       const testMetrics = extractTestFileMetrics(

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -1,5 +1,6 @@
 import { assertAlmostEquals, assertEquals } from "@std/assert";
 import {
+  type Artifact,
   computeBaseline,
   computeCiWallTimeRevisitSignals,
   extractMetrics,
@@ -7,6 +8,7 @@ import {
   fetchPRBody,
   githubGet,
   type Job,
+  newestArtifactsByName,
   parsePerfMetricsBackfillFile,
   parsePerfMetricsFile,
   serializePerfMetrics,
@@ -731,4 +733,27 @@ Deno.test("githubGet does not retry non-transient GitHub responses", async () =>
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+Deno.test("newestArtifactsByName keeps the latest re-run upload per name", () => {
+  const artifact = (id: number, name: string): Artifact => ({
+    id,
+    name,
+    size_in_bytes: 1,
+    expired: false,
+  });
+  // API order is newest-first; a naive last-write-wins iteration would let
+  // the stale attempt-1 artifact shadow the re-run's upload.
+  const result = newestArtifactsByName([
+    artifact(200, "test-timing-pattern-unit-4"),
+    artifact(150, "test-timing-pattern-unit-1"),
+    artifact(100, "test-timing-pattern-unit-4"),
+  ]);
+  assertEquals(
+    result.map((a) => [a.name, a.id]).sort(),
+    [
+      ["test-timing-pattern-unit-1", 150],
+      ["test-timing-pattern-unit-4", 200],
+    ],
+  );
 });

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -356,6 +356,22 @@ export async function fetchArtifactsForRun(
   return data.artifacts;
 }
 
+/**
+ * Newest artifact per name. Re-running a single job uploads a same-named
+ * artifact alongside the original attempt's, and the API lists newest first —
+ * naive iteration lets the stale one win. Artifact ids are monotonic.
+ */
+export function newestArtifactsByName(artifacts: Artifact[]): Artifact[] {
+  const byName = new Map<string, Artifact>();
+  for (const artifact of artifacts) {
+    const existing = byName.get(artifact.name);
+    if (!existing || artifact.id > existing.id) {
+      byName.set(artifact.name, artifact);
+    }
+  }
+  return [...byName.values()];
+}
+
 // ---------------------------------------------------------------------------
 // JUnit artifact parsing
 // ---------------------------------------------------------------------------

--- a/tasks/perf-regression.ts
+++ b/tasks/perf-regression.ts
@@ -51,6 +51,7 @@ import {
   MIN_BASELINE_RUNS,
   MIN_REGRESSION_PCT,
   MIN_SAMPLES,
+  newestArtifactsByName,
   normalizeName,
   parseBaselineOverrides,
   parseDenoTestLog,
@@ -474,9 +475,11 @@ async function main() {
           }
         }
 
-        const timingArtifacts = artifacts.filter(
+        // Newest per name: re-run attempts upload duplicates, and iterating
+        // them all would double-count the run in the baseline timeline.
+        const timingArtifacts = newestArtifactsByName(artifacts.filter(
           (a) => a.name.startsWith("test-timing-") && !a.expired,
-        );
+        ));
 
         if (timingArtifacts.length > 0) {
           for (const artifact of timingArtifacts) {


### PR DESCRIPTION
## Problem

`packages/patterns/scrabble/multi-user.test.tsx` fails intermittently in CI with

```
✗ 1 non-idempotent computation(s):
  [alice] action:fid1:s7PNuPbpfhcWmgrXTrId6vBg9id8FydQwgUSfrChLXU.js:386:7:fid1:DnqYRSr
```

(e.g. [this run](https://github.com/commontoolsinc/labs/actions/runs/27291962359), Pattern Unit Tests 4/5, attempt 2 — a docs/patterns-only PR where the same shard passed twice on identical code).

Mapping the compiled-bundle location `…js:386:7` back to source (graph-snapshot dump at the failing commit) identifies the flagged computation as alice's `assert_sees_both`:

```tsx
const assert_sees_both = computed(() =>
  (game.players ?? []).length === 2 &&
  game.players?.[0]?.name === "Alice" && ...
);
```

— a pure function of its inputs. It cannot be genuinely non-idempotent; its inputs must have changed between the two runs the detector compared.

## Root cause

The inline idempotency check re-runs every computation right after its first run and flags differing writes. The first run's body and the recheck are separated by **microtask continuations** (the invoke/finalize promise chain). A concurrent write can land exactly in that window — in multi-user `cf test`, a cross-runtime sync apply (bob's join landing in alice's runtime); more generally also another transaction's commit/rollback. The recheck then re-runs the computation against newer state, sees different writes, and records a false violation. The functional assertions all tolerate propagation (they retry), but the violation is collected at the end and fails the test.

The race is deterministic to reproduce: have a computation's input written by a separate transaction in a microtask queued during the first run — see the new `scheduler-pull-idempotency` test, which fails without the fix.

## Fix

When the recheck sees differing writes, compare the two runs' **read invariants**:

- input read by both runs changed **and isn't covered by the action's own writes** → a concurrent writer moved the state mid-window; the comparison says nothing about idempotency → **skip**
- input moved **because the action wrote it** (reads-what-it-writes) → accumulator anti-pattern → **still flagged**
- inputs equal, writes differ → genuine nondeterminism (timestamps, random shuffles) → **still flagged**

Read invariants come from a new `getReadDetails()` on V2 transactions: per-document snapshots and frozen read values are pinned for the transaction's lifetime, so the values the first run observed stay recoverable after commit. Chronicle-style transactions fall back to journal history attestations (`getTransactionReadDetails()` in `transaction-inspection.ts`).

The comparison only runs when writes differ (a would-be violation), so the hot recheck path is unchanged.

## Also

- Idempotency-violation reports (single-runtime and multi-user `cf test`) now append the differing write keys, so a future flake names the cells that diverged instead of just a compiled-bundle source location.
- Fixed a vacuous filter in an existing recheck test (cell ids are cause-derived hashes, so filtering write keys by the cause string matched nothing).

## Verification

- New unit test red without the fix, green with it; new accumulator unit test guards the still-flagged path.
- All four `packages/patterns/test/non-idempotent/` fixtures still detected (shuffle, timestamp, accumulator, set-to-array).
- Full `packages/runner` suite: 564 passed, 0 failed. `packages/cli`: 43 passed.
- All four multi-user pattern tests (scrabble, lunch-poll, cozy-poll, cfc-group-chat-demo) and scrabble single-user pass.
- 240 stress runs of scrabble multi-user pre-fix never reproduced locally (CI-timing dependent), hence the deterministic unit-level reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false idempotency violations in the inline recheck by skipping comparisons when inputs changed between the run and the recheck, removing the scrabble multi-user CI flake. Also ensures CI perf metrics use the newest `test-timing-*` artifacts so reruns correctly clear or update regressions; docs updated to cover the inline recheck, `expectNonIdempotent`, and the concurrent-write guard.

- **Bug Fixes**
  - Skip comparisons when read invariants show an input moved externally between the first run and the recheck; self-feedback and equal-input nondeterminism still flag.
  - Cover writes from both runs and match cell scope when checking own-write coverage to avoid cross-scope misclassification and masking write-then-read nondeterminism.
  - Include scope in invariant keys and include shallow-read spaces so non-recursive reads are compared.
  - Add `getReadDetails()` to V2 transactions and a Chronicle fallback via `getTransactionReadDetails()` to supply read invariants.
  - CI perf: pick the newest `test-timing-*` artifact per name in `tasks/perf-check.ts` and `tasks/perf-regression.ts` to honor reruns and avoid double counting.

- **New Features**
  - `packages/cli` reporters append differing write keys to idempotency violations in both single-runtime and multi-user modes.

<sup>Written for commit 6cd4aed360ff0cfefd47ec20d6b23ec01e49bee7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

