### PR TITLE
feat(ui): cf-empty-state component (CT-1706)

### DIFF
--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -104,6 +104,7 @@ cell means none confirmed — check the component source before assuming.
 | `cf-drag-source` | Wraps draggable content; pairs with `cf-drop-zone` (see [drag-and-drop](../patterns/meta/drag-and-drop.md)) | `$cell` |
 | `cf-draggable` | Absolutely-positioned draggable container (x/y) | |
 | `cf-drop-zone` | Droppable region emitting `cf-drop` events (see [drag-and-drop](../patterns/meta/drag-and-drop.md)) | |
+| `cf-empty-state` | Centered, muted placeholder for empty lists (see [cf-empty-state](#cf-empty-state)) | |
 | `cf-fab` | Morphing floating action button that expands into a panel | |
 | `cf-file-download` | File download button (encapsulates blob/anchor download) | `$data`, `$filename` |
 | `cf-file-input` | Generic file upload | |
@@ -336,6 +337,32 @@ fade-edges, or a styled/hidden scrollbar.
   </cf-vscroll>
   <cf-message-input slot="footer" />
 </cf-screen>
+```
+
+---
+
+## cf-empty-state
+
+Centered, muted placeholder for empty lists and regions. Use instead of ad-hoc
+`<div style="text-align: center; color: ...; padding: 2rem;">` blocks.
+
+The message comes from the `message` attribute (simple case) or the default
+slot. Optional `icon` and `action` slots render above and below the message.
+
+```tsx
+// Simple case — message attribute
+{items.get().length === 0
+  ? <cf-empty-state message="No items yet. Add one below!" />
+  : null}
+
+// With icon and a call to action
+<cf-empty-state>
+  <span slot="icon">📋</span>
+  Your shopping list is empty.
+  <cf-button slot="action" size="sm" onClick={addItem}>
+    Add first item
+  </cf-button>
+</cf-empty-state>
 ```
 
 ---

--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -2996,6 +2996,7 @@ interface CFAvatarElement extends CFHTMLElement {}
 interface CFProfileBadgeElement extends CFHTMLElement {}
 interface CFBadgeElement extends CFHTMLElement {}
 interface CFChipElement extends CFHTMLElement {}
+interface CFEmptyStateElement extends CFHTMLElement {}
 interface CFProgressElement extends CFHTMLElement {}
 interface CFSkeletonElement extends CFHTMLElement {}
 interface CFSeparatorElement extends CFHTMLElement {}
@@ -4259,6 +4260,10 @@ interface CFChipAttributes<T> extends CFHTMLAttributes<T> {
   "oncf-click"?: EventHandler<{}>;
 }
 
+interface CFEmptyStateAttributes<T> extends CFHTMLAttributes<T> {
+  "message"?: string | CellLike<string>;
+}
+
 interface CFProgressAttributes<T> extends CFHTMLAttributes<T> {
   "value"?: number | CellLike<number>;
   "max"?: number | CellLike<number>;
@@ -5284,6 +5289,10 @@ declare global {
       "cf-separator": CFDOM.DetailedHTMLProps<
         CFSeparatorAttributes<CFSeparatorElement>,
         CFSeparatorElement
+      >;
+      "cf-empty-state": CFDOM.DetailedHTMLProps<
+        CFEmptyStateAttributes<CFEmptyStateElement>,
+        CFEmptyStateElement
       >;
       "cf-tile": CFDOM.DetailedHTMLProps<
         CFTileAttributes<CFTileElement>,

--- a/packages/patterns/catalog/catalog.tsx
+++ b/packages/patterns/catalog/catalog.tsx
@@ -81,6 +81,7 @@ interface CatalogInput {
           { id: "label"; label: "Label" },
           { id: "chip"; label: "Chip" },
           { id: "badge"; label: "Badge" },
+          { id: "empty-state"; label: "Empty State" },
           { id: "separator"; label: "Separator" },
           { id: "markdown"; label: "Markdown" },
           { id: "svg"; label: "SVG" },

--- a/packages/patterns/catalog/stories/cf-empty-state-story.tsx
+++ b/packages/patterns/catalog/stories/cf-empty-state-story.tsx
@@ -1,0 +1,74 @@
+import { NAME, pattern, UI, type VNode, Writable } from "commonfabric";
+
+import { Controls, TextControl } from "../ui/controls/index.ts";
+
+// deno-lint-ignore no-empty-interface
+interface EmptyStateStoryInput {}
+interface EmptyStateStoryOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  controls: VNode;
+}
+
+const sectionLabelStyle = {
+  fontSize: "12px",
+  fontWeight: "600",
+  color: "#6b7280",
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+};
+
+export default pattern<EmptyStateStoryInput, EmptyStateStoryOutput>(() => {
+  const message = new Writable("No items yet. Add one below!");
+
+  return {
+    [NAME]: "cf-empty-state Story",
+    [UI]: (
+      <div
+        style={{
+          padding: "1rem",
+          maxWidth: "480px",
+          display: "flex",
+          flexDirection: "column",
+          gap: "1.5rem",
+        }}
+      >
+        <div>
+          <div style={sectionLabelStyle}>Message only</div>
+          <cf-empty-state message={message} />
+        </div>
+
+        <div>
+          <div style={sectionLabelStyle}>With icon</div>
+          <cf-empty-state>
+            <span slot="icon">📋</span>
+            Your shopping list is empty. Type above to add items!
+          </cf-empty-state>
+        </div>
+
+        <div>
+          <div style={sectionLabelStyle}>With action</div>
+          <cf-empty-state>
+            <span slot="icon">📚</span>
+            No items yet. Add something to read!
+            <cf-button slot="action" size="sm">
+              Add first item
+            </cf-button>
+          </cf-empty-state>
+        </div>
+      </div>
+    ),
+    controls: (
+      <Controls>
+        <>
+          <TextControl
+            label="message"
+            description="Placeholder text for the message-only example"
+            defaultValue="No items yet. Add one below!"
+            value={message}
+          />
+        </>
+      </Controls>
+    ),
+  };
+});

--- a/packages/patterns/catalog/ui/story-renderer.tsx
+++ b/packages/patterns/catalog/ui/story-renderer.tsx
@@ -28,6 +28,7 @@ import TextStory from "../stories/cf-text-story.tsx";
 import LabelStory from "../stories/cf-label-story.tsx";
 import ChipStory from "../stories/cf-chip-story.tsx";
 import BadgeStory from "../stories/cf-badge-story.tsx";
+import EmptyStateStory from "../stories/cf-empty-state-story.tsx";
 import AvatarStory from "../stories/cf-avatar-story.tsx";
 import ProfileBadgeStory from "../stories/cf-profile-badge-story.tsx";
 import AlertStory from "../stories/cf-alert-story.tsx";
@@ -135,6 +136,8 @@ export default pattern<StoryRendererInput, StoryRendererOutput>(
           return ChipStory({});
         case "badge":
           return BadgeStory({});
+        case "empty-state":
+          return EmptyStateStory({});
         case "avatar":
           return AvatarStory({});
         case "profile-badge":

--- a/packages/ui/src/v2/components/cf-empty-state/cf-empty-state.test.ts
+++ b/packages/ui/src/v2/components/cf-empty-state/cf-empty-state.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Tests for CFEmptyState component
+ */
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { CFEmptyState } from "./cf-empty-state.ts";
+
+describe("CFEmptyState", () => {
+  it("should be defined", () => {
+    expect(CFEmptyState).toBeDefined();
+  });
+
+  it("registers the custom element", () => {
+    expect(customElements.get("cf-empty-state")).toBe(CFEmptyState);
+  });
+
+  it("should create element instance", () => {
+    const element = new CFEmptyState();
+    expect(element).toBeInstanceOf(CFEmptyState);
+  });
+
+  it("should have default properties", () => {
+    const element = new CFEmptyState();
+    expect(element.message).toBe("");
+  });
+
+  it("should accept a message property", () => {
+    const element = new CFEmptyState();
+    element.message = "No items yet. Add one below!";
+    expect(element.message).toBe("No items yet. Add one below!");
+  });
+});

--- a/packages/ui/src/v2/components/cf-empty-state/cf-empty-state.ts
+++ b/packages/ui/src/v2/components/cf-empty-state/cf-empty-state.ts
@@ -1,0 +1,150 @@
+import { css, html } from "lit";
+import { BaseElement } from "../../core/base-element.ts";
+
+/**
+ * CFEmptyState - Centered, muted placeholder for empty lists and regions
+ *
+ * Replaces the ad-hoc "no items yet" divs duplicated across patterns with
+ * a single themed component: centered text in a muted tone with comfortable
+ * padding, plus optional icon and action slots.
+ *
+ * @element cf-empty-state
+ *
+ * @attr {string} message - Placeholder text (convenience for the simple case;
+ *   the default slot overrides it when provided)
+ *
+ * @slot - Message content (overrides the message attribute)
+ * @slot icon - Optional icon or illustration shown above the message
+ * @slot action - Optional call to action shown below the message
+ *
+ * @csspart empty-state - The outer container
+ * @csspart icon - The icon container
+ * @csspart message - The message container
+ * @csspart action - The action container
+ *
+ * @example Simple
+ * <cf-empty-state message="No items yet. Add one below!"></cf-empty-state>
+ *
+ * @example With icon and action
+ * <cf-empty-state>
+ *   <span slot="icon">📋</span>
+ *   Your shopping list is empty.
+ *   <cf-button slot="action">Add first item</cf-button>
+ * </cf-empty-state>
+ */
+export class CFEmptyState extends BaseElement {
+  static override styles = [
+    BaseElement.baseStyles,
+    css`
+      :host {
+        --cf-empty-state-color: var(
+          --cf-theme-color-text-muted,
+          var(--cf-colors-gray-500, #94979e)
+        );
+        --cf-empty-state-padding: var(--cf-spacing-8, 2rem);
+        --cf-empty-state-gap: var(--cf-spacing-3, 0.75rem);
+        --cf-empty-state-font-size: var(--cf-font-body-size, 0.875rem);
+        --cf-empty-state-icon-size: var(--cf-font-size-2xl, 1.5rem);
+
+        display: block;
+        box-sizing: border-box;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: inherit;
+      }
+
+      .empty-state {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: var(--cf-empty-state-gap);
+        padding: var(--cf-empty-state-padding);
+        text-align: center;
+        color: var(--cf-empty-state-color);
+        font-size: var(--cf-empty-state-font-size);
+        line-height: var(--cf-font-body-line-height, 1.25rem);
+      }
+
+      .icon {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: var(--cf-empty-state-icon-size);
+        line-height: 1;
+      }
+
+      .icon.empty {
+        display: none;
+      }
+
+      .action {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .action.empty {
+        display: none;
+      }
+    `,
+  ];
+
+  static override properties = {
+    message: { type: String },
+    _hasIcon: { state: true },
+    _hasAction: { state: true },
+  };
+
+  declare message: string;
+  declare _hasIcon: boolean;
+  declare _hasAction: boolean;
+
+  constructor() {
+    super();
+    this.message = "";
+    this._hasIcon = false;
+    this._hasAction = false;
+  }
+
+  override render() {
+    return html`
+      <div class="empty-state" part="empty-state">
+        <div
+          class="icon ${this._hasIcon ? "" : "empty"}"
+          part="icon"
+          aria-hidden="true"
+        >
+          <slot
+            name="icon"
+            @slotchange="${this._handleIconSlotChange}"
+          ></slot>
+        </div>
+        <div class="message" part="message">
+          <slot>${this.message}</slot>
+        </div>
+        <div class="action ${this._hasAction ? "" : "empty"}" part="action">
+          <slot
+            name="action"
+            @slotchange="${this._handleActionSlotChange}"
+          ></slot>
+        </div>
+      </div>
+    `;
+  }
+
+  private _handleIconSlotChange = (e: Event) => {
+    const slot = e.target as HTMLSlotElement;
+    this._hasIcon = slot.assignedElements().length > 0;
+  };
+
+  private _handleActionSlotChange = (e: Event) => {
+    const slot = e.target as HTMLSlotElement;
+    this._hasAction = slot.assignedElements().length > 0;
+  };
+}
+
+globalThis.customElements.define("cf-empty-state", CFEmptyState);

--- a/packages/ui/src/v2/components/cf-empty-state/index.ts
+++ b/packages/ui/src/v2/components/cf-empty-state/index.ts
@@ -1,0 +1,7 @@
+import { CFEmptyState } from "./cf-empty-state.ts";
+
+if (!customElements.get("cf-empty-state")) {
+  customElements.define("cf-empty-state", CFEmptyState);
+}
+
+export { CFEmptyState };

--- a/packages/ui/src/v2/index.ts
+++ b/packages/ui/src/v2/index.ts
@@ -43,6 +43,7 @@ export * from "./components/cf-collapsible/index.ts";
 export * from "./components/cf-copy-button/index.ts";
 export * from "./components/cf-draggable/index.ts";
 export * from "./components/cf-drop-zone/index.ts";
+export * from "./components/cf-empty-state/index.ts";
 export * from "./components/cf-fab/index.ts";
 export * from "./components/cf-file-download/index.ts";
 export * from "./components/cf-file-input/index.ts";


### PR DESCRIPTION
## What

Adds `cf-empty-state`, a small v2 UI component: a centered, muted placeholder for empty lists and regions, with an optional icon above and an action (e.g. "add first item" button) below the message.

## Why

~10 patterns duplicate the same inline-styled empty-state block (`<div style="text-align: center; color: var(--cf-color-gray-500); padding: 2rem;">No items yet...</div>`), e.g.:

- `packages/patterns/todo-list/todo-list.tsx:149-155`
- `packages/patterns/shopping-list.tsx:446-458`
- `packages/patterns/do-list/do-list.tsx:402-408`
- `packages/patterns/reading-list/reading-list.tsx:232-238`
- `packages/patterns/card-piles/main.tsx:232-236` ("Drop cards here")

This component gives them one themed, token-only home (`--cf-theme-color-text-muted`, `--cf-spacing-*`, `--cf-font-*` — no hardcoded values with token equivalents). Migrating the patterns themselves is left for a follow-up.

## API

- `message` attribute for the simple case; default slot overrides it
- `icon` slot (above) and `action` slot (below), each hidden when unslotted
- CSS parts: `empty-state`, `icon`, `message`, `action`
- Per-component CSS variables: `--cf-empty-state-{color,padding,gap,font-size,icon-size}`

## Changes

- `packages/ui/src/v2/components/cf-empty-state/` — component, index, unit tests
- `packages/ui/src/v2/index.ts` — export (one line)
- `packages/html/src/jsx.d.ts` — `cf-empty-state` intrinsic element typing
- `packages/patterns/catalog/catalog.tsx` + `ui/story-renderer.tsx` + `stories/cf-empty-state-story.tsx` — Display catalog entry and story (message-only / with icon / with action)
- `docs/common/components/COMPONENTS.md` — index row + `## cf-empty-state` section

## Test plan

- `cd packages/ui && deno task test` — 92 passed (559 steps), 0 failed (+ 36 sanitize-svg tests pass)
- `deno task cf check packages/patterns/catalog/stories/cf-empty-state-story.tsx --no-run` — exit 0
- `deno task cf check packages/patterns/catalog/catalog.tsx --no-run` — exit 0
- `deno lint` + `deno fmt --check` on all added/changed files — clean
- No `setAttribute`/attribute reflection in the constructor (per prior browser-throw bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `cf-empty-state`, a v2 UI component for centered, muted placeholders in empty lists/regions, reducing duplicated inline empty-state code across patterns. Addresses Linear CT-1706.

- New Features
  - `cf-empty-state` web component with message text and optional icon/action.
  - API: `message` attribute; default slot overrides it; `icon` and `action` slots auto-hide when empty.
  - Styling: token-only; CSS parts (`empty-state`, `icon`, `message`, `action`) and vars `--cf-empty-state-{color,padding,gap,font-size,icon-size}`.
  - Typings/exports: JSX intrinsic element in `packages/html/src/jsx.d.ts`; export from `packages/ui/src/v2/index.ts`.
  - Docs/examples/tests: COMPONENTS.md entry/section, catalog story, and unit tests.

<sup>Written for commit 1ce8ce80a8e3c9330960a8ebf780f987dab3b27b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

