### PR TITLE
fix(cfc): sink-ceiling follow-ups — bound LLM tool-loop turns by the deployment ceiling

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -57,6 +57,7 @@ import {
   cfcObservationFitsCeiling,
   type CfcObservationResult,
   joinCfcObservedConfidentiality,
+  meetCfcObservationCeilings,
   uniqueCfcAtoms,
 } from "../cfc/observation.ts";
 import { cfcSchemaToObject, resolveCfcSchemaRefs } from "../cfc/schema-refs.ts";
@@ -1298,9 +1299,16 @@ function materializeDialogRequestSnapshot(
 ): DialogRequestSnapshot {
   const { system, maxTokens, model } = inputs.withTx(tx).get();
   const context = inputs.key("context").withTx(tx).get();
-  const observationMaxConfidentiality = inputs.key(
-    "observationMaxConfidentiality",
-  ).withTx(tx).get() as readonly unknown[] | undefined;
+  // Bound the pattern-supplied observation ceiling by the deployment's llmDialog
+  // ceiling so post-commit tool-loop reads (which carry no sink-request input)
+  // cannot exceed it (#3993 review).
+  const observationMaxConfidentiality = effectiveObservationCeiling(
+    runtime,
+    "llmDialog",
+    inputs.key("observationMaxConfidentiality").withTx(tx).get() as
+      | readonly unknown[]
+      | undefined,
+  );
   const toolsCell = inputs.key("tools").withTx(tx) as Cell<
     Record<string, Schema<typeof LLMToolSchema>>
   >;
@@ -1317,8 +1325,12 @@ function materializeDialogRequestSnapshot(
     };
   }
 
