### PR TITLE
fix(runner): make inSpace child pieces independently loadable from their own space (CT-1687)

### DIFF
--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -433,6 +433,17 @@ The cache is designed around this:
   server**: the server becomes the sole acceptor of that write integrity (it
   only stamps the label from its own compilation step), making the label a hard
   guarantee — with no change to the read path, which already requires it.
+- **Cross-space closure replication (CT-1687).** Cache docs do not only live
+  where they compiled: when a pattern materializes a child piece in another
+  space (`Factory.inSpace(...)`), the runner replicates the child pattern's
+  source + compiled closures into the child's space so the piece is
+  independently loadable there (`PatternManager.replicatePatternToSpace`).
+  Chain-of-custody holds — compiled docs are read through the integrity-gated
+  loader (a user can only replicate docs already carrying their own stamp) and
+  re-stamped on the child-space write by a legitimate child-space writer. Note
+  for the server-compilation end state: a client can then no longer stamp
+  replicated compiled docs, so child spaces will need server-side replication
+  or by-identity source recovery instead.
 - **CFC verified-source derives from the source set, not the cached JS.** A
   poisoned-but-SES-safe JS document must not be able to spoof `fn.src` /
   authorship, so the CFC verified-source identity is anchored to the

--- a/packages/runner/src/builder/pattern-metadata.ts
+++ b/packages/runner/src/builder/pattern-metadata.ts
@@ -97,10 +97,13 @@ export function brandTrustedPattern<T>(value: T): T {
 }
 
 // Derivation tracking: `copy → root original`. Replaces the former
-// `unsafe_originalPattern` symbol backref. Registered ONLY by runner-owned
+// `unsafe_originalPattern` symbol backref. Registered ONLY by trusted-builder
 // copy sites (`noteDerivedCopy` callers: build-time graph serialization in
 // json-utils, traversal copies in traverse-utils, binding copies in
-// pattern-binding) — authored/forged values never enter, since nothing on the
+// pattern-binding, and the `asScope`/`inSpace` factory derivations in
+// builder/pattern.ts — the latter reachable from authored pattern code, which
+// is sound because both objects are builder-minted and already branded) —
+// forged values never enter, since nothing on the
 // object itself can establish the link. Module-level (not per-manager): the
 // copy sites live in builder-layer utilities with no PatternManager handle,
 // and the linked facts (trust brands, content-addressed entry refs) are

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -20,7 +20,7 @@ import {
   type UnsafeBinding,
 } from "./types.ts";
 import { opaqueRef } from "./opaque-ref.ts";
-import { brandTrustedPattern } from "./pattern-metadata.ts";
+import { brandTrustedPattern, noteDerivedCopy } from "./pattern-metadata.ts";
 import {
   applyArgumentIfcToResult,
   applyInputIfcToOutput,
@@ -439,10 +439,21 @@ function factoryFromPattern<T, R>(
       } as Pattern & toJSON,
     ) as PatternFactory<T, R>;
 
