### PR TITLE
feat(skills): pattern-critic rules for unidiomatic pattern code (CT-1704)

### DIFF
--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -206,11 +206,12 @@ lines in the checklist, count them under `Warnings` in the summary, and treat
 severity as `minor`. Skip files under `deprecated/`. The tells below are seed
 examples, not a boundary — the underlying principle is: if a shipped `cf-*`
 component or theme token already expresses the intent, hand-rolling it is a
-warning.
+warning. Where a tell here overlaps category 6's "arbitrary one-off visual
+overrides" row, report it once, here, as `[WARN]` — not there as `[FAIL]`.
 
 | Look for | Why it's wrong | Use instead |
 |----------|----------------|-------------|
-| hex color literals inside `style=` strings or style objects (e.g. `#6b7280`) | bypasses theming; breaks dark mode and per-space themes | `--cf-color-*` / `--cf-theme-*` tokens |
+| hex color literals inside `style=` strings or style objects (e.g. `#6b7280`) | bypasses theming; breaks dark mode and per-space themes | `--cf-theme-color-*` semantic tokens (preferred) or `--cf-colors-*` palette tokens — note the plural: no singular `--cf-color-*` family exists |
 | `font-size` / `font-weight` inside `style=` (e.g. `"font-size: 0.75rem; color: ..."`) | hand-rolled typography drifts off the type scale | `<cf-text variant="..." tone="...">` |
 | a handler whose entire body is `cell.set(event.detail?.value ?? ...)`, wired to `oncf-input`/`oncf-change` | re-implements two-way binding as boilerplate | `$value` / `$checked` on the control |
 | `if (event?.key === "Enter")` keydown handlers | re-implements submit by hand | `cf-input` emits `cf-submit` on Enter; multi-field forms use `cf-form` + a submit button |
@@ -220,7 +221,9 @@ warning.
 Do not warn on:
 
 - `var(--cf-...)` references inside `style=` — tokens in inline style are the
-  idiom for one-off layout
+  idiom for one-off layout. Exception: a reference to the undefined singular
+  family with a hex fallback (e.g. `var(--cf-color-gray-500, #6b7280)`) is
+  still a `[WARN]` — the token resolves to nothing, so the hex is what renders
 - genuinely dynamic inline styles computed from data (positions, sizes,
   data-driven colors in charts or drag layers) where no static token applies
 - `$selectedIndex` on `cf-picker` — that is the component's own API, not

--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -199,6 +199,36 @@ state carry over? If not, it is probably `PerSession<>`.
 | handlers still work | existing functionality is not broken |
 | no unintended side effects | changes stay scoped to the intended area |
 
+### 15. Unidiomatic UI Authoring (advisory)
+
+Findings in this category are warnings, not failures: emit them as `[WARN]`
+lines in the checklist, count them under `Warnings` in the summary, and treat
+severity as `minor`. Skip files under `deprecated/`. The tells below are seed
+examples, not a boundary — the underlying principle is: if a shipped `cf-*`
+component or theme token already expresses the intent, hand-rolling it is a
+warning.
+
+| Look for | Why it's wrong | Use instead |
+|----------|----------------|-------------|
+| hex color literals inside `style=` strings or style objects (e.g. `#6b7280`) | bypasses theming; breaks dark mode and per-space themes | `--cf-color-*` / `--cf-theme-*` tokens |
+| `font-size` / `font-weight` inside `style=` (e.g. `"font-size: 0.75rem; color: ..."`) | hand-rolled typography drifts off the type scale | `<cf-text variant="..." tone="...">` |
+| a handler whose entire body is `cell.set(event.detail?.value ?? ...)`, wired to `oncf-input`/`oncf-change` | re-implements two-way binding as boilerplate | `$value` / `$checked` on the control |
+| `if (event?.key === "Enter")` keydown handlers | re-implements submit by hand | `cf-input` emits `cf-submit` on Enter; multi-field forms use `cf-form` + a submit button |
+| `Writable<number>` selection index plus index-adjustment logic when the list mutates | indexes go stale on reorder/insert/remove and force compensation code (see `record.tsx` `trashSubPiece`) | hold the selected item itself in a `Writable<Item \| null>` — the stored link survives reorder and removal |
+| inline `padding` + `border-radius` + `background` pill/badge blobs; hand-rolled label-above-input stacks; hand-rolled centered "no items" divs | re-implements shipped components, each slightly differently | `cf-badge` / `cf-chip`; `cf-field` for labeled controls; `cf-empty-state` for empty lists |
+
+Do not warn on:
+
+- `var(--cf-...)` references inside `style=` — tokens in inline style are the
+  idiom for one-off layout
+- genuinely dynamic inline styles computed from data (positions, sizes,
+  data-driven colors in charts or drag layers) where no static token applies
+- `$selectedIndex` on `cf-picker` — that is the component's own API, not
+  authored selection state
+- a handler doing dependent work beyond the single `.set()` (though if the
+  control is also cell-bound, the self-feedback rule in category 5 applies)
+- `Escape` or arrow-key handlers — no component affordance covers those
+
 ## Output Format
 
 The review should be emitted as a structured checklist with explicit pass/fail

