### PR TITLE
chore(runner): identity-D follow-ups — split plan doc, drop dead fallbackLookup, log verified→fallback downgrade

### DIFF
--- a/docs/specs/content-addressed-action-identity-implementation-plan.md
+++ b/docs/specs/content-addressed-action-identity-implementation-plan.md
@@ -265,6 +265,14 @@ BEFORE C2 and assert it still loads (legacy-read canary, kept until PR E).
 
 ## PR D — delete pattern-scoped registries + host/test registrar
 
+Status: split. D1 — items 1 + 3 (registry deletion + regression guard,
+`multi-instance-resolution.test.ts`) — landed in #4013, which also moved CFC
+provenance recording from `PatternManager.indexArtifact` to
+`Engine.evaluateGraph` / `recordModuleProvenance` so it covers loads that
+bypass `PatternManager.compilePattern`. D2 — item 2 (the host registrar) —
+has NOT landed: `unsafe-host:` counter refs + `trustedHostFunctionIndex` are
+still live in `harness/executable-registry.ts`.
+
 1. Delete `verifiedPatternFunctions`, `verifiedPatternLoadIds`,
    `associatePattern` (registry + `Harness` + engine passthrough +
    `pattern-manager.ts associateVerifiedFunctions` caller), and the
@@ -287,8 +295,9 @@ runtimes exercise repeated loads of identical programs).
 
 ## PR E — the flip (gated; not scheduled yet)
 
