### PR TITLE
refactor: exhaustive wrapper-spelling vocabulary across schema-generator + ts-transformers

### DIFF
--- a/packages/schema-generator/deno.json
+++ b/packages/schema-generator/deno.json
@@ -5,6 +5,7 @@
     ".": "./src/index.ts",
     "./interface": "./src/interface.ts",
     "./cell-brand": "./src/typescript/cell-brand.ts",
+    "./wrapper-names": "./src/typescript/wrapper-names.ts",
     "./type-traversal": "./src/typescript/type-traversal.ts",
     "./property-optionality": "./src/typescript/property-optionality.ts",
     "./property-name": "./src/typescript/property-name.ts"

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -4,6 +4,12 @@ import type { JSONSchemaMutable } from "@commonfabric/api";
 import { NativeTypeFormatter } from "./formatters/native-type-formatter.ts";
 import { getPropertyNameText } from "./typescript/property-name.ts";
 import type { CellWrapperKind } from "./typescript/cell-brand.ts";
+import {
+  isWrapperSpelling,
+  spellingsWhere,
+  WRAPPER_SPELLING_TO_KIND,
+  type WrapperSpelling,
+} from "./typescript/wrapper-names.ts";
 
 /**
  * Names that should be treated as Cell-like wrapper types.
@@ -15,37 +21,65 @@ import type { CellWrapperKind } from "./typescript/cell-brand.ts";
  * which keys off RESOLVED `CellWrapperKind` values (where `Writable` has already
  * normalized to `Cell` and `OpaqueCell` belongs with the rest).
  */
-const CELL_LIKE_WRAPPER_NAMES = new Set([
-  "Cell",
-  "Writable",
-  "ReadonlyCell",
-  "WriteonlyCell",
-  "ComparableCell",
-]);
-const OPAQUE_WRAPPER_NAMES = new Set(["OpaqueCell"]);
+const CELL_LIKE_WRAPPER_NAMES = spellingsWhere({
+  Cell: true,
+  Writable: true,
+  ReadonlyCell: true,
+  WriteonlyCell: true,
+  ComparableCell: true,
+  OpaqueCell: false, // split into OPAQUE_WRAPPER_NAMES (see NB above)
+  Stream: false, // handled separately at each call site
+  SqliteDb: false, // handled separately at each call site
+  OpaqueRef: false,
+  OpaqueRefMethods: false,
+  CellTypeConstructor: false,
+  ScopedCellTypeConstructor: false,
+});
+const OPAQUE_WRAPPER_NAMES = spellingsWhere({
+  OpaqueCell: true,
+  Cell: false,
+  Writable: false,
+  ReadonlyCell: false,
+  WriteonlyCell: false,
+  ComparableCell: false,
+  Stream: false,
+  SqliteDb: false,
+  OpaqueRef: false,
+  OpaqueRefMethods: false,
+  CellTypeConstructor: false,
+  ScopedCellTypeConstructor: false,
+});
 type NodeWrapperKind = "Default" | CellWrapperKind;
 
 function getEntityNameText(name: ts.EntityName): string {
   return ts.isIdentifier(name) ? name.text : name.right.text;
 }
 
