### PR TITLE
refactor(patterns): migrate form-demo + email to cf-field/theme tokens (CT-1705)

### DIFF
--- a/packages/patterns/email.tsx
+++ b/packages/patterns/email.tsx
@@ -55,9 +55,8 @@ export const EmailModule = pattern<EmailModuleInput, EmailModuleInput>(
         () => `${MODULE_METADATA.icon} ${label}: ${displayText}`,
       ),
       [UI]: (
-        <cf-vstack style={{ gap: "12px" }}>
-          <cf-vstack style={{ gap: "4px" }}>
-            <label style={{ fontSize: "12px", color: "#6b7280" }}>Label</label>
+        <cf-vstack gap="3">
+          <cf-field label="Label">
             <cf-autocomplete
               $value={label}
               items={labelItems}
@@ -65,15 +64,14 @@ export const EmailModule = pattern<EmailModuleInput, EmailModuleInput>(
               allowCustom
               style={{ width: "100%" }}
             />
-          </cf-vstack>
-          <cf-vstack style={{ gap: "4px" }}>
-            <label style={{ fontSize: "12px", color: "#6b7280" }}>Email</label>
+          </cf-field>
+          <cf-field label="Email">
             <cf-input
               type="email"
               $value={address}
               placeholder="email@example.com"
             />
-          </cf-vstack>
+          </cf-field>
         </cf-vstack>
       ),
       label,

--- a/packages/patterns/form-demo.tsx
+++ b/packages/patterns/form-demo.tsx
@@ -107,23 +107,17 @@ export const EditPerson = pattern<
         >
           <cf-vstack gap="3">
             {/* Name field */}
-            <cf-vstack gap="1">
-              <label style="font-weight: 500; font-size: 0.875rem;">
-                Name *
-              </label>
+            <cf-field label="Name" required>
               <cf-input
                 name="name"
                 $value={formData.key("name")}
                 placeholder="Enter full name"
                 required
               />
-            </cf-vstack>
+            </cf-field>
 
             {/* Email field */}
-            <cf-vstack gap="1">
-              <label style="font-weight: 500; font-size: 0.875rem;">
-                Email *
-              </label>
+            <cf-field label="Email" required>
               <cf-input
                 name="email"
                 $value={formData.key("email")}
@@ -131,13 +125,10 @@ export const EditPerson = pattern<
                 placeholder="email@example.com"
                 required
               />
-            </cf-vstack>
+            </cf-field>
 
             {/* Role field */}
-            <cf-vstack gap="1">
-              <label style="font-weight: 500; font-size: 0.875rem;">
-                Role
-              </label>
+            <cf-field label="Role">
               <cf-select
                 name="role"
                 $value={formData.key("role")}
@@ -146,7 +137,7 @@ export const EditPerson = pattern<
                   { label: "Admin", value: "admin" },
                 ]}
               />
-            </cf-vstack>
+            </cf-field>
 
             {/* Form actions */}
             <cf-hstack gap="2" style="margin-top: 1rem;">
