### PR TITLE
fix(ts-transformers): graft authored Default values back onto shrunken capture leaves

### DIFF
--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -1,5 +1,6 @@
 import ts from "typescript";
 import { getPropertyNameText } from "@commonfabric/schema-generator/property-name";
+import { isDefaultAliasSymbol } from "@commonfabric/schema-generator/property-optionality";
 import {
   createRegisteredTypeLiteral,
   typeToTypeNodeWithRegistry,
@@ -666,6 +667,170 @@ function getSymbolPropertyHead(
   return undefined;
 }
 
+/**
+ * The authored `Default<…>` reference on a type node, if any: directly, or as
+ * a member of a top-level union (`boolean | Default<false>`). Deliberately
+ * does NOT descend into type arguments of other references — a Default inside
+ * `Writable<Default<…>>` belongs to the cell-like handling, not the leaf.
+ */
+function findAuthoredDefaultReference(
+  node: ts.TypeNode,
+  checker: ts.TypeChecker,
+): ts.TypeReferenceNode | undefined {
+  if (ts.isParenthesizedTypeNode(node)) {
+    return findAuthoredDefaultReference(node.type, checker);
+  }
+  if (ts.isUnionTypeNode(node)) {
+    for (const member of node.types) {
+      const found = findAuthoredDefaultReference(member, checker);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  if (
+    ts.isTypeReferenceNode(node) &&
+    getTypeReferenceNodeName(node) === "Default" &&
+    node.typeArguments && node.typeArguments.length > 0 &&
+    node.pos >= 0
+  ) {
+    // Resolve through import aliases: at a use site the symbol is the
+    // ImportSpecifier in the using file, not the api declaration.
+    let symbol = checker.getSymbolAtLocation(node.typeName);
+    if (symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+      symbol = checker.getAliasedSymbol(symbol);
+    }
+    if (isDefaultAliasSymbol(symbol)) {
+      return node;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Re-synthesize a default-VALUE type node as fresh synthetic literals, in the
+ * style of `getStaticDefaultTypeNode` (destructuring-lowering.ts): authored
+ * nodes can't be reused across source files — the printer slices the
+ * DESTINATION file's text at the original positions — so the value is rebuilt
+ * from its literal content. Returns undefined for anything that isn't
+ * literal-shaped; the caller then simply grafts no default.
+ */
+function resynthesizeDefaultValueTypeNode(
+  node: ts.TypeNode,
+  factory: ts.NodeFactory,
+  checker: ts.TypeChecker,
+): ts.TypeNode | undefined {
+  if (ts.isParenthesizedTypeNode(node)) {
+    return resynthesizeDefaultValueTypeNode(node.type, factory, checker);
+  }
+  if (ts.isLiteralTypeNode(node)) {
+    const literal = node.literal;
+    if (ts.isStringLiteral(literal)) {
+      return factory.createLiteralTypeNode(
+        factory.createStringLiteral(literal.text),
+      );
+    }
+    if (ts.isNumericLiteral(literal)) {
+      return factory.createLiteralTypeNode(
+        factory.createNumericLiteral(literal.text),
+      );
+    }
+    if (
+      ts.isPrefixUnaryExpression(literal) &&
+      literal.operator === ts.SyntaxKind.MinusToken &&
+      ts.isNumericLiteral(literal.operand)
+    ) {
+      return factory.createLiteralTypeNode(
+        factory.createPrefixUnaryExpression(
+          ts.SyntaxKind.MinusToken,
+          factory.createNumericLiteral(literal.operand.text),
+        ),
+      );
+    }
+    switch (literal.kind) {
+      case ts.SyntaxKind.TrueKeyword:
+        return factory.createLiteralTypeNode(factory.createTrue());
+      case ts.SyntaxKind.FalseKeyword:
+        return factory.createLiteralTypeNode(factory.createFalse());
+      case ts.SyntaxKind.NullKeyword:
+        return factory.createLiteralTypeNode(factory.createNull());
+      default:
+        return undefined;
+    }
+  }
+  if (node.kind === ts.SyntaxKind.UndefinedKeyword) {
+    return factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword);
+  }
+  if (ts.isTupleTypeNode(node)) {
+    const elements: ts.TypeNode[] = [];
+    for (const element of node.elements) {
+      const synthesized = resynthesizeDefaultValueTypeNode(
+        element,
+        factory,
+        checker,
+      );
+      if (!synthesized) return undefined;
+      elements.push(synthesized);
+    }
+    return factory.createTupleTypeNode(elements);
+  }
+  if (ts.isTypeLiteralNode(node)) {
+    const members: ts.TypeElement[] = [];
+    for (const member of node.members) {
+      if (!ts.isPropertySignature(member) || !member.type || !member.name) {
+        return undefined;
+      }
+      const name = getPropertyNameText(member.name, checker);
+      if (name === undefined) return undefined;
+      const synthesized = resynthesizeDefaultValueTypeNode(
+        member.type,
+        factory,
+        checker,
+      );
+      if (!synthesized) return undefined;
+      members.push(
+        factory.createPropertySignature(
+          undefined,
+          createPropertyName(name, factory),
+          undefined,
+          synthesized,
+        ),
+      );
+    }
+    return factory.createTypeLiteralNode(members);
+  }
+  return undefined;
+}
+
+/**
+ * When a leaf property's AUTHORED declaration spells `Default<T, V>`, recover
+ * V for the shrunken node. The checker type cannot provide it: the
+ * conditional alias resolves away and the literal V widens
+ * (`Default<string, "">` → `DefaultMarker<string>`), so the authored node —
+ * read in place, never reused in output — is the only remaining source.
+ */
+function getAuthoredDefaultValueTypeNode(
+  prop: ts.Symbol,
+  factory: ts.NodeFactory,
+  checker: ts.TypeChecker,
+): ts.TypeNode | undefined {
+  const declaration = prop.valueDeclaration ?? prop.declarations?.[0];
+  if (
+    !declaration ||
+    !(ts.isPropertySignature(declaration) ||
+      ts.isPropertyDeclaration(declaration)) ||
+    !declaration.type
+  ) {
+    return undefined;
+  }
+  const reference = findAuthoredDefaultReference(declaration.type, checker);
+  if (!reference?.typeArguments?.length) return undefined;
+  // One-arg form `Default<V>` means V = T.
+  const valueNode = reference.typeArguments[1] ?? reference.typeArguments[0];
+  return valueNode
+    ? resynthesizeDefaultValueTypeNode(valueNode, factory, checker)
+    : undefined;
+}
+
 function findPropertySymbol(
   type: ts.Type,
   head: string,
@@ -923,6 +1088,15 @@ function buildShrunkTypeNodeFromType(
       continue;
     }
 
+    // A leaf property whose authored declaration spells Default<T, V> gets V
+    // grafted back as `__cfHelpers.Default<shrunken, V>` (the same wrapping
+    // the destructuring-defaults machinery plants). The checker-built node
+    // alone loses the Default spelling and widens the literal V away, which
+    // silently drops the property's `"default"` from injected capture schemas.
+    const authoredDefault = prop
+      ? getAuthoredDefaultValueTypeNode(prop, factory, checker)
+      : undefined;
+
     // Nested primitive leaves still need their original runtime shape. For
     // object properties like `input.text.length`, shrinking `text` to
     // `{ length: number }` changes a string leaf into an object and breaks the
@@ -930,12 +1104,15 @@ function buildShrunkTypeNodeFromType(
     // root-level primitive projections (e.g. `summary.length`) are still
     // handled by the recursive shrink above.
     if (!hasDirectAccess && isPrimitiveScalarLikeType(propType)) {
-      const propTypeNode = typeToTypeNodeWithRegistry(
+      const shrunkLeaf = typeToTypeNodeWithRegistry(
         propType,
         { checker, factory, sourceFile },
         typeRegistry,
         typeToNodeFlags,
       );
+      const propTypeNode = authoredDefault
+        ? wrapTypeNodeWithDefault(shrunkLeaf, authoredDefault, factory)
+        : shrunkLeaf;
       properties.push(
         factory.createPropertySignature(
           undefined,
@@ -969,13 +1146,19 @@ function buildShrunkTypeNodeFromType(
       continue;
     }
 
-    const propTypeNode = shrunkChild ??
+    const shrunkPropTypeNode = shrunkChild ??
       typeToTypeNodeWithRegistry(
         propType,
         { checker, factory, sourceFile },
         typeRegistry,
         typeToNodeFlags,
       );
+    // Graft only on pure-leaf access: with deeper paths in play, the shrunken
+    // child shape may not match the authored default's shape.
+    const onlyDirectAccess = childPaths.every((path) => path.length === 0);
+    const propTypeNode = authoredDefault && onlyDirectAccess
+      ? wrapTypeNodeWithDefault(shrunkPropTypeNode, authoredDefault, factory)
+      : shrunkPropTypeNode;
 
     properties.push(
       factory.createPropertySignature(

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -689,12 +689,14 @@ function findAuthoredDefaultReference(
   }
   if (
     ts.isTypeReferenceNode(node) &&
-    getTypeReferenceNodeName(node) === "Default" &&
     node.typeArguments && node.typeArguments.length > 0 &&
     node.pos >= 0
   ) {
-    // Resolve through import aliases: at a use site the symbol is the
-    // ImportSpecifier in the using file, not the api declaration.
+    // Symbol-verified, NOT name-gated: a renamed import (`Default as D`)
+    // must still graft, matching isDefaultTypeRef's symbol-resolution
+    // behavior in regular input schemas. Resolve through import aliases —
+    // at a use site the symbol is the ImportSpecifier in the using file,
+    // not the api declaration.
     let symbol = checker.getSymbolAtLocation(node.typeName);
     if (symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0) {
       symbol = checker.getAliasedSymbol(symbol);

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.expected.jsx
@@ -25,8 +25,19 @@ interface Item {
     // Renamed import: detection is symbol-verified, not name-gated.
     rank: RenamedDefault<number, 7>;
 }
+// GENERIC reference: a capture through `Tagged<number>[]` can never be
+// projected node-driven — recovering the declared type of a generic by
+// symbol would leak unsubstituted type parameters — so this leaf is always
+// served by the type-driven shrink, and only the graft can restore its
+// `"default"`. Pins the graft path even once node-driven shrinking projects
+// through non-generic named references again.
+interface Tagged<T> {
+    value: T;
+    note: Default<string, "n/a">;
+}
 interface Input {
     items: Item[];
+    boxes: Tagged<number>[];
 }
 const __cfLift_1 = __cfHelpers.lift<{
     items: {
@@ -103,12 +114,39 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_4 = __cfHelpers.lift<{
+    boxes: {
+        note: __cfHelpers.Default<string | (string & { readonly [DEFAULT_MARKER]: string; }), "n/a">;
+    }[];
+}, boolean>(({ boxes }) => boxes[0]?.note === "n/a", {
+    type: "object",
+    properties: {
+        boxes: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    note: {
+                        type: "string",
+                        "default": "n/a"
+                    }
+                },
+                required: ["note"]
+            }
+        }
+    },
+    required: ["boxes"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
+    const boxes = __cf_pattern_input.key("boxes");
     const firstDone = __cfLift_1({ items: items }).for("firstDone", true);
     const firstLabelEmpty = __cfLift_2({ items: items }).for("firstLabelEmpty", true);
     const firstRank = __cfLift_3({ items: items }).for("firstRank", true);
-    return { firstDone, firstLabelEmpty, firstRank };
+    const firstBoxNote = __cfLift_4({ boxes: boxes }).for("firstBoxNote", true);
+    return { firstDone, firstLabelEmpty, firstRank, firstBoxNote };
 }, {
     type: "object",
     properties: {
@@ -117,9 +155,25 @@ export default pattern((__cf_pattern_input) => {
             items: {
                 $ref: "#/$defs/Item"
             }
+        },
+        boxes: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    value: {
+                        type: "number"
+                    },
+                    note: {
+                        type: "string",
+                        "default": "n/a"
+                    }
+                },
+                required: ["value", "note"]
+            }
         }
     },
-    required: ["items"],
+    required: ["items", "boxes"],
     $defs: {
         Item: {
             type: "object",
@@ -150,9 +204,12 @@ export default pattern((__cf_pattern_input) => {
         },
         firstRank: {
             type: "boolean"
+        },
+        firstBoxNote: {
+            type: "boolean"
         }
     },
-    required: ["firstDone", "firstLabelEmpty", "firstRank"]
+    required: ["firstDone", "firstLabelEmpty", "firstRank", "firstBoxNote"]
 } as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
@@ -160,5 +217,6 @@ __cfHardenFn(h);
 __cfReg({
     __cfLift_1,
     __cfLift_2,
-    __cfLift_3
+    __cfLift_3,
+    __cfLift_4
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.expected.jsx
@@ -7,7 +7,7 @@ function __cfHardenFn(fn: Function) {
     return fn;
 }
 import { __cfHelpers } from "commonfabric";
-import { computed, type Default, pattern } from "commonfabric";
+import { computed, type Default, type Default as RenamedDefault, pattern, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
@@ -22,6 +22,8 @@ const __cfAmdHooks = undefined;
 interface Item {
     done: boolean | Default<false>;
     label: Default<string, "">;
+    // Renamed import: detection is symbol-verified, not name-gated.
+    rank: RenamedDefault<number, 7>;
 }
 interface Input {
     items: Item[];
@@ -76,11 +78,37 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_3 = __cfHelpers.lift<{
+    items: {
+        rank: __cfHelpers.Default<number | (number & { readonly [DEFAULT_MARKER]: number; }), 7>;
+    }[];
+}, boolean>(({ items }) => items[0]?.rank === 7, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    rank: {
+                        type: "number",
+                        "default": 7
+                    }
+                },
+                required: ["rank"]
+            }
+        }
+    },
+    required: ["items"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     const firstDone = __cfLift_1({ items: items }).for("firstDone", true);
     const firstLabelEmpty = __cfLift_2({ items: items }).for("firstLabelEmpty", true);
-    return { firstDone, firstLabelEmpty };
+    const firstRank = __cfLift_3({ items: items }).for("firstRank", true);
+    return { firstDone, firstLabelEmpty, firstRank };
 }, {
     type: "object",
     properties: {
@@ -103,9 +131,12 @@ export default pattern((__cf_pattern_input) => {
                 label: {
                     type: "string",
                     "default": ""
+                },
+                rank: {
+                    type: "number"
                 }
             },
-            required: ["done", "label"]
+            required: ["done", "label", "rank"]
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, {
@@ -116,14 +147,18 @@ export default pattern((__cf_pattern_input) => {
         },
         firstLabelEmpty: {
             type: "boolean"
+        },
+        firstRank: {
+            type: "boolean"
         }
     },
-    required: ["firstDone", "firstLabelEmpty"]
+    required: ["firstDone", "firstLabelEmpty", "firstRank"]
 } as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     __cfLift_1,
-    __cfLift_2
+    __cfLift_2,
+    __cfLift_3
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.expected.jsx
@@ -1,0 +1,129 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { computed, type Default, pattern } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+// FIXTURE: default-survives-capture-shrink
+// Verifies: Default<…> annotations on properties survive capture shrinking
+// as alias references, so the injected capture schemas keep their
+// `"default"` values. When the shrunken type node expands the alias
+// structurally (`boolean | (false & { [DEFAULT_MARKER]: false })`), the
+// schema generator no longer recognizes the spelling and silently drops
+// the default — and literal default values can widen away entirely
+// (`Default<string, "">` → `{ [DEFAULT_MARKER]: string }`).
+interface Item {
+    done: boolean | Default<false>;
+    label: Default<string, "">;
+}
+interface Input {
+    items: Item[];
+}
+const __cfLift_1 = __cfHelpers.lift<{
+    items: {
+        done: __cfHelpers.Default<boolean | (false & { readonly [DEFAULT_MARKER]: false; }), false>;
+    }[];
+}, boolean>(({ items }) => items[0]?.done === true, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    done: {
+                        type: "boolean",
+                        "default": false
+                    }
+                },
+                required: ["done"]
+            }
+        }
+    },
+    required: ["items"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_2 = __cfHelpers.lift<{
+    items: {
+        label: __cfHelpers.Default<string | (string & { readonly [DEFAULT_MARKER]: string; }), "">;
+    }[];
+}, boolean>(({ items }) => items[0]?.label === "", {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    label: {
+                        type: "string",
+                        "default": ""
+                    }
+                },
+                required: ["label"]
+            }
+        }
+    },
+    required: ["items"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+export default pattern((__cf_pattern_input) => {
+    const items = __cf_pattern_input.key("items");
+    const firstDone = __cfLift_1({ items: items }).for("firstDone", true);
+    const firstLabelEmpty = __cfLift_2({ items: items }).for("firstLabelEmpty", true);
+    return { firstDone, firstLabelEmpty };
+}, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Item"
+            }
+        }
+    },
+    required: ["items"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean",
+                    "default": false
+                },
+                label: {
+                    type: "string",
+                    "default": ""
+                }
+            },
+            required: ["done", "label"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        firstDone: {
+            type: "boolean"
+        },
+        firstLabelEmpty: {
+            type: "boolean"
+        }
+    },
+    required: ["firstDone", "firstLabelEmpty"]
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.input.tsx
@@ -1,0 +1,24 @@
+import { computed, type Default, pattern } from "commonfabric";
+
+// FIXTURE: default-survives-capture-shrink
+// Verifies: Default<…> annotations on properties survive capture shrinking
+// as alias references, so the injected capture schemas keep their
+// `"default"` values. When the shrunken type node expands the alias
+// structurally (`boolean | (false & { [DEFAULT_MARKER]: false })`), the
+// schema generator no longer recognizes the spelling and silently drops
+// the default — and literal default values can widen away entirely
+// (`Default<string, "">` → `{ [DEFAULT_MARKER]: string }`).
+interface Item {
+  done: boolean | Default<false>;
+  label: Default<string, "">;
+}
+
+interface Input {
+  items: Item[];
+}
+
+export default pattern<Input>(({ items }) => {
+  const firstDone = computed(() => items[0]?.done === true);
+  const firstLabelEmpty = computed(() => items[0]?.label === "");
+  return { firstDone, firstLabelEmpty };
+});

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.input.tsx
@@ -20,13 +20,26 @@ interface Item {
   rank: RenamedDefault<number, 7>;
 }
 
-interface Input {
-  items: Item[];
+// GENERIC reference: a capture through `Tagged<number>[]` can never be
+// projected node-driven — recovering the declared type of a generic by
+// symbol would leak unsubstituted type parameters — so this leaf is always
+// served by the type-driven shrink, and only the graft can restore its
+// `"default"`. Pins the graft path even once node-driven shrinking projects
+// through non-generic named references again.
+interface Tagged<T> {
+  value: T;
+  note: Default<string, "n/a">;
 }
 
-export default pattern<Input>(({ items }) => {
+interface Input {
+  items: Item[];
+  boxes: Tagged<number>[];
+}
+
+export default pattern<Input>(({ items, boxes }) => {
   const firstDone = computed(() => items[0]?.done === true);
   const firstLabelEmpty = computed(() => items[0]?.label === "");
   const firstRank = computed(() => items[0]?.rank === 7);
-  return { firstDone, firstLabelEmpty, firstRank };
+  const firstBoxNote = computed(() => boxes[0]?.note === "n/a");
+  return { firstDone, firstLabelEmpty, firstRank, firstBoxNote };
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.input.tsx
@@ -1,4 +1,9 @@
-import { computed, type Default, pattern } from "commonfabric";
+import {
+  computed,
+  type Default,
+  type Default as RenamedDefault,
+  pattern,
+} from "commonfabric";
 
 // FIXTURE: default-survives-capture-shrink
 // Verifies: Default<…> annotations on properties survive capture shrinking
@@ -11,6 +16,8 @@ import { computed, type Default, pattern } from "commonfabric";
 interface Item {
   done: boolean | Default<false>;
   label: Default<string, "">;
+  // Renamed import: detection is symbol-verified, not name-gated.
+  rank: RenamedDefault<number, 7>;
 }
 
 interface Input {
@@ -20,5 +27,6 @@ interface Input {
 export default pattern<Input>(({ items }) => {
   const firstDone = computed(() => items[0]?.done === true);
   const firstLabelEmpty = computed(() => items[0]?.label === "");
-  return { firstDone, firstLabelEmpty };
+  const firstRank = computed(() => items[0]?.rank === 7);
+  return { firstDone, firstLabelEmpty, firstRank };
 });


### PR DESCRIPTION
Closes the second #4017 schema regression (flagged in #4071): `Default<T,V>` annotations losing their `"default"` values in injected capture schemas.

## Root cause

Since #4017, factory result types keep their named interfaces, so the type-based capture shrink (`buildShrunkTypeNodeFromType`) engages on them and rebuilds leaf property nodes from **checker types** — which cannot express `Default<T,V>`:

- the conditional alias resolves away (only the inner `DefaultMarker` survives, even with `UseAliasDefinedOutsideCurrentScope` — tested), and
- the literal default value **widens inside the type itself**: `Default<string,"">` → `DefaultMarker<string>`, tested through both `getTypeOfSymbolAtLocation` and `getTypeFromTypeNode`.

So the value is genuinely unrecoverable from the type. The schema generator can't help either: a probe showed the synthetic capture literal severs the symbol chain (`getPropertiesOfType` returns declaration-less symbols by the time the object-formatter runs).

## Design

The last place the real property symbol is alive is the shrink itself — and its authored declaration still spells `Default<T,V>`. **Reading** a cross-file authored node is safe; only printing foreign-positioned nodes breaks (we measured `Default<string, ve_>` garbage when transplanting — an earlier deep-clone approach was considered and rejected for exactly that reason; this PR moves values, not nodes). So on pure-leaf access the shrink now:

1. finds the authored `Default` reference (direct or top-level union member; symbol-verified via `isDefaultAliasSymbol`, resolved through import aliases; deliberately not descending into wrapper type args — `Writable<Default<…>>` stays with the cell-like handling),
2. **re-synthesizes** the default value as fresh literal nodes — the exact approach `getStaticDefaultTypeNode` (destructuring-lowering) already uses, never reusing authored nodes across files,
3. wraps the shrunken leaf with the existing `wrapTypeNodeWithDefault` → `__cfHelpers.Default<shrunken, V>`, the spelling the schema pipeline already consumes for destructuring defaults.

Non-literal default values bail to current behavior (no graft, no wrong output).

## Verification

- New fixture `schema-injection/default-survives-capture-shrink` pins both forms (`boolean | Default<false>`, `Default<string, "">` — the widening case). **No other golden changed.**
- editable-list's transformed capture schemas are back to exact `"default"` parity with their pre-#4017 baseline (73/73 occurrences); test still 28/28.
- ts-transformers 292 passed; schema-generator green; `deno task integration pattern-tests` 59/59; fmt/lint/check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve Default<T, V> values on capture leaf properties after type shrinking in `ts-transformers`, so injected capture schemas keep their default entries. Also works for renamed imports and leaves under generic references.

- **Bug Fixes**
  - Detect authored `Default<…>` on leaf props (direct or top-level union) via symbol resolution; renamed imports work.
  - Re-synthesize literal default value nodes and wrap the shrunken leaf with `__cfHelpers.Default<shrunken, V>`.
  - Apply only on pure-leaf access; skip nested wrappers and non-literal defaults.
  - Fixture `schema-injection/default-survives-capture-shrink` now also pins a generic-ref capture (`Tagged<number>[]`) to ensure defaults survive under generics.

<sup>Written for commit 10a9073deb783fe237e08189403571289b0c8693. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

