### PR TITLE
chore(cfc): hygiene — delete dead StorageValue.labels + sink rollout gate (audit 28)

### DIFF
--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -72,7 +72,6 @@ export { evaluateHarnessWriteFileAuthorization } from "./harness-write-policy.ts
 export {
   DEFAULT_SINK_MAX_CONFIDENTIALITY,
   INITIAL_SINK_INVENTORY,
-  INITIAL_SINK_ROLLOUT_GATE,
   isInitialSinkInventoryName,
 } from "./sink-inventory.ts";
 export type { SinkMaxConfidentiality } from "./sink-inventory.ts";

--- a/packages/runner/src/cfc/sink-inventory.ts
+++ b/packages/runner/src/cfc/sink-inventory.ts
@@ -21,11 +21,6 @@ export const INITIAL_SINK_INVENTORY: readonly InitialSinkName[] = Object.freeze(
   [...INITIAL_SINK_NAMES],
 );
 
-export const INITIAL_SINK_ROLLOUT_GATE: readonly InitialSinkName[] = Object
-  .freeze(
-    [...INITIAL_SINK_NAMES],
-  );
-
 export const isInitialSinkInventoryName = (
   name: string,
 ): name is InitialSinkName =>

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1,5 +1,5 @@
 import type { Immutable } from "@commonfabric/utils/types";
-import type { CellScope, ImmutableJSONValue } from "@commonfabric/api";
+import type { CellScope } from "@commonfabric/api";
 import type {
   EntityDocument,
   PatchOp,
@@ -100,17 +100,10 @@ export interface IReadOptions {
   nonRecursive?: boolean;
 }
 
-// This type is used to tag a document with any important metadata.
-// Currently, the only supported type is confidentiality.
-export type Labels = {
-  confidentiality?: ImmutableJSONValue[];
-};
-
 /** Immutable storage value container. */
 export interface StorageValue<T extends FabricValue = FabricValue> {
   readonly value: Immutable<T>;
   readonly source?: EntityId;
-  readonly labels?: Immutable<Labels>;
 }
 
 /** Optional `StorageValue<T>`. */

--- a/packages/runner/test/cfc-sink-inventory.test.ts
+++ b/packages/runner/test/cfc-sink-inventory.test.ts
@@ -2,7 +2,6 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   INITIAL_SINK_INVENTORY,
-  INITIAL_SINK_ROLLOUT_GATE,
   isInitialSinkInventoryName,
 } from "../src/cfc/mod.ts";
 
@@ -17,7 +16,6 @@ describe("CFC sink inventory", () => {
       "generateText",
       "generateObject",
     ]);
-    expect(INITIAL_SINK_ROLLOUT_GATE).toEqual(INITIAL_SINK_INVENTORY);
     expect(isInitialSinkInventoryName("fetchData")).toBe(true);
     expect(isInitialSinkInventoryName("generateObject")).toBe(true);
     expect(isInitialSinkInventoryName("navigateTo")).toBe(false);


### PR DESCRIPTION
## Audit item 28 — Hygiene

This ships the unambiguous dead-code deletion (28a) and documents the findings for the three "decide/document" sub-parts (28b–d). 28b turned out materially more involved than the audit's "Minor (S)" estimate — details below.

### (a) Delete dead code — `StorageValue.labels` + `INITIAL_SINK_ROLLOUT_GATE` ✅
Both confirmed dead repo-wide (no type import, no field access, no consumers):
- `StorageValue.labels` + the `Labels` type + the now-unused `ImmutableJSONValue` import in `storage/interface.ts`.
- `INITIAL_SINK_ROLLOUT_GATE` in `cfc/sink-inventory.ts` (a frozen duplicate of `INITIAL_SINK_INVENTORY`) + its `cfc/mod.ts` re-export.

The audit flagged both as "dormant security-looking code." Full runner suite green with these removed.

### (b) Redact `Caveat.source` in introspection — deferred, with a precise boundary 🔜
The intent (inv-12): stop the **display/introspection** path from surfacing `Caveat.source` (the principal that introduced a caveat), so a pattern can't learn which identities are associated with a label.

Investigation found this is **not** a one-line redaction, because the label-view read is reused across three semantic roles:
- **display** — `runtime-processor.ts` `handleGetCfcLabel` returns `cfcLabelViewForCell(cell)` to the client (the genuine introspection surface);
- **observation labeling** — `cell.ts` feeds `cfcLabelViewForCell(cell)` into `cfcConfidentialityForObservationNode`; the `generateObject` "InjectionSafe labels" test asserts the observed label **keeps** `source`;
- **carried-label serialization** — `runtime-client/backends/utils.ts` attaches `cfcLabelViewForCell(cell)` to a `cellRef` that round-trips **back into a cell** via `getCellFromLink(..., cfcLabelView)`.

So redacting at `cloneCfcLabel` (a core clone reached by `mergeCfcLabelViews`/`rebaseCfcLabelView`/`cfcLabelViewsEqual`) or at `cfcLabelViewForCell` corrupts enforcement / observation / round-tripped labels. The **only** safe seam is the `handleGetCfcLabel` display *response* (and only after confirming the client treats it as display-only). That warrants a focused, runtime-client-tested follow-up rather than a rushed change here. Deferred to keep this hygiene PR sound; no half-correct redaction shipped.

### (c) `/value` prefix wire-format — documented equivalence (no change)
The leading-`"value"` equivalence is already implemented and documented: `canonicalizeLogicalPath` (`cfc/canonical.ts`, with a doc comment) and `canonicalizeCfcLogicalPath` (`cfc/label-view-core.ts`) both strip a leading `"value"` so prefixed/unprefixed logical paths canonicalize identically. The two helpers are duplicated across layers (display vs. canonical/enforcement) but intentionally; consolidation is a larger refactor out of scope for hygiene.

### (d) spec §15 registry sync — documented (no change)
The runtime atom-type registry (`CFC_ATOM_TYPE` in `packages/api/cfc.ts`: `LinkReference`, `PromptSlotInfluence`, `Caveat`, plus the `represents-principal`/`authored-by` claim kinds) is internally consistent. Full string-by-string sync against spec §15 needs the spec doc (not in this repo) and is a doc-consistency task for the spec owner, not a code defect.

## Net
One concrete fix (28a) shipped and verified; 28b deferred with a precise safe-boundary writeup; 28c/28d documented as already-handled / spec-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Perf baseline (CI runner variance — not this PR)

The flagged perf metrics shift run-to-run (parking-coordinator + the integration job here; different patterns on #4052) — CI runner variance, not this dead-code deletion (zero runtime refs to the removed symbols). Accepting the current measurements as the baseline per the perf check's instructions:

```
NEW_PERF_BASELINE: job: Pattern Integration Tests (3/4) = 175s
NEW_PERF_BASELINE: subtest: pattern-unit-3/pattern-unit-tests > packages/patterns/factory-outputs/parking-coordinator/main.test.tsx = 122s
```
