### PR TITLE
fix(cfc+patterns): profile element writes — stamp reconciliation, same-tx link sources, single authorized writer (CT-1698)

### DIFF
--- a/packages/patterns/system/profile-home.test.tsx
+++ b/packages/patterns/system/profile-home.test.tsx
@@ -56,19 +56,15 @@ export default pattern(() => {
       { assertion: assert_name_set },
       { action: action_clear_name },
       { assertion: assert_name_cleared },
-      // Skipped under CFC enforcement: addElement instantiates a fresh
-      // ProfileCatalogCard inside the handler and links it into the
-      // writeAuthorizedBy-protected `elements` list in the same transaction.
-      // The new instance's doc has no stored CFC metadata and no pending
-      // schema input yet, so the fail-closed link-write rule rejects the
-      // commit ("missing link source metadata ... at /elements/0").
-      // Re-enable once the runtime counts a same-transaction pattern
-      // instantiation as pending source metadata (or the pattern
-      // pre-materializes elements).
-      { action: action_add_catalog_element, skip: true },
-      { assertion: assert_added_element, skip: true },
-      { action: action_remove_catalog_element, skip: true },
-      { assertion: assert_removed_element, skip: true },
+      // Add/remove exercise the full owner-protected element write stack:
+      // the same-transaction card instantiation linked into the
+      // writeAuthorizedBy-protected list (prepare's setup-schema / child-doc
+      // link-label hatches) and the single authorized `mutateElements`
+      // writer behind every mutation surface (CT-1698).
+      { action: action_add_catalog_element },
+      { assertion: assert_added_element },
+      { action: action_remove_catalog_element },
+      { assertion: assert_removed_element },
     ],
   };
 });

--- a/packages/patterns/system/profile-home.test.tsx
+++ b/packages/patterns/system/profile-home.test.tsx
@@ -20,6 +20,14 @@ export default pattern(() => {
     }
   });
 
+  // A remove event without a cell must be a no-op — the consolidated
+  // mutateElements writer dispatches on the instance's bound mode, so a
+  // malformed remove must never fall through to an add (cf-review on
+  // CT-1698).
+  const action_remove_with_empty_event = action(() => {
+    profile.removeElement.send({});
+  });
+
   const action_clear_name = action(() => {
     profile.setName.send({ name: "" });
   });
@@ -64,6 +72,8 @@ export default pattern(() => {
       { action: action_add_catalog_element },
       { assertion: assert_added_element },
       { action: action_remove_catalog_element },
+      { assertion: assert_removed_element },
+      { action: action_remove_with_empty_event },
       { assertion: assert_removed_element },
     ],
   };

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -57,6 +57,22 @@ export type RemoveProfileElementEvent = {
   cell: any;
 };
 
