### PR TITLE
docs(specs): pattern imports — cf: scheme design + implementation plan

### DIFF
--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -411,7 +411,10 @@ import costs nothing the deployed pattern hasn't already paid.
 A runtime is no longer bound to one memory host: `spaceHostMap`
 (`storage/v2-remote-session.ts:createStorageAddressResolver`, PR #3947)
 routes each space to its host, and a foreign-host session is an ordinary
-authenticated memory session. So a `cf://host/space/ref` reference resolves
+authenticated memory session. (`spaceHostMap` itself is an **interim
+mechanism** — per-space host resolution will evolve; this design depends only
+on the property "a space's cells are readable wherever the space lives", not
+on the map's current shape.) So a `cf://host/space/ref` reference resolves
 exactly like a local one — slug chase, piece/meta hops, and `pattern:<identity>`
 source-doc reads are all cell reads in a space that happens to live on
 another host, under that host's normal authz. No resolve endpoint, no
@@ -484,6 +487,16 @@ unchanged.
   reads under existing space authz — including cross-host (`spaceHostMap`
   sessions authenticate like any other). Nothing exposes data a space-read
   doesn't already grant.
+- **Pattern source is data with provenance.** Patterns can contain private
+  information (literals, prompts, embedded knowledge), so source docs are not
+  exempt from CFC: fetching an imported pattern's source is a labeled read,
+  and the compile-cache write-back that copies fetched source docs into the
+  importing space is a labeled **flow** that must respect the source's
+  provenance (fail closed when a label forbids it). Wiring CFC labels through
+  fetch and write-back is deliberate **follow-up work** — flagged here so the
+  initial implementation doesn't silently launder source across spaces; until
+  it lands, cross-space imports should be treated as moving data with the
+  same care as any cross-space link.
 
 ## Failure modes (all compile-time errors with actionable messages)
 
@@ -550,12 +563,14 @@ unchanged.
    with identical pins (status quo for runtime modules, now also for fabric
    refs). Acceptable, but worth stating in the compile-cache invalidation
    docs.
-7. **What "publicly readable" means.** Memory sessions are authenticated;
-   importing requires *some* identity the publishing space grants read to.
-   Does publication mean "readable by any authenticated identity" (a broad
-   grant), and is an anonymous, CDN-cacheable HTTP mirror for published
-   patterns ever wanted on top (trust-free via hash verification, but a
-   second distribution path to maintain)?
+7. **What "publicly readable" means — and a possible public endpoint.**
+   Memory sessions are authenticated; importing requires *some* identity the
+   publishing space grants read to. Does publication mean "readable by any
+   authenticated identity" (a broad grant)? An anonymous, CDN-cacheable HTTP
+   endpoint serving **public** patterns by identity may still be useful on
+   top (trust-free via hash verification) — deliberately left open rather
+   than rejected; it only makes sense for content whose labels permit
+   unrestricted disclosure (see the provenance note in § Security).
 8. **Dynamic space→host routes.** `spaceHostMap` is fixed at storage
    construction; host-qualified refs discovered mid-compile need dynamic
    route registration (or a short-lived secondary session). Small, but it

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -3,7 +3,7 @@
 Letting authored patterns import other patterns published in the fabric:
 
 ```tsx
-import { TodoItem, todoSchema } from "cf:kitchen/todo-list";   // a slug — names a piece OR a published pattern
+import { TodoItem, todoSchema } from "cf:/kitchen/todo-list";  // a slug — names a piece OR a published pattern
 import { TodoItem } from "cf:pattern:9f2ab…e41";               // a content-addressed source, directly
 ```
 
@@ -99,14 +99,19 @@ Because both come up, and only one is the pin:
 
 ### One grammar, no type tag
 
+The prefix encodes the qualification level, like relative path / absolute
+path / protocol-relative URL:
+
 ```
-cf:[//host/][<space>/]<ref>[/<subpath>][@<pin>]
+cf:<ref>[/<subpath>][@<pin>]                       ; current space
+cf:/<space>/<ref>[/<subpath>][@<pin>]              ; explicit space
+cf://<host>/<space>/<ref>[/<subpath>][@<pin>]      ; explicit toolshed
 
 ref     = slug                ; no ":" — isSlugAddress convention
         | "of:" hash          ; cell URI (pattern meta cell, or a piece's entity id)
         | "pattern:" hash     ; entry-module identity (content-addressed source)
-space   = space-name | space-did | "~"     ; "~" = the compiling space
-host    = domain[":"port]                  ; a toolshed
+space   = space-name | space-did
+host    = domain[":"port]     ; a toolshed
 pin     = entry-module identity hex
 ```
 
@@ -114,33 +119,32 @@ Examples:
 
 ```tsx
 import { TodoItem } from "cf:todo-list";                            // slug, current space
-import { TodoItem } from "cf:kitchen/todo-list";                    // space by name
-import { TodoItem } from "cf:did:key:z6Mk…/todo-list";              // space by DID
+import { todoSchema } from "cf:todo-list/schemas";                  // subpath (phase 2)
+import { TodoItem } from "cf:/kitchen/todo-list";                   // space by name
+import { TodoItem } from "cf:/did:key:z6Mk…/todo-list";             // space by DID
 import { TodoItem } from "cf://toolshed.common.tools/kitchen/todo-list";  // explicit toolshed
-import { todoSchema } from "cf:~/todo-list/schemas";                // subpath (phase 2; "~" required)
 import { TodoItem } from "cf:pattern:9f2ab…e41";                    // content-addressed, space-free
-import { TodoItem } from "cf:kitchen/of:bafy…";                     // pattern meta cell by URI
+import { TodoItem } from "cf:/kitchen/of:bafy…";                    // pattern meta cell by URI
 
 // What a deployed importer actually stores (§ Snapshot semantics):
-import { TodoItem } from "cf:kitchen/todo-list@9f2ab…e41";
+import { TodoItem } from "cf:/kitchen/todo-list@9f2ab…e41";
 ```
 
-Parsing rules (each segment class is syntactically disjoint):
+Parsing rules (each form is disjoint by prefix; no segment counting needed):
 
-- After `cf:`, a leading `//` introduces a **host** (URL-authority style); a
-  single leading `/` is permitted and ignored. Hosts only appear in the
-  authority position, so no dot-sniffing of path segments is needed.
 - The **pin** is always a trailing `@<hash>`; strip it first. Slugs, space
   names, DIDs, and hosts cannot contain `@`.
-- Segments split on `/`. **One segment** ⇒ it is the `ref`, current space.
-  **Two or more** ⇒ the first is the `space` (name, DID — colons inside a
-  segment are fine — or `~`), the second is the `ref`, the rest is `subpath`.
-  Consequence: a subpath on a current-space ref requires the `~` placeholder
-  (`cf:~/todo-list/schemas`); a misparse fails loudly at space resolution.
+- After `cf:`: `//` ⇒ the next segment is a **host**, then space, then ref.
+  A single `/` ⇒ the next segment is a **space** (name or DID — colons inside
+  a segment are fine), then ref. No slash ⇒ the first segment is the `ref` in
+  the current space. All remaining segments are the `subpath`. Because
+  space-qualification *requires* the leading slash, `cf:todo-list/schemas` is
+  unambiguously ref + subpath — no placeholder needed.
 - A `ref` containing `:` is a cell URI (`of:`, `pattern:`); otherwise it must
   validate as a slug. `pattern:` refs are space-free-capable (content
-  addressed; the space, if given, is only a resolution hint). Slug refs always
-  need a space (slug ids are space-scoped: `slugIdForSpace`).
+  addressed; the space, if given, is only a resolution hint). Slug refs are
+  always space-scoped (slug ids are `slugIdForSpace(space, slug)`), with the
+  current space as default.
 - The emitted-namespace specifiers `cf:module/<hash>` and `cf:cache-root/`
   remain compiler-internal and are **rejected in authored source**.
 
@@ -214,7 +218,7 @@ Mechanics:
    the specifier in the stored source** to the pinned form:
 
    ```tsx
-   import { TodoItem } from "cf:kitchen/todo-list@9f2ab…e41";
+   import { TodoItem } from "cf:/kitchen/todo-list@9f2ab…e41";
    ```
 
    The stored program is then fully deterministic: compilation, identity, and
@@ -352,15 +356,19 @@ with storage and network access, and `ProgramResolver.resolveSource` is async)
 Engine wraps the authored resolver; on a `cf:` specifier:
 
 1. **Reference → identity**: pinned (or `pattern:` ref) → use the hash, never
-   touch the mutable pointer. Unpinned (dev only) → run the uniform chase:
-   resolve space (`~`/name/DID), slug cell redirect, piece `meta(…)` hop,
-   meta-cell `entryIdentity`.
+   touch the mutable pointer. Unpinned (authoring/dev only) → run the uniform
+   chase **as ordinary cell reads through the compiling runtime's storage**
+   (slug cell redirect, piece `meta(…)` hop, meta-cell `entryIdentity`) —
+   `cf check`/`cf dev` already construct a runtime (`packages/cli/lib/dev.ts`),
+   and every production compile happens inside one, so no resolution endpoint
+   is involved and space authz is exactly memory-read authz. The one
+   exception is host-qualified refs (§ Toolshed surface).
 2. **Identity → source set**, first hit wins, every hop hash-verified:
    1. local/space compile-cache source docs (`pattern:<identity>`, walking
       import links);
    2. the space named in the reference (if any);
-   3. the toolshed registry endpoint (below);
-   4. for host-qualified refs, that host's registry endpoint.
+   3. the toolshed pattern endpoint (below);
+   4. for host-qualified refs, that host's pattern endpoint.
 3. **Verify**: recompute `computeModuleHashes` over the fetched program (its
    own namespace, its own authored paths) and require the entry hash to equal
    the requested identity. Mismatch = compile error. This is what makes every
@@ -399,23 +407,36 @@ import costs nothing the deployed pattern hasn't already paid.
 
 ### 4. Toolshed surface
 
-Two new endpoints (names indicative), both per-toolshed — this is the host in
-a host-qualified reference, defaulting to the toolshed the compiling runtime's
-session is connected to:
+Mutable-pointer resolution does **not** get an endpoint for the common case:
+every compile context has a runtime (CLI commands construct one; production
+compiles run inside one), and the chase is ordinary cell reads over the
+existing memory session — which also means space authz is inherited rather
+than re-implemented in an HTTP route.
 
-- `GET /api/registry/resolve/:space/:ref` → `{ spaceDid, chain: [...],
-  entryIdentity, patternId }` — runs the uniform resolution chase for a slug
-  or cell-URI ref and reports the terminal identity (plus the chain, for
-  tooling/error messages). Auth: requires read access to the space (same
-  authz as a memory read; this is a convenience projection, not a bypass).
-  Used by CLI/CI pin steps and cross-toolshed resolution without a full
-  memory session.
+One new endpoint, needed for cross-host content:
+
 - `GET /api/registry/pattern/:identity` → the source set
   (`{ main, files: [{name, contents}] }`, plus per-module identities) for a
   **published** pattern. Backed by publication-as-naming: assigning a slug to
   a pattern meta cell in a toolshed-readable space (sugar: `cf publish`).
   Responses are immutable and cacheable (`Cache-Control: immutable`, like
   blobs); clients verify by re-hashing, so mirroring is safe.
