### PR TITLE
feat(runner,llm,runtime-client,ui): route space-bound compute to the space's host

### DIFF
--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -312,6 +312,7 @@ export class RuntimeInternals extends EventTarget {
   }
 
   async uploadBlob(options: {
+    space: DID;
     contentType: string;
     body: Uint8Array;
     suffix?: string;

--- a/packages/llm/src/client.ts
+++ b/packages/llm/src/client.ts
@@ -442,6 +442,15 @@ export class LLMClient {
   async generateObject(
     request: LLMGenerateObjectRequest,
     abortSignal?: AbortSignal,
+    opts?: {
+      /**
+       * Full LLM endpoint URL for THIS call (e.g.
+       * `new URL("/api/ai/llm", host)`); the module-level default
+       * (setLLMUrl) is the fallback. Lets one runtime route per-space
+       * work to that space's host.
+       */
+      endpoint?: string | URL;
+    },
   ): Promise<LLMGenerateObjectResponse> {
     // Check for mock mode
     if (mockCatalog.isEnabled()) {
@@ -461,7 +470,8 @@ export class LLMClient {
       throw new Error(TEST_GUARD_MESSAGE);
     }
 
-    const response = await fetch(llmApiUrl + "/generateObject", {
+    const endpoint = opts?.endpoint?.toString() ?? llmApiUrl;
+    const response = await fetch(endpoint + "/generateObject", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(request),
@@ -500,6 +510,10 @@ export class LLMClient {
     request: LLMRequest,
     callback?: PartialCallback,
     abortSignal?: AbortSignal,
+    opts?: {
+      /** Per-call LLM endpoint; module-level default is the fallback. */
+      endpoint?: string | URL;
+    },
   ): Promise<LLMResponse> {
     if (request.stream && !callback) {
       throw new Error(
@@ -549,7 +563,7 @@ export class LLMClient {
       throw new Error(TEST_GUARD_MESSAGE);
     }
 
-    const response = await fetch(llmApiUrl, {
+    const response = await fetch(opts?.endpoint?.toString() ?? llmApiUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(request),

--- a/packages/runner/src/builtins/fetch-data.ts
+++ b/packages/runner/src/builtins/fetch-data.ts
@@ -358,8 +358,14 @@ async function startFetch(
   // Body preprocessing (stringify non-string bodies) is handled by the
   // snapshotInputs callback in tryClaimMutex, so options is ready to use.
   try {
+    // Relative URLs resolve against the executing space's host when the
+    // space is host-mapped (federation: one runtime spans hosts). An
+    // unmapped space keeps the pattern environment's api base — which on
+    // some deployments (toolshed) deliberately differs from the runtime's
+    // default memory host, so hostForSpace's fallback is NOT used here.
+    const mappedHost = runtime.spaceHostMap?.[inputsCell.space];
     const response = await fetch(
-      new URL(url, getPatternEnvironment().apiUrl),
+      new URL(url, mappedHost ?? getPatternEnvironment().apiUrl),
       {
         signal: abortSignal,
         ...options,

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -2989,7 +2989,10 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
     };
 
   // TODO(bf): sendRequest must be given a callback, even if it does nothing
-  const doWork = () => client.sendRequest(llmParams, () => {}, abortSignal);
+  const doWork = () =>
+    client.sendRequest(llmParams, () => {}, abortSignal, {
+      endpoint: new URL("/api/ai/llm", runtime.hostForSpace(space)),
+    });
 
   const resultPromise = queueName
     ? runtime.getOrCreateQueue(queueName).enqueue(doWork)

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -2989,10 +2989,16 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
     };
 
   // TODO(bf): sendRequest must be given a callback, even if it does nothing
+  const mappedLlmHost = runtime.spaceHostMap?.[space];
   const doWork = () =>
-    client.sendRequest(llmParams, () => {}, abortSignal, {
-      endpoint: new URL("/api/ai/llm", runtime.hostForSpace(space)),
-    });
+    client.sendRequest(
+      llmParams,
+      () => {},
+      abortSignal,
+      mappedLlmHost
+        ? { endpoint: new URL("/api/ai/llm", mappedLlmHost) }
+        : undefined,
+    );
 
   const resultPromise = queueName
     ? runtime.getOrCreateQueue(queueName).enqueue(doWork)

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -227,13 +227,20 @@ async function executeWithToolsLoop(params: {
       requestParams.tools = toolCatalog.llmTools;
     }
 
-    // Route the call to the executing space's host — one runtime spans
-    // hosts, and an LLM call belongs to the space whose pattern made it.
+    // Route the call to the executing space's host when the space is
+    // host-mapped (one runtime spans hosts; an LLM call belongs to the
+    // space whose pattern made it). An UNMAPPED space keeps the
+    // module-level default endpoint — like fetch-data, hostForSpace's
+    // apiUrl fallback is NOT used, because deployments may split the
+    // pattern-facing api host from the runtime's memory host.
+    const mappedLlmHost = runtime.spaceHostMap?.[space];
     const llmResult = await client.sendRequest(
       requestParams,
       updatePartial,
       undefined,
-      { endpoint: new URL("/api/ai/llm", runtime.hostForSpace(space)) },
+      mappedLlmHost
+        ? { endpoint: new URL("/api/ai/llm", mappedLlmHost) }
+        : undefined,
     );
 
     if (thisRun !== getCurrentRun()) return;
@@ -1342,16 +1349,15 @@ export function generateObject<T extends Record<string, unknown>>(
                   messages: currentMessages,
                 };
 
+                const mappedLlmHost = runtime
+                  .spaceHostMap?.[parentCell.space];
                 const llmResult = await client.sendRequest(
                   requestParams,
                   updatePartial,
                   undefined,
-                  {
-                    endpoint: new URL(
-                      "/api/ai/llm",
-                      runtime.hostForSpace(parentCell.space),
-                    ),
-                  },
+                  mappedLlmHost
+                    ? { endpoint: new URL("/api/ai/llm", mappedLlmHost) }
+                    : undefined,
                 );
 
                 if (isRunCancelled()) return;
@@ -1649,6 +1655,8 @@ export function generateObject<T extends Record<string, unknown>>(
                 ...liveContextDocs.observedConfidentiality,
               ]).length,
             });
+            const mappedLlmHost = runtime
+              .spaceHostMap?.[parentCell.space];
             const response = await client.generateObject(
               {
                 ...generateObjectParams,
@@ -1656,12 +1664,9 @@ export function generateObject<T extends Record<string, unknown>>(
                   "You are a helpful assistant.",
               },
               undefined,
-              {
-                endpoint: new URL(
-                  "/api/ai/llm",
-                  runtime.hostForSpace(parentCell.space),
-                ),
-              },
+              mappedLlmHost
+                ? { endpoint: new URL("/api/ai/llm", mappedLlmHost) }
+                : undefined,
             ) as {
               object: T;
             };

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -227,7 +227,14 @@ async function executeWithToolsLoop(params: {
       requestParams.tools = toolCatalog.llmTools;
     }
 
-    const llmResult = await client.sendRequest(requestParams, updatePartial);
+    // Route the call to the executing space's host — one runtime spans
+    // hosts, and an LLM call belongs to the space whose pattern made it.
+    const llmResult = await client.sendRequest(
+      requestParams,
+      updatePartial,
+      undefined,
+      { endpoint: new URL("/api/ai/llm", runtime.hostForSpace(space)) },
+    );
 
     if (thisRun !== getCurrentRun()) return;
 
@@ -1338,6 +1345,13 @@ export function generateObject<T extends Record<string, unknown>>(
                 const llmResult = await client.sendRequest(
                   requestParams,
                   updatePartial,
+                  undefined,
+                  {
+                    endpoint: new URL(
+                      "/api/ai/llm",
+                      runtime.hostForSpace(parentCell.space),
+                    ),
+                  },
                 );
 
                 if (isRunCancelled()) return;
@@ -1635,11 +1649,20 @@ export function generateObject<T extends Record<string, unknown>>(
                 ...liveContextDocs.observedConfidentiality,
               ]).length,
             });
-            const response = await client.generateObject({
-              ...generateObjectParams,
-              system: ((system ?? "") + liveContextDocs.docs).trim() ||
-                "You are a helpful assistant.",
-            }) as {
+            const response = await client.generateObject(
+              {
+                ...generateObjectParams,
+                system: ((system ?? "") + liveContextDocs.docs).trim() ||
+                  "You are a helpful assistant.",
+              },
+              undefined,
+              {
+                endpoint: new URL(
+                  "/api/ai/llm",
+                  runtime.hostForSpace(parentCell.space),
+                ),
+              },
+            ) as {
               object: T;
             };
             logGenerateObject("client-generateObject-complete", {

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -389,7 +389,13 @@ export class Runtime {
         );
       }
     }
-    this.spaceHostMap = options.spaceHostMap;
+    // Snapshot + freeze: the map is fixed for the runtime's lifetime
+    // (the per-space provider cache and routing decisions assume
+    // space → host never changes), so a caller mutating their object
+    // after construction must not change routing.
+    this.spaceHostMap = options.spaceHostMap
+      ? Object.freeze({ ...options.spaceHostMap })
+      : undefined;
     this.staticCache = isDeno()
       ? new StaticCacheFS()
       : new StaticCacheHTTP(new URL("/static", this.apiUrl));

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -376,6 +376,19 @@ export class Runtime {
 
     this.id = options.storageManager.id;
     this.apiUrl = new URL(options.apiUrl);
+    // Validate eagerly, mirroring the storage layer's resolver: a
+    // malformed host should fail at configuration time naming the
+    // space, not mid-builtin as a bare Invalid URL.
+    for (const [space, host] of Object.entries(options.spaceHostMap ?? {})) {
+      try {
+        new URL(host);
+      } catch (cause) {
+        throw new Error(
+          `Invalid spaceHostMap entry for ${space}: "${host}"`,
+          { cause },
+        );
+      }
+    }
     this.spaceHostMap = options.spaceHostMap;
     this.staticCache = isDeno()
       ? new StaticCacheFS()

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -188,6 +188,14 @@ export interface ExperimentalOptions {
 
 export interface RuntimeOptions {
   apiUrl: URL;
+  /**
+   * Optional space DID → host base URL map (federation). Space-bound
+   * work (LLM calls, fetches, blob uploads) for a mapped space targets
+   * that host; absent map or entry ⇒ `apiUrl`. Mirrors the storage
+   * layer's map (StorageManager Options.spaceHostMap) — pass the same
+   * one. Fixed for the runtime's lifetime.
+   */
+  spaceHostMap?: Record<string, string>;
   storageManager: IStorageManager;
   consoleHandler?: ConsoleHandler;
   errorHandlers?: ErrorHandler[];
@@ -326,6 +334,7 @@ export class Runtime {
   /** Resolved experimental flags (all properties present, defaulting to `false`). */
   readonly experimental: ExperimentalOptions;
   readonly apiUrl: URL;
+  readonly spaceHostMap?: Record<string, string>;
   readonly userIdentityDID: DID;
   /** Cache of resolved PatternFactory.inSpace("name") space DIDs. */
   private readonly spaceNameToDid = new Map<string, MemorySpace>();
@@ -367,6 +376,7 @@ export class Runtime {
 
     this.id = options.storageManager.id;
     this.apiUrl = new URL(options.apiUrl);
+    this.spaceHostMap = options.spaceHostMap;
     this.staticCache = isDeno()
       ? new StaticCacheFS()
       : new StaticCacheHTTP(new URL("/static", this.apiUrl));
@@ -1105,13 +1115,38 @@ export class Runtime {
     return this.runner.start(resultCell);
   }
 
+  /**
+   * The host that serves a space's space-bound work (LLM, fetch, blob).
+   * A space in `spaceHostMap` resolves to its mapped host; everything
+   * else to the default `apiUrl`. The single compute-side analogue of
+   * the storage layer's per-space address resolver.
+   */
+  hostForSpace(space: MemorySpace): URL {
+    return new URL(this.spaceHostMap?.[space] ?? this.apiUrl);
+  }
+
+  /**
+   * True iff the default host AND every distinct mapped host are
+   * reachable — one runtime can span hosts, so health is the
+   * conjunction over all of them.
+   */
   async healthCheck(): Promise<boolean> {
-    try {
-      const url = new URL("/_health", this.apiUrl);
-      const res = await fetch(url);
-      return res.ok;
-    } catch (_) {
-      return false;
+    const hosts = new Set([this.apiUrl.toString()]);
+    for (const host of Object.values(this.spaceHostMap ?? {})) {
+      try {
+        hosts.add(new URL(host).toString());
+      } catch {
+        return false; // a malformed mapped host is unhealthy by definition
+      }
     }
+    const checks = [...hosts].map(async (host) => {
+      try {
+        const res = await fetch(new URL("/_health", host));
+        return res.ok;
+      } catch (_) {
+        return false;
+      }
+    });
+    return (await Promise.all(checks)).every(Boolean);
   }
 }

--- a/packages/runner/test/runtime-host-for-space.test.ts
+++ b/packages/runner/test/runtime-host-for-space.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+
+const signer = await Identity.fromPassphrase("runtime-host-for-space");
+const spaceA = signer.did();
+const spaceB = "did:key:z6Mk-host-for-space-b" as MemorySpace;
+
+function makeRuntime(spaceHostMap?: Record<string, string>) {
+  const storageManager = StorageManager.emulate({ as: signer });
+  return new Runtime({
+    apiUrl: new URL("http://host-a.test/"),
+    spaceHostMap,
+    storageManager,
+  });
+}
+
+describe("Runtime.hostForSpace", () => {
+  it("resolves mapped spaces to their host and others to apiUrl", async () => {
+    const runtime = makeRuntime({ [spaceB]: "http://host-b.test" });
+    try {
+      expect(runtime.hostForSpace(spaceA).toString()).toBe(
+        "http://host-a.test/",
+      );
+      expect(runtime.hostForSpace(spaceB).toString()).toBe(
+        "http://host-b.test/",
+      );
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("healthCheck fans out over the default and every mapped host", async () => {
+    const dialed: string[] = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      dialed.push(String(input));
+      return Promise.resolve(new Response("ok", { status: 200 }));
+    }) as typeof fetch;
+    const runtime = makeRuntime({
+      [spaceB]: "http://host-b.test",
+      "did:key:z6Mk-host-for-space-c": "http://host-b.test", // dupe host
+    });
+    try {
+      expect(await runtime.healthCheck()).toBe(true);
+      expect(dialed.sort()).toEqual([
+        "http://host-a.test/_health",
+        "http://host-b.test/_health",
+      ]);
+    } finally {
+      globalThis.fetch = realFetch;
+      await runtime.dispose();
+    }
+  });
+
+  it("healthCheck is false when any host is unreachable", async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = ((input: RequestInfo | URL) =>
+      Promise.resolve(
+        new Response("", {
+          status: String(input).includes("host-b") ? 500 : 200,
+        }),
+      )) as typeof fetch;
+    const runtime = makeRuntime({ [spaceB]: "http://host-b.test" });
+    try {
+      expect(await runtime.healthCheck()).toBe(false);
+    } finally {
+      globalThis.fetch = realFetch;
+      await runtime.dispose();
+    }
+  });
+});

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -745,9 +745,13 @@ describe("RuntimeProcessor blob upload IPC", () => {
     };
     // The constructor performs full runtime initialization; this focused unit
     // test calls the handler with the fields it reads directly.
+    const hostForSpaceCalls: string[] = [];
     const processor = {
       runtime: {
-        hostForSpace: () => new URL("http://toolshed.test/base"),
+        hostForSpace: (space: string) => {
+          hostForSpaceCalls.push(space);
+          return new URL("http://toolshed.test/base");
+        },
       },
     } as unknown as RuntimeProcessor;
 
@@ -771,6 +775,8 @@ describe("RuntimeProcessor blob upload IPC", () => {
     expect(requestedUrl).toBe(
       "http://toolshed.test/did:key:test-space/blobs/upload.png",
     );
+    // The host is resolved for the REQUEST's space, not any init space.
+    expect(hostForSpaceCalls).toEqual(["did:key:test-space"]);
     expect(requestedPayload).toEqual({
       type: "image/png",
       body: new FabricBytes(new Uint8Array([1, 2, 3])),

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -746,14 +746,16 @@ describe("RuntimeProcessor blob upload IPC", () => {
     // The constructor performs full runtime initialization; this focused unit
     // test calls the handler with the fields it reads directly.
     const processor = {
-      apiUrl: new URL("http://toolshed.test/base"),
-      space: "did:key:test-space",
+      runtime: {
+        hostForSpace: () => new URL("http://toolshed.test/base"),
+      },
     } as unknown as RuntimeProcessor;
 
     try {
       await expect(
         RuntimeProcessor.prototype.handleUploadBlob.call(processor, {
           type: RequestType.UploadBlob,
+          space: "did:key:test-space" as never,
           contentType: "image/png",
           body: [1, 2, 3],
           suffix: "png",

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -279,8 +279,6 @@ export class RuntimeProcessor {
   private pieceManager: PieceManager;
   private cc: PiecesController;
   private spaces = new Map<DID, SpaceContext>();
-  private apiUrl: URL;
-  private space: DID;
   private identity: Identity;
   private _isDisposed = false;
   private disposingPromise: Promise<void> | undefined;
@@ -302,17 +300,14 @@ export class RuntimeProcessor {
     runtime: Runtime,
     pieceManager: PieceManager,
     cc: PiecesController,
-    apiUrl: URL,
-    space: DID,
+    initSpace: DID,
     identity: Identity,
     telemetry: RuntimeTelemetry,
   ) {
     this.runtime = runtime;
     this.pieceManager = pieceManager;
     this.cc = cc;
-    this.spaces.set(space, { pieceManager, cc });
-    this.apiUrl = apiUrl;
-    this.space = space;
+    this.spaces.set(initSpace, { pieceManager, cc });
     this.identity = identity;
     this.telemetry = telemetry;
     this.telemetry.addEventListener("telemetry", this.#onTelemetry);
@@ -425,7 +420,6 @@ export class RuntimeProcessor {
       runtime,
       pieceManager,
       cc,
-      apiUrlObj,
       space,
       identity,
       telemetry,
@@ -1021,6 +1015,12 @@ export class RuntimeProcessor {
   async handleUploadBlob(
     request: UploadBlobRequest,
   ): Promise<UploadBlobResponse> {
+    // Guard for untyped callers: the request must name the blob's space
+    // (required since the federation work) — fail with a named error
+    // rather than a confusing server 404 on /undefined/blobs/….
+    if (!request.space || !String(request.space).startsWith("did:")) {
+      throw new Error("uploadBlob requires a space DID");
+    }
     const suffix = (request.suffix ?? "bin").replace(/^\./, "") || "bin";
     const bytes = Uint8Array.from(request.body);
     // The blob belongs to the named space, so it uploads to — and its

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -133,6 +133,7 @@ export function runtimeOptionsFromInitializationData(
   const apiUrlObj = new URL(data.apiUrl);
   return {
     apiUrl: apiUrlObj,
+    spaceHostMap: data.spaceHostMap,
     storageManager,
     patternEnvironment: { apiUrl: apiUrlObj },
     telemetry,

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1023,9 +1023,12 @@ export class RuntimeProcessor {
   ): Promise<UploadBlobResponse> {
     const suffix = (request.suffix ?? "bin").replace(/^\./, "") || "bin";
     const bytes = Uint8Array.from(request.body);
+    // The blob belongs to the named space, so it uploads to — and its
+    // returned URL resolves against — THAT space's host.
+    const host = this.runtime.hostForSpace(request.space);
     const target = new URL(
-      `/${this.space}/blobs/upload.${encodeURIComponent(suffix)}`,
-      this.apiUrl,
+      `/${request.space}/blobs/upload.${encodeURIComponent(suffix)}`,
+      host,
     );
     // Blob upload payloads must preserve FabricBytes even when the wider
     // process is running with legacy memory JSON flags.
@@ -1049,7 +1052,7 @@ export class RuntimeProcessor {
     }
     return {
       id: result.id,
-      url: resolveBlobUrl(result.url, this.apiUrl, this.space),
+      url: resolveBlobUrl(result.url, host, request.space),
     };
   }
 

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -381,6 +381,8 @@ export interface SetBreakpointsRequest extends BaseRequest {
 
 export interface UploadBlobRequest extends BaseRequest {
   type: RequestType.UploadBlob;
+  /** The space the blob belongs to — uploads target ITS host. */
+  space: DID;
   contentType: string;
   body: number[];
   suffix?: string;

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -500,12 +500,14 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
   }
 
   async uploadBlob(options: {
+    space: DID;
     contentType: string;
     body: Uint8Array;
     suffix?: string;
   }): Promise<UploadBlobResponse> {
     return await this.#conn.request<RequestType.UploadBlob>({
       type: RequestType.UploadBlob,
+      space: options.space,
       contentType: options.contentType,
       body: Array.from(options.body),
       suffix: options.suffix,

--- a/packages/shell/integration/blob-upload.test.ts
+++ b/packages/shell/integration/blob-upload.test.ts
@@ -29,23 +29,32 @@ describe("shell blob upload", () => {
     );
 
     const result = await shell.page().evaluate(async () => {
-      const rt = (globalThis as unknown as {
+      const g = globalThis as unknown as {
         commonfabric?: {
           rt?: {
             uploadBlob(options: {
+              space: string;
               contentType: string;
               body: Uint8Array;
               suffix?: string;
             }): Promise<{ id: string; url: string }>;
           };
-          space?: string;
         };
-      }).commonfabric?.rt;
+        app?: { state?: () => { identity?: { did?: () => string } } };
+      };
+      const rt = g.commonfabric?.rt;
       if (!rt) {
         throw new Error("Runtime client was not exposed");
       }
+      // Blob uploads name their space; the home space (= identity DID)
+      // is this test's target.
+      const space = g.app?.state?.()?.identity?.did?.();
+      if (!space) {
+        throw new Error("No identity available to derive the home space");
+      }
 
       const upload = await rt.uploadBlob({
+        space,
         contentType: "image/gif",
         suffix: "gif",
         body: new Uint8Array([

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -1528,14 +1528,10 @@ export class CFCodeEditor extends BaseElement {
       : this.contextSpace;
 
     if (!runtime || !space) {
-      this.emit("cf-error", {
-        error: new Error(
-          !runtime
-            ? "Runtime is not available for pasted image storage"
-            : "Space is not available for pasted image storage",
-        ),
-        message: "Runtime is not available for pasted image storage",
-      });
+      const message = !runtime
+        ? "Runtime is not available for pasted image storage"
+        : "Space is not available for pasted image storage";
+      this.emit("cf-error", { error: new Error(message), message });
       return;
     }
 

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -69,7 +69,8 @@ import { stringSchema } from "@commonfabric/runner/schemas";
 import { type InputTimingOptions } from "../../core/input-timing-controller.ts";
 import { createStringCellController } from "../../core/cell-controller.ts";
 import { consume } from "@lit/context";
-import { runtimeContext } from "../../runtime-context.ts";
+import { runtimeContext, spaceContext } from "../../runtime-context.ts";
+import type { DID } from "@commonfabric/identity";
 import { type StoredFile, uploadFile } from "../../utils/file-cell-storage.ts";
 import {
   Mentionable,
@@ -232,6 +233,10 @@ export class CFCodeEditor extends BaseElement {
   @consume({ context: runtimeContext, subscribe: true })
   @property({ attribute: false })
   accessor runtime: RuntimeClient | undefined = undefined;
+
+  @consume({ context: spaceContext, subscribe: true })
+  @property({ attribute: false })
+  accessor contextSpace: DID | undefined = undefined;
 
   private _editorView: EditorView | undefined;
   private _lang = new Compartment();
@@ -1516,8 +1521,13 @@ export class CFCodeEditor extends BaseElement {
     const runtime = isCellHandle(this.value)
       ? this.value.runtime()
       : this.runtime;
+    // The pasted image's blob belongs to the edited cell's space; fall
+    // back to the view's space from context.
+    const space = isCellHandle(this.value)
+      ? this.value.space()
+      : this.contextSpace;
 
-    if (!runtime) {
+    if (!runtime || !space) {
       this.emit("cf-error", {
         error: new Error("Runtime is not available for pasted image storage"),
         message: "Runtime is not available for pasted image storage",
@@ -1528,7 +1538,7 @@ export class CFCodeEditor extends BaseElement {
     try {
       const storedFiles: StoredFile[] = [];
       for (const file of files) {
-        storedFiles.push(await uploadFile({ file, runtime }));
+        storedFiles.push(await uploadFile({ file, runtime, space }));
       }
 
       const markdown = storedFiles

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -1529,7 +1529,11 @@ export class CFCodeEditor extends BaseElement {
 
     if (!runtime || !space) {
       this.emit("cf-error", {
-        error: new Error("Runtime is not available for pasted image storage"),
+        error: new Error(
+          !runtime
+            ? "Runtime is not available for pasted image storage"
+            : "Space is not available for pasted image storage",
+        ),
         message: "Runtime is not available for pasted image storage",
       });
       return;

--- a/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
+++ b/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
@@ -11,7 +11,8 @@ import {
   defaultTheme,
 } from "../theme-context.ts";
 import { formatFileSize } from "../../utils/image-compression.ts";
-import { runtimeContext } from "../../runtime-context.ts";
+import { runtimeContext, spaceContext } from "../../runtime-context.ts";
+import type { DID } from "@commonfabric/identity";
 import {
   type StoredFile,
   type StoreFileOptions,
@@ -241,6 +242,10 @@ export class CFFileInput extends BaseElement {
   @property({ attribute: false })
   accessor runtime: RuntimeClient | undefined = undefined;
 
+  @consume({ context: spaceContext, subscribe: true })
+  @property({ attribute: false })
+  accessor space: DID | undefined = undefined;
+
   protected getFiles(): StoredFile[] {
     return [...this.storedFiles];
   }
@@ -264,9 +269,13 @@ export class CFFileInput extends BaseElement {
     if (!this.runtime) {
       throw new Error("Runtime is not available for file storage");
     }
+    if (!this.space) {
+      throw new Error("Space is not available for file storage");
+    }
     return await uploadFile({
       file,
       runtime: this.runtime,
+      space: this.space,
       includeDataUrl: this.includeData,
       ...metadata,
     });

--- a/packages/ui/src/v2/utils/file-cell-storage.test.ts
+++ b/packages/ui/src/v2/utils/file-cell-storage.test.ts
@@ -43,10 +43,12 @@ describe("file-cell-storage", () => {
     const stored = await uploadFile({
       file,
       runtime,
+      space: "did:key:z6Mk-file-cell-storage-test" as never,
       includeDataUrl: true,
     });
 
     expect(request).toMatchObject({
+      space: "did:key:z6Mk-file-cell-storage-test",
       contentType: "text/plain",
       suffix: "txt",
     });

--- a/packages/ui/src/v2/utils/file-cell-storage.ts
+++ b/packages/ui/src/v2/utils/file-cell-storage.ts
@@ -1,3 +1,4 @@
+import type { DID } from "@commonfabric/identity";
 import type { RuntimeClient } from "@commonfabric/runtime-client";
 
 export interface StoredFile {
@@ -19,6 +20,8 @@ export interface StoredFile {
 export interface StoreFileOptions {
   file: File;
   runtime: RuntimeClient;
+  /** The space the file's blob belongs to — part of its address. */
+  space: DID;
   width?: number;
   height?: number;
   metadata?: Record<string, unknown>;
@@ -28,11 +31,13 @@ export interface StoreFileOptions {
 export async function uploadFile(
   options: StoreFileOptions,
 ): Promise<StoredFile> {
-  const { file, runtime, width, height, metadata, includeDataUrl } = options;
+  const { file, runtime, space, width, height, metadata, includeDataUrl } =
+    options;
   const createdAt = Date.now();
   const mediaType = file.type || "application/octet-stream";
   const buffer = await file.arrayBuffer();
   const upload = await runtime.uploadBlob({
+    space,
     contentType: mediaType,
     body: new Uint8Array(buffer),
     suffix: fileSuffix(file.name, mediaType),


### PR DESCRIPTION
## What

Your #3947 approval note, implemented: *"a follow-up pr should look at the remaining uses of the default url and move to this mechanism for any space-bound uses, e.g. blob upload, llm, fetchData base url, etc."*

- **`Runtime.hostForSpace(space)`** — the compute-side analogue of the storage resolver. `RuntimeOptions` takes the same optional `spaceHostMap` the storage layer does (pass the same one; entries are validated eagerly, naming the space). `healthCheck` fans out over the default host plus every distinct mapped host — one runtime spans hosts, so health is the conjunction.
- **LLM**: `LLMClient.sendRequest/generateObject` accept a per-call `opts.endpoint`; all four builtin call sites route a **host-mapped** space's calls to `/api/ai/llm` on its host. An **unmapped** space keeps the module-level default (`setLLMUrl`) — deliberately NOT `hostForSpace`'s fallback, because deployments may split the pattern-facing api host from the runtime's memory host (toolshed: `API_URL` ≠ `MEMORY_URL`). Unmapped behavior is byte-identical.
- **fetch-data**: relative URLs for a mapped space resolve against its host; unmapped spaces keep `getPatternEnvironment().apiUrl` (same reasoning, documented inline).
- **Blob upload**: `UploadBlobRequest` carries a **required** `space` (the #3995 convention) — the worker posts to and resolves the returned URL against that space's host, with a named-error guard for untyped callers. Threaded through `RuntimeClient`/`RuntimeInternals`/ui `uploadFile`; `cf-file-input`/`cf-code-editor` take the space from their bound cell, else the view's `spaceContext`. **Named behavior change**: in a non-home view, uploads now land under the viewed space's namespace (previously always the worker's init space) — that's the point.
- **Deliberately untouched**, so it's a decision and not an oversight: `wish`'s system-pattern sources (already lazy upstream; platform assets stay on the pattern environment's default host, same class as `getPatternEnvironment` for authored code); `stream-data` (passes URLs to fetch with no base today — nothing to re-route); the static cache and program resolver (default-host platform assets).
- For embedders: `cf-file-input` outside a `spaceContext` provider now throws a named error on upload; the `space` accessor is a plain property, so embedders can also pass it directly.

## Tests

`hostForSpace` mapped/default + healthCheck fan-out (incl. host dedupe + malformed-entry=unhealthy); blob IPC asserts the host is resolved for the request's space; ui `uploadFile` asserts the forwarded space; shell blob integration names its space. Full check/lint/fmt green; runner (585), runtime-client, lib-shell, shell, piece, ui suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes space-bound compute (LLM, fetch, blob upload) to each space’s host via a per-space resolver; unmapped behavior stays the same. Adds multi-host health checks, freezes the per-space host map, and requires a `space` for uploads with accurate UI `cf-error` messages.

- **New Features**
  - `runner`: `RuntimeOptions.spaceHostMap` and `Runtime.hostForSpace(space)` with early validation; map is snapshotted and frozen; `healthCheck` fans out over the default and all distinct mapped hosts.
  - `llm`: `LLMClient.sendRequest/generateObject` accept a per-call `endpoint`; built-ins route to `/api/ai/llm` on the mapped host, otherwise use the `setLLMUrl` default.
  - `runner` fetch-data: relative URLs resolve against the mapped host; unmapped spaces use `getPatternEnvironment().apiUrl`.
  - `runtime-client`/`ui` blob upload: `UploadBlobRequest.space` is required; uploads and returned URLs resolve against that space’s host. `uploadFile` passes `space`; `cf-file-input` and `cf-code-editor` take the cell’s space or the view’s `spaceContext`, with distinct errors for missing runtime vs missing space and `cf-error` message text that matches the actual failure.

- **Migration**
  - If federated, pass `spaceHostMap` when creating a `Runtime`.
  - Always include `space` in `RuntimeClient.uploadBlob({ ... })`.
  - When embedding `cf-file-input` or `cf-code-editor` outside a `spaceContext`, set the `space` property or wrap with a provider (otherwise a named error is thrown).

<sup>Written for commit ff5390a8be6b2df21dba08131c7c7ab39b531cca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Perf-check note

Threshold-edge churn, not regression: across three runs the OVER metric rotated (core-piece-values job duration → runner-integration step → gmail-agentic-search), each within 2s/15% of its margin, while main's own runs show the same metrics oscillating around the identical thresholds (gmail-agentic-search is the same main-side drift #3995 already declared). PR4's only unmapped-path additions are a once-at-construction validation loop and a frozen snapshot — nothing on these jobs' paths. Declaring per the tool's suggestion:

NEW_PERF_BASELINE: step: runner integration = 63s
NEW_PERF_BASELINE: subtest: pattern-unit-3/pattern-unit-tests > packages/patterns/google/core/experimental/gmail-agentic-search.test.tsx = 32s
