### PR TITLE
fix(cfc): grow-only merge sqlite per-column ifc across re-derivations (audit S8)

### DIFF
--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -250,6 +250,8 @@ const unionAtoms = (
 // A write ceiling (`maxConfidentiality`) tightens only: absent = unlimited, so a
 // present ceiling beats absent, and two present ceilings meet at their
 // intersection (the smaller allowed set). It can never widen or be removed.
+// An EMPTY intersection stays `[]`, which the verifier reads as "public only"
+// (the tightest ceiling) — collapsing it to undefined would forge "no ceiling".
 const tightenCeiling = (
   prior: unknown[] | undefined,
   next: unknown[] | undefined,
@@ -259,6 +261,24 @@ const tightenCeiling = (
   return prior.filter((atom) => next.some((n) => deepEqual(n, atom)));
 };
 
+// Integrity atoms are trust/provenance claims, NOT a confidentiality grade: a
+// row read from a column carries them to satisfy downstream `requiredIntegrity`
+// gates. So a re-derivation may keep or NARROW a column's integrity but must
+// never MINT trust the prior store didn't already carry — unioning would let a
+// re-declared `integrity: ["b"]` forge a claim the column was never trusted for
+// (mirrors schema-merge.ts, where integrity is subset-clamped like the ceiling).
+// Identical to `tightenCeiling` EXCEPT the prior-absent case yields undefined
+// (no prior trust to inherit) rather than adopting `next` wholesale.
+const clampIntegrity = (
+  prior: unknown[] | undefined,
+  next: unknown[] | undefined,
+): unknown[] | undefined => {
+  if (prior === undefined) return undefined;
+  if (next === undefined) return prior;
+  const kept = prior.filter((atom) => next.some((n) => deepEqual(n, atom)));
+  return kept.length > 0 ? kept : undefined;
+};
+
 const mergeColumnIfcGrowOnly = (
   prior: ColumnIfc,
   next: ColumnIfc | undefined,
@@ -266,7 +286,7 @@ const mergeColumnIfcGrowOnly = (
   const n = next ?? {};
   const merged: ColumnIfc = {};
   const confidentiality = unionAtoms(prior.confidentiality, n.confidentiality);
-  const integrity = unionAtoms(prior.integrity, n.integrity);
+  const integrity = clampIntegrity(prior.integrity, n.integrity);
   const maxConfidentiality = tightenCeiling(
     prior.maxConfidentiality,
     n.maxConfidentiality,

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -304,7 +304,7 @@ export const growOnlyMergeDbTables = (
       (priorTableRaw as { properties?: Record<string, unknown> } | undefined)
         ?.properties;
     if (!priorProps || typeof priorProps !== "object") continue;
-    let resultTable = result[tableName] as
+    const resultTable = result[tableName] as
       | { properties?: Record<string, unknown> }
       | undefined;
     if (!resultTable || typeof resultTable !== "object") {

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -38,6 +38,7 @@ import { parseCfLinkToSigil } from "./sqlite/cf-link.ts";
 import { type IFCLabel, mergeLabel } from "../cfc/label-view-core.ts";
 import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
 import { columnDeclaresIfc } from "@commonfabric/memory/v2";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
 
 type SqliteDbRef = {
   id: string;
@@ -229,6 +230,117 @@ function deriveNullOriginIfc(tables: LabelTables): IFCLabel | undefined {
     : undefined;
 }
 
+type ColumnIfc = {
+  confidentiality?: unknown[];
+  integrity?: unknown[];
+  maxConfidentiality?: unknown[];
+};
+
+const unionAtoms = (
+  a: unknown[] | undefined,
+  b: unknown[] | undefined,
+): unknown[] | undefined => {
+  const out: unknown[] = [...(a ?? [])];
+  for (const atom of b ?? []) {
+    if (!out.some((existing) => deepEqual(existing, atom))) out.push(atom);
+  }
+  return out.length > 0 ? out : undefined;
+};
+
+// A write ceiling (`maxConfidentiality`) tightens only: absent = unlimited, so a
+// present ceiling beats absent, and two present ceilings meet at their
+// intersection (the smaller allowed set). It can never widen or be removed.
+const tightenCeiling = (
+  prior: unknown[] | undefined,
+  next: unknown[] | undefined,
+): unknown[] | undefined => {
+  if (prior === undefined) return next;
+  if (next === undefined) return prior;
+  return prior.filter((atom) => next.some((n) => deepEqual(n, atom)));
+};
+
+const mergeColumnIfcGrowOnly = (
+  prior: ColumnIfc,
+  next: ColumnIfc | undefined,
+): ColumnIfc => {
+  const n = next ?? {};
+  const merged: ColumnIfc = {};
+  const confidentiality = unionAtoms(prior.confidentiality, n.confidentiality);
+  const integrity = unionAtoms(prior.integrity, n.integrity);
+  const maxConfidentiality = tightenCeiling(
+    prior.maxConfidentiality,
+    n.maxConfidentiality,
+  );
+  if (confidentiality) merged.confidentiality = confidentiality;
+  if (integrity) merged.integrity = integrity;
+  if (maxConfidentiality) merged.maxConfidentiality = maxConfidentiality;
+  return merged;
+};
+
+/**
+ * Grow-only merge of a db handle's per-column `ifc` across re-derivations
+ * (§8.12.1: a store's effective label is monotone — it may strengthen but never
+ * weaken). `tables[].ifc` lives in mutable handle-cell value data, outside the
+ * schema-envelope monotonicity the labelMap enforces, so a re-derivation reading
+ * a weaker input could silently lower a column's read label or widen its write
+ * ceiling (audit S8). Every column the PRIOR handle labeled keeps at least that
+ * label: read confidentiality/integrity union (grow); the write ceiling tightens
+ * only; a dropped table/column is restored. New tables/columns in `next` are
+ * additive and pass through (a fresh column or a stricter re-declaration is
+ * allowed — only weakening is clamped).
+ */
+export const growOnlyMergeDbTables = (
+  prior: Record<string, unknown> | undefined,
+  next: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined => {
+  if (!prior) return next;
+  if (!next) return prior;
+  const result = cloneIfNecessary(
+    next as Parameters<typeof cloneIfNecessary>[0],
+    { frozen: false },
+  ) as Record<string, unknown>;
+  for (const [tableName, priorTableRaw] of Object.entries(prior)) {
+    const priorProps =
+      (priorTableRaw as { properties?: Record<string, unknown> } | undefined)
+        ?.properties;
+    if (!priorProps || typeof priorProps !== "object") continue;
+    let resultTable = result[tableName] as
+      | { properties?: Record<string, unknown> }
+      | undefined;
+    if (!resultTable || typeof resultTable !== "object") {
+      // Prior declared a table that `next` dropped — restore it wholesale.
+      result[tableName] = cloneIfNecessary(
+        priorTableRaw as Parameters<typeof cloneIfNecessary>[0],
+        { frozen: false },
+      );
+      continue;
+    }
+    const resultProps = (resultTable.properties ??= {}) as Record<
+      string,
+      { ifc?: ColumnIfc }
+    >;
+    for (const [colName, priorColRaw] of Object.entries(priorProps)) {
+      const priorIfc = (priorColRaw as { ifc?: ColumnIfc } | undefined)?.ifc;
+      if (!columnDeclaresIfc(priorIfc)) continue;
+      const resultCol = resultProps[colName] as { ifc?: ColumnIfc } | undefined;
+      if (!resultCol || typeof resultCol !== "object") {
+        // Prior labeled a column that `next` dropped — restore it wholesale so
+        // its non-ifc structure (e.g. `type`) survives alongside the label.
+        resultProps[colName] = cloneIfNecessary(
+          priorColRaw as Parameters<typeof cloneIfNecessary>[0],
+          { frozen: false },
+        ) as { ifc?: ColumnIfc };
+        continue;
+      }
+      resultCol.ifc = mergeColumnIfcGrowOnly(
+        priorIfc as ColumnIfc,
+        resultCol.ifc,
+      );
+    }
+  }
+  return result;
+};
+
 /**
  * CFC read-labeling: from each result column's TRUE origin (table, column),
  * build a schema for the result-cell's `result` array whose per-field `ifc`
@@ -349,9 +461,16 @@ export function sqliteDatabase(
       // the acting reader). "creator" would be wrong for linked dbs; the
       // handle's creation is where ownership is minted.
       const owner = runtime.trustSnapshotProvider()?.actingPrincipal;
+      // Grow-only merge the per-column `ifc` against any prior committed handle
+      // value at this (causally-stable) id: the store's effective label is
+      // monotone, so a re-derivation reading a weaker `tables` input cannot lower
+      // a column's read label or widen its write ceiling (audit S8). First
+      // creation (no prior) passes the declared tables through unchanged.
+      const prior = handle.withTx(tx).get() as SqliteDbRef | undefined;
+      const tables = growOnlyMergeDbTables(prior?.tables, options?.tables);
       handle.withTx(tx).set({
         id,
-        tables: options?.tables,
+        tables,
         scope,
         ...(owner !== undefined && { owner }),
       });

--- a/packages/runner/test/sqlite-tables-ifc-monotone.test.ts
+++ b/packages/runner/test/sqlite-tables-ifc-monotone.test.ts
@@ -34,12 +34,47 @@ describe("growOnlyMergeDbTables (audit S8)", () => {
     ]);
   });
 
-  it("unions confidentiality/integrity (strengthening is allowed)", () => {
+  it("unions confidentiality (read label may strengthen)", () => {
     const prior = {
-      t: table({ c: { ifc: { confidentiality: ["a"], integrity: ["x"] } } }),
+      t: table({ c: { ifc: { confidentiality: ["a"] } } }),
     };
     const next = {
-      t: table({ c: { ifc: { confidentiality: ["b"], integrity: ["y"] } } }),
+      t: table({ c: { ifc: { confidentiality: ["b"] } } }),
+    };
+    const merged = growOnlyMergeDbTables(prior, next) as Record<string, {
+      properties: Record<string, { ifc?: { confidentiality?: unknown[] } }>;
+    }>;
+    expect(merged.t.properties.c.ifc?.confidentiality).toEqual(["a", "b"]);
+  });
+
+  it("does NOT union integrity: a re-declared claim can't mint trust", () => {
+    // Integrity atoms are trust claims that satisfy downstream requiredIntegrity
+    // gates. Prior trusted the column for ["x"]; a re-derivation declaring ["y"]
+    // must NOT yield ["x","y"] — that would forge a claim "y" the store never had
+    // (and re-derivations read potentially-weaker inputs). Subset-clamp instead.
+    const prior = {
+      t: table({ c: { ifc: { integrity: ["x"] } } }),
+    };
+    const next = {
+      t: table({ c: { ifc: { integrity: ["y"] } } }),
+    };
+    const merged = growOnlyMergeDbTables(prior, next) as Record<string, {
+      properties: Record<string, { ifc?: { integrity?: unknown[] } }>;
+    }>;
+    // "y" was never trusted and "x" was not re-asserted: intersection is empty.
+    expect(merged.t.properties.c.ifc?.integrity).toBeUndefined();
+  });
+
+  it("never mints integrity on a column the prior store didn't trust", () => {
+    // Prior column carries a read label but NO integrity. A re-derivation adding
+    // integrity would mint trust from nothing — clamp it away.
+    const prior = {
+      t: table({ c: { ifc: { confidentiality: ["a"] } } }),
+    };
+    const next = {
+      t: table({
+        c: { ifc: { confidentiality: ["a"], integrity: ["forged"] } },
+      }),
     };
     const merged = growOnlyMergeDbTables(prior, next) as Record<string, {
       properties: Record<
@@ -47,8 +82,21 @@ describe("growOnlyMergeDbTables (audit S8)", () => {
         { ifc?: { confidentiality?: unknown[]; integrity?: unknown[] } }
       >;
     }>;
-    expect(merged.t.properties.c.ifc?.confidentiality).toEqual(["a", "b"]);
-    expect(merged.t.properties.c.ifc?.integrity).toEqual(["x", "y"]);
+    expect(merged.t.properties.c.ifc?.integrity).toBeUndefined();
+    expect(merged.t.properties.c.ifc?.confidentiality).toEqual(["a"]);
+  });
+
+  it("allows integrity to NARROW (subset re-declaration)", () => {
+    const prior = {
+      t: table({ c: { ifc: { integrity: ["a", "b"] } } }),
+    };
+    const next = {
+      t: table({ c: { ifc: { integrity: ["a"] } } }),
+    };
+    const merged = growOnlyMergeDbTables(prior, next) as Record<string, {
+      properties: Record<string, { ifc?: { integrity?: unknown[] } }>;
+    }>;
+    expect(merged.t.properties.c.ifc?.integrity).toEqual(["a"]);
   });
 
   it("never widens a write ceiling: a present ceiling can't be removed", () => {
@@ -81,6 +129,21 @@ describe("growOnlyMergeDbTables (audit S8)", () => {
     }>;
     // Only the meet survives — the smaller allowed set.
     expect(merged.t.properties.c.ifc?.maxConfidentiality).toEqual(["b"]);
+  });
+
+  it("keeps a disjoint ceiling intersection as [] (public-only), not absent", () => {
+    // The verifier reads `undefined` as "no ceiling" but `[]` as "public only"
+    // (the tightest ceiling). Two ceilings with no atom in common must meet at
+    // [], NOT collapse to undefined — that would forge an unlimited ceiling.
+    const prior = { t: table({ c: { ifc: { maxConfidentiality: ["a"] } } }) };
+    const next = { t: table({ c: { ifc: { maxConfidentiality: ["b"] } } }) };
+    const merged = growOnlyMergeDbTables(prior, next) as Record<string, {
+      properties: Record<
+        string,
+        { ifc?: { maxConfidentiality?: unknown[] } }
+      >;
+    }>;
+    expect(merged.t.properties.c.ifc?.maxConfidentiality).toEqual([]);
   });
 
   it("restores a labeled table that a re-derivation drops entirely", () => {
@@ -120,17 +183,19 @@ describe("growOnlyMergeDbTables (audit S8)", () => {
     const prior = { t: table({ a: { ifc: { confidentiality: ["x"] } } }) };
     const next = {
       t: table({
-        a: { ifc: { confidentiality: ["x"], integrity: ["new"] } }, // stricter
+        // Stricter via confidentiality (a read label only grows). Adding
+        // integrity here would be a mint, covered by its own test above.
+        a: { ifc: { confidentiality: ["x", "more"] } },
         b: { ifc: { confidentiality: ["y"] } }, // new column
       }),
     };
     const merged = growOnlyMergeDbTables(prior, next) as Record<string, {
       properties: Record<
         string,
-        { ifc?: { confidentiality?: unknown[]; integrity?: unknown[] } }
+        { ifc?: { confidentiality?: unknown[] } }
       >;
     }>;
-    expect(merged.t.properties.a.ifc?.integrity).toEqual(["new"]);
+    expect(merged.t.properties.a.ifc?.confidentiality).toEqual(["x", "more"]);
     expect(merged.t.properties.b.ifc?.confidentiality).toEqual(["y"]);
   });
 });

--- a/packages/runner/test/sqlite-tables-ifc-monotone.test.ts
+++ b/packages/runner/test/sqlite-tables-ifc-monotone.test.ts
@@ -1,0 +1,136 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { growOnlyMergeDbTables } from "../src/builtins/sqlite-builtins.ts";
+
+// Audit S8: a db handle's per-column `ifc` lives in mutable handle-cell value
+// data, outside the schema-envelope monotonicity the labelMap enforces. A
+// re-derivation reading a weaker `tables` input could silently lower a column's
+// read label or widen its write ceiling — a store's effective label going DOWN,
+// which §8.12.1 forbids. growOnlyMergeDbTables clamps every re-derivation to be
+// monotone (strengthen-only) against the prior committed handle value.
+const table = (
+  cols: Record<string, Record<string, unknown>>,
+) => ({ type: "object", properties: cols });
+
+describe("growOnlyMergeDbTables (audit S8)", () => {
+  it("passes the declared tables through unchanged on first creation", () => {
+    const next = {
+      emails: table({ from: { ifc: { confidentiality: ["sender"] } } }),
+    };
+    expect(growOnlyMergeDbTables(undefined, next)).toEqual(next);
+  });
+
+  it("keeps a prior read label that a re-derivation tries to DROP", () => {
+    const prior = {
+      emails: table({ from: { ifc: { confidentiality: ["sender"] } } }),
+    };
+    // Attacker / weaker re-declaration: the column loses its ifc.
+    const next = { emails: table({ from: {} }) };
+    const merged = growOnlyMergeDbTables(prior, next) as Record<string, {
+      properties: Record<string, { ifc?: { confidentiality?: unknown[] } }>;
+    }>;
+    expect(merged.emails.properties.from.ifc?.confidentiality).toEqual([
+      "sender",
+    ]);
+  });
+
+  it("unions confidentiality/integrity (strengthening is allowed)", () => {
+    const prior = {
+      t: table({ c: { ifc: { confidentiality: ["a"], integrity: ["x"] } } }),
+    };
+    const next = {
+      t: table({ c: { ifc: { confidentiality: ["b"], integrity: ["y"] } } }),
+    };
+    const merged = growOnlyMergeDbTables(prior, next) as Record<string, {
+      properties: Record<
+        string,
+        { ifc?: { confidentiality?: unknown[]; integrity?: unknown[] } }
+      >;
+    }>;
+    expect(merged.t.properties.c.ifc?.confidentiality).toEqual(["a", "b"]);
+    expect(merged.t.properties.c.ifc?.integrity).toEqual(["x", "y"]);
+  });
+
+  it("never widens a write ceiling: a present ceiling can't be removed", () => {
+    const prior = {
+      t: table({ c: { ifc: { maxConfidentiality: ["lo"] } } }),
+    };
+    // Re-derivation drops the ceiling (would make the column unlimited).
+    const next = { t: table({ c: {} }) };
+    const merged = growOnlyMergeDbTables(prior, next) as Record<string, {
+      properties: Record<
+        string,
+        { ifc?: { maxConfidentiality?: unknown[] } }
+      >;
+    }>;
+    expect(merged.t.properties.c.ifc?.maxConfidentiality).toEqual(["lo"]);
+  });
+
+  it("tightens a write ceiling to the intersection when both are present", () => {
+    const prior = {
+      t: table({ c: { ifc: { maxConfidentiality: ["a", "b"] } } }),
+    };
+    const next = {
+      t: table({ c: { ifc: { maxConfidentiality: ["b", "c"] } } }),
+    };
+    const merged = growOnlyMergeDbTables(prior, next) as Record<string, {
+      properties: Record<
+        string,
+        { ifc?: { maxConfidentiality?: unknown[] } }
+      >;
+    }>;
+    // Only the meet survives — the smaller allowed set.
+    expect(merged.t.properties.c.ifc?.maxConfidentiality).toEqual(["b"]);
+  });
+
+  it("restores a labeled table that a re-derivation drops entirely", () => {
+    const prior = {
+      secrets: table({ k: { ifc: { confidentiality: ["s"] } } }),
+    };
+    const next = { other: table({ x: {} }) };
+    const merged = growOnlyMergeDbTables(prior, next) as Record<string, {
+      properties: Record<string, { ifc?: { confidentiality?: unknown[] } }>;
+    }>;
+    expect(merged.secrets.properties.k.ifc?.confidentiality).toEqual(["s"]);
+    expect(merged.other).toBeDefined();
+  });
+
+  it("restores a labeled column dropped from a still-present table", () => {
+    const prior = {
+      t: table({
+        secret: { type: "string", ifc: { confidentiality: ["s"] } },
+        plain: { type: "string" },
+      }),
+    };
+    // Table stays, but the labeled column is removed entirely.
+    const next = { t: table({ plain: { type: "string" } }) };
+    const merged = growOnlyMergeDbTables(prior, next) as Record<string, {
+      properties: Record<
+        string,
+        { type?: string; ifc?: { confidentiality?: unknown[] } }
+      >;
+    }>;
+    // The whole column comes back — its non-ifc structure (`type`) included.
+    expect(merged.t.properties.secret.type).toEqual("string");
+    expect(merged.t.properties.secret.ifc?.confidentiality).toEqual(["s"]);
+    expect(merged.t.properties.plain).toBeDefined();
+  });
+
+  it("lets new columns and a stricter re-declaration through", () => {
+    const prior = { t: table({ a: { ifc: { confidentiality: ["x"] } } }) };
+    const next = {
+      t: table({
+        a: { ifc: { confidentiality: ["x"], integrity: ["new"] } }, // stricter
+        b: { ifc: { confidentiality: ["y"] } }, // new column
+      }),
+    };
+    const merged = growOnlyMergeDbTables(prior, next) as Record<string, {
+      properties: Record<
+        string,
+        { ifc?: { confidentiality?: unknown[]; integrity?: unknown[] } }
+      >;
+    }>;
+    expect(merged.t.properties.a.ifc?.integrity).toEqual(["new"]);
+    expect(merged.t.properties.b.ifc?.confidentiality).toEqual(["y"]);
+  });
+});


### PR DESCRIPTION
## Audit S8 — sqlite per-column `ifc` is mutable outside label monotonicity

A `db` handle's per-column `ifc` (the read label + write ceiling for each SQLite column) lives in the handle cell's **value data** (`tables[].properties[col].ifc`), not in the CFC label-map envelope. The label-map is monotone by construction; this value data is not. So a re-derivation of the `sqliteDatabase` builtin that read a **weaker `tables` input** could silently:

- drop a column's read `confidentiality` / `integrity` (lowering its read label), or
- remove / widen a column's `maxConfidentiality` write ceiling.

Either is a store's effective label going **down**, which §8.12.1 forbids.

## Fix

`growOnlyMergeDbTables(prior, next)` clamps every re-derivation to be monotone against the **prior committed handle value**, read at the handle's causally-stable id (`handle.withTx(tx).get()`) before the `set`:

- **read label** — `confidentiality` / `integrity` atoms **union** (strengthen-only);
- **write ceiling** — `maxConfidentiality` **tightens to the intersection** and can never be removed (absent = unlimited, so present beats absent);
- **dropped labeled table or column** — restored wholesale (structure + label), so a re-derivation can't shed a label by omission.

First creation (no prior) passes the declared `tables` through unchanged. New tables/columns and **stricter** re-declarations are additive and pass through — only weakening is clamped.

## Scope

The residual vector — a direct write to the handle cell's value, bypassing the builtin — requires a sandbox escape, the same privileged-persistence assumption S18 already relies on. Out of scope here.

## Tests

`packages/runner/test/sqlite-tables-ifc-monotone.test.ts` (8 cases): first-creation passthrough; drop-read-label clamp; union confidentiality+integrity; ceiling can't be removed; ceiling tightens to intersection; dropped table restored; dropped column restored (with non-ifc structure); new columns + stricter re-declaration pass through.

Full runner suite green locally (577 passed / 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents SQLite per-column `ifc` from weakening on re-derivation by grow-only merging with the prior handle. Enforces monotone read labels and write ceilings (audit S8) and blocks minting integrity.

- **Bug Fixes**
  - Added `growOnlyMergeDbTables` and wired it into `sqliteDatabase` before `set` to clamp re-derivations against the prior committed handle.
  - Read labels: confidentiality unions (strengthen-only); integrity clamps to intersection (subset-only) and never mints. Write ceilings tighten to the intersection, cannot be removed, and a disjoint intersection stays `[]` (public-only), not `undefined`.
  - Restores dropped labeled tables/columns; new tables/columns and stricter confidentiality declarations pass through.
  - Added focused tests for first-create passthrough, integrity clamp (no union, mint-from-nothing blocked, narrowing allowed), ceiling behavior (including `[]` case), and restore cases; minor `prefer-const` cleanup.

<sup>Written for commit de574ee30919e7bcaff00536848de7e1d2c1aa1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

