### PR TITLE
docs(patterns): fix stale file references in DEPRECATED_IDIOMS.md (CT-1715)

### DIFF
--- a/packages/patterns/DEPRECATED_IDIOMS.md
+++ b/packages/patterns/DEPRECATED_IDIOMS.md
@@ -1,13 +1,14 @@
 # Deprecated Idioms - Migration Task List
 
 This document tracks deprecated idioms found in the patterns directory that need
-to be updated to the current API.
+to be updated to the current API. For per-file status (which patterns are
+current vs legacy), see the status tiers in [index.md](./index.md).
 
 ## Summary
 
-- **Total files scanned**: 50
-- **Files with deprecated idioms**: 21
-- **Priority levels**: High (4), Medium (13), Low (4)
+Most of the original migration list is complete: the affected files have either
+been migrated or removed. The entries below are the verified remaining
+occurrences.
 
 ## Deprecated APIs to Replace
 
@@ -19,365 +20,26 @@ to be updated to the current API.
 6. Unnecessary `[ID]` usage → use `Writable.equals()` instead for
    finding/removing items
 
-## High Priority Files
+## Remaining Occurrences
 
-### 1. chatbot.tsx
+### chatbot.tsx
 
-**Priority**: High (core functionality) **Location**:
-`packages/patterns/chatbot.tsx`
+**Location**: `packages/patterns/chatbot.tsx`
 
-- **Line 64**: `derive()` → `computed()`
-  ```typescript
-  const chatLog = derive(() => {
-  ```
+- `clearChat`: simple `handler()` → inline handler
 
-- **Line 84**: `lift()` → `computed()` or refactor
-  ```typescript
-  lift(async () => {
-  ```
+### default-app.tsx
 
-- **Line 123**: Simple `handler()` → inline handler
-  ```typescript
-  const sendMessage = handler<...>(...)
-  ```
+**Location**: `packages/patterns/system/default-app.tsx`
 
-### 2. chatbot-list-view.tsx
+- `removePiece`: instance `.equals()` → `Writable.equals(a, b)`
+- `toggleMenu`, `closeMenu`: simple `handler()` → inline handler
 
-**Priority**: High (core functionality) **Location**:
-`packages/patterns/chatbot-list-view.tsx`
+### omnibox-fab.tsx
 
-- **Line 32**: `derive()` → `computed()`
-  ```typescript
-  const chatbots = derive(() => {
-  ```
+**Location**: `packages/patterns/system/omnibox-fab.tsx`
 
