### PR TITLE
docs(patterns): status tiers for packages/patterns (CT-1701)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,8 @@ already does).
 **Reference:**
 
 - `packages/patterns/index.md` - Catalog of all pattern examples with summaries,
-  data types, and keywords
+  data types, and keywords. Check its "Status tiers" section before imitating
+  any pattern — only `exemplar` entries are style references.
 
 **Important:** Ignore the top level `deprecated-patterns` folder - it is
 defunct.

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -5,6 +5,106 @@ Prefix the URLs with
 
 ---
 
+# Status tiers
+
+This directory mixes exemplars, capability demos, regression fixtures, and
+legacy experiments. They do NOT carry equal authority. Before imitating any
+pattern, check its tier here (tracked in CT-1701):
+
+- **exemplar** — current best practice. Copy idioms from these.
+- **demo** — illustrates a specific capability or integration. The capability
+  usage is real, but the surrounding wiring may be verbose, dated, or
+  intentionally contrived. Imitate the capability call, not the style.
+- **fixture** — regression/test scaffolding. Exists to pin down a bug or
+  exercise the runtime. Never imitate.
+- **legacy** — superseded or judged non-idiomatic. Do not copy. See also
+  `DEPRECATED_IDIOMS.md` for API-level migrations.
+
+Any pattern not listed below (newly added, or missed) should be treated as
+**demo** until triaged.
+
+## exemplar
+
+`catalog/` (type-checked component catalog + `catalog/stories/`), `counter/`,
+`do-list/`, `fair-share/`, `form-demo.tsx`, `notes/`, `reading-list/` (canonical
+list-detail example), `simple-list/`, `todo-list/`.
+
+Caveat: `simple-list/simple-list.tsx` exports `MODULE_METADATA` so it can embed
+in the legacy Record containers — do not copy that export (see the `record/`
+note under legacy).
+
+## demo
+
+Capability and app demos (root files): `annotation.tsx`,
+`annotation-manager.tsx`, `aside.tsx`, `bookmarks.tsx`, `chatbot.tsx`,
+`cheeseboard.tsx`, `compiler.tsx`, `deep-research.tsx`, `dice.tsx` (+
+`dice-handlers.ts`), `group-chat-lobby.tsx`, `group-chat-room.tsx`, `image.tsx`,
+`image-analysis.tsx`, `link-preview.tsx`, `map-demo.tsx`, `mobile-app-demo.tsx`,
+`pattern-index.tsx`, `self.tsx`, `self-improving-classifier.tsx`,
+`shopping-list.tsx`, `store-mapper.tsx`, `text-swapper.tsx`.
+
+App and integration directories: `activity-log/`, `agent/`, `airtable/`,
+`auth/`, `base/`, `battleship/`, `budget-tracker/`, `calendar/`, `card-piles/`,
+`contacts/`, `cozy-poll/`, `examples/`, `experimental/` (explicitly unhardened
+explorations), `github-activity/`, `google/` (the `core/` tree; `google/WIP/` is
+legacy), `habit-tracker/`, `lunch-poll/`, `profile-group-chat/`,
+`project-list/`, `router/`, `scoped-group-chat/`, `scoped-user-directory/`,
+`scrabble/`, `shared-profile-demo/`, `shared-profile-roster/`, `suggestable/`,
+`weekly-calendar/`.
+
+CFC spec demos (intentionally verbose wiring): `cfc/`,
+`cfc-agent-prompt-injection-demo/`, `cfc-authorized-save/`,
+`cfc-authorship-chat/`, `cfc-group-chat-demo/`, `cfc-render-policy-demo/`,
+`cfc-row-label-mailbox/`, `cfc-row-label-records/`, `cfc-spec-gallery/`,
+`cfc-staged-publish/`, `cfc-trusted-component-examples/`,
+`cfc-trusted-surfaces/`.
+
+System patterns: `system/` — live, load-bearing product patterns (home,
+default-app, suggestions). They run the product but are of mixed idiom vintage;
+not a style reference.
+
+## fixture
+
+`gideon-tests/`, `integration/`, `test/`, `scope-bug-computed-vnode-blank/`,
+`scope-bug-ct1597-forward/`, `scope-bug-ct1597-reduce/`, `cell-link.tsx`
+(suggestion tester), `nested-map-ifelse-test.tsx`, `render-test.tsx`,
+`self-reference-test.tsx`, and every `*.test.ts(x)` file anywhere in this
+package.
+
+## legacy
+
+**`record/`, `record.tsx`, `record-backup.tsx`, `record-icon.tsx`, and
+`container-protocol.ts`** — the registry/`MODULE_METADATA` approach is a
+parallel composition system; do not copy it — compose patterns directly as JSX
+tags + wish discovery instead. Whether `record/` is retired outright or kept as
+a demo is an open question, deliberately deferred to the review of the CT-1701
+tiering PR.
+
+**Attribute/module clones feeding that registry** — their `MODULE_METADATA`
+ceremony exists only to register with Record containers and is not a model to
+follow: `address.tsx`, `age-category.tsx`, `birthday.tsx`, `custom-field.tsx`,
+`dietary-restrictions.tsx`, `email.tsx`, `emoji-picker.tsx`, `gender.tsx`,
+`giftprefs.tsx`, `link.tsx`, `location.tsx`, `location-track.tsx`,
+`nickname.tsx`, `occurrence-tracker.tsx`, `phone.tsx`, `photo.tsx`,
+`rating.tsx`, `relationship.tsx`, `social.tsx`, `status.tsx`, `tags.tsx`,
+`text-import.tsx`, `timeline.tsx`, `timing.tsx`, `type-picker.tsx`.
+
+**`deprecated/`** — already explicitly deprecated; ignored by tooling and agents
+(see AGENTS.md).
+
+**`factory-outputs/`** (+ its support files `vehicles.ts`, `vehicles.test.ts`) —
+machine-generated pattern-factory outputs kept with their eval scores; never
+intended as style references.
+
+**`google/WIP/`** — parked, unfinished work that never graduated into
+`google/core/`.
+
+Support files with no tier (not patterns): `deno.json`, `mod.ts`, `index.md`,
+`README.md`, `DEPRECATED_IDIOMS.md`, `PREEXISTING_BUGS.md`,
+`test-ui-helpers.ts`, `tools/` (codegen tooling).
+
+---
+
 ## `annotation.tsx`
 
 A first-class annotation pattern that points at existing cells/pieces, forms

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -69,7 +69,9 @@ not a style reference.
 `scope-bug-ct1597-forward/`, `scope-bug-ct1597-reduce/`, `cell-link.tsx`
 (suggestion tester), `nested-map-ifelse-test.tsx`, `render-test.tsx`,
 `self-reference-test.tsx`, and every `*.test.ts(x)` file anywhere in this
