### PR TITLE
Add toolshed container build for k8s

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+dist
+**/cache
+**/node_modules
+packages/toolshed/shell-frontend
+packages/toolshed/shell-frontend-dev
+packages/toolshed/COMPILED
+packages/toolshed/*.log
+packages/shell/dist
+tutorials
+cf.pem
+*.pem

--- a/Dockerfile.toolshed
+++ b/Dockerfile.toolshed
@@ -1,0 +1,33 @@
+# Toolshed container image (M0 spike — see common-cluster docs/implementation-plan.md)
+#
+# Build context must be the labs repo ROOT (workspace imports resolve from the
+# root deno.json). Modeled on clusterduck's Dockerfile.worker labs-builder
+# stage, pinned to the Deno version tasks/check.sh requires.
+#
+#   docker build -f Dockerfile.toolshed --build-arg COMMIT_SHA=$(git rev-parse HEAD) \
+#     -t us-central1-docker.pkg.dev/commontools-core/containers/toolshed:m0 .
+
+FROM denoland/deno:2.8.1 AS builder
+
+WORKDIR /build/labs
+COPY . .
+
+RUN deno install --frozen
+
+# Docker layers make Deno.rename a cross-device move; patch build-binaries to cp.
+RUN sed -i 's|await Deno\.rename(shellOut, toolshedShellFrontend);|await new Deno.Command("cp", { args: ["-r", shellOut, toolshedShellFrontend] }).output(); await Deno.remove(shellOut, { recursive: true });|g' tasks/build-binaries.ts
+
+ARG COMMIT_SHA
+RUN COMMIT_SHA=$COMMIT_SHA deno task build-binaries
+
+FROM denoland/deno:2.8.1
+
+COPY --from=builder /build/labs/dist/toolshed /usr/local/bin/toolshed
+
+# Warm run: bakes the @db/sqlite FFI libsqlite3.so into the image's deno plug
+# cache so pods don't need github.com egress on first database open.
+RUN ENV=production CFTS_AI_GATEWAY_URL= DB_PATH=/tmp/warm.db timeout 15s toolshed || [ $? -eq 124 ] \
+    && rm -rf /tmp/warm.db* /tmp/cf-compilation-cache
+
+EXPOSE 8000
+ENTRYPOINT ["toolshed"]


### PR DESCRIPTION
Adds `Dockerfile.toolshed` (repo-root context) + `.dockerignore` — the container build used by the common-cluster M0 spike, which proved toolshed running on GKE under gVisor with a ZFS PVC, WebSockets through Envoy Gateway, and the memory protocol round-tripping via cf.

Build: two-stage on `denoland/deno:2.8.1` — `deno install --frozen`, `deno task build-binaries` (with the cross-device `Deno.rename` → `cp` patch, same workaround clusterduck used), then a slim runtime stage that warm-runs the binary once to bake the `@db/sqlite` FFI lib into the deno plug cache (no github.com egress needed in pods).

Notes: the checked-in `packages/toolshed/Dockerfile` is stale/broken (Deno 2.1.9, package-dir context can't resolve workspace imports, no shell-frontend assets) — left untouched here; wiring this into CI as an image-publish job is M2.3 in the common-cluster implementation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Dockerfile.toolshed` and `.dockerignore` to build a k8s-ready `toolshed` container using repo-root workspace imports. Produces a self-contained image on `denoland/deno:2.8.1`, with `@db/sqlite` FFI pre-baked for no egress on first DB open; used by the common-cluster M0 spike.

- **New Features**
  - Two-stage build on `denoland/deno:2.8.1` with `deno install --frozen` and `deno task build-binaries`.
  - Patches cross-device `Deno.rename` to `cp` in `tasks/build-binaries.ts`.
  - Warm-run embeds `@db/sqlite` FFI in the Deno plug cache; avoids `github.com` egress in pods.
  - Uses repo-root build context so workspace imports and shell assets resolve correctly.
  - Exposes port 8000; `ENTRYPOINT` is `toolshed`. Adds `.dockerignore` to shrink context.

- **Migration**
  - Build from the repo root: `docker build -f Dockerfile.toolshed --build-arg COMMIT_SHA=$(git rev-parse HEAD) -t <registry>/toolshed:<tag> .`. The existing `packages/toolshed/Dockerfile` remains unchanged and is deprecated for k8s.

<sup>Written for commit d6a73147807f339201287eca2a07b1061c57f655. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

