### PR TITLE
fix(runner): materialize cross-space link targets on read (CT-1667)

### DIFF
--- a/docs/specs/shared-profile-rosters.md
+++ b/docs/specs/shared-profile-rosters.md
@@ -76,29 +76,24 @@ Store a reference to the contributor's profile cell (the `result` of their
 `cf-cell-link` / `cf-render`):
 
 - **Pros:** Always current — a profile rename propagates to every roster that
-  links it.
-- **Cons:** Resolving the link requires reaching the *other* user's profile
-  space. That is exactly the cross-space reachability the runtime does **not**
-  guarantee for arbitrary users; it works cleanly for the current viewer's own
-  profile but is not guaranteed for a roster full of other people's profile
-  links. It also couples the roster's render to remote spaces' availability.
+  links it. The runtime materializes cross-space link targets on read (a read
+  that finds the target absent kicks an async load and re-renders on arrival —
+  CT-1667, PR #4019), so the link resolves for any viewer with access to the
+  profile's space.
+- **Cons:** First render shows blanks until the cross-space load lands, and
+  the roster's freshness couples to the remote space's availability — offline
+  or unreachable profile spaces render empty rather than stale.
 
 ### Verdict
 
 **Default to a snapshot.** It matches the "each user contributes their own data"
-model, keeps the shared roster fully self-describing inside the space, and avoids
-depending on other users' profile spaces being reachable. Reach for a live link
-only when (a) freshness genuinely matters and (b) you have confirmed the linked
-profiles resolve for *all* viewers in your deployment — and even then, consider a
-**hybrid**: store the snapshot for reliable rendering *and* keep the link
-alongside it for an explicit "refresh from profile" action.
-
-> Uncertainty flagged: persisting another user's live profile cell into a
-> `PerSpace` array and having *every* viewer dereference it across space
-> boundaries is not something this spec verified end to end. The current
-> viewer's own `#profile` result is known to render (see
-> `packages/patterns/shared-profile-demo/main.tsx`). Treat the live-link roster
-> as the advanced path and validate cross-space resolution before relying on it.
+model, keeps the shared roster fully self-describing inside the space, and
+renders identically (and immediately) for all viewers regardless of remote
+space availability. Reach for a live link when freshness genuinely matters —
+it resolves cross-space for any authorized viewer — and consider a **hybrid**:
+store the snapshot for immediate, availability-independent rendering *and*
+keep the link alongside it for live freshness or an explicit "refresh from
+profile" action.
 
 ## Reference demo
 
@@ -367,9 +362,10 @@ const profileWish = wish({ query: "#profile" }); // result is ProfileHomeOutput-
 // Render an entry with: <cf-cell-link $cell={entry.profile} /> or <cf-render $cell={entry.profile} />.
 ```
 
-Validate cross-space resolution for *all* viewers before shipping this — see the
-uncertainty note above. A hybrid (snapshot for rendering + link for an explicit
-refresh) is usually the safer way to get freshness.
+Cross-space resolution works for any viewer with access to the profile's
+space (CT-1667, PR #4019); the trade-off is availability — entries render
+blank while the remote space is unreachable. A hybrid (snapshot for immediate
+rendering + link for freshness or an explicit refresh) gives both.
 
 ## Recommended approach for chat/game patterns
 
@@ -382,8 +378,8 @@ refresh) is usually the safer way to get freshness.
    the fields). This returns the user's default profile under PR #3830, with the
    framework picker handling the multi-profile case.
 3. **Store a snapshot** (name + avatar copied at join time) in the roster by
-   default. Use a live link only when freshness matters and cross-space
-   resolution is confirmed; prefer a hybrid if you need both.
+   default. Use a live link when freshness matters; prefer a hybrid if you
+   want freshness without coupling first render to remote-space availability.
 4. Append idempotently — guard on "already joined" so re-renders and reconnects
    don't duplicate entries (see the `join` handler above).
 5. Render every other participant's name/avatar directly from `participants`.
@@ -400,8 +396,8 @@ It follows the snapshot model above and renders with the identity components:
   component covering the image / glyph / initials cases uniformly (no hand-rolled
   `<img>` + placeholder `<div>`).
 - The current viewer's own identity renders via the trusted
-  **`<cf-profile-badge $profile={profileWish.result} />`** — the one place a live
-  profile cell is reliably resolvable (the viewer's own `#profile`).
+  **`<cf-profile-badge $profile={profileWish.result} />`**. (Live profile cells
+  now also resolve cross-space for other authorized viewers — CT-1667.)
 
 Verified deployed (`cf piece new … main.tsx`): renders with 0 console errors;
 participant rows show image/emoji/initials avatars; the viewer badge shows the
@@ -410,9 +406,10 @@ profile (or a graceful "Unknown profile" fallback when the identity has none).
 ## Follow-ups (not done here)
 
 - The runnable pattern uses a **snapshot** roster. A live-link / hybrid variant
