### PR TITLE
test(runner): pin the setup-written schema-meta hatch for same-tx link sources (CT-1698)

### DIFF
--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -2532,6 +2532,77 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     }
   });
 
+  it("labels a SAME-TRANSACTION link source from its setup-written schema meta", async () => {
+    // A piece instantiated by this transaction gets its result schema written
+    // at the doc's ["schema"] meta during setup (updateResultSchemaMeta). A
+    // handler that materializes such a piece and links it into a protected
+    // list in ONE commit (profile-home's addElement, CT-1698) leaves the
+    // source with no stored CFC metadata and no pending schema input — the
+    // setup-written schema, read back read-your-writes, is what keeps the
+    // link write from failing closed. The persisted link label must derive
+    // from the SOURCE's own schema: the target-schema child-doc fallback
+    // (previous test) could only produce ["personal-space"] here, so
+    // ["card-space"] proves the setup-schema hatch supplied the label.
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const seed = runtime.edit();
+      seed.setCfcEnforcementMode("enforce-explicit");
+      const target = runtime.getCell(
+        signer.did(),
+        "cfc-link-setup-schema-target",
+        {
+          type: "object",
+          ifc: { confidentiality: ["personal-space"] },
+        },
+        seed,
+      );
+      target.set({ existing: true });
+      seed.prepareCfc();
+      expect((await seed.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      const piece = runtime.getCell(
+        signer.did(),
+        "cfc-link-setup-schema-source",
+        undefined,
+        tx,
+      );
+      piece.set({ title: "fresh card" });
+      // What piece setup writes for a fresh instance (updateResultSchemaMeta).
+      piece.setMetaRaw("schema", {
+        type: "object",
+        ifc: { confidentiality: ["card-space"] },
+        properties: { title: { type: "string" } },
+      });
+      const linkedTarget = runtime.getCell(
+        signer.did(),
+        "cfc-link-setup-schema-target",
+        undefined,
+        tx,
+      );
+      linkedTarget.set(piece);
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+
+      const verify = runtime.edit();
+      const metadata = readStoredCfcMetadata(verify, {
+        space: signer.did(),
+        id: linkedTarget.getAsNormalizedFullLink().id,
+        scope: "space",
+      });
+      const rootEntry = metadata?.labelMap.entries.find((entry) =>
+        entry.path.length === 0 && entry.origin === "link"
+      );
+      expect(rootEntry?.label.confidentiality).toEqual(["card-space"]);
+      verify.abort?.();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("validates link writes against affected stored schema claims", async () => {
     const { runtime, storageManager } = createRuntime();
     try {


### PR DESCRIPTION
## What

Adds one focused cfc-boundary case pinning the `setupResultSchemaFor` knowability hatch in `derivePersistedLinkLabel` — the "count a same-transaction pattern instantiation as pending source metadata" condition behind profile-home's re-enabled element tests.

## Why

#4038 gave `derivePersistedLinkLabel` two knowability hatches for link sources minted by the writing transaction: the source piece's setup-written `["schema"]` meta (`setupResultSchemaFor`, read-your-writes), and the target-schema child-doc fallback. Only the fallback got a direct runner-level pin; the setup-schema hatch was covered solely end-to-end through `profile-home.test.tsx`, so a regression in it would surface as a distant pattern-test failure rather than a pointed runner failure.

## How

The new case mimics piece setup (root value write + `setMetaRaw("schema", ...)` carrying the piece's **own** ifc label) and links the fresh doc into a labeled location in the same commit. The assertion is on label *content*, not just commit success: the persisted link label must be the SOURCE schema's `["card-space"]`. The child-doc fallback can only produce the target-derived `["personal-space"]` here, so the assertion identifies *which* hatch supplied the label.

Red-proven: with `setupResultSchemaFor` temporarily neutered, this test fails exactly that way (label degrades to `["personal-space"]`, commit still succeeds) while the neighboring same-tx child-doc and pre-existing fail-closed cases stay green.

## Testing

- `packages/runner` suite: 585 passed (3051 steps), 0 failed
- `deno task integration pattern-tests`: all 60 files green, including `profile-home.test.tsx` (6/6 under enforce-explicit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runner test that pins the setup-written `["schema"]` meta hatch in `derivePersistedLinkLabel` for same-transaction link sources (CT-1698).
It verifies the persisted link label comes from the source schema (`["card-space"]`) via `setupResultSchemaFor`, not the target fallback (`["personal-space"]`).

<sup>Written for commit eadadc28e29afca8017940643646b95d17eff15c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

