### PR TITLE
feat(ui): cf-render provides spaceContext from its rendered piece

### DIFF
--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -1,7 +1,9 @@
 import { css, html, PropertyValues } from "lit";
 import { createRef, type Ref, ref } from "lit/directives/ref.js";
 import { state } from "lit/decorators.js";
+import { ContextProvider } from "@lit/context";
 import { BaseElement } from "../../core/base-element.ts";
+import { spaceContext } from "../../runtime-context.ts";
 import { render } from "@commonfabric/html/client";
 import type { CellHandle } from "@commonfabric/runtime-client";
 import { type VNode } from "@commonfabric/runtime-client";
@@ -114,6 +116,13 @@ export class CFRender extends BaseElement {
   };
 
   declare cell: CellHandle;
+
+  // The render root of a piece knows the piece's space (its cell's),
+  // so it provides spaceContext for everything it renders — event
+  // handlers, uploads, and any cf-* inside the pattern act in the
+  // PIECE's space, not whatever view happens to host the render
+  // (seefeldb's #4058 note: get the space from the piece's own cells).
+  #spaceProvider = new ContextProvider(this, { context: spaceContext });
   declare variant: UIVariant | undefined;
 
   // Use Lit ref directive for stable container reference across re-renders
@@ -160,6 +169,17 @@ export class CFRender extends BaseElement {
 
     const cellChanged = changedProperties.has("cell");
     const variantChanged = changedProperties.has("variant");
+
+    if (cellChanged) {
+      // Keep the provided space in lockstep with the rendered piece.
+      let space;
+      try {
+        space = this.cell?.space();
+      } catch {
+        space = undefined;
+      }
+      this.#spaceProvider.setValue(space);
+    }
 
     if (cellChanged || variantChanged) {
       let shouldRerender = false;


### PR DESCRIPTION
## What

Your #4058 follow-up note: *"there is probably a stream attached to an event handler and we should get the space from there. More plumbing for a follow up PR."*

Implemented at the render root rather than per-event: the handler streams of a piece live in the piece's space, and `cf-render` already holds that fact — its cell's space. So `cf-render` now **provides `spaceContext` for its subtree** (a `ContextProvider` kept in lockstep with the rendered cell). Every space-consuming component inside a rendered pattern — `cf-file-input`'s uploads, `cf-code-editor`'s paste path when unbound — acts in the **piece's** space, with zero per-component or per-event plumbing.

This also closes #4058's embedder caveat: hosts that never provide a view-level `spaceContext` (e.g. loom's PatternHost) get correct spaces inside renders for free. A view-level provider (shell RootView) still applies outside renders; the nearest provider wins, which is the right precedence — the piece over the view.

## Notes

- One provider per render root; value updates when the `.cell` property changes; undefined when the cell can't name a space.
- CI: `Pattern Unit Tests (4/5)` is red on main itself (#4072, regression from #4017) — unrelated, will clear when main is fixed.
- Tested via type-check + ui suite; the context handshake is Lit's own machinery. A browser-harness round-trip test can ride the next ui browser-test batch if you want one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`cf-render` now provides `spaceContext` to its subtree from the rendered piece’s cell, so components inside a pattern act in the piece’s space. This resolves the embedder gap noted in #4058 where hosts without a view-level provider produced wrong spaces.

- **New Features**
  - Added a `ContextProvider` in `cf-render` to publish `spaceContext` for its render root.
  - Keeps the provided space in sync when `cell` changes; falls back to `undefined` if it can’t resolve a space.
  - Ensures `cf-file-input` uploads and unbound `cf-code-editor` paste paths use the piece’s space; nearest provider wins, view-level provider still applies outside renders.

<sup>Written for commit 3a9e2b157484c63a52d8cfe5ce30d92929e61a75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

