### PR TITLE
feat(ui): cf-text truncate + directional stack padding (CT-1715)

### DIFF
--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -116,7 +116,7 @@ cell means none confirmed — check the component source before assuming.
 | `cf-heading` | Theme-compliant heading replacing `h1`–`h6` | |
 | `cf-hgroup` | Horizontal group with automatic gap management | |
 | `cf-hscroll` | Horizontal scroll container | |
-| `cf-hstack` | Horizontal stack layout (flexbox) | |
+| `cf-hstack` | Horizontal stack layout (flexbox) (see [stacks](#cf-vstack--cf-hstack)) | |
 | `cf-iframe` | Iframe for executing arbitrary scripts | |
 | `cf-image-input` | Image capture/upload with compression, EXIF, camera support | |
 | `cf-input` | Text input with validation and reactive binding | `$value` |
@@ -169,7 +169,7 @@ cell means none confirmed — check the component source before assuming.
 | `cf-table` | Semantic table with striped/hover/bordered styling | |
 | `cf-tabs` | Container managing ARIA tab navigation and panels | `$value` |
 | `cf-tags` | Tag pills with add/remove functionality | |
-| `cf-text` | Generic text primitive for non-label typography | |
+| `cf-text` | Generic text primitive for non-label typography (see [cf-text](#cf-text)) | |
 | `cf-textarea` | Multi-line text input with auto-resize and reactive binding | `$value` |
 | `cf-theme` | Provides a theme to a subtree and applies CSS variables | |
 | `cf-tile` | Page/item preview tile with click handling | |
@@ -184,7 +184,7 @@ cell means none confirmed — check the component source before assuming.
 | `cf-vgroup` | Vertical group with automatic gap management | |
 | `cf-voice-input` | Voice recording and transcription | `$transcription` |
 | `cf-vscroll` | Vertical scroll container (snap-to-bottom, fade edges) | |
-| `cf-vstack` | Vertical stack layout (flexbox) | |
+| `cf-vstack` | Vertical stack layout (flexbox) (see [stacks](#cf-vstack--cf-hstack)) | |
 | `cf-webhook` | Webhook integration: receives payloads into a stream | `$inbox`, `$config` |
 
 ---
@@ -416,6 +416,63 @@ slot. Optional `icon` and `action` slots render above and below the message.
     Add first item
   </cf-button>
 </cf-empty-state>
+```
+
+---
+
+## cf-text
+
+Generic text primitive for non-label typography: captions, helper copy,
+metadata, descriptions. Use `cf-label` only when text labels a specific
+control.
+
+- `variant` — typography role: `caption`, `body-compact`, `body` (default),
+  `body-large`, `heading-sm`, `heading-md`, `heading-lg`
+- `tone` — semantic color: `default`, `muted`, `tertiary`, `disabled`,
+  `primary`, `success`, `warning`, `error`
+- `block` — render as block text instead of inline text
+- `truncate` — clip overflowing text to a single line with an ellipsis. Use
+  instead of ad-hoc
+  `style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"`.
+  `truncate` implies block display, so combining it with `block` is allowed
+  but redundant. The host also gets `min-width: 0` so it shrinks and
+  truncates correctly inside flex rows like `cf-hstack`.
+
+```tsx
+// Truncated note next to fixed-width siblings in a row
+<cf-hstack gap="2" align="center">
+  <cf-text truncate tone="muted">{item.notes}</cf-text>
+  <cf-badge size="xs">{item.status}</cf-badge>
+</cf-hstack>
+```
+
+---
+
+## cf-vstack / cf-hstack
+
+Vertical and horizontal flexbox stacks. Shared layout props:
+
+- `gap` — space between items (`0`–`24` numeric scale or `xs`–`xl`)
+- `align` / `justify` — flexbox alignment
+- `reverse` — reverse the direction (`wrap` is cf-hstack only)
+- `padding` — uniform padding around the stack (same scale as `gap`)
+- `px` / `py` — horizontal / vertical axis padding (same scale)
+- `pt` / `pr` / `pb` / `pl` — single-side padding (same scale)
+
+Padding precedence: single-side props (`pt`/`pr`/`pb`/`pl`) override the axis
+props (`px`/`py`) on their side, which override the uniform `padding`. Use
+these instead of inline `style="padding-top: ..."` overrides.
+
+```tsx
+// Uniform padding, but tighter on top
+<cf-vstack gap="2" padding="4" pt="2">
+  {items}
+</cf-vstack>
+
+// Axis-only padding
+<cf-hstack gap="2" px="4" py="1">
+  {toolbarButtons}
+</cf-hstack>
 ```
 
 ---

--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -3306,6 +3306,18 @@ type TailwindNumberType =
 interface CFStackAttributes<T> extends CFHTMLAttributes<T> {
   "gap"?: TailwindNumberType;
   "padding"?: TailwindNumberType;
+  /** Horizontal (left/right) padding; overrides `padding` on those sides. */
+  "px"?: TailwindNumberType;
+  /** Vertical (top/bottom) padding; overrides `padding` on those sides. */
+  "py"?: TailwindNumberType;
+  /** Padding-top; overrides `padding`/`py` on that side. */
+  "pt"?: TailwindNumberType;
+  /** Padding-right; overrides `padding`/`px` on that side. */
+  "pr"?: TailwindNumberType;
+  /** Padding-bottom; overrides `padding`/`py` on that side. */
+  "pb"?: TailwindNumberType;
+  /** Padding-left; overrides `padding`/`px` on that side. */
+  "pl"?: TailwindNumberType;
   "align"?: "start" | "center" | "end" | "stretch" | "baseline";
   "justify"?: "start" | "center" | "end" | "between" | "around" | "evenly";
   "wrap"?: boolean;
@@ -4216,6 +4228,8 @@ interface CFTextAttributes<T> extends CFHTMLAttributes<T> {
       | "error"
     >;
   "block"?: boolean | CellLike<boolean>;
+  /** Single-line ellipsis truncation. Implies block display. */
+  "truncate"?: boolean | CellLike<boolean>;
 }
 
 interface CFBadgeAttributes<T> extends CFHTMLAttributes<T> {

--- a/packages/patterns/catalog/stories/cf-text-story.tsx
+++ b/packages/patterns/catalog/stories/cf-text-story.tsx
@@ -38,6 +38,7 @@ export default pattern<TextStoryInput, TextStoryOutput>(() => {
   const variant = new Writable<TextVariant>("body");
   const tone = new Writable<TextTone>("default");
   const block = new Writable(true);
+  const truncate = new Writable(false);
   const content = new Writable("Text content");
 
   return {
@@ -77,9 +78,26 @@ export default pattern<TextStoryInput, TextStoryOutput>(() => {
           </cf-text>
         </cf-vstack>
 
+        <cf-hstack
+          gap="2"
+          align="center"
+          style="max-width: 240px; border: 1px dashed #cbd5e1; border-radius: 4px; padding: 4px;"
+        >
+          <cf-text truncate>
+            Truncated text clips to a single line with an ellipsis, even inside
+            a flex row like cf-hstack.
+          </cf-text>
+          <cf-badge size="xs" color="neutral">tag</cf-badge>
+        </cf-hstack>
+
         <cf-card>
           <cf-vstack slot="content" gap="2">
-            <cf-text variant={variant} tone={tone} block={block}>
+            <cf-text
+              variant={variant}
+              tone={tone}
+              block={block}
+              truncate={truncate}
+            >
               {content}
             </cf-text>
             <cf-text variant="caption" tone="muted" block>
@@ -128,6 +146,12 @@ export default pattern<TextStoryInput, TextStoryOutput>(() => {
             description="Display as block text"
             defaultValue="true"
             checked={block}
+          />
+          <SwitchControl
+            label="truncate"
+            description="Single-line ellipsis (implies block)"
+            defaultValue="false"
+            checked={truncate}
           />
           <TextControl
             label="children"

--- a/packages/patterns/catalog/stories/cf-vstack-story.tsx
+++ b/packages/patterns/catalog/stories/cf-vstack-story.tsx
@@ -122,6 +122,59 @@ export default pattern<VStackStoryInput, VStackStoryOutput>(() => {
             </cf-vstack>
           </cf-hstack>
         </div>
+
+        <div>
+          <div
+            style={{
+              fontSize: "14px",
+              fontWeight: "600",
+              marginBottom: "8px",
+              color: "#2e3438",
+            }}
+          >
+            Directional Padding
+          </div>
+          <cf-hstack gap="4">
+            <cf-vstack
+              gap="1"
+              padding="4"
+              style="border: 1px dashed #cbd5e1; border-radius: 4px; flex: 1; background: #f1f5f9;"
+            >
+              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                padding=4
+              </span>
+              <div style="background: #e0e7ff; padding: 4px 8px; border-radius: 4px;">
+                Uniform
+              </div>
+            </cf-vstack>
+            <cf-vstack
+              gap="1"
+              padding="4"
+              pt="1"
+              style="border: 1px dashed #cbd5e1; border-radius: 4px; flex: 1; background: #f1f5f9;"
+            >
+              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                padding=4 pt=1
+              </span>
+              <div style="background: #bbf7d0; padding: 4px 8px; border-radius: 4px;">
+                pt overrides top
+              </div>
+            </cf-vstack>
+            <cf-vstack
+              gap="1"
+              px="6"
+              py="2"
+              style="border: 1px dashed #cbd5e1; border-radius: 4px; flex: 1; background: #f1f5f9;"
+            >
+              <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                px=6 py=2
+              </span>
+              <div style="background: #bfdbfe; padding: 4px 8px; border-radius: 4px;">
+                Axis padding
+              </div>
+            </cf-vstack>
+          </cf-hstack>
+        </div>
       </div>
     ),
     controls: (

--- a/packages/patterns/reading-list/reading-list.tsx
+++ b/packages/patterns/reading-list/reading-list.tsx
@@ -211,8 +211,8 @@ export default pattern<ReadingListInput, ReadingListOutput>(({ items }) => {
                         <cf-text
                           variant="caption"
                           tone="muted"
-                          block
-                          style="font-style: italic; margin-top: 0.25rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100%;"
+                          truncate
+                          style="font-style: italic; margin-top: 0.25rem;"
                         >
                           {item.notes}
                         </cf-text>

--- a/packages/patterns/todo-list/todo-list.tsx
+++ b/packages/patterns/todo-list/todo-list.tsx
@@ -158,7 +158,7 @@ export default pattern<TodoListInput, TodoListOutput>(({ items }) => {
                     Completed ({computed(() => completedItems.length)})
                   </cf-text>
                 </summary>
-                <cf-vstack gap="2" style="padding-top: 0.5rem;">
+                <cf-vstack gap="2" pt="2">
                   {completedCards}
                   <cf-hstack justify="end">
                     <cf-button

--- a/packages/ui/src/v2/components/cf-hstack/cf-hstack.test.ts
+++ b/packages/ui/src/v2/components/cf-hstack/cf-hstack.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for CFHStack component
+ */
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { CFHStack } from "./cf-hstack.ts";
+
+/**
+ * Extracts the class info object passed to classMap in render().
+ */
+function renderedClasses(element: CFHStack): Record<string, boolean> {
+  const result = element.render() as unknown as {
+    values: Array<{ values: unknown[] }>;
+  };
+  return result.values[0].values[0] as Record<string, boolean>;
+}
+
+describe("CFHStack", () => {
+  it("should be defined", () => {
+    expect(CFHStack).toBeDefined();
+  });
+
+  it("registers the custom element", () => {
+    expect(customElements.get("cf-hstack")).toBe(CFHStack);
+  });
+
+  it("should have default properties", () => {
+    const element = new CFHStack();
+    expect(element.gap).toBe("0");
+    expect(element.align).toBe("stretch");
+    expect(element.justify).toBe("start");
+    expect(element.wrap).toBe(false);
+    expect(element.reverse).toBe(false);
+    expect(element.padding).toBe("0");
+    expect(element.px).toBe("");
+    expect(element.py).toBe("");
+    expect(element.pt).toBe("");
+    expect(element.pr).toBe("");
+    expect(element.pb).toBe("");
+    expect(element.pl).toBe("");
+  });
+
+  it("does not apply directional padding classes by default", () => {
+    const classes = renderedClasses(new CFHStack());
+    expect(classes["p-0"]).toBe(true);
+    expect(classes["px-"]).toBe(false);
+    expect(classes["py-"]).toBe(false);
+    expect(classes["pt-"]).toBe(false);
+    expect(classes["pr-"]).toBe(false);
+    expect(classes["pb-"]).toBe(false);
+    expect(classes["pl-"]).toBe(false);
+  });
+
+  it("applies directional padding classes when set", () => {
+    const element = new CFHStack();
+    element.py = "2";
+    element.pl = "4";
+    const classes = renderedClasses(element);
+    expect(classes["p-0"]).toBe(true);
+    expect(classes["py-2"]).toBe(true);
+    expect(classes["pl-4"]).toBe(true);
+  });
+});

--- a/packages/ui/src/v2/components/cf-hstack/cf-hstack.ts
+++ b/packages/ui/src/v2/components/cf-hstack/cf-hstack.ts
@@ -14,6 +14,15 @@ import { layoutSpacingUtilityStyles } from "../../styles/layout-spacing.ts";
  * @attr {boolean} wrap - Allow items to wrap
  * @attr {boolean} reverse - Reverse the direction
  * @attr {string} padding - Padding around the stack (0, 1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24, xs, sm, md, lg, xl)
+ * @attr {string} px - Horizontal (left/right) padding; same scale as padding
+ * @attr {string} py - Vertical (top/bottom) padding; same scale as padding
+ * @attr {string} pt - Padding-top; same scale as padding
+ * @attr {string} pr - Padding-right; same scale as padding
+ * @attr {string} pb - Padding-bottom; same scale as padding
+ * @attr {string} pl - Padding-left; same scale as padding
+ *
+ * Directional padding overrides the uniform `padding` on its side, and the
+ * single-side props (pt/pr/pb/pl) override the axis props (px/py) on theirs.
  *
  * @slot - Content to be stacked horizontally
  *
@@ -101,6 +110,12 @@ export class CFHStack extends BaseElement {
     wrap: { type: Boolean },
     reverse: { type: Boolean },
     padding: { type: String },
+    px: { type: String },
+    py: { type: String },
+    pt: { type: String },
+    pr: { type: String },
+    pb: { type: String },
+    pl: { type: String },
   };
 
   declare gap: string;
@@ -109,6 +124,12 @@ export class CFHStack extends BaseElement {
   declare wrap: boolean;
   declare reverse: boolean;
   declare padding: string;
+  declare px: string;
+  declare py: string;
+  declare pt: string;
+  declare pr: string;
+  declare pb: string;
+  declare pl: string;
 
   constructor() {
     super();
@@ -118,6 +139,12 @@ export class CFHStack extends BaseElement {
     this.wrap = false;
     this.reverse = false;
     this.padding = "0";
+    this.px = "";
+    this.py = "";
+    this.pt = "";
+    this.pr = "";
+    this.pb = "";
+    this.pl = "";
   }
 
   override render() {
@@ -127,6 +154,12 @@ export class CFHStack extends BaseElement {
       [`align-${this.align}`]: true,
       [`justify-${this.justify}`]: true,
       [`p-${this.padding}`]: true,
+      [`px-${this.px}`]: !!this.px,
+      [`py-${this.py}`]: !!this.py,
+      [`pt-${this.pt}`]: !!this.pt,
+      [`pr-${this.pr}`]: !!this.pr,
+      [`pb-${this.pb}`]: !!this.pb,
+      [`pl-${this.pl}`]: !!this.pl,
       wrap: this.wrap,
       reverse: this.reverse,
     };

--- a/packages/ui/src/v2/components/cf-text/cf-text-truncate.browser.test.ts
+++ b/packages/ui/src/v2/components/cf-text/cf-text-truncate.browser.test.ts
@@ -1,0 +1,96 @@
+import { assert, assertEquals } from "@std/assert";
+import "../cf-hstack/cf-hstack.ts";
+import "./cf-text.ts";
+
+type UpdatingElement = HTMLElement & {
+  updateComplete: Promise<unknown>;
+};
+
+async function settleLayout(root: ParentNode): Promise<void> {
+  const elements = Array.from(
+    root.querySelectorAll("cf-hstack, cf-text"),
+  ) as UpdatingElement[];
+
+  await Promise.all(elements.map((element) => element.updateComplete));
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  await Promise.all(elements.map((element) => element.updateComplete));
+}
+
+const LONG_TEXT =
+  "A very long single line of text that should be clipped to an ellipsis " +
+  "instead of overflowing or wrapping onto additional lines in the row.";
+
+Deno.test("cf-text truncate applies single-line ellipsis styles", async () => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const text = document.createElement("cf-text");
+  text.setAttribute("truncate", "");
+  text.textContent = LONG_TEXT;
+  document.body.append(text);
+
+  try {
+    await settleLayout(document.body);
+
+    const style = getComputedStyle(text);
+    assertEquals(style.overflow, "hidden");
+    assertEquals(style.textOverflow, "ellipsis");
+    assertEquals(style.whiteSpace, "nowrap");
+    assertEquals(style.display, "block");
+  } finally {
+    text.remove();
+  }
+});
+
+Deno.test("cf-text truncate shrinks and clips inside a cf-hstack", async () => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const fixture = document.createElement("div");
+  fixture.style.cssText = "width: 240px;";
+  fixture.innerHTML = `
+    <cf-hstack gap="2">
+      <cf-text truncate id="truncated"></cf-text>
+      <button>Action</button>
+    </cf-hstack>
+  `;
+  const truncated = fixture.querySelector("#truncated") as HTMLElement;
+  truncated.textContent = LONG_TEXT;
+  document.body.append(fixture);
+
+  try {
+    await settleLayout(fixture);
+
+    // The text element must shrink to fit the 240px row (minus the button)
+    // rather than forcing the row wider than its container.
+    assert(
+      truncated.clientWidth <= 240,
+      `expected clientWidth <= 240, got ${truncated.clientWidth}`,
+    );
+    // And its content must overflow (be clipped) inside that width.
+    assert(
+      truncated.scrollWidth > truncated.clientWidth,
+      `expected scrollWidth (${truncated.scrollWidth}) > ` +
+        `clientWidth (${truncated.clientWidth})`,
+    );
+    // Single line: the slotted text must occupy exactly one line.
+    // (The element box itself may be stretched by the flex row, so measure
+    // the text content directly via a Range. Chrome may report both the
+    // unclipped and the ellipsized rect for the same line, so count
+    // distinct line tops rather than rects.)
+    const range = document.createRange();
+    range.selectNodeContents(truncated);
+    const lineTops = new Set(
+      Array.from(range.getClientRects()).map((rect) => Math.round(rect.top)),
+    );
+    assertEquals(
+      lineTops.size,
+      1,
+      `expected text on 1 line, got ${lineTops.size} distinct line tops`,
+    );
+  } finally {
+    fixture.remove();
+  }
+});

--- a/packages/ui/src/v2/components/cf-text/cf-text.test.ts
+++ b/packages/ui/src/v2/components/cf-text/cf-text.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for CFText component
+ */
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { CFText } from "./cf-text.ts";
+
+function stylesText(): string {
+  return (CFText.styles as Array<{ cssText: string }>)
+    .map((style) => style.cssText)
+    .join("\n");
+}
+
+describe("CFText", () => {
+  it("should be defined", () => {
+    expect(CFText).toBeDefined();
+  });
+
+  it("registers the custom element", () => {
+    expect(customElements.get("cf-text")).toBe(CFText);
+  });
+
+  it("should create element instance", () => {
+    const element = new CFText();
+    expect(element).toBeInstanceOf(CFText);
+  });
+
+  it("should have default properties", () => {
+    const element = new CFText();
+    expect(element.variant).toBe("body");
+    expect(element.tone).toBe("default");
+    expect(element.block).toBe(false);
+    expect(element.truncate).toBe(false);
+  });
+
+  it("should accept the truncate property", () => {
+    const element = new CFText();
+    element.truncate = true;
+    expect(element.truncate).toBe(true);
+  });
+
+  it("reflects truncate as an attribute selector in styles", () => {
+    const truncateRule = stylesText()
+      .split(":host([truncate])")[1];
+    expect(truncateRule).toBeDefined();
+    const block = truncateRule.slice(0, truncateRule.indexOf("}"));
+    expect(block).toContain("display: block");
+    expect(block).toContain("overflow: hidden");
+    expect(block).toContain("text-overflow: ellipsis");
+    expect(block).toContain("white-space: nowrap");
+    // min-width: 0 is required for truncation inside flex rows (cf-hstack).
+    expect(block).toContain("min-width: 0");
+    expect(block).toContain("max-width: 100%");
+  });
+
+  it("keeps the block attribute styles intact alongside truncate", () => {
+    const text = stylesText();
+    expect(text).toContain(":host([block])");
+  });
+});

--- a/packages/ui/src/v2/components/cf-text/cf-text.ts
+++ b/packages/ui/src/v2/components/cf-text/cf-text.ts
@@ -31,6 +31,11 @@ export type TextTone =
  * @attr {string} variant - Typography role. Defaults to "body".
  * @attr {string} tone - Semantic color tone. Defaults to "default".
  * @attr {boolean} block - Render as block text instead of inline text.
+ * @attr {boolean} truncate - Clip overflowing text to a single line with an
+ *   ellipsis. Implies block display (truncation requires a block formatting
+ *   context), so combining it with `block` is allowed but redundant. The host
+ *   gets `min-width: 0` so it can shrink and truncate inside flex rows such
+ *   as cf-hstack.
  *
  * @slot - Text content
  */
@@ -39,17 +44,20 @@ export class CFText extends BaseElement {
     variant: { type: String, reflect: true },
     tone: { type: String, reflect: true },
     block: { type: Boolean, reflect: true },
+    truncate: { type: Boolean, reflect: true },
   };
 
   declare variant: TextVariant;
   declare tone: TextTone;
   declare block: boolean;
+  declare truncate: boolean;
 
   constructor() {
     super();
     this.variant = "body";
     this.tone = "default";
     this.block = false;
+    this.truncate = false;
   }
 
   static override styles = [
@@ -73,6 +81,17 @@ export class CFText extends BaseElement {
 
       :host([block]) {
         display: block;
+      }
+
+      :host([truncate]) {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        /* Allow the host to shrink below its content size so it can
+          actually truncate inside flex rows (e.g. cf-hstack). */
+        min-width: 0;
+        max-width: 100%;
       }
 
       :host([variant="caption"]) {

--- a/packages/ui/src/v2/components/cf-vstack/cf-vstack-padding.browser.test.ts
+++ b/packages/ui/src/v2/components/cf-vstack/cf-vstack-padding.browser.test.ts
@@ -1,0 +1,70 @@
+import { assertEquals } from "@std/assert";
+import "./cf-vstack.ts";
+
+type UpdatingElement = HTMLElement & {
+  updateComplete: Promise<unknown>;
+};
+
+async function mountVStack(
+  attributes: Record<string, string>,
+): Promise<{ host: UpdatingElement; stack: HTMLElement }> {
+  const host = document.createElement("cf-vstack") as UpdatingElement;
+  for (const [name, value] of Object.entries(attributes)) {
+    host.setAttribute(name, value);
+  }
+  document.body.append(host);
+  await host.updateComplete;
+  const stack = host.shadowRoot!.querySelector(".stack") as HTMLElement;
+  return { host, stack };
+}
+
+Deno.test("directional padding overrides uniform padding on its side", async () => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const { host, stack } = await mountVStack({ padding: "4", pt: "2" });
+  try {
+    const style = getComputedStyle(stack);
+    assertEquals(style.paddingTop, "8px"); // pt=2 -> 0.5rem
+    assertEquals(style.paddingRight, "16px"); // padding=4 -> 1rem
+    assertEquals(style.paddingBottom, "16px");
+    assertEquals(style.paddingLeft, "16px");
+  } finally {
+    host.remove();
+  }
+});
+
+Deno.test("single-side padding overrides the axis padding on its side", async () => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const { host, stack } = await mountVStack({ px: "4", pl: "1" });
+  try {
+    const style = getComputedStyle(stack);
+    assertEquals(style.paddingLeft, "4px"); // pl=1 -> 0.25rem
+    assertEquals(style.paddingRight, "16px"); // px=4 -> 1rem
+    assertEquals(style.paddingTop, "0px"); // padding defaults to 0
+    assertEquals(style.paddingBottom, "0px");
+  } finally {
+    host.remove();
+  }
+});
+
+Deno.test("t-shirt scale values work for directional padding", async () => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const { host, stack } = await mountVStack({ py: "md" });
+  try {
+    const style = getComputedStyle(stack);
+    assertEquals(style.paddingTop, "8px"); // md -> 0.5rem
+    assertEquals(style.paddingBottom, "8px");
+    assertEquals(style.paddingLeft, "0px");
+    assertEquals(style.paddingRight, "0px");
+  } finally {
+    host.remove();
+  }
+});

--- a/packages/ui/src/v2/components/cf-vstack/cf-vstack.test.ts
+++ b/packages/ui/src/v2/components/cf-vstack/cf-vstack.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for CFVStack component
+ */
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import { layoutSpacingUtilityStyles } from "../../styles/layout-spacing.ts";
+import { CFVStack } from "./cf-vstack.ts";
+
+/**
+ * Extracts the class info object passed to classMap in render().
+ * The first template value is the classMap directive result; its
+ * `values[0]` is the class info record.
+ */
+function renderedClasses(element: CFVStack): Record<string, boolean> {
+  const result = element.render() as unknown as {
+    values: Array<{ values: unknown[] }>;
+  };
+  return result.values[0].values[0] as Record<string, boolean>;
+}
+
+describe("CFVStack", () => {
+  it("should be defined", () => {
+    expect(CFVStack).toBeDefined();
+  });
+
+  it("registers the custom element", () => {
+    expect(customElements.get("cf-vstack")).toBe(CFVStack);
+  });
+
+  it("should have default properties", () => {
+    const element = new CFVStack();
+    expect(element.gap).toBe("0");
+    expect(element.align).toBe("stretch");
+    expect(element.justify).toBe("start");
+    expect(element.reverse).toBe(false);
+    expect(element.padding).toBe("0");
+    expect(element.px).toBe("");
+    expect(element.py).toBe("");
+    expect(element.pt).toBe("");
+    expect(element.pr).toBe("");
+    expect(element.pb).toBe("");
+    expect(element.pl).toBe("");
+  });
+
+  it("does not apply directional padding classes by default", () => {
+    const classes = renderedClasses(new CFVStack());
+    expect(classes["p-0"]).toBe(true);
+    expect(classes["px-"]).toBe(false);
+    expect(classes["py-"]).toBe(false);
+    expect(classes["pt-"]).toBe(false);
+    expect(classes["pr-"]).toBe(false);
+    expect(classes["pb-"]).toBe(false);
+    expect(classes["pl-"]).toBe(false);
+  });
+
+  it("applies directional padding classes when set", () => {
+    const element = new CFVStack();
+    element.padding = "4";
+    element.pt = "2";
+    element.px = "md";
+    const classes = renderedClasses(element);
+    expect(classes["p-4"]).toBe(true);
+    expect(classes["pt-2"]).toBe(true);
+    expect(classes["px-md"]).toBe(true);
+  });
+
+  it("orders utilities so directional padding overrides uniform padding", () => {
+    const cssText = layoutSpacingUtilityStyles.cssText;
+    // With equal specificity, later rules win: .p-* < .px-*/.py-* < sides.
+    expect(cssText.indexOf(".p-4 ")).toBeLessThan(cssText.indexOf(".px-4 "));
+    expect(cssText.indexOf(".px-4 ")).toBeLessThan(cssText.indexOf(".pt-4 "));
+    expect(cssText.indexOf(".py-4 ")).toBeLessThan(cssText.indexOf(".pt-4 "));
+  });
+
+  it("defines directional utilities for the full padding scale", () => {
+    const cssText = layoutSpacingUtilityStyles.cssText;
+    const scale = [
+      "0",
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "8",
+      "10",
+      "12",
+      "16",
+      "20",
+      "24",
+      "xs",
+      "sm",
+      "md",
+      "lg",
+      "xl",
+    ];
+    for (const value of scale) {
+      for (const prefix of ["px", "py", "pt", "pr", "pb", "pl"]) {
+        expect(cssText).toContain(`.${prefix}-${value} `);
+      }
+    }
+    expect(cssText).toContain("padding-top: var(--cf-spacing-2, 0.5rem)");
+    expect(cssText).toContain("padding-left: var(--cf-spacing-md, 0.5rem)");
+  });
+});

--- a/packages/ui/src/v2/components/cf-vstack/cf-vstack.ts
+++ b/packages/ui/src/v2/components/cf-vstack/cf-vstack.ts
@@ -13,6 +13,15 @@ import { layoutSpacingUtilityStyles } from "../../styles/layout-spacing.ts";
  * @attr {string} justify - Justify content (start, center, end, between, around, evenly)
  * @attr {boolean} reverse - Reverse the direction
  * @attr {string} padding - Padding around the stack (0, 1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24, xs, sm, md, lg, xl)
+ * @attr {string} px - Horizontal (left/right) padding; same scale as padding
+ * @attr {string} py - Vertical (top/bottom) padding; same scale as padding
+ * @attr {string} pt - Padding-top; same scale as padding
+ * @attr {string} pr - Padding-right; same scale as padding
+ * @attr {string} pb - Padding-bottom; same scale as padding
+ * @attr {string} pl - Padding-left; same scale as padding
+ *
+ * Directional padding overrides the uniform `padding` on its side, and the
+ * single-side props (pt/pr/pb/pl) override the axis props (px/py) on theirs.
  *
  * @slot - Content to be stacked vertically
  *
@@ -90,6 +99,12 @@ export class CFVStack extends BaseElement {
     justify: { type: String },
     reverse: { type: Boolean },
     padding: { type: String },
+    px: { type: String },
+    py: { type: String },
+    pt: { type: String },
+    pr: { type: String },
+    pb: { type: String },
+    pl: { type: String },
   };
 
   declare gap: string;
@@ -97,6 +112,12 @@ export class CFVStack extends BaseElement {
   declare justify: string;
   declare reverse: boolean;
   declare padding: string;
+  declare px: string;
+  declare py: string;
+  declare pt: string;
+  declare pr: string;
+  declare pb: string;
+  declare pl: string;
 
   constructor() {
     super();
@@ -105,6 +126,12 @@ export class CFVStack extends BaseElement {
     this.justify = "start";
     this.reverse = false;
     this.padding = "0";
+    this.px = "";
+    this.py = "";
+    this.pt = "";
+    this.pr = "";
+    this.pb = "";
+    this.pl = "";
   }
 
   override render() {
@@ -114,6 +141,12 @@ export class CFVStack extends BaseElement {
       [`align-${this.align}`]: true,
       [`justify-${this.justify}`]: true,
       [`p-${this.padding}`]: true,
+      [`px-${this.px}`]: !!this.px,
+      [`py-${this.py}`]: !!this.py,
+      [`pt-${this.pt}`]: !!this.pt,
+      [`pr-${this.pr}`]: !!this.pr,
+      [`pb-${this.pb}`]: !!this.pb,
+      [`pl-${this.pl}`]: !!this.pl,
       reverse: this.reverse,
     };
 

--- a/packages/ui/src/v2/styles/layout-spacing.ts
+++ b/packages/ui/src/v2/styles/layout-spacing.ts
@@ -200,4 +200,383 @@ export const layoutSpacingUtilityStyles = css`
   .p-xl {
     padding: var(--cf-spacing-xl, 1rem);
   }
+
+  /*
+  * Directional padding utilities. Declared after the uniform .p-* utilities
+  * (and the px and py axes before single sides) so that, at equal
+  * specificity, a directional value overrides the uniform padding on its
+  * side.
+  */
+
+  /* Horizontal padding utilities */
+  .px-0 {
+    padding-left: var(--cf-spacing-0, 0);
+    padding-right: var(--cf-spacing-0, 0);
+  }
+  .px-1 {
+    padding-left: var(--cf-spacing-1, 0.25rem);
+    padding-right: var(--cf-spacing-1, 0.25rem);
+  }
+  .px-2 {
+    padding-left: var(--cf-spacing-2, 0.5rem);
+    padding-right: var(--cf-spacing-2, 0.5rem);
+  }
+  .px-3 {
+    padding-left: var(--cf-spacing-3, 0.75rem);
+    padding-right: var(--cf-spacing-3, 0.75rem);
+  }
+  .px-4 {
+    padding-left: var(--cf-spacing-4, 1rem);
+    padding-right: var(--cf-spacing-4, 1rem);
+  }
+  .px-5 {
+    padding-left: var(--cf-spacing-5, 1.25rem);
+    padding-right: var(--cf-spacing-5, 1.25rem);
+  }
+  .px-6 {
+    padding-left: var(--cf-spacing-6, 1.5rem);
+    padding-right: var(--cf-spacing-6, 1.5rem);
+  }
+  .px-8 {
+    padding-left: var(--cf-spacing-8, 2rem);
+    padding-right: var(--cf-spacing-8, 2rem);
+  }
+  .px-10 {
+    padding-left: var(--cf-spacing-10, 2.5rem);
+    padding-right: var(--cf-spacing-10, 2.5rem);
+  }
+  .px-12 {
+    padding-left: var(--cf-spacing-12, 3rem);
+    padding-right: var(--cf-spacing-12, 3rem);
+  }
+  .px-16 {
+    padding-left: var(--cf-spacing-16, 4rem);
+    padding-right: var(--cf-spacing-16, 4rem);
+  }
+  .px-20 {
+    padding-left: var(--cf-spacing-20, 5rem);
+    padding-right: var(--cf-spacing-20, 5rem);
+  }
+  .px-24 {
+    padding-left: var(--cf-spacing-24, 6rem);
+    padding-right: var(--cf-spacing-24, 6rem);
+  }
+  .px-xs {
+    padding-left: var(--cf-spacing-xs, 0.125rem);
+    padding-right: var(--cf-spacing-xs, 0.125rem);
+  }
+  .px-sm {
+    padding-left: var(--cf-spacing-sm, 0.25rem);
+    padding-right: var(--cf-spacing-sm, 0.25rem);
+  }
+  .px-md {
+    padding-left: var(--cf-spacing-md, 0.5rem);
+    padding-right: var(--cf-spacing-md, 0.5rem);
+  }
+  .px-lg {
+    padding-left: var(--cf-spacing-lg, 0.75rem);
+    padding-right: var(--cf-spacing-lg, 0.75rem);
+  }
+  .px-xl {
+    padding-left: var(--cf-spacing-xl, 1rem);
+    padding-right: var(--cf-spacing-xl, 1rem);
+  }
+
+  /* Vertical padding utilities */
+  .py-0 {
+    padding-top: var(--cf-spacing-0, 0);
+    padding-bottom: var(--cf-spacing-0, 0);
+  }
+  .py-1 {
+    padding-top: var(--cf-spacing-1, 0.25rem);
+    padding-bottom: var(--cf-spacing-1, 0.25rem);
+  }
+  .py-2 {
+    padding-top: var(--cf-spacing-2, 0.5rem);
+    padding-bottom: var(--cf-spacing-2, 0.5rem);
+  }
+  .py-3 {
+    padding-top: var(--cf-spacing-3, 0.75rem);
+    padding-bottom: var(--cf-spacing-3, 0.75rem);
+  }
+  .py-4 {
+    padding-top: var(--cf-spacing-4, 1rem);
+    padding-bottom: var(--cf-spacing-4, 1rem);
+  }
+  .py-5 {
+    padding-top: var(--cf-spacing-5, 1.25rem);
+    padding-bottom: var(--cf-spacing-5, 1.25rem);
+  }
+  .py-6 {
+    padding-top: var(--cf-spacing-6, 1.5rem);
+    padding-bottom: var(--cf-spacing-6, 1.5rem);
+  }
+  .py-8 {
+    padding-top: var(--cf-spacing-8, 2rem);
+    padding-bottom: var(--cf-spacing-8, 2rem);
+  }
+  .py-10 {
+    padding-top: var(--cf-spacing-10, 2.5rem);
+    padding-bottom: var(--cf-spacing-10, 2.5rem);
+  }
+  .py-12 {
+    padding-top: var(--cf-spacing-12, 3rem);
+    padding-bottom: var(--cf-spacing-12, 3rem);
+  }
+  .py-16 {
+    padding-top: var(--cf-spacing-16, 4rem);
+    padding-bottom: var(--cf-spacing-16, 4rem);
+  }
+  .py-20 {
+    padding-top: var(--cf-spacing-20, 5rem);
+    padding-bottom: var(--cf-spacing-20, 5rem);
+  }
+  .py-24 {
+    padding-top: var(--cf-spacing-24, 6rem);
+    padding-bottom: var(--cf-spacing-24, 6rem);
+  }
+  .py-xs {
+    padding-top: var(--cf-spacing-xs, 0.125rem);
+    padding-bottom: var(--cf-spacing-xs, 0.125rem);
+  }
+  .py-sm {
+    padding-top: var(--cf-spacing-sm, 0.25rem);
+    padding-bottom: var(--cf-spacing-sm, 0.25rem);
+  }
+  .py-md {
+    padding-top: var(--cf-spacing-md, 0.5rem);
+    padding-bottom: var(--cf-spacing-md, 0.5rem);
+  }
+  .py-lg {
+    padding-top: var(--cf-spacing-lg, 0.75rem);
+    padding-bottom: var(--cf-spacing-lg, 0.75rem);
+  }
+  .py-xl {
+    padding-top: var(--cf-spacing-xl, 1rem);
+    padding-bottom: var(--cf-spacing-xl, 1rem);
+  }
+
+  /* Padding-top utilities */
+  .pt-0 {
+    padding-top: var(--cf-spacing-0, 0);
+  }
+  .pt-1 {
+    padding-top: var(--cf-spacing-1, 0.25rem);
+  }
+  .pt-2 {
+    padding-top: var(--cf-spacing-2, 0.5rem);
+  }
+  .pt-3 {
+    padding-top: var(--cf-spacing-3, 0.75rem);
+  }
+  .pt-4 {
+    padding-top: var(--cf-spacing-4, 1rem);
+  }
+  .pt-5 {
+    padding-top: var(--cf-spacing-5, 1.25rem);
+  }
+  .pt-6 {
+    padding-top: var(--cf-spacing-6, 1.5rem);
+  }
+  .pt-8 {
+    padding-top: var(--cf-spacing-8, 2rem);
+  }
+  .pt-10 {
+    padding-top: var(--cf-spacing-10, 2.5rem);
+  }
+  .pt-12 {
+    padding-top: var(--cf-spacing-12, 3rem);
+  }
+  .pt-16 {
+    padding-top: var(--cf-spacing-16, 4rem);
+  }
+  .pt-20 {
+    padding-top: var(--cf-spacing-20, 5rem);
+  }
+  .pt-24 {
+    padding-top: var(--cf-spacing-24, 6rem);
+  }
+  .pt-xs {
+    padding-top: var(--cf-spacing-xs, 0.125rem);
+  }
+  .pt-sm {
+    padding-top: var(--cf-spacing-sm, 0.25rem);
+  }
+  .pt-md {
+    padding-top: var(--cf-spacing-md, 0.5rem);
+  }
+  .pt-lg {
+    padding-top: var(--cf-spacing-lg, 0.75rem);
+  }
+  .pt-xl {
+    padding-top: var(--cf-spacing-xl, 1rem);
+  }
+
+  /* Padding-right utilities */
+  .pr-0 {
+    padding-right: var(--cf-spacing-0, 0);
+  }
+  .pr-1 {
+    padding-right: var(--cf-spacing-1, 0.25rem);
+  }
+  .pr-2 {
+    padding-right: var(--cf-spacing-2, 0.5rem);
+  }
+  .pr-3 {
+    padding-right: var(--cf-spacing-3, 0.75rem);
+  }
+  .pr-4 {
+    padding-right: var(--cf-spacing-4, 1rem);
+  }
+  .pr-5 {
+    padding-right: var(--cf-spacing-5, 1.25rem);
+  }
+  .pr-6 {
+    padding-right: var(--cf-spacing-6, 1.5rem);
+  }
+  .pr-8 {
+    padding-right: var(--cf-spacing-8, 2rem);
+  }
+  .pr-10 {
+    padding-right: var(--cf-spacing-10, 2.5rem);
+  }
+  .pr-12 {
+    padding-right: var(--cf-spacing-12, 3rem);
+  }
+  .pr-16 {
+    padding-right: var(--cf-spacing-16, 4rem);
+  }
+  .pr-20 {
+    padding-right: var(--cf-spacing-20, 5rem);
+  }
+  .pr-24 {
+    padding-right: var(--cf-spacing-24, 6rem);
+  }
+  .pr-xs {
+    padding-right: var(--cf-spacing-xs, 0.125rem);
+  }
+  .pr-sm {
+    padding-right: var(--cf-spacing-sm, 0.25rem);
+  }
+  .pr-md {
+    padding-right: var(--cf-spacing-md, 0.5rem);
+  }
+  .pr-lg {
+    padding-right: var(--cf-spacing-lg, 0.75rem);
+  }
+  .pr-xl {
+    padding-right: var(--cf-spacing-xl, 1rem);
+  }
+
+  /* Padding-bottom utilities */
+  .pb-0 {
+    padding-bottom: var(--cf-spacing-0, 0);
+  }
+  .pb-1 {
+    padding-bottom: var(--cf-spacing-1, 0.25rem);
+  }
+  .pb-2 {
+    padding-bottom: var(--cf-spacing-2, 0.5rem);
+  }
+  .pb-3 {
+    padding-bottom: var(--cf-spacing-3, 0.75rem);
+  }
+  .pb-4 {
+    padding-bottom: var(--cf-spacing-4, 1rem);
+  }
+  .pb-5 {
+    padding-bottom: var(--cf-spacing-5, 1.25rem);
+  }
+  .pb-6 {
+    padding-bottom: var(--cf-spacing-6, 1.5rem);
+  }
+  .pb-8 {
+    padding-bottom: var(--cf-spacing-8, 2rem);
+  }
+  .pb-10 {
+    padding-bottom: var(--cf-spacing-10, 2.5rem);
+  }
+  .pb-12 {
+    padding-bottom: var(--cf-spacing-12, 3rem);
+  }
+  .pb-16 {
+    padding-bottom: var(--cf-spacing-16, 4rem);
+  }
+  .pb-20 {
+    padding-bottom: var(--cf-spacing-20, 5rem);
+  }
+  .pb-24 {
+    padding-bottom: var(--cf-spacing-24, 6rem);
+  }
+  .pb-xs {
+    padding-bottom: var(--cf-spacing-xs, 0.125rem);
+  }
+  .pb-sm {
+    padding-bottom: var(--cf-spacing-sm, 0.25rem);
+  }
+  .pb-md {
+    padding-bottom: var(--cf-spacing-md, 0.5rem);
+  }
+  .pb-lg {
+    padding-bottom: var(--cf-spacing-lg, 0.75rem);
+  }
+  .pb-xl {
+    padding-bottom: var(--cf-spacing-xl, 1rem);
+  }
+
+  /* Padding-left utilities */
+  .pl-0 {
+    padding-left: var(--cf-spacing-0, 0);
+  }
+  .pl-1 {
+    padding-left: var(--cf-spacing-1, 0.25rem);
+  }
+  .pl-2 {
+    padding-left: var(--cf-spacing-2, 0.5rem);
+  }
+  .pl-3 {
+    padding-left: var(--cf-spacing-3, 0.75rem);
+  }
+  .pl-4 {
+    padding-left: var(--cf-spacing-4, 1rem);
+  }
+  .pl-5 {
+    padding-left: var(--cf-spacing-5, 1.25rem);
+  }
+  .pl-6 {
+    padding-left: var(--cf-spacing-6, 1.5rem);
+  }
+  .pl-8 {
+    padding-left: var(--cf-spacing-8, 2rem);
+  }
+  .pl-10 {
+    padding-left: var(--cf-spacing-10, 2.5rem);
+  }
+  .pl-12 {
+    padding-left: var(--cf-spacing-12, 3rem);
+  }
+  .pl-16 {
+    padding-left: var(--cf-spacing-16, 4rem);
+  }
+  .pl-20 {
+    padding-left: var(--cf-spacing-20, 5rem);
+  }
+  .pl-24 {
+    padding-left: var(--cf-spacing-24, 6rem);
+  }
+  .pl-xs {
+    padding-left: var(--cf-spacing-xs, 0.125rem);
+  }
+  .pl-sm {
+    padding-left: var(--cf-spacing-sm, 0.25rem);
+  }
+  .pl-md {
+    padding-left: var(--cf-spacing-md, 0.5rem);
+  }
+  .pl-lg {
+    padding-left: var(--cf-spacing-lg, 0.75rem);
+  }
+  .pl-xl {
+    padding-left: var(--cf-spacing-xl, 1rem);
+  }
 `;


### PR DESCRIPTION
## Summary

Review of pattern migration PR #4035 found two component gaps that forced inline styles to remain in patterns:

1. No single-line-ellipsis affordance on `cf-text` — the reading-list notes line hand-rolled `overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100%`.
2. Layout stacks only supported uniform padding (`.p-*`), so a `padding-top: 0.5rem` had to stay inline in todo-list.

This PR adds both as small additive features.

### `truncate` on cf-text

```tsx
<cf-hstack gap="2" align="center">
  <cf-text truncate tone="muted">{item.notes}</cf-text>
  <cf-badge size="xs">{item.status}</cf-badge>
</cf-hstack>
```

Single-line ellipsis: `overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`, plus `display: block` (truncation needs a block formatting context — so `truncate` implies `block`; combining them is allowed but redundant) and `min-width: 0` / `max-width: 100%` so the host actually shrinks and truncates inside flex rows like `cf-hstack`.

### Directional padding on cf-vstack / cf-hstack

New props `pt` / `pr` / `pb` / `pl` and the axes `px` / `py`, accepting the same scale as the existing `padding` prop (`0`–`24` and `xs`–`xl`). The utilities follow the exact `.p-*` generation pattern in `layout-spacing.ts` — no parallel mechanism. Precedence (equal specificity, source order): single-side props override `px`/`py` on their side, which override the uniform `padding`.

```tsx
<cf-vstack gap="2" padding="4" pt="2">…</cf-vstack>
```

### Also in this PR

- `jsx.d.ts`: typed the new attributes for pattern JSX (`truncate` on `CFTextAttributes`, directional props on `CFStackAttributes`).
- Tests: unit tests for cf-text / cf-vstack / cf-hstack, plus `.browser.test.ts` layout tests (run locally in real Chrome via `deno-web-test`) proving truncation inside a 240px `cf-hstack` (clipped width, one line box) and computed-style padding precedence.
- Catalog stories: cf-text story gains a truncate example + control; cf-vstack story gains a directional-padding comparison row.
- `COMPONENTS.md`: new `cf-text` and `cf-vstack / cf-hstack` sections documenting the props and precedence.
- Proof in patterns: `reading-list.tsx` notes line now uses `truncate` (only `font-style`/`margin-top` remain inline) and `todo-list.tsx` uses `pt="2"` instead of `style="padding-top: 0.5rem"`. Verified with `cf check --no-run` and `cf test` for both patterns.

## Test results

- `packages/ui` `deno task test`: 101 passed (583 steps) + 36 passed (sanitize-svg browser), 0 failed
- Browser layout tests via deno-web-test (Chrome): truncate 2/2, padding precedence 3/3
- `cf test` reading-list: 12 passed, 0 failed, 21 skipped; todo-list: 21 passed, 0 failed
- `deno lint` / `deno fmt --check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds single-line truncation to `cf-text` and directional padding to `cf-vstack`/`cf-hstack` to remove inline styles and meet CT-1715. Improves layout control and keeps truncation working inside flex rows.

- **New Features**
  - `cf-text`: `truncate` for single-line ellipsis; implies block; adds `min-width: 0`/`max-width: 100%` for proper flex-row shrinking.
  - `cf-vstack` / `cf-hstack`: directional padding props `px`/`py`/`pt`/`pr`/`pb`/`pl` (same scale as `padding`); precedence is sides > axes > uniform.
  - Typed attributes in `jsx.d.ts`, updated docs and catalog stories, and tests for truncation and padding precedence.

- **Migration**
  - Replace inline ellipsis styles with `<cf-text truncate>…</cf-text>`.
  - Replace inline `padding-*` styles with `pt`/`pr`/`pb`/`pl` or `px`/`py` on stacks.

<sup>Written for commit e2da2c2e7e42f37d382e51e76b1508dd99941bfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

