### PR TITLE
fix(html,runtime-client,ui): S15 render-policy follow-ups — threading test, fail-closed knob, drag-preview boundary fallback

### DIFF
--- a/packages/html/src/worker/mod.ts
+++ b/packages/html/src/worker/mod.ts
@@ -20,4 +20,7 @@ export type {
   WorkerRenderNode,
   WorkerVNode,
 } from "./types.ts";
-export { isWorkerVNode } from "./types.ts";
+export {
+  isWorkerVNode,
+  normalizeRenderDeclassificationPolicy,
+} from "./types.ts";

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -41,7 +41,10 @@ import type {
   WorkerRenderNode,
   WorkerVNode,
 } from "./types.ts";
-import { isWorkerVNode } from "./types.ts";
+import {
+  isWorkerVNode,
+  normalizeRenderDeclassificationPolicy,
+} from "./types.ts";
 import {
   type CfcLabelView,
   cfcLabelViewForCell,
@@ -107,8 +110,11 @@ export class WorkerReconciler {
   constructor(options: WorkerReconcilerOptions) {
     this.onOps = options.onOps;
     this.onError = options.onError;
-    this.renderDeclassificationPolicy = options.renderDeclassificationPolicy ??
-      "allow";
+    // Security knob: a present-but-unknown value fails closed to "deny";
+    // only an absent option keeps the documented "allow" default.
+    this.renderDeclassificationPolicy = normalizeRenderDeclassificationPolicy(
+      options.renderDeclassificationPolicy,
+    );
   }
 
   /**

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -211,9 +211,6 @@ export interface ReconcileContext {
 }
 
 /**
- * Options for the worker reconciler.
- */
-/**
  * Whether author-supplied `declassifyConfidentiality` on a
  * `<cf-cfc-render-boundary>` is honored.
  *
@@ -233,6 +230,25 @@ export interface ReconcileContext {
  */
 export type RenderDeclassificationPolicy = "allow" | "deny";
 
+/**
+ * Normalize an untrusted render-declassification policy value.
+ *
+ * The policy is a security knob that crosses postMessage seams (e.g.
+ * `InitializationData`) with no runtime validation, so a typo'd host config or
+ * a version-skewed peer could otherwise silently fail OPEN to `"allow"`. A
+ * present-but-unknown value therefore normalizes to `"deny"` (fail closed);
+ * only an absent value keeps the documented `"allow"` default.
+ */
+export function normalizeRenderDeclassificationPolicy(
+  value: unknown,
+): RenderDeclassificationPolicy {
+  if (value === undefined) return "allow";
+  return value === "allow" ? "allow" : "deny";
+}
+
+/**
+ * Options for the worker reconciler.
+ */
 export interface WorkerReconcilerOptions {
   /** Callback when operations are ready to send to main thread */
   onOps: (

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -4,6 +4,7 @@ import { isCell as isRuntimeCell, Runtime } from "@commonfabric/runner";
 import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import type { WorkerVNode } from "../src/worker/types.ts";
+import { normalizeRenderDeclassificationPolicy } from "../src/worker/types.ts";
 import { WorkerReconciler } from "../src/worker/reconciler.ts";
 import type { VDomOp } from "../src/vdom-ops.ts";
 
@@ -484,6 +485,226 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
             renderedText.includes("Sensitive diagnosis: migraine"),
             true,
           );
+        } finally {
+          cancel();
+        }
+      },
+    );
+
+    await t.step(
+      "treats an unknown render policy value as deny (fail closed)",
+      async () => {
+        // The policy crosses postMessage seams (InitializationData) with no
+        // runtime validation; a typo'd host config or version-skewed peer must
+        // not silently fail OPEN to "allow". Absent stays "allow" — covered by
+        // the 'declassifies that label' step above, which passes no option.
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+          renderDeclassificationPolicy: "allow-all" as never,
+        });
+        const root: WorkerVNode = {
+          type: "vnode",
+          name: "cf-cfc-render-boundary",
+          props: {
+            maxConfidentiality: [],
+            declassifyConfidentiality: [healthRecordAtom],
+          },
+          children: [confidential as never],
+        };
+
+        const cancel = reconciler.mount(root);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          const renderedText = collector.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(
+            renderedText.includes("Sensitive diagnosis: migraine"),
+            false,
+          );
+          assertEquals(
+            renderedText.includes("Content hidden by policy"),
+            true,
+          );
+        } finally {
+          cancel();
+        }
+      },
+    );
+
+    await t.step(
+      "deny ignores declassification carried by reactive policy props",
+      async () => {
+        // Mirror of "renders materialized children when reactive policy props
+        // declassify": the boundary's props (including the author's
+        // declassifyConfidentiality) arrive through a Cell, and under "deny"
+        // they must NOT release the labeled value.
+        const propsTx = runtime.edit();
+        const propsCell = runtime.getCell(
+          signer.did(),
+          "cfc-render-policy-deny-declassify-props",
+          undefined,
+          propsTx,
+        );
+        propsCell.setRawUntyped({
+          maxConfidentiality: [],
+          declassifyConfidentiality: [healthRecordAtom],
+          $value: confidential.getAsLink({ includeSchema: true }),
+        });
+        const propsCommitResult = await propsTx.commit();
+        assertEquals(propsCommitResult.ok !== undefined, true);
+
+        const boundaryProps = runtime.getCell(
+          signer.did(),
+          "cfc-render-policy-deny-declassify-props",
+        );
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+          renderDeclassificationPolicy: "deny",
+        });
+        const root: WorkerVNode = {
+          type: "vnode",
+          name: "cf-cfc-render-boundary",
+          props: boundaryProps as never,
+          children: [{
+            type: "vnode",
+            name: "div",
+            props: { id: "deny-reactive-policy-secret" },
+            children: ["Sensitive diagnosis: migraine"],
+          }],
+        };
+
+        const cancel = reconciler.mount(root);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          const renderedText = collector.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(
+            renderedText.includes("Sensitive diagnosis: migraine"),
+            false,
+          );
+          assertEquals(renderedText.includes("Content hidden by policy"), true);
+        } finally {
+          cancel();
+        }
+      },
+    );
+
+    await t.step(
+      "deny keeps children blocked when a boundary update adds declassification",
+      async () => {
+        // Mirror of "reveals materialized children when boundary updates to
+        // declassify": under "deny" the post-mount update that adds
+        // declassifyConfidentiality must NOT release the labeled value.
+        // Deliberately no collector.clear(): the secret must never appear in
+        // the op stream, before or after the update.
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+          renderDeclassificationPolicy: "deny",
+        });
+        const rootCell = new MockCell(
+          {
+            type: "vnode",
+            name: "cf-cfc-render-boundary",
+            props: {
+              maxConfidentiality: [],
+              $value: confidential,
+            },
+            children: [{
+              type: "vnode",
+              name: "div",
+              props: { id: "deny-initially-blocked-secret" },
+              children: ["Sensitive diagnosis: migraine"],
+            }],
+          } satisfies WorkerVNode,
+        );
+
+        const cancel = reconciler.mount(rootCell as never);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          rootCell.set(
+            {
+              type: "vnode",
+              name: "cf-cfc-render-boundary",
+              props: {
+                maxConfidentiality: [],
+                declassifyConfidentiality: [healthRecordAtom],
+                $value: confidential,
+              },
+              children: [{
+                type: "vnode",
+                name: "div",
+                props: { id: "deny-still-blocked-secret" },
+                children: ["Sensitive diagnosis: migraine"],
+              }],
+            } satisfies WorkerVNode,
+          );
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          const renderedText = collector.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(
+            renderedText.includes("Sensitive diagnosis: migraine"),
+            false,
+          );
+          assertEquals(renderedText.includes("Content hidden by policy"), true);
+        } finally {
+          cancel();
+        }
+      },
+    );
+
+    await t.step(
+      "deny keeps children blocked when a reactive prop update adds declassification",
+      async () => {
+        // Mirror of "reveals materialized children when reactive policy props
+        // update": the props Cell gains declassifyConfidentiality after mount;
+        // under "deny" the children must stay blocked. No collector.clear():
+        // the secret must never appear in the op stream.
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+          renderDeclassificationPolicy: "deny",
+        });
+        const propsCell = new MockPropsCell({
+          maxConfidentiality: [],
+          $value: confidential,
+        });
+        const root: WorkerVNode = {
+          type: "vnode",
+          name: "cf-cfc-render-boundary",
+          props: propsCell as never,
+          children: [{
+            type: "vnode",
+            name: "div",
+            props: { id: "deny-reactive-props-updated-secret" },
+            children: ["Sensitive diagnosis: migraine"],
+          }],
+        };
+
+        const cancel = reconciler.mount(root);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          propsCell.set({
+            maxConfidentiality: [],
+            declassifyConfidentiality: [healthRecordAtom],
+            $value: confidential,
+          });
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          const renderedText = collector.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(
+            renderedText.includes("Sensitive diagnosis: migraine"),
+            false,
+          );
+          assertEquals(renderedText.includes("Content hidden by policy"), true);
         } finally {
           cancel();
         }
