### PR TITLE
runner: dual-write $patternRef at the pattern JSON boundary [identity E3]

### DIFF
--- a/docs/specs/content-addressed-action-identity-implementation-plan.md
+++ b/docs/specs/content-addressed-action-identity-implementation-plan.md
@@ -471,6 +471,20 @@ One-time effect: stored pattern-bearing values gain a `$patternRef` key, so
 the first re-serialization after upgrade diffs once per value (same class as
 E1's serialized-module change).
 
+Known dual-write gap (deliberate, flagged by Codex review): STRUCTURAL
+pattern copies — the plain bound copies `unwrapOneLevelAndBindtoDoc` builds
+from `pattern.nodes`-derived bindings — persist without `$patternRef`, since
+they carry no `toJSON` and `getImmutableCell` stringifies them directly. The
+load-bearing instance (the list-builtin `op`) is already covered by the
+`substituteOpPatternRefs` sentinel, which stamps the ref from the copy's
+derivation chain at instantiation. Stamping refs into the remaining bound
+copies would change the content of immutable inputs cells (the CT-1623
+id-churn class) for a vintage that rewrites on every re-instantiation anyway
+— so they stay bare until the Phase 4 flip changes the internal serializer
+itself. The aging signal dual-write exists for is the LIVE-factory boundary
+writes (llm toolDef patterns, patterns passed directly in piece arguments),
+which are the values that persist across sessions.
+
 ## Sequencing & parallelism
 
 A → B → C → D strictly (B's `entryRefByValue` promotion is C's lookup

--- a/docs/specs/content-addressed-action-identity-implementation-plan.md
+++ b/docs/specs/content-addressed-action-identity-implementation-plan.md
@@ -3,8 +3,11 @@
 Companion to [`content-addressed-action-identity.md`](./content-addressed-action-identity.md)
 (the design). One PR per letter; each lands green and is independently
 revertible. Phase 0 (ordinal-free `implementationRef` + legacy-alias shim)
-shipped in #3997; A–D shipped in #4006/#4008/#4009/#4013; E is in flight (see
-"PR E — the flip" for the recorded gating decisions and the E1 status).
+shipped in #3997; A–D shipped in #4006/#4008/#4009/#4013; E shipped in three
+PRs — E1 #4053, E2 #4064, E3 (pattern JSON boundary, scoped to dual-write) —
+see "PR E — the flip" for the recorded gating decisions per part. Phase 4
+(retire the legacy read path + the refs-only pattern-JSON flip) is the open
+remainder.
 
 ## Last Updated
 
@@ -405,7 +408,68 @@ loading AND executing; it must stay green until the legacy read path retires.
    the `$opFallback` decision (explicit `serializePatternGraph()` escape
    hatch vs eviction pinning). This piece can split into its own PR if the
    blast radius (json round-trip consumers, `pattern-binding` deserialization)
-   warrants.
+   warrants. (It did — see E3 below.)
+
+### E3 — pattern JSON boundary (landed SCOPED: dual-write, not refs-only)
+
+#### Gating decisions (recorded 2026-06-11)
+
+- **`$opFallback` / escape-hatch decision: option (a).**
+  `serializePatternGraph()` (builder/json-utils.ts) is the internal graph
+  serializer; `toJSONWithLegacyAliases` routes pattern values through it
+  under an ambient internal-serialization context that suppresses
+  `$patternRef`. The fallback keeps embedding a full graph and
+  `map-op-by-identity.test.ts` stays meaningful (sentinel resolves by
+  identity; eviction falls back to the graph). The context flag (not just a
+  separate function) is required because factory `toJSON` closures
+  deliberately serialize the ROOT factory — the one carrying `.program` set
+  post-construction — so internal serialization must keep calling `toJSON`
+  and steer its behavior, not bypass it.
+- **Refs-only emission: DEFERRED to Phase 4.** Pattern artifacts have no
+  session-lifetime strong index (E1's
+  `verifiedImplementationsByEntryRef` is function-object-keyed, javascript
+  modules only): a stored `$patternRef` resolves only via the FIFO-bounded
+  `addressableByIdentity` (sync) or `loadPatternByIdentity` (async).
+  Production graph consumers found by the read audit: the list builtins'
+  `resolveOpPattern` (sync Action — cannot await) and llm-dialog tool
+  invocation (cross-session; compiled-artifact presence in the reading
+  space not guaranteed for arbitrary pattern values). Cross-session
+  resolvability could not be measured (no production-space sample — the
+  same blocker as gate 2). The flip needs: a session-lifetime pattern
+  index or refcount pinning (design open question 2), async-capable or
+  pre-resolved reads at the two consumers, and stored-data aging evidence
+  (dual-written values are now measurable, like `$implRef` was).
+- **Write/read audit (2026-06-11):** pattern graphs reach storage at three
+  cell-write sites — pattern values in piece arguments
+  (`runner.ts updateArgument`), the list-builtin inputs sentinel
+  (`getImmutableCell` after `substituteOpPatternRefs`), nested sub-pattern
+  arguments — plus stdout-only CLI `--pattern-json`. No wire/IPC protocol
+  field carries pattern graphs (`getPatternSources` is source-based; shell/
+  runtime-client move pattern ids + sources). `pattern-binding` operates on
+  in-memory bound copies only (no stored-JSON deserialization).
+
+#### What landed
+
+- `patternToJSON` dual-writes `$patternRef: { identity, symbol }` (from the
+  module-level `getArtifactEntryRef`, content-derived → byte-stable across
+  sessions) alongside the unchanged graph; internal serialization
+  (`serializePatternGraph`) emits the bare graph, keeping `Pattern.nodes`
+  and `$opFallback` ref-free.
+- Dual-read: `resolveOpPattern` resolves a ref+graph value from its carried
+  graph on a cache miss (instead of hard-failing a running node);
+  `resolveStoredPattern` (shared helper) gives llm-dialog's two raw
+  toolDef-pattern reads the prefer-live-canonical behavior — the resolved
+  factory carries the trust brand and entry ref a deserialized graph lacks.
+- Canary: `test/pre-e3-pattern-value-canary.test.ts` + committed fixture
+  (`test/fixtures/pre-e3-serialized-pattern.json`, capture script alongside)
+  pins BOTH stored vintages — pre-E3 bare graph and dual-write ref+graph —
+  loading and EXECUTING through `runtime.run` and `resolveOpPattern`,
+  without the module ever evaluating in the reading session. It must stay
+  green until the graph read path retires.
+
+One-time effect: stored pattern-bearing values gain a `$patternRef` key, so
+the first re-serialization after upgrade diffs once per value (same class as
+E1's serialized-module change).
 
 ## Sequencing & parallelism
 

--- a/docs/specs/content-addressed-action-identity.md
+++ b/docs/specs/content-addressed-action-identity.md
@@ -40,8 +40,28 @@ Phase 3 shipped in two PRs:
   deferred to the cycle that retires this read path; decisions recorded in
   the implementation plan).
 
-Phase 4 (drop the retained read path + the §7 refs-only pattern JSON / E3)
-remains open, gated on stored-data evidence or a runtime-version cutoff.
+- **E3 (pattern JSON boundary, scoped to dual-write)**: `Pattern.toJSON()`
+  emits the pattern's content-addressed `$patternRef: { identity, symbol }`
+  ALONGSIDE the full graph; internal graph serialization
+  (`serializePatternGraph`, the §7 escape hatch — used by builder-time node
+  serialization and thus the `$opFallback` graphs) stays a bare graph, so the
+  in-memory representation and the eviction fallback can never silently
+  become refs. Readers dual-read: `resolveOpPattern` and llm-dialog's tool
+  invocation (`resolveStoredPattern`) prefer the live canonical pattern by
+  identity and fall back to the carried graph. Refs-ONLY emission was
+  assessed and deferred (see §7 below and the implementation plan's E3
+  gating record): there is no session-lifetime strong index for pattern
+  artifacts — E1's implementation index is function-keyed, javascript
+  modules only — so stored refs resolve solely through the FIFO-bounded
+  artifact index (sync) or `loadPatternByIdentity` (async), neither of which
+  covers the sync list builtins or cross-session llm-dialog reads.
+  Canary: `test/pre-e3-pattern-value-canary.test.ts` pins both stored
+  vintages (bare graph; ref+graph) loading and executing.
+
+Phase 4 (drop the retained read path + the §7 refs-only pattern JSON flip)
+remains open, gated on stored-data evidence or a runtime-version cutoff —
+and, for the pattern-JSON flip, on a session-lifetime pattern artifact index
+(eviction pinning, open question 2).
 
 The design assumes the shipped state after the AMD-loader removal: the ESM
 module-record loader is the only loader, every module has a content-addressed
@@ -353,22 +373,48 @@ but `toJSON` runs when a value is *written to a cell* — after
 - `Pattern.nodes` / `result` / `initial` stay as the in-memory instantiation
   representation only; nothing outside the runner consumes them as JSON.
 
-Known things this trips (each becomes a work item):
+Status (E3, 2026-06-11): shipped as DUAL-WRITE, not refs-only. The boundary
+now emits `$patternRef` alongside the graph; the escape hatch below landed;
+the refs-only flip is deferred to Phase 4. The gating finding: unlike
+javascript functions (E1's session-lifetime
+`verifiedImplementationsByEntryRef`), pattern artifacts have NO strong index —
+a stored `$patternRef` resolves only through the FIFO-bounded
+`addressableByIdentity` (sync) or `loadPatternByIdentity` (async). The
+write-path audit found pattern graphs persist at exactly three cell-write
+sites (pattern values in piece arguments, the list-builtin inputs sentinel,
+nested sub-pattern arguments; no wire/IPC surface carries graphs), and the
+read-path audit found two production consumers of stored graphs: the list
+builtins' `resolveOpPattern` (a sync Action — cannot await a by-identity
+load) and llm-dialog's tool invocation (cross-session: the toolDef pattern's
+module may never re-evaluate in the reading session, and its compiled
+artifact being loadable from the space is not guaranteed for arbitrary
+pattern values). Refs-only emission therefore needs eviction pinning (open
+question 2) plus stored-data evidence first — the same shape as gate 2.
+
+Known things this trips (each was a work item; states recorded inline):
 
 - **`$opFallback`** embeds a full serialized graph *on purpose* (eviction
   resilience). Refs-only `toJSON` would silently turn the fallback into a ref
