### PR TITLE
builder: delete unsafe_parentPattern (write-only) [identity A]

### DIFF
--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -223,7 +223,6 @@ export type Node = {
 
 // Used to get back to original pattern from a JSONified representation.
 export const unsafe_originalPattern = Symbol("unsafe_originalPattern");
-export const unsafe_parentPattern = Symbol("unsafe_parentPattern");
 
 declare module "@commonfabric/api" {
   interface Pattern {
@@ -238,7 +237,6 @@ declare module "@commonfabric/api" {
     // ./pattern-metadata.ts so exported patterns can be frozen. Use
     // get/setPatternProgram and get/setVerifiedLoadId.
     [unsafe_originalPattern]?: Pattern;
-    [unsafe_parentPattern]?: Pattern;
   }
 }
 

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -124,7 +124,6 @@ export {
   TYPE,
   UI,
   unsafe_originalPattern,
-  unsafe_parentPattern,
   type UnsafeBinding,
   type VNode,
   WebhookConfigSchema,

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -5,7 +5,6 @@ import {
   type JSONSchema,
   type Pattern,
   unsafe_originalPattern,
-  unsafe_parentPattern,
 } from "./builder/types.ts";
 import {
   getVerifiedLoadId,
@@ -341,20 +340,6 @@ export function unwrapOneLevelAndBindtoDoc<T, U>(
     } else return binding;
   }
   return convert(binding, true, options?.targetSchema) as T;
-}
-
-export function unsafe_noteParentOnPatterns(
-  pattern: Pattern,
-  binding: unknown,
-): void {
-  // For now we just do top-level bindings
-  if (isRecord(binding)) {
-    for (const key in binding) {
-      if (isRecord(binding[key]) && binding[key][unsafe_originalPattern]) {
-        binding[key][unsafe_parentPattern] = pattern;
-      }
-    }
-  }
 }
 
 /**

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -3,7 +3,6 @@ import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
   isPattern,
   type JSONSchema,
-  type Pattern,
   unsafe_originalPattern,
 } from "./builder/types.ts";
 import {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -34,7 +34,6 @@ import { type Action } from "./scheduler.ts";
 import { RetryImmediately } from "./scheduler/retry-immediately.ts";
 import {
   findAllWriteRedirectCells,
-  unsafe_noteParentOnPatterns,
   unwrapOneLevelAndBindtoDoc,
 } from "./pattern-binding.ts";
 import { resolveLink } from "./link-resolution.ts";
@@ -3622,10 +3621,6 @@ export class Runner {
       internalCellLink,
       resultCellLink,
     );
-
-    // For `map` and future other node types that take closures, we need to
-    // note the parent pattern on the closure patterns.
-    unsafe_noteParentOnPatterns(pattern, mappedInputBindings);
 
     // CT-1623: for the list builtins, replace a pattern-valued input (the `op`)
     // with a compact `{ $patternRef }` sentinel when its content-addressed entry


### PR DESCRIPTION
PR A of the content-addressed action identity plan ([plan](https://github.com/commontoolsinc/labs/pull/4003), [design](docs/specs/content-addressed-action-identity.md)).

`unsafe_parentPattern` was write-only: set by `unsafe_noteParentOnPatterns` during raw-node instantiation, read nowhere in `src/`. This deletes the symbol, its `Pattern` declaration, the write site and its `instantiateRawNode` call, and the `index.ts` export. Zero references remain repo-wide.

Verification: runner suite 565 passed / 0 failed; `deno check`/`lint`/`fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the write-only `unsafe_parentPattern` and all related wiring from the runner; no behavior change. Also cleans up an unused type import. Part of the content-addressed action identity plan.

- **Refactors**
  - Delete `unsafe_parentPattern` symbol and its `Pattern` declaration in `@commonfabric/api` augmentation.
  - Remove `unsafe_noteParentOnPatterns` and its call site in the runner.
  - Drop `unsafe_parentPattern` from `packages/runner/src/index.ts` exports.
  - Remove unused `Pattern` type import in `packages/runner/src/pattern-binding.ts`.
  - Test suite passes; typecheck, lint, and format are clean.

<sup>Written for commit f4b9d49328aad1067d4e217e2250422c21a2daa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

