### PR TITLE
chore(ts-transformers): retire dead OpaqueRefMethods owner detection (rename PR D)

### DIFF
--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -32,7 +32,6 @@ const CELL_LIKE_WRAPPER_NAMES = spellingsWhere({
   SqliteDb: false, // handled separately at each call site
   OpaqueRef: false,
   Reactive: false,
-  OpaqueRefMethods: false,
   CellTypeConstructor: false,
   ScopedCellTypeConstructor: false,
 });
@@ -47,7 +46,6 @@ const OPAQUE_WRAPPER_NAMES = spellingsWhere({
   SqliteDb: false,
   OpaqueRef: false,
   Reactive: false,
-  OpaqueRefMethods: false,
   CellTypeConstructor: false,
   ScopedCellTypeConstructor: false,
 });
@@ -73,7 +71,6 @@ const NODE_WRAPPER_SPELLINGS: Readonly<Record<WrapperSpelling, boolean>> = {
   SqliteDb: true,
   OpaqueRef: false,
   Reactive: false,
-  OpaqueRefMethods: false,
   CellTypeConstructor: false,
   ScopedCellTypeConstructor: false,
 };

--- a/packages/schema-generator/src/typescript/wrapper-names.ts
+++ b/packages/schema-generator/src/typescript/wrapper-names.ts
@@ -28,7 +28,6 @@ export type WrapperSpelling =
   | "SqliteDb"
   | "OpaqueRef"
   | "Reactive"
-  | "OpaqueRefMethods"
   | "CellTypeConstructor"
   | "ScopedCellTypeConstructor";
 
