### PR TITLE
fix(ts-transformers): shrink index-signature captures to optional properties

### DIFF
--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -908,7 +908,12 @@ function buildShrunkTypeNodeFromType(
       ) ?? checker.getIndexTypeOfType(type, ts.IndexKind.String);
       if (!indexType) continue;
       propType = indexType;
-      isOptional = typeIncludesUndefined(indexType);
+      // An index signature types whatever keys happen to exist — it never
+      // guarantees this particular key is present. The shrunken property must
+      // be optional, or the injected schema marks it `required` and values
+      // lacking the key fail validation (the whole capture then reads
+      // undefined at runtime).
+      isOptional = true;
     }
 
     const hasDirectAccess = childPaths.some((path) => path.length === 0);

--- a/packages/ts-transformers/test/fixtures/schema-injection/index-signature-extras-optional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/index-signature-extras-optional.expected.jsx
@@ -1,0 +1,126 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { computed, pattern } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+// FIXTURE: index-signature-extras-optional
+// Verifies: a capture path that resolves through a string index signature
+// (an "extras" key like `priority` below) shrinks to an OPTIONAL property.
+// Index signatures never guarantee a key exists, so the shrunken capture
+// schema must not list the key in `required` — otherwise elements without
+// the extra fail schema validation and the whole capture reads undefined
+// (regression: editable-list assert_extra_passthrough after #4017).
+interface TaggedItem {
+    id: string;
+    label: string;
+    // deno-lint-ignore no-explicit-any
+    [extra: string]: any;
+}
+interface Input {
+    items: TaggedItem[];
+}
+const __cfLift_1 = __cfHelpers.lift<{
+    items: {
+        priority?: any;
+    }[];
+}, boolean>(({ items }) => items[2]?.priority === 9, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    priority: true
+                }
+            }
+        }
+    },
+    required: ["items"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_2 = __cfHelpers.lift<{
+    items: {
+        label: string;
+    }[];
+}, boolean>(({ items }) => items[2]?.label === "Gamma", {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    label: {
+                        type: "string"
+                    }
+                },
+                required: ["label"]
+            }
+        }
+    },
+    required: ["items"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+export default pattern((__cf_pattern_input) => {
+    const items = __cf_pattern_input.key("items");
+    // Extras key: only exists on some elements; must shrink to `priority?`.
+    const extraIsNine = __cfLift_1({ items: items }).for("extraIsNine", true);
+    // Declared key for contrast: stays required as before.
+    const labelIsGamma = __cfLift_2({ items: items }).for("labelIsGamma", true);
+    return { extraIsNine, labelIsGamma };
+}, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/TaggedItem"
+            }
+        }
+    },
+    required: ["items"],
+    $defs: {
+        TaggedItem: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                label: {
+                    type: "string"
+                }
+            },
+            additionalProperties: true,
+            required: ["id", "label"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        extraIsNine: {
+            type: "boolean"
+        },
+        labelIsGamma: {
+            type: "boolean"
+        }
+    },
+    required: ["extraIsNine", "labelIsGamma"]
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/schema-injection/index-signature-extras-optional.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/index-signature-extras-optional.input.tsx
@@ -1,0 +1,27 @@
+import { computed, pattern } from "commonfabric";
+
+// FIXTURE: index-signature-extras-optional
+// Verifies: a capture path that resolves through a string index signature
+// (an "extras" key like `priority` below) shrinks to an OPTIONAL property.
+// Index signatures never guarantee a key exists, so the shrunken capture
+// schema must not list the key in `required` — otherwise elements without
+// the extra fail schema validation and the whole capture reads undefined
+// (regression: editable-list assert_extra_passthrough after #4017).
+interface TaggedItem {
+  id: string;
+  label: string;
+  // deno-lint-ignore no-explicit-any
+  [extra: string]: any;
+}
+
+interface Input {
+  items: TaggedItem[];
+}
+
+export default pattern<Input>(({ items }) => {
+  // Extras key: only exists on some elements; must shrink to `priority?`.
+  const extraIsNine = computed(() => items[2]?.priority === 9);
+  // Declared key for contrast: stays required as before.
+  const labelIsGamma = computed(() => items[2]?.label === "Gamma");
+  return { extraIsNine, labelIsGamma };
+});


### PR DESCRIPTION
Fixes the Pattern Unit Tests failure on main ([run 27378444323](https://github.com/commontoolsinc/labs/actions/runs/27378444323)): `editable-list.test.tsx` `assert_extra_passthrough`, "Expected true, got undefined".

## Root cause

Type-shrinking's `buildShrunkTypeNodeFromType` handles capture paths with no declared property symbol by resolving through the receiver's index signature — but it emitted the resulting property as **non-optional** (`isOptional = typeIncludesUndefined(indexType)`, which is `false` for `any`). Schema-injection then marked the key `required` in the lift's input schema:

```ts
const __cfLift = __cfHelpers.lift<{ items: { priority: any }[] }, boolean>(
  ({ items }) => items[2]?.priority === 9,
  { ..., items: { type: "object", properties: { priority: true }, required: ["priority"] } }, ...)
```

An index signature never guarantees a particular key exists. `editable-list` items Alpha and Beta carry no `priority` extra, so every element failed validation, the whole `items` capture read `undefined`, and the assertion computed produced `undefined`.

## Why it appeared as #4017 × #4048

The bug is older than both, but unreachable until they met: pre-#4017, factory result types went through `StripCell<R>`, whose homomorphic mapped type expanded `EditableListItem` into an anonymous object that escaped shrinking with the **full** object schema (`additionalProperties: true`). #4017 made factory results keep the named interface, so shrinking engaged and collapsed the capture to the accessed extras key. #4048 (editable-list, landed after #4017's merge-base) is the first in-tree pattern reading an extras key off a factory result — #4017's own CI never compiled it. Cross-check that pinned the mechanism: `assert_gamma_present` gets the same usage-collapsed schema but passes, because `label` is declared and present on every item.

## Fix

One line of substance: a property materialized from an index signature is always optional. The shrunken type now reads `priority?: any` and the key is omitted from `required`.

New fixture `schema-injection/index-signature-extras-optional` pins the contract (extras key optional, declared key still required). **No other golden changed.**

## Verification

- `editable-list.test.tsx`: 28/28 (was 27/28 on main)
- ts-transformers + schema-generator suites green; goldens otherwise byte-identical
- `deno task integration pattern-tests`: 59/59
- `deno fmt --check` / `deno lint` / `deno check` clean

Not addressed here (separate, quieter #4017 regression observed in the same transformed-output diff): `Default<…>` aliases in inferred capture types now expand to raw `DEFAULT_MARKER` intersections and their schema `"default"` values are dropped. Nothing currently fails on it; tracked in my notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrink index-signature captures to optional properties in `ts-transformers` so schema injection no longer marks extras keys as required. Fixes the editable-list extras validation failure and restores pattern tests.

- **Bug Fixes**
  - Materialize properties resolved via index signatures as optional during type shrinking to prevent `required` in injected schemas.
  - Added fixture `schema-injection/index-signature-extras-optional` to lock the contract (extras optional, declared keys required).

<sup>Written for commit f6956ab2db0afde14fc0e7ea765089cf14f3fa4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

