### PR TITLE
feat(html): default render confidentiality ceiling (S16 phase D — first egress)

### DIFF
--- a/docs/specs/cfc-spec-changes.md
+++ b/docs/specs/cfc-spec-changes.md
@@ -203,6 +203,22 @@ in the implementation (`RUNTIME_MINTED_INTEGRITY_ATOM_TYPES`) but listed as
 merely an "example" in §15.6 — promote to a registered atom with its minting
 discipline.
 
+**SC-21 [normative] Read-classification markers as the J exclusion profile.**
+Phase B (pointwise precision) only holds because flow derivation excludes
+machinery reads, and post-#3911 the traversal journal cannot distinguish
+machinery from consumption on its own: dependency seeding, link/slot
+dereference, and scheduling tags all journal as ordinary reads. The
+implementation closes this with explicit read-classification markers
+(`internalVerifierRead`, `linkResolutionProbe`, `schedulerDependencyRead`)
+plus the link-origin/pointer-vs-content split; J consumes only unmarked
+content reads. The spec states the pointer/content split (SC-8) but not the
+marker vocabulary or the obligation that every runtime-internal read path be
+classified — an unmarked machinery read silently coarsens J (sound), while a
+wrongly-marked consumption read is a leak (unsound, the dangerous direction).
+Make the profile normative: enumerate the classes, state the
+default-is-consumption rule, and require that markers are only attachable by
+runtime code (never pattern-controlled).
+
 ## Queue (from the audit, not yet worked through in a design session)
 
 These were identified during the audit as spec-absent implementation mechanisms

