### PR TITLE
fix(runner): key wish sidecar pattern caches by the fetch URL

### DIFF
--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -1141,8 +1141,8 @@ function releaseSharedHashtagResolver(runtime: Runtime, key: string): void {
 // cache tracks the URL each fetch was started for: `setPatternEnvironment`
 // can change the apiUrl while a fetch is in flight, so a launch for a
 // different URL starts a fresh fetch, and a superseded fetch leaves the cache
-// untouched when it settles.
-function createSidecarPatternCache(options: {
+// untouched and resolves to undefined when it settles.
+export function createSidecarPatternCache(options: {
   // File name under `api/patterns/system/`. Also labels errors.
   name: string;
   // Compile with the user's home space as cache context, so the
@@ -1201,8 +1201,8 @@ function createSidecarPatternCache(options: {
     },
     // Memoized fetch for the current environment's URL, started by this call
     // when none is in flight for that URL. When this call starts the fetch,
-    // `onSuccess` runs once it resolves with a pattern, unless a fetch for
-    // another URL superseded it.
+    // `onSuccess` runs once it resolves with a pattern, unless a later fetch
+    // superseded it. A superseded fetch resolves to undefined.
     fetch(
       runtime: Runtime,
       onSuccess?: (pattern: Pattern) => void,
@@ -1211,8 +1211,14 @@ function createSidecarPatternCache(options: {
       if (!fetchPromise || fetchUrl !== url) {
         fetchUrl = url;
         pattern = undefined;
-        fetchPromise = fetchPattern(runtime, url).then((fetched) => {
-          if (fetchUrl !== url) return fetched;
+        const started: Promise<Pattern | undefined> = fetchPattern(
+          runtime,
+          url,
+        ).then((fetched) => {
+          // Only the fetch the cache currently points to records and reports
+          // its result; launches chained on a superseded fetch get undefined
+          // so a stale pattern is never run.
+          if (fetchPromise !== started) return undefined;
           pattern = fetched;
           if (fetched) {
             onSuccess?.(fetched);
@@ -1221,6 +1227,7 @@ function createSidecarPatternCache(options: {
           }
           return fetched;
         });
+        fetchPromise = started;
       }
       return fetchPromise;
     },

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -1142,6 +1142,11 @@ function releaseSharedHashtagResolver(runtime: Runtime, key: string): void {
 // can change the apiUrl while a fetch is in flight, so a launch for a
 // different URL starts a fresh fetch, and a superseded fetch leaves the cache
 // untouched and resolves to undefined when it settles.
+//
+// The cache is keyed only on the URL, not the user identity, even with
+// `compileInUserSpace`. A same-apiUrl identity switch reuses the prior user's
+// compiled pattern, which is intended: these system patterns are
+// space-independent and run against the current runtime.
 export function createSidecarPatternCache(options: {
   // File name under `api/patterns/system/`. Also labels errors.
   name: string;

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -36,18 +36,6 @@ import { setRunnableName } from "../runner-utils.ts";
 import { isCellScope, narrowestScope } from "../scope.ts";
 import { scopedCell } from "./scope-policy.ts";
 
-// Resolved lazily (not at module load): in the browser worker this module is
-// imported before the runtime calls `setPatternEnvironment` with the real API
-// URL, so a module-level const would capture the default — the worker's own
-// origin, i.e. the frontend server. That is only correct when the shell is
-// served by the API host (as in CI); against a separate frontend the fetch
-// gets the SPA index.html fallback and pattern compilation fails.
-const suggestionTsxPath = () =>
-  getPatternEnvironment().apiUrl + "api/patterns/system/suggestion.tsx";
-const profileCreateTsxPath = () =>
-  getPatternEnvironment().apiUrl + "api/patterns/system/profile-create.tsx";
-const profilePickerTsxPath = () =>
-  getPatternEnvironment().apiUrl + "api/patterns/system/profile-picker.tsx";
 const wishFlowLogger = getLogger("runner.wish-flow", {
   enabled: true,
   level: "warn",
@@ -1148,87 +1136,110 @@ function releaseSharedHashtagResolver(runtime: Runtime, key: string): void {
   resolvers?.delete(key);
 }
 
-// fetchSuggestionPattern runs at runtime scope, shared across all wish invocations
-let suggestionPatternFetchPromise: Promise<Pattern | undefined> | undefined;
-let suggestionPattern: Pattern | undefined;
-let profileCreatePatternFetchPromise: Promise<Pattern | undefined> | undefined;
-let profileCreatePattern: Pattern | undefined;
-let profilePickerPatternFetchPromise: Promise<Pattern | undefined> | undefined;
-let profilePickerPattern: Pattern | undefined;
+// Fetch-and-compile cache for one sidecar pattern (suggestion /
+// profile-create / profile-picker), shared across all wish invocations. The
+// cache tracks the URL each fetch was started for: `setPatternEnvironment`
+// can change the apiUrl while a fetch is in flight, so a launch for a
+// different URL starts a fresh fetch, and a superseded fetch leaves the cache
+// untouched when it settles.
+function createSidecarPatternCache(options: {
+  // File name under `api/patterns/system/`. Also labels errors.
+  name: string;
+  // Compile with the user's home space as cache context, so the
+  // (space-independent) system pattern is reused across reloads for this
+  // user (CT-1623, per-space cache).
+  compileInUserSpace?: boolean;
+  // Drop a failed fetch from the cache so a later launch retries it.
+  retryOnFailure?: boolean;
+}) {
+  let fetchPromise: Promise<Pattern | undefined> | undefined;
+  let fetchUrl: string | undefined;
+  let pattern: Pattern | undefined;
 
-async function fetchSuggestionPattern(
-  runtime: Runtime,
-): Promise<Pattern | undefined> {
-  try {
-    const program = await runtime.harness.resolve(
-      new HttpProgramResolver(suggestionTsxPath()),
-    );
+  // Resolved lazily (not at module load): in the browser worker this module
+  // is imported before the runtime calls `setPatternEnvironment` with the
+  // real API URL, so a module-load-time const would capture the default — the
+  // worker's own origin, i.e. the frontend server. That is only correct when
+  // the shell is served by the API host (as in CI); against a separate
+  // frontend the fetch gets the SPA index.html fallback and pattern
+  // compilation fails.
+  const patternUrl = () =>
+    getPatternEnvironment().apiUrl + `api/patterns/system/${options.name}`;
 
-    if (!program) {
-      throw new WishError("Can't load suggestion.tsx");
+  async function fetchPattern(
+    runtime: Runtime,
+    url: string,
+  ): Promise<Pattern | undefined> {
+    try {
+      const program = await runtime.harness.resolve(
+        new HttpProgramResolver(url),
+      );
+
+      if (!program) {
+        throw new WishError(`Can't load ${options.name}`);
+      }
+      const compiled = await runtime.patternManager.compilePattern(
+        program,
+        options.compileInUserSpace
+          ? { space: runtime.userIdentityDID }
+          : undefined,
+      );
+
+      if (!compiled) throw new WishError(`Can't compile ${options.name}`);
+
+      return compiled;
+    } catch (e) {
+      console.error(`Can't load ${options.name}`, e);
+      return undefined;
     }
-    // Cache the (space-independent) system pattern in the user's home space so
-    // it's reused across reloads for this user (CT-1623, per-space cache).
-    const pattern = await runtime.patternManager.compilePattern(program, {
-      space: runtime.userIdentityDID,
-    });
-
-    if (!pattern) throw new WishError("Can't compile suggestion.tsx");
-
-    return pattern;
-  } catch (e) {
-    console.error("Can't load suggestion.tsx", e);
-    return undefined;
   }
+
+  return {
+    // Pattern from a completed fetch for the current environment's URL.
+    cached(): Pattern | undefined {
+      return fetchUrl === patternUrl() ? pattern : undefined;
+    },
+    // Memoized fetch for the current environment's URL, started by this call
+    // when none is in flight for that URL. When this call starts the fetch,
+    // `onSuccess` runs once it resolves with a pattern, unless a fetch for
+    // another URL superseded it.
+    fetch(
+      runtime: Runtime,
+      onSuccess?: (pattern: Pattern) => void,
+    ): Promise<Pattern | undefined> {
+      const url = patternUrl();
+      if (!fetchPromise || fetchUrl !== url) {
+        fetchUrl = url;
+        pattern = undefined;
+        fetchPromise = fetchPattern(runtime, url).then((fetched) => {
+          if (fetchUrl !== url) return fetched;
+          pattern = fetched;
+          if (fetched) {
+            onSuccess?.(fetched);
+          } else if (options.retryOnFailure) {
+            fetchPromise = undefined;
+          }
+          return fetched;
+        });
+      }
+      return fetchPromise;
+    },
+  };
 }
 
-async function fetchProfileCreatePattern(
-  runtime: Runtime,
-): Promise<Pattern | undefined> {
-  try {
-    const program = await runtime.harness.resolve(
-      new HttpProgramResolver(profileCreateTsxPath()),
-    );
-
-    if (!program) {
-      throw new WishError("Can't load profile-create.tsx");
-    }
-    // Cache the (space-independent) system pattern in the user's home space so
-    // it's reused across reloads for this user (CT-1623, per-space cache).
-    const pattern = await runtime.patternManager.compilePattern(program, {
-      space: runtime.userIdentityDID,
-    });
-
-    if (!pattern) throw new WishError("Can't compile profile-create.tsx");
-
-    return pattern;
-  } catch (e) {
-    console.error("Can't load profile-create.tsx", e);
-    return undefined;
-  }
-}
-
-async function fetchProfilePickerPattern(
-  runtime: Runtime,
-): Promise<Pattern | undefined> {
-  try {
-    const program = await runtime.harness.resolve(
-      new HttpProgramResolver(profilePickerTsxPath()),
-    );
-
-    if (!program) {
-      throw new WishError("Can't load profile-picker.tsx");
-    }
-    const pattern = await runtime.patternManager.compilePattern(program);
-
-    if (!pattern) throw new WishError("Can't compile profile-picker.tsx");
-
-    return pattern;
-  } catch (e) {
-    console.error("Can't load profile-picker.tsx", e);
-    return undefined;
-  }
-}
+const suggestionPatternCache = createSidecarPatternCache({
+  name: "suggestion.tsx",
+  compileInUserSpace: true,
+});
+const profileCreatePatternCache = createSidecarPatternCache({
+  name: "profile-create.tsx",
+  compileInUserSpace: true,
+  retryOnFailure: true,
+});
+const profilePickerPatternCache = createSidecarPatternCache({
+  name: "profile-picker.tsx",
+  retryOnFailure: true,
+});
 
 function errorUI(message: string): VNode {
   return h("span", { style: "color: red" }, `⚠️ ${message}`);
@@ -1529,31 +1540,26 @@ export function wish(
       );
     }
 
-    if (!suggestionPattern) {
-      if (!suggestionPatternFetchPromise) {
-        suggestionPatternFetchPromise = fetchSuggestionPattern(runtime).then(
-          (pattern) => {
-            suggestionPattern = pattern;
-            return pattern;
-          },
-        );
-      }
+    const cachedSuggestionPattern = suggestionPatternCache.cached();
+    if (!cachedSuggestionPattern) {
       // Once fetch completes, run the pattern without a tx (it creates its own)
-      void suggestionPatternFetchPromise.then((pattern) => {
-        if (!cancelled && pattern && suggestionPatternResultCell) {
-          runtime.run(
-            undefined,
-            pattern,
-            suggestionPatternInput,
-            suggestionPatternResultCell!,
-          );
-        }
-      });
+      void suggestionPatternCache.fetch(runtime).then(
+        (pattern) => {
+          if (!cancelled && pattern && suggestionPatternResultCell) {
+            runtime.run(
+              undefined,
+              pattern,
+              suggestionPatternInput,
+              suggestionPatternResultCell!,
+            );
+          }
+        },
+      );
     } else {
       if (!cancelled && suggestionPatternResultCell) {
         runtime.run(
           tx,
-          suggestionPattern,
+          cachedSuggestionPattern,
           suggestionPatternInput,
           suggestionPatternResultCell,
         );
@@ -1660,24 +1666,16 @@ export function wish(
       };
     };
 
-    if (!profileCreatePattern) {
-      if (!profileCreatePatternFetchPromise) {
-        profileCreatePatternFetchPromise = fetchProfileCreatePattern(runtime)
-          .then((pattern) => {
-            profileCreatePattern = pattern;
-            if (pattern && profileCreatePatternReadyCell) {
-              const readyTx = runtime.edit();
-              profileCreatePatternReadyCell.withTx(readyTx).set(true);
-              runtime.prepareTxForCommit(readyTx);
-              readyTx.commit();
-            }
-            if (!pattern) {
-              profileCreatePatternFetchPromise = undefined;
-            }
-            return pattern;
-          });
-      }
-      void profileCreatePatternFetchPromise.then((pattern) => {
+    const cachedProfileCreatePattern = profileCreatePatternCache.cached();
+    if (!cachedProfileCreatePattern) {
+      void profileCreatePatternCache.fetch(runtime, () => {
+        if (profileCreatePatternReadyCell) {
+          const readyTx = runtime.edit();
+          profileCreatePatternReadyCell.withTx(readyTx).set(true);
+          runtime.prepareTxForCommit(readyTx);
+          readyTx.commit();
+        }
+      }).then((pattern) => {
         if (!cancelled && pattern && profileCreatePatternResultCell) {
           runSidecarInOwnTx(
             profileCreatePatternResultCell,
@@ -1689,7 +1687,7 @@ export function wish(
     } else if (!cancelled && profileCreatePatternResultCell) {
       runtime.run(
         tx,
-        profileCreatePattern,
+        cachedProfileCreatePattern,
         profileCreateInputForTx(tx),
         profileCreatePatternResultCell.withTx(tx),
       );
@@ -1760,30 +1758,23 @@ export function wish(
       };
     };
 
-    if (!profilePickerPattern) {
-      if (!profilePickerPatternFetchPromise) {
-        profilePickerPatternFetchPromise = fetchProfilePickerPattern(runtime)
-          .then((pattern) => {
-            profilePickerPattern = pattern;
-            if (!pattern) {
-              profilePickerPatternFetchPromise = undefined;
-            }
-            return pattern;
-          });
-      }
-      void profilePickerPatternFetchPromise.then((pattern) => {
-        if (!cancelled && pattern && profilePickerPatternResultCell) {
-          runSidecarInOwnTx(
-            profilePickerPatternResultCell,
-            pattern,
-            pickerInputForTx,
-          );
-        }
-      });
+    const cachedProfilePickerPattern = profilePickerPatternCache.cached();
+    if (!cachedProfilePickerPattern) {
+      void profilePickerPatternCache.fetch(runtime).then(
+        (pattern) => {
+          if (!cancelled && pattern && profilePickerPatternResultCell) {
+            runSidecarInOwnTx(
+              profilePickerPatternResultCell,
+              pattern,
+              pickerInputForTx,
+            );
+          }
+        },
+      );
     } else if (!cancelled && profilePickerPatternResultCell) {
       runtime.run(
         tx,
-        profilePickerPattern,
+        cachedProfilePickerPattern,
         pickerInputForTx(tx),
         profilePickerPatternResultCell.withTx(tx),
       );
@@ -2026,7 +2017,7 @@ export function wish(
               // launch it and send its result cell so the picker's output
               // flows through. Otherwise fall back to first result and kick
               // off the fetch for next time.
-              if (suggestionPattern) {
+              if (suggestionPatternCache.cached()) {
                 measureWishPhase(
                   "send-suggestion",
                   queryKey,

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -3216,23 +3216,24 @@ describe("tagMatchesHashtag", () => {
 });
 
 describe("createSidecarPatternCache", () => {
-  it("resolves a superseded fetch to undefined and keeps the newer fetch's pattern", async () => {
-    const originalFetch = globalThis.fetch;
-    const originalEnvironment = getPatternEnvironment();
+  let originalFetch: typeof globalThis.fetch;
+  let originalEnvironment: ReturnType<typeof getPatternEnvironment>;
 
-    // The fetch for env-a.test stays pending until released, so the fetch for
-    // env-b.test supersedes it and settles first.
-    let releaseFirstFetch = () => {};
-    const firstFetchGate = new Promise<void>((resolve) => {
-      releaseFirstFetch = resolve;
-    });
-    globalThis.fetch = (async (input: Request | URL | string) => {
-      const url = new URL(input instanceof Request ? input.url : String(input));
-      if (url.host === "env-a.test") await firstFetchGate;
-      return new Response(`source from ${url.host}`, { status: 200 });
-    }) as typeof fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalEnvironment = getPatternEnvironment();
+  });
 
-    const fakeRuntime = {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    setPatternEnvironment(originalEnvironment);
+  });
+
+  // Fake runtime whose harness.resolve hands back the resolver's main() source
+  // and whose compilePattern echoes that source, so the compiled result names
+  // the URL it came from.
+  const makeFakeRuntime = () =>
+    ({
       harness: {
         resolve: (resolver: { main(): Promise<{ contents: string }> }) =>
           resolver.main(),
@@ -3242,29 +3243,112 @@ describe("createSidecarPatternCache", () => {
           Promise.resolve({ source: program.contents }),
       },
       userIdentityDID: "did:key:sidecar-cache-test",
-    } as unknown as Runtime;
+    }) as unknown as Runtime;
 
-    try {
-      const cache = createSidecarPatternCache({
-        name: "profile-create.tsx",
-        retryOnFailure: true,
-      });
+  // fetch mock that 200s with a body naming the host. Hosts in `failFirst` 404
+  // on their first request and succeed afterward. The `gate` host's requests
+  // stay pending until the returned `release` is called.
+  const installFetchMock = (
+    options: { gate?: string; failFirst?: string[] } = {},
+  ) => {
+    let release = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const failFirst = new Set(options.failFirst ?? []);
+    const calls: string[] = [];
+    globalThis.fetch = (async (input: Request | URL | string) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      calls.push(url.host);
+      if (url.host === options.gate) await gate;
+      // delete returns true once per host, so only the first request 404s.
+      return failFirst.delete(url.host)
+        ? new Response("not found", { status: 404 })
+        : new Response(`source from ${url.host}`, { status: 200 });
+    }) as typeof fetch;
+    return { release, calls };
+  };
 
-      setPatternEnvironment({ apiUrl: new URL("https://env-a.test/") });
-      const firstFetch = cache.fetch(fakeRuntime);
+  it("resolves a superseded fetch to undefined and keeps the newer fetch's pattern", async () => {
+    // The fetch for env-a.test stays pending until released, so the fetch for
+    // env-b.test supersedes it and settles first.
+    const { release } = installFetchMock({ gate: "env-a.test" });
+    const fakeRuntime = makeFakeRuntime();
+    const cache = createSidecarPatternCache({
+      name: "profile-create.tsx",
+      retryOnFailure: true,
+    });
 
-      setPatternEnvironment({ apiUrl: new URL("https://env-b.test/") });
-      const secondFetch = cache.fetch(fakeRuntime);
+    setPatternEnvironment({ apiUrl: new URL("https://env-a.test/") });
+    const firstFetch = cache.fetch(fakeRuntime);
 
-      expect(await secondFetch).toEqual({ source: "source from env-b.test" });
-      expect(cache.cached()).toEqual({ source: "source from env-b.test" });
+    setPatternEnvironment({ apiUrl: new URL("https://env-b.test/") });
+    const secondFetch = cache.fetch(fakeRuntime);
 
-      releaseFirstFetch();
-      expect(await firstFetch).toBeUndefined();
-      expect(cache.cached()).toEqual({ source: "source from env-b.test" });
-    } finally {
-      globalThis.fetch = originalFetch;
-      setPatternEnvironment(originalEnvironment);
-    }
+    expect(await secondFetch).toEqual({ source: "source from env-b.test" });
+    expect(cache.cached()).toEqual({ source: "source from env-b.test" });
+
+    release();
+    expect(await firstFetch).toBeUndefined();
+    expect(cache.cached()).toEqual({ source: "source from env-b.test" });
+  });
+
+  it("retries after a failed fetch when retryOnFailure is set", async () => {
+    // First fetch 404s, the rest succeed.
+    const { calls } = installFetchMock({ failFirst: ["env-a.test"] });
+    const fakeRuntime = makeFakeRuntime();
+    setPatternEnvironment({ apiUrl: new URL("https://env-a.test/") });
+    const cache = createSidecarPatternCache({
+      name: "profile-create.tsx",
+      retryOnFailure: true,
+    });
+
+    expect(await cache.fetch(fakeRuntime)).toBeUndefined();
+    expect(cache.cached()).toBeUndefined();
+    // The cleared memoization lets a later launch re-fetch the same URL.
+    expect(await cache.fetch(fakeRuntime)).toEqual({
+      source: "source from env-a.test",
+    });
+    expect(calls).toEqual(["env-a.test", "env-a.test"]);
+  });
+
+  it("keeps a failed fetch without retrying when retryOnFailure is not set", async () => {
+    const { calls } = installFetchMock({ failFirst: ["env-a.test"] });
+    const fakeRuntime = makeFakeRuntime();
+    setPatternEnvironment({ apiUrl: new URL("https://env-a.test/") });
+    // suggestion.tsx's policy: a failed fetch is kept, not retried.
+    const cache = createSidecarPatternCache({ name: "suggestion.tsx" });
+
+    expect(await cache.fetch(fakeRuntime)).toBeUndefined();
+    expect(await cache.fetch(fakeRuntime)).toBeUndefined();
+    expect(cache.cached()).toBeUndefined();
+    expect(calls).toEqual(["env-a.test"]);
+  });
+
+  it("invokes onSuccess only for the fetch that records its pattern", async () => {
+    const { release } = installFetchMock({ gate: "env-a.test" });
+    const fakeRuntime = makeFakeRuntime();
+    const cache = createSidecarPatternCache({
+      name: "profile-create.tsx",
+      retryOnFailure: true,
+    });
+
+    const recorded: unknown[] = [];
+    const record = (pattern: unknown) => recorded.push(pattern);
+
+    setPatternEnvironment({ apiUrl: new URL("https://env-a.test/") });
+    const firstFetch = cache.fetch(fakeRuntime, record);
+
+    setPatternEnvironment({ apiUrl: new URL("https://env-b.test/") });
+    const secondFetch = cache.fetch(fakeRuntime, record);
+
+    expect(await secondFetch).toEqual({ source: "source from env-b.test" });
+
+    release();
+    await firstFetch;
+
+    // The winning env-b fetch reports through onSuccess; the superseded env-a
+    // fetch does not.
+    expect(recorded).toEqual([{ source: "source from env-b.test" }]);
   });
 });

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -9,7 +9,11 @@ import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
 import { entityIdFrom } from "../src/create-ref.ts";
 import { NAME, UI } from "../src/builder/types.ts";
-import { parseWishTarget, tagMatchesHashtag } from "../src/builtins/wish.ts";
+import {
+  createSidecarPatternCache,
+  parseWishTarget,
+  tagMatchesHashtag,
+} from "../src/builtins/wish.ts";
 import {
   getPatternEnvironment,
   setPatternEnvironment,
@@ -3208,5 +3212,59 @@ describe("tagMatchesHashtag", () => {
     // The hashtag #todo_list is parsed as #todo (underscore ends the hashtag)
     expect(tagMatchesHashtag("#todo_list", "todo")).toBe(true);
     expect(tagMatchesHashtag("#todo_list", "todo_list")).toBe(false);
+  });
+});
+
+describe("createSidecarPatternCache", () => {
+  it("resolves a superseded fetch to undefined and keeps the newer fetch's pattern", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalEnvironment = getPatternEnvironment();
+
+    // The fetch for env-a.test stays pending until released, so the fetch for
+    // env-b.test supersedes it and settles first.
+    let releaseFirstFetch = () => {};
+    const firstFetchGate = new Promise<void>((resolve) => {
+      releaseFirstFetch = resolve;
+    });
+    globalThis.fetch = (async (input: Request | URL | string) => {
+      const url = new URL(input instanceof Request ? input.url : String(input));
+      if (url.host === "env-a.test") await firstFetchGate;
+      return new Response(`source from ${url.host}`, { status: 200 });
+    }) as typeof fetch;
+
+    const fakeRuntime = {
+      harness: {
+        resolve: (resolver: { main(): Promise<{ contents: string }> }) =>
+          resolver.main(),
+      },
+      patternManager: {
+        compilePattern: (program: { contents: string }) =>
+          Promise.resolve({ source: program.contents }),
+      },
+      userIdentityDID: "did:key:sidecar-cache-test",
+    } as unknown as Runtime;
+
+    try {
+      const cache = createSidecarPatternCache({
+        name: "profile-create.tsx",
+        retryOnFailure: true,
+      });
+
+      setPatternEnvironment({ apiUrl: new URL("https://env-a.test/") });
+      const firstFetch = cache.fetch(fakeRuntime);
+
+      setPatternEnvironment({ apiUrl: new URL("https://env-b.test/") });
+      const secondFetch = cache.fetch(fakeRuntime);
+
+      expect(await secondFetch).toEqual({ source: "source from env-b.test" });
+      expect(cache.cached()).toEqual({ source: "source from env-b.test" });
+
+      releaseFirstFetch();
+      expect(await firstFetch).toBeUndefined();
+      expect(cache.cached()).toEqual({ source: "source from env-b.test" });
+    } finally {
+      globalThis.fetch = originalFetch;
+      setPatternEnvironment(originalEnvironment);
+    }
   });
 });


### PR DESCRIPTION
The suggestion, profile-create, and profile-picker sidecar patterns are memoized in module-level state shared across all wish invocations: an in-flight fetch promise plus the compiled pattern. That state was not keyed by the URL the fetch was started for. setPatternEnvironment can change the apiUrl while a fetch is in flight, and a launch after the change would chain onto the pending fetch aimed at the old URL. If that stale fetch then failed, the memoized promise was cleared for future launches, but the launches already chained onto it received nothing and nothing retried. The pattern was never fetched from the new URL.

This raced in packages/runner/test/wish.test.ts roughly once in eight runs under load. The step "renders #profile wish UI as a create-profile input when the profile is missing" starts a deferred, un-awaited profile-create fetch. Before that fetch reaches the network, it waits on the harness compiler initialization of a runtime the test teardown has already disposed, which can take several seconds on a busy machine. The next step ("fetches the profile-create pattern from the pattern environment apiUrl set after module load") sets a test apiUrl, installs a recording fetch mock, and launches its own wish. That launch chained onto the still-pending stale fetch, so no request to the new URL was ever made and the step timed out at its five-second deadline with the recorded URL list empty. The same sequence can occur in production: in the browser worker wish.ts is imported before the runtime calls setPatternEnvironment with the real API URL, so a wish launched before the environment is set leaves a doomed fetch that later launches would chain onto.

Each cache now records the URL its fetch was started for. A launch whose resolved URL differs starts a fresh fetch instead of reusing the pending one, and a superseded fetch leaves the cache untouched when it settles. Failure handling is unchanged: profile-create and profile-picker drop a failed fetch so a later launch retries, and suggestion keeps the failed result.

The three copy-pasted cache blocks, fetch-and-compile functions, and URL helpers are consolidated into one createSidecarPatternCache factory. Each cache is declared by its file name, compile-space option, and retry policy.

Verified by running the wish test file 32 times under four-way parallel load: four failures before the change, none after.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale wish sidecar patterns from running after `apiUrl` changes by keying caches to the fetch URL and guarding with promise identity; superseded fetches resolve to undefined so older results can’t overwrite newer runs.

- **Bug Fixes**
  - Cache per-URL and active promise; a different URL or overtaken fetch starts a new request. Superseded fetches return undefined and never update the cache or run. Retry policy unchanged: `profile-create` and `profile-picker` retry on failure; `suggestion` keeps the failed result.

- **Refactors**
  - Consolidated logic into an exported `createSidecarPatternCache` (lazy URL resolution, optional compile-in-user-space, retry policy) and applied to `suggestion.tsx`, `profile-create.tsx`, and `profile-picker.tsx`. Added tests for supersession, failure→retry, no-retry, and onSuccess firing only for the winning fetch.

<sup>Written for commit 798441148664007ebb8a27f4a847923a2c2ad46f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

