### PR TITLE
fix(cfc): provenance-only reads don't gate requiredIntegrity (audit S7)

### DIFF
--- a/packages/patterns/cfc-group-chat-demo/main.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.test.tsx
@@ -364,14 +364,16 @@ export default pattern(() => {
       { action: action_set_room_bob },
       { action: bobChat.addTrustedRoom, trustedUi: roomGesture },
       { assertion: assert_bob_cannot_add_room_after_lockdown },
-      // Skipped under single-runtime wiring: granting Bob admin writes the
-      // RequiresIntegrity admins list, but this test colocates registry,
-      // profiles and messages in one doc, so the grant transaction's
-      // participant-row reads carry non-admin integrity labels and CFC's
-      // requiredIntegrity (which quantifies over every labeled read) rejects
-      // the write. The piece-shaped wiring is covered under enforcement by
-      // integration/cfc-group-chat-demo-multi-runtime.test.ts ("admins can
-      // grant admin to another user by name").
+      // Granting Bob admin writes the RequiresIntegrity admins list. The CFC
+      // requiredIntegrity over-rejection that used to block this (audit S7 —
+      // the grant's provenance-only participant-row reads quantified into the
+      // gate) is now FIXED (see cfc-required-integrity-provenance.test.ts), so
+      // the grant transaction commits. The steps stay skipped only for the same
+      // single-doc subject-matching limitation as the removal block above (the
+      // self-match misses when registry and profiles share one doc, so the
+      // post-grant admin lookups don't reflect the grant); the piece-shaped
+      // wiring is covered under enforcement by
+      // integration/cfc-group-chat-demo-multi-runtime.test.ts.
       {
         action: chat.toggleParticipantAdmin,
         event: { name: "Bob" },

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1693,6 +1693,40 @@ const ifcEntryAppliesToAttemptedWrite = (
   );
 };
 
+// Structural-link provenance atoms the runtime mints when a value is
+// dereferenced / fetched. They describe HOW a value was obtained, never an
+// endorsement an author can require via requiredIntegrity.
+const STRUCTURAL_LINK_PROVENANCE_ATOM_TYPES = new Set<string>([
+  CFC_ATOM_TYPE.LinkReference,
+  CFC_ATOM_TYPE.Origin,
+]);
+
+const isNonEndorsementProvenanceAtom = (atom: unknown): boolean =>
+  (isRecord(atom) && typeof atom.type === "string" &&
+    STRUCTURAL_LINK_PROVENANCE_ATOM_TYPES.has(atom.type)) ||
+  // The current-principal claim family (authored-by / represents-principal) is
+  // an identity provenance claim gated separately by
+  // currentPrincipalIntegrityReason, never a requiredIntegrity target.
+  isCurrentPrincipalClaimAtom(atom);
+
+// A consumed read whose label carries no confidentiality and whose integrity is
+// ENTIRELY non-endorsement provenance (a link reference / origin / a
+// current-principal claim) is structural plumbing, not a data input. It must
+// not gate a requiredIntegrity write: the transaction-global quantification
+// would otherwise false-reject an unrelated protected write (audit S7 — e.g.
+// cfc-group-chat-demo's admin grant reads adminRegistry.bootstrapAdmin.subject,
+// label [represents-principal, LinkReference], and that lookup fails the admins
+// list's requiredIntegrity:[group-chat-admin]). A read carrying ANY
+// confidentiality, or any genuine endorsement integrity atom, stays in the gate
+// — that keeps the cross-cell prompt-injection screen sound (its briefing reads
+// carry confidentiality; its endorsement reads carry real integrity).
+const isProvenanceOnlyConsumedLabel = (label: IFCLabel): boolean => {
+  if ((label.confidentiality?.length ?? 0) > 0) return false;
+  const integrity = label.integrity ?? [];
+  return integrity.length > 0 &&
+    integrity.every(isNonEndorsementProvenanceAtom);
+};
+
 const verifyInputRequirements = (
   tx: IExtendedStorageTransaction,
   schema: JSONSchema,
@@ -1725,7 +1759,15 @@ const verifyInputRequirements = (
       ),
       canonicalizeLogicalPath(read.path),
     ),
-  })).filter((read) => read.label !== undefined);
+  })).filter((read) =>
+    read.label !== undefined &&
+    // Provenance-only reads (link/origin/current-principal, no confidentiality)
+    // are structural plumbing, not endorsable inputs — excluding them stops the
+    // transaction-global quantification from false-rejecting unrelated
+    // protected writes (audit S7). Confidentiality- or endorsement-bearing
+    // reads stay, keeping the prompt-injection screen sound.
+    !isProvenanceOnlyConsumedLabel(read.label)
+  );
 
   for (const entry of walkIfcSchema(schema)) {
     if (

--- a/packages/runner/test/cfc-required-integrity-provenance.test.ts
+++ b/packages/runner/test/cfc-required-integrity-provenance.test.ts
@@ -1,0 +1,177 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { URI } from "@commonfabric/memory/interface";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-ri-provenance");
+
+// Audit S7: verifyInputRequirements quantifies requiredIntegrity over EVERY
+// labeled read in the transaction (transaction-global). A read that carries
+// only structural/identity PROVENANCE (a link dereference, a current-principal
+// claim) — never an endorsement — then false-rejects an unrelated protected
+// write. Concrete in cfc-group-chat-demo: granting admin reads
+// adminRegistry.bootstrapAdmin.subject (label [represents-principal,
+// LinkReference]) and that read fails the admins list's
+// requiredIntegrity:[group-chat-admin]. Fix (audit candidate D, vetted by the
+// oracle as the only incremental scoping that keeps the cross-cell
+// prompt-injection screen sound): drop a consumed read from the gate only when
+// it carries no confidentiality and its integrity is entirely non-endorsement
+// provenance. A confidentiality-bearing read (the prompt-injection briefing)
+// still gates.
+const LINK_REFERENCE_ATOM = {
+  type: "https://commonfabric.org/cfc/atom/LinkReference",
+};
+const REPRESENTS_PRINCIPAL_ATOM = {
+  kind: "represents-principal",
+  subject: signer.did(),
+};
+const ADMIN_ATOM = "group-chat-admin";
+
+// Seed a doc's stored CFC metadata directly via an ungated path-[] full-document
+// write (how the runtime persists it), so a later read picks up the given label.
+const seedLabeledDoc = async (
+  runtime: Runtime,
+  id: string,
+  value: unknown,
+  label: { integrity?: unknown[]; confidentiality?: unknown[] },
+): Promise<void> => {
+  const seed = runtime.edit();
+  const cell = runtime.getCell(signer.did(), id, undefined, seed);
+  const docId = cell.getAsNormalizedFullLink().id as URI;
+  seed.writeOrThrow({
+    space: signer.did(),
+    id: docId,
+    type: "application/json",
+    path: [],
+  }, {
+    value,
+    cfc: {
+      version: 1,
+      schemaHash: `seed-${id}`,
+      labelMap: { version: 1, entries: [{ path: [], label }] },
+    },
+  });
+  expect((await seed.commit()).ok).toBeDefined();
+};
+
+const SINK_SCHEMA = {
+  type: "object",
+  properties: {
+    out: { type: "string", ifc: { requiredIntegrity: [ADMIN_ATOM] } },
+  },
+  required: ["out"],
+} as const satisfies JSONSchema;
+
+describe("CFC requiredIntegrity provenance scoping (S7)", () => {
+  it("a provenance-only read does not gate a requiredIntegrity write", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      // A lookup doc whose stored label is entirely provenance: a link
+      // reference + a current-principal claim, no confidentiality.
+      await seedLabeledDoc(runtime, "ri-prov-lookup", "lookup", {
+        integrity: [REPRESENTS_PRINCIPAL_ATOM, LINK_REFERENCE_ATOM],
+      });
+
+      const tx = runtime.edit();
+      // Read the provenance-only lookup (records a confidential-free, provenance
+      // labeled read), then write the protected sink in the same tx.
+      runtime.getCell(signer.did(), "ri-prov-lookup", undefined, tx).get();
+      const sink = runtime.getCell(
+        signer.did(),
+        "ri-prov-sink",
+        SINK_SCHEMA,
+        tx,
+      );
+      sink.set({ out: "granted" });
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("a confidentiality-bearing read still gates requiredIntegrity (prompt-injection soundness)", async () => {
+    // The security side: a read that carries confidentiality (like the
+    // prompt-injection briefing) and lacks the required atom must STILL fail —
+    // it is a genuine data input, not provenance. This is what keeps the
+    // cross-cell prompt-injection screen sound under the fix.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      await seedLabeledDoc(runtime, "ri-conf-src", "briefing", {
+        confidentiality: ["prompt-injection-risk"],
+      });
+
+      const tx = runtime.edit();
+      runtime.getCell(signer.did(), "ri-conf-src", undefined, tx).get();
+      const sink = runtime.getCell(
+        signer.did(),
+        "ri-conf-sink",
+        SINK_SCHEMA,
+        tx,
+      );
+      sink.set({ out: "derived" });
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(String((result.error as Error | undefined)?.message)).toContain(
+        "requiredIntegrity failed",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("a read mixing a real integrity atom with provenance still gates", async () => {
+    // Only ENTIRELY-provenance reads are excluded. A read carrying a genuine
+    // (non-provenance) integrity atom that isn't the required one must still
+    // fail — provenance riding alongside real data must not launder it.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      await seedLabeledDoc(runtime, "ri-mixed-src", "data", {
+        // "other-endorsement" is a genuine endorsement atom, not provenance.
+        integrity: [LINK_REFERENCE_ATOM, "other-endorsement"],
+      });
+
+      const tx = runtime.edit();
+      runtime.getCell(signer.did(), "ri-mixed-src", undefined, tx).get();
+      const sink = runtime.getCell(
+        signer.did(),
+        "ri-mixed-sink",
+        SINK_SCHEMA,
+        tx,
+      );
+      sink.set({ out: "derived" });
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(String((result.error as Error | undefined)?.message)).toContain(
+        "requiredIntegrity failed",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

CFC spec-audit **S7**. `verifyInputRequirements` quantifies `requiredIntegrity` (and `maxConfidentiality`) over **every labeled read in the transaction** (transaction-global). A read carrying only structural/identity *provenance* — a link dereference (`LinkReference`/`Origin`) or a current-principal claim (`authored-by`/`represents-principal`), **none of which is ever a `requiredIntegrity` target** — then false-rejects an unrelated protected write.

**Concrete repro** (the audit's named case): in `cfc-group-chat-demo`, granting a user admin writes the `RequiresIntegrity<…>` admins list, but the grant transaction also reads `adminRegistry.bootstrapAdmin.subject` (stored label `[represents-principal, LinkReference]`) and participant rows. Those lookups lack `group-chat-admin`, so the transaction-global `consumed.every(...)` fails the admins write. The identical flow **passes** when registry/profiles live in separate docs — enforcement outcome depended on doc layout.

## The fix

Drop a consumed read from the gate **only when** it carries no confidentiality **and** its integrity is *entirely* non-endorsement provenance (`LinkReference` / `Origin` / a current-principal claim). A read with **any confidentiality** or **any genuine endorsement integrity atom** still gates.

This was the candidate vetted (by a deep cross-pattern investigation, all four `requiredIntegrity` use sites) as **the only incremental scoping that keeps the cross-cell prompt-injection screen sound**:

- The prompt-injection `recipient` gate is intrinsically **cross-cell** (the endorsement atoms live on the direct-command input, not the write target — proven by `cfc-integrity-mint-gate.test.ts`, where the required-integrity read is on `mint-gate-src` and the write on `mint-gate-sink`). **Path-scoping the consumed set to the target cell would make that gate vacuous → a false-pass on the security-critical screen.** This PR does *not* path-scope.
- The prompt-injection briefing reads carry **confidentiality** (`prompt-injection-risk` / `Caveat`), so they're never dropped — the screen still bites.
- `InjectionSafe` / `UserSurfaceInput` / `PromptSlotBound` are endorsement atoms and are **not** in the exclusion set, so requiredIntegrity gates over them are unaffected.

## Deliberately deferred (phase work)

- **Per-write data-flow provenance** (the principled end state — quantify only over reads that *flowed into* the write). Needs new write-provenance plumbing; documented as a follow-on in `docs/plans/runner_cfc_implementation.md`.
- **The vacuous-pass tightening** (audit #14 — make in-scope unlabeled reads fail-closed). Unsound *without* data-flow scoping (it would massively over-reject against the transaction-global set), so it must land with the data-flow work, not here.

## Testing

New `cfc-required-integrity-provenance.test.ts`, red-green:
- a provenance-only read **no longer gates** a `requiredIntegrity` write (was rejected, now commits);
- a **confidentiality-bearing** read **still gates** (prompt-injection soundness);
- a read **mixing** provenance with a genuine endorsement atom **still gates** (no laundering).

`cfc-integrity-mint-gate.test.ts` (the InjectionSafe-forgery regression) is unaffected. Full `packages/runner` suite: **570 passed, 0 failed**.

In `cfc-group-chat-demo/main.test.tsx` the grant transaction now **commits** (the CFC blocker is gone). Its steps stay `skip: true` only for an **unrelated** single-doc subject-matching limitation (same as the removal block above it, covered under enforcement by the multi-runtime integration suite) — comment updated to reflect that S7 is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