-- **Line 45**: Simple `handler()` → inline handler
-  ```typescript
-  const createChatbot = handler<...>(...)
-  ```
-
-### 3. default-app.tsx
-
-**Priority**: High (core functionality) **Location**:
-`packages/patterns/default-app.tsx`
-
-- **Line 28**: `cell()` → `new Writable()`
-  ```typescript
-  const currentView = cell("home");
-  ```
-
-- **Line 56**: `derive()` → `computed()`
-  ```typescript
-  const viewComponent = derive(() => {
-  ```
-
-### 4. omnibox-fab.tsx
-
-**Priority**: High (core functionality) **Location**:
-`packages/patterns/omnibox-fab.tsx`
-
-- **Line 19**: `cell()` → `new Writable()`
-  ```typescript
-  const isOpen = cell(false);
-  ```
-
-- **Line 34**: Simple `handler()` → inline handler
-  ```typescript
-  const toggleOpen = handler(() => {
-  ```
-
-## Medium Priority Files
-
-### 5. todo-list.tsx
-
-**Priority**: Medium **Location**: `packages/patterns/todo-list.tsx`
-
-- **Line 23**: `derive()` → `computed()`
-  ```typescript
-  const completedCount = derive(() => {
-  ```
-
-- **Line 45**: Simple `handler()` → inline handler
-  ```typescript
-  const addTodo = handler<...>(...)
-  ```
-
-- **Line 67**: `.equals()` → `Writable.equals()`
-  ```typescript
-  if (item.equals(todo)) {
-  ```
-
-### 6. shopping-list.tsx
-
-**Priority**: Medium **Location**: `packages/patterns/shopping-list.tsx`
-
-- **Line 18**: `cell()` → `new Writable()`
-  ```typescript
-  const items = cell([]);
-  ```
-
-- **Line 34**: `derive()` → `computed()`
-  ```typescript
-  const groupedItems = derive(() => {
-  ```
-
-- **Line 56**: Simple `handler()` → inline handler
-  ```typescript
-  const addItem = handler<...>(...)
-  ```
-
-### 7. kanban-board.tsx
-
-**Priority**: Medium **Location**: `packages/patterns/kanban-board.tsx`
-
-- **Line 42**: `derive()` → `computed()`
-  ```typescript
-  const columnTasks = derive(() => {
-  ```
-
-- **Line 78**: Simple `handler()` → inline handler
-  ```typescript
-  const moveTask = handler<...>(...)
-  ```
-
-- **Line 95**: `lift()` → `computed()` or refactor
-  ```typescript
-  lift(() => {
-  ```
-
-### 8. calendar-view.tsx
-
-**Priority**: Medium **Location**: `packages/patterns/calendar-view.tsx`
-
-- **Line 29**: `derive()` → `computed()`
-  ```typescript
-  const monthEvents = derive(() => {
-  ```
-
-- **Line 67**: Simple `handler()` → inline handler
-  ```typescript
-  const selectDate = handler<...>(...)
-  ```
-
-### 9. markdown-editor.tsx
-
-**Priority**: Medium **Location**: `packages/patterns/markdown-editor.tsx`
-
-- **Line 15**: `cell()` → `new Writable()`
-  ```typescript
-  const content = cell("");
-  ```
-
-- **Line 23**: `derive()` → `computed()`
-  ```typescript
-  const preview = derive(() => {
-  ```
-
-### 10. data-table.tsx
-
-**Priority**: Medium **Location**: `packages/patterns/data-table.tsx`
-
-- **Line 35**: `derive()` → `computed()`
-  ```typescript
-  const sortedData = derive(() => {
-  ```
-
-- **Line 58**: `derive()` → `computed()`
-  ```typescript
-  const filteredData = derive(() => {
-  ```
-
-- **Line 89**: Simple `handler()` → inline handler
-  ```typescript
-  const setSortColumn = handler<...>(...)
-  ```
-
-### 11. form-builder.tsx
-
-**Priority**: Medium **Location**: `packages/patterns/form-builder.tsx`
-
-- **Line 28**: `cell()` → `new Writable()`
-  ```typescript
-  const fields = cell([]);
-  ```
-
-- **Line 45**: `derive()` → `computed()`
-  ```typescript
-  const validationErrors = derive(() => {
-  ```
-
-- **Line 78**: Simple `handler()` → inline handler
-  ```typescript
-  const addField = handler<...>(...)
-  ```
-
-### 12. chart-widget.tsx
-
-**Priority**: Medium **Location**: `packages/patterns/chart-widget.tsx`
-
-- **Line 19**: `derive()` → `computed()`
-  ```typescript
-  const chartData = derive(() => {
-  ```
-
-- **Line 45**: `lift()` → `computed()` or refactor
-  ```typescript
-  lift(() => {
-  ```
-
-### 13. notification-center.tsx
-
-**Priority**: Medium **Location**: `packages/patterns/notification-center.tsx`
-
-- **Line 22**: `cell()` → `new Writable()`
-  ```typescript
-  const notifications = cell([]);
-  ```
-
-- **Line 34**: Simple `handler()` → inline handler
-  ```typescript
-  const dismissNotification = handler<...>(...)
-  ```
-
-- **Line 56**: `.equals()` → `Writable.equals()`
-  ```typescript
-  if (notif.equals(target)) {
-  ```
-
-### 14. search-filter.tsx
-
-**Priority**: Medium **Location**: `packages/patterns/search-filter.tsx`
-
-- **Line 17**: `cell()` → `new Writable()`
-  ```typescript
-  const query = cell("");
-  ```
-
-- **Line 25**: `derive()` → `computed()`
-  ```typescript
-  const results = derive(() => {
-  ```
-
-### 15. settings-panel.tsx
-
-**Priority**: Medium **Location**: `packages/patterns/settings-panel.tsx`
-
-- **Line 23**: `cell()` → `new Writable()`
-  ```typescript
-  const settings = cell({});
-  ```
-
-- **Line 45**: Simple `handler()` → inline handler
-  ```typescript
-  const updateSetting = handler<...>(...)
-  ```
-
-### 16. image-gallery.tsx
-
-**Priority**: Medium **Location**: `packages/patterns/image-gallery.tsx`
-
-- **Line 19**: `derive()` → `computed()`
-  ```typescript
-  const displayedImages = derive(() => {
-  ```
-
-- **Line 56**: Simple `handler()` → inline handler
-  ```typescript
-  const selectImage = handler<...>(...)
-  ```
-
-### 17. file-browser.tsx
-
-**Priority**: Medium **Location**: `packages/patterns/file-browser.tsx`
-
-- **Line 28**: `cell()` → `new Writable()`
-  ```typescript
-  const currentPath = cell("/");
-  ```
-
-- **Line 42**: `derive()` → `computed()`
-  ```typescript
-  const currentFiles = derive(() => {
-  ```
-
-- **Line 78**: `lift()` → `computed()` or refactor
-  ```typescript
-  lift(() => {
-  ```
-
-## Low Priority Files
-
-### 18. theme-switcher.tsx
-
-**Priority**: Low (utility) **Location**: `packages/patterns/theme-switcher.tsx`
-
-- **Line 12**: `cell()` → `new Writable()`
-  ```typescript
-  const theme = cell("light");
-  ```
-
-- **Line 23**: Simple `handler()` → inline handler
-  ```typescript
-  const toggleTheme = handler(() => {
-  ```
-
-### 19. color-picker.tsx
-
-**Priority**: Low (utility) **Location**: `packages/patterns/color-picker.tsx`
-
-- **Line 15**: `derive()` → `computed()`
-  ```typescript
-  const rgbValue = derive(() => {
-  ```
-
-### 20. progress-tracker.tsx
-
-**Priority**: Low (utility) **Location**:
-`packages/patterns/progress-tracker.tsx`
-
-- **Line 18**: `derive()` → `computed()`
-  ```typescript
-  const percentage = derive(() => {
-  ```
-
-- **Line 34**: `[ID]` usage - only needed if items are reordered
-  (sorting/shuffling). If just adding/removing without reordering, use
-  `Writable.equals()` for finding items instead.
-  ```typescript
-  [ID]: step.id
-  ```
-
-### 21. badge-component.tsx
-
-**Priority**: Low (utility) **Location**:
-`packages/patterns/badge-component.tsx`
-
-- **Line 12**: `derive()` → `computed()`
-  ```typescript
-  const badgeText = derive(() => {
-  ```
-
-- **Line 28**: `[ID]` usage - only needed if items are reordered
-  (sorting/shuffling). If just adding/removing without reordering, use
-  `Writable.equals()` for finding items instead.
-  ```typescript
-  [ID]: badge.id
-  ```
-
-## Migration Strategy
-
-### Phase 1: High Priority (4 files)
-
-Update core functionality patterns first to ensure critical features work with
-new API.
-
-### Phase 2: Medium Priority (13 files)
-
-Update commonly used patterns and examples.
-
-### Phase 3: Low Priority (4 files)
-
-Update utility components and less frequently used patterns.
+- `toggle`, `closeFab`: simple `handler()` → inline handler
 
 ## Update Checklist for Each File
 


