### PR TITLE
feat(ui): cf-field labeled field wrapper (CT-1703)

### DIFF
--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -105,6 +105,7 @@ cell means none confirmed — check the component source before assuming.
 | `cf-draggable` | Absolutely-positioned draggable container (x/y) | |
 | `cf-drop-zone` | Droppable region emitting `cf-drop` events (see [drag-and-drop](../patterns/meta/drag-and-drop.md)) | |
 | `cf-fab` | Morphing floating action button that expands into a panel | |
+| `cf-field` | Labeled field wrapper: muted label, optional required/error/help text (see [cf-field](#cf-field)) | |
 | `cf-file-download` | File download button (encapsulates blob/anchor download) | `$data`, `$filename` |
 | `cf-file-input` | Generic file upload | |
 | `cf-form` | Transactional form wrapper buffering field writes until submit (see [cf-form](#cf-form)) | |
@@ -272,6 +273,58 @@ array indices, which drift when lists change.
 Contributor-facing internals (FormFieldController, file organization, design
 decisions) live in
 [`packages/ui/docs/forms-internals.md`](../../../packages/ui/docs/forms-internals.md).
+
+---
+
+## cf-field
+
+`cf-field` is a layout/typography wrapper for labeled form fields. It replaces
+the hand-rolled label-above-control stack repeated throughout patterns:
+
+```tsx
+// Before
+<cf-vstack gap="1">
+  <label style={{ fontSize: "12px", color: "#6b7280" }}>Email</label>
+  <cf-input type="email" $value={address} />
+</cf-vstack>
+
+// After
+<cf-field label="Email">
+  <cf-input type="email" $value={address} />
+</cf-field>
+```
+
+Attributes:
+
+- `label` — small muted label rendered above the control
+- `required` — appends a danger-colored asterisk to the label
+- `error` — error text below the control in the danger color (replaces `help`
+  while set)
+- `help` — muted helper text below the control
+
+The default slot takes any control (`cf-input`, `cf-select`, `cf-textarea`,
+…). All colors and sizes come from theme tokens, so fields adapt to the
+ambient `cf-theme`.
+
+```tsx
+<cf-field label="Username" required error={usernameError}>
+  <cf-input $value={username} placeholder="Pick a username" />
+</cf-field>
+
+<cf-field label="Bio" help="Shown on your public profile.">
+  <cf-textarea $value={bio} />
+</cf-field>
+```
+
+Notes:
+
+- `cf-field` is presentation only — it renders whatever `error` string it is
+  given. Validation logic and submit gating belong to
+  [`cf-form`](#cf-form) or the pattern.
+- Shadow DOM prevents a native `for`/`id` association with the slotted
+  control, so clicking the label focuses (and for custom elements, clicks)
+  the first slotted element instead — same approach as `cf-label`. For full
+  assistive-technology support, also set `aria-label` on the control itself.
 
 ---
 

--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -2989,6 +2989,7 @@ interface CFToggleGroupElement extends CFHTMLElement {}
 interface CFRadioElement extends CFHTMLElement {}
 interface CFInputOTPElement extends CFHTMLElement {}
 interface CFLabelElement extends CFHTMLElement {}
+interface CFFieldElement extends CFHTMLElement {}
 
 // Display components
 interface CFTextElement extends CFHTMLElement {}
@@ -4168,6 +4169,13 @@ interface CFLabelAttributes<T> extends CFHTMLAttributes<T> {
   }>;
 }
 
+interface CFFieldAttributes<T> extends CFHTMLAttributes<T> {
+  "label"?: string | CellLike<string>;
+  "required"?: boolean | CellLike<boolean>;
+  "error"?: string | CellLike<string>;
+  "help"?: string | CellLike<string>;
+}
+
 // Display component attributes
 interface CFTextAttributes<T> extends CFHTMLAttributes<T> {
   "variant"?:
@@ -5250,6 +5258,10 @@ declare global {
       "cf-label": CFDOM.DetailedHTMLProps<
         CFLabelAttributes<CFLabelElement>,
         CFLabelElement
+      >;
+      "cf-field": CFDOM.DetailedHTMLProps<
+        CFFieldAttributes<CFFieldElement>,
+        CFFieldElement
       >;
 
       // Display components

--- a/packages/patterns/catalog/catalog.tsx
+++ b/packages/patterns/catalog/catalog.tsx
@@ -40,6 +40,7 @@ interface CatalogInput {
           { id: "button"; label: "Button" },
           { id: "checkbox"; label: "Checkbox" },
           { id: "code-editor"; label: "Code Editor" },
+          { id: "field"; label: "Field" },
           { id: "input"; label: "Input" },
           { id: "picker"; label: "Picker" },
           { id: "textarea"; label: "Textarea" },

--- a/packages/patterns/catalog/stories/cf-field-story.tsx
+++ b/packages/patterns/catalog/stories/cf-field-story.tsx
@@ -1,0 +1,51 @@
+import { NAME, pattern, UI, type VNode } from "commonfabric";
+
+// deno-lint-ignore no-empty-interface
+interface FieldStoryInput {}
+interface FieldStoryOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  controls: VNode;
+}
+
+export default pattern<FieldStoryInput, FieldStoryOutput>(() => {
+  return {
+    [NAME]: "cf-field Story",
+    [UI]: (
+      <div
+        style={{
+          padding: "1rem",
+          display: "flex",
+          flexDirection: "column",
+          gap: "16px",
+          maxWidth: "320px",
+        }}
+      >
+        <cf-field label="Name">
+          <cf-input placeholder="Enter full name" />
+        </cf-field>
+        <cf-field label="Email" required>
+          <cf-input type="email" placeholder="email@example.com" />
+        </cf-field>
+        <cf-field
+          label="Username"
+          error="That username is already taken"
+        >
+          <cf-input placeholder="Pick a username" />
+        </cf-field>
+        <cf-field label="Bio" help="Shown on your public profile.">
+          <cf-textarea placeholder="A few words about you" />
+        </cf-field>
+        <cf-text variant="caption" tone="muted" block>
+          cf-field wraps any control: cf-input, cf-select, cf-textarea, etc.
+          When error is set it replaces the help text.
+        </cf-text>
+      </div>
+    ),
+    controls: (
+      <div style={{ color: "#6b7280", fontSize: "13px", padding: "8px 12px" }}>
+        No interactive controls. Attributes: label, required, error, help.
+      </div>
+    ),
+  };
+});

--- a/packages/patterns/catalog/ui/story-renderer.tsx
+++ b/packages/patterns/catalog/ui/story-renderer.tsx
@@ -26,6 +26,7 @@ import ToolbarStory from "../stories/cf-toolbar-story.tsx";
 import HeadingStory from "../stories/cf-heading-story.tsx";
 import TextStory from "../stories/cf-text-story.tsx";
 import LabelStory from "../stories/cf-label-story.tsx";
+import FieldStory from "../stories/cf-field-story.tsx";
 import ChipStory from "../stories/cf-chip-story.tsx";
 import BadgeStory from "../stories/cf-badge-story.tsx";
 import AvatarStory from "../stories/cf-avatar-story.tsx";
@@ -131,6 +132,8 @@ export default pattern<StoryRendererInput, StoryRendererOutput>(
           return TextStory({});
         case "label":
           return LabelStory({});
+        case "field":
+          return FieldStory({});
         case "chip":
           return ChipStory({});
         case "badge":

--- a/packages/ui/src/v2/components/cf-field/cf-field.test.ts
+++ b/packages/ui/src/v2/components/cf-field/cf-field.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for CFField component
+ */
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { CFField } from "./cf-field.ts";
+
+describe("CFField", () => {
+  it("should be defined", () => {
+    expect(CFField).toBeDefined();
+  });
+
+  it("should have customElement definition", () => {
+    expect(customElements.get("cf-field")).toBe(CFField);
+  });
+
+  it("should create element instance", () => {
+    const element = new CFField();
+    expect(element).toBeInstanceOf(CFField);
+  });
+
+  it("should have default properties", () => {
+    const element = new CFField();
+    expect(element.label).toBe("");
+    expect(element.required).toBe(false);
+    expect(element.error).toBe("");
+    expect(element.help).toBe("");
+  });
+
+  it("should not set attributes in constructor (custom element spec)", () => {
+    // The custom element spec forbids setAttribute during construction.
+    const element = new CFField();
+    expect(element.getAttribute("label")).toBeNull();
+    expect(element.getAttribute("required")).toBeNull();
+  });
+
+  if (typeof document !== "undefined") {
+    it("should be creatable via document.createElement", async () => {
+      const element = document.createElement("cf-field") as CFField;
+      document.body.append(element);
+      await element.updateComplete;
+
+      expect(element).toBeInstanceOf(CFField);
+
+      element.remove();
+    });
+
+    it("should render label text with required indicator", async () => {
+      const element = document.createElement("cf-field") as CFField;
+      element.label = "Email";
+      element.required = true;
+      document.body.append(element);
+      await element.updateComplete;
+
+      const label = element.shadowRoot?.querySelector(".label");
+      expect(label?.textContent).toContain("Email");
+      const indicator = element.shadowRoot?.querySelector(
+        ".required-indicator",
+      );
+      expect(indicator?.textContent).toBe("*");
+
+      element.remove();
+    });
+
+    it("should not render a label element when label is empty", async () => {
+      const element = document.createElement("cf-field") as CFField;
+      document.body.append(element);
+      await element.updateComplete;
+
+      expect(element.shadowRoot?.querySelector(".label")).toBeNull();
+
+      element.remove();
+    });
+
+    it("should render help text when set", async () => {
+      const element = document.createElement("cf-field") as CFField;
+      element.label = "Name";
+      element.help = "Shown on your profile";
+      document.body.append(element);
+      await element.updateComplete;
+
+      const help = element.shadowRoot?.querySelector(".help");
+      expect(help?.textContent).toBe("Shown on your profile");
+      expect(element.shadowRoot?.querySelector(".error")).toBeNull();
+
+      element.remove();
+    });
+
+    it("should render error text instead of help when both are set", async () => {
+      const element = document.createElement("cf-field") as CFField;
+      element.label = "Name";
+      element.help = "Shown on your profile";
+      element.error = "Name is required";
+      document.body.append(element);
+      await element.updateComplete;
+
+      const error = element.shadowRoot?.querySelector(".error");
+      expect(error?.textContent).toBe("Name is required");
+      expect(error?.getAttribute("role")).toBe("alert");
+      expect(element.shadowRoot?.querySelector(".help")).toBeNull();
+
+      element.remove();
+    });
+
+    it("should return the slotted control via getControl()", async () => {
+      const element = document.createElement("cf-field") as CFField;
+      element.label = "Email";
+      const input = document.createElement("input");
+      element.append(input);
+      document.body.append(element);
+      await element.updateComplete;
+
+      expect(element.getControl()).toBe(input);
+
+      element.remove();
+    });
+
+    it("should focus the slotted control when the label is clicked", async () => {
+      const element = document.createElement("cf-field") as CFField;
+      element.label = "Email";
+      const input = document.createElement("input");
+      element.append(input);
+      document.body.append(element);
+      await element.updateComplete;
+
+      const label = element.shadowRoot?.querySelector(
+        ".label",
+      ) as HTMLElement;
+      label.click();
+
+      expect(document.activeElement).toBe(input);
+
+      element.remove();
+    });
+  }
+});

--- a/packages/ui/src/v2/components/cf-field/cf-field.ts
+++ b/packages/ui/src/v2/components/cf-field/cf-field.ts
@@ -1,0 +1,183 @@
+import { css, html, nothing } from "lit";
+import { BaseElement } from "../../core/base-element.ts";
+
+/**
+ * CFField - Labeled form field wrapper.
+ *
+ * Replaces the hand-rolled "muted label above a control" stack used
+ * throughout patterns:
+ *
+ * ```html
+ * <cf-vstack>
+ *   <label style="font-size: 12px; color: #6b7280">Label</label>
+ *   <cf-input $value={field} />
+ * </cf-vstack>
+ * ```
+ *
+ * This is a layout/typography wrapper only — it renders a small muted label
+ * above the slotted control, plus optional help and error text below it. It
+ * is not a form engine: validation wiring belongs to cf-form / the control.
+ *
+ * Accessibility: shadow DOM prevents a programmatic `for`/`id` association
+ * between the internal label and the slotted (light DOM) control, and cf-*
+ * controls are not native labelable elements anyway. As a pragmatic
+ * substitute, clicking the label focuses (and for custom elements, clicks)
+ * the first slotted element — the same approach cf-label takes. For full
+ * AT support, also set an `aria-label` on the control itself.
+ *
+ * @element cf-field
+ *
+ * @attr {string} label - Field label text shown above the control
+ * @attr {boolean} required - Shows a required indicator (asterisk) after the label
+ * @attr {string} error - Error text shown below the control in the danger color (replaces help)
+ * @attr {string} help - Muted helper text shown below the control
+ *
+ * @slot - Default slot for the field control (cf-input, cf-select, cf-textarea, ...)
+ *
+ * @example
+ * <cf-field label="Email" required help="We never share this.">
+ *   <cf-input type="email" placeholder="email@example.com"></cf-input>
+ * </cf-field>
+ */
+
+export class CFField extends BaseElement {
+  static override styles = [
+    BaseElement.baseStyles,
+    css`
+      :host {
+        --cf-field-gap: var(--cf-spacing-1, 0.25rem);
+        --cf-field-font-size: var(--cf-font-caption-size, 0.75rem);
+        --cf-field-line-height: var(--cf-font-caption-line-height, 1rem);
+        --cf-field-label-weight: var(--cf-font-caption-weight, 500);
+        --cf-field-color-label: var(--cf-theme-color-text-muted, #71747a);
+        --cf-field-color-help: var(--cf-theme-color-text-muted, #71747a);
+        --cf-field-color-error: var(--cf-theme-color-error, hsl(0, 100%, 50%));
+
+        display: block;
+        box-sizing: border-box;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: inherit;
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--cf-field-gap);
+      }
+
+      .label {
+        font-size: var(--cf-field-font-size);
+        line-height: var(--cf-field-line-height);
+        font-weight: var(--cf-field-label-weight);
+        letter-spacing: var(--cf-font-caption-letter-spacing, 0);
+        color: var(--cf-field-color-label);
+        cursor: pointer;
+        user-select: none;
+      }
+
+      .required-indicator {
+        color: var(--cf-field-color-error);
+        font-weight: var(--cf-font-weight-semibold, 600);
+        margin-left: 0.125rem;
+      }
+
+      .help,
+      .error {
+        font-size: var(--cf-field-font-size);
+        line-height: var(--cf-field-line-height);
+        margin: 0;
+      }
+
+      .help {
+        color: var(--cf-field-color-help);
+      }
+
+      .error {
+        color: var(--cf-field-color-error);
+      }
+    `,
+  ];
+
+  static override properties = {
+    label: { type: String },
+    required: { type: Boolean },
+    error: { type: String },
+    help: { type: String },
+  };
+
+  declare label: string;
+  declare required: boolean;
+  declare error: string;
+  declare help: string;
+
+  constructor() {
+    super();
+    this.label = "";
+    this.required = false;
+    this.error = "";
+    this.help = "";
+  }
+
+  override render() {
+    return html`
+      <div class="field" part="field">
+        ${this.label
+          ? html`
+            <label class="label" part="label" @click="${this
+              ._handleLabelClick}">
+              ${this.label} ${this.required
+                ? html`
+                  <span class="required-indicator" part="required" aria-hidden="true">*</span>
+                `
+                : nothing}
+            </label>
+          `
+          : nothing}
+        <slot></slot>
+        ${this.error
+          ? html`
+            <div class="error" part="error" role="alert">${this.error}</div>
+          `
+          : this.help
+          ? html`
+            <div class="help" part="help">${this.help}</div>
+          `
+          : nothing}
+      </div>
+    `;
+  }
+
+  /**
+   * Shadow DOM blocks native label/control association, so clicking the
+   * label focuses (and for custom elements, clicks) the slotted control.
+   */
+  private _handleLabelClick = (): void => {
+    const control = this.getControl();
+    if (!control) return;
+
+    if ("focus" in control && typeof control.focus === "function") {
+      control.focus();
+      // Custom elements often delegate focus internally on click
+      if (control.tagName.includes("-")) {
+        control.click();
+      }
+    }
+  };
+
+  /**
+   * Get the first slotted control element
+   */
+  getControl(): HTMLElement | null {
+    const slot = this.shadowRoot?.querySelector(
+      "slot:not([name])",
+    ) as HTMLSlotElement | null;
+    const assigned = slot?.assignedElements({ flatten: true }) ?? [];
+    return (assigned[0] as HTMLElement) ?? null;
+  }
+}
+
+globalThis.customElements.define("cf-field", CFField);

--- a/packages/ui/src/v2/components/cf-field/index.ts
+++ b/packages/ui/src/v2/components/cf-field/index.ts
@@ -1,0 +1,7 @@
+import { CFField } from "./cf-field.ts";
+
+if (!customElements.get("cf-field")) {
+  customElements.define("cf-field", CFField);
+}
+
+export { CFField };

--- a/packages/ui/src/v2/index.ts
+++ b/packages/ui/src/v2/index.ts
@@ -44,6 +44,7 @@ export * from "./components/cf-copy-button/index.ts";
 export * from "./components/cf-draggable/index.ts";
 export * from "./components/cf-drop-zone/index.ts";
 export * from "./components/cf-fab/index.ts";
+export * from "./components/cf-field/index.ts";
 export * from "./components/cf-file-download/index.ts";
 export * from "./components/cf-file-input/index.ts";
 export * from "./components/form/index.ts";


### PR DESCRIPTION
## What

Adds `cf-field`, a v2 UI component that wraps a form control with a small muted label, optional required indicator, error text, and help text:

```tsx
<cf-field label="Email" required help="We never share this.">
  <cf-input type="email" $value={address} />
</cf-field>
```

## Why

The most-duplicated UI shape in `packages/patterns` (~47 occurrences) is a hand-rolled labeled field:

```tsx
<cf-vstack gap="1">
  <label style={{ fontSize: "12px", color: "#6b7280" }}>Label</label>
  <cf-input $value={field} />
</cf-vstack>
```

(e.g. `email.tsx`, `form-demo.tsx`, `self.tsx`.) These hardcode hex colors and px font sizes, bypassing the theme. `cf-field` standardizes the shape on theme tokens (`--cf-spacing-1`, `--cf-font-caption-*`, `--cf-theme-color-text-muted`, `--cf-theme-color-error`) so fields adapt to the ambient `cf-theme`.

## Scope / design notes

- Layout/typography wrapper only — `error` is just text rendering; validation wiring stays with `cf-form` / the pattern.
- When `error` is set it replaces `help` (documented).
- Accessibility: shadow DOM prevents native `for`/`id` association with the slotted light-DOM control, so clicking the label focuses (and for custom elements, clicks) the first slotted element — same approach as `cf-label`. Limitation documented in JSDoc and COMPONENTS.md.
- No attribute work in the constructor (custom element spec; prior bug class).

## Changes

- `packages/ui/src/v2/components/cf-field/` — component, index, unit tests
- `packages/ui/src/v2/index.ts` — export
- `packages/html/src/jsx.d.ts` — `cf-field` intrinsic element typing
- `packages/patterns/catalog/` — catalog entry (`Inputs > Field`) + `stories/cf-field-story.tsx` (basic, required, error, help)
- `docs/common/components/COMPONENTS.md` — index row + `## cf-field` section

## Test plan

- `cd packages/ui && deno task test` — 92 passed (559 steps), 0 failed (includes new `cf-field.test.ts`: defaults, no constructor attributes, label/required rendering, help vs error precedence, `role="alert"`, `getControl()`, label-click focus)
- `deno task cf check packages/patterns/catalog/stories/cf-field-story.tsx --no-run` — exit 0
- `deno task cf check packages/patterns/catalog/catalog.tsx --no-run` — exit 0
- `deno lint` on all touched files — clean; `deno fmt --check` — clean

Migration of the ~47 existing call sites is intentionally left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `cf-field`, a v2 labeled field wrapper that standardizes labels, required indicators, help, and error text around form controls using theme tokens. Addresses Linear CT-1703 by replacing hand-rolled label+control stacks in `packages/patterns` and improving accessibility.

- **New Features**
  - `cf-field` component with `label`, `required`, `help`, and `error` (error overrides help); default slot accepts any control (`cf-input`, `cf-select`, `cf-textarea`, …).
  - Clicking the label focuses the first slotted control; accessibility limitation documented.
  - Uses `cf-theme` tokens for spacing, caption typography, and colors.
  - Added export in `packages/ui/src/v2/index.ts`, intrinsic JSX typing in `packages/html/src/jsx.d.ts`, catalog story, docs in `docs/common/components/COMPONENTS.md`, and unit tests.

<sup>Written for commit 107d11f2a12289b3f0c5f053d31d453fe96c774a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