+
+And one *possible* endpoint, deferred until host-qualified refs land:
+
+- `GET /api/registry/resolve/:space/:ref` → `{ spaceDid, chain, entryIdentity }`
+  — runs the chase server-side. Its only justified scenario is **pin time for
+  a cross-toolshed mutable ref** (`cf://other-host/...`): the author's runtime
+  has a memory session to *its* toolshed only, and usually no identity on the
+  foreign host, so reading the remote slug/piece chain needs either a one-shot
+  foreign memory session or this GET. That is a rare, authoring-time,
+  human-in-the-loop operation — and if cross-host refs are simply required to
+  be born pinned (resolve once via the publisher's host at authoring time),
+  the compile path never needs it at all. Decide when phase 3 starts; the
+  conservative default is to ship publication (slug → pattern in a public
+  space) such that the chase for *published* names is readable
+  unauthenticated, making this endpoint a thin projection rather than new
+  authority.
 
 The existing `/api/patterns/:filename` (repo-file serving) is unrelated and
 unchanged.
@@ -438,10 +459,11 @@ unchanged.
 1. **`cf:pattern:<hash>`, same-space.** No new endpoints, no pinning step —
    resolution entirely via existing cell-cache source docs +
    `computeModuleHashes` verification. Proves the resolver/mounting/emit seams.
-2. **Slug/piece refs + pinning**, current toolshed; registry resolve endpoint;
-   deploy-time pin rewrite; `cf deps update`.
+2. **Slug/piece refs + pinning**, current toolshed — still no endpoints
+   (resolution = the compiling runtime's storage reads); deploy-time pin
+   rewrite; `cf deps update`.
 3. **`cf publish` + registry pattern endpoint + host-qualified refs**
-   (cross-toolshed).
+   (cross-toolshed); decide the resolve-endpoint question here.
 4. **Subpaths; `npm:`/esm.sh vendoring** on the same rails.
 
 ## Security considerations
@@ -479,9 +501,10 @@ unchanged.
 
 ## Test plan
 
-- **Grammar**: parse/format round-trips; host/space/ref/subpath/pin
-  disambiguation table (incl. `~`, DIDs-as-space, `of:`/`pattern:` refs);
-  rejection of `cf:module/` and `cf:cache-root/` in authored source.
+- **Grammar**: parse/format round-trips; prefix-form table (`cf:ref`,
+  `cf:/space/ref`, `cf://host/space/ref`, subpaths, pins, DIDs-as-space,
+  `of:`/`pattern:` refs); rejection of `cf:module/` and `cf:cache-root/` in
+  authored source.
 - **Resolution chase**: slug→piece→pattern, slug→pattern (direct
   publication), `of:<patternId>` start, `pattern:<hash>` terminal; "not a
   pattern" failures per chain shape.

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -59,9 +59,10 @@ Design.
   pointer (resolved once, at pin time) or a content hash. Pattern lineage
   (`parents`, `spec` in the pattern meta cell) is metadata, not a resolution
   input.
-- **A package registry product.** The toolshed surface below is a content
-  mirror plus a pointer-resolution endpoint, both trust-free (hash-verified by
-  the client); discovery and curation are out of scope.
+- **A package registry product.** There is no registry service at all: every
+  resolution hop — including cross-host — is an ordinary authenticated cell
+  read, and content is hash-verified by the client regardless of which host
+  served it. Discovery and curation are out of scope.
 
 ## Background: what exists today
 
@@ -76,6 +77,7 @@ Design.
 | Slug cells: generic **redirect link to any cell** (`setSlugLink` is target-agnostic; only `resolvePieceAddress` layers a "must be a piece" check) | `packages/piece/src/slugs.ts:34-80` | Slugs can name pieces *or* patterns today, mechanically |
 | Slug ids: `hashOf({causal:{space, slug}})`; slug grammar `[a-z0-9]+(-[a-z0-9]+)*`, ≤80 chars; **`isSlugAddress(t) = !t.includes(":")`** | `packages/runner/src/slugs.ts` | The existing slug-vs-URI discriminator the grammar reuses |
 | `loadPatternByIdentity(entryIdentity, symbol, space)` | `packages/runner/src/pattern-manager.ts:985` | Existing by-identity load path the resolver builds on |
+| Per-space host routing: `spaceHostMap` resolves each space to its memory host; foreign-host sessions are ordinary authenticated memory sessions (#3947) | `packages/runner/src/storage/v2-remote-session.ts:47` | Cross-toolshed refs are just cell reads in a space routed to another host — no HTTP endpoints needed |
 
 ### The two "pattern by hash" handles, explicitly
 
@@ -360,15 +362,14 @@ Engine wraps the authored resolver; on a `cf:` specifier:
    chase **as ordinary cell reads through the compiling runtime's storage**
    (slug cell redirect, piece `meta(…)` hop, meta-cell `entryIdentity`) —
    `cf check`/`cf dev` already construct a runtime (`packages/cli/lib/dev.ts`),
-   and every production compile happens inside one, so no resolution endpoint
-   is involved and space authz is exactly memory-read authz. The one
-   exception is host-qualified refs (§ Toolshed surface).
+   and every production compile happens inside one, so space authz is exactly
+   memory-read authz. Host-qualified refs are the same reads with the space
+   routed to its host via `spaceHostMap` (§ Cross-host references).
 2. **Identity → source set**, first hit wins, every hop hash-verified:
    1. local/space compile-cache source docs (`pattern:<identity>`, walking
       import links);
-   2. the space named in the reference (if any);
-   3. the toolshed pattern endpoint (below);
-   4. for host-qualified refs, that host's pattern endpoint.
+   2. the space named in the reference, routed to its host if the ref is
+      host-qualified.
 3. **Verify**: recompute `computeModuleHashes` over the fetched program (its
    own namespace, its own authored paths) and require the entry hash to equal
    the requested identity. Mismatch = compile error. This is what makes every
@@ -405,38 +406,34 @@ share compiled artifacts and live module namespaces
 (`modulesByIdentity`, `addressableByIdentity` in `pattern-manager.ts`) — the
 import costs nothing the deployed pattern hasn't already paid.
 
-### 4. Toolshed surface
+### 4. Cross-host references: no service surface at all
 
-Mutable-pointer resolution does **not** get an endpoint for the common case:
-every compile context has a runtime (CLI commands construct one; production
-compiles run inside one), and the chase is ordinary cell reads over the
-existing memory session — which also means space authz is inherited rather
-than re-implemented in an HTTP route.
+A runtime is no longer bound to one memory host: `spaceHostMap`
+(`storage/v2-remote-session.ts:createStorageAddressResolver`, PR #3947)
+routes each space to its host, and a foreign-host session is an ordinary
+authenticated memory session. So a `cf://host/space/ref` reference resolves
+exactly like a local one — slug chase, piece/meta hops, and `pattern:<identity>`
+source-doc reads are all cell reads in a space that happens to live on
+another host, under that host's normal authz. No resolve endpoint, no
+content endpoint; nothing re-implements space authorization in an HTTP
+route, and hash verification of fetched sources is unchanged (it never
+depended on the transport).
 
-One new endpoint, needed for cross-host content:
+Consequences:
 
-- `GET /api/registry/pattern/:identity` → the source set
-  (`{ main, files: [{name, contents}] }`, plus per-module identities) for a
-  **published** pattern. Backed by publication-as-naming: assigning a slug to
-  a pattern meta cell in a toolshed-readable space (sugar: `cf publish`).
-  Responses are immutable and cacheable (`Cache-Control: immutable`, like
-  blobs); clients verify by re-hashing, so mirroring is safe.
-
-And one *possible* endpoint, deferred until host-qualified refs land:
-
-- `GET /api/registry/resolve/:space/:ref` → `{ spaceDid, chain, entryIdentity }`
-  — runs the chase server-side. Its only justified scenario is **pin time for
-  a cross-toolshed mutable ref** (`cf://other-host/...`): the author's runtime
-  has a memory session to *its* toolshed only, and usually no identity on the
-  foreign host, so reading the remote slug/piece chain needs either a one-shot
-  foreign memory session or this GET. That is a rare, authoring-time,
-  human-in-the-loop operation — and if cross-host refs are simply required to
-  be born pinned (resolve once via the publisher's host at authoring time),
-  the compile path never needs it at all. Decide when phase 3 starts; the
-  conservative default is to ship publication (slug → pattern in a public
-  space) such that the chase for *published* names is readable
-  unauthenticated, making this endpoint a thin projection rather than new
-  authority.
+- **Publication is purely a data/authz act**: make the slug cell, the pattern
+  meta cell, and the `pattern:<identity>` source docs readable in a space
+  (`cf publish` is sugar for writing them to such a space and assigning the
+  slug). Whoever can read the space can import; nobody else can.
+- **The host segment maps to a `spaceHostMap` entry.** One mechanical work
+  item: the map is fixed at storage construction today
+  (`v2.ts` options), while a host-qualified ref is discovered mid-compile —
+  the resolver needs either dynamic registration of a space→host route on the
+  live session or a short-lived secondary session for the foreign space.
+- A cacheable, anonymous HTTP mirror for published patterns (CDN-style
+  distribution to readers with no fabric identity) remains *possible* later —
+  it would be trust-free thanks to hash verification — but it is an
+  optimization, not part of this design (§ Open questions).
 
 The existing `/api/patterns/:filename` (repo-file serving) is unrelated and
 unchanged.
@@ -456,14 +453,14 @@ unchanged.
 
 ### Phasing
 
-1. **`cf:pattern:<hash>`, same-space.** No new endpoints, no pinning step —
-   resolution entirely via existing cell-cache source docs +
-   `computeModuleHashes` verification. Proves the resolver/mounting/emit seams.
-2. **Slug/piece refs + pinning**, current toolshed — still no endpoints
-   (resolution = the compiling runtime's storage reads); deploy-time pin
-   rewrite; `cf deps update`.
-3. **`cf publish` + registry pattern endpoint + host-qualified refs**
-   (cross-toolshed); decide the resolve-endpoint question here.
+1. **`cf:pattern:<hash>`, same-space.** No pinning step — resolution entirely
+   via existing cell-cache source docs + `computeModuleHashes` verification.
+   Proves the resolver/mounting/emit seams.
+2. **Slug/piece refs + pinning**, current toolshed; deploy-time pin rewrite;
+   `cf deps update`. (Resolution = the compiling runtime's storage reads
+   throughout — no phase adds a service endpoint.)
+3. **`cf publish` + host-qualified refs** — cross-host reads via
+   `spaceHostMap` routing, incl. the dynamic-route work item above.
 4. **Subpaths; `npm:`/esm.sh vendoring** on the same rails.
 
 ## Security considerations
@@ -476,16 +473,17 @@ unchanged.
   swapping a piece's pattern cannot change any pinned importer; it changes
   only future pins. This closes the classic "dependency hijack via mutable
   pointer" hole by construction.
-- **Mirrors and registries are trust-free.** Every fetched source set is
-  verified by recomputing the Merkle identity; a malicious toolshed can refuse
-  to serve but cannot substitute code.
+- **Hosts are trust-free for content.** Every fetched source set is verified
+  by recomputing the Merkle identity; a malicious host can refuse to serve
+  but cannot substitute code.
 - **CFC.** Module identities are already the content-addressed provenance
   CFC verified-identity resolution uses
   (`docs/specs/content-addressed-action-identity.md`); imported modules verify
   and register exactly like authored ones. No new identity kind is introduced.
-- **No ambient escalation surface.** The registry endpoints expose only what a
-  space-read already grants (resolve endpoint) or what publishing deliberately
-  made public (pattern endpoint).
+- **No new authorization surface.** Resolution and content fetch are memory
+  reads under existing space authz — including cross-host (`spaceHostMap`
+  sessions authenticate like any other). Nothing exposes data a space-read
+  doesn't already grant.
 
 ## Failure modes (all compile-time errors with actionable messages)
 
@@ -494,7 +492,7 @@ unchanged.
 | Slug/space not found, or no read access | "cannot resolve cf:… (space/slug/permission)" naming the failing hop |
 | Chain does not terminate at a pattern (slug → data cell, piece without pattern, …) | "cf:… does not resolve to a pattern" + the chain followed |
 | Unpinned mutable ref in deployed/`--frozen` compile | "unpinned fabric import; run `cf deps update` / deploy to pin" |
-| Source set unavailable at every resolution hop | "source for pattern:<hash> not found (tried: local, space …, registry …)" |
+| Source set unavailable at every resolution hop | "source for pattern:<hash> not found (tried: local cache, space … on host …)" |
 | Hash mismatch on fetched source | "integrity failure for <hash> from <source>" (and the hop is skipped, next source tried) |
 | Cycle during live (unpinned) resolution | "cyclic imports: A → B → A" |
 | Imported source fails SES verification | existing verifier error, attributed to the imported module's original path |
@@ -517,7 +515,7 @@ unchanged.
 - **Dedupe**: importer of a running piece's pattern reuses its compiled docs
   and live module namespace (assert on `esmCacheStats` / `modulesByIdentity`
   hits).
-- **Verification**: tampered source set from a mock registry → integrity
+- **Verification**: tampered source set served by a mock host → integrity
   error; fallback hop succeeds.
 - **Multi-runtime** (`multiUserTest` harness): user 1 deploys + publishes;
   user 2 imports across spaces; CFC verified identity intact.
@@ -531,8 +529,8 @@ unchanged.
    source-disclosure; explicit publish is the conservative default proposed
    here.
 2. **Space-name resolution.** Refs with space *names* (not DIDs) need a
-   name→DID resolution authority; the shell resolves names client-side today.
-   The registry resolve endpoint can own this, but name squatting/renaming
+   name→DID mapping per host; the shell resolves names client-side today and
+   there is no service surface here to hang it on. Name squatting/renaming
    semantics need a decision before phase 2 (DID-form refs sidestep it).
 3. **Slug-cell typing.** The uniform chase duck-types its hops
    (`meta("pattern")` present ⇒ piece; matches `patternMetaSchema` ⇒ pattern
@@ -552,3 +550,13 @@ unchanged.
    with identical pins (status quo for runtime modules, now also for fabric
    refs). Acceptable, but worth stating in the compile-cache invalidation
    docs.
+7. **What "publicly readable" means.** Memory sessions are authenticated;
+   importing requires *some* identity the publishing space grants read to.
+   Does publication mean "readable by any authenticated identity" (a broad
+   grant), and is an anonymous, CDN-cacheable HTTP mirror for published
+   patterns ever wanted on top (trust-free via hash verification, but a
+   second distribution path to maintain)?
+8. **Dynamic space→host routes.** `spaceHostMap` is fixed at storage
+   construction; host-qualified refs discovered mid-compile need dynamic
+   route registration (or a short-lived secondary session). Small, but it
+   touches session lifecycle — design alongside phase 3.

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -1,0 +1,470 @@
+# Pattern Imports — `import { … } from "cf:…"`
+
+Letting authored patterns import other patterns published in the fabric:
+
+```tsx
+import { TodoItem, todoSchema } from "cf:piece/kitchen/todo-list";   // a deployed piece
+import { TodoItem } from "cf:pattern/9f2ab…e41";                     // a content-addressed source
+```
+
+A reference is either a **deployed piece** — meaning "the pattern currently
+used by that piece", a mutable pointer — or a **content-addressed pattern
+source** — the immutable thing a deployed piece points to. Both resolve to the
+same underlying artifact: a content-addressed source program whose entry-module
+identity lives in the same namespace as the compile cache and `cf:module/<hash>`
+(`packages/runner/src/harness/module-identity.ts`).
+
+## Status
+
+Design.
+
+## Last Updated
+
+2026-06-10
+
+## Motivation
+
+- **Reuse without copy-paste.** Today a pattern can import only its own files
+  (`./`, `../`, `/`) and three allowlisted runtime modules
+  (`packages/runner/src/sandbox/runtime-module-policy.ts`). Sharing a schema or
+  a sub-pattern across separately-deployed patterns means duplicating source.
+- **Typed reuse.** The `fetchProgram` builtin
+  (`packages/runner/src/builtins/fetch-program.ts`) fetches and compiles remote
+  programs at *runtime*, untyped at the call site. An import is compile-time:
+  TypeScript checks the binding names and types against the real source.
+- **Foundation for external packages.** The same resolution seam, pinning
+  model, and collision rules are designed so that `npm:`/esm.sh support can be
+  added later without revisiting this design (§ External packages).
+
+## Non-goals
+
+- **Live/reactive imports.** An importer does NOT recompile or re-run when the
+  referenced piece's pattern changes. Runtime composition that follows a live
+  pointer is a different feature (e.g. `getPattern`, wish); imports are static.
+- **Version ranges / semver resolution.** References are exact: a slug pointer
+  (resolved once, at pin time) or a content hash. Pattern lineage (`parents`,
+  `spec` in the pattern meta cell) is metadata, not a resolution input.
+- **A package registry product.** The toolshed surface below is a content
+  mirror plus a pointer-resolution endpoint, both trust-free (hash-verified by
+  the client); naming, discovery, and curation are out of scope.
+
+## Background: what exists today
+
+| Piece of machinery | Where | Role here |
+|---|---|---|
+| `ProgramResolver` seam (`main()` / `resolveSource(specifier)`, async) | `packages/js-compiler/program.ts`, `typescript/resolver.ts` | The hook where fabric imports plug in; compilation already runs inside a runtime with storage + network access |
+| Authored-import policy | `packages/runner/src/sandbox/runtime-module-policy.ts:25` | Single dispatch point to extend for `cf:` specifiers |
+| Per-module Merkle identity (source + deps; external deps fold the full specifier string into the leaf: `runtime:${specifier}@${fingerprint}`) | `packages/runner/src/harness/module-identity.ts:145-149` | Makes pinned specifiers content-derived with **no hashing changes** (§ Snapshot semantics) |
+| Piece → pattern pointers: `meta("pattern")` = patternId URI; `meta("patternIdentity")` = `{ identity, symbol }` (entry-module identity) | `packages/runner/src/runner.ts:4137-4159` | "Current pattern of a piece" is read here at pin time |
+| Pattern meta cell: `program {main, files}`, `entryIdentity`, `parents`, `spec` | `packages/runner/src/pattern-manager.ts:55-90` | Source-of-truth for a pattern's source set |
+| Compile cache: source docs `pattern:<identity>`, compiled docs `compileCache:<rtVersion>/<identity>` | `packages/runner/src/compilation-cache/cell-cache.ts` | Content-addressed per-module source + compiled storage; imports resolve from and dedupe into it |
+| Slugs: `[a-z0-9]+(-[a-z0-9]+)*`, ≤80 chars; slug id = `hashOf({causal:{space, slug}})`, redirect cell | `packages/runner/src/slugs.ts`, `packages/piece/src/slugs.ts` | Human-readable piece locators |
+| `loadPatternByIdentity(entryIdentity, symbol, space)` | `packages/runner/src/pattern-manager.ts:985` | Existing by-identity load path the resolver builds on |
+
+## Specifier syntax
+
+### Recommended: the `cf:` scheme
+
+Two authored forms, one scheme:
+
+```tsx
+// Deployed piece — "the pattern this piece currently runs":
+import { TodoItem } from "cf:piece/todo-list";                                // slug in the current space
+import { TodoItem } from "cf:piece/kitchen/todo-list";                        // space by name
+import { TodoItem } from "cf:piece/did:key:z6Mk…/todo-list";                  // space by DID
+import { TodoItem } from "cf:piece/toolshed.common.tools/kitchen/todo-list";  // explicit toolshed host
+import { TodoItem } from "cf:piece/~/todo-list/schemas";                      // ~ = current space (needed with subpaths)
+
+// Content-addressed pattern source (immutable):
+import { TodoItem } from "cf:pattern/9f2ab…e41";
+import { todoSchema } from "cf:pattern/9f2ab…e41/schemas";                    // subpath (phase 2)
+
+// Pinned piece reference — what a deployed importer actually stores (§ Snapshot semantics):
+import { TodoItem } from "cf:piece/kitchen/todo-list@9f2ab…e41";
+```
+
+Grammar (`<hash>` is the prefix-free module-identity hex, the same string that
+appears in `cf:module/<hash>` and the compile-cache keys):
+
+```
+fabric-import  = "cf:piece/" locator [ "/" subpath ] [ "@" hash ]
+               | "cf:pattern/" hash [ "/" subpath ]
+
+locator        = slug                          ; current space, current toolshed
+               | space "/" piece               ; explicit space
+               | host "/" space "/" piece      ; explicit toolshed
+
+space          = space-name | space-did | "~"  ; "~" = the compiling space
+piece          = slug | "fid1:" hash           ; slug or entity id
+host           = domain[":" port]              ; recognized by containing "." or being localhost[:port]
+```
+
+Disambiguation rules (each segment class is syntactically disjoint):
+
+- The pin is always a trailing `@<hash>`; strip it first. Slugs, space names,
+  DIDs, and hosts cannot contain `@`.
+- A leading segment is a **host** iff it contains a `.` (or is
+  `localhost[:port]`). Slugs and space names used in references must match the
+  slug grammar (no `.`/`:`); DIDs start with `did:` but contain no `.` before
+  the method-specific part — references requiring an explicit host always use
+  the 3-segment form, so the dot rule only has to separate hosts from space
+  names.
+- A single-segment `cf:piece/<slug>` is the current-space shorthand. Subpaths
+  on current-space references require the `~` placeholder
+  (`cf:piece/~/<slug>/<subpath>`) so segment counting stays unambiguous.
+
+Why this shape:
+
+- **`cf:` already exists** as the runtime's identity scheme (`cf:module/<hash>`
+  in compiled output and `fn.src`). Authored imports get sibling namespaces
+  (`cf:piece/`, `cf:pattern/`); the emitted namespace `cf:module/` stays
+  compiler-internal and is rejected in authored source.
+- **A scheme cannot collide** with npm bare specifiers (npm names cannot
+  contain `:`), with `npm:`/`jsr:` (different prefixes), or with `https:` URLs
+  (§ External packages).
+- **Valid ESM specifier.** Schemes are legal in import specifiers; resolution
+  is entirely ours via the `ProgramResolver`/compiler-host seam, and TypeScript
+  is satisfied through the same mechanism that resolves `commonfabric` today
+  (`packages/js-compiler/typescript/compiler.ts:176-207`).
+
+### Alternatives considered
+
+1. **URL-authority form: `cf://toolshed.common.tools/kitchen/todo-list`.**
+   Standard URL parsing and a natural home for the host, but the common cases
+   (current toolshed, current space) have no natural spelling — `cf:///kitchen/…`
+   or an empty authority is awkward — and it diverges stylistically from
+   `cf:module/<hash>`, which is authority-less. Rejected.
+2. **Bare scope: `@fabric/kitchen/todo-list`.** Reads like npm, which is
+   exactly the problem: it squats on the npm scope namespace we want to keep
+   clean for real packages later, and "looks installable" misleads. Rejected.
+3. **Pin as a separate sidecar lockfile** instead of in-specifier `@<hash>` —
+   see § Snapshot semantics for why the pin lives in the source.
+
+## Snapshot semantics: how piece references determine hashes
+
+The question: a piece's current pattern is a mutable pointer. When does an
+importer's hash sample it?
+
+**Decision: a one-time snapshot at *pin time* (deploy/authoring), persisted in
+the source itself — never at compile time, never continuously.**
+
+Mechanics:
+
+1. When a pattern containing an unpinned `cf:piece/...` import is **deployed**
+   (or a dev/iterate flow explicitly resolves dependencies), the toolchain
+   reads the piece's current `meta("patternIdentity").identity` (fallback:
+   `meta("pattern")` → pattern meta cell → `entryIdentity`, computing it from
+   `program` if absent) and **rewrites the specifier in the stored source** to
+   the pinned form:
+
+   ```tsx
+   import { TodoItem } from "cf:piece/kitchen/todo-list@9f2ab…e41";
+   ```
+
+   The stored program is then fully deterministic: compilation, identity, and
+   execution never read the piece pointer again.
+
+2. **The pinned hash folds into the importer's identity for free.** Module
+   identity already hashes external deps as `runtime:${specifier}@${fingerprint}`
+   (`module-identity.ts:145-149`) — the specifier string contains the pin, so
+   two importers differing only in pin have different module identities, and
+   transitively different program ids (`engine.ts:computeId` hashes the source
+   files, which contain the specifier). No changes to any hashing code.
+
+3. **No re-resolution on recompile.** Cold compiles (cache-version bumps,
+   eviction) recompile from the stored, pinned source. This is the reason the
+   pin lives *in the source* rather than being an emergent property of "first
+   compile": if resolution happened at compile time, an unrelated cold compile
+   of an unchanged program could silently re-pin to a newer target — a
+   different program identity with no authoring action. Pin-in-source makes
+   identity a pure function of stored bytes.
+
+4. **Updating is an explicit authoring action.** `cf deps update
+   [<specifier>]` (and an equivalent affordance in the shell's iterate flow)
+   re-resolves the piece pointer and rewrites the pin — an ordinary source
+   edit, visible in lineage (`parents`) like any other edit. The unpinned form
+   never reaches deployed storage: deploying with an unpinned piece reference
+   pins it; a stored program containing an unpinned `cf:piece/` specifier is a
+   compile error. `cf dev`/`cf check` resolve unpinned references live against
+   the connected toolshed and print what they resolved to.
+
+Why not continuous tracking: re-snapshotting on target change would make the
+importer's identity (and therefore its compiled artifacts, scheduler keys, and
+every downstream content address) change without any edit to the importer —
+exactly the build-order/reload-churn class of instability the content-addressed
+identity work eliminated. Live composition stays a runtime feature.
+
+In-source pinning vs a lockfile side-table: a side-table (`resolvedImports` on
+the pattern meta cell) would preserve authored bytes exactly, but then program
+identity becomes a function of *(source, lockmap)* and every consumer of
+`computeId`/`computeModuleHashes`/`cf check` must thread the lockmap. The
+in-source pin keeps "identity = hash of source" true, keeps the pin visible and
+diffable, and retains provenance (the piece pointer stays in the specifier, so
+tooling knows what to re-resolve). This deliberately borrows the
+`npm:pkg@version` shape — the pin step is "lockfile semantics, written back
+into the import statement."
+
+### What `cf:pattern/<hash>` means exactly
+
+The hash is the **entry-module identity** of the referenced source program —
+the same prefix-free Merkle hash over (authored source, authored path, dep
+hashes) used by the compile cache and `$patternRef`
+(`docs/specs/content-addressed-action-identity.md`). Chosen over the
+alternative candidates:
+
+- *patternId* (`of:<hash>` of the pattern meta cell, what `meta("pattern")`
+  stores): resolvable, but it is a causal ref whose derivation is not purely
+  source-content in all paths, so a fetched program can't be verified against
+  it by re-hashing alone. The pin records what `meta("patternIdentity")`
+  carries instead — already the fast-path identity pieces store.
+- *whole-program id* (`computeId`): entry-point and sibling-file sensitive, and
+  not the namespace existing load machinery (`loadPatternByIdentity`, compile
+  cache) keys on.
+
+Because the identity is a Merkle root, the transitive source closure is
+discoverable and verifiable from it (source docs in the cell cache store
+per-module source + resolved import links), and cycles are impossible by
+construction — a hash cannot reference itself. (Unpinned piece references can
+form cycles — A imports piece B whose pattern imports piece A — only during
+live dev resolution, where the resolver needs an ordinary cycle guard; pinned
+chains are DAGs.)
+
+## What an import gives you
+
+The imported module's **exports**: patterns, schemas (`schemas.tsx` sharing is
+a first-class use case), types, lifts/handlers, plain helpers. Imports are
+type-checked against the real fetched source, not declarations. The entry
+module is the program's `main`; subpaths (`/schemas` etc.) address other files
+in the same program and are a phase-2 extension (same resolution, an extra path
+join inside the mounted program).
+
+## Coexistence with esm.sh / npm / jsr (later)
+
+**(a) No collisions, by partition of the specifier space:**
+
+| Specifier class | Owner | Status |
+|---|---|---|
+| `./ ../ /` | program-relative files | today |
+| bare (`commonfabric`, `turndown`, …) | **reserved for runtime modules only**, allowlist | today; never used for packages |
+| `cf:piece/ cf:pattern/` | this spec (authored) | new |
+| `cf:module/` | compiled output only; rejected in authored source | today |
+| `npm: jsr: https:` | future external packages | reserved now |
+
+Reserving bare specifiers for runtime modules is the load-bearing rule: future
+packages must be scheme-qualified, so no import-map shadowing ambiguity can
+arise between a runtime module, a fabric reference, and an npm package. The
+policy check stays a single dispatch on prefix
+(`isAllowedAuthoredImportSpecifier`).
+
+**(b) Syntax and semantics worth borrowing:**
+
+- **Deno's `npm:pkg@version/subpath` and `jsr:@scope/pkg@version`** — the
+  trailing-`@version` pin position is exactly what `cf:piece/...@<hash>`
+  borrows, so pinned fabric refs and pinned npm refs read the same way.
+- **Lockfile semantics, but written into the source** (above). For npm, a
+  version pin is *not* content-addressed (registries are mutable), so the pin
+  step should additionally **vendor**: fetch the resolved module graph (e.g.
+  from esm.sh), store it as a content-addressed source set in the fabric — the
+  same source-doc shape patterns use — and record the vendored identity. An
+  npm import then *is* a `cf:pattern/<hash>` underneath: one resolution path,
+  one storage shape, one verification step, integrity for free, reproducible
+  offline. The authored specifier keeps the npm provenance
+  (`npm:preact@10.26.4` plus the vendored pin), mirroring the piece/pattern
+  split: mutable pointer in the specifier, content hash as the pin.
+- **esm.sh's target/bundle query conventions** (`?target=es2022`, `?bundle`)
+  only if we ever serve compiled variants; authored-source identity hashing
+  deliberately ignores compiled form, so these stay out of identity.
+
+Caveat to record now: vendored npm code must pass the same SES verifier as
+authored modules (no top-level mutable bindings, no ambient DOM/process access)
+— most utility libraries will pass, many won't. That filter is a feature, but
+it bounds which packages are importable; it does not affect this spec's
+mechanics.
+
+## Build sketch
+
+Compilation already happens inside a runtime (`Engine` is `runtime.harness`,
+with storage and network access, and `ProgramResolver.resolveSource` is async)
+— so resolution is a download/read away, as suspected. The pieces:
+
+### 1. Specifier parsing + policy
+
+- New `packages/runner/src/sandbox/fabric-import-specifier.ts`: parse/format
+  for the grammar above (locator, pin, subpath; host/space/slug
+  disambiguation).
+- `runtime-module-policy.ts`: `isAllowedAuthoredImportSpecifier` accepts
+  `cf:piece/` and `cf:pattern/` prefixes (and continues to reject `cf:module/`
+  in authored source).
+
+### 2. Resolution (a `FabricProgramResolver` wrapper)
+
+Engine wraps the authored resolver; on a `cf:` specifier:
+
+1. **Locator → identity** (piece refs): pinned → use the pin, never read the
+   piece. Unpinned (dev only) → resolve space (name → DID via toolshed, or
+   `~` → compiling space), slug → slug cell redirect → piece, read
+   `meta("patternIdentity").identity` (fallback chain per § Snapshot
+   semantics).
+2. **Identity → source set**, first hit wins, every hop hash-verified:
+   1. local/space compile cache source docs (`pattern:<identity>`, walking
+      import links);
+   2. the referenced piece's space (for piece refs);
+   3. the toolshed registry endpoint (below);
+   4. for host-qualified refs, that host's registry endpoint.
+3. **Verify**: recompute `computeModuleHashes` over the fetched program (its
+   own namespace, its own authored paths) and require the entry hash to equal
+   the requested identity. Mismatch = compile error. This is what makes every
+   mirror trust-free.
+4. **Mount for type-checking**: splice the fetched files into the TS program
+   under a reserved prefix (e.g. `/~cf/<identity>/<original-path>`), and
+   thread a specifier→mounted-entry alias map into the compiler so
+   `resolveModuleNameLiterals` (`compiler.ts:176`) maps the `cf:` specifier to
+   the mounted file. Relative imports inside the subtree resolve as ordinary
+   path joins.
+
+### 3. Identity and emit: keep the imported subtree in its own universe
+
+The subtle part. Imported modules must keep their **published** identities
+(authored paths hashed in their own program namespace) so that compiled
+artifacts dedupe with the already-deployed pattern and verification means
+anything. Therefore:
+
+- The importer's modules treat the `cf:` specifier as an **external dep** for
+  identity purposes (status quo hashing; the pin in the specifier carries the
+  content into the hash — § Snapshot semantics).
+- The imported subtree is **not re-emitted** as part of the importer's
+  compilation. Mounted files participate in type-checking only; the importer's
+  emitted module records reference `cf:module/<published-identity>` edges
+  (`module-record-compiler.ts` already emits cross-module edges in exactly
+  this form).
+- If the compiled set for the imported identity is missing (runtime-version
+  bump, never compiled here), compile the imported program **as its own
+  compilation** (existing `loadPatternByIdentity`-shaped path) and let the
+  compile cache absorb it; then the importer's edges resolve normally.
+
+Payoff: at runtime, an importer and a running piece of the imported pattern
+share compiled artifacts and live module namespaces
+(`modulesByIdentity`, `addressableByIdentity` in `pattern-manager.ts`) — the
+import costs nothing the deployed pattern hasn't already paid.
+
+### 4. Toolshed surface
+
+Two new endpoints (names indicative), both per-toolshed — this is the "which
+toolshed" in a host-qualified reference, defaulting to the toolshed the
+compiling runtime's session is connected to:
+
+- `GET /api/registry/piece/:space/:pieceRef` → `{ spaceDid, pieceId,
+  patternId, patternIdentity }` — resolves a space name/DID + slug/entity-id
+  to the piece's current pattern pointers. Auth: requires read access to the
+  space (same authz as a memory read; this is a convenience projection, not a
+  bypass). Used by CLI/CI pin steps and cross-toolshed resolution without a
+  full memory session.
+- `GET /api/registry/pattern/:identity` → the source set
+  (`{ main, files: [{name, contents}] }`, plus per-module identities) for a
+  **published** pattern. Backed by a publish flow: `cf publish` (or
+  deploy-to-a-public-space) writes the source docs to a well-known
+  toolshed-readable space. Responses are immutable and cacheable
+  (`Cache-Control: immutable`, like blobs); clients verify by re-hashing, so
+  mirroring is safe.
+
+The existing `/api/patterns/:filename` (repo-file serving) is unrelated and
+unchanged.
+
+### 5. CLI / shell
+
+- `cf deploy`: pins unpinned piece refs (writes the rewritten source into the
+  pattern meta `program`), publishes source sets if the target is public.
+- `cf deps update [specifier]`: re-resolve + rewrite pins.
+- `cf dev` / `cf check`: live-resolve unpinned refs against the connected
+  toolshed; `--frozen` to forbid (CI). `--show-transformed` shows mounted
+  files like any other program file.
+- Shell iterate flow: show pins; "update dependencies" action mirrors
+  `cf deps update`.
+
+### Phasing
+
+1. **`cf:pattern/<hash>`, same-space.** No new endpoints, no pinning step —
+   resolution entirely via existing cell-cache source docs +
+   `computeModuleHashes` verification. Proves the resolver/mounting/emit seams.
+2. **`cf:piece/…` + pinning + slugs**, current toolshed; registry piece
+   endpoint; deploy-time pin rewrite; `cf deps update`.
+3. **Publish flow + registry pattern endpoint + host-qualified refs**
+   (cross-toolshed).
+4. **Subpaths; `npm:`/esm.sh vendoring** on the same rails.
+
+## Security considerations
+
+- **Imported code runs with the importing pattern's full authority.** An
+  import is a trust decision equivalent to pasting the source in: same SES
+  verification, same CFC treatment, same space access. The pin makes that
+  decision about *exact bytes* — review-at-pin is meaningful.
+- **Slug re-pointing is inert for deployed importers.** Re-pointing a piece (or
+  swapping its pattern) cannot change any pinned importer; it changes only
+  future pins. This closes the classic "dependency hijack via mutable pointer"
+  hole by construction.
+- **Mirrors and registries are trust-free.** Every fetched source set is
+  verified by recomputing the Merkle identity; a malicious toolshed can refuse
+  to serve but cannot substitute code.
+- **CFC.** Module identities are already the content-addressed provenance
+  CFC verified-identity resolution uses
+  (`docs/specs/content-addressed-action-identity.md`); imported modules verify
+  and register exactly like authored ones. No new identity kind is introduced.
+- **No ambient escalation surface.** The registry endpoints expose only what a
+  space-read already grants (piece endpoint) or what publishing deliberately
+  made public (pattern endpoint).
+
+## Failure modes (all compile-time errors with actionable messages)
+
+| Failure | Error |
+|---|---|
+| Slug/space/piece not found, or no read access | "cannot resolve cf:piece/… (space/slug/permission)" naming the failing hop |
+| Piece has no pattern pointer | "piece … has no current pattern" |
+| Unpinned piece ref in deployed/`--frozen` compile | "unpinned fabric import; run `cf deps update` / deploy to pin" |
+| Source set unavailable at every resolution hop | "source for cf:pattern/<hash> not found (tried: local, space …, registry …)" |
+| Hash mismatch on fetched source | "integrity failure for <hash> from <source>" (and the hop is skipped, next source tried) |
+| Cycle during live (unpinned) resolution | "cyclic piece imports: A → B → A" |
+| Imported source fails SES verification | existing verifier error, attributed to the imported module's original path |
+
+## Test plan
+
+- **Grammar**: parse/format round-trips; host/space/slug disambiguation table;
+  rejection of `cf:module/` in authored source.
+- **Identity folding** (red-green): two importers identical except for the pin
+  hash get different module identities; pin rewrite changes `computeId`.
+- **Snapshot semantics**: deploy piece A; deploy importer B (pin captured);
+  update A's piece to a new pattern; B's compile, identity, and behavior are
+  byte-identical until `cf deps update`, after which only the specifier line
+  differs.
+- **Dedupe**: importer of a running piece's pattern reuses its compiled docs
+  and live module namespace (assert on `esmCacheStats` / `modulesByIdentity`
+  hits).
+- **Verification**: tampered source set from a mock registry → integrity
+  error; fallback hop succeeds.
+- **Multi-runtime** (`multiUserTest` harness): user 1 deploys + publishes;
+  user 2 imports across spaces; CFC verified identity intact.
+- **Failure modes**: one test per row of the table.
+
+## Open questions
+
+1. **Publish granularity.** Is "publish" a distinct user action (`cf publish`)
+   or implicit for any piece readable by the reference resolver? Implicit is
+   ergonomic but turns space-read into source-disclosure; explicit publish is
+   the conservative default proposed here.
+2. **Space-name resolution.** Piece refs with space *names* (not DIDs) need a
+   name→DID resolution authority; the shell resolves names client-side today.
+   The registry piece endpoint can own this, but name squatting/renaming
+   semantics need a decision before phase 2 (DID-form refs sidestep it).
+3. **Type-only imports.** Should `import type { … }` from a fabric ref skip
+   the pin requirement (types don't affect runtime identity)? Tempting, but
+   the transformer lowers types into schemas — so types DO affect emitted
+   behavior, and the conservative answer is no special-casing. Revisit with
+   evidence.
+4. **Subpath surface.** Whether subpaths may address any file in the program
+   or only files the entry re-exports (an "exports map" discipline, like npm's
+   `exports`). Start permissive, tighten if published-internal-file coupling
+   becomes a problem.
+5. **Runtime-fingerprint interaction.** External-dep leaves include
+   `runtimeFingerprint`; a runtime upgrade thus shifts importer identities even
+   with identical pins (status quo for runtime modules, now also for fabric
+   refs). Acceptable, but worth stating in the compile-cache invalidation
+   docs.

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -406,6 +406,14 @@ share compiled artifacts and live module namespaces
 (`modulesByIdentity`, `addressableByIdentity` in `pattern-manager.ts`) — the
 import costs nothing the deployed pattern hasn't already paid.
 
+**Availability is a compile-time concern only.** The compile's write-back
+copies the imported modules' source + compiled docs into the **compiling
+space** (content-addressed keys, idempotent), so both rehydration paths —
+warm (compiled-doc links) and cold (source docs re-fetched by hash) — read
+locally. The referenced space/host must be reachable when a ref is pinned or
+first compiled, never to reload a deployed importer. (This copy is exactly
+the provenance-relevant flow flagged under § Security.)
+
 ### 4. Cross-host references: no service surface at all
 
 A runtime is no longer bound to one memory host: `spaceHostMap`

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -3,16 +3,25 @@
 Letting authored patterns import other patterns published in the fabric:
 
 ```tsx
-import { TodoItem, todoSchema } from "cf:piece/kitchen/todo-list";   // a deployed piece
-import { TodoItem } from "cf:pattern/9f2ab…e41";                     // a content-addressed source
+import { TodoItem, todoSchema } from "cf:kitchen/todo-list";   // a slug — names a piece OR a published pattern
+import { TodoItem } from "cf:pattern:9f2ab…e41";               // a content-addressed source, directly
 ```
 
-A reference is either a **deployed piece** — meaning "the pattern currently
-used by that piece", a mutable pointer — or a **content-addressed pattern
-source** — the immutable thing a deployed piece points to. Both resolve to the
-same underlying artifact: a content-addressed source program whose entry-module
-identity lives in the same namespace as the compile cache and `cf:module/<hash>`
-(`packages/runner/src/harness/module-identity.ts`).
+A reference names a **starting cell** — by slug or by cell URI, optionally
+qualified by space and toolshed host — and resolution **follows the pointer
+chain until it reaches a content-addressed pattern source**. A slug may point
+at a deployed piece (then we mean "the pattern that piece currently runs" —
+one more hop through `meta("pattern")`) or directly at a pattern (a named,
+updatable publication). Either way the chain terminates at an entry-module
+identity in the same namespace as the compile cache and `cf:module/<hash>`
+(`packages/runner/src/harness/module-identity.ts`), and that terminal hash is
+what deployed importers pin.
+
+There is deliberately **no type tag in the specifier** (`cf:piece/…` vs
+`cf:pattern/…` was considered and dropped, § Alternatives): slug cells are
+already type-agnostic redirects, the slug-vs-URI distinction already has a
+codebase convention (`isSlugAddress` = "no colon"), and the piece/pattern
+distinction evaporates at pin time — both freeze to the same kind of hash.
 
 ## Status
 
@@ -20,7 +29,7 @@ Design.
 
 ## Last Updated
 
-2026-06-10
+2026-06-11
 
 ## Motivation
 
@@ -32,6 +41,10 @@ Design.
   (`packages/runner/src/builtins/fetch-program.ts`) fetches and compiles remote
   programs at *runtime*, untyped at the call site. An import is compile-time:
   TypeScript checks the binding names and types against the real source.
+- **A publishing story that is just naming.** Pointing a slug at a pattern
+  meta cell in a readable space *is* publication: a human-readable, updatable
+  name (a dist-tag) for a content-addressed artifact. No registry product
+  required.
 - **Foundation for external packages.** The same resolution seam, pinning
   model, and collision rules are designed so that `npm:`/esm.sh support can be
   added later without revisiting this design (§ External packages).
@@ -39,14 +52,16 @@ Design.
 ## Non-goals
 
 - **Live/reactive imports.** An importer does NOT recompile or re-run when the
-  referenced piece's pattern changes. Runtime composition that follows a live
-  pointer is a different feature (e.g. `getPattern`, wish); imports are static.
-- **Version ranges / semver resolution.** References are exact: a slug pointer
-  (resolved once, at pin time) or a content hash. Pattern lineage (`parents`,
-  `spec` in the pattern meta cell) is metadata, not a resolution input.
+  slug or piece it references moves to a new pattern. Runtime composition that
+  follows a live pointer is a different feature (e.g. `getPattern`, wish);
+  imports are static.
+- **Version ranges / semver resolution.** References are exact: a mutable
+  pointer (resolved once, at pin time) or a content hash. Pattern lineage
+  (`parents`, `spec` in the pattern meta cell) is metadata, not a resolution
+  input.
 - **A package registry product.** The toolshed surface below is a content
   mirror plus a pointer-resolution endpoint, both trust-free (hash-verified by
-  the client); naming, discovery, and curation are out of scope.
+  the client); discovery and curation are out of scope.
 
 ## Background: what exists today
 
@@ -55,70 +70,102 @@ Design.
 | `ProgramResolver` seam (`main()` / `resolveSource(specifier)`, async) | `packages/js-compiler/program.ts`, `typescript/resolver.ts` | The hook where fabric imports plug in; compilation already runs inside a runtime with storage + network access |
 | Authored-import policy | `packages/runner/src/sandbox/runtime-module-policy.ts:25` | Single dispatch point to extend for `cf:` specifiers |
 | Per-module Merkle identity (source + deps; external deps fold the full specifier string into the leaf: `runtime:${specifier}@${fingerprint}`) | `packages/runner/src/harness/module-identity.ts:145-149` | Makes pinned specifiers content-derived with **no hashing changes** (§ Snapshot semantics) |
-| Piece → pattern pointers: `meta("pattern")` = patternId URI; `meta("patternIdentity")` = `{ identity, symbol }` (entry-module identity) | `packages/runner/src/runner.ts:4137-4159` | "Current pattern of a piece" is read here at pin time |
-| Pattern meta cell: `program {main, files}`, `entryIdentity`, `parents`, `spec` | `packages/runner/src/pattern-manager.ts:55-90` | Source-of-truth for a pattern's source set |
-| Compile cache: source docs `pattern:<identity>`, compiled docs `compileCache:<rtVersion>/<identity>` | `packages/runner/src/compilation-cache/cell-cache.ts` | Content-addressed per-module source + compiled storage; imports resolve from and dedupe into it |
-| Slugs: `[a-z0-9]+(-[a-z0-9]+)*`, ≤80 chars; slug id = `hashOf({causal:{space, slug}})`, redirect cell | `packages/runner/src/slugs.ts`, `packages/piece/src/slugs.ts` | Human-readable piece locators |
+| Piece → pattern pointers: `meta("pattern")` = patternId URI (`of:<hash>`); `meta("patternIdentity")` = `{ identity, symbol }` (entry-module identity) | `packages/runner/src/runner.ts:4137-4159` | One hop in the resolution chain |
+| Pattern meta cell: `program {main, files}`, `entryIdentity`, `parents`, `spec`; cell id = patternId (`of:<hash>`, a causal ref) | `packages/runner/src/pattern-manager.ts:55-90` | Source-of-truth envelope for a pattern's source set |
+| Compile cache: source docs at cell key **`pattern:<identity>`**, compiled docs at `compileCache:<rtVersion>/<identity>` | `packages/runner/src/compilation-cache/cell-cache.ts:71-81` | **The URI a pattern is saved under by hash.** Content-addressed per-module source + compiled storage; imports resolve from and dedupe into it |
+| Slug cells: generic **redirect link to any cell** (`setSlugLink` is target-agnostic; only `resolvePieceAddress` layers a "must be a piece" check) | `packages/piece/src/slugs.ts:34-80` | Slugs can name pieces *or* patterns today, mechanically |
+| Slug ids: `hashOf({causal:{space, slug}})`; slug grammar `[a-z0-9]+(-[a-z0-9]+)*`, ≤80 chars; **`isSlugAddress(t) = !t.includes(":")`** | `packages/runner/src/slugs.ts` | The existing slug-vs-URI discriminator the grammar reuses |
 | `loadPatternByIdentity(entryIdentity, symbol, space)` | `packages/runner/src/pattern-manager.ts:985` | Existing by-identity load path the resolver builds on |
+
+### The two "pattern by hash" handles, explicitly
+
+Because both come up, and only one is the pin:
+
+- **`of:<patternId>`** — the pattern **meta cell**'s entity URI
+  (`toURI(createRef(...))`, `packages/runner/src/uri-utils.ts:12`). A *causal*
+  ref: resolvable (it's a cell address) but not re-hash-verifiable from fetched
+  content alone, and its derivation is not purely source-content in all paths.
+  Usable as a reference *starting point*; never the pin.
+- **`pattern:<identity>`** — the per-module **source-set document key**
+  (`cell-cache.ts:sourceDocKey`), where `<identity>` is the prefix-free
+  entry-module Merkle hash (authored source + authored path + dep hashes;
+  `computeModuleHashes`). Verifiable by re-hashing, entry-point independent,
+  and the namespace all existing by-identity machinery keys on
+  (`cf:module/<hash>`, compile cache, `$patternRef`,
+  `meta("patternIdentity")`). **This is the pin**, and `cf:pattern:<identity>`
+  is its reference spelling.
 
 ## Specifier syntax
 
-### Recommended: the `cf:` scheme
+### One grammar, no type tag
 
-Two authored forms, one scheme:
+```
+cf:[//host/][<space>/]<ref>[/<subpath>][@<pin>]
+
+ref     = slug                ; no ":" — isSlugAddress convention
+        | "of:" hash          ; cell URI (pattern meta cell, or a piece's entity id)
+        | "pattern:" hash     ; entry-module identity (content-addressed source)
+space   = space-name | space-did | "~"     ; "~" = the compiling space
+host    = domain[":"port]                  ; a toolshed
+pin     = entry-module identity hex
+```
+
+Examples:
 
 ```tsx
-// Deployed piece — "the pattern this piece currently runs":
-import { TodoItem } from "cf:piece/todo-list";                                // slug in the current space
-import { TodoItem } from "cf:piece/kitchen/todo-list";                        // space by name
-import { TodoItem } from "cf:piece/did:key:z6Mk…/todo-list";                  // space by DID
-import { TodoItem } from "cf:piece/toolshed.common.tools/kitchen/todo-list";  // explicit toolshed host
-import { TodoItem } from "cf:piece/~/todo-list/schemas";                      // ~ = current space (needed with subpaths)
+import { TodoItem } from "cf:todo-list";                            // slug, current space
+import { TodoItem } from "cf:kitchen/todo-list";                    // space by name
+import { TodoItem } from "cf:did:key:z6Mk…/todo-list";              // space by DID
+import { TodoItem } from "cf://toolshed.common.tools/kitchen/todo-list";  // explicit toolshed
+import { todoSchema } from "cf:~/todo-list/schemas";                // subpath (phase 2; "~" required)
+import { TodoItem } from "cf:pattern:9f2ab…e41";                    // content-addressed, space-free
+import { TodoItem } from "cf:kitchen/of:bafy…";                     // pattern meta cell by URI
 
-// Content-addressed pattern source (immutable):
-import { TodoItem } from "cf:pattern/9f2ab…e41";
-import { todoSchema } from "cf:pattern/9f2ab…e41/schemas";                    // subpath (phase 2)
-
-// Pinned piece reference — what a deployed importer actually stores (§ Snapshot semantics):
-import { TodoItem } from "cf:piece/kitchen/todo-list@9f2ab…e41";
+// What a deployed importer actually stores (§ Snapshot semantics):
+import { TodoItem } from "cf:kitchen/todo-list@9f2ab…e41";
 ```
 
-Grammar (`<hash>` is the prefix-free module-identity hex, the same string that
-appears in `cf:module/<hash>` and the compile-cache keys):
+Parsing rules (each segment class is syntactically disjoint):
 
-```
-fabric-import  = "cf:piece/" locator [ "/" subpath ] [ "@" hash ]
-               | "cf:pattern/" hash [ "/" subpath ]
+- After `cf:`, a leading `//` introduces a **host** (URL-authority style); a
+  single leading `/` is permitted and ignored. Hosts only appear in the
+  authority position, so no dot-sniffing of path segments is needed.
+- The **pin** is always a trailing `@<hash>`; strip it first. Slugs, space
+  names, DIDs, and hosts cannot contain `@`.
+- Segments split on `/`. **One segment** ⇒ it is the `ref`, current space.
+  **Two or more** ⇒ the first is the `space` (name, DID — colons inside a
+  segment are fine — or `~`), the second is the `ref`, the rest is `subpath`.
+  Consequence: a subpath on a current-space ref requires the `~` placeholder
+  (`cf:~/todo-list/schemas`); a misparse fails loudly at space resolution.
+- A `ref` containing `:` is a cell URI (`of:`, `pattern:`); otherwise it must
+  validate as a slug. `pattern:` refs are space-free-capable (content
+  addressed; the space, if given, is only a resolution hint). Slug refs always
+  need a space (slug ids are space-scoped: `slugIdForSpace`).
+- The emitted-namespace specifiers `cf:module/<hash>` and `cf:cache-root/`
+  remain compiler-internal and are **rejected in authored source**.
 
-locator        = slug                          ; current space, current toolshed
-               | space "/" piece               ; explicit space
-               | host "/" space "/" piece      ; explicit toolshed
+### Resolution rule (uniform, type-free)
 
-space          = space-name | space-did | "~"  ; "~" = the compiling space
-piece          = slug | "fid1:" hash           ; slug or entity id
-host           = domain[":" port]              ; recognized by containing "." or being localhost[:port]
-```
+Starting from the named cell, follow pointers until a pattern source is
+reached:
 
-Disambiguation rules (each segment class is syntactically disjoint):
+1. slug → slug cell's redirect target (`resolveSlugTargetCell`);
+2. a cell with `meta("pattern")` (a **piece**) → prefer
+   `meta("patternIdentity").identity`; else follow `meta("pattern")` to the
+   meta cell;
+3. a **pattern meta cell** → `entryIdentity` (computing it from `program` via
+   `computeModuleHashes` if absent — legacy metas);
+4. a `pattern:<identity>` ref → already terminal.
 
-- The pin is always a trailing `@<hash>`; strip it first. Slugs, space names,
-  DIDs, and hosts cannot contain `@`.
-- A leading segment is a **host** iff it contains a `.` (or is
-  `localhost[:port]`). Slugs and space names used in references must match the
-  slug grammar (no `.`/`:`); DIDs start with `did:` but contain no `.` before
-  the method-specific part — references requiring an explicit host always use
-  the 3-segment form, so the dot rule only has to separate hosts from space
-  names.
-- A single-segment `cf:piece/<slug>` is the current-space shorthand. Subpaths
-  on current-space references require the `~` placeholder
-  (`cf:piece/~/<slug>/<subpath>`) so segment counting stays unambiguous.
+Anything that doesn't chase to a pattern is a compile error ("does not resolve
+to a pattern", naming the chain followed). The chain is short (≤3 hops) and
+each hop is an ordinary cell read under ordinary space authz.
 
 Why this shape:
 
 - **`cf:` already exists** as the runtime's identity scheme (`cf:module/<hash>`
-  in compiled output and `fn.src`). Authored imports get sibling namespaces
-  (`cf:piece/`, `cf:pattern/`); the emitted namespace `cf:module/` stays
-  compiler-internal and is rejected in authored source.
+  in compiled output and `fn.src`); authored references get the human-facing
+  side of the same scheme.
 - **A scheme cannot collide** with npm bare specifiers (npm names cannot
   contain `:`), with `npm:`/`jsr:` (different prefixes), or with `https:` URLs
   (§ External packages).
@@ -126,43 +173,52 @@ Why this shape:
   is entirely ours via the `ProgramResolver`/compiler-host seam, and TypeScript
   is satisfied through the same mechanism that resolves `commonfabric` today
   (`packages/js-compiler/typescript/compiler.ts:176-207`).
+- **It is the shell's URL shape with a scheme on it** —
+  `/{spaceNameOrDid}/{pieceIdOrSlug}` — so users learn one addressing model.
+- **Publication = naming.** `slug → pattern meta cell` in a readable space is
+  the whole publish story; updating the slug is publishing a new version
+  (dist-tag semantics). Pieces and published patterns are then *the same kind
+  of reference target*, differing only by one hop.
 
 ### Alternatives considered
 
-1. **URL-authority form: `cf://toolshed.common.tools/kitchen/todo-list`.**
-   Standard URL parsing and a natural home for the host, but the common cases
-   (current toolshed, current space) have no natural spelling — `cf:///kitchen/…`
-   or an empty authority is awkward — and it diverges stylistically from
-   `cf:module/<hash>`, which is authority-less. Rejected.
+1. **Type-tagged namespaces: `cf:piece/…` and `cf:pattern/…`** (this spec's
+   first draft). Encodes in the specifier whether the name is a live piece or
+   a published source. Dropped: slug cells are type-agnostic redirects anyway,
+   the tag duplicates information that resolution discovers in one hop and
+   that the pin erases entirely, and it forbids the natural
+   slug-points-at-pattern publishing story (or forces `cf:piece/` to
+   sometimes name patterns, which is worse). The only real loss is that a
+   reader can't tell pointer kind from the import line — but the pinned form
+   is what's stored, and the pin means the same thing in both cases.
 2. **Bare scope: `@fabric/kitchen/todo-list`.** Reads like npm, which is
    exactly the problem: it squats on the npm scope namespace we want to keep
    clean for real packages later, and "looks installable" misleads. Rejected.
 3. **Pin as a separate sidecar lockfile** instead of in-specifier `@<hash>` —
    see § Snapshot semantics for why the pin lives in the source.
 
-## Snapshot semantics: how piece references determine hashes
+## Snapshot semantics: how mutable references determine hashes
 
-The question: a piece's current pattern is a mutable pointer. When does an
-importer's hash sample it?
+Both mutable pointer kinds — a slug (re-assignable) and a piece's current
+pattern (changes on iterate/edit) — raise the same question: when does an
+importer's hash sample the pointer?
 
 **Decision: a one-time snapshot at *pin time* (deploy/authoring), persisted in
 the source itself — never at compile time, never continuously.**
 
 Mechanics:
 
-1. When a pattern containing an unpinned `cf:piece/...` import is **deployed**
-   (or a dev/iterate flow explicitly resolves dependencies), the toolchain
-   reads the piece's current `meta("patternIdentity").identity` (fallback:
-   `meta("pattern")` → pattern meta cell → `entryIdentity`, computing it from
-   `program` if absent) and **rewrites the specifier in the stored source** to
-   the pinned form:
+1. When a pattern containing an unpinned mutable reference is **deployed** (or
+   a dev/iterate flow explicitly resolves dependencies), the toolchain runs
+   the resolution rule to the terminal entry-module identity and **rewrites
+   the specifier in the stored source** to the pinned form:
 
    ```tsx
-   import { TodoItem } from "cf:piece/kitchen/todo-list@9f2ab…e41";
+   import { TodoItem } from "cf:kitchen/todo-list@9f2ab…e41";
    ```
 
    The stored program is then fully deterministic: compilation, identity, and
-   execution never read the piece pointer again.
+   execution never read the slug or piece again.
 
 2. **The pinned hash folds into the importer's identity for free.** Module
    identity already hashes external deps as `runtime:${specifier}@${fingerprint}`
@@ -181,12 +237,13 @@ Mechanics:
 
 4. **Updating is an explicit authoring action.** `cf deps update
    [<specifier>]` (and an equivalent affordance in the shell's iterate flow)
-   re-resolves the piece pointer and rewrites the pin — an ordinary source
-   edit, visible in lineage (`parents`) like any other edit. The unpinned form
-   never reaches deployed storage: deploying with an unpinned piece reference
-   pins it; a stored program containing an unpinned `cf:piece/` specifier is a
-   compile error. `cf dev`/`cf check` resolve unpinned references live against
-   the connected toolshed and print what they resolved to.
+   re-runs resolution and rewrites the pin — an ordinary source edit, visible
+   in lineage (`parents`) like any other edit. The unpinned form never reaches
+   deployed storage: deploying with an unpinned mutable reference pins it; a
+   stored program containing one is a compile error. `cf dev`/`cf check`
+   resolve unpinned references live against the connected toolshed and print
+   what they resolved to. `cf:pattern:<hash>` refs are born pinned (the ref
+   *is* the pin; no rewrite).
 
 Why not continuous tracking: re-snapshotting on target change would make the
 importer's identity (and therefore its compiled artifacts, scheduler keys, and
@@ -199,35 +256,29 @@ the pattern meta cell) would preserve authored bytes exactly, but then program
 identity becomes a function of *(source, lockmap)* and every consumer of
 `computeId`/`computeModuleHashes`/`cf check` must thread the lockmap. The
 in-source pin keeps "identity = hash of source" true, keeps the pin visible and
-diffable, and retains provenance (the piece pointer stays in the specifier, so
-tooling knows what to re-resolve). This deliberately borrows the
+diffable, and retains provenance (the mutable pointer stays in the specifier,
+so tooling knows what to re-resolve). This deliberately borrows the
 `npm:pkg@version` shape — the pin step is "lockfile semantics, written back
 into the import statement."
 
-### What `cf:pattern/<hash>` means exactly
+### Why the pin is the entry-module identity
 
-The hash is the **entry-module identity** of the referenced source program —
-the same prefix-free Merkle hash over (authored source, authored path, dep
-hashes) used by the compile cache and `$patternRef`
-(`docs/specs/content-addressed-action-identity.md`). Chosen over the
-alternative candidates:
+The pin records what `meta("patternIdentity")` already carries. The
+alternatives fail:
 
-- *patternId* (`of:<hash>` of the pattern meta cell, what `meta("pattern")`
-  stores): resolvable, but it is a causal ref whose derivation is not purely
-  source-content in all paths, so a fetched program can't be verified against
-  it by re-hashing alone. The pin records what `meta("patternIdentity")`
-  carries instead — already the fast-path identity pieces store.
-- *whole-program id* (`computeId`): entry-point and sibling-file sensitive, and
-  not the namespace existing load machinery (`loadPatternByIdentity`, compile
-  cache) keys on.
+- *patternId* (`of:<hash>`): a causal ref whose derivation is not purely
+  source-content, so a fetched program can't be verified against it by
+  re-hashing alone — fine as a reference starting point, unusable as an
+  integrity anchor.
+- *whole-program id* (`computeId`): entry-point and sibling-file sensitive,
+  and not the namespace existing load machinery keys on.
 
 Because the identity is a Merkle root, the transitive source closure is
-discoverable and verifiable from it (source docs in the cell cache store
-per-module source + resolved import links), and cycles are impossible by
-construction — a hash cannot reference itself. (Unpinned piece references can
-form cycles — A imports piece B whose pattern imports piece A — only during
-live dev resolution, where the resolver needs an ordinary cycle guard; pinned
-chains are DAGs.)
+discoverable and verifiable from it (source docs at `pattern:<identity>` store
+per-module source + resolved import links), and pinned chains cannot cycle — a
+hash cannot reference itself. (Unpinned mutable references can form cycles —
+A imports slug B whose pattern imports slug A — only during live dev
+resolution, where the resolver needs an ordinary cycle guard.)
 
 ## What an import gives you
 
@@ -246,8 +297,8 @@ join inside the mounted program).
 |---|---|---|
 | `./ ../ /` | program-relative files | today |
 | bare (`commonfabric`, `turndown`, …) | **reserved for runtime modules only**, allowlist | today; never used for packages |
-| `cf:piece/ cf:pattern/` | this spec (authored) | new |
-| `cf:module/` | compiled output only; rejected in authored source | today |
+| `cf:` (authored reference grammar above) | this spec | new |
+| `cf:module/`, `cf:cache-root/` | compiled output / cache internals; rejected in authored source | today |
 | `npm: jsr: https:` | future external packages | reserved now |
 
 Reserving bare specifiers for runtime modules is the load-bearing rule: future
@@ -259,18 +310,18 @@ policy check stays a single dispatch on prefix
 **(b) Syntax and semantics worth borrowing:**
 
 - **Deno's `npm:pkg@version/subpath` and `jsr:@scope/pkg@version`** — the
-  trailing-`@version` pin position is exactly what `cf:piece/...@<hash>`
-  borrows, so pinned fabric refs and pinned npm refs read the same way.
+  trailing-`@version` pin position is exactly what `cf:…@<hash>` borrows, so
+  pinned fabric refs and pinned npm refs read the same way.
 - **Lockfile semantics, but written into the source** (above). For npm, a
   version pin is *not* content-addressed (registries are mutable), so the pin
   step should additionally **vendor**: fetch the resolved module graph (e.g.
   from esm.sh), store it as a content-addressed source set in the fabric — the
-  same source-doc shape patterns use — and record the vendored identity. An
-  npm import then *is* a `cf:pattern/<hash>` underneath: one resolution path,
-  one storage shape, one verification step, integrity for free, reproducible
-  offline. The authored specifier keeps the npm provenance
-  (`npm:preact@10.26.4` plus the vendored pin), mirroring the piece/pattern
-  split: mutable pointer in the specifier, content hash as the pin.
+  same `pattern:<identity>` source-doc shape — and record the vendored
+  identity. An npm import then *is* a `cf:pattern:<hash>` underneath: one
+  resolution path, one storage shape, one verification step, integrity for
+  free, reproducible offline. The authored specifier keeps the npm provenance
+  (`npm:preact@10.26.4` plus the vendored pin), mirroring the fabric split:
+  mutable pointer in the specifier, content hash as the pin.
 - **esm.sh's target/bundle query conventions** (`?target=es2022`, `?bundle`)
   only if we ever serve compiled variants; authored-source identity hashing
   deliberately ignores compiled form, so these stay out of identity.
@@ -290,25 +341,24 @@ with storage and network access, and `ProgramResolver.resolveSource` is async)
 ### 1. Specifier parsing + policy
 
 - New `packages/runner/src/sandbox/fabric-import-specifier.ts`: parse/format
-  for the grammar above (locator, pin, subpath; host/space/slug
-  disambiguation).
+  for the grammar above (host/space/ref/subpath/pin), reusing
+  `isSlugAddress`/`validateSlug`.
 - `runtime-module-policy.ts`: `isAllowedAuthoredImportSpecifier` accepts
-  `cf:piece/` and `cf:pattern/` prefixes (and continues to reject `cf:module/`
-  in authored source).
+  specifiers parsing under the `cf:` reference grammar (and continues to
+  reject the emitted namespaces `cf:module/`, `cf:cache-root/`).
 
 ### 2. Resolution (a `FabricProgramResolver` wrapper)
 
 Engine wraps the authored resolver; on a `cf:` specifier:
 
-1. **Locator → identity** (piece refs): pinned → use the pin, never read the
-   piece. Unpinned (dev only) → resolve space (name → DID via toolshed, or
-   `~` → compiling space), slug → slug cell redirect → piece, read
-   `meta("patternIdentity").identity` (fallback chain per § Snapshot
-   semantics).
+1. **Reference → identity**: pinned (or `pattern:` ref) → use the hash, never
+   touch the mutable pointer. Unpinned (dev only) → run the uniform chase:
+   resolve space (`~`/name/DID), slug cell redirect, piece `meta(…)` hop,
+   meta-cell `entryIdentity`.
 2. **Identity → source set**, first hit wins, every hop hash-verified:
-   1. local/space compile cache source docs (`pattern:<identity>`, walking
+   1. local/space compile-cache source docs (`pattern:<identity>`, walking
       import links);
-   2. the referenced piece's space (for piece refs);
+   2. the space named in the reference (if any);
    3. the toolshed registry endpoint (below);
    4. for host-qualified refs, that host's registry endpoint.
 3. **Verify**: recompute `computeModuleHashes` over the fetched program (its
@@ -349,31 +399,33 @@ import costs nothing the deployed pattern hasn't already paid.
 
 ### 4. Toolshed surface
 
-Two new endpoints (names indicative), both per-toolshed — this is the "which
-toolshed" in a host-qualified reference, defaulting to the toolshed the
-compiling runtime's session is connected to:
+Two new endpoints (names indicative), both per-toolshed — this is the host in
+a host-qualified reference, defaulting to the toolshed the compiling runtime's
+session is connected to:
 
-- `GET /api/registry/piece/:space/:pieceRef` → `{ spaceDid, pieceId,
-  patternId, patternIdentity }` — resolves a space name/DID + slug/entity-id
-  to the piece's current pattern pointers. Auth: requires read access to the
-  space (same authz as a memory read; this is a convenience projection, not a
-  bypass). Used by CLI/CI pin steps and cross-toolshed resolution without a
-  full memory session.
+- `GET /api/registry/resolve/:space/:ref` → `{ spaceDid, chain: [...],
+  entryIdentity, patternId }` — runs the uniform resolution chase for a slug
+  or cell-URI ref and reports the terminal identity (plus the chain, for
+  tooling/error messages). Auth: requires read access to the space (same
+  authz as a memory read; this is a convenience projection, not a bypass).
+  Used by CLI/CI pin steps and cross-toolshed resolution without a full
+  memory session.
 - `GET /api/registry/pattern/:identity` → the source set
   (`{ main, files: [{name, contents}] }`, plus per-module identities) for a
-  **published** pattern. Backed by a publish flow: `cf publish` (or
-  deploy-to-a-public-space) writes the source docs to a well-known
-  toolshed-readable space. Responses are immutable and cacheable
-  (`Cache-Control: immutable`, like blobs); clients verify by re-hashing, so
-  mirroring is safe.
+  **published** pattern. Backed by publication-as-naming: assigning a slug to
+  a pattern meta cell in a toolshed-readable space (sugar: `cf publish`).
+  Responses are immutable and cacheable (`Cache-Control: immutable`, like
+  blobs); clients verify by re-hashing, so mirroring is safe.
 
 The existing `/api/patterns/:filename` (repo-file serving) is unrelated and
 unchanged.
 
 ### 5. CLI / shell
 
-- `cf deploy`: pins unpinned piece refs (writes the rewritten source into the
-  pattern meta `program`), publishes source sets if the target is public.
+- `cf deploy`: pins unpinned mutable refs (writes the rewritten source into
+  the pattern meta `program`).
+- `cf publish <pattern> [--slug name] [--space …]`: ensure source docs exist
+  in the target space + assign the slug to the meta cell.
 - `cf deps update [specifier]`: re-resolve + rewrite pins.
 - `cf dev` / `cf check`: live-resolve unpinned refs against the connected
   toolshed; `--frozen` to forbid (CI). `--show-transformed` shows mounted
@@ -383,12 +435,12 @@ unchanged.
 
 ### Phasing
 
-1. **`cf:pattern/<hash>`, same-space.** No new endpoints, no pinning step —
+1. **`cf:pattern:<hash>`, same-space.** No new endpoints, no pinning step —
    resolution entirely via existing cell-cache source docs +
    `computeModuleHashes` verification. Proves the resolver/mounting/emit seams.
-2. **`cf:piece/…` + pinning + slugs**, current toolshed; registry piece
-   endpoint; deploy-time pin rewrite; `cf deps update`.
-3. **Publish flow + registry pattern endpoint + host-qualified refs**
+2. **Slug/piece refs + pinning**, current toolshed; registry resolve endpoint;
+   deploy-time pin rewrite; `cf deps update`.
+3. **`cf publish` + registry pattern endpoint + host-qualified refs**
    (cross-toolshed).
 4. **Subpaths; `npm:`/esm.sh vendoring** on the same rails.
 
@@ -398,10 +450,10 @@ unchanged.
   import is a trust decision equivalent to pasting the source in: same SES
   verification, same CFC treatment, same space access. The pin makes that
   decision about *exact bytes* — review-at-pin is meaningful.
-- **Slug re-pointing is inert for deployed importers.** Re-pointing a piece (or
-  swapping its pattern) cannot change any pinned importer; it changes only
-  future pins. This closes the classic "dependency hijack via mutable pointer"
-  hole by construction.
+- **Re-pointing is inert for deployed importers.** Re-assigning a slug or
+  swapping a piece's pattern cannot change any pinned importer; it changes
+  only future pins. This closes the classic "dependency hijack via mutable
+  pointer" hole by construction.
 - **Mirrors and registries are trust-free.** Every fetched source set is
   verified by recomputing the Merkle identity; a malicious toolshed can refuse
   to serve but cannot substitute code.
@@ -410,31 +462,35 @@ unchanged.
   (`docs/specs/content-addressed-action-identity.md`); imported modules verify
   and register exactly like authored ones. No new identity kind is introduced.
 - **No ambient escalation surface.** The registry endpoints expose only what a
-  space-read already grants (piece endpoint) or what publishing deliberately
+  space-read already grants (resolve endpoint) or what publishing deliberately
   made public (pattern endpoint).
 
 ## Failure modes (all compile-time errors with actionable messages)
 
 | Failure | Error |
 |---|---|
-| Slug/space/piece not found, or no read access | "cannot resolve cf:piece/… (space/slug/permission)" naming the failing hop |
-| Piece has no pattern pointer | "piece … has no current pattern" |
-| Unpinned piece ref in deployed/`--frozen` compile | "unpinned fabric import; run `cf deps update` / deploy to pin" |
-| Source set unavailable at every resolution hop | "source for cf:pattern/<hash> not found (tried: local, space …, registry …)" |
+| Slug/space not found, or no read access | "cannot resolve cf:… (space/slug/permission)" naming the failing hop |
+| Chain does not terminate at a pattern (slug → data cell, piece without pattern, …) | "cf:… does not resolve to a pattern" + the chain followed |
+| Unpinned mutable ref in deployed/`--frozen` compile | "unpinned fabric import; run `cf deps update` / deploy to pin" |
+| Source set unavailable at every resolution hop | "source for pattern:<hash> not found (tried: local, space …, registry …)" |
 | Hash mismatch on fetched source | "integrity failure for <hash> from <source>" (and the hop is skipped, next source tried) |
-| Cycle during live (unpinned) resolution | "cyclic piece imports: A → B → A" |
+| Cycle during live (unpinned) resolution | "cyclic imports: A → B → A" |
 | Imported source fails SES verification | existing verifier error, attributed to the imported module's original path |
 
 ## Test plan
 
-- **Grammar**: parse/format round-trips; host/space/slug disambiguation table;
-  rejection of `cf:module/` in authored source.
+- **Grammar**: parse/format round-trips; host/space/ref/subpath/pin
+  disambiguation table (incl. `~`, DIDs-as-space, `of:`/`pattern:` refs);
+  rejection of `cf:module/` and `cf:cache-root/` in authored source.
+- **Resolution chase**: slug→piece→pattern, slug→pattern (direct
+  publication), `of:<patternId>` start, `pattern:<hash>` terminal; "not a
+  pattern" failures per chain shape.
 - **Identity folding** (red-green): two importers identical except for the pin
   hash get different module identities; pin rewrite changes `computeId`.
 - **Snapshot semantics**: deploy piece A; deploy importer B (pin captured);
-  update A's piece to a new pattern; B's compile, identity, and behavior are
-  byte-identical until `cf deps update`, after which only the specifier line
-  differs.
+  move A's piece (and separately: re-point the slug) to a new pattern; B's
+  compile, identity, and behavior are byte-identical until `cf deps update`,
+  after which only the specifier line differs.
 - **Dedupe**: importer of a running piece's pattern reuses its compiled docs
   and live module namespace (assert on `esmCacheStats` / `modulesByIdentity`
   hits).
@@ -446,24 +502,29 @@ unchanged.
 
 ## Open questions
 
-1. **Publish granularity.** Is "publish" a distinct user action (`cf publish`)
-   or implicit for any piece readable by the reference resolver? Implicit is
-   ergonomic but turns space-read into source-disclosure; explicit publish is
-   the conservative default proposed here.
-2. **Space-name resolution.** Piece refs with space *names* (not DIDs) need a
+1. **Publish granularity.** Is "publish" a distinct user action (`cf publish`
+   / slug assignment) or implicit for any pattern readable by the reference
+   resolver? Implicit is ergonomic but turns space-read into
+   source-disclosure; explicit publish is the conservative default proposed
+   here.
+2. **Space-name resolution.** Refs with space *names* (not DIDs) need a
    name→DID resolution authority; the shell resolves names client-side today.
-   The registry piece endpoint can own this, but name squatting/renaming
+   The registry resolve endpoint can own this, but name squatting/renaming
    semantics need a decision before phase 2 (DID-form refs sidestep it).
-3. **Type-only imports.** Should `import type { … }` from a fabric ref skip
+3. **Slug-cell typing.** The uniform chase duck-types its hops
+   (`meta("pattern")` present ⇒ piece; matches `patternMetaSchema` ⇒ pattern
+   meta). Good enough, or should slug assignment stamp an explicit kind on
+   the slug cell for better errors and tooling?
+4. **Type-only imports.** Should `import type { … }` from a fabric ref skip
    the pin requirement (types don't affect runtime identity)? Tempting, but
    the transformer lowers types into schemas — so types DO affect emitted
    behavior, and the conservative answer is no special-casing. Revisit with
    evidence.
-4. **Subpath surface.** Whether subpaths may address any file in the program
+5. **Subpath surface.** Whether subpaths may address any file in the program
    or only files the entry re-exports (an "exports map" discipline, like npm's
    `exports`). Start permissive, tighten if published-internal-file coupling
    becomes a problem.
-5. **Runtime-fingerprint interaction.** External-dep leaves include
+6. **Runtime-fingerprint interaction.** External-dep leaves include
    `runtimeFingerprint`; a runtime upgrade thus shifts importer identities even
    with identical pins (status quo for runtime modules, now also for fabric
    refs). Acceptable, but worth stating in the compile-cache invalidation

--- a/docs/specs/pattern-imports/README.md
+++ b/docs/specs/pattern-imports/README.md
@@ -4,7 +4,7 @@ Letting authored patterns import other patterns published in the fabric:
 
 ```tsx
 import { TodoItem, todoSchema } from "cf:/kitchen/todo-list";  // a slug — names a piece OR a published pattern
-import { TodoItem } from "cf:pattern:9f2ab…e41";               // a content-addressed source, directly
+import { TodoItem } from "cf:pattern:AvcnyZ…rC1c";               // a content-addressed source, directly
 ```
 
 A reference names a **starting cell** — by slug or by cell URI, optionally
@@ -83,7 +83,7 @@ Design.
 
 Because both come up, and only one is the pin:
 
-- **`of:<patternId>`** — the pattern **meta cell**'s entity URI
+- **`of:fid1:<patternId>`** — the pattern **meta cell**'s entity URI
   (`toURI(createRef(...))`, `packages/runner/src/uri-utils.ts:12`). A *causal*
   ref: resolvable (it's a cell address) but not re-hash-verifiable from fetched
   content alone, and its derivation is not purely source-content in all paths.
@@ -110,12 +110,21 @@ cf:/<space>/<ref>[/<subpath>][@<pin>]              ; explicit space
 cf://<host>/<space>/<ref>[/<subpath>][@<pin>]      ; explicit toolshed
 
 ref     = slug                ; no ":" — isSlugAddress convention
-        | "of:" hash          ; cell URI (pattern meta cell, or a piece's entity id)
+        | "of:fid1:" hash     ; cell URI (pattern meta cell, or a piece's entity id)
         | "pattern:" hash     ; entry-module identity (content-addressed source)
 space   = space-name | space-did
 host    = domain[":"port]     ; a toolshed
-pin     = entry-module identity hex
+pin     = "@" hash            ; entry-module identity
+hash    = 43 base64url chars  ; hashStringOf/hashOf output (value-hash.ts):
+                              ; [A-Za-z0-9_-], case-SENSITIVE, no padding —
+                              ; e.g. Avcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c
 ```
+
+(Hashes are **not** hex: `hashStringOf` emits unprefixed base64url
+(`packages/data-model/src/value-hash.ts:553`), and entity URIs carry the
+`fid1:` tag inside `of:` — `of:fid1:<hash>` is what `toURI` produces. The
+base64url alphabet contains no `/`, `@`, or `:`, so pin-splitting and
+segment-splitting stay unambiguous.)
 
 Examples:
 
@@ -125,11 +134,11 @@ import { todoSchema } from "cf:todo-list/schemas";                  // subpath (
 import { TodoItem } from "cf:/kitchen/todo-list";                   // space by name
 import { TodoItem } from "cf:/did:key:z6Mk…/todo-list";             // space by DID
 import { TodoItem } from "cf://toolshed.common.tools/kitchen/todo-list";  // explicit toolshed
-import { TodoItem } from "cf:pattern:9f2ab…e41";                    // content-addressed, space-free
-import { TodoItem } from "cf:/kitchen/of:bafy…";                    // pattern meta cell by URI
+import { TodoItem } from "cf:pattern:AvcnyZ…rC1c";                    // content-addressed, space-free
+import { TodoItem } from "cf:/kitchen/of:fid1:ZwjMI…A2Os";          // pattern meta cell by URI
 
 // What a deployed importer actually stores (§ Snapshot semantics):
-import { TodoItem } from "cf:/kitchen/todo-list@9f2ab…e41";
+import { TodoItem } from "cf:/kitchen/todo-list@AvcnyZ…rC1c";
 ```
 
 Parsing rules (each form is disjoint by prefix; no segment counting needed):
@@ -220,7 +229,7 @@ Mechanics:
    the specifier in the stored source** to the pinned form:
 
    ```tsx
-   import { TodoItem } from "cf:/kitchen/todo-list@9f2ab…e41";
+   import { TodoItem } from "cf:/kitchen/todo-list@AvcnyZ…rC1c";
    ```
 
    The stored program is then fully deterministic: compilation, identity, and

--- a/docs/specs/pattern-imports/implementation-plan.md
+++ b/docs/specs/pattern-imports/implementation-plan.md
@@ -94,7 +94,12 @@ Reload paths:
 
 - **fabric ref / fabric specifier** — an authored import specifier under the
   `cf:` grammar (`cf:pattern:<hash>`, `cf:/kitchen/todo-list@<hash>`, …).
-- **pin** — the trailing `@<hex>` entry-module identity on a mutable ref.
+- **pin** — the trailing `@<hash>` entry-module identity on a mutable ref.
+- **hash** — 43 base64url chars (`[A-Za-z0-9_-]`, case-SENSITIVE, no
+  padding), the unprefixed output of `hashStringOf`/`hashOf`
+  (`packages/data-model/src/value-hash.ts:553`). NOT hex — e.g.
+  `Avcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c`. Never lowercase or
+  otherwise normalize a hash.
 - **terminal identity** — the entry-module identity a ref resolves to.
 - **subtree** — the source closure of one imported pattern (its own program).
 - **mount** — a subtree's files spliced into a compilation under
@@ -117,10 +122,13 @@ export interface FabricRef {
   space?: string;
   ref:
     | { kind: "slug"; slug: string }
+    // "of" = entity URI (stored/spelled "of:fid1:<hash>"); "pattern" =
+    // entry-module identity ("pattern:<hash>"). hash is the bare base64url
+    // part (no "fid1:" tag) in both cases.
     | { kind: "uri"; scheme: "of" | "pattern"; hash: string };
   /** Path inside the target program (phase 4; parsed, rejected downstream). */
   subpath?: string;
-  /** Trailing @<hex> pin. */
+  /** Trailing @<hash> pin (base64url — see glossary; never normalized). */
   pin?: string;
 }
 
@@ -176,9 +184,16 @@ Parsing algorithm — implement exactly this order:
    - otherwise: no host, no space; all of `rest` per step 6.
 6. **Ref + subpath**: of the remaining `"/"`-separated segments, the FIRST is
    the ref token; the rest (joined by `"/"`) is `subpath` (omit when empty).
-   - Ref token contains `":"` → URI form: must match
-     `/^(of|pattern):([0-9a-f]+)$/` with the hash matching `HASH_RE`;
-     anything else with a colon throws `"unsupported cell URI scheme"`.
+   - Ref token contains `":"` → URI form. Accepted shapes (hash part must
+     match `HASH_RE`):
+     - `pattern:<hash>` → `{ scheme: "pattern", hash }`
+     - `of:fid1:<hash>` → `{ scheme: "of", hash }` (what `toURI` emits —
+       `packages/runner/src/uri-utils.ts:12`; the `fid1:` tag is required
+       inside `of:`)
+     - `fid1:<hash>` → alias for `of:fid1:<hash>` (the shell's bare piece-id
+       form); `formatFabricRef` canonicalizes to `of:fid1:<hash>`.
+     Anything else with a colon throws `"unsupported cell URI scheme"`
+     (including `of:<hash>` without the `fid1:` tag, and `data:`).
    - No colon → slug form: validate with `validateSlug` from
      `packages/runner/src/slugs.ts` (re-throw its message wrapped in
      FabricRefError).
@@ -189,9 +204,19 @@ Parsing algorithm — implement exactly this order:
    the URI hash throws `"conflicting pin"`. (Equal is allowed, normalized to
    pin-absent by `formatFabricRef`.)
 
-`HASH_RE`: lowercase hex, length 32–128: `/^[0-9a-f]{32,128}$/`. Add a unit
-test that feeds a REAL hash from `computeModuleHashes` (import it, hash a
-tiny program) and asserts it matches — do not guess the emitted length.
+`HASH_RE`: **base64url, exactly 43 chars, case-sensitive**:
+`/^[A-Za-z0-9_-]{43}$/`. This is the unprefixed `hashStringOf` output
+(SHA-256 → 43 unpadded base64url chars; `value-hash.ts:553`) — NOT hex.
+Add two canary unit tests pinning the real formats so a future hash-encoding
+change fails here first:
+1. feed a REAL module identity from `computeModuleHashes` (import it, hash a
+   tiny one-file program) → `HASH_RE` matches, and
+   `parseFabricRef("cf:pattern:" + h)` succeeds;
+2. feed a REAL entity URI from `createRef(...)`+`toURI(...)`
+   (`uri-utils.ts`) → it has the `of:fid1:` shape and
+   `parseFabricRef("cf:/somespace/" + uri)` succeeds.
+Never lowercase, trim, or re-encode hashes anywhere in parsing or
+formatting — they compare byte-exact.
 
 ### M0.2 Policy: `packages/runner/src/sandbox/runtime-module-policy.ts`
 
@@ -229,15 +254,25 @@ Table-driven. Minimum cases (✓ = parses, ✗ = throws, ∅ = undefined):
 | `cf://host.example/kitchen/todo-list` | ✓ host + space |
 | `cf://host.example:8000/kitchen/todo-list` | ✓ host with port |
 | `cf://host.example/todo-list` | ✗ host requires space |
-| `cf:/kitchen/todo-list@<hex64>` | ✓ pin |
-| `cf:todo-list@deadbeef` (too short) | ✗ malformed pin |
-| `cf:pattern:<hex64>` | ✓ uri/pattern; `pinnedIdentity` = hash |
-| `cf:pattern:<hex64>@<same>` | ✓ normalizes (format drops pin) |
-| `cf:pattern:<hexA>@<hexB>` | ✗ conflicting pin |
-| `cf:/kitchen/of:<hex64>` | ✓ uri/of |
-| `cf:of:<hex64>` | ✓ uri/of, no space |
-| `cf:fid1:abc` | ✗ unsupported scheme |
-| `cf:module/<hex64>` | ✗ reserved |
+(`<b64u43>` below = a 43-char base64url hash, e.g.
+`Avcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c` — note it exercises uppercase,
+`-`, and `_`.)
+
+| `cf:/kitchen/todo-list@<b64u43>` | ✓ pin |
+| `cf:todo-list@abc` (too short) | ✗ malformed pin |
+| `cf:todo-list@<b64u43 with "=" appended>` | ✗ malformed pin (no padding) |
+| `cf:todo-list@<44 chars>` | ✗ malformed pin (length) |
+| `cf:pattern:<b64u43>` | ✓ uri/pattern; `pinnedIdentity` = hash |
+| `cf:pattern:<b64u43, hex-only chars>` | ✓ (hex-looking hashes are legal base64url) |
+| `cf:pattern:<b64u43>@<same>` | ✓ normalizes (format drops pin) |
+| `cf:pattern:<b64uA>@<b64uB>` | ✗ conflicting pin |
+| `cf:pattern:<UPPERCASED b64u43>@<original>` | ✗ conflicting pin (case-sensitive — no normalization) |
+| `cf:/kitchen/of:fid1:<b64u43>` | ✓ uri/of |
+| `cf:of:fid1:<b64u43>` | ✓ uri/of, no space |
+| `cf:fid1:<b64u43>` | ✓ uri/of alias; formats as `cf:of:fid1:<b64u43>` |
+| `cf:of:<b64u43>` (no fid1 tag) | ✗ unsupported cell URI scheme |
+| `cf:data:abc` | ✗ unsupported cell URI scheme |
+| `cf:module/<b64u43>` | ✗ reserved |
 | `cf:cache-root/x` | ✗ reserved |
 | `cf:Has_Upper` | ✗ slug grammar |
 | `cf:` / `cf:/` / `cf://` | ✗ |
@@ -326,7 +361,8 @@ File: `packages/runner/src/sandbox/module-record-compiler.ts`.
    so `export * from "cf:pattern:<h>"` re-exports correctly.
 
 Tests: extend the existing module-record-compiler test file: program of
-`/a.tsx` (imports `"cf:pattern:deadbeef…"`) + `/~cf/<h>/main.tsx`, alias map +
+`/a.tsx` (imports `"cf:pattern:<b64u43>"`, any valid-shape hash) +
+`/~cf/<h>/main.tsx`, alias map +
 an `identityByPath` where the mounted file's identity is a fixed fake hash;
 assert the record for `/a.tsx` has
 `resolutions["cf:pattern:…"] === "cf:module/<fake>"`, and a star-re-export
@@ -724,7 +760,10 @@ Algorithm (spec § Resolution rule — implement hops exactly):
    use a DID"` (names are NOT in M2 scope — spec open question).
 2. Start cell:
    - slug → M2.1 resolver (wrap `SlugResolutionError` with the chain so far).
-   - `of:` URI → `runtime.getCellFromEntityId(space, {"/": hash})`, `sync()`.
+   - `of:` URI → reconstruct the entity id from the parsed hash via the
+     `uri-utils.ts` helpers (`fromURI("of:fid1:" + hash)` / the `{"/": id}`
+     shape — mirror an existing `getCellFromEntityId` call site rather than
+     hand-building the string), then `sync()`.
    - `pattern:` → already terminal (return immediately; callers normally
      short-circuit via `pinnedIdentity` and never get here).
 3. Piece hop: if the cell has pattern metadata — use the SAME accessors the
@@ -823,7 +862,7 @@ file layout, e.g. how `dev.ts` registers).
   pattern meta). Before writing the program: run `rewriteFabricPins` over
   every file, with `resolvePin` = M2.2 chase via the connected runtime; if
   any rewrite happened, print each (`pinned cf:/kitchen/todo-list →
-  @9f2ab…`). The STORED program is the pinned one. Deploying with an
+  @AvcnyZ…`). The STORED program is the pinned one. Deploying with an
   unresolvable ref fails the deploy with the chase's error.
 - **`cf deps update [file] [--import <specifier>]`**: new command; operates
   on the local working files (filesystem), not deployed state: parse, chase

--- a/docs/specs/pattern-imports/implementation-plan.md
+++ b/docs/specs/pattern-imports/implementation-plan.md
@@ -1,0 +1,919 @@
+# Pattern Imports — Implementation Plan
+
+Implements `docs/specs/pattern-imports/README.md`. **Read the spec first**;
+this plan tells you *how*, the spec tells you *what and why*. When this plan
+and the spec disagree, stop and ask — do not improvise.
+
+## How to work this plan
+
+- Work milestones strictly in order (M0 → M1 → M2). Within a milestone, tasks
+  are ordered by dependency; do not reorder.
+- Every task is red-green: write the listed tests first, watch them fail for
+  the right reason, then implement. Run the package's test task
+  (`deno task test` in the package dir) before moving on.
+- Commit per task (small, coherent commits). Pre-commit hooks misbehave in
+  worktrees for new files; verify locally, then `git commit --no-verify`.
+- Use `deno task cf check <fixture>.tsx --show-transformed --no-run` when you
+  need to see what the compiler actually emitted.
+- **Do not modify any file not listed in a task without flagging it.** If you
+  find yourself needing to, the plan missed something — say so in the commit
+  message and keep the deviation minimal.
+- M3/M4 are sketched for orientation only. Do not start them.
+
+## Decisions already made — do not relitigate
+
+These were settled in the spec + design review. Implement as stated:
+
+1. **One grammar, no type tag**: `cf:<ref>`, `cf:/<space>/<ref>`,
+   `cf://<host>/<space>/<ref>`, trailing `@<pin>`. Resolution chases pointers
+   to an entry-module identity.
+2. **Pin-in-source** (rewrite the import specifier at pin time). No lockfile
+   side-table. No pin resolution at compile time for stored programs.
+3. **Imported subtrees keep their published identities.** Mounted files hash
+   with their original authored paths (per-subtree prefix strip), so
+   identities, cache docs, and live modules dedupe with the already-deployed
+   pattern. This is Strategy A; the "fresh identities per importer" variant
+   (A′) was considered and rejected (no dedupe, divergent CFC provenance).
+4. **Self-contained bundles**: imported modules ARE compiled and emitted as
+   part of the importer's record graph (no lazy cross-bundle loading at
+   evaluation time). Dedup happens via identity (cache hits, idempotent
+   write-back, `modulesByIdentity`), not via emission-skipping.
+5. **Source set stays per-program**: an importer's source docs do NOT link to
+   the imported subtree's source docs (the `cf:` specifier itself carries the
+   target identity; loaders parse it). The **compiled** set DOES link across
+   the boundary (it has no Merkle-union verification, and the link gives the
+   warm loader the full closure for free).
+6. **No service endpoints.** All resolution and fetch are cell reads through
+   the compiling runtime's storage session.
+7. **v1 limitation**: an imported subtree whose modules use root-absolute
+   internal imports (`import … from "/utils.ts"`) is rejected at fetch time
+   with a clear error. Relative (`./`, `../`) imports only inside subtrees.
+8. **CFC provenance of fetched source is follow-up work** (spec § Security).
+   Do not build label propagation now; do not silently strip it either —
+   the write-back path reuses existing write machinery so labels flow (or
+   fail) exactly as any cell write does today.
+
+## Architecture recap (what plugs in where)
+
+```
+authored source ──pretransformProgramForModules──► /<id>/-prefixed program
+      │                                                  (engine.ts:227)
+      ▼
+engine.resolve(resolver)  ◄── FabricAwareResolver wraps EngineProgramResolver   [M1.4]
+      │                        • intercepts cf: specifiers
+      │                        • loadVerifiedSourceClosure(space, hash)  (cell-cache.ts)
+      │                        • mounts files at /~cf/<hash>/<storedFilename>
+      ▼
+resolved program (authored ∪ mounted files)
+      │
+      ├─ computeFabricModuleIdentities: authored set stripped /<id>,            [M1.3]
+      │  each subtree stripped /~cf/<hash> → PUBLISHED identities, merged map
+      │
+      ├─ compiler.compileToModules(..., { specifierAliases })                   [M1.1]
+      │     TypeScriptHost maps "cf:…" → mounted entry path (type-check)
+      │
+      ├─ compileSourcesToRecords(..., { specifierAliases, identityByPath })     [M1.2]
+      │     record resolutions: "cf:…" → "cf:module/<published-identity>"
+      │
+      └─ CacheableModule[]: mounted modules carry original filenames;           [M1.5]
+         importer modules gain fabric edges {specifier, targetIdentity}
+              │
+              ├─ writeSourceDocs: fabric edges NOT stored as links              [M1.6]
+              └─ writeCompiledDocs: fabric edges stored as links (warm walk)
+```
+
+Reload paths:
+- **Warm** (compiled docs): `loadCompiledClosure` follows the fabric link →
+  full closure → `evaluateCachedModules`. Verify this works; small fixes only.
+  [M1.7]
+- **Cold** (source docs): importer closure excludes subtrees by design; the
+  same `FabricAwareResolver` wrapped around `compileResolvedToRecordGraph`'s
+  resolver re-fetches each subtree by the hash in the specifier. [M1.7]
+
+## Glossary (use these exact terms in code comments)
+
+- **fabric ref / fabric specifier** — an authored import specifier under the
+  `cf:` grammar (`cf:pattern:<hash>`, `cf:/kitchen/todo-list@<hash>`, …).
+- **pin** — the trailing `@<hex>` entry-module identity on a mutable ref.
+- **terminal identity** — the entry-module identity a ref resolves to.
+- **subtree** — the source closure of one imported pattern (its own program).
+- **mount** — a subtree's files spliced into a compilation under
+  `/~cf/<terminalIdentity>/<storedFilename>`.
+- **fabric edge** — an import edge whose specifier is a fabric ref; external
+  for Merkle identity, aliased for type-check and record resolution.
+- **authored set** — the importer's own files (everything not under `/~cf/`).
+
+---
+
+## M0 — Grammar and policy (pure functions, no I/O)
+
+### M0.1 New file: `packages/runner/src/sandbox/fabric-import-specifier.ts`
+
+```ts
+export interface FabricRef {
+  /** Toolshed host (authority); only present in the cf://host/... form. */
+  host?: string;
+  /** Space name or DID; absent = the compiling space. */
+  space?: string;
+  ref:
+    | { kind: "slug"; slug: string }
+    | { kind: "uri"; scheme: "of" | "pattern"; hash: string };
+  /** Path inside the target program (phase 4; parsed, rejected downstream). */
+  subpath?: string;
+  /** Trailing @<hex> pin. */
+  pin?: string;
+}
+
+export class FabricRefError extends Error {
+  constructor(message: string, readonly specifier: string) { /* … */ }
+}
+
+/**
+ * Parse an import specifier under the cf: reference grammar.
+ * - Returns undefined when the specifier does not start with "cf:" —
+ *   callers treat it as not-a-fabric-ref (relative import, runtime module…).
+ * - THROWS FabricRefError when it starts with "cf:" but is malformed or
+ *   reserved. A cf:-prefixed specifier is never silently ignored.
+ */
+export function parseFabricRef(specifier: string): FabricRef | undefined;
+
+/** True iff parseFabricRef returns a value (false for undefined OR throw). */
+export function isFabricImportSpecifier(specifier: string): boolean;
+
+/** Canonical string for a ref (parse(format(r)) deep-equals r). */
+export function formatFabricRef(ref: FabricRef): string;
+
+/**
+ * The identity a ref resolves to WITHOUT touching any mutable pointer:
+ * the pin if present, else the hash of a pattern: URI ref, else undefined
+ * (meaning: resolution requires the chase — M2).
+ */
+export function pinnedIdentity(ref: FabricRef): string | undefined;
+
+/** Re-format with a (new) pin set; used by the pin-rewrite tooling (M2.3). */
+export function withPin(ref: FabricRef, pin: string): FabricRef;
+```
+
+Parsing algorithm — implement exactly this order:
+
+1. If the specifier does not start with `"cf:"`, return `undefined`.
+2. Strip `"cf:"`. Call the remainder `rest`.
+3. **Reserved namespaces** (emitted/internal — never authored): if `rest`
+   starts with `"module/"` or `"cache-root/"`, throw
+   `FabricRefError("'cf:module/…' / 'cf:cache-root/…' are compiler-internal
+   namespaces and cannot be imported", specifier)`.
+4. **Pin**: if `rest` contains `"@"`, split at the LAST `"@"`. The right part
+   must match `HASH_RE` (below) or throw (`"malformed pin"`). The left part
+   replaces `rest`.
+5. **Authority/space prefix**:
+   - `rest` starts with `"//"`: strip it; split on `"/"`; first segment is
+     `host` (must be non-empty, must contain no `"@"`; validate loosely:
+     `/^[a-z0-9.-]+(:\d+)?$/i`, throw otherwise); the SECOND segment is the
+     space (required in this form — throw `"host-qualified refs require a
+     space"` if fewer than 3 segments); remaining segments per step 6.
+   - `rest` starts with a single `"/"`: strip it; first segment is `space`;
+     remaining segments per step 6.
+   - otherwise: no host, no space; all of `rest` per step 6.
+6. **Ref + subpath**: of the remaining `"/"`-separated segments, the FIRST is
+   the ref token; the rest (joined by `"/"`) is `subpath` (omit when empty).
+   - Ref token contains `":"` → URI form: must match
+     `/^(of|pattern):([0-9a-f]+)$/` with the hash matching `HASH_RE`;
+     anything else with a colon throws `"unsupported cell URI scheme"`.
+   - No colon → slug form: validate with `validateSlug` from
+     `packages/runner/src/slugs.ts` (re-throw its message wrapped in
+     FabricRefError).
+7. **Space validation**: if present and not a DID (`/^did:[a-z0-9]+:.+$/`),
+   it must validate as a slug (space *names* share the slug grammar — spec
+   § Specifier syntax). Throw otherwise.
+8. **Consistency**: a `pattern:` URI ref with a pin whose hash differs from
+   the URI hash throws `"conflicting pin"`. (Equal is allowed, normalized to
+   pin-absent by `formatFabricRef`.)
+
+`HASH_RE`: lowercase hex, length 32–128: `/^[0-9a-f]{32,128}$/`. Add a unit
+test that feeds a REAL hash from `computeModuleHashes` (import it, hash a
+tiny program) and asserts it matches — do not guess the emitted length.
+
+### M0.2 Policy: `packages/runner/src/sandbox/runtime-module-policy.ts`
+
+Extend `isAllowedAuthoredImportSpecifier` (line 25):
+
+```ts
+export function isAllowedAuthoredImportSpecifier(specifier: string): boolean {
+  if (specifier.startsWith("cf:")) {
+    try { return parseFabricRef(specifier) !== undefined; }
+    catch { return false; }
+  }
+  return isRuntimeModuleIdentifier(specifier) ||
+    ALLOWED_LOCAL_IMPORT_PREFIXES.some((p) => specifier.startsWith(p));
+}
+```
+
+`isAllowedCompiledDependencySpecifier` (line 32) composes the same predicate —
+verify it needs no separate change (it delegates). Grep for every caller of
+both functions and read each call site; list them in the commit message with
+a one-line "unaffected because…" each. (Expected: the SES compiled-body
+verifier and the authored-import check; if you find more, flag it.)
+
+### M0.3 Tests: `packages/runner/test/fabric-import-specifier.test.ts`
+
+Table-driven. Minimum cases (✓ = parses, ✗ = throws, ∅ = undefined):
+
+| Specifier | Expect |
+|---|---|
+| `./foo.ts`, `commonfabric`, `npm:x` | ∅ |
+| `cf:todo-list` | ✓ slug, no space |
+| `cf:todo-list/schemas` | ✓ slug + subpath `schemas` |
+| `cf:/kitchen/todo-list` | ✓ space `kitchen` |
+| `cf:/kitchen/todo-list/a/b.ts` | ✓ subpath `a/b.ts` |
+| `cf:/did:key:z6Mk…/todo-list` | ✓ DID space |
+| `cf://host.example/kitchen/todo-list` | ✓ host + space |
+| `cf://host.example:8000/kitchen/todo-list` | ✓ host with port |
+| `cf://host.example/todo-list` | ✗ host requires space |
+| `cf:/kitchen/todo-list@<hex64>` | ✓ pin |
+| `cf:todo-list@deadbeef` (too short) | ✗ malformed pin |
+| `cf:pattern:<hex64>` | ✓ uri/pattern; `pinnedIdentity` = hash |
+| `cf:pattern:<hex64>@<same>` | ✓ normalizes (format drops pin) |
+| `cf:pattern:<hexA>@<hexB>` | ✗ conflicting pin |
+| `cf:/kitchen/of:<hex64>` | ✓ uri/of |
+| `cf:of:<hex64>` | ✓ uri/of, no space |
+| `cf:fid1:abc` | ✗ unsupported scheme |
+| `cf:module/<hex64>` | ✗ reserved |
+| `cf:cache-root/x` | ✗ reserved |
+| `cf:Has_Upper` | ✗ slug grammar |
+| `cf:` / `cf:/` / `cf://` | ✗ |
+| `cf:/kitchen/` (empty ref) | ✗ |
+
+Round-trip: for every ✓ case, `parseFabricRef(formatFabricRef(parse(s)))`
+deep-equals `parse(s)`. Policy tests: each ✓ case is allowed, each ✗/∅
+`cf:`-prefixed case is rejected by `isAllowedAuthoredImportSpecifier`.
+
+**Acceptance M0**: new tests green; full `packages/runner` suite green
+(policy change must not break existing import tests).
+
+---
+
+## M1 — `cf:pattern:<hash>` end-to-end, same space
+
+Scope guard: in M1 the resolver handles ONLY refs where
+`pinnedIdentity(ref) !== undefined` and `ref.host === undefined`. Everything
+else throws `"fabric ref requires resolution of a mutable pointer — not yet
+supported (M2)"` or `"cross-host fabric refs not yet supported (M3)"`.
+Subpaths throw `"subpaths not yet supported (M4)"`.
+
+### M1.1 js-compiler: specifier aliases for type resolution
+
+File: `packages/js-compiler/typescript/compiler.ts`.
+
+1. Add to `TypeScriptCompilerOptions` (line 227):
+   ```ts
+   /**
+    * Maps an import specifier (verbatim text) to a program file name. Used
+    * for scheme-prefixed specifiers (cf:…) that the path-join and
+    * runtime-module rules cannot resolve. The target MUST be a file in the
+    * program.
+    */
+   specifierAliases?: ReadonlyMap<string, string>;
+   ```
+2. Thread it into the `TypeScriptHost` constructor (line 123) and use it in
+   `resolveModuleNameLiterals` (line 176) — check the alias map FIRST (before
+   the relative-path branch; alias text is exact, so order is safe — but
+   first keeps the dispatch obvious):
+   ```ts
+   const aliased = this.specifierAliases?.get(name);
+   if (aliased !== undefined) {
+     return {
+       resolvedModule: {
+         resolvedFileName: aliased,
+         extension: aliased.endsWith(".tsx") ? ts.Extension.Tsx : ts.Extension.Ts,
+       },
+     };
+   }
+   ```
+3. Also accept aliases in `resolveProgram`'s config? **No** — resolution of
+   fabric specifiers happens in the runner's resolver wrapper (M1.4); the
+   js-compiler's `resolveProgram` sees them resolve successfully via
+   `graph.resolveSource` and never consults the unresolved-module policy.
+   Do not touch `resolver.ts`.
+
+Tests: `packages/js-compiler/test/` — find the existing compiler test file
+and add: a two-file program where `/main.tsx` imports `"x-scheme:thing"` and
+`specifierAliases` maps it to `/dep.tsx`; assert type-checking sees `/dep.tsx`
+exports (a deliberate type error through the alias must be reported), and the
+emitted body for `/main.tsx` contains `require("x-scheme:thing")` (the alias
+affects type resolution, NOT emitted specifier text).
+
+### M1.2 Record graph: alias resolutions
+
+File: `packages/runner/src/sandbox/module-record-compiler.ts`.
+
+1. Add `specifierAliases?: ReadonlyMap<string, string>` to
+   `CompileSourcesOptions`.
+2. In the per-source resolutions loop (the
+   `internal → cf:module/… / runtimeModules → cf:runtime/… / unknown` chain),
+   insert an alias branch BEFORE the unknown-external fallback:
+   ```ts
+   } else if (options.specifierAliases?.has(spec)) {
+     const target = options.specifierAliases.get(spec)!;
+     const targetSpecifier = specifierByPath.get(target);
+     if (targetSpecifier === undefined) {
+       throw new Error(`specifier alias '${spec}' → '${target}' does not name a program file`);
+     }
+     resolutions[spec] = targetSpecifier;
+   }
+   ```
+3. Mirror the alias in the `export * from` walk (`resolveFullExports`): the
+   star-target resolution uses `findInternalTarget`; add the same alias check
+   so `export * from "cf:pattern:<h>"` re-exports correctly.
+
+Tests: extend the existing module-record-compiler test file: program of
+`/a.tsx` (imports `"cf:pattern:deadbeef…"`) + `/~cf/<h>/main.tsx`, alias map +
+an `identityByPath` where the mounted file's identity is a fixed fake hash;
+assert the record for `/a.tsx` has
+`resolutions["cf:pattern:…"] === "cf:module/<fake>"`, and a star-re-export
+variant surfaces the mounted file's export names.
+
+### M1.3 Per-subtree identities: `computeFabricModuleIdentities`
+
+File: `packages/runner/src/sandbox/module-record-compiler.ts` (next to
+`computeModuleIdentities`).
+
+```ts
+export const FABRIC_MOUNT_ROOT = "/~cf/";
+
+export interface FabricMount {
+  /** Terminal identity the subtree was fetched by (and must hash back to). */
+  entryIdentity: string;
+  /** Mounted path of the subtree's entry file. */
+  entryPath: string;          // `${FABRIC_MOUNT_ROOT}${entryIdentity}${storedEntryFilename}`
+  /** The fabric specifiers that resolve to this mount (≥1). */
+  specifiers: string[];
+}
+
+/**
+ * Identity map for a program containing fabric mounts. Authored files hash
+ * with `idPrefix` stripped (status quo); each mount's files hash as their own
+ * standalone program with `/~cf/<entryIdentity>` stripped, so they reproduce
+ * their PUBLISHED identities. Throws if a mount's entry does not hash back to
+ * `entryIdentity` (integrity failure — wrong bytes mounted).
+ */
+export function computeFabricModuleIdentities(
+  sources: Source[],
+  mounts: readonly FabricMount[],
+  options: { idPrefix?: string; runtimeFingerprint?: string } = {},
+): Map<string, string>;
+```
+
+Implementation:
+1. Partition `sources` by name: each file under
+   `${FABRIC_MOUNT_ROOT}${m.entryIdentity}/` belongs to mount `m`; everything
+   else is the authored set. A file under `FABRIC_MOUNT_ROOT` matching NO
+   mount → throw (corrupt assembly).
+2. Authored set → `computeModuleIdentities(authored, options)` unchanged.
+   (The fabric edges inside authored sources resolve as EXTERNAL deps because
+   the mounted file names never match the specifier — this is what folds the
+   pin into the importer's hash. Do not "fix" that.)
+3. Each mount → `computeModuleIdentities(mountFiles,
+   { idPrefix: `/~cf/${m.entryIdentity}`, runtimeFingerprint })`.
+   **Note**: subtree files may themselves contain fabric specifiers
+   (transitive imports) — those are external deps within the subtree
+   computation, exactly as they were when the subtree was published. Files of
+   a TRANSITIVE mount are NOT part of this mount's partition (they live under
+   their own `/~cf/<h2>/` prefix).
+4. Verify `result.get(m.entryPath) === m.entryIdentity`; throw with both
+   values on mismatch.
+5. Merge all maps (key sets are disjoint by construction) and return.
+
+Tests (new file `packages/runner/test/fabric-module-identity.test.ts`):
+- Two-file subtree published standalone (compute identities with no prefix),
+  then the same files mounted under `/~cf/<entry>/…` inside a host program →
+  identities identical to standalone; authored file's identity changes when
+  (only) the pin hash inside its specifier text changes.
+- Mount entry mismatch (tampered byte) → throws.
+- File under `/~cf/` with no matching mount → throws.
+- Two mounts whose subtrees both contain `/main.tsx` → no interference.
+
+### M1.4 The resolver wrapper: `FabricAwareResolver`
+
+New file: `packages/runner/src/harness/fabric-resolver.ts`.
+
+```ts
+export interface FabricResolutionContext {
+  runtime: Runtime;          // this.ctRuntime from the engine
+  space: MemorySpace;        // the cell-cache space of this compile
+}
+
+export class FabricAwareResolver implements ProgramResolver {
+  constructor(inner: ProgramResolver, ctx: FabricResolutionContext) {}
+  main(): Promise<Source>;                       // delegate
+  resolveSource(id: string): Promise<Source | undefined>;
+  /** Mounts + alias map accumulated during the resolve walk. */
+  mounts(): FabricMount[];
+  specifierAliases(): Map<string, string>;
+}
+```
+
+`resolveSource(identifier)` behavior, in order:
+
+1. If `identifier` starts with `FABRIC_MOUNT_ROOT`: serve from the internal
+   `mountedFiles: Map<path, Source>`; return `undefined` if absent (lets the
+   normal missing-import error fire with the mounted path in it).
+2. `parseFabricRef(identifier)`:
+   - `undefined` → delegate to `inner.resolveSource`.
+   - throws → re-throw (policy already rejects these; belt and suspenders).
+3. Fabric ref:
+   a. Scope checks (M1): `host` set → throw M3 message; `subpath` set → throw
+      M4 message; `pinnedIdentity(ref)` undefined → throw M2 message.
+      `ref.space` set and ≠ compiling space → M1: throw
+      `"cross-space fabric refs not yet supported (M2)"`.
+   b. Dedupe: if a mount for this identity exists, register the specifier on
+      it and return the SAME entry Source object already returned before
+      (identity-keyed `mountByIdentity` map).
+   c. Depth guard: more than 32 distinct mounts in one compile → throw
+      `"fabric import graph too deep/large"` (runaway-recursion backstop —
+      transitive mounts arrive through this same method as the walk reaches
+      mounted files' own fabric specifiers).
+   d. Fetch: open a read tx exactly like `replicateClosures` does
+      (`packages/runner/src/pattern-manager.ts:620` — `runtime.edit()` /
+      `finally tx.abort?.(…)`), call `loadVerifiedSourceClosure(runtime,
+      ctx.space, hash, tx)`. `undefined` → throw
+      `"source for pattern:<hash> not found in space <space> (or failed
+      integrity verification)"`.
+   e. **Root-absolute import check** (decision 7): for every doc, run
+      `collectImportSpecifiers` (from `@commonfabric/js-compiler`); any
+      specifier starting with `"/"` → throw `"imported pattern <hash> uses
+      root-absolute imports; not supported"`. (Relative and fabric and
+      runtime-module specifiers pass.)
+   f. Mount: for each doc, `mountedFiles.set("/~cf/" + hash + doc.filename,
+      { name: …, contents: doc.code })`. Entry path =
+      `/~cf/<hash><entryFilename>` where `entryFilename` comes from
+      `verifySourceDocs`'s `entryFilename` (already returned inside
+      `loadVerifiedSourceClosure` — if not surfaced, extend
+      `loadVerifiedSourceClosure` to return `{ docs, entryFilename }`; check
+      its callers: `replicateClosures` and the pattern-manager cold path —
+      adjust both destructurings).
+   g. Record `FabricMount` + alias (`identifier → entryPath`); return the
+      entry Source.
+
+Pitfalls to encode as comments + tests:
+- The walk calls `resolveSource` with the verbatim specifier text (bare
+  specifiers pass through `resolveSpecifier` unchanged —
+  `packages/js-compiler/typescript/resolver.ts:97`). Two files importing the
+  same text → `sources.has(identifier)` dedupes upstream; two DIFFERENT
+  texts pinning the same hash (e.g. `cf:pattern:<h>` and a pinned slug form
+  in M2) → step (b) returns the same Source object, and `resolveProgram`
+  stores it under BOTH identifiers → **duplicate entries in
+  `program.files`**. Therefore M1.5 must dedupe `moduleFiles` by name (see
+  there). Write the test now (two import lines, same hash) and let it go
+  green in M1.5.
+- Authored programs must not collide with the mount root: in
+  `compileToRecordGraph` authored names carry the `/<id>/` prefix so they
+  can't start with `/~cf/`; in `compileResolvedToRecordGraph` they are
+  unprefixed stored names — add an explicit guard in M1.5: any AUTHORED
+  input file (pre-resolve) named under `/~cf/` → throw.
+
+Unit tests (`packages/runner/test/fabric-resolver.test.ts`): use an
+in-process runtime (mirror the setup of existing cell-cache tests — find
+`cell-cache` or `compile-cache` test files and copy their runtime/space
+bootstrap). Seed source docs by running `writeSourceDocs` with a small
+hand-built module set. Cover: fetch+mount happy path; missing hash; tampered
+doc (flip a byte in a stored cell → verification failure surfaces as
+not-found error); root-absolute rejection; dedupe-by-identity; M2/M3/M4
+scope errors.
+
+### M1.5 Engine integration
+
+File: `packages/runner/src/harness/engine.ts`.
+
+1. Add to `TypeScriptHarnessProcessOptions`
+   (`packages/runner/src/harness/types.ts:21`):
+   ```ts
+   /**
+    * Enables fabric (cf:) imports for this compile: the space whose cell
+    * cache fabric refs are fetched from / verified against. Absent → any
+    * fabric specifier in the program is a compile error ("fabric imports
+    * require a space context").
+    */
+   fabricImports?: { space: MemorySpace };
+   ```
+2. `compileToRecordGraph` (engine.ts:212):
+   - Wrap the resolver (line 228):
+     ```ts
+     const engineResolver = new EngineProgramResolver(mappedProgram, this.ctRuntime.staticCache);
+     const resolver = options.fabricImports
+       ? new FabricAwareResolver(engineResolver, { runtime: this.ctRuntime, space: options.fabricImports.space })
+       : engineResolver;
+     ```
+     When `fabricImports` is absent, fabric specifiers reach
+     `isUnresolvedModuleOk` and throw `Could not resolve…` — wrap that into
+     the friendlier error: BEFORE resolving, scan `mappedProgram` files with
+     `collectImportSpecifiers` for `cf:`-parsing specifiers and throw
+     `"fabric imports require a space context (options.fabricImports)"` if
+     found without the option. (Cheap, explicit, testable.)
+   - After `this.resolve(resolver)`: collect
+     `const mounts = options.fabricImports ? resolver.mounts() : []` and
+     `const aliases = …specifierAliases()`.
+   - **Dedupe `moduleFiles` by `name`** after the `.d.ts` filter, asserting
+     equal contents on duplicates (see M1.4 pitfall):
+     ```ts
+     const byName = new Map<string, Source>();
+     for (const f of moduleFiles) {
+       const prev = byName.get(f.name);
+       if (prev !== undefined && prev.contents !== f.contents) throw new Error(…);
+       byName.set(f.name, f);
+     }
+     const uniqueModuleFiles = [...byName.values()];
+     ```
+   - Guard: any file of the ORIGINAL `program.files` (pre-pretransform input)
+     named under `/~cf/` → throw `"/~cf/ is a reserved namespace"`.
+   - Identity computation (line 242): replace `computeModuleIdentities(…)`
+     with `computeFabricModuleIdentities(uniqueModuleFiles, mounts,
+     { idPrefix: \`/${id}\` })`. (With zero mounts it must behave byte-for-byte
+     like today — M1.3 guarantees it; add a regression assertion to an
+     existing engine test rather than trusting it.)
+   - Pass `specifierAliases: aliases` into BOTH `compiler.compileToModules`
+     (line 282) and `compileSourcesToRecords` (line 324).
+   - Fabric edges into write-back descriptors (line 407): `importEdges` comes
+     from `resolveModuleImports` whose `externalDeps` include fabric
+     specifiers. Extend the `modules` mapping:
+     ```ts
+     const fabricEdges = (importEdges.get(file.name)?.externalDeps ?? [])
+       .filter((s) => isFabricImportSpecifier(s))
+       .map((s) => {
+         const target = aliases.get(s);
+         if (target === undefined) throw new Error(`unresolved fabric specifier '${s}' survived compile`);
+         return { specifier: s, targetIdentity: identityByPath.get(target)! };
+       });
+     // imports: [...internalDeps-mapped, ...fabricEdges]
+     ```
+   - `filename` for mounted files (line 422): `stripModuleIdPrefix(file.name,
+     id)` only strips `/<id>`; mounted names need the mount prefix stripped
+     instead. Write a small helper
+     `storedFilenameFor(name, id, mounts)` → authored: status quo; mounted:
+     `name.slice(("/~cf/" + m.entryIdentity).length)`.
+3. `compileResolvedToRecordGraph` (engine.ts:454): same wrapper + same merged
+   identity computation + same aliases into `compileToModules` + same fabric
+   edges, with `idPrefix` ABSENT for the authored set (stored names are
+   prefix-free) and `space` from a new optional parameter
+   `options?: { fabricImports?: { space: MemorySpace } }`. The caller
+   (pattern-manager, M1.7) threads the space it already has. NOTE: this path
+   builds no record graph itself — it returns `CacheableModule[]`; the
+   emitted set now contains mounted modules too, which is exactly what the
+   cached-module evaluator needs (self-contained closure).
+
+Tests (`packages/runner/test/fabric-imports-engine.test.ts`, in-process
+runtime):
+- Seed: compile + write-back a small two-file pattern P (existing engine
+  compile helpers; mirror how `esm-*`/cell-cache tests drive
+  `compileToRecordGraph` + `writeSourceDocs`/`writeCompiledDocs`). Record its
+  `entryIdentity`.
+- Importer I with `import { x } from "cf:pattern:<P-entry>"`:
+  - compiles; record graph contains a record keyed
+    `cf:module/<P-entry>`; I's record resolutions map the specifier to it.
+  - `modules` write-back set: P's modules appear with their ORIGINAL
+    filenames + identities; I's entry carries the fabric edge.
+  - Evaluation: I's exports work; P's pattern callable through I.
+  - Type error variant: I uses a wrong member name → compile fails with a TS
+    diagnostic naming the member (proves real type-checking through the
+    alias).
+  - Identity sensitivity: byte-change P → republish under new hash; I pinned
+    to OLD hash still compiles to the OLD identity (reads old docs); I with
+    the NEW hash has a different module identity than the old I.
+  - No `fabricImports` option → the friendly "requires a space context"
+    error.
+  - Same hash imported via two specifier texts → compiles (dedupe), one
+    record.
+  - Transitive: P itself imports `cf:pattern:<Q>` → I→P→Q compiles and
+    evaluates; Q mounted once.
+  - `--show-transformed` path (`getTransformedProgram`) includes mounted
+    files (smoke assertion: a mounted filename appears).
+
+### M1.6 Cache write-back: source-side link filtering
+
+File: `packages/runner/src/compilation-cache/cell-cache.ts`.
+
+1. `storedImportRefs` (line 119): skip fabric edges when building SOURCE
+   links:
+   ```ts
+   const refs = module.imports
+     .filter((imp) => !isFabricImportSpecifier(imp.specifier))
+     .map(…);
+   ```
+   `unreachedRoots` (line 96) stays UNTOUCHED — it must keep seeing fabric
+   edges as reachability (otherwise every mounted module gets a synthetic
+   root link from the importer's entry, dragging subtrees back into the
+   importer's source closure — the exact thing decision 5 forbids).
+2. **Compiled side**: find `writeCompiledDocs` / the compiled-doc builder in
+   this file (below the source-set section). Confirm which import list it
+   stores. Required end state: compiled docs DO carry fabric edges as links
+   (`{specifier: "cf:pattern:…", link → compiledDocKey(rtv, <identity>)}`).
+   If it shares `storedImportRefs`, give that function an
+   `{ includeFabricEdges: boolean }` parameter rather than duplicating it.
+3. `verifySourceDocs` needs NO change (importer closures no longer contain
+   subtree docs). Add a regression test proving it: write back an importer's
+   modules, `loadVerifiedSourceClosure(importerEntry)` → returns ONLY the
+   importer's own docs, verification ok, and the importer doc's stored
+   imports contain no fabric specifier.
+
+Tests (extend the existing cell-cache test file): the regression above; plus
+compiled-closure walk: `loadCompiledClosure(importerEntry)` returns importer
+AND subtree compiled docs (fabric link followed); plus `replicateClosures`
+of an importer — **expected to fail or lose the subtree** (source closure
+excludes it). Fix inside `replicateClosures`: after replicating the
+importer's closure, parse each replicated source doc's external specifiers
+(`collectImportSpecifiers` + `isFabricImportSpecifier` + `pinnedIdentity`)
+and recurse per subtree identity (visited-set on identities). Test: replicate
+importer to a second space → importer loads cold in that space.
+
+### M1.7 Reload paths (warm + cold)
+
+File: `packages/runner/src/pattern-manager.ts`.
+
+1. Locate the by-identity load (`loadPatternByIdentity`, ~line 985) and read
+   it END TO END before changing anything. Identify:
+   - the warm branch (`loadCompiledClosure` → `evaluateCachedModules`-style
+     evaluation), and
+   - the cold branch (`loadVerifiedSourceClosure` →
+     `compileResolvedToRecordGraph`).
+2. **Warm**: with M1.6 the compiled closure includes subtree docs. Follow the
+   code from closure → records and verify the record builder maps the fabric
+   edge's specifier to `cf:module/<identity>` using the STORED import edges
+   (the same mechanism internal edges use). If it re-derives resolutions from
+   specifier text + `findInternalTarget` instead, extend it with a branch:
+   "specifier parses as fabric ref → resolution = `cf:module/<stored edge
+   identity>`". Add a test before touching code: deploy importer (M1.5 test
+   helper), drop the in-memory pattern cache (new runtime instance on the
+   same storage — mirror how resume tests do this; see
+   `resume-by-identity`-named tests), `loadPatternByIdentity(importerEntry)`
+   → warm load works.
+3. **Cold**: force the cold path (bump
+   `COMPILE_CACHE_RUNTIME_VERSION` in the test via its option/parameter if
+   injectable, or write source docs only) → `compileResolvedToRecordGraph`
+   must receive `{ fabricImports: { space } }` from this call site. The
+   FabricAwareResolver inside it refetches subtrees (they exist in the same
+   space). Test: cold load of the importer works, and the recompiled module
+   identities EQUAL the originals (assert on returned `entryIdentity` and a
+   spot-check module).
+4. Eviction/`addressableByIdentity`: no changes — but add one test: after
+   importer evaluation, `artifactFromIdentitySync(<P-entry>, <symbol>)`
+   resolves (proves imported modules registered under their published
+   identities → op-by-identity / `$patternRef` referencing imported patterns
+   works).
+
+### M1.8 CLI surfacing
+
+Files: `packages/cli/lib/dev.ts`, `packages/cli/commands/dev.ts`.
+
+- `cf check`/`cf dev` compile via `engine.compileToRecordGraph` (dev.ts:52).
+  Thread `fabricImports: { space }` only when the dev session has a space
+  (inspect how `dev.ts` builds the runtime and whether a space/identity is
+  configured; if none, leave the option absent — the M1.5 friendly error then
+  tells the user why). Add `--space <did>` plumbing ONLY if it already exists
+  in the command's option surface; otherwise leave a TODO comment referencing
+  M2 (do not invent new CLI flags in M1).
+- Acceptance: a fixture pattern with a fabric import produces the
+  "requires a space context" error through `cf check` (snapshot the message),
+  not a raw `Could not resolve` error.
+
+**Acceptance M1** (run all): new test files green; full
+`packages/runner`, `packages/js-compiler`, `packages/cli` suites green;
+the M1.5 end-to-end test demonstrates: compile, type-check, evaluate,
+write-back, warm reload, cold reload, cross-runtime resume, tamper rejection.
+
+---
+
+## M2 — Mutable refs (slug / piece / of:) + pinning
+
+### M2.1 Generic slug→cell resolution in runner
+
+`packages/piece/src/slugs.ts:108` (`resolveSlugTargetCell`) is the model; it
+uses only `runtime` + `space`. Lift it:
+
+- New: `packages/runner/src/slug-resolution.ts` —
+  `resolveSlugTargetCell(runtime: Runtime, space: MemorySpace, slug: string):
+  Promise<Cell<unknown>>` — copy the body, replacing `manager.runtime`/
+  `manager.getSpace()`; move `SlugResolutionError` here and re-export from
+  the piece package for compatibility.
+- `packages/piece/src/slugs.ts` delegates to it (keep its piece-specific
+  `resolvePieceAddress` checks where they are).
+- Tests: move/duplicate the existing piece slug-resolution tests' generic
+  cases to a runner test; piece suite must stay green untouched otherwise.
+
+### M2.2 The chase: ref → terminal identity
+
+New: `packages/runner/src/fabric-ref-resolution.ts`.
+
+```ts
+export interface FabricChaseResult {
+  entryIdentity: string;
+  /** Human-readable hops for errors/tooling, e.g.
+   *  ["slug:todo-list", "piece:of:…", "patternMeta:of:…", "entryIdentity:…"] */
+  chain: string[];
+}
+
+export async function resolveFabricRefToIdentity(
+  runtime: Runtime,
+  compilingSpace: MemorySpace,
+  ref: FabricRef,
+): Promise<FabricChaseResult>;
+```
+
+Algorithm (spec § Resolution rule — implement hops exactly):
+
+1. Space: `ref.space` undefined → `compilingSpace`; a DID → use as-is; a name
+   → M2 throws `"space names require name→DID resolution (open question 2);
+   use a DID"` (names are NOT in M2 scope — spec open question).
+2. Start cell:
+   - slug → M2.1 resolver (wrap `SlugResolutionError` with the chain so far).
+   - `of:` URI → `runtime.getCellFromEntityId(space, {"/": hash})`, `sync()`.
+   - `pattern:` → already terminal (return immediately; callers normally
+     short-circuit via `pinnedIdentity` and never get here).
+3. Piece hop: if the cell has pattern metadata — use the SAME accessors the
+   runner uses (`getPatternIdentityRef` / `getPatternId` around
+   `packages/runner/src/runner.ts:4137`; export them if module-private):
+   - `patternIdentity` present → its `.identity` IS the terminal identity;
+     append hops; done.
+   - else `patternId` present → load the pattern meta cell by that URI
+     (mirror how `PatternManager` reads meta cells — `patternMetaSchema`),
+     continue at 4.
+   - neither, and the cell itself is not a pattern meta cell → throw
+     `"cf:… does not resolve to a pattern (chain: …)"`.
+4. Pattern-meta hop: `entryIdentity` field present → done. Absent → throw
+   `"pattern meta for cf:… has no entryIdentity (legacy pattern; re-deploy
+   it)"`. (Computing it from `program` requires a full pretransform+hash
+   pass — deliberately out of scope; the error names the remedy.)
+
+No cycle guard needed (≤3 hops, no recursion).
+
+Tests (`packages/runner/test/fabric-ref-resolution.test.ts`): build, in an
+in-process runtime: a pattern meta cell with `entryIdentity`; a fake piece
+cell carrying `meta("pattern")`/`meta("patternIdentity")` (use the real
+setters from runner.ts — find `setMetaRaw("pattern", …)` usage at
+runner.ts:901 and mirror it); slug → piece; slug → pattern meta directly;
+slug → plain data cell (error + chain); missing slug; `of:` directly to meta
+cell; piece with only legacy `patternId`; meta without `entryIdentity`
+(error message).
+
+### M2.3 Pin rewriting (byte-precise source surgery)
+
+New: `packages/runner/src/fabric-pin-rewrite.ts`.
+
+```ts
+export interface PinRewrite { specifier: string; pinned: string; line: number }
+
+/**
+ * Rewrite fabric import/export/import-type specifiers in ONE source text.
+ * `resolvePin(ref)` returns the identity to pin (or null = leave untouched).
+ * Returns the new text + the rewrites performed. MUST only change the
+ * string-literal spans — byte-identical elsewhere (no reprinting).
+ */
+export async function rewriteFabricPins(
+  contents: string,
+  resolvePin: (ref: FabricRef, specifier: string) => Promise<string | null>,
+): Promise<{ contents: string; rewrites: PinRewrite[] }>;
+```
+
+Implementation: `ts.createSourceFile`, walk EXACTLY the three node shapes
+`collectImportSpecifiers` walks (import decl / export-from / ImportTypeNode —
+copy that visitor, `packages/js-compiler/typescript/resolver.ts:127`),
+collect `{ literal.getStart()+1, literal.end-1, text }` spans, compute
+replacements with `formatFabricRef(withPin(ref, pin))`, apply BACK TO FRONT
+on the original string. Skip non-fabric specifiers; skip refs where
+`pinnedIdentity` already matches; error on a fabric ref inside a dynamic
+`import()` expression? — dynamic imports are unsupported by the compiler
+(resolver.ts comment) so they cannot occur in valid programs; ignore.
+
+Tests: fixtures with weird-but-valid formatting (multiline imports, comments
+between clause and specifier, `export * from`, `import type`, single vs
+double quotes — PRESERVE the original quote character: detect from the
+literal's raw text). Assert byte-identity outside the replaced spans
+(compare prefix/suffix slices, not just "compiles").
+
+### M2.4 Engine: unpinned refs in dev mode
+
+- `TypeScriptHarnessProcessOptions.fabricImports` gains
+  `allowUnpinned?: boolean` and the engine threads it into
+  `FabricAwareResolver`.
+- Resolver step (a) update: ref with no `pinnedIdentity` →
+  - `allowUnpinned` false/absent → throw `"unpinned fabric import 'cf:…';
+    pin it (cf deps update) or deploy to pin"`.
+  - true → run M2.2's chase, then proceed exactly as a pinned ref with the
+    chased identity; record `{ specifier, resolvedIdentity, chain }` in a new
+    `resolvedPins()` accessor.
+  - cross-space (`ref.space` a DID ≠ compiling space): fetch via
+    `loadVerifiedSourceClosure(runtime, refSpace, …)` — the storage session
+    routes; CFC caveat is documented follow-up (decision 8). The write-back
+    then copies the docs into the compiling space (this is `replicateClosures`
+    semantics through the normal compile path — no extra code, but ADD a test
+    asserting it happens, and a `logger.info` naming source space → dest
+    space for the provenance audit trail).
+- Engine surfaces `resolvedPins` in `compileToRecordGraph`'s return value
+  (additive field).
+
+Tests: unpinned + allowUnpinned=false → error; =true → compiles and
+`resolvedPins` carries the chain; pinned ref never touches the slug (delete
+the slug cell after pinning, recompile → still works).
+
+### M2.5 CLI: pin-on-deploy + `cf deps update`
+
+Read `packages/cli/` command structure first (mirror an existing command's
+file layout, e.g. how `dev.ts` registers).
+
+- **Deploy pinning**: find the deploy path (`cf` skill docs:
+  `pattern-deploy`; the CLI command that writes a pattern's program to the
+  pattern meta). Before writing the program: run `rewriteFabricPins` over
+  every file, with `resolvePin` = M2.2 chase via the connected runtime; if
+  any rewrite happened, print each (`pinned cf:/kitchen/todo-list →
+  @9f2ab…`). The STORED program is the pinned one. Deploying with an
+  unresolvable ref fails the deploy with the chase's error.
+- **`cf deps update [file] [--import <specifier>]`**: new command; operates
+  on the local working files (filesystem), not deployed state: parse, chase
+  every mutable fabric ref (or just `--import`), rewrite pins in place,
+  print a per-file diff summary. `--check` flag: exit non-zero if any pin
+  would change (CI freshness gate).
+- **`cf dev`/`cf check`**: pass `allowUnpinned: true` + print
+  `resolvedPins` ("resolved cf:… → <hash> (not pinned — deploy or run cf
+  deps update)").
+
+Tests: CLI-level tests follow whatever harness existing cli tests use (look
+in `packages/cli` for test conventions; if commands are thin over lib
+functions, test the lib functions and add one smoke test per command).
+
+### M2.6 End-to-end snapshot-semantics test (the spec's core scenario)
+
+One integration test (runner-level, in-process, two "deploys"):
+
+1. Deploy pattern P v1; create piece from it; assign slug `dep`.
+2. Author importer I with `cf:dep` (unpinned); simulate deploy: pin → assert
+   source now contains `cf:dep@<v1-entry>`; deploy I; run it.
+3. Update the piece to P v2 (new pattern meta + `patternIdentity`).
+4. Recompile/reload I from its stored program: byte-identical behavior,
+   SAME module identities as step 2 (assert hash equality), v1 code still
+   runs.
+5. Re-pin (M2.3 with the chase): only the import line differs; new identity;
+   v2 code runs.
+6. Re-point the slug at an unrelated data cell: pinned I still loads (pin
+   never re-reads the slug); a fresh unpinned resolve now fails with the
+   "does not resolve to a pattern" chain error.
+
+**Acceptance M2**: all the above green; full repo test suite green
+(`deno task test` at root, or at minimum runner + js-compiler + piece + cli).
+
+---
+
+## M3 / M4 — sketches only (do NOT implement)
+
+- **M3 cross-host + publish**: `cf publish` (write source docs + meta + slug
+  to a target space), host-qualified refs (needs dynamic space→host routes —
+  spec open question 8; `spaceHostMap` is interim), CFC label propagation for
+  fetched source (spec § Security), possible public-pattern HTTP endpoint
+  (spec open question 7 — left open).
+- **M4 subpaths + npm vendoring**: subpath = alias to a non-entry mounted
+  file (grammar already parses it); `npm:` = fetch via esm.sh → vendor as a
+  content-addressed source set → same rails.
+
+## Invariants checklist (the reviewer will check every one)
+
+1. A compile with zero fabric imports is byte-for-byte unchanged (identities,
+   records, cache docs, behavior). Guard: run the existing engine + cache
+   test suites untouched; they must pass without edits (any needed edit =
+   design smell, stop and flag).
+2. A mounted module's computed identity ALWAYS equals the identity it was
+   fetched by (M1.3 throws otherwise) — never trust, always recompute.
+3. The importer's module identity changes iff its own bytes change — and the
+   pin is part of its bytes. No identity input lives outside `program.files`.
+4. Source closures never span programs; compiled closures may (links).
+5. Fabric specifiers never appear in: emitted record KEYS (only
+   `cf:module/<hash>`), source-doc links, slug cells. They appear verbatim
+   in: authored source, record `resolutions` keys, compiled require() calls,
+   CacheableModule/compiled-doc import edges.
+6. Every error message names the failing specifier and (where applicable) the
+   chain of hops — copy the exact strings from this plan.
+7. No new HTTP surface, no new authz checks — reads go through normal cell
+   reads and fail with normal authz errors.
+8. `/~cf/` is reserved: authored files under it are rejected everywhere.
+
+## Risk register (check early, in this order)
+
+| Risk | Check | Fallback |
+|---|---|---|
+| Injected helper module (`transformInjectHelperModule` → `transformCfDirective`) references a path that breaks under mount prefixing | FIRST test in M1.4: mount a closure produced by a real `compileToRecordGraph` write-back (which contains whatever the helper injects), not a hand-built one | If the helper import is non-relative and path-ambiguous: serve it from the wrapper by suffix-matching within the requesting subtree — but ESCALATE first; this needs a design look |
+| `loadCompiledClosure` verifies link/edge consistency in a way fabric links violate | M1.6 compiled-walk test before any M1.7 work | Teach its check the fabric branch (same shape as verifySourceDocs partition — but escalate; the compiled set's integrity model is CFC labels, changes there are security-sensitive |
+| `evaluateCachedModules` record building can't map fabric edges | M1.7 step 2 test-first | Small resolution branch keyed on `isFabricImportSpecifier` |
+| Engine cache-hit (`fullHit`) misbehaves with mounted identities | M1.5 test: SECOND compile of the importer is a full hit (no TS compile — assert via the `compile-cache-hit` log or `esmCacheStats`) | — |
+| TS extension inference for mounted entry (`.tsx` vs `.ts`) | M1.1 alias test uses a `.tsx` target | use stored filename's real extension (already in plan) |
+| `validateSource` / emit-stem ambiguity with mounted names | M1.5 e2e covers; stems differ by mount dir | — |
+
+## What NOT to do
+
+- Do NOT modify `computeModuleHashes` / `module-identity.ts`. All fabric
+  awareness lives a layer above (M1.3 partitions, then calls it).
+- Do NOT rewrite specifier text in stored/authored source anywhere except
+  the explicit pin-rewrite tool (M2.3) invoked by deploy/`deps update`.
+- Do NOT add fabric links to SOURCE docs or "fix" `verifySourceDocs` to
+  union across programs.
+- Do NOT re-pretransform mounted sources (they are stored post-pretransform;
+  they enter via the resolver, which naturally skips pretransform).
+- Do NOT thread a space through globals/singletons — it rides options.
+- Do NOT touch CFC label code paths in this work (decision 8); if a test
+  fails on labels, stop and escalate rather than loosening a check.
+- Do NOT introduce new CLI flags beyond `cf deps update`'s listed ones.


### PR DESCRIPTION
## What

Design spec + detailed implementation plan for importing published patterns into patterns:

```tsx
import { TodoItem, todoSchema } from "cf:/kitchen/todo-list";  // slug → piece OR published pattern
import { TodoItem } from "cf:pattern:9f2ab…e41";               // content-addressed source
```

- **`docs/specs/pattern-imports/README.md`** — the design. One `cf:` grammar with no type tag (`cf:<ref>` / `cf:/<space>/<ref>` / `cf://<host>/<space>/<ref>`, trailing `@<pin>`); resolution follows the pointer chain (slug → piece → pattern meta) to an entry-module identity. Pins are written into the source specifier at deploy time, which makes importer identity content-derived with zero hashing changes (the external-dep leaf already folds the specifier string in). Imported subtrees keep their published identities, so compiled artifacts and live modules dedupe with the deployed pattern. No service endpoints: resolution and fetch are ordinary cell reads through the compiling runtime's storage; cross-host rides per-space host routing (#3947, framed as interim). Availability is compile-time only — write-back localizes the imported docs into the compiling space. CFC provenance of fetched source is flagged follow-up work; a public-pattern HTTP endpoint is left open.
- **`docs/specs/pattern-imports/implementation-plan.md`** — milestone-ordered plan written for literal execution (exact seams with line refs, signatures, error strings, red-green test tables): M0 grammar/policy, M1 `cf:pattern:<hash>` end-to-end same-space, M2 mutable refs + chase + byte-precise pin rewriting + CLI; plus an invariants checklist, risk register, and do-not list that double as the review rubric.

## Why

Patterns today can import only their own files and three runtime modules; sharing a schema or sub-pattern across deployments means copy-paste. This gives typed, content-addressed reuse — and a publishing story that is just naming (slug → pattern meta cell in a readable space) — on rails that later extend to `npm:`/esm.sh vendoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a design spec and implementation plan for importing published patterns via `cf:` ESM specifiers, enabling typed, content-addressed reuse across spaces. Imports pin to entry-module hashes at deploy time and resolve through ordinary cell reads with no new endpoints.

- **New Features**
  - `cf:` import grammar: `cf:<ref>`, `cf:/<space>/<ref>`, `cf://<host>/<space>/<ref>`, optional `@<pin>`; `ref` supports slugs, `of:fid1:<hash>` (alias `fid1:<hash>`), and `pattern:<hash>`; hashes are 43-char base64url, case-sensitive, no padding; authored code rejects `cf:module/` and `cf:cache-root/`.
  - Pin-on-deploy writes `@<entryIdentity>` into source; no lockfile; importer identity stays a pure function of bytes; `cf deps update` refreshes pins; unpinned refs allowed only in dev with explicit resolution.
  - Uniform resolution (slug → piece → pattern meta → entry identity) via ordinary storage reads; cross-host uses `spaceHostMap`; availability is compile-time only with write-back localizing imported docs in the importing space.
  - Imported subtrees keep published identities; compiled artifacts dedupe and are shared at runtime; warm/cold reloads use existing cache paths.
  - Implementation plan (M0–M2): parser/policy in `packages/runner` with hash-format canary tests, TypeScript aliasing in `@js-compiler`, resolver + per-subtree identity + cache links, deploy-time pin rewrite and CLI; future phases add host-qualified refs and subpaths; CFC provenance of fetched source is follow-up work.

<sup>Written for commit d0e7b0e172e5cb25c7439f0c46cb1e647fdab69a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