--- a/packages/html/src/worker/mod.ts
+++ b/packages/html/src/worker/mod.ts
@@ -13,6 +13,7 @@ export type {
   ChildNodeState,
   NodeState,
   ReconcileContext,
+  RenderConfidentialityCeiling,
   RenderDeclassificationPolicy,
   WorkerJSXElement,
   WorkerProps,

--- a/packages/html/src/worker/mod.ts
+++ b/packages/html/src/worker/mod.ts
@@ -23,5 +23,6 @@ export type {
 } from "./types.ts";
 export {
   isWorkerVNode,
+  normalizeRenderConfidentialityCeiling,
   normalizeRenderDeclassificationPolicy,
 } from "./types.ts";

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -182,6 +182,25 @@ export class WorkerReconciler {
       addCancel(
         vnode.sink((resolvedVnode: unknown) => {
           logger.debug("root-cell-update", () => ({ resolvedVnode }));
+          // The mounted cell is an egress like any descendant cell: gate its
+          // own label against the root policy (the host ceiling when
+          // configured) before rendering its resolved content. Checked per
+          // update so label changes re-evaluate, mirroring renderCellChild.
+          if (
+            !this.canRenderCellUnderPolicy(
+              vnode as Cell<unknown>,
+              this.rootRenderPolicy,
+            )
+          ) {
+            this.reconcileIntoWrapper(
+              ctx,
+              wrapperState,
+              this.blockedPlaceholderVNode(),
+              this.rootRenderPolicy,
+            );
+            this.rootChildId = wrapperState.currentChild?.nodeId ?? null;
+            return;
+          }
           // Validate that the resolved value is a valid render node
           if (!this.isValidRenderNode(resolvedVnode)) {
             this.onError?.(

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -44,9 +44,11 @@ import type {
 } from "./types.ts";
 import {
   isWorkerVNode,
+  normalizeRenderConfidentialityCeiling,
   normalizeRenderDeclassificationPolicy,
 } from "./types.ts";
 import {
+  CFC_LABEL_READ_FAILED_ATOM,
   type CfcLabelView,
   cfcLabelViewForCell,
   markRendererTrustedEvent,
@@ -123,7 +125,11 @@ export class WorkerReconciler {
     this.renderDeclassificationPolicy = normalizeRenderDeclassificationPolicy(
       options.renderDeclassificationPolicy,
     );
-    const ceiling = options.renderConfidentialityCeiling;
+    // Same seam discipline: malformed ceilings normalize to the empty
+    // (public-only) ceiling rather than crashing or failing open.
+    const ceiling = normalizeRenderConfidentialityCeiling(
+      options.renderConfidentialityCeiling,
+    );
     this.rootRenderPolicy = ceiling === undefined ? DEFAULT_RENDER_POLICY : {
       declassifyConfidentiality: [],
       maxConfidentiality: [...(ceiling.atoms ?? [])],
@@ -872,26 +878,40 @@ export class WorkerReconciler {
         return true;
       }
       return schemaLabels.every((atom) =>
-        policy.declassifyConfidentiality.some((declassified) =>
-          deepEqual(declassified, atom)
-        ) ||
-        this.canRenderConfidentialityAtom(atom, policy)
+        this.atomRenderableUnderPolicy(atom, policy)
       );
     }
 
     for (const atom of this.confidentialityLabels(labelView)) {
-      if (
-        policy.declassifyConfidentiality.some((declassified) =>
-          deepEqual(declassified, atom)
-        )
-      ) {
-        continue;
-      }
-      if (!this.canRenderConfidentialityAtom(atom, policy)) {
+      if (!this.atomRenderableUnderPolicy(atom, policy)) {
         return false;
       }
     }
     return true;
+  }
+
+  /**
+   * Per-atom admission under a render policy. The read-failure marker is
+   * UNGRANTABLE (audit item 22): it means "the label could not be read", so
+   * neither author declassification nor a ceiling entry — even one naming
+   * the exported marker string — may admit it. Every other atom checks
+   * declassification first, then the ceiling.
+   */
+  private atomRenderableUnderPolicy(
+    atom: unknown,
+    policy: RenderPolicy,
+  ): boolean {
+    if (deepEqual(atom, CFC_LABEL_READ_FAILED_ATOM)) {
+      return false;
+    }
+    if (
+      policy.declassifyConfidentiality.some((declassified) =>
+        deepEqual(declassified, atom)
+      )
+    ) {
+      return true;
+    }
+    return this.canRenderConfidentialityAtom(atom, policy);
   }
 
   private confidentialityLabels(labelView: CfcLabelView): readonly unknown[] {

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -29,6 +29,7 @@ import {
 import type { CellRef } from "@commonfabric/runtime-client";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
+import { isRecord } from "@commonfabric/utils/types";
 import type {
   ChildNodeState,
   NodeState,
@@ -73,6 +74,9 @@ const TEXT_INTEGRITY_PROP_SINKS: ReadonlyMap<string, ReadonlySet<string>> =
 const DEFAULT_RENDER_POLICY: RenderPolicy = {
   declassifyConfidentiality: [],
 };
+// Mirrors CFC_ATOM_TYPE.Caveat in @commonfabric/api/cfc (not a dependency of
+// this package).
+const CFC_CAVEAT_ATOM_TYPE = "https://commonfabric.org/cfc/atom/Caveat";
 
 /**
  * Reserved node ID for the container element.
@@ -106,6 +110,10 @@ export class WorkerReconciler {
   private readonly onOps: (ops: VDomOp[]) => void;
   private readonly onError?: (error: Error) => void;
   private readonly renderDeclassificationPolicy: RenderDeclassificationPolicy;
+  // Root-of-tree render policy: the host's default ceiling when configured
+  // (spec §8.10.6), otherwise the historical unbounded policy. Authored
+  // boundaries can only narrow from here.
+  private readonly rootRenderPolicy: RenderPolicy;
 
   constructor(options: WorkerReconcilerOptions) {
     this.onOps = options.onOps;
@@ -115,6 +123,12 @@ export class WorkerReconciler {
     this.renderDeclassificationPolicy = normalizeRenderDeclassificationPolicy(
       options.renderDeclassificationPolicy,
     );
+    const ceiling = options.renderConfidentialityCeiling;
+    this.rootRenderPolicy = ceiling === undefined ? DEFAULT_RENDER_POLICY : {
+      declassifyConfidentiality: [],
+      maxConfidentiality: [...(ceiling.atoms ?? [])],
+      caveatKindAllow: [...(ceiling.caveatKinds ?? [])],
+    };
   }
 
   /**
@@ -181,7 +195,7 @@ export class WorkerReconciler {
             ctx,
             wrapperState,
             resolvedVnode as WorkerRenderNode,
-            DEFAULT_RENDER_POLICY,
+            this.rootRenderPolicy,
           );
           // Track the root child for cleanup
           this.rootChildId = wrapperState.currentChild?.nodeId ?? null;
@@ -193,7 +207,7 @@ export class WorkerReconciler {
         ctx,
         vnode,
         new Set(),
-        DEFAULT_RENDER_POLICY,
+        this.rootRenderPolicy,
       );
       if (state) {
         addCancel(state.cancel);
@@ -390,6 +404,10 @@ export class WorkerReconciler {
           parentPolicy.maxConfidentiality,
           localMax,
         ),
+        // The host's caveat-kind allowance is part of the default ceiling
+        // profile; boundaries narrow maxConfidentiality but never widen or
+        // shed the kind allowance.
+        caveatKindAllow: parentPolicy.caveatKindAllow,
         declassifyConfidentiality: [
           ...parentPolicy.declassifyConfidentiality,
           ...declassifyConfidentiality,
@@ -768,7 +786,13 @@ export class WorkerReconciler {
         right.maxConfidentiality,
       );
 
-    return maxConfidentialityEquals &&
+    const caveatKindsEqual = (left.caveatKindAllow ?? []).length ===
+        (right.caveatKindAllow ?? []).length &&
+      (left.caveatKindAllow ?? []).every((kind, index) =>
+        kind === (right.caveatKindAllow ?? [])[index]
+      );
+
+    return maxConfidentialityEquals && caveatKindsEqual &&
       this.atomListsEqual(
         left.declassifyConfidentiality,
         right.declassifyConfidentiality,
@@ -883,7 +907,22 @@ export class WorkerReconciler {
     if (max === undefined) {
       return true;
     }
-    return max.some((allowed) => deepEqual(allowed, atom));
+    if (max.some((allowed) => deepEqual(allowed, atom))) {
+      return true;
+    }
+    // Default-ceiling caveat-kind allowance (spec §8.10.6): Caveat-type
+    // atoms of an allow-listed kind render — these are the
+    // display-dischargeable classes (e.g. prompt influence), admitted by
+    // kind rather than by enumerating every (kind, source) instance.
+    const kinds = policy.caveatKindAllow;
+    if (
+      kinds !== undefined && kinds.length > 0 &&
+      isRecord(atom) && atom.type === CFC_CAVEAT_ATOM_TYPE &&
+      typeof atom.kind === "string" && kinds.includes(atom.kind)
+    ) {
+      return true;
+    }
+    return false;
   }
 
   private refreshTextIntegrityBoundary(

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -100,6 +100,15 @@ export interface RenderPolicy {
   maxConfidentiality?: readonly unknown[];
 
   /**
+   * Caveat kinds admitted by the host's default render ceiling (spec
+   * §8.10.6): a Caveat-type confidentiality atom renders when its `kind` is
+   * listed here even if the atom is not in `maxConfidentiality`. Inherited
+   * unchanged through authored boundaries — narrowing narrows
+   * `maxConfidentiality`, never widens kinds.
+   */
+  caveatKindAllow?: readonly string[];
+
+  /**
    * Confidentiality atoms this subtree may declassify before applying the max bound.
    * This is a temporary low-level capability hook for trusted UI experiments.
    */
@@ -246,6 +255,7 @@ export function normalizeRenderDeclassificationPolicy(
   return value === "allow" ? "allow" : "deny";
 }
 
+
 /**
  * Options for the worker reconciler.
  */
@@ -264,6 +274,13 @@ export interface WorkerReconcilerOptions {
    * {@link RenderDeclassificationPolicy}.
    */
   renderDeclassificationPolicy?: RenderDeclassificationPolicy;
+
+  /**
+   * Default render ceiling applied at the tree root. Defaults to undefined
+   * (no ceiling — today's behavior). See
+   * {@link RenderConfidentialityCeiling}.
+   */
+  renderConfidentialityCeiling?: RenderConfidentialityCeiling;
 }
 
 /**

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -271,6 +271,33 @@ export interface RenderConfidentialityCeiling {
 }
 
 /**
+ * Normalize an untrusted render-confidentiality ceiling.
+ *
+ * Like the declassification policy, the ceiling crosses postMessage seams
+ * (e.g. `InitializationData`) with no runtime validation. Fail-closed here
+ * means a present-but-malformed value becomes the EMPTY ceiling (public-only
+ * rendering) — never a mount crash, and never fail-open to unbounded. Only
+ * an absent value keeps the documented no-ceiling default; malformed fields
+ * inside an otherwise well-formed ceiling drop to empty individually.
+ */
+export function normalizeRenderConfidentialityCeiling(
+  value: unknown,
+): RenderConfidentialityCeiling | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "object" || value === null) return {};
+  const { atoms, caveatKinds } = value as {
+    atoms?: unknown;
+    caveatKinds?: unknown;
+  };
+  return {
+    atoms: Array.isArray(atoms) ? atoms : [],
+    caveatKinds: Array.isArray(caveatKinds)
+      ? caveatKinds.filter((kind): kind is string => typeof kind === "string")
+      : [],
+  };
+}
+
+/**
  * Options for the worker reconciler.
  */
 export interface WorkerReconcilerOptions {

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -255,6 +255,20 @@ export function normalizeRenderDeclassificationPolicy(
   return value === "allow" ? "allow" : "deny";
 }
 
+/**
+ * Host-supplied default render ceiling (spec §8.10.6, S16 phase D): the
+ * confidentiality a display surface admits when no authored boundary
+ * narrows further. `atoms` are admitted by structural equality (the place
+ * for acting-user identity atoms); `caveatKinds` admits Caveat-type atoms
+ * by kind (the display-dischargeable classes). Everything else renders as
+ * the blocked placeholder. Undefined = no default ceiling (today's
+ * behavior); the profile may only be tightened, not loosened, without a
+ * new release judgment.
+ */
+export interface RenderConfidentialityCeiling {
+  atoms?: readonly unknown[];
+  caveatKinds?: readonly string[];
+}
 
 /**
  * Options for the worker reconciler.

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -2297,6 +2297,73 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         }
       },
     );
+
+    // The mounted root cell is an egress like any descendant cell: its own
+    // label must pass the root policy before its resolved content renders.
+    await t.step(
+      "default ceiling gates a labeled cell mounted as the root",
+      async () => {
+        const blocked = createOpsCollector();
+        const blockedReconciler = new WorkerReconciler({
+          onOps: blocked.onOps,
+          renderConfidentialityCeiling: { atoms: [], caveatKinds: [] },
+        });
+        const cancelBlocked = blockedReconciler.mount(confidential);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          const renderedText = blocked.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(
+            renderedText.includes("Sensitive diagnosis: migraine"),
+            false,
+          );
+          assertEquals(renderedText.includes("Content hidden by policy"), true);
+        } finally {
+          cancelBlocked();
+        }
+
+        const admitted = createOpsCollector();
+        const admittedReconciler = new WorkerReconciler({
+          onOps: admitted.onOps,
+          renderConfidentialityCeiling: {
+            atoms: [healthRecordAtom],
+            caveatKinds: [],
+          },
+        });
+        const cancelAdmitted = admittedReconciler.mount(confidential);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          const renderedText = admitted.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(
+            renderedText.includes("Sensitive diagnosis: migraine"),
+            true,
+          );
+        } finally {
+          cancelAdmitted();
+        }
+      },
+    );
+
+    await t.step(
+      "a labeled root cell still renders when no ceiling is configured",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({ onOps: collector.onOps });
+        const cancel = reconciler.mount(confidential);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          const renderedText = collector.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(
+            renderedText.includes("Sensitive diagnosis: migraine"),
+            true,
+          );
+        } finally {
+          cancel();
+        }
+      },
+    );
   } finally {
     await runtime.dispose();
     await storageManager.close();

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -2364,6 +2364,128 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         }
       },
     );
+
+    // Audit item 22 (ungrantable marker): "cfc:label-read-failed" means
+    // "the label could not be read", so it must never fit a render policy —
+    // even one that names the exported marker string — in either the
+    // ceiling or the declassification direction.
+    await t.step(
+      "neither ceiling nor declassification admits the read-failure marker",
+      async () => {
+        const seedTx = runtime.edit();
+        const markerCellSeed = runtime.getCell<string>(
+          signer.did(),
+          "cfc-render-policy-read-failed",
+          undefined,
+          seedTx,
+        );
+        const markerLink = markerCellSeed.getAsNormalizedFullLink();
+        seedTx.writeOrThrow({
+          space: signer.did(),
+          id: markerLink.id!,
+          type: "application/json",
+          path: [],
+        }, {
+          value: "Label-read-failed content",
+          cfc: {
+            version: 1,
+            schemaHash: "test-schema",
+            labelMap: {
+              version: 1,
+              entries: [{
+                path: [],
+                // The exported marker string verbatim — the bypass shape is
+                // a config that allow-lists it.
+                label: { confidentiality: ["cfc:label-read-failed"] },
+              }],
+            },
+          },
+        });
+        assertEquals((await seedTx.commit()).ok !== undefined, true);
+        const markerLabeled = runtime.getCell<string>(
+          signer.did(),
+          "cfc-render-policy-read-failed",
+        );
+
+        const ceiling = createOpsCollector();
+        const ceilingReconciler = new WorkerReconciler({
+          onOps: ceiling.onOps,
+          renderConfidentialityCeiling: {
+            atoms: ["cfc:label-read-failed"],
+          },
+        });
+        const cancelCeiling = ceilingReconciler.mount(markerLabeled);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          const renderedText = ceiling.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(
+            renderedText.includes("Label-read-failed content"),
+            false,
+          );
+          assertEquals(renderedText.includes("Content hidden by policy"), true);
+        } finally {
+          cancelCeiling();
+        }
+
+        const declassify = createOpsCollector();
+        const declassifyReconciler = new WorkerReconciler({
+          onOps: declassify.onOps,
+        });
+        const root: WorkerVNode = {
+          type: "vnode",
+          name: "cf-cfc-render-boundary",
+          props: {
+            maxConfidentiality: [],
+            declassifyConfidentiality: ["cfc:label-read-failed"],
+          },
+          children: [markerLabeled as never],
+        };
+        const cancelDeclassify = declassifyReconciler.mount(root);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          const renderedText = declassify.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(
+            renderedText.includes("Label-read-failed content"),
+            false,
+          );
+          assertEquals(renderedText.includes("Content hidden by policy"), true);
+        } finally {
+          cancelDeclassify();
+        }
+      },
+    );
+
+    // The ceiling crosses the postMessage seam unvalidated; a malformed
+    // shape must fail CLOSED (empty ceiling — public-only rendering), never
+    // crash the mount and never fail open to unbounded.
+    await t.step(
+      "a malformed ceiling fails closed instead of crashing the mount",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+          renderConfidentialityCeiling: {
+            atoms: 7,
+            caveatKinds: "signed-release",
+          } as never,
+        });
+        const cancel = reconciler.mount(confidential);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          const renderedText = collector.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(
+            renderedText.includes("Sensitive diagnosis: migraine"),
+            false,
+          );
+          assertEquals(renderedText.includes("Content hidden by policy"), true);
+        } finally {
+          cancel();
+        }
+      },
+    );
   } finally {
     await runtime.dispose();
     await storageManager.close();

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -2126,6 +2126,177 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
         }
       },
     );
+
+    // --- Default render ceiling (spec §8.10.6, S16 phase D) ---------------
+    // A host-supplied root ceiling gates labeled cells with NO authored
+    // boundary in the tree: atoms render only when listed exactly or when
+    // they are Caveat atoms of an allow-listed kind.
+
+    const PROMPT_INFLUENCE_KIND =
+      "https://commonfabric.org/cfc/concepts/prompt-influence";
+    const influenceCaveatAtom = {
+      type: "https://commonfabric.org/cfc/atom/Caveat",
+      kind: PROMPT_INFLUENCE_KIND,
+      source: "of:influence-source",
+    };
+
+    const caveatTx = runtime.edit();
+    const influenced = runtime.getCell<string>(
+      signer.did(),
+      "cfc-render-policy-influenced",
+      undefined,
+      caveatTx,
+    );
+    const influencedLink = influenced.getAsNormalizedFullLink();
+    caveatTx.writeOrThrow({
+      space: signer.did(),
+      id: influencedLink.id!,
+      type: "application/json",
+      path: [],
+    }, {
+      value: "Influenced draft text",
+      cfc: {
+        version: 1,
+        schemaHash: "test-influence-schema",
+        labelMap: {
+          version: 1,
+          entries: [{
+            path: [],
+            label: { confidentiality: [influenceCaveatAtom] },
+          }],
+        },
+      },
+    });
+    assertEquals((await caveatTx.commit()).ok !== undefined, true);
+
+    const plainRoot = (child: unknown): WorkerVNode => ({
+      type: "vnode",
+      name: "div",
+      props: {},
+      children: [child as never],
+    });
+
+    await t.step(
+      "default ceiling blocks unlisted atoms with no authored boundary",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+          renderConfidentialityCeiling: { atoms: [], caveatKinds: [] },
+        });
+        const cancel = reconciler.mount(plainRoot(confidential));
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          const renderedText = collector.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(
+            renderedText.includes("Sensitive diagnosis: migraine"),
+            false,
+          );
+          assertEquals(renderedText.includes("Content hidden by policy"), true);
+        } finally {
+          cancel();
+        }
+      },
+    );
+
+    await t.step(
+      "default ceiling admits exactly listed atoms",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+          renderConfidentialityCeiling: {
+            atoms: [healthRecordAtom],
+            caveatKinds: [],
+          },
+        });
+        const cancel = reconciler.mount(plainRoot(confidential));
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          const renderedText = collector.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(
+            renderedText.includes("Sensitive diagnosis: migraine"),
+            true,
+          );
+        } finally {
+          cancel();
+        }
+      },
+    );
+
+    await t.step(
+      "default ceiling admits allow-listed caveat kinds and blocks others",
+      async () => {
+        const allowed = createOpsCollector();
+        const allowedReconciler = new WorkerReconciler({
+          onOps: allowed.onOps,
+          renderConfidentialityCeiling: {
+            atoms: [],
+            caveatKinds: [PROMPT_INFLUENCE_KIND],
+          },
+        });
+        const cancelAllowed = allowedReconciler.mount(plainRoot(influenced));
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          const renderedText = allowed.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(renderedText.includes("Influenced draft text"), true);
+        } finally {
+          cancelAllowed();
+        }
+
+        const blocked = createOpsCollector();
+        const blockedReconciler = new WorkerReconciler({
+          onOps: blocked.onOps,
+          renderConfidentialityCeiling: { atoms: [], caveatKinds: [] },
+        });
+        const cancelBlocked = blockedReconciler.mount(plainRoot(influenced));
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          const renderedText = blocked.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(renderedText.includes("Influenced draft text"), false);
+          assertEquals(renderedText.includes("Content hidden by policy"), true);
+        } finally {
+          cancelBlocked();
+        }
+      },
+    );
+
+    await t.step(
+      "authored boundaries still narrow under the default ceiling",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+          renderConfidentialityCeiling: {
+            atoms: [healthRecordAtom],
+            caveatKinds: [],
+          },
+        });
+        const root: WorkerVNode = {
+          type: "vnode",
+          name: "cf-cfc-render-boundary",
+          props: { maxConfidentiality: [] },
+          children: [confidential as never],
+        };
+        const cancel = reconciler.mount(root);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          const renderedText = collector.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(
+            renderedText.includes("Sensitive diagnosis: migraine"),
+            false,
+          );
+          assertEquals(renderedText.includes("Content hidden by policy"), true);
+        } finally {
+          cancel();
+        }
+      },
+    );
   } finally {
     await runtime.dispose();
     await storageManager.close();

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -88,6 +88,7 @@ export {
   validateAgainstSchema,
 } from "./schema-sanitization.ts";
 export {
+  CFC_LABEL_READ_FAILED_ATOM,
   cfcConfidentialityForObservationNode,
   cfcJsonPointerForPath,
   cfcObservationFitsCeiling,

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1938,16 +1938,18 @@ describe("RuntimeProcessor vdom mount render policy", () => {
         type: RequestType.VDomUnmount,
         mountId: 1,
       });
-      // Let queued reconciler flushes drain while the stub is in place.
-      await new Promise((resolve) => setTimeout(resolve, 10));
       return policy;
     } finally {
+      // Reconciler flushes are queueMicrotask batches, so everything queued
+      // by mount/unmount fires before this await's continuation — restoring
+      // postMessage after it means the stub is in place through the last
+      // flush, with no timer heuristics.
+      await runtime.dispose();
       if (hadPostMessage) {
         (globalThis as any).postMessage = originalPostMessage;
       } else {
         delete (globalThis as any).postMessage;
       }
-      await runtime.dispose();
     }
   }
 

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1876,3 +1876,98 @@ describe("RuntimeProcessor per-space piece contexts", () => {
     }
   });
 });
+
+// S16 phase D: the host's render confidentiality ceiling must reach every
+// mount's reconciler — a ceiling configured at initialization that never
+// arrives at the egress surface is silently unbounded rendering.
+describe("RuntimeProcessor vdom mount render policy", () => {
+  const handleVDomMount = (RuntimeProcessor.prototype as any).handleVDomMount;
+  const handleVDomUnmount =
+    (RuntimeProcessor.prototype as any).handleVDomUnmount;
+
+  type RootRenderPolicy = {
+    maxConfidentiality?: readonly unknown[];
+    caveatKindAllow?: readonly string[];
+  };
+
+  async function mountAndGetRootPolicy(
+    renderConfidentialityCeiling:
+      | { atoms?: unknown[]; caveatKinds?: string[] }
+      | undefined,
+  ): Promise<RootRenderPolicy> {
+    const { runtime } = createRuntime();
+    const space = cfcSigner.did();
+    const tx = runtime.edit();
+    const cell = runtime.getCell<string>(
+      space,
+      "vdom-mount-render-policy",
+      undefined,
+      tx,
+    );
+    cell.set("hello");
+    const commit = await tx.commit();
+    expect(commit.ok !== undefined).toBe(true);
+
+    const state = {
+      runtime,
+      vdomMounts: new Map<
+        number,
+        { reconciler: unknown; cancel: () => void }
+      >(),
+      vdomBatchIdCounter: 0,
+      renderDeclassificationPolicy: "allow",
+      renderConfidentialityCeiling,
+      handleVDomUnmount,
+    };
+    // handleVDomMount's onOps/onError callbacks post to the worker scope;
+    // stub postMessage for the main-thread test.
+    const hadPostMessage = "postMessage" in globalThis;
+    const originalPostMessage = (globalThis as any).postMessage;
+    (globalThis as any).postMessage = () => {};
+    try {
+      handleVDomMount.call(state, {
+        type: RequestType.VDomMount,
+        mountId: 1,
+        cell: cell.getAsNormalizedFullLink() as unknown as CellRef,
+      });
+      const mount = state.vdomMounts.get(1);
+      expect(mount).toBeDefined();
+      const policy = (mount!.reconciler as { rootRenderPolicy?: unknown })
+        .rootRenderPolicy as RootRenderPolicy;
+      handleVDomUnmount.call(state, {
+        type: RequestType.VDomUnmount,
+        mountId: 1,
+      });
+      // Let queued reconciler flushes drain while the stub is in place.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return policy;
+    } finally {
+      if (hadPostMessage) {
+        (globalThis as any).postMessage = originalPostMessage;
+      } else {
+        delete (globalThis as any).postMessage;
+      }
+      await runtime.dispose();
+    }
+  }
+
+  it("threads the configured ceiling into each mount's reconciler", async () => {
+    const userAtom = {
+      type: "https://commonfabric.org/cfc/atom/Resource",
+      class: "ActingUser",
+      subject: cfcSigner.did(),
+    };
+    const caveatKind = "https://commonfabric.org/cfc/concepts/prompt-influence";
+    const policy = await mountAndGetRootPolicy({
+      atoms: [userAtom],
+      caveatKinds: [caveatKind],
+    });
+    expect(policy.maxConfidentiality).toEqual([userAtom]);
+    expect(policy.caveatKindAllow).toEqual([caveatKind]);
+  });
+
+  it("keeps mounts unbounded when no ceiling is configured", async () => {
+    const policy = await mountAndGetRootPolicy(undefined);
+    expect(policy.maxConfidentiality).toBeUndefined();
+  });
+});

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -120,6 +120,7 @@ import {
 import { cellRefToKey } from "../shared/utils.ts";
 import { RemoteResponse } from "@commonfabric/runtime-client";
 import {
+  normalizeRenderConfidentialityCeiling,
   normalizeRenderDeclassificationPolicy,
   type RenderConfidentialityCeiling,
   type RenderDeclassificationPolicy,
@@ -443,7 +444,8 @@ export class RuntimeProcessor {
     // any present-but-unknown value becomes "deny"; absent stays "allow".
     processor.renderDeclassificationPolicy =
       normalizeRenderDeclassificationPolicy(data.renderDeclassificationPolicy);
-    processor.renderConfidentialityCeiling = data.renderConfidentialityCeiling;
+    processor.renderConfidentialityCeiling =
+      normalizeRenderConfidentialityCeiling(data.renderConfidentialityCeiling);
     // Site-table v0: the home space carries did → host hints; the
     // runtime reads them as its live host lookup (2026-06-09 federation
     // session — "move the lookup into the runtime itself"). Refusals

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -121,6 +121,7 @@ import { cellRefToKey } from "../shared/utils.ts";
 import { RemoteResponse } from "@commonfabric/runtime-client";
 import {
   normalizeRenderDeclassificationPolicy,
+  type RenderConfidentialityCeiling,
   type RenderDeclassificationPolicy,
   WorkerReconciler,
 } from "@commonfabric/html/worker";
@@ -305,6 +306,9 @@ export class RuntimeProcessor {
   // Render-boundary declassification policy applied to every mount's
   // reconciler. Set from InitializationData; "allow" preserves prior behavior.
   private renderDeclassificationPolicy: RenderDeclassificationPolicy = "allow";
+  // Host-supplied default render ceiling applied to every mount's
+  // reconciler. Undefined preserves prior behavior (no ceiling).
+  private renderConfidentialityCeiling?: RenderConfidentialityCeiling;
 
   private constructor(
     runtime: Runtime,

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -443,6 +443,7 @@ export class RuntimeProcessor {
     // any present-but-unknown value becomes "deny"; absent stays "allow".
     processor.renderDeclassificationPolicy =
       normalizeRenderDeclassificationPolicy(data.renderDeclassificationPolicy);
+    processor.renderConfidentialityCeiling = data.renderConfidentialityCeiling;
     // Site-table v0: the home space carries did → host hints; the
     // runtime reads them as its live host lookup (2026-06-09 federation
     // session — "move the lookup into the runtime itself"). Refusals
@@ -1401,6 +1402,7 @@ export class RuntimeProcessor {
     // Create a reconciler that sends ops to the main thread
     const reconciler = new WorkerReconciler({
       renderDeclassificationPolicy: this.renderDeclassificationPolicy,
+      renderConfidentialityCeiling: this.renderConfidentialityCeiling,
       onOps: (ops: VDomOp[]) => {
         const batchId = this.vdomBatchIdCounter++;
         self.postMessage({

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -155,6 +155,15 @@ export interface InitializationData {
   // `declassifyConfidentiality` so a pattern can't release a secret upward
   // through a render boundary (audit S15).
   renderDeclassificationPolicy?: "allow" | "deny";
+  // Host-supplied default render ceiling (spec §8.10.6, S16 phase D):
+  // confidentiality a display surface admits by default — exact `atoms`
+  // (the place for acting-user identity atoms) plus Caveat `caveatKinds`
+  // (display-dischargeable classes). Undefined = no ceiling (current
+  // behavior).
+  renderConfidentialityCeiling?: {
+    atoms?: unknown[];
+    caveatKinds?: string[];
+  };
   // Static trust snapshot applied to worker-owned transactions.
   trustSnapshot?: {
     id: string;

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -110,6 +110,7 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
       experimental: options.experimental,
       cfcEnforcementMode: options.cfcEnforcementMode,
       renderDeclassificationPolicy: options.renderDeclassificationPolicy,
+      renderConfidentialityCeiling: options.renderConfidentialityCeiling,
       trustSnapshot: options.trustSnapshot,
     });
     return new RuntimeClient(initialized, options);


### PR DESCRIPTION
## Summary

Phase D — the final phase of the S16 default transition (rebuilt onto main after #4024 merged; previously stacked on #4024 → #4022 → #4012). Rendering is the decided first label-gated egress: a host-supplied **default ceiling** at the render-tree root (spec §8.10.6 / SC-16), knob-gated exactly like #3994's declassification policy — default `undefined` keeps today's unbounded behavior, so nothing changes until a host opts in.

Also queues **SC-21** in `docs/specs/cfc-spec-changes.md`: the read-classification marker profile (phase B's J exclusions) should become normative spec text.
## Changes

- `WorkerReconcilerOptions.renderConfidentialityCeiling: { atoms?, caveatKinds? }`: `atoms` admitted by structural equality (where acting-user identity atoms go), Caveat-type atoms admitted by `kind` (the display-dischargeable classes). Everything else renders as the existing blocked placeholder. Authored `<cf-cfc-render-boundary>` boundaries narrow from the ceiling; the kind allowance is inherited and never widened.
- Threaded host→worker mirroring the #3994 plumbing: `InitializationData` → `RuntimeProcessor` → every mount's reconciler; `RuntimeClient` forwards the option.
- Derived (flow) labels from phases A–C reach the ceiling automatically through the existing label-view machinery — **propagation and egress now compose end-to-end**: read labeled data → write a derived copy anywhere → a ceiling-configured surface blocks it.

## Testing

4 new steps in `worker-reconciler-cfc-render-policy.test.ts` (block-by-default under an empty ceiling, exact-atom admit, caveat-kind admit + block, authored narrowing under a ceiling); the 30 existing render-policy steps unchanged. html 28/0, runtime-client 14/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a host-configurable default render confidentiality ceiling at the HTML worker root to gate labeled content; boundaries can only narrow. Also fixes runtime forwarding so every mount receives the ceiling, gates labeled root cells on each update, and hardens gates by rejecting the read-failure marker and failing closed on malformed ceilings. Queues a spec update (SC-21) to make read-classification markers normative for J’s exclusion profile.

- **New Features**
  - Added `renderConfidentialityCeiling: { atoms?, caveatKinds? }` to `@commonfabric/html/worker` reconciler options; applied as the root policy.
  - Caveat handling: admit Caveat-type atoms by `kind`; other atoms must match `atoms` exactly; otherwise render the blocked placeholder. Boundaries narrow only; kind allowance is inherited.
  - Exports: `RenderConfidentialityCeiling` and `normalizeRenderConfidentialityCeiling`. Docs: queued SC-21.

- **Bug Fixes**
  - `@commonfabric/runtime-client`: normalize and thread `renderConfidentialityCeiling` via `InitializationData` → `RuntimeProcessor` → each mount’s `WorkerReconciler`; `RuntimeClient` forwards the option.
  - Gate a labeled root cell against the ceiling on each update.
  - Reject `CFC_LABEL_READ_FAILED_ATOM` before declassification and ceiling membership (never render); re-exported from `@commonfabric/runner/cfc`.
  - Tests cover malformed ceiling fail-closed, marker ungrantable, root-cell gating, caveat-kind admit/block, boundary narrowing, and runtime threading to reconciler.

<sup>Written for commit d0e17294e9c0ab8b5f3d9f4ce153855c2a732411. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

