### PR TITLE
feat(runner): content-addressed $implRef + CFC provenance [identity C]

### DIFF
--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -18,6 +18,7 @@ import {
 } from "./types.ts";
 import { getTopFrame } from "./pattern.ts";
 import { getPatternProgram, noteDerivedCopy } from "./pattern-metadata.ts";
+import { getVerifiedProvenance } from "../harness/verified-provenance.ts";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { Runtime } from "../runtime.ts";
 import {
@@ -405,6 +406,24 @@ export function moduleToJSON(module: Module) {
         "JavaScript function modules must carry implementationRef before serialization",
       );
     }
+    // Content-addressed reference (dual-write with implementationRef until
+    // the flip — see docs/specs/content-addressed-action-identity.md): when
+    // the implementation function has module-scope provenance, serialize its
+    // `{ identity, symbol }` so a rehydrated module resolves by identity.
+    // `toJSON` runs at cell-write time — post-evaluation, after provenance was
+    // recorded by the module indexing. Dynamic (in-action-created) artifacts
+    // have no symbol and serialize without a ref (in-session only, as before).
+    const provenance = module.type === "javascript"
+      ? getVerifiedProvenance(implementation)
+      : undefined;
+    const implRef = provenance?.symbol
+      ? {
+        $implRef: {
+          identity: provenance.identity,
+          symbol: provenance.symbol,
+        },
+      }
+      : {};
     const preview = (implementation as { preview?: string }).preview ??
       implementation.toString().slice(0, 200);
     const location = (implementation as { src?: string }).src;
