### PR TITLE
feat(runtime-client,runner,home-schemas): site-table v0 — the runtime reads where spaces live

### DIFF
--- a/packages/home-schemas/mod.ts
+++ b/packages/home-schemas/mod.ts
@@ -45,8 +45,13 @@ export {
 } from "./learned.ts";
 
 export {
+  type SiteTable,
+  siteTableCause,
+  siteTableSchema,
   type SpaceEntry,
   spaceEntrySchema,
+  type SpaceHostEntry,
+  spaceHostEntrySchema,
   type SpacesList,
   spacesListSchema,
 } from "./spaces.ts";

--- a/packages/home-schemas/spaces.ts
+++ b/packages/home-schemas/spaces.ts
@@ -24,3 +24,48 @@ export const spacesListSchema = {
 } as const satisfies JSONSchema;
 
 export type SpacesList = Schema<typeof spacesListSchema>;
+
+/**
+ * Site table: where each space lives. The home space carries a per-user
+ * table of `did → host` facts — the v0 of hint-driven space resolution
+ * (2026-06-09 federation session: "the smallest possible slice"). The
+ * runtime reads it as its live host lookup; writers include the local
+ * daemon (syncing its served sources) and link-receipt flows.
+ *
+ * Entries are HINTS: unverified in v0 (the space's own log is the
+ * integrity boundary, not the host), and a hint must never silently
+ * re-point a space the runtime already opened.
+ */
+export const spaceHostEntrySchema = {
+  type: "object",
+  properties: {
+    /** The space DID this fact is about — the table key. */
+    did: { type: "string" },
+    /** Base URL of the host currently serving the space. */
+    host: { type: "string" },
+    /** ISO timestamp of when this fact was recorded. */
+    updatedAt: { type: "string" },
+    /** Who recorded it (e.g. "local-source-sync", "share-link"). */
+    source: { type: "string" },
+  },
+  required: ["did", "host"],
+} as const satisfies JSONSchema;
+
+export type SpaceHostEntry = Schema<typeof spaceHostEntrySchema>;
+
+export const siteTableSchema = {
+  type: "array",
+  items: spaceHostEntrySchema,
+  default: [],
+} as const satisfies JSONSchema;
+
+export type SiteTable = Schema<typeof siteTableSchema>;
+
+/**
+ * Canonical cause for the home-space site-table cell, shared by the
+ * runtime (reader) and embedder daemons (writers) so both address the
+ * same document: `getCell(userDid, siteTableCause(userDid), siteTableSchema)`.
+ */
+export function siteTableCause(userDid: string): { siteTable: string } {
+  return { siteTable: userDid };
+}

--- a/packages/home-schemas/spaces.ts
+++ b/packages/home-schemas/spaces.ts
@@ -35,6 +35,19 @@ export type SpacesList = Schema<typeof spacesListSchema>;
  * Entries are HINTS: unverified in v0 (the space's own log is the
  * integrity boundary, not the host), and a hint must never silently
  * re-point a space the runtime already opened.
