### PR TITLE
fix(fuse): sync piece NAME before naming mounted piece dirs (CI fuse-exec timeout since #3911)

### DIFF
--- a/packages/cli/integration/fuse-exec.sh
+++ b/packages/cli/integration/fuse-exec.sh
@@ -2,12 +2,36 @@
 set -euo pipefail
 
 export LOG_TO_STDERR=1
+# Surface piece-list build/sync diagnostics in the daemon log; without this a
+# "piece dir never appeared" timeout gives no signal about what the daemon saw.
+export CF_FUSE_DEBUG=1
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
 error() {
   >&2 echo "ERROR: $1"
+  dump_mount_state
   exit 1
+}
+
+# On failure, show what the mounted tree actually contains so "path never
+# appeared" failures distinguish an empty piece list from a misnamed entry.
+dump_mount_state() {
+  if [ -z "${MOUNTPOINT:-}" ] || [ -z "${SPACE:-}" ]; then
+    return 0
+  fi
+  local pieces_dir="$MOUNTPOINT/$SPACE/pieces"
+  >&2 echo "--- mount state dump ---"
+  if path_exists "$pieces_dir" 2; then
+    >&2 ls -la "$pieces_dir" 2>&1 || true
+    if path_exists "$pieces_dir/pieces.json" 2; then
+      >&2 echo "--- pieces.json ---"
+      >&2 cat "$pieces_dir/pieces.json" 2>&1 || true
+    fi
+  else
+    >&2 echo "(pieces dir not reachable: $pieces_dir)"
+  fi
+  >&2 echo "--- end mount state dump ---"
 }
 
 success() {

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -190,6 +190,7 @@ type SubscribePiece = (
   pieceIno: bigint,
   pieceName: string,
   spaceName: string,
+  state: unknown,
 ) => Promise<Array<() => void>>;
 
 type HydratePieceProp = (
@@ -1352,6 +1353,54 @@ Deno.test("CellBridge.addPieceToSpace assigns -2 suffix on name collision", asyn
   assertEquals(tree.lookup(state.piecesIno, "My-Note-2") !== undefined, true);
 });
 
+// Regression: on a cold runtime the piece list doesn't load the linked piece
+// docs, so a synchronous piece.name() read returns undefined until the NAME
+// doc is synced. addPieceToSpace must await that sync before choosing the
+// directory name — otherwise the piece mounts under the opaque id-derived
+// fallback name, permanently if no later change event fires (CI fuse-exec
+// "Timed out waiting for path: pieces/Fuse-Exec-Fixture").
+Deno.test("CellBridge.addPieceToSpace syncs a late-loading name before naming the directory", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "home", []);
+
+  // name() returns undefined until getCell().asSchema(...).sync() resolves —
+  // mirroring PieceController.name() reading a doc that loads asynchronously.
+  let nameLoaded = false;
+  const piece = {
+    id: "of:cold-start",
+    name: () => (nameLoaded ? "Fuse Exec Fixture" : undefined),
+    getCell: () => ({
+      asSchema: () => ({
+        sync: () => {
+          nameLoaded = true;
+          return Promise.resolve();
+        },
+      }),
+    }),
+    getPatternMeta: () => Promise.resolve({ patternName: "fixture" }),
+    input: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+    result: {
+      getCell: () => Promise.resolve(makeCell({}, undefined)),
+      get: () => Promise.resolve({}),
+    },
+  };
+
+  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
+    .addPieceToSpace.bind(bridge);
+  const name = await addPiece(state, piece, "home");
+
+  assertEquals(name, "Fuse-Exec-Fixture");
+  assertEquals(
+    tree.lookup(state.piecesIno, "Fuse-Exec-Fixture") !== undefined,
+    true,
+    "piece dir should use the synced name, not the id fallback",
+  );
+});
+
 Deno.test("CellBridge.addPieceToSpace assigns -2 and -3 suffixes for three collisions", async () => {
   const tree = new FsTree();
   const bridge = new CellBridge(tree, "/tmp/cf-exec");
@@ -1888,6 +1937,7 @@ Deno.test({
         tree.lookup(state.piecesIno, "Old-Name")!,
         "Old-Name",
         "home",
+        state,
       );
 
     // Store updated subs
@@ -2031,6 +2081,7 @@ Deno.test({
         tree.lookup(state.piecesIno, "Start-Here")!,
         "Start-Here",
         "home",
+        state,
       );
 
     state.pieceSubs.set("Start-Here", subs);

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -1998,7 +1998,13 @@ export class CellBridge {
     piece: PieceController,
     spaceName: string,
   ): Promise<string> {
-    let name = resolveProjectedPieceName(piece.name(), piece.id);
+    const rawName = piece.name();
+    let name = resolveProjectedPieceName(rawName, piece.id);
+    this.debugLog(
+      `[${spaceName}] addPieceToSpace: id=${piece.id} rawName=${
+        JSON.stringify(rawName)
+      } resolved=${name}`,
+    );
     if (state.usedNames.has(name)) {
       let suffix = 2;
       while (state.usedNames.has(`${name}-${suffix}`)) suffix++;
@@ -2151,6 +2157,9 @@ export class CellBridge {
     spaceName: string,
   ): Promise<void> {
     const allPieces = await state.pieces.getAllPieces();
+    this.debugLog(
+      `[${spaceName}] syncPieceListOnce: live=${allPieces.length} tracked=${state.pieceMap.size}`,
+    );
 
     // Build set of current entity IDs
     const liveIds = new Set(allPieces.map((p) => p.id));

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -6,6 +6,7 @@
 
 import type { Cell, PatternMeta } from "@commonfabric/runner";
 import { schemaToTypeString } from "@commonfabric/runner";
+import { nameSchema } from "@commonfabric/runner/schemas";
 import { cfcLabelViewForCell } from "@commonfabric/runner/cfc";
 import {
   type CfcLabel,
@@ -1898,6 +1899,10 @@ export class CellBridge {
     const allPieces = await pieces.getAllPieces();
     this.debugLog(`[${spaceName}] Found ${allPieces.length} pieces`);
 
+    // Warm the NAME docs in parallel so the awaited per-piece name sync in
+    // addPieceToSpace below doesn't serialize one roundtrip per piece.
+    await Promise.all(allPieces.map((piece) => this.syncPieceName(piece)));
+
     for (const piece of allPieces) {
       await this.addPieceToSpace(state, piece, spaceName);
     }
@@ -1990,6 +1995,22 @@ export class CellBridge {
   }
 
   /**
+   * Best-effort load of a piece's NAME doc through the same schema path that
+   * `piece.name()` reads synchronously. The piece list deliberately doesn't
+   * load linked piece docs (its items are `asCell`), so on a cold runtime
+   * `piece.name()` races the doc load and would fall back to the opaque
+   * id-derived directory name — permanently, if no later change event fires.
+   */
+  private async syncPieceName(piece: PieceController): Promise<void> {
+    if (typeof piece.getCell !== "function") return;
+    try {
+      await (piece.getCell() as Cell<unknown>).asSchema(nameSchema).sync();
+    } catch {
+      // Name stays unavailable; addPieceToSpace falls back to the piece id.
+    }
+  }
+
+  /**
    * Add a single piece to a space's tree.
    * Returns the assigned display name.
    */
@@ -1998,6 +2019,13 @@ export class CellBridge {
     piece: PieceController,
     spaceName: string,
   ): Promise<string> {
+    // The piece list deliberately doesn't load the linked piece docs
+    // (pieceListSchema items are `asCell`), so on a cold runtime the
+    // synchronous `piece.name()` read races the doc load and the directory
+    // would be created under the opaque id-derived fallback name — and never
+    // renamed if no further change event arrives. Await the NAME through the
+    // same schema path `name()` reads before choosing the directory name.
+    await this.syncPieceName(piece);
     const rawName = piece.name();
     let name = resolveProjectedPieceName(rawName, piece.id);
     this.debugLog(
@@ -2027,7 +2055,13 @@ export class CellBridge {
     await this.buildSourceTree(pieceIno, piece, state, name);
     await this.refreshPieceManifest(state, piece);
 
-    const subs = await this.subscribePiece(piece, pieceIno, name, spaceName);
+    const subs = await this.subscribePiece(
+      piece,
+      pieceIno,
+      name,
+      spaceName,
+      state,
+    );
     state.pieceSubs.set(name, subs);
 
     // Create a lightweight stub entity dir so `ls entities/` shows stable IDs
@@ -2780,6 +2814,7 @@ export class CellBridge {
     pieceIno: bigint,
     pieceName: string,
     spaceName: string,
+    state: SpaceState,
   ): Promise<Cancel[]> {
     const cancels: Cancel[] = [];
 
@@ -2857,8 +2892,14 @@ export class CellBridge {
       const cancelRootSub = nameTrackingCell.sink((newValue: unknown) => {
         setTimeout(() => {
           try {
-            const state = this.spaces.get(spaceName);
-            if (!state) return;
+            // Use the state captured at subscription time, NOT
+            // this.spaces.get(): during the initial buildSpaceTree the space
+            // isn't registered in this.spaces yet, so a lookup would silently
+            // drop every name event that fires while the tree is being built
+            // (and a static piece may never fire again). Only bail if the
+            // space has since been disconnected or replaced.
+            const registered = this.spaces.get(spaceName);
+            if (registered !== undefined && registered !== state) return;
 
             // Find the piece's current FUSE name by searching pieceMap.
             let currentName: string | undefined;

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -327,7 +327,10 @@ export async function main(argv: string[] = Deno.args) {
     };
   }
 
-  const debug = args.debug;
+  // CF_FUSE_DEBUG=1 enables debug logging even when --debug isn't passed.
+  // The background supervisor doesn't forward --debug to the daemon child,
+  // but env vars are inherited, so this is the reliable switch in CI.
+  const debug = args.debug || Deno.env.get("CF_FUSE_DEBUG") === "1";
   const requestedCfcMode = String(args["cfc-mode"] ?? "");
   if (requestedCfcMode && !parseCfcMode(requestedCfcMode)) {
     console.warn(

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -199,7 +199,13 @@ export class PieceManager {
   async getPieces(): Promise<Cell<Cell<unknown>[]>> {
     const defaultPattern = await this.getDefaultPattern(true);
     if (!defaultPattern) {
-      // Return empty array cell if no default pattern
+      // Return empty array cell if no default pattern. Loud on purpose: any
+      // subscription made against this placeholder never fires again, so a
+      // cold-cache miss here silently freezes piece listings (e.g. FUSE).
+      console.warn(
+        `getPieces: no default pattern found for space ${this.space}; ` +
+          "returning detached empty piece list",
+      );
       return this.runtime.getCell(this.space, "empty-pieces", pieceListSchema);
     }
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -872,6 +872,19 @@ export class Runner {
         ? descriptor.schema.default as JSONValue | undefined
         : undefined;
       if (currentValue === undefined && schemaDefault !== undefined) {
+        if (manifestMatch !== -1) {
+          // The manifest already references this cell (a previous run
+          // materialized it), yet it reads undefined here — on a cold cache
+          // this usually means the doc just isn't loaded, and writing the
+          // default would clobber persisted state (CT-1666 class of bug).
+          logger.warn("internal-default-over-manifest", () => [
+            `materializeDerivedInternalCells: applying schema default over`,
+            `undefined for existing manifest entry`,
+            `partialCause=${JSON.stringify(descriptor.partialCause)}`,
+            `cell=${derivedCell.getAsNormalizedFullLink().id}`,
+            `result=${resultCell.getAsNormalizedFullLink().id}`,
+          ]);
+        }
         derivedCell.setRawUntyped(fabricFromNativeValue(schemaDefault));
       }
     }


### PR DESCRIPTION
## Problem

"CLI Integration Tests (fuse)" failed on ~5 of 6 main runs since #3911 (every run before it passed), blocking unrelated PRs: the daemon mounts cleanly, `pieces/` appears, but `pieces/Fuse-Exec-Fixture` never materializes within the 20s wait.

## Root cause (captured in CI by the diagnostics commit)

The instrumented failing run showed:

```
[R76liJsDxB] Found 1 pieces
[R76liJsDxB] addPieceToSpace: id=fid1:4bv8… rawName=undefined resolved=fid1-4bv8…
```

and the mount-state dump showed the piece mounted under the id-derived fallback name.

Two layered defects in `packages/fuse/cell-bridge.ts`:

1. **Cold-start name race.** The piece list deliberately doesn't load linked piece docs (`pieceListSchema` items are `asCell` — "we don't want to recursively load them"), so `addPieceToSpace`'s synchronous `piece.name()` read races the piece-doc load. #3911's internal-manifest indirection on the `allPieces` read path made the race reliably lose on cold CI runtimes (it happens to win locally, which is why the suite passes on macOS).
2. **Silent rename-sink drop.** The `[NAME]`-change sink that should heal a misnamed dir resolves its `SpaceState` via `this.spaces.get(spaceName)` — which isn't registered until `buildSpaceTree` returns. Every event fired during the initial build is silently dropped, and a static piece never fires again, so the fallback name is permanent.

## Fix

- `addPieceToSpace` awaits `syncPieceName()` — loads NAME through the same schema path `name()` reads — before choosing the directory name; `buildSpaceTree` warms all names in parallel so mounts don't serialize N roundtrips.
- The rename sink uses the `SpaceState` captured at subscription time (with a liveness check against `this.spaces`).

Regression test simulates the late-loading name and is red without the fix.

The diagnostics from the first commit stay: `CF_FUSE_DEBUG=1` daemon logging (the `--debug` flag isn't forwarded to the background child), mount-state dump on test failure, a warning when `PieceManager.getPieces` falls back to the detached `empty-pieces` placeholder, and a CT-1666-class tripwire warning in `materializeDerivedInternalCells` (neither warning fired in the captured failure — the internal-state clobber theory was ruled out).

## Verification

- New regression test red→green; `packages/fuse` suite: 197 passed.
- `fuse-exec.sh` passes locally (source mode and compiled binary, including through a 60ms-per-chunk latency proxy).
- Fuse CI job on this PR: **passed** on the fix commit (vs ~1-in-6 pass rate on main). Will rerun for additional samples once the workflow completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)