-  too, defeating it. Either give the fallback an explicit
-  `serializePatternGraph()` escape hatch (internal serializer, not `toJSON`),
-  or drop the fallback and solve eviction pinning first (open question 2 —
-  these two decisions are now coupled).
+  too, defeating it. RESOLVED via the explicit `serializePatternGraph()`
+  escape hatch (json-utils): `toJSONWithLegacyAliases` — the builder-time
+  node serializer the `$opFallback` graphs descend from — routes pattern
+  values through it under an internal-serialization context that suppresses
+  `$patternRef`, making the internal/boundary split structural. Without it,
+  builder calls inside a running action that reference an already-indexed
+  imported pattern would embed refs into `Pattern.nodes`.
 - Anything that JSON-round-trips patterns and expects a graph: json-utils
   round-trip tests, pattern-as-value deserialization in `pattern-binding`,
   debug tooling. Deserialization of a ref requires the module to be loadable
   by identity (in-memory, or storage-backed via the compile cache) — which is
   the whole point, but makes by-identity load the only rehydration path.
+  UNDER DUAL-WRITE: readers prefer the ref (`resolveStoredPattern`) and keep
+  the graph as fallback, so nothing requires by-identity load yet; the
+  remaining graph consumers are pinned by
+  `test/pre-e3-pattern-value-canary.test.ts`.
 - Wire/IPC surfaces that today receive pattern JSON (runtime-client
-  `getPatternSources` is source-based and unaffected; audit any other
-  protocol field carrying serialized patterns).
+  `getPatternSources` is source-based and unaffected; the E3 audit found no
+  other protocol field carrying serialized pattern graphs — IPC carries
+  pattern ids/sources only).
 
 ## Persisted-data compatibility
 

--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -17,7 +17,11 @@ import {
   type toJSON,
 } from "./types.ts";
 import { getTopFrame } from "./pattern.ts";
-import { getPatternProgram, noteDerivedCopy } from "./pattern-metadata.ts";
+import {
+  getArtifactEntryRef,
+  getPatternProgram,
+  noteDerivedCopy,
+} from "./pattern-metadata.ts";
 import { getVerifiedProvenance } from "../harness/verified-provenance.ts";
 import { Runtime } from "../runtime.ts";
 import { isCellLink, isLegacyAlias, parseLink } from "../link-utils.ts";
@@ -122,11 +126,16 @@ export function toJSONWithLegacyAliases(
     if (depth > 0) return {}; // Actually circular
     seen.set(value as object, depth + 1);
 
-    // If this is a pattern, call its toJSON method to get the properly
-    // serialized version.
+    // If this is a pattern, serialize it through the INTERNAL graph
+    // serializer (its toJSON under the internal-serialization context): this
+    // function builds the in-memory node representation, so embedded
+    // sub-pattern graphs must stay bare — no boundary `$patternRef`.
     const valueToProcess = (isPattern(value) &&
         typeof (value as unknown as toJSON).toJSON === "function")
-      ? (value as unknown as toJSON).toJSON() as Record<string, any>
+      ? serializePatternGraph(value as unknown as Pattern) as Record<
+        string,
+        any
+      >
       : (value as Record<string, any>);
 
     const result: any = {};
@@ -443,6 +452,45 @@ export function moduleToJSON(module: Module) {
   };
 }
 
