### PR TITLE
feat(cfc): integrity propagation — hereditary meet + TransformedBy (S16 phase C)

### DIFF
--- a/packages/api/cfc.ts
+++ b/packages/api/cfc.ts
@@ -32,9 +32,16 @@ export const CFC_ATOM_TYPE = {
   InjectionSafe: `${CFC_ATOM_BASE}InjectionSafe`,
   LinkReference: `${CFC_ATOM_BASE}LinkReference`,
   Origin: `${CFC_ATOM_BASE}Origin`,
+  // Hereditary certification (spec §15.1.1 / §3.1.6.1): survives combination
+  // via the class-aware meet — present on an output only when present on
+  // every input.
+  PolicyCertified: `${CFC_ATOM_BASE}PolicyCertified`,
   PromptSlotBound: `${CFC_ATOM_BASE}PromptSlotBound`,
   PromptSlotInfluence: `${CFC_ATOM_BASE}PromptSlotInfluence`,
   Resource: `${CFC_ATOM_BASE}Resource`,
+  // Runtime-minted derivation provenance (spec §8.9.3): which implementation
+  // produced this value. Evidence — not authorable in schemas.
+  TransformedBy: `${CFC_ATOM_BASE}TransformedBy`,
   UserSurfaceInput: `${CFC_ATOM_BASE}UserSurfaceInput`,
 } as const;
 