+// Spellings that participate in node-level wrapper detection. OpaqueRef is
+// deliberately excluded: wrapperKindForName has never treated it as a node
+// wrapper, and its callers (Default-literal and type-name resolution) must
+// not start unwrapping it — revisit with the OpaqueRef deprecation.
+const NODE_WRAPPER_SPELLINGS: Readonly<Record<WrapperSpelling, boolean>> = {
+  Cell: true,
+  Writable: true,
+  ReadonlyCell: true,
+  WriteonlyCell: true,
+  ComparableCell: true,
+  OpaqueCell: true,
+  Stream: true,
+  SqliteDb: true,
+  OpaqueRef: false,
+  OpaqueRefMethods: false,
+  CellTypeConstructor: false,
+  ScopedCellTypeConstructor: false,
+};
+
 function wrapperKindForName(name: string): NodeWrapperKind | undefined {
-  switch (name) {
-    case "Default":
-      return "Default";
-    case "Cell":
-    case "Writable":
-      return "Cell";
-    case "ReadonlyCell":
-    case "WriteonlyCell":
-    case "ComparableCell":
-    case "Stream":
-    case "SqliteDb":
-    case "OpaqueCell":
-      return name;
-    default:
-      return undefined;
+  if (name === "Default") return "Default";
+  if (!isWrapperSpelling(name) || !NODE_WRAPPER_SPELLINGS[name]) {
+    return undefined;
   }
+  return WRAPPER_SPELLING_TO_KIND[name];
 }
 
 export { getPropertyNameText };

--- a/packages/schema-generator/src/typescript/wrapper-names.ts
+++ b/packages/schema-generator/src/typescript/wrapper-names.ts
@@ -1,0 +1,89 @@
+import type { CellWrapperKind } from "./cell-brand.ts";
+
+/**
+ * The authored-spelling axis of the wrapper vocabulary.
+ *
+ * `CellWrapperKind` (cell-brand.ts) is the RESOLVED-kind axis: what a wrapper
+ * is after alias normalization (`Writable` has become `Cell`). This union is
+ * the SPELLING axis: every type/interface NAME that a transformer or schema
+ * pass matches against when classifying wrapper-ish types syntactically —
+ * authored wrapper references (`Cell`, `Writable`, …), the callable
+ * constructor-type interfaces, and the internal methods-owner interface.
+ *
+ * Membership sets are derived from exhaustive classification tables
+ * (`Record<WrapperSpelling, boolean>` via `spellingsWhere`), so adding a
+ * spelling here is a compile error at every classification site until the
+ * new spelling is deliberately classified there. Keep each table co-located
+ * with its consumer and its rationale; this module owns only the vocabulary
+ * and the spelling→kind normalization.
+ */
+export type WrapperSpelling =
+  | "Cell"
+  | "Writable"
+  | "ReadonlyCell"
+  | "WriteonlyCell"
+  | "ComparableCell"
+  | "OpaqueCell"
+  | "Stream"
+  | "SqliteDb"
+  | "OpaqueRef"
+  | "OpaqueRefMethods"
+  | "CellTypeConstructor"
+  | "ScopedCellTypeConstructor";
+
+/**
+ * Resolved kind for each spelling, or undefined for spellings that are not
+ * wrapper type references. The `Writable` → `Cell` normalization lives here,
+ * once.
+ */
+export const WRAPPER_SPELLING_TO_KIND = {
+  Cell: "Cell",
+  // Authored alias of Cell that better expresses write-access semantics.
+  Writable: "Cell",
+  ReadonlyCell: "ReadonlyCell",
+  WriteonlyCell: "WriteonlyCell",
+  ComparableCell: "ComparableCell",
+  OpaqueCell: "OpaqueCell",
+  Stream: "Stream",
+  SqliteDb: "SqliteDb",
+  // Deprecation intended — see the note on CellWrapperKind in cell-brand.ts.
+  OpaqueRef: "OpaqueRef",
+  // Internal methods-owner interface behind OpaqueRef, not a type reference.
+  OpaqueRefMethods: undefined,
+  // The interface typing the `Cell` constructor/namespace value (api/index.ts).
+  CellTypeConstructor: undefined,
+  // The interface typing the scoped-cell factory value (api/index.ts).
+  ScopedCellTypeConstructor: undefined,
+} as const satisfies Readonly<
+  Record<WrapperSpelling, CellWrapperKind | undefined>
+>;
+
+// Every CellWrapperKind must be reachable from at least one spelling; a new
+// kind fails to compile here until a spelling row maps to it.
+type SpelledKinds = NonNullable<
+  typeof WRAPPER_SPELLING_TO_KIND[WrapperSpelling]
+>;
+type AssertAllKindsSpelled = Exclude<CellWrapperKind, SpelledKinds> extends
+  never ? true : never;
+const _allKindsSpelled: AssertAllKindsSpelled = true;
+
+export const WRAPPER_SPELLINGS = Object.keys(
+  WRAPPER_SPELLING_TO_KIND,
+) as readonly WrapperSpelling[];
+
+const WRAPPER_SPELLING_SET: ReadonlySet<string> = new Set(WRAPPER_SPELLINGS);
+
+export function isWrapperSpelling(name: string): name is WrapperSpelling {
+  return WRAPPER_SPELLING_SET.has(name);
+}
+
+/**
+ * Derive a membership set from an exhaustive classification table. Consumers
+ * keep their own predicate (and its rationale) but must classify every
+ * spelling.
+ */
+export function spellingsWhere(
+  table: Readonly<Record<WrapperSpelling, boolean>>,
+): ReadonlySet<string> {
+  return new Set(WRAPPER_SPELLINGS.filter((spelling) => table[spelling]));
+}

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -31,6 +31,7 @@
  */
 import ts from "typescript";
 
+import { spellingsWhere } from "@commonfabric/schema-generator/wrapper-names";
 import { CF_HELPERS_IDENTIFIER } from "../core/cf-helpers.ts";
 import { isCommonFabricSymbol } from "../core/common-fabric-symbols.ts";
 import { getEnclosingFunctionLikeDeclaration } from "./function-predicates.ts";
@@ -58,22 +59,37 @@ const ARRAY_OWNER_NAMES = new Set([
   "ReadonlyArray",
 ]);
 
-const OPAQUE_REF_OWNER_NAMES = new Set([
-  "OpaqueRefMethods",
-  "OpaqueRef",
-]);
+// Owners of OpaqueRef-style method declarations (array-method detection).
+const OPAQUE_REF_OWNER_NAMES = spellingsWhere({
+  OpaqueRefMethods: true,
+  OpaqueRef: true,
+  Cell: false,
+  Writable: false,
+  ReadonlyCell: false,
+  WriteonlyCell: false,
+  ComparableCell: false,
+  OpaqueCell: false,
+  Stream: false,
+  SqliteDb: false,
+  CellTypeConstructor: false,
+  ScopedCellTypeConstructor: false,
+});
 
-const CELL_LIKE_CLASSES = new Set([
-  "Cell",
-  "Writable", // Alias for Cell that better expresses write-access semantics
-  "OpaqueCell",
-  "Stream",
-  "ComparableCell",
-  "ReadonlyCell",
-  "WriteonlyCell",
-  "CellTypeConstructor",
-  "ScopedCellTypeConstructor",
-]);
+// Wrapper spellings whose method calls classify as cell-like (get/set/etc.).
+const CELL_LIKE_CLASSES = spellingsWhere({
+  Cell: true,
+  Writable: true,
+  OpaqueCell: true,
+  Stream: true,
+  ComparableCell: true,
+  ReadonlyCell: true,
+  WriteonlyCell: true,
+  CellTypeConstructor: true,
+  ScopedCellTypeConstructor: true,
+  SqliteDb: false,
+  OpaqueRef: false, // owner detection handled via OPAQUE_REF_OWNER_NAMES
+  OpaqueRefMethods: false,
+});
 
 const CELL_FACTORY_NAMES = new Set(["of"]);
 const CELL_FOR_NAMES = new Set(["for"]);

--- a/packages/ts-transformers/src/transformers/cast-validation.ts
+++ b/packages/ts-transformers/src/transformers/cast-validation.ts
@@ -7,28 +7,46 @@
  * - `as Cell<...>` and other cell-like types: WARNING - prefer proper type annotations
  */
 import ts from "typescript";
+import { spellingsWhere } from "@commonfabric/schema-generator/wrapper-names";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 
 /**
  * Cell-like types that should trigger a warning when cast to.
  * These types have special reactive semantics that casts can bypass.
  */
-const CELL_LIKE_TYPE_NAMES = new Set([
-  "Cell",
-  "OpaqueCell",
-  "Stream",
-  "ComparableCell",
-  "ReadonlyCell",
-  "WriteonlyCell",
-  "Writable",
-  "CellTypeConstructor",
-]);
+const CELL_LIKE_TYPE_NAMES = spellingsWhere({
+  Cell: true,
+  OpaqueCell: true,
+  Stream: true,
+  ComparableCell: true,
+  ReadonlyCell: true,
+  WriteonlyCell: true,
+  Writable: true,
+  CellTypeConstructor: true,
+  ScopedCellTypeConstructor: false,
+  SqliteDb: false,
+  OpaqueRef: false, // error, not warning — see FORBIDDEN_CAST_TYPE_NAMES
+  OpaqueRefMethods: false,
+});
 
 /**
  * Types that should trigger an error when cast to.
  * Casting to these types is never allowed.
  */
-const FORBIDDEN_CAST_TYPE_NAMES = new Set(["OpaqueRef"]);
+const FORBIDDEN_CAST_TYPE_NAMES = spellingsWhere({
+  OpaqueRef: true,
+  Cell: false,
+  Writable: false,
+  ReadonlyCell: false,
+  WriteonlyCell: false,
+  ComparableCell: false,
+  OpaqueCell: false,
+  Stream: false,
+  SqliteDb: false,
+  OpaqueRefMethods: false,
+  CellTypeConstructor: false,
+  ScopedCellTypeConstructor: false,
+});
 
 export class CastValidationTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -1,5 +1,6 @@
 import ts from "typescript";
 import { getPropertyNameText } from "@commonfabric/schema-generator/property-name";
+import { spellingsWhere } from "@commonfabric/schema-generator/wrapper-names";
 import {
   createRegisteredTypeLiteral,
   typeToTypeNodeWithRegistry,
@@ -690,18 +691,30 @@ function findPropertySymbol(
   return undefined;
 }
 
+// Wrapper spellings the shrinking pass treats as cell-like type NODES (the
+// reference may carry capability narrowing rather than a structural change).
+const CELL_LIKE_TYPE_NODE_NAMES = spellingsWhere({
+  Cell: true,
+  Writable: true,
+  OpaqueCell: true,
+  OpaqueRef: true,
+  ComparableCell: true,
+  ReadonlyCell: true,
+  WriteonlyCell: true,
+  Stream: true,
+  // SqliteDb references are not rewritten by shrinking; the brand survives
+  // capability shrinking via its own path (#3860).
+  SqliteDb: false,
+  OpaqueRefMethods: false,
+  CellTypeConstructor: false,
+  ScopedCellTypeConstructor: false,
+});
+
 export function isCellLikeTypeNode(node: ts.TypeNode): boolean {
   if (!ts.isTypeReferenceNode(node)) return false;
   const name = getTypeReferenceNodeName(node);
   if (!name) return false;
-  return name === "Cell" ||
-    name === "Writable" ||
-    name === "OpaqueCell" ||
-    name === "OpaqueRef" ||
-    name === "ComparableCell" ||
-    name === "ReadonlyCell" ||
-    name === "WriteonlyCell" ||
-    name === "Stream";
+  return CELL_LIKE_TYPE_NODE_NAMES.has(name);
 }
 
 function getTypeReferenceNodeName(


### PR DESCRIPTION
## Problem

Wrapper-name membership lived in six independent hand-spelled lists across the two packages — `isCellLikeTypeNode` (type-shrinking), the warn/forbid cast sets (cast-validation), `CELL_LIKE_CLASSES` + `OPAQUE_REF_OWNER_NAMES` (call-kind), and `CELL_LIKE_WRAPPER_NAMES`/`OPAQUE_WRAPPER_NAMES` (type-utils) — with no compile-time linkage to `CellWrapperKind`. The differences between the lists are mostly deliberate (different predicates), but nothing enforced the deliberateness: a new wrapper kind silently missed every list that should have considered it. SqliteDb is the live example — present in `CellWrapperKind` and the exhaustively-checked `CELL_CAPABILITY_KIND_MAP`, absent from every spelling list.

## Design

New `@commonfabric/schema-generator/wrapper-names` owns the **spelling axis** of the vocabulary (the resolved-kind axis stays in `cell-brand.ts`):

- `WrapperSpelling` — every name any pass matches syntactically: authored wrapper references, the constructor-type interfaces (`CellTypeConstructor`, `ScopedCellTypeConstructor`), and the internal `OpaqueRefMethods` interface (included for correctness-coverage over abstraction purity, per discussion).
- `WRAPPER_SPELLING_TO_KIND` — the single home of `Writable → Cell` normalization, with a type-level assertion that every `CellWrapperKind` is reachable from some spelling (a new kind fails to compile until a spelling maps to it).
- `spellingsWhere()` — derives a membership set from an exhaustive `Record<WrapperSpelling, boolean>`.

Each consumer keeps its own predicate and rationale co-located (per the `CELL_CAPABILITY_KIND_MAP` precedent), but membership is now a classification table: **adding a spelling or kind is a compile error at every site until deliberately classified**, and retiring one (the intended OpaqueRef deprecation) becomes a compiler-enumerated checklist instead of grep-and-hope. OpaqueRef rows carry the deprecation breadcrumb.

## Behavior

Preserving, by construction — every derived set is member-identical to the list it replaces, including `wrapperKindForName` (where OpaqueRef deliberately remains a non-wrapper). Verified:

- ts-transformers: 292 passed (618 steps), goldens byte-identical
- schema-generator: 24 passed (229 steps), goldens byte-identical
- runtime: `deno task integration pattern-tests` — all pattern tests pass
- fmt/lint/check clean on all touched files (the 43 `deno task check` errors in schema-generator `test/fixtures/**` are pre-existing on main)

## Flagged for follow-up (deliberately NOT changed here)

1. `getNamedTypeKey` in type-utils has three inline name chains that have drifted: the typeNode path excludes OpaqueRef, the alias path excludes OpaqueCell, the symbol-name path excludes both. Looks like accretion, not intent — preserved as-is, worth a deliberate pass.
2. SqliteDb's `false` rows (cast-validation warn set, call-kind `CELL_LIKE_CLASSES`) preserve current behavior but may deserve `true` — e.g. should `as SqliteDb<T>` warn like other cell-likes?
3. The remaining single-name equality checks (`name === "Stream"` etc.) and `common-fabric-formatter`'s alias lists could adopt the same tables in a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes wrapper-name spelling into `@commonfabric/schema-generator/wrapper-names` and replaces hand-written lists with exhaustive, compile-time-checked tables across `schema-generator` and `ts-transformers`. Preserves behavior and prevents new kinds (e.g. `SqliteDb`) from being silently missed.

- **Refactors**
  - Added `WrapperSpelling`, `WRAPPER_SPELLING_TO_KIND` (`Writable` → `Cell`), `isWrapperSpelling`, and `spellingsWhere()`, with a type check that every `CellWrapperKind` is spelled.
  - `schema-generator`: Replaced `CELL_LIKE_WRAPPER_NAMES`/`OPAQUE_WRAPPER_NAMES` with tables; added `NODE_WRAPPER_SPELLINGS` and updated `wrapperKindForName` to use `isWrapperSpelling` + `WRAPPER_SPELLING_TO_KIND` (still excludes `OpaqueRef` as a node wrapper). Exported `./wrapper-names` via `deno.json`.
  - `ts-transformers`: Replaced membership lists with tables in `call-kind` (`CELL_LIKE_CLASSES`, `OPAQUE_REF_OWNER_NAMES`), `cast-validation` (warn set and forbidden set), and `type-shrinking` (`isCellLikeTypeNode`).
  - Tests and goldens unchanged.

<sup>Written for commit ffebd56f639f820472ff35ef5a47db77595a18c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