+// Ambient context: true while serializing the runtime-INTERNAL graph
+// representation (builder-time node serialization via
+// `toJSONWithLegacyAliases`, and through it the `$opFallback` eviction
+// fallback graphs). The JSON boundary (`Pattern.toJSON()`, fired by
+// JSON.stringify and by cell writes via native-conversion's HasToJSON) adds
+// the content-addressed `$patternRef` on top of the graph; internal
+// serialization must NOT, or in-memory `Pattern.nodes` would grow refs for
+// any sub-pattern whose module is already indexed (e.g. builder calls inside
+// a running action referencing an imported, already-evaluated pattern) and
+// the eviction fallback would silently become a ref (design §7's $opFallback
+// trap). Synchronous push/pop — serialization never awaits.
+let internalGraphSerialization = false;
+
+/**
+ * Serialize a pattern's full node-graph — the runtime-internal representation
+ * (design §7: the graph is internal; the boundary speaks refs-first). Used by
+ * `toJSONWithLegacyAliases` (builder-time node serialization, which the
+ * `$opFallback` graphs descend from) and debug tooling.
+ *
+ * Calls the pattern's own `toJSON` rather than `patternToJSON` directly:
+ * factory `toJSON` closures deliberately serialize the ROOT factory (which
+ * carries `.program`, set after construction — see builder/pattern.ts), so
+ * the indirection is load-bearing.
+ */
+export function serializePatternGraph(
+  pattern: Pattern,
+): Record<string, unknown> {
+  const previous = internalGraphSerialization;
+  internalGraphSerialization = true;
+  try {
+    const withToJSON = pattern as unknown as Partial<toJSON>;
+    return (typeof withToJSON.toJSON === "function"
+      ? withToJSON.toJSON()
+      : patternToJSON(pattern)) as Record<string, unknown>;
+  } finally {
+    internalGraphSerialization = previous;
+  }
+}
+
 export function patternToJSON(pattern: Pattern) {
   // Serialize only the STABLE program identity ({main, mainExport}), never the
   // authored `files`. The `files` array serializes non-canonically (two
@@ -463,7 +511,7 @@ export function patternToJSON(pattern: Pattern) {
         : {}),
     }
     : undefined;