-  (rendering *other* users' rosters via `cf-profile-badge` bound to their profile
-  cell) still needs the cross-space resolution validation called out above before
-  it can be relied on for real multiplayer.
+  (rendering *other* users' entries via `cf-profile-badge` bound to their profile
+  cell) is unblocked now that cross-space link targets materialize on read
+  (CT-1667, PR #4019); it still deserves a multi-user browser pass before being
+  promoted to the recommended path.
 
 ## References
 

--- a/packages/patterns/system/profile-create.tsx
+++ b/packages/patterns/system/profile-create.tsx
@@ -84,11 +84,12 @@ export const setDefaultProfile = handler<
   unknown,
   {
     defaultProfile: Writable<ProfileHomeOutput | undefined>;
-    // Take the profile as a LINK cell, not a resolved value: resolving the full
-    // ProfileHomeOutput requires reading its owner-protected name/avatar/elements
-    // across the profile's space boundary, which returns undefined (CT-1667 read
-    // gap) → the action argument fails schema validation → "stream action argument
-    // is undefined … not running". We only need the link to write into defaultProfile.
+    // Take the profile as a LINK cell, not a resolved value: the handler only
+    // needs the link to write into defaultProfile, and a link argument doesn't
+    // require the profile's cross-space values to be loaded at event time —
+    // resolving the full value here would fail required-field validation
+    // ("stream action argument is undefined … not running") whenever the
+    // profile's space hasn't materialized locally yet.
     profile: Cell<ProfileHomeOutput>;
   }
 >((_, { defaultProfile, profile }) => {
@@ -103,8 +104,8 @@ export const setMruProfile = handler<
   unknown,
   {
     mru: Writable<ProfileHomeOutput[]>;
-    // Link cell, not a resolved value — same CT-1667 cross-space-read reason as
-    // setDefaultProfile above (resolving the owner-protected fields yields undefined).
+    // Link cell, not a resolved value — same event-time-validation reason as
+    // setDefaultProfile above.
     profile: Cell<ProfileHomeOutput>;
   }
 >((_, { mru, profile }) => {

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -989,18 +989,14 @@ export class CellImpl<T extends FabricValue>
       });
 
       // Wait for the scheduler to process all pending work, then resolve.
-      // Convergence (CT-1667): the read may have kicked async loads of link
-      // targets absent from the local replica (typically across a space
-      // boundary). Each arrival re-runs the read action (the absent doc is a
-      // tracked dependency) and can discover the NEXT hop, so loop — bounded
-      // — until no cross-space loads remain. Pulls that kicked nothing take
-      // the zero-iteration path and keep their existing timing.
+      // If the read kicked async loads of cross-space link targets, await
+      // them and re-idle — each arrival re-runs the read and can reveal the
+      // next hop — bounded. Pulls that kicked nothing take the
+      // zero-iteration path and keep their previous timing.
       this.runtime.scheduler.idle().then(async () => {
         const storage = this.runtime.storageManager;
-        // The pending pool is manager-global, so this pull may also wait on
-        // loads kicked by concurrent readers — same semantics as `synced()`,
-        // and converging on them is harmless (the loop exits as soon as the
-        // pool drains).
+        // The pending pool is manager-global (same semantics as `synced()`):
+        // this pull may also wait on loads kicked by concurrent readers.
         let round = 0;
         for (; round < 10; round++) {
           if ((storage.pendingCrossSpacePromiseCount?.() ?? 0) === 0) break;

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -988,8 +988,20 @@ export class CellImpl<T extends FabricValue>
         isEffect: true,
       });
 
-      // Wait for the scheduler to process all pending work, then resolve
-      this.runtime.scheduler.idle().then(() => {
+      // Wait for the scheduler to process all pending work, then resolve.
+      // Convergence (CT-1667): the read may have kicked async loads of link
+      // targets absent from the local replica (typically across a space
+      // boundary). Each arrival re-runs the read action (the absent doc is a
+      // tracked dependency) and can discover the NEXT hop, so loop — bounded
+      // — until no cross-space loads remain. Pulls that kicked nothing take
+      // the zero-iteration path and keep their existing timing.
+      this.runtime.scheduler.idle().then(async () => {
+        const storage = this.runtime.storageManager;
+        for (let round = 0; round < 10; round++) {
+          if ((storage.pendingCrossSpacePromiseCount?.() ?? 0) === 0) break;
+          await (storage.crossSpaceSettled?.() ?? Promise.resolve());
+          await this.runtime.scheduler.idle();
+        }
         cancel?.();
         resolve(result);
       });

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -997,10 +997,23 @@ export class CellImpl<T extends FabricValue>
       // the zero-iteration path and keep their existing timing.
       this.runtime.scheduler.idle().then(async () => {
         const storage = this.runtime.storageManager;
-        for (let round = 0; round < 10; round++) {
+        // The pending pool is manager-global, so this pull may also wait on
+        // loads kicked by concurrent readers — same semantics as `synced()`,
+        // and converging on them is harmless (the loop exits as soon as the
+        // pool drains).
+        let round = 0;
+        for (; round < 10; round++) {
           if ((storage.pendingCrossSpacePromiseCount?.() ?? 0) === 0) break;
           await (storage.crossSpaceSettled?.() ?? Promise.resolve());
           await this.runtime.scheduler.idle();
+        }
+        if (
+          round === 10 && (storage.pendingCrossSpacePromiseCount?.() ?? 0) > 0
+        ) {
+          logger.warn("pull", () => [
+            "pull() convergence bound exhausted with cross-space loads still",
+            `pending: ${this.sourceURI}`,
+          ]);
         }
         cancel?.();
         resolve(result);

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -289,7 +289,10 @@ export function resolveLink(
       if (crossSpace) {
         const maybePromise = runtime.getCellFromLink(link).sync();
         if (maybePromise instanceof Promise) {
-          const promise = maybePromise.finally(() => {
+          // Swallow sync failures: this kick is best-effort (the read still
+          // resolves from the local replica) and an unhandled rejection here
+          // would otherwise escape the resolution path.
+          const promise = maybePromise.catch(() => {}).finally(() => {
             runtime.storageManager.removeCrossSpacePromise(promise);
           }) as unknown as Promise<void>;
           runtime.storageManager.addCrossSpacePromise(promise);

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -595,6 +595,39 @@ export class Runtime {
     return wrapped;
   }
 
+  // (space, id) pairs for which a missing-link-target load has been kicked
+  // this session. The kicked sync establishes a live per-doc subscription, so
+  // a later creation of the doc still arrives — one kick per doc suffices.
+  private missingDocLoadKicks = new Set<string>();
+
+  /**
+   * Kick an asynchronous load of a linked document that a read traversal
+   * found absent from the local replica (CT-1667). Per-space server queries
+   * cannot follow links across space boundaries, so the target of a
+   * cross-space link is never covered by the originating subscription — and
+   * a minimal-schema subscription can leave even same-space link targets
+   * uncovered. The load is fire-and-forget but registered as a cross-space
+   * promise, so `storageManager.synced()` (and `Cell.pull()`'s convergence
+   * loop) can await it; when the doc arrives, the tracked read dependency
+   * re-runs the reader. Deduped per (space, id): the kicked sync leaves a
+   * live subscription behind, so repeat kicks add nothing.
+   */
+  ensureLinkedDocLoaded(link: NormalizedFullLink): void {
+    const key = `${link.space}\0${link.id}`;
+    if (this.missingDocLoadKicks.has(key)) return;
+    this.missingDocLoadKicks.add(key);
+    const maybePromise = this.getCellFromLink(link).sync();
+    if (maybePromise instanceof Promise) {
+      const promise = maybePromise.catch(() => {
+        // Allow a retry on failure (e.g. transient disconnect).
+        this.missingDocLoadKicks.delete(key);
+      }).finally(() => {
+        this.storageManager.removeCrossSpacePromise(promise);
+      }) as unknown as Promise<void>;
+      this.storageManager.addCrossSpacePromise(promise);
+    }
+  }
+
   getCfcStats(): Readonly<CfcRuntimeStats> {
     return { ...this.cfcStats };
   }

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -601,16 +601,14 @@ export class Runtime {
   private missingDocLoadKicks = new Set<string>();
 
   /**
-   * Kick an asynchronous load of a linked document that a read traversal
-   * found absent from the local replica (CT-1667). Per-space server queries
-   * cannot follow links across space boundaries, so the target of a
-   * cross-space link is never covered by the originating subscription — and
-   * a minimal-schema subscription can leave even same-space link targets
-   * uncovered. The load is fire-and-forget but registered as a cross-space
-   * promise, so `storageManager.synced()` (and `Cell.pull()`'s convergence
-   * loop) can await it; when the doc arrives, the tracked read dependency
-   * re-runs the reader. Deduped per (space, id): the kicked sync leaves a
-   * live subscription behind, so repeat kicks add nothing.
+   * Asynchronously load a cross-space link target that a read found absent
+   * from the local replica (CT-1667): per-space server queries cannot follow
+   * links across space boundaries, so the client must fetch such targets
+   * itself. Fire-and-forget, but registered as a cross-space promise so
+   * `storageManager.synced()` and `Cell.pull()`'s convergence loop can await
+   * it; the absent doc is a tracked read, so the reader re-runs on arrival.
+   * Deduped per (space, id): the kicked sync leaves a live subscription
+   * behind, so repeat kicks add nothing.
    */
   ensureLinkedDocLoaded(link: NormalizedFullLink): void {
     const key = `${link.space}\0${link.id}`;

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1068,7 +1068,15 @@ export function validateAndTransform(
   const traverser = new SchemaObjectTraverser<any>(
     tx!,
     selector,
-    createDefaultTraversalContext(options?.traverseCells ?? false),
+    createDefaultTraversalContext(
+      options?.traverseCells ?? false,
+      undefined,
+      undefined,
+      // Absent link targets (typically across a space boundary, which the
+      // source doc's per-space subscription cannot cover) get an async load
+      // kicked; the tracked read re-runs the reader on arrival (CT-1667).
+      (missing) => runtime.ensureLinkedDocLoaded(missing),
+    ),
     objectCreator,
   );
   const { ok: val, error: _err } = traverser.traverse(doc, link);

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1072,9 +1072,8 @@ export function validateAndTransform(
       options?.traverseCells ?? false,
       undefined,
       undefined,
-      // Absent link targets (typically across a space boundary, which the
-      // source doc's per-space subscription cannot cover) get an async load
-      // kicked; the tracked read re-runs the reader on arrival (CT-1667).
+      // Absent cross-space link targets get an async load kicked; the
+      // tracked read re-runs the reader on arrival.
       (missing) => runtime.ensureLinkedDocLoaded(missing),
     ),
     objectCreator,

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -162,6 +162,22 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
   removeCrossSpacePromise(promise: Promise<void>): void;
 
   /**
+   * Number of cross-space promises currently pending (async loads of link
+   * targets in other spaces, kicked during link resolution or read
+   * traversal). Zero in steady state — `Cell.pull()` uses this to decide
+   * whether a convergence round is needed at all (CT-1667).
+   */
+  pendingCrossSpacePromiseCount?(): number;
+
+  /**
+   * Wait for the currently pending cross-space promises (and any they
+   * transitively kick) to settle, WITHOUT waiting for full provider sync the
+   * way `synced()` does. Used by `Cell.pull()`'s convergence loop so pulls
+   * that kicked no loads keep their existing timing.
+   */
+  crossSpaceSettled?(): Promise<void>;
+
+  /**
    * Load cell from storage. Will also subscribe to new changes.
    *
    * @returns Promise that resolves when the cell sync is complete.

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -623,6 +623,16 @@ export class StorageManager implements IStorageManager {
     this.#crossSpacePromises.delete(promise);
   }
 
+  pendingCrossSpacePromiseCount(): number {
+    return this.#crossSpacePromises.size;
+  }
+
+  crossSpaceSettled(): Promise<void> {
+    const { resolve, promise } = Promise.withResolvers<void>();
+    void this.resolveCrossSpace(resolve);
+    return promise;
+  }
+
   subscribe(subscription: IStorageNotification): void {
     this.#subscription.subscribe(subscription);
   }

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -920,14 +920,12 @@ export type TraversalContext = {
   includeMeta: boolean;
   metaDocsVisited: Set<string>;
   /**
-   * Called when a followed link's target document is entirely absent from
-   * the local replica (CT-1667). Per-space server queries cannot follow
-   * links across space boundaries (and minimal-schema subscriptions can
-   * leave even same-space targets uncovered), so the traversal is the first
-   * place the gap is observable. The runtime-aware caller kicks an async
-   * load (see `Runtime.ensureLinkedDocLoaded`); the traversal itself only
-   * reports. Optional: schema-tracking traversals on the server have no
-   * runtime and no replica gap.
+   * Reports a followed link whose target document is absent from the local
+   * replica and lives in ANOTHER space. Per-space server queries cannot
+   * follow links across space boundaries, so such a target is never covered
+   * by the subscription that loaded the source doc — the client must fetch
+   * it itself (see `Runtime.ensureLinkedDocLoaded`). Optional: server-side
+   * schema traversals have no replica gap.
    */
   onMissingLinkTarget?: (link: NormalizedFullLink) => void;
 };
@@ -1874,32 +1872,32 @@ function followPointer(
         "traverse",
         () => ["followPointer found missing/retracted fact", valueEntry],
       );
-      // A linked doc absent from the local replica may simply never have
-      // been fetched — the subscription that loaded the SOURCE doc cannot
-      // cover targets across a space boundary (CT-1667). Report it so the
-      // runtime can kick an async load; this read still resolves notFound
-      // and the tracked dependency re-runs the reader when the doc arrives.
-      // Pass the link with the narrowed selector schema so the fetch covers
-      // the shape this traversal actually needs. The selector was re-rooted
-      // at the TARGET doc (its path is `["value", ...inDocPath]`), so when
-      // one exists its path — minus the "value" prefix — is the path the
-      // schema describes; pairing the schema with the bare link path would
-      // register a malformed watch selector.
-      context.onMissingLinkTarget?.({
-        space: link.space,
-        id: link.id,
-        path: selector !== undefined
-          ? selector.path.slice(1) as readonly string[]
-          : link.path,
-        scope: link.scope,
-        ...(selector?.schema !== undefined || link.schema !== undefined
-          ? {
-            schema: (selector?.schema ?? link.schema) as
-              | JSONSchema
-              | undefined,
-          }
-          : {}),
-      } as NormalizedFullLink);
+      // A CROSS-SPACE target absent from the replica cannot have been
+      // covered by the source doc's per-space subscription — report it for
+      // an async load. This read still resolves notFound; the absent doc is
+      // a tracked read, so the reader re-runs when it arrives. Same-space
+      // absent targets are NOT reported: they are either covered by the
+      // originating query or genuinely absent, and kicking them turns every
+      // read of an optional value into a server query. The reported link
+      // carries the selector's target-rooted path (minus its "value"
+      // prefix) and schema so the fetch covers the shape this read needs.
+      if (link.space !== doc.address.space) {
+        context.onMissingLinkTarget?.({
+          space: link.space,
+          id: link.id,
+          path: selector !== undefined
+            ? selector.path.slice(1) as readonly string[]
+            : link.path,
+          scope: link.scope,
+          ...(selector?.schema !== undefined || link.schema !== undefined
+            ? {
+              schema: (selector?.schema ?? link.schema) as
+                | JSONSchema
+                | undefined,
+            }
+            : {}),
+        } as NormalizedFullLink);
+      }
       // We include the path in the address, so that information is available,
       return [notFound(target), selector];
     } else if (error.name !== "NotFoundError") {

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1880,11 +1880,17 @@ function followPointer(
       // runtime can kick an async load; this read still resolves notFound
       // and the tracked dependency re-runs the reader when the doc arrives.
       // Pass the link with the narrowed selector schema so the fetch covers
-      // the shape this traversal actually needs.
+      // the shape this traversal actually needs. The selector was re-rooted
+      // at the TARGET doc (its path is `["value", ...inDocPath]`), so when
+      // one exists its path — minus the "value" prefix — is the path the
+      // schema describes; pairing the schema with the bare link path would
+      // register a malformed watch selector.
       context.onMissingLinkTarget?.({
         space: link.space,
         id: link.id,
-        path: link.path,
+        path: selector !== undefined
+          ? selector.path.slice(1) as readonly string[]
+          : link.path,
         scope: link.scope,
         ...(selector?.schema !== undefined || link.schema !== undefined
           ? {

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -919,6 +919,17 @@ export type TraversalContext = {
   schemaTracker: MapSet<string, SchemaPathSelector>;
   includeMeta: boolean;
   metaDocsVisited: Set<string>;
+  /**
+   * Called when a followed link's target document is entirely absent from
+   * the local replica (CT-1667). Per-space server queries cannot follow
+   * links across space boundaries (and minimal-schema subscriptions can
+   * leave even same-space targets uncovered), so the traversal is the first
+   * place the gap is observable. The runtime-aware caller kicks an async
+   * load (see `Runtime.ensureLinkedDocLoaded`); the traversal itself only
+   * reports. Optional: schema-tracking traversals on the server have no
+   * runtime and no replica gap.
+   */
+  onMissingLinkTarget?: (link: NormalizedFullLink) => void;
 };
 
 export function createTraversalContext(
@@ -927,6 +938,7 @@ export function createTraversalContext(
   schemaTracker: MapSet<string, SchemaPathSelector>,
   includeMeta: boolean = false,
   metaDocsVisited: Set<string> = new Set<string>(),
+  onMissingLinkTarget?: (link: NormalizedFullLink) => void,
 ): TraversalContext {
   return {
     tracker,
@@ -934,6 +946,7 @@ export function createTraversalContext(
     schemaTracker,
     includeMeta,
     metaDocsVisited,
+    onMissingLinkTarget,
   };
 }
 
@@ -942,6 +955,7 @@ export function createDefaultTraversalContext(
   schemaTracker: MapSet<string, SchemaPathSelector> =
     new MapSetStringToPathSelectors(true),
   metaDocsVisited: Set<string> = new Set<string>(),
+  onMissingLinkTarget?: (link: NormalizedFullLink) => void,
 ): TraversalContext {
   return createTraversalContext(
     new CompoundCycleTracker<
@@ -952,6 +966,7 @@ export function createDefaultTraversalContext(
     schemaTracker,
     includeMeta,
     metaDocsVisited,
+    onMissingLinkTarget,
   );
 }
 
@@ -1859,6 +1874,26 @@ function followPointer(
         "traverse",
         () => ["followPointer found missing/retracted fact", valueEntry],
       );
+      // A linked doc absent from the local replica may simply never have
+      // been fetched — the subscription that loaded the SOURCE doc cannot
+      // cover targets across a space boundary (CT-1667). Report it so the
+      // runtime can kick an async load; this read still resolves notFound
+      // and the tracked dependency re-runs the reader when the doc arrives.
+      // Pass the link with the narrowed selector schema so the fetch covers
+      // the shape this traversal actually needs.
+      context.onMissingLinkTarget?.({
+        space: link.space,
+        id: link.id,
+        path: link.path,
+        scope: link.scope,
+        ...(selector?.schema !== undefined || link.schema !== undefined
+          ? {
+            schema: (selector?.schema ?? link.schema) as
+              | JSONSchema
+              | undefined,
+          }
+          : {}),
+      } as NormalizedFullLink);
       // We include the path in the address, so that information is available,
       return [notFound(target), selector];
     } else if (error.name !== "NotFoundError") {
@@ -2055,6 +2090,7 @@ function traverseMetaLinkedDoc(
     context.schemaTracker,
     context.includeMeta,
     context.metaDocsVisited,
+    context.onMissingLinkTarget,
   );
   const traverser = new SchemaObjectTraverser(
     tx,

--- a/packages/runner/test/cross-space-value-read.test.ts
+++ b/packages/runner/test/cross-space-value-read.test.ts
@@ -24,10 +24,22 @@ class SharedServerStorageManager extends EmulatedStorageManager {
     server: MemoryV2Server.Server,
     options: Omit<Options, "memoryHost" | "spaceHostMap">,
   ): SharedServerStorageManager {
-    return new SharedServerStorageManager(
+    const manager = new SharedServerStorageManager(
       { ...options, memoryHost: new URL("memory://") },
       () => server,
     );
+    manager.sharedServer = server;
+    return manager;
+  }
+
+  private sharedServer!: MemoryV2Server.Server;
+
+  // The server is SHARED between managers and closed once by the test's
+  // afterEach — serve it without ever initializing the base class's private
+  // `#server`, whose `close()` would otherwise close the shared server once
+  // per manager.
+  protected override server(): MemoryV2Server.Server {
+    return this.sharedServer;
   }
 }
 
@@ -183,6 +195,11 @@ describe("cross-space value reads (CT-1667)", () => {
     }
   });
 
+  // This is THE regression guard: red without the fix (the deep value read
+  // goes through traverse's followPointer, which had no fetch trigger at
+  // all). The key-path-pull and sink steps above/below converge through
+  // link-resolution's pre-existing cross-space kick under loopback timing —
+  // they pin the contract but already passed on main in this harness.
   it("a whole-value pull() of the linking parent materializes the child", async () => {
     const rt1 = new Runtime({
       apiUrl: new URL(import.meta.url),

--- a/packages/runner/test/cross-space-value-read.test.ts
+++ b/packages/runner/test/cross-space-value-read.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("cross-space-value-read");
+const spaceH = signer.did(); // "home" — holds the link
+const spaceP = (await Identity.fromPassphrase("cross-space target P")).did();
+
+// A storage manager with its OWN per-space client replicas, loopback-connected
+// to a SHARED in-process memory server. This is what a real browser/CLI
+// session looks like: data written by another session only reaches this one
+// through an explicit per-space server query/subscription. The plain
+// `StorageManager.emulate` masks CT-1667 in the common test shape because a
+// shared manager means shared replicas — reads find data the reader never
+// fetched.
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    return new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+  });
+
+// CT-1667: a value READ through a cross-space link never materializes the
+// target's fields in a session that didn't create them. The home Profile tab
+// binds `cf-profile-badge` (minimal `{name, avatar}` schema) and `cf-render`
+// to a profile living in its own space; both show blanks because the
+// profile-space docs behind the link are never fetched — derived cell handles
+// inherit `synced` from their parent even across the space boundary (where
+// the parent's per-space server query cannot have covered them), and the
+// schema traversal returns notFound for the absent docs without triggering a
+// fetch. Only explicit per-path `.pull()`s on fresh cells (the wish.ts
+// workaround) materialize them.
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        "import { handler, pattern, Writable } from 'commonfabric';",
+        "",
+        "export const child = pattern<{ name: string }>(({ name }) => ({",
+        "  name,",
+        "  greeting: 'hello',",
+        "}));",
+        "",
+        "type ChildOutput = { name: string; greeting: string };",
+        "",
+        "const create = handler<",
+        "  { name?: string },",
+        "  { items: Writable<ChildOutput[]> }",
+        ">((event, { items }) => {",
+        `  items.push(child.inSpace("${spaceP}")({`,
+        "    name: event.name ?? 'Ada',",
+        "  }) as ChildOutput);",
+        "});",
+        "",
+        "export default pattern(() => {",
+        "  const items = new Writable<ChildOutput[]>([]).for('items');",
+        "  return { items, create: create({ items }) };",
+        "});",
+      ].join("\n"),
+    },
+  ],
+};
+
+const RESULT_CAUSE = "cross-space value read parent";
+
+const linkListSchema = {
+  type: "array",
+  items: { type: "unknown", asCell: ["cell"] },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+// The badge-style minimal read schema on the child.
+const nameSchema = {
+  type: "object",
+  properties: {
+    name: { type: "string" },
+    greeting: { type: "string" },
+  },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+describe("cross-space value reads (CT-1667)", () => {
+  let server: MemoryV2Server.Server;
+  let writerStorage: SharedServerStorageManager;
+  let readerStorage: SharedServerStorageManager;
+
+  beforeEach(() => {
+    server = newSharedServer();
+    writerStorage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    readerStorage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+  });
+  afterEach(async () => {
+    await writerStorage?.close();
+    await readerStorage?.close();
+    await server?.close();
+  });
+
+  // Session 1 (writer): create the parent in H and the child in P, fully
+  // synced to the server. Returns the H-space parent result link.
+  async function createPieces(rt1: Runtime) {
+    const tx1 = rt1.edit();
+    const parent = await rt1.patternManager.compilePattern(PROGRAM, {
+      space: spaceH,
+      tx: tx1,
+    });
+    const resultCell1 = rt1.getCell<Record<string, unknown>>(
+      spaceH,
+      RESULT_CAUSE,
+      undefined,
+      tx1,
+    );
+    // deno-lint-ignore no-explicit-any
+    const r1 = rt1.run(tx1, parent as any, {}, resultCell1);
+    await tx1.commit();
+    await r1.pull();
+    r1.key("create").send({ name: "Ada" });
+    await r1.pull();
+    await rt1.idle();
+    // Sanity: the child materialized in P and reads fine in the creating
+    // runtime (everything is in its own replicas).
+    // deno-lint-ignore no-explicit-any
+    const links = r1.key("items").asSchema(linkListSchema).get() as any[];
+    expect(links.length).toBe(1);
+    expect(links[0].getAsNormalizedFullLink().space).toBe(spaceP);
+    await rt1.patternManager.flushCompileCacheWrites();
+    await rt1.storageManager.synced();
+    return r1.getAsNormalizedFullLink();
+  }
+
+  it("pull() + get() through the link materializes the child's fields", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: writerStorage,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: readerStorage,
+    });
+    try {
+      const parentLink = await createPieces(rt1);
+
+      // Reader session: home-space context. Read the child's field THROUGH
+      // the cross-space link, the way a generic consumer (cf-render, a
+      // computed) would — no per-path workaround pulls.
+      const parentCell = rt2.getCellFromLink(parentLink);
+      await parentCell.sync();
+
+      const childField = parentCell.key("items").key(0).key("name");
+      // pull() itself must converge — no storageManager.synced() assist (the
+      // convergence loop awaits the kicked cross-space loads).
+      const pulled = await childField.pull();
+      expect(pulled).toBe("Ada");
+      expect(childField.get()).toBe("Ada");
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  it("a whole-value pull() of the linking parent materializes the child", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: writerStorage,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: readerStorage,
+    });
+    try {
+      const parentLink = await createPieces(rt1);
+
+      const parentCell = rt2.getCellFromLink(parentLink);
+      await parentCell.sync();
+      // Pull the parent's whole items value (deep) — the cross-space child is
+      // part of it. This is the "naive resolve" shape from the issue.
+      const itemsCell = parentCell.key("items");
+      await itemsCell.pull();
+      // deno-lint-ignore no-explicit-any
+      const items = itemsCell.get() as any[];
+      expect(Array.isArray(items)).toBe(true);
+      expect(items.length).toBe(1);
+      expect(items[0]?.name).toBe("Ada");
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  it("sink() with a minimal schema on the child link fires with the value", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: writerStorage,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: readerStorage,
+    });
+    try {
+      const parentLink = await createPieces(rt1);
+
+      const parentCell = rt2.getCellFromLink(parentLink);
+      await parentCell.sync();
+      // Resolve the child link to a cell (what cf-profile-badge does with
+      // $profile) and subscribe with a minimal schema. NOTE: derived from the
+      // parent's read — the handle inherits the parent's synced state.
+      // deno-lint-ignore no-explicit-any
+      const links = parentCell.key("items").asSchema(linkListSchema)
+        // deno-lint-ignore no-explicit-any
+        .get() as any[];
+      expect(links.length).toBe(1);
+      const childCell = links[0].asSchema(nameSchema);
+
+      // deno-lint-ignore no-explicit-any
+      const seen: any[] = [];
+      const cancel = childCell.sink((value: unknown) => {
+        seen.push(value);
+      });
+      await rt2.idle();
+      await rt2.storageManager.synced();
+      await rt2.idle();
+      cancel();
+      const last = seen.at(-1);
+      expect(last?.name).toBe("Ada");
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});


### PR DESCRIPTION
Fixes CT-1667 (High): a value read through a **cross-space link** silently resolved `undefined` in any session that didn't create the data — the blank `cf-profile-badge`/`cf-render` profile fields, and the underlying cause of the picker's silent no-ops worked around in #3955.

## Root cause

Per-space server queries cannot follow links across space boundaries, so the target docs behind a cross-space link were never fetched — and the client had no recovery:

1. The schema traversal (`followPointer`) returned `notFound` for the absent doc **without triggering a load** (only `resolveLink`'s path-resolution kick existed, which shallow/`asCell` reads bypass).
2. Derived cell handles inherit `synced` from their parent — honest within a space (the originating server query pushed the same-space closure), structurally false across one.
3. `pull()` resolved at scheduler idle, before any async load could land.

**CFC was never the cause** — it has no read-side redaction; owner-protected and plain fields failed identically. The only things that worked were the explicit per-path `.pull()` workarounds (`wish.ts` `subscribeProfileName` / `#profileName`), which is exactly why the picker shows names while everything else showed blanks.

Why the suite never caught it: `StorageManager.emulate` in the usual single-manager shape means **shared replicas** — every read finds data some other runtime fetched. The new test runs **two storage managers loopback-connected to one shared in-process memory server** (real per-space replicas, the browser/CLI session shape) and reproduces the gap faithfully.

## Fix (three coordinated pieces)

- **traverse.ts** — `TraversalContext.onMissingLinkTarget`: `followPointer` reports a followed link whose target doc is entirely absent from the local replica, with the narrowed selector schema so the fetch covers the shape the read needs.
- **runtime.ts** — `ensureLinkedDocLoaded`: kicks an async load for the reported target, deduped per `(space, id)` (the sync leaves a live subscription behind, so one kick suffices and a later-created doc still arrives), registered as a cross-space promise so `storageManager.synced()` and pull's convergence can await it. Wired into `validateAndTransform`'s traversal context. Because the absent doc is a tracked read dependency, reactive consumers (sinks, the badge, computed) re-run on arrival with no further changes.
- **cell.ts** — `pull()` convergence: after idle, while kicked loads are pending, await them and re-idle (bounded at 10 rounds; each arrival can reveal the next hop). Pulls that kicked nothing take the zero-iteration path and keep their **exact previous timing** (`pendingCrossSpacePromiseCount`/`crossSpaceSettled` are new on `StorageManager`; `synced()` untouched).

## Verification

- New regression test `packages/runner/test/cross-space-value-read.test.ts` (two-session harness): through-link key-path `pull()`, deep whole-value `pull()`, and badge-style minimal-schema `sink()` — the deep-read case is red without the fix.
- Full `packages/runner` suite: **576 passed, 0 failed**.
- **Live against a local toolshed**, where all of these previously returned `undefined`:
  - through-link key read, deep `items` read, and minimal-schema child read of a cross-space piece → all materialize;
  - the real product path: deployed the actual `ProfileCreate`/`ProfileHome` stack, created a profile (its own `inSpace` space), `setName` via the owner flow, then read the **owner-protected `name`** through the home-space link with the badge schema → `"Ada Lovelace"`.

## Notes / scope

- The `wish.ts` per-path pulls are now redundant but left in place (harmless; removing them belongs in a follow-up cleanup, not a runner-semantics PR).
- The kick fires once per `(space, id)` per session for any linked-but-absent doc, including genuinely-deleted targets — one extra no-op query + subscription each; bounded by distinct absent links traversed.
- Pattern-layer consumers can now read cross-space values directly; the `Cell<>`-link convention for handler *state* (#3955) remains good practice for avoiding required-field validation on values that may not be loaded yet at event time.

Closes CT-1667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1667: cross-space link reads now materialize missing target docs during read, so values no longer resolve to undefined. Scope limited to cross-space targets to avoid extra queries and keep pull performance stable.

- Bug Fixes
  - Traversal reports only cross-space missing link targets via `onMissingLinkTarget`, passing the narrowed selector and target-rooted path so the kicked watch is well-formed; same-space absences are not kicked.
  - Runtime dedupes a per-(space,id) load with `ensureLinkedDocLoaded`, tracks it as a cross-space promise for `synced()`/pull to await, and clears dedupe on failure; the pre-existing link-resolution kick now catch-swallows errors.
  - `Cell.pull()` converges: while cross-space loads are pending it waits (`crossSpaceSettled`) and re-idles with a bound and a warning on exhaustion; pulls that kick nothing keep prior timing.
  - Storage exposes `pendingCrossSpacePromiseCount()` and `crossSpaceSettled()`; regression test runs two storage managers against one shared in-memory server (and avoids double-closing). This restores correct data in `cf-profile-badge` and `cf-render`.
  - Docs: update roster guidance to note cross-space links now materialize for authorized viewers, and clarify `profile-create.tsx` uses a link `Cell<>` in handlers to avoid event-time validation depending on not-yet-loaded values.

<sup>Written for commit baec4b00b304ddfa472a04fd478085f25030fb40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