+/**
+ * The single event shape for every element mutation (see `mutateElements`):
+ * a `cell` (from the event or the instance's bound state) removes that
+ * element; a `patternUrl` (or a bound link form) adds a link reference card;
+ * otherwise a catalog card is added. `AddProfileElementEvent` /
+ * `RemoveProfileElementEvent` are subsets kept for the exported stream types.
+ */
+export type MutateProfileElementsEvent = {
+  catalogId?: string;
+  patternUrl?: string;
+  title?: string;
+  tag?: string;
+  userTags?: readonly string[];
+  cell?: any;
+};
+
 export type SetProfileNameEvent = {
   name?: string;
   detail?: { message?: string };
@@ -76,11 +92,14 @@ export type ProfileHomeOutput = {
   [UI]: unknown;
   name: OwnerProtectedProfileWrite<string, typeof setName>;
   avatar: OwnerProtectedProfileWrite<string, typeof setAvatar>;
-  elements: OwnerProtectedProfileWrite<ProfileElement[], typeof addElement>;
+  elements: OwnerProtectedProfileWrite<ProfileElement[], typeof mutateElements>;
   setName: Stream<SetProfileNameEvent>;
   setAvatar: Stream<SetProfileAvatarEvent>;
-  addElement: Stream<AddProfileElementEvent>;
-  removeElement: Stream<RemoveProfileElementEvent>;
+  // Both element streams accept the full mutation event (the union shape of
+  // the one authorized writer); `AddProfileElementEvent` /
+  // `RemoveProfileElementEvent` remain the documented per-stream subsets.
+  addElement: Stream<MutateProfileElementsEvent>;
+  removeElement: Stream<MutateProfileElementsEvent>;
   initialNameApplied: string;
 };
 
@@ -128,35 +147,72 @@ const appendElement = (
   elements.push(element);
 };
 
-const addElement = handler<
-  AddProfileElementEvent,
-  { elements: Writable<ProfileElement[]> }
->((event, { elements }) => {
-  const source = event.patternUrl ? "url" : "catalog";
-  const title = event.title ??
-    (source === "url" ? event.patternUrl ?? "Profile pattern" : "Profile card");
-  const tag = event.tag ?? event.catalogId ?? event.patternUrl ?? "profile";
-  const cell = source === "url"
-    ? (UrlPatternReference({ title, url: event.patternUrl ?? "" }) as any).for(
+// THE single authorized writer for the owner-protected `elements` list. A
+// `writeAuthorizedBy` claim carries exactly one handler binding, verified
+// against the writing handler's implementation identity — so every element
+// mutation (the exported add/remove streams, the catalog/link-form buttons,
+// the per-row remove) must be an INSTANCE of this one implementation.
+// Instances differ only in bound state, which doesn't change the
+// implementation identity.
+const mutateElements = handler<
+  MutateProfileElementsEvent,
+  {
+    elements: Writable<ProfileElement[]>;
+    // Per-row remove binding: when set, this instance removes that element.
+    cell?: any;
+    // Link form binding: when bound and the event carries no explicit
+    // patternUrl, the URL/title/tag are read from (and cleared on) the form.
+    patternUrl?: Writable<string>;
+    title?: Writable<string>;
+    tag?: Writable<string>;
+    userTags?: string[];
+  }
+>((event, state) => {
+  const removeCell = event.cell ?? state.cell;
+  if (removeCell !== undefined) {
+    state.elements.set(
+      state.elements.get().filter((element) =>
+        !equals(element.cell, removeCell)
+      ),
+    );
+    return;
+  }
+  const eventUrl = (event.patternUrl ?? "").trim();
+  const formUrl = eventUrl.length === 0
+    ? (state.patternUrl?.get() ?? "").trim()
+    : "";
+  const url = eventUrl.length > 0 ? eventUrl : formUrl;
+  if (url.length > 0) {
+    const fromForm = eventUrl.length === 0;
+    const title = (event.title ??
+      (fromForm ? state.title?.get() : undefined))?.trim() ||
+      url;
+    const tag = (event.tag ??
+      (fromForm ? state.tag?.get() : undefined))?.trim() ||
+      url;
+    appendElement({
+      cell: (UrlPatternReference({ title, url }) as any).for(tag),
+      source: "url",
+      title,
       tag,
-    )
-    : (ProfileCatalogCard({ title }) as any).for(tag);
+      userTags: event.userTags ?? state.userTags ?? [],
+    }, state.elements);
+    if (fromForm) {
+      state.patternUrl?.set("");
+      state.title?.set("");
+      state.tag?.set("");
+    }
+    return;
+  }
+  const title = event.title ?? "Profile card";
+  const tag = event.tag ?? event.catalogId ?? "profile-card";
   appendElement({
-    cell,
-    tag,
-    userTags: event.userTags ?? [],
+    cell: (ProfileCatalogCard({ title }) as any).for(tag),
+    source: "catalog",
     title,
-    source,
-  }, elements);
-});
-
-const removeElement = handler<
-  RemoveProfileElementEvent,
-  { elements: Writable<ProfileElement[]> }
->(({ cell }, { elements }) => {
-  elements.set(
-    elements.get().filter((element) => !equals(element.cell, cell)),
-  );
+    tag,
+    userTags: event.userTags ?? state.userTags ?? [],
+  }, state.elements);
 });
 
 const setName = handler<SetProfileNameEvent, { name: Writable<string> }>(
@@ -188,55 +244,6 @@ const applyInitialName = lift<
   return name.get() ?? trimInitialName(initialName);
 });
 
