### PR TITLE
feat(cfc): redact Caveat.source from getCfcLabel introspection (audit 28b)

### DIFF
--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -59,19 +59,28 @@ export const cloneCfcLabel = (label: IFCLabel): IFCLabel => {
 export const hasCfcLabelValues = (label: IFCLabel): boolean =>
   LABEL_KEYS.some((key) => Array.isArray(label[key]) && label[key]!.length > 0);
 
-// Strip `Caveat.source` — the principal identity that introduced a caveat —
-// from a single atom. Other atom types and the caveat's `kind`/`by` are left
-// intact; only the identity is removed.
+// Recursively strip `Caveat.source` — the principal identity that introduced a
+// caveat — from an atom and every atom nested inside it. CFC atoms nest (e.g.
+// `PromptSlotBound.source` / `Caveat.by` are themselves `CfcAtom`s), so a Caveat
+// can appear at any depth; walk the whole structure and drop `source` from each
+// Caveat found, leaving its `kind`/`by`/`type` and all other atoms intact.
 const redactCaveatSourceAtom = (atom: unknown): unknown => {
-  if (
-    atom !== null && typeof atom === "object" && !Array.isArray(atom) &&
-    (atom as { type?: unknown }).type === CFC_ATOM_TYPE.Caveat &&
-    "source" in (atom as Record<string, unknown>)
-  ) {
-    const { source: _source, ...rest } = atom as Record<string, unknown>;
-    return rest;
+  if (Array.isArray(atom)) {
+    return atom.map(redactCaveatSourceAtom);
   }
-  return atom;
+  if (atom === null || typeof atom !== "object") {
+    return atom;
+  }
+  const obj = atom as Record<string, unknown>;
+  const dropSource = obj.type === CFC_ATOM_TYPE.Caveat;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (dropSource && key === "source") {
+      continue;
+    }
+    out[key] = redactCaveatSourceAtom(value);
+  }
+  return out;
 };
 
 /**

--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -1,4 +1,5 @@
 import { encodePointer } from "../../../memory/v2/path.ts";
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import { uniqueCfcAtoms } from "./observation.ts";
 
 export type IFCLabel = {
@@ -57,6 +58,51 @@ export const cloneCfcLabel = (label: IFCLabel): IFCLabel => {
 
 export const hasCfcLabelValues = (label: IFCLabel): boolean =>
   LABEL_KEYS.some((key) => Array.isArray(label[key]) && label[key]!.length > 0);
+
+// Strip `Caveat.source` — the principal identity that introduced a caveat —
+// from a single atom. Other atom types and the caveat's `kind`/`by` are left
+// intact; only the identity is removed.
+const redactCaveatSourceAtom = (atom: unknown): unknown => {
+  if (
+    atom !== null && typeof atom === "object" && !Array.isArray(atom) &&
+    (atom as { type?: unknown }).type === CFC_ATOM_TYPE.Caveat &&
+    "source" in (atom as Record<string, unknown>)
+  ) {
+    const { source: _source, ...rest } = atom as Record<string, unknown>;
+    return rest;
+  }
+  return atom;
+};
+
+/**
+ * Redact `Caveat.source` identities from a label view for the pattern-facing
+ * INTROSPECTION surface (`getCfcLabel()` → `handleCellGetCfcLabel`). Surfacing
+ * the source lets a pattern learn which principal a caveat came from — an
+ * information-flow leak (audit item 28b, inv-12; full inv-12 labeling stays
+ * phased).
+ *
+ * Apply ONLY at the `handleCellGetCfcLabel` display response. It is deliberately
+ * NOT used by `cloneCfcLabel`, `cfcLabelViewFromMetadata`, or `cfcLabelViewForCell`
+ * — those feed observation labeling (`cfcConfidentialityForObservationNode`), the
+ * dereference-trace path `prepare.ts` consumes, and the carried-label view that
+ * round-trips back into cells via `getCellFromLink`, all of which must keep
+ * `source` intact.
+ */
+export const redactCaveatSourcesForDisplay = (
+  view: CfcLabelView,
+): CfcLabelView => ({
+  version: 1,
+  entries: view.entries.map((entry) => {
+    const label: IFCLabel = {};
+    for (const key of LABEL_KEYS) {
+      const value = entry.label[key];
+      if (Array.isArray(value) && value.length > 0) {
+        label[key] = value.map(redactCaveatSourceAtom);
+      }
+    }
+    return { path: entry.path, label };
+  }),
+});
 
 const sortEntries = (entries: CfcLabelViewEntry[]): CfcLabelViewEntry[] =>
   entries.sort((left, right) => {

--- a/packages/runner/src/cfc/label-view.ts
+++ b/packages/runner/src/cfc/label-view.ts
@@ -27,6 +27,7 @@ export {
   mergeCfcLabelViews,
   rebaseCfcLabelView,
 } from "./label-view-state.ts";
+export { redactCaveatSourcesForDisplay } from "./label-view-core.ts";
 
 type LabelQueryableCell = {
   getAsNormalizedFullLink(): NormalizedFullLink;

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -8,6 +8,7 @@ export {
   getCarriedCfcLabelView,
   mergeCfcLabelViews,
   rebaseCfcLabelView,
+  redactCaveatSourcesForDisplay,
 } from "./label-view.ts";
 export type {
   AttemptedWrite,

--- a/packages/runner/test/cfc-caveat-source-redaction.test.ts
+++ b/packages/runner/test/cfc-caveat-source-redaction.test.ts
@@ -59,4 +59,38 @@ describe("redactCaveatSourcesForDisplay (audit 28b)", () => {
     expect(redacted.entries[0].label.confidentiality).toEqual(["plain"]);
     expect(redacted.entries[0].label.integrity).toEqual(["trusted"]);
   });
+
+  it("strips a Caveat.source NESTED inside another atom (recursive)", () => {
+    // CFC atoms nest: a PromptSlotBound's `source` is itself a CfcAtom, here a
+    // Caveat. The outer atom keeps its structure, but the nested caveat's source
+    // identity must still be removed.
+    const view: CfcLabelView = {
+      version: 1,
+      entries: [{
+        path: [],
+        label: {
+          confidentiality: [{
+            type: CFC_ATOM_TYPE.PromptSlotBound,
+            role: "instruction",
+            source: {
+              type: CFC_ATOM_TYPE.Caveat,
+              kind: "k",
+              source: "did:nest",
+            },
+          }],
+        },
+      }],
+    };
+    const redacted = redactCaveatSourcesForDisplay(view);
+    const outer = redacted.entries[0].label.confidentiality?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(outer.type).toBe(CFC_ATOM_TYPE.PromptSlotBound);
+    expect(outer.role).toBe("instruction");
+    const nested = outer.source as Record<string, unknown>;
+    expect(nested.type).toBe(CFC_ATOM_TYPE.Caveat);
+    expect(nested.kind).toBe("k");
+    expect("source" in nested).toBe(false);
+  });
 });

--- a/packages/runner/test/cfc-caveat-source-redaction.test.ts
+++ b/packages/runner/test/cfc-caveat-source-redaction.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  type CfcLabelView,
+  redactCaveatSourcesForDisplay,
+} from "../src/cfc/label-view.ts";
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
+
+// Audit item 28b (inv-12): the pattern-facing introspection surface
+// (`getCfcLabel()` → `handleCellGetCfcLabel`) must not surface `Caveat.source`
+// — the principal that introduced a caveat. `redactCaveatSourcesForDisplay` is
+// the view-level redaction applied only at that display response.
+
+const caveat = (source: string) => ({
+  type: CFC_ATOM_TYPE.Caveat,
+  kind: "derived-from",
+  source,
+});
+
+describe("redactCaveatSourcesForDisplay (audit 28b)", () => {
+  it("strips Caveat.source while keeping kind/type", () => {
+    const view: CfcLabelView = {
+      version: 1,
+      entries: [{
+        path: [],
+        label: { confidentiality: [caveat("did:alice")] },
+      }],
+    };
+    const redacted = redactCaveatSourcesForDisplay(view);
+    const atom = redacted.entries[0].label.confidentiality?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(atom.type).toBe(CFC_ATOM_TYPE.Caveat);
+    expect(atom.kind).toBe("derived-from");
+    expect("source" in atom).toBe(false);
+  });
+
+  it("does not mutate the input view (display copy is fresh)", () => {
+    const original = caveat("did:alice");
+    const view: CfcLabelView = {
+      version: 1,
+      entries: [{ path: ["x"], label: { integrity: [original] } }],
+    };
+    redactCaveatSourcesForDisplay(view);
+    // The source survives on the original — only the returned copy is redacted.
+    expect((original as Record<string, unknown>).source).toBe("did:alice");
+  });
+
+  it("leaves non-caveat atoms untouched across both label keys", () => {
+    const view: CfcLabelView = {
+      version: 1,
+      entries: [{
+        path: [],
+        label: { confidentiality: ["plain"], integrity: ["trusted"] },
+      }],
+    };
+    const redacted = redactCaveatSourcesForDisplay(view);
+    expect(redacted.entries[0].label.confidentiality).toEqual(["plain"]);
+    expect(redacted.entries[0].label.integrity).toEqual(["trusted"]);
+  });
+});

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -18,6 +18,7 @@ import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { cellRefToSigilLink } from "./utils.ts";
 import { Runtime } from "@commonfabric/runner";
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import * as V2Storage from "../../runner/src/storage/v2.ts";
 import { parseLink } from "../../runner/src/link-utils.ts";
 
@@ -892,6 +893,60 @@ describe("RuntimeProcessor CFC label IPC", () => {
         }],
       },
     });
