### PR TITLE
fix(ts-transformers): restore node-driven shrinking through synthetic named type references

### DIFF
--- a/packages/ts-transformers/src/ast/type-building.ts
+++ b/packages/ts-transformers/src/ast/type-building.ts
@@ -590,6 +590,55 @@ export function cloneTypeNode<T extends ts.TypeNode>(typeNode: T): T {
 }
 
 /**
+ * Deep-clones a TypeNode for emission, stripping source positions throughout.
+ *
+ * Declaration members resolved through a TypeReference may live in a different
+ * source file than the one being emitted. The printer extracts literal text
+ * (e.g. the `""` in `Default<string, "">`) by source position from the file it
+ * is currently printing, so reusing those nodes verbatim emits garbage tokens.
+ * A position-free deep clone makes every node synthetic, forcing the printer
+ * to print structurally (literals fall back to their `.text`).
+ *
+ * Pass `typeRegistry` to carry each node's registered Type onto its clone.
+ */
+export function cloneTypeNodeDeepForEmission<T extends ts.TypeNode>(
+  typeNode: T,
+  typeRegistry?: WeakMap<ts.Node, ts.Type>,
+): T {
+  const nullContext = (ts as typeof ts & {
+    nullTransformationContext?: ts.TransformationContext;
+  }).nullTransformationContext;
+  if (!nullContext) return typeNode;
+  const cloneShallow = (ts.factory as typeof ts.factory & {
+    cloneNode<TNode extends ts.Node>(node: TNode): TNode;
+  }).cloneNode;
+
+  const visit = <N extends ts.Node>(node: N): N => {
+    // Post-order: children first, so leaf nodes (identifiers, literals,
+    // keywords) get cloned explicitly while composite nodes are recreated by
+    // visitEachChild's update calls when any child changed.
+    let result = ts.visitEachChild(
+      node,
+      (child) => visit(child),
+      nullContext,
+    ) as N;
+    if (result === node) {
+      result = cloneShallow(node);
+    }
+    // update* calls copy the original's text range for source maps; strip it
+    // so the printer treats the node as synthesized everywhere.
+    ts.setTextRange(result, { pos: -1, end: -1 });
+    const registered = typeRegistry?.get(node);
+    if (registered) {
+      typeRegistry!.set(result, registered);
+    }
+    return result;
+  };
+
+  return visit(typeNode);
+}
+
+/**
  * Builds TypeScript type elements from a capture tree structure.
  * Works for both nested properties within a tree node and root-level entries.
  * Recursively builds nested type literals for hierarchical captures.

--- a/packages/ts-transformers/src/ast/type-building.ts
+++ b/packages/ts-transformers/src/ast/type-building.ts
@@ -590,6 +590,36 @@ export function cloneTypeNode<T extends ts.TypeNode>(typeNode: T): T {
 }
 
 /**
+ * Resolve a source-positioned type-reference name to its commonfabric export
+ * name, or undefined when it is not a commonfabric export.
+ *
+ * Import aliases are resolved first, so `import { Default as D }` still
+ * reports `Default`. User-defined aliases over commonfabric types resolve to
+ * a symbol whose parent is the user's module, not commonfabric, and are
+ * deliberately left alone (rewriting them would drop their hidden type
+ * arguments — see qualifyCommonFabricTypeRefs).
+ */
+function commonFabricExportNameAtLocation(
+  name: ts.Identifier,
+  checker: ts.TypeChecker,
+): string | undefined {
+  try {
+    let symbol = checker.getSymbolAtLocation(name);
+    if (!symbol) return undefined;
+    if (symbol.flags & ts.SymbolFlags.Alias) {
+      symbol = checker.getAliasedSymbol(symbol);
+    }
+    const parent = (symbol as unknown as { parent?: ts.Symbol }).parent;
+    const parentName = parent?.name;
+    return parentName === "commonfabric" || parentName === '"commonfabric"'
+      ? symbol.name
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Deep-clones a TypeNode for emission, stripping source positions throughout.
  *
  * Declaration members resolved through a TypeReference may live in a different
@@ -600,10 +630,18 @@ export function cloneTypeNode<T extends ts.TypeNode>(typeNode: T): T {
  * to print structurally (literals fall back to their `.text`).
  *
  * Pass `typeRegistry` to carry each node's registered Type onto its clone.
+ *
+ * Pass `checker` to also qualify commonfabric refs to `__cfHelpers.X` while
+ * the original nodes still carry source positions. The declaration's imports
+ * (e.g. `Default`) are not necessarily in scope in the consumer file, and the
+ * type-level qualification pass cannot recover them afterwards: the checker
+ * normalizes conditional aliases like `Default<T, V>` away, so the paired
+ * type retains no commonfabric aliasSymbol to match on.
  */
 export function cloneTypeNodeDeepForEmission<T extends ts.TypeNode>(
   typeNode: T,
   typeRegistry?: WeakMap<ts.Node, ts.Type>,
+  checker?: ts.TypeChecker,
 ): T {
   const nullContext = (ts as typeof ts & {
     nullTransformationContext?: ts.TransformationContext;
@@ -624,6 +662,28 @@ export function cloneTypeNodeDeepForEmission<T extends ts.TypeNode>(
     ) as N;
     if (result === node) {
       result = cloneShallow(node);
+    }
+    // Qualify while the ORIGINAL node still has a position to resolve from;
+    // the cloned type arguments (already position-stripped) carry over.
+    if (
+      checker &&
+      ts.isTypeReferenceNode(node) &&
+      ts.isIdentifier(node.typeName) &&
+      node.typeName.pos >= 0
+    ) {
+      const exportName = commonFabricExportNameAtLocation(
+        node.typeName,
+        checker,
+      );
+      if (exportName) {
+        result = ts.factory.createTypeReferenceNode(
+          ts.factory.createQualifiedName(
+            ts.factory.createIdentifier("__cfHelpers"),
+            ts.factory.createIdentifier(exportName),
+          ),
+          (result as ts.Node as ts.TypeReferenceNode).typeArguments,
+        ) as ts.Node as N;
+      }
     }
     // update* calls copy the original's text range for source maps; strip it
     // so the printer treats the node as synthesized everywhere.

--- a/packages/ts-transformers/src/ast/type-inference.ts
+++ b/packages/ts-transformers/src/ast/type-inference.ts
@@ -498,6 +498,43 @@ function tryGetTypeFromTypeNodeDirect(
   }
 }
 
+/**
+ * Recover the declared type of a synthetic TypeReference via the symbol the
+ * checker's node builder attached to the synthesized typeName identifier.
+ *
+ * TypeReference nodes printed by `checker.typeToTypeNode` (e.g. the
+ * `EditableListItem` in a capture's inferred `{ items: EditableListItem[] }`)
+ * have no binder information, so `checker.getTypeFromTypeNode` resolves them
+ * to the error type. The node builder, however, stores the referenced symbol
+ * on the identifier it synthesizes — recover the type from there.
+ *
+ * Generic references are skipped: `getDeclaredTypeOfSymbol` would return the
+ * uninstantiated generic, whose members leak unsubstituted type parameters.
+ */
+function tryGetDeclaredTypeFromSynthesizedName(
+  typeNode: ts.TypeReferenceNode,
+  checker: ts.TypeChecker,
+): ts.Type | undefined {
+  if (typeNode.typeArguments?.length) return undefined;
+  const name = ts.isIdentifier(typeNode.typeName)
+    ? typeNode.typeName
+    : typeNode.typeName.right;
+  let symbol = (name as ts.Identifier & { symbol?: ts.Symbol }).symbol;
+  if (!symbol) return undefined;
+  try {
+    if (symbol.flags & ts.SymbolFlags.Alias) {
+      symbol = checker.getAliasedSymbol(symbol);
+    }
+    const declared = checker.getDeclaredTypeOfSymbol(symbol);
+    if ((declared as ts.InterfaceType).typeParameters?.length) {
+      return undefined;
+    }
+    return declared;
+  } catch {
+    return undefined;
+  }
+}
+
 function ensureCompositeChildTypesRegistered(
   typeNode: ts.TypeNode,
   checker: ts.TypeChecker,
@@ -557,6 +594,15 @@ function tryRegisterCompositeSyntheticType(
   }
 
   const internalChecker = checker as InternalTypeChecker;
+
+  if (ts.isTypeReferenceNode(typeNode)) {
+    const declared = tryGetDeclaredTypeFromSynthesizedName(typeNode, checker);
+    if (declared && !isAnyOrUnknownType(declared)) {
+      typeRegistry.set(typeNode, declared);
+      return declared;
+    }
+    return retried;
+  }
 
   if (ts.isParenthesizedTypeNode(typeNode)) {
     const inner = ensureTypeNodeRegistered(

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -4,6 +4,7 @@ import { spellingsWhere } from "@commonfabric/schema-generator/wrapper-names";
 import {
   cloneTypeNodeDeepForEmission,
   createRegisteredTypeLiteral,
+  qualifyCommonFabricTypeRefs,
   typeToTypeNodeWithRegistry,
 } from "../ast/type-building.ts";
 import { createPropertyName } from "../utils/identifiers.ts";
@@ -1269,8 +1270,20 @@ function buildShrunkTypeNodeFromTypeNode(
       // different source file than the one being emitted. Deep-clone the
       // result position-free so literal types (e.g. `Default<string, "">`)
       // print from their own text instead of extracting garbage tokens from
-      // the emit file by position.
-      return cloneTypeNodeDeepForEmission(shrunk, typeRegistry);
+      // the emit file by position. Then qualify commonfabric refs to
+      // `__cfHelpers.X` — the declaration's imports (e.g. `Default`) are not
+      // necessarily in scope in the consumer file, and this branch otherwise
+      // bypasses the normalization typeToTypeNodeWithRegistry applies.
+      const cloned = cloneTypeNodeDeepForEmission(
+        shrunk,
+        typeRegistry,
+        checker,
+      );
+      return qualifyCommonFabricTypeRefs(cloned, typeRegistry?.get(cloned), {
+        checker,
+        factory,
+        typeRegistry,
+      });
     }
     // Could not resolve to concrete members — let the caller fall back.
     return undefined;

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -2,6 +2,7 @@ import ts from "typescript";
 import { getPropertyNameText } from "@commonfabric/schema-generator/property-name";
 import { spellingsWhere } from "@commonfabric/schema-generator/wrapper-names";
 import {
+  cloneTypeNodeDeepForEmission,
   createRegisteredTypeLiteral,
   typeToTypeNodeWithRegistry,
 } from "../ast/type-building.ts";
@@ -1264,7 +1265,12 @@ function buildShrunkTypeNodeFromTypeNode(
       if (isUnchangedShrink(members, shrunk)) {
         return node;
       }
-      return shrunk;
+      // The projection reuses declaration member nodes, which may live in a
+      // different source file than the one being emitted. Deep-clone the
+      // result position-free so literal types (e.g. `Default<string, "">`)
+      // print from their own text instead of extracting garbage tokens from
+      // the emit file by position.
+      return cloneTypeNodeDeepForEmission(shrunk, typeRegistry);
     }
     // Could not resolve to concrete members — let the caller fall back.
     return undefined;

--- a/packages/ts-transformers/test/ast/type-building.test.ts
+++ b/packages/ts-transformers/test/ast/type-building.test.ts
@@ -1,0 +1,57 @@
+import { assertEquals, assertStrictEquals } from "@std/assert";
+import ts from "typescript";
+
+import { cloneTypeNodeDeepForEmission } from "../../src/ast/type-building.ts";
+
+// The printer extracts literal text by source position from the file it is
+// printing. A declaration member's type node reused in ANOTHER file therefore
+// emits garbage tokens for literal types (e.g. the `""` in
+// `Default<string, "">` printed as whatever sits at those offsets in the emit
+// file). cloneTypeNodeDeepForEmission strips positions throughout so literals
+// print from their own `.text`.
+Deno.test("cloneTypeNodeDeepForEmission prints cross-file literal types from their own text", () => {
+  const declarationFile = ts.createSourceFile(
+    "declaration.ts",
+    `interface I { label: Default<string, "default-text">; }`,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+  );
+  const iface = declarationFile.statements[0] as ts.InterfaceDeclaration;
+  const member = iface.members[0] as ts.PropertySignature;
+  const typeNode = member.type!;
+
+  // A different, shorter emit file: position-based extraction cannot
+  // reproduce the literal from here.
+  const emitFile = ts.createSourceFile(
+    "emit.ts",
+    "export {};",
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+  );
+  const printer = ts.createPrinter({ removeComments: true });
+
+  const cloned = cloneTypeNodeDeepForEmission(typeNode);
+  const printed = printer.printNode(ts.EmitHint.Unspecified, cloned, emitFile);
+
+  assertEquals(printed, `Default<string, "default-text">`);
+});
+
+Deno.test("cloneTypeNodeDeepForEmission carries typeRegistry entries onto clones", () => {
+  const declarationFile = ts.createSourceFile(
+    "declaration.ts",
+    `interface I { label: Default<string, "x">; }`,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+  );
+  const iface = declarationFile.statements[0] as ts.InterfaceDeclaration;
+  const member = iface.members[0] as ts.PropertySignature;
+  const typeNode = member.type!;
+
+  const fakeType = { flags: ts.TypeFlags.String } as ts.Type;
+  const typeRegistry = new WeakMap<ts.Node, ts.Type>();
+  typeRegistry.set(typeNode, fakeType);
+
+  const cloned = cloneTypeNodeDeepForEmission(typeNode, typeRegistry);
+
+  assertStrictEquals(typeRegistry.get(cloned), fakeType);
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-factory-result-projection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-factory-result-projection.expected.jsx
@@ -105,7 +105,7 @@ const List = pattern(() => {
 const __cfLift_2 = __cfHelpers.lift<{
     list: {
         items: {
-            done: boolean | Default<false>;
+            done: boolean | __cfHelpers.Default<false>;
         }[];
     };
 }, boolean>(({ list }) => list.items[0]?.done === true, {
@@ -138,7 +138,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 const __cfLift_3 = __cfHelpers.lift<{
     list: {
         items: {
-            label: Default<string, "">;
+            label: __cfHelpers.Default<string, "">;
         }[];
     };
 }, boolean>(({ list }) => list.items[2]?.label === "Gamma", {

--- a/packages/ts-transformers/test/fixtures/closures/computed-factory-result-projection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-factory-result-projection.expected.jsx
@@ -1,0 +1,253 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { computed, Default, NAME, pattern } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface ListItem {
+    id: string;
+    done: boolean | Default<false>;
+    label: Default<string, "">;
+    // deno-lint-ignore no-explicit-any
+    [extra: string]: any;
+}
+interface ListOutput {
+    [NAME]: string;
+    items: ListItem[];
+    total: number;
+}
+interface ListInput {
+    seed?: Default<string, "">;
+}
+const __cfLift_1 = __cfHelpers.lift<{
+    items: {
+        length: number;
+    };
+}, number>(({ items }) => items.length, {
+    type: "object",
+    properties: {
+        items: {
+            type: "object",
+            properties: {
+                length: {
+                    type: "number"
+                }
+            },
+            required: ["length"]
+        }
+    },
+    required: ["items"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema);
+const List = pattern(() => {
+    const items: ListItem[] = [];
+    return {
+        [NAME]: "list",
+        items,
+        total: __cfLift_1({ items: {
+                length: items.length
+            } }),
+    };
+}, {
+    type: "object",
+    properties: {
+        seed: {
+            type: "string",
+            "default": ""
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/ListItem"
+            }
+        },
+        total: {
+            type: "number"
+        },
+        $NAME: {
+            type: "string"
+        }
+    },
+    required: ["items", "total", "$NAME"],
+    $defs: {
+        ListItem: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                done: {
+                    type: "boolean",
+                    "default": false
+                },
+                label: {
+                    type: "string",
+                    "default": ""
+                }
+            },
+            additionalProperties: true,
+            required: ["id", "done", "label"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_2 = __cfHelpers.lift<{
+    list: {
+        items: {
+            done: boolean | Default<false>;
+        }[];
+    };
+}, boolean>(({ list }) => list.items[0]?.done === true, {
+    type: "object",
+    properties: {
+        list: {
+            type: "object",
+            properties: {
+                items: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: {
+                            done: {
+                                type: "boolean",
+                                "default": false
+                            }
+                        },
+                        required: ["done"]
+                    }
+                }
+            },
+            required: ["items"]
+        }
+    },
+    required: ["list"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_3 = __cfHelpers.lift<{
+    list: {
+        items: {
+            label: Default<string, "">;
+        }[];
+    };
+}, boolean>(({ list }) => list.items[2]?.label === "Gamma", {
+    type: "object",
+    properties: {
+        list: {
+            type: "object",
+            properties: {
+                items: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: {
+                            label: {
+                                type: "string",
+                                "default": ""
+                            }
+                        },
+                        required: ["label"]
+                    }
+                }
+            },
+            required: ["items"]
+        }
+    },
+    required: ["list"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_4 = __cfHelpers.lift<{
+    list: {
+        items: {
+            priority?: any;
+        }[];
+    };
+}, boolean>(({ list }) => list.items[2]?.priority === 9, {
+    type: "object",
+    properties: {
+        list: {
+            type: "object",
+            properties: {
+                items: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: {
+                            priority: true
+                        }
+                    }
+                }
+            },
+            required: ["items"]
+        }
+    },
+    required: ["list"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+// FIXTURE: computed-factory-result-projection
+// Pins lift-capture shrinking through an UNSTRIPPED factory result type (the
+// capture's inferred type node prints named interface references, which carry
+// their symbol only on the synthesized identifier — see
+// tryGetDeclaredTypeFromSynthesizedName). Two behaviors guarded here:
+//   1. A declared-key read projects through the named reference and keeps the
+//      authored `Default<...>` alias, so the schema keeps `"default"` (and
+//      the projected `Default<string, "">` literal prints from its own text;
+//      the cross-file variant of that print is unit-tested next to
+//      cloneTypeNodeDeepForEmission).
+//   2. An index-signature key read (`priority`) must NOT be marked required —
+//      items that legitimately omit the key would fail schema validation
+//      (main regression: editable-list assert_extra_passthrough).
+export default pattern(() => {
+    const list = List({});
+    const firstDone = __cfLift_2({ list: {
+            items: list.key("items")
+        } }).for("firstDone", true);
+    const labelGamma = __cfLift_3({ list: {
+            items: list.key("items")
+        } }).for("labelGamma", true);
+    const extraPassthrough = __cfLift_4({ list: {
+            items: list.key("items")
+        } }).for("extraPassthrough", true);
+    return {
+        firstDone,
+        labelGamma,
+        extraPassthrough,
+    };
+}, false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        firstDone: {
+            type: "boolean"
+        },
+        labelGamma: {
+            type: "boolean"
+        },
+        extraPassthrough: {
+            type: "boolean"
+        }
+    },
+    required: ["firstDone", "labelGamma", "extraPassthrough"]
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    List,
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-factory-result-projection.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-factory-result-projection.input.tsx
@@ -1,0 +1,55 @@
+import { computed, Default, NAME, pattern } from "commonfabric";
+
+interface ListItem {
+  id: string;
+  done: boolean | Default<false>;
+  label: Default<string, "">;
+  // deno-lint-ignore no-explicit-any
+  [extra: string]: any;
+}
+
+interface ListOutput {
+  [NAME]: string;
+  items: ListItem[];
+  total: number;
+}
+
+interface ListInput {
+  seed?: Default<string, "">;
+}
+
+const List = pattern<ListInput, ListOutput>(() => {
+  const items: ListItem[] = [];
+  return {
+    [NAME]: "list",
+    items,
+    total: computed(() => items.length),
+  };
+});
+
+// FIXTURE: computed-factory-result-projection
+// Pins lift-capture shrinking through an UNSTRIPPED factory result type (the
+// capture's inferred type node prints named interface references, which carry
+// their symbol only on the synthesized identifier — see
+// tryGetDeclaredTypeFromSynthesizedName). Two behaviors guarded here:
+//   1. A declared-key read projects through the named reference and keeps the
+//      authored `Default<...>` alias, so the schema keeps `"default"` (and
+//      the projected `Default<string, "">` literal prints from its own text;
+//      the cross-file variant of that print is unit-tested next to
+//      cloneTypeNodeDeepForEmission).
+//   2. An index-signature key read (`priority`) must NOT be marked required —
+//      items that legitimately omit the key would fail schema validation
+//      (main regression: editable-list assert_extra_passthrough).
+export default pattern(() => {
+  const list = List({});
+
+  const firstDone = computed(() => list.items[0]?.done === true);
+  const labelGamma = computed(() => list.items[2]?.label === "Gamma");
+  const extraPassthrough = computed(() => list.items[2]?.priority === 9);
+
+  return {
+    firstDone,
+    labelGamma,
+    extraPassthrough,
+  };
+});

--- a/packages/ts-transformers/test/fixtures/closures/pattern-preserve-opaque-input.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-preserve-opaque-input.expected.jsx
@@ -21,25 +21,17 @@ const __cfLift_1 = __cfHelpers.lift<{
     type: "object",
     properties: {
         input: {
-            $ref: "#/$defs/State",
-            asCell: ["readonly"]
-        }
-    },
-    required: ["input"],
-    $defs: {
-        State: {
             type: "object",
             properties: {
                 foo: {
                     type: "string"
-                },
-                bar: {
-                    type: "string"
                 }
             },
-            required: ["foo", "bar"]
+            required: ["foo"],
+            asCell: ["readonly"]
         }
-    }
+    },
+    required: ["input"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);


### PR DESCRIPTION
**Status: draft — overlaps work by @mathpirate; see comparison below.** Originally opened to unbreak main (Pattern Unit Tests 4/5, editable-list `assert_extra_passthrough`); #4071 landed the index-signature-optional fix first and main is green again — this PR is rebased on top of it and the duplicate hunk is dropped. (EditableList itself has since been retired on main, #4086, so the transformer behaviors are pinned by this PR's own fixture rather than that pattern's test.)

What remains here addresses the *second* #4017 regression (`Default<T,V>` values dropped from injected capture schemas — the same one #4077 targets) plus a general precision loss, by repairing the underlying mechanism instead of grafting values back:

## Root cause addressed

Since #4017, a consumer capture's inferred type node prints **named interface references** (`items: ListItem[]`). Synthesized references carry no binder info, so `getTypeFromTypeNode` resolves them to the error type — the node-driven shrink candidate goes blind, and the type-driven candidate (which cannot express `Default<T,V>`, see #4077's analysis) wins everywhere a named ref appears.

## Fix (two parts)

- **`type-inference.ts`** — `tryRegisterCompositeSyntheticType` gains a TypeReference branch recovering the declared type via the symbol the checker's node builder attaches to synthesized typeName identifiers (generics skipped, import aliases resolved). Node-driven shrinking projects through named refs again; the existing Default-containment preference rule then picks the projection that kept the **authored** `Default<...>` alias, so `"default"` emission returns via the same mechanism that produced it pre-#4017.
- **`type-building.ts`** — `cloneTypeNodeDeepForEmission`: projections reuse declaration member nodes, which can live in another source file; the printer extracts literal text by position from the emit file, producing the `Default<string, ve_>` garbage that #4077's design notes measured. A **position-stripped** deep clone at the TypeReference projection exit makes literals print from their own `.text` (unit-tested cross-file), with typeRegistry associations carried onto clones.

## Review feedback addressed (cubic + codex P2)

The projection exit now also **qualifies commonfabric refs to `__cfHelpers.X`**, two layers deep: the cloned projection runs through `qualifyCommonFabricTypeRefs` (ImportType forms + pairable refs), and the clone helper itself resolves authored typeNames via `getSymbolAtLocation` *while they still carry source positions* — necessary because the checker normalizes `Default<T,V>` away at the type level (probe-verified: the paired type is `boolean | (false & DefaultMarker<false>)`, no aliasSymbol left for the lockstep walk). Emitted annotations now read `__cfHelpers.Default<string, "">` — resolvable regardless of the consumer's imports, strictly better than the pre-#4017 baseline (which emitted these unqualified). Schemas are byte-identical; `containsDefaultTypeNode` already matches the qualified spelling, so candidate preference is unchanged.

## Relationship to #4077

Same regression, different layer: #4077 re-synthesizes the default *value* onto the type-driven leaf (narrow, no other goldens move); this PR re-enables the node-driven candidate so the authored alias survives end-to-end (broader: named-ref captures generally project again). Visible consequence: `pattern-preserve-opaque-input` re-pins — its lift schema kept the full `$ref: State` only because the named ref could not be resolved; it now narrows the readonly cell to the single key it reads. If both land, #4077's graft fixture would re-pin to the qualified-alias spelling on its leaf captures.

Deferring to @mathpirate on which shape to take (or both — they compose as defense-in-depth).

## Tests

- New fixture `computed-factory-result-projection`: declared-key projection keeps `"default"` through an unstripped factory result (type args pin the qualified `__cfHelpers.Default<...>` spelling); extras key stays non-required (pins #4071's behavior on the factory-result path too).
- Unit tests for `cloneTypeNodeDeepForEmission` (cross-file literal print, registry carry-over).

## Verification (rebased on `4d22dcdc5`)

- ts-transformers 294 passed; schema-generator 24 passed
- all five `pattern-tests` shards green locally; repo `deno task check` green; fmt/lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Perf-check overrides (proven CI noise)

Both flagged subtests were timed locally on this branch vs main (3×/2× runs): habit-tracker 1.30–1.34s vs main 1.30–1.60s, note-md 2.45s vs main 2.48s — no regression; the branch is marginally faster on note-md. The shard-4 suite total moved only +4.7% (within margin), and different subtests tripped on different rerun attempts. Job-level +97% on runtime-client already vanished on rerun.

NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/notes/note-md.test.tsx = 25s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/habit-tracker/habit-tracker.test.tsx = 12s