### PR TITLE
fix(cfc): fail closed when an LLM-observation label read errors (audit 22)

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -47,7 +47,10 @@ import {
   isCellResultForDereferencing,
 } from "../query-result-proxy.ts";
 import { ContextualFlowControl } from "../cfc.ts";
-import { type CfcLabelView, cfcLabelViewForCell } from "../cfc/label-view.ts";
+import {
+  type CfcLabelView,
+  cfcLabelViewForCellFailClosed,
+} from "../cfc/label-view.ts";
 import {
   cfcConfidentialityForObservationNode,
   cfcObservationFitsCeiling,
@@ -1436,7 +1439,7 @@ function buildAvailableCellsDocumentationWithObservation(
         contextSpace: space,
         rootLink: link,
         labelView: observationMaxConfidentiality
-          ? cfcLabelViewForCell(concreteCell)
+          ? cfcLabelViewForCellFailClosed(concreteCell)
           : undefined,
         observationMaxConfidentiality,
       });
@@ -1546,7 +1549,7 @@ function getObservedDialogMessages(
   messages: readonly BuiltInLLMMessage[];
   observedConfidentiality: readonly unknown[];
 } {
-  const labelView = cfcLabelViewForCell(messagesCell);
+  const labelView = cfcLabelViewForCellFailClosed(messagesCell);
   const observedConfidentiality = joinCfcObservedConfidentiality(
     messages.map((_message, index) => {
       const stored = messageObservations[index.toString()];
@@ -2149,7 +2152,7 @@ async function handleRead(
     seen: new Set(),
     contextSpace: space,
     rootLink: cell.getAsNormalizedFullLink(),
-    labelView: cfcLabelViewForCell(cell),
+    labelView: cfcLabelViewForCellFailClosed(cell),
     observationMaxConfidentiality,
   });
 
@@ -2321,7 +2324,7 @@ async function handleInvoke(
       rootLink: concreteResult.getAsNormalizedFullLink(),
       labelView: useResultSchemaForObservation
         ? undefined
-        : cfcLabelViewForCell(concreteResult),
+        : cfcLabelViewForCellFailClosed(concreteResult),
       observationMaxConfidentiality,
     });
     return {
@@ -2349,7 +2352,7 @@ async function handleInvoke(
         seen: new Set(),
         contextSpace: space,
         rootLink: result.getAsNormalizedFullLink(),
-        labelView: cfcLabelViewForCell(result),
+        labelView: cfcLabelViewForCellFailClosed(result),
         observationMaxConfidentiality,
       });
       return {

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -20,7 +20,7 @@ import {
 import type { Schema } from "@commonfabric/api/schema";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
-import { cfcLabelViewForCell } from "../cfc/label-view.ts";
+import { cfcLabelViewForCellFailClosed } from "../cfc/label-view.ts";
 import {
   schemaWithInjectionSafeAnnotations,
   validateAgainstSchema,
@@ -89,7 +89,7 @@ function summarizeGenerateObjectRequest(details: {
 }
 
 function collectCellConfidentiality(cell: Cell<any>): readonly unknown[] {
-  const labelView = cfcLabelViewForCell(cell.resolveAsCell());
+  const labelView = cfcLabelViewForCellFailClosed(cell.resolveAsCell());
   if (labelView === undefined) {
     return [];
   }

--- a/packages/runner/src/cfc/label-view.ts
+++ b/packages/runner/src/cfc/label-view.ts
@@ -38,87 +38,160 @@ type LinkedValueMetadata = {
   path: readonly string[];
 };
 
+// Sentinel confidentiality atom injected when a cell's label could not be read
+// because a metadata read ERRORED (as opposed to being cleanly absent). It is
+// not a real principal/tag, so it is absent from every declared observation
+// ceiling — any observation node it taints fails `cfcObservationFitsCeiling`
+// and is redacted. This lets the LLM-observation path fail CLOSED on read errors
+// (audit item 22): a swallowed read error must not let confidential data
+// serialize to the model as if it were public. The shared `cfcLabelViewForCell`
+// seam (renderer / fuse / runtime-client) is intentionally left untouched — it
+// already treats a missing label as blocked, so only LLM egress needs this.
+export const CFC_LABEL_READ_FAILED_ATOM = "cfc:label-read-failed";
+
+// `readFailed` distinguishes a genuine metadata read error (fail closed) from a
+// cleanly-absent label (`readOrThrow` already maps NotFound/TypeMismatch to
+// undefined without throwing, so those are NOT failures).
+type StoredMetadataResult = {
+  metadata: CfcMetadata | undefined;
+  readFailed: boolean;
+};
+
+type LinkedValueMetadataResult = {
+  linkedValue: LinkedValueMetadata | undefined;
+  readFailed: boolean;
+};
+
+export type CfcLabelViewStatus = {
+  view: CfcLabelView | undefined;
+  readFailed: boolean;
+};
+
 const storedMetadataForCell = (
   cell: LabelQueryableCell,
   link: NormalizedFullLink,
-): CfcMetadata | undefined => {
+): StoredMetadataResult => {
   if (!cell.runtime) {
-    return undefined;
+    return { metadata: undefined, readFailed: false };
   }
   try {
-    return readStoredCfcMetadata(
-      cell.runtime.readTx(cell.tx),
-      {
-        space: link.space,
-        id: link.id,
-      },
-    );
+    return {
+      metadata: readStoredCfcMetadata(
+        cell.runtime.readTx(cell.tx),
+        {
+          space: link.space,
+          id: link.id,
+        },
+      ),
+      readFailed: false,
+    };
   } catch {
-    return undefined;
+    return { metadata: undefined, readFailed: true };
   }
 };
 
 const linkedValueMetadataForCell = (
   cell: LabelQueryableCell,
   link: NormalizedFullLink,
-): LinkedValueMetadata | undefined => {
+): LinkedValueMetadataResult => {
   if (!cell.runtime || link.path.length === 0) {
-    return undefined;
+    return { linkedValue: undefined, readFailed: false };
   }
   try {
     const tx = cell.runtime.readTx(cell.tx);
     const value = tx.readValueOrThrow(link);
     if (!isPrimitiveCellLink(value)) {
-      return undefined;
+      return { linkedValue: undefined, readFailed: false };
     }
     const target = parseLink(value, link);
     if (target?.id === undefined || target.space === undefined) {
-      return undefined;
+      return { linkedValue: undefined, readFailed: false };
     }
     const metadata = readStoredCfcMetadata(tx, {
       space: target.space,
       id: target.id,
       scope: target.scope,
     });
-    return metadata === undefined ? undefined : { metadata, path: target.path };
+    return {
+      linkedValue: metadata === undefined
+        ? undefined
+        : { metadata, path: target.path },
+      readFailed: false,
+    };
   } catch {
-    return undefined;
+    return { linkedValue: undefined, readFailed: true };
   }
 };
 
-export const cfcLabelViewForCell = (
+/**
+ * Acquire a cell's display label view AND report whether a metadata read
+ * errored while doing so. `cfcLabelViewForCell` drops the flag (the common
+ * consumers treat a missing view as blocked); the LLM-observation path consults
+ * it via `cfcLabelViewForCellFailClosed`.
+ */
+export const cfcLabelViewForCellWithStatus = (
   cell: unknown,
-): CfcLabelView | undefined => {
+): CfcLabelViewStatus => {
   if (
     !isRecord(cell) ||
     typeof cell.getAsNormalizedFullLink !== "function"
   ) {
-    return getCarriedCfcLabelView(cell);
+    return { view: getCarriedCfcLabelView(cell), readFailed: false };
   }
 
   let link: NormalizedFullLink;
   try {
     link = (cell as LabelQueryableCell).getAsNormalizedFullLink();
   } catch {
-    return getCarriedCfcLabelView(cell);
+    return { view: getCarriedCfcLabelView(cell), readFailed: false };
   }
 
-  const metadataView = cfcLabelViewFromMetadata(
-    storedMetadataForCell(cell as LabelQueryableCell, link),
-    link.path,
-  );
-  const linkedValue = linkedValueMetadataForCell(
-    cell as LabelQueryableCell,
-    link,
-  );
+  const stored = storedMetadataForCell(cell as LabelQueryableCell, link);
+  const metadataView = cfcLabelViewFromMetadata(stored.metadata, link.path);
+  const linked = linkedValueMetadataForCell(cell as LabelQueryableCell, link);
   const linkedValueView = cfcLabelViewFromMetadata(
-    linkedValue?.metadata,
-    linkedValue?.path ?? [],
+    linked.linkedValue?.metadata,
+    linked.linkedValue?.path ?? [],
   );
 
+  return {
+    view: mergeCfcLabelViews([
+      metadataView,
+      linkedValueView,
+      getCarriedCfcLabelView(cell),
+    ]),
+    readFailed: stored.readFailed || linked.readFailed,
+  };
+};
+
+export const cfcLabelViewForCell = (
+  cell: unknown,
+): CfcLabelView | undefined => cfcLabelViewForCellWithStatus(cell).view;
+
+/**
+ * Fail-closed label acquisition for the LLM-observation egress path (audit 22).
+ * Identical to `cfcLabelViewForCell` EXCEPT that when a metadata read errored,
+ * the returned view is tainted at the root with `CFC_LABEL_READ_FAILED_ATOM`, so
+ * every observation node under it fails any declared confidentiality ceiling and
+ * is redacted rather than serialized to the model as public. A cleanly-absent
+ * label (no read error) is unchanged, so normal unlabelled data is not
+ * over-redacted.
+ */
+export const cfcLabelViewForCellFailClosed = (
+  cell: unknown,
+): CfcLabelView | undefined => {
+  const { view, readFailed } = cfcLabelViewForCellWithStatus(cell);
+  if (!readFailed) {
+    return view;
+  }
   return mergeCfcLabelViews([
-    metadataView,
-    linkedValueView,
-    getCarriedCfcLabelView(cell),
+    view,
+    {
+      version: 1,
+      entries: [{
+        path: [],
+        label: { confidentiality: [CFC_LABEL_READ_FAILED_ATOM] },
+      }],
+    },
   ]);
 };

--- a/packages/runner/src/cfc/label-view.ts
+++ b/packages/runner/src/cfc/label-view.ts
@@ -8,6 +8,7 @@ import {
 import type { Runtime } from "../runtime.ts";
 import { readStoredCfcMetadata } from "./metadata.ts";
 import type { CfcMetadata } from "./types.ts";
+import { CFC_LABEL_READ_FAILED_ATOM } from "./observation.ts";
 import {
   type CfcLabelView,
   type CfcLabelViewEntry,
@@ -37,17 +38,6 @@ type LinkedValueMetadata = {
   metadata: CfcMetadata;
   path: readonly string[];
 };
-
-// Sentinel confidentiality atom injected when a cell's label could not be read
-// because a metadata read ERRORED (as opposed to being cleanly absent). It is
-// not a real principal/tag, so it is absent from every declared observation
-// ceiling — any observation node it taints fails `cfcObservationFitsCeiling`
-// and is redacted. This lets the LLM-observation path fail CLOSED on read errors
-// (audit item 22): a swallowed read error must not let confidential data
-// serialize to the model as if it were public. The shared `cfcLabelViewForCell`
-// seam (renderer / fuse / runtime-client) is intentionally left untouched — it
-// already treats a missing label as blocked, so only LLM egress needs this.
-export const CFC_LABEL_READ_FAILED_ATOM = "cfc:label-read-failed";
 
 // `readFailed` distinguishes a genuine metadata read error (fail closed) from a
 // cleanly-absent label (`readOrThrow` already maps NotFound/TypeMismatch to

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -11,6 +11,15 @@ export type CfcObservationMaxConfidentiality =
   | readonly unknown[]
   | undefined;
 
+// Marker confidentiality atom injected when a cell's label could not be read
+// because a metadata read ERRORED (as opposed to being cleanly absent), so the
+// LLM-observation path can fail CLOSED on read errors (audit item 22): a
+// swallowed read error must not let confidential data serialize to the model as
+// if it were public. `cfcObservationFitsCeiling` treats this marker as
+// UNGRANTABLE — an observation carrying it never fits a ceiling, even one that
+// names the marker, so it cannot be allow-listed by an author-supplied ceiling.
+export const CFC_LABEL_READ_FAILED_ATOM = "cfc:label-read-failed";
+
 export interface CfcOpaqueLink {
   "@link": string;
 }
@@ -78,6 +87,19 @@ export const cfcObservationFitsCeiling = (
   // atoms) fits any ceiling, including the empty one.
   if (observationMaxConfidentiality === undefined) {
     return true;
+  }
+
+  // The read-failed marker is UNGRANTABLE: an observation that carries it never
+  // fits a declared ceiling, even one that names the marker. The atom is an
+  // exported string, so an author-supplied ceiling could otherwise allow-list it
+  // and defeat the fail-closed redaction (audit item 22). Reject it explicitly
+  // before the per-atom membership check rather than relying on its absence.
+  if (
+    confidentiality.some((value) =>
+      deepEqual(value, CFC_LABEL_READ_FAILED_ATOM)
+    )
+  ) {
+    return false;
   }
 
   return confidentiality.every((value) =>

--- a/packages/runner/test/cfc-llm-observation-failclosed.test.ts
+++ b/packages/runner/test/cfc-llm-observation-failclosed.test.ts
@@ -1,12 +1,12 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
-  CFC_LABEL_READ_FAILED_ATOM,
   cfcLabelViewForCell,
   cfcLabelViewForCellFailClosed,
   cfcLabelViewForCellWithStatus,
 } from "../src/cfc/label-view.ts";
 import {
+  CFC_LABEL_READ_FAILED_ATOM,
   cfcConfidentialityForObservationNode,
   cfcObservationFitsCeiling,
 } from "../src/cfc/observation.ts";
@@ -90,8 +90,23 @@ describe("LLM observation fail-closed on metadata read error (audit 22)", () => 
       logicalPath: ["0"],
     });
     expect(observed).toContain(CFC_LABEL_READ_FAILED_ATOM);
-    // The sentinel is absent from any real ceiling → node does not fit → redact.
+    // The marker is absent from any real ceiling → node does not fit → redact.
     expect(cfcObservationFitsCeiling(observed, REAL_CEILING)).toBe(false);
+  });
+
+  it("treats the read-failed marker as UNGRANTABLE (can't be allow-listed)", () => {
+    // A caller could otherwise name the marker atom in their own ceiling to
+    // re-open the fail-open. The marker must never fit a ceiling, even one that
+    // lists it (or lists everything).
+    const observed = [CFC_LABEL_READ_FAILED_ATOM];
+    expect(cfcObservationFitsCeiling(observed, [CFC_LABEL_READ_FAILED_ATOM]))
+      .toBe(false);
+    expect(
+      cfcObservationFitsCeiling(observed, [
+        CFC_LABEL_READ_FAILED_ATOM,
+        ...REAL_CEILING,
+      ]),
+    ).toBe(false);
   });
 
   it("does NOT over-redact cleanly-unlabelled data (no error → no sentinel)", () => {

--- a/packages/runner/test/cfc-llm-observation-failclosed.test.ts
+++ b/packages/runner/test/cfc-llm-observation-failclosed.test.ts
@@ -1,0 +1,108 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  CFC_LABEL_READ_FAILED_ATOM,
+  cfcLabelViewForCell,
+  cfcLabelViewForCellFailClosed,
+  cfcLabelViewForCellWithStatus,
+} from "../src/cfc/label-view.ts";
+import {
+  cfcConfidentialityForObservationNode,
+  cfcObservationFitsCeiling,
+} from "../src/cfc/observation.ts";
+
+// Audit item 22 — the LLM observation path must fail CLOSED on a metadata READ
+// ERROR. `cfcConfidentialityForObservationNode` treats an absent label as
+// unconfidential (public), and `cfcObservationFitsCeiling` lets public data
+// through any ceiling. So if acquiring a cell's label *errors* and is swallowed
+// to `undefined`, confidential data would serialize to the LLM as if public.
+// `cfcLabelViewForCellFailClosed` taints the observation with a sentinel atom
+// (absent from every real ceiling) so the node is redacted instead.
+//
+// The renderer's shared `cfcLabelViewForCell` seam is intentionally left
+// unchanged (it already treats a missing label as blocked) — only the LLM
+// egress path adopts the fail-closed variant.
+
+const cellWhoseMetadataReadErrors = {
+  getAsNormalizedFullLink: () => ({
+    id: "of:labelled-cell",
+    space: "did:key:test",
+    type: "application/json",
+    path: [],
+  }),
+  runtime: {
+    readTx: () => ({
+      readOrThrow: () => {
+        throw new Error("storage read error");
+      },
+      readValueOrThrow: () => {
+        throw new Error("storage read error");
+      },
+    }),
+  },
+};
+
+const cellWithAbsentMetadata = {
+  getAsNormalizedFullLink: () => ({
+    id: "of:unlabelled-cell",
+    space: "did:key:test",
+    type: "application/json",
+    path: [],
+  }),
+  runtime: {
+    readTx: () => ({
+      // No `["cfc"]` doc: a clean read returning undefined (NOT an error).
+      readOrThrow: () => undefined,
+      readValueOrThrow: () => undefined,
+    }),
+  },
+};
+
+const REAL_CEILING = ["some-real-confidentiality-atom"];
+
+describe("LLM observation fail-closed on metadata read error (audit 22)", () => {
+  it("reports readFailed when a metadata read errors (vs. cleanly absent)", () => {
+    expect(
+      cfcLabelViewForCellWithStatus(cellWhoseMetadataReadErrors).readFailed,
+    )
+      .toBe(true);
+    expect(cfcLabelViewForCellWithStatus(cellWithAbsentMetadata).readFailed)
+      .toBe(false);
+  });
+
+  it("demonstrates the fail-OPEN: the plain seam swallows the error to undefined", () => {
+    // This is the renderer-safe behavior (undefined = blocked there), but for
+    // the LLM observer undefined means "unconfidential" → fits any ceiling.
+    const view = cfcLabelViewForCell(cellWhoseMetadataReadErrors);
+    expect(view).toBeUndefined();
+    const observed = cfcConfidentialityForObservationNode({
+      labelView: view,
+      logicalPath: ["0"],
+    });
+    // Fail-open: a read error looks like public data and is admitted.
+    expect(cfcObservationFitsCeiling(observed, REAL_CEILING)).toBe(true);
+  });
+
+  it("fails CLOSED: the fail-closed seam taints the node so it is redacted", () => {
+    const view = cfcLabelViewForCellFailClosed(cellWhoseMetadataReadErrors);
+    const observed = cfcConfidentialityForObservationNode({
+      labelView: view,
+      logicalPath: ["0"],
+    });
+    expect(observed).toContain(CFC_LABEL_READ_FAILED_ATOM);
+    // The sentinel is absent from any real ceiling → node does not fit → redact.
+    expect(cfcObservationFitsCeiling(observed, REAL_CEILING)).toBe(false);
+  });
+
+  it("does NOT over-redact cleanly-unlabelled data (no error → no sentinel)", () => {
+    const view = cfcLabelViewForCellFailClosed(cellWithAbsentMetadata);
+    expect(view).toBeUndefined();
+    const observed = cfcConfidentialityForObservationNode({
+      labelView: view,
+      logicalPath: ["0"],
+    });
+    expect(observed).toEqual([]);
+    // Absent metadata stays public (unchanged behavior) — fits any ceiling.
+    expect(cfcObservationFitsCeiling(observed, REAL_CEILING)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Audit item 22 — LLM observation fails OPEN on a metadata read error

`cfcLabelViewForCell` swallows a metadata **read error** into `undefined` (two `catch { return undefined }` seams in `label-view.ts`). The same seam feeds two consumers with **opposite** `undefined` semantics:

- the **renderer** treats `undefined` as *blocked* (fail-closed, safe);
- the **LLM observation** path treats `undefined` as *unconfidential* — `cfcConfidentialityForObservationNode` yields no atoms and `cfcObservationFitsCeiling` admits public data through any ceiling.

So a swallowed read error lets confidential data serialize to the model **as if it were public**. The audit files this as "Minor" / low-exploitability (you must induce a genuine metadata read error), but it's a real fail-open.

Crucially, the read-error path is distinct from the common "no label" case: `readOrThrow` already maps `NotFoundError`/`TypeMismatchError` to `undefined` **without throwing**, so the `catch` only ever masked *genuine* errors. The happy path (unlabelled data) is unaffected.

## Fix — scoped to LLM egress (renderer's shared seam untouched)

- `label-view.ts` now reports `readFailed` via `cfcLabelViewForCellWithStatus`. `cfcLabelViewForCell` keeps its existing undefined-on-missing contract, so the renderer / fuse / runtime-client consumers are unchanged.
- `cfcLabelViewForCellFailClosed` taints the observation at the root with the `CFC_LABEL_READ_FAILED_ATOM` sentinel **only when a read errored**. The sentinel appears in no real ceiling, so every observation node under it fails the ceiling check and is **redacted** (dialog `serializeForLLMObservation` path) / contributes an unsatisfiable confidentiality atom that **locks the tool-call egress** (`generateObject` path).
- `llm-dialog.ts` + `llm.ts` observation sites adopt the fail-closed variant.

A cleanly-absent label (no read error) is unchanged, so normal unlabelled data is **not** over-redacted.

## Tests

`packages/runner/test/cfc-llm-observation-failclosed.test.ts`:
- `readFailed` is `true` on a read error, `false` on a cleanly-absent label;
- the plain seam's fail-OPEN is demonstrated (error → `undefined` → fits any ceiling);
- the fail-closed seam taints the node so it does **not** fit a real ceiling (redacted);
- absent metadata is not over-redacted (stays public, unchanged).

Full runner suite green locally (580 passed / 0 failed).

## Scope note

This covers the runtime LLM builtins (`packages/runner`). The `cf-harness` LLM path (`packages/cf-harness`) is a separate invocation layer with its own label handling and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail-closed LLM observation when a CFC label read errors, so confidential data can’t be treated as public. The read-failed marker is now ungrantable and can’t be allow-listed.

- **Bug Fixes**
  - `label-view.ts`: added `cfcLabelViewForCellWithStatus` to surface `readFailed`; kept `cfcLabelViewForCell` unchanged. Added `cfcLabelViewForCellFailClosed` that taints the root with `CFC_LABEL_READ_FAILED_ATOM` on read errors.
  - `observation.ts`: made `CFC_LABEL_READ_FAILED_ATOM` ungrantable in `cfcObservationFitsCeiling` (rejects any observation carrying it, even if the ceiling names it).
  - Switched LLM observation sites in `packages/runner/src/builtins/llm-dialog.ts` and `packages/runner/src/builtins/llm.ts` to the fail-closed seam.
  - Cleanly absent labels are unchanged (no over-redaction).
  - Added `packages/runner/test/cfc-llm-observation-failclosed.test.ts` covering read-error detection, fail-open vs fail-closed, clean-absence, and the ungrantable marker.

<sup>Written for commit a9331d6969a7a86ca93e08bd3c240f494189df9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