@@ -1909,4 +2130,23 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
     await runtime.dispose();
     await storageManager.close();
   }
+});
+
+Deno.test("normalizeRenderDeclassificationPolicy", async (t) => {
+  await t.step("absent value keeps the documented 'allow' default", () => {
+    assertEquals(normalizeRenderDeclassificationPolicy(undefined), "allow");
+  });
+
+  await t.step("known values pass through", () => {
+    assertEquals(normalizeRenderDeclassificationPolicy("allow"), "allow");
+    assertEquals(normalizeRenderDeclassificationPolicy("deny"), "deny");
+  });
+
+  await t.step("present-but-unknown values fail closed to 'deny'", () => {
+    assertEquals(normalizeRenderDeclassificationPolicy("allow-all"), "deny");
+    assertEquals(normalizeRenderDeclassificationPolicy(""), "deny");
+    assertEquals(normalizeRenderDeclassificationPolicy(null), "deny");
+    assertEquals(normalizeRenderDeclassificationPolicy(0), "deny");
+    assertEquals(normalizeRenderDeclassificationPolicy({}), "deny");
+  });
 });

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -114,6 +114,7 @@ import {
 import { cellRefToKey } from "../shared/utils.ts";
 import { RemoteResponse } from "@commonfabric/runtime-client";
 import {
+  normalizeRenderDeclassificationPolicy,
   type RenderDeclassificationPolicy,
   WorkerReconciler,
 } from "@commonfabric/html/worker";
@@ -432,8 +433,11 @@ export class RuntimeProcessor {
       identity,
       telemetry,
     );
+    // InitializationData crosses postMessage with no runtime validation, so a
+    // typo'd host config or version-skewed peer must fail CLOSED, not open:
+    // any present-but-unknown value becomes "deny"; absent stays "allow".
     processor.renderDeclassificationPolicy =
-      data.renderDeclassificationPolicy ?? "allow";
+      normalizeRenderDeclassificationPolicy(data.renderDeclassificationPolicy);
     return processor;
   }
 

--- a/packages/runtime-client/integration/client.test.ts
+++ b/packages/runtime-client/integration/client.test.ts
@@ -11,6 +11,7 @@ import {
   CellHandle,
   type JSONSchema,
   RuntimeClient,
+  type RuntimeClientOptions,
   type VNode,
 } from "@commonfabric/runtime-client";
 import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
@@ -1131,6 +1132,117 @@ export default pattern<Record<string, never>>(() => {
       cancel();
     });
   });
