### PR TITLE
cf-harness: atomic artifact writes + require CFC sidecar transports for enforce modes

### DIFF
--- a/packages/cf-harness/src/artifacts.ts
+++ b/packages/cf-harness/src/artifacts.ts
@@ -59,8 +59,21 @@ const resolveTranscriptPathWithinRunRoot = (
     : fallbackPath;
 };
 
+// Artifacts such as run-state.json are the canonical audit and resume record and
+// are rewritten on every tool call. A crash partway through a plain truncating
+// write would leave a half-written file that breaks resume and corrupts the CFC
+// audit trail. Write to a sibling temp file and rename, which is atomic on the
+// same filesystem, so readers only ever observe a complete prior or new version.
 const writeJsonFile = async (path: string, value: unknown): Promise<void> => {
-  await Deno.writeTextFile(path, `${JSON.stringify(value, null, 2)}\n`);
+  const contents = `${JSON.stringify(value, null, 2)}\n`;
+  const tempPath = `${path}.${crypto.randomUUID()}.tmp`;
+  try {
+    await Deno.writeTextFile(tempPath, contents);
+    await Deno.rename(tempPath, path);
+  } catch (error) {
+    await Deno.remove(tempPath).catch(() => {});
+    throw error;
+  }
 };
 
 export interface HarnessArtifactStore {

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -56,6 +56,8 @@ import type {
 } from "./contracts/transcript.ts";
 import { CfHarnessEngine } from "./engine.ts";
 import {
+  CFC_INVOCATION_CONTEXT_DIR_ENV,
+  CFC_RESULT_DIR_ENV,
   DEFAULT_DOCKER_RUNSC_IMAGE,
   DEFAULT_FABRIC_MOUNT_PATH,
 } from "./sandbox/docker-runsc.ts";
@@ -117,6 +119,8 @@ const CLI_STRING_FLAGS = [
   "structured-result-schema-file",
   "run-manifest",
   "cfc-enforcement-mode",
+  "cfc-result-dir",
+  "cfc-invocation-context-dir",
   "sandbox-image",
   "max-model-turns",
   "fabric-mount",
@@ -173,6 +177,8 @@ export interface CfHarnessCliConfig {
   structuredResult?: CfHarnessStructuredResultConfig;
   runManifestPath?: string;
   cfcEnforcementModeOverride?: CfcEnforcementMode;
+  cfcResultDir?: string;
+  cfcInvocationContextDir?: string;
   browserAccess?: HarnessBrowserAccessLease;
   maxModelTurns: number;
   printTranscript: boolean;
@@ -350,6 +356,8 @@ Options:
   --browser-access-profile-mode <mode> persistent | transient
   --browser-access-account-access <access> available | none
   --cfc-enforcement-mode <mode> disabled | observe | enforce-explicit | enforce-strict
+  --cfc-result-dir <path>       Host dir where runsc writes the CFC result sidecar (required for enforce-* modes)
+  --cfc-invocation-context-dir <path> Host dir where the harness writes the CFC invocation-context sidecar (required for enforce-* modes)
   --sandbox-image <image>       Docker image for the runsc-cfc sandbox (default: ${DEFAULT_DOCKER_RUNSC_IMAGE})
   --fabric-mount <path>         Host path for a Fabric FUSE mount (mounted at /fabric in the sandbox)
   --host-mount <spec>           Extra host bind mount (repeatable: name=<id>,source=<host>,target=<sandbox>,mode=readonly|writable)
@@ -363,7 +371,28 @@ Environment:
   OPENAI_API_KEY                Fallback API key if CF_HARNESS_API_KEY is unset
   CF_HARNESS_DOCKER_NETWORK_MODE none | bridge | host (default: bridge)
   CF_HARNESS_SANDBOX_IMAGE      Default value for --sandbox-image
+  ${CFC_RESULT_DIR_ENV} Fallback for --cfc-result-dir
+  ${CFC_INVOCATION_CONTEXT_DIR_ENV} Fallback for --cfc-invocation-context-dir
 `;
+
+// CFC sidecar transport dirs may be supplied by flag (resolved against cwd so
+// relative paths work) or env-var fallback (already an absolute host path by
+// convention). The docker-runsc layer re-validates that the result is absolute.
+const resolveOptionalCfcDir = (
+  flagValue: unknown,
+  envValue: string | undefined,
+  cwd: string,
+  flagName: string,
+): string | undefined => {
+  if (typeof flagValue === "string") {
+    const trimmed = flagValue.trim();
+    if (trimmed === "") {
+      throw new Error(`${flagName} requires a non-empty path`);
+    }
+    return resolve(cwd, trimmed);
+  }
+  return envValue;
+};
 
 const parsePositiveInteger = (
   input: string | undefined,
@@ -1190,6 +1219,10 @@ export const parseCfHarnessCliArgs = async (
       ),
       CF_CFC_MODE: Deno.env.get("CF_CFC_MODE"),
       CF_HARNESS_SANDBOX_IMAGE: Deno.env.get("CF_HARNESS_SANDBOX_IMAGE"),
+      [CFC_RESULT_DIR_ENV]: Deno.env.get(CFC_RESULT_DIR_ENV),
+      [CFC_INVOCATION_CONTEXT_DIR_ENV]: Deno.env.get(
+        CFC_INVOCATION_CONTEXT_DIR_ENV,
+      ),
     };
   const rawSandboxImage = typeof args["sandbox-image"] === "string"
     ? args["sandbox-image"].trim()
@@ -1215,6 +1248,18 @@ export const parseCfHarnessCliArgs = async (
       "cfc enforcement mode must be one of disabled, observe, enforce-explicit, enforce-strict",
     );
   }
+  const cfcResultDir = resolveOptionalCfcDir(
+    args["cfc-result-dir"],
+    nonEmptyEnvValue(env[CFC_RESULT_DIR_ENV]),
+    cwd,
+    "--cfc-result-dir",
+  );
+  const cfcInvocationContextDir = resolveOptionalCfcDir(
+    args["cfc-invocation-context-dir"],
+    nonEmptyEnvValue(env[CFC_INVOCATION_CONTEXT_DIR_ENV]),
+    cwd,
+    "--cfc-invocation-context-dir",
+  );
   const rawFabricMount = typeof args["fabric-mount"] === "string"
     ? args["fabric-mount"].trim()
     : undefined;
@@ -1264,6 +1309,10 @@ export const parseCfHarnessCliArgs = async (
     ...(runManifestPath !== undefined ? { runManifestPath } : {}),
     ...(cfcEnforcementModeOverride !== undefined
       ? { cfcEnforcementModeOverride }
+      : {}),
+    ...(cfcResultDir !== undefined ? { cfcResultDir } : {}),
+    ...(cfcInvocationContextDir !== undefined
+      ? { cfcInvocationContextDir }
       : {}),
     ...(browserAccess !== undefined ? { browserAccess } : {}),
     maxModelTurns: parsePositiveInteger(
@@ -1881,6 +1930,12 @@ export const runCfHarnessCli = async (
         ...(parsed.sandboxImage !== undefined
           ? { sandboxImage: parsed.sandboxImage }
           : {}),
+        ...(parsed.cfcResultDir !== undefined
+          ? { cfcResultDir: parsed.cfcResultDir }
+          : {}),
+        ...(parsed.cfcInvocationContextDir !== undefined
+          ? { cfcInvocationContextDir: parsed.cfcInvocationContextDir }
+          : {}),
         model: parsed.model ?? artifacts.runState.model,
         gatewayBaseUrl: parsed.gatewayBaseUrl,
         gatewayAuthMode: parsed.gatewayAuthMode,
@@ -1953,6 +2008,12 @@ export const runCfHarnessCli = async (
         artifactRoot: parsed.artifactRoot,
         ...(parsed.sandboxImage !== undefined
           ? { sandboxImage: parsed.sandboxImage }
+          : {}),
+        ...(parsed.cfcResultDir !== undefined
+          ? { cfcResultDir: parsed.cfcResultDir }
+          : {}),
+        ...(parsed.cfcInvocationContextDir !== undefined
+          ? { cfcInvocationContextDir: parsed.cfcInvocationContextDir }
           : {}),
         model: parsed.model,
         gatewayBaseUrl: parsed.gatewayBaseUrl,

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -319,9 +319,10 @@ export class CfHarnessEngine {
         cfcInvocationContextDir: options.cfcInvocationContextDir,
       })
       : this.config.sandbox;
-    // Capture the engine-owned docker-runsc config so we can refuse to *run* an
-    // enforce-mode tool whose sandbox lacks the CFC sidecar transports (the
-    // check fires at run start, not construction — see #assertCfcTransportReady).
+    // Capture the engine-owned docker-runsc config so we can refuse to *run*
+    // enforce-mode sandbox work — capability probes or tools — whose sandbox
+    // lacks the CFC sidecar transports (the check fires at run start, not
+    // construction — see #assertCfcTransportReady).
     // Only when the engine constructs the runtime itself: an injected
     // sandboxRuntime is the thing that actually executes and carries its own
     // enforcement guarantees, while `sandboxConfig` in that branch is the
@@ -729,11 +730,12 @@ export class CfHarnessEngine {
     return policyTracePath;
   }
 
-  // Fail fast before any tool runs under enforcement on a sandbox that lacks the
-  // CFC sidecar transports. Checked at run start rather than construction so an
-  // engine can be built and inspected (config threading, capability probes)
-  // without a live CFC wiring; the floor only applies once tools actually
-  // execute. Idempotent so the cost is paid once per run.
+  // Fail fast before any sandbox execution under enforcement on a sandbox that
+  // lacks the CFC sidecar transports — capability probes included, since they
+  // run scripts inside the same sandbox (not just builtin tools). Checked at
+  // run start rather than construction so an engine can be built and inspected
+  // (config threading, --describe-capabilities) without a live CFC wiring.
+  // Idempotent so the cost is paid once per run.
   #assertCfcTransportReady(): void {
     if (this.#cfcTransportChecked || this.#ownedRunscConfig === undefined) {
       return;
@@ -746,6 +748,10 @@ export class CfHarnessEngine {
   }
 
   async ensureDiagnosticsInitialized(): Promise<HarnessRunState> {
+    // The capability probes below execute scripts inside the sandbox, so the
+    // enforce-mode transport floor applies here too — and must throw before
+    // the try block below, which records probe errors instead of propagating.
+    this.#assertCfcTransportReady();
     if (this.#runState.capabilitySnapshot !== undefined) {
       return this.getRunState();
     }

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -77,6 +77,7 @@ import type { HarnessTranscriptMessage } from "./contracts/transcript.ts";
 import type { BuiltinToolId } from "./contracts/tool-descriptor.ts";
 import type { CfcLabelView } from "@commonfabric/runner/cfc";
 import {
+  assertDockerRunscCfcTransportForMode,
   DockerRunscSandboxRuntime,
   resolveDockerRunscSandboxConfig,
 } from "./sandbox/docker-runsc.ts";
@@ -93,6 +94,7 @@ import {
 } from "./sandbox/process-runner.ts";
 import type {
   DockerRunscAdditionalMountConfig,
+  DockerRunscSandboxConfig,
   HarnessSandboxConfig,
   SandboxRuntime,
 } from "./sandbox/types.ts";
@@ -168,6 +170,8 @@ export interface CreateHarnessEngineOptions
   workspaceHostPath?: string;
   sandboxImage?: string;
   additionalMounts?: readonly DockerRunscAdditionalMountConfig[];
+  cfcResultDir?: string;
+  cfcInvocationContextDir?: string;
   sandboxRuntime?: SandboxRuntime;
   artifactStore?: HarnessArtifactStore;
   processRunner?: ProcessRunner;
@@ -188,25 +192,40 @@ const isToolOutputWithId = (value: unknown): value is ToolOutputWithId =>
   "outputId" in value &&
   typeof value.outputId === "string";
 
+interface ResolveSandboxConfigOptions {
+  workspaceHostPath?: string;
+  sandboxImage?: string;
+  additionalMounts?: readonly DockerRunscAdditionalMountConfig[];
+  cfcResultDir?: string;
+  cfcInvocationContextDir?: string;
+}
+
 const resolveSandboxConfig = (
   config: HarnessConfig,
-  workspaceHostPath?: string,
-  sandboxImage?: string,
-  additionalMounts?: readonly DockerRunscAdditionalMountConfig[],
+  options: ResolveSandboxConfigOptions,
 ): HarnessSandboxConfig => {
   if (config.sandbox !== undefined) {
     return config.sandbox;
   }
-  if (workspaceHostPath === undefined) {
+  if (options.workspaceHostPath === undefined) {
     throw new Error(
       "sandbox config is required when no workspaceHostPath default is provided",
     );
   }
   return resolveDockerRunscSandboxConfig({
-    workspaceHostPath,
-    ...(sandboxImage !== undefined ? { image: sandboxImage } : {}),
-    ...(additionalMounts !== undefined && additionalMounts.length > 0
-      ? { additionalMounts }
+    workspaceHostPath: options.workspaceHostPath,
+    ...(options.sandboxImage !== undefined
+      ? { image: options.sandboxImage }
+      : {}),
+    ...(options.additionalMounts !== undefined &&
+        options.additionalMounts.length > 0
+      ? { additionalMounts: options.additionalMounts }
+      : {}),
+    ...(options.cfcResultDir !== undefined
+      ? { cfcResultDir: options.cfcResultDir }
+      : {}),
+    ...(options.cfcInvocationContextDir !== undefined
+      ? { cfcInvocationContextDir: options.cfcInvocationContextDir }
       : {}),
   });
 };
@@ -283,6 +302,8 @@ export class CfHarnessEngine {
   #outputSequence: number;
   readonly #now: () => string;
   readonly #hostMounts: readonly HostSandboxMount[];
+  readonly #ownedRunscConfig?: DockerRunscSandboxConfig;
+  #cfcTransportChecked = false;
 
   constructor(options: CreateHarnessEngineOptions = {}) {
     this.#now = options.now ?? (() => new Date().toISOString());
@@ -290,13 +311,21 @@ export class CfHarnessEngine {
     const runId = options.runState?.runId ?? options.runId ??
       crypto.randomUUID();
     const sandboxConfig = options.sandboxRuntime === undefined
-      ? resolveSandboxConfig(
-        this.config,
-        options.workspaceHostPath,
-        options.sandboxImage,
-        options.additionalMounts,
-      )
+      ? resolveSandboxConfig(this.config, {
+        workspaceHostPath: options.workspaceHostPath,
+        sandboxImage: options.sandboxImage,
+        additionalMounts: options.additionalMounts,
+        cfcResultDir: options.cfcResultDir,
+        cfcInvocationContextDir: options.cfcInvocationContextDir,
+      })
       : this.config.sandbox;
+    // Capture the engine-owned docker-runsc config so we can refuse to *run* an
+    // enforce-mode tool whose sandbox lacks the CFC sidecar transports (the
+    // check fires at run start, not construction — see #assertCfcTransportReady).
+    // Injected sandbox runtimes carry their own enforcement guarantees.
+    this.#ownedRunscConfig = sandboxConfig?.kind === "docker-runsc-cfc"
+      ? sandboxConfig
+      : undefined;
     this.hostProcessRunner = options.processRunner ?? new DenoProcessRunner();
     this.sandbox = options.sandboxRuntime ??
       createSandboxRuntime(sandboxConfig!, options.processRunner);
@@ -696,6 +725,22 @@ export class CfHarnessEngine {
     return policyTracePath;
   }
 
+  // Fail fast before any tool runs under enforcement on a sandbox that lacks the
+  // CFC sidecar transports. Checked at run start rather than construction so an
+  // engine can be built and inspected (config threading, capability probes)
+  // without a live CFC wiring; the floor only applies once tools actually
+  // execute. Idempotent so the cost is paid once per run.
+  #assertCfcTransportReady(): void {
+    if (this.#cfcTransportChecked || this.#ownedRunscConfig === undefined) {
+      return;
+    }
+    assertDockerRunscCfcTransportForMode(
+      this.#runState.cfcEnforcementMode,
+      this.#ownedRunscConfig,
+    );
+    this.#cfcTransportChecked = true;
+  }
+
   async ensureDiagnosticsInitialized(): Promise<HarnessRunState> {
     if (this.#runState.capabilitySnapshot !== undefined) {
       return this.getRunState();
@@ -755,6 +800,7 @@ export class CfHarnessEngine {
     if (tool === undefined) {
       throw new Error(`unknown builtin tool: ${toolId}`);
     }
+    this.#assertCfcTransportReady();
     await this.ensureDiagnosticsInitialized();
     this.#runState = setHarnessRunStatus(
       this.#runState,

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -322,8 +322,12 @@ export class CfHarnessEngine {
     // Capture the engine-owned docker-runsc config so we can refuse to *run* an
     // enforce-mode tool whose sandbox lacks the CFC sidecar transports (the
     // check fires at run start, not construction — see #assertCfcTransportReady).
-    // Injected sandbox runtimes carry their own enforcement guarantees.
-    this.#ownedRunscConfig = sandboxConfig?.kind === "docker-runsc-cfc"
+    // Only when the engine constructs the runtime itself: an injected
+    // sandboxRuntime is the thing that actually executes and carries its own
+    // enforcement guarantees, while `sandboxConfig` in that branch is the
+    // unused resolved config and may describe a different sandbox entirely.
+    this.#ownedRunscConfig = options.sandboxRuntime === undefined &&
+        sandboxConfig?.kind === "docker-runsc-cfc"
       ? sandboxConfig
       : undefined;
     this.hostProcessRunner = options.processRunner ?? new DenoProcessRunner();

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -23,10 +23,15 @@ import type {
   SandboxShellRequest,
 } from "./types.ts";
 import type {
+  CfcEnforcementMode,
   CfcSandboxJsonValue,
   CfcSandboxResult,
   CfcStreamChannel,
   IFCLabel,
+} from "@commonfabric/runner/cfc";
+import {
+  CFC_ENFORCING_STRICTNESS,
+  cfcEnforcementStrictness,
 } from "@commonfabric/runner/cfc";
 
 export const DEFAULT_DOCKER_RUNSC_IMAGE =
@@ -281,6 +286,56 @@ export const resolveDockerRunscSandboxConfig = (
       ? { cfcInvocationContextTransport }
       : {}),
   };
+};
+
+/**
+ * In `enforce-*` modes the runtime depends on two trusted sidecar transports:
+ *
+ *  - `cfcInvocationContextTransport` — the harness writes the initial-taint
+ *    invocation context the sandbox reads in. Without it the sandbox starts
+ *    untainted, so input labels (prompt-slot influence, prior observed labels)
+ *    are silently dropped.
+ *  - `cfcResultDir` — runsc writes the final-taint result the harness reads
+ *    back to mediate output. Without it every command's CFC result is absent
+ *    and enforce-mode mediation fail-closes every observation.
+ *
+ * Both come from `CF_HARNESS_RUNSC_CFC_*` env vars or explicit config and are
+ * easy to omit. A run can then claim to enforce while the dangerous half
+ * (missing input taint) degrades with no operator-visible signal. The engine
+ * calls this at run start (before the first tool executes) so a mis-wired
+ * enforce run aborts loudly rather than emitting silent denials mid-run.
+ * `disabled`/`observe` impose no such floor.
+ */
+export const assertDockerRunscCfcTransportForMode = (
+  mode: CfcEnforcementMode,
+  config: Pick<
+    DockerRunscSandboxConfig,
+    "cfcResultDir" | "cfcInvocationContextTransport"
+  >,
+): void => {
+  // `disabled` and `observe` do not mediate or deny tool output, so a missing
+  // transport cannot silently weaken them; only the enforcing floor requires it.
+  if (cfcEnforcementStrictness(mode) < CFC_ENFORCING_STRICTNESS) {
+    return;
+  }
+  const missing: string[] = [];
+  if (config.cfcInvocationContextTransport === undefined) {
+    missing.push(
+      `CFC invocation-context transport (set --cfc-invocation-context-dir or ${CFC_INVOCATION_CONTEXT_DIR_ENV})`,
+    );
+  }
+  if (config.cfcResultDir === undefined) {
+    missing.push(
+      `CFC result transport (set --cfc-result-dir or ${CFC_RESULT_DIR_ENV})`,
+    );
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `cfc enforcement mode '${mode}' requires the runsc sandbox to wire ${
+        missing.join(" and ")
+      }; refusing to start a run that would silently degrade enforcement`,
+    );
+  }
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -2626,6 +2626,11 @@ Deno.test({
           "agent-browser:scripts/capture-workflow.sh",
           "--skill-script-execution-target",
           "host",
+          // Host skill-script execution is outside CFC mediation; this test
+          // exercises target threading, not enforcement, so run with CFC off
+          // rather than wiring sidecar transports it would never use.
+          "--cfc-enforcement-mode",
+          "disabled",
           "--browser-access-lease-id",
           "lease-1",
           "--browser-access-cdp-url",

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertMatch, assertThrows } from "@std/assert";
 import {
+  assertDockerRunscCfcTransportForMode,
   DEFAULT_DOCKER_RUNSC_IMAGE,
   DockerRunscSandboxRuntime,
   resolveDefaultContainerUser,
@@ -708,4 +709,44 @@ Deno.test("DockerRunscSandboxRuntime mounts host bind roots with read/write mode
     "sandbox:latest",
     "/bin/pwd",
   ]);
+});
+
+Deno.test("assertDockerRunscCfcTransportForMode allows non-enforce modes without transports", () => {
+  assertDockerRunscCfcTransportForMode("disabled", {});
+  assertDockerRunscCfcTransportForMode("observe", {});
+});
+
+Deno.test("assertDockerRunscCfcTransportForMode rejects enforce modes without transports", () => {
+  for (const mode of ["enforce-explicit", "enforce-strict"] as const) {
+    assertThrows(
+      () => assertDockerRunscCfcTransportForMode(mode, {}),
+      Error,
+      "invocation-context transport",
+    );
+    assertThrows(
+      () =>
+        assertDockerRunscCfcTransportForMode(mode, {
+          cfcInvocationContextTransport: { kind: "sidecar", dir: "/host/ctx" },
+        }),
+      Error,
+      "result transport",
+    );
+    assertThrows(
+      () =>
+        assertDockerRunscCfcTransportForMode(mode, {
+          cfcResultDir: "/host/results",
+        }),
+      Error,
+      "invocation-context transport",
+    );
+  }
+});
+
+Deno.test("assertDockerRunscCfcTransportForMode allows enforce modes with both transports", () => {
+  for (const mode of ["enforce-explicit", "enforce-strict"] as const) {
+    assertDockerRunscCfcTransportForMode(mode, {
+      cfcResultDir: "/host/results",
+      cfcInvocationContextTransport: { kind: "sidecar", dir: "/host/ctx" },
+    });
+  }
 });

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -126,6 +126,55 @@ Deno.test("CfHarnessEngine accepts a default sandbox image override", () => {
   );
 });
 
+Deno.test("CfHarnessEngine constructs in enforce mode without CFC transports", () => {
+  // Construction must stay cheap and inspectable; the transport floor is only
+  // enforced once a tool actually runs (see the run-start test below).
+  const engine = new CfHarnessEngine({
+    workspaceHostPath: "/host/project",
+    cfcEnforcementMode: "enforce-strict",
+  });
+  assertEquals(engine.getRunState().cfcEnforcementMode, "enforce-strict");
+});
+
+Deno.test("CfHarnessEngine refuses to run a tool in enforce mode without CFC transports", async () => {
+  const engine = new CfHarnessEngine({
+    runId: "run-1",
+    workspaceHostPath: "/host/project",
+    cfcEnforcementMode: "enforce-explicit",
+  });
+  await assertRejects(
+    () => engine.invokeBuiltinTool("bash", { command: "echo hi" }),
+    Error,
+    "requires the runsc sandbox to wire",
+  );
+});
+
+Deno.test("CfHarnessEngine runs a tool in enforce mode when CFC transports are wired", async () => {
+  const cfcResultDir = await Deno.makeTempDir({ prefix: "cf-harness-result-" });
+  const cfcInvocationContextDir = await Deno.makeTempDir({
+    prefix: "cf-harness-ctx-",
+  });
+  const runner = new FakeProcessRunner([
+    { stdout: "container-1\n", stderr: "", exitCode: 0 },
+    { stdout: "hi\n", stderr: "", exitCode: 0 },
+    { stdout: "0\n", stderr: "", exitCode: 0 },
+    { stdout: "", stderr: "", exitCode: 0 },
+  ]);
+  const engine = new CfHarnessEngine({
+    runId: "run-1",
+    workspaceHostPath: "/host/project",
+    cfcEnforcementMode: "enforce-explicit",
+    cfcResultDir,
+    cfcInvocationContextDir,
+    processRunner: runner,
+  });
+  // The guard does not fire; execution reaches the (faked) docker lifecycle
+  // (the exact mediated output is covered elsewhere — here we only assert the
+  // transport floor lets the run proceed and an outputId is produced).
+  const result = await engine.invokeBuiltinTool("bash", { command: "echo hi" });
+  assertEquals(typeof result.output.outputId, "string");
+});
+
 Deno.test("CfHarnessEngine lets bash-no-sandbox host commands handle missing workspace paths", async () => {
   const workspaceHostPath = await Deno.makeTempDir({
     prefix: "cf-harness-engine-missing-",

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -11,6 +11,7 @@ import { CAPABILITY_PROBE_SENTINEL } from "../src/diagnostics.ts";
 import { CfHarnessEngine } from "../src/engine.ts";
 import type { HarnessRunState } from "../src/run-state.ts";
 import { RESERVED_ARTIFACT_PATH_DETAIL } from "../src/tools/reserved-artifacts.ts";
+import { resolveDockerRunscSandboxConfig } from "../src/sandbox/docker-runsc.ts";
 import type {
   ProcessRunner,
   ProcessRunRequest,
@@ -171,6 +172,26 @@ Deno.test("CfHarnessEngine runs a tool in enforce mode when CFC transports are w
   // The guard does not fire; execution reaches the (faked) docker lifecycle
   // (the exact mediated output is covered elsewhere — here we only assert the
   // transport floor lets the run proceed and an outputId is produced).
+  const result = await engine.invokeBuiltinTool("bash", { command: "echo hi" });
+  assertEquals(typeof result.output.outputId, "string");
+});
+
+Deno.test("CfHarnessEngine does not apply the CFC transport floor to an injected sandbox runtime", async () => {
+  // An injected sandboxRuntime is the thing that actually executes and carries
+  // its own enforcement guarantees. The engine must not validate the *resolved
+  // config's* transports against it: that config is unused here and may describe
+  // a different sandbox, so doing so would falsely reject an otherwise valid
+  // enforce-mode run. (Regression for the run-start transport floor.)
+  const engine = new CfHarnessEngine({
+    runId: "run-1",
+    workspaceHostPath: "/host/project",
+    cfcEnforcementMode: "enforce-strict",
+    // A docker-runsc-cfc config with no CFC sidecar transports wired.
+    sandbox: resolveDockerRunscSandboxConfig({
+      workspaceHostPath: "/host/project",
+    }),
+    sandboxRuntime: new FakeSandboxRuntime(),
+  });
   const result = await engine.invokeBuiltinTool("bash", { command: "echo hi" });
   assertEquals(typeof result.output.outputId, "string");
 });

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -129,7 +129,8 @@ Deno.test("CfHarnessEngine accepts a default sandbox image override", () => {
 
 Deno.test("CfHarnessEngine constructs in enforce mode without CFC transports", () => {
   // Construction must stay cheap and inspectable; the transport floor is only
-  // enforced once a tool actually runs (see the run-start test below).
+  // enforced once the run starts — at diagnostics init (capability probes) or
+  // the first tool call, whichever comes first (see the run-start tests below).
   const engine = new CfHarnessEngine({
     workspaceHostPath: "/host/project",
     cfcEnforcementMode: "enforce-strict",
@@ -148,6 +149,29 @@ Deno.test("CfHarnessEngine refuses to run a tool in enforce mode without CFC tra
     Error,
     "requires the runsc sandbox to wire",
   );
+});
+
+Deno.test("CfHarnessEngine refuses to run capability probes in enforce mode without CFC transports", async () => {
+  // The prompt loop initializes diagnostics before the first model turn, and
+  // the capability probes execute scripts inside the sandbox — so the
+  // transport floor must fire before any sandbox execution, not only at the
+  // first builtin tool call. The probe error swallowing inside diagnostics
+  // init must not absorb the floor violation into a failure record.
+  const runner = new FakeProcessRunner();
+  const engine = new CfHarnessEngine({
+    runId: "run-1",
+    workspaceHostPath: "/host/project",
+    cfcEnforcementMode: "enforce-explicit",
+    processRunner: runner,
+  });
+  await assertRejects(
+    () => engine.ensureDiagnosticsInitialized(),
+    Error,
+    "requires the runsc sandbox to wire",
+  );
+  // Nothing reached the docker lifecycle: the run failed closed before any
+  // sandbox execution.
+  assertEquals(runner.calls.length, 0);
 });
 
 Deno.test("CfHarnessEngine runs a tool in enforce mode when CFC transports are wired", async () => {


### PR DESCRIPTION
## What this does

Two correctness/robustness fixes to the cf-harness CFC enforcement surface, found during a correctness pass over `cf-harness` measured against the `specs/cfc/` requirements and the gVisor CFC fork. Each is a separate commit.

### 1. Atomic artifact writes (`fix: atomic artifact writes via temp-file rename`)

`run-state.json` is the canonical resume + CFC audit record and is rewritten on **every** tool call via a plain truncating `Deno.writeTextFile`. A crash mid-write left a half-written file that breaks resume and corrupts the audit trail. Switched `writeJsonFile` to write a sibling temp file and `rename` (atomic on the same filesystem), with temp cleanup on failure. All artifact persists route through `writeJsonFile`, so this covers run-state, transcript, policy trace, tool outputs, etc. No behavior change on the happy path.

### 2. Require CFC sidecar transports for enforce modes (`feat: require CFC sidecar transports for enforce modes`)

**The bug:** enforce modes silently depend on two trusted sidecar transports being wired:

- **invocation-context transport** — the harness writes the initial-taint context the sandbox reads *in*. Missing ⇒ the sandbox starts untainted and input labels (prompt-slot influence, prior observed labels) are silently dropped.
- **result dir** (`cfcResultDir`) — runsc writes the final-taint result the harness reads *back* to mediate output. Missing ⇒ every command's CFC result is absent and enforce-mode mediation fail-closes every observation.

Both came **only** from `CF_HARNESS_RUNSC_CFC_*` env vars. The CLI never set them, and nothing validated them. So `--cfc-enforcement-mode enforce-strict` without those env vars produces a run that fails closed on all output (safe, but looks like a mysteriously dead agent) **and** silently seeds no input taint (unsafe) — with zero operator-visible signal that enforcement is degraded.

**The fix:** `assertDockerRunscCfcTransportForMode` rejects an enforce-mode run whose docker-runsc sandbox lacks either transport. Added first-class CLI flags `--cfc-result-dir` / `--cfc-invocation-context-dir` (resolved against cwd) alongside the existing env-var fallback, so a run records how it was wired instead of relying on ambient env.

---

## Design decisions in #2 — please evaluate

Two choices here are judgment calls. I'm flagging both so reviewers can push back.

### A. Gate at **run start**, not at construction

I considered enforcing the transport floor in the `CfHarnessEngine` constructor (strongest fail-fast). I moved it to run start (`#assertCfcTransportReady`, idempotent) instead — fired at diagnostics init (whose capability probes execute scripts inside the sandbox) or the first tool invocation, whichever comes first — because:

- An engine is legitimately constructed and **inspected** without ever executing sandbox code — config-threading tests, `--describe-capabilities`. A construction-time throw breaks those for no safety gain: no sandboxed command has run, so nothing has leaked. (An earlier revision wrongly listed capability probes as inspection — willkelly's review caught that the probes run scripts in the sandbox via the prompt loop's diagnostics init *before* the first tool call, so the floor now fires there too.)
- The invariant I actually care about is *"nothing executes in the sandbox under enforcement without the transports,"* and run-start is exactly that boundary. It still fails fast — before the **first** command — so a mis-wired real run aborts loudly rather than emitting silent denials.
- Concretely: gating at construction broke ~23 CLI plumbing tests that build a real engine in the default `enforce-explicit` mode and mock the prompt loop. Those failures weren't false positives to suppress — they're the tell that construction-time is too early. (The one test that genuinely executes a tool, host `run_skill_script`, I switched to `--cfc-enforcement-mode disabled` with a comment, since host skill-script execution is outside CFC mediation by design and that test exercises target threading, not enforcement.)

Trade-off: a misconfigured enforce run that never starts (no diagnostics init, no tool call) won't be flagged. That's acceptable — such a run does nothing observable and seeds no taint. If reviewers prefer maximal fail-fast, moving the call into the constructor is a one-line change, but it requires every construct-and-inspect call site (incl. tests) to wire transports or pin a non-enforce mode.

### B. Require **both** transports, and only for the `enforce-*` floor

- **Both, not just the result dir.** The result transport alone gives fail-closed *output* (visibly broken, so self-correcting). The invocation-context transport is the dangerous one to omit: it fails *open* on input — the sandbox just starts untainted and the operator sees a working-looking agent. Requiring both closes the silent-degradation path, which is the whole point.
- **Only `enforce-explicit` / `enforce-strict`.** The predicate is `cfcEnforcementStrictness(mode) < CFC_ENFORCING_STRICTNESS` (reusing the runner's canonical floor constant). `disabled` and `observe` neither mediate nor deny tool output, so a missing transport can't silently weaken them — `observe` is explicitly *not* gated. (I initially used `=== 0`, which wrongly swept in `observe`; the test suite caught it.)

---

## Testing

- New validator unit tests over every `(mode × transport)` combination (`docker-runsc-sandbox.test.ts`).
- New engine tests: construction in enforce-without-transport **succeeds**; the first tool run **aborts**; a tool run with both transports wired **proceeds** (`engine.test.ts`).
- Full `cf-harness` suite green (407 passed). `deno fmt --check`, `deno lint`, `deno check` clean on all changed files.

## Out of scope (documented, not fixed here)

A fuller assessment from the pass — including that the `bash` curl-policy only constrains the literal word `curl` (real egress is gated by gVisor sink rules + docker `--network`), a small TOCTOU window in `bash-no-sandbox` host-path checks, and gVisor egress heuristics (port-443 TLS inference, snooped DNS cache) — lives in `session_outputs/2026-06-10_cf-harness-correctness-pass/ASSESSMENT.md`. Happy to spin any of those into follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make artifact writes atomic to prevent corrupt resume/audit files, and require CFC sidecar transports for enforce modes with a run-start guard limited to harness-managed docker-runsc sandboxes. Adds `--cfc-result-dir` and `--cfc-invocation-context-dir` and fails fast before capability probes or the first tool if wiring is missing.

- **Bug Fixes**
  - Write JSON artifacts via temp file + rename to ensure atomic writes (run-state, transcript, policy trace, tool outputs).
  - Apply the enforce-mode transport guard at diagnostics init (before capability probes) and on first tool call.
  - Scope the transport check to engine-owned docker-runsc runtimes so injected runtimes aren’t falsely rejected.

- **Migration**
  - For `enforce-explicit` and `enforce-strict` with a harness-managed docker-runsc sandbox, set both `--cfc-result-dir <host-path>` and `--cfc-invocation-context-dir <host-path>` (or `CF_HARNESS_RUNSC_CFC_*` env vars). Missing either errors before any sandbox execution. `disabled` and `observe` are unchanged.

<sup>Written for commit eb57e3a800c18dfb6a3e07179d05da9e542a4f30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