-  const cellsDocs = observationMaxConfidentiality &&
-      observationMaxConfidentiality.length > 0
+  // A DECLARED bound — even the empty one — engages observation-aware
+  // serialization: [] means "public only" (cfcObservationFitsCeiling), and the
+  // deployment sink ceiling folds in as exactly that, so treating it like the
+  // absent bound would disable redaction right when the strictest bound is set
+  // (#3993 review).
+  const cellsDocs = observationMaxConfidentiality !== undefined
     ? buildAvailableCellsDocumentationWithObservation(
       runtime,
       space,
@@ -1422,8 +1434,9 @@ function buildAvailableCellsDocumentationWithObservation(
     }
 
     try {
-      let value = observationMaxConfidentiality &&
-          observationMaxConfidentiality.length > 0
+      // Declared-empty bound (public only) must take the observation-aware
+      // read path too — see the cellsDocs guard above (#3993 review).
+      let value = observationMaxConfidentiality !== undefined
         ? readCellValueForObservation(concreteCell)
         : concreteCell.get() ?? concreteCell.getRaw();
       if (
@@ -1861,6 +1874,36 @@ type ToolCallExecutionResult = {
   observedConfidentiality?: readonly unknown[];
 };
 
+/**
+ * Fold the deployment's per-sink confidentiality ceiling into a
+ * pattern-supplied observation bound, yielding the EFFECTIVE bound the LLM
+ * builtins enforce while serializing reads for the model.
+ *
+ * The pattern-supplied `observationMaxConfidentiality` is adversary-controlled
+ * in the CFC threat model (and unbounded when omitted), so a deployment that
+ * declares a ceiling for this sink must additionally bound every value that can
+ * reach the model — including the post-commit tool-loop reads, which carry no
+ * `sink-request` input and so are never gated by `prepareBoundaryCommit`
+ * (#3993 review). The meet (`pattern ∧ deployment`) is the intersection of the
+ * two allowlists: pattern omitted → deployment ceiling alone; sink has no
+ * deployment ceiling → pattern bound alone (unchanged behavior); declared empty
+ * deployment ceiling → public-only regardless of the pattern bound.
+ */
+function effectiveObservationCeiling(
+  runtime: Runtime,
+  sink: string,
+  patternBound: readonly unknown[] | undefined,
+): readonly unknown[] | undefined {
+  const ceilings = runtime.cfcSinkMaxConfidentiality;
+  // Object.hasOwn guard: the sink name is a runner-controlled literal today, but
+  // a name colliding with an Object.prototype member must resolve to "no
+  // ceiling", not an inherited function.
+  const deploymentCeiling = Object.hasOwn(ceilings, sink)
+    ? ceilings[sink]
+    : undefined;
+  return meetCfcObservationCeilings(patternBound, deploymentCeiling);
+}
+
 function toolAllowsObservedConfidentiality(
   toolCatalog: ToolCatalog,
   toolName: string,
@@ -2004,6 +2047,7 @@ export const llmToolExecutionHelpers = {
   prepareSchemaForLLM,
   serializeForLLMObservation,
   toolAllowsObservedConfidentiality,
+  effectiveObservationCeiling,
 };
 
 /**
@@ -2837,11 +2881,18 @@ async function startRequest(
   const { system, maxTokens, model } = inputs.get();
   const queueName = capturedRequest?.queueName ??
     (inputs.key("queue").get() as unknown as string | undefined);
+  // The snapshot already carries the deployment-bounded ceiling. When there is
+  // no snapshot, fold the deployment llmDialog ceiling in here too so a
+  // direct/recovery path can't observe past it (#3993 review).
   const observationMaxConfidentiality = capturedRequest
     ?.observationMaxConfidentiality ??
-    (inputs.key("observationMaxConfidentiality").get() as
-      | readonly unknown[]
-      | undefined);
+    effectiveObservationCeiling(
+      runtime,
+      "llmDialog",
+      inputs.key("observationMaxConfidentiality").get() as
+        | readonly unknown[]
+        | undefined,
+    );
   const builtinTools = inputs.key("builtinTools").get() !== false;
 
   const messagesCell = inputs.key("messages");
@@ -2896,10 +2947,13 @@ async function startRequest(
     };
   }
 
-  // Build available cells documentation (both context and pinned cells)
+  // Build available cells documentation (both context and pinned cells).
+  // This rebuild happens POST-COMMIT (no sink-request input gates these
+  // reads), so a declared bound — including the empty "public only" one the
+  // deployment sink ceiling can fold in — must engage observation-aware
+  // serialization; only the truly absent bound may skip it (#3993 review).
   const context = inputs.key("context").get();
-  const cellsDocs = observationMaxConfidentiality &&
-      observationMaxConfidentiality.length > 0
+  const cellsDocs = observationMaxConfidentiality !== undefined
     ? buildAvailableCellsDocumentationWithObservation(
       runtime,
       space,

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -347,6 +347,7 @@ function buildContextDocumentation(
   runtime: Runtime,
   space: any,
   tx: IExtendedStorageTransaction,
+  sink: string,
 ): { docs: string; observedConfidentiality: readonly unknown[] } {
   const context = inputs.key("context").withTx(tx).get();
   if (!context) {
@@ -381,9 +382,16 @@ function buildContextDocumentation(
         pinnedCellsSchema,
         tx,
       ),
-      inputs.key("observationMaxConfidentiality").withTx(tx).get() as
-        | readonly unknown[]
-        | undefined,
+      // Bound the pattern-supplied ceiling by the deployment ceiling for this
+      // sink so neither the context docs nor the tool loop observe past it
+      // (#3993 review).
+      llmToolExecutionHelpers.effectiveObservationCeiling(
+        runtime,
+        sink,
+        inputs.key("observationMaxConfidentiality").withTx(tx).get() as
+          | readonly unknown[]
+          | undefined,
+      ),
     );
 }
 
@@ -498,6 +506,7 @@ export function llm(
       runtime,
       parentCell.space,
       tx,
+      "llm",
     );
     const outputScope = tx.getNarrowestReadScope();
 
@@ -618,11 +627,16 @@ export function llm(
                 toolCatalog,
                 initialObservedConfidentiality:
                   contextDocs.observedConfidentiality,
-                observationMaxConfidentiality: inputs.key(
-                  "observationMaxConfidentiality",
-                ).get() as
-                  | readonly unknown[]
-                  | undefined,
+                // Deployment-bounded so post-commit tool reads can't exceed the
+                // llm sink ceiling (#3993 review).
+                observationMaxConfidentiality: llmToolExecutionHelpers
+                  .effectiveObservationCeiling(
+                    runtime,
+                    "llm",
+                    inputs.key("observationMaxConfidentiality").get() as
+                      | readonly unknown[]
+                      | undefined,
+                  ),
                 updatePartial,
                 runtime,
                 space: parentCell.space,
@@ -796,6 +810,7 @@ export function generateText(
       runtime,
       parentCell.space,
       tx,
+      "generateText",
     );
     const outputScope = tx.getNarrowestReadScope();
 
@@ -936,11 +951,16 @@ export function generateText(
                 toolCatalog,
                 initialObservedConfidentiality:
                   contextDocs.observedConfidentiality,
-                observationMaxConfidentiality: inputs.key(
-                  "observationMaxConfidentiality",
-                ).get() as
-                  | readonly unknown[]
-                  | undefined,
+                // Deployment-bounded so post-commit tool reads can't exceed the
+                // generateText sink ceiling (#3993 review).
+                observationMaxConfidentiality: llmToolExecutionHelpers
+                  .effectiveObservationCeiling(
+                    runtime,
+                    "generateText",
+                    inputs.key("observationMaxConfidentiality").get() as
+                      | readonly unknown[]
+                      | undefined,
+                  ),
                 updatePartial,
                 runtime,
                 space: parentCell.space,
@@ -1057,11 +1077,18 @@ export function generateObject<T extends Record<string, unknown>>(
     const context = inputs.key("context").withTx(tx).get() as
       | Record<string, unknown>
       | undefined;
-    const observationMaxConfidentiality = inputs.key(
-      "observationMaxConfidentiality",
-    ).withTx(tx).get() as
-      | readonly unknown[]
-      | undefined;
+    // Bound the pattern-supplied ceiling by the deployment generateObject
+    // ceiling once here; every downstream consumer (context docs, the tools
+    // loop, and the direct path) inherits the effective bound, so post-commit
+    // tool reads can't observe past the deployment ceiling (#3993 review).
+    const observationMaxConfidentiality = llmToolExecutionHelpers
+      .effectiveObservationCeiling(
+        runtime,
+        "generateObject",
+        inputs.key("observationMaxConfidentiality").withTx(tx).get() as
+          | readonly unknown[]
+          | undefined,
+      );
     const outputScope = tx.getNarrowestReadScope();
 
     if (!cellsInitialized || cellScope !== outputScope) {

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -92,8 +92,9 @@ export const cfcObservationFitsCeiling = (
   // The read-failed marker is UNGRANTABLE: an observation that carries it never
   // fits a declared ceiling, even one that names the marker. The atom is an
   // exported string, so an author-supplied ceiling could otherwise allow-list it
-  // and defeat the fail-closed redaction (audit item 22). Reject it explicitly
-  // before the per-atom membership check rather than relying on its absence.
+  // and defeat the fail-closed redaction (audit item 22). atomsOutsideCeiling
+  // already forces the marker outside every declared ceiling; keep this explicit
+  // rejection too as defense in depth for the redaction path.
   if (
     confidentiality.some((value) =>
       deepEqual(value, CFC_LABEL_READ_FAILED_ATOM)
@@ -102,9 +103,8 @@ export const cfcObservationFitsCeiling = (
     return false;
   }
 
-  return confidentiality.every((value) =>
-    observationMaxConfidentiality.some((allowed) => deepEqual(allowed, value))
-  );
+  return atomsOutsideCeiling(confidentiality, observationMaxConfidentiality)
+    .length === 0;
 };
 
 /**
@@ -113,8 +113,16 @@ export const cfcObservationFitsCeiling = (
  * `undefined` ceiling means "no ceiling" — nothing is outside it. A declared but
  * empty ceiling is "public only", so every confidential atom is outside it.
  *
+ * `CFC_LABEL_READ_FAILED_ATOM` is UNGRANTABLE (audit item 22): it is always
+ * outside a DECLARED ceiling, even one that explicitly lists it, so a config
+ * naming the exported marker string cannot allow-list a swallowed label-read
+ * error. An `undefined` ceiling still admits it — no bound declared means no
+ * check at all, matching `cfcObservationFitsCeiling`'s early return (the
+ * sink-request gate never consults this helper for an undeclared ceiling).
+ *
  * Shared by the prepare-time sink-request ceiling check so the gate and the
- * fits-test agree on membership semantics (deep-equal over structured atoms).
+ * fits-test agree on membership semantics — including the ungrantable marker —
+ * by construction (deep-equal over structured atoms).
  */
 export const atomsOutsideCeiling = (
   confidentiality: readonly unknown[],
@@ -124,6 +132,7 @@ export const atomsOutsideCeiling = (
     return [];
   }
   return confidentiality.filter((value) =>
+    deepEqual(value, CFC_LABEL_READ_FAILED_ATOM) ||
     !ceiling.some((allowed) => deepEqual(allowed, value))
   ) as ImmutableJSONValue[];
 };

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -107,6 +107,53 @@ export const cfcObservationFitsCeiling = (
   );
 };
 
+/**
+ * The confidentiality atoms in `confidentiality` that fall OUTSIDE `ceiling`
+ * (the membership complement that makes `cfcObservationFitsCeiling` false). An
+ * `undefined` ceiling means "no ceiling" — nothing is outside it. A declared but
+ * empty ceiling is "public only", so every confidential atom is outside it.
+ *
+ * Shared by the prepare-time sink-request ceiling check so the gate and the
+ * fits-test agree on membership semantics (deep-equal over structured atoms).
+ */
+export const atomsOutsideCeiling = (
+  confidentiality: readonly unknown[],
+  ceiling: CfcObservationMaxConfidentiality,
+): ImmutableJSONValue[] => {
+  if (ceiling === undefined) {
+    return [];
+  }
+  return confidentiality.filter((value) =>
+    !ceiling.some((allowed) => deepEqual(allowed, value))
+  ) as ImmutableJSONValue[];
+};
+
+/**
+ * Meet two confidentiality ceilings (allowlists) into the effective bound that
+ * satisfies BOTH: a value fits the result iff it fits each input. Since fitting
+ * means "every atom is a ceiling member" (`cfcObservationFitsCeiling`), fitting
+ * both means the atom set sits within the set INTERSECTION of the two
+ * allowlists.
+ *
+ * Edge cases (each preserves `cfcObservationFitsCeiling` semantics):
+ * - `undefined` ceiling = "no ceiling" = allow everything, so it is the
+ *   identity: `meet(undefined, x) === x` and `meet(x, undefined) === x`.
+ * - A declared empty ceiling is "public only", and intersection with anything
+ *   stays empty, so `meet([], x)` is public-only — the strict bound wins.
+ *
+ * Used to fold a deployment per-sink ceiling into a pattern-supplied observation
+ * bound so post-commit LLM tool-loop reads cannot exceed the deployment ceiling
+ * (review follow-up to #3993).
+ */
+export const meetCfcObservationCeilings = (
+  a: CfcObservationMaxConfidentiality,
+  b: CfcObservationMaxConfidentiality,
+): CfcObservationMaxConfidentiality => {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return a.filter((value) => b.some((other) => deepEqual(other, value)));
+};
+
 export const cfcJsonPointerForPath = (
   path: readonly (string | number)[],
 ): string =>

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -39,7 +39,7 @@ import { encodePointer } from "../../../memory/v2/path.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import { atomPropagationClass } from "./atom-classes.ts";
 import { canonicalizeLogicalPath } from "./canonical.ts";
-import { uniqueCfcAtoms } from "./observation.ts";
+import { atomsOutsideCeiling, uniqueCfcAtoms } from "./observation.ts";
 import { mergeCfcSchemaEnvelopes } from "./schema-merge.ts";
 import {
   CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
@@ -2888,9 +2888,6 @@ const collectConsumedConfidentiality = (
   tx: IExtendedStorageTransaction,
 ): readonly unknown[] => {
   const atoms: unknown[] = [];
-  const addAtom = (atom: unknown): void => {
-    if (!atoms.some((existing) => deepEqual(existing, atom))) atoms.push(atom);
-  };
   for (const read of tx.getReadActivities?.() ?? []) {
     if (isInternalVerifierRead(read.meta)) continue;
     const metadata = storedMetadataFor(
@@ -2924,10 +2921,11 @@ const collectConsumedConfidentiality = (
         : (isPrefix(entryPath, path) ||
           (read.nonRecursive !== true && isPrefix(path, entryPath)));
       if (!overlapsRead) continue;
-      for (const atom of entry.label.confidentiality ?? []) addAtom(atom);
+      atoms.push(...(entry.label.confidentiality ?? []));
     }
   }
-  return atoms;
+  // Structural dedup (deep-equal) — the same dedup the rest of CFC uses.
+  return uniqueCfcAtoms(atoms);
 };
 
 // §5.2.1 / §7.3-7.5 egress gate: a recorded sink-request input whose sink
@@ -2943,7 +2941,12 @@ const verifySinkRequestCeilings = (
   const gatedSinks = new Map<string, readonly unknown[]>();
   for (const input of state.writePolicyInputs) {
     if (input.kind !== "sink-request") continue;
-    const ceiling = ceilings[input.sink];
+    // Own-property lookup only: a sink named like an Object.prototype member
+    // ("constructor", "hasOwnProperty", …) must mean "no ceiling declared",
+    // not resolve an inherited function (review on #3993).
+    const ceiling = Object.hasOwn(ceilings, input.sink)
+      ? ceilings[input.sink]
+      : undefined;
     if (ceiling !== undefined) gatedSinks.set(input.sink, ceiling);
   }
   if (gatedSinks.size === 0) return [];
@@ -2951,9 +2954,9 @@ const verifySinkRequestCeilings = (
   if (consumed.length === 0) return [];
   const reasons: string[] = [];
   for (const [sink, ceiling] of gatedSinks) {
-    const offending = consumed.filter((atom) =>
-      !ceiling.some((allowed) => deepEqual(allowed, atom))
-    );
+    // Same membership semantics as cfcObservationFitsCeiling (shared helper),
+    // so the egress gate and the observation fits-test cannot drift.
+    const offending = atomsOutsideCeiling(consumed, ceiling);
     if (offending.length > 0) {
       // Name the offending atom(s) so an observe-mode diagnostic identifies the
       // exact (sink, atom) pair that needs a ceiling entry (review on #3993).

--- a/packages/runner/test/cfc-llm-observation-failclosed.test.ts
+++ b/packages/runner/test/cfc-llm-observation-failclosed.test.ts
@@ -6,6 +6,7 @@ import {
   cfcLabelViewForCellWithStatus,
 } from "../src/cfc/label-view.ts";
 import {
+  atomsOutsideCeiling,
   CFC_LABEL_READ_FAILED_ATOM,
   cfcConfidentialityForObservationNode,
   cfcObservationFitsCeiling,
@@ -107,6 +108,31 @@ describe("LLM observation fail-closed on metadata read error (audit 22)", () => 
         ...REAL_CEILING,
       ]),
     ).toBe(false);
+  });
+
+  it("atomsOutsideCeiling owns the same ungrantable-marker rule", () => {
+    // The shared membership helper backs the prepare-time sink-request egress
+    // gate, where it is the ONLY enforcement — if it honored a ceiling that
+    // names the marker, the gate would disagree with cfcObservationFitsCeiling
+    // and a deployment config could allow-list the read-failure taint.
+    expect(
+      atomsOutsideCeiling(
+        [CFC_LABEL_READ_FAILED_ATOM],
+        [CFC_LABEL_READ_FAILED_ATOM, ...REAL_CEILING],
+      ),
+    ).toEqual([CFC_LABEL_READ_FAILED_ATOM]);
+    // Real atoms inside the ceiling stay inside; only the marker is forced out.
+    expect(
+      atomsOutsideCeiling(
+        [CFC_LABEL_READ_FAILED_ATOM, ...REAL_CEILING],
+        [CFC_LABEL_READ_FAILED_ATOM, ...REAL_CEILING],
+      ),
+    ).toEqual([CFC_LABEL_READ_FAILED_ATOM]);
+    // An undefined ceiling is "no bound declared" — nothing is outside it,
+    // marker included, matching cfcObservationFitsCeiling's early return. The
+    // sink gate never consults the helper for an undeclared ceiling.
+    expect(atomsOutsideCeiling([CFC_LABEL_READ_FAILED_ATOM], undefined))
+      .toEqual([]);
   });
 
   it("does NOT over-redact cleanly-unlabelled data (no error → no sentinel)", () => {

--- a/packages/runner/test/cfc-sink-ceiling.test.ts
+++ b/packages/runner/test/cfc-sink-ceiling.test.ts
@@ -6,6 +6,7 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
 import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
+import { CFC_LABEL_READ_FAILED_ATOM } from "../src/cfc/observation.ts";
 import type { SinkMaxConfidentiality } from "../src/cfc/mod.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
 
@@ -27,9 +28,28 @@ const CONFIDENTIAL_SCHEMA = internSchema(
   true,
 );
 
+// The fail-closed read-error marker (audit item 22) stored as a real label, as
+// taint propagation would persist it. Used to prove the egress gate treats it
+// as UNGRANTABLE even when a deployment ceiling explicitly lists it.
+const MARKER_LABELLED_SCHEMA = internSchema(
+  {
+    type: "object",
+    properties: {
+      secret: {
+        type: "string",
+        ifc: { confidentiality: [CFC_LABEL_READ_FAILED_ATOM] },
+      },
+    },
+    required: ["secret"],
+  } satisfies JSONSchema,
+  true,
+);
+
 const seedConfidentialCell = async (
   runtime: Runtime,
   id: string,
+  schema = CONFIDENTIAL_SCHEMA,
+  atoms: readonly unknown[] = ["medical"],
 ): Promise<void> => {
   const seed = runtime.edit();
   const target = runtime.getCell(signer.did(), id, undefined, seed);
@@ -43,12 +63,12 @@ const seedConfidentialCell = async (
     value: { secret: "rosebud" },
     cfc: {
       version: 1,
-      schemaHash: CONFIDENTIAL_SCHEMA.taggedHashString,
+      schemaHash: schema.taggedHashString,
       labelMap: {
         version: 1,
         entries: [{
           path: ["secret"],
-          label: { confidentiality: ["medical"] },
+          label: { confidentiality: [...atoms] },
         }],
       },
     },
@@ -56,9 +76,9 @@ const seedConfidentialCell = async (
   seed.writeOrThrow({
     space: signer.did(),
     scope: "space",
-    id: `cid:${CONFIDENTIAL_SCHEMA.taggedHashString}`,
+    id: `cid:${schema.taggedHashString}`,
     path: [],
-  }, { value: CONFIDENTIAL_SCHEMA.schema });
+  }, { value: schema.schema });
   expect((await seed.commit()).ok).toBeDefined();
 };
 
@@ -68,12 +88,13 @@ const readConfidentialThenSink = (
   runtime: Runtime,
   id: string,
   sink = "fetchData",
+  schema = CONFIDENTIAL_SCHEMA,
 ): { commit: () => Promise<{ ok?: unknown; error?: unknown }> } => {
   const tx = runtime.edit();
   const cell = runtime.getCell(
     signer.did(),
     id,
-    CONFIDENTIAL_SCHEMA.schema,
+    schema.schema,
     tx,
   );
   // Reading the labeled field marks the tx CFC-relevant and records the
@@ -267,6 +288,39 @@ describe("CFC sink-request confidentiality ceiling", () => {
         // With no CFC-relevant activity the boundary check is skipped entirely;
         // either way the public request must commit.
         expect((await tx.commit()).ok).toBeDefined();
+      },
+    );
+  });
+
+  it("rejects the read-failed marker even when the ceiling lists it (ungrantable)", async () => {
+    // CFC_LABEL_READ_FAILED_ATOM is the fail-closed taint for label-read
+    // errors (audit item 22). It is an exported string a deployment config
+    // could name in a sink ceiling — but granting it would re-open the
+    // fail-closed hole, so the egress gate must reject it even when the
+    // ceiling explicitly lists it, exactly like cfcObservationFitsCeiling.
+    await withRuntime(
+      {
+        mode: "enforce-explicit",
+        ceilings: { fetchData: [CFC_LABEL_READ_FAILED_ATOM, "medical"] },
+      },
+      async (runtime) => {
+        await seedConfidentialCell(
+          runtime,
+          "sink-ceiling-ungrantable",
+          MARKER_LABELLED_SCHEMA,
+          [CFC_LABEL_READ_FAILED_ATOM],
+        );
+        const { commit } = readConfidentialThenSink(
+          runtime,
+          "sink-ceiling-ungrantable",
+          "fetchData",
+          MARKER_LABELLED_SCHEMA,
+        );
+        const result = await commit();
+        expect(result.error).toBeDefined();
+        expect(String((result.error as Error).message)).toContain(
+          "exceeds ceiling for fetchData",
+        );
       },
     );
   });

--- a/packages/runner/test/llm-dialog.test.ts
+++ b/packages/runner/test/llm-dialog.test.ts
@@ -2100,6 +2100,150 @@ describe("llmDialog", () => {
       },
     });
   });
+
+  it("bounds tool-loop follow-up turns by the deployment sink ceiling (#3993 review)", async () => {
+    // A tool-bearing dialog reads a labeled cell during a follow-up turn. The
+    // pattern declares a generous observation bound (["internal"]), so without a
+    // deployment ceiling the internal note would ship to the LLM in turn 2 — the
+    // initial-request ceiling never gates these post-commit tool reads. With a
+    // deployment ceiling of llmDialog: [] (public-only) the effective bound must
+    // collapse to [] (pattern ∧ deployment) and the note must be redacted.
+    const secret = "internal-only-secret-payload";
+
+    let turn2Request: { messages: readonly BuiltInLLMMessage[] } | undefined;
+    addMockResponse(
+      (req) => req.messages.length === 1 && req.tools?.["readInternal"] !== undefined,
+      {
+        role: "assistant",
+        content: [{
+          type: "tool-call",
+          toolCallId: "call_read_internal_ceiling",
+          toolName: "readInternal",
+          input: {},
+        }],
+        id: "ceiling-turn-1",
+      },
+    );
+    addMockResponse(
+      (req) => {
+        const matches = req.messages.some((m) =>
+          m.role === "tool" && Array.isArray(m.content) &&
+          m.content.some((c: any) =>
+            c.type === "tool-result" && c.toolName === "readInternal"
+          )
+        );
+        if (matches) {
+          turn2Request = { messages: req.messages };
+        }
+        return matches;
+      },
+      {
+        role: "assistant",
+        content: "Done.",
+        id: "ceiling-turn-2",
+      },
+    );
+
+    const resultSchema = {
+      type: "object",
+      properties: {
+        addMessage: { ...LLMMessageSchema, asCell: ["stream"] },
+        pending: { type: "boolean" },
+        messages: {
+          type: "array",
+          items: { type: "object", additionalProperties: true },
+        },
+      },
+      required: ["addMessage"],
+    } as const satisfies JSONSchema;
+
+    const readInternal = pattern(
+      () => {
+        return { note: secret };
+      },
+      { type: "object" },
+      {
+        type: "object",
+        properties: { note: { type: "string" } },
+        required: ["note"],
+        ifc: { confidentiality: ["internal"] },
+      } as const satisfies JSONSchema,
+    );
+
+    const ceilingStorageManager = StorageManager.emulate({ as: signer });
+    const ceilingRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: ceilingStorageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      // Deployment ceiling: the llmDialog sink may carry no confidentiality.
+      cfcSinkMaxConfidentiality: { llmDialog: [] },
+    });
+    const ceilingTx = ceilingRuntime.edit();
+    const { commonfabric } = createTrustedBuilder(ceilingRuntime);
+
+    try {
+      const testPattern = commonfabric.pattern(
+        () => {
+          const messages = commonfabric.Cell.of<BuiltInLLMMessage[]>([]);
+          const dialog = commonfabric.llmDialog({
+            messages,
+            // Generous pattern-supplied bound — would let "internal" ship.
+            observationMaxConfidentiality: ["internal"],
+            tools: {
+              readInternal: commonfabric.patternTool(
+                readInternal,
+              ) as unknown as BuiltInLLMTool,
+            },
+          });
+          return {
+            addMessage: dialog.addMessage,
+            pending: dialog.pending,
+            messages,
+          };
+        },
+        false,
+        resultSchema,
+      );
+
+      const resultCell = ceilingRuntime.getCell(
+        space,
+        "llmDialog-sink-ceiling-tool-loop-test",
+        resultSchema,
+        ceilingTx,
+      );
+
+      const result = ceilingRuntime.run(ceilingTx, testPattern, {}, resultCell);
+      ceilingTx.commit();
+
+      const addMessage = await result.key("addMessage").pull();
+      addMessage.send({ role: "user", content: "Read the briefing." });
+
+      // user, assistant(tool-call), tool(result), assistant(final).
+      await expect(waitForMessages(result, 4)).resolves.toBeUndefined();
+
+      const messages = (await result.key("messages").pull())!;
+      const toolMessage = messages[2];
+      expect(toolMessage.role).toBe("tool");
+      // The tool EXECUTED (it was not denied and did not error) — the leak is
+      // prevented by redacting its labeled result to an opaque link, so a
+      // failed invocation must not masquerade as a successful redaction.
+      const output = (toolMessage.content as any)[0].output;
+      expect(output.type).toBe("json");
+      expect(JSON.stringify(output.value)).toContain("@link");
+      const toolText = JSON.stringify(toolMessage.content);
+      // The secret must not appear in the tool-result that feeds turn 2.
+      expect(toolText).not.toContain(secret);
+
+      // And the actual follow-up request the LLM saw must not carry it either.
+      expect(turn2Request).toBeDefined();
+      expect(JSON.stringify(turn2Request!.messages)).not.toContain(secret);
+    } finally {
+      await ceilingTx.commit();
+      await ceilingRuntime.idle();
+      await ceilingRuntime.dispose();
+      await ceilingStorageManager.close();
+    }
+  });
 });
 
 function waitForMessages(result: any, expectedCount: number) {

--- a/packages/runner/test/llm-dialog.test.ts
+++ b/packages/runner/test/llm-dialog.test.ts
@@ -2112,7 +2112,8 @@ describe("llmDialog", () => {
 
     let turn2Request: { messages: readonly BuiltInLLMMessage[] } | undefined;
     addMockResponse(
-      (req) => req.messages.length === 1 && req.tools?.["readInternal"] !== undefined,
+      (req) =>
+        req.messages.length === 1 && req.tools?.["readInternal"] !== undefined,
       {
         role: "assistant",
         content: [{


### PR DESCRIPTION
Follow-up to #3993 (post-merge review). Audit item 21 added a host-configured per-sink confidentiality ceiling (`Runtime({ cfcSinkMaxConfidentiality })` → `verifySinkRequestCeilings` in `prepare.ts`). This PR addresses the verified post-merge review findings.

## Finding 1 — [major] LLM tool-loop follow-up turns bypassed the ceiling (shipped option **b**)

The ceiling gated only the **initial** recorded request snapshot. An LLM tool loop runs **post-commit**: `executeToolCalls` reads cells — including labeled ones — in fresh transactions that carry no `sink-request` input, so `prepareBoundaryCommit` never sees them, then ships the results to the model via `client.sendRequest` with no ceiling consultation. The only bound was `observationMaxConfidentiality`, which is **pattern-supplied** (adversary-controlled, unbounded when omitted). Once a deployment declared an LLM ceiling, a tool-bearing pattern could still exfiltrate any readable labeled cell on turn 2.

**Fix (option b — meet):** fold the deployment ceiling into the effective observation bound where it is computed — `effective = pattern-supplied ∧ deployment ceiling` for that sink (intersection of allowlists via the new `meetCfcObservationCeilings`). Pattern omitted → deployment ceiling alone; no deployment ceiling for that sink → pattern bound alone (unchanged); declared-empty deployment ceiling → public-only regardless of the pattern bound (respects `cfcObservationFitsCeiling`'s "declared-empty = public-only" rule). The effective bound flows into the context docs, the tool loop, and the direct path, so every value reaching the model is redacted to it. Applied at **all** LLM tool-loop send sites: `llm()`, `generateText()`, `generateObject()` (`llm.ts`) and `materializeDialogRequestSnapshot` + `startRequest` (`llm-dialog.ts`).

The meet **composes soundly** with the existing redaction (`serializeForLLMObservation` → `cfcObservationFitsCeiling`), so option b held — no fallback to option a/c was needed.

**Also fixed a latent bug the meet exposes:** the `cellsDocs`/value-read sites keyed observation-aware serialization on `observationMaxConfidentiality.length > 0`, which treats the declared-empty "public only" bound (exactly what an empty deployment ceiling folds in) as "no bound" and disables redaction precisely when the strictest bound is set. Now engages observation-aware serialization whenever the bound is **declared** (`!== undefined`).

**Red→green:** new test `bounds tool-loop follow-up turns by the deployment sink ceiling` in `llm-dialog.test.ts`. A tool-bearing `llmDialog` declares a generous pattern bound (`["internal"]`); a tool reads an `internal`-labeled cell. Under deployment ceiling `{ llmDialog: [] }` the effective bound collapses to `[]`.
- **RED** at the inherited baseline (fix stashed): the secret shipped — `AssertionError: '…"note":"internal-only-secret-payload"…' doesn't contain "@link"`.
- **GREEN** with the fix: the tool result is redacted to an opaque `@link`, the secret appears in neither the tool-result message nor the follow-up `sendRequest`. The test also asserts the tool **executed** (json result with `@link`) rather than being denied/errored, so a failed invocation can't masquerade as redaction.

## Finding 2 — [minor] Duplicated core machinery (fixed)

`prepare.ts` re-implemented `uniqueCfcAtoms` (the deep-equal dedup) and the offending-atom filter (the membership complement of `cfcObservationFitsCeiling`). Extracted a shared `atomsOutsideCeiling(atoms, ceiling)` next to `cfcObservationFitsCeiling`; `verifySinkRequestCeilings` now uses it and `collectConsumedConfidentiality` uses `uniqueCfcAtoms`. Pure refactor; `cfc-sink-ceiling.test.ts` stays green.

## Finding 3 — [minor] No end-to-end test through a real builtin (**skipped, with a discovered gap**)

I attempted the requested integration case (real `fetchData` action with a labeled cell linked into `options`, ceiling `{ fetchData: [] }`, assert commit rejected + fetch never fires) and **the rejection does not occur** — but not because the gate is broken. Instrumented trace:

- The fetchData input materialization (`inputsCell.asSchema(fetchDataInputSchema).get()`) **resolves the labeled value** through the link (snapshot carried `"rosebud"`), but `tx.getCfcState().relevant === false` afterward.
- That read path does **not** go through the `schemaHasIfc(schema) || storedCfcMetadataAppliesToPath(tx, resolvedLink)` relevance gate in `schema.ts` that label-aware reads use (`storedCfcMetadataAppliesToPath` is never consulted for the labeled source). The generic `fetchDataInputSchema` carries no `ifc`, and the cross-link schema isn't combined in.
- With the tx not CFC-relevant, `prepareTxForCommit` skips `prepareCfc()`, so `prepareBoundaryCommit`/`verifySinkRequestCeilings` never run — even with `{ fetchData: [] }`, the fetch fired with the secret in headers.

This is a **separate, pre-existing soundness gap** (the *initial* sink request, not the tool loop): a labeled value pulled through a schema-less link into a sink's request escapes the ceiling because the consuming transaction is never marked CFC-relevant. It is orthogonal to this PR's tool-loop focus and would need a foundational relevance-marking change on link-resolved reads (broad blast radius across every sink). I did **not** ship a test asserting a rejection that does not happen. The existing direct tests in `cfc-sink-ceiling.test.ts` already cover "real labeled read (with its labeled schema, marking relevance) + real `fetchData` `sink-request` input → rejected at the gate," so the gate itself is exercised; only the builtin-internal read path under-marks relevance. Flagging the gap separately for its own task.

## Finding 4 — [nit] Prototype-chain lookup armor (fixed)

`verifySinkRequestCeilings` did `ceilings[input.sink]` on an `Object.fromEntries` object; a sink named like an `Object.prototype` member would resolve an inherited function and throw at `.some`. Now guarded with `Object.hasOwn(ceilings, input.sink)` → treated as "no ceiling declared".

## Verification

`deno check` clean on every touched file. Touched suites (run via packages/runner's `deno.json`, `ENV=test deno test …`): `cfc-sink-ceiling` 7/7, `llm-dialog` 18/18, `llm-dialog-helpers` 51/51, `generate-object-tools` 20/20, plus `cfc-observation`, `cfc-ceiling-empty`, `cfc-tool-ceiling-empty`, `cfc-sink-inventory`, `cfc-sink-request-policy`, `cfc-sink-release-reject-surfaced`, `cfc-runtime-options`, `cfc-llm-observation-failclosed`, `cfc-boundary`, `cfc-prepare-bypass`, `cfc-label-view`, `cfc-flow-labels`, and the generate-text/object/llm outbox + smoke suites — all green. Rebased onto current `origin/main` and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound all LLM tool-loop follow-up turns to the deployment’s per-sink confidentiality ceiling by intersecting the pattern’s observation bound with the deployment ceiling across `llm`, `generateText`, `generateObject`, and `llmDialog`. Also make the read-failed marker ungrantable and ensure declared-empty ceilings enforce public-only.

- **Bug Fixes**
  - Meet-combine the effective bound (`pattern ∧ deployment`) via `meetCfcObservationCeilings` in `llm()`, `generateText()`, `generateObject()`, and `llmDialog` snapshot/start so all model-bound values are redacted to it.
  - Engage observation-aware serialization whenever a bound is declared (including `[]`), not only when `length > 0`.
  - Treat `CFC_LABEL_READ_FAILED_ATOM` as ungrantable in `atomsOutsideCeiling`; `cfcObservationFitsCeiling` now delegates membership to it, so redaction and the sink-request gate agree; a ceiling that lists the marker is still rejected.
  - Guard per-sink ceiling lookup with `Object.hasOwn` to avoid prototype-chain collisions.
  - Tests: `bounds tool-loop follow-up turns by the deployment sink ceiling`; `atomsOutsideCeiling owns the same ungrantable-marker rule`; `rejects the read-failed marker even when the ceiling lists it (ungrantable)`.

- **Refactors**
  - Extract `atomsOutsideCeiling` to share ceiling-membership semantics with `cfcObservationFitsCeiling`; route `verifySinkRequestCeilings` through it, and use `uniqueCfcAtoms` for dedup in `collectConsumedConfidentiality`.

<sup>Written for commit 25230a18ebc3e80067fa1bd6ed1ad738b9bd8814. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