+  });
+
+  it("redacts Caveat.source from the introspection response (audit 28b)", async () => {
+    const ref: CellRef = {
+      id: "of:cfc-caveat-cell" as CellRef["id"],
+      space: "did:key:test" as CellRef["space"],
+      scope: "space",
+      path: [],
+    };
+    const processor = {
+      runtime: {
+        getCellFromLink: () => ({
+          runtime: {
+            readTx: () => ({
+              readOrThrow: () => ({
+                value: "labelled data",
+                cfc: {
+                  version: 1,
+                  schemaHash: "test-schema",
+                  labelMap: {
+                    version: 1,
+                    entries: [{
+                      path: [],
+                      label: {
+                        confidentiality: [{
+                          type: CFC_ATOM_TYPE.Caveat,
+                          kind: "derived-from",
+                          source: "did:key:alice",
+                        }],
+                      },
+                    }],
+                  },
+                },
+              }),
+            }),
+          },
+          getAsNormalizedFullLink: () => ref,
+          getMetaRaw: () => undefined,
+          sync: () => Promise.resolve(),
+        }),
+      },
+    } as unknown as RuntimeProcessor;
+
+    const response = await RuntimeProcessor.prototype.handleCellGetCfcLabel
+      .call(
+        processor,
+        { type: RequestType.CellGetCfcLabel, cell: ref },
+      );
+    const atom = response.cfcLabel?.entries[0].label.confidentiality
+      ?.[0] as Record<string, unknown>;
+    // The caveat survives with its kind/type, but the source identity is gone.
+    expect(atom.type).toBe(CFC_ATOM_TYPE.Caveat);
+    expect(atom.kind).toBe("derived-from");
+    expect("source" in atom).toBe(false);
   });
 
   it("returns label views on resolved cell refs", () => {

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -25,7 +25,10 @@ import {
   setPatternEnvironment,
   type SigilLink,
 } from "@commonfabric/runner";
-import { cfcLabelViewForCell } from "@commonfabric/runner/cfc";
+import {
+  cfcLabelViewForCell,
+  redactCaveatSourcesForDisplay,
+} from "@commonfabric/runner/cfc";
 import { NameSchema, rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import { StorageManager } from "../../runner/src/storage/cache.ts";
 import {
@@ -649,8 +652,17 @@ export class RuntimeProcessor {
     });
     await syncMetaLinkedDocs(rootCell);
     await cell.sync();
+    // `getCfcLabel()` is the pattern-facing INTROSPECTION surface: the response
+    // is returned to the caller, not round-tripped back into a cell. Redact
+    // `Caveat.source` identities here so a pattern can't learn which principal
+    // introduced a caveat (audit item 28b, inv-12). Observation labeling, the
+    // dereference-trace enforcement path, and the carried-label view all read
+    // the label through other seams and keep `source`.
+    const cfcLabel = cfcLabelViewForCell(cell);
     return {
-      cfcLabel: cfcLabelViewForCell(cell),
+      cfcLabel: cfcLabel === undefined
+        ? undefined
+        : redactCaveatSourcesForDisplay(cfcLabel),
     };
   }
 


### PR DESCRIPTION
## Audit item 28b — redact `Caveat.source` from CFC-label introspection (inv-12)

`getCfcLabel()` (→ `handleCellGetCfcLabel` in runtime-client) is the pattern-facing **introspection** surface for CFC labels. It surfaced `Caveat.source` — the principal identity that introduced a caveat — letting a pattern learn which identities are associated with a label.

### Fix
`redactCaveatSourcesForDisplay` (runner `cfc/label-view-core.ts`) returns a fresh view with `Caveat.source` stripped (keeping `type`/`kind`/`by`). `runtime-processor` applies it to the `handleCellGetCfcLabel` response only.

### Why this exact boundary
The label view is read through several seams that **must keep `source`** for correctness — so the redaction cannot live in a shared/core function:

| Seam | Role | Needs `source`? |
|------|------|------|
| `cloneCfcLabel` / `mergeCfcLabelViews` / `cfcLabelViewsEqual` | core clone/merge/equality | ✅ (equality, enforcement) |
| `cfcLabelViewForCell` → `cfcConfidentialityForObservationNode` (`cell.ts`) | observation labeling | ✅ |
| dereference-trace path (`prepare.ts`) | commit-time enforcement | ✅ |
| `utils.ts` `cellRef.cfcLabelView` → `getCellFromLink` | carried label, round-trips into cells | ✅ |
| **`handleCellGetCfcLabel` response** → `cell-handle.getCfcLabel()` | **display/introspection, returned to caller** | ❌ → **redact here** |

`handleCellGetCfcLabel`'s response is returned to the caller and is **not** round-tripped back into a cell, so it is the only safe place to redact. (An earlier draft that redacted in `cloneCfcLabel` and then `cfcLabelViewForCell` regressed observation labeling — caught by the `generateObject` "InjectionSafe labels" test — which is why this lands at the response.)

Full inv-12 labeling stays phased; this is the scoped `Caveat.source` redaction the audit calls for.

### Tests
- **runner** `cfc-caveat-source-redaction.test.ts`: strips `source` / keeps `kind`+`type`; does not mutate the input view; leaves non-caveat atoms across both label keys untouched.
- **runtime-client** `runtime-processor.test.ts`: end-to-end — a caveat-bearing stored label comes back through `handleCellGetCfcLabel` **without** `source`. Existing getCfcLabel tests (non-caveat labels) still pass unchanged.

Follow-up to #4051 (item 28a), which documented this boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Perf baseline (CI runner variance — not this PR)

The flagged perf metrics shift run-to-run (different patterns over threshold each run across two independent additive PRs) — CI runner variance, not this change (the redactor only runs on `getCfcLabel`, never in pattern hot paths). Accepting the current measurements as the baseline per the perf check's instructions:

```
NEW_PERF_BASELINE: job: Package Integration Tests (runner) = 98s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc/trusted-surfaces/main.test.tsx = 25s
NEW_PERF_BASELINE: subtest: pattern-unit-3/pattern-unit-tests > packages/patterns/factory-outputs/parking-coordinator/main.test.tsx = 116s
```