-  return {
+  const graph = {
     argumentSchema: pattern.argumentSchema,
     resultSchema: pattern.resultSchema,
     ...(pattern.derivedInternalCells
@@ -473,4 +521,22 @@ export function patternToJSON(pattern: Pattern) {
     nodes: pattern.nodes,
     ...(programIdentity ? { program: programIdentity } : {}),
   };
+  if (internalGraphSerialization) return graph;
+  // JSON boundary (cell writes, JSON.stringify): dual-write the pattern's
+  // content-addressed entry ref alongside the graph (design §7, scoped — see
+  // the implementation plan's E3 section). The ref is content-derived, so
+  // identical bytes re-emit the identical ref across sessions; readers
+  // (resolveOpPattern, llm-dialog tool invocation) prefer it to resolve the
+  // live canonical pattern and fall back to the carried graph. Refs-ONLY
+  // emission is deferred: stored refs today resolve only through the
+  // FIFO-bounded artifact index (sync) or by-identity load (async) — neither
+  // covers the sync list builtins cross-session, so the graph must travel
+  // until a session-lifetime pattern index (eviction pinning) exists.
+  const entryRef = getArtifactEntryRef(pattern);
+  return entryRef
+    ? {
+      $patternRef: { identity: entryRef.identity, symbol: entryRef.symbol },
+      ...graph,
+    }
+    : graph;
 }

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -27,6 +27,7 @@ import { isBoolean, isObject, isRecord } from "@commonfabric/utils/types";
 import type { Cell, MemorySpace, Stream } from "../cell.ts";
 import { isCell, isStream } from "../cell.ts";
 import { type CellScope, ID, NAME, type Pattern } from "../builder/types.ts";
+import { resolveStoredPattern } from "./op-pattern-ref.ts";
 import { type Action, ignoreReadForScheduling } from "../scheduler.ts";
 import { Runtime } from "../runtime.ts";
 import { spaceCellSchema } from "../runtime.ts";
@@ -2248,6 +2249,14 @@ async function handleInvoke(
     extraParams = resolved.extraParams ?? {};
     handler = resolved.handler;
   }
+
+  // A pattern read raw from a cell is the boundary serialization: prefer
+  // resolving the live canonical pattern via its $patternRef (trust brand +
+  // entry ref intact), fall back to the stored graph (pre-dual-write data or
+  // evicted module).
+  pattern = resolveStoredPattern(runtime, pattern) as
+    | Readonly<Pattern>
+    | undefined;
 
   const input = traverseAndCellify(runtime, space, toolCall.input) as object;
 

--- a/packages/runner/src/builtins/op-pattern-ref.ts
+++ b/packages/runner/src/builtins/op-pattern-ref.ts
@@ -64,19 +64,43 @@ export function resolveOpPattern(
   rawOp: unknown,
   builtinName: string,
 ): Pattern {
-  if (isPatternRefSentinel(rawOp)) {
-    const { identity, symbol } = rawOp.$patternRef;
+  const resolved = resolveStoredPattern(runtime, rawOp);
+  if (resolved === undefined && isPatternRefSentinel(rawOp)) {
+    throw new Error(
+      `${builtinName}: op pattern ${rawOp.$patternRef.identity}#` +
+        `${rawOp.$patternRef.symbol} is not in the evaluated-module cache ` +
+        `and has no embedded fallback`,
+    );
+  }
+  return resolved as Pattern;
+}
+
+/**
+ * Resolve a pattern VALUE read raw from a cell into a runnable `Pattern`.
+ *
+ * Boundary-serialized pattern values carry `$patternRef` (PR E3 dual-write,
+ * possibly with an `$opFallback` from the list-builtin sentinel): prefer
+ * resolving the LIVE canonical pattern by identity — it carries the trust
+ * brand and content-addressed entry ref a deserialized graph lacks — then
+ * fall back to the embedded/carried graph (pre-E3 vintages; module evicted
+ * from the bounded cache). A bare unresolvable ref yields `undefined`; any
+ * other value passes through unchanged (legacy stored graphs).
+ */
+export function resolveStoredPattern(
+  runtime: Runtime,
+  raw: unknown,
+): Pattern | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (isPatternRefSentinel(raw)) {
+    const { identity, symbol } = raw.$patternRef;
     const resolved = runtime.patternManager.artifactFromIdentitySync(
       identity,
       symbol,
     ) as Pattern | undefined;
     if (resolved) return resolved;
-    if (rawOp.$opFallback) return rawOp.$opFallback;
-    if (isPattern(rawOp)) return rawOp as unknown as Pattern;
-    throw new Error(
-      `${builtinName}: op pattern ${identity}#${symbol} is not in the ` +
-        `evaluated-module cache and has no embedded fallback`,
-    );
+    if (raw.$opFallback) return raw.$opFallback;
+    if (isPattern(raw)) return raw as unknown as Pattern;
+    return undefined;
   }
-  return rawOp as Pattern;
+  return raw as Pattern;
 }

--- a/packages/runner/src/builtins/op-pattern-ref.ts
+++ b/packages/runner/src/builtins/op-pattern-ref.ts
@@ -1,5 +1,5 @@
 import { isRecord } from "@commonfabric/utils/types";
-import type { Pattern } from "../builder/types.ts";
+import { isPattern, type Pattern } from "../builder/types.ts";
 import type { Runtime } from "../runtime.ts";
 
 /**
@@ -52,6 +52,10 @@ export function isPatternRefSentinel(
  *   mid-session — a sync Action cannot await `loadPatternByIdentity`), fall back
  *   to the sentinel's retained `$opFallback` graph so a running node never breaks
  *   just because its op rolled out of the bounded cache.
+ * - A pattern VALUE serialized by the dual-write boundary (PR E3) carries
+ *   `$patternRef` ALONGSIDE its full graph — sentinel-shaped, but with the
+ *   graph in the value itself rather than under `$opFallback`. On a cache
+ *   miss, resolve from the carried graph (same eviction rationale as above).
  * - Otherwise (legacy / ESM loader off / no entry ref), `op` is the embedded
  *   pattern graph itself, used as-is.
  */
@@ -68,6 +72,7 @@ export function resolveOpPattern(
     ) as Pattern | undefined;
     if (resolved) return resolved;
     if (rawOp.$opFallback) return rawOp.$opFallback;
+    if (isPattern(rawOp)) return rawOp as unknown as Pattern;
     throw new Error(
       `${builtinName}: op pattern ${identity}#${symbol} is not in the ` +
         `evaluated-module cache and has no embedded fallback`,

--- a/packages/runner/test/fixtures/capture-pre-e3.ts
+++ b/packages/runner/test/fixtures/capture-pre-e3.ts
@@ -1,5 +1,10 @@
 // One-off capture script for the pre-E3 serialized-pattern fixture.
 // Run: deno run -A test/fixtures/capture-pre-e3.ts (from packages/runner)
+//
+// The `preE3` vintage was captured BEFORE the $patternRef dual-write and is
+// preserved verbatim when re-running (committed stored data does not change
+// because the writer did). Re-running against the current checkout refreshes
+// only the `dualWrite` vintage.
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../../src/runtime.ts";
@@ -35,18 +40,30 @@ await runtime.idle();
 // value undergoes when written to a cell (native-conversion HasToJSON).
 const serialized = JSON.parse(JSON.stringify(compiled));
 
+const fixtureUrl = new URL(
+  "./pre-e3-serialized-pattern.json",
+  import.meta.url,
+);
+let preE3 = serialized;
+try {
+  const existing = JSON.parse(await Deno.readTextFile(fixtureUrl));
+  if (existing?.serialized?.preE3) preE3 = existing.serialized.preE3;
+} catch {
+  // First capture: the current writer IS the pre-E3 writer.
+}
+
 const fixture = {
   comment:
-    "Captured by PR E3 from the PRE-E3 writer (patternToJSON before $patternRef dual-write). A stored pattern VALUE of this vintage is a bare node-graph with no $patternRef; it must keep executing through the graph read paths (runtime.run on a deserialized graph; resolveOpPattern legacy branch) for as long as stored data can carry it. Regenerate by re-running test/fixtures/capture-pre-e3.ts against a pre-E3 checkout.",
+    "Stored pattern-VALUE vintages (PR E3). preE3: captured from the writer BEFORE the $patternRef dual-write — a bare node-graph; preserved verbatim on re-capture. dualWrite: the current writer's boundary output — $patternRef alongside the graph. Both must keep executing through the graph read paths (runtime.run on a deserialized graph; resolveOpPattern) for as long as stored data can carry them. Refresh dualWrite by re-running test/fixtures/capture-pre-e3.ts.",
   program: PROGRAM,
-  serialized: { preE3: serialized },
+  serialized: { preE3, dualWrite: serialized },
 };
 
 await Deno.writeTextFile(
-  new URL("./pre-e3-serialized-pattern.json", import.meta.url),
+  fixtureUrl,
   JSON.stringify(fixture, null, 2) + "\n",
 );
-console.log("captured", Object.keys(serialized));
+console.log("captured dualWrite keys:", Object.keys(serialized));
 
 await runtime.dispose();
 await storageManager.close();

--- a/packages/runner/test/fixtures/capture-pre-e3.ts
+++ b/packages/runner/test/fixtures/capture-pre-e3.ts
@@ -1,0 +1,52 @@
+// One-off capture script for the pre-E3 serialized-pattern fixture.
+// Run: deno run -A test/fixtures/capture-pre-e3.ts (from packages/runner)
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../../src/runtime.ts";
+import type { RuntimeProgram } from "../../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("pre-e3-pattern-value-canary");
+
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        "import { pattern } from 'commonfabric';",
+        "export default pattern<{ items: { v: number }[] }>(({ items }) => {",
+        "  return { vs: items.map((item) => item.v) };",
+        "});",
+      ].join("\n"),
+    },
+  ],
+};
+
+const storageManager = StorageManager.emulate({ as: signer });
+const runtime = new Runtime({
+  apiUrl: new URL(import.meta.url),
+  storageManager,
+});
+
+const compiled = await runtime.patternManager.compilePattern(PROGRAM);
+await runtime.idle();
+
+// JSON.stringify fires Pattern.toJSON() — the exact serialization a pattern
+// value undergoes when written to a cell (native-conversion HasToJSON).
+const serialized = JSON.parse(JSON.stringify(compiled));
+
+const fixture = {
+  comment:
+    "Captured by PR E3 from the PRE-E3 writer (patternToJSON before $patternRef dual-write). A stored pattern VALUE of this vintage is a bare node-graph with no $patternRef; it must keep executing through the graph read paths (runtime.run on a deserialized graph; resolveOpPattern legacy branch) for as long as stored data can carry it. Regenerate by re-running test/fixtures/capture-pre-e3.ts against a pre-E3 checkout.",
+  program: PROGRAM,
+  serialized: { preE3: serialized },
+};
+
+await Deno.writeTextFile(
+  new URL("./pre-e3-serialized-pattern.json", import.meta.url),
+  JSON.stringify(fixture, null, 2) + "\n",
+);
+console.log("captured", Object.keys(serialized));
+
+await runtime.dispose();
+await storageManager.close();