### PR DESCRIPTION
## Summary

Correction pass over `packages/patterns/DEPRECATED_IDIOMS.md`, which is linked from `README.md` (#4037) and the status tiers in `index.md` (#4034). Every file path and line-number claim was verified against the current tree. The idiom guidance itself (old API → new API mappings, update checklist, notes) is preserved unchanged.

## Moved (paths updated)

| Old reference | Current location |
|---|---|
| `packages/patterns/default-app.tsx` | `packages/patterns/system/default-app.tsx` |
| `packages/patterns/omnibox-fab.tsx` | `packages/patterns/system/omnibox-fab.tsx` |

## Dropped — file deleted from the tree

- `chatbot-list-view.tsx` (removed in b26184f3b, #2348)
- `kanban-board.tsx` (removed in 1735004d6, #2437)
- `image-gallery.tsx` (added in 793c67d85, since removed)

## Dropped — file never existed in the repo

The original generated list fabricated 13 entries with no git history at all: `calendar-view.tsx`, `markdown-editor.tsx`, `data-table.tsx`, `form-builder.tsx`, `chart-widget.tsx`, `notification-center.tsx`, `search-filter.tsx`, `settings-panel.tsx`, `file-browser.tsx`, `theme-switcher.tsx`, `color-picker.tsx`, `progress-tracker.tsx`, `badge-component.tsx`.

## Dropped — already migrated

`todo-list.tsx` (now `todo-list/todo-list.tsx`) and `shopping-list.tsx` no longer contain any of the listed idioms (`derive`/`lift`/`cell()`/`.equals()`/`[ID]`).

## Other corrections

- All line numbers removed (they rot); the three surviving entries (`chatbot.tsx`, `system/default-app.tsx`, `system/omnibox-fab.tsx`) now reference verified remaining occurrences by symbol (`clearChat`, `removePiece`, `toggleMenu`/`closeMenu`, `toggle`/`closeFab`).
- Stale Summary counts (50 scanned / 21 affected) and the Migration Strategy phase counts removed along with the entries they counted.
- One-line cross-reference added to the status tiers in `index.md`.

Verified: every path in the final doc exists in the tree; `deno fmt --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed stale references in `packages/patterns/DEPRECATED_IDIOMS.md` and synced the migration list with the current tree (CT-1715). This keeps the guidance accurate and easier to maintain.

- **Bug Fixes**
  - Updated moved paths: `default-app.tsx` → `system/default-app.tsx`, `omnibox-fab.tsx` → `system/omnibox-fab.tsx`.
  - Dropped entries for files that were removed or never existed; removed stale counts and phase sections.
  - Replaced line numbers with symbol references, verified all remaining paths, and added a cross-link to status tiers in `index.md`.

<sup>Written for commit 6d4e3a16081d5acce78ff971ddaef07db4a36b02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

