### PR TITLE
feat(html): vdom-level space — reconciler stamps each element's cell space

### DIFF
--- a/packages/html/src/main/applicator.ts
+++ b/packages/html/src/main/applicator.ts
@@ -13,6 +13,7 @@ import type { VDomBatch, VDomOp } from "../vdom-ops.ts";
 import { CellHandle, cellRefToKey } from "@commonfabric/runtime-client";
 import { setPropDefault, type SetPropHandler } from "../render-utils.ts";
 import { getLogger } from "@commonfabric/utils/logger";
+import { provideElementSpace } from "./space-context.ts";
 
 const logger = getLogger("vdom-applicator", { enabled: false, level: "debug" });
 
@@ -123,7 +124,7 @@ export class DomApplicator {
   private applyOp(op: VDomOp): void {
     switch (op.op) {
       case "create-element":
-        this.createElement(op.nodeId, op.tagName);
+        this.createElement(op.nodeId, op.tagName, op.space);
         break;
 
       case "create-text":
@@ -282,8 +283,11 @@ export class DomApplicator {
 
   // ============== Operation Implementations ==============
 
-  private createElement(nodeId: number, tagName: string): void {
+  private createElement(nodeId: number, tagName: string, space?: string): void {
     const element = this.document.createElement(tagName);
+    if (space !== undefined) {
+      provideElementSpace(element, space);
+    }
     this.nodes.set(nodeId, element);
   }
 

--- a/packages/html/src/main/mod.ts
+++ b/packages/html/src/main/mod.ts
@@ -9,6 +9,7 @@ export { createDomApplicator, DomApplicator } from "./applicator.ts";
 export type { DomApplicatorOptions } from "./applicator.ts";
 
 export { createVDomRenderer, renderVDom, VDomRenderer } from "./renderer.ts";
+export { provideElementSpace, SPACE_CONTEXT_KEY } from "./space-context.ts";
 export type { VDomRendererOptions } from "./renderer.ts";
 
 export {

--- a/packages/html/src/main/space-context.ts
+++ b/packages/html/src/main/space-context.ts
@@ -1,0 +1,34 @@
+/**
+ * The element-level "space" context: the worker reconciler stamps each
+ * create-element op with the space of the cell whose render produced it
+ * (elided when the parent's matches), and the applicator answers the
+ * standard context-request protocol for it here — dependency-free.
+ *
+ * The KEY is the string "space": @lit/context's createContext returns
+ * its key argument verbatim, so consumers built with
+ * createContext("space") (e.g. @commonfabric/ui's spaceContext) match
+ * this provider by value with no shared import. Nearest provider wins
+ * by event propagation, which is exactly right for cross-space
+ * transclusion: a transcluded subtree's boundary element answers
+ * before any outer piece or view provider.
+ */
+export const SPACE_CONTEXT_KEY = "space";
+
+type ContextRequestEvent = Event & {
+  context: unknown;
+  callback: (value: string | undefined, unsubscribe?: () => void) => void;
+  subscribe?: boolean;
+};
+
+export function provideElementSpace(element: EventTarget, space: string) {
+  element.addEventListener("context-request", (event) => {
+    const request = event as ContextRequestEvent;
+    if (request.context !== SPACE_CONTEXT_KEY) return;
+    if (typeof request.callback !== "function") return;
+    event.stopPropagation();
+    // The value is fixed for the element's lifetime (the reconciler
+    // replaces the element when its producing cell changes spaces), so
+    // a single callback satisfies both one-shot and subscribe modes.
+    request.callback(space, () => {});
+  });
+}

--- a/packages/html/src/vdom-ops.ts
+++ b/packages/html/src/vdom-ops.ts
@@ -14,6 +14,14 @@ export interface CreateElementOp {
   op: "create-element";
   nodeId: number;
   tagName: string;
+  /**
+   * The space of the cell whose render produced this element, present
+   * only when it differs from the nearest ancestor element that
+   * carried one. The applicator turns it into the element's context
+   * space, so components inside a rendered pattern act in the PIECE's
+   * space — correct across cross-space transclusion.
+   */
+  space?: string;
 }
 
 /**

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -143,6 +143,15 @@ export class WorkerReconciler {
    * @param vnode - The root VNode, Cell<VNode>, or Cell<unknown> to mount
    * @returns A cancel function to unmount the tree
    */
+  /** Best-effort space of a cell; undefined when it can't name one. */
+  private spaceOfCell(cell: Cell<unknown>): string | undefined {
+    try {
+      return cell.space;
+    } catch {
+      return undefined;
+    }
+  }
+
   mount(vnode: WorkerVNode | Cell<WorkerVNode> | Cell<unknown>): Cancel {
     logger.debug(
       "mount",
@@ -154,7 +163,11 @@ export class WorkerReconciler {
       this.rootCancel();
     }
 
-    const ctx = this.createContext();
+    let ctx = this.createContext();
+    if (isCell(vnode)) {
+      const rootSpace = this.spaceOfCell(vnode);
+      if (rootSpace) ctx = { ...ctx, space: rootSpace };
+    }
     const [cancel, addCancel] = useCancelGroup();
 
     // Handle Cell<VNode> at the root
@@ -2177,9 +2190,23 @@ export class WorkerReconciler {
       return null;
     }
 
-    // Create element
+    // Create element. Stamp the producing cell's space when it differs
+    // from the nearest ancestor element that carried one — descendants
+    // inherit, so transcluded subtrees re-stamp at their boundary.
+    const stampSpace = ctx.space !== undefined &&
+        ctx.space !== ctx.emittedSpace
+      ? ctx.space
+      : undefined;
     const nodeId = ctx.nextNodeId();
-    this.queueOps([{ op: "create-element", nodeId, tagName: sanitized.name }]);
+    this.queueOps([{
+      op: "create-element",
+      nodeId,
+      tagName: sanitized.name,
+      ...(stampSpace !== undefined ? { space: stampSpace } : {}),
+    }]);
+    if (stampSpace !== undefined) {
+      ctx = { ...ctx, emittedSpace: stampSpace };
+    }
     const childPolicy = this.childRenderPolicyForNode(
       sanitized,
       policy,
@@ -2888,6 +2915,12 @@ export class WorkerReconciler {
     childKey: string,
     policy: RenderPolicy,
   ): ChildNodeState {
+    // A followed cell is a (potential) transclusion boundary: its
+    // subtree renders in the CELL's space, not the surrounding one.
+    const cellSpace = this.spaceOfCell(cell);
+    if (cellSpace !== undefined && cellSpace !== ctx.space) {
+      ctx = { ...ctx, space: cellSpace };
+    }
     const [cancel, addCancel] = useCancelGroup();
 
     // Create child state that will track the current node

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -185,6 +185,20 @@ export interface ChildNodeState {
  * Context passed through the reconciliation process.
  */
 export interface ReconcileContext {
+  /**
+   * The space of the cell whose render produced the current subtree.
+   * Changes at cell-follow boundaries (renderCellChild) — including
+   * cross-space transclusion, where a piece renders another piece's UI.
+   */
+  space?: string;
+
+  /**
+   * The space stamped on the nearest ancestor create-element op.
+   * Elements only carry `space` when it differs from this (seefeldb's
+   * elision: leave it off when the parent's space is the same).
+   */
+  emittedSpace?: string;
+
   /** Function to emit VDOM operations */
   emit: (
     ops: import("../vdom-ops.ts").VDomOp[],

--- a/packages/html/test/worker-reconciler-space-stamp.test.ts
+++ b/packages/html/test/worker-reconciler-space-stamp.test.ts
@@ -1,0 +1,156 @@
+import { assertEquals } from "@std/assert";
+import { WorkerReconciler } from "../src/worker/reconciler.ts";
+import type { VDomOp } from "../src/vdom-ops.ts";
+import { provideElementSpace } from "../src/main/space-context.ts";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "@commonfabric/runner";
+
+// Space stamping (seefeldb's #4074 design): each create-element op
+// carries the space of the cell whose render produced it, elided when
+// the nearest stamped ancestor's space is the same — so cross-space
+// TRANSCLUSION re-stamps at its boundary and everything else inherits.
+
+function createOpsCollector() {
+  const allOps: VDomOp[] = [];
+  return {
+    onOps: (ops: VDomOp[]) => allOps.push(...ops),
+    creates: () =>
+      allOps.filter((op) => op.op === "create-element") as Array<
+        { op: string; nodeId: number; tagName: string; space?: string }
+      >,
+  };
+}
+
+Deno.test("worker reconciler - space stamping across transclusion", async (t) => {
+  const signer = await Identity.fromPassphrase("test space stamp");
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    storageManager,
+    apiUrl: new URL("http://localhost"),
+  });
+  const dummyTx = runtime.edit();
+  const dummyCell = runtime.getCell(signer.did(), "dummy", undefined, dummyTx);
+  const CellImplConstructor = dummyCell.constructor;
+
+  class MockCell extends (CellImplConstructor as any) {
+    #space: string;
+    constructor(public value: any, space: string) {
+      super(runtime, undefined, undefined, false, undefined, "cell");
+      this.value = value;
+      this.#space = space;
+    }
+    get space() {
+      return this.#space;
+    }
+    sink(callback: (value: any) => void) {
+      callback(this.value);
+      return () => {};
+    }
+    isStream() {
+      return false;
+    }
+    get() {
+      return this.value;
+    }
+    getAsNormalizedFullLink() {
+      return {
+        id: "of:mock",
+        space: this.#space,
+        path: [],
+        scope: "space",
+      };
+    }
+  }
+
+  const spaceA = "did:key:z6Mk-stamp-outer";
+  const spaceB = "did:key:z6Mk-stamp-transcluded";
+
+  await t.step(
+    "root stamps; same-space child elides; transcluded subtree re-stamps",
+    async () => {
+      const transcluded = new MockCell(
+        { type: "vnode", name: "span", props: {}, children: ["inner"] },
+        spaceB,
+      );
+      const root = new MockCell(
+        {
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: [
+            { type: "vnode", name: "p", props: {}, children: ["same"] },
+            transcluded,
+          ],
+        },
+        spaceA,
+      );
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({ onOps: collector.onOps });
+      const cancel = reconciler.mount(root as any);
+      await new Promise((resolve) => setTimeout(resolve, 0)); // op flush
+      const byTag = Object.fromEntries(
+        collector.creates().map((op) => [op.tagName, op.space]),
+      );
+      // Root element carries the mounting cell's space.
+      assertEquals(byTag["div"], spaceA);
+      // Same-space child inherits (elided).
+      assertEquals(byTag["p"], undefined);
+      // The transcluded cell's subtree re-stamps with ITS space.
+      assertEquals(byTag["span"], spaceB);
+      cancel();
+    },
+  );
+
+  await t.step("static mounts carry no space", async () => {
+    const collector = createOpsCollector();
+    const reconciler = new WorkerReconciler({ onOps: collector.onOps });
+    const cancel = reconciler.mount({
+      type: "vnode",
+      name: "div",
+      props: {},
+      children: [],
+    } as any);
+    await new Promise((resolve) => setTimeout(resolve, 0)); // op flush
+    assertEquals(collector.creates()[0].space, undefined);
+    cancel();
+  });
+
+  await runtime.dispose();
+  await storageManager.close();
+});
+
+Deno.test("provideElementSpace answers the context protocol for 'space'", () => {
+  const target = new EventTarget();
+  provideElementSpace(target, "did:key:z6Mk-ctx");
+  let received: string | undefined;
+  let stopped = false;
+  const event = Object.assign(
+    new Event("context-request", { bubbles: true }),
+    {
+      context: "space",
+      callback: (value: string | undefined) => {
+        received = value;
+      },
+    },
+  );
+  const origStop = event.stopPropagation.bind(event);
+  event.stopPropagation = () => {
+    stopped = true;
+    origStop();
+  };
+  target.dispatchEvent(event);
+  assertEquals(received, "did:key:z6Mk-ctx");
+  assertEquals(stopped, true);
+
+  // Other contexts pass through untouched.
+  let otherAnswered = false;
+  const other = Object.assign(new Event("context-request"), {
+    context: "runtime",
+    callback: () => {
+      otherAnswered = true;
+    },
+  });
+  target.dispatchEvent(other);
+  assertEquals(otherAnswered, false);
+});


### PR DESCRIPTION
## What

Your design from the #4074 review, implemented (closes #4079):

> *since in the reconciler in the worker everything lives on a cell, why not just copy the space id into each vdom element as FYI and that is then the context space. then optionally optimize by leaving it off if the parent node's space is the same. gets you a similar effect as [#4074] but naturally supports cross-space transclusion correctly.*

- **Worker**: `ReconcileContext` tracks the walk's current space — set at `mount` from the mounted cell, re-derived at every followed cell (`renderCellChild`, the transclusion boundary). `create-element` ops carry `space` only when it differs from the nearest stamped ancestor (your elision).
- **Main**: the applicator answers the standard `context-request` protocol for the `'space'` key on stamped elements — **dependency-free**: `createContext` returns its key verbatim, so `@commonfabric/ui`'s `spaceContext` consumers match by value with no shared import, and nearest-provider-wins by event propagation means a transcluded boundary element answers before any outer piece or view provider.
- $value-bound components still prefer their bound cell's space (unchanged since #4058) — this covers the stream/event-handler case that had no mechanism.

## Tests

Stamping across a transclusion boundary (root stamps, same-space child elides, transcluded subtree re-stamps); static mounts carry nothing; the context protocol round-trip (answers `'space'`, ignores other context keys, stops propagation). Full check/lint/fmt green; html (31), ui (36), runtime-client (15) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stamp the producing cell’s space onto each created vDOM element and expose it as the "space" context, so components render in the correct space across cross-space transclusion without extra providers.

- New Features
  - Worker reconciler tracks the current cell `space` and stamps `create-element` ops only when it differs from the nearest stamped ancestor (elision). Space is set at mount from the root cell and re-derived at followed cell boundaries.
  - Main applicator sets element `space` on creation and answers `'context-request'` for `'space'` via `provideElementSpace` (exported with `SPACE_CONTEXT_KEY`); works with `@commonfabric/ui` consumers using `createContext('space')` without a shared import.
  - API updates: `CreateElementOp` adds optional `space`; `ReconcileContext` adds `space` and `emittedSpace`.

<sup>Written for commit 9005755473729fd25d98c5bdf21c3049e858c904. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