@@ -237,16 +228,16 @@ export default pattern<FormDemoInput, FormDemoOutput>(({ people }) => {
         <cf-vstack slot="header" gap="2">
           <cf-hstack justify="between" align="center">
             <cf-heading level={4}>People Directory</cf-heading>
-            <span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">
+            <cf-text tone="tertiary">
               {peopleCount}{" "}
               {computed(() => people.get().length === 1 ? "person" : "people")}
-            </span>
+            </cf-text>
           </cf-hstack>
         </cf-vstack>
 
         {/* Main content - list of people */}
         <cf-vscroll flex showScrollbar fadeEdges>
-          <cf-vstack gap="2" style="padding: 1rem;">
+          <cf-vstack gap="2" padding="4">
             {people.map((person) => (
               <cf-card
                 style="cursor: pointer;"
@@ -259,29 +250,20 @@ export default pattern<FormDemoInput, FormDemoOutput>(({ people }) => {
                 })}
               >
                 <cf-hstack gap="2" align="center">
-                  <cf-vstack gap="1" style="flex: 1;">
-                    <span style="font-weight: 600; font-size: 1rem;">
+                  <cf-vstack gap="1" style="flex: 1;" align="start">
+                    <cf-text variant="heading-sm">
                       {person.name || "(unnamed)"}
-                    </span>
-                    <span style="font-size: 0.875rem; color: var(--cf-color-gray-600);">
+                    </cf-text>
+                    <cf-text tone="muted">
                       {person.email}
-                    </span>
-                    <span
-                      style={{
-                        fontSize: "0.75rem",
-                        padding: "2px 8px",
-                        borderRadius: "4px",
-                        background: person.role === "admin"
-                          ? "var(--cf-color-blue-100)"
-                          : "var(--cf-color-gray-100)",
-                        color: person.role === "admin"
-                          ? "var(--cf-color-blue-700)"
-                          : "var(--cf-color-gray-700)",
-                        width: "fit-content",
-                      }}
+                    </cf-text>
+                    <cf-badge
+                      variant="outline"
+                      color={person.role === "admin" ? "primary" : "neutral"}
+                      size="sm"
                     >
                       {person.role}
-                    </span>
+                    </cf-badge>
                   </cf-vstack>
                   <cf-button
                     variant="ghost"
@@ -295,16 +277,14 @@ export default pattern<FormDemoInput, FormDemoOutput>(({ people }) => {
 
             {ifElse(
               computed(() => people.get().length === 0),
-              <div style="text-align: center; color: var(--cf-color-gray-500); padding: 2rem;">
-                No people yet. Click "Add Person" to create one!
-              </div>,
+              <cf-empty-state message='No people yet. Click "Add Person" to create one!' />,
               null,
             )}
           </cf-vstack>
         </cf-vscroll>
 
         {/* Footer - Add button */}
-        <cf-hstack slot="footer" gap="2" style="padding: 1rem;">
+        <cf-hstack slot="footer" gap="2" padding="4">
           <cf-button
             variant="primary"
             onClick={startCreate}


### PR DESCRIPTION
## Summary

First migration PR proving out the just-merged `cf-field` (#4032) and `cf-empty-state` (#4031) components. Styling/structure migration only — schemas, handlers, exports, `$value` bindings, and `MODULE_METADATA` are untouched.

## Before / after highlights

**form-demo.tsx**
- 3x hand-rolled `<cf-vstack gap="1"><label style="font-weight: 500; font-size: 0.875rem;">…</label><cf-input/select …/></cf-vstack>` → `<cf-field label="…" [required]>` wrapping the control. The `*` that was baked into the label text ("Name *") now comes from cf-field's `required` attribute; `required` stays on the inputs so cf-form's HTML5 validation gating is unchanged.
- Header count `<span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">` → `<cf-text tone="tertiary">` (tertiary token = the same #94979e ramp value).
- Person card: name span (`font-weight: 600; font-size: 1rem`) → `<cf-text variant="heading-sm">`; email span (gray-600) → `<cf-text tone="muted">`; the hand-built role pill (fontSize/padding/borderRadius + blue-100/gray-100 background ternary) → `<cf-badge variant="outline" color={admin ? "primary" : "neutral"}>`.
- Empty-state `<div style="text-align: center; color: var(--cf-color-gray-500); padding: 2rem;">` → `<cf-empty-state message="…" />` (same `ifElse` guard).
- `style="padding: 1rem;"` on the list vstack and footer hstack → `padding="4"` props (spacing-4 = 1rem).

**email.tsx**
- Both `<label style={{ fontSize: "12px", color: "#6b7280" }}>` sandwiches → `<cf-field label="…">` (this was the exact idiom cf-field's docstring uses as its "before" example).
- `style={{ gap: "12px" }}` → `gap="3"` (spacing-3 = 0.75rem); inner `gap: 4px` stacks subsumed by cf-field's own label gap.
- `MODULE_METADATA` / registry integration untouched.

## Acceptance proof

```
$ grep -nE '#[0-9a-fA-F]{3,8}\b' packages/patterns/form-demo.tsx packages/patterns/email.tsx
(no matches)
$ grep -nE 'font-size|fontSize|font-weight|fontWeight' packages/patterns/form-demo.tsx packages/patterns/email.tsx
(no matches)
```

## Verification

- `deno task cf check packages/patterns/form-demo.tsx --no-run` — exit 0
- `deno task cf check packages/patterns/email.tsx --no-run` — exit 0
- `INTEGRATION_TEST_FLAGS='--filter=Compile' deno task integration patterns` ("Compile all patterns" suite, the only tests touching these files): `ok | 1 passed (59 steps) | 0 failed`, including `Executes: email.tsx ... ok (147ms)` and `Executes: form-demo.tsx ... ok (224ms)`
- `deno lint` + `deno fmt --check` on both files — clean

Net LOC: **-22** (26 insertions, 48 deletions).

## Notes / follow-ups

- **cf-form → cf-field `error` wiring skipped** (task item 6): `cf-form-invalid`'s detail carries DOM `element` references, which don't cross the pattern sandbox cleanly, and surfacing per-field strings would need new per-field error state + a handler mapping elements→fields. HTML5 constraint validation already gates submit with native messages, so behavior is unchanged. Left as follow-up.
- **Screenshots skipped** — no lightweight path (no catalog story for form-demo/email; standing up dev servers was out of scope for this PR).
- Two deliberate minor visual deltas from token mapping: card name renders at heading-sm (1.125rem/600 vs the old ad-hoc 1rem/600 — no 1rem/600 cf-text variant exists), and the role pill is now a cf-badge outline rather than a tinted-background pill. Both are the idiomatic component equivalents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate `form-demo` and `email` patterns to `cf-field` and theme tokens, removing inline styles and hardcoded colors. Keeps behavior and APIs unchanged, aligning with CT-1705.

- **Refactors**
  - Replaced label+control wrappers with `cf-field` (uses `required`; HTML5 validation unchanged).
  - Moved ad-hoc text styles to `cf-text` tones/variants; header count uses `cf-text tone="tertiary"`.
  - Role pill → `cf-badge` outline; empty state div → `cf-empty-state`.
  - Converted inline padding/gap to spacing props (e.g., `gap="3"`, `padding="4"`).
  - No changes to schemas, handlers, exports, `$value`, or `MODULE_METADATA`.
  - Removed all hex colors and inline font-size/weight; net LOC −22.

<sup>Written for commit b4a3579810ca3efa7b5aa35ac00ebadcae8dad03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

