### PR TITLE
docs(patterns): replace stale README catalog with orientation signpost

### DIFF
--- a/packages/patterns/README.md
+++ b/packages/patterns/README.md
@@ -1,152 +1,27 @@
-# Pattern Index
+# Patterns
 
-This index catalogs all patterns in this directory, organized alphabetically.
-Each entry includes a brief summary, the data types used, and relevant
-keywords/features.
+End-user programs ("patterns") for the Common Fabric runtime, plus the component
+catalog and the system patterns that ship with the product.
 
-## Patterns
+This README is intentionally just a signpost. The maintained references are:
 
-- array-in-cell-ast-nocomponents.tsx: Simple list with add functionality using
-  array in cell
-  - **Data types**: array of objects (text strings)
-  - **Keywords**: handler, map, array operations, common-send-message
+- **[index.md](./index.md)** — the canonical pattern catalog: every pattern with
+  a summary, data types, and keywords. Start with its **Status tiers** section,
+  which says whether a given pattern is an _exemplar_ (imitate it), a _demo_
+  (illustrates one capability; wiring may be intentionally verbose), a _fixture_
+  (regression scaffolding; never imitate), or _legacy_ (do not copy).
+- **[catalog/catalog.tsx](./catalog/catalog.tsx)** — the authoritative,
+  type-checked UI component catalog; live usage in
+  [catalog/stories/](./catalog/stories/). Narrative component docs live in
+  [docs/common/components/COMPONENTS.md](../../docs/common/components/COMPONENTS.md).
+- **[DEPRECATED_IDIOMS.md](./DEPRECATED_IDIOMS.md)** — API-level migrations (old
+  idiom → current idiom).
+- **[skills/pattern-dev](../../skills/pattern-dev/SKILL.md)** — the workflow
+  guide for authoring patterns; broader pattern documentation is indexed from
+  [docs/common/README.md](../../docs/common/README.md).
 
-- array-in-cell-with-remove-ast-nocomponents.tsx: List with add and remove
-  operations on array
-  - **Data types**: array of objects (text strings)
-  - **Keywords**: handler, map, array operations, get/set, cf-button
+The `deprecated/` subdirectory is defunct — ignore it entirely.
 
