### PR TITLE
feat(patterns): EditableList composable primitive (CT-1710)

### DIFF
--- a/docs/common/patterns/primitives.md
+++ b/docs/common/patterns/primitives.md
@@ -1,0 +1,127 @@
+# Primitives: the composition contract
+
+A **primitive** is a pattern designed to be embedded inside other patterns —
+used as a JSX tag, not deployed standalone. Primitives own a slice of *logic and
+model* (an editable list, a confirm-action gate, a master/detail selection)
+while leaving rendering to the host. They live under
+`packages/patterns/primitives/` and form the `primitive` tier in
+[`packages/patterns/index.md`](../../../packages/patterns/index.md).
+
+This document defines the contract every primitive follows. The worked example
+is `EditableList` (`packages/patterns/primitives/editable-list.tsx`); later
+primitives (ConfirmAction, MasterDetail) follow the same shape.
+
+## What a primitive exposes
+
+In priority order:
+
+1. **Cells + Streams pre-bound to the caller's data.** This is the real
+   product. The caller passes a `Writable<T>` it owns; the primitive binds its
+   handlers to that cell and returns the bound `Stream<>`s. The caller wires
+   nothing by hand — passing the cell *is* the wiring.
+2. **A convenience layer** of fuzzy / agent-friendly Streams (e.g.
+   text-addressed `*ByText`). Optional, additive, clearly labelled as
+   convenience — never the core model.
+3. **An optional default `[UI]`.** A static `VNode` giving a caller who just
+   wants the thing a working experience for free. A caller who wants custom
+   rendering simply does not render it.
+
+## The crux: a sub-pattern CAN mutate a parent-owned cell
+
+This is the question that makes or breaks embedding, and the answer is **yes**.
+
+When a parent writes:
+
+```tsx
+const list = EditableList({ items: myItems }); // myItems: Writable<Item[]>
+```
+
+the primitive receives the **same** reactive cell — not a copy. Handlers inside
+the primitive that call `items.push(...)` / `items.set(...)` mutate the parent's
+cell, and the change syncs back to the parent automatically. Evidence:
+
+- [`reactivity.md`](../concepts/reactivity.md): `Writable<>` is *write intent*
+  on a shared reactive cell, not a fresh cell.
+- [`composition.md`](./composition.md): "Both patterns receive the same `items`
+  cell — changes sync automatically."
+- `packages/patterns/examples/cf-render.tsx`: the embedded `Counter` mutates the
+  parent's `state.value` via its own handler.
+
+Because of this, a primitive does **not** need the parent to pass in Streams or
+handlers. The primitive defines the handlers, binds them to the cell it was
+given, and hands the bound Streams back. (The escape hatch — a primitive that
+genuinely cannot mutate its input, e.g. a cross-space owner-protected cell —
+would instead expose Streams the parent wires to its own handlers. EditableList
+does not need this; same-space `Writable<T[]>` mutation works.)
+
+## Identity, not index, not title
+
+Core mutations address an item by a **stable id** carried on the item, never by
+its array position. Index-based selection/mutation breaks under reordering and
+concurrent edits — it is the central fragility this composition overhaul
+removes. `addItem` mints an id when the caller omits one; `removeItem` /
+`updateItem` / `toggleItem` all take `{ id }`.
+
+Title/text addressing, where offered, is a **separate, explicit convenience
+layer** (e.g. `removeItemByText`) for agent-driveability — fuzzy
+(case-insensitive, first-match) and documented as such. It sits *on top of* the
+identity core; it is not the identity model.
+
+## Headless vs default rendering
+
+- **Default (rendered):** drop the primitive in your vdom and render its `[UI]`:
+
+  ```tsx
+  <EditableList items={myItems} />
+  ```
+
+  You get the built-in experience. The default UI is opinionated about item
+  shape — for EditableList it reads `done` (checkbox) and `label` (text). That
+  assumption applies *only* to the default UI.
+
+- **Headless (logic only):** embed for the model, render your own rows:
+
+  ```tsx
+  const list = EditableList({ items: myItems });
+  // ...elsewhere in your vdom:
+  {list.items.map((it) => (
+    <my-row>
+      <span>{it.label}</span>
+      <cf-button onClick={() => list.toggleItem.send({ id: it.id })}>
+        toggle
+      </cf-button>
+    </my-row>
+  ))}
+  ```
+
+  A headless caller may ignore the default UI's shape assumptions entirely and
+  key rows off whatever extra fields it added to its items (the item type carries
+  an index signature so extra fields pass through the model untouched).
+
+### Why no render-prop / VNode input
+
+A primitive does **not** accept a "render each row" callback or `VNode` input.
+Render props and VNode-valued inputs fight the CTS transformer and the
+reactive reconciler (`[UI]` must be a static VNode; passing functions/VNodes as
+reactive inputs leads to "unexpected object" reconciler errors). The headless
+path — consume cells + streams, render your own `.map()` — achieves full custom
+rendering without that machinery.
+
+## Authoring checklist
+
+- Item type carries a stable `id` plus whatever the model needs; an index
+  signature lets callers extend it.
+- Core handlers operate by `id`, bound to the caller's `Writable<T[]>`.
+- Counts / derived values are **named `computed` cells** (so they resolve
+  through `runSynced` + `.get()` in tests).
+- `[UI]` is a static `VNode`; gate empty/non-empty with `ifElse` as a *child* of
+  a static wrapper, never by wrapping `[UI]` in `computed()`.
+- Default rows use `$checked` / `$value` two-way binding — do not add setter
+  handlers that just write the same value back.
+- Optional convenience (`*ByText`) streams are additive and documented as fuzzy.
+
+## See also
+
+- [Pattern Composition](./composition.md) — the embedding mechanics.
+- [Reactivity](../concepts/reactivity.md) — why `Writable<>` shares a cell.
+- `packages/patterns/primitives/editable-list.tsx` — the worked example.