--- a/skills/pattern-critic/SKILL.md
+++ b/skills/pattern-critic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pattern-critic
-description: Critic agent that reviews pattern code for violations of documented rules, gotchas, and anti-patterns. Produces categorized checklist output with [PASS]/[FAIL] for each rule.
+description: Critic agent that reviews pattern code for violations of documented rules, gotchas, and anti-patterns. Produces categorized checklist output with [PASS]/[FAIL]/[WARN] for each rule.
 ---
 
 Start with the shared critique guidance in:
@@ -11,10 +11,11 @@ Read that guide first. It is the canonical reference. Severity definitions
 (`critical`/`major`/`minor`/`info`) live in the guide; use them as defined
 there.
 
-Whatever else happens, honor the output contract: emit the guide's [PASS]/[FAIL]
-categorized checklist and end with the Summary counts and the Priority Fixes
-list. If nothing fails, say so explicitly in two lines. Write the review to the
-output path you were given (in the factory: `reviews/critic-NN.md`).
+Whatever else happens, honor the output contract: emit the guide's
+[PASS]/[FAIL]/[WARN] categorized checklist and end with the Summary counts and
+the Priority Fixes list. If nothing fails, say so explicitly in two lines. Write
+the review to the output path you were given (in the factory:
+`reviews/critic-NN.md`).
 
 Be explicit about SES and determinism issues. Flag direct `Date.now()` or
 `Math.random()`, authored timers, and any call — including `safeDateNow()` /

--- a/skills/pattern-critic/SKILL.md
+++ b/skills/pattern-critic/SKILL.md
@@ -25,6 +25,12 @@ clear intent (non-idempotent use). Also flag bound-control self-feedback: if a
 same cell as a reactive-loop hazard unless it is clearly necessary and
 idempotent.
 
+Also run the guide's advisory UI-idiom checks (category 15): hardcoded hex
+colors and inline typography in `style=`, `.set()`-only input handlers,
+hand-rolled Enter-key submit, index-based selection state, and hand-rolled
+badge/field/empty-state markup. Those emit as `[WARN]` and count toward the
+Warnings summary line, never Failed.
+
 Then use the detailed references already maintained in the repo for:
 
 - `docs/development/debugging/README.md`


### PR DESCRIPTION
Adds six advisory rules (new category **15. Unidiomatic UI Authoring** in `docs/common/ai/pattern-critique-guide.md`, the canonical rules source the pattern-critic skill defers to), plus a pointer in `skills/pattern-critic/SKILL.md` so the checks surface in the [PASS]/[FAIL] checklist as `[WARN]` entries counted under the existing Warnings summary line. Nothing is wired into CI.

The six rules, with audit counts:

1. **Hardcoded hex colors in `style=`** — 328 occurrences in the audit; `#6b7280` alone appears everywhere (~330 lines in `packages/patterns` today). Use `--cf-color-*` / `--cf-theme-*` tokens.
2. **Inline typography blobs** (`font-size`/`font-weight` in `style=`) — 35+ files (46 files match today). Use `<cf-text variant=... tone=...>`.
3. **Trivial setter handlers** (body is only `cell.set(event.detail?.value ?? ...)` from an input event) — ~400 of ~575 audited handlers. Use `$value`/`$checked` two-way binding.
4. **Hand-rolled Enter-key handlers** (`if (event?.key === "Enter")`) — ~15 files. `cf-input` emits `cf-submit` on Enter; multi-field forms use `cf-form` + submit button.
5. **Index-based selection state** (`Writable<number>` plus index-compensation when the list mutates; `record.tsx` `trashSubPiece` carries ~20 lines of it). Hold the selected item as a cell link — it survives reorder/removal.
6. **Hand-rolled pill/badge styling, label stacks, empty-state divs** — 40+ patterns (23 files with `border-radius` inline today). Use `cf-badge`/`cf-chip`; `cf-field` for labeled controls; `cf-empty-state` for empty lists.

Each rule documents allowed exceptions inline (data-driven dynamic styles, `var(--cf-...)` in `style=`, `cf-picker`'s `$selectedIndex` API, handlers doing dependent work, Escape/arrow keys) to avoid false positives. Component pointers verified against `docs/common/components/COMPONENTS.md` on main (`cf-field`, `cf-empty-state` both present) and `cf-input`'s `cf-submit`-on-Enter behavior verified in `packages/ui/src/v2/components/cf-input/cf-input.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds advisory “Unidiomatic UI Authoring” rules to the pattern critic and surfaces them as [WARN] entries in the checklist. Addresses CT-1704 by nudging patterns toward tokens and shipped components.

- New Features
  - Adds category 15 in `docs/common/ai/pattern-critique-guide.md`: minor warnings, counted under Warnings, skip `deprecated/`, and prefer reporting overlaps with category 6 here as `[WARN]` (not `[FAIL]` there).
  - Wires `skills/pattern-critic/SKILL.md` to run these checks; outputs `[WARN]` only (no CI changes).
  - Covers six tells with fixes: hex colors in `style=` → `--cf-theme-color-*` or `--cf-colors-*` tokens (not `--cf-color-*`); inline typography → `<cf-text>`; `.set()`-only input handlers → `$value`/`$checked`; Enter‑key submit handlers → `cf-submit` via `cf-input`/`cf-form`; index‑based selection → store the item link; hand‑rolled pill/field/empty state → `cf-badge`/`cf-chip`/`cf-field`/`cf-empty-state`. Exceptions are documented; dead-token fallbacks like `var(--cf-color-..., #hex)` still warn.

<sup>Written for commit ba097fb6da4f873e3097ac5014053a6ec8a9a37d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