-- array-in-cell-with-remove-editable.tsx: Editable list with add, remove, and
-  update operations
-  - **Data types**: array of objects (text strings)
-  - **Keywords**: handler, map, array operations, cf-input, cf-button,
-    oncf-change
-
-- aside.tsx: Full-screen layout demonstration with header, footer, and sidebars
-  - **Data types**: none (layout only)
-  - **Keywords**: cf-screen, cf-autolayout, slots (left/right/header/footer),
-    tabNames
-
-- system/backlinks-index.tsx: Backlinks computation system for bi-directional
-  references between pieces
-  - **Data types**: array of objects (MentionableCharm with mentioned/backlinks
-    arrays)
-  - **Keywords**: lift, array operations, backlinks, mentionable pattern,
-    OpaqueRef
-
-- piece-ref-in-cell.tsx: Storing and navigating to piece references within cells
-  - **Data types**: object containing piece reference
-  - **Keywords**: lift, cell, navigateTo, ifElse, derive, isInitialized flag
-
-- pieces-ref-in-cell.tsx: Managing an array of piece references with navigation
-  - **Data types**: array of piece objects
-  - **Keywords**: lift, cell, navigateTo, array operations, isInitialized flag,
-    map
-
-- chatbot-list-view.tsx: Chat application with sidebar list of chat sessions
-  - **Data types**: array of objects (CharmEntry with ID and piece), selected
-    piece object
-  - **Keywords**: lift, handler, navigateTo, cf-select, cf-render,
-    cf-autolayout, wish, [ID]
-
-- cfc-agent-prompt-injection-demo/main.tsx: Side-by-side chatbot demo showing
-  raw prompt-influence taint versus a schema-limited subagent sanitization path
-  - **Data types**: array of LLM messages, confidential string, decision log
-    entries
-  - **Keywords**: llmDialog, patternTool, prompt-injection, confidentiality,
-    cf-chat, tool-calling
-
-- chatbot.tsx: Full-featured chatbot with LLM integration and attachments
-  - **Data types**: array of LLM messages, array of attachments (objects), array
-    of pieces
-  - **Keywords**: llmDialog, handler, derive, wish, cf-chat, cf-prompt-input,
-    cf-select, Stream, generateObject
-
-- cheeseboard.tsx: Fetch and display pizza schedule from web
-  - **Data types**: array of tuples (date/pizza strings), web response object
-  - **Keywords**: fetchData, lift, string parsing, map
-
-- system/common-fabric.tsx: Reusable tool patterns and handlers for LLM
-  integration
-  - **Data types**: array of list items (objects), API response objects
-  - **Keywords**: handler, pattern as tool, fetchData, derive, ifElse
-
-- counter.tsx: Basic counter with increment/decrement operations
-  - **Data types**: number
-  - **Keywords**: handler, str template, derive (via pure function), cf-button,
-    Stream
-
-- examples/cf-checkbox-cell.tsx: Checkbox component with bidirectional binding
-  - **Data types**: boolean
-  - **Keywords**: cf-checkbox, $checked (bidirectional binding), handler
-    (optional), ifElse, oncf-change
-
-- cf-checkbox-handler.tsx: Checkbox with explicit handler for state changes
-  - **Data types**: boolean
-  - **Keywords**: cf-checkbox, handler, checked property, oncf-change, ifElse
-
-- examples/cf-render.tsx: Rendering sub-patterns with cf-render component
-  - **Data types**: number (counter value)
-  - **Keywords**: cf-render, $cell, nested patterns, pattern composition,
-    handler
-
-- cf-select.tsx: Dropdown select component with various value types
-  - **Data types**: string, number
-  - **Keywords**: cf-select, $value (bidirectional binding), items (label/value
-    objects)
-
-- examples/cf-tags.tsx: Tags input component
-  - **Data types**: array of strings
-  - **Keywords**: cf-tags, handler, oncf-change, array of strings
-
-- system/default-app.tsx: Default application with piece management and
-  navigation
-  - **Data types**: array of pieces (MentionableCharm objects)
-  - **Keywords**: wish, derive, navigateTo, handler, cf-table, cf-button,
-    multiple pattern instantiation
-
-- dice.tsx: Dice roller with random number generation
-  - **Data types**: number
-  - **Keywords**: handler, random values, cf-button, Stream
-
-- fetch-data.tsx: GitHub repository data fetcher
-  - **Data types**: complex API response object, string (URL)
-  - **Keywords**: fetchData, lift, derive, cf-input, $value, string parsing
-
-- instantiate-pattern.tsx: Factory pattern for creating counter instances
-  - **Data types**: number, piece references
-  - **Keywords**: navigateTo, handler, pattern instantiation, factory pattern
-
-- linkedlist-in-cell.tsx: Linked list data structure implementation
-  - **Data types**: linked list object (recursive structure with value/next)
-  - **Keywords**: cell, derive, handler, custom data structure, recursive
-    structure
-
-- system/link-tool.tsx: Tool for creating data links between piece cells
-  - **Data types**: string (source path), string (target path)
-  - **Keywords**: link built-in, handler, piece navigation, cell linking, path
-    parsing
-
-- list-operations.tsx: Advanced array operations with ID-based tracking
-  - **Data types**: array of objects with [ID] property
-  - **Keywords**: [ID], derive, lift, filter, map, concat, reduce, handler,
-    array operations, get/set
-
-- examples/llm.tsx: Simple LLM question/answer interface
-  - **Data types**: string (question), LLM response content, array of messages
-  - **Keywords**: llm, cell, derive, handler, cf-message-input, oncf-send
-
-- nested-counter.tsx: Counter with nested sub-counter instances
-  - **Data types**: number
-  - **Keywords**: nested patterns, pattern composition, passing cells, str
-    template, handler
-
-- notes/note.tsx: Note-taking app with backlinks and mentions
-  - **Data types**: string (title/content), array of pieces
-    (mentioned/backlinks)
-  - **Keywords**: wish, handler, navigateTo, cf-code-editor, $mentionable,
-    $mentioned, backlinks, cell
-
-- output_schema.tsx: Demonstrates explicit output schema typing
-  - **Data types**: number, VNode
-  - **Keywords**: handler, output schema, type safety, cf-button
+A previous version of this file was a hand-maintained duplicate of the catalog;
+it drifted badly. Add new catalog entries to `index.md` only (and give them a
+status tier).


### PR DESCRIPTION
## Summary
- packages/patterns/README.md was a hand-maintained duplicate of index.md that drifted badly: it catalogued root-level files that no longer exist (chatbot-list-view.tsx, linkedlist-in-cell.tsx, list-operations.tsx, output_schema.tsx, piece-ref-in-cell.tsx, array-in-cell-*.tsx — most moved to deprecated/ or were deleted).
- Rewritten as a short orientation signpost: points to index.md (the canonical catalog, including the Status tiers section from #4034), catalog/catalog.tsx + COMPONENTS.md, DEPRECATED_IDIOMS.md, and the pattern-dev skill. Ends with an explicit "add entries to index.md only" instruction so the duplication doesn't regrow.
- Kept (rather than deleted) because GitHub renders README.md in the directory view — a signpost there is worth having. Verified nothing references patterns/README in docs/, skills/, AGENTS.md, or packages/.

Pairs with #4034 (CT-1701 tiering); the Status tiers mention assumes that PR lands, but nothing here breaks if this merges first.

## Test plan
- Docs-only; `deno fmt` clean; link targets verified to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the stale `packages/patterns/README.md` catalog with a short signpost that links to `index.md` (canonical catalog and Status tiers), `catalog/catalog.tsx` + component docs, `DEPRECATED_IDIOMS.md`, and `skills/pattern-dev` to eliminate duplication and drift. Supports CT-1701 by directing readers to `index.md`’s Status tiers.

<sup>Written for commit 55848d05a0a9bf7ed68944e7ebf066ee8f2af772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

