### PR TITLE
test(cfc): S7 follow-ups — author-minted provenance-atom misuse test + gate/egress naming

### DIFF
--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2000,6 +2000,17 @@ const isNonEndorsementProvenanceAtom = (atom: unknown): boolean =>
 // confidentiality, or any genuine endorsement integrity atom, stays in the gate
 // — that keeps the cross-cell prompt-injection screen sound (its briefing reads
 // carry confidentiality; its endorsement reads carry real integrity).
+//
+// TODO(data-flow): this exemption is an incremental scoping, not the end state
+// (both follow-ons deliberately deferred by #4015): (a) per-write data-flow
+// provenance — gate each protected write on the reads that actually fed it,
+// not the transaction-global consumed set — via the dedicated write-attempt
+// logging sketched in docs/plans/runner_cfc_implementation.md under "Potential
+// and Final Write Sets"; (b) the audit #14 vacuous-pass tightening (a
+// requiredIntegrity gate whose consumed set is empty passes today; see the
+// "vacuous-pass S7 / Wave 2 #14" row in
+// docs/specs/cfc-s16-default-transition-design.md §10), which is unsound to
+// apply without (a) — it would over-reject.
 const isProvenanceOnlyConsumedLabel = (label: IFCLabel): boolean => {
   if ((label.confidentiality?.length ?? 0) > 0) return false;
   const integrity = label.integrity ?? [];
@@ -2024,7 +2035,10 @@ const verifyInputRequirements = (
     path: readonly string[],
   ) => ImplementationIdentity | undefined,
 ): string | undefined => {
-  const consumed = [...(tx.getReadActivities?.() ?? [])].filter((read) =>
+  // The consumed reads this gate quantifies over (provenance-only reads
+  // excluded). Distinct from the egress side's transaction-global consumed
+  // set (collectConsumedConfidentiality), which keeps every labeled read.
+  const gatedReads = [...(tx.getReadActivities?.() ?? [])].filter((read) =>
     !isInternalVerifierRead(read.meta)
   ).map((read) => ({
     ...read,
@@ -2087,8 +2101,8 @@ const verifyInputRequirements = (
       return writeAuthorizedByFailure;
     }
     const requiredIntegrity = ifc?.requiredIntegrity ?? [];
-    if (requiredIntegrity.length > 0 && consumed.length > 0) {
-      const ok = consumed.every((read) =>
+    if (requiredIntegrity.length > 0 && gatedReads.length > 0) {
+      const ok = gatedReads.every((read) =>
         requiredIntegrity.every((required) =>
           (read.label?.integrity ?? []).some((actual) =>
             deepEqual(actual, required)
@@ -2103,8 +2117,8 @@ const verifyInputRequirements = (
     // undefined means no ceiling; a declared (even empty) ceiling is enforced.
     // An empty ceiling is "public only": any consumed confidential atom fails.
     const maxConfidentiality = ifc?.maxConfidentiality;
-    if (maxConfidentiality !== undefined && consumed.length > 0) {
-      const ok = consumed.every((read) =>
+    if (maxConfidentiality !== undefined && gatedReads.length > 0) {
+      const ok = gatedReads.every((read) =>
         (read.label?.confidentiality ?? []).every((value) =>
           maxConfidentiality.some((allowed) => deepEqual(allowed, value))
         )

--- a/packages/runner/test/cfc-required-integrity-provenance.test.ts
+++ b/packages/runner/test/cfc-required-integrity-provenance.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
+import { parseLink } from "../src/link-utils.ts";
 import type { URI } from "@commonfabric/memory/interface";
 import type { JSONSchema } from "../src/builder/types.ts";
 
@@ -160,6 +161,106 @@ describe("CFC requiredIntegrity provenance scoping (S7)", () => {
         signer.did(),
         "ri-mixed-sink",
         SINK_SCHEMA,
+        tx,
+      );
+      sink.set({ out: "derived" });
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(String((result.error as Error | undefined)?.message)).toContain(
+        "requiredIntegrity failed",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("an author-forged provenance atom is stripped and cannot satisfy the gate", async () => {
+    // Misuse direction of the S7 exemption: a pattern author self-attaches the
+    // LinkReference provenance atom through the only surface untrusted code
+    // has — an ifc.integrity schema declaration (NOT the privileged metadata
+    // seeding used by the other steps; mirrors cfc-integrity-mint-gate). The
+    // S4 mint gate (gateRuntimeMintedIntegrity) strips it at persist time, so
+    // (a) the stored label keeps only the confidentiality — the read is NOT
+    // provenance-only and still gates — and (b) the forged atom cannot
+    // satisfy a requiredIntegrity gate keyed to LinkReference. Were the strip
+    // bypassed, the forged atom would persist AND satisfy that gate (the
+    // commit below would succeed) — both assertions catch it.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const seed = runtime.edit();
+      const srcSchema = {
+        type: "string",
+        ifc: {
+          // The confidentiality atom keeps the read labeled (and in the gate)
+          // after the forged integrity is stripped, mirroring the mint-gate
+          // suite's author-side declaration.
+          confidentiality: ["s"],
+          integrity: [LINK_REFERENCE_ATOM],
+        },
+      } as const satisfies JSONSchema;
+      const src = runtime.getCell(
+        signer.did(),
+        "ri-forged-prov-src",
+        srcSchema,
+        seed,
+      );
+      src.set("attacker-controlled");
+      seed.prepareCfc();
+      expect((await seed.commit()).ok).toBeDefined();
+
+      // Non-vacuity anchor: assert the S4 strip actually ran — the persisted
+      // labelMap kept the confidentiality but NOT the forged LinkReference.
+      const persistedId = parseLink(src.getAsLink()).id!;
+      const replica = storageManager.open(signer.did()).replica as unknown as {
+        getDocument(id: string): {
+          cfc?: {
+            labelMap?: {
+              entries: Array<{
+                path: string[];
+                label: {
+                  confidentiality?: unknown[];
+                  integrity?: Array<{ type?: string }>;
+                };
+              }>;
+            };
+          };
+        } | undefined;
+      };
+      const entries = replica.getDocument(persistedId)?.cfc?.labelMap
+        ?.entries ?? [];
+      expect(
+        entries.flatMap((e) => e.label.integrity ?? [])
+          .some((a) => a?.type?.endsWith("/LinkReference")),
+      ).toBe(false);
+      expect(
+        entries.flatMap((e) => e.label.confidentiality ?? []).includes("s"),
+      ).toBe(true);
+
+      // A sink keyed to the very atom the author tried to mint. The stripped
+      // read still gates (confidentiality-bearing, so not provenance-only)
+      // and its integrity no longer carries LinkReference: the write fails.
+      const tx = runtime.edit();
+      runtime.getCell(signer.did(), "ri-forged-prov-src", srcSchema, tx).get();
+      const sink = runtime.getCell(
+        signer.did(),
+        "ri-forged-prov-sink",
+        {
+          type: "object",
+          properties: {
+            out: {
+              type: "string",
+              ifc: { requiredIntegrity: [LINK_REFERENCE_ATOM] },
+            },
+          },
+          required: ["out"],
+        } as const satisfies JSONSchema,
         tx,
       );
       sink.set({ out: "derived" });


### PR DESCRIPTION
Follow-up to #4015 (post-merge review — verdict clean; these are the optional hardening items).

## 1. Misuse-direction test (the substantive item)

`cfc-required-integrity-provenance.test.ts` covered the S7 false-positive direction (provenance-only reads no longer gate) and the soundness direction (confidentiality-bearing / mixed reads still gate), but the "pattern author tries to self-attach a provenance atom" direction was only covered indirectly by the InjectionSafe mint-gate suites. New self-contained step: an author declares `ifc: { confidentiality: ["s"], integrity: [LinkReference] }` through the schema authoring surface (NOT the privileged metadata-seeding helper the other steps use; declaration shape mirrors `cfc-integrity-mint-gate.test.ts`). The S4 strip (`gateRuntimeMintedIntegrity`) removes the forged atom at persist — asserted directly on the stored labelMap — so the read is NOT provenance-only (confidentiality remains), still gates, and the forged atom cannot satisfy a `requiredIntegrity` gate keyed to `LinkReference`.

Design note: the sink is keyed to `LinkReference` itself because that is the only outcome-differentiating choice — with any other required atom the commit fails whether or not the strip ran, making the step vacuous as a strip guard.

**Non-vacuity evidence** (run locally, then reverted):
- Temporarily removed `CFC_ATOM_TYPE.LinkReference` from `RUNTIME_MINTED_INTEGRITY_ATOM_TYPES` (the exact regression this guards): the step goes RED at the persisted-label assertion — the forged atom survived into the stored labelMap.
- With that assertion also disabled (strip still bypassed): the step goes RED at the gate assertion — the commit SUCCEEDS because the forged `LinkReference` satisfies the `requiredIntegrity` gate, so `toContain("requiredIntegrity failed")` fails.
- Strip restored: all 4 steps green. Both anchors independently catch a strip bypass.

## 2. [nit] Gate vs egress naming collision

`prepare.ts` had two locals named `consumed` with different semantics: the `verifyInputRequirements` gate set (post-#4015 it excludes provenance-only reads) and the egress set in `verifySinkRequestCeilings` fed by `collectConsumedConfidentiality` (deliberately transaction-global, keeps every labeled read). Renamed the gate's local to `gatedReads` (plus a one-line comment on the distinction) so future diffs can't confuse the two. No behavior change.

## 3. [nit] Anchor the deferred end-state in code

Added a `TODO(data-flow)` next to `isProvenanceOnlyConsumedLabel` pointing at the principled follow-ons this exemption is a step toward, both deliberately deferred by #4015: per-write data-flow provenance scoping (dedicated write-attempt logging, per `docs/plans/runner_cfc_implementation.md` under "Potential and Final Write Sets") and the audit #14 vacuous-pass tightening (the "vacuous-pass S7 / Wave 2 #14" row in `docs/specs/cfc-s16-default-transition-design.md` §10), which is unsound to apply without per-write scoping.

## Verification

- `deno fmt --check` + `deno check` on both touched files: clean.
- `deno test` on `cfc-required-integrity-provenance.test.ts` (4 steps), `cfc-integrity-mint-gate.test.ts`, and `cfc-link-integrity-gate.test.ts`: 3 passed (6 steps), 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a focused test to ensure a pattern author cannot self-attach a `LinkReference` provenance atom: the S4 strip (`gateRuntimeMintedIntegrity`) removes the forged atom on persist, the read still gates on its confidentiality, and the forged atom cannot satisfy a `requiredIntegrity` gate. Also renames the gate-local `consumed` to `gatedReads` in `prepare.ts` and adds a TODO clarifying the deferred per-write data-flow end state to avoid confusion with egress tracking.

<sup>Written for commit 1143c82be142f8b5ca3cb30241dc98dcb73798d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

