### PR TITLE
fix(patterns): rename dead --cf-color-* refs to real token families (CT-1715)

### DIFF
--- a/packages/patterns/activity-log/activity-log.tsx
+++ b/packages/patterns/activity-log/activity-log.tsx
@@ -159,7 +159,7 @@ export default pattern<ActivityLogInput, ActivityLogOutput>(
               {filtered.map((event: ActivityEvent) => (
                 <cf-hstack
                   gap="2"
-                  style="align-items: flex-start; border-bottom: 1px solid var(--cf-color-gray-100); padding-bottom: 0.5rem;"
+                  style="align-items: flex-start; border-bottom: 1px solid var(--cf-colors-gray-100); padding-bottom: 0.5rem;"
                 >
                   <cf-vstack gap="0" style="flex: 1; min-width: 0;">
                     <cf-hstack
@@ -172,7 +172,7 @@ export default pattern<ActivityLogInput, ActivityLogOutput>(
                       </cf-label>
                       {event.pieceName
                         ? (
-                          <cf-label style="color: var(--cf-color-gray-500);">
+                          <cf-label style="color: var(--cf-colors-gray-500);">
                             {event.pieceName}
                           </cf-label>
                         )
@@ -183,13 +183,13 @@ export default pattern<ActivityLogInput, ActivityLogOutput>(
                     </cf-hstack>
                     {event.note
                       ? (
-                        <cf-label style="color: var(--cf-color-gray-600); font-size: 0.875em;">
+                        <cf-label style="color: var(--cf-colors-gray-600); font-size: 0.875em;">
                           {event.note}
                         </cf-label>
                       )
                       : null}
                   </cf-vstack>
-                  <cf-label style="color: var(--cf-color-gray-400); font-size: 0.75em; white-space: nowrap; flex-shrink: 0;">
+                  <cf-label style="color: var(--cf-colors-gray-400); font-size: 0.75em; white-space: nowrap; flex-shrink: 0;">
                     {new Date(event.timestamp).toLocaleTimeString()}
                   </cf-label>
                 </cf-hstack>
@@ -198,7 +198,7 @@ export default pattern<ActivityLogInput, ActivityLogOutput>(
               {computed(() =>
                 filtered.length === 0
                   ? (
-                    <cf-label style="color: var(--cf-color-gray-400); text-align: center; padding: 2rem 0;">
+                    <cf-label style="color: var(--cf-colors-gray-400); text-align: center; padding: 2rem 0;">
                       No events yet
                     </cf-label>
                   )

--- a/packages/patterns/agent/agent.tsx
+++ b/packages/patterns/agent/agent.tsx
@@ -180,9 +180,9 @@ export default pattern<AgentInput, AgentOutput>(
 
     const statusColor = computed(() => {
       const s = status.get();
-      if (s === "running") return "var(--cf-color-blue-500, #3b82f6)";
-      if (s === "error") return "var(--cf-color-red-500, #ef4444)";
-      return "var(--cf-color-gray-400, #9ca3af)";
+      if (s === "running") return "var(--cf-colors-blue-500, #3b82f6)";
+      if (s === "error") return "var(--cf-colors-red-500, #ef4444)";
+      return "var(--cf-colors-gray-400, #9ca3af)";
     });
 
     const summaryText = computed(() => {
@@ -236,7 +236,7 @@ export default pattern<AgentInput, AgentOutput>(
             style={{
               padding: "0.75rem 1rem",
               alignItems: "center",
-              borderBottom: "1px solid var(--cf-color-border, #e5e5e7)",
+              borderBottom: "1px solid var(--cf-theme-color-border, #e5e5e7)",
             }}
           >
             {/* Click-to-edit name */}
@@ -351,7 +351,7 @@ export default pattern<AgentInput, AgentOutput>(
                   gap="2"
                   style={{
                     fontSize: "13px",
-                    color: "var(--cf-color-text-secondary, #6b7280)",
+                    color: "var(--cf-theme-color-text-secondary, #6b7280)",
                     alignItems: "center",
                   }}
                 >

--- a/packages/patterns/auth/auth-manager-descriptor.ts
+++ b/packages/patterns/auth/auth-manager-descriptor.ts
@@ -32,11 +32,11 @@ export interface AuthManagerDescriptor {
 
 /** Status colors shared across all auth managers */
 export const STATUS_COLORS: Record<AuthState, string> = {
-  loading: "var(--cf-color-yellow-500, #eab308)",
-  "needs-login": "var(--cf-color-red-500, #ef4444)",
-  "missing-scopes": "var(--cf-color-orange-500, #f97316)",
-  "token-expired": "var(--cf-color-red-500, #ef4444)",
-  ready: "var(--cf-color-green-500, #22c55e)",
+  loading: "var(--cf-colors-warning, #eab308)",
+  "needs-login": "var(--cf-colors-red-500, #ef4444)",
+  "missing-scopes": "var(--cf-colors-coral, #f97316)",
+  "token-expired": "var(--cf-colors-red-500, #ef4444)",
+  ready: "var(--cf-colors-green-500, #22c55e)",
 };
 
 /** Status messages shared across all auth managers */

--- a/packages/patterns/base/contacts.tsx
+++ b/packages/patterns/base/contacts.tsx
@@ -219,7 +219,7 @@ export default pattern<Input, Output>(({ contacts, groups }) => {
                   <cf-card
                     style={computed(() =>
                       selectedIndex.get() === index
-                        ? "background: var(--cf-color-blue-50, #eff6ff); border: 1px solid var(--cf-color-blue-300, #93c5fd); cursor: pointer;"
+                        ? "background: var(--cf-colors-blue-50, #eff6ff); border: 1px solid var(--cf-colors-blue-500, #93c5fd); cursor: pointer;"
                         : "cursor: pointer;"
                     )}
                     onClick={selectContact({ selectedIndex, index })}

--- a/packages/patterns/calendar/calendar.tsx
+++ b/packages/patterns/calendar/calendar.tsx
@@ -105,7 +105,7 @@ export default pattern<CalendarInput, CalendarOutput>(({ events }) => {
         <cf-vstack slot="header" gap="1">
           <cf-hstack justify="between" align="center">
             <cf-heading level={4}>Calendar ({eventCount})</cf-heading>
-            <span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">
+            <span style="font-size: 0.875rem; color: var(--cf-colors-gray-500);">
               {todayDate}
             </span>
           </cf-hstack>
@@ -117,7 +117,7 @@ export default pattern<CalendarInput, CalendarOutput>(({ events }) => {
               const sorted = sortedEvents;
               if (sorted.length === 0) {
                 return (
-                  <div style="text-align: center; color: var(--cf-color-gray-500); padding: 2rem;">
+                  <div style="text-align: center; color: var(--cf-colors-gray-500); padding: 2rem;">
                     No events yet. Add one below!
                   </div>
                 );
@@ -139,17 +139,17 @@ export default pattern<CalendarInput, CalendarOutput>(({ events }) => {
                           fontWeight: "600",
                           fontSize: "0.875rem",
                           color: dateIsToday
-                            ? "var(--cf-color-primary-500)"
+                            ? "var(--cf-colors-primary-500)"
                             : dateIsPast
-                            ? "var(--cf-color-gray-400)"
-                            : "var(--cf-color-gray-700)",
+                            ? "var(--cf-colors-gray-400)"
+                            : "var(--cf-colors-gray-700)",
                         }}
                       >
                         {formatDate(date)}
                       </span>
                       {dateIsToday
                         ? (
-                          <span style="font-size: 0.75rem; background: var(--cf-color-primary-100); color: var(--cf-color-primary-700); padding: 0.125rem 0.5rem; border-radius: 999px;">
+                          <span style="font-size: 0.75rem; background: var(--cf-colors-primary-100); color: var(--cf-colors-primary-700); padding: 0.125rem 0.5rem; border-radius: 999px;">
                             Today
                           </span>
                         )
@@ -162,7 +162,7 @@ export default pattern<CalendarInput, CalendarOutput>(({ events }) => {
                   <cf-card>
                     <cf-hstack gap="2" align="center">
                       {event.time && (
-                        <span style="font-size: 0.875rem; color: var(--cf-color-gray-500); min-width: 50px;">
+                        <span style="font-size: 0.875rem; color: var(--cf-colors-gray-500); min-width: 50px;">
                           {event.time}
                         </span>
                       )}
@@ -171,7 +171,7 @@ export default pattern<CalendarInput, CalendarOutput>(({ events }) => {
                           {event.title || "(untitled)"}
                         </span>
                         {event.notes && (
-                          <span style="font-size: 0.75rem; color: var(--cf-color-gray-500); font-style: italic; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100%;">
+                          <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500); font-style: italic; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100%;">
                             {event.notes}
                           </span>
                         )}

--- a/packages/patterns/calendar/event-detail.tsx
+++ b/packages/patterns/calendar/event-detail.tsx
@@ -70,7 +70,7 @@ export default pattern<EventDetailInput, EventDetailOutput>(
               <cf-card>
                 <cf-vstack gap="2">
                   <cf-vstack gap="1">
-                    <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-color-gray-500);">
+                    <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-colors-gray-500);">
                       Title
                     </label>
                     <cf-input $value={title} placeholder="Event title" />
@@ -78,14 +78,14 @@ export default pattern<EventDetailInput, EventDetailOutput>(
 
                   <cf-hstack gap="2">
                     <cf-vstack gap="1" style="flex: 1;">
-                      <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-color-gray-500);">
+                      <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-colors-gray-500);">
                         Date
                       </label>
                       <cf-input $value={date} type="date" />
                     </cf-vstack>
 
                     <cf-vstack gap="1" style="flex: 1;">
-                      <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-color-gray-500);">
+                      <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-colors-gray-500);">
                         Time
                       </label>
                       <cf-input $value={time} type="time" />
@@ -96,7 +96,7 @@ export default pattern<EventDetailInput, EventDetailOutput>(
 
               <cf-card>
                 <cf-vstack gap="1">
-                  <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-color-gray-500);">
+                  <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-colors-gray-500);">
                     Notes
                   </label>
                   <cf-textarea

--- a/packages/patterns/card-piles/main.tsx
+++ b/packages/patterns/card-piles/main.tsx
@@ -94,7 +94,7 @@ const cardStyle = {
   width: "70px",
   height: "100px",
   background: "white",
-  border: "2px solid var(--cf-color-border, #e2e8f0)",
+  border: "2px solid var(--cf-theme-color-border, #e2e8f0)",
   borderRadius: "8px",
   display: "flex",
   flexDirection: "column",
@@ -108,10 +108,10 @@ const cardStyle = {
 const pileStyle = {
   minWidth: "120px",
   minHeight: "180px",
-  border: "2px dashed var(--cf-color-border, #cbd5e1)",
+  border: "2px dashed var(--cf-theme-color-border, #cbd5e1)",
   borderRadius: "12px",
   padding: "1rem",
-  background: "var(--cf-color-bg-secondary, #f8fafc)",
+  background: "var(--cf-theme-color-surface, #f8fafc)",
   display: "flex",
   flexDirection: "column",
   gap: "0.5rem",
@@ -119,7 +119,7 @@ const pileStyle = {
 
 const pileLabelStyle = {
   fontSize: "12px",
-  color: "var(--cf-color-text-secondary, #64748b)",
+  color: "var(--cf-theme-color-text-secondary, #64748b)",
   fontWeight: "600",
   marginBottom: "0.5rem",
 } as const;
@@ -132,7 +132,7 @@ const cardListStyle = {
 } as const;
 
 const emptyPileStyle = {
-  color: "var(--cf-color-text-secondary, #94a3b8)",
+  color: "var(--cf-theme-color-text-secondary, #94a3b8)",
   fontSize: "13px",
   fontStyle: "italic",
   textAlign: "center",

--- a/packages/patterns/catalog/stories/cf-card-story.tsx
+++ b/packages/patterns/catalog/stories/cf-card-story.tsx
@@ -23,7 +23,7 @@ export default pattern<CardStoryInput, CardStoryOutput>(() => {
         <cf-card>
           <cf-vstack gap="1">
             <cf-heading level={5}>Basic Card</cf-heading>
-            <span style="color: var(--cf-color-gray-600);">
+            <span style="color: var(--cf-colors-gray-600);">
               A simple card with text content. Cards provide built-in padding.
             </span>
           </cf-vstack>
@@ -34,7 +34,7 @@ export default pattern<CardStoryInput, CardStoryOutput>(() => {
             <span style="font-size: 2rem;">🎨</span>
             <cf-vstack gap="0" style="flex: 1;">
               <span style="font-weight: 600;">Card with Icon</span>
-              <span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.875rem; color: var(--cf-colors-gray-500);">
                 Horizontal layout with icon and text
               </span>
             </cf-vstack>

--- a/packages/patterns/catalog/stories/cf-hgroup-story.tsx
+++ b/packages/patterns/catalog/stories/cf-hgroup-story.tsx
@@ -66,7 +66,7 @@ export default pattern<HGroupStoryInput, HGroupStoryOutput>(() => {
           </div>
           <cf-vstack gap="2">
             <cf-vstack gap="1">
-              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                 gap=sm
               </span>
               <cf-hgroup gap="sm">
@@ -82,7 +82,7 @@ export default pattern<HGroupStoryInput, HGroupStoryOutput>(() => {
               </cf-hgroup>
             </cf-vstack>
             <cf-vstack gap="1">
-              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                 gap=md
               </span>
               <cf-hgroup gap="md">
@@ -98,7 +98,7 @@ export default pattern<HGroupStoryInput, HGroupStoryOutput>(() => {
               </cf-hgroup>
             </cf-vstack>
             <cf-vstack gap="1">
-              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                 gap=lg
               </span>
               <cf-hgroup gap="lg">

--- a/packages/patterns/catalog/stories/cf-hstack-story.tsx
+++ b/packages/patterns/catalog/stories/cf-hstack-story.tsx
@@ -76,7 +76,7 @@ export default pattern<HStackStoryInput, HStackStoryOutput>(() => {
               align="start"
               style="border: 1px dashed #cbd5e1; padding: 8px; border-radius: 4px; min-height: 60px;"
             >
-              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                 align=start
               </span>
               <div style="background: #fde68a; padding: 4px 12px; border-radius: 4px; height: 40px;">
@@ -91,7 +91,7 @@ export default pattern<HStackStoryInput, HStackStoryOutput>(() => {
               align="center"
               style="border: 1px dashed #cbd5e1; padding: 8px; border-radius: 4px; min-height: 60px;"
             >
-              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                 align=center
               </span>
               <div style="background: #bbf7d0; padding: 4px 12px; border-radius: 4px; height: 40px;">
@@ -106,7 +106,7 @@ export default pattern<HStackStoryInput, HStackStoryOutput>(() => {
               align="end"
               style="border: 1px dashed #cbd5e1; padding: 8px; border-radius: 4px; min-height: 60px;"
             >
-              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                 align=end
               </span>
               <div style="background: #bfdbfe; padding: 4px 12px; border-radius: 4px; height: 40px;">

--- a/packages/patterns/catalog/stories/cf-loader-story.tsx
+++ b/packages/patterns/catalog/stories/cf-loader-story.tsx
@@ -37,19 +37,19 @@ export default pattern<LoaderStoryInput, LoaderStoryOutput>(() => {
           <div style={{ display: "flex", gap: "24px", alignItems: "center" }}>
             <cf-vstack gap="1" align="center">
               <cf-loader size="sm" show-elapsed={showElapsed} />
-              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                 sm
               </span>
             </cf-vstack>
             <cf-vstack gap="1" align="center">
               <cf-loader size="md" show-elapsed={showElapsed} />
-              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                 md
               </span>
             </cf-vstack>
             <cf-vstack gap="1" align="center">
               <cf-loader size="lg" show-elapsed={showElapsed} />
-              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                 lg
               </span>
             </cf-vstack>

--- a/packages/patterns/catalog/stories/cf-progress-story.tsx
+++ b/packages/patterns/catalog/stories/cf-progress-story.tsx
@@ -32,7 +32,7 @@ export default pattern<ProgressStoryInput, ProgressStoryOutput>(() => {
         <cf-vstack gap="1">
           <span style="font-weight: 600;">Various Values</span>
           <cf-hstack gap="2" align="center">
-            <span style="font-size: 0.75rem; color: var(--cf-color-gray-500); width: 30px;">
+            <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500); width: 30px;">
               0%
             </span>
             <div style={{ flex: "1" }}>
@@ -40,7 +40,7 @@ export default pattern<ProgressStoryInput, ProgressStoryOutput>(() => {
             </div>
           </cf-hstack>
           <cf-hstack gap="2" align="center">
-            <span style="font-size: 0.75rem; color: var(--cf-color-gray-500); width: 30px;">
+            <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500); width: 30px;">
               25%
             </span>
             <div style={{ flex: "1" }}>
@@ -48,7 +48,7 @@ export default pattern<ProgressStoryInput, ProgressStoryOutput>(() => {
             </div>
           </cf-hstack>
           <cf-hstack gap="2" align="center">
-            <span style="font-size: 0.75rem; color: var(--cf-color-gray-500); width: 30px;">
+            <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500); width: 30px;">
               50%
             </span>
             <div style={{ flex: "1" }}>
@@ -56,7 +56,7 @@ export default pattern<ProgressStoryInput, ProgressStoryOutput>(() => {
             </div>
           </cf-hstack>
           <cf-hstack gap="2" align="center">
-            <span style="font-size: 0.75rem; color: var(--cf-color-gray-500); width: 30px;">
+            <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500); width: 30px;">
               75%
             </span>
             <div style={{ flex: "1" }}>
@@ -64,7 +64,7 @@ export default pattern<ProgressStoryInput, ProgressStoryOutput>(() => {
             </div>
           </cf-hstack>
           <cf-hstack gap="2" align="center">
-            <span style="font-size: 0.75rem; color: var(--cf-color-gray-500); width: 30px;">
+            <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500); width: 30px;">
               100%
             </span>
             <div style={{ flex: "1" }}>

--- a/packages/patterns/catalog/stories/cf-vgroup-story.tsx
+++ b/packages/patterns/catalog/stories/cf-vgroup-story.tsx
@@ -61,7 +61,7 @@ export default pattern<VGroupStoryInput, VGroupStoryOutput>(() => {
           </div>
           <cf-hstack gap="4">
             <cf-vstack gap="1" style="flex: 1;">
-              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                 gap=sm
               </span>
               <cf-vgroup gap="sm">
@@ -77,7 +77,7 @@ export default pattern<VGroupStoryInput, VGroupStoryOutput>(() => {
               </cf-vgroup>
             </cf-vstack>
             <cf-vstack gap="1" style="flex: 1;">
-              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                 gap=md
               </span>
               <cf-vgroup gap="md">
@@ -93,7 +93,7 @@ export default pattern<VGroupStoryInput, VGroupStoryOutput>(() => {
               </cf-vgroup>
             </cf-vstack>
             <cf-vstack gap="1" style="flex: 1;">
-              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                 gap=lg
               </span>
               <cf-vgroup gap="lg">

--- a/packages/patterns/catalog/stories/cf-vstack-story.tsx
+++ b/packages/patterns/catalog/stories/cf-vstack-story.tsx
@@ -73,7 +73,7 @@ export default pattern<VStackStoryInput, VStackStoryOutput>(() => {
               gap="0"
               style="border: 1px dashed #cbd5e1; padding: 8px; border-radius: 4px; flex: 1;"
             >
-              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                 gap=0
               </span>
               <div style="background: #fde68a; padding: 4px 8px; border-radius: 4px;">
@@ -90,7 +90,7 @@ export default pattern<VStackStoryInput, VStackStoryOutput>(() => {
               gap="2"
               style="border: 1px dashed #cbd5e1; padding: 8px; border-radius: 4px; flex: 1;"
             >
-              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                 gap=2
               </span>
               <div style="background: #bbf7d0; padding: 4px 8px; border-radius: 4px;">
@@ -107,7 +107,7 @@ export default pattern<VStackStoryInput, VStackStoryOutput>(() => {
               gap="4"
               style="border: 1px dashed #cbd5e1; padding: 8px; border-radius: 4px; flex: 1;"
             >
-              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                 gap=4
               </span>
               <div style="background: #bfdbfe; padding: 4px 8px; border-radius: 4px;">

--- a/packages/patterns/cfc-agent-prompt-injection-demo/main.tsx
+++ b/packages/patterns/cfc-agent-prompt-injection-demo/main.tsx
@@ -147,9 +147,9 @@ const AGENT_PANEL_STYLE = {
   height: AGENT_PANEL_HEIGHT,
   minHeight: "0",
   overflow: "hidden",
-  border: "1px solid var(--cf-color-gray-200, #eaecf0)",
+  border: "1px solid var(--cf-colors-gray-200, #eaecf0)",
   borderRadius: "12px",
-  background: "var(--cf-color-background, #fff)",
+  background: "var(--cf-theme-color-background, #fff)",
   padding: "1rem",
 };
 const AGENT_PANEL_STACK_STYLE = {
@@ -164,7 +164,7 @@ const PRIMARY_CONTROL_STYLE = {
   border: "0",
   borderRadius: "8px",
   padding: "0.6rem 0.85rem",
-  background: "var(--cf-color-blue-600, #4f6df5)",
+  background: "var(--cf-colors-blue-600, #4f6df5)",
   color: "white",
   cursor: "pointer",
   font: "inherit",
@@ -172,8 +172,8 @@ const PRIMARY_CONTROL_STYLE = {
 
 const SECONDARY_CONTROL_STYLE = {
   ...PRIMARY_CONTROL_STYLE,
-  background: "var(--cf-color-gray-100, #f2f4f7)",
-  color: "var(--cf-color-gray-900, #101828)",
+  background: "var(--cf-colors-gray-100, #f2f4f7)",
+  color: "var(--cf-colors-gray-900, #101828)",
 };
 
 type LabelPreviewProps = {
@@ -193,9 +193,9 @@ function LabelPreview(
         display: "grid",
         gap: "0.5rem",
         padding: "0.75rem",
-        border: "1px solid var(--cf-color-gray-200, #eaecf0)",
+        border: "1px solid var(--cf-colors-gray-200, #eaecf0)",
         borderRadius: "12px",
-        background: "var(--cf-color-gray-25, #fcfcfd)",
+        background: "var(--cf-colors-gray-50, #fcfcfd)",
       }}
     >
       {integrity.length > 0
@@ -482,10 +482,10 @@ Your job in this half is to fail visibly when the document tries to seize contro
           style={{
             flex: 1,
             minHeight: "0",
-            border: "1px solid var(--cf-color-gray-200)",
+            border: "1px solid var(--cf-colors-gray-200)",
             borderRadius: "12px",
             padding: "0.75rem",
-            background: "var(--cf-color-gray-25, #fcfcfd)",
+            background: "var(--cf-colors-gray-50, #fcfcfd)",
           }}
         >
           {unsafeHasMessages
@@ -493,7 +493,7 @@ Your job in this half is to fail visibly when the document tries to seize contro
             : (
               <div
                 style={{
-                  color: "var(--cf-color-gray-500)",
+                  color: "var(--cf-colors-gray-500)",
                   padding: "2rem 1rem",
                   textAlign: "center",
                 }}
@@ -606,10 +606,10 @@ string.`;
           style={{
             flex: 1,
             minHeight: "0",
-            border: "1px solid var(--cf-color-gray-200)",
+            border: "1px solid var(--cf-colors-gray-200)",
             borderRadius: "12px",
             padding: "0.75rem",
-            background: "var(--cf-color-gray-25, #fcfcfd)",
+            background: "var(--cf-colors-gray-50, #fcfcfd)",
           }}
         >
           {safeHasMessages
@@ -617,7 +617,7 @@ string.`;
             : (
               <div
                 style={{
-                  color: "var(--cf-color-gray-500)",
+                  color: "var(--cf-colors-gray-500)",
                   padding: "2rem 1rem",
                   textAlign: "center",
                 }}
@@ -779,7 +779,7 @@ string.`;
                       lineHeight: "1.5",
                       padding: "0.75rem",
                       borderRadius: "12px",
-                      background: "var(--cf-color-gray-50)",
+                      background: "var(--cf-colors-gray-50)",
                     }}
                   >
                     {DEMO_PROMPT}
@@ -808,7 +808,7 @@ string.`;
                       lineHeight: "1.5",
                       padding: "0.75rem",
                       borderRadius: "12px",
-                      background: "var(--cf-color-gray-50)",
+                      background: "var(--cf-colors-gray-50)",
                     }}
                   >
                   {HOSTILE_BRIEFING_BODY}
@@ -851,7 +851,7 @@ string.`;
                     : (
                       <div
                         style={{
-                          color: "var(--cf-color-gray-500)",
+                          color: "var(--cf-colors-gray-500)",
                           padding: "1rem 0",
                         }}
                       >

--- a/packages/patterns/cfc-group-chat-demo/main.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.tsx
@@ -103,7 +103,7 @@ const SharedTranscript = pattern<
             <span
               style={{
                 fontSize: "12px",
-                color: "var(--cf-color-text-secondary)",
+                color: "var(--cf-theme-color-text-secondary)",
               }}
             >
               {messageCell.authorName}
@@ -123,11 +123,11 @@ const SharedTranscript = pattern<
                     ? "14px 14px 4px 14px"
                     : "14px 14px 14px 4px",
                   background: isMine
-                    ? "var(--cf-color-primary, #2563eb)"
-                    : "var(--cf-color-surface-raised, #f3f4f6)",
+                    ? "var(--cf-theme-color-primary, #2563eb)"
+                    : "var(--cf-theme-color-surface, #f3f4f6)",
                   color: isMine
-                    ? "var(--cf-color-on-primary, #ffffff)"
-                    : "var(--cf-color-text, #111827)",
+                    ? "var(--cf-theme-color-primary-foreground, #ffffff)"
+                    : "var(--cf-theme-color-text, #111827)",
                   overflowWrap: "anywhere",
                   whiteSpace: "pre-wrap",
                 }}

--- a/packages/patterns/cfc-group-chat-demo/trusted.tsx
+++ b/packages/patterns/cfc-group-chat-demo/trusted.tsx
@@ -994,7 +994,7 @@ export const TrustedAdminPanel = pattern<
                   wrap
                   style={{
                     padding: "0.5rem 0.75rem",
-                    border: "1px solid var(--cf-color-border, #e5e7eb)",
+                    border: "1px solid var(--cf-theme-color-border, #e5e7eb)",
                     borderRadius: "0.75rem",
                   }}
                 >

--- a/packages/patterns/contacts/contact-book.tsx
+++ b/packages/patterns/contacts/contact-book.tsx
@@ -149,18 +149,18 @@ export default pattern<ContactBookInput, ContactBookOutput>(
                           {contact.name || "(unnamed)"}
                         </span>
                         {contact.email && (
-                          <span style="font-size: 0.875rem; color: var(--cf-color-gray-600);">
+                          <span style="font-size: 0.875rem; color: var(--cf-colors-gray-600);">
                             {contact.email}
                           </span>
                         )}
                         {contact.company && (
-                          <span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">
+                          <span style="font-size: 0.875rem; color: var(--cf-colors-gray-500);">
                             {contact.company}
                           </span>
                         )}
                         {/* Show relationships */}
                         {contactRelations.map((rel: Relationship) => (
-                          <span style="font-size: 0.75rem; color: var(--cf-color-primary-500);">
+                          <span style="font-size: 0.75rem; color: var(--cf-colors-primary-500);">
                             ↔ {rel.fromName === contact.name
                               ? rel.toName
                               : rel.fromName}
@@ -182,7 +182,7 @@ export default pattern<ContactBookInput, ContactBookOutput>(
 
               {ifElse(
                 computed(() => contacts.get().length === 0),
-                <div style="text-align: center; color: var(--cf-color-gray-500); padding: 2rem;">
+                <div style="text-align: center; color: var(--cf-colors-gray-500); padding: 2rem;">
                   No contacts yet. Add one below!
                 </div>,
                 null,

--- a/packages/patterns/contacts/contact-detail.tsx
+++ b/packages/patterns/contacts/contact-detail.tsx
@@ -29,7 +29,7 @@ export default pattern<ContactDetailInput, ContactDetailOutput>(
         <cf-card>
           <cf-vstack gap="2">
             <cf-vstack gap="1">
-              <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-color-gray-500);">
+              <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-colors-gray-500);">
                 Name
               </label>
               <cf-input
@@ -39,7 +39,7 @@ export default pattern<ContactDetailInput, ContactDetailOutput>(
             </cf-vstack>
 
             <cf-vstack gap="1">
-              <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-color-gray-500);">
+              <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-colors-gray-500);">
                 Email
               </label>
               <cf-input
@@ -50,7 +50,7 @@ export default pattern<ContactDetailInput, ContactDetailOutput>(
             </cf-vstack>
 
             <cf-vstack gap="1">
-              <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-color-gray-500);">
+              <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-colors-gray-500);">
                 Phone
               </label>
               <cf-input
@@ -61,7 +61,7 @@ export default pattern<ContactDetailInput, ContactDetailOutput>(
             </cf-vstack>
 
             <cf-vstack gap="1">
-              <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-color-gray-500);">
+              <label style="font-size: 0.75rem; font-weight: 500; color: var(--cf-colors-gray-500);">
                 Company
               </label>
               <cf-input

--- a/packages/patterns/counter/counter.tsx
+++ b/packages/patterns/counter/counter.tsx
@@ -87,7 +87,7 @@ const Counter = pattern<CounterInput, CounterOutput>(({ value }) => {
 
           <div
             id="counter-result"
-            style={{ color: "var(--cf-color-gray-500)" }}
+            style={{ color: "var(--cf-colors-gray-500)" }}
           >
             Counter is the {ordinalDisplay} number
           </div>

--- a/packages/patterns/do-list/do-list.tsx
+++ b/packages/patterns/do-list/do-list.tsx
@@ -317,7 +317,7 @@ const DoItemCard = pattern<
           )}
 
           <details style="margin-top: 8px; margin-left: 24px;">
-            <summary style="cursor: pointer; font-size: 0.8rem; color: var(--cf-color-gray-500);">
+            <summary style="cursor: pointer; font-size: 0.8rem; color: var(--cf-colors-gray-500);">
               AI Suggestions
             </summary>
             <Suggestion
@@ -349,7 +349,7 @@ const CompletedItemCard = pattern<
       >
         <cf-hstack gap="2" align="center">
           <cf-checkbox $checked={item.done} />
-          <span style="text-decoration: line-through; flex: 1; color: var(--cf-color-gray-500);">
+          <span style="text-decoration: line-through; flex: 1; color: var(--cf-colors-gray-500);">
             {item.title}
           </span>
         </cf-hstack>
@@ -401,7 +401,7 @@ export default pattern<DoListInput, DoListOutput>(({ items }) => {
 
         {hasNoItems
           ? (
-            <div style="text-align: center; color: var(--cf-color-gray-500); padding: 1rem;">
+            <div style="text-align: center; color: var(--cf-colors-gray-500); padding: 1rem;">
               No items yet. Add one below!
             </div>
           )
@@ -414,7 +414,7 @@ export default pattern<DoListInput, DoListOutput>(({ items }) => {
           <cf-button
             variant="ghost"
             size="sm"
-            style="font-size: 0.8rem; color: var(--cf-color-gray-500);"
+            style="font-size: 0.8rem; color: var(--cf-colors-gray-500);"
             onClick={() => archiveCompleted.send({})}
           >
             Archive completed
@@ -442,7 +442,7 @@ export default pattern<DoListInput, DoListOutput>(({ items }) => {
         <cf-vstack slot="header" gap="1">
           <cf-hstack justify="between" align="center">
             <cf-heading level={4}>Do List</cf-heading>
-            <span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">
+            <span style="font-size: 0.875rem; color: var(--cf-colors-gray-500);">
               {computed(() => activeItems.length)} items
             </span>
           </cf-hstack>
@@ -454,7 +454,7 @@ export default pattern<DoListInput, DoListOutput>(({ items }) => {
 
             {hasNoItems
               ? (
-                <div style="text-align: center; color: var(--cf-color-gray-500); padding: 2rem;">
+                <div style="text-align: center; color: var(--cf-colors-gray-500); padding: 2rem;">
                   No items yet. Add one below!
                 </div>
               )
@@ -463,7 +463,7 @@ export default pattern<DoListInput, DoListOutput>(({ items }) => {
             {ifElse(
               hasCompleted,
               <details style="margin-top: 1rem;">
-                <summary style="cursor: pointer; font-size: 0.875rem; color: var(--cf-color-gray-500); padding: 0.5rem 0;">
+                <summary style="cursor: pointer; font-size: 0.875rem; color: var(--cf-colors-gray-500); padding: 0.5rem 0;">
                   Completed ({computed(() => completedItems.length)})
                 </summary>
                 <cf-vstack gap="2" style="padding-top: 0.5rem;">
@@ -472,7 +472,7 @@ export default pattern<DoListInput, DoListOutput>(({ items }) => {
                     <cf-button
                       variant="ghost"
                       size="sm"
-                      style="font-size: 0.8rem; color: var(--cf-color-gray-500);"
+                      style="font-size: 0.8rem; color: var(--cf-colors-gray-500);"
                       onClick={() => archiveCompleted.send({})}
                     >
                       Archive all

--- a/packages/patterns/examples/summary-index-tester.tsx
+++ b/packages/patterns/examples/summary-index-tester.tsx
@@ -46,7 +46,7 @@ export default pattern<Record<string, never>>((_) => {
             <span
               style={{
                 fontSize: "13px",
-                color: "var(--cf-color-text-secondary)",
+                color: "var(--cf-theme-color-text-secondary)",
               }}
             >
               Showing {filteredCount} results
@@ -69,7 +69,7 @@ export default pattern<Record<string, never>>((_) => {
                   <td
                     style={{
                       fontSize: "13px",
-                      color: "var(--cf-color-text-secondary)",
+                      color: "var(--cf-theme-color-text-secondary)",
                     }}
                   >
                     {entry.summary}

--- a/packages/patterns/experimental/chat-note.tsx
+++ b/packages/patterns/experimental/chat-note.tsx
@@ -462,7 +462,7 @@ const ChatNote = pattern<Input, Output>(
             gap="2"
             padding="4"
             style={{
-              borderBottom: "1px solid var(--cf-color-border, #e5e5e7)",
+              borderBottom: "1px solid var(--cf-theme-color-border, #e5e5e7)",
             }}
           >
             {/* Parent notebook chip */}
@@ -477,7 +477,7 @@ const ChatNote = pattern<Input, Output>(
               <span
                 style={{
                   fontSize: "13px",
-                  color: "var(--cf-color-text-secondary)",
+                  color: "var(--cf-theme-color-text-secondary)",
                 }}
               >
                 In:
@@ -533,8 +533,8 @@ const ChatNote = pattern<Input, Output>(
                   padding: "4px 8px",
                   fontSize: "13px",
                   borderRadius: "6px",
-                  border: "1px solid var(--cf-color-border, #e5e5e7)",
-                  background: "var(--cf-color-bg, white)",
+                  border: "1px solid var(--cf-theme-color-border, #e5e5e7)",
+                  background: "var(--cf-theme-color-background, white)",
                   cursor: "pointer",
                 }}
               >

--- a/packages/patterns/factory-outputs/lot-watch/main.tsx
+++ b/packages/patterns/factory-outputs/lot-watch/main.tsx
@@ -1436,7 +1436,7 @@ export default pattern<LotWatchInput, LotWatchOutput>(
           {/* Header with tab navigation */}
           <div
             slot="header"
-            style="padding: 0.75rem 1rem; display: flex; flex-direction: column; gap: 0.5rem; border-bottom: 1px solid var(--cf-color-gray-200);"
+            style="padding: 0.75rem 1rem; display: flex; flex-direction: column; gap: 0.5rem; border-bottom: 1px solid var(--cf-colors-gray-200);"
           >
             <cf-hstack justify="between" align="center">
               <cf-heading level={4}>Lot Watch</cf-heading>
@@ -1520,7 +1520,7 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                         gap="2"
                         wrap
                       >
-                        <span style="font-size: 0.75rem; color: var(--cf-color-gray-500); white-space: nowrap;">
+                        <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500); white-space: nowrap;">
                           Reporting as
                         </span>
                         {hasReporter
@@ -1561,7 +1561,7 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                             <cf-heading level={5}>
                               Step 1 of 3 — Take a photo
                             </cf-heading>
-                            <span style="text-align: center; font-size: 0.875rem; color: var(--cf-color-gray-500);">
+                            <span style="text-align: center; font-size: 0.875rem; color: var(--cf-colors-gray-500);">
                               Photograph the car. We'll read the plate
                               automatically while you pick the spot.
                             </span>
@@ -1695,7 +1695,7 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                               </span>
                               {extraction.pending
                                 ? (
-                                  <span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">
+                                  <span style="font-size: 0.875rem; color: var(--cf-colors-gray-500);">
                                     Reading the plate…
                                   </span>
                                 )
@@ -1715,7 +1715,7 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                                       {extraction.result?.plateNumber}{" "}
                                       {extraction.result?.plateState}
                                     </span>
-                                    <span style="font-size: 0.7rem; color: var(--cf-color-gray-500);">
+                                    <span style="font-size: 0.7rem; color: var(--cf-colors-gray-500);">
                                       confidence:{" "}
                                       {extraction.result?.confidence}
                                     </span>
@@ -1849,7 +1849,7 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                     {noSightings
                       ? (
                         <cf-card>
-                          <span style="color: var(--cf-color-gray-500); font-size: 0.875rem;">
+                          <span style="color: var(--cf-colors-gray-500); font-size: 0.875rem;">
                             No sightings yet. Use 📸 Capture to document a car
                             in one of your spots.
                           </span>
@@ -1876,10 +1876,10 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                                   <span style="font-weight: 600; font-family: monospace;">
                                     {g.plate} ({g.state})
                                   </span>
-                                  <span style="font-size: 0.75rem; color: var(--cf-color-gray-600);">
+                                  <span style="font-size: 0.75rem; color: var(--cf-colors-gray-600);">
                                     {g.description} · spots {g.spotsLabel}
                                   </span>
-                                  <span style="font-size: 0.7rem; color: var(--cf-color-gray-500);">
+                                  <span style="font-size: 0.7rem; color: var(--cf-colors-gray-500);">
                                     {g.firstSeen} → {g.lastSeen}
                                   </span>
                                 </cf-vstack>
@@ -1926,7 +1926,7 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                                   />
                                 )
                                 : (
-                                  <div style="width: 80px; height: 60px; background: var(--cf-color-gray-100); border-radius: 6px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 1.5rem;">
+                                  <div style="width: 80px; height: 60px; background: var(--cf-colors-gray-100); border-radius: 6px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 1.5rem;">
                                     🚗
                                   </div>
                                 )}
@@ -2005,7 +2005,7 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                             {/* Notes */}
                             {row.notes
                               ? (
-                                <span style="font-size: 0.75rem; color: var(--cf-color-gray-600); font-style: italic; padding: 0.375rem 0.5rem; background: var(--cf-color-gray-50); border-radius: 4px;">
+                                <span style="font-size: 0.75rem; color: var(--cf-colors-gray-600); font-style: italic; padding: 0.375rem 0.5rem; background: var(--cf-colors-gray-50); border-radius: 4px;">
                                   {row.notes}
                                 </span>
                               )
@@ -2156,7 +2156,7 @@ export default pattern<LotWatchInput, LotWatchOutput>(
 
                             {/* Footer: reporter + time + delete */}
                             <cf-hstack justify="between" align="center" wrap>
-                              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                                 {row.reportedBy} — {row.dateStr} {row.timeStr}
                               </span>
 
@@ -2242,7 +2242,7 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                     <cf-card>
                       <cf-vstack gap="2">
                         <cf-heading level={6}>Spot Occupancy</cf-heading>
-                        <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                        <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                           Total sightings per spot, and how many were non-ours.
                         </span>
                         {spotOccupancy.map((row) => (
@@ -2250,13 +2250,13 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                             justify="between"
                             align="center"
                             gap="2"
-                            style="padding: 0.375rem 0.5rem; border: 1px solid var(--cf-color-gray-200); border-radius: 0.5rem;"
+                            style="padding: 0.375rem 0.5rem; border: 1px solid var(--cf-colors-gray-200); border-radius: 0.5rem;"
                           >
                             <span style="font-weight: 600;">
                               Spot #{row.spotNum}
                             </span>
                             <cf-hstack gap="2" align="center">
-                              <span style="font-size: 0.75rem; color: var(--cf-color-gray-600);">
+                              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-600);">
                                 {row.total} total
                               </span>
                               {row.nonOursCount > 0
@@ -2330,7 +2330,7 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                                     <span style="font-weight: 600; font-family: monospace;">
                                       {g.plate}
                                     </span>
-                                    <span style="font-size: 0.7rem; color: var(--cf-color-gray-500);">
+                                    <span style="font-size: 0.7rem; color: var(--cf-colors-gray-500);">
                                       ({g.state})
                                     </span>
                                     <span
@@ -2353,12 +2353,12 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                                   </cf-hstack>
                                   {g.org
                                     ? (
-                                      <span style="font-size: 0.75rem; color: var(--cf-color-gray-600);">
+                                      <span style="font-size: 0.75rem; color: var(--cf-colors-gray-600);">
                                         {g.org}
                                       </span>
                                     )
                                     : null}
-                                  <span style="font-size: 0.7rem; color: var(--cf-color-gray-500);">
+                                  <span style="font-size: 0.7rem; color: var(--cf-colors-gray-500);">
                                     {g.description
                                       ? g.description + " · "
                                       : ""}spots {g.spotsLabel} · last{" "}
@@ -2391,7 +2391,7 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                         <cf-heading level={6}>Recent Activity</cf-heading>
                         {noRecentActivity
                           ? (
-                            <span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">
+                            <span style="font-size: 0.875rem; color: var(--cf-colors-gray-500);">
                               No sightings match the current filters.
                             </span>
                           )
@@ -2400,7 +2400,7 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                           <cf-hstack
                             gap="2"
                             align="center"
-                            style="padding: 0.375rem 0; border-bottom: 1px solid var(--cf-color-gray-100);"
+                            style="padding: 0.375rem 0; border-bottom: 1px solid var(--cf-colors-gray-100);"
                           >
                             {r.imgSrc
                               ? (
@@ -2411,7 +2411,7 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                                 />
                               )
                               : (
-                                <div style="width: 48px; height: 36px; background: var(--cf-color-gray-100); border-radius: 4px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 1rem;">
+                                <div style="width: 48px; height: 36px; background: var(--cf-colors-gray-100); border-radius: 4px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 1rem;">
                                   🚗
                                 </div>
                               )}
@@ -2442,7 +2442,7 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                                   </span>
                                 )
                                 : null}
-                              <span style="font-size: 0.7rem; color: var(--cf-color-gray-500);">
+                              <span style="font-size: 0.7rem; color: var(--cf-colors-gray-500);">
                                 {r.reportedBy} · {r.when}
                               </span>
                             </cf-vstack>

--- a/packages/patterns/factory-outputs/lot-with-coordinator-demo/main.tsx
+++ b/packages/patterns/factory-outputs/lot-with-coordinator-demo/main.tsx
@@ -110,7 +110,7 @@ export default pattern<Record<string, never>, Out>(() => {
             <span style="font-size: 0.875rem; font-weight: 600;">
               🔗 Composed demo
             </span>
-            <span style="font-size: 0.7rem; color: var(--cf-color-gray-600);">
+            <span style="font-size: 0.7rem; color: var(--cf-colors-gray-600);">
               These two patterns share the same `people` cell. Tag a plate as
               "Gideon's car" in Lot Watch and Gideon appears in Parking
               Coordinator's people list.

--- a/packages/patterns/factory-outputs/parking-coordinator/main.tsx
+++ b/packages/patterns/factory-outputs/parking-coordinator/main.tsx
@@ -1464,11 +1464,11 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
           {/* Header */}
           <div
             slot="header"
-            style="padding: 0.75rem 1rem; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid var(--cf-color-gray-200);"
+            style="padding: 0.75rem 1rem; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid var(--cf-colors-gray-200);"
           >
             <cf-heading level={4}>Parking</cf-heading>
             <div style="display: flex; align-items: center; gap: 0.75rem;">
-              <span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.875rem; color: var(--cf-colors-gray-500);">
                 {todayFormatted}
               </span>
               <cf-button
@@ -1497,7 +1497,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                 {noPeople
                   ? (
                     <cf-card>
-                      <span style="color: var(--cf-color-gray-500); font-size: 0.875rem;">
+                      <span style="color: var(--cf-colors-gray-500); font-size: 0.875rem;">
                         No team members yet — ask your admin to add people.
                       </span>
                     </cf-card>
@@ -1524,7 +1524,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                           </span>
                           {stripSpotLabel
                             ? (
-                              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                              <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                                 {stripSpotLabel}
                               </span>
                             )
@@ -1597,7 +1597,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                       </span>
                       {noPeople
                         ? (
-                          <span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">
+                          <span style="font-size: 0.875rem; color: var(--cf-colors-gray-500);">
                             No team members yet — ask your admin to add people.
                           </span>
                         )
@@ -1666,7 +1666,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                   <cf-hstack justify="between" align="center" wrap gap="2">
                     <cf-vstack gap="1">
                       <cf-heading level={6}>Admin Access</cf-heading>
-                      <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                      <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                         Demo manager access lets any user change who can manage
                         parking spots.
                       </span>
@@ -1688,7 +1688,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
 
                   {noPeople
                     ? (
-                      <span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">
+                      <span style="font-size: 0.875rem; color: var(--cf-colors-gray-500);">
                         Add people before assigning admins.
                       </span>
                     )
@@ -1706,7 +1706,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                         align="center"
                         gap="2"
                         wrap
-                        style="padding: 0.5rem 0.75rem; border: 1px solid var(--cf-color-gray-200); border-radius: 0.75rem;"
+                        style="padding: 0.5rem 0.75rem; border: 1px solid var(--cf-colors-gray-200); border-radius: 0.75rem;"
                       >
                         <cf-vstack gap="0">
                           <cf-hstack gap="2" align="center" wrap>
@@ -1716,7 +1716,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                               variant={rowIsAdmin ? "accent" : "default"}
                             />
                           </cf-hstack>
-                          <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                          <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                             {rowEmail}
                           </span>
                         </cf-vstack>
@@ -1743,7 +1743,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
 
                 {weekMonthInfo
                   ? (
-                    <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                    <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                       {weekMonthInfo}
                     </span>
                   )
@@ -1773,7 +1773,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                           borderRadius: "4px 4px 0 0",
                           color: isToday
                             ? "#92400e"
-                            : "var(--cf-color-gray-600)",
+                            : "var(--cf-colors-gray-600)",
                         }}
                       >
                         <span style="display: block;">{shortName}</span>
@@ -1790,7 +1790,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                           padding: "0.25rem 0.5rem",
                           fontSize: "0.75rem",
                           fontWeight: "600",
-                          color: "var(--cf-color-gray-700)",
+                          color: "var(--cf-colors-gray-700)",
                           display: "flex",
                           alignItems: "center",
                         }}
@@ -1842,7 +1842,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                   />
                                   {gridConflictName
                                     ? (
-                                      <span style="font-size: 0.625rem; color: var(--cf-color-red-600);">
+                                      <span style="font-size: 0.625rem; color: var(--cf-colors-red-600);">
                                         Already assigned to{" "}
                                         {gridConflictName}. Overwrite?
                                       </span>
@@ -1892,7 +1892,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                       <cf-button
                                         variant="ghost"
                                         size="sm"
-                                        style="padding: 0; font-size: 0.625rem; line-height: 1; min-height: unset; color: var(--cf-color-red-500);"
+                                        style="padding: 0; font-size: 0.625rem; line-height: 1; min-height: unset; color: var(--cf-colors-red-500);"
                                         onClick={() =>
                                           cancelRequest.send({
                                             requestId: gridReq.id,
@@ -1904,7 +1904,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                     : null}
                                   {gridIsManual
                                     ? (
-                                      <span style="position: absolute; top: 2px; right: 3px; font-size: 0.5rem; color: var(--cf-color-gray-400); font-weight: 700;">
+                                      <span style="position: absolute; top: 2px; right: 3px; font-size: 0.5rem; color: var(--cf-colors-gray-400); font-weight: 700;">
                                         M
                                       </span>
                                     )
@@ -1917,7 +1917,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                     style={`color: ${
                                       gridIsToday
                                         ? "#92400e"
-                                        : "var(--cf-color-green-500)"
+                                        : "var(--cf-colors-green-500)"
                                     }; font-size: 0.625rem;`}
                                   >
                                     Free
@@ -1971,7 +1971,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                           <cf-card style="text-align: center; padding: 1.5rem;">
                             <cf-vstack gap="2" align="center">
                               <span style="font-size: 2rem;">👥</span>
-                              <span style="color: var(--cf-color-gray-500); font-size: 0.875rem;">
+                              <span style="color: var(--cf-colors-gray-500); font-size: 0.875rem;">
                                 No team members yet. Add the first person below.
                               </span>
                             </cf-vstack>
@@ -2017,7 +2017,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                           <cf-card
                             style={computed(() =>
                               isEditing
-                                ? "border: 2px solid var(--cf-color-blue-300);"
+                                ? "border: 2px solid var(--cf-colors-blue-500);"
                                 : ""
                             )}
                           >
@@ -2206,7 +2206,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                       const err = editDraftVehicleError.get();
                                       if (!err) return null;
                                       return (
-                                        <span style="font-size: 0.75rem; color: var(--cf-color-red-600);">
+                                        <span style="font-size: 0.75rem; color: var(--cf-colors-red-600);">
                                           {err}
                                         </span>
                                       );
@@ -2247,7 +2247,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                         <span style="font-weight: 600;">
                                           {personName}
                                         </span>
-                                        <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                                        <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                                           #{priorityRank}
                                         </span>
                                         {defaultSpot
@@ -2258,10 +2258,10 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                           )
                                           : null}
                                       </cf-hstack>
-                                      <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                                      <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                                         {email}
                                       </span>
-                                      <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                                      <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                                         {commuteIcon(commuteMode)} {commuteMode}
                                       </span>
                                     </cf-vstack>
@@ -2314,7 +2314,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
 
                                   {spotPreferences.length > 0
                                     ? (
-                                      <span style="font-size: 0.75rem; color: var(--cf-color-gray-400);">
+                                      <span style="font-size: 0.75rem; color: var(--cf-colors-gray-400);">
                                         Prefers: {spotPreferences.map((n) =>
                                           "#" + n
                                         )
@@ -2339,7 +2339,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                     ? (
                                       <cf-card style="background: #fef2f2; border: 1px solid #fecaca;">
                                         <cf-vstack gap="1">
-                                          <span style="font-size: 0.75rem; color: var(--cf-color-red-700);">
+                                          <span style="font-size: 0.75rem; color: var(--cf-colors-red-700);">
                                             This person has upcoming requests.
                                             They will be preserved. Remove
                                             anyway?
@@ -2376,7 +2376,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
 
                       {addPersonFormOpen.get()
                         ? (
-                          <cf-card style="border: 2px dashed var(--cf-color-gray-200);">
+                          <cf-card style="border: 2px dashed var(--cf-colors-gray-200);">
                             <cf-vstack gap="2">
                               <cf-heading level={6}>Add Person</cf-heading>
                               <cf-hstack gap="2" wrap>
@@ -2553,7 +2553,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                   const err = draftVehicleError.get();
                                   if (!err) return null;
                                   return (
-                                    <span style="font-size: 0.75rem; color: var(--cf-color-red-600);">
+                                    <span style="font-size: 0.75rem; color: var(--cf-colors-red-600);">
                                       {err}
                                     </span>
                                   );
@@ -2564,7 +2564,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                 const err = addPersonError.get();
                                 if (!err) return null;
                                 return (
-                                  <span style="font-size: 0.75rem; color: var(--cf-color-red-600);">
+                                  <span style="font-size: 0.75rem; color: var(--cf-colors-red-600);">
                                     {err}
                                   </span>
                                 );
@@ -2666,7 +2666,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                         </cf-checkbox>
                                         {spotDeactivateWarning
                                           ? (
-                                            <span style="font-size: 0.75rem; color: var(--cf-color-amber-600);">
+                                            <span style="font-size: 0.75rem; color: var(--cf-colors-warning);">
                                               Has upcoming allocations — they
                                               will remain.
                                             </span>
@@ -2706,8 +2706,8 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                           <span
                                             style={`font-weight: 700; font-size: 1rem; color: ${
                                               spotActive2
-                                                ? "var(--cf-color-gray-800)"
-                                                : "var(--cf-color-gray-400)"
+                                                ? "var(--cf-colors-gray-800)"
+                                                : "var(--cf-colors-gray-400)"
                                             };`}
                                           >
                                             #{spotNum2}
@@ -2716,8 +2716,8 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                             <span
                                               style={`font-size: 0.875rem; color: ${
                                                 spotActive2
-                                                  ? "var(--cf-color-gray-700)"
-                                                  : "var(--cf-color-gray-400)"
+                                                  ? "var(--cf-colors-gray-700)"
+                                                  : "var(--cf-colors-gray-400)"
                                               }; text-decoration: ${
                                                 spotActive2
                                                   ? "none"
@@ -2728,7 +2728,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                             </span>
                                             {spotNotes2
                                               ? (
-                                                <span style="font-size: 0.75rem; color: var(--cf-color-gray-400);">
+                                                <span style="font-size: 0.75rem; color: var(--cf-colors-gray-400);">
                                                   {spotNotes2}
                                                 </span>
                                               )
@@ -2769,7 +2769,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                         ? (
                                           <cf-card style="background: #fef2f2; border: 1px solid #fecaca; margin-top: 0.5rem;">
                                             <cf-vstack gap="1">
-                                              <span style="font-size: 0.75rem; color: var(--cf-color-red-700);">
+                                              <span style="font-size: 0.75rem; color: var(--cf-colors-red-700);">
                                                 Spot #{spotNum2}{" "}
                                                 has upcoming allocations. They
                                                 will be preserved. Remove
@@ -2807,7 +2807,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
 
                           {addSpotFormOpen.get()
                             ? (
-                              <cf-card style="border: 2px dashed var(--cf-color-gray-200);">
+                              <cf-card style="border: 2px dashed var(--cf-colors-gray-200);">
                                 <cf-vstack gap="2">
                                   <cf-heading level={6}>Add Spot</cf-heading>
                                   <cf-hstack gap="2" wrap>
@@ -2846,7 +2846,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                     const err = addSpotError.get();
                                     if (!err) return null;
                                     return (
-                                      <span style="font-size: 0.75rem; color: var(--cf-color-red-600);">
+                                      <span style="font-size: 0.75rem; color: var(--cf-colors-red-600);">
                                         {err}
                                       </span>
                                     );

--- a/packages/patterns/google/WIP/google-docs-importer.tsx
+++ b/packages/patterns/google/WIP/google-docs-importer.tsx
@@ -370,11 +370,11 @@ export default pattern<Input, Output>(
                     style={{
                       marginTop: "8px",
                       padding: "8px 12px",
-                      backgroundColor: "var(--cf-color-red-50, #fef2f2)",
-                      border: "1px solid var(--cf-color-red-200, #fecaca)",
+                      backgroundColor: "var(--cf-colors-red-50, #fef2f2)",
+                      border: "1px solid var(--cf-colors-red-200, #fecaca)",
                       borderRadius: "6px",
                       fontSize: "12px",
-                      color: "var(--cf-color-red-700, #b91c1c)",
+                      color: "var(--cf-colors-red-700, #b91c1c)",
                       whiteSpace: "pre-wrap",
                     }}
                   >
@@ -418,8 +418,7 @@ export default pattern<Input, Output>(
                   <div
                     style={{
                       padding: "16px",
-                      backgroundColor:
-                        "var(--cf-color-surface-secondary, #f9fafb)",
+                      backgroundColor: "var(--cf-theme-color-surface, #f9fafb)",
                       borderRadius: "8px",
                       fontFamily: "monospace",
                       fontSize: "13px",

--- a/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.tsx
+++ b/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.tsx
@@ -818,11 +818,11 @@ export default pattern<Input, Output>(
                       style={{
                         marginTop: "8px",
                         padding: "8px 12px",
-                        backgroundColor: "var(--cf-color-red-50, #fef2f2)",
-                        border: "1px solid var(--cf-color-red-200, #fecaca)",
+                        backgroundColor: "var(--cf-colors-red-50, #fef2f2)",
+                        border: "1px solid var(--cf-colors-red-200, #fecaca)",
                         borderRadius: "6px",
                         fontSize: "12px",
-                        color: "var(--cf-color-red-700, #b91c1c)",
+                        color: "var(--cf-colors-red-700, #b91c1c)",
                       }}
                     >
                       {lastError}
@@ -900,11 +900,11 @@ export default pattern<Input, Output>(
                   <div
                     style={{
                       borderRadius: "8px",
-                      border: "1px solid var(--cf-color-border, #e0e0e0)",
+                      border: "1px solid var(--cf-theme-color-border, #e0e0e0)",
                       marginBottom: "8px",
                       overflow: "hidden",
                       backgroundColor: item.state?.status === "skipped"
-                        ? "var(--cf-color-surface-secondary, #f5f5f5)"
+                        ? "var(--cf-theme-color-surface, #f5f5f5)"
                         : "white",
                       opacity: item.state?.status === "skipped" ? 0.6 : 1,
                     }}
@@ -997,7 +997,7 @@ export default pattern<Input, Output>(
                                 padding: "2px 6px",
                                 borderRadius: "10px",
                                 backgroundColor:
-                                  "var(--cf-color-surface-secondary, #f0f0f0)",
+                                  "var(--cf-theme-color-surface, #f0f0f0)",
                                 color: "#666",
                               }}
                             >
@@ -1015,10 +1015,10 @@ export default pattern<Input, Output>(
                         <div
                           style={{
                             borderTop:
-                              "1px solid var(--cf-color-border, #e0e0e0)",
+                              "1px solid var(--cf-theme-color-border, #e0e0e0)",
                             padding: "16px",
                             backgroundColor:
-                              "var(--cf-color-surface-secondary, #fafafa)",
+                              "var(--cf-theme-color-surface, #fafafa)",
                           }}
                         >
                           {/* Full quoted text - ternary for conditional content */}
@@ -1029,7 +1029,7 @@ export default pattern<Input, Output>(
                                   padding: "12px",
                                   marginBottom: "12px",
                                   borderLeft:
-                                    "3px solid var(--cf-color-blue-500, #3b82f6)",
+                                    "3px solid var(--cf-colors-blue-500, #3b82f6)",
                                   backgroundColor: "white",
                                   borderRadius: "4px",
                                 }}
@@ -1102,9 +1102,9 @@ export default pattern<Input, Output>(
                   <div
                     style={{
                       padding: "16px",
-                      backgroundColor: "var(--cf-color-green-50, #f0fdf4)",
+                      backgroundColor: "var(--cf-colors-green-50, #f0fdf4)",
                       borderRadius: "8px",
-                      border: "1px solid var(--cf-color-green-200, #bbf7d0)",
+                      border: "1px solid var(--cf-colors-green-100, #bbf7d0)",
                       marginTop: "12px",
                     }}
                   >
@@ -1120,7 +1120,7 @@ export default pattern<Input, Output>(
                         style={{
                           fontSize: "14px",
                           fontWeight: 600,
-                          color: "var(--cf-color-green-700, #15803d)",
+                          color: "var(--cf-colors-green-600, #15803d)",
                         }}
                       >
                         AI Suggested Response

--- a/packages/patterns/habit-tracker/habit-tracker.tsx
+++ b/packages/patterns/habit-tracker/habit-tracker.tsx
@@ -122,7 +122,7 @@ export default pattern<HabitTrackerInput, HabitTrackerOutput>(
                 <span style="font-weight: 500;">
                   {habit.name || "(unnamed)"}
                 </span>
-                <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                   Streak: {streak} days
                 </span>
               </cf-vstack>
@@ -158,14 +158,14 @@ export default pattern<HabitTrackerInput, HabitTrackerOutput>(
                       borderRadius: "4px",
                       backgroundColor: dayCompleted
                         ? habit.color
-                        : "var(--cf-color-gray-200)",
+                        : "var(--cf-colors-gray-200)",
                       display: "flex",
                       alignItems: "center",
                       justifyContent: "center",
                       fontSize: "0.625rem",
                       color: dayCompleted
                         ? "white"
-                        : "var(--cf-color-gray-400)",
+                        : "var(--cf-colors-gray-400)",
                     }}
                   >
                     {date.slice(-2)}
@@ -185,7 +185,7 @@ export default pattern<HabitTrackerInput, HabitTrackerOutput>(
           <cf-vstack slot="header" gap="2">
             <cf-hstack justify="between" align="center">
               <cf-heading level={4}>Habits ({habitCount})</cf-heading>
-              <span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">
+              <span style="font-size: 0.875rem; color: var(--cf-colors-gray-500);">
                 {todayDate}
               </span>
             </cf-hstack>
@@ -198,7 +198,7 @@ export default pattern<HabitTrackerInput, HabitTrackerOutput>(
               {computed(() =>
                 habits.get().length === 0
                   ? (
-                    <div style="text-align: center; color: var(--cf-color-gray-500); padding: 2rem;">
+                    <div style="text-align: center; color: var(--cf-colors-gray-500); padding: 2rem;">
                       No habits yet. Add one below!
                     </div>
                   )

--- a/packages/patterns/image.tsx
+++ b/packages/patterns/image.tsx
@@ -44,7 +44,7 @@ export default pattern<ImageInput, ImageOutput>(({ url, caption }) => {
             <div
               style={{
                 fontSize: "14px",
-                color: "var(--cf-color-gray-500)",
+                color: "var(--cf-colors-gray-500)",
                 textAlign: "center",
                 padding: "4px 0",
               }}

--- a/packages/patterns/map-demo.tsx
+++ b/packages/patterns/map-demo.tsx
@@ -277,7 +277,7 @@ export default pattern<Input, Output>(
             <cf-hstack justify="between" align="center">
               <cf-heading level={4}>Trip Planner</cf-heading>
               <cf-hstack gap="2">
-                <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                   {stopCount} stops | {areaCount} areas
                 </span>
               </cf-hstack>
@@ -290,10 +290,10 @@ export default pattern<Input, Output>(
               {/* Initialization prompt for empty state */}
               {ifElse(
                 computed(() => !initialized.get() && stops.get().length === 0),
-                <cf-card style="background: var(--cf-color-yellow-50); border: 1px solid var(--cf-color-yellow-300);">
+                <cf-card style="background: var(--cf-theme-color-status-warning-subtle); border: 1px solid var(--cf-theme-color-status-warning-soft);">
                   <cf-vstack gap="2" align="center">
                     <cf-heading level={5}>Welcome to Trip Planner!</cf-heading>
-                    <p style="text-align: center; color: var(--cf-color-gray-600); margin: 0;">
+                    <p style="text-align: center; color: var(--cf-colors-gray-600); margin: 0;">
                       Get started with demo data or click on the map to add your
                       first stop.
                     </p>
@@ -378,7 +378,7 @@ export default pattern<Input, Output>(
                 <cf-vstack gap="2">
                   <cf-hstack justify="between" align="center">
                     <cf-heading level={5}>Trip Stops</cf-heading>
-                    <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                    <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                       Click map to add
                     </span>
                   </cf-hstack>
@@ -392,8 +392,8 @@ export default pattern<Input, Output>(
                         borderRadius: "0.5rem",
                         backgroundColor: ifElse(
                           computed(() => selectedStopIndex.get() === index),
-                          "var(--cf-color-blue-100)",
-                          "var(--cf-color-gray-50)",
+                          "var(--cf-colors-blue-100)",
+                          "var(--cf-colors-gray-50)",
                         ),
                       }}
                     >
@@ -405,7 +405,7 @@ export default pattern<Input, Output>(
                           $value={stop.title}
                           style="font-weight: 500;"
                         />
-                        <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                        <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                           {computed(
                             () =>
                               `${formatCoord(stop.position.lat)}, ${
@@ -436,7 +436,7 @@ export default pattern<Input, Output>(
 
                   {ifElse(
                     computed(() => stops.get().length === 0),
-                    <div style="text-align: center; color: var(--cf-color-gray-500); padding: 1rem;">
+                    <div style="text-align: center; color: var(--cf-colors-gray-500); padding: 1rem;">
                       Click on the map to add your first stop!
                     </div>,
                     null,
@@ -478,7 +478,7 @@ export default pattern<Input, Output>(
                           $value={area.title}
                           style="font-weight: 500;"
                         />
-                        <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                        <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                           Radius: {area.radius}m
                         </span>
                       </cf-vstack>
@@ -512,7 +512,7 @@ export default pattern<Input, Output>(
 
                   {ifElse(
                     computed(() => areasOfInterest.get().length === 0),
-                    <div style="text-align: center; color: var(--cf-color-gray-500); padding: 1rem;">
+                    <div style="text-align: center; color: var(--cf-colors-gray-500); padding: 1rem;">
                       No areas defined. Click "Add Area" to highlight a region.
                     </div>,
                     null,
@@ -534,7 +534,7 @@ export default pattern<Input, Output>(
                             computed(() =>
                               index < stops.get().length - 1
                             ),
-                            <span style="color: var(--cf-color-gray-400);">
+                            <span style="color: var(--cf-colors-gray-400);">
                               {" "}
                               -&gt;{" "}
                             </span>,
@@ -543,7 +543,7 @@ export default pattern<Input, Output>(
                         </cf-hstack>
                       ))}
                     </cf-hstack>
-                    <span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">
+                    <span style="font-size: 0.875rem; color: var(--cf-colors-gray-500);">
                       {stopCount} stops connected by dashed route line
                     </span>
                   </cf-vstack>
@@ -552,10 +552,10 @@ export default pattern<Input, Output>(
               )}
 
               {/* Instructions */}
-              <cf-card style="background: var(--cf-color-blue-50);">
+              <cf-card style="background: var(--cf-colors-blue-50);">
                 <cf-vstack gap="1">
                   <cf-heading level={5}>How to Use</cf-heading>
-                  <ul style="margin: 0; padding-left: 1.25rem; font-size: 0.875rem; color: var(--cf-color-gray-600);">
+                  <ul style="margin: 0; padding-left: 1.25rem; font-size: 0.875rem; color: var(--cf-colors-gray-600);">
                     <li>Click anywhere on the map to add a new stop</li>
                     <li>Drag markers to reposition stops</li>
                     <li>Use "Fit to All Stops" to zoom to see all markers</li>

--- a/packages/patterns/notes/daily-journal.tsx
+++ b/packages/patterns/notes/daily-journal.tsx
@@ -478,7 +478,7 @@ ${notesXml}
                             style={{
                               fontSize: "11px",
                               fontWeight: "500",
-                              color: "var(--cf-color-gray-500)",
+                              color: "var(--cf-colors-gray-500)",
                               textTransform: "uppercase",
                               letterSpacing: "0.05em",
                             }}
@@ -491,7 +491,7 @@ ${notesXml}
                                 style={{
                                   padding: "6px 8px",
                                   borderRadius: "6px",
-                                  background: "var(--cf-color-gray-50)",
+                                  background: "var(--cf-colors-gray-50)",
                                   fontSize: "13px",
                                 }}
                               >
@@ -499,7 +499,7 @@ ${notesXml}
                                 {" — "}
                                 <span
                                   style={{
-                                    color: "var(--cf-color-gray-600)",
+                                    color: "var(--cf-colors-gray-600)",
                                   }}
                                 >
                                   {theme.detail}
@@ -520,7 +520,7 @@ ${notesXml}
                               style={{
                                 fontSize: "11px",
                                 fontWeight: "500",
-                                color: "var(--cf-color-gray-500)",
+                                color: "var(--cf-colors-gray-500)",
                                 textTransform: "uppercase",
                                 letterSpacing: "0.05em",
                               }}
@@ -552,7 +552,7 @@ ${notesXml}
                               style={{
                                 fontSize: "11px",
                                 fontWeight: "500",
-                                color: "var(--cf-color-gray-500)",
+                                color: "var(--cf-colors-gray-500)",
                                 textTransform: "uppercase",
                                 letterSpacing: "0.05em",
                               }}
@@ -580,7 +580,7 @@ ${notesXml}
                             margin: 0,
                             fontSize: "13px",
                             fontStyle: "italic",
-                            color: "var(--cf-color-gray-600)",
+                            color: "var(--cf-colors-gray-600)",
                           }}
                         >
                           {weeklyRollup?.mood}
@@ -589,7 +589,7 @@ ${notesXml}
                       <div
                         style={{
                           textAlign: "center",
-                          color: "var(--cf-color-gray-500)",
+                          color: "var(--cf-colors-gray-500)",
                           padding: "0.5rem",
                           fontSize: "13px",
                         }}
@@ -615,7 +615,7 @@ ${notesXml}
                       style={{
                         fontSize: "11px",
                         fontWeight: "500",
-                        color: "var(--cf-color-gray-500)",
+                        color: "var(--cf-colors-gray-500)",
                         textTransform: "uppercase",
                         letterSpacing: "0.05em",
                       }}
@@ -647,7 +647,7 @@ ${notesXml}
               style={{
                 margin: 0,
                 fontSize: "13px",
-                color: "var(--cf-color-text-secondary)",
+                color: "var(--cf-theme-color-text-secondary)",
               }}
             >
               Available variables: {"{{date}}"}, {"{{dayOfWeek}}"},

--- a/packages/patterns/notes/note-md.tsx
+++ b/packages/patterns/notes/note-md.tsx
@@ -139,7 +139,7 @@ export default pattern<NoteMdInput, NoteMdOutput>(
               display: computed(() => (hasBacklinks ? "block" : "none")),
               marginTop: "2rem",
               paddingTop: "1rem",
-              borderTop: "1px solid var(--cf-color-border, #e5e5e7)",
+              borderTop: "1px solid var(--cf-theme-color-border, #e5e5e7)",
             }}
           >
             <span
@@ -148,7 +148,7 @@ export default pattern<NoteMdInput, NoteMdOutput>(
                 fontWeight: "600",
                 textTransform: "uppercase",
                 letterSpacing: "0.05em",
-                color: "var(--cf-color-gray-500, #6b7280)",
+                color: "var(--cf-colors-gray-500, #6b7280)",
                 marginBottom: "0.5rem",
                 display: "block",
               }}
@@ -181,7 +181,7 @@ export default pattern<NoteMdInput, NoteMdOutput>(
             gap="3"
             align="center"
             style={{
-              borderBottom: "1px solid var(--cf-color-border, #e5e5e7)",
+              borderBottom: "1px solid var(--cf-theme-color-border, #e5e5e7)",
             }}
           >
             <cf-heading level={1} style={{ flex: "1" }}>

--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -397,7 +397,7 @@ const Note = pattern<NoteInput, NoteOutput>(
             gap="2"
             padding="4"
             style={{
-              borderBottom: "1px solid var(--cf-color-border, #e5e5e7)",
+              borderBottom: "1px solid var(--cf-theme-color-border, #e5e5e7)",
             }}
           >
             {/* Parent notebook chip */}
@@ -412,7 +412,7 @@ const Note = pattern<NoteInput, NoteOutput>(
               <span
                 style={{
                   fontSize: "13px",
-                  color: "var(--cf-color-text-secondary)",
+                  color: "var(--cf-theme-color-text-secondary)",
                 }}
               >
                 In:
@@ -505,8 +505,8 @@ const Note = pattern<NoteInput, NoteOutput>(
                   position: "fixed",
                   top: "112px",
                   right: "16px",
-                  background: "var(--cf-color-bg, white)",
-                  border: "1px solid var(--cf-color-border, #e5e5e7)",
+                  background: "var(--cf-theme-color-background, white)",
+                  border: "1px solid var(--cf-theme-color-border, #e5e5e7)",
                   borderRadius: "12px",
                   boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
                   minWidth: "180px",
@@ -536,7 +536,7 @@ const Note = pattern<NoteInput, NoteOutput>(
                   style={{
                     display: allNotesDividerDisplay,
                     height: "1px",
-                    background: "var(--cf-color-border, #e5e5e7)",
+                    background: "var(--cf-theme-color-border, #e5e5e7)",
                     margin: "4px 8px",
                   }}
                 />

--- a/packages/patterns/notes/notebook.tsx
+++ b/packages/patterns/notes/notebook.tsx
@@ -975,7 +975,7 @@ const Notebook = pattern<NotebookInput, NotebookOutput>(
                 <span
                   style={{
                     fontSize: "13px",
-                    color: "var(--cf-color-text-secondary)",
+                    color: "var(--cf-theme-color-text-secondary)",
                   }}
                 >
                   In:
@@ -1027,7 +1027,7 @@ const Notebook = pattern<NotebookInput, NotebookOutput>(
                       justifyContent: "space-between",
                       padding: "8px",
                       borderRadius: "8px",
-                      background: "var(--cf-color-bg-primary, #fff)",
+                      background: "var(--cf-theme-color-background, #fff)",
                     }}
                   >
                     {/* Editable Title */}
@@ -1110,8 +1110,8 @@ const Notebook = pattern<NotebookInput, NotebookOutput>(
                     padding: "48px 24px",
                     cursor: "pointer",
                     borderRadius: "8px",
-                    border: "2px dashed var(--cf-color-border, #e5e5e7)",
-                    background: "var(--cf-color-bg-secondary, #f9f9f9)",
+                    border: "2px dashed var(--cf-theme-color-border, #e5e5e7)",
+                    background: "var(--cf-theme-color-surface, #f9f9f9)",
                   }}
                   onClick={showNewNoteModalAction}
                 >
@@ -1122,7 +1122,7 @@ const Notebook = pattern<NotebookInput, NotebookOutput>(
                     style={{
                       fontSize: "15px",
                       fontWeight: "500",
-                      color: "var(--cf-color-text-primary)",
+                      color: "var(--cf-theme-color-text)",
                     }}
                   >
                     Click to create your first note
@@ -1143,7 +1143,7 @@ const Notebook = pattern<NotebookInput, NotebookOutput>(
                           style={{
                             background: computed(() =>
                               selectedNoteIndices.get().includes(index)
-                                ? "var(--cf-color-bg-secondary, #f5f5f7)"
+                                ? "var(--cf-theme-color-surface, #f5f5f7)"
                                 : "transparent"
                             ),
                           }}
@@ -1230,7 +1230,7 @@ const Notebook = pattern<NotebookInput, NotebookOutput>(
                       alignItems: "center",
                       padding: "4px 0",
                       fontSize: "13px",
-                      color: "var(--cf-color-text-secondary, #6e6e73)",
+                      color: "var(--cf-theme-color-text-secondary, #6e6e73)",
                     }}
                   >
                     {/* Checkbox column (32px + 4px padding) */}
@@ -1260,7 +1260,7 @@ const Notebook = pattern<NotebookInput, NotebookOutput>(
                   gap="3"
                   style={{
                     display: actionBarDisplay,
-                    background: "var(--cf-color-bg-secondary, #f5f5f7)",
+                    background: "var(--cf-theme-color-surface, #f5f5f7)",
                     borderRadius: "8px",
                     alignItems: "center",
                     marginTop: "8px",
@@ -1314,7 +1314,7 @@ const Notebook = pattern<NotebookInput, NotebookOutput>(
                       allPieces,
                       notebooks,
                     })}
-                    style={{ color: "var(--cf-color-danger, #dc3545)" }}
+                    style={{ color: "var(--cf-theme-color-error, #dc3545)" }}
                   >
                     Delete
                   </cf-button>
@@ -1449,7 +1449,7 @@ const Notebook = pattern<NotebookInput, NotebookOutput>(
             style={{
               display: backlinksDisplay,
               alignItems: "center",
-              borderTop: "1px solid var(--cf-color-border, #e5e5e7)",
+              borderTop: "1px solid var(--cf-theme-color-border, #e5e5e7)",
               flexWrap: "wrap",
             }}
           >
@@ -1457,7 +1457,7 @@ const Notebook = pattern<NotebookInput, NotebookOutput>(
               style={{
                 fontSize: "12px",
                 lineHeight: "28px",
-                color: "var(--cf-color-text-secondary, #666)",
+                color: "var(--cf-theme-color-text-secondary, #666)",
               }}
             >
               Linked from:

--- a/packages/patterns/notes/voice-note.tsx
+++ b/packages/patterns/notes/voice-note.tsx
@@ -77,7 +77,7 @@ const VoiceNote = pattern<Input, Output>(({ title }) => {
           <cf-card>
             <div style={{ padding: "1rem" }}>
               <h3 style={{ marginTop: 0 }}>Record a Voice Note</h3>
-              <p style={{ color: "var(--cf-color-gray-600)" }}>
+              <p style={{ color: "var(--cf-colors-gray-600)" }}>
                 Hold the microphone button to record. Release to transcribe.
               </p>
 
@@ -95,13 +95,13 @@ const VoiceNote = pattern<Input, Output>(({ title }) => {
                   style={{
                     marginTop: "1rem",
                     padding: "1rem",
-                    backgroundColor: "var(--cf-color-blue-50)",
+                    backgroundColor: "var(--cf-colors-blue-50)",
                     borderRadius: "0.375rem",
                   }}
                 >
                   <strong>Latest Transcription:</strong>
                   <p>{transcriptionText}</p>
-                  <small style={{ color: "var(--cf-color-gray-600)" }}>
+                  <small style={{ color: "var(--cf-colors-gray-600)" }}>
                     Duration: {transcriptionDuration.toFixed(1)}s
                   </small>
                 </div>
@@ -117,7 +117,7 @@ const VoiceNote = pattern<Input, Output>(({ title }) => {
 
               {!hasNotes
                 ? (
-                  <p style={{ color: "var(--cf-color-gray-500)" }}>
+                  <p style={{ color: "var(--cf-colors-gray-500)" }}>
                     No voice notes yet. Record one above!
                   </p>
                 )
@@ -127,7 +127,7 @@ const VoiceNote = pattern<Input, Output>(({ title }) => {
                       <div
                         style={{
                           padding: "0.75rem",
-                          border: "1px solid var(--cf-color-gray-200)",
+                          border: "1px solid var(--cf-colors-gray-200)",
                           borderRadius: "0.375rem",
                           position: "relative",
                         }}
@@ -146,7 +146,7 @@ const VoiceNote = pattern<Input, Output>(({ title }) => {
                             </p>
                             <small
                               style={{
-                                color: "var(--cf-color-gray-600)",
+                                color: "var(--cf-colors-gray-600)",
                                 display: "block",
                               }}
                             >

--- a/packages/patterns/occurrence-tracker.tsx
+++ b/packages/patterns/occurrence-tracker.tsx
@@ -328,7 +328,7 @@ export const OccurrenceTrackerModule = pattern<
               <span
                 style={{
                   textAlign: "center",
-                  color: "var(--cf-color-gray-400)",
+                  color: "var(--cf-colors-gray-400)",
                   padding: "1rem 0",
                 }}
               >
@@ -347,7 +347,7 @@ export const OccurrenceTrackerModule = pattern<
               <span
                 style={{
                   fontSize: "0.875rem",
-                  color: "var(--cf-color-gray-500)",
+                  color: "var(--cf-colors-gray-500)",
                 }}
               >
                 Last recorded:
@@ -392,7 +392,7 @@ export const OccurrenceTrackerModule = pattern<
           justify="around"
           style={{
             padding: "0.75rem",
-            background: "var(--cf-color-gray-50)",
+            background: "var(--cf-colors-gray-50)",
             borderRadius: "8px",
           }}
         >
@@ -408,7 +408,7 @@ export const OccurrenceTrackerModule = pattern<
             <span
               style={{
                 fontSize: "0.75rem",
-                color: "var(--cf-color-gray-500)",
+                color: "var(--cf-colors-gray-500)",
               }}
             >
               Total
@@ -426,7 +426,7 @@ export const OccurrenceTrackerModule = pattern<
             <span
               style={{
                 fontSize: "0.75rem",
-                color: "var(--cf-color-gray-500)",
+                color: "var(--cf-colors-gray-500)",
               }}
             >
               Avg frequency
@@ -442,7 +442,7 @@ export const OccurrenceTrackerModule = pattern<
               style={{
                 cursor: "pointer",
                 fontSize: "0.875rem",
-                color: "var(--cf-color-gray-600)",
+                color: "var(--cf-colors-gray-600)",
                 padding: "0.5rem 0",
               }}
             >
@@ -462,7 +462,7 @@ export const OccurrenceTrackerModule = pattern<
                   align="center"
                   style={{
                     padding: "0.5rem",
-                    background: "var(--cf-color-gray-50)",
+                    background: "var(--cf-colors-gray-50)",
                     borderRadius: "6px",
                   }}
                 >
@@ -493,7 +493,7 @@ export const OccurrenceTrackerModule = pattern<
                     style={{
                       padding: "0.25rem 0.5rem",
                       fontSize: "1rem",
-                      color: "var(--cf-color-gray-400)",
+                      color: "var(--cf-colors-gray-400)",
                       minWidth: "auto",
                     }}
                     title="Delete"

--- a/packages/patterns/self-improving-classifier.tsx
+++ b/packages/patterns/self-improving-classifier.tsx
@@ -438,15 +438,15 @@ function getTierColor(tier: Tier | undefined): string {
   switch (tier) {
     case 0:
     default:
-      return "var(--cf-color-gray-400)";
+      return "var(--cf-colors-gray-400)";
     case 1:
-      return "var(--cf-color-info-500)";
+      return "var(--cf-colors-info)";
     case 2:
-      return "var(--cf-color-success-500)";
+      return "var(--cf-theme-color-success)";
     case 3:
-      return "var(--cf-color-warning-500)";
+      return "var(--cf-theme-color-warning)";
     case 4:
-      return "var(--cf-color-error-500)";
+      return "var(--cf-theme-color-error)";
   }
 }
 
@@ -2058,7 +2058,7 @@ Each suggestion should have:
                       <span style="font-size: 1.5rem; font-weight: 600;">
                         {stats.totalExamples}
                       </span>
-                      <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                      <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                         Examples
                       </span>
                     </cf-vstack>
@@ -2066,7 +2066,7 @@ Each suggestion should have:
                       <span style="font-size: 1.5rem; font-weight: 600;">
                         {stats.positiveExamples}
                       </span>
-                      <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                      <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                         YES
                       </span>
                     </cf-vstack>
@@ -2074,7 +2074,7 @@ Each suggestion should have:
                       <span style="font-size: 1.5rem; font-weight: 600;">
                         {stats.negativeExamples}
                       </span>
-                      <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                      <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                         NO
                       </span>
                     </cf-vstack>
@@ -2082,14 +2082,14 @@ Each suggestion should have:
                       <span style="font-size: 1.5rem; font-weight: 600;">
                         {stats.totalRules}
                       </span>
-                      <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                      <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                         Rules
                       </span>
                     </cf-vstack>
                   </cf-hstack>
                   {ifElse(
                     computed(() => stats.autoClassified > 0),
-                    <span style="font-size: 0.875rem; color: var(--cf-color-gray-500); text-align: center;">
+                    <span style="font-size: 0.875rem; color: var(--cf-colors-gray-500); text-align: center;">
                       Correction rate:{" "}
                       {computed(() => (stats.correctionRate * 100).toFixed(1))}%
                     </span>,
@@ -2111,7 +2111,7 @@ Each suggestion should have:
                       const entries = newItemFieldEntries;
                       return !entries || entries.length === 0;
                     }),
-                    <span style="color: var(--cf-color-gray-400); font-size: 0.875rem;">
+                    <span style="color: var(--cf-colors-gray-400); font-size: 0.875rem;">
                       No fields added yet
                     </span>,
                     <cf-vstack gap="1">
@@ -2189,10 +2189,10 @@ Each suggestion should have:
               {/* Currently classifying - show loader or result */}
               {ifElse(
                 computed(() => currentItem.get() !== null),
-                <cf-card style="border-left: 4px solid var(--cf-color-info-500);">
+                <cf-card style="border-left: 4px solid var(--cf-colors-info);">
                   <cf-vstack gap="2">
                     {/* Show item being classified */}
-                    <pre style="font-size: 0.75rem; overflow: auto; max-height: 100px; margin: 0; background: var(--cf-color-gray-50); padding: 0.5rem; border-radius: 4px;">
+                    <pre style="font-size: 0.75rem; overflow: auto; max-height: 100px; margin: 0; background: var(--cf-colors-gray-50); padding: 0.5rem; border-radius: 4px;">
                       {computed(() => {
                         const result = currentClassificationResult;
                         if (result) {
@@ -2217,8 +2217,8 @@ Each suggestion should have:
                                   currentClassificationResult?.classification
                                     .classification ?? false
                                 ),
-                                "var(--cf-color-success-600)",
-                                "var(--cf-color-error-600)",
+                                "var(--cf-theme-color-success)",
+                                "var(--cf-theme-color-error)",
                               ),
                             }}
                           >
@@ -2231,7 +2231,7 @@ Each suggestion should have:
                               "NO",
                             )}
                           </span>
-                          <span style="color: var(--cf-color-gray-500); font-size: 0.875rem;">
+                          <span style="color: var(--cf-colors-gray-500); font-size: 0.875rem;">
                             ({computed(() =>
                               (
                                 (currentClassificationResult?.classification
@@ -2244,7 +2244,7 @@ Each suggestion should have:
                           </span>
                         </cf-hstack>
 
-                        <span style="font-size: 0.875rem; color: var(--cf-color-gray-600);">
+                        <span style="font-size: 0.875rem; color: var(--cf-colors-gray-600);">
                           {computed(() =>
                             currentClassificationResult?.classification
                               .reasoning ?? ""
@@ -2296,17 +2296,17 @@ Each suggestion should have:
               {/* Undone Auto-Classification - Manual Review */}
               {ifElse(
                 computed(() => undoneAutoItem.get() !== null),
-                <cf-card style="border-left: 4px solid var(--cf-color-warning-500);">
+                <cf-card style="border-left: 4px solid var(--cf-theme-color-warning);">
                   <cf-vstack gap="2">
                     <cf-hstack gap="2" align="center">
                       <cf-heading level={5}>Manual Review</cf-heading>
-                      <span style="font-size: 0.75rem; color: var(--cf-color-warning-600);">
+                      <span style="font-size: 0.75rem; color: var(--cf-theme-color-warning);">
                         (undone auto-classification)
                       </span>
                     </cf-hstack>
 
                     {/* Show item fields */}
-                    <pre style="font-size: 0.75rem; overflow: auto; max-height: 100px; margin: 0; background: var(--cf-color-gray-50); padding: 0.5rem; border-radius: 4px;">
+                    <pre style="font-size: 0.75rem; overflow: auto; max-height: 100px; margin: 0; background: var(--cf-colors-gray-50); padding: 0.5rem; border-radius: 4px;">
                       {computed(() => {
                         const undone = undoneAutoItem.get();
                         return undone
@@ -2324,8 +2324,8 @@ Each suggestion should have:
                             computed(() =>
                               undoneAutoItem.get()?.label ?? false
                             ),
-                            "var(--cf-color-success-600)",
-                            "var(--cf-color-error-600)",
+                            "var(--cf-theme-color-success)",
+                            "var(--cf-theme-color-error)",
                           ),
                         }}
                       >
@@ -2335,7 +2335,7 @@ Each suggestion should have:
                           "NO",
                         )}
                       </span>
-                      <span style="color: var(--cf-color-gray-500); font-size: 0.875rem;">
+                      <span style="color: var(--cf-colors-gray-500); font-size: 0.875rem;">
                         ({computed(() =>
                           (
                             (undoneAutoItem.get()?.confidence ?? 0) * 100
@@ -2345,7 +2345,7 @@ Each suggestion should have:
                       </span>
                     </cf-hstack>
 
-                    <span style="font-size: 0.875rem; color: var(--cf-color-gray-600);">
+                    <span style="font-size: 0.875rem; color: var(--cf-colors-gray-600);">
                       {computed(() => undoneAutoItem.get()?.reasoning ?? "")}
                     </span>
 
@@ -2388,7 +2388,7 @@ Each suggestion should have:
                   <cf-vstack gap="2">
                     <cf-heading level={5}>Awaiting Confirmation</cf-heading>
                     {pendingClassifications.map((pending) => (
-                      <cf-card style="background: var(--cf-color-gray-50);">
+                      <cf-card style="background: var(--cf-colors-gray-50);">
                         <cf-vstack gap="2">
                           <pre style="font-size: 0.75rem; overflow: auto; max-height: 100px; margin: 0;">
                             {computed(() =>
@@ -2402,8 +2402,8 @@ Each suggestion should have:
                                 fontWeight: "600",
                                 color: ifElse(
                                   pending.result.classification,
-                                  "var(--cf-color-success-600)",
-                                  "var(--cf-color-error-600)",
+                                  "var(--cf-theme-color-success)",
+                                  "var(--cf-theme-color-error)",
                                 ),
                               }}
                             >
@@ -2413,7 +2413,7 @@ Each suggestion should have:
                                 "NO",
                               )}
                             </span>
-                            <span style="color: var(--cf-color-gray-500); font-size: 0.875rem;">
+                            <span style="color: var(--cf-colors-gray-500); font-size: 0.875rem;">
                               ({computed(() =>
                                 (pending.result.confidence * 100).toFixed(0)
                               )}% confidence via{" "}
@@ -2421,7 +2421,7 @@ Each suggestion should have:
                             </span>
                           </cf-hstack>
 
-                          <span style="font-size: 0.875rem; color: var(--cf-color-gray-600);">
+                          <span style="font-size: 0.875rem; color: var(--cf-colors-gray-600);">
                             {pending.result.reasoning ?? ""}
                           </span>
 
@@ -2481,7 +2481,7 @@ Each suggestion should have:
                       <cf-hstack
                         gap="2"
                         align="center"
-                        style="padding: 0.5rem; background: var(--cf-color-gray-50); border-radius: 4px;"
+                        style="padding: 0.5rem; background: var(--cf-colors-gray-50); border-radius: 4px;"
                       >
                         {/* Tier badge */}
                         <span
@@ -2501,14 +2501,14 @@ Each suggestion should have:
                         </span>
                         <cf-vstack gap="0" style="flex: 1;">
                           <span style="font-weight: 500;">{rule.name}</span>
-                          <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                          <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                             {rule.targetField}: /{rule.pattern}/{ifElse(
                               rule.caseInsensitive,
                               "i",
                               "",
                             )} → {ifElse(rule.predicts, "YES", "NO")}
                           </span>
-                          <span style="font-size: 0.75rem; color: var(--cf-color-gray-400);">
+                          <span style="font-size: 0.75rem; color: var(--cf-colors-gray-400);">
                             P:{" "}
                             {computed(() => (rule.precision * 100).toFixed(0))}%
                             | F1: {computed(() =>
@@ -2535,7 +2535,7 @@ Each suggestion should have:
               {/* Suggested Rules */}
               {ifElse(
                 computed(() => visibleSuggestions.length > 0),
-                <cf-card style="border-left: 4px solid var(--cf-color-success-500);">
+                <cf-card style="border-left: 4px solid var(--cf-theme-color-success);">
                   <cf-vstack gap="2">
                     <cf-hstack gap="2" align="center" justify="between">
                       <cf-heading level={5}>Suggested Rules</cf-heading>
@@ -2548,19 +2548,19 @@ Each suggestion should have:
                       </cf-button>
                     </cf-hstack>
                     {visibleSuggestions.map(({ suggestion, originalIndex }) => (
-                      <cf-card style="background: var(--cf-color-success-50);">
+                      <cf-card style="background: var(--cf-theme-color-success-light);">
                         <cf-vstack gap="2">
                           <cf-vstack gap="0">
                             <span style="font-weight: 500;">
                               {suggestion.name}
                             </span>
-                            <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                            <span style="font-size: 0.75rem; color: var(--cf-colors-gray-500);">
                               {suggestion.targetField}: /{suggestion.pattern}/ →
                               {" "}
                               {suggestion.predicts ? "YES" : "NO"}
                             </span>
                           </cf-vstack>
-                          <span style="font-size: 0.875rem; color: var(--cf-color-gray-600);">
+                          <span style="font-size: 0.875rem; color: var(--cf-colors-gray-600);">
                             {suggestion.reasoning}
                           </span>
                           <cf-hstack gap="2">
@@ -2598,11 +2598,11 @@ Each suggestion should have:
               {/* Auto-Classified Items (with Undo) */}
               {ifElse(
                 computed(() => recentAutoClassified.get().length > 0),
-                <cf-card style="margin-bottom: 1rem; border-left: 4px solid var(--cf-color-warning-500);">
+                <cf-card style="margin-bottom: 1rem; border-left: 4px solid var(--cf-theme-color-warning);">
                   <cf-vstack gap="2">
                     <cf-hstack align="center" gap="2">
                       <h5 style="margin: 0;">Auto-Classified</h5>
-                      <span style="font-size: 0.75rem; color: var(--cf-color-warning-600);">
+                      <span style="font-size: 0.75rem; color: var(--cf-theme-color-warning);">
                         (click Undo to review manually)
                       </span>
                     </cf-hstack>
@@ -2612,7 +2612,8 @@ Each suggestion should have:
                         align="center"
                         style={{
                           padding: "0.5rem",
-                          background: "var(--cf-color-warning-50)",
+                          background:
+                            "var(--cf-theme-color-status-warning-subtle)",
                           borderRadius: "4px",
                         }}
                       >
@@ -2635,8 +2636,8 @@ Each suggestion should have:
                             fontWeight: "600",
                             color: ifElse(
                               autoItem.label,
-                              "var(--cf-color-success-600)",
-                              "var(--cf-color-error-600)",
+                              "var(--cf-theme-color-success)",
+                              "var(--cf-theme-color-error)",
                             ),
                           }}
                         >
@@ -2677,7 +2678,7 @@ Each suggestion should have:
               {ifElse(
                 computed(() => examples.get().length > 0),
                 <details>
-                  <summary style="cursor: pointer; padding: 0.5rem; color: var(--cf-color-gray-600);">
+                  <summary style="cursor: pointer; padding: 0.5rem; color: var(--cf-colors-gray-600);">
                     Recent Examples ({computed(() => examples.get().length)})
                   </summary>
                   <cf-vstack gap="1" style="margin-top: 0.5rem;">
@@ -2698,11 +2699,11 @@ Each suggestion should have:
                               computed(() =>
                                 selectedExampleId.get() === example.input.id
                               ),
-                              "var(--cf-color-info-100)",
+                              "var(--cf-colors-blue-100)",
                               ifElse(
                                 example.wasCorrection,
-                                "var(--cf-color-warning-50)",
-                                "var(--cf-color-gray-50)",
+                                "var(--cf-theme-color-status-warning-subtle)",
+                                "var(--cf-colors-gray-50)",
                               ),
                             ),
                             borderRadius: ifElse(
@@ -2714,7 +2715,7 @@ Each suggestion should have:
                             ),
                             borderLeft: ifElse(
                               example.isInteresting,
-                              "3px solid var(--cf-color-warning-400)",
+                              "3px solid var(--cf-theme-color-warning)",
                               "none",
                             ),
                           }}
@@ -2724,21 +2725,21 @@ Each suggestion should have:
                               fontWeight: "600",
                               color: ifElse(
                                 example.label,
-                                "var(--cf-color-success-600)",
-                                "var(--cf-color-error-600)",
+                                "var(--cf-theme-color-success)",
+                                "var(--cf-theme-color-error)",
                               ),
                             }}
                           >
                             {ifElse(example.label, "YES", "NO")}
                           </span>
-                          <span style="flex: 1; font-size: 0.875rem; color: var(--cf-color-gray-600);">
+                          <span style="flex: 1; font-size: 0.875rem; color: var(--cf-colors-gray-600);">
                             {getExamplePreview(example)}
                           </span>
-                          <span style="font-size: 0.75rem; color: var(--cf-color-gray-400);">
+                          <span style="font-size: 0.75rem; color: var(--cf-colors-gray-400);">
                             {getExampleDecidedBy(example)}
                             {ifElse(example.wasCorrection, " (corrected)", "")}
                           </span>
-                          <span style="font-size: 0.75rem; color: var(--cf-color-gray-400);">
+                          <span style="font-size: 0.75rem; color: var(--cf-colors-gray-400);">
                             {ifElse(
                               computed(() =>
                                 selectedExampleId.get() === example.input.id
@@ -2758,17 +2759,17 @@ Each suggestion should have:
                             style={{
                               marginTop: "0",
                               borderRadius: "0 0 4px 4px",
-                              borderTop: "1px solid var(--cf-color-gray-200)",
-                              background: "var(--cf-color-gray-25)",
+                              borderTop: "1px solid var(--cf-colors-gray-200)",
+                              background: "var(--cf-colors-gray-50)",
                             }}
                           >
                             <cf-vstack gap="2">
                               {/* All input fields */}
                               <cf-vstack gap="1">
-                                <span style="font-weight: 600; font-size: 0.75rem; color: var(--cf-color-gray-500); text-transform: uppercase;">
+                                <span style="font-weight: 600; font-size: 0.75rem; color: var(--cf-colors-gray-500); text-transform: uppercase;">
                                   Input Fields
                                 </span>
-                                <pre style="font-size: 0.75rem; overflow: auto; max-height: 150px; margin: 0; background: white; padding: 0.5rem; border-radius: 4px; border: 1px solid var(--cf-color-gray-200);">
+                                <pre style="font-size: 0.75rem; overflow: auto; max-height: 150px; margin: 0; background: white; padding: 0.5rem; border-radius: 4px; border: 1px solid var(--cf-colors-gray-200);">
                                   {computed(() =>
                                     toIndentedDebugString(
                                       example.input.fields,
@@ -2780,7 +2781,7 @@ Each suggestion should have:
                               {/* Classification details */}
                               <cf-hstack gap="4" wrap>
                                 <cf-vstack gap="0">
-                                  <span style="font-weight: 600; font-size: 0.625rem; color: var(--cf-color-gray-500); text-transform: uppercase;">
+                                  <span style="font-weight: 600; font-size: 0.625rem; color: var(--cf-colors-gray-500); text-transform: uppercase;">
                                     Label
                                   </span>
                                   <span
@@ -2788,8 +2789,8 @@ Each suggestion should have:
                                       fontWeight: "600",
                                       color: ifElse(
                                         example.label,
-                                        "var(--cf-color-success-600)",
-                                        "var(--cf-color-error-600)",
+                                        "var(--cf-theme-color-success)",
+                                        "var(--cf-theme-color-error)",
                                       ),
                                     }}
                                   >
@@ -2797,7 +2798,7 @@ Each suggestion should have:
                                   </span>
                                 </cf-vstack>
                                 <cf-vstack gap="0">
-                                  <span style="font-weight: 600; font-size: 0.625rem; color: var(--cf-color-gray-500); text-transform: uppercase;">
+                                  <span style="font-weight: 600; font-size: 0.625rem; color: var(--cf-colors-gray-500); text-transform: uppercase;">
                                     Confidence
                                   </span>
                                   <span style="font-size: 0.875rem;">
@@ -2807,7 +2808,7 @@ Each suggestion should have:
                                   </span>
                                 </cf-vstack>
                                 <cf-vstack gap="0">
-                                  <span style="font-weight: 600; font-size: 0.625rem; color: var(--cf-color-gray-500); text-transform: uppercase;">
+                                  <span style="font-weight: 600; font-size: 0.625rem; color: var(--cf-colors-gray-500); text-transform: uppercase;">
                                     Decided By
                                   </span>
                                   <span style="font-size: 0.875rem;">
@@ -2815,7 +2816,7 @@ Each suggestion should have:
                                   </span>
                                 </cf-vstack>
                                 <cf-vstack gap="0">
-                                  <span style="font-weight: 600; font-size: 0.625rem; color: var(--cf-color-gray-500); text-transform: uppercase;">
+                                  <span style="font-weight: 600; font-size: 0.625rem; color: var(--cf-colors-gray-500); text-transform: uppercase;">
                                     Timestamp
                                   </span>
                                   <span style="font-size: 0.875rem;">
@@ -2832,10 +2833,10 @@ Each suggestion should have:
                               {ifElse(
                                 computed(() => !!example.reasoning),
                                 <cf-vstack gap="1">
-                                  <span style="font-weight: 600; font-size: 0.625rem; color: var(--cf-color-gray-500); text-transform: uppercase;">
+                                  <span style="font-weight: 600; font-size: 0.625rem; color: var(--cf-colors-gray-500); text-transform: uppercase;">
                                     Reasoning
                                   </span>
-                                  <span style="font-size: 0.875rem; color: var(--cf-color-gray-600);">
+                                  <span style="font-size: 0.875rem; color: var(--cf-colors-gray-600);">
                                     {example.reasoning}
                                   </span>
                                 </cf-vstack>,
@@ -2848,7 +2849,7 @@ Each suggestion should have:
                                 <cf-hstack
                                   gap="1"
                                   align="center"
-                                  style="font-size: 0.75rem; color: var(--cf-color-warning-600); padding: 0.25rem 0.5rem; background: var(--cf-color-warning-50); border-radius: 4px;"
+                                  style="font-size: 0.75rem; color: var(--cf-theme-color-warning); padding: 0.25rem 0.5rem; background: var(--cf-theme-color-status-warning-subtle); border-radius: 4px;"
                                 >
                                   <span style="font-weight: 500;">
                                     Correction:

--- a/packages/patterns/shopping-list.tsx
+++ b/packages/patterns/shopping-list.tsx
@@ -396,7 +396,7 @@ export default pattern<Input, Output>(({ items, storeLayout }) => {
             <span
               style={{
                 fontSize: "13px",
-                color: "var(--cf-color-gray-500)",
+                color: "var(--cf-colors-gray-500)",
                 flex: 1,
               }}
             >
@@ -448,7 +448,7 @@ export default pattern<Input, Output>(({ items, storeLayout }) => {
                       <div
                         style={{
                           textAlign: "center",
-                          color: "var(--cf-color-gray-500)",
+                          color: "var(--cf-colors-gray-500)",
                           padding: "2rem",
                         }}
                       >
@@ -535,8 +535,8 @@ export default pattern<Input, Output>(({ items, storeLayout }) => {
                                 fontSize: "12px",
                                 padding: "4px 8px",
                                 borderRadius: "4px",
-                                background: "var(--cf-color-green-100)",
-                                color: "var(--cf-color-green-700)",
+                                background: "var(--cf-colors-green-100)",
+                                color: "var(--cf-colors-green-600)",
                               }}
                             >
                               {itemWithAisle.item.aisleOverride}
@@ -559,8 +559,8 @@ export default pattern<Input, Output>(({ items, storeLayout }) => {
                                 fontSize: "12px",
                                 padding: "4px 8px",
                                 borderRadius: "4px",
-                                background: "var(--cf-color-blue-100)",
-                                color: "var(--cf-color-blue-700)",
+                                background: "var(--cf-colors-blue-100)",
+                                color: "var(--cf-colors-blue-600)",
                               }}
                             >
                               {itemWithAisle.aisle.result?.location || "Other"}

--- a/packages/patterns/store-mapper.tsx
+++ b/packages/patterns/store-mapper.tsx
@@ -1065,7 +1065,7 @@ export default pattern<Input, Output>(
                         style={{
                           textAlign: "center",
                           fontSize: "12px",
-                          color: "var(--cf-color-gray-500)",
+                          color: "var(--cf-colors-gray-500)",
                         }}
                       >
                         <span style={{ color: "#3b82f6" }}>■</span>{" "}
@@ -1452,7 +1452,7 @@ export default pattern<Input, Output>(
                       <div
                         style={{
                           textAlign: "center",
-                          color: "var(--cf-color-gray-500)",
+                          color: "var(--cf-colors-gray-500)",
                           padding: "2rem",
                         }}
                       >
@@ -1743,8 +1743,8 @@ export default pattern<Input, Output>(
                               padding: "4px 8px",
                               borderRadius: "4px",
                               background: dept.location === "unassigned"
-                                ? "var(--cf-color-yellow-100)"
-                                : "var(--cf-color-green-100)",
+                                ? "var(--cf-theme-color-status-warning-soft)"
+                                : "var(--cf-colors-green-100)",
                             }}
                           >
                             {dept.location}
@@ -2070,7 +2070,7 @@ export default pattern<Input, Output>(
                       <p
                         style={{
                           fontSize: "14px",
-                          color: "var(--cf-color-gray-500)",
+                          color: "var(--cf-colors-gray-500)",
                         }}
                       >
                         Record where items are actually located for future
@@ -2125,7 +2125,7 @@ export default pattern<Input, Output>(
                             <cf-hstack
                               gap="2"
                               align="center"
-                              style="padding: 0.5rem; background: var(--cf-color-gray-50); border-radius: 6px;"
+                              style="padding: 0.5rem; background: var(--cf-colors-gray-50); border-radius: 6px;"
                             >
                               <span style={{ flex: 1 }}>
                                 <strong>{loc.itemName}</strong> →{" "}
@@ -2156,7 +2156,7 @@ export default pattern<Input, Output>(
                       <div
                         style={{
                           textAlign: "center",
-                          color: "var(--cf-color-gray-500)",
+                          color: "var(--cf-colors-gray-500)",
                           padding: "2rem",
                         }}
                       >
@@ -2179,7 +2179,7 @@ export default pattern<Input, Output>(
                       <p
                         style={{
                           fontSize: "14px",
-                          color: "var(--cf-color-gray-500)",
+                          color: "var(--cf-colors-gray-500)",
                         }}
                       >
                         This outline is used by the Shopping List for AI-powered
@@ -2187,7 +2187,7 @@ export default pattern<Input, Output>(
                       </p>
                       <pre
                         style={{
-                          background: "var(--cf-color-gray-50)",
+                          background: "var(--cf-colors-gray-50)",
                           padding: "1rem",
                           borderRadius: "6px",
                           fontSize: "13px",

--- a/packages/patterns/suggestable/budget-planner.tsx
+++ b/packages/patterns/suggestable/budget-planner.tsx
@@ -91,7 +91,7 @@ const BudgetPlanner = pattern<BudgetInput, BudgetOutput>(
             <cf-heading level={4}>
               {computed(() => topic || "Budget Planner")}
             </cf-heading>
-            <span style="color: var(--cf-color-text-secondary); font-size: 0.85rem;">
+            <span style="color: var(--cf-theme-color-text-secondary); font-size: 0.85rem;">
               Budget: ${maxAmount}
             </span>
           </cf-vstack>
@@ -99,7 +99,7 @@ const BudgetPlanner = pattern<BudgetInput, BudgetOutput>(
           <cf-vstack gap="3" style="padding: 1.5rem;">
             {ifElse(
               response.pending,
-              <div style="color: var(--cf-color-text-secondary);">
+              <div style="color: var(--cf-theme-color-text-secondary);">
                 <cf-loader show-elapsed /> Generating budget...
               </div>,
               <cf-vstack gap="3">
@@ -109,7 +109,7 @@ const BudgetPlanner = pattern<BudgetInput, BudgetOutput>(
                       {item.name}
                     </span>
                     <cf-hstack gap="1" align="center">
-                      <span style="color: var(--cf-color-text-secondary); font-size: 0.85rem;">
+                      <span style="color: var(--cf-theme-color-text-secondary); font-size: 0.85rem;">
                         $
                       </span>
                       <cf-input
@@ -122,7 +122,8 @@ const BudgetPlanner = pattern<BudgetInput, BudgetOutput>(
 
                 <div
                   style={{
-                    borderTop: "2px solid var(--cf-color-border, #e5e7eb)",
+                    borderTop:
+                      "2px solid var(--cf-theme-color-border, #e5e7eb)",
                     paddingTop: "0.75rem",
                     marginTop: "0.25rem",
                   }}
@@ -139,7 +140,7 @@ const BudgetPlanner = pattern<BudgetInput, BudgetOutput>(
                     <span
                       style={{
                         flex: "1",
-                        color: "var(--cf-color-text-secondary)",
+                        color: "var(--cf-theme-color-text-secondary)",
                         fontSize: "0.85rem",
                       }}
                     >
@@ -150,8 +151,8 @@ const BudgetPlanner = pattern<BudgetInput, BudgetOutput>(
                         fontSize: "0.85rem",
                         color: computed(() =>
                           remaining < 0
-                            ? "var(--cf-color-danger, #ef4444)"
-                            : "var(--cf-color-text-secondary)"
+                            ? "var(--cf-theme-color-error, #ef4444)"
+                            : "var(--cf-theme-color-text-secondary)"
                         ),
                       }}
                     >

--- a/packages/patterns/suggestable/checklist.tsx
+++ b/packages/patterns/suggestable/checklist.tsx
@@ -85,7 +85,7 @@ const Checklist = pattern<ChecklistInput, ChecklistOutput>(
           <cf-vstack gap="2" style="padding: 1.5rem;">
             {ifElse(
               response.pending,
-              <div style="color: var(--cf-color-text-secondary);">
+              <div style="color: var(--cf-theme-color-text-secondary);">
                 <cf-loader show-elapsed /> Generating checklist...
               </div>,
               <div>

--- a/packages/patterns/suggestable/diagram.tsx
+++ b/packages/patterns/suggestable/diagram.tsx
@@ -57,10 +57,10 @@ const Diagram = pattern<DiagramInput, DiagramOutput>(({ topic, context }) => {
         <cf-vstack gap="3" style="padding: 1.5rem;">
           {ifElse(
             response.pending,
-            <div style="color: var(--cf-color-text-secondary);">
+            <div style="color: var(--cf-theme-color-text-secondary);">
               <cf-loader show-elapsed /> Generating diagram...
             </div>,
-            <pre style="font-family: monospace; font-size: 0.85rem; line-height: 1.4; overflow-x: auto; white-space: pre; background: var(--cf-color-surface-secondary, #f5f5f5); padding: 1rem; border-radius: 0.5rem;">
+            <pre style="font-family: monospace; font-size: 0.85rem; line-height: 1.4; overflow-x: auto; white-space: pre; background: var(--cf-theme-color-surface, #f5f5f5); padding: 1rem; border-radius: 0.5rem;">
               {response.result}
             </pre>,
           )}

--- a/packages/patterns/suggestable/question.tsx
+++ b/packages/patterns/suggestable/question.tsx
@@ -88,7 +88,7 @@ const Question = pattern<QuestionInput, QuestionOutput>(
           <cf-vstack gap="3" style="padding: 1.5rem;">
             {ifElse(
               response.pending,
-              <div style="color: var(--cf-color-text-secondary);">
+              <div style="color: var(--cf-theme-color-text-secondary);">
                 <cf-loader show-elapsed /> Generating question...
               </div>,
               <cf-question

--- a/packages/patterns/suggestable/summary.tsx
+++ b/packages/patterns/suggestable/summary.tsx
@@ -59,7 +59,7 @@ const Summary = pattern<SummaryInput, SummaryOutput>(({ topic, context }) => {
         <cf-vstack gap="3" style="padding: 1.5rem;">
           {ifElse(
             response.pending,
-            <div style="color: var(--cf-color-text-secondary);">
+            <div style="color: var(--cf-theme-color-text-secondary);">
               <cf-loader show-elapsed /> Generating summary...
             </div>,
             <div style="line-height: 1.6; white-space: pre-wrap;">

--- a/packages/patterns/suggestable/svg-diagram.tsx
+++ b/packages/patterns/suggestable/svg-diagram.tsx
@@ -58,7 +58,7 @@ const SvgDiagram = pattern<SvgDiagramInput, SvgDiagramOutput>(
           <cf-vstack gap="3" style="padding: 1.5rem;">
             {ifElse(
               response.pending,
-              <div style="color: var(--cf-color-text-secondary);">
+              <div style="color: var(--cf-theme-color-text-secondary);">
                 <cf-loader show-elapsed /> Generating diagram...
               </div>,
               <cf-svg content={response.result} />,

--- a/packages/patterns/system/backlinks-index.tsx
+++ b/packages/patterns/system/backlinks-index.tsx
@@ -144,7 +144,7 @@ const EntryRow = pattern<Entry, { [UI]: VNode }>(({ piece, backlinks }) => {
                 $cell={link}
                 style={{
                   fontSize: "12px",
-                  color: "var(--cf-color-text-secondary)",
+                  color: "var(--cf-theme-color-text-secondary)",
                 }}
               />
             ))}
@@ -209,7 +209,7 @@ const BacklinksIndex = pattern<Input, Output>(({ allPieces }) => {
           <span
             style={{
               fontSize: "13px",
-              color: "var(--cf-color-text-secondary)",
+              color: "var(--cf-theme-color-text-secondary)",
             }}
           >
             {filteredCount} of {totalCount} pieces

--- a/packages/patterns/system/default-app-ben.tsx
+++ b/packages/patterns/system/default-app-ben.tsx
@@ -322,7 +322,7 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
               fontSize: "14px",
               padding: "6px 12px",
               textDecoration: "none",
-              color: "var(--cf-color-text-secondary)",
+              color: "var(--cf-theme-color-text-secondary)",
             }}
           >
             Mentions
@@ -334,7 +334,7 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
               fontSize: "14px",
               padding: "6px 12px",
               textDecoration: "none",
-              color: "var(--cf-color-text-secondary)",
+              color: "var(--cf-theme-color-text-secondary)",
             }}
           >
             Search
@@ -346,7 +346,7 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
               fontSize: "14px",
               padding: "6px 12px",
               textDecoration: "none",
-              color: "var(--cf-color-text-secondary)",
+              color: "var(--cf-theme-color-text-secondary)",
             }}
           >
             Graph
@@ -358,7 +358,7 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
               fontSize: "14px",
               padding: "6px 12px",
               textDecoration: "none",
-              color: "var(--cf-color-text-secondary)",
+              color: "var(--cf-theme-color-text-secondary)",
             }}
           >
             History
@@ -396,8 +396,8 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
                 position: "fixed",
                 top: "112px",
                 right: "16px",
-                background: "var(--cf-color-bg, white)",
-                border: "1px solid var(--cf-color-border, #e5e5e7)",
+                background: "var(--cf-theme-color-background, white)",
+                border: "1px solid var(--cf-theme-color-border, #e5e5e7)",
                 borderRadius: "12px",
                 boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
                 minWidth: "160px",
@@ -436,7 +436,7 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
               <div
                 style={{
                   height: "1px",
-                  background: "var(--cf-color-border, #e5e5e7)",
+                  background: "var(--cf-theme-color-border, #e5e5e7)",
                   margin: "4px 8px",
                 }}
               />

--- a/packages/patterns/system/default-app.tsx
+++ b/packages/patterns/system/default-app.tsx
@@ -187,7 +187,7 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
               fontSize: "14px",
               padding: "6px 12px",
               textDecoration: "none",
-              color: "var(--cf-color-text-secondary)",
+              color: "var(--cf-theme-color-text-secondary)",
             }}
           >
             Mentions
@@ -199,7 +199,7 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
               fontSize: "14px",
               padding: "6px 12px",
               textDecoration: "none",
-              color: "var(--cf-color-text-secondary)",
+              color: "var(--cf-theme-color-text-secondary)",
             }}
           >
             Search
@@ -236,8 +236,8 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
                 position: "fixed",
                 top: "112px",
                 right: "16px",
-                background: "var(--cf-color-bg, white)",
-                border: "1px solid var(--cf-color-border, #e5e5e7)",
+                background: "var(--cf-theme-color-background, white)",
+                border: "1px solid var(--cf-theme-color-border, #e5e5e7)",
                 borderRadius: "12px",
                 boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
                 minWidth: "160px",
@@ -262,7 +262,7 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
               <div
                 style={{
                   height: "1px",
-                  background: "var(--cf-color-border, #e5e5e7)",
+                  background: "var(--cf-theme-color-border, #e5e5e7)",
                   margin: "4px 8px",
                 }}
               />

--- a/packages/patterns/system/knowledge-graph.tsx
+++ b/packages/patterns/system/knowledge-graph.tsx
@@ -347,7 +347,7 @@ Use exact piece names from the piece list above for fromName/toName/pieceNames.`
           <span
             style={{
               fontSize: "13px",
-              color: "var(--cf-color-text-secondary)",
+              color: "var(--cf-theme-color-text-secondary)",
             }}
           >
             {baseEdgeCount} base links, {agentEdgeCount} agent links,{" "}
@@ -372,7 +372,7 @@ Use exact piece names from the piece list above for fromName/toName/pieceNames.`
                         <td
                           style={{
                             fontSize: "13px",
-                            color: "var(--cf-color-text-secondary)",
+                            color: "var(--cf-theme-color-text-secondary)",
                           }}
                         >
                           {node.summary}
@@ -396,7 +396,7 @@ Use exact piece names from the piece list above for fromName/toName/pieceNames.`
                   <td
                     style={{
                       fontSize: "13px",
-                      color: "var(--cf-color-text-secondary)",
+                      color: "var(--cf-theme-color-text-secondary)",
                       textAlign: "center",
                     }}
                   >

--- a/packages/patterns/system/piece-grid.tsx
+++ b/packages/patterns/system/piece-grid.tsx
@@ -28,7 +28,7 @@ export default pattern<Input>(({ pieces, [SELF]: self }) => {
         {filtered.map((piece: Piece) => (
           <div
             style={{
-              border: "1px solid var(--cf-color-border, #e5e5e7)",
+              border: "1px solid var(--cf-theme-color-border, #e5e5e7)",
               borderRadius: "12px",
               overflow: "hidden",
             }}

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -111,7 +111,9 @@ const UrlPatternReference = pattern<
     [UI]: (
       <cf-vstack gap="2" style={{ padding: "12px" }}>
         <strong>{title}</strong>
-        <span style={{ color: "var(--cf-color-text-secondary)" }}>{url}</span>
+        <span style={{ color: "var(--cf-theme-color-text-secondary)" }}>
+          {url}
+        </span>
       </cf-vstack>
     ),
   }),
@@ -354,7 +356,9 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
                   <cf-cell-link $cell={element.cell}>
                     {element.title ?? element.tag}
                   </cf-cell-link>
-                  <span style={{ color: "var(--cf-color-text-secondary)" }}>
+                  <span
+                    style={{ color: "var(--cf-theme-color-text-secondary)" }}
+                  >
                     {element.userTags.map((tag) => `#${tag}`).join(" ")}
                   </span>
                   <cf-button

--- a/packages/patterns/system/quick-capture.tsx
+++ b/packages/patterns/system/quick-capture.tsx
@@ -227,7 +227,7 @@ ${profileSection}`;
               {hasMessages
                 ? <cf-chat $messages={messages} pending={pending} />
                 : (
-                  <div style="text-align: center; color: var(--cf-color-gray-500); padding: 2rem;">
+                  <div style="text-align: center; color: var(--cf-colors-gray-500); padding: 2rem;">
                     Paste text, meeting notes, or ideas below. The agent will
                     break them into linked notes.
                   </div>

--- a/packages/patterns/system/space-overview.tsx
+++ b/packages/patterns/system/space-overview.tsx
@@ -161,7 +161,7 @@ Be concise and insightful. Focus on patterns and connections, not just listing t
                       style={{
                         margin: 0,
                         fontSize: "14px",
-                        color: "var(--cf-color-gray-500)",
+                        color: "var(--cf-colors-gray-500)",
                         textTransform: "uppercase",
                         letterSpacing: "0.05em",
                       }}
@@ -174,7 +174,7 @@ Be concise and insightful. Focus on patterns and connections, not just listing t
                         style={{
                           padding: "0.75rem",
                           borderRadius: "8px",
-                          background: "var(--cf-color-gray-50)",
+                          background: "var(--cf-colors-gray-50)",
                         }}
                       >
                         <strong style={{ fontSize: "14px" }}>
@@ -184,7 +184,7 @@ Be concise and insightful. Focus on patterns and connections, not just listing t
                           style={{
                             margin: 0,
                             fontSize: "13px",
-                            color: "var(--cf-color-gray-600)",
+                            color: "var(--cf-colors-gray-600)",
                           }}
                         >
                           {theme.description}
@@ -198,7 +198,7 @@ Be concise and insightful. Focus on patterns and connections, not just listing t
                       style={{
                         margin: 0,
                         fontSize: "14px",
-                        color: "var(--cf-color-gray-500)",
+                        color: "var(--cf-colors-gray-500)",
                         textTransform: "uppercase",
                         letterSpacing: "0.05em",
                       }}
@@ -219,7 +219,7 @@ Be concise and insightful. Focus on patterns and connections, not just listing t
                           style={{
                             margin: 0,
                             fontSize: "14px",
-                            color: "var(--cf-color-gray-500)",
+                            color: "var(--cf-colors-gray-500)",
                             textTransform: "uppercase",
                             letterSpacing: "0.05em",
                           }}
@@ -246,7 +246,7 @@ Be concise and insightful. Focus on patterns and connections, not just listing t
                       style={{
                         margin: 0,
                         fontSize: "14px",
-                        color: "var(--cf-color-gray-500)",
+                        color: "var(--cf-colors-gray-500)",
                         textTransform: "uppercase",
                         letterSpacing: "0.05em",
                       }}
@@ -267,7 +267,7 @@ Be concise and insightful. Focus on patterns and connections, not just listing t
                 </cf-vstack>
               )
               : (
-                <div style="text-align: center; color: var(--cf-color-gray-500); padding: 2rem;">
+                <div style="text-align: center; color: var(--cf-colors-gray-500); padding: 2rem;">
                   {pending ? <span>Exploring the space...</span> : <span />}
                 </div>
               )}

--- a/packages/patterns/system/suggestion-history.tsx
+++ b/packages/patterns/system/suggestion-history.tsx
@@ -71,7 +71,7 @@ const SuggestionHistory = pattern<Input, Output>(() => {
           {allEntries.map((entry: SuggestionHistoryEntry) => (
             <div
               style={{
-                border: "1px solid var(--cf-color-border, #e5e5e7)",
+                border: "1px solid var(--cf-theme-color-border, #e5e5e7)",
                 borderRadius: "12px",
                 overflow: "hidden",
               }}
@@ -101,7 +101,7 @@ const SuggestionHistory = pattern<Input, Output>(() => {
                 <div
                   style={{
                     fontSize: "12px",
-                    color: "var(--cf-color-text-secondary)",
+                    color: "var(--cf-theme-color-text-secondary)",
                   }}
                 >
                   {entry.timestamp}

--- a/packages/patterns/system/summary-index.tsx
+++ b/packages/patterns/system/summary-index.tsx
@@ -111,7 +111,7 @@ const SummaryIndex = pattern<Input, Output>(() => {
           <span
             style={{
               fontSize: "13px",
-              color: "var(--cf-color-text-secondary)",
+              color: "var(--cf-theme-color-text-secondary)",
             }}
           >
             {filteredCount} of {entryCount} pieces
@@ -127,7 +127,7 @@ const SummaryIndex = pattern<Input, Output>(() => {
                   <td
                     style={{
                       fontSize: "13px",
-                      color: "var(--cf-color-text-secondary)",
+                      color: "var(--cf-theme-color-text-secondary)",
                     }}
                   >
                     {entry.summary}

--- a/packages/patterns/weekly-calendar/event.tsx
+++ b/packages/patterns/weekly-calendar/event.tsx
@@ -281,7 +281,7 @@ const Event = pattern<Input, Output>(
             gap="2"
             padding="4"
             style={{
-              borderBottom: "1px solid var(--cf-color-border, #e5e5e7)",
+              borderBottom: "1px solid var(--cf-theme-color-border, #e5e5e7)",
             }}
           >
             <cf-hstack gap="3" style={{ alignItems: "center" }}>
@@ -337,7 +337,7 @@ const Event = pattern<Input, Output>(
               <span
                 style={{
                   fontSize: "0.875rem",
-                  color: "var(--cf-color-text-secondary, #6e6e73)",
+                  color: "var(--cf-theme-color-text-secondary, #6e6e73)",
                 }}
               >
                 {dateDisplay} | {timeDisplay} ({durationDisplay})
@@ -420,7 +420,7 @@ const Event = pattern<Input, Output>(
                 backlinks.get().length > 0 ? "flex" : "none"
               ),
               alignItems: "center",
-              borderTop: "1px solid var(--cf-color-border, #e5e5e7)",
+              borderTop: "1px solid var(--cf-theme-color-border, #e5e5e7)",
               flexWrap: "wrap",
             }}
           >
@@ -428,7 +428,7 @@ const Event = pattern<Input, Output>(
               style={{
                 fontSize: "12px",
                 lineHeight: "28px",
-                color: "var(--cf-color-text-secondary, #666)",
+                color: "var(--cf-theme-color-text-secondary, #666)",
               }}
             >
               Linked from:

--- a/packages/patterns/weekly-calendar/weekly-calendar.tsx
+++ b/packages/patterns/weekly-calendar/weekly-calendar.tsx
@@ -1245,7 +1245,7 @@ const WeeklyCalendar = pattern<Input, Output>(
                 backlinks.get().length > 0 ? "flex" : "none"
               ),
               alignItems: "center",
-              borderTop: "1px solid var(--cf-color-border, #e5e5e7)",
+              borderTop: "1px solid var(--cf-theme-color-border, #e5e5e7)",
               flexWrap: "wrap",
             }}
           >
@@ -1253,7 +1253,7 @@ const WeeklyCalendar = pattern<Input, Output>(
               style={{
                 fontSize: "12px",
                 lineHeight: "28px",
-                color: "var(--cf-color-text-secondary, #666)",
+                color: "var(--cf-theme-color-text-secondary, #666)",
               }}
             >
               Linked from:


### PR DESCRIPTION
## Summary

Many patterns referenced a CSS custom property family that **does not exist**: `--cf-color-*` (singular). The real families, defined in `packages/ui/src/v2/styles/variables.ts` and `theme-context.ts`, are `--cf-colors-*` (plural palette) and `--cf-theme-color-*` (semantic). A dead reference like `var(--cf-color-gray-500, #6b7280)` silently renders the hex fallback; without a fallback it renders nothing (inherits/invalid).

This is a **mechanical rename pass**: **366 dead references fixed across 58 files**. Hex fallbacks are preserved as-is; no markup restructuring (cf-text/cf-badge migration is separate CT-1715 work).

### Before / after

```diff
-<cf-label style="color: var(--cf-color-gray-500);">
+<cf-label style="color: var(--cf-colors-gray-500);">

-background: isMine ? "var(--cf-color-primary, #2563eb)" : "var(--cf-color-surface-raised, #f3f4f6)",
+background: isMine ? "var(--cf-theme-color-primary, #2563eb)" : "var(--cf-theme-color-surface, #f3f4f6)",
```

### Mapping rules

- Palette shades → `--cf-colors-*` equivalent (gray/blue/red/green/primary ramps); nearest real shade when the exact one doesn't exist (`gray-25`→`gray-50`, `blue-300`→`blue-500`, `blue-700`→`blue-600`, `green-200`→`green-100`, `green-700`→`green-600`)
- Semantic names → `--cf-theme-color-*` (`text`, `text-secondary`, `border`, `background`/`bg`, `surface`/`bg-secondary`/`surface-raised`, `primary`, `on-primary`→`primary-foreground`, `danger`→`error`, `error-*`→`error`, `success-*`→`success`/`success-light`, `warning-*`→`warning`)
- No yellow ramp exists → warning family (`yellow-500`→`--cf-colors-warning`, `yellow-50`→`--cf-theme-color-status-warning-subtle`, `yellow-100`/`yellow-300`→`--cf-theme-color-status-warning-soft`)
- `orange-500`→`--cf-colors-coral` (kept distinct from yellow→warning in the auth status legend), `amber-600`→`--cf-colors-warning`, `info-500`→`--cf-colors-info`, `info-100`→`--cf-colors-blue-100`

Skipped per scope: `deprecated/`, `reading-list/`, `todo-list/`, `form-demo.tsx`, `email.tsx` (already migrated), and test/fixture dirs.

### Verification

- `deno task cf check <file> --no-run` on all 58 touched files: **54 pass**; 4 fail with pre-existing SES/handler-placement errors that fail identically on `origin/main` (verified in a clean worktree): `base/contacts.tsx`, `google/WIP/google-docs-importer.tsx`, `google/core/experimental/google-docs-comment-orchestrator.tsx`, `weekly-calendar/weekly-calendar.tsx` — none token-related
- `deno lint` on touched files: clean; `deno fmt --check`: clean

Proof grep (zero singular refs outside skipped dirs):

```console
$ git grep -nE 'cf-color-' packages/patterns | grep -v 'cf-colors-' | grep -v 'cf-theme-color' \
    | grep -vE '^packages/patterns/(deprecated/|reading-list/|todo-list/|form-demo\.tsx|email\.tsx|scope-bug-|gideon-tests/|test/|integration/|render-test\.tsx|nested-map-ifelse-test\.tsx|self-reference-test\.tsx)' | wc -l
0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes patterns that referenced nonexistent `--cf-color-*` CSS vars by switching to real token families. Restores theme-driven colors and removes reliance on hex fallbacks. Addresses CT-1715.

- **Bug Fixes**
  - Replaced `--cf-color-*` with `--cf-colors-*` (palette) and `--cf-theme-color-*` (semantic) across 366 references in 58 files.
  - Kept hex fallbacks; mapped gaps to supported tokens (e.g., yellow → warning family, `orange-500` → `--cf-colors-coral`, `info-*` → `--cf-colors-info`, nearest gray/blue/green shades where needed).
  - Verified with `cf check` and linters; only pre-existing non-token errors remain; skipped deprecated and fixture dirs per CT-1715 scope.

<sup>Written for commit 2ae5247a05ca8aa03c4ed34abe6a0a13ec416482. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

