### PR TITLE
refactor(patterns): migrate todo-list + reading-list to cf-text/cf-badge/cf-empty-state (CT-1708)

### DIFF
--- a/packages/patterns/reading-list/reading-item-detail.tsx
+++ b/packages/patterns/reading-list/reading-item-detail.tsx
@@ -83,39 +83,27 @@ export default pattern<ReadingItemDetailInput, ReadingItemDetailOutput>(
           </cf-vstack>
 
           <cf-vscroll flex showScrollbar fadeEdges>
-            <cf-vstack gap="3" style="padding: 1rem;">
+            <cf-vstack gap="3" padding="4">
               <cf-card>
                 <cf-vstack gap="2">
-                  <cf-vstack gap="1">
-                    <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-color-gray-500);">
-                      Title
-                    </label>
+                  <cf-field label="Title">
                     <cf-input $value={title} placeholder="Title" />
-                  </cf-vstack>
+                  </cf-field>
 
-                  <cf-vstack gap="1">
-                    <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-color-gray-500);">
-                      Author
-                    </label>
+                  <cf-field label="Author">
                     <cf-input $value={author} placeholder="Author name" />
-                  </cf-vstack>
+                  </cf-field>
 
-                  <cf-vstack gap="1">
-                    <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-color-gray-500);">
-                      URL
-                    </label>
+                  <cf-field label="URL">
                     <cf-input
                       $value={url}
                       placeholder="https://..."
                       type="url"
                     />
-                  </cf-vstack>
+                  </cf-field>
 
                   <cf-hstack gap="2">
-                    <cf-vstack gap="1" style="flex: 1;">
-                      <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-color-gray-500);">
-                        Type
-                      </label>
+                    <cf-field label="Type" style="flex: 1;">
                       <cf-select
                         $value={type}
                         items={[
@@ -125,12 +113,9 @@ export default pattern<ReadingItemDetailInput, ReadingItemDetailOutput>(
                           { label: "🎬 Video", value: "video" },
                         ]}
                       />
-                    </cf-vstack>
+                    </cf-field>
 
-                    <cf-vstack gap="1" style="flex: 1;">
-                      <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-color-gray-500);">
-                        Status
-                      </label>
+                    <cf-field label="Status" style="flex: 1;">
                       <cf-select
                         $value={status}
                         items={[
@@ -140,13 +125,10 @@ export default pattern<ReadingItemDetailInput, ReadingItemDetailOutput>(
                           { label: "Abandoned", value: "abandoned" },
                         ]}
                       />
-                    </cf-vstack>
+                    </cf-field>
                   </cf-hstack>
 
-                  <cf-vstack gap="1">
-                    <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-color-gray-500);">
-                      Rating
-                    </label>
+                  <cf-field label="Rating">
                     <cf-select
                       $value={rating}
                       items={[
@@ -158,21 +140,18 @@ export default pattern<ReadingItemDetailInput, ReadingItemDetailOutput>(
                         { label: "★★★★★ (5)", value: 5 },
                       ]}
                     />
-                  </cf-vstack>
+                  </cf-field>
                 </cf-vstack>
               </cf-card>
 
               <cf-card>
-                <cf-vstack gap="1">
-                  <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-color-gray-500);">
-                    Notes
-                  </label>
+                <cf-field label="Notes">
                   <cf-textarea
                     $value={notes}
                     placeholder="Your thoughts, highlights, quotes..."
                     rows={8}
                   />
-                </cf-vstack>
+                </cf-field>
               </cf-card>
             </cf-vstack>
           </cf-vscroll>

