### PR TITLE
runner: writers stop emitting implementationRef; engine implementation index [identity E1]

### DIFF
--- a/docs/specs/content-addressed-action-identity-implementation-plan.md
+++ b/docs/specs/content-addressed-action-identity-implementation-plan.md
@@ -3,11 +3,12 @@
 Companion to [`content-addressed-action-identity.md`](./content-addressed-action-identity.md)
 (the design). One PR per letter; each lands green and is independently
 revertible. Phase 0 (ordinal-free `implementationRef` + legacy-alias shim)
-shipped in #3997.
+shipped in #3997; A–D shipped in #4006/#4008/#4009/#4013; E is in flight (see
+"PR E — the flip" for the recorded gating decisions and the E1 status).
 
 ## Last Updated
 
-2026-06-10
+2026-06-11
 
 ## Guiding constraints
 
@@ -285,11 +286,59 @@ BEFORE C2 and assert it still loads (legacy-read canary, kept until PR E).
 Verify: full runner suite; multi-runtime/multi-user cf tests (worker-isolated
 runtimes exercise repeated loads of identical programs).
 
-## PR E — the flip (gated; not scheduled yet)
+## PR E — the flip (gated)
 
 Gate: B–D soaked on main; stored-data aging assessed (graphs rewrite on piece
 re-instantiation, so legacy refs age out; sample production spaces if
 available).
