### PR TITLE
chore: migrate authoring surfaces from OpaqueRef to Reactive (rename PR C)

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1799,7 +1799,6 @@
     },
     "uuid@9.0.1": {
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": true,
       "bin": true
     },
     "w3c-keyname@2.2.8": {

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -13,7 +13,7 @@ When entries are added or modified, provenance can be found in this file's git h
 
 | Question | Answer Location | Last Updated |
 |----------|-----------------|--------------|
-| What type should handlers use in Output interfaces? | `docs/common/concepts/handler.md` - Section "Exporting Handlers as Streams". Use `Stream<T>` (not `OpaqueRef<T>`) for handlers in Output interfaces. `Stream<T>` represents a write-only channel that other pieces can call via `.send()`. | 2026-06-10 |
+| What type should handlers use in Output interfaces? | `docs/common/concepts/handler.md` - Section "Exporting Handlers as Streams". Use `Stream<T>` (not `Reactive<T>`) for handlers in Output interfaces. `Stream<T>` represents a write-only channel that other pieces can call via `.send()`. | 2026-06-10 |
 | How do I run the cf command? | `skills/cf/SKILL.md` - Section "Running CF". Always use `deno task cf [command]`. There is no binary to build or verify for normal development - `cf` runs TypeScript directly via deno. | 2026-03-25 |
 | How do I compare objects for identity? Why does my custom `id` property not work? | `docs/common/concepts/identity.md` and `docs/development/debugging/gotchas/custom-id-property-pitfall.md`. Use `equals()` from `commonfabric`. Properties in `.map()` callbacks are Cells, not plain values. | 2026-03-25 |
 | Why do I get "reactive reference outside context" when using input props in `[NAME]` or `new Writable()`? | `docs/development/debugging/gotchas/reactive-reference-outside-context.md`. Input props are reactive values that can only be accessed inside reactive contexts (`computed()`, `lift()`, JSX, event handlers). Wrap `[NAME]` in `computed()`, initialize cells with static values and set from event handlers. | 2026-01-14 |

--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -509,7 +509,7 @@ interface MapMarker {
   title?: string;
   description?: string;
   icon?: string;        // Emoji or icon name
-  popup?: OpaqueRef<any>; // Advanced: pattern reference for rich popup
+  popup?: Reactive<any>; // Advanced: pattern reference for rich popup
   draggable?: boolean;
 }
 
@@ -521,7 +521,7 @@ interface MapCircle {
   strokeWidth?: number;
   title?: string;
   description?: string;
-  popup?: OpaqueRef<any>;
+  popup?: Reactive<any>;
 }
 
 interface MapPolyline {

--- a/packages/patterns/budget-tracker/data-view.tsx
+++ b/packages/patterns/budget-tracker/data-view.tsx
@@ -2,15 +2,15 @@
  * Budget Tracker - Data View Sub-Pattern
  *
  * Displays computed summaries: totals, by-category breakdown, budget status.
- * Read-only view - uses OpaqueRef<> since it only reads data.
+ * Read-only view - uses Reactive<> since it only reads data.
  */
-import { computed, NAME, OpaqueRef, pattern, UI } from "commonfabric";
+import { computed, NAME, pattern, Reactive, UI } from "commonfabric";
 import { type CategoryBudget, type Expense } from "./schemas.tsx";
 
-// Sub-patterns use OpaqueRef for read-only access (no Writable<> needed)
+// Sub-patterns use Reactive for read-only access (no Writable<> needed)
 interface Input {
-  expenses: OpaqueRef<Expense[]>;
-  budgets: OpaqueRef<CategoryBudget[]>;
+  expenses: Reactive<Expense[]>;
+  budgets: Reactive<CategoryBudget[]>;
 }
 
 // Use single type param to avoid conflict bug

--- a/packages/patterns/do-list/do-list.tsx
+++ b/packages/patterns/do-list/do-list.tsx
@@ -5,8 +5,8 @@ import {
   handler,
   ifElse,
   NAME,
-  OpaqueRef,
   pattern,
+  Reactive,
   Stream,
   UI,
   type VNode,
@@ -39,14 +39,14 @@ export interface DoListOutput {
   summary: string;
   mentionable: { [NAME]: string; summary: string; [UI]: VNode }[];
   // UI handlers (use cell references via equals())
-  addItem: OpaqueRef<
+  addItem: Reactive<
     Stream<{ title: string; indent?: number; attachments?: Writable<any>[] }>
   >;
-  removeItem: OpaqueRef<Stream<{ item: DoItem }>>;
-  updateItem: OpaqueRef<
+  removeItem: Reactive<Stream<{ item: DoItem }>>;
+  updateItem: Reactive<
     Stream<{ item: DoItem; title?: string; done?: boolean }>
   >;
-  addItems: OpaqueRef<
+  addItems: Reactive<
     Stream<{
       items: Array<{
         title: string;
@@ -57,9 +57,9 @@ export interface DoListOutput {
   >;
   // LLM-friendly handlers (use title matching)
   /** Remove a task and its subtasks by title */
-  removeItemByTitle: OpaqueRef<Stream<{ title: string }>>;
+  removeItemByTitle: Reactive<Stream<{ title: string }>>;
   /** Update a task by title. Set done to mark complete, newTitle to rename, attachments to add references. */
-  updateItemByTitle: OpaqueRef<
+  updateItemByTitle: Reactive<
     Stream<{
       title: string;
       newTitle?: string;
@@ -67,7 +67,7 @@ export interface DoListOutput {
       attachments?: Writable<any>[];
     }>
   >;
-  archiveCompleted: OpaqueRef<Stream<unknown>>;
+  archiveCompleted: Reactive<Stream<unknown>>;
 }
 
 // ===== Module-scope Handlers =====

--- a/packages/patterns/examples/cf-render.tsx
+++ b/packages/patterns/examples/cf-render.tsx
@@ -48,7 +48,7 @@ export const Counter = pattern<PatternState>((state) => {
       <div>
         {
           /* Even though we could end up passing extra data to decrement, our schema prevents that actually reaching the handler.
-          In fact, we are passing `value` as an OpaqueRef<number> here but it becomes a Writable<number> at invocation time */
+          In fact, we are passing `value` as an Reactive<number> here but it becomes a Writable<number> at invocation time */
         }
         <cf-button onClick={decrement(state)}>
           dec to {previous(state.value)}

--- a/packages/patterns/gideon-tests/test-opaque-ref.tsx
+++ b/packages/patterns/gideon-tests/test-opaque-ref.tsx
@@ -1,4 +1,4 @@
-import { generateObject, JSONSchema, OpaqueRef, pattern } from "commonfabric";
+import { generateObject, JSONSchema, pattern, Reactive } from "commonfabric";
 
 interface Email {
   id: string;
@@ -10,9 +10,9 @@ interface ExtractedData {
 }
 
 // Generic building block - T is a type parameter
-function BuildingBlock<T>(emails: OpaqueRef<Email[]>, schema: JSONSchema) {
+function BuildingBlock<T>(emails: Reactive<Email[]>, schema: JSONSchema) {
   // This is the problematic case: generateObject<T> where T is a type parameter
-  // The result is OpaqueRef<T | undefined> where T is unresolved
+  // The result is Reactive<T | undefined> where T is unresolved
   const analyses = emails.map((email: Email) => {
     const analysis = generateObject<T>({
       prompt: email.content,
@@ -22,7 +22,7 @@ function BuildingBlock<T>(emails: OpaqueRef<Email[]>, schema: JSONSchema) {
     return {
       email,
       analysis,
-      result: analysis.result, // OpaqueRef<T | undefined> - T is a type parameter!
+      result: analysis.result, // Reactive<T | undefined> - T is a type parameter!
     };
   });
 
@@ -30,7 +30,7 @@ function BuildingBlock<T>(emails: OpaqueRef<Email[]>, schema: JSONSchema) {
 }
 
 // Pattern that uses the building block
-export default pattern(({ emails }: { emails: OpaqueRef<Email[]> }) => {
+export default pattern(({ emails }: { emails: Reactive<Email[]> }) => {
   const data = BuildingBlock<ExtractedData>(emails, { type: "object" });
   return { data };
 });

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -361,16 +361,16 @@ interface DoListOutput {
   items: DoItem[];
   itemCount: number;
   compactUI: VNode;
-  addItem: OpaqueRef<Stream<{ title: string; indent?: number }>>;
-  removeItem: OpaqueRef<Stream<{ item: DoItem }>>;
-  updateItem: OpaqueRef<
+  addItem: Reactive<Stream<{ title: string; indent?: number }>>;
+  removeItem: Reactive<Stream<{ item: DoItem }>>;
+  updateItem: Reactive<
     Stream<{ item: DoItem; title?: string; done?: boolean }>
   >;
-  addItems: OpaqueRef<
+  addItems: Reactive<
     Stream<{ items: Array<{ title: string; indent?: number }> }>
   >;
-  removeItemByTitle: OpaqueRef<Stream<{ title: string }>>;
-  updateItemByTitle: OpaqueRef<
+  removeItemByTitle: Reactive<Stream<{ title: string }>>;
+  updateItemByTitle: Reactive<
     Stream<{ title: string; newTitle?: string; done?: boolean }>
   >;
 }
@@ -469,8 +469,8 @@ interface Output {
   doneCount: number;
   remainingCount: number;
   storeLayout: string;
-  addItem: OpaqueRef<Stream<{ detail: { message: string } }>>;
-  addItems: OpaqueRef<Stream<{ itemNames: string[] }>>;
+  addItem: Reactive<Stream<{ detail: { message: string } }>>;
+  addItems: Reactive<Stream<{ itemNames: string[] }>>;
 }
 ```
 

--- a/packages/patterns/shopping-list.tsx
+++ b/packages/patterns/shopping-list.tsx
@@ -15,9 +15,9 @@ import {
   handler,
   NAME,
   navigateTo,
-  OpaqueRef,
   pattern,
   patternTool,
+  Reactive,
   Stream,
   UI,
   Writable,
@@ -51,9 +51,9 @@ export interface Output {
   remainingCount: number;
   storeLayout: string;
   // Omnibot handlers
-  addItem: OpaqueRef<Stream<{ detail: { message: string } }>>;
-  addItemForOmnibot: OpaqueRef<Stream<{ itemText: string }>>;
-  addItems: OpaqueRef<Stream<{ itemNames: string[] }>>;
+  addItem: Reactive<Stream<{ detail: { message: string } }>>;
+  addItemForOmnibot: Reactive<Stream<{ itemText: string }>>;
+  addItems: Reactive<Stream<{ itemNames: string[] }>>;
 }
 
 // Demo store layout from Andronico's on Shattuck (community-patterns)

--- a/packages/ui/src/v2/components/cf-map/cf-map.ts
+++ b/packages/ui/src/v2/components/cf-map/cf-map.ts
@@ -84,7 +84,7 @@ const mapValueSchema: JSONSchema = {
           description: { type: "string" },
           icon: { type: "string" },
           draggable: { type: "boolean" },
-          // popup is OpaqueRef, left unspecified to preserve as-is
+          // popup is Reactive, left unspecified to preserve as-is
         },
       },
     },
@@ -100,7 +100,7 @@ const mapValueSchema: JSONSchema = {
           strokeWidth: { type: "number" },
           title: { type: "string" },
           description: { type: "string" },
-          // popup is OpaqueRef, left unspecified to preserve as-is
+          // popup is Reactive, left unspecified to preserve as-is
         },
       },
     },
@@ -1116,7 +1116,7 @@ export class CFMap extends BaseElement {
   ): HTMLElement {
     const container = document.createElement("div");
 
-    // Check if we have an OpaqueRef popup (advanced mode)
+    // Check if we have an Reactive popup (advanced mode)
     if (feature.popup) {
       // Create a cf-render element for the popup content
       const cfRender = document.createElement("cf-render");

--- a/packages/ui/src/v2/components/cf-map/types.ts
+++ b/packages/ui/src/v2/components/cf-map/types.ts
@@ -2,7 +2,7 @@
  * Type definitions for the CF Map component
  */
 
-import type { OpaqueRef } from "@commonfabric/api";
+import type { Reactive } from "@commonfabric/api";
 
 /**
  * Represents a geographic coordinate with latitude and longitude
@@ -27,7 +27,7 @@ export interface Bounds {
  *
  * Popup content follows a progressive model:
  * - Simple: Use `title`, `description`, `icon` fields (pure data, rendered by cf-map)
- * - Advanced: Use `popup` field with a Cell/OpaqueRef that has a [UI] property
+ * - Advanced: Use `popup` field with a Cell/Reactive that has a [UI] property
  */
 export interface MapMarker {
   position: LatLng;
@@ -38,7 +38,7 @@ export interface MapMarker {
   icon?: string; // emoji, URL, or icon name
 
   // Advanced popup content (Cell with [UI] property)
-  popup?: OpaqueRef<any>;
+  popup?: Reactive<any>;
 
   // Behavior
   draggable?: boolean;
@@ -61,7 +61,7 @@ export interface MapCircle {
   // Popup (same pattern as markers)
   title?: string;
   description?: string;
-  popup?: OpaqueRef<any>;
+  popup?: Reactive<any>;
 }
 
 /**


### PR DESCRIPTION
Third of four PRs renaming the authoring-surface `OpaqueRef<T>` to `Reactive<T>`. **Stacked on #4045** — retarget after it merges.

## What

Mechanical spelling swap (`OpaqueRef<` → `Reactive<` + import updates) across everything that authors the deprecated name:

- **Patterns**: `do-list`, `shopping-list`, `budget-tracker/data-view`, `gideon-tests/test-opaque-ref`, `examples/cf-render` (typed comment)
- **UI**: `cf-map` (`popup?: Reactive<any>` in types.ts + its comments in cf-map.ts)
- **Living docs**: pattern catalog (`index.md`, `README.md`), `docs/FAQ.md`, `COMPONENTS.md`

## Deliberately not migrated

- Prose comments describing the **runtime** OpaqueRef proxy (google extractors, `extractor-module`, the closure-capture gotcha doc): the runner's runtime concept keeps its name — only the authored type was renamed. Renaming those would make the docs wrong. (Diverges from the handoff plan, which listed the gotcha doc; on reading, all its mentions are runtime-value statements like "at runtime `people.get()` is an OpaqueRef".)
- Historical specs (`docs/specs/**`) — they describe past design.
- `PatternFunction`/`schema.ts` internals — held back for #4017 coordination (see #4045).

## Verification

- `deno fmt --check` / `deno lint` / `deno check` clean on all migrated files
- Transform spot-check: `cf check --show-transformed --no-run` on do-list + shopping-list, diffed against pre-migration output — byte-identical except the authored spelling and content-hash module ids; emitted schemas unchanged
- ui suite: 36 passed; runtime: all 59 integration pattern tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the authored type `OpaqueRef<T>` to `Reactive<T>` across patterns, `cf-map`, and docs. No behavior or schema changes; the runtime “OpaqueRef” term remains where it describes runtime values.

- **Refactors**
  - Mechanical rename and import updates in `do-list`, `shopping-list`, `budget-tracker/data-view`, `gideon-tests/test-opaque-ref`, `examples/cf-render`, and the pattern catalog (`index.md`).
  - Updated `cf-map` to type `popup` as `Reactive<any>` and adjusted comments; types now import from `@commonfabric/api`.
  - Docs refreshed in `docs/FAQ.md` and `docs/common/components/COMPONENTS.md`; clarified that handlers use `Stream<T>` (not `Reactive<T>`).

<sup>Written for commit 6594a7e9605c5fe7a40537f6ea5e6a43db5ee444. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