--- a/packages/patterns/reading-list/reading-list.tsx
+++ b/packages/patterns/reading-list/reading-list.tsx
@@ -162,7 +162,8 @@ export default pattern<ReadingListInput, ReadingListOutput>(({ items }) => {
       <cf-screen>
         <cf-vstack slot="header" gap="2">
           <cf-hstack justify="between" align="center">
-            <cf-heading level={4}>Reading List ({totalCount})</cf-heading>
+            <cf-heading level={4}>Reading List</cf-heading>
+            <cf-text tone="muted">{totalCount} items</cf-text>
           </cf-hstack>
 
           <cf-tabs $value={filterStatus}>
@@ -177,39 +178,44 @@ export default pattern<ReadingListInput, ReadingListOutput>(({ items }) => {
         </cf-vstack>
 
         <cf-vscroll flex showScrollbar fadeEdges>
-          <cf-vstack gap="2" style="padding: 1rem;">
+          <cf-vstack gap="2" padding="4">
             {computed(() => {
               return filteredItems.filter((item) => item).map((
                 item: ReadingItemPiece,
               ) => (
                 <cf-card>
                   <cf-hstack gap="2" align="center">
-                    <span style="font-size: 1.5rem;">
+                    <cf-text variant="heading-lg">
                       {getTypeEmoji(item.type)}
-                    </span>
+                    </cf-text>
                     <cf-vstack gap="0" style="flex: 1;">
-                      <span style="font-weight: 500;">
+                      <cf-text block style="font-weight: 500;">
                         {item.title || "(untitled)"}
-                      </span>
+                      </cf-text>
                       {item.author && (
-                        <span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">
+                        <cf-text tone="muted" block>
                           by {item.author}
-                        </span>
+                        </cf-text>
                       )}
                       <cf-hstack gap="2" align="center">
-                        <span style="font-size: 0.75rem; color: var(--cf-color-gray-400);">
+                        <cf-badge size="xs" color="neutral">
                           {item.status}
-                        </span>
+                        </cf-badge>
                         {renderStars(item.rating) && (
-                          <span style="font-size: 0.75rem; color: var(--cf-color-warning-500);">
+                          <cf-text variant="caption" tone="warning">
                             {renderStars(item.rating)}
-                          </span>
+                          </cf-text>
                         )}
                       </cf-hstack>
                       {item.notes && (
-                        <span style="font-size: 0.75rem; color: var(--cf-color-gray-500); font-style: italic; margin-top: 0.25rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100%;">
+                        <cf-text
+                          variant="caption"
+                          tone="muted"
+                          block
+                          style="font-style: italic; margin-top: 0.25rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100%;"
+                        >
                           {item.notes}
-                        </span>
+                        </cf-text>
                       )}
                     </cf-vstack>
                     <cf-button
@@ -231,36 +237,31 @@ export default pattern<ReadingListInput, ReadingListOutput>(({ items }) => {
 
             {hasNoFilteredItems
               ? (
-                <div style="text-align: center; color: var(--cf-color-gray-500); padding: 2rem;">
-                  No items yet. Add something to read!
-                </div>
+                <cf-empty-state message="No items yet. Add something to read!" />
               )
               : null}
           </cf-vstack>
         </cf-vscroll>
 
-        <cf-vstack slot="footer" gap="2" style="padding: 1rem;">
-          <cf-hstack gap="2">
-            <cf-input
-              $value={newTitle}
-              placeholder="Title..."
-              style="flex: 1;"
-            />
-            <cf-input
-              $value={newAuthor}
-              placeholder="Author..."
-              style="width: 150px;"
-            />
-            <cf-select
-              $value={newType}
-              items={[
-                { label: "📄 Article", value: "article" },
-                { label: "📚 Book", value: "book" },
-                { label: "📑 Paper", value: "paper" },
-                { label: "🎬 Video", value: "video" },
-              ]}
-              style="width: 120px;"
-            />
+        <cf-vstack slot="footer" gap="2" padding="4">
+          <cf-hstack gap="2" align="end">
+            <cf-field label="Title" style="flex: 1;">
+              <cf-input $value={newTitle} placeholder="Title..." />
+            </cf-field>
+            <cf-field label="Author" style="width: 150px;">
+              <cf-input $value={newAuthor} placeholder="Author..." />
+            </cf-field>
+            <cf-field label="Type" style="width: 120px;">
+              <cf-select
+                $value={newType}
+                items={[
+                  { label: "📄 Article", value: "article" },
+                  { label: "📚 Book", value: "book" },
+                  { label: "📑 Paper", value: "paper" },
+                  { label: "🎬 Video", value: "video" },
+                ]}
+              />
+            </cf-field>
             <cf-button
               variant="primary"
               onClick={() =>

--- a/packages/patterns/todo-list/todo-list.tsx
+++ b/packages/patterns/todo-list/todo-list.tsx
@@ -80,9 +80,9 @@ const CompletedTodoItem = pattern<
       <cf-card style="opacity: 0.7;">
         <cf-hstack gap="2" align="center">
           <cf-checkbox $checked={item.done} />
-          <span style="text-decoration: line-through; flex: 1; color: var(--cf-color-gray-500);">
+          <cf-text tone="muted" style="text-decoration: line-through; flex: 1;">
             {item.title}
-          </span>
+          </cf-text>
         </cf-hstack>
       </cf-card>
     ),
@@ -136,29 +136,27 @@ export default pattern<TodoListInput, TodoListOutput>(({ items }) => {
         <cf-vstack slot="header" gap="1">
           <cf-hstack justify="between" align="center">
             <cf-heading level={4}>Todo List</cf-heading>
-            <span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">
+            <cf-text tone="muted">
               {computed(() => activeItems.length)} items
-            </span>
+            </cf-text>
           </cf-hstack>
         </cf-vstack>
 
         <cf-vscroll flex showScrollbar fadeEdges>
-          <cf-vstack gap="2" style="padding: 1rem;">
+          <cf-vstack gap="2" padding="4">
             {itemCards}
 
             {hasNoItems
-              ? (
-                <div style="text-align: center; color: var(--cf-color-gray-500); padding: 2rem;">
-                  No items yet. Add one below!
-                </div>
-              )
+              ? <cf-empty-state message="No items yet. Add one below!" />
               : null}
 
             {ifElse(
               hasCompleted,
               <details style="margin-top: 1rem;">
-                <summary style="cursor: pointer; font-size: 0.875rem; color: var(--cf-color-gray-500); padding: 0.5rem 0;">
-                  Completed ({computed(() => completedItems.length)})
+                <summary style="cursor: pointer; padding: 0.5rem 0;">
+                  <cf-text tone="muted">
+                    Completed ({computed(() => completedItems.length)})
+                  </cf-text>
                 </summary>
                 <cf-vstack gap="2" style="padding-top: 0.5rem;">
                   {completedCards}
@@ -167,7 +165,6 @@ export default pattern<TodoListInput, TodoListOutput>(({ items }) => {
                       color="neutral"
                       variant="ghost"
                       size="sm"
-                      style="font-size: 0.8rem; color: var(--cf-color-gray-500);"
                       onClick={() => archiveCompleted.send()}
                     >
                       Archive all
@@ -180,7 +177,7 @@ export default pattern<TodoListInput, TodoListOutput>(({ items }) => {
           </cf-vstack>
         </cf-vscroll>
 
-        <cf-hstack slot="footer" gap="2" style="padding: 1rem;">
+        <cf-hstack slot="footer" gap="2" padding="4">
           <cf-message-input
             placeholder="Add a todo item..."
             style="flex: 1;"


### PR DESCRIPTION
Styling/markup-only migration of the two exemplar list patterns to the new typography/state components (cf-field + cf-empty-state landed in #4032/#4031), ahead of Phase 3 (EditableList) so that later diff stays purely structural. Behavior parity preserved: no changes to list logic, handlers, schemas, or `$value`/`$checked` bindings; `[UI]` stays a static VNode and `ifElse`/ternaries stay children of static wrappers.

## Diff highlights

**todo-list.tsx**
- "No items yet" div → `<cf-empty-state message="No items yet. Add one below!" />`
- Header count span + completed-item line-through span + `<details>` summary text → `<cf-text tone="muted">`
- "Archive all" button: dropped redundant inline font/color override (ghost/neutral/sm already covers it)
- `style="padding: 1rem"` on list/footer stacks → `padding="4"` prop

**reading-list.tsx**
- Empty-state div → `<cf-empty-state>`
- Header `Reading List ({N})` → `<cf-heading>Reading List</cf-heading>` + `<cf-text tone="muted">{N} items</cf-text>` (mirrors todo-list header)
- Item card: emoji span → `cf-text variant="heading-lg"`; title span → `cf-text block`; author → `cf-text tone="muted"`; hand-rolled status text → `<cf-badge size="xs" color="neutral">`; stars → `cf-text variant="caption" tone="warning"`; notes → `cf-text variant="caption" tone="muted" block`
- Add form: Title/Author inputs + Type select wrapped in `<cf-field label=...>` (widths/flex moved to the field wrappers, `align="end"` keeps the Add button on the control row)
- Inline `padding: 1rem` → `padding="4"`

**reading-item-detail.tsx**
- All 7 hand-rolled `<label style="font-size: 0.75rem; ... var(--cf-color-gray-500)">` + control stacks → `<cf-field label=...>`
- Inline `padding: 1rem` → `padding="4"`

Note: the old code referenced `--cf-color-gray-400/500` and `--cf-color-warning-500`, which **don't exist** in `packages/ui/src/v2/styles/variables.ts` (real tokens are `--cf-colors-*` / `--cf-theme-*`) — i.e. those spans were silently falling back to inherited colors. All color now comes from component theme tokens.

## Acceptance proof

```
$ grep -rnE '#[0-9a-fA-F]{3,8}\b|font-size' packages/patterns/todo-list/todo-list.tsx \
    packages/patterns/reading-list/reading-list.tsx packages/patterns/reading-list/reading-item-detail.tsx
(no matches, exit 1)

$ grep -rn "cf-color-" packages/patterns/todo-list/ packages/patterns/reading-list/
(no matches, exit 1)
```

## Verification

- `deno task cf check <file> --no-run` → exit 0 on all three files
- `deno task cf test packages/patterns/todo-list/todo-list.test.tsx` → 21 passed, 0 failed
- `deno task cf test packages/patterns/reading-list/reading-list.test.tsx` → 12 passed, 0 failed, 21 skipped (pre-existing `skip: true` flags)
- `deno task cf test packages/patterns/reading-list/reading-item-detail.test.tsx` → 16 passed, 0 failed
- `deno lint` + `deno fmt --check` on the three files → clean
- Screenshots skipped: no lightweight render path without standing up dev servers

**Net LOC: −23** (66 insertions, 89 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the todo-list and reading-list patterns to `cf-text`, `cf-badge`, `cf-empty-state`, and `cf-field` for consistent typography and states, aligning with CT-1708. UI-only refactor with no behavior changes and prepares for EditableList.

- **Refactors**
  - Replaced empty-state divs with `cf-empty-state`.
  - Consolidated text and metadata to `cf-text`; used `cf-badge` for status.
  - Wrapped form controls in `cf-field` (reading-item-detail and add form).
  - Switched inline padding to `padding="4"` on stack components.
  - Removed `--cf-color-*` references; colors now come from component theme tokens.
  - Kept list logic, schemas, and `$value`/`$checked` bindings unchanged.

<sup>Written for commit 373ab31805c889e5812e132a8af3d3c39f10cf81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

