### PR TITLE
builder: derived-copy identity via side tables; delete unsafe_originalPattern [identity B]

### DIFF
--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -15,10 +15,9 @@ import {
   type OpaqueRef,
   type Pattern,
   type toJSON,
-  unsafe_originalPattern,
 } from "./types.ts";
 import { getTopFrame } from "./pattern.ts";
-import { getPatternProgram } from "./pattern-metadata.ts";
+import { getPatternProgram, noteDerivedCopy } from "./pattern-metadata.ts";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { Runtime } from "../runtime.ts";
 import {
@@ -179,8 +178,10 @@ export function toJSONWithLegacyAliases(
     // Restore depth so shared references can be re-serialized
     seen.set(value as object, depth);
 
-    // Retain the original pattern reference for downstream processing.
-    if (isPattern(value)) result[unsafe_originalPattern] = value;
+    // Register the copy's derivation link so trust and the content-addressed
+    // entry ref carry to the serialized copy (side table; symbol keys would be
+    // dropped by JSON anyway).
+    if (isPattern(value)) noteDerivedCopy(result, value);
 
     return result;
   }

--- a/packages/runner/src/builder/pattern-metadata.ts
+++ b/packages/runner/src/builder/pattern-metadata.ts
@@ -1,5 +1,5 @@
 import type { RuntimeProgram } from "../harness/types.ts";
-import { isPattern, type Pattern, unsafe_originalPattern } from "./types.ts";
+import { isPattern, type Pattern } from "./types.ts";
 
 /**
  * Side-table storage for pattern metadata that is associated *after* a pattern
@@ -96,29 +96,116 @@ export function brandTrustedPattern<T>(value: T): T {
   return value;
 }
 
+// Derivation tracking: `copy → root original`. Replaces the former
+// `unsafe_originalPattern` symbol backref. Registered ONLY by runner-owned
+// copy sites (`noteDerivedCopy` callers: build-time graph serialization in
+// json-utils, traversal copies in traverse-utils, binding copies in
+// pattern-binding) — authored/forged values never enter, since nothing on the
+// object itself can establish the link. Module-level (not per-manager): the
+// copy sites live in builder-layer utilities with no PatternManager handle,
+// and the linked facts (trust brands, content-addressed entry refs) are
+// globally meaningful. WeakMap keys are the per-runtime live objects, so
+// multiple runtimes in one process cannot collide.
+const derivedFrom = new WeakMap<object, object>();
+
+// Content-addressed `{ identity, symbol }` entry ref per live builder
+// artifact. Written (first-write-wins) by the PatternManager's indexing of
+// evaluated modules (`indexArtifact`, gated on `isTrustedBuilderArtifact`);
+// promoted here from the manager so derived copies can resolve refs without a
+// manager handle. The reverse index (`addressableByIdentity`, identity → live
+// value) stays per-manager — it holds live values per runtime and is bounded.
+const entryRefByValue = new WeakMap<
+  object,
+  { identity: string; symbol: string }
+>();
+
+/**
+ * Resolve a (possibly derived) value to its root original. Identity for
+ * values that were never copied. Bounded: the chain is a tree toward the
+ * root original (copies are fresh objects), but guard against cycles anyway.
+ */
+export function resolveOriginal<T>(value: T): T {
+  let current = asKey(value);
+  if (!current) return value;
+  const seen = new Set<object>();
+  while (true) {
+    const next = derivedFrom.get(current);
+    if (!next || next === current || seen.has(next)) break;
+    seen.add(current);
+    current = next;
+  }
+  return current as T;
+}
+
+/**
+ * Record that `copy` is a derivation/serialized copy of `original`, carrying
+ * its identity facts forward:
+ *
+ * - trust propagates EAGERLY (sound: builders brand their artifacts at
+ *   creation time, before any copy can be made);
+ * - the entry ref propagates eagerly when already known, but lookups still
+ *   walk `derivedFrom` lazily ({@link getArtifactEntryRef}) because refs are
+ *   indexed only post-evaluation — AFTER build-time copies were made.
+ *
+ * Only runner-owned copy sites may call this; it is the sole way a copy can
+ * inherit trust, so forged values (which are never passed here with a trusted
+ * original) gain nothing.
+ */
+export function noteDerivedCopy(copy: unknown, original: unknown): void {
+  const c = asKey(copy);
+  const o = asKey(original);
+  if (!c || !o || c === o) return;
+  const root = resolveOriginal(o);
+  derivedFrom.set(c, root);
+  if (trustedPatterns.has(root)) trustedPatterns.add(c);
+  if (trustedBuilderArtifacts().has(root)) trustedBuilderArtifacts().add(c);
+  const ref = entryRefByValue.get(root);
+  if (ref && !entryRefByValue.has(c)) entryRefByValue.set(c, ref);
+}
+
+/**
+ * Associate a content-addressed `{ identity, symbol }` entry ref with a live
+ * builder artifact. First write wins (an artifact may be reachable under
+ * several symbols; the first registration is canonical, matching the
+ * pre-existing `valueToEntryRef` semantics).
+ */
+export function setArtifactEntryRef(
+  value: unknown,
+  ref: { identity: string; symbol: string },
+): void {
+  const key = asKey(value);
+  if (key && !entryRefByValue.has(key)) entryRefByValue.set(key, ref);
+}
+
+/**
+ * The content-addressed `{ identity, symbol }` entry ref for a value — the
+ * exact object first, then its root original (a copy made before the ref was
+ * indexed resolves through the derivation link).
+ */
+export function getArtifactEntryRef(
+  value: unknown,
+): { identity: string; symbol: string } | undefined {
+  const key = asKey(value);
+  if (!key) return undefined;
+  return entryRefByValue.get(key) ??
+    entryRefByValue.get(resolveOriginal(key) as object);
+}
+
 /**
  * True only for a value that is structurally a pattern AND has trusted builder
  * provenance — either it carries the brand directly, or it is a derivation /
- * serialized copy whose `unsafe_originalPattern` chain reaches a branded
- * original. Use this at trust-granting sites; a `__cf_data`-forged pattern-shaped
- * object is `isPattern` but NOT `isTrustedPattern` (it carries no brand, and the
- * `unsafe_originalPattern` symbol is module-private — authored code cannot set
- * it to point at a real pattern).
+ * serialized copy registered via {@link noteDerivedCopy} (which propagates the
+ * brand eagerly). A `__cf_data`-forged pattern-shaped object is `isPattern`
+ * but NOT `isTrustedPattern`: no own property can grant trust (the brand and
+ * derivation link live in runner-private WeakSets/WeakMaps), and forged values
+ * never reach `noteDerivedCopy` with a trusted original.
  */
 export function isTrustedPattern(value: unknown): value is Pattern {
   if (!isPattern(value)) return false;
-  // Walk the original-pattern chain; a branded ancestor confers trust on copies.
-  let current: unknown = value;
-  const seen = new Set<unknown>();
-  while (
-    current && (typeof current === "object" || typeof current === "function")
-  ) {
-    if (trustedPatterns.has(current as object)) return true;
-    if (seen.has(current)) break;
-    seen.add(current);
-    current = (current as Record<symbol, unknown>)[unsafe_originalPattern];
-  }
-  return false;
+  const key = asKey(value);
+  if (!key) return false;
+  return trustedPatterns.has(key) ||
+    trustedPatterns.has(resolveOriginal(key) as object);
 }
 
 /** Stamp a value as produced by a trusted non-pattern builder (lift/handler/…). */
@@ -130,33 +217,19 @@ export function brandTrustedBuilderArtifact<T>(value: T): T {
 
 /**
  * True for any value with trusted-builder provenance — a trusted pattern OR a
- * branded lift/handler/node-factory — walking the `unsafe_originalPattern` chain
- * so derivation / serialized copies inherit trust. This is the gate that decides
+ * branded lift/handler/node-factory — including derivation / serialized
+ * copies registered via {@link noteDerivedCopy}. This is the gate that decides
  * whether a `__cfReg`-registered value may receive a content-addressed
  * `{ identity, symbol }` reference; forged plain data carries no brand and is
- * rejected.
+ * rejected. Pure WeakSet/WeakMap probes — no property reads, so exotic values
+ * (e.g. a Proxy with a throwing get trap) cannot abort registration/lookup.
  */
 export function isTrustedBuilderArtifact(value: unknown): boolean {
-  let current: unknown = value;
-  const seen = new Set<unknown>();
-  while (
-    current && (typeof current === "object" || typeof current === "function")
-  ) {
-    if (
-      trustedBuilderArtifacts().has(current as object) ||
-      trustedPatterns.has(current as object)
-    ) {
-      return true;
-    }
-    if (seen.has(current)) break;
-    seen.add(current);
-    // Fail closed: reading the (module-private) symbol off an exotic value — e.g.
-    // a Proxy with a throwing get trap — must not abort registration/lookup.
-    try {
-      current = (current as Record<symbol, unknown>)[unsafe_originalPattern];
-    } catch {
-      return false;
-    }
+  const key = asKey(value);
+  if (!key) return false;
+  if (trustedBuilderArtifacts().has(key) || trustedPatterns.has(key)) {
+    return true;
   }
-  return false;
+  const root = resolveOriginal(key) as object;
+  return trustedBuilderArtifacts().has(root) || trustedPatterns.has(root);
 }

--- a/packages/runner/src/builder/traverse-utils.ts
+++ b/packages/runner/src/builder/traverse-utils.ts
@@ -1,10 +1,6 @@
 import { isRecord } from "@commonfabric/utils/types";
-import {
-  isOpaqueRef,
-  isPattern,
-  type Opaque,
-  unsafe_originalPattern,
-} from "./types.ts";
+import { isOpaqueRef, isPattern, type Opaque } from "./types.ts";
+import { noteDerivedCopy } from "./pattern-metadata.ts";
 import { isCell } from "../cell.ts";
 import { isCellResultForDereferencing } from "../query-result-proxy.ts";
 
@@ -44,16 +40,13 @@ export function traverseValue(
           [key, v],
         ) => [key, traverseValue(v, fn, seen)]),
       );
-      // `Object.entries` drops symbol keys, so a pattern copied here would lose
-      // its link back to the original (branded, content-addressed) factory —
-      // severing `findOriginalPattern`/`getArtifactEntryRef`, which is how a
-      // pattern passed as an `op` is later identified by `{ identity, symbol }`.
-      // Preserve that link (the deepest original) on the copy. Mirrors the same
-      // `unsafe_originalPattern` retention in `toJSONWithLegacyAliases`.
-      if (isPattern(value)) {
-        (copy as Record<symbol, unknown>)[unsafe_originalPattern] =
-          (value as Record<symbol, unknown>)[unsafe_originalPattern] ?? value;
-      }
+      // A pattern copied here must keep its link back to the original
+      // (branded, content-addressed) factory — otherwise
+      // `resolveOriginal`/`getArtifactEntryRef` would be severed, which is how
+      // a pattern passed as an `op` is later identified by
+      // `{ identity, symbol }`. Mirrors the registration in
+      // `toJSONWithLegacyAliases`.
+      if (isPattern(value)) noteDerivedCopy(copy, value);
       return copy;
     }
   } else {

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -221,9 +221,6 @@ export type Node = {
   outputs: JSONValue;
 };
 
-// Used to get back to original pattern from a JSONified representation.
-export const unsafe_originalPattern = Symbol("unsafe_originalPattern");
-
 declare module "@commonfabric/api" {
   interface Pattern {
     argumentSchema: JSONSchema;
@@ -232,11 +229,11 @@ declare module "@commonfabric/api" {
     initial?: JSONValue;
     result: JSONValue;
     nodes: Node[];
-    // NOTE: `program` (rehydration source) and the verified-load id are no
-    // longer stored on the pattern object — they live in WeakMaps in
-    // ./pattern-metadata.ts so exported patterns can be frozen. Use
-    // get/setPatternProgram and get/setVerifiedLoadId.
-    [unsafe_originalPattern]?: Pattern;
+    // NOTE: `program` (rehydration source), the verified-load id, and the
+    // derivation link to a copy's original all live in WeakMaps/WeakSets in
+    // ./pattern-metadata.ts (so exported patterns can be frozen, and so no
+    // own property can carry trust). Use get/setPatternProgram,
+    // get/setVerifiedLoadId, noteDerivedCopy/resolveOriginal.
   }
 }
 

--- a/packages/runner/src/builtins/op-pattern-ref.ts
+++ b/packages/runner/src/builtins/op-pattern-ref.ts
@@ -11,7 +11,7 @@ import type { Runtime } from "../runtime.ts";
  * instantiation (see `Runner.substituteOpPatternRefs`), once the op pattern's
  * entry ref is known. Because it is plain data (no symbol keys), it survives the
  * `getImmutableCell` JSON round-trip that strips the in-memory
- * `unsafe_originalPattern` backref — so the builtin reads it back intact and
+ * derivation backref — so the builtin reads it back intact and
  * resolves the live canonical pattern without deserializing a graph or mapping
  * functions back by `implementationRef`.
  */

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -123,7 +123,6 @@ export {
   type toJSON,
   TYPE,
   UI,
-  unsafe_originalPattern,
   type UnsafeBinding,
   type VNode,
   WebhookConfigSchema,

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -1,12 +1,9 @@
 import { isRecord } from "@commonfabric/utils/types";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
-import {
-  isPattern,
-  type JSONSchema,
-  unsafe_originalPattern,
-} from "./builder/types.ts";
+import { isPattern, type JSONSchema } from "./builder/types.ts";
 import {
   getVerifiedLoadId,
+  noteDerivedCopy,
   setVerifiedLoadId,
 } from "./builder/pattern-metadata.ts";
 import { type AnyCell } from "./cell.ts";
@@ -328,9 +325,10 @@ export function unwrapOneLevelAndBindtoDoc<T, U>(
           convert(value, shouldBind, cfc.getSchemaAtPath(targetSchema, [key])),
         ]),
       );
-      if (binding[unsafe_originalPattern]) {
-        result[unsafe_originalPattern] = binding[unsafe_originalPattern];
-      }
+      // Carry the derivation link (trust + content-addressed entry ref) onto
+      // the bound copy so a pattern value re-bound here still resolves its
+      // `{ identity, symbol }` and stays trusted.
+      if (isPattern(binding)) noteDerivedCopy(result, binding);
       const verifiedLoadId = getVerifiedLoadId(binding);
       if (verifiedLoadId) {
         setVerifiedLoadId(result, verifiedLoadId);

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -1,16 +1,13 @@
 import { getLogger } from "@commonfabric/utils/logger";
+import { isPattern, Module, Pattern, Schema } from "./builder/types.ts";
 import {
-  isPattern,
-  Module,
-  Pattern,
-  Schema,
-  unsafe_originalPattern,
-} from "./builder/types.ts";
-import {
+  getArtifactEntryRef,
   getPatternProgram,
   getVerifiedLoadId,
   isTrustedBuilderArtifact,
   isTrustedPattern,
+  resolveOriginal,
+  setArtifactEntryRef,
   setPatternProgram,
   setVerifiedLoadId,
 } from "./builder/pattern-metadata.ts";
@@ -100,17 +97,10 @@ export class PatternManager {
   private patternIdMap = new Map<URI, Pattern>();
   // Map from pattern object instance to patternId
   private patternToIdMap = new WeakMap<Pattern, URI>();
-  // Map from a builder artifact (pattern / lift / handler) to its content-
-  // addressed {identity, symbol} reference — the module's identity (prefix-free
-  // `cf:module/<hash>` minus the scheme) and the symbol it was registered/exported
-  // under. Learned on the ESM path: for an authored export the symbol is its
-  // export name; for a hoisted artifact it is the `__cfReg` key. Lets a value be
-  // referenced by {identity, symbol} and resolved straight from the in-memory
-  // cache without the program/meta indirection.
-  private valueToEntryRef = new WeakMap<
-    object,
-    { identity: string; symbol: string }
-  >();
+  // The forward value → {identity, symbol} map lives module-level in
+  // builder/pattern-metadata.ts (`setArtifactEntryRef`/`getArtifactEntryRef`)
+  // so builder-layer copy sites can carry refs onto derived copies without a
+  // PatternManager handle.
   // THE in-memory reverse index for content-addressed builder artifacts: module
   // identity -> (symbol -> live value). The single source for
   // `artifactFromIdentitySync` (the inverse of the forward `valueToEntryRef`),
@@ -242,10 +232,9 @@ export class PatternManager {
   }
 
   private findOriginalPattern(pattern: Pattern): Pattern {
-    while (pattern[unsafe_originalPattern]) {
-      pattern = pattern[unsafe_originalPattern];
-    }
-    return pattern;
+    // Derivation links live in the module-level side table (pattern-metadata);
+    // the former `unsafe_originalPattern` symbol backref is gone.
+    return resolveOriginal(pattern);
   }
 
   // Roots already fully seeded per verifiedLoadId. The walk is idempotent
@@ -911,7 +900,7 @@ export class PatternManager {
     // `indexArtifact` would drop exported lift/handler forward refs — the gap
     // Codex flagged on an earlier revision of #3912.
     if (isTrustedPattern(pattern)) {
-      this.valueToEntryRef.set(pattern, { identity: entryIdentity, symbol });
+      setArtifactEntryRef(pattern, { identity: entryIdentity, symbol });
       if (loadId) {
         this.seedVerifiedLoadIds(pattern, loadId);
       }
@@ -1008,9 +997,7 @@ export class PatternManager {
     // the forward ref stays pinned to the original — acceptable because the
     // value is, by content identity, the original. `getArtifactEntryRef`
     // consumers tolerate this (it resolves to a real, addressable artifact).
-    if (!this.valueToEntryRef.has(value as object)) {
-      this.valueToEntryRef.set(value as object, { identity, symbol });
-    }
+    setArtifactEntryRef(value, { identity, symbol });
   }
 
   /**
@@ -1061,7 +1048,7 @@ export class PatternManager {
     // Refresh recency.
     this.modulesByIdentity.delete(entryIdentity);
     this.modulesByIdentity.set(entryIdentity, cached);
-    this.valueToEntryRef.set(pattern, { identity: entryIdentity, symbol });
+    setArtifactEntryRef(pattern, { identity: entryIdentity, symbol });
     if (cached.loadId) this.seedVerifiedLoadIds(pattern, cached.loadId);
     return pattern;
   }
@@ -1118,7 +1105,7 @@ export class PatternManager {
     if (isTrustedPattern(pattern)) {
       setPatternProgram(pattern, program);
       if (entryIdentity) {
-        this.valueToEntryRef.set(pattern, {
+        setArtifactEntryRef(pattern, {
           identity: entryIdentity,
           symbol: exportName,
         });
@@ -1139,12 +1126,10 @@ export class PatternManager {
   getArtifactEntryRef(
     value: object,
   ): { identity: string; symbol: string } | undefined {
-    // `valueToEntryRef` is keyed by the EXACT registered/exported value. Check
-    // the exact object FIRST, then the normalized original: a copied/wrapped
-    // artifact whose `unsafe_originalPattern` root differs from the keyed object
-    // would otherwise never resolve its ref.
-    return this.valueToEntryRef.get(value) ??
-      this.valueToEntryRef.get(this.findOriginalPattern(value as Pattern));
+    // Exact object first, then the derivation root — handled by the
+    // module-level store (refs are indexed post-evaluation, after build-time
+    // copies were made, so the lookup walks the derivation link lazily).
+    return getArtifactEntryRef(value);
   }
 
   /**

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3548,10 +3548,10 @@ export class Runner {
    * The embedded graph is retained as `$opFallback` (correctness over the
    * bounded module cache — see `resolveOpPattern`). `inputBindings` here is the
    * freshly bound (mutable, unfrozen) copy produced by
-   * `unwrapOneLevelAndBindtoDoc`; its pattern values still carry the in-memory
-   * `unsafe_originalPattern` backref, so `getArtifactEntryRef` can resolve the ref
-   * (assigned post-eval by `registerEvaluatedModules`). With no known ref the op
-   * is left as the embedded graph (legacy / ESM-loader-off).
+   * `unwrapOneLevelAndBindtoDoc`; its pattern values carry their derivation
+   * link (`noteDerivedCopy`), so `getArtifactEntryRef` can resolve the ref
+   * (assigned post-eval by `registerEvaluatedModules`). With no known ref the
+   * op is left as the embedded graph.
    */
   private substituteOpPatternRefs(
     moduleRefName: string | undefined,
@@ -3625,8 +3625,8 @@ export class Runner {
     // CT-1623: for the list builtins, replace a pattern-valued input (the `op`)
     // with a compact `{ $patternRef }` sentinel when its content-addressed entry
     // ref is known. This is the post-eval moment where the in-memory op object
-    // (reachable via `unsafe_originalPattern`, preserved through binding) carries
-    // its `{ identity, symbol }`; the sentinel then survives the immutable-cell
+    // (linked to its original via `noteDerivedCopy`, preserved through binding)
+    // carries its `{ identity, symbol }`; the sentinel then survives the immutable-cell
     // JSON round-trip, so the builtin resolves the live canonical pattern by
     // identity instead of deserializing the embedded graph.
     this.substituteOpPatternRefs(moduleRefName, mappedInputBindings);

--- a/packages/runner/test/cfreg-security.test.ts
+++ b/packages/runner/test/cfreg-security.test.ts
@@ -10,8 +10,8 @@ import { verifyCompiledModuleBody } from "../src/sandbox/module-record-verifier.
 import {
   brandTrustedBuilderArtifact,
   isTrustedBuilderArtifact,
+  noteDerivedCopy,
 } from "../src/builder/pattern-metadata.ts";
-import { unsafe_originalPattern } from "../src/builder/types.ts";
 
 // Security invariants for the `__cfReg` content-addressed registration mechanism
 // (CT-1623). The compiled module body is treated as UNTRUSTED; defenses live in
@@ -79,21 +79,26 @@ describe("isTrustedBuilderArtifact rejects forged values", () => {
     expect(isTrustedBuilderArtifact(forged)).toBe(false);
   });
 
-  it("is not fooled by a STRING-keyed 'unsafe_originalPattern'", () => {
-    // The trust chain follows the module-private SYMBOL `unsafe_originalPattern`,
-    // which authored code cannot reference. A string property of the same name
-    // is inert, so it cannot launder trust onto a forged object.
+  it("is not fooled by ANY own property pointing at a branded value", () => {
+    // Trust lives exclusively in runner-private WeakSets/WeakMaps
+    // (pattern-metadata.ts); no property an attacker can set on an object —
+    // string-keyed, symbol-keyed, or otherwise — can launder trust onto it.
     const branded = brandTrustedBuilderArtifact({});
-    const forged = { ["unsafe_originalPattern"]: branded };
+    const forged = {
+      ["unsafe_originalPattern"]: branded,
+      [Symbol("unsafe_originalPattern")]: branded,
+      original: branded,
+    };
     expect(isTrustedBuilderArtifact(forged)).toBe(false);
   });
 
-  it("accepts a genuinely branded artifact (and copies linking to it)", () => {
+  it("accepts a genuinely branded artifact (and registered derived copies)", () => {
     const artifact = brandTrustedBuilderArtifact({});
     expect(isTrustedBuilderArtifact(artifact)).toBe(true);
-    // A derivation copy whose symbol chain reaches the branded original inherits
-    // trust (this is the legitimate path the chain walk exists for).
-    const copy = { [unsafe_originalPattern]: artifact };
+    // A derivation copy registered by a runner-owned copy site inherits trust
+    // (the legitimate path noteDerivedCopy exists for).
+    const copy = {};
+    noteDerivedCopy(copy, artifact);
     expect(isTrustedBuilderArtifact(copy)).toBe(true);
   });
 });

--- a/packages/runner/test/derived-copy-identity.test.ts
+++ b/packages/runner/test/derived-copy-identity.test.ts
@@ -1,0 +1,104 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  brandTrustedBuilderArtifact,
+  brandTrustedPattern,
+  getArtifactEntryRef,
+  isTrustedBuilderArtifact,
+  isTrustedPattern,
+  noteDerivedCopy,
+  resolveOriginal,
+  setArtifactEntryRef,
+} from "../src/builder/pattern-metadata.ts";
+
+/**
+ * Derived-copy identity carry (PR B of
+ * docs/specs/content-addressed-action-identity-implementation-plan.md).
+ *
+ * Copies of builder artifacts (build-time graph serialization, traversal,
+ * binding) register `copy → original` in a module-level WeakMap via
+ * `noteDerivedCopy` — replacing the `unsafe_originalPattern` symbol backref.
+ * Trust propagates eagerly (brands always precede copies: builders brand at
+ * creation time); entry refs resolve lazily through `resolveOriginal` because
+ * refs are indexed only post-evaluation, AFTER build-time copies were made.
+ */
+
+const patternShape = () => ({
+  argumentSchema: { type: "object" as const },
+  resultSchema: { type: "object" as const },
+  nodes: [],
+  result: {},
+});
+
+describe("noteDerivedCopy trust carry", () => {
+  it("a copy of a branded pattern is trusted; a forged object is not", () => {
+    const original = brandTrustedPattern(patternShape());
+    const copy = patternShape();
+    noteDerivedCopy(copy, original);
+    expect(isTrustedPattern(copy)).toBe(true);
+
+    // Forged values gain nothing: no own property can grant trust...
+    const forged = {
+      ...patternShape(),
+      ["unsafe_originalPattern"]: original,
+    };
+    expect(isTrustedPattern(forged)).toBe(false);
+    // ...and a forged value never reaches noteDerivedCopy with a trusted
+    // original, so it stays untrusted.
+    expect(isTrustedBuilderArtifact({ forged: true })).toBe(false);
+  });
+
+  it("copies of copies resolve to the root original", () => {
+    const original = brandTrustedBuilderArtifact({ kind: "factory" });
+    const copy1 = { kind: "copy1" };
+    noteDerivedCopy(copy1, original);
+    const copy2 = { kind: "copy2" };
+    noteDerivedCopy(copy2, copy1);
+    expect(resolveOriginal(copy2)).toBe(original);
+    expect(isTrustedBuilderArtifact(copy2)).toBe(true);
+  });
+
+  it("an untrusted original confers nothing", () => {
+    const original = patternShape();
+    const copy = patternShape();
+    noteDerivedCopy(copy, original);
+    expect(isTrustedPattern(copy)).toBe(false);
+  });
+});
+
+describe("entry-ref resolution through copies", () => {
+  it("resolves a ref registered BEFORE the copy (eager)", () => {
+    const original = brandTrustedPattern(patternShape());
+    setArtifactEntryRef(original, { identity: "id-eager", symbol: "default" });
+    const copy = patternShape();
+    noteDerivedCopy(copy, original);
+    expect(getArtifactEntryRef(copy)).toEqual({
+      identity: "id-eager",
+      symbol: "default",
+    });
+  });
+
+  it("resolves a ref registered AFTER the copy (lazy — the build-time order)", () => {
+    // Build-time copies are made during module evaluation; refs are indexed
+    // post-evaluation by registerEvaluatedModules. The lookup must therefore
+    // walk to the original at resolution time.
+    const original = brandTrustedPattern(patternShape());
+    const copy = patternShape();
+    noteDerivedCopy(copy, original);
+    setArtifactEntryRef(original, { identity: "id-lazy", symbol: "op" });
+    expect(getArtifactEntryRef(copy)).toEqual({
+      identity: "id-lazy",
+      symbol: "op",
+    });
+  });
+
+  it("first-write-wins for a value's ref", () => {
+    const original = brandTrustedPattern(patternShape());
+    setArtifactEntryRef(original, { identity: "first", symbol: "a" });
+    setArtifactEntryRef(original, { identity: "second", symbol: "b" });
+    expect(getArtifactEntryRef(original)).toEqual({
+      identity: "first",
+      symbol: "a",
+    });
+  });
+});


### PR DESCRIPTION
PR B of the content-addressed action identity plan ([plan](https://github.com/commontoolsinc/labs/blob/main/docs/specs/content-addressed-action-identity-implementation-plan.md), design: `docs/specs/content-addressed-action-identity.md`).

Copies of builder artifacts (build-time graph serialization in `json-utils`, traversal copies in `traverse-utils`, binding copies in `pattern-binding`) now register `copy → original` in a runner-private module-level WeakMap via `noteDerivedCopy`, replacing the `unsafe_originalPattern` symbol backref:

- **Trust propagates eagerly at copy time** (sound: builders brand artifacts at creation, before any copy exists), so `isTrustedPattern` / `isTrustedBuilderArtifact` collapse from chain walks (cycle guards, try/catch property reads) to pure WeakSet/WeakMap probes — no property is ever read off the value, so exotic/forged objects cannot influence the result.
- **The `{identity, symbol}` entry-ref map promotes to module level** (`setArtifactEntryRef`/`getArtifactEntryRef` in pattern-metadata), giving builder-layer copy sites access without a PatternManager handle. Ref lookups still resolve **lazily** through the derivation link: refs are indexed post-evaluation, *after* build-time copies were made — pinned by an explicit ordering test.
- The binding copy site links whenever the binding is structurally a pattern (superset of the old carried-backref-only condition; an untrusted root propagates nothing).
- `unsafe_originalPattern` (symbol, `Pattern` declaration, export) deleted; zero references remain outside intentional forgery-test string keys.

**Tests**: new `derived-copy-identity.test.ts` (trust carry, copy-of-copy root resolution, eager and lazy ref resolution, first-write-wins); `cfreg-security.test.ts` forgery suite ported to "no own property grants trust" (string key, symbol look-alike, plain link all inert). Canaries green: `map-op-by-identity` (op ref resolution through binding copies) untouched.

Runner suite: **568 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the `unsafe_originalPattern` backref with runner-private side tables for derived-copy identity. Trust checks are now constant-time, and `{ identity, symbol }` refs seamlessly resolve through copies.

- **Refactors**
  - Register `copy → original` via `noteDerivedCopy` in `json-utils`, `traverse-utils`, and `pattern-binding`.
  - Move the `{ identity, symbol }` map to module scope with `setArtifactEntryRef`/`getArtifactEntryRef`; lookups resolve lazily via `resolveOriginal`.
  - Simplify trust: `isTrustedPattern` and `isTrustedBuilderArtifact` use WeakSet/WeakMap probes only (no property reads).
  - Remove `unsafe_originalPattern` (symbol, type, export) and update call sites.

- **Tests**
  - Add `derived-copy-identity.test.ts` covering trust carry, copy-of-copy roots, eager/lazy ref resolution, and first-write-wins.
  - Update `cfreg-security.test.ts` to assert “no own property grants trust”; forged values remain inert.

<sup>Written for commit ef245e8eaba36a1206a9c9fa953ab645b9f4c511. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