--- a/packages/runner/src/cfc/atom-classes.ts
+++ b/packages/runner/src/cfc/atom-classes.ts
@@ -1,0 +1,43 @@
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { isRecord } from "@commonfabric/utils/types";
+
+/**
+ * Integrity-atom propagation classes (spec §15 registry, §3.1.6.1):
+ *
+ * - `hereditary`: survives combination via the class-aware meet — an output
+ *   carries it only when EVERY input carried it (weakest-link, the
+ *   `PolicyCertified` family).
+ * - `value-bound`: bound to a specific value identity; any transformation
+ *   invalidates the binding, so it never propagates through the default
+ *   transition.
+ * - `provenance`: records how/where a value came to be (builtins, links,
+ *   gestures, prompt slots); meaningful only for the value it was minted
+ *   on, never propagated.
+ *
+ * Unknown atom types default to `value-bound` (SC-10): dropping on
+ * combination under-claims integrity, which is the fail-safe direction.
+ */
+export type PropagationClass = "hereditary" | "value-bound" | "provenance";
+
+const CLASS_BY_TYPE = new Map<string, PropagationClass>([
+  [CFC_ATOM_TYPE.PolicyCertified, "hereditary"],
+  [CFC_ATOM_TYPE.InjectionSafe, "value-bound"],
+  [CFC_ATOM_TYPE.LinkReference, "value-bound"],
+  [CFC_ATOM_TYPE.PromptSlotBound, "value-bound"],
+  [CFC_ATOM_TYPE.Caveat, "value-bound"],
+  [CFC_ATOM_TYPE.Resource, "value-bound"],
+  [CFC_ATOM_TYPE.Builtin, "provenance"],
+  [CFC_ATOM_TYPE.Origin, "provenance"],
+  [CFC_ATOM_TYPE.PromptSlotInfluence, "provenance"],
+  [CFC_ATOM_TYPE.TransformedBy, "provenance"],
+  [CFC_ATOM_TYPE.UserSurfaceInput, "provenance"],
+]);
+
+export const atomPropagationClass = (atom: unknown): PropagationClass => {
+  if (isRecord(atom) && typeof atom.type === "string") {
+    return CLASS_BY_TYPE.get(atom.type) ?? "value-bound";
+  }
+  // String atoms and kind-shaped records (authored-by /
+  // represents-principal) have no registered class — fail-safe.
+  return "value-bound";
+};

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1289,9 +1289,17 @@ const deriveFlowJoin = (
   const confidentiality = uniqueCfcAtoms(atoms);
   const integrity: unknown[] = [...(hereditaryMeet ?? [])];
   // Derivation provenance (§8.9.3 TransformedBy, staged: identity binding
-  // only — no per-input refs/witnesses yet). Minted only alongside an
-  // entry that exists anyway; runtime-minted (schema-forgery gated).
-  const identity = tx.getCfcState().implementationIdentity;
+  // only — no per-input refs/witnesses yet). The flow join is one per-tx
+  // label stamped on every written doc, so the identity must hold for the
+  // whole tx: minted only when every non-privileged write was authored
+  // under the same defined identity, captured at write time (see
+  // `CfcTxState.writeIdentity`) — not whichever identity is current at
+  // prepare, which a later run in the same tx may have changed and which
+  // an unattributed write must not borrow. Ambiguity omits the atom
+  // (fail-safe under-claim). Minted only alongside an entry that exists
+  // anyway; runtime-minted (schema-forgery gated).
+  const writeIdentity = tx.getCfcState().writeIdentity;
+  const identity = writeIdentity.multiple ? undefined : writeIdentity.identity;
   if (
     identity !== undefined &&
     (confidentiality.length > 0 || integrity.length > 0)

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -37,6 +37,7 @@ import {
 import { getValueAtPath, setValueAtPath } from "../path-utils.ts";
 import { encodePointer } from "../../../memory/v2/path.ts";
 import { ContextualFlowControl } from "../cfc.ts";
+import { atomPropagationClass } from "./atom-classes.ts";
 import { canonicalizeLogicalPath } from "./canonical.ts";
 import { uniqueCfcAtoms } from "./observation.ts";
 import { mergeCfcSchemaEnvelopes } from "./schema-merge.ts";
@@ -1244,10 +1245,19 @@ const forEachFlowObservation = (
   return false;
 };
 
-const deriveFlowConfidentiality = (
+const deriveFlowJoin = (
   tx: IExtendedStorageTransaction,
-): unknown[] => {
+): { confidentiality: unknown[]; integrity: unknown[] } => {
   const atoms: unknown[] = [];
+  // Class-aware integrity meet (§8.9.3 / §3.1.6.2): hereditary atoms
+  // survive only when EVERY contributing observation carries them. An
+  // observation with no resolved label has empty integrity and empties the
+  // meet — weakest link, which is what carries PolicyCertified-class
+  // certification honestly: a single uncertified input means the output is
+  // uncertified. (In practice most transactions read some unlabeled doc,
+  // so the meet is usually empty until inputs are universally certified —
+  // staged conformance per SC-9, never over-claiming.)
+  let hereditaryMeet: unknown[] | undefined;
   const metadataByDoc = new Map<string, CfcMetadata | undefined>();
   forEachFlowObservation(
     tx,
@@ -1265,10 +1275,30 @@ const deriveFlowConfidentiality = (
       if (label?.confidentiality?.length) {
         atoms.push(...label.confidentiality);
       }
+      const hereditary = (label?.integrity ?? []).filter((atom) =>
+        atomPropagationClass(atom) === "hereditary"
+      );
+      hereditaryMeet = hereditaryMeet === undefined
+        ? [...hereditary]
+        : hereditaryMeet.filter((kept) =>
+          hereditary.some((atom) => deepEqual(atom, kept))
+        );
       return false;
     },
   );
-  return uniqueCfcAtoms(atoms);
+  const confidentiality = uniqueCfcAtoms(atoms);
+  const integrity: unknown[] = [...(hereditaryMeet ?? [])];
+  // Derivation provenance (§8.9.3 TransformedBy, staged: identity binding
+  // only — no per-input refs/witnesses yet). Minted only alongside an
+  // entry that exists anyway; runtime-minted (schema-forgery gated).
+  const identity = tx.getCfcState().implementationIdentity;
+  if (
+    identity !== undefined &&
+    (confidentiality.length > 0 || integrity.length > 0)
+  ) {
+    integrity.push({ type: CFC_ATOM_TYPE.TransformedBy, identity });
+  }
+  return { confidentiality, integrity: uniqueCfcAtoms(integrity) };
 };
 
 /**
@@ -2453,8 +2483,13 @@ const RUNTIME_MINTED_INTEGRITY_ATOM_TYPES = new Set<string>([
   CFC_ATOM_TYPE.Builtin,
   CFC_ATOM_TYPE.LinkReference,
   CFC_ATOM_TYPE.Origin,
+  // Hereditary certification must come from the certification process, not
+  // a pattern-authored schema — forging it would survive every combination.
+  CFC_ATOM_TYPE.PolicyCertified,
   CFC_ATOM_TYPE.PromptSlotBound,
   CFC_ATOM_TYPE.PromptSlotInfluence,
+  // Derivation provenance is evidence minted by the flow stage (§8.9.3).
+  CFC_ATOM_TYPE.TransformedBy,
   CFC_ATOM_TYPE.UserSurfaceInput,
 ]);
 
@@ -2918,18 +2953,23 @@ export const prepareBoundaryCommit = (
   const flowMode = state.flowLabelsMode;
   const flowPersist = flowMode === "persist";
   const flowTargets = flowMode === "off" ? undefined : valueWriteTargets(tx);
-  const flowConfidentiality = flowMode === "off"
-    ? []
-    : deriveFlowConfidentiality(tx);
+  const flowJoin = flowMode === "off"
+    ? { confidentiality: [], integrity: [] }
+    : deriveFlowJoin(tx);
+  const flowConfidentiality = flowJoin.confidentiality;
+  const flowIntegrity = flowJoin.integrity;
+  const flowHasLabels = flowConfidentiality.length > 0 ||
+    flowIntegrity.length > 0;
   if (
     flowMode === "observe" &&
     flowTargets !== undefined &&
     flowTargets.size > 0 &&
-    flowConfidentiality.length > 0
+    flowHasLabels
   ) {
     state.diagnostics.push(
       `flow-labels(observe): would derive ${flowConfidentiality.length} ` +
-        `confidentiality atom(s) onto ${flowTargets.size} written doc(s)`,
+        `confidentiality / ${flowIntegrity.length} integrity atom(s) onto ` +
+        `${flowTargets.size} written doc(s)`,
     );
   }
   for (const [key, target] of valueWriteTargets(tx)) {
@@ -2973,7 +3013,7 @@ export const prepareBoundaryCommit = (
       if (targetKeys.has(key)) {
         continue;
       }
-      if (flowConfidentiality.length > 0) {
+      if (flowHasLabels) {
         targetKeys.add(key);
         continue;
       }
@@ -3233,7 +3273,7 @@ export const prepareBoundaryCommit = (
       }
     }
 
-    if (flowPersist && flowConfidentiality.length > 0) {
+    if (flowPersist && flowHasLabels) {
       // Attach the per-tx join at each written path. Within one tx every
       // write carries the same join, so deeper written paths are redundant
       // with a shallower written ancestor and are collapsed away (§4.6.4
@@ -3286,7 +3326,14 @@ export const prepareBoundaryCommit = (
         }
         persistedLabelEntries.push({
           path,
-          label: { confidentiality: [...flowConfidentiality] },
+          label: {
+            ...(flowConfidentiality.length > 0
+              ? { confidentiality: [...flowConfidentiality] }
+              : {}),
+            ...(flowIntegrity.length > 0
+              ? { integrity: [...flowIntegrity] }
+              : {}),
+          },
           origin: "derived",
         });
       }

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -334,6 +334,22 @@ export type CfcTxState = {
     WritePolicyInput,
     ImplementationIdentity | undefined
   >;
+  // Implementation identity active at each non-privileged write, collapsed to
+  // a per-tx uniformity summary (§8.9.3 TransformedBy). Flow labels are one
+  // per-tx join stamped on every written doc, so derivation provenance is
+  // honest only when every write was authored under the same defined
+  // identity: a write under a different identity — or before any was set —
+  // makes the tx-level claim ambiguous, `multiple` collapses it, and the
+  // mint is omitted (fail-safe under-claim, SC-10). Same capture rationale
+  // as `writePolicyInputIdentities` above: attribution must not borrow an
+  // identity a later run in the same transaction happens to set. The
+  // runtime's own privileged persistence writes are excluded — bookkeeping,
+  // not authorship.
+  writeIdentity: {
+    sawWrite: boolean;
+    multiple: boolean;
+    identity?: ImplementationIdentity;
+  };
   trustSnapshot?: TrustSnapshot;
   implementationIdentity?: ImplementationIdentity;
   outbox: PostCommitSideEffect[];

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -1,4 +1,5 @@
 import { Immutable, isRecord } from "@commonfabric/utils/types";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
 import {
   type FabricObject,
@@ -112,6 +113,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     triggerReads: [],
     writePolicyInputs: [],
     writePolicyInputIdentities: new Map(),
+    writeIdentity: { sawWrite: false, multiple: false },
     outbox: [],
     diagnostics: [],
     unprivilegedSystemWrites: [],
@@ -275,6 +277,32 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.cfcState.unprivilegedSystemWrites.push(
       `${address.id}/${address.path.join("/")}`,
     );
+  }
+
+  // Capture the implementation identity active at this write into the per-tx
+  // uniformity summary (§8.9.3 TransformedBy — see `CfcTxState.writeIdentity`).
+  // The flow join is one per-tx label, so derivation provenance is minted only
+  // when every non-privileged write was authored under the same defined
+  // identity: identities are captured at write time, like
+  // `recordCfcWritePolicyInput()` does, so a later run in the same transaction
+  // cannot lend its identity to earlier writes (and an unattributed write
+  // cannot borrow a later one). Privileged persistence writes (label maps,
+  // `cid:` schema docs) are bookkeeping, not authorship, and are skipped —
+  // also keeping the summary stable across prepare/invalidate/re-prepare.
+  private noteWriteIdentity(): void {
+    if (this.#privilegedSystemWriteDepth > 0) return;
+    const summary = this.cfcState.writeIdentity;
+    if (summary.multiple) return;
+    const current = this.cfcState.implementationIdentity;
+    if (!summary.sawWrite) {
+      summary.sawWrite = true;
+      summary.identity = current;
+      return;
+    }
+    if (!deepEqual(summary.identity, current)) {
+      summary.multiple = true;
+      summary.identity = undefined;
+    }
   }
 
   invalidateCfc(reason: string): void {
@@ -637,6 +665,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   ): Result<IAttestation, WriteError | WriterError> {
     this.assertWritable("write()");
     this.noteSystemWrite(address);
+    this.noteWriteIdentity();
     if (this.cfcState.prepare.status === "prepared") {
       this.invalidateCfc("write-after-prepare");
     }
@@ -650,6 +679,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   ): void {
     this.assertWritable("writeOrThrow()");
     this.noteSystemWrite(address);
+    this.noteWriteIdentity();
     if (this.cfcState.prepare.status === "prepared") {
       this.invalidateCfc("write-after-prepare");
     }
@@ -743,11 +773,15 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       // widened to document-root addresses.
       const noteSystemWrite = (address: IMemorySpaceAddress) =>
         this.noteSystemWrite(address);
+      // Note the write identity per yielded write (not once up front): an
+      // empty batch must not mark the tx as written-to.
+      const noteWriteIdentity = () => this.noteWriteIdentity();
       const result = this.tx.writeBatch(
         (function* () {
           for (const write of writes) {
             const address = toMemorySpaceAddress(write.address);
             noteSystemWrite(address);
+            noteWriteIdentity();
             yield { address, value: write.value };
           }
         })(),

--- a/packages/runner/test/cfc-flow-integrity.test.ts
+++ b/packages/runner/test/cfc-flow-integrity.test.ts
@@ -221,6 +221,142 @@ describe("CFC flow labels: integrity propagation (phase C)", () => {
     }
   });
 
+  // TransformedBy is an attribution claim, and the flow stage operates at tx
+  // granularity (one join stamped on every written doc). The claim is only
+  // honest when every write in the tx was authored under the same defined
+  // identity — captured at write time, like `writePolicyInputIdentities`
+  // ("a later run in the same transaction may change the identity"). Any
+  // ambiguity omits the atom: a fail-safe under-claim, never a borrowed one.
+  const isTransformedBy = (atom: unknown): boolean =>
+    (atom as { type?: string } | null)?.type === CFC_ATOM_TYPE.TransformedBy;
+
+  it("omits TransformedBy when writes span multiple identities (no borrowing)", async () => {
+    const { storageManager, runtime } = makeRuntime();
+    try {
+      await seedDoc(runtime, "flow-tb-multi-src", [certified("p1")]);
+
+      const tx = runtime.edit();
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "writer.x",
+      });
+      const src = runtime.getCell(space, "flow-tb-multi-src", undefined, tx);
+      const raw = src.getRaw() as { n: number };
+      const out1 = runtime.getCell(space, "flow-tb-multi-out1", undefined, tx);
+      const out1Id = out1.getAsNormalizedFullLink().id;
+      tx.writeOrThrow(
+        { space, scope: "space", id: out1Id, path: ["value"] },
+        { copied: raw.n },
+      );
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "writer.y",
+      });
+      const out2 = runtime.getCell(space, "flow-tb-multi-out2", undefined, tx);
+      const out2Id = out2.getAsNormalizedFullLink().id;
+      tx.writeOrThrow(
+        { space, scope: "space", id: out2Id, path: ["value"] },
+        { copied: raw.n },
+      );
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      for (const id of [out1Id, out2Id]) {
+        const integrity = derivedIntegrity(storageManager, id);
+        // The hereditary meet still flows...
+        expect(integrity).toContainEqual(certified("p1"));
+        // ...but stamping the per-tx join with the last-active identity
+        // would attribute writer.x's output to writer.y.
+        expect(integrity.some(isTransformedBy)).toBe(false);
+      }
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("omits TransformedBy when a write predates the first identity (unattributed)", async () => {
+    const { storageManager, runtime } = makeRuntime();
+    try {
+      await seedDoc(runtime, "flow-tb-unattr-src", [certified("p1")]);
+
+      const tx = runtime.edit();
+      const src = runtime.getCell(space, "flow-tb-unattr-src", undefined, tx);
+      const raw = src.getRaw() as { n: number };
+      const out1 = runtime.getCell(space, "flow-tb-unattr-out1", undefined, tx);
+      const out1Id = out1.getAsNormalizedFullLink().id;
+      // Unattributed write: no implementation identity has been set yet.
+      tx.writeOrThrow(
+        { space, scope: "space", id: out1Id, path: ["value"] },
+        { copied: raw.n },
+      );
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "late-identity",
+      });
+      const out2 = runtime.getCell(space, "flow-tb-unattr-out2", undefined, tx);
+      const out2Id = out2.getAsNormalizedFullLink().id;
+      tx.writeOrThrow(
+        { space, scope: "space", id: out2Id, path: ["value"] },
+        { copied: raw.n },
+      );
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      // The unattributed write must not borrow the later trusted identity.
+      for (const id of [out1Id, out2Id]) {
+        const integrity = derivedIntegrity(storageManager, id);
+        expect(integrity).toContainEqual(certified("p1"));
+        expect(integrity.some(isTransformedBy)).toBe(false);
+      }
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("attributes TransformedBy to the identity that authored the writes, not the one current at prepare", async () => {
+    const { storageManager, runtime } = makeRuntime();
+    try {
+      await seedDoc(runtime, "flow-tb-author-src", [certified("p1")]);
+
+      const tx = runtime.edit();
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "the-author",
+      });
+      const src = runtime.getCell(space, "flow-tb-author-src", undefined, tx);
+      const raw = src.getRaw() as { n: number };
+      const out = runtime.getCell(space, "flow-tb-author-out", undefined, tx);
+      const outId = out.getAsNormalizedFullLink().id;
+      tx.writeOrThrow(
+        { space, scope: "space", id: outId, path: ["value"] },
+        { copied: raw.n },
+      );
+      // A later run in the same tx changes the identity but writes nothing:
+      // the write-authoring identity is still uniform.
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "the-bystander",
+      });
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const integrity = derivedIntegrity(storageManager, outId);
+      expect(integrity).toContainEqual({
+        type: CFC_ATOM_TYPE.TransformedBy,
+        identity: { kind: "builtin", builtinId: "the-author" },
+      });
+      expect(integrity).not.toContainEqual({
+        type: CFC_ATOM_TYPE.TransformedBy,
+        identity: { kind: "builtin", builtinId: "the-bystander" },
+      });
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("strips schema-forged PolicyCertified and TransformedBy (runtime-minted gate)", async () => {
     const { storageManager, runtime } = makeRuntime();
     try {

--- a/packages/runner/test/cfc-flow-integrity.test.ts
+++ b/packages/runner/test/cfc-flow-integrity.test.ts
@@ -1,0 +1,269 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import { atomPropagationClass } from "../src/cfc/atom-classes.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-flow-integrity");
+const space = signer.did();
+
+type StoredEntry = {
+  path: string[];
+  label: { confidentiality?: unknown[]; integrity?: unknown[] };
+  origin?: string;
+};
+
+const certified = (policy: string) => ({
+  type: CFC_ATOM_TYPE.PolicyCertified,
+  policy,
+});
+
+// S16 phase C: integrity propagation through the default transition —
+// class-aware hereditary meet (§8.9.3/§3.1.6.2: an output is certified only
+// when every observed input was) plus runtime-minted TransformedBy
+// derivation provenance.
+describe("CFC flow labels: integrity propagation (phase C)", () => {
+  const makeRuntime = () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      cfcFlowLabels: "persist",
+    });
+    return { storageManager, runtime };
+  };
+
+  const seedDoc = async (
+    runtime: Runtime,
+    cause: string,
+    integrity: unknown[],
+  ): Promise<string> => {
+    const seed = runtime.edit();
+    const cell = runtime.getCell(space, cause, undefined, seed);
+    const id = cell.getAsNormalizedFullLink().id;
+    seed.writeOrThrow({ space, scope: "space", id, path: [] }, {
+      value: { n: 1 },
+      cfc: {
+        version: 1,
+        schemaHash: "seed-schema",
+        labelMap: {
+          version: 1,
+          entries: [{ path: [], label: { integrity } }],
+        },
+      },
+    });
+    expect((await seed.commit()).ok).toBeDefined();
+    return id;
+  };
+
+  const entriesOf = (
+    storageManager: ReturnType<typeof StorageManager.emulate>,
+    id: string,
+  ): StoredEntry[] => {
+    const replica = storageManager.open(space).replica as unknown as {
+      getDocument(id: string): {
+        cfc?: { labelMap?: { entries: StoredEntry[] } };
+      } | undefined;
+    };
+    return replica.getDocument(id)?.cfc?.labelMap?.entries ?? [];
+  };
+
+  const derivedIntegrity = (
+    storageManager: ReturnType<typeof StorageManager.emulate>,
+    id: string,
+  ): unknown[] =>
+    entriesOf(storageManager, id)
+      .filter((e) => e.origin === "derived")
+      .flatMap((e) => e.label.integrity ?? []);
+
+  it("classifies atoms with a fail-safe default", () => {
+    expect(atomPropagationClass(certified("p"))).toBe("hereditary");
+    expect(atomPropagationClass({ type: CFC_ATOM_TYPE.InjectionSafe }))
+      .toBe("value-bound");
+    expect(atomPropagationClass({ type: CFC_ATOM_TYPE.Builtin, name: "x" }))
+      .toBe("provenance");
+    // Unknown record types, plain strings, kind-shaped records: value-bound.
+    expect(atomPropagationClass({ type: "https://example.com/custom" }))
+      .toBe("value-bound");
+    expect(atomPropagationClass("trusted")).toBe("value-bound");
+    expect(atomPropagationClass({ kind: "authored-by", subject: "x" }))
+      .toBe("value-bound");
+  });
+
+  it("propagates hereditary atoms only when every observed input carries them", async () => {
+    const { storageManager, runtime } = makeRuntime();
+    try {
+      await seedDoc(runtime, "flow-int-a", [
+        certified("p1"),
+        { type: CFC_ATOM_TYPE.InjectionSafe },
+        "value-bound-ish",
+      ]);
+      await seedDoc(runtime, "flow-int-b", [
+        certified("p1"),
+        certified("p2"),
+      ]);
+
+      const tx = runtime.edit();
+      const a = runtime.getCell(space, "flow-int-a", undefined, tx);
+      const b = runtime.getCell(space, "flow-int-b", undefined, tx);
+      const rawA = a.getRaw() as { n: number };
+      const rawB = b.getRaw() as { n: number };
+      // Raw write: `cell.set()` journals a read of the (unlabeled) target
+      // doc's prior value, and the weakest-link meet rightly empties on any
+      // uncertified observation. A read-free write keeps the observation
+      // set to exactly the two certified inputs.
+      const out = runtime.getCell(space, "flow-int-out", undefined, tx);
+      const outId = out.getAsNormalizedFullLink().id;
+      tx.writeOrThrow(
+        { space, scope: "space", id: outId, path: ["value"] },
+        { sum: rawA.n + rawB.n },
+      );
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const integrity = derivedIntegrity(storageManager, outId);
+      // p1 on every input: survives the meet. p2 only on B: dropped.
+      // Value-bound atoms never propagate.
+      expect(integrity).toContainEqual(certified("p1"));
+      expect(integrity).not.toContainEqual(certified("p2"));
+      expect(integrity).not.toContainEqual({
+        type: CFC_ATOM_TYPE.InjectionSafe,
+      });
+      expect(integrity).not.toContainEqual("value-bound-ish");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("empties the meet when any observed input lacks the atom (weakest link)", async () => {
+    const { storageManager, runtime } = makeRuntime();
+    try {
+      await seedDoc(runtime, "flow-wl-a", [certified("p1")]);
+      // Doc B carries a confidentiality label (so it resolves) but NO
+      // certification.
+      const seed = runtime.edit();
+      const bCell = runtime.getCell(space, "flow-wl-b", undefined, seed);
+      const bId = bCell.getAsNormalizedFullLink().id;
+      seed.writeOrThrow({ space, scope: "space", id: bId, path: [] }, {
+        value: { n: 2 },
+        cfc: {
+          version: 1,
+          schemaHash: "seed-schema",
+          labelMap: {
+            version: 1,
+            entries: [{ path: [], label: { confidentiality: ["plain"] } }],
+          },
+        },
+      });
+      expect((await seed.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      const a = runtime.getCell(space, "flow-wl-a", undefined, tx);
+      const b = runtime.getCell(space, "flow-wl-b", undefined, tx);
+      const rawA = a.getRaw() as { n: number };
+      const rawB = b.getRaw() as { n: number };
+      const out = runtime.getCell(space, "flow-wl-out", undefined, tx);
+      out.set({ sum: rawA.n + rawB.n });
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const integrity = derivedIntegrity(
+        storageManager,
+        out.getAsNormalizedFullLink().id,
+      );
+      expect(integrity).not.toContainEqual(certified("p1"));
+      // The confidentiality still flows.
+      const conf = entriesOf(storageManager, out.getAsNormalizedFullLink().id)
+        .filter((e) => e.origin === "derived")
+        .flatMap((e) => e.label.confidentiality ?? []);
+      expect(conf).toContainEqual("plain");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("mints TransformedBy with the transaction's implementation identity", async () => {
+    const { storageManager, runtime } = makeRuntime();
+    try {
+      await seedDoc(runtime, "flow-tb-src", [certified("p1")]);
+
+      const tx = runtime.edit();
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "flow-test-builtin",
+      });
+      const src = runtime.getCell(space, "flow-tb-src", undefined, tx);
+      const raw = src.getRaw() as { n: number };
+      const out = runtime.getCell(space, "flow-tb-out", undefined, tx);
+      const outId = out.getAsNormalizedFullLink().id;
+      tx.writeOrThrow(
+        { space, scope: "space", id: outId, path: ["value"] },
+        { copied: raw.n },
+      );
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const integrity = derivedIntegrity(storageManager, outId);
+      expect(integrity).toContainEqual({
+        type: CFC_ATOM_TYPE.TransformedBy,
+        identity: { kind: "builtin", builtinId: "flow-test-builtin" },
+      });
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("strips schema-forged PolicyCertified and TransformedBy (runtime-minted gate)", async () => {
+    const { storageManager, runtime } = makeRuntime();
+    try {
+      const forged = internSchema(
+        {
+          type: "object",
+          properties: {
+            field: {
+              type: "string",
+              ifc: {
+                integrity: [
+                  certified("forged"),
+                  { type: CFC_ATOM_TYPE.TransformedBy, identity: "fake" },
+                  "plain-claim",
+                ],
+              },
+            },
+          },
+          required: ["field"],
+        } satisfies JSONSchema,
+        true,
+      );
+      const tx = runtime.edit();
+      const cell = runtime.getCell(space, "flow-forge", forged.schema, tx);
+      cell.set({ field: "hello" });
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const declared = entriesOf(
+        storageManager,
+        cell.getAsNormalizedFullLink().id,
+      ).filter((e) => e.origin === "declared").flatMap((e) =>
+        e.label.integrity ?? []
+      );
+      expect(declared).toContainEqual("plain-claim");
+      expect(declared).not.toContainEqual(certified("forged"));
+      expect(declared).not.toContainEqual({
+        type: CFC_ATOM_TYPE.TransformedBy,
+        identity: "fake",
+      });
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Phase C of the S16 default transition (stacked on #4022 → #4012 → main; base auto-retargets as the chain merges). The default transition now derives **integrity**, staged per SC-9 so no stage over-claims.

## Changes

- **Propagation-class registry** (`cfc/atom-classes.ts`) mirroring spec §15: `PolicyCertified` is hereditary; `InjectionSafe`/`LinkReference`/`PromptSlotBound`/`Caveat`/`Resource` are value-bound; `Builtin`/`Origin`/`PromptSlotInfluence`/`TransformedBy`/`UserSurfaceInput` are provenance. Unknown atoms (plain strings, kind-shaped records, unregistered types) default to **value-bound** — dropping on combination under-claims, the fail-safe direction (SC-10).
- **Class-aware meet** (§8.9.3/§3.1.6.2): a derived entry carries a hereditary atom only when *every* flow observation carried it. An observation with no resolved label empties the meet — weakest link, which is what makes PolicyCertified-class certification honest. Notably `cell.set()` journals a read of the target's prior value, so only read-free writes over fully certified inputs stay certified (documented in tests).
- **TransformedBy derivation provenance** minted from the transaction's implementation identity (identity binding only — per-input refs/witnesses are later stages), only alongside an entry that exists anyway (no labelMap growth from provenance alone).
- **Forgery gate**: `PolicyCertified` and `TransformedBy` join the runtime-minted set — schema-authored claims of either are stripped (S4 posture). Forged hereditary certification would otherwise survive every combination.
- New atom constants `PolicyCertified`/`TransformedBy` in `@commonfabric/api/cfc`.
- Fixes `PreparedDigestInput` test/bench literals missing `triggerReads` (caught by `deno task check`; suite runs use `--no-check` — #4011 shepherd follow-up).

## Testing

New `cfc-flow-integrity.test.ts`: registry classification, meet-survives-when-universal, weakest-link emptying, TransformedBy minting with identity, forged-claim stripping. Full runner suite 572/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements integrity propagation in the CFC default transition via a class-aware hereditary meet, and derives `TransformedBy` from the write-time implementation identity with uniformity gating. Exports new atoms and strips schema‑forged certification; also fixes `TransformedBy` attribution and minor test issues.

- **New Features**
  - Propagation-class registry; unknown atoms default to value-bound.
  - Class-aware meet: hereditary atoms survive only if all observations carry them; unlabeled observations empty the meet.
  - `TransformedBy` minted from a per-write identity summary when all non-privileged writes share the same defined identity; only alongside an existing entry.
  - Strip schema-authored `PolicyCertified` and `TransformedBy` (runtime-minted only).
  - Export `PolicyCertified` and `TransformedBy` in `@commonfabric/api/cfc`.

- **Bug Fixes**
  - Correct `TransformedBy` attribution to the identity that authored the writes; omit when mixed or unattributed, and ignore privileged persistence writes.
  - Add `triggerReads` to `PreparedDigestInput` literals in tests/bench; remove an unused import to satisfy lint.

<sup>Written for commit d19f87421e393a82936e08c1258defe9d2cd6621. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Perf baseline override

```
NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/battleship/multiplayer/lobby.test.tsx = 19s
```

Justification: the flagged metric moved between perf-check runs on the identical head (first run flagged Pattern Unit shard 2/5 wall time, the rerun flagged this single multiplayer-sync subtest at +26%) — timing-noise whack-a-mole, not a regression. The only always-on code this PR adds is noteWriteIdentity: a few field reads and at most one deepEqual of a small identity record per write, incapable of +4s on one test. The flow-derivation changes run only under the default-off cfcFlowLabels dial, which pattern unit tests do not enable. Precedent: #4011 (95s runner-integration override), #3987 (108s).