+
+  describe("CFC render-policy threading (S15)", () => {
+    // Guards the field-by-field copy in RuntimeClient.initialize() and the
+    // RuntimeProcessor.initialize() -> WorkerReconciler plumbing: during
+    // #3994's own review cycle the initialize() payload DROPPED
+    // renderDeclassificationPolicy, so {renderDeclassificationPolicy: "deny"}
+    // silently behaved as "allow" (fail open). This exercises the REAL
+    // threading end to end: initialize -> worker InitializationData ->
+    // RuntimeProcessor -> every mount's reconciler.
+    const SECRET_TEXT = "Sensitive diagnosis: migraine";
+    const SECRET_ATOM = "s15-threading-secret";
+    const BLOCKED_TEXT = "Content hidden by policy";
+
+    // Mount (via the worker renderer) a <cf-cfc-render-boundary> whose author
+    // props declassify the label of a confidential cell rendered as its child.
+    async function renderAuthorDeclassifiedSecret(
+      rt: RuntimeClient,
+      space: Session["space"],
+    ) {
+      const nonce = crypto.randomUUID();
+      const secretSchema = {
+        type: "string",
+        ifc: { confidentiality: [SECRET_ATOM] },
+      } as const satisfies JSONSchema;
+      const secret = await rt.getCell<string>(
+        space,
+        "s15-render-policy-secret-" + nonce,
+        secretSchema,
+      );
+      await secret.set(SECRET_TEXT);
+      await rt.idle();
+      await secret.sync();
+
+      const vdom = await rt.getCell(
+        space,
+        "s15-render-policy-vdom-" + nonce,
+        undefined,
+      );
+      await vdom.set({
+        type: "vnode",
+        name: "cf-cfc-render-boundary",
+        props: {
+          maxConfidentiality: [],
+          declassifyConfidentiality: [SECRET_ATOM],
+        },
+        children: [secret],
+      });
+      await rt.idle();
+      await vdom.sync();
+
+      const mock = new MockDoc(
+        `<!DOCTYPE html><html><body><div id="root"></div></body></html>`,
+      );
+      const { document, renderOptions } = mock;
+      const root = document.getElementById("root")!;
+      const cancel = render(
+        root,
+        vdom.asSchema(rendererVDOMSchema) as any,
+        renderOptions,
+      );
+      return { root, cancel };
+    }
+
+    it("threads renderDeclassificationPolicy 'deny' through initialize to the worker reconciler", async () => {
+      const session = await createTestSession();
+      await using rt = await createRuntimeClient(session, {
+        renderDeclassificationPolicy: "deny",
+      });
+
+      const { root, cancel } = await renderAuthorDeclassifiedSecret(
+        rt,
+        session.space,
+      );
+      try {
+        // Wait for the blocked placeholder (positive signal) rather than for
+        // the absence of the secret, which would pass vacuously pre-render.
+        await waitFor(
+          () => Promise.resolve(root.innerHTML.includes(BLOCKED_TEXT)),
+          { timeout: 10000 },
+        );
+        assertEquals(
+          root.innerHTML.includes(SECRET_TEXT),
+          false,
+          "deny must ignore the author's declassifyConfidentiality",
+        );
+      } finally {
+        cancel();
+      }
+    });
+
+    it("absent renderDeclassificationPolicy keeps the 'allow' default (control)", async () => {
+      // Same fixtures as the deny case: proves the block above comes from the
+      // threaded policy, not from broken fixtures or an always-blocking gate.
+      const session = await createTestSession();
+      await using rt = await createRuntimeClient(session);
+
+      const { root, cancel } = await renderAuthorDeclassifiedSecret(
+        rt,
+        session.space,
+      );
+      try {
+        await waitFor(
+          () => Promise.resolve(root.innerHTML.includes(SECRET_TEXT)),
+          { timeout: 10000 },
+        );
+        assertEquals(root.innerHTML.includes(BLOCKED_TEXT), false);
+      } finally {
+        cancel();
+      }
+    });
+  });
 });
 
 async function createTestSession(): Promise<Session> {
@@ -1140,7 +1252,10 @@ async function createTestSession(): Promise<Session> {
   });
 }
 