-package.
+package. (The blanket `*.test.ts(x)` rule is about pattern-authoring idioms —
+test _style_ is governed by `docs/common/workflows/pattern-testing.md`, and the
+exemplars' own test files remain good references for it.)
 
 ## legacy
 

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -336,8 +336,9 @@ interface TodoListOutput {
 
 ## `simple-list/simple-list.tsx`
 
-A checklist with indent support. Works standalone or embedded in Record
-containers.
+A checklist with indent support. Works standalone (it also carries a legacy
+`MODULE_METADATA` export for Record containers — see the status-tier caveat
+above; don't copy that part).
 
 **Keywords:** checklist, indentation, composable
 

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -175,6 +175,9 @@ Phase skills consult as needed:
 - Actions/handlers: `docs/common/concepts/action.md`,
   `docs/common/concepts/handler.md`
 - Testing: `docs/common/workflows/pattern-testing.md`
+- Existing patterns: `packages/patterns/index.md` — check the "Status tiers"
+  section before copying idioms from any pattern; only `exemplar` entries are
+  style references.
 - Components: `packages/patterns/catalog/catalog.tsx` — the authoritative,
   type-checked component catalog. Story files in
   `packages/patterns/catalog/stories/` show live usage for each component. Also


### PR DESCRIPTION
## What

Docs-only, zero behavior change. Adds a **Status tiers** section to the top of `packages/patterns/index.md` assigning every root pattern file and subdirectory to one of four tiers, plus a one-sentence pointer in `AGENTS.md` and `skills/pattern-dev/SKILL.md` telling agents to check the tier before imitating a pattern.

## The tier system

- **exemplar** (9) — current best practice; copy idioms: `catalog/`, `counter/`, `do-list/`, `fair-share/`, `form-demo.tsx`, `notes/`, `reading-list/`, `simple-list/`, `todo-list/`. (Caveat noted: simple-list's `MODULE_METADATA` export exists only for legacy Record embedding — don't copy that part.)
- **demo** (~62) — illustrates a capability/integration; wiring may be verbose or dated. All `cfc-*` spec demos, `examples/`, `experimental/`, integrations (`google/core`, `airtable/`, `auth/`), app demos, games, and `system/` (live product patterns of mixed idiom vintage — load-bearing, not a style reference).
- **fixture** (10 named + all `*.test.*`) — regression/test scaffolding, never imitate: `scope-bug-*`, `gideon-tests/`, `test/`, `integration/`, `render-test.tsx`, `nested-map-ifelse-test.tsx`, `self-reference-test.tsx`, `cell-link.tsx`.
- **legacy** (34) — superseded or non-idiomatic; do not copy.

Unlisted/new patterns default to **demo** until triaged.

## The record/ verdict

`record/`, `record.tsx`, `record-backup.tsx`, `record-icon.tsx`, and `container-protocol.ts` are **legacy**, with the agreed note encoded verbatim in the doc: the registry/`MODULE_METADATA` approach is a parallel composition system; do not copy it — compose patterns directly as JSX tags + wish discovery instead.

**Open question (deliberately deferred to this PR's review):** retire `record/` outright vs keep it as a demo of the sub-piece architecture. The doc records the deferral.

The legacy bucket also includes all 25 `MODULE_METADATA` attribute/module clones (grep-verified against `container-protocol` imports) — not just the 9 named in the audit (email, phone, birthday, nickname, gender, rating, status, tags, address) but also age-category, custom-field, dietary-restrictions, emoji-picker, giftprefs, link, location, location-track, occurrence-tracker, photo, relationship, social, text-import, timeline, timing, type-picker, which exist for the same registry ceremony.

## Judgment calls (with reasoning)

- `experimental/` → **demo**: explicitly unhardened explorations, but the folksonomy system has working demos and an integration test (`integration/chat-note.test.ts`); not superseded, so not legacy.
- `factory-outputs/` (+ `vehicles.ts`/`vehicles.test.ts`) → **legacy**: machine-generated pattern-factory outputs kept with eval scores (`score.json`, `spec.md`); never intended as style references. (Conceptually fixture-adjacent, but they're eval artifacts, not regression scaffolding.)
- `google/WIP/` → **legacy**: a single parked importer that never graduated into `google/core/`; effectively abandoned.
- `deprecated/` → legacy; already explicitly deprecated and ignored.

## Needs human call

- `system/` — live product patterns (home, default-app, suggestions); tiered **demo** with a "load-bearing, not a style reference" note. If you want a fifth "product" tier, this is the candidate.
- `base/` — self-describes as the canonical "schelling point" for person data; tiered **demo** because I couldn't verify it reflects current idioms.
- `fair-share/` — promoted to **exemplar** on the strength of its catalog entry (equals() identity, PerUser, integer-cents money); demote if that's too generous.
- `tools/` — left untiered as codegen tooling (not patterns), listed under "support files".
- `packages/patterns/README.md` is stale (titled "Pattern Index", references files that now live in `deprecated/`); out of scope here but worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Status tiers section to `packages/patterns/index.md` that classifies all patterns (exemplar/demo/fixture/legacy) per CT-1701. Marked `record/*`, `container-protocol.ts`, and all `MODULE_METADATA` registry clones as legacy, clarified the fixture-tier blanket rule does not cover test style (see `docs/common/workflows/pattern-testing.md`), updated `AGENTS.md` and `skills/pattern-dev/SKILL.md` to remind readers to check tiers, and aligned the `simple-list/simple-list.tsx` blurb with its legacy `MODULE_METADATA` caveat; docs-only.

- **Migration**
  - Only copy idioms from `exemplar` entries.
  - Treat unlisted patterns as `demo` until triaged.
  - Do not copy the `record/*` registry or any `MODULE_METADATA` patterns; compose with JSX tags + wish discovery.
  - For test style, follow `docs/common/workflows/pattern-testing.md`; exemplar tests remain good references.

<sup>Written for commit 854ec03eaf7423f1279dabe4f985efe320a6ff38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