@@ -423,6 +442,7 @@ export function moduleToJSON(module: Module) {
       : undefined;
     return {
       ...rest,
+      ...implRef,
       ...(module.type === "javascript" &&
           admittedImplementation !== implementation
         ? {

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -477,6 +477,14 @@ function handlerInternal<E, T>(
     return eventStream;
   }, module);
 
+  // Provenance brand, like every factory from `createNodeFactory` (whose
+  // comment always claimed handler coverage — handler factories are built
+  // here and bypassed it): only a branded artifact may acquire a
+  // content-addressed `{ identity, symbol }` reference via `__cfReg`
+  // indexing, and a non-exported handler's `$implRef`/CFC provenance depends
+  // on exactly that registration.
+  brandTrustedBuilderArtifact(factory);
+
   return factory;
 }
 

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -185,6 +185,14 @@ declare module "@commonfabric/api" {
     type: "ref" | "javascript" | "pattern" | "raw" | "isolated" | "passthrough";
     implementation?: ((...args: any[]) => any) | Pattern | string;
     implementationRef?: string;
+    /**
+     * Content-addressed reference to the module-scope builder artifact whose
+     * implementation this module runs: the defining module's content identity
+     * and the artifact's export/`__cfReg` symbol. Dual-written alongside
+     * `implementationRef` during the migration; resolution prefers it
+     * (see docs/specs/content-addressed-action-identity.md).
+     */
+    $implRef?: { identity: string; symbol: string };
     wrapper?: "handler";
     argumentSchema?: JSONSchema;
     resultSchema?: JSONSchema;

--- a/packages/runner/src/cfc/implementation-identity.ts
+++ b/packages/runner/src/cfc/implementation-identity.ts
@@ -168,8 +168,16 @@ const resolveProvenanceImplementationIdentity = (
     };
   }
 
+  // Mirror the legacy resolver's `getVerifiedBundleId(...) ?? verifiedLoadId`
+  // fallback: a stored legacy `writeAuthorizedBy` claim may carry the raw
+  // `verifiedLoadId` as its `bundleId` (when the bundle id wasn't registered at
+  // stamp time), and the `bundleId` verification arm in cfc/prepare.ts is an
+  // exact equality. Dropping the fallback here would leave `bundleId`
+  // `undefined` on a `getVerifiedBundleId` miss and fail those legacy claims
+  // closed. The `moduleIdentity` arm remains the primary; this only keeps the
+  // legacy arm symmetric with the path that produced those claims.
   const bundleId = typeof verifiedLoadId === "string" && verifiedLoadId.length
-    ? harness?.getVerifiedBundleId?.(verifiedLoadId)
+    ? harness?.getVerifiedBundleId?.(verifiedLoadId) ?? verifiedLoadId
     : undefined;
 
   return {

--- a/packages/runner/src/cfc/implementation-identity.ts
+++ b/packages/runner/src/cfc/implementation-identity.ts
@@ -2,6 +2,10 @@ import type { Module } from "../builder/types.ts";
 import type { Harness, HarnessedFunction } from "../harness/types.ts";
 import type { ImplementationIdentity } from "./types.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import {
+  getVerifiedProvenance,
+  identityFromCanonicalSource,
+} from "../harness/verified-provenance.ts";
 
 export const resolvePolicyFacingImplementationIdentity = (
   module: Module,
@@ -22,6 +26,12 @@ export const resolvePolicyFacingImplementationIdentity = (
     return undefined;
   }
   if (typeof debugName !== "string" || debugName.length === 0) {
+    // Content-addressed provenance needs no load scoping — the function
+    // object's registration during verified evaluation IS the proof.
+    const provenanceIdentity = resolveProvenanceImplementationIdentity(
+      options,
+    );
+    if (provenanceIdentity) return provenanceIdentity;
     if (
       typeof options.verifiedLoadId !== "string" ||
       options.verifiedLoadId.length === 0
@@ -56,6 +66,9 @@ const resolveVerifiedImplementationIdentity = (
     implementation?: HarnessedFunction;
   },
 ): ImplementationIdentity => {
+  // Legacy path (dual-read until the flip): implementationRef × verifiedLoadId
+  // registry checks. The content-addressed provenance path was already tried
+  // by the caller (resolvePolicyFacingImplementationIdentity).
   const implementationRef = (module as { implementationRef?: string })
     .implementationRef;
   const { verifiedLoadId, harness, implementation } = options;
@@ -111,6 +124,72 @@ const resolveVerifiedImplementationIdentity = (
       column: sourceLocation.column,
     },
     ...(bindingMetadata?.bindingPath ? {} : {
+      codeHash: hashOf(Function.prototype.toString.call(implementation))
+        .toString(),
+    }),
+  };
+};
+
+/**
+ * Resolve `kind: "verified"` from the function object's content-addressed
+ * provenance (see harness/verified-provenance.ts). Returns undefined when the
+ * function has no provenance — callers fall back to the legacy registry path.
+ *
+ * `bundleId` is still attached (from the load's registry) so stored
+ * `writeAuthorizedBy` claims written before the moduleIdentity switch keep
+ * verifying; new claims are stamped with BOTH (see cfc/prepare.ts).
+ */
+const resolveProvenanceImplementationIdentity = (
+  options: {
+    verifiedLoadId?: string;
+    harness?: Pick<Harness, "getVerifiedBundleId">;
+    implementation?: HarnessedFunction;
+  },
+): ImplementationIdentity | undefined => {
+  const { implementation, verifiedLoadId, harness } = options;
+  if (typeof implementation !== "function") return undefined;
+  const provenance = getVerifiedProvenance(implementation);
+  if (!provenance) return undefined;
+
+  const src = (implementation as { src?: string }).src;
+  const sourceLocation = parseVerifiedSourceLocation(src);
+  // Fail closed: the canonical source location must point INTO the provenance
+  // module. A mismatch means the src annotation and the registration disagree
+  // — treat as unsupported rather than guessing.
+  if (
+    !sourceLocation ||
+    identityFromCanonicalSource(src) !== provenance.identity
+  ) {
+    return {
+      kind: "unsupported",
+      className: "verified",
+      reason:
+        "provenance identity must match the implementation's canonical source",
+    };
+  }
+
+  const bundleId = typeof verifiedLoadId === "string" && verifiedLoadId.length
+    ? harness?.getVerifiedBundleId?.(verifiedLoadId)
+    : undefined;
+
+  return {
+    kind: "verified",
+    moduleIdentity: provenance.identity,
+    ...(provenance.symbol ? { symbol: provenance.symbol } : {}),
+    ...(bundleId ? { bundleId } : {}),
+    ...(provenance.bindingIdentity
+      ? {
+        sourceFile: normalizeIdentitySource(
+          provenance.bindingIdentity.sourceFile,
+        ),
+        bindingPath: [...provenance.bindingIdentity.bindingPath],
+      }
+      : {}),
+    sourceLocation: {
+      line: sourceLocation.line,
+      column: sourceLocation.column,
+    },
+    ...(provenance.bindingIdentity ? {} : {
       codeHash: hashOf(Function.prototype.toString.call(implementation))
         .toString(),
     }),

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -320,10 +320,21 @@ const writeAuthorizedByReason = (
       path.join("/")
     }`;
   }
+  // Identity arm (fail closed): a claim stamped with the content-addressed
+  // moduleIdentity must match it; a legacy claim (bundleId only, written
+  // before the moduleIdentity switch) must match the live bundleId. A claim
+  // carrying neither is rejected. New claims are stamped with BOTH (see
+  // rebindWriteAuthorizedByClaims), so the bundleId arm only serves stored
+  // legacy data and retires with it.
+  const identityArmMatches = typeof bindingIdentity.moduleIdentity === "string"
+    ? (typeof identity.moduleIdentity === "string" &&
+      identity.moduleIdentity.length > 0 &&
+      identity.moduleIdentity === bindingIdentity.moduleIdentity)
+    : (typeof identity.bundleId === "string" &&
+      identity.bundleId.length > 0 &&
+      identity.bundleId === bindingIdentity.bundleId);
   if (
-    typeof identity.bundleId !== "string" ||
-    identity.bundleId.length === 0 ||
-    identity.bundleId !== bindingIdentity.bundleId ||
+    !identityArmMatches ||
     normalizeIdentitySource(identity.sourceFile) !==
       normalizeIdentitySource(bindingIdentity.file) ||
     !arraysEqual(identity.bindingPath, bindingIdentity.path)
@@ -335,7 +346,12 @@ const writeAuthorizedByReason = (
 
 const parseWriteAuthorizedByBindingIdentity = (
   claim: unknown,
-): { bundleId?: string; file: string; path: string[] } | undefined => {
+): {
+  bundleId?: string;
+  moduleIdentity?: string;
+  file: string;
+  path: string[];
+} | undefined => {
   if (!isRecord(claim) || !isRecord(claim.__ctWriterIdentityOf)) {
     return undefined;
   }
@@ -350,6 +366,9 @@ const parseWriteAuthorizedByBindingIdentity = (
   return {
     ...(typeof identity.bundleId === "string"
       ? { bundleId: identity.bundleId }
+      : {}),
+    ...(typeof identity.moduleIdentity === "string"
+      ? { moduleIdentity: identity.moduleIdentity }
       : {}),
     file: identity.file,
     path: [...identity.path],
@@ -716,7 +735,10 @@ const stripWriterIdentityBundleIds = (value: unknown): unknown => {
 
   const next: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
-    if (key === "bundleId" && typeof value.file === "string") {
+    if (
+      (key === "bundleId" || key === "moduleIdentity") &&
+      typeof value.file === "string"
+    ) {
       continue;
     }
     next[key] = stripWriterIdentityBundleIds(entry);
@@ -777,27 +799,34 @@ const rebindWriteAuthorizedByClaims = (
   schema: JSONSchema,
   identity: ImplementationIdentity | undefined,
 ): JSONSchema => {
-  if (
-    !identity || identity.kind !== "verified" ||
-    typeof identity.bundleId !== "string" ||
-    identity.bundleId.length === 0
-  ) {
+  if (!identity || identity.kind !== "verified") {
+    return schema;
+  }
+  const bundleId = typeof identity.bundleId === "string" &&
+      identity.bundleId.length > 0
+    ? identity.bundleId
+    : undefined;
+  const moduleIdentity = typeof identity.moduleIdentity === "string" &&
+      identity.moduleIdentity.length > 0
+    ? identity.moduleIdentity
+    : undefined;
+  if (!bundleId && !moduleIdentity) {
     return schema;
   }
   return rebindWriteAuthorizedByClaimsInner(
     schema,
-    identity.bundleId,
+    { bundleId, moduleIdentity },
   ) as JSONSchema;
 };
 
 const rebindWriteAuthorizedByClaimsInner = (
   value: unknown,
-  bundleId: string,
+  ids: { bundleId?: string; moduleIdentity?: string },
 ): unknown => {
   if (Array.isArray(value)) {
     let changed = false;
     const next = value.map((entry) => {
-      const rebound = rebindWriteAuthorizedByClaimsInner(entry, bundleId);
+      const rebound = rebindWriteAuthorizedByClaimsInner(entry, ids);
       changed ||= rebound !== entry;
       return rebound;
     });
@@ -810,23 +839,28 @@ const rebindWriteAuthorizedByClaimsInner = (
   let changed = false;
   const next: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
-    const rebound = rebindWriteAuthorizedByClaimsInner(entry, bundleId);
+    const rebound = rebindWriteAuthorizedByClaimsInner(entry, ids);
     changed ||= rebound !== entry;
     next[key] = rebound;
   }
 
   if (isRecord(value.ifc) && isRecord(value.ifc.writeAuthorizedBy)) {
     const claim = value.ifc.writeAuthorizedBy;
+    // Stamp an unstamped claim with BOTH identity arms: the content-addressed
+    // moduleIdentity (the durable one) and the legacy bundleId (kept so a
+    // rollback or an older reader can still verify; retired with the flip).
     if (
       isRecord(claim.__ctWriterIdentityOf) &&
-      claim.__ctWriterIdentityOf.bundleId === undefined
+      claim.__ctWriterIdentityOf.bundleId === undefined &&
+      claim.__ctWriterIdentityOf.moduleIdentity === undefined
     ) {
       const nextIfc = { ...value.ifc };
       nextIfc.writeAuthorizedBy = {
         ...claim,
         __ctWriterIdentityOf: {
           ...claim.__ctWriterIdentityOf,
-          bundleId,
+          ...(ids.bundleId ? { bundleId: ids.bundleId } : {}),
+          ...(ids.moduleIdentity ? { moduleIdentity: ids.moduleIdentity } : {}),
         },
       };
       next.ifc = nextIfc;

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -179,6 +179,16 @@ export type ImplementationIdentity =
   | { kind: "builtin"; builtinId: string }
   | {
     kind: "verified";
+    /**
+     * Content-addressed module identity (prefix-free `cf:module/<hash>`
+     * hash) — reload-stable and robust to unrelated module changes in the
+     * same program. Present on provenance-resolved identities; `bundleId`
+     * (the per-program concatenated-script hash) is retained alongside for
+     * stored writeAuthorizedBy claims written before the switch.
+     */
+    moduleIdentity?: string;
+    /** Export/`__cfReg` symbol of the registered factory, when module-scope. */
+    symbol?: string;
     bundleId?: string;
     sourceFile?: string;
     bindingPath?: string[];

--- a/packages/runner/src/harness/verified-provenance.ts
+++ b/packages/runner/src/harness/verified-provenance.ts
@@ -1,0 +1,101 @@
+import { VERIFIED_BINDING_METADATA_FIELD } from "@commonfabric/utils/sandbox-contract";
+
+/**
+ * Content-addressed provenance for verified implementation functions.
+ *
+ * An entry exists ONLY for a function object that became verified through one
+ * of the runner-owned registration channels:
+ *
+ *  1. post-evaluation module indexing (`PatternManager.indexArtifact`): the
+ *     implementation function of an exported / `__cfReg`-registered builder
+ *     artifact, with the module's content identity and the artifact's
+ *     export/`__cfReg` symbol;
+ *  2. the in-action registrar (`Runner.invokeJavaScriptImplementation`): a
+ *     builder artifact created DURING a verified action's execution, with the
+ *     identity derived from the new function's canonical source location and
+ *     `dynamic: true` (in-session only — such artifacts never resolve across
+ *     a reload, unchanged from the legacy behavior).
+ *
+ * The WeakMap itself is the anti-spoof proof for CFC: an attacker-supplied
+ * function — even with byte-identical source text — was never registered
+ * during a verified evaluation, so it has no entry. There is no string key to
+ * collide and no load scoping required. This replaces (and during the
+ * transition runs alongside) the `implementationRef` × `verifiedLoadId`
+ * registry checks; see docs/specs/content-addressed-action-identity.md.
+ */
+export type VerifiedProvenance = {
+  /** Module content identity (prefix-free `cf:module/<hash>` hash). */
+  identity: string;
+  /** Export / `__cfReg` symbol of the registered factory (absent: dynamic). */
+  symbol?: string;
+  /** Created during a verified action's execution (in-session only). */
+  dynamic?: true;
+  /** CT-1665 verified binding identity, when the factory carried one. */
+  bindingIdentity?: { sourceFile: string; bindingPath: string[] };
+};
+
+const provenanceByFn = new WeakMap<object, VerifiedProvenance>();
+
+/**
+ * Record provenance for a verified implementation function. First write wins:
+ * the first registration (export or `__cfReg` of the defining module) is
+ * canonical; later re-registrations of the same live function under other
+ * symbols don't reassign it (mirrors the entry-ref first-write-wins
+ * semantics).
+ */
+export function recordVerifiedProvenance(
+  fn: unknown,
+  provenance: VerifiedProvenance,
+): void {
+  if (typeof fn !== "function") return;
+  if (!provenanceByFn.has(fn)) provenanceByFn.set(fn, provenance);
+}
+
+/** The provenance for a function registered during verified evaluation. */
+export function getVerifiedProvenance(
+  fn: unknown,
+): VerifiedProvenance | undefined {
+  if (typeof fn !== "function" && (typeof fn !== "object" || fn === null)) {
+    return undefined;
+  }
+  return provenanceByFn.get(fn as object);
+}
+
+/**
+ * Read the CT-1665 verified-binding annotation off a builder factory (the
+ * transformer's `__cfBindVerifiedBinding` attaches it to the factory object,
+ * which shares its implementation function with the node module).
+ */
+export function readBindingIdentity(
+  value: unknown,
+): { sourceFile: string; bindingPath: string[] } | undefined {
+  if (!value || (typeof value !== "object" && typeof value !== "function")) {
+    return undefined;
+  }
+  const metadata =
+    (value as Record<string, unknown>)[VERIFIED_BINDING_METADATA_FIELD];
+  if (!metadata || typeof metadata !== "object") return undefined;
+  const sourceFile = (metadata as Record<string, unknown>).sourceFile;
+  const bindingPath = (metadata as Record<string, unknown>).bindingPath;
+  if (
+    typeof sourceFile !== "string" ||
+    !Array.isArray(bindingPath) ||
+    !bindingPath.every((entry) => typeof entry === "string")
+  ) {
+    return undefined;
+  }
+  return { sourceFile, bindingPath: [...bindingPath] };
+}
+
+/**
+ * Derive the module content identity from a function's canonical source
+ * location (`cf:module/<identity>/<path>:line:col`), or undefined for
+ * non-canonical sources (host functions, builtins).
+ */
+export function identityFromCanonicalSource(
+  src: unknown,
+): string | undefined {
+  if (typeof src !== "string") return undefined;
+  const match = /^cf:module\/([^/]+)\//.exec(src);
+  return match ? match[1] : undefined;
+}

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -24,6 +24,7 @@ import type {
 import { RuntimeProgram } from "./harness/types.ts";
 import type { CachedCompiledModule } from "./sandbox/module-record-compiler.ts";
 import {
+  identityFromCanonicalSource,
   readBindingIdentity,
   recordVerifiedProvenance,
 } from "./harness/verified-provenance.ts";
@@ -1008,7 +1009,21 @@ export class PatternManager {
     // carries the CT-1665 binding annotation when present.
     const implementation =
       (value as { implementation?: unknown }).implementation ?? value;
-    if (typeof implementation === "function") {
+    // Skip a CONFIRMED cross-module mismatch: a re-exporting module surfaces a
+    // function defined elsewhere under its OWN identity, but the function's
+    // canonical `fn.src` names the defining module. Provenance is
+    // first-write-wins and CFC fails closed on an identity/`fn.src` mismatch,
+    // so a re-exporter (possibly indexed first) stamping its identity would
+    // make a valid verified artifact resolve as `unsupported`. Recording only
+    // when the src doesn't name a different module leaves the defining
+    // module's matching record to stick. A non-canonical src is left alone.
+    const srcIdentity = identityFromCanonicalSource(
+      (implementation as { src?: string }).src,
+    );
+    if (
+      typeof implementation === "function" &&
+      (srcIdentity === undefined || srcIdentity === identity)
+    ) {
       recordVerifiedProvenance(implementation, {
         identity,
         symbol,

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -23,6 +23,10 @@ import type {
 } from "./harness/types.ts";
 import { RuntimeProgram } from "./harness/types.ts";
 import type { CachedCompiledModule } from "./sandbox/module-record-compiler.ts";
+import {
+  readBindingIdentity,
+  recordVerifiedProvenance,
+} from "./harness/verified-provenance.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import {
   COMPILE_CACHE_RUNTIME_VERSION,
@@ -998,6 +1002,21 @@ export class PatternManager {
     // value is, by content identity, the original. `getArtifactEntryRef`
     // consumers tolerate this (it resolves to a real, addressable artifact).
     setArtifactEntryRef(value, { identity, symbol });
+    // Content-addressed CFC provenance for the artifact's implementation
+    // function: registering through this (trust-gated) indexing path is what
+    // makes a function "verified" under the by-identity model. The factory
+    // carries the CT-1665 binding annotation when present.
+    const implementation =
+      (value as { implementation?: unknown }).implementation ?? value;
+    if (typeof implementation === "function") {
+      recordVerifiedProvenance(implementation, {
+        identity,
+        symbol,
+        ...(readBindingIdentity(value) === undefined
+          ? {}
+          : { bindingIdentity: readBindingIdentity(value)! }),
+      });
+    }
   }
 
   /**

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -87,6 +87,10 @@ import {
   type ImplementationIdentity,
 } from "./cfc/types.ts";
 import { setVerifiedFunctionRegistrar } from "./sandbox/function-hardening.ts";
+import {
+  identityFromCanonicalSource,
+  recordVerifiedProvenance,
+} from "./harness/verified-provenance.ts";
 import { diffAndUpdate } from "./data-updating.ts";
 import { setResultCell } from "./result-utils.ts";
 export {
@@ -2348,28 +2352,27 @@ export class Runner {
       )
       : undefined;
 
-    if (module.implementationRef) {
-      const cached = this.functionCache.get(module);
-      if (cached) {
-        fn = cached;
-      } else {
-        const executable = this.runtime.harness.getExecutableFunction(
-          module.implementationRef,
-          patternId,
-        );
-        fn = executable
-          ? executable as (...args: any[]) => any
-          : this.getFallbackJavaScriptImplementation(module);
-        this.functionCache.set(module, fn);
-      }
+    const cached = this.functionCache.get(module);
+    if (cached) {
+      fn = cached;
     } else {
-      const cached = this.functionCache.get(module);
-      if (cached) {
-        fn = cached;
-      } else {
-        fn = this.getFallbackJavaScriptImplementation(module);
-        this.functionCache.set(module, fn);
-      }
+      // Resolution order (docs/specs/content-addressed-action-identity.md):
+      // 1. content-addressed `$implRef` — resolve the registered builder
+      //    artifact by `{ identity, symbol }` from the in-memory index (only
+      //    trust-gated artifacts are indexed, so whatever resolves is
+      //    builder-made) and run its implementation;
+      // 2. legacy `implementationRef` registry lookup (dual-read until the
+      //    flip);
+      // 3. the stringified-source fallback (SES-sandboxed, CFC-unverified).
+      fn = this.resolveByImplRef(module) ??
+        (module.implementationRef
+          ? this.runtime.harness.getExecutableFunction(
+            module.implementationRef,
+            patternId,
+          ) as (...args: any[]) => any | undefined
+          : undefined) ??
+        this.getFallbackJavaScriptImplementation(module);
+      this.functionCache.set(module, fn);
     }
 
     const namedFn = fn as {
@@ -2386,6 +2389,36 @@ export class Runner {
     }
 
     return { fn, name, verifiedLoadId };
+  }
+
+  /**
+   * Resolve a module's implementation through its content-addressed
+   * `$implRef` (the defining module's content identity + the registered
+   * artifact's export/`__cfReg` symbol). Returns undefined on a miss (no ref,
+   * never registered, or rolled out of the bounded index) — callers fall back
+   * to the legacy ref or the stringified source.
+   */
+  private resolveByImplRef(
+    module: Module,
+  ): ((...args: any[]) => any) | undefined {
+    const ref = (module as { $implRef?: { identity: string; symbol: string } })
+      .$implRef;
+    if (
+      !ref || typeof ref.identity !== "string" ||
+      typeof ref.symbol !== "string"
+    ) {
+      return undefined;
+    }
+    const artifact = this.runtime.patternManager.artifactFromIdentitySync(
+      ref.identity,
+      ref.symbol,
+    );
+    if (!artifact) return undefined;
+    const implementation =
+      (artifact as { implementation?: unknown }).implementation ?? artifact;
+    return typeof implementation === "function"
+      ? implementation as (...args: any[]) => any
+      : undefined;
   }
 
   /**
@@ -3524,6 +3557,17 @@ export class Runner {
           implementationRef,
           implementation as (input: any) => void,
         );
+        // Content-addressed provenance for artifacts created DURING a
+        // verified action's execution: the identity derives from the new
+        // function's canonical source location (it was compiled as part of a
+        // verified module). In-session only (`dynamic`), matching the legacy
+        // behavior — such artifacts never resolve across a reload.
+        const identity = identityFromCanonicalSource(
+          (implementation as { src?: string }).src,
+        );
+        if (identity) {
+          recordVerifiedProvenance(implementation, { identity, dynamic: true });
+        }
       },
     );
     try {

--- a/packages/runner/test/cfc-nonexported-binding-identity.test.ts
+++ b/packages/runner/test/cfc-nonexported-binding-identity.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 
 // CT-1665: An owner-protected field bound by `WriteAuthorizedBy<T, typeof fn>`
@@ -69,26 +70,31 @@ function recordedBindingPaths(rt: Runtime): string[][] {
     .filter((p): p is string[] => Array.isArray(p));
 }
 
-// Capture the binding metadata resolved through the PUBLIC harness API while a
-// handler runs — the exact lookup the CFC verifier performs at commit. Returns
-// the bindingPaths that resolved to a non-empty result during `fn()`.
+// Capture the bindingPaths of the writer identities STAMPED on transactions
+// while a handler runs — the value the CFC verifier consumes at commit.
+// Channel-agnostic: the identity may resolve through the content-addressed
+// provenance WeakMap or the legacy implementationRef registry; what matters
+// is the identity (with its bindingPath) reaching the transaction.
 async function bindingPathsResolvedDuring(
   rt: Runtime,
   fn: () => void,
 ): Promise<string[][]> {
-  const harness = rt.harness as any;
-  const orig = harness.getVerifiedBindingMetadata.bind(harness);
+  const proto = ExtendedStorageTransaction.prototype as unknown as {
+    setCfcImplementationIdentity: (identity: unknown) => void;
+  };
+  const orig = proto.setCfcImplementationIdentity;
   const resolved: string[][] = [];
-  harness.getVerifiedBindingMetadata = (ref: string) => {
-    const res = orig(ref);
-    if (res?.bindingPath) resolved.push(res.bindingPath);
-    return res;
+  proto.setCfcImplementationIdentity = function (identity: unknown) {
+    const bindingPath = (identity as { bindingPath?: string[] } | undefined)
+      ?.bindingPath;
+    if (Array.isArray(bindingPath)) resolved.push(bindingPath);
+    return orig.call(this, identity);
   };
   try {
     fn();
     await (rt as any).idle?.();
   } finally {
-    harness.getVerifiedBindingMetadata = orig;
+    proto.setCfcImplementationIdentity = orig;
   }
   return resolved;
 }

--- a/packages/runner/test/content-addressed-identity-adversarial.test.ts
+++ b/packages/runner/test/content-addressed-identity-adversarial.test.ts
@@ -1,0 +1,802 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
+import {
+  getVerifiedProvenance,
+  recordVerifiedProvenance,
+} from "../src/harness/verified-provenance.ts";
+import { VERIFIED_BINDING_METADATA_FIELD } from "@commonfabric/utils/sandbox-contract";
+import {
+  brandTrustedBuilderArtifact,
+  isTrustedBuilderArtifact,
+} from "../src/builder/pattern-metadata.ts";
+import type { JSONSchema, Module, Pattern } from "../src/builder/types.ts";
+import type { HarnessedFunction } from "../src/harness/types.ts";
+
+/**
+ * C5 red-team gate for PR C (content-addressed `$implRef` + CFC provenance) of
+ * docs/specs/content-addressed-action-identity-implementation-plan.md.
+ *
+ * Each test is an attack on a fail-closed property; the assertion is the
+ * defended outcome. The mirror style is test/cfreg-security.test.ts (pin the
+ * runtime trust seams) and test/content-addressed-identity.test.ts (the happy
+ * path these attacks try to subvert).
+ *
+ * The trust model these attacks probe:
+ *   - A function is "verified" ONLY via a provenance WeakMap entry, written by
+ *     two runner-owned channels (trust-gated module indexing, and the in-action
+ *     registrar). An attacker-supplied object never traverses either, so it has
+ *     no entry — there is no string key to collide.
+ *   - `$implRef` in serialized data is a HINT for WHICH genuine indexed artifact
+ *     to run. It can never name a forged executable (only trust-gated artifacts
+ *     are indexed) and it never feeds the CFC identity: identity is computed from
+ *     the RESOLVED function's provenance, so editing the ref cannot borrow
+ *     another module's authority.
+ *   - writeAuthorizedBy is an ownership gate: a verified-binding claim verifies
+ *     only when the resolved identity's moduleIdentity (or legacy bundleId),
+ *     file, AND path all match. Any mismatch — or a claim with neither id field —
+ *     fails closed.
+ */
+
+const signer = await Identity.fromPassphrase("ca-identity-adversarial");
+
+// A handler program with TWO module-scope handlers, so we have two distinct
+// genuine artifacts/identities to cross-wire in the $implRef-confusion attacks.
+const PROGRAM = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: `/// <cts-enable />
+import { handler, pattern, Writable } from "commonfabric";
+
+const setName = handler<{ name?: string }, { name: Writable<string> }>(
+  (event, state) => { state.name.set(event.name ?? ""); },
+);
+
+const setLabel = handler<{ label?: string }, { label: Writable<string> }>(
+  (event, state) => { state.label.set(event.label ?? "L:" + (event.label ?? "")); },
+);
+
+export default pattern(() => {
+  const name = new Writable<string>("").for("name");
+  const label = new Writable<string>("").for("label");
+  return {
+    name,
+    label,
+    setName: setName({ name }),
+    setLabel: setLabel({ label }),
+  };
+});
+`,
+  }],
+};
+
+describe("content-addressed identity — adversarial (C5 red-team gate)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const setup = async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "observe",
+    });
+    const pattern = await runtime.patternManager.compilePattern(PROGRAM);
+    await runtime.idle();
+    return pattern as Pattern;
+  };
+
+  const handlerModules = (pattern: Pattern): Module[] =>
+    pattern.nodes
+      .filter((n) =>
+        (n.module as Module).type === "javascript" &&
+        (n.module as Module).wrapper === "handler"
+      )
+      .map((n) => n.module as Module);
+
+  // ---------------------------------------------------------------------------
+  // Attack 1 — forged function with byte-identical source, built outside eval.
+  // ---------------------------------------------------------------------------
+  describe("attack 1: byte-identical forged function", () => {
+    it("a forged twin (identical source, no eval registration) has no provenance and resolves unsupported", async () => {
+      const pattern = await setup();
+      const real = handlerModules(pattern)[0]
+        .implementation as HarnessedFunction;
+      expect(getVerifiedProvenance(real)).toBeDefined();
+
+      // Reconstruct the exact source bytes OUTSIDE any verified evaluation.
+      const forged = new Function(
+        `return ${Function.prototype.toString.call(real)}`,
+      )() as HarnessedFunction;
+      expect(getVerifiedProvenance(forged)).toBeUndefined();
+
+      const identity = resolvePolicyFacingImplementationIdentity(
+        handlerModules(pattern)[0],
+        {
+          harness: runtime!.harness,
+          verifiedLoadId: "load:forged",
+          implementation: forged,
+        },
+      );
+      // Never "verified": no provenance, no legacy registry entry.
+      expect(identity?.kind).not.toBe("verified");
+    });
+
+    it("a forged twin that ALSO steals the real fn's canonical src still gets no provenance", async () => {
+      const pattern = await setup();
+      const real = handlerModules(pattern)[0]
+        .implementation as HarnessedFunction;
+      const stolenSrc = (real as { src?: string }).src!;
+      expect(stolenSrc).toContain("cf:module/");
+
+      // The forged fn carries the genuine canonical src — but src is just an
+      // own-property; verification keys on the provenance WeakMap, which has no
+      // entry for this object.
+      const forged = Object.assign(
+        new Function(`return ${Function.prototype.toString.call(real)}`)(),
+        { src: stolenSrc },
+      ) as HarnessedFunction;
+      expect(getVerifiedProvenance(forged)).toBeUndefined();
+
+      const identity = resolvePolicyFacingImplementationIdentity(
+        handlerModules(pattern)[0],
+        { harness: runtime!.harness, implementation: forged },
+      );
+      expect(identity?.kind).not.toBe("verified");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Attack 2 — $implRef replay / confusion. State graphs are attacker data.
+  // ---------------------------------------------------------------------------
+  describe("attack 2: $implRef replay/confusion", () => {
+    it("$implRef at a non-existent or host: identity resolves nothing executable (miss → fallback)", async () => {
+      await setup();
+      const pm = runtime!.patternManager;
+      // Never-evaluated identity.
+      expect(pm.artifactFromIdentitySync("not-a-real-identity", "default"))
+        .toBeUndefined();
+      // host:-shaped identity — there is no entry, so a miss.
+      expect(pm.artifactFromIdentitySync("host:evil", "setName"))
+        .toBeUndefined();
+    });
+
+    it("$implRef pointing at a real identity with the WRONG symbol misses (never a forged fn)", async () => {
+      const pattern = await setup();
+      const pm = runtime!.patternManager;
+      const mod = handlerModules(pattern)[0];
+      const prov = getVerifiedProvenance(
+        mod.implementation as HarnessedFunction,
+      )!;
+      // The genuine identity, but a symbol that was never registered under it.
+      expect(
+        pm.artifactFromIdentitySync(prov.identity, "symbol-not-registered"),
+      )
+        .toBeUndefined();
+      // Sanity: the genuine symbol DOES resolve, to a builder artifact (never raw data).
+      const ok = pm.artifactFromIdentitySync(prov.identity, prov.symbol!);
+      expect(ok).toBeDefined();
+      expect(isTrustedBuilderArtifact(ok)).toBe(true);
+    });
+
+    it("CFC identity is computed from the RESOLVED fn's provenance, NOT from $implRef in the data", async () => {
+      const pattern = await setup();
+      const [modA, modB] = handlerModules(pattern);
+      const fnA = modA.implementation as HarnessedFunction;
+      const provA = getVerifiedProvenance(fnA)!;
+      const provB = getVerifiedProvenance(
+        modB.implementation as HarnessedFunction,
+      )!;
+      // The two handlers live in the SAME module, so they share a moduleIdentity;
+      // their distinct `symbol`s are the per-binding discriminator (and what a
+      // verified-binding writeAuthorizedBy claim keys on via bindingPath).
+      expect(provA.identity).toBe(provB.identity);
+      expect(provA.symbol).not.toBe(provB.symbol);
+
+      // Forge module A's serialized graph so its $implRef borrows B's
+      // {identity, symbol} (the classic authority-borrow). State graphs are
+      // attacker-influençable — assume the attacker rewrote the ref freely.
+      const forgedModuleA = {
+        ...modA,
+        $implRef: { identity: provB.identity, symbol: provB.symbol },
+      } as unknown as Module;
+
+      // CFC identity is resolved from the function actually invoked (fnA), never
+      // from the ref in the data: the resolver reads fnA's provenance, so the
+      // policy-facing identity carries A's symbol — the forged ref to B is inert.
+      const identity = resolvePolicyFacingImplementationIdentity(
+        forgedModuleA,
+        {
+          harness: runtime!.harness,
+          implementation: fnA,
+        },
+      );
+      expect(identity?.kind).toBe("verified");
+      const v = identity as {
+        kind: "verified";
+        moduleIdentity?: string;
+        symbol?: string;
+      };
+      expect(v.moduleIdentity).toBe(provA.identity);
+      expect(v.symbol).toBe(provA.symbol);
+      expect(v.symbol).not.toBe(provB.symbol);
+    });
+
+    it("a bad $implRef cannot make a __cf_data-forged value executable: the index never holds one", async () => {
+      const pattern = await setup();
+      const pm = runtime!.patternManager;
+      const prov = getVerifiedProvenance(
+        handlerModules(pattern)[0].implementation as HarnessedFunction,
+      )!;
+      // Whatever the (genuine) identity+symbol resolve to, it is a trusted
+      // builder artifact, never a plain/forged value — that is the only thing a
+      // resolved $implRef can ever hand back.
+      const artifact = pm.artifactFromIdentitySync(prov.identity, prov.symbol!);
+      expect(isTrustedBuilderArtifact(artifact)).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Attack 3 — __cf_data-forged factory shapes through the indexing sink.
+  // ---------------------------------------------------------------------------
+  describe("attack 3: __cf_data-forged factory shapes", () => {
+    it("an unbranded {implementation, __cfVerifiedBindingIdentity} shape is dropped by the trust gate", () => {
+      const forgedFactory = {
+        implementation: function forgedImpl() {},
+        [VERIFIED_BINDING_METADATA_FIELD]: {
+          sourceFile: "/victim.tsx",
+          bindingPath: ["ownerOnlyHandler"],
+        },
+      };
+      // The gate that indexArtifact consults before recording provenance.
+      expect(isTrustedBuilderArtifact(forgedFactory)).toBe(false);
+      // And it carries no provenance (it never went through indexArtifact).
+      expect(getVerifiedProvenance(forgedFactory.implementation))
+        .toBeUndefined();
+    });
+
+    it("even a branded look-alike's nested implementation gains nothing without going through indexArtifact", () => {
+      // brandTrustedBuilderArtifact would let the OBJECT pass the gate, but
+      // provenance for the IMPLEMENTATION fn is written only by indexArtifact /
+      // the in-action registrar — never by branding alone.
+      const fn = function notVerified() {};
+      const branded = brandTrustedBuilderArtifact({
+        implementation: fn,
+        [VERIFIED_BINDING_METADATA_FIELD]: {
+          sourceFile: "/victim.tsx",
+          bindingPath: ["ownerOnlyHandler"],
+        },
+      });
+      expect(isTrustedBuilderArtifact(branded)).toBe(true);
+      expect(getVerifiedProvenance(fn)).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Attack 4 — bindingIdentity spoofing (highest-value: ownership gate).
+  // ---------------------------------------------------------------------------
+  describe("attack 4: bindingIdentity spoofing of writeAuthorizedBy ownership", () => {
+    it("an attacker-chosen __cfVerifiedBindingIdentity on an unbranded factory yields no verified binding", () => {
+      // The factory carries a binding annotation pointing at a victim's
+      // owner-protected cell. Without the trust brand it never reaches
+      // indexArtifact, so readBindingIdentity is never consulted FOR PROVENANCE
+      // and the fn stays unverified.
+      const fn = function attacker() {};
+      const factory = Object.assign(fn, {
+        [VERIFIED_BINDING_METADATA_FIELD]: {
+          sourceFile: "/victim.tsx",
+          bindingPath: ["victimOwnedField"],
+        },
+      });
+      expect(isTrustedBuilderArtifact(factory)).toBe(false);
+      expect(getVerifiedProvenance(factory)).toBeUndefined();
+    });
+
+    it("a verified-binding writeAuthorizedBy claim fails closed when the resolved identity's bindingPath differs", async () => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+        cfcEnforcementMode: "enforce-explicit",
+        trustSnapshotProvider: () => ({
+          id: "ts-attack4",
+          actingPrincipal: signer.did(),
+        }),
+      });
+      const tx = runtime.edit();
+      const schema = {
+        type: "object",
+        properties: {
+          owned: {
+            type: "string",
+            ifc: {
+              writeAuthorizedBy: {
+                __ctWriterIdentityOf: {
+                  // Claim is owned by VICTIM module + path.
+                  moduleIdentity: "victim-module-identity",
+                  file: "/victim.tsx",
+                  path: ["victimOwnedField"],
+                },
+              },
+            },
+          },
+        },
+        required: ["owned"],
+      } as unknown as JSONSchema;
+      const cell = runtime.getCell(signer.did(), "attack4-binding", schema, tx);
+
+      // Attacker's verified identity claims a DIFFERENT module/path (their own).
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity: "attacker-module-identity",
+        sourceFile: "/attacker.tsx",
+        bindingPath: ["attackerOwnedField"],
+      });
+      cell.set({ owned: "stolen" });
+
+      // moduleIdentity, file, AND path must all match; none do → fail closed.
+      const digest = tx.prepareCfc();
+      expect(digest).toBe("");
+      const result = await tx.commit();
+      expect(result.error).toBeDefined();
+    });
+
+    it("the claim's bindingPath cannot be satisfied by a matching moduleIdentity alone (path must also match)", async () => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+        cfcEnforcementMode: "enforce-explicit",
+        trustSnapshotProvider: () => ({
+          id: "ts-attack4b",
+          actingPrincipal: signer.did(),
+        }),
+      });
+      const tx = runtime.edit();
+      const schema = {
+        type: "object",
+        properties: {
+          owned: {
+            type: "string",
+            ifc: {
+              writeAuthorizedBy: {
+                __ctWriterIdentityOf: {
+                  moduleIdentity: "shared-module-identity",
+                  file: "/shared.tsx",
+                  path: ["ownerHandler"],
+                },
+              },
+            },
+          },
+        },
+        required: ["owned"],
+      } as unknown as JSONSchema;
+      const cell = runtime.getCell(
+        signer.did(),
+        "attack4b-binding",
+        schema,
+        tx,
+      );
+
+      // Same module + file, but a DIFFERENT binding (a sibling handler in the
+      // same module must not be able to write the owner's field).
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity: "shared-module-identity",
+        sourceFile: "/shared.tsx",
+        bindingPath: ["someOtherHandler"],
+      });
+      cell.set({ owned: "stolen" });
+
+      const digest = tx.prepareCfc();
+      expect(digest).toBe("");
+      const result = await tx.commit();
+      expect(result.error).toBeDefined();
+    });
+
+    it("an already-stamped claim is NOT re-stamped by a different verified writer (no rebind on stamped claims)", async () => {
+      // The rebind that stamps an unstamped claim no-ops once a claim already
+      // carries an id field. So a stored owner-protected field (claim already
+      // stamped with the OWNER's moduleIdentity) cannot be re-stamped — and thus
+      // cannot be written — by a different verified handler. This is the durable
+      // ownership boundary for pre-existing fields.
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+        cfcEnforcementMode: "enforce-explicit",
+        trustSnapshotProvider: () => ({
+          id: "ts-attack4d",
+          actingPrincipal: signer.did(),
+        }),
+      });
+      const tx = runtime.edit();
+      const schema = {
+        type: "object",
+        properties: {
+          owned: {
+            type: "string",
+            ifc: {
+              writeAuthorizedBy: {
+                __ctWriterIdentityOf: {
+                  // ALREADY stamped to the owner module — not unstamped.
+                  moduleIdentity: "owner-module",
+                  file: "/owner.tsx",
+                  path: ["ownerHandler"],
+                },
+              },
+            },
+          },
+        },
+        required: ["owned"],
+      } as unknown as JSONSchema;
+      const cell = runtime.getCell(
+        signer.did(),
+        "attack4d-binding",
+        schema,
+        tx,
+      );
+      // Different verified writer — the rebind cannot overwrite the owner's stamp.
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity: "attacker-module",
+        sourceFile: "/attacker.tsx",
+        bindingPath: ["attackerHandler"],
+      });
+      cell.set({ owned: "stolen" });
+      const digest = tx.prepareCfc();
+      expect(digest).toBe("");
+      const result = await tx.commit();
+      expect(result.error).toBeDefined();
+    });
+
+    it("a fully matching verified-binding identity is accepted (defense is not vacuous)", async () => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+        cfcEnforcementMode: "enforce-explicit",
+        trustSnapshotProvider: () => ({
+          id: "ts-attack4c",
+          actingPrincipal: signer.did(),
+        }),
+      });
+      const tx = runtime.edit();
+      const schema = {
+        type: "object",
+        properties: {
+          owned: {
+            type: "string",
+            ifc: {
+              writeAuthorizedBy: {
+                __ctWriterIdentityOf: {
+                  moduleIdentity: "match-module-identity",
+                  file: "/match.tsx",
+                  path: ["ownerHandler"],
+                },
+              },
+            },
+          },
+        },
+        required: ["owned"],
+      } as unknown as JSONSchema;
+      const cell = runtime.getCell(
+        signer.did(),
+        "attack4c-binding",
+        schema,
+        tx,
+      );
+
+      tx.setCfcImplementationIdentity({
+        kind: "verified",
+        moduleIdentity: "match-module-identity",
+        sourceFile: "/match.tsx",
+        bindingPath: ["ownerHandler"],
+      });
+      cell.set({ owned: "authorized" });
+
+      const result = await tx.commit();
+      // The writeAuthorizedBy arm passes; any remaining reason would be unrelated
+      // to identity-borrowing. Assert specifically no writeAuthorizedBy failure.
+      if (result.error) {
+        expect(String(result.error)).not.toContain("writeAuthorizedBy");
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Attack 5 — claim forgery in stored schemas (hand-built __ctWriterIdentityOf).
+  // ---------------------------------------------------------------------------
+  describe("attack 5: forged stored writeAuthorizedBy claims", () => {
+    const driveClaim = async (
+      claim: Record<string, unknown>,
+      identity: Record<string, unknown>,
+      name: string,
+    ) => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+        cfcEnforcementMode: "enforce-explicit",
+        trustSnapshotProvider: () => ({
+          id: `ts-${name}`,
+          actingPrincipal: signer.did(),
+        }),
+      });
+      const tx = runtime.edit();
+      const schema = {
+        type: "object",
+        properties: {
+          owned: { type: "string", ifc: { writeAuthorizedBy: claim } },
+        },
+        required: ["owned"],
+      } as unknown as JSONSchema;
+      const cell = runtime.getCell(signer.did(), name, schema, tx);
+      tx.setCfcImplementationIdentity(identity as never);
+      cell.set({ owned: "x" });
+      const digest = tx.prepareCfc();
+      const result = await tx.commit();
+      return { digest, result };
+    };
+
+    it("a claim with moduleIdentity matching but file/path NOT fails closed", async () => {
+      const { digest, result } = await driveClaim(
+        {
+          __ctWriterIdentityOf: {
+            moduleIdentity: "m1",
+            file: "/owner.tsx",
+            path: ["ownerHandler"],
+          },
+        },
+        {
+          kind: "verified",
+          moduleIdentity: "m1", // matches
+          sourceFile: "/attacker.tsx", // does NOT
+          bindingPath: ["attackerHandler"], // does NOT
+        },
+        "attack5-id-match-pathmismatch",
+      );
+      expect(digest).toBe("");
+      expect(result.error).toBeDefined();
+    });
+
+    it("a claim with file/path matching but moduleIdentity NOT fails closed", async () => {
+      const { digest, result } = await driveClaim(
+        {
+          __ctWriterIdentityOf: {
+            moduleIdentity: "owner-module",
+            file: "/owner.tsx",
+            path: ["ownerHandler"],
+          },
+        },
+        {
+          kind: "verified",
+          moduleIdentity: "attacker-module", // does NOT
+          sourceFile: "/owner.tsx", // matches
+          bindingPath: ["ownerHandler"], // matches
+        },
+        "attack5-pathmatch-idmismatch",
+      );
+      expect(digest).toBe("");
+      expect(result.error).toBeDefined();
+    });
+
+    it("a claim carrying NEITHER id field (no moduleIdentity, no bundleId) fails closed against a non-rebinding writer", async () => {
+      // NOTE: a VERIFIED writer would trigger rebindWriteAuthorizedByClaims,
+      // which stamps an UNSTAMPED claim with the writer's own moduleIdentity —
+      // the by-design self-authoring path (a handler authoring its OWN fresh
+      // claim), NOT an attack. To isolate the fail-closed property of a claim
+      // that genuinely carries no id field, use a builtin writer: the rebind
+      // does not fire for non-verified writers, so the verified-binding claim is
+      // checked as-is and cannot match (it demands a verified writer anyway).
+      const { digest, result } = await driveClaim(
+        {
+          __ctWriterIdentityOf: {
+            // No moduleIdentity, no bundleId.
+            file: "/owner.tsx",
+            path: ["ownerHandler"],
+          },
+        },
+        { kind: "builtin", builtinId: "someBuiltin" },
+        "attack5-no-id-field",
+      );
+      expect(digest).toBe("");
+      expect(result.error).toBeDefined();
+    });
+
+    it("an unstamped claim authored by a verified writer is stamped to THAT writer (self-authoring, not borrowing)", async () => {
+      // The flip side of the note above, pinned explicitly: when a verified
+      // handler writes a field whose claim has no id field yet, the claim is
+      // bound to the writer's own moduleIdentity/file/path. This is the
+      // legitimate creation step; it does NOT let the writer borrow a DIFFERENT
+      // owner's authority, because the stamp is the writer's own identity. (The
+      // borrow attempts — wrong moduleIdentity / wrong path against an ALREADY
+      // STAMPED claim — are the failing cases above.)
+      const { digest, result } = await driveClaim(
+        {
+          __ctWriterIdentityOf: { file: "/self.tsx", path: ["selfHandler"] },
+        },
+        {
+          kind: "verified",
+          moduleIdentity: "self-module",
+          sourceFile: "/self.tsx",
+          bindingPath: ["selfHandler"],
+        },
+        "attack5-self-authoring",
+      );
+      // Accepted: the writer authored its own claim (file/path agree with the
+      // writer's identity, and the missing id field is stamped to self).
+      if (result.error) {
+        expect(String(result.error)).not.toContain("writeAuthorizedBy");
+      }
+      expect(typeof digest).toBe("string");
+    });
+
+    it("a legacy claim (bundleId only) does NOT match a moduleIdentity-only identity (no cross-arm confusion)", async () => {
+      const { digest, result } = await driveClaim(
+        {
+          __ctWriterIdentityOf: {
+            bundleId: "legacy-bundle", // legacy arm only
+            file: "/owner.tsx",
+            path: ["ownerHandler"],
+          },
+        },
+        {
+          kind: "verified",
+          // moduleIdentity present but the identity carries NO bundleId, so the
+          // legacy (bundleId) arm the claim selects cannot be satisfied.
+          moduleIdentity: "legacy-bundle", // must not be read as a bundleId
+          sourceFile: "/owner.tsx",
+          bindingPath: ["ownerHandler"],
+        },
+        "attack5-bundleid-arm-no-confusion",
+      );
+      expect(digest).toBe("");
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Attack 6 — fn.src spoofing vs the provenance identity.
+  // ---------------------------------------------------------------------------
+  describe("attack 6: fn.src spoofing", () => {
+    // These probe resolveProvenanceImplementationIdentity directly: we fabricate
+    // a provenance entry (the trusted channel's effect) on a function WE control,
+    // then mismatch its src. recordVerifiedProvenance is the exact write the real
+    // indexer performs; here we use it to isolate the src↔provenance check.
+
+    it("a verified fn whose src names a DIFFERENT module than its provenance fails closed", () => {
+      const fn = Object.assign(() => undefined, {
+        src: "cf:module/REAL_MODULE_A/main.tsx:4:12",
+      });
+      recordVerifiedProvenance(fn, {
+        identity: "REAL_MODULE_A",
+        symbol: "ownerHandler",
+      });
+      // Now spoof src to claim it belongs to a different (victim) module.
+      (fn as { src: string }).src = "cf:module/VICTIM_MODULE_B/main.tsx:4:12";
+
+      const identity = resolvePolicyFacingImplementationIdentity(
+        { type: "javascript" } as Module,
+        { harness: runtime?.harness, implementation: fn },
+      );
+      expect(identity?.kind).toBe("unsupported");
+    });
+
+    it("a verified fn whose src OMITS the cf:module prefix fails closed (no identity to extract)", () => {
+      const fn = Object.assign(() => undefined, {
+        src: "/main.tsx:4:12", // no cf:module/<hash>/ prefix
+      });
+      recordVerifiedProvenance(fn, {
+        identity: "SOME_MODULE",
+        symbol: "ownerHandler",
+      });
+      const identity = resolvePolicyFacingImplementationIdentity(
+        { type: "javascript" } as Module,
+        { harness: runtime?.harness, implementation: fn },
+      );
+      // identityFromCanonicalSource("/main.tsx...") is undefined ≠ provenance id.
+      expect(identity?.kind).toBe("unsupported");
+    });
+
+    it("a verified fn whose src matches its provenance resolves verified (check is not vacuous)", () => {
+      const fn = Object.assign(() => undefined, {
+        src: "cf:module/CONSISTENT_MODULE/main.tsx:7:3",
+      });
+      recordVerifiedProvenance(fn, {
+        identity: "CONSISTENT_MODULE",
+        symbol: "ownerHandler",
+      });
+      const identity = resolvePolicyFacingImplementationIdentity(
+        { type: "javascript" } as Module,
+        { harness: runtime?.harness, implementation: fn },
+      );
+      expect(identity?.kind).toBe("verified");
+      const v = identity as { kind: "verified"; moduleIdentity?: string };
+      expect(v.moduleIdentity).toBe("CONSISTENT_MODULE");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Attack 7 — dynamic (in-action-minted) artifact path.
+  // ---------------------------------------------------------------------------
+  describe("attack 7: dynamic in-session artifacts", () => {
+    it("a dynamic-provenance fn with consistent src resolves verified but carries no symbol (no cross-session ref)", () => {
+      const fn = Object.assign(() => undefined, {
+        src: "cf:module/DYN_MODULE/main.tsx:2:1",
+      });
+      // Mirrors the in-action registrar: identity from canonical src, dynamic,
+      // NO symbol.
+      recordVerifiedProvenance(fn, { identity: "DYN_MODULE", dynamic: true });
+
+      const identity = resolvePolicyFacingImplementationIdentity(
+        { type: "javascript" } as Module,
+        { harness: runtime?.harness, implementation: fn },
+      );
+      // It is verified IN SESSION (the provenance exists and src matches)...
+      expect(identity?.kind).toBe("verified");
+      const v = identity as { kind: "verified"; symbol?: string };
+      // ...but carries no symbol, so it serializes WITHOUT a resolvable $implRef
+      // — i.e. no cross-session authority (it cannot be re-resolved on reload).
+      expect(v.symbol).toBeUndefined();
+      expect(getVerifiedProvenance(fn)!.symbol).toBeUndefined();
+    });
+
+    it("a dynamic-provenance fn whose src disagrees with its identity still fails closed", () => {
+      const fn = Object.assign(() => undefined, {
+        src: "cf:module/OTHER_MODULE/main.tsx:2:1",
+      });
+      recordVerifiedProvenance(fn, { identity: "DYN_MODULE", dynamic: true });
+      const identity = resolvePolicyFacingImplementationIdentity(
+        { type: "javascript" } as Module,
+        { harness: runtime?.harness, implementation: fn },
+      );
+      expect(identity?.kind).toBe("unsupported");
+    });
+
+    it("a dynamic artifact (no symbol) serializes without $implRef", async () => {
+      // moduleToJSON only emits $implRef when provenance.symbol is present, so a
+      // dynamic (symbol-less) artifact never gets a serialized, reload-resolvable
+      // reference — confirming in-session-only authority on the serialization seam.
+      const pattern = await setup();
+      const mod = handlerModules(pattern)[0];
+      const fn = mod.implementation as HarnessedFunction;
+      // Drop the real (symbol-bearing) entry by GC isn't possible; instead build
+      // a fresh fn with only dynamic provenance and a module shaped like the real
+      // one, then serialize it.
+      const dyn = Object.assign(function dynImpl() {}, {
+        src: (fn as { src?: string }).src,
+        implementationRef: "dyn-ref",
+      });
+      recordVerifiedProvenance(dyn, {
+        identity: getVerifiedProvenance(fn)!.identity,
+        dynamic: true,
+      });
+      const dynModule = {
+        type: "javascript" as const,
+        implementation: dyn,
+        implementationRef: "dyn-ref",
+        toJSON: undefined as unknown,
+      };
+      // moduleToJSON is reached via the builder; call the same path the real
+      // module uses. We re-import it lazily to avoid widening the import surface.
+      const { moduleToJSON } = await import("../src/builder/json-utils.ts");
+      const json = moduleToJSON(dynModule as unknown as Module) as Record<
+        string,
+        unknown
+      >;
+      expect(json.$implRef).toBeUndefined();
+    });
+  });
+});

--- a/packages/runner/test/content-addressed-identity.test.ts
+++ b/packages/runner/test/content-addressed-identity.test.ts
@@ -169,3 +169,48 @@ describe("content-addressed action identity", () => {
     expect(missing).toBeUndefined();
   });
 });
+
+describe("provenance bundleId fallback (legacy claim compat)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  it("falls back to verifiedLoadId when the bundle id is unregistered", async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "observe",
+    });
+    const pattern = await runtime.patternManager.compilePattern(PROGRAM);
+    await runtime.idle();
+    const node = pattern.nodes.find((n) =>
+      (n.module as Module).type === "javascript" &&
+      (n.module as Module).wrapper === "handler"
+    );
+    const module = node!.module as Module;
+    const fn = module.implementation as HarnessedFunction;
+
+    // A harness whose getVerifiedBundleId MISSES (legacy stamp-time scenario):
+    // the resolved identity's bundleId must mirror the legacy resolver and
+    // fall back to the raw verifiedLoadId, so a legacy bundleId-only
+    // writeAuthorizedBy claim stamped with that value still verifies.
+    const identity = resolvePolicyFacingImplementationIdentity(module, {
+      harness: {
+        getVerifiedBundleId: () => undefined,
+      } as never,
+      verifiedLoadId: "load:legacy-bundle",
+      implementation: fn,
+    });
+    expect(identity?.kind).toBe("verified");
+    expect((identity as { bundleId?: string }).bundleId).toBe(
+      "load:legacy-bundle",
+    );
+  });
+});

--- a/packages/runner/test/content-addressed-identity.test.ts
+++ b/packages/runner/test/content-addressed-identity.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
+import { getVerifiedProvenance } from "../src/harness/verified-provenance.ts";
+import type { Module, Pattern } from "../src/builder/types.ts";
+import type { HarnessedFunction } from "../src/harness/types.ts";
+
+/**
+ * PR C of docs/specs/content-addressed-action-identity-implementation-plan.md:
+ * content-addressed `$implRef` dual-write + CFC provenance.
+ *
+ * - Functions become "verified" by being registered through the trust-gated
+ *   module indexing during evaluation; their provenance carries the defining
+ *   module's content identity and the artifact's export/`__cfReg` symbol.
+ * - Serialized javascript modules carry `$implRef: { identity, symbol }`
+ *   (alongside the legacy `implementationRef` until the flip).
+ * - CFC policy identity resolves from the provenance (`moduleIdentity`,
+ *   reload-stable) with the legacy registry as fallback; a forged function —
+ *   even with byte-identical source — has no provenance and fails closed.
+ */
+
+const signer = await Identity.fromPassphrase("content-addressed-identity");
+
+const PROGRAM = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: `/// <cts-enable />
+import { handler, pattern, Writable } from "commonfabric";
+
+const setName = handler<{ name?: string }, { name: Writable<string> }>(
+  (event, state) => { state.name.set(event.name ?? ""); },
+);
+
+export default pattern(() => {
+  const name = new Writable<string>("").for("name");
+  return { name, setName: setName({ name }) };
+});
+`,
+  }],
+};
+
+describe("content-addressed action identity", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const setup = async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "observe",
+    });
+    const pattern = await runtime.patternManager.compilePattern(PROGRAM);
+    await runtime.idle();
+    return pattern as Pattern;
+  };
+
+  const handlerModuleOf = (pattern: Pattern): Module => {
+    const node = pattern.nodes.find((n) =>
+      (n.module as Module).type === "javascript" &&
+      (n.module as Module).wrapper === "handler"
+    );
+    expect(node).toBeDefined();
+    return node!.module as Module;
+  };
+
+  it("records provenance for compiled module-scope artifacts", async () => {
+    const pattern = await setup();
+    const module = handlerModuleOf(pattern);
+    const fn = module.implementation as HarnessedFunction;
+    expect(typeof fn).toBe("function");
+
+    const provenance = getVerifiedProvenance(fn);
+    expect(provenance).toBeDefined();
+    expect(typeof provenance!.identity).toBe("string");
+    expect(provenance!.identity.length).toBeGreaterThan(0);
+    // The non-exported `bump` handler registers via the transformer's
+    // `__cfReg` hoist; its symbol is the hoist/binding name.
+    expect(typeof provenance!.symbol).toBe("string");
+    // The canonical fn.src points into the same module identity.
+    expect((fn as { src?: string }).src ?? "").toContain(
+      `cf:module/${provenance!.identity}`,
+    );
+  });
+
+  it("serializes javascript modules with $implRef (dual-write)", async () => {
+    const pattern = await setup();
+    const module = handlerModuleOf(pattern);
+    const json = (module as Module & { toJSON?: () => unknown }).toJSON
+      ? (module as Module & { toJSON: () => unknown }).toJSON() as Record<
+        string,
+        unknown
+      >
+      : JSON.parse(JSON.stringify(module));
+
+    const ref = json.$implRef as { identity: string; symbol: string };
+    expect(ref).toBeDefined();
+    const provenance = getVerifiedProvenance(
+      module.implementation as HarnessedFunction,
+    )!;
+    expect(ref.identity).toBe(provenance.identity);
+    expect(ref.symbol).toBe(provenance.symbol);
+    // Legacy field still written during the dual-write window.
+    expect(typeof json.implementationRef).toBe("string");
+  });
+
+  it("CFC identity resolves from provenance with a stable moduleIdentity", async () => {
+    const pattern = await setup();
+    const module = handlerModuleOf(pattern);
+    const fn = module.implementation as HarnessedFunction;
+
+    const identity = resolvePolicyFacingImplementationIdentity(module, {
+      harness: runtime!.harness,
+      implementation: fn,
+    });
+    expect(identity).toBeDefined();
+    expect(identity!.kind).toBe("verified");
+    const verified = identity as {
+      kind: "verified";
+      moduleIdentity?: string;
+      sourceLocation?: { line: number; column: number };
+    };
+    expect(verified.moduleIdentity).toBe(getVerifiedProvenance(fn)!.identity);
+    expect(verified.sourceLocation).toBeDefined();
+  });
+
+  it("a forged function with identical source fails closed", async () => {
+    const pattern = await setup();
+    const module = handlerModuleOf(pattern);
+    const fn = module.implementation as HarnessedFunction;
+
+    // Byte-identical source text, constructed OUTSIDE verified evaluation:
+    // no provenance entry, no registry entry — `unsupported`, never
+    // `verified`.
+    const forged = new Function(
+      `return ${Function.prototype.toString.call(fn)}`,
+    )() as HarnessedFunction;
+    expect(getVerifiedProvenance(forged)).toBeUndefined();
+
+    const identity = resolvePolicyFacingImplementationIdentity(module, {
+      harness: runtime!.harness,
+      verifiedLoadId: "load:forged",
+      implementation: forged,
+    });
+    expect(identity?.kind).toBe("unsupported");
+  });
+
+  it("$implRef from a stale/foreign ref resolves nothing executable", async () => {
+    await setup();
+    // A ref pointing at an identity that was never evaluated resolves to
+    // undefined in the index — the resolver falls back (legacy ref or
+    // stringified source); it can never make non-builder data executable
+    // because only trust-gated artifacts are indexed.
+    const missing = runtime!.patternManager.artifactFromIdentitySync(
+      "not-a-real-identity",
+      "default",
+    );
+    expect(missing).toBeUndefined();
+  });
+});

--- a/packages/runner/test/reexport-provenance.test.ts
+++ b/packages/runner/test/reexport-provenance.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
+import { getVerifiedProvenance } from "../src/harness/verified-provenance.ts";
+import type { Module, Pattern } from "../src/builder/types.ts";
+import type { HarnessedFunction } from "../src/harness/types.ts";
+
+/**
+ * Regression for the re-export provenance hazard (Codex review of PR C, fixed
+ * with the source-identity guard in `Engine.recordModuleProvenance`):
+ *
+ * A re-exporting module (`export { setName } from "./handlers"`) surfaces the
+ * defining module's function under the RE-EXPORTER's identity. Provenance is
+ * first-write-wins and CFC fails closed on an identity/`fn.src` mismatch, so
+ * letting the re-exporter (potentially visited first) stamp its own identity
+ * would make a genuinely-verified handler resolve as `unsupported`. The guard
+ * records provenance only when the function's canonical `fn.src` names the
+ * recording module, so only the defining module's registration sticks.
+ */
+
+const signer = await Identity.fromPassphrase("reexport-provenance");
+
+const PROGRAM = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/handlers.tsx",
+      contents: `/// <cts-enable />
+import { handler, Writable } from "commonfabric";
+export const setName = handler<{ name?: string }, { name: Writable<string> }>(
+  (event, state) => { state.name.set(event.name ?? ""); },
+);
+`,
+    },
+    {
+      // The entry re-exports the handler AND uses it, so the entry module is
+      // evaluated/indexed and surfaces `setName` under its own identity.
+      name: "/main.tsx",
+      contents: `/// <cts-enable />
+import { pattern, Writable } from "commonfabric";
+import { setName } from "./handlers.tsx";
+export { setName } from "./handlers.tsx";
+export default pattern(() => {
+  const name = new Writable<string>("").for("name");
+  return { name, setName: setName({ name }) };
+});
+`,
+    },
+  ],
+};
+
+describe("re-export provenance", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  it("a re-exported handler still resolves as verified (defining identity wins)", async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "observe",
+    });
+
+    const pattern = await runtime.patternManager.compilePattern(
+      PROGRAM,
+    ) as Pattern;
+    await runtime.idle();
+
+    const node = pattern.nodes.find((n) =>
+      (n.module as Module).type === "javascript" &&
+      (n.module as Module).wrapper === "handler"
+    );
+    expect(node).toBeDefined();
+    const module = node!.module as Module;
+    const fn = module.implementation as HarnessedFunction;
+
+    // Provenance identity matches the function's own canonical source — the
+    // DEFINING module (handlers.tsx), never the re-exporting entry.
+    const provenance = getVerifiedProvenance(fn);
+    expect(provenance).toBeDefined();
+    expect((fn as { src?: string }).src ?? "").toContain(
+      `cf:module/${provenance!.identity}`,
+    );
+
+    // CFC resolves it as verified — NOT unsupported (the bug would have made a
+    // re-exporter's identity stamp it, failing the fn.src consistency check).
+    const identity = resolvePolicyFacingImplementationIdentity(module, {
+      harness: runtime.harness,
+      implementation: fn,
+    });
+    expect(identity?.kind).toBe("verified");
+  });
+});


### PR DESCRIPTION
PR C of the content-addressed action identity plan ([plan](https://github.com/commontoolsinc/labs/blob/main/docs/specs/content-addressed-action-identity-implementation-plan.md), design: `docs/specs/content-addressed-action-identity.md`). Stacked on A (#4006) + B (#4008), both merged.

Routes verified-function identity through the content-addressed `{identity, symbol}` model, dual-written with the legacy `implementationRef` so nothing flips yet.

**New provenance side table** (`harness/verified-provenance.ts`): `WeakMap<Function, {identity, symbol, bindingIdentity?, dynamic?}>`, populated by (1) the trust-gated module indexing (`indexArtifact`) for exported/`__cfReg` artifacts and (2) the in-action registrar for artifacts created during a verified action (identity from the fn's canonical `cf:module` src; in-session only, marked `dynamic`). **The WeakMap is the anti-spoof proof** — a forged function, even with byte-identical source, has no entry.

**Found while building**: `handlerInternal` never branded its factories — `createNodeFactory`'s brand comment always claimed handler coverage, but handler factories are built in a different function and bypassed it. That's exactly why non-exported handlers weren't `{identity, symbol}`-addressable and `implementationRef` stayed load-bearing. Now branded.

**Serialization / resolution**: `moduleToJSON` dual-writes `$implRef`; `resolveJavaScriptFunction` resolves `$implRef` → `artifactFromIdentitySync` first, then the legacy ref registry, then the stringified-source SES fallback.

**CFC identity**: `resolvePolicyFacingImplementationIdentity` prefers fn provenance (no load scoping), emitting `moduleIdentity` (reload-stable, robust to unrelated module changes — strictly better than the per-program `bundleId`), **failing closed when `fn.src` disagrees with the provenance module**; legacy ref×loadId path retained as fallback.

**Persisted `writeAuthorizedBy` claims** (`cfc/prepare.ts`): stamped with BOTH `moduleIdentity` and `bundleId`; verification accepts the moduleIdentity arm, or the bundleId arm for legacy stored claims, fail-closed on either mismatch. This is the data-migration piece — `bundleId` retires at the flip (PR E).

### Security — C5 red-team gate

An adversarial review (oracle agent) attacked the model and landed every probe as a test (`content-addressed-identity-adversarial.test.ts`, 31 steps): byte-identical forged functions, `$implRef` replay/cross-identity laundering (CFC identity comes from the *resolved* fn's provenance, never the ref in the data), `__cf_data`-forged factory shapes, bindingIdentity spoofing of `writeAuthorizedBy` (the ownership gate), forged stored claims, `fn.src` spoofing, and the dynamic-artifact path. **Verdict: all fail closed, no holes.**

### Tests
- `content-addressed-identity.test.ts` — provenance registration, `$implRef` dual-write, `moduleIdentity` stability, forged-identical-source fail-closed, stale-ref non-resolution.
- `content-addressed-identity-adversarial.test.ts` — the C5 suite (31 steps).
- CT-1665 binding-metadata test ported to the channel-agnostic transaction seam (the writer identity actually stamped), since the harness binding-metadata channel it spied on is now bypassed for non-exported handlers.

Runner suite: **572 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds content-addressed `$implRef` for JavaScript modules and a provenance-backed, spoof-resistant CFC identity that prefers `moduleIdentity`. Legacy behavior is preserved via dual write/read and `bundleId` compatibility.

- **New Features**
  - Dual-write `$implRef: { identity, symbol }` in `moduleToJSON`; Runner resolves in order: `$implRef` → legacy `implementationRef` → stringified source. Dynamic artifacts (no `symbol`) stay in-session and serialize without `$implRef`.
  - Provenance WeakMap keyed by function, populated by trust-gated indexing and the in-action registrar; `handlerInternal` now brands factories so non-exported handlers are indexable.
  - CFC identity resolves from function provenance and emits `moduleIdentity` (+`symbol`, plus `bundleId` for legacy verification). Fails closed when canonical `fn.src` disagrees with the provenance module; legacy `implementationRef × verifiedLoadId` path retained as fallback.
  - `writeAuthorizedBy` claims are stamped with both `moduleIdentity` and `bundleId`; verification accepts either arm and rejects claims with neither.

- **Bug Fixes**
  - Re-export provenance guard: record provenance only when a function’s canonical `fn.src` names the recording module, preventing re-exported modules from stamping the wrong identity.
  - Restored provenance-path `bundleId` fallback to `verifiedLoadId` so legacy bundleId-only claims (stamped before `moduleIdentity`) continue to verify when the bundle id is unregistered.

<sup>Written for commit 1c3b03ec6292c69f21bfe72efe87c8489f9ebf0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

