### PR TITLE
feat: teach transformers the "Reactive" wrapper spelling (rename PR A)

### DIFF
--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -31,6 +31,7 @@ const CELL_LIKE_WRAPPER_NAMES = spellingsWhere({
   Stream: false, // handled separately at each call site
   SqliteDb: false, // handled separately at each call site
   OpaqueRef: false,
+  Reactive: false,
   OpaqueRefMethods: false,
   CellTypeConstructor: false,
   ScopedCellTypeConstructor: false,
@@ -45,6 +46,7 @@ const OPAQUE_WRAPPER_NAMES = spellingsWhere({
   Stream: false,
   SqliteDb: false,
   OpaqueRef: false,
+  Reactive: false,
   OpaqueRefMethods: false,
   CellTypeConstructor: false,
   ScopedCellTypeConstructor: false,
@@ -55,10 +57,11 @@ function getEntityNameText(name: ts.EntityName): string {
   return ts.isIdentifier(name) ? name.text : name.right.text;
 }
 
-// Spellings that participate in node-level wrapper detection. OpaqueRef is
-// deliberately excluded: wrapperKindForName has never treated it as a node
-// wrapper, and its callers (Default-literal and type-name resolution) must
-// not start unwrapping it — revisit with the OpaqueRef deprecation.
+// Spellings that participate in node-level wrapper detection. OpaqueRef (and
+// its successor spelling Reactive) is deliberately excluded: wrapperKindForName
+// has never treated it as a node wrapper, and its callers (Default-literal and
+// type-name resolution) must not start unwrapping it — revisit with the
+// OpaqueRef deprecation.
 const NODE_WRAPPER_SPELLINGS: Readonly<Record<WrapperSpelling, boolean>> = {
   Cell: true,
   Writable: true,
@@ -69,6 +72,7 @@ const NODE_WRAPPER_SPELLINGS: Readonly<Record<WrapperSpelling, boolean>> = {
   Stream: true,
   SqliteDb: true,
   OpaqueRef: false,
+  Reactive: false,
   OpaqueRefMethods: false,
   CellTypeConstructor: false,
   ScopedCellTypeConstructor: false,
@@ -438,7 +442,7 @@ export function getNamedTypeKey(
   if (
     aliasName === "Default" || CELL_LIKE_WRAPPER_NAMES.has(aliasName ?? "") ||
     aliasName === "Stream" || aliasName === "SqliteDb" ||
-    aliasName === "OpaqueRef"
+    aliasName === "OpaqueRef" || aliasName === "Reactive"
   ) {
     return undefined;
   }

--- a/packages/schema-generator/src/typescript/wrapper-names.ts
+++ b/packages/schema-generator/src/typescript/wrapper-names.ts
@@ -27,6 +27,7 @@ export type WrapperSpelling =
   | "Stream"
   | "SqliteDb"
   | "OpaqueRef"
+  | "Reactive"
   | "OpaqueRefMethods"
   | "CellTypeConstructor"
   | "ScopedCellTypeConstructor";
@@ -48,6 +49,9 @@ export const WRAPPER_SPELLING_TO_KIND = {
   SqliteDb: "SqliteDb",
   // Deprecation intended — see the note on CellWrapperKind in cell-brand.ts.
   OpaqueRef: "OpaqueRef",
+  // Successor spelling for OpaqueRef (api will alias OpaqueRef = Reactive);
+  // classified identically everywhere until OpaqueRef is removed.
+  Reactive: "OpaqueRef",
   // Internal methods-owner interface behind OpaqueRef, not a type reference.
   OpaqueRefMethods: undefined,
   // The interface typing the `Cell` constructor/namespace value (api/index.ts).

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -63,6 +63,8 @@ const ARRAY_OWNER_NAMES = new Set([
 const OPAQUE_REF_OWNER_NAMES = spellingsWhere({
   OpaqueRefMethods: true,
   OpaqueRef: true,
+  // Identity alias — can never own method declarations; row matches OpaqueRef.
+  Reactive: true,
   Cell: false,
   Writable: false,
   ReadonlyCell: false,
@@ -88,6 +90,7 @@ const CELL_LIKE_CLASSES = spellingsWhere({
   ScopedCellTypeConstructor: true,
   SqliteDb: false,
   OpaqueRef: false, // owner detection handled via OPAQUE_REF_OWNER_NAMES
+  Reactive: false, // same as OpaqueRef
   OpaqueRefMethods: false,
 });
 

--- a/packages/ts-transformers/src/transformers/cast-validation.ts
+++ b/packages/ts-transformers/src/transformers/cast-validation.ts
@@ -26,6 +26,7 @@ const CELL_LIKE_TYPE_NAMES = spellingsWhere({
   ScopedCellTypeConstructor: false,
   SqliteDb: false,
   OpaqueRef: false, // error, not warning — see FORBIDDEN_CAST_TYPE_NAMES
+  Reactive: false, // error, not warning — see FORBIDDEN_CAST_TYPE_NAMES
   OpaqueRefMethods: false,
 });
 
@@ -35,6 +36,7 @@ const CELL_LIKE_TYPE_NAMES = spellingsWhere({
  */
 const FORBIDDEN_CAST_TYPE_NAMES = spellingsWhere({
   OpaqueRef: true,
+  Reactive: true,
   Cell: false,
   Writable: false,
   ReadonlyCell: false,

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -698,6 +698,7 @@ const CELL_LIKE_TYPE_NODE_NAMES = spellingsWhere({
   Writable: true,
   OpaqueCell: true,
   OpaqueRef: true,
+  Reactive: true,
   ComparableCell: true,
   ReadonlyCell: true,
   WriteonlyCell: true,


### PR DESCRIPTION
First of four PRs renaming the authoring-surface `OpaqueRef<T>` to `Reactive<T>` (name from Berni; plan approved by Gideon). **Stacked on #4007** — retarget to main after it merges.

## What

Adds `"Reactive"` to the `WrapperSpelling` vocabulary, mapped to resolved kind `"OpaqueRef"`. The exhaustive-table design from #4007 did its job: the compiler enumerated every classification site, and each `Reactive` row is classified **identically to its `OpaqueRef` row**:

| Table | Row | Why |
|---|---|---|
| `CELL_LIKE_WRAPPER_NAMES` (type-utils) | `false` | same as OpaqueRef |
| `OPAQUE_WRAPPER_NAMES` (type-utils) | `false` | same as OpaqueRef |
| `NODE_WRAPPER_SPELLINGS` (type-utils) | `false` | node-wrapper detection must not unwrap it |
| `getNamedTypeKey` alias chain (type-utils) | excluded | don't hoist the alias into a definition |
| `OPAQUE_REF_OWNER_NAMES` (call-kind) | `true` | inert — identity alias can't own methods |
| `CELL_LIKE_CLASSES` (call-kind) | `false` | same as OpaqueRef |
| `CELL_LIKE_TYPE_NAMES` (cast-validation) | `false` | error not warning, see below |
| `FORBIDDEN_CAST_TYPE_NAMES` (cast-validation) | `true` | `as Reactive<T>` errors like `as OpaqueRef<T>` |
| `CELL_LIKE_TYPE_NODE_NAMES` (type-shrinking) | `true` | `Reactive<Stream<...>>` shrinks like `OpaqueRef<Stream<...>>` |

## Why inert

Nothing exports or authors `Reactive` yet — that's PR B (api: `export type Reactive<T> = T` + deprecate `OpaqueRef`) and PR C (migrate patterns/ui/docs). Landing the transformer vocabulary first means PR B can't create a window where authored `Reactive` spellings are silently misclassified.

## Verification

- `deno fmt --check` / `deno lint` / `deno check` clean on all five edited files
- schema-generator suite: 24 passed (229 steps)
- ts-transformers suite: 292 passed (618 steps), goldens byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teach `schema-generator` and `ts-transformers` to recognize the `Reactive<T>` wrapper spelling, normalizing to the `OpaqueRef` kind. Behavior is unchanged; this prepares the `OpaqueRef<T>` → `Reactive<T>` rename.

- **Refactors**
  - Map `Reactive` in `WrapperSpelling` to kind `"OpaqueRef"` (`WRAPPER_SPELLING_TO_KIND`), exclude from node-wrapper detection, and prevent alias hoisting in `getNamedTypeKey`.
  - Classify `Reactive` exactly like `OpaqueRef`: owner detection (`OPAQUE_REF_OWNER_NAMES`), not cell-like (`CELL_LIKE_*`), forbid `as Reactive<T>` casts, and apply identical type shrinking (`CELL_LIKE_TYPE_NODE_NAMES`, e.g., `Reactive<Stream<...>>`).
  - No API export yet; authored code and goldens unchanged.

<sup>Written for commit cb473512bd5c82c6d5621f866d8932d413848312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