--- a/docs/common/patterns/primitives.md
+++ b/docs/common/patterns/primitives.md
@@ -54,13 +54,17 @@ genuinely cannot mutate its input, e.g. a cross-space owner-protected cell —
 would instead expose Streams the parent wires to its own handlers. EditableList
 does not need this; same-space `Writable<T[]>` mutation works.)
 
-## Identity, not index, not title
+## Identity, not index, not title (collection primitives)
 
-Core mutations address an item by a **stable id** carried on the item, never by
-its array position. Index-based selection/mutation breaks under reordering and
-concurrent edits — it is the central fragility this composition overhaul
-removes. `addItem` mints an id when the caller omits one; `removeItem` /
-`updateItem` / `toggleItem` all take `{ id }`.
+For **collection** primitives — ones that own a list/set of items
+(`EditableList`, `MasterDetail`) — core mutations address an item by a **stable
+id** carried on the item, never by its array position. Index-based
+selection/mutation breaks under reordering and concurrent edits — it is the
+central fragility this composition overhaul removes. `addItem` mints an id when
+the caller omits one; `removeItem` / `updateItem` / `toggleItem` all take
+`{ id }`. Primitives with no collection (e.g. `ConfirmAction`, a single-gate
+primitive) have nothing to address by id and this section does not apply to
+them.
 
 Title/text addressing, where offered, is a **separate, explicit convenience
 layer** (e.g. `removeItemByText`) for agent-driveability — fuzzy
@@ -97,6 +101,14 @@ identity core; it is not the identity model.
   A headless caller may ignore the default UI's shape assumptions entirely and
   key rows off whatever extra fields it added to its items (the item type carries
   an index signature so extra fields pass through the model untouched).