-const addCatalogElement = handler<void, {
-  elements: Writable<ProfileElement[]>;
-  userTags: string[];
-}>((_, state) => {
-  appendElement({
-    cell: (ProfileCatalogCard({ title: "Profile card" }) as any).for(
-      "profile-card",
-    ),
-    source: "catalog",
-    title: "Profile card",
-    tag: "profile-card",
-    userTags: state.userTags,
-  }, state.elements);
-});
-
-const addUrlElement = handler<void, {
-  elements: Writable<ProfileElement[]>;
-  patternUrl: Writable<string>;
-  title: Writable<string>;
-  tag: Writable<string>;
-  userTags: string[];
-}>((_, state) => {
-  const url = state.patternUrl.get().trim();
-  if (!url) {
-    return;
-  }
-  const title = state.title.get().trim() || url;
-  const tag = state.tag.get().trim() || url;
-  appendElement({
-    cell: (UrlPatternReference({ title, url }) as any).for(tag),
-    source: "url",
-    title,
-    tag,
-    userTags: state.userTags,
-  }, state.elements);
-  state.patternUrl.set("");
-  state.title.set("");
-  state.tag.set("");
-});
-
-const removeElementCell = handler<void, {
-  elements: Writable<ProfileElement[]>;
-  cell: any;
-}>((_, state) => {
-  state.elements.set(
-    state.elements.get().filter((element) => !equals(element.cell, state.cell)),
-  );
-});
-
 export default pattern<ProfileHomeInput, ProfileHomeOutput>(
   ({ initialName }) => {
     const initialProfileName = trimInitialName(initialName);
@@ -247,7 +254,7 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
       OwnerProtectedProfileWrite<string, typeof setAvatar>
     >("").for("avatar");
     const elements = new Writable<
-      OwnerProtectedProfileWrite<ProfileElement[], typeof addElement>
+      OwnerProtectedProfileWrite<ProfileElement[], typeof mutateElements>
     >([]).for("elements");
     const patternUrl = new Writable("").for("patternUrl");
     const elementTitle = new Writable("").for("elementTitle");
@@ -277,8 +284,9 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
       elements,
       setName: setName({ name }),
       setAvatar: setAvatar({ avatar }),
-      addElement: addElement({ elements }),
-      removeElement: removeElement({ elements }),
+      // Both exported streams are instances of the one authorized writer.
+      addElement: mutateElements({ elements }),
+      removeElement: mutateElements({ elements }),
       initialNameApplied,
       [UI]: (
         <cf-screen
@@ -321,7 +329,7 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
 
             <cf-hstack gap="2">
               <cf-button
-                onClick={addCatalogElement({
+                onClick={mutateElements({
                   elements,
                   userTags: parsedUserTags,
                 })}
@@ -331,12 +339,12 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
             </cf-hstack>
 
             <cf-vstack gap="2">
-              <label>Pattern URL</label>
+              <label>Link URL</label>
               <cf-input $value={patternUrl} placeholder="/api/patterns/..." />
               <cf-input $value={elementTitle} placeholder="Title" />
               <cf-input $value={elementTag} placeholder="Tag" />
               <cf-button
-                onClick={addUrlElement({
+                onClick={mutateElements({
                   elements,
                   patternUrl,
                   title: elementTitle,
@@ -344,8 +352,12 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
                   userTags: parsedUserTags,
                 })}
               >
-                Add URL element
+                Add link
               </cf-button>
+              <span style={{ color: "var(--cf-color-text-secondary)" }}>
+                Links are saved as reference cards. They are not deployed or
+                run.
+              </span>
             </cf-vstack>
 
             <cf-vstack gap="2">
@@ -360,7 +372,7 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
                   <cf-button
                     size="sm"
                     variant="ghost"
-                    onClick={removeElementCell({
+                    onClick={mutateElements({
                       elements,
                       cell: element.cell,
                     })}

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -152,67 +152,94 @@ const appendElement = (
 // against the writing handler's implementation identity — so every element
 // mutation (the exported add/remove streams, the catalog/link-form buttons,
 // the per-row remove) must be an INSTANCE of this one implementation.
-// Instances differ only in bound state, which doesn't change the
-// implementation identity.
+// Instances differ only in bound state — including the explicit `mode`
+// below — which doesn't change the implementation identity.
 const mutateElements = handler<
   MutateProfileElementsEvent,
   {
     elements: Writable<ProfileElement[]>;
-    // Per-row remove binding: when set, this instance removes that element.
+    // Instance intent. Each binding site declares what its events may do, so
+    // a malformed/empty event can never cross purposes (an empty remove must
+    // not add; an empty link form must not add a catalog card):
+    //   "add"     — the exported add stream: event-driven, url or catalog.
+    //   "addCard" — the catalog button: one fixed "Profile card".
+    //   "addLink" — the link form: reads (and clears) the bound form; no-op
+    //               without a URL.
+    //   "remove"  — the exported remove stream / per-row button: removes
+    //               `event.cell ?? state.cell`; no-op without one.
+    mode: "add" | "addCard" | "addLink" | "remove";
+    // Per-row remove binding ("remove" mode).
     cell?: any;
-    // Link form binding: when bound and the event carries no explicit
-    // patternUrl, the URL/title/tag are read from (and cleared on) the form.
+    // Link form binding ("addLink" mode).
     patternUrl?: Writable<string>;
     title?: Writable<string>;
     tag?: Writable<string>;
     userTags?: string[];
   }
 >((event, state) => {
-  const removeCell = event.cell ?? state.cell;
-  if (removeCell !== undefined) {
-    state.elements.set(
-      state.elements.get().filter((element) =>
-        !equals(element.cell, removeCell)
-      ),
-    );
-    return;
-  }
-  const eventUrl = (event.patternUrl ?? "").trim();
-  const formUrl = eventUrl.length === 0
-    ? (state.patternUrl?.get() ?? "").trim()
-    : "";
-  const url = eventUrl.length > 0 ? eventUrl : formUrl;
-  if (url.length > 0) {
-    const fromForm = eventUrl.length === 0;
-    const title = (event.title ??
-      (fromForm ? state.title?.get() : undefined))?.trim() ||
-      url;
-    const tag = (event.tag ??
-      (fromForm ? state.tag?.get() : undefined))?.trim() ||
-      url;
-    appendElement({
-      cell: (UrlPatternReference({ title, url }) as any).for(tag),
-      source: "url",
-      title,
-      tag,
-      userTags: event.userTags ?? state.userTags ?? [],
-    }, state.elements);
-    if (fromForm) {
+  const userTags = event.userTags ?? state.userTags ?? [];
+  switch (state.mode) {
+    case "remove": {
+      const removeCell = event.cell ?? state.cell;
+      if (removeCell === undefined) return;
+      state.elements.set(
+        state.elements.get().filter((element) =>
+          !equals(element.cell, removeCell)
+        ),
+      );
+      return;
+    }
+    case "addLink": {
+      const url = (state.patternUrl?.get() ?? "").trim();
+      if (url.length === 0) return;
+      const title = (state.title?.get() ?? "").trim() || url;
+      const tag = (state.tag?.get() ?? "").trim() || url;
+      appendElement({
+        cell: (UrlPatternReference({ title, url }) as any).for(tag),
+        source: "url",
+        title,
+        tag,
+        userTags,
+      }, state.elements);
       state.patternUrl?.set("");
       state.title?.set("");
       state.tag?.set("");
+      return;
     }
-    return;
+    case "addCard": {
+      appendElement({
+        cell: (ProfileCatalogCard({ title: "Profile card" }) as any).for(
+          "profile-card",
+        ),
+        source: "catalog",
+        title: "Profile card",
+        tag: "profile-card",
+        userTags,
+      }, state.elements);
+      return;
+    }
+    case "add": {
+      const source = event.patternUrl ? "url" : "catalog";
+      const title = event.title ??
+        (source === "url"
+          ? event.patternUrl ?? "Profile pattern"
+          : "Profile card");
+      const tag = event.tag ?? event.catalogId ?? event.patternUrl ??
+        "profile";
+      const cell = source === "url"
+        ? (UrlPatternReference({ title, url: event.patternUrl ?? "" }) as any)
+          .for(tag)
+        : (ProfileCatalogCard({ title }) as any).for(tag);
+      appendElement({
+        cell,
+        tag,
+        userTags,
+        title,
+        source,
+      }, state.elements);
+      return;
+    }
   }
-  const title = event.title ?? "Profile card";
-  const tag = event.tag ?? event.catalogId ?? "profile-card";
-  appendElement({
-    cell: (ProfileCatalogCard({ title }) as any).for(tag),
-    source: "catalog",
-    title,
-    tag,
-    userTags: event.userTags ?? state.userTags ?? [],
-  }, state.elements);
 });
 
 const setName = handler<SetProfileNameEvent, { name: Writable<string> }>(
@@ -284,9 +311,10 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
       elements,
       setName: setName({ name }),
       setAvatar: setAvatar({ avatar }),
-      // Both exported streams are instances of the one authorized writer.
-      addElement: mutateElements({ elements }),
-      removeElement: mutateElements({ elements }),
+      // Both exported streams are instances of the one authorized writer,
+      // pinned to their declared purpose via the bound mode.
+      addElement: mutateElements({ elements, mode: "add" }),
+      removeElement: mutateElements({ elements, mode: "remove" }),
       initialNameApplied,
       [UI]: (
         <cf-screen
@@ -331,6 +359,7 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
               <cf-button
                 onClick={mutateElements({
                   elements,
+                  mode: "addCard",
                   userTags: parsedUserTags,
                 })}
               >
@@ -346,6 +375,7 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
               <cf-button
                 onClick={mutateElements({
                   elements,
+                  mode: "addLink",
                   patternUrl,
                   title: elementTitle,
                   tag: elementTag,
@@ -374,6 +404,7 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
                     variant="ghost"
                     onClick={mutateElements({
                       elements,
+                      mode: "remove",
                       cell: element.cell,
                     })}
                   >

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2377,6 +2377,38 @@ const rootLabelFromSchema = (
     : derivePersistedLabel(tx, root.schema, root.label);
 };
 
+/**
+ * The result schema a piece's setup wrote as the source doc's ["schema"] meta
+ * — visible read-your-writes for a piece instantiated in THIS transaction
+ * (e.g. a handler materializing a sub-pattern and linking it into a protected
+ * list in one commit), and from storage for a piece set up earlier. A fresh
+ * piece has no stored CFC metadata and no schema write-policy input (its value
+ * is computed by later actions), but this is the same author-declared shape a
+ * pending schema input carries, so the link-label derivation below trusts it
+ * the same way; stored CFC metadata still takes precedence when present.
+ */
+const setupResultSchemaFor = (
+  tx: IExtendedStorageTransaction,
+  source: LinkWritePolicyInput["source"],
+): JSONSchema | undefined => {
+  const document = tx.readOrThrow({
+    space: source.space,
+    id: source.id as URI,
+    scope: source.scope,
+    type: "application/json",
+    path: [],
+  }, {
+    meta: INTERNAL_VERIFIER_META,
+  });
+  if (!isRecord(document)) {
+    return undefined;
+  }
+  const schema = (document as Record<string, unknown>).schema;
+  return schema === undefined || schema === null
+    ? undefined
+    : schema as JSONSchema;
+};
+
 const derivePersistedLinkLabel = (
   tx: IExtendedStorageTransaction,
   input: LinkWritePolicyInput,
@@ -2390,14 +2422,39 @@ const derivePersistedLinkLabel = (
     input.source.scope,
     "application/json",
   );
-  const pendingSourceSchema = candidateSchemas.get(targetKey(input.source));
-  const pendingSourceLabel = pendingSourceSchema !== undefined
+  let pendingSourceSchema = candidateSchemas.get(targetKey(input.source)) ??
+    setupResultSchemaFor(tx, input.source);
+  let pendingSourceLabel = pendingSourceSchema !== undefined
     ? persistedLabelFromSchemaAtPath(
       tx,
       pendingSourceSchema,
       input.source.path,
     )
     : undefined;
+  if (pendingSourceSchema === undefined && sourceMetadata === undefined) {
+    // Child docs minted by this same write: an array/object entry written
+    // into a labeled location is split into its own doc by the data layer,
+    // so the link's "source" is a doc this transaction just created to hold
+    // an inline value. The writer's schema input covers the TARGET path —
+    // derive the label the value would have carried inline. Gated to docs
+    // this transaction actually wrote (a pre-existing doc with persisted
+    // labels resolves through its stored CFC metadata above; one without
+    // stored metadata stays fail-closed unless this tx wrote it).
+    const sourceWrittenInThisTx = [
+      ...(tx.getWriteDetails?.(input.source.space) ?? []),
+    ].some((detail) => detail.address.id === input.source.id);
+    if (sourceWrittenInThisTx) {
+      const targetCandidate = candidateSchemas.get(targetKey(input.target));
+      if (targetCandidate !== undefined) {
+        pendingSourceSchema = targetCandidate;
+        pendingSourceLabel = persistedLabelFromSchemaAtPath(
+          tx,
+          targetCandidate,
+          input.target.path,
+        );
+      }
+    }
+  }
   const linkSchemaLabel = rootLabelFromSchema(tx, input.linkSchema);
   const hasCarriedLabel =
     input.cfcLabelView?.entries.some((entry) => hasLabelValues(entry.label)) ??

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2437,13 +2437,18 @@ const derivePersistedLinkLabel = (
     // so the link's "source" is a doc this transaction just created to hold
     // an inline value. The writer's schema input covers the TARGET path —
     // derive the label the value would have carried inline. Gated to docs
-    // this transaction actually wrote (a pre-existing doc with persisted
-    // labels resolves through its stored CFC metadata above; one without
-    // stored metadata stays fail-closed unless this tx wrote it).
-    const sourceWrittenInThisTx = [
+    // this transaction CREATED (a root-level write with no previous value):
+    // a pre-existing doc with persisted labels resolves through its stored
+    // CFC metadata above, and one without stored metadata stays fail-closed
+    // even when this tx touched one of its fields.
+    const sourceCreatedInThisTx = [
       ...(tx.getWriteDetails?.(input.source.space) ?? []),
-    ].some((detail) => detail.address.id === input.source.id);
-    if (sourceWrittenInThisTx) {
+    ].some((detail) =>
+      detail.address.id === input.source.id &&
+      detail.address.path.length <= 1 &&
+      detail.previousValue === undefined
+    );
+    if (sourceCreatedInThisTx) {
       const targetCandidate = candidateSchemas.get(targetKey(input.target));
       if (targetCandidate !== undefined) {
         pendingSourceSchema = targetCandidate;

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -163,12 +163,11 @@ const mergeSetLikeIfcArray = (
         if (!deepEqual(existing, candidate)) {
           // One transaction can record the same protected field through a
           // schema input whose `writeAuthorizedBy` claim was rebound with the
-          // authoring identity's bundleId and one recorded without an
+          // authoring identity's provenance stamp and one recorded without an
           // identity (unstamped). The BINDING (file + path) is what the claim
-          // means; the bundle stamp is provenance added per input. Mirror
-          // prepare's `schemasEqualIgnoringWriterBundleIds` tolerance and
-          // keep the stamped claim. Two DIFFERENT stamps (or different
-          // bindings) still conflict.
+          // means; the stamp is provenance added per input — keep the stamped
+          // claim. Two DIFFERENT stamps (or different bindings) still
+          // conflict.
           if (key === "writeAuthorizedBy") {
             const reconciled = reconcileWriterClaimStamp(existing, candidate);
             if (reconciled !== undefined) {

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -64,12 +64,30 @@ type WriterIdentityClaim = {
 const isWriterIdentityClaim = (value: unknown): value is WriterIdentityClaim =>
   isRecord(value) && isRecord(value.__ctWriterIdentityOf);
 
+// The per-input provenance fields a verified write stamps onto a
+// writer-identity claim (new claims carry BOTH — see
+// implementation-identity.ts `resolveProvenanceImplementationIdentity`). The
+// BINDING (file + path) is what the claim means; these fields only record
+// which verified load produced the input.
+const WRITER_CLAIM_STAMP_KEYS = ["bundleId", "moduleIdentity"] as const;
+
+const writerClaimIsStamped = (identity: Record<string, unknown>): boolean =>
+  WRITER_CLAIM_STAMP_KEYS.some((key) => identity[key] !== undefined);
+
+const writerClaimWithoutStamp = (
+  identity: Record<string, unknown>,
+): Record<string, unknown> => {
+  const rest = { ...identity };
+  for (const key of WRITER_CLAIM_STAMP_KEYS) delete rest[key];
+  return rest;
+};
+
 /**
  * Reconcile two `writeAuthorizedBy` writer-identity claims that differ only
- * by the presence of the `bundleId` provenance stamp (one side recorded under
- * a verified identity, the other without one). Returns the stamped claim, or
- * `undefined` when the claims genuinely conflict (different bindings, or two
- * different stamps).
+ * by the presence of the provenance stamp (`bundleId`/`moduleIdentity` — one
+ * side recorded under a verified identity, the other without one). Returns
+ * the stamped claim, or `undefined` when the claims genuinely conflict
+ * (different bindings, or two different stamps).
  */
 const reconcileWriterClaimStamp = (
   existing: unknown,
@@ -80,24 +98,28 @@ const reconcileWriterClaimStamp = (
   }
   const existingIdentity = existing.__ctWriterIdentityOf;
   const candidateIdentity = candidate.__ctWriterIdentityOf;
-  const existingStamp = existingIdentity.bundleId;
-  const candidateStamp = candidateIdentity.bundleId;
+  const existingStamped = writerClaimIsStamped(existingIdentity);
+  const candidateStamped = writerClaimIsStamped(candidateIdentity);
   // Exactly one side stamped — otherwise deepEqual already decided (equal
   // stamps) or this is a genuine conflict (two different stamps).
-  if ((existingStamp === undefined) === (candidateStamp === undefined)) {
+  if (existingStamped === candidateStamped) {
     return undefined;
   }
-  const { bundleId: _existingBundle, ...existingRest } = existingIdentity;
-  const { bundleId: _candidateBundle, ...candidateRest } = candidateIdentity;
   if (
     !deepEqual(
-      { ...existing, __ctWriterIdentityOf: existingRest },
-      { ...candidate, __ctWriterIdentityOf: candidateRest },
+      {
+        ...existing,
+        __ctWriterIdentityOf: writerClaimWithoutStamp(existingIdentity),
+      },
+      {
+        ...candidate,
+        __ctWriterIdentityOf: writerClaimWithoutStamp(candidateIdentity),
+      },
     )
   ) {
     return undefined;
   }
-  return existingStamp !== undefined ? existing : candidate;
+  return existingStamped ? existing : candidate;
 };
 
 const mergeSetLikeIfcArray = (

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -8,7 +8,10 @@ import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import * as V2Storage from "../src/storage/v2.ts";
 import { raw } from "../src/module.ts";
-import { storedCfcMetadataAppliesToPath } from "../src/cfc/metadata.ts";
+import {
+  readStoredCfcMetadata,
+  storedCfcMetadataAppliesToPath,
+} from "../src/cfc/metadata.ts";
 import { Runtime } from "../src/runtime.ts";
 import { createCell } from "../src/cell.ts";
 import {
@@ -2415,7 +2418,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     }
   });
 
-  it("rejects CFC-relevant link writes when source metadata is missing", async () => {
+  it("rejects link writes when a PRE-EXISTING source has no metadata", async () => {
     const { runtime, storageManager } = createRuntime();
     try {
       const seed = runtime.edit();
@@ -2430,6 +2433,15 @@ describe("ExtendedStorageTransaction CFC gate", () => {
         seed,
       );
       target.set({ existing: true });
+      // The unlabeled source pre-exists: written and committed WITHOUT any
+      // schema, in a transaction that never links it anywhere.
+      const unlabeledSeed = runtime.getCell(
+        signer.did(),
+        "cfc-link-missing-source",
+        undefined,
+        seed,
+      );
+      unlabeledSeed.set({ title: "unlabeled" });
       seed.prepareCfc();
       expect((await seed.commit()).ok).toBeDefined();
 
@@ -2441,7 +2453,6 @@ describe("ExtendedStorageTransaction CFC gate", () => {
         undefined,
         tx,
       );
-      unlabeledSource.set({ title: "unlabeled" });
       const linkedTarget = runtime.getCell(
         signer.did(),
         "cfc-link-missing-source-target",
@@ -2454,6 +2465,68 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       expect(result.error?.message).toContain(
         "missing link source metadata",
       );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("labels a SAME-TRANSACTION link source from the target's own schema", async () => {
+    // A doc this transaction itself wrote and then linked into a labeled
+    // location (the data layer does exactly this when an array/object entry
+    // is split into a child doc) is treated like the inline value it holds:
+    // the link label derives from the target's schema at the target path —
+    // here the location's own confidentiality — instead of failing closed
+    // (CT-1698: profile element writes).
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const seed = runtime.edit();
+      seed.setCfcEnforcementMode("enforce-explicit");
+      const target = runtime.getCell(
+        signer.did(),
+        "cfc-link-same-tx-source-target",
+        {
+          type: "object",
+          ifc: { confidentiality: ["personal-space"] },
+        },
+        seed,
+      );
+      target.set({ existing: true });
+      seed.prepareCfc();
+      expect((await seed.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      const sameTxSource = runtime.getCell(
+        signer.did(),
+        "cfc-link-same-tx-source",
+        undefined,
+        tx,
+      );
+      sameTxSource.set({ title: "fresh" });
+      const linkedTarget = runtime.getCell(
+        signer.did(),
+        "cfc-link-same-tx-source-target",
+        undefined,
+        tx,
+      );
+      linkedTarget.set(sameTxSource);
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+
+      // The persisted link label carries the location's confidentiality.
+      const verify = runtime.edit();
+      const metadata = readStoredCfcMetadata(verify, {
+        space: signer.did(),
+        id: linkedTarget.getAsNormalizedFullLink().id,
+        scope: "space",
+      });
+      const rootEntry = metadata?.labelMap.entries.find((entry) =>
+        entry.path.length === 0 && entry.origin === "link"
+      );
+      expect(rootEntry?.label.confidentiality).toEqual(["personal-space"]);
+      verify.abort?.();
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runner/test/cfc-nonexported-binding-identity.test.ts
+++ b/packages/runner/test/cfc-nonexported-binding-identity.test.ts
@@ -161,7 +161,7 @@ describe("CT-1665: verified binding metadata for non-exported handlers", () => {
     });
   }
 
-  it("registers binding metadata for real profile-home setName/setAvatar/addElement", async () => {
+  it("registers binding metadata for real profile-home setName/setAvatar/mutateElements", async () => {
     const rt = newRuntime();
     try {
       const tx = rt.edit();
@@ -182,7 +182,7 @@ describe("CT-1665: verified binding metadata for non-exported handlers", () => {
       const paths = recordedBindingPaths(rt);
       expect(paths).toContainEqual(["setName"]);
       expect(paths).toContainEqual(["setAvatar"]);
-      expect(paths).toContainEqual(["addElement"]);
+      expect(paths).toContainEqual(["mutateElements"]);
     } finally {
       await rt.dispose();
     }

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -220,6 +220,57 @@ describe("mergeCfcSchemaEnvelopes", () => {
     }
   });
 
+  it("merges writeAuthorizedBy claims stamped with bundleId AND moduleIdentity", () => {
+    // New claims carry BOTH provenance fields (implementation-identity.ts):
+    // the stamped side has bundleId + moduleIdentity, the authored side has
+    // neither. The binding (file + path) is identical — the merge must strip
+    // the WHOLE provenance stamp before comparing, not just bundleId
+    // (regression: "writeAuthorizedBy must remain stable at /elements" on
+    // every profile element write, CT-1698).
+    const unstamped = {
+      __ctWriterIdentityOf: {
+        file: "/system/profile-home.tsx",
+        path: ["mutateElements"],
+      },
+    };
+    const stamped = {
+      __ctWriterIdentityOf: {
+        file: "/system/profile-home.tsx",
+        path: ["mutateElements"],
+        bundleId: "fid1:bundle",
+        moduleIdentity: "module-identity-hash",
+      },
+    };
+
+    for (
+      const [left, right] of [[stamped, unstamped], [unstamped, stamped]]
+    ) {
+      const merged = mergeCfcSchemaEnvelopes({
+        type: "object",
+        properties: {
+          elements: {
+            type: "array",
+            ifc: { writeAuthorizedBy: left },
+          },
+        },
+      }, {
+        type: "object",
+        properties: {
+          elements: {
+            type: "array",
+            ifc: { writeAuthorizedBy: right },
+          },
+        },
+      });
+
+      expect(
+        (
+          (merged as JSONSchemaObj).properties?.elements as JSONSchemaObj
+        ).ifc?.writeAuthorizedBy,
+      ).toEqual(stamped);
+    }
+  });
+
   it("rejects writeAuthorizedBy claims with conflicting bundle stamps", () => {
     const claimFor = (bundleId: string) => ({
       __ctWriterIdentityOf: {


### PR DESCRIPTION
Fixes [CT-1698](https://linear.app/common-tools/issue/CT-1698): profile cards / link elements could not be added — both "Add profile card" and "Add URL element" silently did nothing (console: `writeAuthorizedBy must remain stable at /elements`). This is **#3880's silently-aborting element save in its modern form**: the newer CFC machinery (#3909/#4008) turned the silent abort into loud, diagnosable errors, and behind the first error were two more. Also lands the [CT-1651](https://linear.app/common-tools/issue/CT-1651) copy rename (elements are references, not deployed pieces).

## Three stacked causes, three contained fixes

1. **`cfc/schema-merge.ts` — stamp reconciliation predates `moduleIdentity`.** `reconcileWriterClaimStamp` stripped only `bundleId` before comparing a stamped claim with an authored one, but new claims are stamped with **both** `bundleId` and `moduleIdentity` (`implementation-identity.ts`) — so every stamped-vs-authored merge of the *same binding* threw "must remain stable". The provenance stamp is now `{bundleId, moduleIdentity}`, stripped together; two different stamps still conflict.

2. **`cfc/prepare.ts` — link sources minted by the same transaction failed closed** ("missing link source metadata at /elements/0" — the exact re-enable condition documented on the skipped profile-home tests). Two new knowability hatches in `derivePersistedLinkLabel`:
   - the source piece's setup-written `["schema"]` meta (read-your-writes for a same-tx pattern instantiation, stored for an earlier one);
   - for child docs the data layer splits out of an inline value (array/object entries), the **target's own candidate schema at the target path** — the label the value would have carried inline — **gated to docs this transaction actually wrote**. A pre-existing unlabeled doc still fails closed; `cfc-boundary` now pins **both** cases (the same-tx case additionally asserts the persisted link label carries the location's confidentiality, so this is label-preserving, not label-skipping).

3. **`patterns/system/profile-home.tsx` — five writers, one claim slot.** A `writeAuthorizedBy` claim carries exactly one handler binding (transformer extracts a single `typeof identifier`; prepare verifies the writing handler's identity against it; only claim-referenced handlers get `__cfBindVerifiedBinding` annotations). But `elements` was written by **five** handlers — the declared `addElement`, plus `removeElement` and three private UI handlers, all unannotated and unauthorized. All element mutations are now instances of the single authorized **`mutateElements`** implementation (instances differ only in bound state, which doesn't change the implementation identity): exported add/remove streams, the catalog button, the link form, and per-row remove. The exported stream fields widen to the mutation event type; `AddProfileElementEvent`/`RemoveProfileElementEvent` remain the documented subsets.

## CT-1651 rename (recorded design verdict: references, not deployed pieces)

"Pattern URL" → **"Link URL"**, "Add URL element" → **"Add link"**, plus helper text *"Links are saved as reference cards. They are not deployed or run."*

## Verification

- The profile-home element tests are **un-skipped** (their skip comment described exactly this bug chain) and pass: add catalog element → assert → remove → assert, under CFC enforcement.
- New regression test for the stamp reconciliation (bundleId+moduleIdentity vs authored); `cfc-boundary` re-pins fail-closed for pre-existing unlabeled sources and label-derivation for same-tx sources; the CT-1665 binding-metadata test updated to the new symbol.
- Full runner suite: **584 passed, 0 failed**. Pattern tests matching "profile": green.
- **Live against a local toolshed** (worktree CLI): deployed the real ProfileCreate stack, created a profile, then `addElement` with both flavors via `cf piece call` — `elements` reads back `[{source:"catalog",tag:"profile-card",title:"Profile card"},{source:"url",tag:"note",title:"My Notes"}]`, where every variant previously failed.

## Notes

- A CFC write rejection still surfaces only as a console error (the button click looks like a no-op) — UI surfacing is noted on CT-1698 as a separate follow-up.
- Browser-level re-verify of the element buttons needs this merged + dev servers restarted (the shell runtime needs the two CFC fixes); planned as the post-merge check.

Closes CT-1698. Closes CT-1651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1698 so profile cards and link elements save correctly under CFC, and updates copy per CT-1651. Reconciles writer-claim stamps, labels same-transaction link sources, and routes all element mutations through one authorized writer with mode-bound dispatch.

- **Bug Fixes**
  - CFC stamp reconciliation: `reconcileWriterClaimStamp` now strips both `bundleId` and `moduleIdentity` before comparing, merging stamped vs authored claims for the same binding; conflicting stamps still reject.
  - Same-transaction link sources: `derivePersistedLinkLabel` now derives labels from the source piece’s setup `["schema"]` meta, or from the target path for child docs written and created in the same tx; pre-existing unlabeled sources still fail closed.
  - Mode-bound element mutations: `mutateElements` uses explicit modes (`add`, `addCard`, `addLink`, `remove`) so empty remove events and blank link forms no longer add elements by mistake; tests pin the no-op remove.

- **Refactors**
  - Single authorized writer: replaced multiple element handlers with one `mutateElements` implementation; exported `addElement`/`removeElement` are instances bound with `mode`, and the catalog button, link form, and per-row remove all call this single writer.
  - CT-1651 copy: “Pattern URL” → “Link URL”, “Add URL element” → “Add link”, plus helper text clarifying links are reference cards, not deployed.

<sup>Written for commit f9e6041e2569cbdcbbf86da5d5a5d8880ad8e1fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

