### PR TITLE
fix(cli): run cf dev/check through the runtime's own harness

### DIFF
--- a/packages/cli/lib/dev.ts
+++ b/packages/cli/lib/dev.ts
@@ -1,7 +1,7 @@
 import { Program } from "@commonfabric/js-compiler";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { Identity } from "@commonfabric/identity";
-import { Engine, Runtime } from "@commonfabric/runner";
+import { Runtime } from "@commonfabric/runner";
 import { experimentalOptionsFromEnv } from "./utils.ts";
 
 async function createRuntime() {
@@ -33,7 +33,13 @@ export async function process(
   options: ProcessOptions,
 ): Promise<{ output: string; main?: Record<string, unknown> }> {
   const runtime = await createRuntime();
-  const engine = new Engine(runtime);
+  // Compile/evaluate through the runtime's OWN harness, not a second Engine.
+  // Verified-load registration, source maps, and module hashes all live on the
+  // engine that evaluates the bundle; the runner and the builder's source-
+  // location annotation consult `runtime.harness`. A separate Engine splits
+  // that state, so `fn.src` stays a raw bundle coordinate and CFC verified-
+  // binding identities (writeAuthorizedBy) fail under enforcement.
+  const engine = runtime.harness;
   const program = await engine.resolve(
     new FileSystemProgramResolver(options.main, options.rootPath),
   );


### PR DESCRIPTION
## Problem

`process()` in `packages/cli/lib/dev.ts` (the `cf dev` / `cf check` path) constructed a **second** `Engine` right after `createRuntime()`. The `Runtime` constructor already creates its own internal Engine (`runtime.harness`). Building a second one splits state: verified-load registration, source maps, and module hashes live on the engine that compiles/evaluates the bundle — but the runner and the builder's source-location annotation consult `runtime.harness` ([builder/module.ts:200,616](https://github.com/commontoolsinc/labs/blob/main/packages/runner/src/builder/module.ts)). That harness never saw the compile, so `mapPosition()` returns null, `fn.src` stays a raw bundle coordinate, and CFC verified-binding identities (`writeAuthorizedBy`) resolve as "unsupported" under enforcement.

This is the same bug fixed for the pattern test runner in `abc824f96` ("fix(cli): run pattern tests through the runtime's own harness"); that commit's message flagged `dev.ts` as the remaining follow-up. This PR is that follow-up.

## Fix

- Drop the now-unused `Engine` **value** import (no type usage in the file).
- `const engine = new Engine(runtime)` → `const engine = runtime.harness`.
- No dispose change needed: `dev.ts` has no dispose path, so there's no double-dispose to reconcile (unlike the multi-user worker, which had to drop its `engine?.dispose()` because `runtime.dispose()` disposes the harness).

This matches how `PiecesController` wires production runtimes.

## Verification

- `deno check packages/cli/lib/dev.ts` — clean.
- `cf check counter.tsx --no-run` and full evaluate (`run:true` default) — exit 0.
- Three CFC-annotated patterns (`cfc-spec-gallery`, `cfc-group-chat-demo/trusted`, `cfc-row-label-records`) evaluate cleanly under the default `enforce-explicit`.
- **Red/green via `cf check counter.tsx --pattern-json`**, inspecting action `"location"` fields:

  | | Action source location |
  |---|---|
  | **Before** (`new Engine(runtime)`) | `fid1:6UgP-…:esm:0.js:27:3` — raw **bundle** coordinate; `mapPosition()` returned null |
  | **After** (`runtime.harness`) | `cf:module/<hash>/packages/patterns/counter/counter.tsx:37:2` — canonical **source** coordinate |

  Per [module.ts:77-79](https://github.com/commontoolsinc/labs/blob/main/packages/runner/src/builder/module.ts), that `cf:module/…` form is what scheduler action ids, fingerprints, and CFC verified-source depend on.

A final scan confirms no other `new Engine(` remains anywhere in `packages/cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route `cf dev`/`cf check` through the runtime’s own harness to fix split engine state. This restores accurate source mapping and CFC verification so actions report canonical source coordinates and enforcement works.

- **Bug Fixes**
  - Use `runtime.harness` instead of creating a second `Engine`.
  - Remove unused `Engine` import from `@commonfabric/runner`.
  - Restore verified-load registration and module hash tracking.
  - Actions now emit `cf:module/...` source paths; CFC enforcement passes.

<sup>Written for commit d9abf277677c7e5342ffd7cd8498d0d5c54c6a27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