+
+### Gating decisions (recorded 2026-06-11)
+
+- **Gate 1 (soak): pass.** A–D merged (#4006/#4008/#4009/#4013) with no
+  reverts and no identity-machinery incidents; the only post-C commits
+  touching the identity-critical files were #4014 (cross-space loading) and
+  #4015 (CFC read gating), both unrelated mechanisms. Caveat: D merged
+  2026-06-10, so soak time is short — mitigated by E1 keeping every read path.
+- **Gate 2 (stored-data aging): could not measure** — no production-space
+  sample was available at decision time, and C/D are days old, so pre-C
+  graphs (`implementationRef` + omitted body, no `$implRef`) certainly
+  persist. Decision: KEEP the legacy read path one more cycle —
+  `ensureImplementationRef` + ordinal-alias shim (+ its test), the
+  `registerVerifiedFunctionImplementation` builder channel, one string-keyed
+  unbounded verified-function index, `getExecutableFunction`, the runner's
+  legacy resolution arm, and the bundleId-only claim-verification arm. E2 is
+  scoped down accordingly (loadId threading and per-load maps still go; the
+  ref-keyed global index stays). Retirement of the kept pair needs either a
+  stored-data sample showing `$implRef`-less graphs aged out or a
+  `COMPILE_CACHE_RUNTIME_VERSION`-style cutoff (design Phase 4).
+- **Gate 3 (eviction pinning): decided in E1** — a strong, session-lifetime,
+  per-engine content-addressed implementation index
+  (`ExecutableRegistry.verifiedImplementationsByEntryRef`, populated by
+  `Engine.recordModuleProvenance`, exposed as
+  `Harness.getVerifiedImplementation`). The bounded artifact index stays the
+  fast path; the engine index is the eviction-proof backing that lets writers
+  omit both `implementationRef` and the body. See design § Open questions 1.
+- **bundleId-arm retention:** the verification arm in `cfc/prepare.ts` stays
+  (stored claims need it); `VerifiedProvenance` now carries the evaluating
+  load's `bundleId` so identities resolved WITHOUT a `verifiedLoadId`
+  (post-flip graphs have no `implementationRef` to look one up by) still
+  satisfy stored bundleId-only claims. The provenance field and the arm retire
+  together, next cycle, gated on stored-data evidence.
+
+### E1 — writer flip (landed as this series' first PR)
+
+Writers stop emitting `implementationRef`/stringified `implementation` exactly
+where the resolvability gate proves the `$implRef` suffices (the gate now
+probes the engine implementation index, which never evicts in-session); the
+"must carry implementationRef" throw is deleted. The admitted-probe is NOT
+deleted (the plan text below predates the finding): it is narrowed to the one
+category `$implRef` cannot cover — registry-admitted host-trusted values
+(`trustedHostFunctionIndex`; closure-bearing, body round-trip impossible) and
+dynamic in-action artifacts (no provenance symbol) — which keep serializing
+`implementationRef` + omitted body until E2's §5 host registrar replaces them.
+Canary: `test/pre-flip-graph-canary.test.ts` + the committed pre-flip fixture
+pin both persisted vintages (pre-#4009 ref-only, #4009..E1 dual-write)
+loading AND executing; it must stay green until the legacy read path retires.
 
 1. Writers stop emitting `implementationRef` and the stringified
    `implementation`; `moduleToJSON`'s `admittedImplementation` probe and the

--- a/docs/specs/content-addressed-action-identity.md
+++ b/docs/specs/content-addressed-action-identity.md
@@ -6,18 +6,37 @@ symbol }` references and object-keyed (WeakMap/WeakSet) trust.
 
 ## Status
 
-Design. Depends on (and assumes) the shipped state after the AMD-loader
-removal: the ESM module-record loader is the only loader, every module has a
-content-addressed identity (`cf:module/<hash>`), and every module-scope builder
-artifact (pattern / lift / handler) is addressable as `{ identity, symbol }` —
-authored exports by export name, hoisted/non-exported artifacts by their
-`__cfReg` key (see `docs/specs/module-loading.md` and the op-by-identity
-migration that introduced the `$patternRef` sentinel,
-`builtins/op-pattern-ref.ts`).
+Phases 0–2 shipped: #3997 (ordinal-free `implementationRef` + legacy-alias
+shim), #4006 (A: `unsafe_parentPattern` deleted), #4008 (B: derived-copy side
+tables, `unsafe_originalPattern` deleted), #4009 (C: `$implRef` dual-write +
+CFC provenance), #4013 (D: pattern-scoped registries deleted, provenance
+recording in `Engine.recordModuleProvenance`).
+
+Phase 3 in progress — **E1 (writer flip)**: writers emit `$implRef` only;
+`implementationRef` and the stringified body are no longer written where the
+reading runtime's engine proves the `$implRef` resolvable through its strong
+content-addressed implementation index
+(`ExecutableRegistry.registerVerifiedImplementation`, the resolution of open
+question 1 — see § Open questions). The legacy `implementationRef` is still
+written for exactly one category: registry-admitted artifacts the `$implRef`
+cannot cover — host-trusted values (`trustedHostFunctionIndex`, whose closures
+cannot survive a stringified round-trip) and dynamic in-action-created
+artifacts (no provenance symbol). Their replacement is the §5 synthetic-identity
+registrar (PR E2). All read paths are retained; `VerifiedProvenance` carries
+the evaluating load's `bundleId` so stored bundleId-only `writeAuthorizedBy`
+claims keep verifying for modules resolved without a `verifiedLoadId`.
+
+The design assumes the shipped state after the AMD-loader removal: the ESM
+module-record loader is the only loader, every module has a content-addressed
+identity (`cf:module/<hash>`), and every module-scope builder artifact
+(pattern / lift / handler) is addressable as `{ identity, symbol }` — authored
+exports by export name, hoisted/non-exported artifacts by their `__cfReg` key
+(see `docs/specs/module-loading.md` and the op-by-identity migration that
+introduced the `$patternRef` sentinel, `builtins/op-pattern-ref.ts`).
 
 ## Last Updated
 
-2026-06-10
+2026-06-11
 
 ## Motivation
 
@@ -463,11 +482,20 @@ canary test compiling+resolving with `$implRef` stripped.
 
 ## Open questions
 
-1. **Eviction pinning.** `addressableByIdentity` is FIFO-bounded; the op path
-   tolerates eviction via `$opFallback`. If Phase 4 drops fallbacks, running
-   patterns must pin their modules' index entries (refcount on running pieces)
-   or the resolver needs a sync-safe re-evaluation path from
-   `modulesByIdentity`. Decide before Phase 4; until then fallbacks cover it.
+1. **Eviction pinning — DECIDED (E1).** `addressableByIdentity` is
+   FIFO-bounded; the op path tolerates eviction via `$opFallback`. Dropping
+   the `implementationRef` writer removed the unbounded legacy registry's
+   eviction insurance for new data, so E1 ships the replacement: a strong,
+   session-lifetime, per-engine content-addressed implementation index
+   (`ExecutableRegistry.verifiedImplementationsByEntryRef`, populated by
+   `Engine.recordModuleProvenance`, surfaced as
+   `Harness.getVerifiedImplementation`, consulted by `resolveByImplRef` after
+   the bounded artifact index misses). Chosen over refcount pinning (piece
+   lifecycle is fuzzy; high complexity) and a WeakRef shadow (fails exactly in
+   the post-eviction-GC scenario it must cover). Memory is bounded by the set
+   of distinct verified implementations per session — strictly less than the
+   legacy per-load registries retained. `$opFallback` (full-graph embed) stays
+   until E3 revisits it.
 2. **`cfc/canonical.ts` digests.** Confirm no *persisted* artifact compares
    `bundleId`s across sessions (believed session-only; verify before Phase 3).
 3. **`location`/`preview` retention.** Keep both on serialized modules for

--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -355,8 +355,13 @@ export function moduleToJSON(module: Module) {
   // attach for the in-builder ergonomics (`mod.with(...)`/`mod.bind(...)`).
   // They are not part of the serialized contract; left in, they would surface
   // as `Cannot store function per se`, so they are destructured out here.
+  // `implementationRef` is likewise runtime-only since the flip (PR E1 of
+  // docs/specs/content-addressed-action-identity.md): rehydration resolves
+  // through `$implRef`, and the in-memory ref only still feeds the legacy
+  // read path for graphs persisted before the flip.
   const {
     implementation: _implementation,
+    implementationRef: _implementationRef,
     toJSON: _toJSON,
     with: _with,
     bind: _bind,
@@ -398,21 +403,14 @@ export function moduleToJSON(module: Module) {
   }
 
   if (typeof implementation === "function") {
-    if (
-      module.type === "javascript" &&
-      typeof module.implementationRef !== "string"
-    ) {
-      throw new Error(
-        "JavaScript function modules must carry implementationRef before serialization",
-      );
-    }
-    // Content-addressed reference (dual-write with implementationRef until
-    // the flip — see docs/specs/content-addressed-action-identity.md): when
-    // the implementation function has module-scope provenance, serialize its
+    // Content-addressed reference (the only ref written since the flip — see
+    // docs/specs/content-addressed-action-identity.md): when the
+    // implementation function has module-scope provenance, serialize its
     // `{ identity, symbol }` so a rehydrated module resolves by identity.
     // `toJSON` runs at cell-write time — post-evaluation, after provenance was
     // recorded by the module indexing. Dynamic (in-action-created) artifacts
-    // have no symbol and serialize without a ref (in-session only, as before).
+    // have no symbol and serialize without a ref; they keep their stringified
+    // body below (in-session re-resolution through the SES fallback).
     const provenance = module.type === "javascript"
       ? getVerifiedProvenance(implementation)
       : undefined;
@@ -423,7 +421,34 @@ export function moduleToJSON(module: Module) {
     const preview = (implementation as { preview?: string }).preview ??
       implementation.toString().slice(0, 200);
     const location = (implementation as { src?: string }).src;
-    const admittedImplementation = module.type === "javascript" &&
+    // Omit the stringified body only when the implementation is resolvable on
+    // load BY THE RUNTIME THAT WILL READ IT: its engine's content-addressed
+    // implementation index admits the `$implRef`. Provenance is
+    // process-global, so a `$implRef` being PRESENT does not by itself prove
+    // the reading runtime can resolve it: a pattern compiled by a standalone
+    // Engine and registered on another runtime carries `$implRef`, but that
+    // runtime's engine never verified-evaluated the module, so it must keep
+    // the stringified body as the fallback or reload throws. The engine index
+    // — unlike the bounded artifact index — never evicts within a session,
+    // which is what lets the writer omit the body without the legacy
+    // `implementationRef` fallback it used to lean on.
+    const implRefResolvable = implRefValue !== undefined &&
+      typeof frame?.runtime?.harness?.getVerifiedImplementation?.(
+          implRefValue.identity,
+          implRefValue.symbol,
+        ) === "function";
+    // Where the `$implRef` does NOT suffice, the legacy admitted-probe
+    // behavior is kept VERBATIM: a module whose function the registry admits —
+    // host-trusted artifacts (`trustedHostFunctionIndex`, e.g. trusted-builder
+    // values whose closures cannot survive a stringified round-trip) and
+    // dynamic in-action-created artifacts (per-load registry, no provenance
+    // symbol) — still serializes `implementationRef` with the body omitted,
+    // because `getExecutableFunction(implementationRef)` is their ONLY
+    // rehydration channel. Their story moves to the synthetic-identity host
+    // registrar in PR E2 (design §5); until then the legacy field is
+    // load-bearing for exactly this category.
+    const admittedImplementation = !implRefResolvable &&
+        module.type === "javascript" &&
         typeof module.implementationRef === "string"
       ? frame?.verifiedLoadId
         ? frame.runtime?.harness?.getVerifiedFunctionInLoad(
@@ -436,23 +461,12 @@ export function moduleToJSON(module: Module) {
           module.implementationRef,
         )
       : undefined;
-    // Omit the stringified body only when the implementation is resolvable on
-    // load BY THE RUNTIME THAT WILL READ IT — either THIS runtime's identity
-    // index already resolves the `$implRef` (content-addressed), or the legacy
-    // verified-function registry admits it. Provenance is process-global, so
-    // a `$implRef` being PRESENT does not by itself prove the reading runtime
-    // can resolve it: a pattern compiled by a standalone Engine and registered
-    // on another runtime carries `$implRef`, but that runtime's index never saw
-    // the artifact (no `compilePattern`/`registerEvaluatedModules`), so it must
-    // keep the stringified body as the fallback or reload throws. Stringify
-    // whenever NEITHER resolution path applies.
-    const implRefResolvable = implRefValue !== undefined &&
-      frame?.runtime?.patternManager?.artifactFromIdentitySync?.(
-          implRefValue.identity,
-          implRefValue.symbol,
-        ) !== undefined;
+    const keepLegacyRef = !implRefResolvable &&
+      admittedImplementation === implementation &&
+      typeof module.implementationRef === "string";
     return {
       ...rest,
+      ...(keepLegacyRef ? { implementationRef: module.implementationRef } : {}),
       ...implRef,
       ...(module.type === "javascript" && !implRefResolvable &&
           admittedImplementation !== implementation

--- a/packages/runner/src/cfc/implementation-identity.ts
+++ b/packages/runner/src/cfc/implementation-identity.ts
@@ -176,9 +176,15 @@ const resolveProvenanceImplementationIdentity = (
   // `undefined` on a `getVerifiedBundleId` miss and fail those legacy claims
   // closed. The `moduleIdentity` arm remains the primary; this only keeps the
   // legacy arm symmetric with the path that produced those claims.
-  const bundleId = typeof verifiedLoadId === "string" && verifiedLoadId.length
-    ? harness?.getVerifiedBundleId?.(verifiedLoadId) ?? verifiedLoadId
-    : undefined;
+  //
+  // Post-flip graphs carry no `implementationRef`, so their rehydrated modules
+  // resolve WITHOUT a `verifiedLoadId` — the provenance-recorded bundle id
+  // (stamped at evaluation time) then keeps stored bundleId-only claims
+  // verifying. Retires with the bundleId arm.
+  const bundleId =
+    (typeof verifiedLoadId === "string" && verifiedLoadId.length
+      ? harness?.getVerifiedBundleId?.(verifiedLoadId) ?? verifiedLoadId
+      : undefined) ?? provenance.bundleId;
 
   return {
     kind: "verified",

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -1057,6 +1057,16 @@ export class Engine extends EventTarget implements Harness {
     return this.executableRegistry.getVerifiedImplementation(identity, symbol);
   }
 
+  registerDynamicVerifiedFunction(
+    implementationRef: string,
+    implementation: HarnessedFunction,
+  ): void {
+    this.executableRegistry.registerDynamicVerifiedFunction(
+      implementationRef,
+      implementation,
+    );
+  }
+
   unsafeTrustHostValue(
     value: unknown,
     options: UnsafeHostTrustOptions,

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -628,10 +628,8 @@ export class Engine extends EventTarget implements Harness {
       // a from-zero scan, and any mis-attribution degrades fail-closed at the
       // CFC identity layer — see the fn.src note in the design doc.)
       const script = [...graph.compiledBodies.values()].join("\n");
-      this.executableRegistry.setVerifiedLoadBundleId(
-        loadId,
-        hashOf(script).toString(),
-      );
+      const bundleId = hashOf(script).toString();
+      this.executableRegistry.setVerifiedLoadBundleId(loadId, bundleId);
       // Register a composed bundle source map for `${loadId}.js` so that
       // `fn.src` / CFC verified-source coordinates (resolved against `script`)
       // map back to the original authored sources — without this the ESM loader
@@ -781,7 +779,11 @@ export class Engine extends EventTarget implements Harness {
       // through `PatternManager.compilePattern`. Keyed by the implementation
       // function object; gated on the same `isTrustedBuilderArtifact` brand the
       // index uses, so forged values get nothing.
-      this.recordModuleProvenance(exportsByIdentity, graph.registrationSink);
+      this.recordModuleProvenance(
+        exportsByIdentity,
+        graph.registrationSink,
+        bundleId,
+      );
 
       // `graph.registrationSink` was populated by each module's `__cfReg` during
       // the `importNow` loop above (committed only for modules that evaluated
@@ -810,6 +812,7 @@ export class Engine extends EventTarget implements Harness {
   private recordModuleProvenance(
     exportsByIdentity: Map<string, Exports>,
     registrationSink: Map<string, Map<string, unknown>>,
+    bundleId: string,
   ): void {
     const record = (identity: string, symbol: string, value: unknown) => {
       if (!isTrustedBuilderArtifact(value)) return;
@@ -836,8 +839,17 @@ export class Engine extends EventTarget implements Harness {
       recordVerifiedProvenance(implementation, {
         identity,
         symbol,
+        bundleId,
         ...(bindingIdentity ? { bindingIdentity } : {}),
       });
+      // The strong content-addressed implementation index — the resolution
+      // (and eviction-insurance) backing for serialized `$implRef`s; see
+      // `ExecutableRegistry.registerVerifiedImplementation`.
+      this.executableRegistry.registerVerifiedImplementation(
+        identity,
+        symbol,
+        implementation as HarnessedFunction,
+      );
     };
     for (const [identity, namespace] of exportsByIdentity) {
       for (const [exportName, value] of Object.entries(namespace)) {
@@ -1036,6 +1048,13 @@ export class Engine extends EventTarget implements Harness {
     implementationRef: string,
   ): HarnessedFunction | undefined {
     return this.executableRegistry.getExecutableFunction(implementationRef);
+  }
+
+  getVerifiedImplementation(
+    identity: string,
+    symbol: string,
+  ): HarnessedFunction | undefined {
+    return this.executableRegistry.getVerifiedImplementation(identity, symbol);
   }
 
   unsafeTrustHostValue(

--- a/packages/runner/src/harness/executable-registry.ts
+++ b/packages/runner/src/harness/executable-registry.ts
@@ -17,6 +17,13 @@ interface AssociatedFunction {
   implementation: HarnessedFunction;
 }
 
+// Reserved `verifiedFunctions` partition for loadId-less dynamic
+// registrations ({@link ExecutableRegistry.registerDynamicVerifiedFunction}).
+// Engine-issued load ids always contain an `:esm:` segment
+// (`${prefix}:esm:${n}`), so this key can never collide with a real load and
+// `beginVerifiedLoad` is never called with it.
+const DYNAMIC_REGISTRATION_PARTITION = "dynamic:in-action";
+
 export class ExecutableRegistry {
   private readonly verifiedFunctions = new Map<
     string,
@@ -100,14 +107,28 @@ export class ExecutableRegistry {
    * artifact's serialized module on the legacy
    * `{ implementationRef, body omitted }` form, whose
    * `getExecutableFunction` lookup is the live-closure rehydration channel.
-   * No per-load partition entry and no load-id mapping are written (there is
-   * no load); re-registration on a later run of the creating action
-   * overwrites to the fresh function, matching per-load registration.
+   * Re-registration on a later run of the creating action overwrites to the
+   * fresh function, matching per-load registration.
+   *
+   * The registration is held in a RESERVED partition of `verifiedFunctions`
+   * (never a real load id — engine ids always carry an `:esm:` segment) so
+   * that `beginVerifiedLoad`'s cross-load repair sees an owner for a shared
+   * ref and repoints the index to the dynamic function instead of deleting
+   * it (cubic P1 on PR #4053). `verifiedFunctionLoadIds` is deliberately NOT
+   * written: there is no load to resolve, and surfacing the partition key as
+   * a `verifiedLoadId` would leak it into CFC bundle-id derivation — the
+   * loadId-less CFC path must keep flowing through provenance.
    */
   registerDynamicVerifiedFunction(
     implementationRef: string,
     implementation: HarnessedFunction,
   ): void {
+    let partition = this.verifiedFunctions.get(DYNAMIC_REGISTRATION_PARTITION);
+    if (!partition) {
+      partition = new Map();
+      this.verifiedFunctions.set(DYNAMIC_REGISTRATION_PARTITION, partition);
+    }
+    partition.set(implementationRef, implementation);
     this.verifiedFunctionIndex.set(implementationRef, implementation);
     this.recordVerifiedBindingMetadata(implementationRef, implementation);
   }

--- a/packages/runner/src/harness/executable-registry.ts
+++ b/packages/runner/src/harness/executable-registry.ts
@@ -36,6 +36,21 @@ export class ExecutableRegistry {
   >();
   private trustedHostFunctionRefs = new WeakMap<HarnessedFunction, string>();
   private nextTrustedHostFunctionId = 0;
+  // Content-addressed implementation index: module identity → symbol → the
+  // implementation function recorded by `Engine.recordModuleProvenance` during
+  // a verified evaluation. Deliberately STRONG and session-unbounded, like the
+  // legacy `verifiedFunctionIndex` whose eviction insurance it replaces: the
+  // bounded artifact index (`PatternManager.addressableByIdentity`, FIFO 1000)
+  // can roll a running pattern's module out mid-session, and a post-flip
+  // serialized graph carries ONLY `$implRef` — no legacy ref, and no body when
+  // the writer proved this index admits the ref. Retention is bounded by the
+  // set of DISTINCT verified implementations evaluated this session, strictly
+  // less than the legacy per-load registries held (one entry per content
+  // identity instead of one per load).
+  private readonly verifiedImplementationsByEntryRef = new Map<
+    string,
+    Map<string, HarnessedFunction>
+  >();
 
   clear(): void {
     this.verifiedFunctions.clear();
@@ -47,6 +62,34 @@ export class ExecutableRegistry {
     this.trustedHostFunctionIndex.clear();
     this.trustedHostFunctionRefs = new WeakMap();
     this.nextTrustedHostFunctionId = 0;
+    this.verifiedImplementationsByEntryRef.clear();
+  }
+
+  /**
+   * Record a verified implementation under its content-addressed
+   * `{ identity, symbol }` entry ref. Overwrites: a re-evaluation of the same
+   * identity resolves to the fresh function (mirroring the artifact index;
+   * any two instances of one module identity are interchangeable — the SES
+   * verifier forbids module-scope mutable state).
+   */
+  registerVerifiedImplementation(
+    identity: string,
+    symbol: string,
+    implementation: HarnessedFunction,
+  ): void {
+    let bucket = this.verifiedImplementationsByEntryRef.get(identity);
+    if (!bucket) {
+      bucket = new Map();
+      this.verifiedImplementationsByEntryRef.set(identity, bucket);
+    }
+    bucket.set(symbol, implementation);
+  }
+
+  getVerifiedImplementation(
+    identity: string,
+    symbol: string,
+  ): HarnessedFunction | undefined {
+    return this.verifiedImplementationsByEntryRef.get(identity)?.get(symbol);
   }
 
   beginVerifiedLoad(loadId: string): void {

--- a/packages/runner/src/harness/executable-registry.ts
+++ b/packages/runner/src/harness/executable-registry.ts
@@ -92,6 +92,26 @@ export class ExecutableRegistry {
     return this.verifiedImplementationsByEntryRef.get(identity)?.get(symbol);
   }
 
+  /**
+   * Admit a DYNAMIC (in-action-created) artifact into the global verified
+   * index under its minted content-derived ref, without a load id. The
+   * loadId-less counterpart of {@link registerVerifiedFunction} for actions
+   * resolved through post-flip `$implRef`-only modules: it keeps the
+   * artifact's serialized module on the legacy
+   * `{ implementationRef, body omitted }` form, whose
+   * `getExecutableFunction` lookup is the live-closure rehydration channel.
+   * No per-load partition entry and no load-id mapping are written (there is
+   * no load); re-registration on a later run of the creating action
+   * overwrites to the fresh function, matching per-load registration.
+   */
+  registerDynamicVerifiedFunction(
+    implementationRef: string,
+    implementation: HarnessedFunction,
+  ): void {
+    this.verifiedFunctionIndex.set(implementationRef, implementation);
+    this.recordVerifiedBindingMetadata(implementationRef, implementation);
+  }
+
   beginVerifiedLoad(loadId: string): void {
     const existing = this.verifiedFunctions.get(loadId);
     if (existing) {

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -208,6 +208,19 @@ export interface Harness extends EventTarget {
     symbol: string,
   ): HarnessedFunction | undefined;
 
+  // Admit a DYNAMIC (in-action-created) artifact into the global executable
+  // index under its minted content-derived `implementationRef`, WITHOUT a
+  // load id. Used by the runner's in-action registrar when the invoking
+  // function resolved through a post-flip `$implRef`-only module (no
+  // `verifiedLoadId` to register under) — the global index is what lets the
+  // artifact's serialized module keep the legacy
+  // `{ implementationRef, body omitted }` live-closure rehydration channel.
+  // Replaced by the synthetic-identity registrar in PR E2 (design §5).
+  registerDynamicVerifiedFunction?(
+    implementationRef: string,
+    implementation: HarnessedFunction,
+  ): void;
+
   unsafeTrustHostValue(
     value: unknown,
     options: UnsafeHostTrustOptions,

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -198,6 +198,16 @@ export interface Harness extends EventTarget {
     implementationRef: string,
   ): HarnessedFunction | undefined;
 
+  // Resolve a verified implementation function by its content-addressed
+  // `{ identity, symbol }` entry ref — the strong (session-lifetime) index
+  // behind serialized `$implRef`s. Unlike the bounded artifact index this
+  // never evicts, so a `$implRef`-only graph stays resolvable for as long as
+  // its module was verified-evaluated in this session.
+  getVerifiedImplementation?(
+    identity: string,
+    symbol: string,
+  ): HarnessedFunction | undefined;
+
   unsafeTrustHostValue(
     value: unknown,
     options: UnsafeHostTrustOptions,

--- a/packages/runner/src/harness/verified-provenance.ts
+++ b/packages/runner/src/harness/verified-provenance.ts
@@ -32,6 +32,16 @@ export type VerifiedProvenance = {
   dynamic?: true;
   /** CT-1665 verified binding identity, when the factory carried one. */
   bindingIdentity?: { sourceFile: string; bindingPath: string[] };
+  /**
+   * The evaluating load's bundle id (hash of the program's concatenated
+   * compiled bodies). Transitional: stored legacy `writeAuthorizedBy` claims
+   * are keyed by bundleId only, and post-flip graphs resolve without a
+   * `verifiedLoadId` (no `implementationRef` to look one up by), so the live
+   * identity sources the bundle id from here instead. Retires together with
+   * the bundleId verification arm (see
+   * docs/specs/content-addressed-action-identity-implementation-plan.md, PR E).
+   */
+  bundleId?: string;
 };
 
 const provenanceByFn = new WeakMap<object, VerifiedProvenance>();

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3577,8 +3577,9 @@ export class Runner {
     // carry no legacy ref — by the resolved function's content-addressed
     // provenance. An unverified function (fallback-resolved or forged) has
     // neither, so it can never register dynamic artifacts as verified.
+    const invokerProvenance = getVerifiedProvenance(fn);
     const verifiedContext = verifiedLoadId !== undefined ||
-      getVerifiedProvenance(fn) !== undefined;
+      invokerProvenance !== undefined;
     if (!verifiedContext) {
       return invoke();
     }
@@ -3591,17 +3592,43 @@ export class Runner {
             implementationRef,
             implementation as (input: any) => void,
           );
+        } else {
+          // loadId-less verified context (the invoker resolved through a
+          // post-flip `$implRef`-only module): admit the dynamic artifact
+          // into the GLOBAL executable index under its minted content-derived
+          // ref, so its serialized module keeps the legacy
+          // `{ implementationRef, body omitted }` form — the live-closure
+          // rehydration channel the per-load registration provides on the
+          // loadId-ful path (PR #4053 review finding). A `$implRef` is not an
+          // option here: a dynamic function frequently has NO canonical
+          // `fn.src` (action-time stacks don't resolve under tamed SES, only
+          // module-eval ones do), so the minted ref — which the builder hands
+          // this registrar directly — is the one deterministic, re-mintable
+          // key. Replaced wholesale by the synthetic-identity registrar in
+          // PR E2 (design §5).
+          this.runtime.harness.registerDynamicVerifiedFunction?.(
+            implementationRef,
+            implementation as (input: any) => void,
+          );
         }
         // Content-addressed provenance for artifacts created DURING a
         // verified action's execution: the identity derives from the new
         // function's canonical source location (it was compiled as part of a
-        // verified module). In-session only (`dynamic`), matching the legacy
-        // behavior — such artifacts never resolve across a reload.
+        // verified module) when one resolves. The inherited bundle id keeps
+        // stored bundleId-only `writeAuthorizedBy` claims verifying for the
+        // dynamic artifact's own writes when CFC identity resolves through
+        // provenance (mirrors the loadId-ful path's getVerifiedBundleId).
         const identity = identityFromCanonicalSource(
           (implementation as { src?: string }).src,
         );
         if (identity) {
-          recordVerifiedProvenance(implementation, { identity, dynamic: true });
+          recordVerifiedProvenance(implementation, {
+            identity,
+            dynamic: true,
+            ...(invokerProvenance?.bundleId
+              ? { bundleId: invokerProvenance.bundleId }
+              : {}),
+          });
         }
       },
     );

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -88,6 +88,7 @@ import {
 } from "./cfc/types.ts";
 import { setVerifiedFunctionRegistrar } from "./sandbox/function-hardening.ts";
 import {
+  getVerifiedProvenance,
   identityFromCanonicalSource,
   recordVerifiedProvenance,
 } from "./harness/verified-provenance.ts";
@@ -2407,12 +2408,22 @@ export class Runner {
       ref.identity,
       ref.symbol,
     );
-    if (!artifact) return undefined;
-    const implementation =
-      (artifact as { implementation?: unknown }).implementation ?? artifact;
-    return typeof implementation === "function"
-      ? implementation as (...args: any[]) => any
-      : undefined;
+    if (artifact) {
+      const implementation =
+        (artifact as { implementation?: unknown }).implementation ?? artifact;
+      if (typeof implementation === "function") {
+        return implementation as (...args: any[]) => any;
+      }
+    }
+    // Eviction insurance: the artifact index is FIFO-bounded and can roll a
+    // running pattern's module out mid-session, and a post-flip graph has no
+    // legacy ref (and no body when the writer proved resolvability). The
+    // engine's content-addressed implementation index is strong for the
+    // session, so the `$implRef` keeps resolving.
+    return this.runtime.harness.getVerifiedImplementation?.(
+      ref.identity,
+      ref.symbol,
+    ) as ((...args: any[]) => any) | undefined;
   }
 
   /**
@@ -3561,17 +3572,26 @@ export class Runner {
       return fn(argument);
     };
 
-    if (!verifiedLoadId || !this.runtime.harness.registerVerifiedFunction) {
+    // A verified execution context is proven either by the legacy load id
+    // (resolved through `implementationRef`) or — for post-flip graphs, which
+    // carry no legacy ref — by the resolved function's content-addressed
+    // provenance. An unverified function (fallback-resolved or forged) has
+    // neither, so it can never register dynamic artifacts as verified.
+    const verifiedContext = verifiedLoadId !== undefined ||
+      getVerifiedProvenance(fn) !== undefined;
+    if (!verifiedContext) {
       return invoke();
     }
 
     const restoreVerifiedFunctionRegistrar = setVerifiedFunctionRegistrar(
       (implementationRef, implementation) => {
-        this.runtime.harness.registerVerifiedFunction!(
-          verifiedLoadId,
-          implementationRef,
-          implementation as (input: any) => void,
-        );
+        if (verifiedLoadId && this.runtime.harness.registerVerifiedFunction) {
+          this.runtime.harness.registerVerifiedFunction(
+            verifiedLoadId,
+            implementationRef,
+            implementation as (input: any) => void,
+          );
+        }
         // Content-addressed provenance for artifacts created DURING a
         // verified action's execution: the identity derives from the new
         // function's canonical source location (it was compiled as part of a

--- a/packages/runner/test/content-addressed-identity.test.ts
+++ b/packages/runner/test/content-addressed-identity.test.ts
@@ -180,6 +180,109 @@ describe("content-addressed action identity", () => {
     expect(r.key("name").get()).toBe("resolved-after-eviction");
   });
 
+  it("in-action-created artifacts stay registry-admitted on the loadId-less path", async () => {
+    // PR #4053 review finding (Codex P1 / cubic P2): a rehydrated
+    // `$implRef`-only module resolves WITHOUT a verifiedLoadId, so the
+    // dynamic-artifact registrar used to skip registry admission entirely —
+    // an artifact minted DURING that action then serialized with a
+    // stringified body and no ref at all, losing the live-closure
+    // rehydration channel the legacy per-load registry provides on the
+    // loadId-ful path. A `$implRef` cannot cover this category (dynamic
+    // functions frequently have no canonical `fn.src` — action-time stacks
+    // don't resolve under tamed SES), so the registrar now admits them into
+    // the GLOBAL executable index under their minted content-derived ref,
+    // keeping the pre-flip `{ implementationRef, body omitted }` serialized
+    // form on both paths until E2's synthetic-identity registrar.
+    const DYNAMIC_PROGRAM = {
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: `/// <cf-disable-transform />
+import { type Cell, handler, lift, pattern } from "commonfabric";
+
+export const dump = handler<Record<string, never>, { out: Cell<string> }>(
+  { type: "object", properties: {} },
+  {
+    type: "object",
+    properties: { out: { type: "string", asCell: ["cell"] } },
+    required: ["out"],
+  },
+  (_event, state) => {
+    const base = 1;
+    // Closure-bearing on purpose: a stringified round-trip would sever
+    // \`base\`, so only registry admission rehydrates this correctly.
+    const created = lift((value: number) => value + base);
+    state.out.set(JSON.stringify(created));
+  },
+);
+
+export default pattern<{ out: string }>(({ out }) => ({
+  out,
+  dump: dump({ out }),
+}));
+`,
+      }],
+    };
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "observe",
+    });
+    const pattern = await runtime.patternManager.compilePattern(
+      DYNAMIC_PROGRAM,
+    ) as Pattern;
+    await runtime.idle();
+
+    // Rehydrate the handler module from its serialized ($implRef-only) form
+    // so resolution yields NO verifiedLoadId — the exact path the finding is
+    // about.
+    const module = handlerModuleOf(pattern);
+    const json = (module as Module & { toJSON: () => unknown })
+      .toJSON() as Record<string, unknown>;
+    expect("implementationRef" in json).toBe(false);
+    const nodes = pattern.nodes.map((node) =>
+      (node.module as Module).type === "javascript" &&
+        (node.module as Module).wrapper === "handler"
+        ? { ...node, module: json as unknown as Module }
+        : node
+    );
+    const rehydrated = { ...pattern, nodes } as unknown as Pattern;
+
+    const tx = runtime.edit();
+    const resultCell = runtime.getCell<{ out: string }>(
+      signer.did(),
+      "dynamic-artifact-loadid-less",
+      undefined,
+      tx,
+    );
+    // deno-lint-ignore no-explicit-any
+    const r = runtime.run(tx, rehydrated, {}, resultCell) as any;
+    await tx.commit();
+    await r.pull();
+    r.key("dump").send({});
+    await runtime.idle();
+
+    const dumped = JSON.parse(r.key("out").get() as string) as {
+      $implRef?: { identity: string; symbol: string };
+      implementationRef?: string;
+      implementation?: string;
+    };
+    // The in-action artifact's serialized form: the legacy admitted shape —
+    // minted content-derived ref, body omitted (matching the loadId-ful
+    // path), no $implRef (no module-scope provenance symbol exists for it).
+    expect(typeof dumped.implementationRef).toBe("string");
+    expect("implementation" in dumped).toBe(false);
+    expect("$implRef" in dumped).toBe(false);
+    // ...and the ref resolves to the LIVE function through the global
+    // executable index (the closure-preserving rehydration channel).
+    expect(
+      typeof runtime.harness.getExecutableFunction?.(
+        dumped.implementationRef!,
+      ),
+    ).toBe("function");
+  });
+
   it("CFC identity resolves from provenance with a stable moduleIdentity", async () => {
     const pattern = await setup();
     const module = handlerModuleOf(pattern);

--- a/packages/runner/test/content-addressed-identity.test.ts
+++ b/packages/runner/test/content-addressed-identity.test.ts
@@ -9,14 +9,17 @@ import type { Module, Pattern } from "../src/builder/types.ts";
 import type { HarnessedFunction } from "../src/harness/types.ts";
 
 /**
- * PR C of docs/specs/content-addressed-action-identity-implementation-plan.md:
- * content-addressed `$implRef` dual-write + CFC provenance.
+ * PRs C and E1 of
+ * docs/specs/content-addressed-action-identity-implementation-plan.md:
+ * content-addressed `$implRef` + CFC provenance, and the writer flip.
  *
  * - Functions become "verified" by being registered through the trust-gated
  *   module indexing during evaluation; their provenance carries the defining
  *   module's content identity and the artifact's export/`__cfReg` symbol.
- * - Serialized javascript modules carry `$implRef: { identity, symbol }`
- *   (alongside the legacy `implementationRef` until the flip).
+ * - Serialized javascript modules carry `$implRef: { identity, symbol }`;
+ *   since the flip (E1) the legacy `implementationRef` is runtime-only and
+ *   the body is omitted when the engine's strong implementation index proves
+ *   the ref resolvable — including after the bounded artifact index evicts.
  * - CFC policy identity resolves from the provenance (`moduleIdentity`,
  *   reload-stable) with the legacy registry as fallback; a forged function —
  *   even with byte-identical source — has no provenance and fails closed.
@@ -94,7 +97,7 @@ describe("content-addressed action identity", () => {
     );
   });
 
-  it("serializes javascript modules with $implRef (dual-write)", async () => {
+  it("serializes javascript modules with $implRef only (no legacy fields)", async () => {
     const pattern = await setup();
     const module = handlerModuleOf(pattern);
     const json = (module as Module & { toJSON?: () => unknown }).toJSON
@@ -111,8 +114,70 @@ describe("content-addressed action identity", () => {
     )!;
     expect(ref.identity).toBe(provenance.identity);
     expect(ref.symbol).toBe(provenance.symbol);
-    // Legacy field still written during the dual-write window.
-    expect(typeof json.implementationRef).toBe("string");
+    // PR E1 (the flip): the legacy `implementationRef` is no longer written,
+    // and the body stays omitted because this runtime's engine resolves the
+    // `$implRef` through its content-addressed implementation index.
+    expect("implementationRef" in json).toBe(false);
+    expect("implementation" in json).toBe(false);
+  });
+
+  it("a $implRef-only module survives artifact-index eviction (engine implementation index)", async () => {
+    const pattern = await setup();
+    const module = handlerModuleOf(pattern);
+    const json = (module as Module & { toJSON: () => unknown })
+      .toJSON() as Record<string, unknown>;
+    const ref = json.$implRef as { identity: string; symbol: string };
+    expect(ref).toBeDefined();
+    expect("implementation" in json).toBe(false);
+
+    // The engine's implementation index admits the ref directly (this is the
+    // strong, session-lifetime index that replaces the legacy registry's
+    // eviction insurance for post-flip data).
+    expect(
+      typeof runtime!.harness.getVerifiedImplementation?.(
+        ref.identity,
+        ref.symbol,
+      ),
+    ).toBe("function");
+
+    // Simulate the bounded artifact index rolling the module out mid-session
+    // (FIFO eviction after ~1000 other identities) — the worst case for a
+    // `$implRef`-only stored graph, which has no legacy ref and no body.
+    const manager = runtime!.patternManager as unknown as {
+      addressableByIdentity: Map<string, unknown>;
+      modulesByIdentity: Map<string, unknown>;
+    };
+    manager.addressableByIdentity.clear();
+    manager.modulesByIdentity.clear();
+    expect(
+      runtime!.patternManager.artifactFromIdentitySync(
+        ref.identity,
+        ref.symbol,
+      ),
+    ).toBeUndefined();
+
+    // A graph carrying only the $implRef must still instantiate and execute.
+    const nodes = pattern.nodes.map((node) =>
+      (node.module as Module).type === "javascript" &&
+        (node.module as Module).wrapper === "handler"
+        ? { ...node, module: json as unknown as Module }
+        : node
+    );
+    const rehydrated = { ...pattern, nodes } as unknown as Pattern;
+    const tx = runtime!.edit();
+    const resultCell = runtime!.getCell<{ name: string }>(
+      signer.did(),
+      "evicted-implref-resolution",
+      undefined,
+      tx,
+    );
+    // deno-lint-ignore no-explicit-any
+    const r = runtime!.run(tx, rehydrated, {}, resultCell) as any;
+    await tx.commit();
+    await r.pull();
+    r.key("setName").send({ name: "resolved-after-eviction" });
+    await runtime!.idle();
+    expect(r.key("name").get()).toBe("resolved-after-eviction");
   });
 
   it("CFC identity resolves from provenance with a stable moduleIdentity", async () => {
@@ -211,6 +276,38 @@ describe("provenance bundleId fallback (legacy claim compat)", () => {
     expect(identity?.kind).toBe("verified");
     expect((identity as { bundleId?: string }).bundleId).toBe(
       "load:legacy-bundle",
+    );
+  });
+
+  it("carries the evaluation's bundleId via provenance when no verifiedLoadId is available", async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "observe",
+    });
+    const pattern = await runtime.patternManager.compilePattern(PROGRAM);
+    await runtime.idle();
+    const node = pattern.nodes.find((n) =>
+      (n.module as Module).type === "javascript" &&
+      (n.module as Module).wrapper === "handler"
+    );
+    const module = node!.module as Module;
+    const fn = module.implementation as HarnessedFunction;
+
+    // Post-flip stored graphs carry no `implementationRef`, so resolution of a
+    // rehydrated module yields NO verifiedLoadId — but a stored legacy
+    // bundleId-only `writeAuthorizedBy` claim still needs the live identity to
+    // carry the bundle id or it fails closed. The id therefore rides on the
+    // provenance recorded at evaluation time.
+    expect(getVerifiedProvenance(fn)?.bundleId).toBeDefined();
+    const identity = resolvePolicyFacingImplementationIdentity(module, {
+      harness: runtime.harness,
+      implementation: fn,
+    });
+    expect(identity?.kind).toBe("verified");
+    expect((identity as { bundleId?: string }).bundleId).toBe(
+      getVerifiedProvenance(fn)!.bundleId,
     );
   });
 });

--- a/packages/runner/test/engine-verified-functions.test.ts
+++ b/packages/runner/test/engine-verified-functions.test.ts
@@ -79,4 +79,41 @@ describe("Engine verified function cleanup", () => {
     expect(executableRegistry.verifiedFunctionIndex.has(only.implementationRef))
       .toBe(false);
   });
+
+  it("load restarts repoint shared refs to the dynamic registration instead of deleting them", () => {
+    // PR #4053 follow-up (cubic P1 on registerDynamicVerifiedFunction):
+    // dynamic (loadId-less) registrations share the implementationRef
+    // keyspace with per-load registrations. If a ref registered by a load is
+    // ALSO dynamically registered, a restart of that load must repoint the
+    // global index at the dynamic function — a bare index write without a
+    // partition entry would instead be DELETED by the cross-load repair
+    // (`findVerifiedFunctionInOtherLoads` finds no owner), severing the
+    // rehydration channel mid-session.
+    const fromLoad = Object.assign(() => "from-load", {
+      implementationRef: "main.tsx#000:handler",
+    });
+    const dynamic = Object.assign(() => "dynamic", {
+      implementationRef: "main.tsx#000:handler",
+    });
+    const executableRegistry = getExecutableRegistry();
+
+    executableRegistry.registerVerifiedFunction(
+      "load:restarting",
+      fromLoad.implementationRef,
+      fromLoad,
+    );
+    executableRegistry.registerDynamicVerifiedFunction(
+      dynamic.implementationRef,
+      dynamic,
+    );
+    expect(
+      executableRegistry.getExecutableFunction(dynamic.implementationRef),
+    ).toBe(dynamic);
+
+    executableRegistry.beginVerifiedLoad("load:restarting");
+
+    expect(
+      executableRegistry.getExecutableFunction(dynamic.implementationRef),
+    ).toBe(dynamic);
+  });
 });

--- a/packages/runner/test/engine.test.ts
+++ b/packages/runner/test/engine.test.ts
@@ -421,7 +421,7 @@ describe("Engine.evaluateRecordGraph()", () => {
     expect(typeof utilExports["triple"]).toBe("function");
   });
 
-  it("serializes verified javascript modules by stable implementationRef", async () => {
+  it("serializes verified javascript modules by stable $implRef", async () => {
     const program: RuntimeProgram = {
       main: "/main.tsx",
       files: [
@@ -447,18 +447,37 @@ describe("Engine.evaluateRecordGraph()", () => {
     );
 
     const module = serialized.nodes[0].module as {
+      $implRef?: { identity: string; symbol: string };
       implementationRef?: string;
       implementation?: string;
     };
-    expect(typeof module.implementationRef).toBe("string");
+    // Since the flip the serialized identity is the content-addressed
+    // `$implRef`; the legacy `implementationRef` is runtime-only and the body
+    // is omitted because this engine's implementation index resolves the ref.
+    expect(module.$implRef).toBeDefined();
+    expect(typeof module.$implRef!.identity).toBe("string");
+    expect(typeof module.$implRef!.symbol).toBe("string");
+    expect("implementationRef" in module).toBe(false);
     expect(module.implementation).toBeUndefined();
     expect(
-      (engine as any).getVerifiedFunction(module.implementationRef),
+      engine.getVerifiedImplementation(
+        module.$implRef!.identity,
+        module.$implRef!.symbol,
+      ),
+    ).toBeDefined();
+    // The legacy read path (kept for pre-flip persisted graphs) still admits
+    // the in-memory module's content-derived ref.
+    const liveModule = (main!.default as { nodes: Array<{ module: unknown }> })
+      .nodes[0].module as { implementationRef?: string };
+    expect(typeof liveModule.implementationRef).toBe("string");
+    expect(
+      // deno-lint-ignore no-explicit-any
+      (engine as any).getVerifiedFunction(liveModule.implementationRef),
     )
       .toBeDefined();
   });
 
-  it("keeps implementationRef stable across separate load sessions of the same source", async () => {
+  it("keeps the serialized identity stable across separate load sessions of the same source", async () => {
     const program: RuntimeProgram = {
       main: "/main.tsx",
       files: [
@@ -489,10 +508,22 @@ describe("Engine.evaluateRecordGraph()", () => {
       ),
     );
 
-    expect(firstSerialized.nodes[0].module.implementationRef).toBeDefined();
-    expect(firstSerialized.nodes[0].module.implementationRef).toBe(
-      secondSerialized.nodes[0].module.implementationRef,
+    // Content-addressed `$implRef` is byte-derived, so two loads of identical
+    // source serialize the identical ref.
+    expect(firstSerialized.nodes[0].module.$implRef).toBeDefined();
+    expect(firstSerialized.nodes[0].module.$implRef).toEqual(
+      secondSerialized.nodes[0].module.$implRef,
     );
+    // The in-memory legacy ref (still minted for the kept pre-flip read path)
+    // is content-derived too — same stability, pinned until the path retires.
+    const firstLive = (first.main!.default as {
+      nodes: Array<{ module: { implementationRef?: string } }>;
+    }).nodes[0].module.implementationRef;
+    const secondLive = (second.main!.default as {
+      nodes: Array<{ module: { implementationRef?: string } }>;
+    }).nodes[0].module.implementationRef;
+    expect(firstLive).toBeDefined();
+    expect(firstLive).toBe(secondLive);
   });
 
   it("rejects authored local-module namespace imports in SES mode", async () => {

--- a/packages/runner/test/fixtures/pre-flip-serialized-module.json
+++ b/packages/runner/test/fixtures/pre-flip-serialized-module.json
@@ -1,0 +1,92 @@
+{
+  "comment": "Captured by PR E1 from the PRE-FLIP writer (moduleToJSON before implementationRef emission was retired). Regenerate by re-running the capture against a pre-E1 checkout if the program source or the transformer's emitted layout changes (legacy implementationRefs are derived from fn.src line:col + compiled preview, so they shift with compiler output; $implRef identities derive from source bytes).",
+  "program": {
+    "main": "/main.tsx",
+    "files": [
+      {
+        "name": "/main.tsx",
+        "contents": "/// <cts-enable />\nimport { handler, pattern, Writable } from \"commonfabric\";\n\nconst bump = handler<{ by?: number }, { count: Writable<number> }>(\n  (event, state) => { state.count.set(state.count.get() + (event.by ?? 1)); },\n);\n\nexport default pattern(() => {\n  const count = new Writable<number>(0).for(\"count\");\n  return { count, bump: bump({ count }) };\n});\n"
+      }
+    ]
+  },
+  "modules": {
+    "dualWrite": {
+      "type": "javascript",
+      "implementationRef": "fid1:Wa-gJmudusRE4DG-aUUZYIjNe76_kQTvThVEgrNd4Zg",
+      "wrapper": "handler",
+      "argumentSchema": {
+        "type": "object",
+        "properties": {
+          "$event": {
+            "type": "object",
+            "properties": {
+              "by": {
+                "type": "number"
+              }
+            }
+          },
+          "$ctx": {
+            "type": "object",
+            "properties": {
+              "count": {
+                "type": "number",
+                "asCell": [
+                  "cell"
+                ]
+              }
+            },
+            "required": [
+              "count"
+            ]
+          }
+        },
+        "required": [
+          "$ctx"
+        ]
+      },
+      "$implRef": {
+        "identity": "oJFbdeP423z-f0TZpyM07kb4ro7XlXQlV2-KGoIwol4",
+        "symbol": "bump"
+      },
+      "preview": "(event, state) => { state.count.set(state.count.get() + (event.by ?? 1)); }",
+      "location": "cf:module/oJFbdeP423z-f0TZpyM07kb4ro7XlXQlV2-KGoIwol4/main.tsx:6:2"
+    },
+    "preC": {
+      "type": "javascript",
+      "implementationRef": "fid1:Wa-gJmudusRE4DG-aUUZYIjNe76_kQTvThVEgrNd4Zg",
+      "wrapper": "handler",
+      "argumentSchema": {
+        "type": "object",
+        "properties": {
+          "$event": {
+            "type": "object",
+            "properties": {
+              "by": {
+                "type": "number"
+              }
+            }
+          },
+          "$ctx": {
+            "type": "object",
+            "properties": {
+              "count": {
+                "type": "number",
+                "asCell": [
+                  "cell"
+                ]
+              }
+            },
+            "required": [
+              "count"
+            ]
+          }
+        },
+        "required": [
+          "$ctx"
+        ]
+      },
+      "preview": "(event, state) => { state.count.set(state.count.get() + (event.by ?? 1)); }",
+      "location": "cf:module/oJFbdeP423z-f0TZpyM07kb4ro7XlXQlV2-KGoIwol4/main.tsx:6:2"
+    }
+  }
+}

--- a/packages/runner/test/json-utils.test.ts
+++ b/packages/runner/test/json-utils.test.ts
@@ -813,11 +813,12 @@ describe("moduleToJSON", () => {
 
     expect(serialized).toMatchObject({
       type: "javascript",
-      implementationRef: "main.tsx#000:doubled",
       implementation: Function.prototype.toString.call(implementation),
       preview: "(value) => value * 2",
       location: "main.tsx:1:1",
     });
+    // Since the flip the legacy ref is runtime-only — never serialized.
+    expect("implementationRef" in serialized).toBe(false);
   });
 
   it("serializes non-javascript function-backed modules without leaking implementations", () => {
@@ -836,11 +837,11 @@ describe("moduleToJSON", () => {
 
     expect(serialized).toMatchObject({
       type: "raw",
-      implementationRef: "main.tsx#001:raw",
       preview: "() => 'ok'",
       location: "main.tsx:2:1",
     });
     expect("implementation" in serialized).toBe(false);
+    expect("implementationRef" in serialized).toBe(false);
   });
 
   it("keeps the fallback body when the registering runtime can't resolve the $implRef (standalone-engine registration)", async () => {
@@ -913,17 +914,23 @@ describe("moduleToJSON", () => {
 
     // The implementation became verified during the STANDALONE Engine's
     // evaluation, so it carries process-global content-addressed provenance
-    // (Engine.recordModuleProvenance) and `moduleToJSON` dual-writes a
-    // `$implRef`. But this pattern was registered WITHOUT going through
-    // `compilePattern`/`registerEvaluatedModules`, so the runtime's own
-    // identity index never saw the artifact and cannot resolve that `$implRef`
-    // on reload (the cross-engine path the deleted `associatePattern` bridge
-    // used to serve). The serializer must therefore KEEP the stringified body
-    // as the fallback — otherwise reload would miss the index, miss the
-    // registry, and throw.
+    // (Engine.recordModuleProvenance) and `moduleToJSON` writes a `$implRef`.
+    // But this pattern was registered WITHOUT going through
+    // `compilePattern`/`registerEvaluatedModules` on THIS runtime, so its
+    // engine's implementation index never saw the artifact and cannot resolve
+    // that `$implRef` on reload (the cross-engine path the deleted
+    // `associatePattern` bridge used to serve). The serializer must therefore
+    // KEEP the stringified body as the fallback — otherwise reload would miss
+    // the index, miss the registry, and throw.
     expect(getVerifiedProvenance(targetModule.implementation)).toBeDefined();
     expect(
       runtime.patternManager.artifactFromIdentitySync(
+        getVerifiedProvenance(targetModule.implementation)!.identity,
+        getVerifiedProvenance(targetModule.implementation)!.symbol!,
+      ),
+    ).toBeUndefined();
+    expect(
+      runtime.harness.getVerifiedImplementation?.(
         getVerifiedProvenance(targetModule.implementation)!.identity,
         getVerifiedProvenance(targetModule.implementation)!.symbol!,
       ),
@@ -936,10 +943,8 @@ describe("moduleToJSON", () => {
     } finally {
       popFrame(frame);
     }
-    expect(serialized).toMatchObject({
-      type: "javascript",
-      implementationRef: targetModule.implementationRef,
-    });
+    expect(serialized).toMatchObject({ type: "javascript" });
+    expect("implementationRef" in serialized).toBe(false);
     expect(serialized).toHaveProperty("$implRef");
     // Body KEPT: this runtime cannot resolve the $implRef, so the fallback is
     // required for a successful reload.

--- a/packages/runner/test/pattern.test.ts
+++ b/packages/runner/test/pattern.test.ts
@@ -231,9 +231,12 @@ describe("pattern", () => {
     const json = JSON.stringify(doublePattern);
     const parsed = JSON.parse(json);
     expect(json.length).toBeGreaterThan(200);
+    // A test-built (never verified-evaluated) module has no provenance, so
+    // the writer keeps the stringified body as the executable fallback. The
+    // legacy `implementationRef` is runtime-only since the flip (PR E1) —
+    // never serialized.
     expect(typeof parsed.nodes[0].module.implementation).toBe("string");
-    expect("implementationRef" in parsed.nodes[0].module).toBe(true);
-    expect(typeof parsed.nodes[0].module.implementationRef).toBe("string");
+    expect("implementationRef" in parsed.nodes[0].module).toBe(false);
   });
 
   it("pattern with map node serializes correctly", () => {

--- a/packages/runner/test/pre-flip-graph-canary.test.ts
+++ b/packages/runner/test/pre-flip-graph-canary.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { Module, Pattern } from "../src/builder/types.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+/**
+ * PR E1 legacy-read canary (docs/specs/content-addressed-action-identity.md):
+ * serialized graphs persisted BEFORE the writer flip carry `implementationRef`
+ * with the function body omitted — in two vintages:
+ *
+ *  - `preC` (pre-#4009): `implementationRef` only; resolution goes through the
+ *    legacy verified-function registry, repopulated when the module
+ *    re-evaluates.
+ *  - `dualWrite` (#4009..E1): `implementationRef` + `$implRef`; resolution
+ *    prefers the content-addressed index.
+ *
+ * The fixture was captured from the pre-flip writer and committed verbatim
+ * (test/fixtures/pre-flip-serialized-module.json). Both vintages must keep
+ * loading and EXECUTING for as long as stored data can carry them — this test
+ * is the tripwire against deleting a read path that persisted data still
+ * needs (it pins the legacy registry path through PR E2's deletions).
+ */
+
+const signer = await Identity.fromPassphrase("pre-flip-graph-canary");
+const space = signer.did();
+
+const fixture = JSON.parse(
+  Deno.readTextFileSync(
+    new URL("./fixtures/pre-flip-serialized-module.json", import.meta.url),
+  ),
+) as {
+  program: RuntimeProgram;
+  modules: Record<string, Record<string, unknown>>;
+};
+
+describe("pre-flip serialized-graph canary", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const setup = async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "observe",
+    });
+    // Re-evaluating the SAME program bytes is the precondition the legacy
+    // path always had: it re-runs the builder, re-mints the (content-derived)
+    // refs, and repopulates the registry + identity index.
+    const pattern = await runtime.patternManager.compilePattern(
+      fixture.program,
+    ) as Pattern;
+    await runtime.idle();
+    return pattern;
+  };
+
+  const runWithFixtureModule = async (
+    pattern: Pattern,
+    fixtureModule: Record<string, unknown>,
+    cause: string,
+  ) => {
+    // Swap the live handler module for the PERSISTED pre-flip JSON, exactly
+    // what instantiation sees when a stored graph rehydrates: a plain-data
+    // module with refs and no live (or stringified) implementation.
+    const nodes = pattern.nodes.map((node) =>
+      (node.module as Module).type === "javascript" &&
+        (node.module as Module).wrapper === "handler"
+        ? { ...node, module: fixtureModule as unknown as Module }
+        : node
+    );
+    expect(nodes.some((n) => n.module === fixtureModule as unknown)).toBe(
+      true,
+    );
+    const rehydrated = { ...pattern, nodes } as unknown as Pattern;
+
+    const tx = runtime!.edit();
+    const resultCell = runtime!.getCell<{ count: number }>(
+      space,
+      cause,
+      undefined,
+      tx,
+    );
+    // deno-lint-ignore no-explicit-any
+    const r = runtime!.run(tx, rehydrated, {}, resultCell) as any;
+    await tx.commit();
+    await r.pull();
+
+    r.key("bump").send({ by: 2 });
+    await runtime!.idle();
+    return r.key("count").get() as number;
+  };
+
+  it("pre-#4009 vintage (implementationRef only, omitted body) still executes", async () => {
+    const pattern = await setup();
+    const module = fixture.modules.preC;
+    expect(typeof module.implementationRef).toBe("string");
+    expect("$implRef" in module).toBe(false);
+    expect("implementation" in module).toBe(false);
+
+    const count = await runWithFixtureModule(pattern, module, "canary-pre-c");
+    expect(count).toBe(2);
+  });
+
+  it("dual-write vintage (implementationRef + $implRef, omitted body) still executes", async () => {
+    const pattern = await setup();
+    const module = fixture.modules.dualWrite;
+    expect(typeof module.implementationRef).toBe("string");
+    expect(module.$implRef).toBeDefined();
+    expect("implementation" in module).toBe(false);
+
+    const count = await runWithFixtureModule(
+      pattern,
+      module,
+      "canary-dual-write",
+    );
+    expect(count).toBe(2);
+  });
+
+  it("the re-evaluated builder re-mints the fixture's exact implementationRef", async () => {
+    // The legacy path's load-bearing property: refs are content-derived, so a
+    // fresh evaluation of identical bytes registers the SAME ref the stored
+    // graph carries. If this breaks, both vintage tests above fail for the
+    // pre-C vintage — this assertion just makes the cause obvious.
+    const pattern = await setup();
+    const node = pattern.nodes.find((n) =>
+      (n.module as Module).type === "javascript" &&
+      (n.module as Module).wrapper === "handler"
+    );
+    expect(node).toBeDefined();
+    const liveRef = (node!.module as { implementationRef?: string })
+      .implementationRef;
+    expect(liveRef).toBe(fixture.modules.preC.implementationRef);
+  });
+});


### PR DESCRIPTION
PR E1 of [content-addressed-action-identity-implementation-plan.md](https://github.com/commontoolsinc/labs/blob/main/docs/specs/content-addressed-action-identity-implementation-plan.md) — the writer half of the flip. Follows #3997, #4006 (A), #4008 (B), #4009 (C), #4013 (D).

## What changes

**Writers** (`moduleToJSON`):
- `implementationRef` is no longer serialized where the resolvability gate proves the `$implRef` suffices; the body stays omitted there too. The gate now probes the engine's **content-addressed implementation index** (below) instead of the bounded artifact index.
- The "must carry implementationRef before serialization" throw is deleted — ref-less modules are legal and keep their stringified body.
- **Deliberate scope deviation from the plan text**: the `admittedImplementation` probe is *narrowed, not deleted*. Host-trusted values (`trustedHostFunctionIndex` — trusted-builder artifacts whose closures cannot survive a stringified round-trip) and dynamic in-action-created artifacts (no provenance symbol) have **no** `$implRef` to resolve by; `getExecutableFunction(implementationRef)` is their only rehydration channel, so they keep serializing `implementationRef` + omitted body. Found red-handed by the `patterns-dynamic` suite (map ops built via `createTrustedBuilder` stopped executing). Their replacement is E2's synthetic-identity host registrar (design §5).

**Eviction insurance (gate-3 decision, design open question 1)**: dropping `implementationRef` from writes removes the *unbounded* legacy registry's insurance against the FIFO-bounded artifact index evicting a running pattern's module. Replacement: `ExecutableRegistry.verifiedImplementationsByEntryRef` — a strong, session-lifetime `identity → symbol → fn` index populated by `Engine.recordModuleProvenance`, exposed as `Harness.getVerifiedImplementation`, consulted by `resolveByImplRef` after the artifact index misses, and used by the writer's omission gate. Per-engine (preserves the cross-engine body-retention invariant from the D-era fix), content-deduped (strictly less retention than the legacy per-load registries). Chosen over refcount pinning (piece lifecycle is fuzzy) and a WeakRef shadow (fails exactly in the post-eviction-GC case it must cover).

**CFC continuity (reviewers: please look here)** — two persisted-data hazards the flip would otherwise create, each with a red-green test:
- `VerifiedProvenance.bundleId`: post-flip graphs have no `implementationRef`, so rehydrated modules resolve **without** a `verifiedLoadId` — a stored pre-#4009 bundleId-only `writeAuthorizedBy` claim would then fail closed (live identity had no `bundleId`). The bundle id is now also stamped into provenance at evaluation time and used as the fallback. Same value as the loadId route, new plumbing; fail-closed behavior unchanged (absent → reject). Retires together with the bundleId verification arm.
- The dynamic-artifact registrar gate in `invokeJavaScriptImplementation` additionally accepts a provenance-proven fn (post-flip data yields no loadId). Trust basis unchanged: fallback-resolved/forged fns have neither loadId nor provenance.

**All read paths are retained.** Gate 2 (stored-data aging) could not be measured — no production-space sample available, and C/D are days old — so the legacy read path stays a full cycle and E2 is scoped down accordingly. All three gate decisions are recorded in the implementation-plan doc in this PR.

## Canary

`test/pre-flip-graph-canary.test.ts` + committed fixture (`test/fixtures/pre-flip-serialized-module.json`, captured from the pre-flip writer before any change): both persisted vintages — pre-#4009 (`implementationRef` only) and #4009..E1 (dual-write), bodies omitted — must keep loading **and executing**. This is the tripwire for E2's deletions too.

## Verification

- `packages/runner` full suite: 584 passed / 0 failed (type-checked)
- piece: 10 passed; html: 28 passed; workspace `deno task check` clean; fmt + lint clean
- smoke: `deno task cf check packages/patterns/address.tsx` exit 0
- New red-green tests: `$implRef`-only serialization; artifact-index-eviction survival (instantiate + execute after clearing both bounded maps); provenance bundleId without `verifiedLoadId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Writers stop serializing `implementationRef` and function bodies when `$implRef` can be resolved via the engine’s content‑addressed implementation index; legacy read paths remain, and provenance now carries `bundleId` to keep CFC claim verification working. Dynamic artifacts created without a `verifiedLoadId` register in a global executable index to keep the `{ implementationRef, body omitted }` shape and rehydrate correctly.

- **New Features**
  - Writers emit only `$implRef` when the engine can resolve it; removed the “must carry `implementationRef`” throw.
  - Narrow exception: host‑trusted closures and dynamic in‑action artifacts still serialize `implementationRef` with body omitted until E2.
  - Added per‑engine implementation index (`ExecutableRegistry.verifiedImplementationsByEntryRef`), exposed via `Harness.getVerifiedImplementation`; runner falls back to it after artifact‑index misses and the writer gate checks it.
  - `VerifiedProvenance.bundleId` is stamped at evaluation; CFC uses it when no `verifiedLoadId` is available.
  - Pre‑flip serialized‑graph canary and fixture ensure both vintages (pre‑#4009 and dual‑write) still load and execute.

- **Bug Fixes**
  - LoadId‑less dynamic artifacts (invoked via `$implRef`‑only modules) are admitted into a global executable index via `registerDynamicVerifiedFunction`, preserving the legacy `{ implementationRef, body omitted }` serialization and live‑closure rehydration; provenance inherits the invoker’s `bundleId`.
  - Dynamic registrations survive cross‑load repair using a reserved `verifiedFunctions` partition, so shared refs are repointed to the dynamic function instead of being deleted.

<sup>Written for commit a35e118c8533a4273ebd8875b4bf24ef9eb47cf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

Perf-check override — proven CI-runner noise, not a code regression (local alternating A/B x3 on the two cheapest flagged subtests: branch == merge-base within noise, notebook 6.6s vs 6.8s, lunch-poll 2.4s vs 2.4s; flags concentrate in pattern-unit shards 3/4 while shards 1/2 exercising the same serialization paths sit at -1%..+7%; trailing-median baseline lags a fleet-wide drift visible in the last 4 PRs' history entries):

NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/main.test.tsx = 25s
NEW_PERF_BASELINE: test: pattern-unit-4/pattern-unit-tests = 275s
NEW_PERF_BASELINE: subtest: pattern-unit-3/pattern-unit-tests > packages/patterns/factory-outputs/parking-coordinator/main.test.tsx = 127s
NEW_PERF_BASELINE: test: pattern-unit-3/pattern-unit-tests = 287s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/notes/notebook.test.tsx = 51s