-async function createRuntimeClient(session: Session): Promise<RuntimeClient> {
+async function createRuntimeClient(
+  session: Session,
+  extraOptions: Partial<RuntimeClientOptions> = {},
+): Promise<RuntimeClient> {
   // If a space identity was created, replace it with a transferrable
   // key in Deno using the same derivation as Session
   if (session.spaceIdentity && session.spaceName) {
@@ -1156,6 +1271,7 @@ async function createRuntimeClient(session: Session): Promise<RuntimeClient> {
     spaceIdentity: session.spaceIdentity,
     spaceDid: session.space,
     spaceName: session.spaceName,
+    ...extraOptions,
   });
 
   await worker.synced(session.space);

--- a/packages/runtime-client/runtime-client.test.ts
+++ b/packages/runtime-client/runtime-client.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { RuntimeClient } from "./runtime-client.ts";
+import type { RuntimeTransport } from "./client/transport.ts";
+
+describe("RuntimeClient.initialize option validation", () => {
+  it("rejects an unknown renderDeclassificationPolicy loudly", async () => {
+    // The policy is a security knob: a typo'd host config must surface as the
+    // host's own error instead of silently flipping the worker to a fallback.
+    // The check throws before the transport is used, so a stub suffices.
+    const transport = {
+      send: () => {
+        throw new Error("transport must not be used");
+      },
+      dispose: () => Promise.resolve(),
+      ready: () => Promise.resolve(),
+      on: () => {},
+      off: () => {},
+    } as unknown as RuntimeTransport;
+    const identity = await Identity.fromPassphrase(
+      "runtime-client-option-validation",
+    );
+
+    await expect(
+      RuntimeClient.initialize(transport, {
+        apiUrl: new URL("http://localhost:9/"),
+        identity,
+        spaceDid: identity.did(),
+        renderDeclassificationPolicy: "allow-all" as never,
+      }),
+    ).rejects.toThrow("Invalid renderDeclassificationPolicy");
+  });
+});

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -85,6 +85,21 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     transport: RuntimeTransport,
     options: RuntimeClientOptions,
   ): Promise<RuntimeClient> {
+    // renderDeclassificationPolicy is a security knob: reject unknown values
+    // loudly here, where the host's own config error can surface early. The
+    // worker side additionally fails CLOSED (treats unknown as "deny") for
+    // peers that don't go through this entry point.
+    const renderPolicy = options.renderDeclassificationPolicy;
+    if (
+      renderPolicy !== undefined && renderPolicy !== "allow" &&
+      renderPolicy !== "deny"
+    ) {
+      throw new Error(
+        `Invalid renderDeclassificationPolicy: ${
+          JSON.stringify(renderPolicy)
+        } (expected "allow" or "deny")`,
+      );
+    }
     const initialized = await (new RuntimeConnection(transport)).initialize({
       apiUrl: options.apiUrl.toString(),
       spaceHostMap: options.spaceHostMap,

--- a/packages/ui/src/v2/core/cfc-render-boundary-scan.test.ts
+++ b/packages/ui/src/v2/core/cfc-render-boundary-scan.test.ts
@@ -222,6 +222,50 @@ describe("mayContainCfcRenderBoundary", () => {
     expect(mayContainCfcRenderBoundary(proxy)).toBe(true);
   });
 
+  it("does not trust an array's own iterator to enumerate children", () => {
+    // A genuine array whose own `Symbol.iterator` yields nothing: iteration
+    // (e.g. `Array.from`) sees an empty array, while index reads — which is
+    // how the legacy renderer walks children — still see the boundary.
+    const hidden: unknown[] = [vnode("cf-cfc-render-boundary")];
+    Object.defineProperty(hidden, Symbol.iterator, {
+      value: function* (): Generator<unknown> {},
+    });
+    expect(Array.from(hidden)).toEqual([]); // iteration hides the element
+    expect(hidden[0]).toBeTruthy(); // index reads expose it
+    expect(mayContainCfcRenderBoundary(hidden)).toBe(true);
+    expect(mayContainCfcRenderBoundary(vnode("div", {}, hidden))).toBe(true);
+  });
+
+  it("treats an array subclass with an overridden iterator as may-contain", () => {
+    class SmugglingArray extends Array<unknown> {}
+    // Overridden on the subclass prototype (not an own property): iteration
+    // yields a boundary that index reads never show, so an iterating consumer
+    // would render it while an index-only scan would certify boundary-free.
+    Object.defineProperty(SmugglingArray.prototype, Symbol.iterator, {
+      value: function* (): Generator<unknown> {
+        yield vnode("cf-cfc-render-boundary");
+      },
+    });
+    const smuggling = new SmugglingArray();
+    smuggling.push(vnode("span", {}, ["looks benign by index"]));
+    expect(mayContainCfcRenderBoundary(smuggling)).toBe(true);
+    expect(mayContainCfcRenderBoundary(vnode("div", {}, smuggling))).toBe(
+      true,
+    );
+  });
+
+  it("still scans plain arrays correctly in both directions", () => {
+    expect(
+      mayContainCfcRenderBoundary([
+        vnode("span", {}, ["fine"]),
+        vnode("cf-cfc-render-boundary"),
+      ]),
+    ).toBe(true);
+    expect(
+      mayContainCfcRenderBoundary([vnode("span", {}, ["fine"]), "text"]),
+    ).toBe(false);
+  });
+
   it("still scans normally around hostile siblings", () => {
     const hostile = {
       get boom(): unknown {

--- a/packages/ui/src/v2/core/cfc-render-boundary-scan.test.ts
+++ b/packages/ui/src/v2/core/cfc-render-boundary-scan.test.ts
@@ -164,4 +164,82 @@ describe("mayContainCfcRenderBoundary", () => {
     }
     expect(mayContainCfcRenderBoundary(tree)).toBe(true);
   });
+
+  it("treats an object with a throwing getter as may-contain", () => {
+    const hostile = {
+      get boom(): unknown {
+        throw new Error("hostile getter");
+      },
+    };
+    expect(mayContainCfcRenderBoundary(hostile)).toBe(true);
+    // Same when nested inside an otherwise benign tree.
+    expect(
+      mayContainCfcRenderBoundary(vnode("div", { content: hostile })),
+    ).toBe(true);
+  });
+
+  it("treats a throwing `name` getter as may-contain", () => {
+    const hostile = {
+      get name(): unknown {
+        throw new Error("hostile name getter");
+      },
+    };
+    expect(mayContainCfcRenderBoundary(hostile)).toBe(true);
+  });
+
+  it("treats proxies with throwing traps as may-contain", () => {
+    const throwingOwnKeys = new Proxy({}, {
+      ownKeys() {
+        throw new Error("hostile ownKeys");
+      },
+    });
+    expect(mayContainCfcRenderBoundary(throwingOwnKeys)).toBe(true);
+
+    const throwingGet = new Proxy({ child: "x" }, {
+      get() {
+        throw new Error("hostile get");
+      },
+    });
+    expect(mayContainCfcRenderBoundary(throwingGet)).toBe(true);
+
+    const throwingGetPrototypeOf = new Proxy({}, {
+      getPrototypeOf() {
+        // Trips the `instanceof CellHandle` brand check.
+        throw new Error("hostile getPrototypeOf");
+      },
+    });
+    expect(mayContainCfcRenderBoundary(throwingGetPrototypeOf)).toBe(true);
+
+    // And nested inside an otherwise benign tree.
+    expect(
+      mayContainCfcRenderBoundary(vnode("div", {}, [throwingOwnKeys])),
+    ).toBe(true);
+  });
+
+  it("treats a revoked proxy as may-contain", () => {
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    revoke();
+    expect(mayContainCfcRenderBoundary(proxy)).toBe(true);
+  });
+
+  it("still scans normally around hostile siblings", () => {
+    const hostile = {
+      get boom(): unknown {
+        throw new Error("hostile getter");
+      },
+    };
+    // The guard is scoped per object: a hostile sibling does not stop a real
+    // boundary elsewhere in the tree from being found...
+    expect(
+      mayContainCfcRenderBoundary(
+        vnode("div", {}, [hostile, vnode("cf-cfc-render-boundary")]),
+      ),
+    ).toBe(true);
+    // ...and a fully benign tree is still certified boundary-free.
+    expect(
+      mayContainCfcRenderBoundary(
+        vnode("div", { id: "x" }, [vnode("span", {}, ["plain"])]),
+      ),
+    ).toBe(false);
+  });
 });

--- a/packages/ui/src/v2/core/cfc-render-boundary-scan.test.ts
+++ b/packages/ui/src/v2/core/cfc-render-boundary-scan.test.ts
@@ -1,0 +1,167 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  $conn,
+  CellHandle,
+  type CellRef,
+  type RuntimeClient,
+} from "@commonfabric/runtime-client";
+import { mayContainCfcRenderBoundary } from "./cfc-render-boundary-scan.ts";
+
+const fakeRuntime = {
+  [$conn]: () => ({
+    request: () => Promise.resolve({}),
+    subscribe: () => Promise.resolve(),
+    unsubscribe: () => Promise.resolve(),
+  }),
+} as unknown as RuntimeClient;
+
+function handle(value?: unknown): CellHandle {
+  const ref: CellRef = {
+    id: "of:boundary-scan-cell" as CellRef["id"],
+    space: "did:key:test" as CellRef["space"],
+    scope: "space",
+    path: [],
+  };
+  return new CellHandle(fakeRuntime, ref, value);
+}
+
+const vnode = (
+  name: string,
+  props: Record<string, unknown> = {},
+  children?: unknown,
+) => ({ type: "vnode", name, props, children });
+
+describe("mayContainCfcRenderBoundary", () => {
+  it("passes primitives and boundary-free trees", () => {
+    expect(mayContainCfcRenderBoundary(undefined)).toBe(false);
+    expect(mayContainCfcRenderBoundary(null)).toBe(false);
+    expect(mayContainCfcRenderBoundary("hello")).toBe(false);
+    expect(mayContainCfcRenderBoundary(42)).toBe(false);
+    expect(
+      mayContainCfcRenderBoundary(
+        vnode("div", { id: "x" }, [
+          vnode("span", {}, ["plain text"]),
+          "more text",
+        ]),
+      ),
+    ).toBe(false);
+  });
+
+  it("flags a boundary at the root", () => {
+    expect(
+      mayContainCfcRenderBoundary(
+        vnode("cf-cfc-render-boundary", {
+          maxConfidentiality: [],
+          declassifyConfidentiality: ["secret"],
+        }, ["guarded"]),
+      ),
+    ).toBe(true);
+  });
+
+  it("flags a boundary nested in children", () => {
+    expect(
+      mayContainCfcRenderBoundary(
+        vnode("div", {}, [
+          vnode("p", {}, ["fine"]),
+          vnode("section", {}, [
+            vnode("cf-cfc-render-boundary", {}, ["guarded"]),
+          ]),
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  it("flags by name without requiring a vnode shape", () => {
+    // The legacy renderer is lenient about shape; the scan must be at least
+    // as lenient when deciding what NOT to render.
+    expect(
+      mayContainCfcRenderBoundary({ name: "cf-cfc-render-boundary" }),
+    ).toBe(true);
+  });
+
+  it("does not flag similarly named nodes", () => {
+    expect(
+      mayContainCfcRenderBoundary(
+        vnode("div", {}, [vnode("cf-cfc-render-boundary-ish")]),
+      ),
+    ).toBe(false);
+    // A prop VALUE equal to the tag name is not a node.
+    expect(
+      mayContainCfcRenderBoundary(
+        vnode("div", { title: "cf-cfc-render-boundary" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("flags a boundary carried in a prop value", () => {
+    // Reactive/component props can carry vdom subtrees.
+    expect(
+      mayContainCfcRenderBoundary(
+        vnode("cf-some-component", {
+          content: vnode("cf-cfc-render-boundary", {}, ["guarded"]),
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("follows $UI chains", () => {
+    expect(
+      mayContainCfcRenderBoundary({
+        $UI: vnode("div", {}, [vnode("cf-cfc-render-boundary")]),
+      }),
+    ).toBe(true);
+  });
+
+  it("scans the cached value of a nested CellHandle", () => {
+    const guarded = handle(vnode("cf-cfc-render-boundary", {}, ["guarded"]));
+    expect(
+      mayContainCfcRenderBoundary(vnode("div", {}, [guarded])),
+    ).toBe(true);
+
+    const benign = handle(vnode("span", {}, ["fine"]));
+    expect(
+      mayContainCfcRenderBoundary(vnode("div", {}, [benign])),
+    ).toBe(false);
+  });
+
+  it("treats an unresolved nested CellHandle as boundary-free", () => {
+    // Documented limit: nested handles materialized from a parent get() start
+    // with no cached value, so treating them as positives would flag nearly
+    // every piece UI. Content that streams in later is out of scope.
+    expect(
+      mayContainCfcRenderBoundary(vnode("div", {}, [handle()])),
+    ).toBe(false);
+  });
+
+  it("treats a cell whose get() throws as may-contain", () => {
+    const broken = handle("ignored");
+    (broken as unknown as { get: () => never }).get = () => {
+      throw new Error("uninspectable");
+    };
+    expect(
+      mayContainCfcRenderBoundary(vnode("div", {}, [broken])),
+    ).toBe(true);
+  });
+
+  it("terminates on cyclic trees", () => {
+    const cyclic: Record<string, unknown> = vnode("div", {});
+    cyclic.children = [cyclic];
+    expect(mayContainCfcRenderBoundary(cyclic)).toBe(false);
+
+    const cyclicWithBoundary: Record<string, unknown> = vnode("div", {});
+    cyclicWithBoundary.children = [
+      cyclicWithBoundary,
+      vnode("cf-cfc-render-boundary"),
+    ];
+    expect(mayContainCfcRenderBoundary(cyclicWithBoundary)).toBe(true);
+  });
+
+  it("fails closed on over-deep trees", () => {
+    let tree: unknown = vnode("span", {}, ["leaf"]);
+    for (let i = 0; i < 100; i++) {
+      tree = vnode("div", {}, [tree]);
+    }
+    expect(mayContainCfcRenderBoundary(tree)).toBe(true);
+  });
+});

--- a/packages/ui/src/v2/core/cfc-render-boundary-scan.ts
+++ b/packages/ui/src/v2/core/cfc-render-boundary-scan.ts
@@ -1,0 +1,75 @@
+import { isCellHandle } from "@commonfabric/runtime-client";
+
+/**
+ * Tag name the worker reconciler treats as a CFC render boundary. Must match
+ * `CFC_RENDER_BOUNDARY_TAG` in `packages/html/src/worker/reconciler.ts`, which
+ * identifies boundary nodes by `node.name`.
+ */
+const CFC_RENDER_BOUNDARY_TAG = "cf-cfc-render-boundary";
+
+/**
+ * Refuse to certify pathologically deep trees as boundary-free: past this
+ * depth the scan gives up and reports "may contain" (fail closed).
+ */
+const MAX_SCAN_DEPTH = 64;
+
+/**
+ * Conservatively detect whether a vdom value may contain a
+ * `<cf-cfc-render-boundary>` node.
+ *
+ * The worker renderer enforces the CFC render policy for boundary nodes
+ * (blocking over-labeled children behind a "Content hidden by policy"
+ * placeholder), but the legacy main-thread renderer used for plain-VNode
+ * input has no CFC awareness and would render the boundary's children
+ * unguarded. Callers on the legacy path (e.g. drag previews) use this scan to
+ * fall back to a generic presentation instead of rendering such trees.
+ *
+ * The scan walks everything synchronously reachable: arrays, vnode children,
+ * props (reactive props can carry vdom), `$UI` chains, and the cached values
+ * of nested `CellHandle`s. It errs toward `true`: an uninspectable cell
+ * (`get()` throws) or an over-deep tree counts as "may contain".
+ *
+ * Known limit, in line with this being a conservative presence check: a
+ * nested cell with no cached value scans as boundary-free, so a boundary that
+ * only streams in later through a cell subscription is not detected. (Nested
+ * handles materialized from a parent `get()` start without cached values, so
+ * treating them as positives would flag virtually every piece UI.)
+ */
+export function mayContainCfcRenderBoundary(value: unknown): boolean {
+  return scan(value, new Set(), 0);
+}
+
+function scan(value: unknown, visited: Set<object>, depth: number): boolean {
+  if (value === null || typeof value !== "object") return false;
+  if (depth >= MAX_SCAN_DEPTH) return true;
+  if (visited.has(value)) return false;
+  visited.add(value);
+
+  if (isCellHandle(value)) {
+    let resolved: unknown;
+    try {
+      resolved = value.get();
+    } catch {
+      // The renderer would still try to render this cell; refuse to certify
+      // what we cannot inspect.
+      return true;
+    }
+    return scan(resolved, visited, depth + 1);
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((entry) => scan(entry, visited, depth + 1));
+  }
+
+  const record = value as Record<string, unknown>;
+  // Flag on the node name alone (no `type === "vnode"` requirement): the
+  // legacy renderer is lenient about shape, and a false positive only costs
+  // the fancy preview.
+  if (record.name === CFC_RENDER_BOUNDARY_TAG) return true;
+
+  // Generic recursion covers `children`, `props` values, and `$UI` chains.
+  for (const key of Object.keys(record)) {
+    if (scan(record[key], visited, depth + 1)) return true;
+  }
+  return false;
+}

--- a/packages/ui/src/v2/core/cfc-render-boundary-scan.ts
+++ b/packages/ui/src/v2/core/cfc-render-boundary-scan.ts
@@ -45,31 +45,49 @@ function scan(value: unknown, visited: Set<object>, depth: number): boolean {
   if (visited.has(value)) return false;
   visited.add(value);
 
-  if (isCellHandle(value)) {
-    let resolved: unknown;
-    try {
+  // Every direct inspection of `value` below is guarded: throwing getters,
+  // proxies with throwing traps, and revoked proxies make the value
+  // uninspectable, and an uninspectable value cannot be certified
+  // boundary-free (fail closed). Each guard covers only this object's own
+  // accesses — recursion happens outside it, so a boundary found deeper
+  // returns `true` the normal way and a genuine bug in the scan itself is
+  // not swallowed.
+
+  let isCell = false;
+  let resolved: unknown;
+  try {
+    // `instanceof` inside `isCellHandle` can throw via a hostile
+    // `getPrototypeOf` trap or a revoked proxy.
+    if (isCellHandle(value)) {
+      isCell = true;
       resolved = value.get();
-    } catch {
-      // The renderer would still try to render this cell; refuse to certify
-      // what we cannot inspect.
-      return true;
     }
-    return scan(resolved, visited, depth + 1);
+  } catch {
+    // The renderer would still try to render this value; refuse to certify
+    // what we cannot inspect.
+    return true;
+  }
+  if (isCell) return scan(resolved, visited, depth + 1);
+
+  // Materialize this object's own values up front (guarded), then recurse.
+  let entries: unknown[];
+  try {
+    if (Array.isArray(value)) {
+      entries = Array.from(value);
+    } else {
+      const record = value as Record<string, unknown>;
+      // Flag on the node name alone (no `type === "vnode"` requirement): the
+      // legacy renderer is lenient about shape, and a false positive only
+      // costs the fancy preview.
+      if (record.name === CFC_RENDER_BOUNDARY_TAG) return true;
+
+      // Generic enumeration covers `children`, `props` values, and `$UI`
+      // chains.
+      entries = Object.keys(record).map((key) => record[key]);
+    }
+  } catch {
+    return true;
   }
 
-  if (Array.isArray(value)) {
-    return value.some((entry) => scan(entry, visited, depth + 1));
-  }
-
-  const record = value as Record<string, unknown>;
-  // Flag on the node name alone (no `type === "vnode"` requirement): the
-  // legacy renderer is lenient about shape, and a false positive only costs
-  // the fancy preview.
-  if (record.name === CFC_RENDER_BOUNDARY_TAG) return true;
-
-  // Generic recursion covers `children`, `props` values, and `$UI` chains.
-  for (const key of Object.keys(record)) {
-    if (scan(record[key], visited, depth + 1)) return true;
-  }
-  return false;
+  return entries.some((entry) => scan(entry, visited, depth + 1));
 }

--- a/packages/ui/src/v2/core/cfc-render-boundary-scan.ts
+++ b/packages/ui/src/v2/core/cfc-render-boundary-scan.ts
@@ -27,7 +27,9 @@ const MAX_SCAN_DEPTH = 64;
  * The scan walks everything synchronously reachable: arrays, vnode children,
  * props (reactive props can carry vdom), `$UI` chains, and the cached values
  * of nested `CellHandle`s. It errs toward `true`: an uninspectable cell
- * (`get()` throws) or an over-deep tree counts as "may contain".
+ * (`get()` throws), an over-deep tree, or an array with a non-default
+ * `Symbol.iterator` (index reads and iteration could disagree) counts as
+ * "may contain".
  *
  * Known limit, in line with this being a conservative presence check: a
  * nested cell with no cached value scans as boundary-free, so a boundary that
@@ -73,7 +75,21 @@ function scan(value: unknown, visited: Set<object>, depth: number): boolean {
   let entries: unknown[];
   try {
     if (Array.isArray(value)) {
-      entries = Array.from(value);
+      // A non-default iterator lets index reads and iteration disagree about
+      // the array's contents, and consumers differ in which they use; refuse
+      // to certify either view as boundary-free.
+      if (
+        Object.hasOwn(value, Symbol.iterator) ||
+        value[Symbol.iterator] !== Array.prototype[Symbol.iterator]
+      ) {
+        return true;
+      }
+      // Walk by index, matching how the legacy renderer enumerates children
+      // (`newChildren[i]` up to `.length` in `bindChildren`). `Array.from`
+      // would consume the iterator protocol instead, which can hide elements
+      // that index reads still expose.
+      entries = [];
+      for (let i = 0; i < value.length; i++) entries.push(value[i]);
     } else {
       const record = value as Record<string, unknown>;
       // Flag on the node name alone (no `type === "vnode"` requirement): the

--- a/packages/ui/src/v2/core/drag-state.ts
+++ b/packages/ui/src/v2/core/drag-state.ts
@@ -1,5 +1,6 @@
-import { type CellHandle, UI } from "@commonfabric/runtime-client";
+import { type CellHandle, isCellHandle, UI } from "@commonfabric/runtime-client";
 import { render } from "@commonfabric/html/client";
+import { mayContainCfcRenderBoundary } from "./cfc-render-boundary-scan.ts";
 import "../components/cf-cell-link/cf-cell-link.ts";
 
 /**
@@ -196,8 +197,18 @@ export function createDragPreview(cell: CellHandle): HTMLElement {
 
   const cellValue = cell.get();
   if (cellValue && typeof cellValue === "object" && UI in cellValue) {
+    const ui = (cellValue as Record<string, unknown>)[UI];
+    // A CellHandle [UI] renders through the worker renderer, which enforces
+    // the CFC render policy itself. A plain-VNode [UI] renders through the
+    // legacy main-thread renderer, which has no CFC awareness — so any tree
+    // that may contain a <cf-cfc-render-boundary> must not be rendered here
+    // and gets the generic pill instead.
+    if (!isCellHandle(ui) && mayContainCfcRenderBoundary(ui)) {
+      _addFallbackPreview(preview, cell);
+      return preview;
+    }
     try {
-      render(preview, (cellValue as Record<string, unknown>)[UI] as any);
+      render(preview, ui as any);
     } catch (error) {
       console.warn("[drag-state] Failed to render [UI] preview:", error);
       _addFallbackPreview(preview, cell);

--- a/packages/ui/src/v2/core/drag-state.ts
+++ b/packages/ui/src/v2/core/drag-state.ts
@@ -1,4 +1,8 @@
-import { type CellHandle, isCellHandle, UI } from "@commonfabric/runtime-client";
+import {
+  type CellHandle,
+  isCellHandle,
+  UI,
+} from "@commonfabric/runtime-client";
 import { render } from "@commonfabric/html/client";
 import { mayContainCfcRenderBoundary } from "./cfc-render-boundary-scan.ts";
 import "../components/cf-cell-link/cf-cell-link.ts";


### PR DESCRIPTION
Follow-up to #3994 (post-merge review). Addresses all findings from the review of the `renderDeclassificationPolicy` knob (audit S15).

## 1. Threading test for the knob (major)

The knob's plumbing — `RuntimeClient.initialize()` field-by-field copy into `InitializationData` → worker `RuntimeProcessor` → every mount's `WorkerReconciler` — silently fail-opened during #3994's own review cycle: the first commit dropped the field from the `initialize()` payload, so `{renderDeclassificationPolicy: "deny"}` behaved as `"allow"`. Nothing guarded that seam.

- New integration test (`packages/runtime-client/integration/client.test.ts`) exercises the real threading: initialize a `RuntimeClient` with `"deny"`, mount (via the worker renderer) a `cf-cfc-render-boundary` whose author `declassifyConfidentiality` would reveal an ifc-labeled cell, and assert the `cf-cfc-blocked` placeholder ("Content hidden by policy") renders instead of the secret. The assertion waits for the positive blocked signal, so it can't pass vacuously pre-render.
- A control test with identical fixtures and no option confirms the documented `"allow"` default still reveals the declassified value — the deny block is the threaded policy at work, not broken fixtures.
- **Non-vacuity (red→green):** temporarily deleting the `renderDeclassificationPolicy:` forwarding line in `RuntimeClient.initialize()` (re-introducing the historical bug) makes the deny test FAIL — the secret renders — while the control stays green. Restoring the line turns the suite green again.
- Unit test (`packages/runtime-client/runtime-client.test.ts`): an unknown policy value passed to `RuntimeClient.initialize()` rejects loudly before the transport is touched.

## 2. Unknown policy values fail closed (minor)

The knob crosses postMessage (`InitializationData`) with no runtime validation; the gate was `=== "deny"` with `?? "allow"` fallbacks, so a typo'd host config or version-skewed peer silently behaved as `"allow"`. Now `normalizeRenderDeclassificationPolicy` (packages/html/src/worker/types.ts) treats a PRESENT-but-unknown value as `"deny"` (fail closed) while absent/undefined keeps the documented `"allow"` default. Applied at both postMessage-facing seams: the `WorkerReconciler` constructor and `RuntimeProcessor.initialize`. `RuntimeClient.initialize` additionally throws on unknown values so the host's own config error surfaces early. Covered by unit tests plus a reconciler-level step asserting an unknown value (`"allow-all"`) blocks (confirmed red without the normalization).

## 3. Drag previews no longer legacy-render CFC boundaries (major, pre-existing)

`createDragPreview` (packages/ui/src/v2/core/drag-state.ts) rendered piece `[UI]` through `render()` from `@commonfabric/html/client`, which routes plain-VNode input to the legacy main-thread renderer — which has zero CFC awareness. A `cf-cfc-render-boundary` the worker path would gate rendered as an inert unknown element with its children shown unguarded, so boundary-guarded content could surface in a drag preview.

Conservative fix: before rendering a plain-VNode `[UI]`, recursively scan the tree (children, props, `$UI` chains, cached values of nested `CellHandle`s) for any node named `cf-cfc-render-boundary`; if one may be present, fall back to the generic `cf-cell-link` pill the preview already uses for non-UI pieces and render errors. `CellHandle`-valued `[UI]` stays on the worker renderer, which enforces the policy itself. The scan fails closed on uninspectable cells and over-deep trees; one documented limit: content that only streams in later through unresolved cell subscriptions is not detected (nested handles materialized from a parent `get()` start with no cached value, so flagging them would disable previews for virtually every piece UI). Helper unit-tested in `packages/ui/src/v2/core/cfc-render-boundary-scan.test.ts` (12 cases incl. cycles, depth cap, prop-carried subtrees).

Note: `packages/cli/lib/piece-render.ts` shares the legacy render path but is owner-context CLI output — intentionally left alone.

## 4. Deny-mode reactive coverage (minor)

The existing deny steps in `packages/html/test/worker-reconciler-cfc-render-policy.test.ts` were static-props only while the allow path had reactive coverage. Added: declassification carried by reactive policy props is ignored under deny; a boundary update or a reactive prop update that ADDS `declassifyConfidentiality` after mount keeps children blocked — asserted over the full op stream (the secret never appears, before or after the update).

## 5. Dangling JSDoc (nit)

The pre-existing `/** Options for the worker reconciler. */` doc had been stranded above the inserted `RenderDeclassificationPolicy` type in `packages/html/src/worker/types.ts`; it's reattached to `WorkerReconcilerOptions` and the new type/function carry their own docs.

## Verification

- `deno check` on every touched file (post-rebase onto current main).
- `packages/html`: `worker-reconciler-cfc-render-policy.test.ts` — 2 passed (37 steps).
- `packages/runtime-client`: `deno task test` — 15 passed (60 steps); `integration/client.test.ts` against a local toolshed — 1 passed (34 steps), including both new threading steps.
- `packages/ui`: package test run — 102 passed (595 steps).
- Red→green transitions verified for the threading test (forwarding line deleted → deny test fails, control green; restored → all green) and the unknown-policy step (red without normalization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures CFC render-policy end to end: threads `renderDeclassificationPolicy`, fails closed on unknown values, and blocks boundary-guarded content in legacy drag previews. Keeps the documented `"allow"` default when the option is absent.

- **Bug Fixes**
  - Threading: `RuntimeClient.initialize` → worker `RuntimeProcessor` → each `WorkerReconciler` now receives the policy; integration test proves `"deny"` blocks and control confirms `"allow"` default.
  - Fail-closed policy: `normalizeRenderDeclassificationPolicy` treats present-but-unknown values as `"deny"`; applied in `WorkerReconciler` and `RuntimeProcessor.initialize` (re-exported from `@commonfabric/html/worker`). `RuntimeClient.initialize` rejects invalid values early.
  - Drag previews: before rendering plain-VNode `[UI]` via `@commonfabric/html/client`, `mayContainCfcRenderBoundary` scans children, props, `$UI` chains, and cached `CellHandle` values; on possible boundary, falls back to the `cf-cell-link` pill. The scan guards throwing getters/proxies (incl. revoked), walks arrays by index to match the renderer, and treats non-default iterators as “may contain.” `CellHandle` `[UI]` still renders via the worker path.

<sup>Written for commit c264f281e0504be176984ee038e7b6f908859563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

