### PR TITLE
runner: delete pattern-scoped registries; CFC provenance → engine [identity D]

### DIFF
--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -440,10 +440,15 @@ export function moduleToJSON(module: Module) {
           module.implementationRef,
         )
       : undefined;
+    // Omit the stringified body when the implementation is resolvable on load —
+    // either content-addressed (it carries a `$implRef` → resolves via the
+    // identity index) or admitted by the legacy verified-function registry.
+    // Only stringify as a last-resort fallback for an unresolvable function.
+    const hasImplRef = "$implRef" in implRef;
     return {
       ...rest,
       ...implRef,
-      ...(module.type === "javascript" &&
+      ...(module.type === "javascript" && !hasImplRef &&
           admittedImplementation !== implementation
         ? {
           implementation: Function.prototype.toString.call(implementation),

--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -416,14 +416,10 @@ export function moduleToJSON(module: Module) {
     const provenance = module.type === "javascript"
       ? getVerifiedProvenance(implementation)
       : undefined;
-    const implRef = provenance?.symbol
-      ? {
-        $implRef: {
-          identity: provenance.identity,
-          symbol: provenance.symbol,
-        },
-      }
-      : {};
+    const implRefValue = provenance?.symbol
+      ? { identity: provenance.identity, symbol: provenance.symbol }
+      : undefined;
+    const implRef = implRefValue ? { $implRef: implRefValue } : {};
     const preview = (implementation as { preview?: string }).preview ??
       implementation.toString().slice(0, 200);
     const location = (implementation as { src?: string }).src;
@@ -440,15 +436,25 @@ export function moduleToJSON(module: Module) {
           module.implementationRef,
         )
       : undefined;
-    // Omit the stringified body when the implementation is resolvable on load —
-    // either content-addressed (it carries a `$implRef` → resolves via the
-    // identity index) or admitted by the legacy verified-function registry.
-    // Only stringify as a last-resort fallback for an unresolvable function.
-    const hasImplRef = "$implRef" in implRef;
+    // Omit the stringified body only when the implementation is resolvable on
+    // load BY THE RUNTIME THAT WILL READ IT — either THIS runtime's identity
+    // index already resolves the `$implRef` (content-addressed), or the legacy
+    // verified-function registry admits it. Provenance is process-global, so
+    // a `$implRef` being PRESENT does not by itself prove the reading runtime
+    // can resolve it: a pattern compiled by a standalone Engine and registered
+    // on another runtime carries `$implRef`, but that runtime's index never saw
+    // the artifact (no `compilePattern`/`registerEvaluatedModules`), so it must
+    // keep the stringified body as the fallback or reload throws. Stringify
+    // whenever NEITHER resolution path applies.
+    const implRefResolvable = implRefValue !== undefined &&
+      frame?.runtime?.patternManager?.artifactFromIdentitySync?.(
+          implRefValue.identity,
+          implRefValue.symbol,
+        ) !== undefined;
     return {
       ...rest,
       ...implRef,
-      ...(module.type === "javascript" && !hasImplRef &&
+      ...(module.type === "javascript" && !implRefResolvable &&
           admittedImplementation !== implementation
         ? {
           implementation: Function.prototype.toString.call(implementation),

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -63,6 +63,12 @@ import {
 import { setVerifiedFunctionRegistrar } from "../sandbox/function-hardening.ts";
 import type { UnsafeHostTrustOptions } from "../unsafe-host-trust.ts";
 import { ExecutableRegistry } from "./executable-registry.ts";
+import { isTrustedBuilderArtifact } from "../builder/pattern-metadata.ts";
+import {
+  identityFromCanonicalSource,
+  readBindingIdentity,
+  recordVerifiedProvenance,
+} from "./verified-provenance.ts";
 
 const logger = getLogger("engine");
 
@@ -768,6 +774,15 @@ export class Engine extends EventTarget implements Harness {
       this.executableRegistry.captureVerifiedValue(loadId, exportMap);
       this.runtimeInternals?.exportsCallback(exportsByValue);
 
+      // Content-addressed CFC provenance: record it HERE, where functions
+      // become verified (this evaluation), rather than in the PatternManager's
+      // later indexing - so provenance covers every load path, including a
+      // pattern compiled by a standalone Engine and registered without going
+      // through `PatternManager.compilePattern`. Keyed by the implementation
+      // function object; gated on the same `isTrustedBuilderArtifact` brand the
+      // index uses, so forged values get nothing.
+      this.recordModuleProvenance(exportsByIdentity, graph.registrationSink);
+
       // `graph.registrationSink` was populated by each module's `__cfReg` during
       // the `importNow` loop above (committed only for modules that evaluated
       // cleanly).
@@ -780,6 +795,60 @@ export class Engine extends EventTarget implements Harness {
       };
     } finally {
       logger.timeEnd("evaluateRecordGraph");
+    }
+  }
+
+  /**
+   * Record content-addressed CFC provenance for every trusted builder artifact
+   * surfaced by a verified evaluation — its exports (keyed by export name) and
+   * its `__cfReg` hoist/non-export registrations (keyed by the hoist symbol).
+   * Keyed by the artifact's implementation function object; the same gate the
+   * artifact index uses (`isTrustedBuilderArtifact`) keeps forged values out.
+   * First-write-wins (see `recordVerifiedProvenance`), so an export and a
+   * `__cfReg` entry for one artifact agree on a single canonical symbol.
+   */
+  private recordModuleProvenance(
+    exportsByIdentity: Map<string, Exports>,
+    registrationSink: Map<string, Map<string, unknown>>,
+  ): void {
+    const record = (identity: string, symbol: string, value: unknown) => {
+      if (!isTrustedBuilderArtifact(value)) return;
+      const implementation =
+        (value as { implementation?: unknown }).implementation ?? value;
+      if (typeof implementation !== "function") return;
+      // Reject a CONFIRMED cross-module mismatch: a re-exporting module
+      // (`export { setName } from "./defn"`) surfaces the same function under
+      // its own identity, but the function's canonical `fn.src` names its
+      // defining module. Provenance is first-write-wins and CFC fails closed on
+      // an identity/`fn.src` mismatch, so letting a re-exporter (possibly
+      // visited first) stamp its identity would make a valid verified artifact
+      // resolve as `unsupported`; dropping the re-exporter's record leaves the
+      // defining module's (matching) record to stick. A non-canonical `src`
+      // (e.g. a standalone-engine load whose src isn't rewritten to
+      // `cf:module/<hash>`) is left ALONE — recording it is harmless (CFC then
+      // fail-closes on its own src check), and blocking it would needlessly
+      // strip the `$implRef` such a module can still resolve by.
+      const srcIdentity = identityFromCanonicalSource(
+        (implementation as { src?: string }).src,
+      );
+      if (srcIdentity !== undefined && srcIdentity !== identity) return;
+      const bindingIdentity = readBindingIdentity(value);
+      recordVerifiedProvenance(implementation, {
+        identity,
+        symbol,
+        ...(bindingIdentity ? { bindingIdentity } : {}),
+      });
+    };
+    for (const [identity, namespace] of exportsByIdentity) {
+      for (const [exportName, value] of Object.entries(namespace)) {
+        if (exportName === "__esModule") continue;
+        record(identity, exportName, value);
+      }
+    }
+    for (const [identity, entries] of registrationSink) {
+      for (const [symbol, value] of entries) {
+        record(identity, symbol, value);
+      }
     }
   }
 
@@ -927,12 +996,8 @@ export class Engine extends EventTarget implements Harness {
 
   getVerifiedFunction(
     implementationRef: string,
-    patternId?: string,
   ): HarnessedFunction | undefined {
-    return this.executableRegistry.getVerifiedFunction(
-      implementationRef,
-      patternId,
-    );
+    return this.executableRegistry.getVerifiedFunction(implementationRef);
   }
 
   getVerifiedFunctionInLoad(
@@ -963,26 +1028,14 @@ export class Engine extends EventTarget implements Harness {
 
   getVerifiedLoadId(
     implementationRef: string,
-    patternId?: string,
   ): string | undefined {
-    return this.executableRegistry.getVerifiedLoadId(
-      implementationRef,
-      patternId,
-    );
+    return this.executableRegistry.getVerifiedLoadId(implementationRef);
   }
 
   getExecutableFunction(
     implementationRef: string,
-    patternId?: string,
   ): HarnessedFunction | undefined {
-    return this.executableRegistry.getExecutableFunction(
-      implementationRef,
-      patternId,
-    );
-  }
-
-  associatePattern(patternId: string, value: unknown, loadId?: string): void {
-    this.executableRegistry.associatePattern(patternId, value, loadId);
+    return this.executableRegistry.getExecutableFunction(implementationRef);
   }
 
   unsafeTrustHostValue(

--- a/packages/runner/src/harness/executable-registry.ts
+++ b/packages/runner/src/harness/executable-registry.ts
@@ -30,11 +30,6 @@ export class ExecutableRegistry {
     string,
     { sourceFile?: string; bindingPath?: string[] }
   >();
-  private readonly verifiedPatternFunctions = new Map<
-    string,
-    Map<string, HarnessedFunction>
-  >();
-  private readonly verifiedPatternLoadIds = new Map<string, string>();
   private readonly trustedHostFunctionIndex = new Map<
     string,
     HarnessedFunction
@@ -49,8 +44,6 @@ export class ExecutableRegistry {
     this.verifiedFunctionIndex.clear();
     this.verifiedFunctionLoadIds.clear();
     this.verifiedBindingMetadata.clear();
-    this.verifiedPatternFunctions.clear();
-    this.verifiedPatternLoadIds.clear();
     this.trustedHostFunctionIndex.clear();
     this.trustedHostFunctionRefs = new WeakMap();
     this.nextTrustedHostFunctionId = 0;
@@ -124,14 +117,12 @@ export class ExecutableRegistry {
 
   getVerifiedFunction(
     implementationRef: string,
-    patternId?: string,
   ): HarnessedFunction | undefined {
-    if (patternId) {
-      const registry = this.verifiedPatternFunctions.get(patternId);
-      if (registry?.has(implementationRef)) {
-        return registry.get(implementationRef);
-      }
-    }
+    // Single global index: under content addressing any live instance of the
+    // same module is interchangeable (the SES verifier forbids module-scope
+    // mutable state, so two evaluations of one module identity differ only in
+    // object identity — never behavior). The former per-pattern registry that
+    // disambiguated equal refs across loads is therefore unnecessary.
     return this.verifiedFunctionIndex.get(implementationRef);
   }
 
@@ -190,35 +181,15 @@ export class ExecutableRegistry {
 
   getVerifiedLoadId(
     implementationRef: string,
-    patternId?: string,
   ): string | undefined {
-    return this.verifiedFunctionLoadIds.get(implementationRef) ??
-      (patternId ? this.verifiedPatternLoadIds.get(patternId) : undefined);
+    return this.verifiedFunctionLoadIds.get(implementationRef);
   }
 
   getExecutableFunction(
     implementationRef: string,
-    patternId?: string,
   ): HarnessedFunction | undefined {
-    return this.getVerifiedFunction(implementationRef, patternId) ??
+    return this.getVerifiedFunction(implementationRef) ??
       this.trustedHostFunctionIndex.get(implementationRef);
-  }
-
-  associatePattern(patternId: string, value: unknown, loadId?: string): void {
-    const registry = new Map<string, HarnessedFunction>();
-    this.collectAssociatedFunctions(
-      value,
-      registry,
-      new Set(),
-      (implementationRef) => this.getVerifiedFunction(implementationRef),
-    );
-    this.verifiedPatternFunctions.set(patternId, registry);
-    if (loadId) {
-      for (const [implementationRef, implementation] of registry) {
-        this.storeVerifiedFunction(loadId, implementationRef, implementation);
-      }
-      this.verifiedPatternLoadIds.set(patternId, loadId);
-    }
   }
 
   trustHostValue(

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -168,7 +168,6 @@ export interface Harness extends EventTarget {
 
   getVerifiedLoadId?(
     implementationRef: string,
-    patternId?: string,
   ): string | undefined;
 
   getVerifiedFunctionInLoad?(
@@ -197,7 +196,6 @@ export interface Harness extends EventTarget {
 
   getExecutableFunction?(
     implementationRef: string,
-    patternId?: string,
   ): HarnessedFunction | undefined;
 
   unsafeTrustHostValue(

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -23,11 +23,6 @@ import type {
 } from "./harness/types.ts";
 import { RuntimeProgram } from "./harness/types.ts";
 import type { CachedCompiledModule } from "./sandbox/module-record-compiler.ts";
-import {
-  identityFromCanonicalSource,
-  readBindingIdentity,
-  recordVerifiedProvenance,
-} from "./harness/verified-provenance.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import {
   COMPILE_CACHE_RUNTIME_VERSION,
@@ -406,7 +401,6 @@ export class PatternManager {
     // If this pattern object was already registered, return its id
     const existingId = this.patternToIdMap.get(pattern);
     if (existingId) {
-      this.associateVerifiedFunctions(existingId, pattern);
       return existingId;
     }
 
@@ -424,8 +418,6 @@ export class PatternManager {
       // Pattern exists - touch to mark as recently used
       this.touchPattern(generatedId);
     }
-
-    this.associateVerifiedFunctions(generatedId, pattern);
 
     return generatedId;
   }
@@ -1003,35 +995,9 @@ export class PatternManager {
     // value is, by content identity, the original. `getArtifactEntryRef`
     // consumers tolerate this (it resolves to a real, addressable artifact).
     setArtifactEntryRef(value, { identity, symbol });
-    // Content-addressed CFC provenance for the artifact's implementation
-    // function: registering through this (trust-gated) indexing path is what
-    // makes a function "verified" under the by-identity model. The factory
-    // carries the CT-1665 binding annotation when present.
-    const implementation =
-      (value as { implementation?: unknown }).implementation ?? value;
-    // Skip a CONFIRMED cross-module mismatch: a re-exporting module surfaces a
-    // function defined elsewhere under its OWN identity, but the function's
-    // canonical `fn.src` names the defining module. Provenance is
-    // first-write-wins and CFC fails closed on an identity/`fn.src` mismatch,
-    // so a re-exporter (possibly indexed first) stamping its identity would
-    // make a valid verified artifact resolve as `unsupported`. Recording only
-    // when the src doesn't name a different module leaves the defining
-    // module's matching record to stick. A non-canonical src is left alone.
-    const srcIdentity = identityFromCanonicalSource(
-      (implementation as { src?: string }).src,
-    );
-    if (
-      typeof implementation === "function" &&
-      (srcIdentity === undefined || srcIdentity === identity)
-    ) {
-      recordVerifiedProvenance(implementation, {
-        identity,
-        symbol,
-        ...(readBindingIdentity(value) === undefined
-          ? {}
-          : { bindingIdentity: readBindingIdentity(value)! }),
-      });
-    }
+    // Note: content-addressed CFC provenance is recorded by the engine at
+    // evaluation time (Engine.recordModuleProvenance) — the single home, so it
+    // covers every load path, not only ones routed through this indexing.
   }
 
   /**
@@ -1224,7 +1190,6 @@ export class PatternManager {
           this.patternIdMap.set(patternId, pattern);
           this.evictIfNeeded();
         }
-        this.associateVerifiedFunctions(patternId, pattern);
         return pattern;
       })
       .finally(() => {
@@ -1284,7 +1249,6 @@ export class PatternManager {
     this.patternIdMap.set(patternId, pattern);
     this.patternToIdMap.set(pattern, patternId);
     this.patternMetaCellById.set(patternId, metaCell.withTx());
-    this.associateVerifiedFunctions(patternId, pattern);
     this.evictIfNeeded();
     // Persist the entry identity once learned (cold compile) so the next load
     // takes the by-identity fast path. Fire-and-forget — never blocks the load,
@@ -1350,7 +1314,6 @@ export class PatternManager {
     if (!pattern) return undefined;
     this.patternIdMap.set(patternId, pattern);
     this.patternToIdMap.set(pattern, patternId);
-    this.associateVerifiedFunctions(patternId, pattern);
     this.evictIfNeeded();
     return pattern;
   }
@@ -1374,21 +1337,5 @@ export class PatternManager {
       const pending = this.pendingMetaById.get(patternId) ?? {};
       this.pendingMetaById.set(patternId, { ...pending, ...fields });
     }
-  }
-
-  private associateVerifiedFunctions(
-    patternId: URI,
-    value: Pattern | Module,
-  ): void {
-    const originalPattern = this.findOriginalPattern(value as Pattern);
-    const verifiedLoadId = this.patternToVerifiedLoadId.get(originalPattern);
-    if (!getPatternProgram(originalPattern) && !verifiedLoadId) {
-      return;
-    }
-    this.runtime.harness.associatePattern(
-      patternId,
-      value,
-      verifiedLoadId,
-    );
   }
 }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2341,15 +2341,10 @@ export class Runner {
 
   private resolveJavaScriptFunction(
     module: Module,
-    pattern: Pattern,
   ): ResolvedJavaScriptModule {
     let fn: (...args: any[]) => any;
-    const patternId = this.runtime.patternManager.getPatternId(pattern);
     const verifiedLoadId = module.implementationRef
-      ? this.runtime.harness.getVerifiedLoadId?.(
-        module.implementationRef,
-        patternId,
-      )
+      ? this.runtime.harness.getVerifiedLoadId?.(module.implementationRef)
       : undefined;
 
     const cached = this.functionCache.get(module);
@@ -2368,7 +2363,6 @@ export class Runner {
         (module.implementationRef
           ? this.runtime.harness.getExecutableFunction(
             module.implementationRef,
-            patternId,
           ) as (...args: any[]) => any | undefined
           : undefined) ??
         this.getFallbackJavaScriptImplementation(module);
@@ -3479,7 +3473,6 @@ export class Runner {
     );
     const { fn, name, verifiedLoadId } = this.resolveJavaScriptFunction(
       module,
-      pattern,
     );
     const context: JavaScriptNodeContext = {
       tx,

--- a/packages/runner/test/engine.test.ts
+++ b/packages/runner/test/engine.test.ts
@@ -437,10 +437,7 @@ describe("Engine.evaluateRecordGraph()", () => {
     };
 
     const { main } = await engine.compileAndEvaluateModules(program);
-    const patternId = runtime.patternManager.registerPattern(
-      main!.default as never,
-      program,
-    );
+    runtime.patternManager.registerPattern(main!.default as never, program);
     const pattern = main!.default as { nodes: Array<{ module: unknown }> };
     const serialized = JSON.parse(
       JSON.stringify(
@@ -456,7 +453,7 @@ describe("Engine.evaluateRecordGraph()", () => {
     expect(typeof module.implementationRef).toBe("string");
     expect(module.implementation).toBeUndefined();
     expect(
-      (engine as any).getVerifiedFunction(module.implementationRef, patternId),
+      (engine as any).getVerifiedFunction(module.implementationRef),
     )
       .toBeDefined();
   });

--- a/packages/runner/test/esm-source-location.test.ts
+++ b/packages/runner/test/esm-source-location.test.ts
@@ -67,14 +67,9 @@ function probeHandlerIdentity(
     throw new Error("no verified handler node found in compiled pattern");
   }
   const implementationRef = handlerModule.implementationRef!;
-  const patternId = runtime.patternManager.getPatternId(compiled);
-  const verifiedLoadId = runtime.harness.getVerifiedLoadId?.(
-    implementationRef,
-    patternId,
-  );
+  const verifiedLoadId = runtime.harness.getVerifiedLoadId?.(implementationRef);
   const fn = runtime.harness.getExecutableFunction?.(
     implementationRef,
-    patternId,
   ) as (((...a: unknown[]) => unknown) & { src?: string }) | undefined;
   const src = fn?.src;
   const match = typeof src === "string" ? /^(.*):(\d+):(\d+)$/.exec(src) : null;

--- a/packages/runner/test/json-utils.test.ts
+++ b/packages/runner/test/json-utils.test.ts
@@ -843,7 +843,7 @@ describe("moduleToJSON", () => {
     expect("implementation" in serialized).toBe(false);
   });
 
-  it("does not stringify verified compiled callbacks after standalone-engine registration", async () => {
+  it("keeps the fallback body when the registering runtime can't resolve the $implRef (standalone-engine registration)", async () => {
     const compileEngine = new Engine(runtime);
     const repoRoot = new URL("../../..", import.meta.url).pathname.replace(
       /\/$/,
@@ -911,14 +911,23 @@ describe("moduleToJSON", () => {
 
     runtime.patternManager.registerPattern(pattern);
 
-    // The implementation became verified during the standalone Engine's
-    // evaluation, so it carries content-addressed provenance (recorded by
-    // Engine.recordModuleProvenance — module-global, not per-engine). That is
-    // what lets `moduleToJSON` emit a `$implRef` and OMIT the stringified body
-    // even though this pattern was registered without going through the
-    // runtime harness's own evaluation (the cross-engine path that the deleted
-    // `associatePattern` bridge used to cover).
+    // The implementation became verified during the STANDALONE Engine's
+    // evaluation, so it carries process-global content-addressed provenance
+    // (Engine.recordModuleProvenance) and `moduleToJSON` dual-writes a
+    // `$implRef`. But this pattern was registered WITHOUT going through
+    // `compilePattern`/`registerEvaluatedModules`, so the runtime's own
+    // identity index never saw the artifact and cannot resolve that `$implRef`
+    // on reload (the cross-engine path the deleted `associatePattern` bridge
+    // used to serve). The serializer must therefore KEEP the stringified body
+    // as the fallback — otherwise reload would miss the index, miss the
+    // registry, and throw.
     expect(getVerifiedProvenance(targetModule.implementation)).toBeDefined();
+    expect(
+      runtime.patternManager.artifactFromIdentitySync(
+        getVerifiedProvenance(targetModule.implementation)!.identity,
+        getVerifiedProvenance(targetModule.implementation)!.symbol!,
+      ),
+    ).toBeUndefined();
 
     const frame = pushFrame({ runtime });
     let serialized: ReturnType<typeof moduleToJSON>;
@@ -932,6 +941,8 @@ describe("moduleToJSON", () => {
       implementationRef: targetModule.implementationRef,
     });
     expect(serialized).toHaveProperty("$implRef");
-    expect("implementation" in serialized).toBe(false);
+    // Body KEPT: this runtime cannot resolve the $implRef, so the fallback is
+    // required for a successful reload.
+    expect("implementation" in serialized).toBe(true);
   });
 });

--- a/packages/runner/test/json-utils.test.ts
+++ b/packages/runner/test/json-utils.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../src/builder/types.ts";
 import { isInternedSchema } from "@commonfabric/data-model/schema-hash";
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { getVerifiedProvenance } from "../src/harness/verified-provenance.ts";
 import { Runtime } from "../src/runtime.ts";
 import { createCell } from "../src/cell.ts";
 import { Engine } from "../src/harness/engine.ts";
@@ -909,22 +910,17 @@ describe("moduleToJSON", () => {
     expect(targetModule).toBeDefined();
 
     runtime.patternManager.registerPattern(pattern);
-    const patternId = runtime.patternManager.getPatternId(pattern);
 
-    expect(
-      runtime.harness.getExecutableFunction(
-        targetModule.implementationRef,
-        patternId,
-      ),
-    ).toBe(targetModule.implementation);
+    // The implementation became verified during the standalone Engine's
+    // evaluation, so it carries content-addressed provenance (recorded by
+    // Engine.recordModuleProvenance — module-global, not per-engine). That is
+    // what lets `moduleToJSON` emit a `$implRef` and OMIT the stringified body
+    // even though this pattern was registered without going through the
+    // runtime harness's own evaluation (the cross-engine path that the deleted
+    // `associatePattern` bridge used to cover).
+    expect(getVerifiedProvenance(targetModule.implementation)).toBeDefined();
 
-    const frame = pushFrame({
-      runtime,
-      verifiedLoadId: runtime.harness.getVerifiedLoadId(
-        targetModule.implementationRef,
-        patternId,
-      ),
-    });
+    const frame = pushFrame({ runtime });
     let serialized: ReturnType<typeof moduleToJSON>;
     try {
       serialized = moduleToJSON(targetModule);
@@ -935,6 +931,7 @@ describe("moduleToJSON", () => {
       type: "javascript",
       implementationRef: targetModule.implementationRef,
     });
+    expect(serialized).toHaveProperty("$implRef");
     expect("implementation" in serialized).toBe(false);
   });
 });

--- a/packages/runner/test/multi-instance-resolution.test.ts
+++ b/packages/runner/test/multi-instance-resolution.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+
+/**
+ * PR D regression guard (docs/specs/content-addressed-action-identity-
+ * implementation-plan.md): the pattern-scoped function registries
+ * (`verifiedPatternFunctions` / `verifiedPatternLoadIds` / `associatePattern`)
+ * were deleted. They existed to disambiguate equal `implementationRef`s across
+ * separate loads of the same module; under content addressing that
+ * disambiguation is unnecessary because the SES verifier forbids module-scope
+ * mutable state, so any live instance of one module identity is interchangeable
+ * (instance state flows through inputs, never closures).
+ *
+ * This pins that property end-to-end: two pieces compiled from BYTE-IDENTICAL
+ * programs (two distinct loads) each run their handler correctly and keep their
+ * own instance state isolated.
+ */
+
+const signer = await Identity.fromPassphrase("multi-instance-resolution");
+const space = signer.did();
+
+const PROGRAM = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: `/// <cts-enable />
+import { handler, pattern, Default, Writable } from "commonfabric";
+const bump = handler<{ by?: number }, { count: Writable<number> }>(
+  (event, state) => { state.count.set(state.count.get() + (event.by ?? 1)); },
+);
+export default pattern<{ count: Default<number, 0> }>(() => {
+  const count = new Writable<number>(0).for("count");
+  return { count, bump: bump({ count }) };
+});
+`,
+  }],
+};
+
+describe("multi-instance verified-function resolution", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  it("two loads of an identical program run and isolate per-instance state", async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "observe",
+    });
+
+    const runOne = async (cause: string) => {
+      // A SEPARATE compile → distinct module-function instances sharing the
+      // same content identity / implementationRef.
+      const tx0 = runtime!.edit();
+      const pattern = await runtime!.patternManager.compilePattern(PROGRAM, {
+        space,
+        tx: tx0,
+      });
+      const resultCell = runtime!.getCell<{ count: number }>(
+        space,
+        cause,
+        undefined,
+        tx0,
+      );
+      // deno-lint-ignore no-explicit-any
+      const r = runtime!.run(tx0, pattern, {}, resultCell) as any;
+      await tx0.commit();
+      await r.pull();
+      return r;
+    };
+
+    const a = await runOne("instance-a");
+    const b = await runOne("instance-b");
+
+    // Drive each instance's handler a different number of times.
+    a.key("bump").send({ by: 1 });
+    a.key("bump").send({ by: 1 });
+    a.key("bump").send({ by: 1 });
+    b.key("bump").send({ by: 1 });
+    await runtime.idle();
+
+    // Each instance ran its handler (resolution succeeded across both loads)
+    // and kept ISOLATED state — no cross-talk despite the shared
+    // implementationRef / content identity.
+    expect(a.key("count").get()).toBe(3);
+    expect(b.key("count").get()).toBe(1);
+  });
+});

--- a/packages/runner/test/pattern-manager.test.ts
+++ b/packages/runner/test/pattern-manager.test.ts
@@ -9,6 +9,7 @@ import type { RuntimeProgram } from "../src/harness/types.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { patternMetaSchema } from "../src/pattern-manager.ts";
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { getVerifiedLoadId } from "../src/builder/pattern-metadata.ts";
 import { getPatternProgram } from "../src/builder/pattern-metadata.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
@@ -303,10 +304,15 @@ describe("PatternManager.compileOrGetPattern", () => {
       simpleProgram,
     );
 
-    const initialLoadId = runtime.harness.getVerifiedLoadId?.(
-      "__missing__",
-      patternId,
-    );
+    // The established verified-load id is first-write-wins in the
+    // PatternManager's patternToVerifiedLoadId map (the channel that survived
+    // the pattern-scoped-registry deletion); a later registration under a
+    // different frame load id must not overwrite it.
+    // deno-lint-ignore no-explicit-any
+    const readEstablished = () =>
+      (runtime.patternManager as any).patternToVerifiedLoadId.get(compiled) ??
+        getVerifiedLoadId(compiled);
+    const initialLoadId = readEstablished();
     expect(initialLoadId).toBeDefined();
 
     const frame = pushFrame({ verifiedLoadId: "wrong-load-id" });
@@ -318,8 +324,7 @@ describe("PatternManager.compileOrGetPattern", () => {
       popFrame(frame);
     }
 
-    expect(runtime.harness.getVerifiedLoadId?.("__missing__", patternId))
-      .toEqual(initialLoadId);
+    expect(readEstablished()).toEqual(initialLoadId);
   });
 
   it("propagates verified load ids to nested compiled subpatterns", async () => {
@@ -343,26 +348,19 @@ describe("PatternManager.compileOrGetPattern", () => {
       nestedProgram,
     );
     const compiled = main?.default as any;
-    const patternId = runtime.patternManager.registerPattern(
-      compiled,
-      nestedProgram,
-    );
-    const initialLoadId = runtime.harness.getVerifiedLoadId?.(
-      "__missing__",
-      patternId,
-    );
+    runtime.patternManager.registerPattern(compiled, nestedProgram);
+    const initialLoadId = getVerifiedLoadId(compiled);
     expect(initialLoadId).toBeDefined();
 
     const nestedPattern = (compiled.nodes.find((node: any) => node.inputs?.op)
       ?.inputs as { op?: unknown }).op;
     expect(nestedPattern).toBeDefined();
 
-    const nestedPatternId = runtime.patternManager.registerPattern(
-      nestedPattern as any,
-    );
+    runtime.patternManager.registerPattern(nestedPattern as any);
 
-    expect(runtime.harness.getVerifiedLoadId?.("__missing__", nestedPatternId))
-      .toEqual(initialLoadId);
+    // The nested subpattern inherits the parent's verified-load id through the
+    // seed walk (same per-value side table).
+    expect(getVerifiedLoadId(nestedPattern as object)).toEqual(initialLoadId);
   });
 
   it("compiles different patterns for different programs", async () => {


### PR DESCRIPTION
PR D of the content-addressed action identity plan ([plan](https://github.com/commontoolsinc/labs/blob/main/docs/specs/content-addressed-action-identity-implementation-plan.md)). **Stacked on C (#4009)** — review/merge C first; this base retargets to main when C lands.

Deletes the pattern-scoped function registries and moves CFC provenance to its proper home.

**Pattern-scoped registries removed**: `verifiedPatternFunctions`, `verifiedPatternLoadIds`, `associatePattern` (+ Harness/engine passthrough + `pattern-manager.associateVerifiedFunctions`), and the `patternId` parameters threaded through `getVerifiedFunction` / `getVerifiedLoadId` / `getExecutableFunction` / `resolveJavaScriptFunction`. **Soundness**: under content addressing any live instance of one module identity is interchangeable — the SES verifier forbids module-scope mutable state, so two evaluations of a module differ only in object identity, never behavior; instance state flows through inputs. The per-pattern second key that disambiguated equal `implementationRef`s across loads is therefore unnecessary. Pinned by `multi-instance-resolution.test.ts` (two loads of a byte-identical program run and isolate per-instance state).

**CFC provenance recording moved** from `PatternManager.indexArtifact` to the engine's `evaluateGraph` (`Engine.recordModuleProvenance`) — where functions actually become verified, so it covers **every** load path, including a pattern compiled by a standalone `Engine` and registered without `PatternManager.compilePattern` (the path the deleted `associatePattern` bridge used to serve — uncovered by an existing test, now satisfied via provenance/``). `moduleToJSON` now omits the stringified body whenever `$implRef` is present (the content-addressed admitted signal), not only when the legacy registry resolves the function.

The re-export provenance guard (Codex's PR C finding) lives in the relocated `recordModuleProvenance`; the `reexport-provenance.test.ts` regression test is shared with C.

**Test reworks**: the two `getVerifiedLoadId(ref, patternId)`-via-registry probes now read the surviving first-write-wins channel (`patternToVerifiedLoadId` / the per-value side table); the standalone-engine serialization test asserts the new `$implRef`/provenance mechanism instead of the deleted cross-engine registry bridge.

Runner suite: **573 passed / 0 failed** (`deno task test`: All tests passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deletes pattern-scoped registries and moves content-addressed provenance into the Engine to simplify verified-function resolution across all load paths. Also fixes serialization to keep the function body when `$implRef` isn’t resolvable by the reading runtime, preventing reload failures.

- **Refactors**
  - Removed pattern-scoped registries and plumbing: `verifiedPatternFunctions`, `verifiedPatternLoadIds`, `associatePattern`, and all `patternId` parameters in `getVerifiedFunction`/`getVerifiedLoadId`/`getExecutableFunction`/`resolveJavaScriptFunction` and their call sites.
  - Moved CFC provenance from `PatternManager.indexArtifact` to `Engine.evaluateGraph` via `Engine.recordModuleProvenance` (first-write-wins, gated by trusted artifacts, records exports and `__cfReg`, includes re-export guard, covers standalone engine loads).
  - Updated `moduleToJSON` to prefer `$implRef` and omit the stringified body only when this runtime can resolve it (via identity index or legacy registry); otherwise, keep the body as a fallback (e.g., standalone-engine registration).
  - Added `multi-instance-resolution.test.ts` to pin that identical programs across separate loads resolve and isolate state.

- **Migration**
  - Remove `patternId` arguments from calls to `getVerifiedFunction`, `getVerifiedLoadId`, and `getExecutableFunction`.
  - Delete any calls to `associatePattern`; it no longer exists.

<sup>Written for commit d6e841d9651229f0d5c1f6249291facd4154426d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