--- a/packages/runner/test/fixtures/pre-e3-serialized-pattern.json
+++ b/packages/runner/test/fixtures/pre-e3-serialized-pattern.json
@@ -1,5 +1,5 @@
 {
-  "comment": "Captured by PR E3 from the PRE-E3 writer (patternToJSON before $patternRef dual-write). A stored pattern VALUE of this vintage is a bare node-graph with no $patternRef; it must keep executing through the graph read paths (runtime.run on a deserialized graph; resolveOpPattern legacy branch) for as long as stored data can carry it. Regenerate by re-running test/fixtures/capture-pre-e3.ts against a pre-E3 checkout.",
+  "comment": "Stored pattern-VALUE vintages (PR E3). preE3: captured from the writer BEFORE the $patternRef dual-write — a bare node-graph; preserved verbatim on re-capture. dualWrite: the current writer's boundary output — $patternRef alongside the graph. Both must keep executing through the graph read paths (runtime.run on a deserialized graph; resolveOpPattern) for as long as stored data can carry them. Refresh dualWrite by re-running test/fixtures/capture-pre-e3.ts.",
   "program": {
     "main": "/main.tsx",
     "files": [
@@ -11,6 +11,172 @@
   },
   "serialized": {
     "preE3": {
+      "argumentSchema": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "v": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "v"
+              ]
+            }
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "resultSchema": {
+        "type": "object",
+        "properties": {
+          "vs": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        },
+        "required": [
+          "vs"
+        ]
+      },
+      "derivedInternalCells": [
+        {
+          "partialCause": [
+            "__patternResult",
+            "vs"
+          ],
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      ],
+      "result": {
+        "vs": {
+          "$alias": {
+            "partialCause": [
+              "__patternResult",
+              "vs"
+            ],
+            "path": [],
+            "scope": "space",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        }
+      },
+      "nodes": [
+        {
+          "module": {
+            "type": "ref",
+            "implementation": "map"
+          },
+          "inputs": {
+            "list": {
+              "$alias": {
+                "cell": "argument",
+                "path": [
+                  "items"
+                ],
+                "scope": "space",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "v": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "v"
+                    ]
+                  }
+                }
+              }
+            },
+            "op": {
+              "argumentSchema": {
+                "type": "object",
+                "properties": {
+                  "element": {
+                    "type": "object",
+                    "properties": {
+                      "v": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "v"
+                    ]
+                  }
+                },
+                "required": [
+                  "element"
+                ]
+              },
+              "resultSchema": {
+                "type": "number"
+              },
+              "result": {
+                "$alias": {
+                  "defer": 1,
+                  "path": [
+                    "element",
+                    "v"
+                  ],
+                  "scope": "space",
+                  "schema": {
+                    "type": "number"
+                  },
+                  "cell": "argument"
+                }
+              },
+              "nodes": []
+            },
+            "params": {}
+          },
+          "outputs": {
+            "$alias": {
+              "partialCause": [
+                "__patternResult",
+                "vs"
+              ],
+              "path": [],
+              "scope": "space",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "program": {
+        "main": "/main.tsx"
+      }
+    },
+    "dualWrite": {
+      "$patternRef": {
+        "identity": "6L6e3nw7p9vmnlajhkiQZA7_lvjs9trVj_mF1uwlVFc",
+        "symbol": "default"
+      },
       "argumentSchema": {
         "type": "object",
         "properties": {

--- a/packages/runner/test/fixtures/pre-e3-serialized-pattern.json
+++ b/packages/runner/test/fixtures/pre-e3-serialized-pattern.json
@@ -1,0 +1,176 @@
+{
+  "comment": "Captured by PR E3 from the PRE-E3 writer (patternToJSON before $patternRef dual-write). A stored pattern VALUE of this vintage is a bare node-graph with no $patternRef; it must keep executing through the graph read paths (runtime.run on a deserialized graph; resolveOpPattern legacy branch) for as long as stored data can carry it. Regenerate by re-running test/fixtures/capture-pre-e3.ts against a pre-E3 checkout.",
+  "program": {
+    "main": "/main.tsx",
+    "files": [
+      {
+        "name": "/main.tsx",
+        "contents": "import { pattern } from 'commonfabric';\nexport default pattern<{ items: { v: number }[] }>(({ items }) => {\n  return { vs: items.map((item) => item.v) };\n});"
+      }
+    ]
+  },
+  "serialized": {
+    "preE3": {
+      "argumentSchema": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "v": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "v"
+              ]
+            }
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "resultSchema": {
+        "type": "object",
+        "properties": {
+          "vs": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        },
+        "required": [
+          "vs"
+        ]
+      },
+      "derivedInternalCells": [
+        {
+          "partialCause": [
+            "__patternResult",
+            "vs"
+          ],
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      ],
+      "result": {
+        "vs": {
+          "$alias": {
+            "partialCause": [
+              "__patternResult",
+              "vs"
+            ],
+            "path": [],
+            "scope": "space",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        }
+      },
+      "nodes": [
+        {
+          "module": {
+            "type": "ref",
+            "implementation": "map"
+          },
+          "inputs": {
+            "list": {
+              "$alias": {
+                "cell": "argument",
+                "path": [
+                  "items"
+                ],
+                "scope": "space",
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "v": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "v"
+                    ]
+                  }
+                }
+              }
+            },
+            "op": {
+              "argumentSchema": {
+                "type": "object",
+                "properties": {
+                  "element": {
+                    "type": "object",
+                    "properties": {
+                      "v": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "v"
+                    ]
+                  }
+                },
+                "required": [
+                  "element"
+                ]
+              },
+              "resultSchema": {
+                "type": "number"
+              },
+              "result": {
+                "$alias": {
+                  "defer": 1,
+                  "path": [
+                    "element",
+                    "v"
+                  ],
+                  "scope": "space",
+                  "schema": {
+                    "type": "number"
+                  },
+                  "cell": "argument"
+                }
+              },
+              "nodes": []
+            },
+            "params": {}
+          },
+          "outputs": {
+            "$alias": {
+              "partialCause": [
+                "__patternResult",
+                "vs"
+              ],
+              "path": [],
+              "scope": "space",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "program": {
+        "main": "/main.tsx"
+      }
+    }
+  }
+}

--- a/packages/runner/test/pattern-ref-dual-write.test.ts
+++ b/packages/runner/test/pattern-ref-dual-write.test.ts
@@ -10,7 +10,10 @@ import {
   serializePatternGraph,
   toJSONWithLegacyAliases,
 } from "../src/builder/json-utils.ts";
-import { resolveOpPattern } from "../src/builtins/op-pattern-ref.ts";
+import {
+  resolveOpPattern,
+  resolveStoredPattern,
+} from "../src/builtins/op-pattern-ref.ts";
 import type { Opaque } from "../src/builder/types.ts";
 
 /**
@@ -151,5 +154,55 @@ describe("resolveOpPattern dual-read", () => {
         "map",
       )
     ).toThrow(/not in the/);
+  });
+});
+
+describe("resolveStoredPattern (llm-dialog stored tool patterns)", () => {
+  const refValue = {
+    $patternRef: { identity: "cf:module/abc", symbol: "default" },
+    argumentSchema: true,
+    resultSchema: true,
+    result: {},
+    nodes: [],
+  } as never;
+
+  it("prefers the live canonical pattern when the identity cache hits", () => {
+    const live = { argumentSchema: true } as never;
+    const fakeRuntime = {
+      patternManager: {
+        artifactFromIdentitySync: (identity: string, symbol: string) => {
+          expect(identity).toBe("cf:module/abc");
+          expect(symbol).toBe("default");
+          return live;
+        },
+      },
+    } as never;
+    expect(resolveStoredPattern(fakeRuntime, refValue)).toBe(live);
+  });
+
+  it("falls back to the carried graph on a cache miss", () => {
+    const fakeRuntime = {
+      patternManager: { artifactFromIdentitySync: () => undefined },
+    } as never;
+    expect(resolveStoredPattern(fakeRuntime, refValue)).toBe(refValue);
+  });
+
+  it("yields undefined for a bare unresolvable ref", () => {
+    const fakeRuntime = {
+      patternManager: { artifactFromIdentitySync: () => undefined },
+    } as never;
+    expect(
+      resolveStoredPattern(
+        fakeRuntime,
+        { $patternRef: { identity: "cf:module/miss", symbol: "s" } },
+      ),
+    ).toBeUndefined();
+  });
+
+  it("passes plain stored graphs and nullish values through", () => {
+    const graph = { nodes: [], result: {} };
+    expect(resolveStoredPattern({} as never, graph)).toBe(graph);
+    expect(resolveStoredPattern({} as never, undefined)).toBeUndefined();
+    expect(resolveStoredPattern({} as never, null)).toBeUndefined();
   });
 });

--- a/packages/runner/test/pattern-ref-dual-write.test.ts
+++ b/packages/runner/test/pattern-ref-dual-write.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import type { Pattern } from "../src/builder/types.ts";
+import {
+  serializePatternGraph,
+  toJSONWithLegacyAliases,
+} from "../src/builder/json-utils.ts";
+import { resolveOpPattern } from "../src/builtins/op-pattern-ref.ts";
+import type { Opaque } from "../src/builder/types.ts";
+
+/**
+ * PR E3 (docs/specs/content-addressed-action-identity.md §7, scoped to
+ * dual-write): the JSON BOUNDARY (`Pattern.toJSON()`, fired by JSON.stringify
+ * and by cell writes via native-conversion's HasToJSON) emits the pattern's
+ * content-addressed `{ identity, symbol }` as `$patternRef` ALONGSIDE the full
+ * graph, while INTERNAL serialization (`serializePatternGraph`, used by
+ * builder-time node serialization through `toJSONWithLegacyAliases`) stays a
+ * bare graph — so `Pattern.nodes` and the `$opFallback` eviction fallback can
+ * never silently become refs.
+ */
+
+const signer = await Identity.fromPassphrase("pattern-ref-dual-write");
+const space = signer.did();
+
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        "import { pattern } from 'commonfabric';",
+        "export default pattern<{ items: { v: number }[] }>(({ items }) => {",
+        "  return { vs: items.map((item) => item.v) };",
+        "});",
+      ].join("\n"),
+    },
+  ],
+};
+
+describe("pattern $patternRef dual-write at the JSON boundary", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("Pattern.toJSON() emits $patternRef alongside the full graph", async () => {
+    const compiled = await runtime.patternManager.compilePattern(PROGRAM);
+    const entryRef = runtime.patternManager.getArtifactEntryRef(compiled);
+    expect(entryRef).toBeDefined();
+
+    // The boundary serialization a pattern value undergoes when written to a
+    // cell (native-conversion HasToJSON) or JSON.stringify'd.
+    const serialized = JSON.parse(JSON.stringify(compiled));
+
+    expect(serialized.$patternRef).toEqual({
+      identity: entryRef!.identity,
+      symbol: entryRef!.symbol,
+    });
+    // Dual-write: the graph stays alongside the ref (readers that cannot
+    // resolve by identity — sync list builtins, cross-session llm-dialog —
+    // keep working from the embedded graph).
+    expect(Array.isArray(serialized.nodes)).toBe(true);
+    expect(serialized.argumentSchema).toBeDefined();
+    expect(serialized.resultSchema).toBeDefined();
+  });
+
+  it("$patternRef is content-derived: two compiles of identical bytes emit the same ref", async () => {
+    const first = JSON.parse(
+      JSON.stringify(await runtime.patternManager.compilePattern(PROGRAM)),
+    );
+    const second = JSON.parse(
+      JSON.stringify(await runtime.patternManager.compilePattern({
+        ...PROGRAM,
+      })),
+    );
+    expect(first.$patternRef).toBeDefined();
+    expect(first.$patternRef).toEqual(second.$patternRef);
+  });
+
+  it("internal graph serialization stays a bare graph even when the ref is known", async () => {
+    const compiled = await runtime.patternManager.compilePattern(PROGRAM);
+    expect(runtime.patternManager.getArtifactEntryRef(compiled)).toBeDefined();
+
+    // serializePatternGraph is the internal serializer (builder-time nodes,
+    // $opFallback): no $patternRef, full graph only.
+    const internal = serializePatternGraph(compiled as unknown as Pattern);
+    expect("$patternRef" in internal).toBe(false);
+    expect(Array.isArray((internal as { nodes: unknown }).nodes)).toBe(true);
+
+    // toJSONWithLegacyAliases routes pattern values through the internal
+    // serializer — this is what keeps in-memory `Pattern.nodes` (and the
+    // `$opFallback` graphs derived from them) ref-free.
+    const viaLegacyAliases = toJSONWithLegacyAliases(
+      compiled as unknown as Opaque<unknown>,
+    ) as Record<string, unknown>;
+    expect("$patternRef" in viaLegacyAliases).toBe(false);
+  });
+
+  it("nodes of a freshly compiled pattern embed bare op graphs (no $patternRef)", async () => {
+    const compiled = await runtime.patternManager.compilePattern(PROGRAM);
+    const json = JSON.stringify((compiled as unknown as Pattern).nodes);
+    expect(json.includes("$patternRef")).toBe(false);
+  });
+});
+
+describe("resolveOpPattern dual-read", () => {
+  it("falls back to the carried graph when a ref+graph value misses the cache", () => {
+    // A pattern VALUE serialized by the dual-write boundary carries BOTH
+    // $patternRef and the full graph. When such a stored value reaches a list
+    // builtin as its op (pattern-as-argument) and the identity cache has
+    // evicted the module, the op must resolve from the value itself — not
+    // hard-fail a running node.
+    const dualWriteValue = {
+      $patternRef: { identity: "cf:module/evicted", symbol: "s" },
+      argumentSchema: true,
+      resultSchema: true,
+      result: {},
+      nodes: [],
+    } as never;
+    const fakeRuntime = {
+      patternManager: { artifactFromIdentitySync: () => undefined },
+    } as never;
+    const resolved = resolveOpPattern(fakeRuntime, dualWriteValue, "map");
+    expect(resolved).toBe(dualWriteValue);
+  });
+
+  it("still throws when the value misses the cache and carries no graph", () => {
+    const fakeRuntime = {
+      patternManager: { artifactFromIdentitySync: () => undefined },
+    } as never;
+    expect(() =>
+      resolveOpPattern(
+        fakeRuntime,
+        { $patternRef: { identity: "cf:module/miss", symbol: "s" } } as never,
+        "map",
+      )
+    ).toThrow(/not in the/);
+  });
+});

--- a/packages/runner/test/pattern-ref-dual-write.test.ts
+++ b/packages/runner/test/pattern-ref-dual-write.test.ts
@@ -28,7 +28,6 @@ import type { Opaque } from "../src/builder/types.ts";
  */
 
 const signer = await Identity.fromPassphrase("pattern-ref-dual-write");
-const space = signer.did();
 
 const PROGRAM: RuntimeProgram = {
   main: "/main.tsx",
@@ -88,9 +87,11 @@ describe("pattern $patternRef dual-write at the JSON boundary", () => {
       JSON.stringify(await runtime.patternManager.compilePattern(PROGRAM)),
     );
     const second = JSON.parse(
-      JSON.stringify(await runtime.patternManager.compilePattern({
-        ...PROGRAM,
-      })),
+      JSON.stringify(
+        await runtime.patternManager.compilePattern({
+          ...PROGRAM,
+        }),
+      ),
     );
     expect(first.$patternRef).toBeDefined();
     expect(first.$patternRef).toEqual(second.$patternRef);

--- a/packages/runner/test/pre-e3-pattern-value-canary.test.ts
+++ b/packages/runner/test/pre-e3-pattern-value-canary.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { Pattern } from "../src/builder/types.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { resolveOpPattern } from "../src/builtins/op-pattern-ref.ts";
+
+/**
+ * PR E3 stored-pattern-value canary (docs/specs/content-addressed-action-
+ * identity.md §7): pattern VALUES persisted to cells before the `$patternRef`
+ * dual-write are bare node-graphs — no ref, no `$opFallback`. Two production
+ * read paths consume them as graphs:
+ *
+ *  - `runtime.run` on a deserialized graph (llm-dialog tool invocation reads
+ *    `toolDef.pattern` raw from a cell and runs it), and
+ *  - the list builtins' legacy branch (`resolveOpPattern` passes a
+ *    non-sentinel graph through unchanged).
+ *
+ * The fixture was captured from the pre-E3 writer and committed verbatim
+ * (test/fixtures/pre-e3-serialized-pattern.json). It must keep loading and
+ * EXECUTING for as long as stored data can carry that vintage — this test is
+ * the tripwire against a refs-only `Pattern.toJSON()` (or a reader change)
+ * silently dropping the graph read path stored data still needs.
+ */
+
+const signer = await Identity.fromPassphrase("pre-e3-pattern-value-canary");
+const space = signer.did();
+
+const fixture = JSON.parse(
+  Deno.readTextFileSync(
+    new URL("./fixtures/pre-e3-serialized-pattern.json", import.meta.url),
+  ),
+) as {
+  program: RuntimeProgram;
+  serialized: Record<string, Record<string, unknown>>;
+};
+
+describe("pre-E3 stored pattern-value canary", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const setup = () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  };
+
+  const runGraph = async (graph: Pattern, cause: string) => {
+    let tx = runtime!.edit();
+    const resultCell = runtime!.getCell<{ vs: number[] }>(
+      space,
+      cause,
+      graph.resultSchema,
+      tx,
+    );
+    const result = runtime!.run(
+      tx,
+      graph,
+      { items: [{ v: 7 }, { v: 8 }, { v: 9 }] },
+      resultCell,
+    );
+    runtime!.prepareTxForCommit(tx);
+    await tx.commit();
+    tx = runtime!.edit();
+    const cancelSink = result.sink(() => {});
+    await runtime!.idle();
+    const vs = await result.key("vs").pull();
+    cancelSink();
+    await tx.commit();
+    return vs;
+  };
+
+  it("pre-E3 vintage (bare graph, no $patternRef) still executes via runtime.run", async () => {
+    setup();
+    const graph = fixture.serialized.preE3 as unknown as Pattern;
+    expect("$patternRef" in graph).toBe(false);
+    expect(Array.isArray(graph.nodes)).toBe(true);
+
+    // What llm-dialog's invoke does with a stored toolDef pattern: parse the
+    // cell value as a graph and run it. NOTE: deliberately no compile of the
+    // fixture program first — a stored graph must run without its module ever
+    // having been evaluated in this session.
+    const vs = await runGraph(structuredClone(graph), "canary-pre-e3-run");
+    expect(vs).toEqual([7, 8, 9]);
+  });
+
+  it("pre-E3 vintage passes through resolveOpPattern's legacy graph branch", () => {
+    setup();
+    const graph = structuredClone(
+      fixture.serialized.preE3,
+    ) as unknown as Pattern;
+    const resolved = resolveOpPattern(runtime!, graph, "map");
+    expect(resolved).toBe(graph);
+  });
+});

--- a/packages/runner/test/pre-e3-pattern-value-canary.test.ts
+++ b/packages/runner/test/pre-e3-pattern-value-canary.test.ts
@@ -103,4 +103,30 @@ describe("pre-E3 stored pattern-value canary", () => {
     const resolved = resolveOpPattern(runtime!, graph, "map");
     expect(resolved).toBe(graph);
   });
+
+  it("dual-write vintage ($patternRef + graph) still executes via runtime.run", async () => {
+    setup();
+    const graph = fixture.serialized.dualWrite as unknown as Pattern;
+    expect("$patternRef" in graph).toBe(true);
+    expect(Array.isArray(graph.nodes)).toBe(true);
+
+    // Again no compile first: the module is NOT in this session's identity
+    // index, so execution must come from the carried graph.
+    const vs = await runGraph(
+      structuredClone(graph),
+      "canary-dual-write-run",
+    );
+    expect(vs).toEqual([7, 8, 9]);
+  });
+
+  it("dual-write vintage resolves from its carried graph on an identity-cache miss", () => {
+    setup();
+    const value = structuredClone(
+      fixture.serialized.dualWrite,
+    ) as unknown as Pattern;
+    // Fresh runtime: nothing is in the bounded identity cache, so the
+    // sentinel-shaped value must resolve from the graph it carries.
+    const resolved = resolveOpPattern(runtime!, value, "map");
+    expect(resolved).toBe(value);
+  });
 });


### PR DESCRIPTION
PR E3 of the content-addressed action-identity migration (design §7), following E1 #4053 and E2 #4064 — **deliberately scoped to dual-write, not refs-only**. The gating decisions are recorded in both spec docs (design §7 status block + implementation plan "E3" section).

## Gate analysis (why not refs-only)

§7's refs-only `Pattern.toJSON()` was assessed and deferred to Phase 4:

- **No session-lifetime strong index exists for pattern artifacts.** E1's `verifiedImplementationsByEntryRef` is function-object-keyed and covers javascript modules only; a stored `$patternRef` resolves solely through the FIFO-bounded `addressableByIdentity` (sync) or `loadPatternByIdentity` (async).
- **Two production read paths consume stored pattern graphs**: the list builtins' `resolveOpPattern` (a sync Action — cannot await a by-identity load; refs-only would reintroduce the eviction cliff CT-1623 closed) and llm-dialog tool invocation (cross-session; the toolDef pattern's compiled artifact being loadable from the reading space is not guaranteed for arbitrary pattern values).
- **Cross-session resolvability could not be measured** — no production-space sample, the same blocker as E1/E2's gate 2.