-Gate: B–D soaked on main; stored-data aging assessed (graphs rewrite on piece
-re-instantiation, so legacy refs age out; sample production spaces if
+Gate: B–D soaked on main — D is split, so this means D1 (#4013) soaked AND
+the D2 host registrar landed; stored-data aging assessed (graphs rewrite on
+piece re-instantiation, so legacy refs age out; sample production spaces if
 available).
 
 1. Writers stop emitting `implementationRef` and the stringified

--- a/packages/runner/src/harness/executable-registry.ts
+++ b/packages/runner/src/harness/executable-registry.ts
@@ -8,10 +8,6 @@ import { VERIFIED_BINDING_METADATA_FIELD } from "@commonfabric/utils/sandbox-con
 import type { UnsafeHostTrustOptions } from "../unsafe-host-trust.ts";
 import type { HarnessedFunction } from "./types.ts";
 
-type AssociatedLookup = (
-  implementationRef: string,
-) => HarnessedFunction | undefined;
-
 interface AssociatedFunction {
   implementationRef: string;
   implementation: HarnessedFunction;
@@ -202,13 +198,7 @@ export class ExecutableRegistry {
       throw new Error("unsafe host trust requires a non-empty reason");
     }
     const registry = new Map<string, HarnessedFunction>();
-    this.collectAssociatedFunctions(
-      value,
-      registry,
-      new Set(),
-      undefined,
-      true,
-    );
+    this.collectAssociatedFunctions(value, registry, new Set(), true);
     for (const [implementationRef, implementation] of registry) {
       this.trustedHostFunctionIndex.set(implementationRef, implementation);
     }
@@ -360,7 +350,6 @@ export class ExecutableRegistry {
     value: unknown,
     registry: Map<string, HarnessedFunction>,
     seen: Set<unknown>,
-    fallbackLookup?: AssociatedLookup,
     allowMintMissingRefs = false,
   ): void {
     if (!value || (typeof value !== "object" && typeof value !== "function")) {
@@ -373,7 +362,6 @@ export class ExecutableRegistry {
 
     const associated = this.extractAssociatedFunction(
       value,
-      fallbackLookup,
       allowMintMissingRefs,
     );
     if (associated) {
@@ -385,7 +373,6 @@ export class ExecutableRegistry {
         child,
         registry,
         seen,
-        fallbackLookup,
         allowMintMissingRefs,
       );
     }
@@ -393,7 +380,6 @@ export class ExecutableRegistry {
 
   private extractAssociatedFunction(
     value: unknown,
-    fallbackLookup?: AssociatedLookup,
     allowMintMissingRefs = false,
   ): AssociatedFunction | null {
     const record = value as {
@@ -428,17 +414,10 @@ export class ExecutableRegistry {
         }
         : null;
     }
-    if (typeof record.implementationRef !== "string") {
-      return null;
-    }
-
-    const rebound = fallbackLookup?.(record.implementationRef);
-    return rebound
-      ? {
-        implementationRef: record.implementationRef,
-        implementation: rebound,
-      }
-      : null;
+    // A ref-only record (no live implementation) carries nothing executable.
+    // The lookup that used to rebind such refs went away with the deleted
+    // pattern-scoped registries (#4013).
+    return null;
   }
 
   private ensureTrustedHostImplementationRef(

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3526,6 +3526,20 @@ export class Runner {
   private getFallbackJavaScriptImplementation(
     module: Module,
   ): (...args: any[]) => any {
+    const implRef =
+      (module as { $implRef?: { identity: string; symbol: string } }).$implRef;
+    if (implRef || module.implementationRef) {
+      // The module carries a content-addressed `$implRef` and/or a legacy
+      // `implementationRef` — it was expected to resolve through the verified
+      // registries — yet resolution fell through to here. The action will run
+      // SES-recompiled and CFC-unverified (`writeAuthorizedBy` sees
+      // `unsupported`), so leave a breadcrumb for enforcement-mode debugging.
+      logger.debug("verified-fallback-downgrade", () => [
+        "Verified function resolution missed; running SES-recompiled," +
+        " CFC-unverified fallback",
+        { implementationRef: module.implementationRef, $implRef: implRef },
+      ]);
+    }
     if (typeof module.implementation === "function") {
       return this.runtime.harness.getInvocation(
         Function.prototype.toString.call(module.implementation),


### PR DESCRIPTION
Follow-up to #4013 (post-merge review — verdict: no regressions; these are the cleanup items).

### 1. docs(specs): mark plan PR D as split

`docs/specs/content-addressed-action-identity-implementation-plan.md` described PR D as one unit bundling the registry deletion, the regression guard, AND the unsafe-host registrar replacement. #4013 landed only the first two (plus moving CFC provenance recording into `Engine.evaluateGraph`/`recordModuleProvenance`); the `unsafe-host:` counter refs + `trustedHostFunctionIndex` are still live in `harness/executable-registry.ts`. Without this note, a reader evaluating PR E's gate ("B–D soaked on main") would wrongly conclude D is complete. The PR D section now records the split (D1 landed as #4013, D2 host registrar pending) and the PR E gate line spells out that it requires D2 too.

### 2. chore(runner): drop dead `fallbackLookup` plumbing

`AssociatedLookup` and the `fallbackLookup` parameter of `collectAssociatedFunctions`/`extractAssociatedFunction` were only ever passed `undefined` once #4013 deleted `associatePattern` (the sole caller that supplied a lookup), making the `rebound = fallbackLookup?.(…)` branch unreachable. Removed the parameter and type; a ref-only record (no live implementation) now returns `null` directly. Verified via `git grep` that nothing else references them. No behavior change.

### 3. chore(runner): debug-log the verified→fallback downgrade

When a module carrying a `$implRef`/`implementationRef` (expected-verified) fails to resolve through the verified registries and lands in `getFallbackJavaScriptImplementation`, the action silently runs SES-recompiled and CFC-unverified — which makes enforcement-mode diagnostics ("why did `writeAuthorizedBy` reject?") expensive to debug. Added one default-off `logger.debug("verified-fallback-downgrade", …)` breadcrumb naming both refs at that branch (placed inside `getFallbackJavaScriptImplementation`, whose only caller is the resolution chain, keeping the edit clear of the region the concurrent identity-C follow-up touches). No behavior change.

### Verification

- `deno check` clean on both touched TS files; `deno fmt --check` clean.
- `packages/runner` tests: `json-utils.test.ts`, `multi-instance-resolution.test.ts`, `pattern-manager.test.ts` — 6 passed (74 steps) / 0 failed.
- Also ran `cfc-implementation-identity.test.ts` + `verified-walk-child-values.test.ts` (host-trust path touched by item 2) and `by-identity-handler-exec.test.ts` (fallback path touched by item 3) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up runner identity follow-ups: removed dead `fallbackLookup` plumbing, added a debug breadcrumb when verified resolution downgrades to the fallback, and updated the identity plan doc to note PR D is split (D1 landed, D2 host registrar pending). No runtime behavior changes.

- **Refactors**
  - Removed `AssociatedLookup` and the `fallbackLookup` parameter from `ExecutableRegistry`; ref-only records now return `null` (unreachable since `associatePattern` was deleted in #4013).

- **New Features**
  - Added `logger.debug("verified-fallback-downgrade", ...)` in `Runner.getFallbackJavaScriptImplementation` to trace when modules with `$implRef`/`implementationRef` fall back to SES-recompiled, unverified execution.

<sup>Written for commit 040be38d4a28866fab6b6382bf6de4305c67b3d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

