### PR TITLE
ci: deploy staging to Rapids during migration

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -786,12 +786,36 @@ jobs:
           cache: false
 
       - name: 🚀 Deploy application to Toolshed (Staging)
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@1530429296e979861824d74fb800013190b5dee0
         with:
           host: ${{ secrets.BASTION_HOST }}
           username: bastion
           key: ${{ secrets.BASTION_SSH_PRIVATE_KEY }}
           script: /opt/cf/deploy.sh ${{ vars.DEPLOYMENT_ENVIRONMENT }} ${{ github.sha }}
+
+  # Automatic deployment to rapids during toolshed migration
+  deploy-rapids:
+    name: "Deploy to Rapids (Staging)"
+    if: github.ref == 'refs/heads/main'
+    needs: ["attest-binaries"]
+    runs-on: ubuntu-latest
+    environment: rapids
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🦕 Setup Deno
+        uses: ./.github/actions/deno-setup
+        with:
+          cache: false
+
+      - name: 🚀 Deploy application to Rapids (Staging)
+        uses: appleboy/ssh-action@1530429296e979861824d74fb800013190b5dee0
+        with:
+          host: ${{ secrets.BASTION_HOST }}
+          username: bastion
+          key: ${{ secrets.BASTION_SSH_PRIVATE_KEY }}
+          script: /opt/cf/deploy.sh rapids ${{ github.sha }} --skip-clusterduck
 
   # Deploy shell static assets to staging GCS bucket
   deploy-shell-staging:
@@ -855,7 +879,7 @@ jobs:
       - name: 🧩 Run post-deploy Patterns integration tests against Toolshed (Staging)
         id: run_tests
         continue-on-error: true
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@1530429296e979861824d74fb800013190b5dee0
         with:
           host: ${{ secrets.BASTION_HOST }}
           username: bastion
@@ -868,7 +892,7 @@ jobs:
 
       - name: 📥 Retrieve test logs on failure
         if: steps.run_tests.outcome == 'failure'
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@1530429296e979861824d74fb800013190b5dee0
         with:
           host: ${{ secrets.BASTION_HOST }}
           username: bastion

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: 🚀 Deploy application to Estuary (Production)
         id: deployment
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@1530429296e979861824d74fb800013190b5dee0
         with:
           host: ${{ secrets.BASTION_HOST }}
           username: bastion


### PR DESCRIPTION
## Summary
- add a `deploy-rapids` staging job that deploys main builds to `rapids` via the bastion wrapper
- pin `appleboy/ssh-action` to a specific commit SHA in staging and production deploy workflows
- skip Clusterduck updates from the Rapids deploy path to avoid duplicating the existing Toolshed/Clusterduck deployment

## Validation
- `deno fmt --check .github/workflows/deno.yml .github/workflows/deploy-production.yml`
- Ruby YAML parse for `.github/workflows/deno.yml` and `.github/workflows/deploy-production.yml`

Note: `actionlint` is not installed in this environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically deploys main builds to Rapids (staging) during the Toolshed migration, using the bastion deploy wrapper. Also pins `appleboy/ssh-action` to a fixed version and skips Clusterduck updates on the Rapids path.

- **New Features**
  - Add Rapids staging deploy job on `main` via bastion; runs `/opt/cf/deploy.sh rapids <sha> --skip-clusterduck`.

- **Dependencies**
  - Pin `appleboy/ssh-action` to a specific commit in staging and production workflows.

<sup>Written for commit 69d334556b616c5fee9f78c06245412825514cff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