The flip needs eviction pinning (design open question 2) + stored-data aging evidence. Dual-written values make that aging measurable, exactly like `$implRef` did in Phase 1.

## What this PR does

- **`$opFallback` decision: option (a), the escape hatch.** `serializePatternGraph()` (json-utils) is the internal graph serializer; `toJSONWithLegacyAliases` routes pattern values through it under an ambient internal-serialization context that suppresses `$patternRef`. The context flag (not a bypass) is required because factory `toJSON` closures deliberately serialize the ROOT factory carrying `.program`. This makes the internal/boundary split structural: `Pattern.nodes` and the `$opFallback` eviction-fallback graphs can never silently become refs (without it, builder calls inside a running action referencing an already-indexed imported pattern would embed refs into nodes).
- **Dual-write**: `patternToJSON` (the JSON boundary — cell writes via native-conversion HasToJSON, `JSON.stringify`) emits `$patternRef: { identity, symbol }` from the module-level `getArtifactEntryRef` alongside the unchanged graph. Content-derived → byte-stable across sessions/compiles (pinned by test).
- **Dual-read**: `resolveOpPattern` resolves a ref+graph value from its carried graph on a cache miss instead of hard-failing a running node; new shared `resolveStoredPattern` gives llm-dialog's two raw toolDef-pattern reads prefer-live-canonical behavior (the resolved factory carries the trust brand + entry ref a deserialized graph lacks).
- **Canary**: `test/pre-e3-pattern-value-canary.test.ts` + committed fixture pins BOTH stored vintages — pre-E3 bare graph and dual-write ref+graph — loading and EXECUTING via `runtime.run` and `resolveOpPattern` **without the module ever evaluating in the reading session**. Stays green until the graph read path retires (Phase 4).
- **Audit written up** in the implementation plan: pattern graphs reach storage at exactly three cell-write sites (pattern values in piece arguments, the list-builtin inputs sentinel, nested sub-pattern arguments); no wire/IPC field carries graphs; `pattern-binding` operates on in-memory bound copies only.

