### PR TITLE
fix(cfc): S18 guard follow-ups — record ["cfc"] writes under disabled mode; share the batch chokepoint

### DIFF
--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -704,13 +704,19 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.assertWritable("writeValuesOrThrow()");
     this.invalidateReadResultCache();
     if (this.tx.writeBatch) {
+      // Keep the batch path on the same noteSystemWrite chokepoint as single
+      // writes (S18). Structurally inert today — the NormalizedFullLink
+      // signature means toMemorySpaceAddress always yields path ["value", ...]
+      // — but the guard must not silently fall away if the signature is ever
+      // widened to document-root addresses.
+      const noteSystemWrite = (address: IMemorySpaceAddress) =>
+        this.noteSystemWrite(address);
       const result = this.tx.writeBatch(
         (function* () {
           for (const write of writes) {
-            yield {
-              address: toMemorySpaceAddress(write.address),
-              value: write.value,
-            };
+            const address = toMemorySpaceAddress(write.address);
+            noteSystemWrite(address);
+            yield { address, value: write.value };
           }
         })(),
       );

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -257,11 +257,15 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   // derivation for OTHER writes, bypassing the commit-boundary derivation +
   // mint-gating (audit S18). prepareBoundaryCommit turns each recorded address
   // into a fail-closed reason, so the violation surfaces uniformly with every
-  // other CFC reason (enforce rejects, observe diagnoses). `disabled` leaves
-  // CFC inert, so the guard does nothing there.
+  // other CFC reason (enforce rejects, observe diagnoses). Recording (and
+  // relevance marking) is deliberately unconditional on the enforcement mode,
+  // like every other CFC signal: setCfcEnforcementMode permits raising the
+  // mode mid-transaction (disabled/observe impose no floor), so a forgery in a
+  // disabled window must still be on record when a later escalation evaluates
+  // it. A transaction still `disabled` at commit never runs
+  // prepareBoundaryCommit, so the record stays inert there.
   private noteSystemWrite(address: IMemorySpaceAddress): void {
     if (this.#privilegedSystemWriteDepth > 0) return;
-    if (this.cfcState.enforcementMode === "disabled") return;
     // The ["cfc"] document field holds the persisted label map. A value-path
     // write (path[0] is a user key) or a path-[] full-document write is not it.
     if (address.path[0] !== "cfc") return;

--- a/packages/runner/test/cfc-privileged-system-write.test.ts
+++ b/packages/runner/test/cfc-privileged-system-write.test.ts
@@ -166,6 +166,85 @@ describe("CFC privileged system write (S18)", () => {
     }
   });
 
+  it("records a ['cfc'] write made while disabled so a mid-tx escalation to enforce rejects", async () => {
+    // setCfcEnforcementMode permits raising the mode mid-transaction
+    // (disabled/observe impose no floor — audit S3), so a forged ["cfc"] write
+    // performed in a disabled window must not survive a later escalation to
+    // enforce. Like every other CFC signal, the write is recorded
+    // unconditionally and only evaluated against the mode at prepare/commit
+    // time.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+    try {
+      const tx = runtime.edit();
+      const target = runtime.getCell(
+        signer.did(),
+        "s18-forge-escalate",
+        undefined,
+        tx,
+      );
+      const id = target.getAsNormalizedFullLink().id as URI;
+      // Forge the label map while the transaction is still disabled.
+      tx.writeOrThrow({
+        space: signer.did(),
+        id,
+        type: "application/json",
+        path: ["cfc"],
+      }, forgedMetadata as unknown as Record<string, unknown>);
+      // The forgery is recorded even though enforcement is disabled.
+      expect(tx.getCfcState().unprivilegedSystemWrites.length).toBe(1);
+
+      tx.setCfcEnforcementMode("enforce-explicit");
+      const result = await tx.commit();
+      expect(result.error).toBeDefined();
+      expect(String((result.error as Error).message).toLowerCase()).toContain(
+        "cfc",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("still commits a never-escalated transaction under disabled mode", async () => {
+    // `disabled` leaves CFC inert end-to-end: the forged write is recorded
+    // (see above) but prepareBoundaryCommit never runs for a transaction whose
+    // mode is still disabled at commit, so nothing turns the record into a
+    // rejection.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+    try {
+      const tx = runtime.edit();
+      const target = runtime.getCell(
+        signer.did(),
+        "s18-forge-disabled",
+        undefined,
+        tx,
+      );
+      const id = target.getAsNormalizedFullLink().id as URI;
+      tx.writeOrThrow({
+        space: signer.did(),
+        id,
+        type: "application/json",
+        path: ["cfc"],
+      }, forgedMetadata as unknown as Record<string, unknown>);
+
+      const result = await tx.commit();
+      expect(result.ok).toBeDefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("does not gate value-path writes or full-document seeds (path [])", async () => {
     // The Cell API writes value paths, never the document ["cfc"] field, so
     // ordinary pattern writes are unaffected. A path-[] full-document seed

--- a/packages/runner/test/cfc-privileged-system-write.test.ts
+++ b/packages/runner/test/cfc-privileged-system-write.test.ts
@@ -245,10 +245,9 @@ describe("CFC privileged system write (S18)", () => {
     }
   });
 
-  it("does not gate value-path writes or full-document seeds (path [])", async () => {
+  it("does not gate value-path writes", async () => {
     // The Cell API writes value paths, never the document ["cfc"] field, so
-    // ordinary pattern writes are unaffected. A path-[] full-document seed
-    // (the legitimate hydration/seed vector) is likewise not gated.
+    // ordinary pattern writes are unaffected.
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
@@ -264,6 +263,60 @@ describe("CFC privileged system write (S18)", () => {
         tx,
       );
       plain.set({ note: "hello" });
+      const result = await tx.commit();
+      expect(result.ok).toBeDefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("does not gate a path-[] full-document write carrying a cfc field", async () => {
+    // Documented deferred residual: the guard keys on path[0] === "cfc", so a
+    // path-[] full-document write whose value embeds a `cfc` record is NOT
+    // gated. This is the shape hydration delivers and the raw-seed idiom other
+    // CFC tests rely on (seedPrivilegedCfc in cfc-boundary.test.ts); per the
+    // sandbox invariant only the logical `value` surface is exposed to
+    // untrusted or user-authored code (docs/plans/runner_cfc_implementation.md
+    // "Document Surface Rules"), so untrusted code cannot reach this vector.
+    // If document-root writes ever become reachable from untrusted code, this
+    // test documents the seam that must then be gated.
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const tx = runtime.edit();
+      const target = runtime.getCell(
+        signer.did(),
+        "s18-root-seed",
+        undefined,
+        tx,
+      );
+      const id = target.getAsNormalizedFullLink().id as URI;
+      // Mirror seedPrivilegedCfc: read the current doc, then write the whole
+      // envelope at path [] with the cfc record embedded.
+      const docAddress = {
+        space: signer.did(),
+        id,
+        type: "application/json" as const,
+        path: [],
+      };
+      let current: unknown;
+      try {
+        current = tx.readOrThrow(docAddress);
+      } catch {
+        current = undefined;
+      }
+      const base = current && typeof current === "object" ? current : {};
+      tx.writeOrThrow(
+        docAddress,
+        { ...base, cfc: forgedMetadata } as unknown as Record<string, unknown>,
+      );
+      expect(tx.getCfcState().unprivilegedSystemWrites.length).toBe(0);
+
       const result = await tx.commit();
       expect(result.ok).toBeDefined();
     } finally {


### PR DESCRIPTION
Follow-up to #3996 (post-merge review). Three findings, each re-verified against current main before fixing.

## 1. Fail-open on mid-tx mode escalation (fixed)

`noteSystemWrite()` in `packages/runner/src/storage/extended-storage-transaction.ts` early-returned when the transaction's enforcement mode was `"disabled"` — before recording. Since `setCfcEnforcementMode` explicitly permits raising the mode mid-transaction (`disabled`/`observe` impose no floor, audit S3), an unprivileged `["cfc"]` label-map write performed in a disabled window was never pushed to `cfcState.unprivilegedSystemWrites` and survived a later escalation to enforce.

**Fix:** record (and mark relevance) unconditionally, like every other CFC signal — the mode is only consulted when the record is evaluated at prepare/commit time. Relevance marking must come along: `Runtime.prepareTxForCommit` and the commit gate only act on `relevant` transactions, so a record without the mark would still commit. Marking relevance on a still-disabled transaction is inert: every commit-gate branch and `prepareTxForCommit` require a non-disabled mode, so `prepareBoundaryCommit` never runs for a fully-disabled transaction and the record never turns into a rejection (covered by a new test).

**Red→green** (test written first, on main):

The new escalation test failed at the recording assertion — the write was never recorded under disabled mode:

```
records a ['cfc'] write made while disabled so a mid-tx escalation to enforce rejects ... FAILED
    [Diff] Actual / Expected
-   0
+   1
```

and end-to-end with that assertion commented out — the forged commit *succeeded* despite escalation to `enforce-explicit`:

```
error: AssertionError: Expected "actual" to not be strictly equal to: undefined.
    at toBeDefined (...)   // expect(result.error).toBeDefined()
```

After the fix:

```
records a ['cfc'] write made while disabled so a mid-tx escalation to enforce rejects ... ok
still commits a never-escalated transaction under disabled mode ... ok
ok | 1 passed (8 steps) | 0 failed
```

## 2. Batch write path skipped the chokepoint (fixed)

`writeValuesOrThrow()`: when `this.tx.writeBatch` exists (the live production path), writes went straight to `writeBatch` and `noteSystemWrite` was never called; only the non-batch fallback loop reached the guard. Currently unexploitable — the method accepts only `NormalizedFullLink`s and `toMemorySpaceAddress` forces `path: ["value", ...]` — but the chokepoint inconsistency would fail silently if the signature were ever widened.

**Fix:** call `noteSystemWrite(address)` for each computed address inside the generator, before yielding, so both branches share the chokepoint; commented that batch addresses are value-surface-only by construction today. No direct unit test through the public surface: addresses from this method structurally cannot reach `["cfc"]` (the guard no-ops on `path[0] === "value"`), so a test would have to bypass the very signature that makes the path safe — the existing direct-write tests cover the guard itself.

## 3. Mislabeled test (fixed)

The case named "does not gate value-path writes or full-document seeds (path [])" only performed a value-surface write and never wrote `path: []`. Renamed it to "does not gate value-path writes", and added an explicit case performing a `path: []` full-document write carrying a `cfc` field, asserting the current intended behavior: it is ungated and commits. The new case mirrors the `seedPrivilegedCfc` helper's address construction (read doc at `path: []`, write back the whole envelope with the `cfc` record embedded) and its comment marks this as the documented deferred residual — per the sandbox invariant, only the logical `value` surface is exposed to untrusted or user-authored code (`docs/plans/runner_cfc_implementation.md`, "Document Surface Rules").

## Verification

- `deno check` on both touched files: clean.
- `packages/runner`: `cfc-privileged-system-write` (8 steps), `cfc-boundary` (88 steps), `cfc-tx-control-guard`, `cfc-runtime-stats`, `cfc-labelmap-components`, `scheduler-core` (26 steps, uses the raw-seed idiom) — all green, re-run after rebasing onto current main (which had since gained #4012 S16-A2 and #4025).
- Confirmed no other test performs a raw `["cfc"]`-path write: `seedPrivilegedCfc` (both copies) rewrites the seed address to `path: []` before writing, so unconditional recording cannot regress them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a fail-open in the CFC guard by always recording unprivileged ["cfc"] writes, even when enforcement is disabled, so mid-transaction escalations correctly reject forged label maps. Also routes batch writes through the same chokepoint and tidies tests.

- **Bug Fixes**
  - Record and mark relevance for unprivileged ["cfc"] writes regardless of mode; disabled commits remain inert, but disabled→enforce escalations now fail as expected.
  - Route `writeBatch` through `noteSystemWrite` so batch and single writes share the S18 chokepoint.
  - Rename the mislabeled value-path test and add an explicit path-[] full-document write case to document the current ungated behavior.

<sup>Written for commit 3e33f680745bec5e553637573402857a88844998. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

