### PR TITLE
feat(cli): expectNonIdempotent fails when no violation is detected

### DIFF
--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -3,7 +3,7 @@
   "tasks": {
     "cli": "deno run --allow-run --allow-env --allow-read ./launcher.ts --labs-root ../.. --config ../../deno.json --cli-entrypoint ./mod.ts --",
     "cli-no-pwd-override": "CF_CLI_NAME=cf deno run --allow-net --allow-ffi --allow-read --allow-write --allow-env --allow-run ./mod.ts",
-    "test": "deno test --allow-ffi --allow-read --allow-write --allow-run --allow-env test/*.test.ts",
+    "test": "deno test --allow-ffi --allow-read --allow-write --allow-run --allow-env --allow-net=127.0.0.1 test/*.test.ts",
     "integration": "CF_CLI_INTEGRATION_USE_LOCAL=1 CF_LOG_LEVEL=error ./integration/integration.sh",
     "fuse-integration": "CF_CLI_INTEGRATION_USE_LOCAL=1 CF_LOG_LEVEL=error ./integration/fuse-exec.sh",
     "acl-integration": "CF_CLI_INTEGRATION_USE_LOCAL=1 CF_LOG_LEVEL=error ./integration/acl.sh"

--- a/packages/cli/lib/multi-user-test-runner.ts
+++ b/packages/cli/lib/multi-user-test-runner.ts
@@ -355,6 +355,8 @@ export async function runMultiUserTestPattern(
     // participant opting out must not mask another participant's failures —
     // so the aggregate result reports only unallowed entries with the flags
     // left off.
+    let anyExpectNonIdempotent = false;
+    let expectedNonIdempotentDetected = false;
     for (const participant of participants) {
       const health = await participant.worker.call("health") as {
         runtimeErrors: string[];
@@ -365,11 +367,30 @@ export async function runMultiUserTestPattern(
           ...health.runtimeErrors.map((e) => `[${participant.spec.name}] ${e}`),
         );
       }
-      if (!participant.expectNonIdempotent) {
+      if (participant.expectNonIdempotent) {
+        anyExpectNonIdempotent = true;
+        if (health.nonIdempotent.length > 0) {
+          expectedNonIdempotentDetected = true;
+        }
+      } else {
         nonIdempotent.push(
           ...health.nonIdempotent.map((e) => `[${participant.spec.name}] ${e}`),
         );
       }
+    }
+    // expectNonIdempotent asserts the detector fires. Which runtime re-runs
+    // the offending computation depends on sync/scheduling, so the
+    // expectation is satisfied when ANY flagged participant saw a violation;
+    // it fails as a synthetic result when none did (the aggregate's flag
+    // field stays unset, so runTests applies no result-level expectation).
+    if (anyExpectNonIdempotent && !expectedNonIdempotentDetected) {
+      results.push({
+        name: "expectNonIdempotent",
+        passed: false,
+        afterAction: null,
+        error: "expected non-idempotent computation(s), none detected",
+        durationMs: 0,
+      });
     }
 
     return {

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -199,7 +199,9 @@ export interface TestRunResult {
   allowRuntimeErrors?: boolean;
   /** Non-idempotent computation names detected by the idempotency check */
   nonIdempotent: string[];
-  /** If true, non-idempotent computations are expected and should not fail the test */
+  /** If true, non-idempotent computations are expected: detected violations
+   * don't fail the test, and detecting NONE fails it (the flag asserts the
+   * detector fires; it is not a mere tolerance). */
   expectNonIdempotent?: boolean;
 }
 
@@ -1577,6 +1579,13 @@ export async function runTests(
             console.log(`    ${name}`);
           }
         }
+      } else if (result.expectNonIdempotent) {
+        // The flag asserts the detector fires — passing silently here would
+        // let detection regressions defang the non-idempotent fixtures.
+        totalFailed++;
+        console.log(
+          "  ✗ expected non-idempotent computation(s), none detected",
+        );
       }
 
       // Report runtime errors

--- a/packages/cli/test/fixtures/expect-non-idempotent/expected-and-violating.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/expected-and-violating.test.tsx
@@ -1,11 +1,7 @@
 /**
- * Test that exercises a non-idempotent accumulator computation.
- * expectNonIdempotent asserts the idempotency check detects it; the test
- * FAILS if no violation is reported. Detection is deterministic here: the
- * computation reads the log it appends to, so the recheck always writes one
- * more entry than the run it verifies.
- *
- * Run: deno task cf test packages/patterns/test/non-idempotent/accumulator.test.tsx --verbose
+ * expectNonIdempotent: true on a genuinely non-idempotent accumulator
+ * (same shape as packages/patterns/test/non-idempotent/accumulator.test.tsx).
+ * The detected violation satisfies the expectation, so this test must PASS.
  */
 import { computed, pattern, Writable } from "commonfabric";
 
@@ -19,7 +15,6 @@ export default pattern(() => {
     log.set([...current, `${value.get()} at run #${current.length + 1}`]);
   });
 
-  // Trivial assertion: log should have at least one entry after initial run
   const hasEntries = computed(() => log.get().length > 0);
 
   return {

--- a/packages/cli/test/fixtures/expect-non-idempotent/expected-but-idempotent.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/expected-but-idempotent.test.tsx
@@ -1,0 +1,19 @@
+/**
+ * expectNonIdempotent: true on a trivially idempotent pattern.
+ *
+ * The flag asserts that the idempotency detector fires, so this test must
+ * FAIL with "expected non-idempotent computation(s), none detected" — a
+ * silent pass here is exactly the detection regression the flag guards.
+ */
+import { computed, pattern, Writable } from "commonfabric";
+
+export default pattern(() => {
+  const value = new Writable("hello");
+
+  const ok = computed(() => value.get() === "hello");
+
+  return {
+    tests: [{ assertion: ok }],
+    expectNonIdempotent: true,
+  };
+});

--- a/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-but-idempotent.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-but-idempotent.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * Multi-user: alice sets expectNonIdempotent: true but both participants are
+ * trivially idempotent. No flagged participant sees a violation, so the run
+ * must FAIL with the synthetic "expectNonIdempotent" result.
+ */
+import { computed, multiUserTest, pattern, Writable } from "commonfabric";
+
+export const alice = pattern(() => {
+  const value = new Writable("alice");
+  const ok = computed(() => value.get() === "alice");
+  return {
+    tests: [{ assertion: ok }],
+    expectNonIdempotent: true,
+  };
+});
+
+export const bob = pattern(() => {
+  const value = new Writable("bob");
+  const ok = computed(() => value.get() === "bob");
+  return {
+    tests: [{ assertion: ok }],
+  };
+});
+
+export default multiUserTest({ participants: { alice, bob } });

--- a/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-one-violation.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/multi-user-expected-one-violation.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * Multi-user: both participants set expectNonIdempotent: true, but only
+ * alice's pattern is actually non-idempotent. Which runtime re-runs the
+ * offending computation depends on scheduling, so ONE flagged participant
+ * seeing a violation satisfies the expectation — the run must PASS even
+ * though bob (also flagged) saw none.
+ */
+import { computed, multiUserTest, pattern, Writable } from "commonfabric";
+
+export const alice = pattern(() => {
+  const value = new Writable("alice");
+  const log = new Writable<string[]>([]);
+
+  // Non-idempotent: appends to log on every re-execution
+  computed(() => {
+    const current = log.get();
+    log.set([...current, `${value.get()} at run #${current.length + 1}`]);
+  });
+
+  const hasEntries = computed(() => log.get().length > 0);
+  return {
+    tests: [{ assertion: hasEntries }],
+    expectNonIdempotent: true,
+  };
+});
+
+export const bob = pattern(() => {
+  const value = new Writable("bob");
+  const ok = computed(() => value.get() === "bob");
+  return {
+    tests: [{ assertion: ok }],
+    expectNonIdempotent: true,
+  };
+});
+
+export default multiUserTest({ participants: { alice, bob } });

--- a/packages/cli/test/fixtures/expect-non-idempotent/unexpected-violation.test.tsx
+++ b/packages/cli/test/fixtures/expect-non-idempotent/unexpected-violation.test.tsx
@@ -1,0 +1,22 @@
+/**
+ * A non-idempotent accumulator WITHOUT expectNonIdempotent. The detected
+ * violation must FAIL the test (the long-standing default behavior).
+ */
+import { computed, pattern, Writable } from "commonfabric";
+
+export default pattern(() => {
+  const value = new Writable("hello");
+  const log = new Writable<string[]>([]);
+
+  // Non-idempotent: appends to log on every re-execution
+  computed(() => {
+    const current = log.get();
+    log.set([...current, `${value.get()} at run #${current.length + 1}`]);
+  });
+
+  const hasEntries = computed(() => log.get().length > 0);
+
+  return {
+    tests: [{ assertion: hasEntries }],
+  };
+});

--- a/packages/cli/test/test-runner-expect-non-idempotent.test.ts
+++ b/packages/cli/test/test-runner-expect-non-idempotent.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Integration-level guard for the `expectNonIdempotent` test-flag semantics.
+ *
+ * The flag is an ASSERTION that the idempotency detector fires, not a mere
+ * tolerance: a flagged test must FAIL when zero violations are detected
+ * (otherwise a detection regression silently defangs the fixtures in
+ * packages/patterns/test/non-idempotent/), and must keep PASSING when
+ * violations are present. Covers both the single-runtime path (runTests
+ * reporting) and the multi-user orchestrator (per-participant aggregation,
+ * where ANY flagged participant seeing a violation satisfies the
+ * expectation).
+ */
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { resolve } from "@std/path";
+import { runTests } from "../lib/test-runner.ts";
+
+const FIXTURES = resolve(
+  import.meta.dirname!,
+  "fixtures/expect-non-idempotent",
+);
+
+function fixture(name: string): string {
+  return resolve(FIXTURES, name);
+}
+
+describe(
+  "expectNonIdempotent semantics",
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    it("fails when flagged but no violation is detected", async () => {
+      const { passed, failed } = await runTests(
+        fixture("expected-but-idempotent.test.tsx"),
+        { root: FIXTURES },
+      );
+      // The fixture's own assertion passes; the unmet expectation must add
+      // exactly one failure.
+      expect(passed).toBe(1);
+      expect(failed).toBe(1);
+    });
+
+    it("passes when flagged and a violation is detected", async () => {
+      const { passed, failed } = await runTests(
+        fixture("expected-and-violating.test.tsx"),
+        { root: FIXTURES },
+      );
+      expect(passed).toBe(1);
+      expect(failed).toBe(0);
+    });
+
+    it("still fails on unexpected violations (no flag)", async () => {
+      const { failed } = await runTests(
+        fixture("unexpected-violation.test.tsx"),
+        { root: FIXTURES },
+      );
+      expect(failed).toBeGreaterThan(0);
+    });
+
+    it("multi-user: fails when no flagged participant saw a violation", async () => {
+      const { passed, failed } = await runTests(
+        fixture("multi-user-expected-but-idempotent.test.tsx"),
+        { root: FIXTURES },
+      );
+      // Both participants' own assertions pass; the unmet expectation must
+      // add exactly one synthetic failure.
+      expect(passed).toBe(2);
+      expect(failed).toBe(1);
+    });
+
+    it("multi-user: passes when any flagged participant saw a violation", async () => {
+      const { passed, failed } = await runTests(
+        fixture("multi-user-expected-one-violation.test.tsx"),
+        { root: FIXTURES },
+      );
+      expect(passed).toBe(2);
+      expect(failed).toBe(0);
+    });
+  },
+);

--- a/packages/patterns/test/non-idempotent/set-to-array.test.tsx
+++ b/packages/patterns/test/non-idempotent/set-to-array.test.tsx
@@ -1,11 +1,21 @@
 /**
  * Test that exercises a non-idempotent Set-to-Array computation.
- * Random sort before Set insertion changes iteration order each run.
- * The idempotency check in cf test should warn about it.
+ * Insertion order into the Set depends on the previous output (a cell this
+ * computation also writes), so the Set's first-occurrence iteration order —
+ * and the array written from it — flips on every run. expectNonIdempotent
+ * asserts the idempotency check detects this; the test FAILS if no
+ * violation is reported.
+ *
+ * Deliberately NOT a random shuffle: with only two distinct tags a random
+ * order repeats itself about half the time, letting the detector's
+ * synchronous recheck see identical writes and miss. Deriving the order
+ * from the previous output makes consecutive runs differ with certainty
+ * (module-level mutable state would be the obvious alternative, but SES
+ * mode rejects top-level `let`).
  *
  * Run: deno task cf test packages/patterns/test/non-idempotent/set-to-array.test.tsx --verbose
  */
-import { computed, nonPrivateRandom, pattern, Writable } from "commonfabric";
+import { computed, pattern, Writable } from "commonfabric";
 
 export default pattern(() => {
   const items = new Writable([
@@ -16,11 +26,15 @@ export default pattern(() => {
   ]);
   const uniqueTags = new Writable<string[]>([]);
 
-  // Non-idempotent: random sort before Set changes iteration order
+  // Non-idempotent: insertion order flips whenever the previous output
+  // already starts with the natural first tag, so the Set's iteration
+  // order alternates [fruit, vegetable] / [vegetable, fruit] between
+  // consecutive runs.
   computed(() => {
     const tags = items.get().map((i) => i.tag);
-    const shuffled = tags.sort(() => nonPrivateRandom() - 0.5);
-    const set = new Set(shuffled);
+    const previousFirst = uniqueTags.get()[0];
+    const ordered = previousFirst === tags[0] ? [...tags].reverse() : tags;
+    const set = new Set(ordered);
     uniqueTags.set([...set]);
   });
 

--- a/packages/patterns/test/non-idempotent/shuffle.test.tsx
+++ b/packages/patterns/test/non-idempotent/shuffle.test.tsx
@@ -1,6 +1,14 @@
 /**
  * Test that exercises a non-idempotent nonPrivateRandom() shuffle computation.
- * The idempotency check in cf test should warn about it.
+ * expectNonIdempotent asserts the idempotency check detects it; the test
+ * FAILS if no violation is reported.
+ *
+ * The permutation alone is not a reliable detection signal: a 5-element
+ * shuffle repeats the previous order 1 in 120 times, which is a real flake
+ * rate once a missed detection fails the test. Recording the raw random
+ * draw alongside makes consecutive runs differ with certainty (two equal
+ * float64 draws are a ~2^-52 event) while keeping the shuffle as the
+ * demonstrated anti-pattern.
  *
  * Run: deno task cf test packages/patterns/test/non-idempotent/shuffle.test.tsx --verbose
  */
@@ -9,8 +17,10 @@ import { computed, nonPrivateRandom, pattern, Writable } from "commonfabric";
 export default pattern(() => {
   const items = new Writable(["alpha", "bravo", "charlie", "delta", "echo"]);
   const shuffled = new Writable<string[]>([]);
+  const lastDraw = new Writable(0);
 
-  // Non-idempotent: nonPrivateRandom() produces different permutations each run
+  // Non-idempotent: nonPrivateRandom() produces different permutations (and
+  // a different recorded draw) each run
   computed(() => {
     const arr = [...items.get()];
     for (let i = arr.length - 1; i > 0; i--) {
@@ -18,6 +28,7 @@ export default pattern(() => {
       [arr[i], arr[j]] = [arr[j], arr[i]];
     }
     shuffled.set(arr);
+    lastDraw.set(nonPrivateRandom());
   });
 
   const hasItems = computed(() => shuffled.get().length > 0);

--- a/packages/patterns/test/non-idempotent/timestamp.test.tsx
+++ b/packages/patterns/test/non-idempotent/timestamp.test.tsx
@@ -1,6 +1,14 @@
 /**
  * Test that exercises a non-idempotent safeDateNow() computation.
- * The idempotency check in cf test should warn about it.
+ * expectNonIdempotent asserts the idempotency check detects it; the test
+ * FAILS if no violation is reported.
+ *
+ * safeDateNow() has millisecond resolution, and the detector's recheck
+ * re-runs the computation immediately — on a fast enough runtime both runs
+ * could land in the same millisecond and write identical timestamps. The
+ * computation spins until the clock ticks so consecutive runs are
+ * GUARANTEED to observe different values; detection must not depend on how
+ * slow the re-run happens to be.
  *
  * Run: deno task cf test packages/patterns/test/non-idempotent/timestamp.test.tsx --verbose
  */
@@ -12,10 +20,13 @@ export default pattern(() => {
 
   // Non-idempotent: safeDateNow() produces different values each run
   computed(() => {
+    const entered = safeDateNow();
+    let stamp = entered;
+    while (stamp === entered) stamp = safeDateNow();
     processed.set(
       items.get().map((i) => ({
         title: i.title,
-        processedAt: safeDateNow(),
+        processedAt: stamp,
       })),
     );
   });


### PR DESCRIPTION
## Summary

`cf test`'s `expectNonIdempotent: true` was tolerate-only: it suppressed failure when idempotency violations were present, but a test still **passed silently when the detector reported nothing** — so the four fixtures in `packages/patterns/test/non-idempotent/` never actually guarded the detector at the integration level (a detection regression would go unnoticed).

The flag now **asserts** detection:

- **Single-runtime** (`runTests` in `packages/cli/lib/test-runner.ts`): zero violations with the flag set fails with `✗ expected non-idempotent computation(s), none detected`. Violations-present behavior is unchanged (`⊘ N non-idempotent computation(s) (expected)`).
- **Multi-user** (`packages/cli/lib/multi-user-test-runner.ts`): the orchestrator appends a synthetic failed result named `expectNonIdempotent` only when **no flagged participant** saw a violation — which runtime re-runs the offending computation depends on sync/scheduling, so any one flagged participant detecting satisfies the expectation. Unflagged participants' violations still fail the run as before (the aggregate's flag field stays unset by design; per-participant flags don't collapse onto a result-level flag).

Checked for reliance on the old tolerate-only semantics: only the four detector fixtures use the flag anywhere in the repo.

## Fixture hardening the new semantics exposed

A missed detection now fails CI, and measuring the fixtures showed three of four only detected probabilistically against the inline recheck (one synchronous re-run per computation execution):

| fixture | measured miss rate | cause | fix |
|---|---|---|---|
| `set-to-array` | 7/10 | random sort over 2 distinct tags ≈ coin flip per recheck | derive insertion order from the previous output (read-your-own-output, like `accumulator`); module-level `let` was rejected — "Top-level mutable bindings are not allowed in SES mode" |
| `shuffle` | 1/30 | identical 5-element permutation is 1/120 per recheck | also record the raw random draw (collision ~2⁻⁵²) |
| `timestamp` | 0/40, but timing-dependent | `safeDateNow()` is ms-resolution `Date.now()`; detection relied on run+recheck crossing an ms boundary | spin until the clock ticks |
| `accumulator` | 0/40 | already deterministic (reads the log it appends to) | comment update only |

After hardening: **30 consecutive runs of the fixture directory with zero misses**.

## Tests

New `packages/cli/test/test-runner-expect-non-idempotent.test.ts` drives both runners through `runTests` (red before the change on the two new-semantics cases, green after):

- flagged + idempotent → fails (single-runtime and multi-user)
- flagged + violating → passes (single-runtime; multi-user with only one of two flagged participants violating)
- unflagged + violating → still fails

Fixtures live in `packages/cli/test/fixtures/expect-non-idempotent/` — deliberately outside `packages/patterns` so the CI pattern sweep never runs the intentionally-failing ones. The cli test task gains `--allow-net=127.0.0.1` for the multi-user in-process memory server.

Context: #4002 fixed the false-positive race in the inline recheck; this closes the integration-level gap in the other direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `expectNonIdempotent` in `cf test` an assertion: tests now fail when no idempotency violations are detected, and still pass when violations are expected. In multi-user runs, the expectation is satisfied if any flagged participant detects a violation; otherwise a synthetic failure is reported.

- New Features
  - Single-runtime: with `expectNonIdempotent`, zero detected violations now fails with "expected non-idempotent computation(s), none detected"; detected violations are marked expected and do not fail.
  - Multi-user: add a synthetic failed result only when no flagged participant saw a violation; unflagged participants’ violations still fail the run.
  - Stability and tests: hardened the four non-idempotent fixtures for deterministic detection (Set order from previous output, record raw random draw, wait for clock tick, clarify accumulator) and added integration tests under `packages/cli/test/fixtures/expect-non-idempotent/`; `deno.json` test task now allows `--allow-net=127.0.0.1`.

- Migration
  - If you use `expectNonIdempotent`, your test now fails unless the detector reports at least one violation. Ensure the pattern truly re-writes on re-run or remove the flag.

<sup>Written for commit e51ce118387479ee36c03406b0d117b88a402dc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