`map-op-by-identity.test.ts` is untouched and stays meaningful: ops still resolve by identity via the sentinel, with the embedded-graph fallback intact.

## One-time effect

Stored pattern-bearing values gain a `$patternRef` key, so the first re-serialization after upgrade diffs once per value (same class as E1's serialized-module change).

## CFC

No trust/provenance/`writeAuthorizedBy` semantics touched. llm-dialog's prefer-ref read strengthens identity fidelity (live branded factory over deserialized graph) without granting anything to forged data — an unresolvable bare ref yields `undefined` (tool invocation fails closed).

## Verification

- Full `packages/runner` suite green; identity-sensitive set green (`map-op-by-identity`, `cfreg-*`, `cfc-implementation-identity`, `cfc-nonexported-binding-identity`, `content-addressed-identity*` incl. adversarial, `resume-by-identity`, `load-by-identity*`, `pattern-manager`, `json-utils`, `pattern`, `engine`, both canaries).
- Workspace `deno task check` green; `deno fmt`/`deno lint` clean on changed files.
- `packages/piece` + `packages/html` test tasks green; `deno task cf check packages/patterns/address.tsx` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dual-write `$patternRef` at the pattern JSON boundary while keeping internal graphs ref-free, so readers prefer identity and fall back to the carried graph without breaking existing data. Docs record the structural-copy dual-write gap; `llm-dialog` now resolves stored tool patterns by `$patternRef`.

- **New Features**
  - `Pattern.toJSON()` now emits `$patternRef: { identity, symbol }` alongside the full graph; refs are content-derived and stable across sessions.
  - `serializePatternGraph` (used by `toJSONWithLegacyAliases`) keeps internal graphs and `$opFallback` ref-free via an internal-serialization context.
  - `resolveStoredPattern` and `resolveOpPattern` prefer the live canonical pattern by `$patternRef`, then fall back to the graph; `resolveOpPattern` throws on a bare ref with no graph, while `resolveStoredPattern` returns `undefined` for a bare unresolvable ref.
  - `llm-dialog` routes stored tool patterns through `resolveStoredPattern`.
  - Canary tests and fixtures pin both vintages (pre-E3 graph-only, and dual-write ref+graph) executing without loading the module; added coverage for content-stable refs and internal serialization.
  - Docs: spec and implementation plan updated with E3 gating decisions and the structural-copy dual-write gap (bound plain copies may persist without `$patternRef` until Phase 4).

- **Migration**
  - One-time effect: stored pattern values gain a `$patternRef` key; the first write after upgrade may diff once per value. Refs-only emission remains deferred to Phase 4.

<sup>Written for commit aa94730da177658917aac30380c4241c92aa044d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

