### PR TITLE
fix(ts-transformers): pass checker to the capability-summary fallback analysis

### DIFF
--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -208,8 +208,8 @@ function getSymbolTypeAtSource(
 interface CapabilitySummaryMemo {
   /** `{ checker, includeNestedCallbacks: true }` analyses. */
   readonly nested: WeakMap<ts.Node, FunctionCapabilitySummary>;
-  /** Checker-less analyses (fallback after a recorded-summary miss). */
-  readonly bare: WeakMap<ts.Node, FunctionCapabilitySummary>;
+  /** Non-nested analyses (fallback after a recorded-summary miss). */
+  readonly fallback: WeakMap<ts.Node, FunctionCapabilitySummary>;
 }
 
 const capabilitySummaryMemos = new WeakMap<
@@ -222,7 +222,7 @@ function capabilitySummaryMemoFor(
 ): CapabilitySummaryMemo {
   let memo = capabilitySummaryMemos.get(context);
   if (!memo) {
-    memo = { nested: new WeakMap(), bare: new WeakMap() };
+    memo = { nested: new WeakMap(), fallback: new WeakMap() };
     capabilitySummaryMemos.set(context, memo);
   }
   return memo;
@@ -248,7 +248,8 @@ function findCapabilitySummaryForParameter(
     : context
     ? (context.lookupCapabilitySummary(fn) ??
       analyzeFunctionCapabilities(fn, {
-        summaryCache: capabilitySummaryMemoFor(context).bare,
+        checker: context.checker,
+        summaryCache: capabilitySummaryMemoFor(context).fallback,
       }))
     : analyzeFunctionCapabilities(fn, {
       checker: options?.checker,


### PR DESCRIPTION
## Summary

Stacked on #3991 (it edits the same expression — merge that first).

The recorded-summary-miss fallback in `findCapabilitySummaryForParameter` was the **only** `analyzeFunctionCapabilities` call site in the codebase that omits the checker. Checker-less analysis silently degrades to permissive defaults — the `!checker || isCellLikeType(...)` patterns in capability-analysis assume cell-like receivers when no checker is available. The omission dates to the capability-first MVP rewrite (#2897) with no sign it was deliberate.

## Measured runtime/schema effects: none observable on the current population

I instrumented the fallback to compare checker-ful vs. checker-less summaries on every hit, across ~585 of the suite's 618 test steps in one isolate:

- The fallback fires **6 times** total (recorded summaries from pattern-callback lowering cover everything else): five authored callbacks in unit-test sources, one synthetic `__cf_pattern_input` callback.
- The checker changed the resulting summary in **0 of 6** cases.
- Golden output: byte-identical. Full package suite: 292 passed (618 steps).
- Runtime verification: `deno task integration pattern-tests` — all 59 pattern tests pass.

So this is a consistency/robustness fix, not a behavior change today: the latent imprecision would only bite on a callback that (a) misses the recording pass and (b) has a receiver the checker would classify as non-cell-like — at which point the old code would over-assume cell-likeness and could shrink/wrap incorrectly.

Also renames the memo map `bare` → `fallback`, since it no longer holds checker-less analyses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass the TypeScript checker to the capability-summary fallback to ensure accurate analysis when recorded summaries are missing. This removes a permissive default and improves consistency with no observed behavior changes.

- **Bug Fixes**
  - In `findCapabilitySummaryForParameter`, call `analyzeFunctionCapabilities` with `checker: context.checker` and cache in `fallback`.
  - Rename memo key `bare` → `fallback` since analyses now include the checker.

<sup>Written for commit c5c860d476911e065c9f6a88a945d9916f752bec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

