### PR TITLE
When traversing anyOf or similar logical schema options, include $defs.

### DIFF
--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -4252,10 +4252,11 @@ function appendPartsToPath(path: ValuePath, parts: string[]): ValuePath {
 
 function schemaWithDefs(parent: JSONSchemaObj, option: JSONSchema): JSONSchema {
   // We need to preserve any parent $defs in the branch
-  return typeof option === "object"
-    ? {
-      ...option,
-      ...(parent.$defs && { "$defs": parent.$defs }),
-    }
-    : option;
+  if (!parent.$defs || !isRecord(option)) {
+    return option;
+  }
+  return {
+    ...option,
+    $defs: parent.$defs,
+  };
 }

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -3307,7 +3307,10 @@ export class SchemaObjectTraverser<V extends FabricValue>
       // unknown & T => T
       let match: TypeValidity.True | TypeValidity.Unknown | undefined;
       for (const option of schemaObj.allOf) {
-        const valid = this.isValidType(option, valueType);
+        const valid = this.isValidType(
+          schemaWithDefs(schemaObj, option),
+          valueType,
+        );
         // ignore undefined result (unknown type), but if any option returns
         // false, the whole thing is false
         if (valid === TypeValidity.False) {
@@ -3331,7 +3334,10 @@ export class SchemaObjectTraverser<V extends FabricValue>
           match = TypeValidity.True;
           break;
         }
-        const valid = this.isValidType(option, valueType);
+        const valid = this.isValidType(
+          schemaWithDefs(schemaObj, option),
+          valueType,
+        );
         if (valid === TypeValidity.False) {
           continue;
         } else if (match !== TypeValidity.Unknown) {
@@ -3355,7 +3361,10 @@ export class SchemaObjectTraverser<V extends FabricValue>
           match = TypeValidity.True;
           break;
         }
-        const valid = this.isValidType(option, valueType);
+        const valid = this.isValidType(
+          schemaWithDefs(schemaObj, option),
+          valueType,
+        );
         if (valid === TypeValidity.False) {
           continue;
         } else if (match !== TypeValidity.Unknown) {
@@ -4239,4 +4248,14 @@ function appendToPath(path: ValuePath, part: string): ValuePath {
 // helper function - since path starts with value, the new array will too
 function appendPartsToPath(path: ValuePath, parts: string[]): ValuePath {
   return [...path, ...parts] as ValuePath;
+}
+
+function schemaWithDefs(parent: JSONSchemaObj, option: JSONSchema): JSONSchema {
+  // We need to preserve any parent $defs in the branch
+  return typeof option === "object"
+    ? {
+      ...option,
+      ...(parent.$defs && { "$defs": parent.$defs }),
+    }
+    : option;
 }


### PR DESCRIPTION
---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/battleship/multiplayer/lobby.test.tsx = 18s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/main.test.tsx = 24s
---END COPY-PASTE---

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preserves parent `$defs` when traversing `allOf`, `anyOf`, and `oneOf` branches so `$ref` resolution works during type validation. Fixes false negatives when options depend on parent definitions.

- **Bug Fixes**
  - Wraps each branch with `schemaWithDefs(parent, option)` before `isValidType`.
  - Adds `schemaWithDefs` to copy parent `$defs` only when the option is an object (`isRecord` guard).
  - Applies to `allOf`, `anyOf`, and `oneOf` in `packages/runner/src/traverse.ts`.

<sup>Written for commit fad9f4b6033a85c43846655c992444d920ad5241. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

