### PR TITLE
test(runner): identity-C follow-ups — direct $implRef resolution-order test + cleanups

### DIFF
--- a/packages/runner/src/harness/verified-provenance.ts
+++ b/packages/runner/src/harness/verified-provenance.ts
@@ -51,14 +51,15 @@ export function recordVerifiedProvenance(
   if (!provenanceByFn.has(fn)) provenanceByFn.set(fn, provenance);
 }
 
-/** The provenance for a function registered during verified evaluation. */
+/**
+ * The provenance for a function registered during verified evaluation. Only
+ * functions are ever recorded (see `recordVerifiedProvenance`), so any
+ * non-function key is a guaranteed miss.
+ */
 export function getVerifiedProvenance(
   fn: unknown,
 ): VerifiedProvenance | undefined {
-  if (typeof fn !== "function" && (typeof fn !== "object" || fn === null)) {
-    return undefined;
-  }
-  return provenanceByFn.get(fn as object);
+  return typeof fn === "function" ? provenanceByFn.get(fn) : undefined;
 }
 
 /**

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2363,7 +2363,7 @@ export class Runner {
         (module.implementationRef
           ? this.runtime.harness.getExecutableFunction(
             module.implementationRef,
-          ) as (...args: any[]) => any | undefined
+          ) as ((...args: any[]) => any) | undefined
           : undefined) ??
         this.getFallbackJavaScriptImplementation(module);
       this.functionCache.set(module, fn);

--- a/packages/runner/test/content-addressed-identity.test.ts
+++ b/packages/runner/test/content-addressed-identity.test.ts
@@ -7,6 +7,7 @@ import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementa
 import { getVerifiedProvenance } from "../src/harness/verified-provenance.ts";
 import type { Module, Pattern } from "../src/builder/types.ts";
 import type { HarnessedFunction } from "../src/harness/types.ts";
+import { trustModule } from "./support/trusted-builder.ts";
 
 /**
  * PR C of docs/specs/content-addressed-action-identity-implementation-plan.md:
@@ -212,5 +213,93 @@ describe("provenance bundleId fallback (legacy claim compat)", () => {
     expect((identity as { bundleId?: string }).bundleId).toBe(
       "load:legacy-bundle",
     );
+  });
+});
+
+describe("$implRef resolution arm (Runner.resolveJavaScriptFunction)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  // A lift makes the resolved executable's EFFECT observable through the
+  // result value, so the assertion below proves the function actually RAN —
+  // not merely that something resolved.
+  const LIFT_PROGRAM = {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: `/// <cts-enable />
+import { lift, pattern } from "commonfabric";
+
+export const double = lift((x: number) => x * 2);
+
+export default pattern<{ value: number }>(({ value }) => ({
+  doubled: double(value),
+}));
+`,
+    }],
+  };
+
+  it("a module with ONLY $implRef (legacy ref and body stripped) resolves and executes", async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "observe",
+    });
+    const pattern = await runtime.patternManager.compilePattern(
+      LIFT_PROGRAM,
+    ) as Pattern;
+    await runtime.idle();
+
+    // Serialize the compiled lift node's module the way a cell write would
+    // (dual-write: $implRef alongside implementationRef), then strip the
+    // legacy fields — the exact shape the planned flip produces (PR E of
+    // docs/specs/content-addressed-action-identity-implementation-plan.md:
+    // writers stop emitting implementationRef and the stringified
+    // implementation).
+    const node = pattern.nodes.find((n) =>
+      (n.module as Module).type === "javascript"
+    );
+    expect(node).toBeDefined();
+    const live = node!.module as Module & { toJSON?: () => unknown };
+    const json =
+      (live.toJSON
+        ? live.toJSON()
+        : JSON.parse(JSON.stringify(live))) as Record<string, unknown>;
+    const ref = json.$implRef as { identity: string; symbol: string };
+    expect(ref).toBeDefined();
+    delete json.implementationRef;
+    delete json.implementation;
+
+    // With both legacy fields gone, neither the legacy-registry arm (needs
+    // module.implementationRef) nor the stringified-source fallback (needs
+    // module.implementation; throws without it) can produce an executable.
+    // Only `resolveByImplRef` can — by resolving the ref in the artifact
+    // index. The functionCache cannot mask either: it keys on
+    // implementationRef, so it neither prewarms nor caches this module.
+    expect(
+      runtime.patternManager.artifactFromIdentitySync(ref.identity, ref.symbol),
+    ).toBeDefined();
+
+    const stripped = trustModule(runtime, json as unknown as Module);
+    const tx = runtime.edit();
+    const resultCell = runtime.getCell<number>(
+      signer.did(),
+      "implref-only-execution",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, stripped, 21, resultCell);
+    await tx.commit();
+    const out = await result.pull();
+    // 21 → 42: the registered artifact's implementation ran via $implRef.
+    expect(out).toBe(42);
   });
 });


### PR DESCRIPTION
Follow-up to #4009 (post-merge review). Every finding was re-verified against current main, since #4013 (identity D) landed after the review and moved the provenance machinery into the engine — two findings were mooted by that move and are skipped below with evidence.

## Fixed

### 1. Direct test of the production `$implRef` resolution arm (the substantive one)

`Runner.resolveJavaScriptFunction` resolves `resolveByImplRef(module) ?? legacy implementationRef registry ?? stringified-source fallback`. Existing suites probe the index (`artifactFromIdentitySync`) and assert `$implRef` is *written*, but nothing drove resolution such that the `$implRef` arm *produces the executable* — the legacy dual-read masks any bug there, and that arm becomes load-bearing at the planned flip (PR E of `docs/specs/content-addressed-action-identity-implementation-plan.md`).

New test in `packages/runner/test/content-addressed-identity.test.ts`: compile a lift program, serialize the lift node's module the way a cell write would (dual-write), then strip `implementationRef` **and** the stringified `implementation` — exactly the shape PR E's flip will produce — and run it via `runtime.run`. With both legacy fields gone:

- the legacy-registry arm cannot fire (no `module.implementationRef`),
- the fallback cannot fire (`getFallbackJavaScriptImplementation` throws without `module.implementation`),
- the functionCache cannot mask (it keys on `implementationRef`, so neither the `discoverAndCacheFunctions` prewarm nor the post-resolve `set` does anything for this module),

so the observed `21 → 42` result proves `resolveByImplRef` resolved **and executed** the registered artifact's implementation.

**Non-vacuity evidence** (as requested by the review): with `resolveByImplRef` temporarily neutered (`return undefined` as its first line), the new test FAILS:

```
error: Error: JavaScript module is missing an executable implementation
    at Runner.getFallbackJavaScriptImplementation (src/runner.ts)
    at Runner.resolveJavaScriptFunction → instantiateJavaScriptNode → … → Runtime.run
FAILED | 2 passed (6 steps) | 1 failed (1 step)
```

Restored, it passes: `ok | 3 passed (7 steps) | 0 failed`.

Side observation (not pinned by a test, flagging for the flip): when a module still carries a *resolvable* legacy `implementationRef`, the `discoverAndCacheFunctions` prewarm populates the functionCache from the legacy registry and the cache check in `resolveJavaScriptFunction` short-circuits BEFORE the `$implRef` arm — so today the content-addressed arm effectively only fires for modules whose legacy ref is absent/unresolvable. Harmless while both refs name the same implementation, and self-resolving at the flip (no legacy ref → prewarm no-ops), but worth knowing when reading "resolution prefers `$implRef`".

### 3. Misleading cast (`runner.ts`)

`as (...args: any[]) => any | undefined` parses as a function returning `any | undefined`, not as an optional function. Now `as ((...args: any[]) => any) | undefined`, matching the intent (adapting `HarnessedFunction | undefined` to the local `fn` type).

### 5. Dead object-key branch (`verified-provenance.ts`)

`getVerifiedProvenance` accepted plain object keys, but `recordVerifiedProvenance` only ever stores function keys, so the object branch could never hit. Dropped; non-function keys short-circuit to `undefined`. Checked all call sites (`json-utils.ts`, `cfc/implementation-identity.ts`, tests) — every one passes a function (or an `unknown` that is a function at runtime; the parameter stays `unknown` so everything compiles), and behavior is observably identical.

## Skipped (mooted by #4013, identity D)

### 2. `readBindingIdentity` double call

The flagged code (`readBindingIdentity(value) === undefined ? {} : { bindingIdentity: readBindingIdentity(value)! }` in `pattern-manager.ts`) was deleted by #4013, which moved provenance recording to `Engine.recordModuleProvenance` — and the moved code already hoists to a single `const bindingIdentity = readBindingIdentity(value)` (`packages/runner/src/harness/engine.ts:835`). Nothing left to fix; `git grep readBindingIdentity` confirms the engine call is the only remaining use.

### 4. Comment attribution in `reexport-provenance.test.ts`

The review flagged the header for crediting the re-export guard to `Engine.recordModuleProvenance`, which didn't exist at #4009 (the guard then lived in `PatternManager.indexArtifact`). #4013 moved the guard INTO `Engine.recordModuleProvenance` (the `srcIdentity !== undefined && srcIdentity !== identity` rejection, `engine.ts:831-834`; the #4013 commit message says so explicitly). The comment now points at the real guard, so it is accurate as written — changing it would be churn.

## Verification

- `deno check` on all touched files: clean.
- `deno fmt --check` / `deno lint` on touched files: clean.
- Test run (repo-style invocation from `packages/runner`): `content-addressed-identity.test.ts`, `content-addressed-identity-adversarial.test.ts`, `reexport-provenance.test.ts`, `cfc-implementation-identity.test.ts`, `json-utils.test.ts` — **8 passed (107 steps), 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a direct execution test that proves `$implRef` resolves and runs when legacy fields are absent, and cleans up two small runner/provenance nits for clarity and safety.

- **New Features**
  - Added a test in `packages/runner/test/content-addressed-identity.test.ts` that strips `implementationRef` and `implementation`, then verifies `resolveByImplRef` executes (21 → 42), ensuring the `$implRef` path is load-bearing and not masked by `functionCache` or fallbacks.

- **Refactors**
  - Fixed a misleading cast in `Runner.resolveJavaScriptFunction` to `((...args: any[]) => any) | undefined`.
  - Simplified `getVerifiedProvenance` to only accept function keys, removing an unreachable object-key branch.

<sup>Written for commit 43d312e369721e99753cb418c9f255c1bb698c50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

