### PR TITLE
ci: reuse toolshed environment for Rapids deploy

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -799,7 +799,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: ["attest-binaries"]
     runs-on: ubuntu-latest
-    environment: rapids
+    environment: toolshed
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- switch the `deploy-rapids` job to use the existing `toolshed` GitHub environment
- keep the actual deploy command targeting `rapids` with `--skip-clusterduck`
- avoids duplicating bastion secrets during the migration window

## Tradeoff
The GitHub deployment UI will attribute the Rapids deploy job to the `toolshed` environment until we create/copy secrets into a dedicated `rapids` environment. The script target remains `rapids`, so this does not change the deployed host.

## Validation
- `deno fmt --check .github/workflows/deno.yml`
- Ruby YAML parse for `.github/workflows/deno.yml`

Note: `actionlint` is not installed in this environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuse the `toolshed` GitHub environment for the `deploy-rapids` CI job to avoid duplicating bastion secrets during migration. The deploy command still targets `rapids` with `--skip-clusterduck`, so the deployed host does not change.

<sup>Written for commit 2ca6d57234d06dd0322b0d52a6c49de3d594ac94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