@@ -52,8 +51,6 @@ export const WRAPPER_SPELLING_TO_KIND = {
   // Successor spelling for OpaqueRef (api will alias OpaqueRef = Reactive);
   // classified identically everywhere until OpaqueRef is removed.
   Reactive: "OpaqueRef",
-  // Internal methods-owner interface behind OpaqueRef, not a type reference.
-  OpaqueRefMethods: undefined,
   // The interface typing the `Cell` constructor/namespace value (api/index.ts).
   CellTypeConstructor: undefined,
   // The interface typing the scoped-cell factory value (api/index.ts).

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -44,7 +44,7 @@ import {
 } from "../core/commonfabric-runtime-registry.ts";
 import {
   getCellKind,
-  isOpaqueRefType,
+  isBrandedCellType,
 } from "../transformers/opaque-ref/opaque-ref.ts";
 import { classifyOpaquePathTerminalCall } from "../transformers/opaque-roots.ts";
 import {
@@ -59,24 +59,6 @@ const ARRAY_OWNER_NAMES = new Set([
   "ReadonlyArray",
 ]);
 
-// Owners of OpaqueRef-style method declarations (array-method detection).
-const OPAQUE_REF_OWNER_NAMES = spellingsWhere({
-  OpaqueRefMethods: true,
-  OpaqueRef: true,
-  // Identity alias — can never own method declarations; row matches OpaqueRef.
-  Reactive: true,
-  Cell: false,
-  Writable: false,
-  ReadonlyCell: false,
-  WriteonlyCell: false,
-  ComparableCell: false,
-  OpaqueCell: false,
-  Stream: false,
-  SqliteDb: false,
-  CellTypeConstructor: false,
-  ScopedCellTypeConstructor: false,
-});
-
 // Wrapper spellings whose method calls classify as cell-like (get/set/etc.).
 const CELL_LIKE_CLASSES = spellingsWhere({
   Cell: true,
@@ -89,9 +71,8 @@ const CELL_LIKE_CLASSES = spellingsWhere({
   CellTypeConstructor: true,
   ScopedCellTypeConstructor: true,
   SqliteDb: false,
-  OpaqueRef: false, // owner detection handled via OPAQUE_REF_OWNER_NAMES
-  Reactive: false, // same as OpaqueRef
-  OpaqueRefMethods: false,
+  OpaqueRef: false,
+  Reactive: false,
 });
 
 const CELL_FACTORY_NAMES = new Set(["of"]);
@@ -982,7 +963,7 @@ export function isReactiveValueExpression(
 
       try {
         const type = checker.getTypeAtLocation(target);
-        if (isOpaqueRefType(type, checker)) {
+        if (isBrandedCellType(type, checker)) {
           return true;
         }
       } catch {
@@ -1091,7 +1072,7 @@ function hasReactiveCollectionProvenanceInternal(
       options.typeRegistry,
       options.logger,
     );
-    if (type && isOpaqueRefType(type, checker)) {
+    if (type && isBrandedCellType(type, checker)) {
       return true;
     }
   }
@@ -1927,10 +1908,7 @@ function resolveSymbolKind(
     const cellKind = detectCellMethodFromDeclaration(resolved, declaration);
     if (cellKind) return cellKind;
 
-    if (
-      isArrayMethodDeclaration(declaration) ||
-      isOpaqueRefMethodDeclaration(declaration)
-    ) {
+    if (isArrayMethodDeclaration(declaration)) {
       return { kind: "array-method", symbol: resolved };
     }
     if (
@@ -2142,14 +2120,6 @@ function isArrayMethodDeclaration(declaration: ts.Declaration): boolean {
     declaration,
     isKnownArrayMethodName,
     ARRAY_OWNER_NAMES,
-  );
-}
-
-function isOpaqueRefMethodDeclaration(declaration: ts.Declaration): boolean {
-  return isMethodDeclarationOwnedBy(
-    declaration,
-    isKnownArrayMethodName,
-    OPAQUE_REF_OWNER_NAMES,
   );
 }
 

--- a/packages/ts-transformers/src/ast/dataflow.ts
+++ b/packages/ts-transformers/src/ast/dataflow.ts
@@ -8,7 +8,7 @@ import {
 } from "./utils.ts";
 import { isFunctionLikeExpression } from "./function-predicates.ts";
 import { symbolDeclaresCommonFabricDefault } from "../core/common-fabric-symbols.ts";
-import { isOpaqueRefType } from "../transformers/opaque-ref/opaque-ref.ts";
+import { isBrandedCellType } from "../transformers/opaque-ref/opaque-ref.ts";
 import { isSafeIdentifierText } from "../utils/identifiers.ts";
 import {
   detectCallKind,
@@ -764,7 +764,7 @@ export function createDataFlowAnalyzer(
 
       const type = tryGetType(expression);
       if (
-        (type && isOpaqueRefType(type, checker)) ||
+        (type && isBrandedCellType(type, checker)) ||
         isReactiveValueExpression(expression, checker)
       ) {
         recordDataFlow(expression, scope, null, true); // Explicit: direct OpaqueRef
@@ -872,7 +872,7 @@ export function createDataFlowAnalyzer(
       }
       const propertyType = tryGetType(expression);
 
-      if (propertyType && isOpaqueRefType(propertyType, checker)) {
+      if (propertyType && isBrandedCellType(propertyType, checker)) {
         if (originatesFromIgnored(expression.expression)) {
           return emptyAnalysis();
         }

--- a/packages/ts-transformers/src/ast/type-inference.ts
+++ b/packages/ts-transformers/src/ast/type-inference.ts
@@ -1,7 +1,7 @@
 import ts from "typescript";
 import {
   getCellKind,
-  isOpaqueRefType,
+  isBrandedCellType,
 } from "../transformers/opaque-ref/opaque-ref.ts";
 import {
   getTypeAtLocationWithFallback,
@@ -270,7 +270,7 @@ export function isCellLikeType(
 ): boolean {
   if (!type) return false;
   return getCellKind(type, checker) !== undefined ||
-    isOpaqueRefType(type, checker);
+    isBrandedCellType(type, checker);
 }
 
 /**
@@ -301,7 +301,7 @@ export function unwrapOpaqueLikeType(
     // For OpaqueRef<T> = OpaqueCell<T> & OpaqueRefInner<T>, we want to extract T
     // Look for an OpaqueCell<T> part and extract its type argument
     for (const part of type.types) {
-      if (isOpaqueRefType(part, checker)) {
+      if (isBrandedCellType(part, checker)) {
         const inner = getTypeReferenceArgument(part);
         if (inner) {
           // Recursively unwrap in case T itself contains OpaqueRef types
@@ -322,7 +322,7 @@ export function unwrapOpaqueLikeType(
     return type;
   }
 
-  if (isOpaqueRefType(type, checker)) {
+  if (isBrandedCellType(type, checker)) {
     const inner = unwrapOpaqueLikeType(
       getTypeReferenceArgument(type),
       checker,
@@ -786,7 +786,7 @@ function findOpaqueRefInUnion(
   for (const member of unionType.types) {
     if (
       member.flags & ts.TypeFlags.Intersection ||
-      isOpaqueRefType(member, checker)
+      isBrandedCellType(member, checker)
     ) {
       return member;
     }
@@ -1089,7 +1089,7 @@ function isEffectiveArrayMember(
 
 /**
  * Helper to check if a type's type argument is an array.
- * Handles unions and intersections recursively, similar to isOpaqueRefType.
+ * Handles unions and intersections recursively, similar to isBrandedCellType.
  */
 export function hasArrayTypeArgument(
   type: ts.Type,

--- a/packages/ts-transformers/src/policy/rewrite-policy.ts
+++ b/packages/ts-transformers/src/policy/rewrite-policy.ts
@@ -1,7 +1,7 @@
 import ts from "typescript";
 import {
   getCellKind,
-  isOpaqueRefType,
+  isBrandedCellType,
 } from "../transformers/opaque-ref/opaque-ref.ts";
 import { isReactiveValueExpression } from "../ast/call-kind.ts";
 import type { ReactiveContextKind } from "../ast/reactive-context.ts";
@@ -17,7 +17,7 @@ export function classifyReactiveReceiverKind(
   type: ts.Type | undefined,
   checker: ts.TypeChecker,
 ): ReactiveReceiverKind {
-  if (type && isOpaqueRefType(type, checker)) {
+  if (type && isBrandedCellType(type, checker)) {
     const kind = getCellKind(type, checker);
     if (kind === "cell" || kind === "stream") {
       return "celllike_requires_rewrite";

--- a/packages/ts-transformers/src/transformers/cast-validation.ts
+++ b/packages/ts-transformers/src/transformers/cast-validation.ts
@@ -27,7 +27,6 @@ const CELL_LIKE_TYPE_NAMES = spellingsWhere({
   SqliteDb: false,
   OpaqueRef: false, // error, not warning — see FORBIDDEN_CAST_TYPE_NAMES
   Reactive: false, // error, not warning — see FORBIDDEN_CAST_TYPE_NAMES
-  OpaqueRefMethods: false,
 });
 
 /**
@@ -45,7 +44,6 @@ const FORBIDDEN_CAST_TYPE_NAMES = spellingsWhere({
   OpaqueCell: false,
   Stream: false,
   SqliteDb: false,
-  OpaqueRefMethods: false,
   CellTypeConstructor: false,
   ScopedCellTypeConstructor: false,
 });

--- a/packages/ts-transformers/src/transformers/opaque-ref/opaque-ref.ts
+++ b/packages/ts-transformers/src/transformers/opaque-ref/opaque-ref.ts
@@ -9,7 +9,7 @@ import {
  * Check if a type is a cell type by looking for the CELL_BRAND property.
  * This includes OpaqueCell, Cell, Stream, and other cell variants.
  */
-export function isOpaqueRefType(
+export function isBrandedCellType(
   type: ts.Type,
   checker: ts.TypeChecker,
 ): boolean {
@@ -18,12 +18,12 @@ export function isOpaqueRefType(
   }
   if (type.flags & ts.TypeFlags.Union) {
     return (type as ts.UnionType).types.some((t) =>
-      isOpaqueRefType(t, checker)
+      isBrandedCellType(t, checker)
     );
   }
   if (type.flags & ts.TypeFlags.Intersection) {
     return (type as ts.IntersectionType).types.some((t) =>
-      isOpaqueRefType(t, checker)
+      isBrandedCellType(t, checker)
     );
   }
 
@@ -67,7 +67,7 @@ export function isSimpleOpaqueRefAccess(
     ts.isIdentifier(expression) || ts.isPropertyAccessExpression(expression)
   ) {
     const type = checker.getTypeAtLocation(expression);
-    return isOpaqueRefType(type, checker);
+    return isBrandedCellType(type, checker);
   }
   return false;
 }

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -15,7 +15,7 @@ import {
 } from "../ast/mod.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import { unwrapExpression } from "../utils/expression.ts";
-import { isOpaqueRefType } from "./opaque-ref/opaque-ref.ts";
+import { isBrandedCellType } from "./opaque-ref/opaque-ref.ts";
 import {
   isPatternFactoryCalleeExpression,
   isPatternFactoryHelperExpression,
@@ -765,7 +765,7 @@ function shouldRetargetReactiveReference(
     context.options.logger,
   );
   if (type) {
-    return isOpaqueRefType(type, context.checker) ||
+    return isBrandedCellType(type, context.checker) ||
       isCellLikeType(type, context.checker);
   }
 

--- a/packages/ts-transformers/src/transformers/structural-reactive-factory.ts
+++ b/packages/ts-transformers/src/transformers/structural-reactive-factory.ts
@@ -2,7 +2,7 @@ import ts from "typescript";
 
 import { detectCallKind } from "../ast/mod.ts";
 import { unwrapExpression } from "../utils/expression.ts";
-import { isOpaqueRefType } from "./opaque-ref/opaque-ref.ts";
+import { isBrandedCellType } from "./opaque-ref/opaque-ref.ts";
 
 export function isPatternFactoryCalleeExpression(
   expression: ts.Expression,
@@ -40,7 +40,7 @@ export function returnsOpaqueRefResult(
 ): boolean {
   try {
     const type = checker.getTypeAtLocation(expression);
-    return isOpaqueRefType(type, checker);
+    return isBrandedCellType(type, checker);
   } catch {
     return false;
   }

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -706,7 +706,6 @@ const CELL_LIKE_TYPE_NODE_NAMES = spellingsWhere({
   // SqliteDb references are not rewritten by shrinking; the brand survives
   // capability shrinking via its own path (#3860).
   SqliteDb: false,
-  OpaqueRefMethods: false,
   CellTypeConstructor: false,
   ScopedCellTypeConstructor: false,
 });

--- a/packages/ts-transformers/test/diagnostics/README.md
+++ b/packages/ts-transformers/test/diagnostics/README.md
@@ -60,6 +60,20 @@ longer emits `__cfHelpers.derive(...)`, so the question they answered is closed.
 Recover them from git history if a similar capture audit is needed for the
 lift-applied form.)
 
+### `probe-array-method-owner-names.ts`
+
+Runs the full pipeline on every fixture input with temporary instrumentation in
+call-kind's `isMethodDeclarationOwnedBy` (see the probe header for the patch)
+and records every array-method-named owner check: which owner name the
+declaration resolved to, against which owner set, and whether it matched.
+
+Used to retire `OPAQUE_REF_OWNER_NAMES` (the OpaqueRefMethods/OpaqueRef
+method-owner set from the pre-#3153 api shape): across 347 fixtures it never
+matched. The same run showed 29 `.map` checks resolving to owner `IDerivable` —
+in neither owner set — yet classified correctly via other paths; adding
+`IDerivable` to the owner set changed no golden, confirming the owner check is
+redundant for branded receivers, not silently load-bearing.
+
 ## When to add a new probe
 
 Good candidates:

--- a/packages/ts-transformers/test/diagnostics/probe-array-method-owner-names.ts
+++ b/packages/ts-transformers/test/diagnostics/probe-array-method-owner-names.ts
@@ -1,0 +1,135 @@
+/**
+ * Audit probe: which owner names does call-kind's array-method detection
+ * actually see across real fixture compilations?
+ *
+ * Background: `OPAQUE_REF_OWNER_NAMES` (OpaqueRefMethods / OpaqueRef) matches
+ * method-declaration owners from the pre-#3153 api shape. `OpaqueRefMethods`
+ * no longer exists in api, and `OpaqueRef<T> = T` is an identity alias that
+ * can't own method declarations — so the suspicion is the set never matches
+ * in production and is kept green only by harness simulations. Meanwhile
+ * array methods on branded receivers live on `IDerivable` (via OpaqueCell),
+ * which is in NEITHER owner set — a possible live gap.
+ *
+ * This probe runs the full transformer pipeline on every fixture input with
+ * temporary instrumentation in `isMethodDeclarationOwnedBy` (call-kind.ts)
+ * recording (method, owner, set, matched) for every owner check whose method
+ * name is a known array-method name.
+ *
+ * Usage (from packages/ts-transformers, with the instrumentation in place):
+ *   deno run -A test/diagnostics/probe-array-method-owner-names.ts
+ *   deno run -A test/diagnostics/probe-array-method-owner-names.ts <substr>
+ *
+ * The instrumentation is not committed; re-apply it in
+ * `isMethodDeclarationOwnedBy` (call-kind.ts) after `findOwnerName`:
+ *
+ *   const probe = (globalThis as {
+ *     __cfProbeOwnerRecords?: Array<
+ *       { method: string; owner: string; set: string; matched: boolean }
+ *     >;
+ *   }).__cfProbeOwnerRecords;
+ *   if (probe) {
+ *     probe.push({
+ *       method: declaration.name.text,
+ *       owner: owner ?? "<none>",
+ *       set: ownerNames === ARRAY_OWNER_NAMES ? "arrayOwners" : "other",
+ *       matched: !!owner && ownerNames.has(owner),
+ *     });
+ *   }
+ *
+ * Output: TSV on stdout (one row per owner check). Summary on stderr.
+ *
+ * Diagnostic; not a test. Safe to delete once the owner-set question closes.
+ */
+import { join } from "@std/path";
+import { walk } from "@std/fs";
+
+import { transformSource } from "../utils.ts";
+import { COMMONFABRIC_TYPES } from "../commonfabric-test-types.ts";
+
+const FIXTURE_ROOT = join(import.meta.dirname!, "..", "fixtures");
+
+interface OwnerRecord {
+  method: string;
+  owner: string;
+  set: string;
+  matched: boolean;
+}
+
+async function loadFixtureFiles(
+  match?: string,
+): Promise<Array<{ rel: string; text: string }>> {
+  const out: Array<{ rel: string; text: string }> = [];
+  for await (const entry of walk(FIXTURE_ROOT, { exts: [".tsx", ".ts"] })) {
+    if (!entry.isFile) continue;
+    if (
+      !entry.name.endsWith(".input.tsx") && !entry.name.endsWith(".input.ts")
+    ) continue;
+    const rel = entry.path.slice(FIXTURE_ROOT.length + 1);
+    if (match && !rel.includes(match)) continue;
+    out.push({ rel, text: await Deno.readTextFile(entry.path) });
+  }
+  return out;
+}
+
+async function main() {
+  const matchArg = Deno.args[0];
+  const files = await loadFixtureFiles(matchArg);
+  console.error(`Loaded ${files.length} fixture(s).`);
+
+  const records: Array<OwnerRecord & { fixture: string }> = [];
+  const sink: OwnerRecord[] = [];
+  (globalThis as { __cfProbeOwnerRecords?: OwnerRecord[] })
+    .__cfProbeOwnerRecords = sink;
+
+  let processed = 0;
+  let transformFailures = 0;
+
+  for (const file of files) {
+    processed++;
+    const before = sink.length;
+    try {
+      await transformSource(file.text, { types: COMMONFABRIC_TYPES });
+    } catch (err) {
+      transformFailures++;
+      console.error(
+        `[skip] ${file.rel}: transform failed: ${
+          (err as Error).message?.slice(0, 80)
+        }`,
+      );
+      continue;
+    }
+    for (const rec of sink.slice(before)) {
+      records.push({ ...rec, fixture: file.rel });
+    }
+  }
+
+  console.log("fixture\tmethod\towner\tset\tmatched");
+  for (const r of records) {
+    console.log(
+      `${r.fixture}\t${r.method}\t${r.owner}\t${r.set}\t${r.matched}`,
+    );
+  }
+
+  const byKey = new Map<string, number>();
+  for (const r of records) {
+    const key = `${r.set}\towner=${r.owner}\tmatched=${r.matched}`;
+    byKey.set(key, (byKey.get(key) ?? 0) + 1);
+  }
+  console.error(
+    `\nProcessed ${processed}, transform failures ${transformFailures}.`,
+  );
+  console.error(`Total owner checks recorded: ${records.length}`);
+  for (const [key, count] of [...byKey.entries()].sort()) {
+    console.error(`  ${key}\tcount=${count}`);
+  }
+  const opaqueMatches = records.filter(
+    (r) => r.set === "opaqueRefOwners" && r.matched,
+  );
+  console.error(
+    opaqueMatches.length === 0
+      ? "\nVERDICT: OPAQUE_REF_OWNER_NAMES never matched on any fixture compilation."
+      : `\nVERDICT: OPAQUE_REF_OWNER_NAMES matched ${opaqueMatches.length} time(s).`,
+  );
+}
+
+await main();

--- a/packages/ts-transformers/test/opaque-ref/brand-detection.test.ts
+++ b/packages/ts-transformers/test/opaque-ref/brand-detection.test.ts
@@ -1,14 +1,14 @@
 import { assert, assertEquals } from "@std/assert";
 import {
   getCellKind,
-  isOpaqueRefType,
+  isBrandedCellType,
 } from "../../src/transformers/opaque-ref/opaque-ref.ts";
 import { analyzeExpression, CELL_VARIANTS_PRELUDE } from "./harness.ts";
 
 Deno.test("detects opaque brand", () => {
   const { checker, expression } = analyzeExpression("state.count");
   const type = checker.getTypeAtLocation(expression);
-  assert(isOpaqueRefType(type, checker));
+  assert(isBrandedCellType(type, checker));
   assertEquals(getCellKind(type, checker), "opaque");
 });
 
@@ -31,7 +31,10 @@ Deno.test("detects cell brand variants", () => {
       prelude: CELL_VARIANTS_PRELUDE,
     });
     const type = checker.getTypeAtLocation(expression);
-    assert(isOpaqueRefType(type, checker), `${expr} should be treated as cell`);
+    assert(
+      isBrandedCellType(type, checker),
+      `${expr} should be treated as cell`,
+    );
     assertEquals(
       getCellKind(type, checker),
       expectedKind,


### PR DESCRIPTION
Last of four PRs in the OpaqueRef→Reactive rename arc. **Stacked on #4046** — retarget after it merges.

## The probe (do this first if reviewing)

The handoff question: is `OPAQUE_REF_OWNER_NAMES` (call-kind's OpaqueRefMethods/OpaqueRef method-owner set, from the pre-#3153 api shape) production-dead? New diagnostic probe (`test/diagnostics/probe-array-method-owner-names.ts`, README entry included) ran the full pipeline over **all 347 fixtures** with instrumentation in `isMethodDeclarationOwnedBy`:

```
arrayOwners      owner=Array          matched=true   count=238
arrayOwners      owner=ReadonlyArray  matched=true   count=9
arrayOwners      owner=IDerivable     matched=false  count=29
opaqueRefOwners  owner=IDerivable     matched=false  count=29

VERDICT: OPAQUE_REF_OWNER_NAMES never matched on any fixture compilation.
```

Two findings, both verified empirically rather than by plausibility:

1. **The set is dead.** It never matched — and structurally cannot: `OpaqueRefMethods` doesn't exist in api, and identity aliases can't own method declarations. Deleting the set + `isOpaqueRefMethodDeclaration` + its disjunct leaves all 292 tests green, goldens byte-identical.
2. **The suspected IDerivable gap is benign.** Branded-receiver `.map` declarations resolve to owner `IDerivable` — in neither owner set — yet classify correctly through other call-kind paths. Cross-check: temporarily adding `IDerivable` to the owner set also changed **no golden**. The owner check is redundant for branded receivers, not silently load-bearing.

## Changes

- Delete `OPAQUE_REF_OWNER_NAMES` + `isOpaqueRefMethodDeclaration` + the disjunct in `resolveSymbolKind`
- Remove the `OpaqueRefMethods` spelling from the `WrapperSpelling` vocabulary (its only `true` row was the deleted table; the compiler enumerated the remaining row deletions)
- Rename `isOpaqueRefType` → `isBrandedCellType` (it detects any CELL_BRANDed type, not OpaqueRef; internal, mechanical, 8 files)
- Commit the probe + README entry

## Deliberately left for later

- Test harnesses still simulating the old `OpaqueRefMethods` shape (`test/opaque-ref/harness.ts`, `test/ast/call-kind.test.ts`, schema-generator's `opaque-opaqueref-stream` fixture): they pass unchanged with the set gone; modernizing what they simulate shifts test-coverage semantics and deserves its own pass.
- Removing the deprecated `OpaqueRef` alias + its vocabulary row — after PRs A–C land and external authors have migrated.
- `common-fabric-formatter.ts` has its own private `isOpaqueRefType` (different code, also brand-based) — same misnomer, schema-generator side, not touched here.

## Verification

- `deno fmt --check` / `deno lint` / `deno check` clean on all 14 files
- ts-transformers: 292 passed (618 steps); schema-generator: 24 passed (229 steps); goldens byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires dead `OpaqueRefMethods` owner detection in `ts-transformers` call-kind and cleans up related schema vocabulary in `schema-generator`. Renames `isOpaqueRefType` to `isBrandedCellType`; behavior is unchanged and probe-verified across 347 fixtures.

- **Refactors**
  - Removed the obsolete owner set and `isOpaqueRefMethodDeclaration`; array-method detection now only checks `Array`/`ReadonlyArray`.
  - Dropped `OpaqueRefMethods` from `WrapperSpelling`, `WRAPPER_SPELLING_TO_KIND`, and `schema-generator` utils; pruned cast and type-shrinking tables.
  - Renamed `isOpaqueRefType` to `isBrandedCellType` and updated all call sites.
  - Added `test/diagnostics/probe-array-method-owner-names.ts` and README notes; probe found zero matches for the old owner set, `IDerivable` owners classify via other paths, and no golden changes.

<sup>Written for commit 883d8a9f2f0bdc7bc97a0848bec230d318ca82e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