+ *
+ * SECURITY (v0, explicit): the table is ordinary home-space data, so
+ * ANYTHING with home-space write access — including patterns running
+ * there — can steer where a not-yet-opened space is fetched from.
+ * That is a deliberate v0 trade (matching "don't even verify in the
+ * first month") and the forcing function for audience-binding the
+ * session handshake before host hints ever come from less-trusted
+ * data.
+ *
+ * Table semantics: an array with no uniqueness constraint — for an
+ * unopened space, the LAST entry for a did wins; REMOVING an entry
+ * does not unregister an already-learned hint until the runtime
+ * restarts.
  */
 export const spaceHostEntrySchema = {
   type: "object",

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -306,6 +306,12 @@ export class RuntimeInternals extends EventTarget {
     await this.#client.synced(space);
   }
 
+  /** See RuntimeClient.registerSpaceHost — the site-table v0 hint API. */
+  async registerSpaceHost(space: DID, host: string): Promise<boolean> {
+    this.#check();
+    return await this.#client.registerSpaceHost(space, host);
+  }
+
   async idle(): Promise<void> {
     this.#check();
     await this.#client.idle();

--- a/packages/runner/src/builtins/fetch-data.ts
+++ b/packages/runner/src/builtins/fetch-data.ts
@@ -363,7 +363,7 @@ async function startFetch(
     // unmapped space keeps the pattern environment's api base — which on
     // some deployments (toolshed) deliberately differs from the runtime's
     // default memory host, so hostForSpace's fallback is NOT used here.
-    const mappedHost = runtime.spaceHostMap?.[inputsCell.space];
+    const mappedHost = runtime.mappedHostFor(inputsCell.space);
     const response = await fetch(
       new URL(url, mappedHost ?? getPatternEnvironment().apiUrl),
       {

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -2989,7 +2989,7 @@ Some operations (especially \`invoke()\` with patterns) create "Pages" - running
     };
 
   // TODO(bf): sendRequest must be given a callback, even if it does nothing
-  const mappedLlmHost = runtime.spaceHostMap?.[space];
+  const mappedLlmHost = runtime.mappedHostFor(space);
   const doWork = () =>
     client.sendRequest(
       llmParams,

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -233,7 +233,7 @@ async function executeWithToolsLoop(params: {
     // module-level default endpoint — like fetch-data, hostForSpace's
     // apiUrl fallback is NOT used, because deployments may split the
     // pattern-facing api host from the runtime's memory host.
-    const mappedLlmHost = runtime.spaceHostMap?.[space];
+    const mappedLlmHost = runtime.mappedHostFor(space);
     const llmResult = await client.sendRequest(
       requestParams,
       updatePartial,
@@ -1349,8 +1349,9 @@ export function generateObject<T extends Record<string, unknown>>(
                   messages: currentMessages,
                 };
 
-                const mappedLlmHost = runtime
-                  .spaceHostMap?.[parentCell.space];
+                const mappedLlmHost = runtime.mappedHostFor(
+                  parentCell.space,
+                );
                 const llmResult = await client.sendRequest(
                   requestParams,
                   updatePartial,
@@ -1655,8 +1656,9 @@ export function generateObject<T extends Record<string, unknown>>(
                 ...liveContextDocs.observedConfidentiality,
               ]).length,
             });
-            const mappedLlmHost = runtime
-              .spaceHostMap?.[parentCell.space];
+            const mappedLlmHost = runtime.mappedHostFor(
+              parentCell.space,
+            );
             const response = await client.generateObject(
               {
                 ...generateObjectParams,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -335,6 +335,8 @@ export class Runtime {
   readonly experimental: ExperimentalOptions;
   readonly apiUrl: URL;
   readonly spaceHostMap?: Record<string, string>;
+  /** Runtime-learned host hints (site table); see registerSpaceHost. */
+  #dynamicHosts = new Map<string, string>();
   readonly userIdentityDID: DID;
   /** Cache of resolved PatternFactory.inSpace("name") space DIDs. */
   private readonly spaceNameToDid = new Map<string, MemorySpace>();
@@ -1135,13 +1137,38 @@ export class Runtime {
   }
 
   /**
+   * The host explicitly known to serve a space, if any: the seed map
+   * wins, then runtime-learned hints (site table). Undefined means
+   * "no per-space fact" — callers choose their own default (storage
+   * and hostForSpace use apiUrl; LLM/fetch keep their module-level
+   * defaults, which may deliberately differ from apiUrl).
+   */
+  mappedHostFor(space: MemorySpace): string | undefined {
+    return this.spaceHostMap?.[space] ?? this.#dynamicHosts.get(space);
+  }
+
+  /**
    * The host that serves a space's space-bound work (LLM, fetch, blob).
-   * A space in `spaceHostMap` resolves to its mapped host; everything
-   * else to the default `apiUrl`. The single compute-side analogue of
-   * the storage layer's per-space address resolver.
+   * A mapped space resolves to its host; everything else to the
+   * default `apiUrl`. The single compute-side analogue of the storage
+   * layer's per-space address resolver.
    */
   hostForSpace(space: MemorySpace): URL {
-    return new URL(this.spaceHostMap?.[space] ?? this.apiUrl);
+    return new URL(this.mappedHostFor(space) ?? this.apiUrl);
+  }
+
+  /**
+   * Record a runtime-learned host hint for a space (the v0 site-table
+   * flow). Storage decides first — the seed map wins and an opened
+   * space is never silently re-pointed — and compute routing follows
+   * exactly when storage accepted, keeping the two layers in agreement.
+   * Returns whether the hint is in effect.
+   */
+  registerSpaceHost(space: MemorySpace, host: string): boolean {
+    const accept = this.storageManager.registerSpaceHost?.(space, host);
+    if (accept === undefined) return false; // manager has no remote resolution
+    if (accept) this.#dynamicHosts.set(space, host);
+    return accept;
   }
 
   /**
@@ -1151,7 +1178,12 @@ export class Runtime {
    */
   async healthCheck(): Promise<boolean> {
     const hosts = new Set([this.apiUrl.toString()]);
-    for (const host of Object.values(this.spaceHostMap ?? {})) {
+    for (
+      const host of [
+        ...Object.values(this.spaceHostMap ?? {}),
+        ...this.#dynamicHosts.values(),
+      ]
+    ) {
       try {
         hosts.add(new URL(host).toString());
       } catch {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -127,6 +127,15 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
   open(space: MemorySpace): IStorageProviderWithReplica;
 
   /**
+   * Record a runtime-learned host hint for a space (federation site
+   * table). Optional: managers without remote, per-space resolution
+   * (emulated/test) simply don't implement it. Returns true when the
+   * hint is in effect; false when refused (seeded differently, or the
+   * space's connection is already open to another host).
+   */
+  registerSpaceHost?(space: MemorySpace, host: string): boolean;
+
+  /**
    * Close all storage providers
    */
   close(): Promise<void>;

--- a/packages/runner/src/storage/v2-emulate.ts
+++ b/packages/runner/src/storage/v2-emulate.ts
@@ -59,6 +59,15 @@ export class EmulatedStorageManager extends StorageManager {
     serverHolder.get = () => this.server();
   }
 
+  /**
+   * Emulated sessions are loopback — there is no per-space host to
+   * resolve, so a host hint can never take effect. Refuse honestly
+   * rather than inherit an acceptance that routes nothing.
+   */
+  override registerSpaceHost(): boolean {
+    return false;
+  }
+
   override async close(): Promise<void> {
     await super.close();
     if (this.#server) {

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -47,6 +47,13 @@ export const MEMORY_STORAGE_PATH = "/api/storage/memory";
 export const createStorageAddressResolver = (
   defaultHost: URL,
   spaceHostMap?: Record<string, string>,
+  /**
+   * Late-bound host hints (space DID → host base URL) learned at
+   * runtime, e.g. from the home-space site table. Consulted AFTER the
+   * seed map and BEFORE the default. The caller owns mutation rules
+   * (a hint must never re-point an already-opened space).
+   */
+  dynamicHosts?: ReadonlyMap<string, string>,
 ): (space: MemorySpace) => URL => {
   const overrides = new Map<string, URL>();
   for (const [space, host] of Object.entries(spaceHostMap ?? {})) {
@@ -60,7 +67,13 @@ export const createStorageAddressResolver = (
     }
   }
   const fallback = new URL(MEMORY_STORAGE_PATH, defaultHost);
-  return (space) => new URL(overrides.get(space) ?? fallback);
+  return (space) => {
+    const seeded = overrides.get(space);
+    if (seeded) return new URL(seeded);
+    const dynamic = dynamicHosts?.get(space);
+    if (dynamic) return new URL(MEMORY_STORAGE_PATH, dynamic);
+    return new URL(fallback);
+  };
 };
 
 class WebSocketTransport implements MemoryClient.Transport {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -541,15 +541,26 @@ export class StorageManager implements IStorageManager {
   #crossSpacePromises = new Set<Promise<void>>();
   #sessionFactory: SessionFactory;
   #spaceIdentity?: Signer;
+  /** Seed map from Options — fixed for the manager's lifetime. */
+  #seedHosts: Record<string, string>;
+  /** Late-bound host hints; see registerSpaceHost. */
+  #dynamicHosts = new Map<string, string>();
 
   static open(options: Options) {
-    return new this(
+    const dynamicHosts = new Map<string, string>();
+    const manager = new this(
       options,
       new RemoteSessionFactory(
-        createStorageAddressResolver(options.memoryHost, options.spaceHostMap),
+        createStorageAddressResolver(
+          options.memoryHost,
+          options.spaceHostMap,
+          dynamicHosts,
+        ),
         options.as,
       ),
     );
+    manager.#dynamicHosts = dynamicHosts;
+    return manager;
   }
 
   protected constructor(
@@ -561,6 +572,43 @@ export class StorageManager implements IStorageManager {
     this.#settings = options.settings ?? defaultSettings;
     this.#sessionFactory = sessionFactory;
     this.#spaceIdentity = options.spaceIdentity;
+    this.#seedHosts = options.spaceHostMap ?? {};
+  }
+
+  /**
+   * Record a runtime-learned host hint for a space (e.g. from the
+   * home-space site table). Returns true when the hint is (now) in
+   * effect for the space's storage connection. Refusals, by design:
+   *
+   * - The seed map wins: a seeded space cannot be re-pointed.
+   * - An already-OPENED space keeps its connection — a hint must never
+   *   silently re-point live storage (re-pointing requires an explicit
+   *   close, which is lifecycle follow-up work).
+   *
+   * Idempotent when the hint matches what is already in effect.
+   */
+  registerSpaceHost(space: MemorySpace, host: string): boolean {
+    let normalized: string;
+    try {
+      normalized = new URL(host).toString();
+    } catch (cause) {
+      throw new Error(
+        `Invalid host for space ${space}: "${host}"`,
+        { cause },
+      );
+    }
+    const seeded = this.#seedHosts[space];
+    if (seeded !== undefined) {
+      return new URL(seeded).toString() === normalized;
+    }
+    const existing = this.#dynamicHosts.get(space);
+    if (this.#providers.has(space)) {
+      // Connection already established — only confirmable, not changeable.
+      return existing !== undefined &&
+        new URL(existing).toString() === normalized;
+    }
+    this.#dynamicHosts.set(space, host);
+    return true;
   }
 
   open(space: MemorySpace): IStorageProviderWithReplica {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -572,7 +572,10 @@ export class StorageManager implements IStorageManager {
     this.#settings = options.settings ?? defaultSettings;
     this.#sessionFactory = sessionFactory;
     this.#spaceIdentity = options.spaceIdentity;
-    this.#seedHosts = options.spaceHostMap ?? {};
+    // Snapshot + freeze: the resolver snapshotted its own copy at
+    // open(), so refusal logic must see the same fixed facts — a
+    // caller mutating their map object must not desynchronize them.
+    this.#seedHosts = Object.freeze({ ...(options.spaceHostMap ?? {}) });
   }
 
   /**

--- a/packages/runner/test/memory-v2-remote-session.test.ts
+++ b/packages/runner/test/memory-v2-remote-session.test.ts
@@ -178,3 +178,66 @@ describe("StorageManager per-space host wiring", () => {
     }
   });
 });
+
+// Site-table v0: runtime-learned host hints. The registry's refusal
+// semantics ARE the contract — seed wins, opened spaces never re-point.
+describe("StorageManager.registerSpaceHost", () => {
+  const spaceSeeded = "did:key:z6Mk-register-seeded" as MemorySpace;
+  const spaceLearned = "did:key:z6Mk-register-learned" as MemorySpace;
+  const spaceOpened = "did:key:z6Mk-register-opened" as MemorySpace;
+
+  async function makeManager() {
+    const signer = await Identity.fromPassphrase("register-space-host");
+    return StorageManager.open({
+      as: signer,
+      memoryHost: new URL("http://host-a.test"),
+      spaceHostMap: { [spaceSeeded]: "http://host-seed.test" },
+    });
+  }
+
+  it("accepts a hint for an untouched space and refuses re-pointing a seeded one", async () => {
+    const manager = await makeManager();
+    expect(manager.registerSpaceHost(spaceLearned, "http://host-b.test"))
+      .toBe(true);
+    // Seed wins: same host confirms, different host refuses.
+    expect(manager.registerSpaceHost(spaceSeeded, "http://host-seed.test"))
+      .toBe(true);
+    expect(manager.registerSpaceHost(spaceSeeded, "http://host-evil.test"))
+      .toBe(false);
+  });
+
+  it("never re-points an opened space, and the hint routes a fresh open", async () => {
+    const realWebSocket = globalThis.WebSocket;
+    (globalThis as { WebSocket: unknown }).WebSocket = RecordingWebSocket;
+    RecordingWebSocket.dialed.length = 0;
+    try {
+      const manager = await makeManager();
+      expect(manager.registerSpaceHost(spaceLearned, "http://host-b.test"))
+        .toBe(true);
+      manager.open(spaceLearned).sync("of:register-probe" as URI)
+        .catch(() => {});
+      await RecordingWebSocket.whenDialed(1);
+      expect(new URL(RecordingWebSocket.dialed[0]).host).toBe("host-b.test");
+      // Now that the space is open: same-host hint confirms; a
+      // different host refuses rather than silently re-pointing.
+      expect(manager.registerSpaceHost(spaceLearned, "http://host-b.test"))
+        .toBe(true);
+      expect(manager.registerSpaceHost(spaceLearned, "http://host-c.test"))
+        .toBe(false);
+      // The opened space refusal also applies with no prior hint.
+      manager.open(spaceOpened).sync("of:register-probe" as URI)
+        .catch(() => {});
+      await RecordingWebSocket.whenDialed(2);
+      expect(manager.registerSpaceHost(spaceOpened, "http://host-d.test"))
+        .toBe(false);
+    } finally {
+      (globalThis as { WebSocket: unknown }).WebSocket = realWebSocket;
+    }
+  });
+
+  it("throws on a malformed host, naming the space", async () => {
+    const manager = await makeManager();
+    expect(() => manager.registerSpaceHost(spaceLearned, "not a url"))
+      .toThrow(`Invalid host for space ${spaceLearned}`);
+  });
+});

--- a/packages/runner/test/runtime-host-for-space.test.ts
+++ b/packages/runner/test/runtime-host-for-space.test.ts
@@ -18,6 +18,52 @@ function makeRuntime(spaceHostMap?: Record<string, string>) {
   });
 }
 
+describe("Runtime.registerSpaceHost", () => {
+  it("follows storage's verdict and routes compute on acceptance", async () => {
+    const storageVerdicts: Array<[string, string]> = [];
+    const storageManager = Object.assign(
+      StorageManager.emulate({ as: signer }),
+      {
+        registerSpaceHost(space: string, host: string) {
+          storageVerdicts.push([space, host]);
+          return host !== "http://refused.test/";
+        },
+      },
+    );
+    const runtime = new Runtime({
+      apiUrl: new URL("http://host-a.test/"),
+      storageManager,
+    });
+    try {
+      expect(runtime.registerSpaceHost(spaceB, "http://host-b.test/"))
+        .toBe(true);
+      expect(runtime.mappedHostFor(spaceB)).toBe("http://host-b.test/");
+      expect(runtime.hostForSpace(spaceB).toString()).toBe(
+        "http://host-b.test/",
+      );
+      // Storage refusal ⇒ compute routing must NOT diverge.
+      const spaceC = "did:key:z6Mk-host-for-space-c" as MemorySpace;
+      expect(runtime.registerSpaceHost(spaceC, "http://refused.test/"))
+        .toBe(false);
+      expect(runtime.mappedHostFor(spaceC)).toBeUndefined();
+      expect(storageVerdicts.length).toBe(2);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("returns false when the manager has no remote resolution", async () => {
+    const runtime = makeRuntime();
+    try {
+      expect(runtime.registerSpaceHost(spaceB, "http://host-b.test/"))
+        .toBe(false);
+      expect(runtime.mappedHostFor(spaceB)).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+    }
+  });
+});
+
 describe("Runtime.hostForSpace", () => {
   it("resolves mapped spaces to their host and others to apiUrl", async () => {
     const runtime = makeRuntime({ [spaceB]: "http://host-b.test" });

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1780,6 +1780,56 @@ describe("RuntimeProcessor per-space piece contexts", () => {
     }
   });
 
+  it("watchSiteTable registers table entries, isolating bad ones", async () => {
+    const { runtime } = createRuntime();
+    const { siteTableCause, siteTableSchema } = await import(
+      "@commonfabric/home-schemas"
+    );
+    const registered: Array<[string, string]> = [];
+    Object.assign(runtime, {
+      registerSpaceHost: (space: string, host: string) => {
+        registered.push([space, host]);
+        // Malformed hosts throw in the real registry — simulate to
+        // assert per-entry isolation.
+        if (host === "not a url") throw new Error("Invalid host");
+        return host !== "http://refused.test/";
+      },
+    });
+    const userDid = runtime.userIdentityDID;
+    const table = runtime.getCell(
+      userDid,
+      siteTableCause(userDid),
+      siteTableSchema,
+    );
+    const tx = runtime.edit();
+    table.withTx(tx).set([
+      { did: "did:key:z6Mk-table-a", host: "http://host-a.test/" },
+      { did: "not-a-did", host: "http://ignored.test/" },
+      { did: "did:key:z6Mk-table-bad", host: "not a url" },
+      { did: "did:key:z6Mk-table-b", host: "http://refused.test/" },
+      { did: "did:key:z6Mk-table-c", host: "http://host-c.test/" },
+    ]);
+    await tx.commit();
+
+    const processor = { runtime } as unknown as RuntimeProcessor;
+    try {
+      (RuntimeProcessor.prototype as unknown as {
+        watchSiteTable(): void;
+      }).watchSiteTable.call(processor);
+      await runtime.idle();
+      // Microtask drain: sync() resolution + first sink fire.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(registered).toEqual([
+        ["did:key:z6Mk-table-a", "http://host-a.test/"],
+        ["did:key:z6Mk-table-bad", "not a url"],
+        ["did:key:z6Mk-table-b", "http://refused.test/"],
+        ["did:key:z6Mk-table-c", "http://host-c.test/"],
+      ]);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
   it("handleRegisterSpaceHost forwards to the runtime and reports the verdict", () => {
     const calls: Array<[string, string]> = [];
     const processor = {
@@ -1790,9 +1840,11 @@ describe("RuntimeProcessor per-space piece contexts", () => {
         },
       },
     } as unknown as RuntimeProcessor;
-    const handle =
-      (RuntimeProcessor.prototype as unknown as Record<string, Function>)
-        .handleRegisterSpaceHost;
+    const handle = (RuntimeProcessor.prototype as unknown as {
+      handleRegisterSpaceHost(
+        r: { type: RequestType; space: string; host: string },
+      ): { value: boolean };
+    }).handleRegisterSpaceHost;
     expect(handle.call(processor, {
       type: RequestType.RegisterSpaceHost,
       space: "did:key:z6Mk-ipc-a",

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1780,6 +1780,32 @@ describe("RuntimeProcessor per-space piece contexts", () => {
     }
   });
 
+  it("handleRegisterSpaceHost forwards to the runtime and reports the verdict", () => {
+    const calls: Array<[string, string]> = [];
+    const processor = {
+      runtime: {
+        registerSpaceHost: (space: string, host: string) => {
+          calls.push([space, host]);
+          return host === "http://accepted.test/";
+        },
+      },
+    } as unknown as RuntimeProcessor;
+    const handle =
+      (RuntimeProcessor.prototype as unknown as Record<string, Function>)
+        .handleRegisterSpaceHost;
+    expect(handle.call(processor, {
+      type: RequestType.RegisterSpaceHost,
+      space: "did:key:z6Mk-ipc-a",
+      host: "http://accepted.test/",
+    })).toEqual({ value: true });
+    expect(handle.call(processor, {
+      type: RequestType.RegisterSpaceHost,
+      space: "did:key:z6Mk-ipc-b",
+      host: "http://refused.test/",
+    })).toEqual({ value: false });
+    expect(calls.length).toBe(2);
+  });
+
   it("managerFor returns only existing contexts (no lazy create)", async () => {
     const { processor, runtime, homeSpace } = await makeProcessorState();
     const spaceB = (await Identity.fromPassphrase(

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -81,6 +81,7 @@ import {
   type PageSyncedRequest,
   type PatternSourcesResponse,
   type RecreateSpaceRootPatternRequest,
+  type RegisterSpaceHostRequest,
   RequestType,
   type SetActionRunTraceEnabledRequest,
   type SetBreakpointsRequest,
@@ -105,6 +106,11 @@ import {
 } from "../protocol/mod.ts";
 import { HttpProgramResolver, Program } from "@commonfabric/js-compiler";
 import { setLLMUrl } from "@commonfabric/llm";
+import {
+  type SiteTable,
+  siteTableCause,
+  siteTableSchema,
+} from "@commonfabric/home-schemas";
 import {
   createCellRef,
   createPageRef,
@@ -433,7 +439,58 @@ export class RuntimeProcessor {
     // any present-but-unknown value becomes "deny"; absent stays "allow".
     processor.renderDeclassificationPolicy =
       normalizeRenderDeclassificationPolicy(data.renderDeclassificationPolicy);
+    // Site-table v0: the home space carries did → host hints; the
+    // runtime reads them as its live host lookup (2026-06-09 federation
+    // session — "move the lookup into the runtime itself"). Refusals
+    // (seeded differently / space already open) are by design; failures
+    // here must not block worker boot.
+    processor.watchSiteTable();
     return processor;
+  }
+
+  /**
+   * Subscribe to the home-space site table and register each entry as
+   * a host hint. Fire-and-forget: resolution hints are an enhancement,
+   * never a boot dependency.
+   */
+  watchSiteTable(): void {
+    try {
+      const userDid = this.runtime.userIdentityDID;
+      const table = this.runtime.getCell(
+        userDid,
+        siteTableCause(userDid),
+        siteTableSchema,
+      );
+      Promise.resolve(table.sync()).then(() => {
+        table.sink((entries: Readonly<SiteTable> | undefined) => {
+          for (const entry of entries ?? []) {
+            if (!entry?.did || !entry.host) continue;
+            if (!String(entry.did).startsWith("did:")) continue;
+            try {
+              this.runtime.registerSpaceHost(
+                entry.did as DID,
+                entry.host,
+              );
+            } catch (error) {
+              console.warn(
+                `[RuntimeProcessor] Ignoring invalid site-table entry for ${entry.did}:`,
+                error instanceof Error ? error.message : error,
+              );
+            }
+          }
+        });
+      }).catch((error: unknown) => {
+        console.warn(
+          "[RuntimeProcessor] Site table unavailable (continuing without hints):",
+          error instanceof Error ? error.message : error,
+        );
+      });
+    } catch (error) {
+      console.warn(
+        "[RuntimeProcessor] Site table watch failed to start:",
+        error instanceof Error ? error.message : error,
+      );
+    }
   }
 
   /**
@@ -895,6 +952,14 @@ export class RuntimeProcessor {
     await pieceManager.synced();
   }
 
+  handleRegisterSpaceHost(
+    request: RegisterSpaceHostRequest,
+  ): BooleanResponse {
+    return {
+      value: this.runtime.registerSpaceHost(request.space, request.host),
+    };
+  }
+
   /** Convergence across every opened space — no space named, none implied. */
   async handleRuntimeSynced(): Promise<void> {
     await Promise.all(
@@ -1203,6 +1268,8 @@ export class RuntimeProcessor {
         return await this.handlePageSynced(request);
       case RequestType.RuntimeSynced:
         return await this.handleRuntimeSynced();
+      case RequestType.RegisterSpaceHost:
+        return this.handleRegisterSpaceHost(request);
       case RequestType.GetGraphSnapshot:
         return this.getGraphSnapshot(request);
       case RequestType.SetPullMode:

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -448,10 +448,20 @@ export class RuntimeProcessor {
     return processor;
   }
 
+  #siteTableCancel: Cancel | undefined;
+  #siteTableWarned = new Set<string>();
+
   /**
    * Subscribe to the home-space site table and register each entry as
    * a host hint. Fire-and-forget: resolution hints are an enhancement,
    * never a boot dependency.
+   *
+   * ORDERING CONTRACT for embedders: this subscription races the first
+   * mount. An embedder about to mount a space it just learned the host
+   * for must push the hint via the RegisterSpaceHost IPC BEFORE that
+   * mount — once a space opens against the default host, the
+   * opened-space rule pins it for the session. The table is the
+   * durable record; the IPC is the ordering guarantee.
    */
   watchSiteTable(): void {
     try {
@@ -462,23 +472,45 @@ export class RuntimeProcessor {
         siteTableSchema,
       );
       Promise.resolve(table.sync()).then(() => {
-        table.sink((entries: Readonly<SiteTable> | undefined) => {
-          for (const entry of entries ?? []) {
-            if (!entry?.did || !entry.host) continue;
-            if (!String(entry.did).startsWith("did:")) continue;
-            try {
-              this.runtime.registerSpaceHost(
-                entry.did as DID,
-                entry.host,
-              );
-            } catch (error) {
-              console.warn(
-                `[RuntimeProcessor] Ignoring invalid site-table entry for ${entry.did}:`,
-                error instanceof Error ? error.message : error,
-              );
+        this.#siteTableCancel = table.sink(
+          (entries: Readonly<SiteTable> | undefined) => {
+            for (const entry of entries ?? []) {
+              if (!entry?.did || !entry.host) continue;
+              if (!String(entry.did).startsWith("did:")) continue;
+              try {
+                const accepted = this.runtime.registerSpaceHost(
+                  entry.did as DID,
+                  entry.host,
+                );
+                // The dual of "never silently re-point": never silently
+                // fail to take effect. Warn (once per fact) when the
+                // hint lost — usually the boot race: the space opened
+                // against the default host first.
+                if (!accepted) {
+                  const key = `${entry.did}|${entry.host}`;
+                  const effective = this.runtime.hostForSpace(
+                    entry.did as DID,
+                  ).toString();
+                  if (
+                    effective !== new URL(entry.host).toString() &&
+                    !this.#siteTableWarned.has(key)
+                  ) {
+                    this.#siteTableWarned.add(key);
+                    console.warn(
+                      `[RuntimeProcessor] Site-table hint for ${entry.did} not in effect ` +
+                        `(space already open or seeded elsewhere); using ${effective}`,
+                    );
+                  }
+                }
+              } catch (error) {
+                console.warn(
+                  `[RuntimeProcessor] Ignoring invalid site-table entry for ${entry.did}:`,
+                  error instanceof Error ? error.message : error,
+                );
+              }
             }
-          }
-        });
+          },
+        );
       }).catch((error: unknown) => {
         console.warn(
           "[RuntimeProcessor] Site table unavailable (continuing without hints):",
@@ -509,6 +541,8 @@ export class RuntimeProcessor {
     this.disposingPromise = (async () => {
       this.telemetry.removeEventListener("telemetry", this.#onTelemetry);
       try {
+        this.#siteTableCancel?.();
+        this.#siteTableCancel = undefined;
         for (const cancel of this.subscriptions.values()) {
           cancel();
         }

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -472,6 +472,9 @@ export class RuntimeProcessor {
         siteTableSchema,
       );
       Promise.resolve(table.sync()).then(() => {
+        // dispose() may have run while sync was in flight — installing
+        // the sink then would leak a live subscription past disposal.
+        if (this._isDisposed) return;
         this.#siteTableCancel = table.sink(
           (entries: Readonly<SiteTable> | undefined) => {
             for (const entry of entries ?? []) {

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -246,6 +246,12 @@ export interface RuntimeSyncedRequest extends BaseRequest {
  * on the live runtime without waiting for a sync round-trip. The
  * worker's refusal semantics apply: seed wins, opened spaces are never
  * re-pointed.
+ *
+ * ORDERING CONTRACT: an embedder that will mount a space it just
+ * learned the host for must send this BEFORE the first mount of that
+ * space — once a space opens against the default host, the
+ * opened-space rule pins it for the session. The table is the durable
+ * record; this IPC is the ordering guarantee.
  */
 export interface RegisterSpaceHostRequest extends BaseRequest {
   type: RequestType.RegisterSpaceHost;

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -50,6 +50,7 @@ export enum RequestType {
   EnsureHomePatternRunning = "runtime:ensureHomePatternRunning",
   Idle = "runtime:idle",
   RuntimeSynced = "runtime:synced",
+  RegisterSpaceHost = "runtime:registerSpaceHost",
   FlushCompileCacheWrites = "runtime:flushCompileCacheWrites",
   GetGraphSnapshot = "runtime:getGraphSnapshot",
   SetPullMode = "runtime:setPullMode",
@@ -236,6 +237,20 @@ export interface IdleRequest extends BaseRequest {
  */
 export interface RuntimeSyncedRequest extends BaseRequest {
   type: RequestType.RuntimeSynced;
+}
+
+/**
+ * Record a runtime-learned host hint for a space (site-table v0).
+ * The durable record is the home-space site table; this IPC lets an
+ * embedder make a just-learned hint (e.g. from a share link) effective
+ * on the live runtime without waiting for a sync round-trip. The
+ * worker's refusal semantics apply: seed wins, opened spaces are never
+ * re-pointed.
+ */
+export interface RegisterSpaceHostRequest extends BaseRequest {
+  type: RequestType.RegisterSpaceHost;
+  space: DID;
+  host: string;
 }
 
 /**
@@ -648,6 +663,7 @@ export type IPCClientRequest =
   | PageGetAllRequest
   | PageSyncedRequest
   | RuntimeSyncedRequest
+  | RegisterSpaceHostRequest
   | VDomEventRequest
   | VDomMountRequest
   | VDomUnmountRequest
@@ -933,6 +949,10 @@ export type Commands = {
   [RequestType.RuntimeSynced]: {
     request: RuntimeSyncedRequest;
     response: EmptyResponse;
+  };
+  [RequestType.RegisterSpaceHost]: {
+    request: RegisterSpaceHostRequest;
+    response: BooleanResponse;
   };
   [RequestType.PageGet]: {
     request: PageGetRequest;

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -299,6 +299,22 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
   }
 
   /**
+   * Record a runtime-learned host hint for a space (site-table v0):
+   * makes a just-learned `space → host` fact effective on the live
+   * runtime. The durable record belongs in the home-space site table;
+   * this is the immediate, in-session half. Returns whether the hint
+   * is in effect (seed wins; an opened space is never re-pointed).
+   */
+  async registerSpaceHost(space: DID, host: string): Promise<boolean> {
+    const res = await this.#conn.request<RequestType.RegisterSpaceHost>({
+      type: RequestType.RegisterSpaceHost,
+      space,
+      host,
+    });
+    return res.value;
+  }
+
+  /**
    * Wait for convergence across EVERY space this worker has opened.
    * Spaceless by design (like idle) — for quiescence checks that don't
    * care about any particular space, e.g. test/debug harnesses.


### PR DESCRIPTION
## What

The v0 of hint-driven space resolution from the 2026-06-09 session, built directly per the closing call there (*"maybe we skip [the intermediate] and just do that directly"* — the runtime reads the lookup itself):

- **`home-schemas`**: the site table — a per-user array of `did → host` HINTS in the home space (`siteTableSchema` + the canonical `siteTableCause`, shared by the runtime as reader and embedder daemons as writers). Unverified in v0, per the session ("don't even verify in the first month").
- **Storage**: `StorageManager.registerSpaceHost(space, host)` — a late-bound hint consulted by the address resolver after the frozen seed map, before the default host. The refusal semantics ARE the contract: **the seed wins, and an already-opened space is never silently re-pointed**. An unopened space (the open-a-shared-link case) picks the hint up on first touch because sessions resolve lazily per space. The emulated manager refuses honestly.
- **Runtime**: `registerSpaceHost` is storage-first and mirrors into compute routing only on acceptance — storage and compute can't disagree. `mappedHostFor(space)` (seed ?? learned) is now the single read path behind `hostForSpace`, LLM/fetch-data mapped routing, and the health fan-out.
- **Worker**: subscribes to the home-space site table after boot and registers entries — fire-and-forget, never a boot dependency. **The losing side of the boot race is loud**: if a hint can't take effect (space already opened against the default host) and the effective host differs, the worker warns once per fact.
- **`RegisterSpaceHost` IPC** (+ RuntimeClient/RuntimeInternals): the in-session half for embedder-learned hints (share-link receipt). **Ordering contract, stated in the IPC doc**: push the hint before the first mount of a just-learned space — the table is the durable record, the IPC is the ordering guarantee.

## The paragraph that needs your eyes

**Security delta (deliberate, v0):** the table is ordinary home-space data, so anything with home-space write access — including patterns running there — can now steer where a **not-yet-opened** space is fetched from. Pre-this-PR, only the embedder's trusted seed map could steer. Combined with v0's no-verification and the replayable `session.open` handshake, this is exactly the forcing function for **audience-binding before host hints ever come from less-trusted data** (the parked PR5 item). The schema documents it; flagging it here for an explicit architect ack.

## Scope (so the long-term owner inherits a seam, not a fork)

Hint-reading is **worker-runtime only** in v0: `cf` CLI, background-charm-service, and toolshed's server runtime stay seed-map-only (a TODO, not an oversight). Removals don't unregister until restart; duplicate dids are last-entry-wins (documented in the schema). The loom-side writer (daemon syncing its served sources into the table + the home-host IndexedDB pin) is the companion loom PR.

## Tests

Registry refusal semantics (seed wins; opened spaces never re-point — asserted against the actually-dialed websocket host; fresh opens route through hints); Runtime/storage verdict agreement incl. refusal-no-divergence; the IPC handler round-trip; watchSiteTable end-to-end over loopback storage with per-entry isolation of malformed rows. Full check/lint/fmt green; runner (590), runtime-client (15), lib-shell, shell, piece suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds v0 of hint-driven space resolution: the runtime reads a per-user DID→host “site table” to route spaces. Seeds still win, and opened spaces are never re-pointed; hints only affect unopened spaces.

- **New Features**
  - `home-schemas`: added `siteTable` schema and `siteTableCause`. Entries are unverified hints; last-entry wins; removals don’t unregister until restart.
  - `runner`: `StorageManager.registerSpaceHost(space, host)` with refusal rules (seed wins; opened spaces not re-pointed). Address resolver consults dynamic hints between seed and default. `mappedHostFor()` added and used by a unified `hostForSpace()`. Health check includes learned hosts. Emulated manager always refuses.
  - `runner` builtins: `fetch-data` and LLM use `mappedHostFor()` for mapped routing.
  - `runtime-client`/`lib-shell`: `RegisterSpaceHost` IPC and client passthrough. Worker subscribes to the home-space site table after boot and registers entries; warns once when a hint can’t take effect.
  - Tests: refusal semantics, storage/runtime agreement, IPC handler, and site-table watch with per-entry isolation.
  - Security (v0): anything with home-space write access can steer where not-yet-opened spaces fetch from; no host verification yet.
  - Hardening: avoid a leaked site-table subscription when disposed during initial sync; snapshot and freeze the seed host map to keep the resolver and refusal logic consistent.

- **Migration**
  - Embedders: when you learn a space’s host (e.g., from a share link), send `RegisterSpaceHost` before first mount. The table is the durable record; the IPC provides ordering.
  - Scope: only the worker runtime reads hints in v0. CLI and other services remain seed-map only.

<sup>Written for commit e7a942cbba3f63f3c6212d89b8b3ec0b195a65dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