-    factory.asScope = (scope: CellScope) =>
-      makePatternFactory(scope, defaultSpace);
-    factory.inSpace = (space?: string | unknown) =>
-      makePatternFactory(defaultScope, space ?? "");
+    // `asScope` / `inSpace` mint fresh factory objects; record them as
+    // derivation copies so identity facts resolve through to the root factory
+    // — in particular the content-addressed artifact entry ref, which is what
+    // lets an `inSpace(...)` child piece carry `patternIdentity` meta and have
+    // its closures replicated into its own space (CT-1687).
+    factory.asScope = (scope: CellScope) => {
+      const derived = makePatternFactory(scope, defaultSpace);
+      noteDerivedCopy(derived, factory);
+      return derived;
+    };
+    factory.inSpace = (space?: string | unknown) => {
+      const derived = makePatternFactory(defaultScope, space ?? "");
+      noteDerivedCopy(derived, factory);
+      return derived;
+    };
     // Provenance brand: only the trusted builder stamps a pattern. Trust-granting
     // sites check `isTrustedPattern` so a `__cf_data`-forged pattern-shaped
     // object cannot acquire program / verified-load-id metadata.

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -27,6 +27,7 @@ import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import {
   COMPILE_CACHE_RUNTIME_VERSION,
   loadCompiledClosure,
+  loadVerifiedSourceClosure,
   ROOT_LINK_SPECIFIER,
   writeCompiledDocs,
   writeSourceDocs,
@@ -127,6 +128,17 @@ export class PatternManager {
   // In-flight compiled-cache write-backs (fire-and-forget); awaited by
   // flushCompileCacheWrites() for graceful shutdown / deterministic tests.
   private compileCacheWrites = new Set<Promise<unknown>>();
+  // `${patternId}\0${space}` pairs whose meta has been persisted this session.
+  // Per-SPACE (not per-pattern): an `inSpace` child piece is loaded from its
+  // own space by a fresh runtime, so the same pattern's meta may need to exist
+  // in several spaces (CT-1687). Entries record durable storage facts, so they
+  // intentionally survive `evictIfNeeded` (a re-save would be an idempotent,
+  // content-addressed write anyway).
+  private savedMetaSpaces = new Set<string>();
+  // `${entryIdentity}\0${space}` closure replications already kicked off this
+  // session (see `replicatePatternToSpace`). An entry is removed on failure so
+  // the next child creation retries.
+  private replicatedClosures = new Set<string>();
 
   constructor(readonly runtime: Runtime) {}
 
@@ -438,18 +450,31 @@ export class PatternManager {
     // and eat the conflict, until we support these kinds of writes properly.
     providedTx = undefined;
 
-    const tx = providedTx ?? this.runtime.edit();
-
-    // Already saved
-    if (this.patternMetaCellById.has(patternId)) {
+    // "Already saved" is per (patternId, space), NOT per pattern: an `inSpace`
+    // child piece is loaded from its OWN space by a fresh runtime, so the meta
+    // must be persisted there even when the parent's space already has a copy
+    // (CT-1687). The first-saved (or first-loaded) meta cell stays canonical in
+    // `patternMetaCellById`; saves into further spaces don't displace it.
+    const spaceKey = `${patternId}\0${space}`;
+    if (this.savedMetaSpaces.has(spaceKey)) return true;
+    const canonicalMetaCell = this.patternMetaCellById.get(patternId);
+    if (canonicalMetaCell && canonicalMetaCell.space === space) {
+      this.savedMetaSpaces.add(spaceKey);
       return true;
     }
 
-    const program = getPatternProgram(this.patternIdMap.get(patternId));
+    const tx = providedTx ?? this.runtime.edit();
+
+    // Prefer the live program; fall back to the canonical meta cell's stored
+    // value when the in-memory pattern is source-free (a by-identity load).
+    const canonicalMeta = canonicalMetaCell?.get();
+    const program = getPatternProgram(this.patternIdMap.get(patternId)) ??
+      canonicalMeta?.program;
     if (!program) return false;
 
     const pending = this.pendingMetaById.get(patternId) ?? {};
     const patternMeta: PatternMeta = {
+      ...(canonicalMeta as Partial<PatternMeta> | undefined),
       program,
       ...(pending as Partial<PatternMeta>),
     } as PatternMeta;
@@ -466,7 +491,10 @@ export class PatternManager {
       });
     }
 
-    this.patternMetaCellById.set(patternId, patternMetaCell.withTx());
+    if (!canonicalMetaCell) {
+      this.patternMetaCellById.set(patternId, patternMetaCell.withTx());
+    }
+    this.savedMetaSpaces.add(spaceKey);
     // If we have a pattern object for this id, ensure the back mapping exists
     const pattern = this.patternIdMap.get(patternId);
     if (pattern) this.patternToIdMap.set(pattern, patternId);
@@ -487,6 +515,135 @@ export class PatternManager {
     if (this.savePattern({ patternId, space }, tx)) {
       await this.getPatternMetaCell({ patternId, space }, tx).sync();
     }
+  }
+
+  /**
+   * Make a cross-space child piece independently loadable from its own space
+   * (CT-1687). A fresh runtime navigating to a `Factory.inSpace(...)` child
+   * loads pattern artifacts from the CHILD's space — but the parent bundle's
+   * meta save and compile-cache write-back both target the space the parent
+   * compiled into, so the child space had nothing and the load died with
+   * "has no stored source". Replicates both recovery paths into `toSpace`:
+   *
+   * - the pattern meta (program), when a program is available (a pattern
+   *   registered with source in hand, or one whose canonical meta cell holds
+   *   the stored program);
+   * - the content-addressed source + compiled closures, when the pattern
+   *   carries an artifact entry ref (the by-identity reload path — the only
+   *   one available to an ESM bundle SUB-pattern, which has no program object).
+   *
+   * Closure replication is fire-and-forget (tracked in `compileCacheWrites`,
+   * awaited by `flushCompileCacheWrites`): the child is loadable in-session
+   * regardless, this only affects fresh runtimes. A failure is logged and
+   * retried on the next child creation — never on the caller's commit path.
+   */
+  replicatePatternToSpace(
+    pattern: Pattern | Module,
+    toSpace: MemorySpace,
+    fromSpace: MemorySpace,
+  ): void {
+    if (toSpace === fromSpace) return;
+    const patternId = this.registerPattern(pattern);
+    this.savePattern({ patternId, space: toSpace });
+
+    const entryRef = this.getArtifactEntryRef(pattern);
+    if (!entryRef) return;
+    const dedupeKey = `${entryRef.identity}\0${toSpace}`;
+    if (this.replicatedClosures.has(dedupeKey)) return;
+    this.replicatedClosures.add(dedupeKey);
+    const replication = this.replicateClosures(
+      entryRef.identity,
+      fromSpace,
+      toSpace,
+    ).catch((error) => {
+      // Release the claim so a later child creation retries.
+      this.replicatedClosures.delete(dedupeKey);
+      logger.error("closure-replication-failed", () => [
+        `entry=${entryRef.identity}`,
+        `from=${fromSpace}`,
+        `to=${toSpace}`,
+        String(error),
+      ]);
+    });
+    this.compileCacheWrites.add(replication);
+    replication.finally(() => this.compileCacheWrites.delete(replication));
+  }
+
+  /**
+   * Copy the source + compiled closures reachable from `entryIdentity` out of
+   * `fromSpace` into `toSpace`, rebuilding the emitted-module shape the write
+   * functions expect. All-or-nothing: a partial compiled closure can never be
+   * served (the loaders require a full, integrity-valid hit), so an incomplete
+   * origin set throws instead of persisting an unservable copy.
+   */
+  private async replicateClosures(
+    entryIdentity: string,
+    fromSpace: MemorySpace,
+    toSpace: MemorySpace,
+  ): Promise<void> {
+    const cacheOpts = {
+      runtimeVersion: COMPILE_CACHE_RUNTIME_VERSION,
+      compilerDid: this.runtime.userIdentityDID,
+    };
+    const readTx = this.runtime.edit();
+    let sourceDocs;
+    let compiledDocs;
+    try {
+      sourceDocs = await loadVerifiedSourceClosure(
+        this.runtime,
+        fromSpace,
+        entryIdentity,
+        readTx,
+      );
+      compiledDocs = await loadCompiledClosure(
+        this.runtime,
+        fromSpace,
+        entryIdentity,
+        cacheOpts,
+        readTx,
+      );
+    } finally {
+      readTx.abort?.("closure-replication read complete");
+    }
+    if (!sourceDocs?.has(entryIdentity)) {
+      throw new Error("source closure unavailable in origin space");
+    }
+    const modules: CacheableModule[] = [];
+    for (const [identity, doc] of sourceDocs) {
+      const compiled = compiledDocs.get(identity);
+      if (!compiled) {
+        throw new Error(`compiled doc missing for ${identity}`);
+      }
+      modules.push({
+        identity,
+        filename: doc.filename,
+        source: doc.code,
+        js: compiled.code,
+        ...(compiled.sourceMap !== undefined
+          ? { sourceMap: compiled.sourceMap }
+          : {}),
+        // The write functions re-derive the entry's root links; keep only the
+        // real import edges.
+        imports: doc.imports
+          .filter((imp) => !imp.specifier.startsWith(ROOT_LINK_SPECIFIER))
+          .map((imp) => ({
+            specifier: imp.specifier,
+            targetIdentity: imp.identity,
+          })),
+      });
+    }
+    const { error } = await this.runtime.editWithRetry((tx) => {
+      writeSourceDocs(this.runtime, toSpace, modules, entryIdentity, tx);
+      writeCompiledDocs(
+        this.runtime,
+        toSpace,
+        modules,
+        entryIdentity,
+        cacheOpts,
+        tx,
+      );
+    });
+    if (error) throw error;
   }
 
   private async syncLinkedPatternSource(

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -128,6 +128,11 @@ export class PatternManager {
   // In-flight compiled-cache write-backs (fire-and-forget); awaited by
   // flushCompileCacheWrites() for graceful shutdown / deterministic tests.
   private compileCacheWrites = new Set<Promise<unknown>>();
+  // The subset of `compileCacheWrites` that are cold-compile closure
+  // write-backs. Tracked separately so `replicateClosures` can await them
+  // before reading the origin space — its own promise lives in
+  // `compileCacheWrites`, so awaiting that whole set would deadlock on itself.
+  private pendingCacheWriteBacks = new Set<Promise<unknown>>();
   // `${patternId}\0${space}` pairs whose meta has been persisted this session.
   // Per-SPACE (not per-pattern): an `inSpace` child piece is loaded from its
   // own space by a fresh runtime, so the same pattern's meta may need to exist
@@ -484,10 +489,32 @@ export class PatternManager {
 
     if (!providedTx) {
       this.runtime.prepareTxForCommit(tx);
-      tx.commit().then((result) => {
-        if (result.error) {
-          logger.warn("pattern", "Pattern already existed", patternId);
+      tx.commit().then(async (result) => {
+        if (!result.error) return;
+        // A commit error here is usually the benign content-addressed
+        // "already existed" conflict (see HACK above) — but for a cross-space
+        // save it can be a real failure (no write access to the child space,
+        // offline). Verify rather than taxonomize: if the meta is readable
+        // with a program, the desired state holds and the claim stands;
+        // otherwise release the claim so the next save into this space
+        // retries instead of silently never landing (CT-1687).
+        try {
+          const metaCell = this.getPatternMetaCell({ patternId, space });
+          await metaCell.sync();
+          if (metaCell.get()?.program) {
+            logger.warn("pattern", "Pattern already existed", patternId);
+            return;
+          }
+        } catch {
+          // fall through to release
         }
+        this.savedMetaSpaces.delete(spaceKey);
+        logger.warn(
+          "pattern",
+          "Pattern meta save failed",
+          patternId,
+          space,
+        );
       });
     }
 
@@ -581,6 +608,14 @@ export class PatternManager {
     fromSpace: MemorySpace,
     toSpace: MemorySpace,
   ): Promise<void> {
+    // The origin-space closure may have been produced by THIS session's cold
+    // compile, whose write-back is itself fire-and-forget and may not have
+    // committed yet. A lost race would throw here — and for a handler-created
+    // child (one space per profile) nothing re-fires the released dedupe key,
+    // leaving that child permanently unloadable. Await the in-flight
+    // write-backs first. (Their own set, not flushCompileCacheWrites: this
+    // replication promise is tracked there and would await itself.)
+    await Promise.allSettled([...this.pendingCacheWriteBacks]);
     const cacheOpts = {
       runtimeVersion: COMPILE_CACHE_RUNTIME_VERSION,
       compilerDid: this.runtime.userIdentityDID,
@@ -589,6 +624,11 @@ export class PatternManager {
     let sourceDocs;
     let compiledDocs;
     try {
+      // Verification recomputes module identities with the default ("")
+      // runtimeFingerprint — the same default every compile path in the tree
+      // uses today. If a non-empty fingerprint is ever threaded into
+      // compilation, it must be threaded here too or verification will
+      // reject every closure (logged as replication failures).
       sourceDocs = await loadVerifiedSourceClosure(
         this.runtime,
         fromSpace,
@@ -858,7 +898,11 @@ export class PatternManager {
         cacheOpts,
       );
       this.compileCacheWrites.add(writeBack);
-      writeBack.finally(() => this.compileCacheWrites.delete(writeBack));
+      this.pendingCacheWriteBacks.add(writeBack);
+      writeBack.finally(() => {
+        this.compileCacheWrites.delete(writeBack);
+        this.pendingCacheWriteBacks.delete(writeBack);
+      });
     }
 
     return this.patternFromEvaluation(result, program, entryIdentity);

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2593,6 +2593,28 @@ export class Runner {
     );
     const crossSpace = resultSpace !== processCell.space;
 
+    // CT-1687: a handler that materializes a child piece in another space
+    // (`Factory.inSpace(...)`) leaves a piece that a fresh runtime must load
+    // FROM THAT SPACE — where neither the pattern meta nor the compiled
+    // closure exist (the handler's bundle artifacts live in the handler's own
+    // space). The whole result pattern materializes inside the target space,
+    // so the per-node cross-space hook in instantiatePatternNode never sees
+    // the transition; replicate here, where the originating space is known.
+    for (const { module } of resultPattern.nodes) {
+      if (
+        module.type === "pattern" &&
+        module.targetSpace !== undefined &&
+        module.targetSpace !== processCell.space &&
+        isPattern(module.implementation)
+      ) {
+        this.runtime.patternManager.replicatePatternToSpace(
+          module.implementation,
+          module.targetSpace,
+          processCell.space,
+        );
+      }
+    }
+
     if (deferForNavigate && result === undefined) {
       const resultCell = this.runtime.getCell(
         resultSpace,
@@ -4027,6 +4049,15 @@ export class Runner {
       // identity. The journal allows the cross-space write once opted in.
       this.enableCrossSpaceChildCommit(
         tx,
+        resultCell.space,
+        resultCellLink.space,
+      );
+      // CT-1687: a fresh runtime navigating to the child piece loads its
+      // pattern artifacts from `resultCell.space` (the child's own space),
+      // where neither the meta nor the compiled closure exist yet. Replicate
+      // them there (fire-and-forget) so the child is independently loadable.
+      this.runtime.patternManager.replicatePatternToSpace(
+        patternImpl,
         resultCell.space,
         resultCellLink.space,
       );

--- a/packages/runner/test/inspace-child-reload.test.ts
+++ b/packages/runner/test/inspace-child-reload.test.ts
@@ -9,6 +9,7 @@ import type { RuntimeProgram } from "../src/harness/types.ts";
 const signer = await Identity.fromPassphrase("inspace-child-reload");
 const spaceA = signer.did();
 const spaceB = (await Identity.fromPassphrase("inspace child target B")).did();
+const spaceC = (await Identity.fromPassphrase("inspace child target C")).did();
 
 // CT-1687: a handler that materializes a child piece in ANOTHER space via
 // `Child.inSpace(...)({...})` (the multi-profile flow: profile-create.tsx pushes
@@ -125,6 +126,76 @@ describe("inSpace child piece reload from its own space (CT-1687)", () => {
       await childCell.pull();
       const value = childCell.getAsQueryResult() as { label: string };
       expect(value.label).toBe("hi");
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  // The build-time variant: the child node sits in the PARENT's graph (not a
+  // handler frame), so the cross-space transition is visible to
+  // `instantiatePatternNode` (resultCell.space !== resultCellLink.space) —
+  // the other replication hook.
+  it("a fresh runtime can start a build-time inSpace child", async () => {
+    const STATIC_PROGRAM: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            "import { pattern } from 'commonfabric';",
+            "",
+            "export const child = pattern<{ label: string }>(({ label }) => ({",
+            "  label,",
+            "}));",
+            "",
+            "export default pattern(() => ({",
+            `  kid: child.inSpace("${spaceC}")({ label: 'static-hi' }),`,
+            "}));",
+          ].join("\n"),
+        },
+      ],
+    };
+
+    const rt1 = newRuntime();
+    const rt2 = newRuntime();
+    try {
+      const tx1 = rt1.edit();
+      const parent = await rt1.patternManager.compilePattern(STATIC_PROGRAM, {
+        space: spaceA,
+        tx: tx1,
+      });
+      const resultCell1 = rt1.getCell<Record<string, unknown>>(
+        spaceA,
+        "inspace static child parent",
+        undefined,
+        tx1,
+      );
+      // deno-lint-ignore no-explicit-any
+      const r1 = rt1.run(tx1, parent as any, {}, resultCell1);
+      await tx1.commit();
+      await r1.pull();
+      await rt1.idle();
+
+      const kidCell = r1.key("kid").asSchema(
+        // deno-lint-ignore no-explicit-any
+        { type: "unknown", asCell: ["cell"] } as any,
+        // deno-lint-ignore no-explicit-any
+      ).get() as any;
+      const kidLink = kidCell.getAsNormalizedFullLink();
+      expect(kidLink.space).toBe(spaceC);
+
+      await rt1.patternManager.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+
+      const childCell = rt2.getCellFromLink(kidLink);
+      await childCell.sync();
+      const started = await rt2.start(childCell);
+      expect(started).toBe(true);
+
+      await childCell.pull();
+      const value = childCell.getAsQueryResult() as { label: string };
+      expect(value.label).toBe("static-hi");
     } finally {
       await rt2.dispose();
       await rt1.dispose();

--- a/packages/runner/test/inspace-child-reload.test.ts
+++ b/packages/runner/test/inspace-child-reload.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("inspace-child-reload");
+const spaceA = signer.did();
+const spaceB = (await Identity.fromPassphrase("inspace child target B")).did();
+
+// CT-1687: a handler that materializes a child piece in ANOTHER space via
+// `Child.inSpace(...)({...})` (the multi-profile flow: profile-create.tsx pushes
+// `ProfileHome.inSpace(name)({initialName})` onto the home `profiles` list) must
+// leave the child independently loadable FROM ITS OWN SPACE. A fresh runtime
+// navigating to the child piece (the shell's piece view) loads pattern artifacts
+// from `resultCell.space` — the child space — where, before the fix, neither the
+// pattern meta (program) nor the content-addressed source/compiled closures were
+// ever persisted: `savePattern` deduped on patternId alone and the sub-pattern
+// object carries no program, and the compile-cache write-back only targets the
+// space the parent bundle compiled into. Symptom: "Pattern <id> has no stored
+// source" → "Failed to load piece"; profiles uneditable.
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        "import { handler, pattern, Writable } from 'commonfabric';",
+        "",
+        "export const child = pattern<{ label: string }>(({ label }) => ({",
+        "  label,",
+        "}));",
+        "",
+        "type ChildOutput = { label: string };",
+        "",
+        "const create = handler<",
+        "  { label?: string },",
+        "  { items: Writable<ChildOutput[]> }",
+        ">((event, { items }) => {",
+        `  items.push(child.inSpace("${spaceB}")({`,
+        "    label: event.label ?? 'hi',",
+        "  }) as ChildOutput);",
+        "});",
+        "",
+        "export default pattern(() => {",
+        "  const items = new Writable<ChildOutput[]>([]).for('items');",
+        "  return { items, create: create({ items }) };",
+        "});",
+      ].join("\n"),
+    },
+  ],
+};
+
+const RESULT_CAUSE = "inspace child reload parent";
+
+const childLinkListSchema = {
+  type: "array",
+  items: { type: "unknown", asCell: ["cell"] },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+describe("inSpace child piece reload from its own space (CT-1687)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  const newRuntime = () =>
+    new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+  });
+  afterEach(async () => {
+    await storageManager?.close();
+  });
+
+  it("a fresh runtime can start the child from space B", async () => {
+    const rt1 = newRuntime();
+    const rt2 = newRuntime();
+    try {
+      // Session 1: run the parent in space A, create the child in space B via
+      // the handler (the profile-create flow).
+      const tx1 = rt1.edit();
+      const parent = await rt1.patternManager.compilePattern(PROGRAM, {
+        space: spaceA,
+        tx: tx1,
+      });
+      const resultCell1 = rt1.getCell<Record<string, unknown>>(
+        spaceA,
+        RESULT_CAUSE,
+        undefined,
+        tx1,
+      );
+      // deno-lint-ignore no-explicit-any
+      const r1 = rt1.run(tx1, parent as any, {}, resultCell1);
+      await tx1.commit();
+      await r1.pull();
+
+      r1.key("create").send({ label: "hi" });
+      await r1.pull();
+      await rt1.idle();
+
+      // The child materialized in space B (link identity, no deep resolve).
+      const links = r1.key("items").asSchema(childLinkListSchema)
+        // deno-lint-ignore no-explicit-any
+        .get() as any[];
+      expect(links.length).toBe(1);
+      const childLink = links[0].getAsNormalizedFullLink();
+      expect(childLink.space).toBe(spaceB);
+
+      await rt1.patternManager.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+
+      // Session 2: a fresh runtime loads the child piece from ITS OWN space —
+      // the shell's navigate-to-piece path. Before the fix this rejects with
+      // "Pattern <id> has no stored source".
+      const childCell = rt2.getCellFromLink(childLink);
+      await childCell.sync();
+      const started = await rt2.start(childCell);
+      expect(started).toBe(true);
+
+      await childCell.pull();
+      const value = childCell.getAsQueryResult() as { label: string };
+      expect(value.label).toBe("hi");
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});


### PR DESCRIPTION
Fixes the CT-1687 navigation failure: clicking a profile's cell-link in the multi-profile picker (#3830) showed **"Failed to load piece — Pattern of:fid1:… has no stored source"**, leaving profiles effectively uneditable (the picker has no inline edit UI).

## Root cause

A `Factory.inSpace(...)` child piece (each profile lives in its own space) was never independently loadable from that space. A fresh runtime navigating to the child loads pattern artifacts from `resultCell.space` — the child's space — where nothing was ever persisted, for three stacked reasons:

1. `savePattern` deduped on `patternId` alone, so the parent space's copy short-circuited every save into another space.
2. An ESM bundle **sub-pattern** (e.g. `ProfileHome` inside the home bundle) carries no `program` object, so even a non-deduped save had nothing to write.
3. The compile-cache write-back (source + compiled closures) only targets the space the parent bundle compiled into — and `inSpace`-derived factories weren't registered as derivation copies, so they didn't even resolve to a content-addressed artifact entry ref (which also meant the child's result cell never got `patternIdentity` meta).

## Fix

- **builder/pattern.ts** — `asScope`/`inSpace` factory copies register via `noteDerivedCopy`, so identity facts (trust, the artifact entry ref) resolve through to the root factory. Child result cells now carry `patternIdentity` meta.
- **pattern-manager.ts** — `savePattern` dedupes per `(patternId, space)` (canonical meta cell stays authoritative; falls back to its stored program when the in-memory pattern is source-free). New `replicatePatternToSpace` copies the **verified source + compiled closures** from the originating space into the child's space — fire-and-forget, tracked by `flushCompileCacheWrites`, all-or-nothing (a partial closure can never be served), deduped per `(entryIdentity, space)` per session with retry-on-failure.
- **runner.ts** — replication hooks at both cross-space child creation sites:
  - `instantiatePatternNode` (parent-graph children, where `resultCell.space !== resultCellLink.space`), and
  - `handleJavaScriptHandlerResult` (handler-frame children — the profile-create path — where the whole deferred result pattern materializes *inside* the target space, so the per-node hook never sees a space transition; the originating space is only visible here).

On reload, the child then takes the existing by-identity path (`loadPatternByIdentityAs`) from its own space's replicated closure.

## Verification

- New regression test `packages/runner/test/inspace-child-reload.test.ts`: a handler pushes `child.inSpace(B)({...})` onto a list (mirrors `profile-create.tsx` 1:1); a **fresh runtime** starts the child piece from space B. Fails with the exact production error before the fix; passes after.
- Full `packages/runner` suite: **570 passed, 0 failed**.
- **Live A/B against a running toolshed** (local dev): child created via the un-fixed CLI → `cf piece step` fails with `Pattern … has no stored source`; child created via the fix-bearing CLI → loads and steps from its own space in a fresh CLI runtime.

## Known limitations (follow-ups, noted in CT-1687)

- **No backfill**: children created before this fix stay unloadable until recreated (replication fires at creation time).
- **Version-skew durability**: compiled-closure docs are keyed by `COMPILE_CACHE_RUNTIME_VERSION`; after a runtime version bump a sub-pattern child has no meta-program recovery path (the replicated *source* docs are in place for a future by-identity source-recovery path).
- Inline *display* of another space's owner-protected profile fields is a separate gap (CT-1667, the cross-space read path).

Closes CT-1687.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `inSpace` child pieces independently loadable from their own space. Fixes CT-1687 where navigating to a profile failed with “has no stored source” in a fresh runtime, and hardens replication against write-back races.

- **Bug Fixes**
  - Builder: `asScope`/`inSpace` factories register via `noteDerivedCopy` so identity (artifact entry ref) flows to children.
  - Pattern manager: `savePattern` dedupes by `(patternId, space)`, falls back to the canonical stored program, and verifies the save on commit error (releases the claim if it didn’t land). New `replicatePatternToSpace` copies verified source and compiled closures from the parent’s space to the child’s space; it now awaits in-flight cold-compile write-backs to avoid races, is fire-and-forget, and retries on failure.
  - Runner: replication hooked in both cross-space creation paths (`handleJavaScriptHandlerResult`, `instantiatePatternNode`).
  - Tests: regression coverage for handler-created and build-time `inSpace` children; both load in a fresh runtime from the child’s space.
  - Docs: module-loading spec notes cross-space closure replication and server-compilation forward-compat.

- **Migration**
  - Recreate previously created `inSpace` children; there’s no backfill for existing items.

<sup>Written for commit 92d191ebe0c5b5aa34615241c0dd9f5166cb77bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