+
+  Caveat: extras pass through as **plain data only**. An index signature emits
+  `additionalProperties: true`, which has no `asCell` marker, so a `Writable<>` /
+  cell-link extra is **not** re-hydrated as a live Cell when read back through
+  the item schema (the "any → true schema → can't distinguish Writable from
+  computed" gotcha). Scalars and plain objects round-trip fine; an item that
+  needs a nested *live* cell must declare it as a typed field with `asCell`
+  rather than relying on the index-signature passthrough.
 
 ### Why no render-prop / VNode input
 

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -11,6 +11,10 @@ This directory mixes exemplars, capability demos, regression fixtures, and
 legacy experiments. They do NOT carry equal authority. Before imitating any
 pattern, check its tier here (tracked in CT-1701):
 
+- **primitive** — designed for embedding in other patterns (used as a JSX tag),
+  headless-able. Exposes streams + cells + an optional default `[UI]`. Copy
+  these idioms when building composable building blocks. See
+  `docs/common/patterns/primitives.md` for the composition contract.
 - **exemplar** — current best practice. Copy idioms from these.
 - **demo** — illustrates a specific capability or integration. The capability
   usage is real, but the surrounding wiring may be verbose, dated, or
@@ -22,6 +26,14 @@ pattern, check its tier here (tracked in CT-1701):
 
 Any pattern not listed below (newly added, or missed) should be treated as
 **demo** until triaged.
+
+## primitive
+
+Composable building blocks designed for embedding in other patterns
+(headless-able). Live under `primitives/`. See
+`docs/common/patterns/primitives.md`.
+
+`primitives/editable-list.tsx`.
 
 ## exemplar
 
@@ -104,6 +116,62 @@ intended as style references.
 Support files with no tier (not patterns): `deno.json`, `mod.ts`, `index.md`,
 `README.md`, `DEPRECATED_IDIOMS.md`, `PREEXISTING_BUGS.md`,
 `test-ui-helpers.ts`, `tools/` (codegen tooling).
+
+---
+
+## `primitives/editable-list.tsx`
+
+**Tier: primitive.** The first composable primitive — an editable, checkable
+list designed to be embedded as a JSX tag inside other patterns. Headless-able:
+render its `[UI]` for a default row experience (checkbox + editable text +
+delete, a cf-message-input adder, cf-empty-state when empty), or ignore the
+`[UI]` and `.map()` your own rows while driving the exposed streams/cells.
+Mutations are addressed by stable `id` (never array index); a separate fuzzy
+text-addressed layer (`*ByText`) exists for agent-driveability. See
+`docs/common/patterns/primitives.md` for the full composition contract.
+
+**Keywords:** primitive, composable, list, editable, headless, identity, stream,
+embed, sub-pattern
+
+### Input Schema
+
+```ts
+interface EditableListItem {
+  id: string; // stable identity (minted by addItem if omitted)
+  done: boolean | Default<false>;
+  label: Default<string, "">; // default row reads this key
+  [extra: string]: any; // pass-through extra fields for headless rows
+}
+
+interface EditableListInput {
+  items?: Writable<EditableListItem[] | Default<[]>>;
+  adder?: Default<"quick" | "none", "quick">;
+  emptyMessage?: Default<string, "No items yet">;
+}
+```
+
+### Output Schema
+
+```ts
+interface EditableListOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  items: EditableListItem[];
+  total: number;
+  active: number;
+  done: number;
+  // CORE: identity-addressed
+  addItem: Stream<{ label?: string; item?: Partial<EditableListItem> }>;
+  removeItem: Stream<{ id: string }>;
+  updateItem: Stream<{ id: string; changes: Partial<EditableListItem> }>;
+  toggleItem: Stream<{ id: string; done?: boolean }>;
+  clearDone: Stream<unknown>;
+  // CONVENIENCE: fuzzy text-addressed (agent layer)
+  addItemByText: Stream<{ text: string }>;
+  updateItemByText: Stream<{ text: string; newText?: string; done?: boolean }>;
+  removeItemByText: Stream<{ text: string }>;
+}
+```
 
 ---
 

--- a/packages/patterns/primitives/editable-list.test.tsx
+++ b/packages/patterns/primitives/editable-list.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * Test Pattern: EditableList primitive
+ *
+ * Exercises the composition contract via runSynced:
+ * - empty → nonempty (counts, empty branch)
+ * - add by text (convenience) + add by id-core stream
+ * - toggle done by id (identity), counts react
+ * - update by id (identity patch); id is never overwritten
+ * - remove by id (identity)
+ * - text-addressed convenience: updateItemByText / removeItemByText
+ * - clearDone
+ *
+ * Run: deno task cf test packages/patterns/primitives/editable-list.test.tsx --verbose
+ */
+import { action, computed, pattern } from "commonfabric";
+import EditableList, { type EditableListItem } from "./editable-list.tsx";
+
+export default pattern(() => {
+  const list = EditableList({});
+
+  // ==========================================================================
+  // Actions
+  // ==========================================================================
+
+  const add_alpha = action(() => {
+    list.addItemByText.send({ text: "Alpha" });
+  });
+  const add_beta = action(() => {
+    // core stream, label-only convenience form
+    list.addItem.send({ label: "Beta" });
+  });
+  const add_gamma_with_extra = action(() => {
+    // core stream carrying an extra (non-default-UI) field
+    list.addItem.send({ item: { label: "Gamma", priority: 9 } });
+  });
+
+  // Identity-addressed: read the live id from the list, then act on it.
+  const toggle_first_done = action(() => {
+    const id = list.items[0]?.id;
+    if (id) list.toggleItem.send({ id });
+  });
+  const update_first_label = action(() => {
+    const id = list.items[0]?.id;
+    if (id) list.updateItem.send({ id, changes: { label: "Alpha!" } });
+  });
+  const attempt_id_overwrite = action(() => {
+    const id = list.items[0]?.id;
+    // changes.id must be ignored — identity is immutable.
+    if (id) list.updateItem.send({ id, changes: { id: "HACKED" } });
+  });
+  const remove_first = action(() => {
+    const id = list.items[0]?.id;
+    if (id) list.removeItem.send({ id });
+  });
+
+  // Text-addressed convenience (fuzzy).
+  const rename_beta_by_text = action(() => {
+    list.updateItemByText.send({ text: "Beta", newText: "Beta2" });
+  });
+  const done_beta_by_text = action(() => {
+    list.updateItemByText.send({ text: "Beta2", done: true });
+  });
+  const remove_gamma_by_text = action(() => {
+    list.removeItemByText.send({ text: "Gamma" });
+  });
+
+  const clear_done = action(() => {
+    list.clearDone.send({});
+  });
+
+  // Whitespace add should be ignored.
+  const add_blank = action(() => {
+    list.addItemByText.send({ text: "   " });
+  });
+
+  // ==========================================================================
+  // Assertions
+  // ==========================================================================
+
+  const assert_initial_empty = computed(() => list.total === 0);
+  const assert_initial_active = computed(() => list.active === 0);
+
+  const assert_one = computed(() => list.total === 1);
+  const assert_first_label_alpha = computed(() =>
+    list.items[0]?.label === "Alpha"
+  );
+  const assert_first_has_id = computed(() =>
+    typeof list.items[0]?.id === "string" && list.items[0].id.length > 0
+  );
+  const assert_first_not_done = computed(() => list.items[0]?.done === false);
+
+  const assert_two = computed(() => list.total === 2);
+  const assert_three = computed(() => list.total === 3);
+
+  const assert_gamma_present = computed(() => list.items[2]?.label === "Gamma");
+  const assert_extra_passthrough = computed(() =>
+    // gamma was added third (index 2) and carried priority:9 untouched.
+    list.items[2]?.priority === 9
+  );
+
+  const assert_first_done = computed(() => list.items[0]?.done === true);
+  const assert_active_after_toggle = computed(() => list.active === 2);
+  const assert_done_count = computed(() => list.done === 1);
+
+  const assert_first_renamed = computed(() =>
+    list.items[0]?.label === "Alpha!"
+  );
+  const assert_id_not_overwritten = computed(() =>
+    list.items[0]?.id !== "HACKED"
+  );
+
+  const assert_after_remove_two = computed(() => list.total === 2);
+  const assert_alpha_gone = computed(() =>
+    list.items.find((i: EditableListItem) => i.label === "Alpha!") === undefined
+  );
+
+  const assert_beta_renamed = computed(() =>
+    list.items.find((i: EditableListItem) => i.label === "Beta2") !== undefined
+  );
+  const assert_beta_done = computed(() =>
+    // After removing Alpha, the list is [Beta2, Gamma]; Beta2 is index 0.
+    list.items[0]?.label === "Beta2" && list.items[0]?.done === true
+  );
+
+  const assert_gamma_removed = computed(() =>
+    list.items.find((i: EditableListItem) => i.label === "Gamma") === undefined
+  );
+  const assert_one_after_text_remove = computed(() => list.total === 1);
+
+  const assert_blank_ignored = computed(() => list.total === 1);
+
+  const assert_empty_after_clear = computed(() => list.total === 0);
+
+  // ==========================================================================
+  // Test Sequence
+  // ==========================================================================
+  return {
+    tests: [
+      // Initial empty
+      { assertion: assert_initial_empty },
+      { assertion: assert_initial_active },
+
+      // Add by text (convenience)
+      { action: add_alpha },
+      { assertion: assert_one },
+      { assertion: assert_first_label_alpha },
+      { assertion: assert_first_has_id },
+      { assertion: assert_first_not_done },
+
+      // Add by core stream
+      { action: add_beta },
+      { assertion: assert_two },
+
+      // Add by core stream with extra field
+      { action: add_gamma_with_extra },
+      { assertion: assert_three },
+      { assertion: assert_gamma_present },
+      { assertion: assert_extra_passthrough },
+
+      // Toggle done by id (identity)
+      { action: toggle_first_done },
+      { assertion: assert_first_done },
+      { assertion: assert_active_after_toggle },
+      { assertion: assert_done_count },
+
+      // Update by id (identity patch) + id immutability
+      { action: update_first_label },
+      { assertion: assert_first_renamed },
+      { action: attempt_id_overwrite },
+      { assertion: assert_id_not_overwritten },
+
+      // Remove by id (identity)
+      { action: remove_first },
+      { assertion: assert_after_remove_two },
+      { assertion: assert_alpha_gone },
+
+      // Text-addressed convenience
+      { action: rename_beta_by_text },
+      { assertion: assert_beta_renamed },
+      { action: done_beta_by_text },
+      { assertion: assert_beta_done },
+      { action: remove_gamma_by_text },
+      { assertion: assert_gamma_removed },
+      { assertion: assert_one_after_text_remove },
+
+      // Whitespace ignored
+      { action: add_blank },
+      { assertion: assert_blank_ignored },
+
+      // clearDone wipes the (done) Beta2
+      { action: clear_done },
+      { assertion: assert_empty_after_clear },
+    ],
+    list,
+  };
+});

--- a/packages/patterns/primitives/editable-list.test.tsx
+++ b/packages/patterns/primitives/editable-list.test.tsx
@@ -73,6 +73,30 @@ export default pattern(() => {
     list.addItemByText.send({ text: "   " });
   });
 
+  // Duplicate-label fuzzy semantics: updateItemByText touches the FIRST match.
+  // The two dups are distinguished by the declared `done` field (NOT an extra —
+  // extras don't survive a full-array set, see the EditableListItem doc).
+  const add_dup_a = action(() => {
+    list.addItem.send({ item: { label: "Dup", done: false } });
+  });
+  const add_dup_b = action(() => {
+    list.addItem.send({ item: { label: "Dup", done: true } });
+  });
+  const update_dup_by_text = action(() => {
+    list.updateItemByText.send({ text: "Dup", newText: "DupChanged" });
+  });
+
+  // No-op safety: mutating an absent id changes nothing.
+  const remove_absent_id = action(() => {
+    list.removeItem.send({ id: "does-not-exist" });
+  });
+  const update_absent_id = action(() => {
+    list.updateItem.send({
+      id: "does-not-exist",
+      changes: { label: "ghost" },
+    });
+  });
+
   // ==========================================================================
   // Assertions
   // ==========================================================================
@@ -130,6 +154,31 @@ export default pattern(() => {
   const assert_blank_ignored = computed(() => list.total === 1);
 
   const assert_empty_after_clear = computed(() => list.total === 0);
+
+  // Duplicate-label first-match assertions. After clearDone the list is empty;
+  // we add two items both labelled "Dup" (the first not-done, the second done).
+  const assert_two_dups = computed(() => list.total === 2);
+  // updateItemByText("Dup") must change ONLY the first match (the not-done one):
+  // exactly one item now reads "DupChanged" and it is the not-done one; the
+  // done one still reads "Dup".
+  const assert_first_dup_changed = computed(() => {
+    const changed = list.items.filter((i: EditableListItem) =>
+      i.label === "DupChanged"
+    );
+    return changed.length === 1 && changed[0]?.done === false;
+  });
+  const assert_second_dup_unchanged = computed(() => {
+    const still = list.items.filter((i: EditableListItem) => i.label === "Dup");
+    return still.length === 1 && still[0]?.done === true;
+  });
+
+  // No-op: removing/updating an absent id leaves the list untouched.
+  const assert_noop_count = computed(() => list.total === 2);
+  const assert_noop_labels = computed(() =>
+    list.items.find((i: EditableListItem) => i.label === "DupChanged") !==
+      undefined &&
+    list.items.find((i: EditableListItem) => i.label === "Dup") !== undefined
+  );
 
   // ==========================================================================
   // Test Sequence
@@ -190,6 +239,20 @@ export default pattern(() => {
       // clearDone wipes the (done) Beta2
       { action: clear_done },
       { assertion: assert_empty_after_clear },
+
+      // Duplicate-label fuzzy semantics: updateItemByText hits the first match.
+      { action: add_dup_a },
+      { action: add_dup_b },
+      { assertion: assert_two_dups },
+      { action: update_dup_by_text },
+      { assertion: assert_first_dup_changed },
+      { assertion: assert_second_dup_unchanged },
+
+      // No-op safety: absent-id remove/update changes nothing.
+      { action: remove_absent_id },
+      { action: update_absent_id },
+      { assertion: assert_noop_count },
+      { assertion: assert_noop_labels },
     ],
     list,
   };

--- a/packages/patterns/primitives/editable-list.tsx
+++ b/packages/patterns/primitives/editable-list.tsx
@@ -45,7 +45,9 @@
  * ### What the DEFAULT UI assumes about item shape (headless does not)
  *
  * The item type is intentionally minimal-but-extensible (an index signature
- * lets callers carry extra fields). The default row reads exactly two keys:
+ * lets callers carry extra PLAIN-DATA fields — see the EditableListItem doc:
+ * live-cell / Writable extras are NOT supported through the passthrough). The
+ * default row reads exactly two keys:
  *   - `done: boolean`  → the checkbox
  *   - `label: string`  → the editable text
  * A headless caller may ignore `label` entirely and key its own rows off
@@ -91,8 +93,16 @@ import {
  * Required by the model: a stable `id` and a `done` flag.
  * Read by the DEFAULT UI only: `label`.
  * The index signature lets callers carry arbitrary extra fields (priority,
- * dueDate, refs, ...) that the model passes through untouched and that headless
- * rows can render.
+ * dueDate, plain refs, ...) that the model passes through untouched and that
+ * headless rows can render.
+ *
+ * IMPORTANT — extras pass through as PLAIN DATA only. The index signature emits
+ * `additionalProperties: true`, which carries no `asCell` marker, so a
+ * `Writable<>` / cell-link extra read back through this schema will NOT be
+ * re-hydrated as a live Cell (the "any → true schema → can't distinguish
+ * Writable from computed" gotcha). Scalars and plain objects round-trip fine; a
+ * primitive that needs a nested *live* cell must declare it as a typed field
+ * with `asCell` rather than relying on the passthrough.
  */
 export interface EditableListItem {
   /** Stable identity. Minted by addItem if not provided. Never an index. */
@@ -271,16 +281,6 @@ const removeItemByTextHandler = handler<
   items.set(current.toSpliced(idx, 1));
 });
 
-// ===== Default-UI row helpers (per-item streams keyed by id) =====
-
-const rowDeleteHandler = handler<
-  unknown,
-  { id: string; items: Writable<EditableListItem[]> }
->((_, { id, items }) => {
-  const current = items.get() ?? [];
-  items.set(current.filter((i) => i.id !== id));
-});
-
 // ===== The primitive =====
 
 export const EditableList = pattern<EditableListInput, EditableListOutput>(
@@ -310,7 +310,8 @@ export const EditableList = pattern<EditableListInput, EditableListOutput>(
 
     // Default rows. Checkbox + text use $checked/$value two-way binding
     // (no setter handler — that would just write the same value back). Delete
-    // is keyed by the item's stable id, NOT its array index.
+    // reuses the already-exposed `removeItem` stream (remove-by-id lives in ONE
+    // place), keyed by the item's stable id, NOT its array index.
     const rows = items.map((item: EditableListItem) => (
       <cf-hstack gap="2" align="center" style="padding: 4px 0;">
         <cf-checkbox $checked={item.done} />
@@ -318,7 +319,8 @@ export const EditableList = pattern<EditableListInput, EditableListOutput>(
         <cf-button
           variant="ghost"
           size="sm"
-          onClick={rowDeleteHandler({ id: item.id, items })}
+          onClick={() =>
+            removeItem.send({ id: item.id })}
         >
           x
         </cf-button>

--- a/packages/patterns/primitives/editable-list.tsx
+++ b/packages/patterns/primitives/editable-list.tsx
@@ -1,0 +1,369 @@
+/**
+ * EditableList — composable list PRIMITIVE
+ * =========================================
+ *
+ * The first occupant of the `primitives/` tier: a pattern designed to be
+ * embedded inside other patterns (used as a JSX tag), not deployed standalone.
+ * It owns the *logic and model* of an editable, checkable list; the host owns
+ * (or borrows) the rendering.
+ *
+ * ## The composition contract this establishes
+ *
+ * A primitive exposes three things, in priority order:
+ *   1. **Cells + Streams** pre-bound to the caller's data — the real product.
+ *   2. A **convenience layer** of fuzzy, text-addressed Streams for agents.
+ *   3. An **optional default `[UI]`** so a caller who just wants a list gets
+ *      one for free, without wiring any rows.
+ *
+ * ### Headless vs default UI
+ *
+ * - **Default**: drop `<EditableList items={myItems} />` into your vdom and you
+ *   get a working list — per-item rows (checkbox + editable text + delete), a
+ *   quick-add row (cf-message-input), and a cf-empty-state when empty.
+ * - **Headless**: don't render its `[UI]`. Instead embed it for the model and
+ *   `.map()` your OWN rows, calling the exposed streams. There is deliberately
+ *   NO VNode / render-prop input — render props fight the CTS transformer.
+ *   Headless looks like:
+ *       const list = EditableList({ items: myItems });
+ *       // ...render list.items yourself, call list.toggleItem.send({ id }) etc.
+ *
+ * ### Identity, NOT index, NOT title
+ *
+ * Every mutation in the CORE layer addresses an item by its stable `id`.
+ * removeItem/updateItem/toggleItem never take an array index — index-based
+ * mutation is exactly the fragility (reorder/concurrent-edit races) this
+ * overhaul kills. addItem mints an `id` if the caller doesn't supply one.
+ *
+ * ### Title/text addressing is a SEPARATE convenience layer
+ *
+ * `addItemByText` / `updateItemByText` / `removeItemByText` are fuzzy
+ * (case-insensitive `label` match), provided so an LLM can drive the list with
+ * the words it already has. They are explicitly NOT the identity model: on
+ * duplicate labels they touch the first match. Prefer the id-based streams in
+ * code; reach for the text streams only from agent tool-calls.
+ *
+ * ### What the DEFAULT UI assumes about item shape (headless does not)
+ *
+ * The item type is intentionally minimal-but-extensible (an index signature
+ * lets callers carry extra fields). The default row reads exactly two keys:
+ *   - `done: boolean`  → the checkbox
+ *   - `label: string`  → the editable text
+ * A headless caller may ignore `label` entirely and key its own rows off
+ * whatever fields it added. Only the default `[UI]` is opinionated about keys.
+ *
+ * ### Can a sub-pattern mutate a parent-owned cell? YES.
+ *
+ * This is the crux of the contract and it is RESOLVED in the affirmative.
+ * When a parent does `EditableList({ items: myItems })`, the sub-pattern
+ * receives the *same* `Writable<TItem[]>` cell — not a copy. `.push()` /
+ * `.set()` from inside the sub-pattern's handlers mutate the parent's cell and
+ * the change syncs back. Evidence:
+ *   - docs/common/concepts/reactivity.md: `Writable<>` is write *intent* on a
+ *     shared reactive cell, not a fresh cell.
+ *   - packages/patterns/examples/cf-render.tsx: `Counter({ value: state.value })`
+ *     — the sub-pattern's handlers `.set()` the parent's `state.value`.
+ *   - docs/common/patterns/composition.md: "Both patterns receive the same
+ *     `items` cell - changes sync automatically."
+ * So the contract exposes id-based Streams the parent wires by simply passing
+ * its cell; no parent-side handler plumbing is required.
+ */
+import {
+  computed,
+  Default,
+  handler,
+  ifElse,
+  NAME,
+  nonPrivateRandom,
+  type OpaqueRef,
+  pattern,
+  safeDateNow,
+  type Stream,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+// ===== Item shape =====
+
+/**
+ * The minimal, extensible item contract.
+ *
+ * Required by the model: a stable `id` and a `done` flag.
+ * Read by the DEFAULT UI only: `label`.
+ * The index signature lets callers carry arbitrary extra fields (priority,
+ * dueDate, refs, ...) that the model passes through untouched and that headless
+ * rows can render.
+ */
+export interface EditableListItem {
+  /** Stable identity. Minted by addItem if not provided. Never an index. */
+  id: string;
+  /** Completion flag — drives the default row's checkbox. */
+  done: boolean | Default<false>;
+  /** Text label — the only text key the default row reads. */
+  label: Default<string, "">;
+  // deno-lint-ignore no-explicit-any
+  [extra: string]: any;
+}
+
+// ===== Input / Output =====
+
+export interface EditableListInput {
+  /** Caller-owned list cell. The sub-pattern mutates THIS cell in place. */
+  items?: Writable<EditableListItem[] | Default<[]>>;
+  /** Whether the default UI shows the cf-message-input quick-adder. */
+  adder?: Default<"quick" | "none", "quick">;
+  /** Empty-state copy for the default UI. */
+  emptyMessage?: Default<string, "No items yet">;
+}
+
+export interface EditableListOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  items: EditableListItem[];
+
+  // ----- counts (named computed cells) -----
+  total: number;
+  active: number;
+  done: number;
+
+  // ----- CORE: identity-addressed streams -----
+  /** Append an item. Mints an id if omitted; you may pass extra fields. */
+  addItem: OpaqueRef<
+    Stream<{ label?: string; item?: Partial<EditableListItem> }>
+  >;
+  /** Remove the item with this id. No-op if absent. */
+  removeItem: OpaqueRef<Stream<{ id: string }>>;
+  /** Patch the item with this id. Only provided fields change. */
+  updateItem: OpaqueRef<
+    Stream<{ id: string; changes: Partial<EditableListItem> }>
+  >;
+  /** Flip (or set) `done` on the item with this id. */
+  toggleItem: OpaqueRef<Stream<{ id: string; done?: boolean }>>;
+  /** Drop every item whose `done` is true. */
+  clearDone: OpaqueRef<Stream<unknown>>;
+
+  // ----- CONVENIENCE: fuzzy text-addressed streams (agent layer) -----
+  /** Add by text. Convenience alias for addItem with a label. */
+  addItemByText: OpaqueRef<Stream<{ text: string }>>;
+  /** Update the first item whose label matches (case-insensitive). */
+  updateItemByText: OpaqueRef<
+    Stream<{ text: string; newText?: string; done?: boolean }>
+  >;
+  /** Remove the first item whose label matches (case-insensitive). */
+  removeItemByText: OpaqueRef<Stream<{ text: string }>>;
+}
+
+// ===== id minting =====
+
+function mintId(): string {
+  const now = safeDateNow().toString(36);
+  const rand = nonPrivateRandom().toString(36).slice(2, 10);
+  return `${now}-${rand}`;
+}
+
+// ===== CORE handlers (identity-addressed) =====
+
+const addItemHandler = handler<
+  { label?: string; item?: Partial<EditableListItem> },
+  { items: Writable<EditableListItem[]> }
+>(({ label, item }, { items }) => {
+  const provided = item ?? {};
+  const text = (label ?? provided.label ?? "").trim();
+  // Allow empty-label items only when the caller explicitly supplies item data
+  // (a headless row may not use `label` at all).
+  if (!text && item === undefined) return;
+  items.push({
+    ...provided,
+    id: provided.id ?? mintId(),
+    label: text,
+    done: provided.done ?? false,
+  });
+});
+
+const removeItemHandler = handler<
+  { id: string },
+  { items: Writable<EditableListItem[]> }
+>(({ id }, { items }) => {
+  const current = items.get() ?? [];
+  const next = current.filter((i) => i.id !== id);
+  if (next.length !== current.length) items.set(next);
+});
+
+const updateItemHandler = handler<
+  { id: string; changes: Partial<EditableListItem> },
+  { items: Writable<EditableListItem[]> }
+>(({ id, changes }, { items }) => {
+  const current = items.get() ?? [];
+  let touched = false;
+  const next = current.map((i) => {
+    if (i.id !== id) return i;
+    touched = true;
+    // Never let a caller overwrite identity.
+    const { id: _ignore, ...safe } = changes;
+    return { ...i, ...safe };
+  });
+  if (touched) items.set(next);
+});
+
+const toggleItemHandler = handler<
+  { id: string; done?: boolean },
+  { items: Writable<EditableListItem[]> }
+>(({ id, done }, { items }) => {
+  const current = items.get() ?? [];
+  let touched = false;
+  const next = current.map((i) => {
+    if (i.id !== id) return i;
+    touched = true;
+    return { ...i, done: done ?? !i.done };
+  });
+  if (touched) items.set(next);
+});
+
+const clearDoneHandler = handler<
+  unknown,
+  { items: Writable<EditableListItem[]> }
+>((_, { items }) => {
+  const current = items.get() ?? [];
+  const next = current.filter((i) => !i.done);
+  if (next.length !== current.length) items.set(next);
+});
+
+// ===== CONVENIENCE handlers (fuzzy text matching) =====
+
+const addItemByTextHandler = handler<
+  { text: string },
+  { items: Writable<EditableListItem[]> }
+>(({ text }, { items }) => {
+  const trimmed = (text ?? "").trim();
+  if (!trimmed) return;
+  items.push({ id: mintId(), label: trimmed, done: false });
+});
+
+const updateItemByTextHandler = handler<
+  { text: string; newText?: string; done?: boolean },
+  { items: Writable<EditableListItem[]> }
+>(({ text, newText, done }, { items }) => {
+  const current = items.get() ?? [];
+  const needle = (text ?? "").toLowerCase();
+  const idx = current.findIndex((i) =>
+    (i.label ?? "").toLowerCase() === needle
+  );
+  if (idx === -1) return;
+  const next = [...current];
+  next[idx] = {
+    ...next[idx],
+    ...(newText !== undefined ? { label: newText } : {}),
+    ...(done !== undefined ? { done } : {}),
+  };
+  items.set(next);
+});
+
+const removeItemByTextHandler = handler<
+  { text: string },
+  { items: Writable<EditableListItem[]> }
+>(({ text }, { items }) => {
+  const current = items.get() ?? [];
+  const needle = (text ?? "").toLowerCase();
+  const idx = current.findIndex((i) =>
+    (i.label ?? "").toLowerCase() === needle
+  );
+  if (idx === -1) return;
+  items.set(current.toSpliced(idx, 1));
+});
+
+// ===== Default-UI row helpers (per-item streams keyed by id) =====
+
+const rowDeleteHandler = handler<
+  unknown,
+  { id: string; items: Writable<EditableListItem[]> }
+>((_, { id, items }) => {
+  const current = items.get() ?? [];
+  items.set(current.filter((i) => i.id !== id));
+});
+
+// ===== The primitive =====
+
+export const EditableList = pattern<EditableListInput, EditableListOutput>(
+  ({ items, adder, emptyMessage }) => {
+    // Counts — named computed cells (resolve through runSynced + .get()).
+    const total = computed(() => (items.get() ?? []).length);
+    const active = computed(() =>
+      (items.get() ?? []).filter((i) => i && !i.done).length
+    );
+    const done = computed(() =>
+      (items.get() ?? []).filter((i) => i && i.done).length
+    );
+    const isEmpty = computed(() => (items.get() ?? []).length === 0);
+    const showAdder = computed(() => (adder ?? "quick") !== "none");
+
+    // Bind core streams to the caller's cell.
+    const addItem = addItemHandler({ items });
+    const removeItem = removeItemHandler({ items });
+    const updateItem = updateItemHandler({ items });
+    const toggleItem = toggleItemHandler({ items });
+    const clearDone = clearDoneHandler({ items });
+
+    // Bind convenience streams.
+    const addItemByText = addItemByTextHandler({ items });
+    const updateItemByText = updateItemByTextHandler({ items });
+    const removeItemByText = removeItemByTextHandler({ items });
+
+    // Default rows. Checkbox + text use $checked/$value two-way binding
+    // (no setter handler — that would just write the same value back). Delete
+    // is keyed by the item's stable id, NOT its array index.
+    const rows = items.map((item: EditableListItem) => (
+      <cf-hstack gap="2" align="center" style="padding: 4px 0;">
+        <cf-checkbox $checked={item.done} />
+        <cf-input $value={item.label} placeholder="..." style="flex: 1;" />
+        <cf-button
+          variant="ghost"
+          size="sm"
+          onClick={rowDeleteHandler({ id: item.id, items })}
+        >
+          x
+        </cf-button>
+      </cf-hstack>
+    ));
+
+    return {
+      [NAME]: computed(() => `List (${active} / ${total})`),
+      [UI]: (
+        <cf-vstack gap="1">
+          {ifElse(
+            isEmpty,
+            <cf-empty-state
+              message={computed(() => emptyMessage ?? "No items yet")}
+            />,
+            <cf-vstack gap="0">{rows}</cf-vstack>,
+          )}
+          {ifElse(
+            showAdder,
+            <cf-message-input
+              placeholder="Add item..."
+              button-text="+"
+              oncf-send={(e: { detail?: { message?: string } }) => {
+                const text = e.detail?.message?.trim();
+                if (text) addItem.send({ label: text });
+              }}
+            />,
+            null,
+          )}
+        </cf-vstack>
+      ),
+      items,
+      total,
+      active,
+      done,
+      addItem,
+      removeItem,
+      updateItem,
+      toggleItem,
+      clearDone,
+      addItemByText,
+      updateItemByText,
+      removeItemByText,
+    };
+  },
+);
+
+export default EditableList;


### PR DESCRIPTION
## Summary

The first composable higher-order **primitive** — a pattern used as a JSX tag inside other patterns. It sets the composition-contract precedent for the CT-1715 reuse overhaul. Lives at `packages/patterns/primitives/editable-list.tsx`, the first occupant of a new `primitives/` tier.

## The contract this establishes

- **Headless-able.** Render its `[UI]` to get a default row experience (per-item: checkbox + editable text + delete; a `cf-message-input` adder; `cf-empty-state` when empty). Or ignore `[UI]`, embed for the model, and `.map()` your own rows while driving the exposed streams/cells. **No VNode/render-prop input** — render props fight the CTS transformer; the headless path achieves full custom rendering via cells + streams instead.
- **Identity, not index, not title.** Core mutations (`removeItem`/`updateItem`/`toggleItem`) address items by a stable `id`, never an array index — index-based mutation is the fragility this overhaul kills. `addItem` mints an id if omitted; `updateItem` refuses to overwrite `id`.
- **Title/text addressing is a separate, explicit convenience layer** (`addItemByText`/`updateItemByText`/`removeItemByText`) — fuzzy, case-insensitive, first-match — layered on top of the identity core for agent-driveability. Documented as convenience, not the identity model.
- **Home + tier.** New `primitives/` dir (plain subdir of `@commonfabric/patterns`, no workspace/deno.json change needed); new `primitive` tier added to `packages/patterns/index.md` legend + listing.

## Resolved: can a sub-pattern mutate a parent-owned cell? **YES.**

When a parent does `EditableList({ items: myItems })`, the primitive receives the **same** `Writable<T[]>` cell, not a copy; `.push()`/`.set()` from its handlers mutate the parent's cell and sync back. Evidence:
- `docs/common/concepts/reactivity.md` — `Writable<>` is *write intent* on a shared reactive cell.
- `docs/common/patterns/composition.md` — "Both patterns receive the same `items` cell — changes sync automatically."
- `packages/patterns/examples/cf-render.tsx` — embedded `Counter` mutates the parent's `state.value`.

So the primitive defines + binds its own handlers to the cell it's given; the parent wires nothing by hand. (Documented escape hatch for the cross-space owner-protected case where in-place mutation is impossible — not needed here.)

## Item-shape decision

A minimal-but-extensible interface (concrete schema for the transformer + an index signature for pass-through extras): every item carries `id: string` and `done: boolean`; the **default UI** reads exactly two keys — `done` (checkbox) and `label` (text). Headless callers may ignore `label` and key rows off their own extra fields. Only the default `[UI]` is opinionated about keys.

## Test plan

`packages/patterns/primitives/editable-list.test.tsx` via `runSynced`, named `computed` assertions: empty→nonempty + counts, add by text + by core stream + with extra field, toggle done by id, update by id (+ id-immutability), remove by id, text-addressed update/remove, whitespace ignored, clearDone. **23 passed, 0 failed.**

## Docs

`docs/common/patterns/primitives.md` — the general composition contract (what a primitive exposes, headless vs rendered embedding, identity-not-index, the sub-pattern-mutation answer, no-render-prop rationale, authoring checklist), with EditableList as the worked example. Reused by later primitives (ConfirmAction, MasterDetail).

## Verification

- `deno task cf check packages/patterns/primitives/editable-list.tsx --no-run` — exit 0
- `deno task cf test packages/patterns/primitives/editable-list.test.tsx` — 23/23 green
- `deno lint` + `deno fmt --check` on all new/changed files — clean

Does **not** migrate simple-list/do-list (that's CT-1712).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `EditableList`, a composable, headless‑able list primitive for embedding inside other patterns. Establishes the new `primitives/` tier and the composition contract, fulfilling Linear CT-1710 and setting up CT-1715.

- **New Features**
  - New primitive at `packages/patterns/primitives/editable-list.tsx` exposing items, computed counts, and core streams; optional `[UI]` with checkbox, editable text, delete (now reuses `removeItem`), quick adder, and empty state. Headless callers render their own rows.
  - Identity-based mutations by stable `id`, plus fuzzy `*ByText` convenience streams; docs scope this rule to collection primitives.
  - Sub‑patterns mutate the parent-owned `Writable<T[]>` directly; changes sync back automatically.
  - Extras passthrough is plain data only; live-cell/Writable extras are not rehydrated—declare typed `asCell` fields for nested live cells.
  - Docs at `docs/common/patterns/primitives.md`; tier listing in `packages/patterns/index.md`; tests in `packages/patterns/primitives/editable-list.test.tsx` updated to 28 passing (includes duplicate-label first-match and absent-id no-op).

<sup>Written for commit 090a0b340bf625d844bbd95c61bb386e3d690455. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

