### PR TITLE
feat(pattern-imports): implement fabric imports plan

### DIFF
--- a/packages/cli/commands/deps.ts
+++ b/packages/cli/commands/deps.ts
@@ -1,5 +1,8 @@
 import { Command } from "@cliffy/command";
+import { dirname, join } from "@std/path";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { loadManager } from "../lib/piece.ts";
+import { collectLocalProgram } from "../lib/dev.ts";
 import { parseSpaceOptions } from "./piece.ts";
 import {
   pinProgramFabricImports,
@@ -40,19 +43,29 @@ export const deps = new Command()
     const config = parseSpaceOptions(options);
     const manager = await loadManager(config);
     const filePath = absPath(file);
-    const contents = await Deno.readTextFile(filePath);
+    // Walk the whole local program (the same walk cf dev/check uses), so pins
+    // in sibling files the entry imports are updated too, not just the entry.
+    const fsRoot = dirname(filePath);
+    const resolver = new FileSystemProgramResolver(filePath);
+    const program = await collectLocalProgram(resolver, {
+      fabricImports: "allow",
+    });
+    const originals = new Map(
+      program.files.map(({ name, contents }) => [name, contents]),
+    );
     const result = await pinProgramFabricImports(
       manager.runtime,
       manager.getSpace(),
-      {
-        main: filePath,
-        files: [{ name: filePath, contents }],
-      },
+      program,
       { importSpecifier: options.import },
     );
 
     for (const rewrite of result.rewrites) {
-      render(`${file}:${rewrite.line} ${renderPinRewrite(rewrite)}`);
+      render(
+        `${join(fsRoot, rewrite.file.slice(1))}:${rewrite.line} ${
+          renderPinRewrite(rewrite)
+        }`,
+      );
     }
 
     if (options.check && result.rewrites.length > 0) {
@@ -61,7 +74,11 @@ export const deps = new Command()
       );
     }
 
-    if (!options.check && result.rewrites.length > 0) {
-      await Deno.writeTextFile(filePath, result.program.files[0].contents);
+    if (!options.check) {
+      for (const { name, contents } of result.program.files) {
+        if (originals.get(name) !== contents) {
+          await Deno.writeTextFile(join(fsRoot, name.slice(1)), contents);
+        }
+      }
     }
   });

--- a/packages/cli/commands/deps.ts
+++ b/packages/cli/commands/deps.ts
@@ -12,7 +12,10 @@ import { absPath } from "../lib/utils.ts";
 import { render } from "../lib/render.ts";
 import { cliText } from "../lib/cli-name.ts";
 
-export const deps = new Command()
+// Typed as Command<any> because cliffy's accumulated option generics don't
+// survive registration in main.ts (same idiom as createDevCommand).
+// deno-lint-ignore no-explicit-any
+export const deps: Command<any> = new Command()
   .name("deps")
   .description("Manage fabric import dependencies.")
   .default("help")

--- a/packages/cli/commands/deps.ts
+++ b/packages/cli/commands/deps.ts
@@ -1,0 +1,67 @@
+import { Command } from "@cliffy/command";
+import { loadManager } from "../lib/piece.ts";
+import { parseSpaceOptions } from "./piece.ts";
+import {
+  pinProgramFabricImports,
+  renderPinRewrite,
+} from "../lib/fabric-deps.ts";
+import { absPath } from "../lib/utils.ts";
+import { render } from "../lib/render.ts";
+import { cliText } from "../lib/cli-name.ts";
+
+export const deps = new Command()
+  .name("deps")
+  .description("Manage fabric import dependencies.")
+  .default("help")
+  .globalOption(
+    "-u,--url <url:string>",
+    "URL representing a host, space, and piece.",
+  )
+  .globalEnv("CF_API_URL=<url:string>", "URL of the fabric instance.", {
+    prefix: "CF_",
+  })
+  .globalOption("-a,--api-url <url:string>", "URL of the fabric instance.")
+  .globalEnv("CF_IDENTITY=<path:string>", "Path to an identity keyfile.", {
+    prefix: "CF_",
+  })
+  .globalOption("-i,--identity <path:string>", "Path to an identity keyfile.")
+  .globalOption("-s,--space <space:string>", "The space name or DID")
+  .command("update", "Pin mutable fabric imports in a local source file.")
+  .arguments("<file:string>")
+  .option(
+    "--import <specifier:string>",
+    "Only update one matching import specifier.",
+  )
+  .option(
+    "--check",
+    "Exit non-zero if any pin would change without writing the file.",
+  )
+  .action(async (options, file) => {
+    const config = parseSpaceOptions(options);
+    const manager = await loadManager(config);
+    const filePath = absPath(file);
+    const contents = await Deno.readTextFile(filePath);
+    const result = await pinProgramFabricImports(
+      manager.runtime,
+      manager.getSpace(),
+      {
+        main: filePath,
+        files: [{ name: filePath, contents }],
+      },
+      { importSpecifier: options.import },
+    );
+
+    for (const rewrite of result.rewrites) {
+      render(`${file}:${rewrite.line} ${renderPinRewrite(rewrite)}`);
+    }
+
+    if (options.check && result.rewrites.length > 0) {
+      throw new Error(
+        cliText("fabric dependencies are not pinned; run cf deps update"),
+      );
+    }
+
+    if (!options.check && result.rewrites.length > 0) {
+      await Deno.writeTextFile(filePath, result.program.files[0].contents);
+    }
+  });

--- a/packages/cli/commands/dev.ts
+++ b/packages/cli/commands/dev.ts
@@ -38,6 +38,7 @@ async function devAction(
     verboseErrors?: boolean;
     patternJson?: boolean;
     root?: string;
+    space?: string;
   },
   ...files: string[]
 ) {
@@ -60,6 +61,7 @@ async function devAction(
         showTransformed: options.showTransformed,
         mainExport: options.mainExport,
         verboseErrors: options.verboseErrors,
+        space: options.space,
       });
       // Only print JSON output when --pattern-json is used
       // (and not when --show-transformed is used, as that already prints to stdout)
@@ -150,9 +152,10 @@ function createDevCommand(cmdName: string): Command<any> {
       "--root <path:string>",
       "Root directory for resolving imports. Allows imports from parent directories within this root.",
     )
-    // TODO(M2): add explicit space selection for fabric imports when CLI
-    // dependency pinning/update support lands. M1 intentionally does not add
-    // a new --space flag.
+    .option(
+      "--space <did:string>",
+      "Space DID for resolving fabric imports.",
+    )
     .arguments("<files...:string>")
     .action(devAction);
 }

--- a/packages/cli/commands/dev.ts
+++ b/packages/cli/commands/dev.ts
@@ -150,6 +150,9 @@ function createDevCommand(cmdName: string): Command<any> {
       "--root <path:string>",
       "Root directory for resolving imports. Allows imports from parent directories within this root.",
     )
+    // TODO(M2): add explicit space selection for fabric imports when CLI
+    // dependency pinning/update support lands. M1 intentionally does not add
+    // a new --space flag.
     .arguments("<files...:string>")
     .action(devAction);
 }

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -2,6 +2,7 @@ import { Command } from "@cliffy/command";
 import { HelpCommand } from "@cliffy/command/help";
 import { acl } from "./acl.ts";
 import { check, dev } from "./dev.ts";
+import { deps } from "./deps.ts";
 import { exec } from "./exec.ts";
 import { fuse } from "./fuse.ts";
 import { init } from "./init.ts";
@@ -70,6 +71,7 @@ export const main = new Command()
   .command("piece", piece)
   .command("check", check)
   .command("dev", dev)
+  .command("deps", deps)
   .command("exec", exec)
   // @ts-ignore for the above type issue
   .command("fuse", fuse)

--- a/packages/cli/fixtures/fabric-import.tsx
+++ b/packages/cli/fixtures/fabric-import.tsx
@@ -1,0 +1,3 @@
+import imported from "cf:pattern:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+export default imported;

--- a/packages/cli/fixtures/fabric-import.tsx
+++ b/packages/cli/fixtures/fabric-import.tsx
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file no-external-import -- the cf: specifier IS the fixture
 import imported from "cf:pattern:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
 export default imported;

--- a/packages/cli/lib/dev.ts
+++ b/packages/cli/lib/dev.ts
@@ -8,8 +8,9 @@ import {
 } from "@commonfabric/js-compiler";
 import { TARGET } from "@commonfabric/js-compiler/typescript";
 import { Identity } from "@commonfabric/identity";
-import { Runtime } from "@commonfabric/runner";
+import { type MemorySpace, Runtime } from "@commonfabric/runner";
 import { experimentalOptionsFromEnv } from "./utils.ts";
+import { renderPinRewrite } from "./fabric-deps.ts";
 
 const FABRIC_IMPORTS_REQUIRE_SPACE_MESSAGE =
   "fabric imports require a space context (options.fabricImports)";
@@ -37,6 +38,7 @@ export interface ProcessOptions {
   showTransformed?: boolean;
   mainExport?: string;
   verboseErrors?: boolean;
+  space?: string;
 }
 
 export async function process(
@@ -54,22 +56,43 @@ export async function process(
     options.main,
     options.rootPath,
   );
-  await assertNoFabricImportsWithoutSpace(resolver);
-  const program = await engine.resolve(resolver);
+  const program = options.space
+    ? await resolveLocalProgramAllowingFabric(resolver)
+    : await engine.resolve(await assertNoFabricImportsWithoutSpace(resolver));
   if (options.mainExport) {
     program.mainExport = options.mainExport;
   }
   const getTransformedProgram = options.showTransformed
     ? renderTransformed
     : undefined;
-  const { id, graph, mainSpecifier } = await engine.compileToRecordGraph(
-    program,
-    {
-      noCheck: !options.check,
-      getTransformedProgram,
-      verboseErrors: options.verboseErrors,
-    },
-  );
+  const { id, graph, mainSpecifier, resolvedPins } = await engine
+    .compileToRecordGraph(
+      program,
+      {
+        noCheck: !options.check,
+        getTransformedProgram,
+        verboseErrors: options.verboseErrors,
+        fabricImports: options.space
+          ? {
+            space: options.space as MemorySpace,
+            allowUnpinned: true,
+          }
+          : undefined,
+      },
+    );
+  for (const pin of resolvedPins) {
+    console.error(
+      `${
+        renderPinRewrite({
+          file: program.main,
+          line: 0,
+          pinned: `${pin.specifier}@${pin.resolvedIdentity}`,
+          specifier: pin.specifier,
+          resolvedIdentity: pin.resolvedIdentity,
+        })
+      } (not pinned - deploy or run cf deps update)`,
+    );
+  }
 
   // Concatenated per-module compiled bodies (the same composition the SES
   // loader evaluates), for inspection via --output.
@@ -102,7 +125,7 @@ function renderTransformed(program: Program) {
 
 async function assertNoFabricImportsWithoutSpace(
   resolver: ProgramResolver,
-): Promise<void> {
+): Promise<ProgramResolver> {
   const main = await resolver.main();
   const pending = [main];
   const seen = new Set<string>();
@@ -125,6 +148,36 @@ async function assertNoFabricImportsWithoutSpace(
       if (resolved !== undefined) pending.push(resolved);
     }
   }
+  return resolver;
+}
+
+async function resolveLocalProgramAllowingFabric(
+  resolver: ProgramResolver,
+): Promise<Program> {
+  const main = await resolver.main();
+  const pending = [main];
+  const seen = new Set<string>();
+  const files: Source[] = [];
+
+  while (pending.length > 0) {
+    const source = pending.shift()!;
+    if (seen.has(source.name)) continue;
+    seen.add(source.name);
+    files.push(source);
+
+    for (const specifier of collectImportSpecifiers(source, TARGET)) {
+      if (isFabricImportSpecifier(specifier)) continue;
+
+      const identifier = resolveImportSpecifier(specifier, source);
+      if (!isFileSystemSourceIdentifier(identifier) || seen.has(identifier)) {
+        continue;
+      }
+      const resolved = await resolver.resolveSource(identifier);
+      if (resolved !== undefined) pending.push(resolved);
+    }
+  }
+
+  return { main: main.name, files };
 }
 
 function isFabricImportSpecifier(specifier: string): boolean {

--- a/packages/cli/lib/dev.ts
+++ b/packages/cli/lib/dev.ts
@@ -1,8 +1,18 @@
-import { Program } from "@commonfabric/js-compiler";
-import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import {
+  collectImportSpecifiers,
+  FileSystemProgramResolver,
+  type Program,
+  type ProgramResolver,
+  resolveImportSpecifier,
+  type Source,
+} from "@commonfabric/js-compiler";
+import { TARGET } from "@commonfabric/js-compiler/typescript";
 import { Identity } from "@commonfabric/identity";
 import { Runtime } from "@commonfabric/runner";
 import { experimentalOptionsFromEnv } from "./utils.ts";
+
+const FABRIC_IMPORTS_REQUIRE_SPACE_MESSAGE =
+  "fabric imports require a space context (options.fabricImports)";
 
 async function createRuntime() {
   const { StorageManager } = await import(
@@ -40,9 +50,12 @@ export async function process(
   // that state, so `fn.src` stays a raw bundle coordinate and CFC verified-
   // binding identities (writeAuthorizedBy) fail under enforcement.
   const engine = runtime.harness;
-  const program = await engine.resolve(
-    new FileSystemProgramResolver(options.main, options.rootPath),
+  const resolver = new FileSystemProgramResolver(
+    options.main,
+    options.rootPath,
   );
+  await assertNoFabricImportsWithoutSpace(resolver);
+  const program = await engine.resolve(resolver);
   if (options.mainExport) {
     program.mainExport = options.mainExport;
   }
@@ -85,4 +98,41 @@ function renderTransformed(program: Program) {
     console.log(`// transformed: ${name}`);
     console.log(contents);
   }
+}
+
+async function assertNoFabricImportsWithoutSpace(
+  resolver: ProgramResolver,
+): Promise<void> {
+  const main = await resolver.main();
+  const pending = [main];
+  const seen = new Set<string>();
+
+  while (pending.length > 0) {
+    const source = pending.shift()!;
+    if (seen.has(source.name)) continue;
+    seen.add(source.name);
+
+    for (const specifier of collectImportSpecifiers(source, TARGET)) {
+      if (isFabricImportSpecifier(specifier)) {
+        throw new Error(FABRIC_IMPORTS_REQUIRE_SPACE_MESSAGE);
+      }
+
+      const identifier = resolveImportSpecifier(specifier, source);
+      if (!isFileSystemSourceIdentifier(identifier) || seen.has(identifier)) {
+        continue;
+      }
+      const resolved = await resolver.resolveSource(identifier);
+      if (resolved !== undefined) pending.push(resolved);
+    }
+  }
+}
+
+function isFabricImportSpecifier(specifier: string): boolean {
+  return specifier.startsWith("cf:");
+}
+
+function isFileSystemSourceIdentifier(
+  identifier: string,
+): identifier is Source["name"] {
+  return identifier.startsWith("/");
 }

--- a/packages/cli/lib/dev.ts
+++ b/packages/cli/lib/dev.ts
@@ -8,9 +8,13 @@ import {
 } from "@commonfabric/js-compiler";
 import { TARGET } from "@commonfabric/js-compiler/typescript";
 import { Identity } from "@commonfabric/identity";
-import { type MemorySpace, Runtime } from "@commonfabric/runner";
+import {
+  type MemorySpace,
+  parseFabricRef,
+  Runtime,
+  type RuntimeProgram,
+} from "@commonfabric/runner";
 import { experimentalOptionsFromEnv } from "./utils.ts";
-import { renderPinRewrite } from "./fabric-deps.ts";
 
 const FABRIC_IMPORTS_REQUIRE_SPACE_MESSAGE =
   "fabric imports require a space context (options.fabricImports)";
@@ -56,9 +60,15 @@ export async function process(
     options.main,
     options.rootPath,
   );
-  const program = options.space
-    ? await resolveLocalProgramAllowingFabric(resolver)
-    : await engine.resolve(await assertNoFabricImportsWithoutSpace(resolver));
+  let program: RuntimeProgram;
+  if (options.space) {
+    program = await collectLocalProgram(resolver, { fabricImports: "allow" });
+  } else {
+    // engine.resolve fails fabric specifiers as generic unresolved modules;
+    // scan first so they get the friendlier requires-a-space message.
+    await collectLocalProgram(resolver, { fabricImports: "reject" });
+    program = await engine.resolve(resolver);
+  }
   if (options.mainExport) {
     program.mainExport = options.mainExport;
   }
@@ -82,15 +92,7 @@ export async function process(
     );
   for (const pin of resolvedPins) {
     console.error(
-      `${
-        renderPinRewrite({
-          file: program.main,
-          line: 0,
-          pinned: `${pin.specifier}@${pin.resolvedIdentity}`,
-          specifier: pin.specifier,
-          resolvedIdentity: pin.resolvedIdentity,
-        })
-      } (not pinned - deploy or run cf deps update)`,
+      `resolved ${pin.specifier} -> @${pin.resolvedIdentity} (not pinned; deploy or run cf deps update to pin)`,
     );
   }
 
@@ -123,36 +125,16 @@ function renderTransformed(program: Program) {
   }
 }
 
-async function assertNoFabricImportsWithoutSpace(
+/**
+ * Walk a local resolver's import graph into a Program, leaving fabric (cf:)
+ * specifiers to the engine's FabricAwareResolver. Malformed cf: specifiers
+ * fail here with their parse error; valid ones either pass through
+ * (`"allow"`) or trigger the requires-a-space error (`"reject"`, for compiles
+ * with no fabric context). Shared by `cf dev`/`cf check` and `cf deps`.
+ */
+export async function collectLocalProgram(
   resolver: ProgramResolver,
-): Promise<ProgramResolver> {
-  const main = await resolver.main();
-  const pending = [main];
-  const seen = new Set<string>();
-
-  while (pending.length > 0) {
-    const source = pending.shift()!;
-    if (seen.has(source.name)) continue;
-    seen.add(source.name);
-
-    for (const specifier of collectImportSpecifiers(source, TARGET)) {
-      if (isFabricImportSpecifier(specifier)) {
-        throw new Error(FABRIC_IMPORTS_REQUIRE_SPACE_MESSAGE);
-      }
-
-      const identifier = resolveImportSpecifier(specifier, source);
-      if (!isFileSystemSourceIdentifier(identifier) || seen.has(identifier)) {
-        continue;
-      }
-      const resolved = await resolver.resolveSource(identifier);
-      if (resolved !== undefined) pending.push(resolved);
-    }
-  }
-  return resolver;
-}
-
-async function resolveLocalProgramAllowingFabric(
-  resolver: ProgramResolver,
+  options: { fabricImports: "allow" | "reject" },
 ): Promise<Program> {
   const main = await resolver.main();
   const pending = [main];
@@ -166,7 +148,13 @@ async function resolveLocalProgramAllowingFabric(
     files.push(source);
 
     for (const specifier of collectImportSpecifiers(source, TARGET)) {
-      if (isFabricImportSpecifier(specifier)) continue;
+      if (specifier.startsWith("cf:")) {
+        parseFabricRef(specifier); // malformed → FabricRefError, here
+        if (options.fabricImports === "reject") {
+          throw new Error(FABRIC_IMPORTS_REQUIRE_SPACE_MESSAGE);
+        }
+        continue;
+      }
 
       const identifier = resolveImportSpecifier(specifier, source);
       if (!isFileSystemSourceIdentifier(identifier) || seen.has(identifier)) {
@@ -178,10 +166,6 @@ async function resolveLocalProgramAllowingFabric(
   }
 
   return { main: main.name, files };
-}
-
-function isFabricImportSpecifier(specifier: string): boolean {
-  return specifier.startsWith("cf:");
 }
 
 function isFileSystemSourceIdentifier(

--- a/packages/cli/lib/fabric-deps.ts
+++ b/packages/cli/lib/fabric-deps.ts
@@ -1,0 +1,65 @@
+import {
+  type MemorySpace,
+  resolveFabricRefToIdentity,
+  rewriteFabricPins,
+  type Runtime,
+  type RuntimeProgram,
+} from "@commonfabric/runner";
+
+export interface ProgramFabricPinRewrite {
+  file: string;
+  specifier: string;
+  pinned: string;
+  resolvedIdentity: string;
+  line: number;
+}
+
+export interface PinProgramOptions {
+  importSpecifier?: string;
+}
+
+export async function pinProgramFabricImports(
+  runtime: Runtime,
+  space: MemorySpace,
+  program: RuntimeProgram,
+  options: PinProgramOptions = {},
+): Promise<{ program: RuntimeProgram; rewrites: ProgramFabricPinRewrite[] }> {
+  const rewrites: ProgramFabricPinRewrite[] = [];
+  const files = [];
+
+  for (const file of program.files) {
+    const resolvedBySpecifier = new Map<string, string>();
+    const rewritten = await rewriteFabricPins(
+      file.contents,
+      async (ref, specifier) => {
+        if (
+          options.importSpecifier !== undefined &&
+          specifier !== options.importSpecifier
+        ) {
+          return null;
+        }
+        const resolved = await resolveFabricRefToIdentity(runtime, space, ref);
+        resolvedBySpecifier.set(specifier, resolved.entryIdentity);
+        return resolved.entryIdentity;
+      },
+    );
+
+    for (const rewrite of rewritten.rewrites) {
+      rewrites.push({
+        file: file.name,
+        ...rewrite,
+        resolvedIdentity: resolvedBySpecifier.get(rewrite.specifier)!,
+      });
+    }
+    files.push({ ...file, contents: rewritten.contents });
+  }
+
+  return {
+    program: { ...program, files },
+    rewrites,
+  };
+}
+
+export function renderPinRewrite(rewrite: ProgramFabricPinRewrite): string {
+  return `pinned ${rewrite.specifier} -> @${rewrite.resolvedIdentity}`;
+}

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -26,6 +26,7 @@ import { dirname, join } from "@std/path";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { setLLMUrl } from "@commonfabric/llm";
 import { isRecord } from "@commonfabric/utils/types";
+import { pinProgramFabricImports, renderPinRewrite } from "./fabric-deps.ts";
 import { isHandlerCell } from "../../fuse/callables.ts";
 import { awaitSyncWithTimeout, experimentalOptionsFromEnv } from "./utils.ts";
 import {
@@ -271,7 +272,7 @@ export async function loadManager(config: SpaceConfig): Promise<PieceManager> {
   });
 }
 
-async function getProgramFromFile(
+export async function getProgramFromFile(
   manager: PieceManager,
   entry: EntryConfig,
 ): Promise<RuntimeProgram> {
@@ -282,6 +283,22 @@ async function getProgramFromFile(
     program.mainExport = entry.mainExport;
   }
   return program;
+}
+
+async function getPinnedProgramFromFile(
+  manager: PieceManager,
+  entry: EntryConfig,
+): Promise<RuntimeProgram> {
+  const program = await getProgramFromFile(manager, entry);
+  const result = await pinProgramFabricImports(
+    manager.runtime,
+    manager.getSpace(),
+    program,
+  );
+  for (const rewrite of result.rewrites) {
+    console.error(renderPinRewrite(rewrite));
+  }
+  return result.program;
 }
 
 // Returns an array of metadata about pieces to display.
@@ -393,7 +410,7 @@ export async function newPiece(
 
   const program = await timeCliPhase(
     "newPiece.getProgramFromFile",
-    () => getProgramFromFile(manager, entry),
+    () => getPinnedProgramFromFile(manager, entry),
   );
   const PIECE_START_TIMEOUT_MS = 60_000;
   const piece = await timeCliPhase("newPiece.create", () => {
@@ -494,7 +511,7 @@ export async function setPiecePattern(
     undefined,
     resolvedConfig.pieceScope,
   );
-  await piece.setPattern(await getProgramFromFile(manager, entry));
+  await piece.setPattern(await getPinnedProgramFromFile(manager, entry));
 }
 
 export async function savePiecePattern(

--- a/packages/cli/test/dev.test.ts
+++ b/packages/cli/test/dev.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { bytesToLines, cf, checkStderr } from "./utils.ts";
+import { bytesToLines, cf, checkStderr, stripAnsi } from "./utils.ts";
 
 describe("cli dev", () => {
   it("Executes a package", async () => {
@@ -73,5 +73,19 @@ describe("cli dev", () => {
     checkStderr(stderr);
     expect(stdout[stdout.length - 1]).toBe("25");
     expect(code).toBe(0);
+  });
+
+  it("surfaces fabric imports without a space as a CLI compile error", async () => {
+    const { code, stdout, stderr } = await cf(
+      "check fixtures/fabric-import.tsx --no-run",
+    );
+    const renderedStderr = stripAnsi(stderr.join("\n"));
+
+    expect(code).not.toBe(0);
+    expect(stdout.length).toBe(0);
+    expect(renderedStderr).toContain(
+      "fabric imports require a space context (options.fabricImports)",
+    );
+    expect(renderedStderr).not.toContain("Could not resolve");
   });
 });

--- a/packages/cli/test/fabric-deps.test.ts
+++ b/packages/cli/test/fabric-deps.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { createRef } from "../../runner/src/create-ref.ts";
+import {
+  type PatternMeta,
+  patternMetaSchema,
+} from "../../runner/src/pattern-manager.ts";
+import { slugIdForSpace } from "../../runner/src/slugs.ts";
+import type { Cell } from "../../runner/src/cell.ts";
+import type { URI } from "../../runner/src/sigil-types.ts";
+import { fromURI, toURI } from "../../runner/src/uri-utils.ts";
+import { pinProgramFabricImports } from "../lib/fabric-deps.ts";
+import { cf } from "./utils.ts";
+
+const signer = await Identity.fromPassphrase("cli fabric deps test");
+const space = signer.did();
+const ENTRY = "Avcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c";
+
+describe("cli fabric deps", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  function newPatternId(): URI {
+    return toURI(createRef({ pattern: "dep" }, "cli fabric deps test"));
+  }
+
+  function patternMetaCell(patternId: URI): Cell<PatternMeta> {
+    return runtime.getCellFromEntityId(
+      space,
+      { "/": fromURI(patternId) },
+      [],
+      patternMetaSchema,
+    );
+  }
+
+  async function writePatternSlug(slug: string): Promise<void> {
+    const patternId = newPatternId();
+    const meta = patternMetaCell(patternId);
+    await runtime.editWithRetry((tx) => {
+      meta.withTx(tx).set(
+        { spec: "pattern", entryIdentity: ENTRY } as PatternMeta,
+      );
+    });
+    const slugCell = runtime.getCellFromEntityId(space, {
+      "/": slugIdForSpace(space, slug),
+    });
+    await runtime.editWithRetry((tx) => {
+      const slugWithTx = slugCell.withTx(tx);
+      slugWithTx.setRawUntyped(
+        meta.withTx(tx).getAsWriteRedirectLink({ base: slugWithTx }),
+      );
+    });
+  }
+
+  it("pins mutable fabric imports in a runtime program", async () => {
+    await writePatternSlug("dep");
+    const result = await pinProgramFabricImports(runtime, space, {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: `import dep from "cf:dep";\nexport default dep;`,
+        },
+      ],
+    });
+
+    expect(result.program.files[0].contents).toBe(
+      `import dep from "cf:dep@${ENTRY}";\nexport default dep;`,
+    );
+    expect(result.rewrites).toEqual([
+      {
+        file: "/main.tsx",
+        specifier: "cf:dep",
+        pinned: `cf:dep@${ENTRY}`,
+        resolvedIdentity: ENTRY,
+        line: 1,
+      },
+    ]);
+  });
+
+  it("exposes deps update help", async () => {
+    const { code, stdout } = await cf("deps update --help");
+
+    expect(code).toBe(0);
+    expect(stdout.join("\n")).toContain("--check");
+  });
+});

--- a/packages/cli/test/fabric-deps.test.ts
+++ b/packages/cli/test/fabric-deps.test.ts
@@ -12,7 +12,9 @@ import { slugIdForSpace } from "../../runner/src/slugs.ts";
 import type { Cell } from "../../runner/src/cell.ts";
 import type { URI } from "../../runner/src/sigil-types.ts";
 import { fromURI, toURI } from "../../runner/src/uri-utils.ts";
+import { InMemoryProgram } from "@commonfabric/js-compiler";
 import { pinProgramFabricImports } from "../lib/fabric-deps.ts";
+import { collectLocalProgram } from "../lib/dev.ts";
 import { cf } from "./utils.ts";
 
 const signer = await Identity.fromPassphrase("cli fabric deps test");
@@ -92,6 +94,65 @@ describe("cli fabric deps", () => {
         line: 1,
       },
     ]);
+  });
+
+  it("pins fabric imports across every file of a program", async () => {
+    await writePatternSlug("dep");
+    const result = await pinProgramFabricImports(runtime, space, {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: `import { s } from "./schemas.tsx";\nexport default s;`,
+        },
+        {
+          name: "/schemas.tsx",
+          contents: `import dep from "cf:dep";\nexport const s = dep;`,
+        },
+      ],
+    });
+
+    expect(result.rewrites).toEqual([
+      {
+        file: "/schemas.tsx",
+        specifier: "cf:dep",
+        pinned: `cf:dep@${ENTRY}`,
+        resolvedIdentity: ENTRY,
+        line: 1,
+      },
+    ]);
+    expect(result.program.files[0].contents).toContain("./schemas.tsx");
+    expect(result.program.files[1].contents).toContain(`cf:dep@${ENTRY}`);
+  });
+
+  it("collectLocalProgram walks local files and dispatches on fabric refs", async () => {
+    const resolver = new InMemoryProgram("/main.tsx", {
+      "/main.tsx":
+        `import { s } from "./schemas.tsx";\nexport default s;`,
+      "/schemas.tsx": `import dep from "cf:dep";\nexport const s = dep;`,
+    });
+
+    const program = await collectLocalProgram(resolver, {
+      fabricImports: "allow",
+    });
+    expect(program.files.map((f) => f.name)).toEqual([
+      "/main.tsx",
+      "/schemas.tsx",
+    ]);
+
+    await expect(
+      collectLocalProgram(resolver, { fabricImports: "reject" }),
+    ).rejects.toThrow("fabric imports require a space context");
+  });
+
+  it("collectLocalProgram surfaces malformed fabric specifiers as parse errors", async () => {
+    const resolver = new InMemoryProgram("/main.tsx", {
+      "/main.tsx": `import dep from "cf:module/abc";\nexport default dep;`,
+    });
+
+    await expect(
+      collectLocalProgram(resolver, { fabricImports: "allow" }),
+    ).rejects.toThrow("compiler-internal namespaces");
   });
 
   it("exposes deps update help", async () => {

--- a/packages/cli/test/fabric-deps.test.ts
+++ b/packages/cli/test/fabric-deps.test.ts
@@ -127,8 +127,7 @@ describe("cli fabric deps", () => {
 
   it("collectLocalProgram walks local files and dispatches on fabric refs", async () => {
     const resolver = new InMemoryProgram("/main.tsx", {
-      "/main.tsx":
-        `import { s } from "./schemas.tsx";\nexport default s;`,
+      "/main.tsx": `import { s } from "./schemas.tsx";\nexport default s;`,
       "/schemas.tsx": `import dep from "cf:dep";\nexport const s = dep;`,
     });
 

--- a/packages/js-compiler/test/typescript.compiler.test.ts
+++ b/packages/js-compiler/test/typescript.compiler.test.ts
@@ -138,6 +138,44 @@ describe("TypeScriptCompiler", () => {
     expect(modules.get("/main.tsx")!.js).toContain('require("@std/math")');
   });
 
+  it("uses specifier aliases for type resolution without rewriting emitted imports", () => {
+    const compiler = new TypeScriptCompiler(types);
+    const specifierAliases = new Map([["x-scheme:thing", "/dep.tsx"]]);
+    const program = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents:
+            `import { value } from "x-scheme:thing";\nexport const run = (): string => value;`,
+        },
+        {
+          name: "/dep.tsx",
+          contents: `export const value: string = "ok";`,
+        },
+      ],
+    };
+
+    const modules = compiler.compileToModules(program, { specifierAliases });
+    expect(modules.get("/main.tsx")!.js).toContain(
+      'require("x-scheme:thing")',
+    );
+
+    const badProgram = {
+      ...program,
+      files: [
+        {
+          name: "/main.tsx",
+          contents:
+            `import { missing } from "x-scheme:thing";\nexport const run = missing;`,
+        },
+        program.files[1],
+      ],
+    };
+    expect(() => compiler.compileToModules(badProgram, { specifierAliases }))
+      .toThrow(`has no exported member 'missing'.`);
+  });
+
   it("Resolves nested relative type imports from runtime module typedefs", async () => {
     const compiler = new TypeScriptCompiler(types);
     const program = new InMemoryProgram("/main.tsx", {

--- a/packages/js-compiler/typescript/compiler.ts
+++ b/packages/js-compiler/typescript/compiler.ts
@@ -122,13 +122,16 @@ class VirtualFs implements ModuleResolutionHost {
 
 class TypeScriptHost extends VirtualFs implements CompilerHost {
   private allowedRuntimeModules: string[];
+  private specifierAliases?: ReadonlyMap<string, string>;
   constructor(
     source: Program,
     typeLibs: TypeLibs,
     allowedRuntimeModules: string[],
+    specifierAliases?: ReadonlyMap<string, string>,
   ) {
     super(source, typeLibs, DEBUG_VIRTUAL_FS);
     this.allowedRuntimeModules = allowedRuntimeModules;
+    this.specifierAliases = specifierAliases;
   }
 
   getDefaultLibFileName(_options: CompilerOptions): string {
@@ -179,6 +182,17 @@ class TypeScriptHost extends VirtualFs implements CompilerHost {
   ): readonly ResolvedModuleWithFailedLookupLocations[] {
     return moduleLiterals.map((literal) => {
       const name = literal.text;
+      const aliased = this.specifierAliases?.get(name);
+      if (aliased !== undefined) {
+        return {
+          resolvedModule: {
+            resolvedFileName: aliased,
+            extension: aliased.endsWith(".tsx")
+              ? ts.Extension.Tsx
+              : ts.Extension.Ts,
+          },
+        };
+      }
       if (name[0] === "." || name[0] === "/") {
         const resolved = path.join(path.dirname(containingFile), name);
         return {
@@ -230,6 +244,12 @@ export interface TypeScriptCompilerOptions {
   // Optional mapping of runtime module name e.g. `"@commonfabric/framework"`,
   // and its corresponding type definitions.
   runtimeModules?: string[];
+  /**
+   * Maps an import specifier (verbatim text) to a program file name. Used for
+   * scheme-prefixed specifiers that the path-join and runtime-module rules
+   * cannot resolve. The target must be a file in the program.
+   */
+  specifierAliases?: ReadonlyMap<string, string>;
   // Transformations to run before JS transforms.
   // Can return either an array of transformer factories (simple case)
   // or a TransformerPipelineResult with factories and getDiagnostics.
@@ -288,7 +308,12 @@ export class TypeScriptCompiler {
     // themselves.
     tsOptions.skipLibCheck = true;
 
-    const host = new TypeScriptHost(program, this.typeLibs, runtimeModules);
+    const host = new TypeScriptHost(
+      program,
+      this.typeLibs,
+      runtimeModules,
+      inputOptions.specifierAliases,
+    );
     const tsProgram = ts.createProgram(sourceNames, tsOptions, host);
 
     const checker = new Checker(tsProgram, {

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -1,27 +1,15 @@
-import type { Cell, URI } from "@commonfabric/runner";
+import type { Cell } from "@commonfabric/runner";
 import {
   getMetaLink,
   isSlugAddress,
-  parseLink,
+  resolveSlugTargetCell as resolveRuntimeSlugTargetCell,
   slugIdForSpace,
+  SlugResolutionError,
   validateSlug,
 } from "@commonfabric/runner";
 import { pieceId, PieceManager } from "./manager.ts";
 
-export class SlugResolutionError extends Error {
-  constructor(
-    message: string,
-    readonly code?:
-      | "invalid"
-      | "missing"
-      | "malformed"
-      | "not-piece"
-      | "missing-piece-id",
-  ) {
-    super(message);
-    this.name = "SlugResolutionError";
-  }
-}
+export { SlugResolutionError };
 
 export async function assignSlug(
   manager: PieceManager,
@@ -109,32 +97,9 @@ export async function resolveSlugTargetCell(
   manager: PieceManager,
   token: string,
 ): Promise<Cell<unknown>> {
-  const slug = validateSlug(token);
-  const slugId = slugIdForSpace(manager.getSpace(), slug);
-  const slugCell = manager.runtime.getCellFromEntityId(
+  return await resolveRuntimeSlugTargetCell(
+    manager.runtime,
     manager.getSpace(),
-    { "/": slugId },
+    token,
   );
-  await slugCell.sync();
-  const raw = slugCell.getRaw();
-  if (raw === undefined) {
-    throw new SlugResolutionError(`Slug "${slug}" not found.`, "missing");
-  }
-
-  const targetLink = parseLink(raw, slugCell);
-  if (!targetLink || targetLink.overwrite !== "redirect") {
-    throw new SlugResolutionError(
-      `Slug "${slug}" does not contain a valid redirect.`,
-      "malformed",
-    );
-  }
-
-  const target = manager.runtime.getCellFromLink({
-    ...targetLink,
-    id: targetLink.id as URI,
-    space: targetLink.space ?? manager.getSpace(),
-    scope: targetLink.scope ?? "space",
-  });
-  await target.sync();
-  return target;
 }

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -6,6 +6,7 @@ import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { type Cell, isCell } from "../cell.ts";
 import type { JSONSchema } from "../builder/types.ts";
 import { readStoredCfcMetadata } from "../cfc/metadata.ts";
+import { isFabricImportSpecifier } from "../sandbox/fabric-import-specifier.ts";
 
 const logger = getLogger("cell-cache");
 
@@ -120,11 +121,16 @@ function storedImportRefs(
   module: CacheableModule,
   entryIdentity: string,
   extraRoots: readonly string[],
+  options: { includeFabricEdges: boolean },
 ): ModuleImportRef[] {
-  const refs: ModuleImportRef[] = module.imports.map((imp) => ({
-    specifier: imp.specifier,
-    identity: imp.targetIdentity,
-  }));
+  const refs: ModuleImportRef[] = module.imports
+    .filter((imp) =>
+      options.includeFabricEdges || !isFabricImportSpecifier(imp.specifier)
+    )
+    .map((imp) => ({
+      specifier: imp.specifier,
+      identity: imp.targetIdentity,
+    }));
   if (module.identity === entryIdentity) {
     for (const rootIdentity of extraRoots) {
       refs.push({
@@ -154,7 +160,9 @@ export function buildSourceDocs(
       kind: "source",
       code: module.source,
       filename: module.filename,
-      imports: storedImportRefs(module, entryIdentity, extraRoots),
+      imports: storedImportRefs(module, entryIdentity, extraRoots, {
+        includeFabricEdges: false,
+      }),
     });
   }
   return out;
@@ -539,17 +547,17 @@ export function writeCompiledDocs(
       ...(module.sourceMap !== undefined
         ? { sourceMap: module.sourceMap }
         : {}),
-      imports: storedImportRefs(module, entryIdentity, extraRoots).map(
-        (ref) => ({
-          specifier: ref.specifier,
-          link: runtime.getCell(
-            space,
-            compiledDocKey(opts.runtimeVersion, ref.identity),
-            undefined,
-            tx,
-          ).getAsLink(),
-        }),
-      ),
+      imports: storedImportRefs(module, entryIdentity, extraRoots, {
+        includeFabricEdges: true,
+      }).map((ref) => ({
+        specifier: ref.specifier,
+        link: runtime.getCell(
+          space,
+          compiledDocKey(opts.runtimeVersion, ref.identity),
+          undefined,
+          tx,
+        ).getAsLink(),
+      })),
     } as StoredCompiledDoc);
   }
 }

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -6,7 +6,11 @@ import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { type Cell, isCell } from "../cell.ts";
 import type { JSONSchema } from "../builder/types.ts";
 import { readStoredCfcMetadata } from "../cfc/metadata.ts";
-import { isFabricImportSpecifier } from "../sandbox/fabric-import-specifier.ts";
+import {
+  isFabricImportSpecifier,
+  parseFabricRef,
+  pinnedIdentity,
+} from "../sandbox/fabric-import-specifier.ts";
 
 const logger = getLogger("cell-cache");
 
@@ -110,6 +114,31 @@ function unreachedRoots(
     }
   }
   return modules.filter((m) => !seen.has(m.identity)).map((m) => m.identity);
+}
+
+/**
+ * Persisted cache entries must be a pure function of their module identity.
+ * An UNPINNED fabric specifier breaks that: the Merkle identity folds the
+ * specifier TEXT (not the resolution result), so two compiles of
+ * byte-identical source can chase to different targets and produce different
+ * documents under the same `pattern:`/`compileCache:` key. Unpinned
+ * resolution (`FabricImportOptions.allowUnpinned`) is therefore dev-only and
+ * must never reach the persistent cache — both write paths fail loudly here.
+ */
+function assertNoUnpinnedFabricImports(
+  modules: readonly CacheableModule[],
+): void {
+  for (const module of modules) {
+    for (const imp of module.imports) {
+      if (!isFabricImportSpecifier(imp.specifier)) continue;
+      const ref = parseFabricRef(imp.specifier);
+      if (ref !== undefined && pinnedIdentity(ref) === undefined) {
+        throw new Error(
+          `refusing to cache module '${module.filename}': unpinned fabric import '${imp.specifier}' (unpinned resolution is dev-only; pin before deploy)`,
+        );
+      }
+    }
+  }
 }
 
 /**
@@ -292,6 +321,7 @@ export function writeSourceDocs(
   entryIdentity: string,
   tx: IExtendedStorageTransaction,
 ): void {
+  assertNoUnpinnedFabricImports(modules);
   const docs = buildSourceDocs(modules, entryIdentity);
   for (const [identity, doc] of docs) {
     // Write with an untyped cell (the recursive read schema would over-constrain
@@ -530,6 +560,7 @@ export function writeCompiledDocs(
   opts: { runtimeVersion: string; compilerDid: string },
   tx: IExtendedStorageTransaction,
 ): void {
+  assertNoUnpinnedFabricImports(modules);
   const extraRoots = unreachedRoots(modules, entryIdentity);
   const schema = compiledDocWriteSchema(opts.compilerDid);
   for (const module of modules) {

--- a/packages/runner/src/fabric-pin-rewrite.ts
+++ b/packages/runner/src/fabric-pin-rewrite.ts
@@ -1,0 +1,119 @@
+import ts from "typescript";
+import {
+  type FabricRef,
+  formatFabricRef,
+  parseFabricRef,
+  pinnedIdentity,
+  withPin,
+} from "./sandbox/fabric-import-specifier.ts";
+
+const REWRITE_TARGET = ts.ScriptTarget.ES2023;
+
+export interface PinRewrite {
+  specifier: string;
+  pinned: string;
+  line: number;
+}
+
+interface RewriteSpan {
+  start: number;
+  end: number;
+  specifier: string;
+  pinned: string;
+  line: number;
+}
+
+/**
+ * Rewrite fabric import/export/import-type specifiers in one source text.
+ * Only the inside of string-literal spans is replaced; all surrounding bytes,
+ * including the original quote character, are preserved.
+ */
+export async function rewriteFabricPins(
+  contents: string,
+  resolvePin: (
+    ref: FabricRef,
+    specifier: string,
+  ) => Promise<string | null>,
+): Promise<{ contents: string; rewrites: PinRewrite[] }> {
+  const sourceFile = ts.createSourceFile(
+    "fabric-pin-rewrite.tsx",
+    contents,
+    REWRITE_TARGET,
+    true,
+  );
+  const literals = collectImportSpecifierLiterals(sourceFile);
+  const replacements: RewriteSpan[] = [];
+
+  for (const literal of literals) {
+    const specifier = literal.text;
+    const ref = parseFabricRef(specifier);
+    if (ref === undefined) continue;
+
+    const pin = await resolvePin(ref, specifier);
+    if (pin === null || pinnedIdentity(ref) === pin) continue;
+
+    const pinned = formatFabricRef(withPin(ref, pin));
+    const literalStart = literal.getStart(sourceFile);
+    const { line } = sourceFile.getLineAndCharacterOfPosition(literalStart);
+    replacements.push({
+      start: literalStart + 1,
+      end: literal.end - 1,
+      specifier,
+      pinned,
+      line: line + 1,
+    });
+  }
+
+  let rewritten = contents;
+  for (
+    const replacement of [...replacements].sort((a, b) => b.start - a.start)
+  ) {
+    rewritten = rewritten.slice(0, replacement.start) + replacement.pinned +
+      rewritten.slice(replacement.end);
+  }
+
+  return {
+    contents: rewritten,
+    rewrites: replacements.map(({ specifier, pinned, line }) => ({
+      specifier,
+      pinned,
+      line,
+    })),
+  };
+}
+
+function collectImportSpecifierLiterals(
+  sourceFile: ts.SourceFile,
+): ts.StringLiteral[] {
+  const literals: ts.StringLiteral[] = [];
+
+  function visit(node: ts.Node) {
+    if (ts.isImportDeclaration(node)) {
+      const moduleSpecifier = node.moduleSpecifier;
+      if (ts.isStringLiteral(moduleSpecifier)) {
+        literals.push(moduleSpecifier);
+      }
+    }
+
+    if (ts.isExportDeclaration(node)) {
+      const moduleSpecifier = node.moduleSpecifier;
+      if (moduleSpecifier && ts.isStringLiteral(moduleSpecifier)) {
+        literals.push(moduleSpecifier);
+      }
+    }
+
+    if (ts.isImportTypeNode(node)) {
+      const argument = node.argument;
+      if (
+        ts.isLiteralTypeNode(argument) && ts.isStringLiteral(argument.literal)
+      ) {
+        literals.push(argument.literal);
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return literals;
+}

--- a/packages/runner/src/fabric-ref-resolution.ts
+++ b/packages/runner/src/fabric-ref-resolution.ts
@@ -1,0 +1,148 @@
+import { isRecord } from "@commonfabric/utils/types";
+import type { Cell } from "./cell.ts";
+import type { Runtime } from "./runtime.ts";
+import type { MemorySpace } from "./storage/interface.ts";
+import type { URI } from "./sigil-types.ts";
+import { fromURI } from "./uri-utils.ts";
+import {
+  type FabricRef,
+  formatFabricRef,
+} from "./sandbox/fabric-import-specifier.ts";
+import {
+  resolveSlugTargetCell,
+  SlugResolutionError,
+} from "./slug-resolution.ts";
+import { getPatternId, getPatternIdentityRef } from "./runner.ts";
+import type { PatternMeta } from "./pattern-manager.ts";
+
+const DID_RE = /^did:[a-z0-9]+:.+$/;
+
+export interface FabricChaseResult {
+  entryIdentity: string;
+  /** Human-readable hops for errors/tooling. */
+  chain: string[];
+}
+
+export async function resolveFabricRefToIdentity(
+  runtime: Runtime,
+  compilingSpace: MemorySpace,
+  ref: FabricRef,
+): Promise<FabricChaseResult> {
+  const specifier = formatFabricRef(ref);
+  const refSpace = resolveRefSpace(ref.space, compilingSpace);
+
+  if (ref.ref.kind === "uri" && ref.ref.scheme === "pattern") {
+    return done(ref.ref.hash, [`pattern:${ref.ref.hash}`]);
+  }
+
+  const chain: string[] = [];
+  let cell: Cell<unknown>;
+  if (ref.ref.kind === "slug") {
+    chain.push(`slug:${ref.ref.slug}`);
+    try {
+      cell = await resolveSlugTargetCell(runtime, refSpace, ref.ref.slug);
+    } catch (cause) {
+      if (cause instanceof SlugResolutionError) {
+        throw new Error(`${cause.message} (chain: ${formatChain(chain)})`, {
+          cause,
+        });
+      }
+      throw cause;
+    }
+  } else {
+    const patternId = `of:fid1:${ref.ref.hash}` as URI;
+    chain.push(`of:${patternId}`);
+    cell = runtime.getCellFromEntityId(
+      refSpace,
+      { "/": fromURI(patternId) },
+    );
+    await cell.sync();
+  }
+
+  return await resolveCellToIdentity(runtime, specifier, cell, chain);
+}
+
+function resolveRefSpace(
+  refSpace: string | undefined,
+  compilingSpace: MemorySpace,
+): MemorySpace {
+  if (refSpace === undefined) return compilingSpace;
+  if (DID_RE.test(refSpace)) return refSpace as MemorySpace;
+  throw new Error(
+    "space names require name→DID resolution (open question 2); use a DID",
+  );
+}
+
+async function resolveCellToIdentity(
+  runtime: Runtime,
+  specifier: string,
+  cell: Cell<unknown>,
+  chain: string[],
+): Promise<FabricChaseResult> {
+  const link = cell.getAsNormalizedFullLink();
+  const cellSpace = link.space;
+  const identityRef = getPatternIdentityRef(cell);
+  const patternId = getPatternId(cell);
+
+  if (identityRef !== undefined || patternId !== undefined) {
+    chain.push(`piece:${link.id}`);
+    if (identityRef !== undefined) {
+      chain.push(`patternIdentity:${identityRef.identity}`);
+      return done(identityRef.identity, chain);
+    }
+
+    const meta = await runtime.patternManager.loadPatternMeta(
+      patternId!,
+      cellSpace,
+    );
+    chain.push(`patternMeta:${patternId}`);
+    return patternMetaToIdentity(specifier, meta, chain);
+  }
+
+  const directMeta = patternMetaFromCell(cell);
+  if (directMeta !== undefined) {
+    chain.push(`patternMeta:${link.id}`);
+    return patternMetaToIdentity(specifier, directMeta, chain);
+  }
+
+  throw new Error(
+    `${specifier} does not resolve to a pattern (chain: ${formatChain(chain)})`,
+  );
+}
+
+function patternMetaToIdentity(
+  specifier: string,
+  meta: PatternMeta,
+  chain: string[],
+): FabricChaseResult {
+  if (typeof meta.entryIdentity !== "string" || meta.entryIdentity === "") {
+    throw new Error(
+      `pattern meta for ${specifier} has no entryIdentity (legacy pattern; re-deploy it) (chain: ${
+        formatChain(chain)
+      })`,
+    );
+  }
+  return done(meta.entryIdentity, chain);
+}
+
+function patternMetaFromCell(cell: Cell<unknown>): PatternMeta | undefined {
+  const raw = cell.get();
+  if (
+    isRecord(raw) &&
+    (raw.spec === "pattern" || "program" in raw || "entryIdentity" in raw)
+  ) {
+    return raw as PatternMeta;
+  }
+  return undefined;
+}
+
+function done(entryIdentity: string, chain: string[]): FabricChaseResult {
+  return {
+    entryIdentity,
+    chain: [...chain, `entryIdentity:${entryIdentity}`],
+  };
+}
+
+function formatChain(chain: readonly string[]): string {
+  return chain.join(" -> ");
+}

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -5,6 +5,7 @@ import {
   type Exports,
   type Harness,
   type HarnessedFunction,
+  type ResolvedFabricPin,
   type RuntimeProgram,
   type TypeScriptHarnessProcessOptions,
 } from "./types.ts";
@@ -229,6 +230,7 @@ export class Engine extends EventTarget implements Harness {
       mainSpecifier: string;
       entryIdentity: string;
       modules: CacheableModule[];
+      resolvedPins: ResolvedFabricPin[];
     }
   > {
     logger.timeStart("compileToRecordGraph");
@@ -245,12 +247,14 @@ export class Engine extends EventTarget implements Harness {
         ? new FabricAwareResolver(engineResolver, {
           runtime: this.ctRuntime,
           space: options.fabricImports.space,
+          allowUnpinned: options.fabricImports.allowUnpinned,
         })
         : undefined;
       const resolver = fabricResolver ?? engineResolver;
       const resolvedProgram = await this.resolve(resolver);
       const mounts = fabricResolver?.mounts() ?? [];
       const specifierAliases = fabricResolver?.specifierAliases() ?? new Map();
+      const resolvedPins = fabricResolver?.resolvedPins() ?? [];
       const resolvedFiles = uniqueSourcesByName(resolvedProgram.files);
       const resolvedForCompile = { ...resolvedProgram, files: resolvedFiles };
 
@@ -456,7 +460,14 @@ export class Engine extends EventTarget implements Harness {
         };
       });
 
-      return { id, graph, mainSpecifier, entryIdentity, modules };
+      return {
+        id,
+        graph,
+        mainSpecifier,
+        entryIdentity,
+        modules,
+        resolvedPins,
+      };
     } finally {
       logger.timeEnd("compileToRecordGraph");
     }
@@ -483,7 +494,9 @@ export class Engine extends EventTarget implements Harness {
   async compileResolvedToRecordGraph(
     resolvedFiles: Source[],
     entryFilename: string,
-    options: { fabricImports?: { space: MemorySpace } } = {},
+    options: {
+      fabricImports?: TypeScriptHarnessProcessOptions["fabricImports"];
+    } = {},
   ): Promise<{ modules: CacheableModule[]; entryIdentity: string }> {
     const { compiler } = await this.getCompilerInternals();
     assertNoReservedFabricPaths(resolvedFiles);
@@ -498,6 +511,7 @@ export class Engine extends EventTarget implements Harness {
       ? new FabricAwareResolver(engineResolver, {
         runtime: this.ctRuntime,
         space: options.fabricImports.space,
+        allowUnpinned: options.fabricImports.allowUnpinned,
       })
       : undefined;
     const resolver = fabricResolver ?? engineResolver;

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -9,6 +9,7 @@ import {
   type TypeScriptHarnessProcessOptions,
 } from "./types.ts";
 import {
+  collectImportSpecifiers,
   getTypeScriptEnvironmentTypes,
   InMemoryProgram,
   type MappedPosition,
@@ -17,22 +18,28 @@ import {
   type Source,
   TypeScriptCompiler,
 } from "@commonfabric/js-compiler";
+import ts from "typescript";
 import {
   CommonFabricTransformerPipeline,
   OpaqueRefErrorTransformer,
 } from "@commonfabric/ts-transformers";
 import { getLogger } from "@commonfabric/utils/logger";
-import { Runtime } from "../runtime.ts";
+import { type MemorySpace, Runtime } from "../runtime.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { StaticCache } from "@commonfabric/static";
 import { pretransformProgramForModules } from "./pretransform.ts";
-import { resolveModuleImports } from "./module-identity.ts";
+import {
+  type ModuleImportEdges,
+  resolveModuleImports,
+} from "./module-identity.ts";
 import {
   buildRecordsFromCompiled,
   type CachedCompiledModule,
   type CompiledModuleGraph,
   compileSourcesToRecords,
-  computeModuleIdentities,
+  computeFabricModuleIdentities,
+  FABRIC_MOUNT_ROOT,
+  type FabricMount,
 } from "../sandbox/module-record-compiler.ts";
 import {
   composeBundleSourceMap,
@@ -69,8 +76,11 @@ import {
   readBindingIdentity,
   recordVerifiedProvenance,
 } from "./verified-provenance.ts";
+import { FabricAwareResolver } from "./fabric-resolver.ts";
+import { isFabricImportSpecifier } from "../sandbox/fabric-import-specifier.ts";
 
 const logger = getLogger("engine");
+const IMPORT_SCAN_TARGET = ts.ScriptTarget.ES2023;
 
 // Extends a TypeScript program with 3P module types, if referenced.
 export class EngineProgramResolver extends InMemoryProgram {
@@ -224,24 +234,41 @@ export class Engine extends EventTarget implements Harness {
     logger.timeStart("compileToRecordGraph");
     try {
       const id = options.identifier ?? computeId(program);
+      assertNoReservedFabricPaths(program.files);
       const mappedProgram = pretransformProgramForModules(program, id);
-      const resolver = new EngineProgramResolver(
+      assertFabricImportsHaveSpace(mappedProgram.files, options);
+      const engineResolver = new EngineProgramResolver(
         mappedProgram,
         this.ctRuntime.staticCache,
       );
+      const fabricResolver = options.fabricImports
+        ? new FabricAwareResolver(engineResolver, {
+          runtime: this.ctRuntime,
+          space: options.fabricImports.space,
+        })
+        : undefined;
+      const resolver = fabricResolver ?? engineResolver;
       const resolvedProgram = await this.resolve(resolver);
+      const mounts = fabricResolver?.mounts() ?? [];
+      const specifierAliases = fabricResolver?.specifierAliases() ?? new Map();
+      const resolvedFiles = uniqueSourcesByName(resolvedProgram.files);
+      const resolvedForCompile = { ...resolvedProgram, files: resolvedFiles };
 
       // Authored (non-.d.ts) sources are the modules that must have a body.
-      const moduleFiles = resolvedProgram.files.filter((f) =>
+      const moduleFiles = resolvedFiles.filter((f) =>
         !f.name.endsWith(".d.ts")
       );
 
       // Prefix-free content identity per resolved module path. Computed here
       // (cheap, no TS compile) so the cache-hit check and the write-back
       // descriptors agree with the graph's `cf:module/<hash>` specifiers.
-      const identityByPath = computeModuleIdentities(moduleFiles, {
-        idPrefix: `/${id}`,
-      });
+      const identityByPath = computeFabricModuleIdentities(
+        moduleFiles,
+        mounts,
+        {
+          idPrefix: `/${id}`,
+        },
+      );
       const entryIdentity = identityByPath.get(mappedProgram.main)!;
 
       // Cache hit: every emitted module already has a cached compiled body
@@ -279,9 +306,10 @@ export class Engine extends EventTarget implements Harness {
         }
       } else {
         const { compiler } = await this.getCompilerInternals();
-        const modules = compiler.compileToModules(resolvedProgram, {
+        const modules = compiler.compileToModules(resolvedForCompile, {
           noCheck: options.noCheck,
           runtimeModules: Engine.runtimeModuleNames(),
+          specifierAliases,
           getTransformedProgram: options.getTransformedProgram
             ? (nextProgram) => options.getTransformedProgram?.(nextProgram)
             : undefined,
@@ -325,6 +353,7 @@ export class Engine extends EventTarget implements Harness {
         precompiledBodies,
         precompiledSourceMaps,
         runtimeModules: runtimeModulesOption,
+        specifierAliases,
         // Strip the whole-program `/<id>` prefix from per-module identities so
         // `cf:module/<hash>` is entry-point independent and dedupes across
         // programs (the content-addressed cache keys off these identities).
@@ -411,15 +440,15 @@ export class Engine extends EventTarget implements Harness {
       const modules: CacheableModule[] = moduleFiles.map((file) => {
         const identity = identityByPath.get(file.name)!;
         const sourceMap = precompiledSourceMaps.get(file.name);
-        const imports = (importEdges.get(file.name)?.internalDeps ?? []).map((
-          dep,
-        ) => ({
-          specifier: dep.specifier,
-          targetIdentity: identityByPath.get(dep.target)!,
-        }));
+        const imports = cacheableImportsFor(
+          file.name,
+          importEdges,
+          identityByPath,
+          specifierAliases,
+        );
         return {
           identity,
-          filename: stripModuleIdPrefix(file.name, id),
+          filename: storedFilenameFor(file.name, id, mounts),
           source: file.contents,
           js: precompiledBodies.get(file.name)!,
           ...(sourceMap === undefined ? {} : { sourceMap }),
@@ -454,24 +483,42 @@ export class Engine extends EventTarget implements Harness {
   async compileResolvedToRecordGraph(
     resolvedFiles: Source[],
     entryFilename: string,
+    options: { fabricImports?: { space: MemorySpace } } = {},
   ): Promise<{ modules: CacheableModule[]; entryIdentity: string }> {
     const { compiler } = await this.getCompilerInternals();
+    assertNoReservedFabricPaths(resolvedFiles);
+    assertFabricImportsHaveSpace(resolvedFiles, options);
     // Resolve to add the runtime `.d.ts` type environment, WITHOUT pretransform
     // (no re-inject/re-prefix — the stored source is already transformed).
-    const resolver = new EngineProgramResolver(
+    const engineResolver = new EngineProgramResolver(
       { main: entryFilename, files: resolvedFiles },
       this.ctRuntime.staticCache,
     );
+    const fabricResolver = options.fabricImports
+      ? new FabricAwareResolver(engineResolver, {
+        runtime: this.ctRuntime,
+        space: options.fabricImports.space,
+      })
+      : undefined;
+    const resolver = fabricResolver ?? engineResolver;
     const resolvedProgram = await this.resolve(resolver);
-    const moduleFiles = resolvedProgram.files.filter((f) =>
+    const mounts = fabricResolver?.mounts() ?? [];
+    const specifierAliases = fabricResolver?.specifierAliases() ?? new Map();
+    const resolvedProgramFiles = uniqueSourcesByName(resolvedProgram.files);
+    const resolvedForCompile = {
+      ...resolvedProgram,
+      files: resolvedProgramFiles,
+    };
+    const moduleFiles = resolvedProgramFiles.filter((f) =>
       !f.name.endsWith(".d.ts")
     );
     // Identities recompute prefix-free over the (already-normalized) closure —
     // they match the stored identities the source docs were keyed by.
-    const identityByPath = computeModuleIdentities(moduleFiles);
+    const identityByPath = computeFabricModuleIdentities(moduleFiles, mounts);
 
-    const emitted = compiler.compileToModules(resolvedProgram, {
+    const emitted = compiler.compileToModules(resolvedForCompile, {
       runtimeModules: Engine.runtimeModuleNames(),
+      specifierAliases,
       beforeTransformers: (program) => {
         const pipeline = new CommonFabricTransformerPipeline();
         return {
@@ -491,15 +538,15 @@ export class Engine extends EventTarget implements Harness {
     const importEdges = resolveModuleImports({ main: "", files: moduleFiles });
     const modules: CacheableModule[] = moduleFiles.map((file) => {
       const out = emitted.get(file.name)!;
-      const imports = (importEdges.get(file.name)?.internalDeps ?? []).map((
-        dep,
-      ) => ({
-        specifier: dep.specifier,
-        targetIdentity: identityByPath.get(dep.target)!,
-      }));
+      const imports = cacheableImportsFor(
+        file.name,
+        importEdges,
+        identityByPath,
+        specifierAliases,
+      );
       return {
         identity: identityByPath.get(file.name)!,
-        filename: file.name,
+        filename: storedFilenameFor(file.name, undefined, mounts),
         source: file.contents,
         js: out.js,
         ...(out.sourceMap === undefined ? {} : { sourceMap: out.sourceMap }),
@@ -1126,6 +1173,102 @@ function computeId(program: Program): string {
     ...program.files.filter(({ name }) => !name.endsWith(".d.ts")),
   ];
   return hashOf(source).toString();
+}
+
+function assertNoReservedFabricPaths(files: readonly Source[]): void {
+  for (const file of files) {
+    if (file.name.startsWith(FABRIC_MOUNT_ROOT)) {
+      throw new Error("/~cf/ is a reserved namespace");
+    }
+  }
+}
+
+function assertFabricImportsHaveSpace(
+  files: readonly Source[],
+  options: { fabricImports?: { space: MemorySpace } },
+): void {
+  if (options.fabricImports !== undefined) return;
+  for (const file of files) {
+    for (
+      const specifier of collectImportSpecifiers(file, IMPORT_SCAN_TARGET)
+    ) {
+      if (isFabricImportSpecifier(specifier)) {
+        throw new Error(
+          "fabric imports require a space context (options.fabricImports)",
+        );
+      }
+    }
+  }
+}
+
+function uniqueSourcesByName(files: readonly Source[]): Source[] {
+  const byName = new Map<string, Source>();
+  for (const file of files) {
+    const previous = byName.get(file.name);
+    if (previous !== undefined) {
+      if (previous.contents !== file.contents) {
+        throw new Error(
+          `Conflicting resolved source contents for '${file.name}'`,
+        );
+      }
+      continue;
+    }
+    byName.set(file.name, file);
+  }
+  return [...byName.values()];
+}
+
+function cacheableImportsFor(
+  fileName: string,
+  importEdges: ReadonlyMap<string, ModuleImportEdges>,
+  identityByPath: ReadonlyMap<string, string>,
+  specifierAliases: ReadonlyMap<string, string>,
+): CacheableModule["imports"] {
+  const edges = importEdges.get(fileName);
+  const internal = (edges?.internalDeps ?? []).map((dep) => ({
+    specifier: dep.specifier,
+    targetIdentity: requiredIdentity(identityByPath, dep.target),
+  }));
+  const fabric = (edges?.externalDeps ?? [])
+    .filter(isFabricImportSpecifier)
+    .map((specifier) => {
+      const target = specifierAliases.get(specifier);
+      if (target === undefined) {
+        throw new Error(
+          `unresolved fabric specifier '${specifier}' survived compile`,
+        );
+      }
+      return {
+        specifier,
+        targetIdentity: requiredIdentity(identityByPath, target),
+      };
+    });
+  return [...internal, ...fabric];
+}
+
+function requiredIdentity(
+  identityByPath: ReadonlyMap<string, string>,
+  path: string,
+): string {
+  const identity = identityByPath.get(path);
+  if (identity === undefined) {
+    throw new Error(`No module identity computed for '${path}'`);
+  }
+  return identity;
+}
+
+function storedFilenameFor(
+  name: string,
+  id: string | undefined,
+  mounts: readonly FabricMount[],
+): string {
+  for (const mount of mounts) {
+    const prefix = `${FABRIC_MOUNT_ROOT}${mount.entryIdentity}`;
+    if (name.startsWith(`${prefix}/`)) {
+      return name.slice(prefix.length);
+    }
+  }
+  return id === undefined ? name : stripModuleIdPrefix(name, id);
 }
 
 /**

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -36,6 +36,7 @@ import {
 import {
   buildRecordsFromCompiled,
   type CachedCompiledModule,
+  cachedModuleSourceNames,
   type CompiledModuleGraph,
   compileSourcesToRecords,
   computeFabricModuleIdentities,
@@ -969,10 +970,17 @@ export class Engine extends EventTarget implements Harness {
       // and the identities are authoritative. Also populate the canonical
       // source map so `fn.src` resolves to `cf:module/<identity>/<path>`.
       registerHashes: () => {
+        // Keyed by the same (collision-disambiguated) source names the record
+        // graph uses for sourceURLs, so stack-resolved fn.src coordinates land
+        // on the right module even when an importer and its fabric dependency
+        // share a filename. The canonical value keeps the AUTHORED filename —
+        // unchanged continuity with the source-compile path.
+        const sourceNames = cachedModuleSourceNames(modules);
         for (const m of modules) {
-          this.moduleHashByPrefixedSource.set(m.filename, m.identity);
+          const name = sourceNames.get(m.identity)!;
+          this.moduleHashByPrefixedSource.set(name, m.identity);
           this.canonicalSourceByPrefixed.set(
-            m.filename,
+            name,
             `cf:module/${m.identity}${m.filename}`,
           );
         }

--- a/packages/runner/src/harness/fabric-resolver.ts
+++ b/packages/runner/src/harness/fabric-resolver.ts
@@ -4,6 +4,7 @@ import {
   type ProgramResolver,
   type Source,
 } from "@commonfabric/js-compiler";
+import { getLogger } from "@commonfabric/utils/logger";
 import {
   loadVerifiedSourceClosure,
   type SourceDoc,
@@ -17,13 +18,16 @@ import {
   FABRIC_MOUNT_ROOT,
   type FabricMount,
 } from "../sandbox/module-record-compiler.ts";
+import { resolveFabricRefToIdentity } from "../fabric-ref-resolution.ts";
+import type { FabricImportOptions, ResolvedFabricPin } from "./types.ts";
 
 const TARGET = ts.ScriptTarget.ES2023;
 const MAX_FABRIC_MOUNTS = 32;
+const DID_RE = /^did:[a-z0-9]+:.+$/;
+const logger = getLogger("fabric-resolver");
 
-export interface FabricResolutionContext {
+export interface FabricResolutionContext extends FabricImportOptions {
   runtime: Runtime;
-  space: MemorySpace;
 }
 
 export class FabricAwareResolver implements ProgramResolver {
@@ -31,6 +35,7 @@ export class FabricAwareResolver implements ProgramResolver {
   #mountByIdentity = new Map<string, FabricMount>();
   #entrySourceByIdentity = new Map<string, Source>();
   #specifierAliases = new Map<string, string>();
+  #resolvedPins: ResolvedFabricPin[] = [];
 
   constructor(
     private readonly inner: ProgramResolver,
@@ -58,14 +63,25 @@ export class FabricAwareResolver implements ProgramResolver {
       throw new Error("subpaths not yet supported (M4)");
     }
 
-    const identity = pinnedIdentity(ref);
+    let identity = pinnedIdentity(ref);
+    const sourceSpace = this.#sourceSpaceFor(ref.space);
     if (identity === undefined) {
-      throw new Error(
-        "fabric ref requires resolution of a mutable pointer — not yet supported (M2)",
+      if (this.ctx.allowUnpinned !== true) {
+        throw new Error(
+          `unpinned fabric import '${identifier}'; pin it (cf deps update) or deploy to pin`,
+        );
+      }
+      const resolved = await resolveFabricRefToIdentity(
+        this.ctx.runtime,
+        this.ctx.space,
+        ref,
       );
-    }
-    if (ref.space !== undefined && ref.space !== this.ctx.space) {
-      throw new Error("cross-space fabric refs not yet supported (M2)");
+      identity = resolved.entryIdentity;
+      this.#resolvedPins.push({
+        specifier: identifier,
+        resolvedIdentity: identity,
+        chain: resolved.chain,
+      });
     }
 
     const existing = this.#mountByIdentity.get(identity);
@@ -81,15 +97,23 @@ export class FabricAwareResolver implements ProgramResolver {
       throw new Error("fabric import graph too deep/large");
     }
 
-    const docs = await this.#loadSourceClosure(identity);
+    if (sourceSpace !== this.ctx.space) {
+      logger.info("fabric-import-cross-space", () => [
+        `source=${sourceSpace}`,
+        `dest=${this.ctx.space}`,
+        `entry=${identity}`,
+      ]);
+    }
+
+    const docs = await this.#loadSourceClosure(identity, sourceSpace);
     if (docs === undefined) {
-      throw new Error(this.#notFoundMessage(identity));
+      throw new Error(this.#notFoundMessage(identity, sourceSpace));
     }
     this.#assertNoRootAbsoluteImports(identity, docs);
 
     const entryDoc = docs.get(identity);
     if (entryDoc === undefined) {
-      throw new Error(this.#notFoundMessage(identity));
+      throw new Error(this.#notFoundMessage(identity, sourceSpace));
     }
     const entryPath = this.#mountPath(identity, entryDoc.filename);
     const mount: FabricMount = {
@@ -125,14 +149,22 @@ export class FabricAwareResolver implements ProgramResolver {
     return new Map(this.#specifierAliases);
   }
 
+  resolvedPins(): ResolvedFabricPin[] {
+    return this.#resolvedPins.map((pin) => ({
+      ...pin,
+      chain: [...pin.chain],
+    }));
+  }
+
   async #loadSourceClosure(
     identity: string,
+    space: MemorySpace,
   ): Promise<Map<string, SourceDoc> | undefined> {
     const tx = this.ctx.runtime.edit();
     try {
       return await loadVerifiedSourceClosure(
         this.ctx.runtime,
-        this.ctx.space,
+        space,
         identity,
         tx,
       );
@@ -161,7 +193,15 @@ export class FabricAwareResolver implements ProgramResolver {
     return `${FABRIC_MOUNT_ROOT}${identity}${filename}`;
   }
 
-  #notFoundMessage(identity: string): string {
-    return `source for pattern:${identity} not found in space ${this.ctx.space} (or failed integrity verification)`;
+  #notFoundMessage(identity: string, space: MemorySpace): string {
+    return `source for pattern:${identity} not found in space ${space} (or failed integrity verification)`;
+  }
+
+  #sourceSpaceFor(refSpace: string | undefined): MemorySpace {
+    if (refSpace === undefined) return this.ctx.space;
+    if (DID_RE.test(refSpace)) return refSpace as MemorySpace;
+    throw new Error(
+      "space names require name→DID resolution (open question 2); use a DID",
+    );
   }
 }

--- a/packages/runner/src/harness/fabric-resolver.ts
+++ b/packages/runner/src/harness/fabric-resolver.ts
@@ -1,0 +1,167 @@
+import ts from "typescript";
+import {
+  collectImportSpecifiers,
+  type ProgramResolver,
+  type Source,
+} from "@commonfabric/js-compiler";
+import {
+  loadVerifiedSourceClosure,
+  type SourceDoc,
+} from "../compilation-cache/cell-cache.ts";
+import type { MemorySpace, Runtime } from "../runtime.ts";
+import {
+  parseFabricRef,
+  pinnedIdentity,
+} from "../sandbox/fabric-import-specifier.ts";
+import {
+  FABRIC_MOUNT_ROOT,
+  type FabricMount,
+} from "../sandbox/module-record-compiler.ts";
+
+const TARGET = ts.ScriptTarget.ES2023;
+const MAX_FABRIC_MOUNTS = 32;
+
+export interface FabricResolutionContext {
+  runtime: Runtime;
+  space: MemorySpace;
+}
+
+export class FabricAwareResolver implements ProgramResolver {
+  #mountedFiles = new Map<string, Source>();
+  #mountByIdentity = new Map<string, FabricMount>();
+  #entrySourceByIdentity = new Map<string, Source>();
+  #specifierAliases = new Map<string, string>();
+
+  constructor(
+    private readonly inner: ProgramResolver,
+    private readonly ctx: FabricResolutionContext,
+  ) {}
+
+  main(): Promise<Source> {
+    return this.inner.main();
+  }
+
+  async resolveSource(identifier: string): Promise<Source | undefined> {
+    if (identifier.startsWith(FABRIC_MOUNT_ROOT)) {
+      return this.#mountedFiles.get(identifier);
+    }
+
+    const ref = parseFabricRef(identifier);
+    if (ref === undefined) {
+      return await this.inner.resolveSource(identifier);
+    }
+
+    if (ref.host !== undefined) {
+      throw new Error("cross-host fabric refs not yet supported (M3)");
+    }
+    if (ref.subpath !== undefined) {
+      throw new Error("subpaths not yet supported (M4)");
+    }
+
+    const identity = pinnedIdentity(ref);
+    if (identity === undefined) {
+      throw new Error(
+        "fabric ref requires resolution of a mutable pointer — not yet supported (M2)",
+      );
+    }
+    if (ref.space !== undefined && ref.space !== this.ctx.space) {
+      throw new Error("cross-space fabric refs not yet supported (M2)");
+    }
+
+    const existing = this.#mountByIdentity.get(identity);
+    if (existing !== undefined) {
+      if (!existing.specifiers.includes(identifier)) {
+        existing.specifiers.push(identifier);
+      }
+      this.#specifierAliases.set(identifier, existing.entryPath);
+      return this.#entrySourceByIdentity.get(identity);
+    }
+
+    if (this.#mountByIdentity.size >= MAX_FABRIC_MOUNTS) {
+      throw new Error("fabric import graph too deep/large");
+    }
+
+    const docs = await this.#loadSourceClosure(identity);
+    if (docs === undefined) {
+      throw new Error(this.#notFoundMessage(identity));
+    }
+    this.#assertNoRootAbsoluteImports(identity, docs);
+
+    const entryDoc = docs.get(identity);
+    if (entryDoc === undefined) {
+      throw new Error(this.#notFoundMessage(identity));
+    }
+    const entryPath = this.#mountPath(identity, entryDoc.filename);
+    const mount: FabricMount = {
+      entryIdentity: identity,
+      entryPath,
+      specifiers: [identifier],
+    };
+
+    for (const doc of docs.values()) {
+      const source: Source = {
+        name: this.#mountPath(identity, doc.filename),
+        contents: doc.code,
+      };
+      this.#mountedFiles.set(source.name, source);
+      if (source.name === entryPath) {
+        this.#entrySourceByIdentity.set(identity, source);
+      }
+    }
+
+    this.#mountByIdentity.set(identity, mount);
+    this.#specifierAliases.set(identifier, entryPath);
+    return this.#entrySourceByIdentity.get(identity);
+  }
+
+  mounts(): FabricMount[] {
+    return [...this.#mountByIdentity.values()].map((mount) => ({
+      ...mount,
+      specifiers: [...mount.specifiers],
+    }));
+  }
+
+  specifierAliases(): Map<string, string> {
+    return new Map(this.#specifierAliases);
+  }
+
+  async #loadSourceClosure(
+    identity: string,
+  ): Promise<Map<string, SourceDoc> | undefined> {
+    const tx = this.ctx.runtime.edit();
+    try {
+      return await loadVerifiedSourceClosure(
+        this.ctx.runtime,
+        this.ctx.space,
+        identity,
+        tx,
+      );
+    } finally {
+      tx.abort?.("fabric source closure read complete");
+    }
+  }
+
+  #assertNoRootAbsoluteImports(
+    identity: string,
+    docs: ReadonlyMap<string, SourceDoc>,
+  ): void {
+    for (const doc of docs.values()) {
+      const source = { name: doc.filename, contents: doc.code };
+      for (const specifier of collectImportSpecifiers(source, TARGET)) {
+        if (specifier.startsWith("/")) {
+          throw new Error(
+            `imported pattern ${identity} uses root-absolute imports; not supported`,
+          );
+        }
+      }
+    }
+  }
+
+  #mountPath(identity: string, filename: string): string {
+    return `${FABRIC_MOUNT_ROOT}${identity}${filename}`;
+  }
+
+  #notFoundMessage(identity: string): string {
+    return `source for pattern:${identity} not found in space ${this.ctx.space} (or failed integrity verification)`;
+  }
+}

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -3,6 +3,7 @@ import type {
   ProgramResolver,
   Source,
 } from "@commonfabric/js-compiler";
+import type { MemorySpace } from "../runtime.ts";
 import type {
   CachedCompiledModule,
   CompiledModuleGraph,
@@ -57,6 +58,12 @@ export interface TypeScriptHarnessProcessOptions {
   // on a miss/partial hit: freshly compiled bodies are always SES-verified.
   // Never set for direct `precompiledModules` injection (untrusted bytes).
   trustedBodies?: boolean;
+  /**
+   * Enables fabric (cf:) imports for this compile: the space whose cell-cache
+   * source docs fabric refs are fetched from and verified against. Absent means
+   * any fabric specifier in the authored program is a compile error.
+   */
+  fabricImports?: { space: MemorySpace };
 }
 
 /** A cached/compiled per-module artifact: emitted JS plus optional source map. */
@@ -153,6 +160,7 @@ export interface Harness extends EventTarget {
   compileResolvedToRecordGraph(
     resolvedFiles: Source[],
     entryFilename: string,
+    options?: { fabricImports?: { space: MemorySpace } },
   ): Promise<{ modules: CacheableModule[]; entryIdentity: string }>;
 
   // Resolves a `ProgramResolver` into a `Program` using the engine's

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -63,7 +63,18 @@ export interface TypeScriptHarnessProcessOptions {
    * source docs fabric refs are fetched from and verified against. Absent means
    * any fabric specifier in the authored program is a compile error.
    */
-  fabricImports?: { space: MemorySpace };
+  fabricImports?: FabricImportOptions;
+}
+
+export interface FabricImportOptions {
+  space: MemorySpace;
+  allowUnpinned?: boolean;
+}
+
+export interface ResolvedFabricPin {
+  specifier: string;
+  resolvedIdentity: string;
+  chain: string[];
 }
 
 /** A cached/compiled per-module artifact: emitted JS plus optional source map. */
@@ -137,6 +148,7 @@ export interface Harness extends EventTarget {
     mainSpecifier: string;
     entryIdentity: string;
     modules: CacheableModule[];
+    resolvedPins: ResolvedFabricPin[];
   }>;
 
   // Evaluate a verified ESM record graph produced by `compileToRecordGraph`.
@@ -160,7 +172,7 @@ export interface Harness extends EventTarget {
   compileResolvedToRecordGraph(
     resolvedFiles: Source[],
     entryFilename: string,
-    options?: { fabricImports?: { space: MemorySpace } },
+    options?: { fabricImports?: FabricImportOptions },
   ): Promise<{ modules: CacheableModule[]; entryIdentity: string }>;
 
   // Resolves a `ProgramResolver` into a `Program` using the engine's

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -68,6 +68,15 @@ export interface TypeScriptHarnessProcessOptions {
 
 export interface FabricImportOptions {
   space: MemorySpace;
+  /**
+   * Dev-only: resolve unpinned mutable refs by chasing the live pointer.
+   * The resulting compile is NOT cacheable — module identity folds the
+   * (unpinned) specifier text, so the chase result varies under a fixed
+   * identity, and persisting it would make `pattern:`/`compileCache:` docs
+   * key-unstable. The cell-cache write path enforces this
+   * (`assertNoUnpinnedFabricImports`); callers that write compiled artifacts
+   * back must never set this flag.
+   */
   allowUnpinned?: boolean;
 }
 

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -170,6 +170,10 @@ export {
   validateSlug,
 } from "./slugs.ts";
 export {
+  type FabricChaseResult,
+  resolveFabricRefToIdentity,
+} from "./fabric-ref-resolution.ts";
+export {
   resolveSlugTargetCell,
   SlugResolutionError,
 } from "./slug-resolution.ts";

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -173,6 +173,12 @@ export {
   type FabricChaseResult,
   resolveFabricRefToIdentity,
 } from "./fabric-ref-resolution.ts";
+export {
+  type FabricRef,
+  FabricRefError,
+  isFabricImportSpecifier,
+  parseFabricRef,
+} from "./sandbox/fabric-import-specifier.ts";
 export { type PinRewrite, rewriteFabricPins } from "./fabric-pin-rewrite.ts";
 export {
   resolveSlugTargetCell,

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -173,6 +173,7 @@ export {
   type FabricChaseResult,
   resolveFabricRefToIdentity,
 } from "./fabric-ref-resolution.ts";
+export { type PinRewrite, rewriteFabricPins } from "./fabric-pin-rewrite.ts";
 export {
   resolveSlugTargetCell,
   SlugResolutionError,

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -169,3 +169,7 @@ export {
   slugIdForSpace,
   validateSlug,
 } from "./slugs.ts";
+export {
+  resolveSlugTargetCell,
+  SlugResolutionError,
+} from "./slug-resolution.ts";

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -61,6 +61,14 @@ const MAX_PATTERN_CACHE_SIZE = 100;
 const MAX_EVALUATED_MODULE_CACHE_SIZE = 1000;
 const FABRIC_IMPORT_SCAN_TARGET = ts.ScriptTarget.ES2023;
 
+/**
+ * Re-derive a stored module's fabric edges from its SOURCE text (source docs
+ * deliberately do not store them as links). Unpinned specifiers are skipped:
+ * they carry no target identity to link, and they cannot legitimately occur
+ * here — the cell-cache write path refuses to persist modules with unpinned
+ * fabric imports (`assertNoUnpinnedFabricImports`), so a skip only ever drops
+ * an edge from data that predates that guard.
+ */
 function fabricImportRefsFromSource(
   doc: SourceDoc,
 ): CacheableModule["imports"] {

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -752,7 +752,10 @@ export class PatternManager {
       return await this.compileViaCellCache(program, cacheCtx);
     }
     const { id, graph, mainSpecifier, entryIdentity } = await this.runtime
-      .harness.compileToRecordGraph(program);
+      .harness.compileToRecordGraph(
+        program,
+        cacheCtx ? { fabricImports: { space: cacheCtx.space } } : {},
+      );
     cacheCtx?.onEntryIdentity?.(entryIdentity);
     const result = this.runtime.harness.evaluateRecordGraph(
       id,
@@ -818,6 +821,7 @@ export class PatternManager {
     let compiled;
     try {
       compiled = await harness.compileToRecordGraph(program, {
+        fabricImports: { space },
         // The bodies returned below come from `loadCompiledClosure`, an
         // integrity-gated (`requiredIntegrity`, fail-closed) read of the
         // compiled set. On a full hit the CFC integrity label is the security
@@ -1025,7 +1029,14 @@ export class PatternManager {
     } finally {
       readTx.abort?.("load-pattern-by-identity read complete");
     }
-    if (!closure.has(entryIdentity)) return undefined;
+    if (!closure.has(entryIdentity)) {
+      return await this.tryColdLoadByIdentity(
+        entryIdentity,
+        symbol,
+        space,
+        cacheOpts,
+      );
+    }
 
     const cachedModules: CachedCompiledModule[] = [...closure].map(
       ([identity, doc]) => ({
@@ -1056,6 +1067,95 @@ export class PatternManager {
       return pattern;
     } catch (error) {
       logger.warn("load-pattern-by-identity-miss", () => [
+        `entry=${entryIdentity}`,
+        `symbol=${symbol}`,
+        String(error),
+      ]);
+      return await this.tryColdLoadByIdentity(
+        entryIdentity,
+        symbol,
+        space,
+        cacheOpts,
+      );
+    }
+  }
+
+  /**
+   * Runtime-version-bump recovery for a content-addressed pattern reference:
+   * recompile from the verified source closure, letting fabric imports refetch
+   * their own source closures from the same space.
+   */
+  private async tryColdLoadByIdentity(
+    entryIdentity: string,
+    symbol: string,
+    space: MemorySpace,
+    cacheOpts: { runtimeVersion: string; compilerDid: string },
+  ): Promise<Pattern | undefined> {
+    const harness = this.runtime.harness;
+    const readTx = this.runtime.edit();
+    let sourceDocs;
+    try {
+      sourceDocs = await loadVerifiedSourceClosure(
+        this.runtime,
+        space,
+        entryIdentity,
+        readTx,
+      );
+    } finally {
+      readTx.abort?.("load-pattern-by-identity source read complete");
+    }
+    if (sourceDocs === undefined) return undefined;
+    const entry = sourceDocs.get(entryIdentity);
+    if (entry === undefined) return undefined;
+
+    const sourceFiles: Source[] = [...sourceDocs.values()].map((doc) => ({
+      name: doc.filename,
+      contents: doc.code,
+    }));
+
+    try {
+      const compiled = await harness.compileResolvedToRecordGraph(
+        sourceFiles,
+        entry.filename,
+        { fabricImports: { space } },
+      );
+      if (compiled.entryIdentity !== entryIdentity) {
+        throw new Error(
+          `source closure recompiled to ${compiled.entryIdentity}, expected ${entryIdentity}`,
+        );
+      }
+      const cachedModules: CachedCompiledModule[] = compiled.modules.map(
+        (module) => ({
+          identity: module.identity,
+          filename: module.filename,
+          code: module.js,
+          ...(module.sourceMap !== undefined
+            ? { sourceMap: module.sourceMap as never }
+            : {}),
+          imports: module.imports,
+        }),
+      );
+      const result = await harness.evaluateCachedModules(
+        cachedModules,
+        entryIdentity,
+        { sourceFiles },
+      );
+      const pattern = this.patternFromMain(result, symbol, entryIdentity);
+      const writeBack = this.writeBackCompileCache(
+        space,
+        compiled.modules,
+        entryIdentity,
+        cacheOpts,
+      );
+      this.compileCacheWrites.add(writeBack);
+      this.pendingCacheWriteBacks.add(writeBack);
+      writeBack.finally(() => {
+        this.compileCacheWrites.delete(writeBack);
+        this.pendingCacheWriteBacks.delete(writeBack);
+      });
+      return pattern;
+    } catch (error) {
+      logger.warn("load-pattern-by-identity-source-miss", () => [
         `entry=${entryIdentity}`,
         `symbol=${symbol}`,
         String(error),

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -1,4 +1,9 @@
+import ts from "typescript";
 import { getLogger } from "@commonfabric/utils/logger";
+import {
+  collectImportSpecifiers,
+  type Source,
+} from "@commonfabric/js-compiler";
 import { Module, Pattern, Schema } from "./builder/types.ts";
 import {
   getArtifactEntryRef,
@@ -27,9 +32,15 @@ import {
   loadCompiledClosure,
   loadVerifiedSourceClosure,
   ROOT_LINK_SPECIFIER,
+  type SourceDoc,
   writeCompiledDocs,
   writeSourceDocs,
 } from "./compilation-cache/cell-cache.ts";
+import {
+  isFabricImportSpecifier,
+  parseFabricRef,
+  pinnedIdentity,
+} from "./sandbox/fabric-import-specifier.ts";
 import { URI } from "./sigil-types.ts";
 import { toURI } from "./uri-utils.ts";
 import { parseLink } from "./link-utils.ts";
@@ -48,6 +59,46 @@ const MAX_PATTERN_CACHE_SIZE = 100;
 // bundle is ~10 modules), and entries are cheap (a reference to an already-live
 // namespace).
 const MAX_EVALUATED_MODULE_CACHE_SIZE = 1000;
+const FABRIC_IMPORT_SCAN_TARGET = ts.ScriptTarget.ES2023;
+
+function fabricImportRefsFromSource(
+  doc: SourceDoc,
+): CacheableModule["imports"] {
+  const source: Source = { name: doc.filename, contents: doc.code };
+  const refs: CacheableModule["imports"] = [];
+  const seen = new Set<string>();
+  for (
+    const specifier of collectImportSpecifiers(
+      source,
+      FABRIC_IMPORT_SCAN_TARGET,
+    )
+  ) {
+    if (!isFabricImportSpecifier(specifier)) continue;
+    const ref = parseFabricRef(specifier);
+    if (ref === undefined) continue;
+    const targetIdentity = pinnedIdentity(ref);
+    if (targetIdentity === undefined) continue;
+    const key = `${specifier}\0${targetIdentity}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    refs.push({ specifier, targetIdentity });
+  }
+  return refs;
+}
+
+function uniqueCacheableImports(
+  imports: CacheableModule["imports"],
+): CacheableModule["imports"] {
+  const seen = new Set<string>();
+  const out: CacheableModule["imports"] = [];
+  for (const imp of imports) {
+    const key = `${imp.specifier}\0${imp.targetIdentity}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(imp);
+  }
+  return out;
+}
 
 export const patternMetaSchema = internSchema(
   {
@@ -523,7 +574,12 @@ export class PatternManager {
     entryIdentity: string,
     fromSpace: MemorySpace,
     toSpace: MemorySpace,
+    visited = new Set<string>(),
   ): Promise<void> {
+    const visitKey = `${fromSpace}\0${toSpace}\0${entryIdentity}`;
+    if (visited.has(visitKey)) return;
+    visited.add(visitKey);
+
     // The origin-space closure may have been produced by THIS session's cold
     // compile, whose write-back is itself fire-and-forget and may not have
     // committed yet. A lost race would throw here — and for a handler-created
@@ -565,10 +621,15 @@ export class PatternManager {
       throw new Error("source closure unavailable in origin space");
     }
     const modules: CacheableModule[] = [];
+    const fabricDependencies = new Set<string>();
     for (const [identity, doc] of sourceDocs) {
       const compiled = compiledDocs.get(identity);
       if (!compiled) {
         throw new Error(`compiled doc missing for ${identity}`);
+      }
+      const fabricImports = fabricImportRefsFromSource(doc);
+      for (const imp of fabricImports) {
+        fabricDependencies.add(imp.targetIdentity);
       }
       modules.push({
         identity,
@@ -580,12 +641,15 @@ export class PatternManager {
           : {}),
         // The write functions re-derive the entry's root links; keep only the
         // real import edges.
-        imports: doc.imports
-          .filter((imp) => !imp.specifier.startsWith(ROOT_LINK_SPECIFIER))
-          .map((imp) => ({
-            specifier: imp.specifier,
-            targetIdentity: imp.identity,
-          })),
+        imports: uniqueCacheableImports([
+          ...doc.imports
+            .filter((imp) => !imp.specifier.startsWith(ROOT_LINK_SPECIFIER))
+            .map((imp) => ({
+              specifier: imp.specifier,
+              targetIdentity: imp.identity,
+            })),
+          ...fabricImports,
+        ]),
       });
     }
     const { error } = await this.runtime.editWithRetry((tx) => {
@@ -600,6 +664,15 @@ export class PatternManager {
       );
     });
     if (error) throw error;
+
+    for (const dependencyIdentity of fabricDependencies) {
+      await this.replicateClosures(
+        dependencyIdentity,
+        fromSpace,
+        toSpace,
+        visited,
+      );
+    }
   }
 
   private async syncLinkedPatternSource(

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -4133,7 +4133,7 @@ function getTxDebugActionId(
  * @param resultCell
  * @returns pattern id
  */
-function getPatternId(resultCell: Cell<unknown>): URI | undefined {
+export function getPatternId(resultCell: Cell<unknown>): URI | undefined {
   return getMetaLink(resultCell, "pattern")?.id;
 }
 
@@ -4143,7 +4143,7 @@ function getPatternId(resultCell: Cell<unknown>): URI | undefined {
  * load the pattern straight from the compiled cache by identity. Returns
  * undefined for legacy result cells that only carry the patternId link.
  */
-function getPatternIdentityRef(
+export function getPatternIdentityRef(
   resultCell: Cell<unknown>,
 ): { identity: string; symbol: string } | undefined {
   const raw = resultCell.getMetaRaw("patternIdentity", {

--- a/packages/runner/src/sandbox/fabric-import-specifier.ts
+++ b/packages/runner/src/sandbox/fabric-import-specifier.ts
@@ -52,6 +52,9 @@ export function parseFabricRef(specifier: string): FabricRef | undefined {
   if (refToken === undefined || refToken.length === 0) {
     throw new FabricRefError("Slug must not be empty.", specifier);
   }
+  if (subpathSegments.some((segment) => segment.length === 0)) {
+    throw new FabricRefError("empty path segment", specifier);
+  }
 
   const ref = parseRefToken(refToken, specifier);
   validateSpace(space, specifier);
@@ -84,8 +87,14 @@ export function isFabricImportSpecifier(specifier: string): boolean {
 }
 
 export function formatFabricRef(ref: FabricRef): string {
+  if (ref.host !== undefined && ref.space === undefined) {
+    throw new FabricRefError(
+      "host-qualified refs require a space",
+      `cf://${ref.host}/…`,
+    );
+  }
   const prefix = ref.host !== undefined
-    ? `//${ref.host}/${ref.space ?? ""}/`
+    ? `//${ref.host}/${ref.space}/`
     : ref.space !== undefined
     ? `/${ref.space}/`
     : "";
@@ -115,6 +124,15 @@ export function pinnedIdentity(ref: FabricRef): string | undefined {
 export function withPin(ref: FabricRef, pin: string): FabricRef {
   if (!HASH_RE.test(pin)) {
     throw new FabricRefError("malformed pin", formatFabricRef(ref));
+  }
+  // A pattern: URI ref is already content-addressed: an equal pin is
+  // redundant (normalized away, mirroring parse) and a different pin is the
+  // same contradiction parseFabricRef rejects — never representable.
+  if (ref.ref.kind === "uri" && ref.ref.scheme === "pattern") {
+    if (ref.ref.hash !== pin) {
+      throw new FabricRefError("conflicting pin", formatFabricRef(ref));
+    }
+    return { ...ref };
   }
   return { ...ref, pin };
 }

--- a/packages/runner/src/sandbox/fabric-import-specifier.ts
+++ b/packages/runner/src/sandbox/fabric-import-specifier.ts
@@ -1,0 +1,209 @@
+import { validateSlug } from "../slugs.ts";
+
+export const HASH_RE = /^[A-Za-z0-9_-]{43}$/;
+
+const HOST_RE = /^[a-z0-9.-]+(:\d+)?$/i;
+const DID_RE = /^did:[a-z0-9]+:.+$/;
+
+export interface FabricRef {
+  /** Toolshed host (authority); only present in the cf://host/... form. */
+  host?: string;
+  /** Space name or DID; absent = the compiling space. */
+  space?: string;
+  ref:
+    | { kind: "slug"; slug: string }
+    | { kind: "uri"; scheme: "of" | "pattern"; hash: string };
+  /** Path inside the target program. */
+  subpath?: string;
+  /** Trailing @<hash> pin. */
+  pin?: string;
+}
+
+export class FabricRefError extends Error {
+  constructor(message: string, readonly specifier: string) {
+    super(`${message}: ${specifier}`);
+    this.name = "FabricRefError";
+  }
+}
+
+export function parseFabricRef(specifier: string): FabricRef | undefined {
+  if (!specifier.startsWith("cf:")) return undefined;
+
+  let rest = specifier.slice("cf:".length);
+  if (rest.startsWith("module/") || rest.startsWith("cache-root/")) {
+    throw new FabricRefError(
+      "'cf:module/...' / 'cf:cache-root/...' are compiler-internal namespaces and cannot be imported",
+      specifier,
+    );
+  }
+
+  let pin: string | undefined;
+  const pinIndex = rest.lastIndexOf("@");
+  if (pinIndex >= 0) {
+    pin = rest.slice(pinIndex + 1);
+    if (!HASH_RE.test(pin)) {
+      throw new FabricRefError("malformed pin", specifier);
+    }
+    rest = rest.slice(0, pinIndex);
+  }
+
+  const { host, space, refSegments } = splitPrefix(rest, specifier);
+  const [refToken, ...subpathSegments] = refSegments;
+  if (refToken === undefined || refToken.length === 0) {
+    throw new FabricRefError("Slug must not be empty.", specifier);
+  }
+
+  const ref = parseRefToken(refToken, specifier);
+  validateSpace(space, specifier);
+
+  if (
+    ref.kind === "uri" && ref.scheme === "pattern" && pin !== undefined
+  ) {
+    if (ref.hash !== pin) {
+      throw new FabricRefError("conflicting pin", specifier);
+    }
+    pin = undefined;
+  }
+
+  const subpath = subpathSegments.join("/");
+  return {
+    ...(host === undefined ? {} : { host }),
+    ...(space === undefined ? {} : { space }),
+    ref,
+    ...(subpath.length === 0 ? {} : { subpath }),
+    ...(pin === undefined ? {} : { pin }),
+  };
+}
+
+export function isFabricImportSpecifier(specifier: string): boolean {
+  try {
+    return parseFabricRef(specifier) !== undefined;
+  } catch {
+    return false;
+  }
+}
+
+export function formatFabricRef(ref: FabricRef): string {
+  const prefix = ref.host !== undefined
+    ? `//${ref.host}/${ref.space ?? ""}/`
+    : ref.space !== undefined
+    ? `/${ref.space}/`
+    : "";
+  const refToken = ref.ref.kind === "slug"
+    ? ref.ref.slug
+    : ref.ref.scheme === "pattern"
+    ? `pattern:${ref.ref.hash}`
+    : `of:fid1:${ref.ref.hash}`;
+  const subpath = ref.subpath === undefined ? "" : `/${ref.subpath}`;
+  const pin = ref.pin === undefined ||
+      (ref.ref.kind === "uri" &&
+        ref.ref.scheme === "pattern" &&
+        ref.ref.hash === ref.pin)
+    ? ""
+    : `@${ref.pin}`;
+
+  return `cf:${prefix}${refToken}${subpath}${pin}`;
+}
+
+export function pinnedIdentity(ref: FabricRef): string | undefined {
+  if (ref.pin !== undefined) return ref.pin;
+  return ref.ref.kind === "uri" && ref.ref.scheme === "pattern"
+    ? ref.ref.hash
+    : undefined;
+}
+
+export function withPin(ref: FabricRef, pin: string): FabricRef {
+  if (!HASH_RE.test(pin)) {
+    throw new FabricRefError("malformed pin", formatFabricRef(ref));
+  }
+  return { ...ref, pin };
+}
+
+function splitPrefix(
+  rest: string,
+  specifier: string,
+): { host?: string; space?: string; refSegments: string[] } {
+  if (rest.startsWith("//")) {
+    const segments = rest.slice(2).split("/");
+    const host = segments[0];
+    if (!host || host.includes("@") || !HOST_RE.test(host)) {
+      throw new FabricRefError("malformed host", specifier);
+    }
+    if (segments.length < 3) {
+      throw new FabricRefError(
+        "host-qualified refs require a space",
+        specifier,
+      );
+    }
+    return {
+      host,
+      space: segments[1],
+      refSegments: segments.slice(2),
+    };
+  }
+
+  if (rest.startsWith("/")) {
+    const segments = rest.slice(1).split("/");
+    return { space: segments[0], refSegments: segments.slice(1) };
+  }
+
+  return { refSegments: rest.split("/") };
+}
+
+function parseRefToken(
+  refToken: string,
+  specifier: string,
+): FabricRef["ref"] {
+  if (refToken.includes(":")) {
+    const parts = refToken.split(":");
+    if (parts.length === 2 && parts[0] === "pattern") {
+      return {
+        kind: "uri",
+        scheme: "pattern",
+        hash: parseHash(parts[1], specifier),
+      };
+    }
+    if (parts.length === 3 && parts[0] === "of" && parts[1] === "fid1") {
+      return {
+        kind: "uri",
+        scheme: "of",
+        hash: parseHash(parts[2], specifier),
+      };
+    }
+    if (parts.length === 2 && parts[0] === "fid1") {
+      return {
+        kind: "uri",
+        scheme: "of",
+        hash: parseHash(parts[1], specifier),
+      };
+    }
+    throw new FabricRefError("unsupported cell URI scheme", specifier);
+  }
+
+  try {
+    return { kind: "slug", slug: validateSlug(refToken) };
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    throw new FabricRefError(message, specifier);
+  }
+}
+
+function parseHash(hash: string, specifier: string): string {
+  if (!HASH_RE.test(hash)) {
+    throw new FabricRefError("malformed hash", specifier);
+  }
+  return hash;
+}
+
+function validateSpace(
+  space: string | undefined,
+  specifier: string,
+): void {
+  if (space === undefined || DID_RE.test(space)) return;
+  try {
+    validateSlug(space);
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    throw new FabricRefError(message, specifier);
+  }
+}

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -294,6 +294,11 @@ export interface CompileSourcesOptions {
    * be consistent with `idPrefix` / `runtimeFingerprint`.
    */
   identityByPath?: Map<string, string>;
+  /**
+   * Maps an authored import specifier to a concrete file already present in the
+   * program. Used for scheme-prefixed fabric refs mounted under reserved paths.
+   */
+  specifierAliases?: ReadonlyMap<string, string>;
 }
 
 export interface CompiledModuleGraph {
@@ -418,9 +423,18 @@ export function compileSourcesToRecords(
       const source = sourceByName.get(current);
       if (!raw || !source) continue;
       for (const targetSpec of raw.starTargets) {
-        const resolved = resolveImportSpecifier(targetSpec, source);
-        const internal = findInternalTarget(fileNames, resolved);
+        const aliased = options.specifierAliases?.get(targetSpec);
+        const internal = aliased ??
+          findInternalTarget(
+            fileNames,
+            resolveImportSpecifier(targetSpec, source),
+          );
         if (internal !== undefined) {
+          if (!fileNames.has(internal)) {
+            throw new Error(
+              `specifier alias '${targetSpec}' -> '${internal}' does not name a program file`,
+            );
+          }
           reachableInternal.add(internal);
           stack.push(internal);
         } else {
@@ -496,6 +510,15 @@ export function compileSourcesToRecords(
         resolutions[spec] = specifierByPath.get(internal)!;
       } else if (spec in runtimeModules) {
         resolutions[spec] = `cf:runtime/${spec}`;
+      } else if (options.specifierAliases?.has(spec)) {
+        const target = options.specifierAliases.get(spec)!;
+        const targetSpecifier = specifierByPath.get(target);
+        if (targetSpecifier === undefined) {
+          throw new Error(
+            `specifier alias '${spec}' -> '${target}' does not name a program file`,
+          );
+        }
+        resolutions[spec] = targetSpecifier;
       } else {
         // Unknown external; leave as-is so a missing-record error is explicit.
         resolutions[spec] = spec;

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -369,6 +369,73 @@ export function computeModuleIdentities(
   return identityByPath;
 }
 
+export const FABRIC_MOUNT_ROOT = "/~cf/";
+
+export interface FabricMount {
+  /** Terminal identity the subtree was fetched by and must hash back to. */
+  entryIdentity: string;
+  /** Mounted path of the subtree's entry file. */
+  entryPath: string;
+  /** The fabric specifiers that resolve to this mount. */
+  specifiers: string[];
+}
+
+/**
+ * Compute module identities for a program that may include mounted fabric
+ * subtrees. Authored files keep the existing idPrefix behavior; each mount is
+ * hashed as its own standalone source set by stripping `/~cf/<identity>`.
+ */
+export function computeFabricModuleIdentities(
+  sources: Source[],
+  mounts: readonly FabricMount[],
+  options: { idPrefix?: string; runtimeFingerprint?: string } = {},
+): Map<string, string> {
+  const authored: Source[] = [];
+  const mountFiles = new Map<FabricMount, Source[]>();
+  for (const mount of mounts) mountFiles.set(mount, []);
+
+  for (const source of sources) {
+    if (!source.name.startsWith(FABRIC_MOUNT_ROOT)) {
+      authored.push(source);
+      continue;
+    }
+
+    const mount = mounts.find((candidate) =>
+      source.name.startsWith(mountPrefix(candidate))
+    );
+    if (mount === undefined) {
+      throw new Error(
+        `corrupt fabric mount assembly: '${source.name}' is under ${FABRIC_MOUNT_ROOT} but matches no mount`,
+      );
+    }
+    mountFiles.get(mount)!.push(source);
+  }
+
+  const result = computeModuleIdentities(authored, options);
+  for (const mount of mounts) {
+    const identities = computeModuleIdentities(mountFiles.get(mount) ?? [], {
+      idPrefix: `${FABRIC_MOUNT_ROOT}${mount.entryIdentity}`,
+      ...(options.runtimeFingerprint !== undefined
+        ? { runtimeFingerprint: options.runtimeFingerprint }
+        : {}),
+    });
+    const actual = identities.get(mount.entryPath);
+    if (actual !== mount.entryIdentity) {
+      throw new Error(
+        `integrity failure for fabric mount ${mount.entryIdentity}: mounted entry '${mount.entryPath}' hashed to '${actual}'`,
+      );
+    }
+    for (const [path, identity] of identities) {
+      result.set(path, identity);
+    }
+  }
+  return result;
+}
+
+function mountPrefix(mount: FabricMount): string {
+  return `${FABRIC_MOUNT_ROOT}${mount.entryIdentity}/`;
+}
+
 export function compileSourcesToRecords(
   sources: Source[],
   options: CompileSourcesOptions = {},

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -696,6 +696,36 @@ export interface CachedCompiledModule {
 }
 
 /**
+ * Unique per-module source name for a cached closure. A single program's
+ * closure has unique filenames, but a fabric importer's closure also carries
+ * its imported subtrees' modules, which routinely share names (`/main.tsx`).
+ * The cached record path keys several side tables by source name
+ * (`specifierByPath` → per-module source maps, export map,
+ * `exportsByIdentity`; the engine's fn.src canonicalization) — a name
+ * collision silently drops one module from all of them. Disambiguate
+ * colliding names with the mount-root convention; a collision-free closure
+ * keeps plain filenames (byte-identical to pre-fabric behavior).
+ */
+export function cachedModuleSourceNames(
+  modules: readonly CachedCompiledModule[],
+): Map<string, string> {
+  const counts = new Map<string, number>();
+  for (const m of modules) {
+    counts.set(m.filename, (counts.get(m.filename) ?? 0) + 1);
+  }
+  const names = new Map<string, string>();
+  for (const m of modules) {
+    names.set(
+      m.identity,
+      counts.get(m.filename)! > 1
+        ? `${FABRIC_MOUNT_ROOT}${m.identity}${m.filename}`
+        : m.filename,
+    );
+  }
+  return names;
+}
+
+/**
  * Build a verified-able record graph **directly from cached compiled modules** —
  * no TypeScript source, no `resolve`, no recompile. This is the warm load path:
  * the content-addressed cache already holds each module's compiled body + its
@@ -715,6 +745,7 @@ export function buildRecordsFromCompiled(
   const runtimeModules = options.runtimeModules ?? {};
   const specifierOf = (identity: string) => `cf:module/${identity}`;
   const byIdentity = new Map(modules.map((m) => [m.identity, m]));
+  const sourceNames = cachedModuleSourceNames(modules);
 
   // Direct export names + `export *` edges (as dependency identities) per module.
   const direct = new Map<
@@ -765,7 +796,7 @@ export function buildRecordsFromCompiled(
 
   for (const m of modules) {
     const specifier = specifierOf(m.identity);
-    specifierByPath.set(m.filename, specifier);
+    specifierByPath.set(sourceNames.get(m.identity)!, specifier);
     compiledBodies.set(specifier, m.code);
     if (m.sourceMap) moduleSourceMaps.set(specifier, m.sourceMap);
 
@@ -784,7 +815,10 @@ export function buildRecordsFromCompiled(
 
     const exportNames = resolveFullExports(m.identity);
     const namespaceExports = [...exportNames, "__esModule"];
-    const sourceUrl = m.filename.replace(/[\r\n\u2028\u2029]/g, "_");
+    const sourceUrl = sourceNames.get(m.identity)!.replace(
+      /[\r\n\u2028\u2029]/g,
+      "_",
+    );
     const compiled = m.code;
     records.set(specifier, {
       imports: importSpecs,

--- a/packages/runner/src/sandbox/runtime-module-policy.ts
+++ b/packages/runner/src/sandbox/runtime-module-policy.ts
@@ -1,3 +1,5 @@
+import { parseFabricRef } from "./fabric-import-specifier.ts";
+
 export type RuntimeModuleIdentifier =
   | "commonfabric"
   | "commonfabric/schema"
@@ -23,6 +25,13 @@ export function isRuntimeModuleIdentifier(
 }
 
 export function isAllowedAuthoredImportSpecifier(specifier: string): boolean {
+  if (specifier.startsWith("cf:")) {
+    try {
+      return parseFabricRef(specifier) !== undefined;
+    } catch {
+      return false;
+    }
+  }
   return isRuntimeModuleIdentifier(specifier) ||
     ALLOWED_LOCAL_IMPORT_PREFIXES.some((prefix) =>
       specifier.startsWith(prefix)

--- a/packages/runner/src/slug-resolution.ts
+++ b/packages/runner/src/slug-resolution.ts
@@ -37,8 +37,8 @@ export async function resolveSlugTargetCell(
     throw new SlugResolutionError(`Slug "${slug}" not found.`, "missing");
   }
 
-  const targetLink = parseLink(raw, slugCell);
-  if (!targetLink || targetLink.overwrite !== "redirect") {
+  const targetLink = parseSlugRedirect(raw, slugCell);
+  if (!targetLink) {
     throw new SlugResolutionError(
       `Slug "${slug}" does not contain a valid redirect.`,
       "malformed",
@@ -53,4 +53,22 @@ export async function resolveSlugTargetCell(
   });
   await target.sync();
   return target;
+}
+
+/**
+ * Parse a slug document's raw payload into its redirect link, or undefined
+ * when the payload is not a valid redirect. parseLink throws plain TypeErrors
+ * on sigil-SHAPED payloads with broken internals (e.g. a non-array path);
+ * this runtime's own write path rejects such values, but a slug cell can be
+ * written by foreign clients over the memory protocol, so the resolver must
+ * fold a parse throw into the same typed "malformed" outcome as a
+ * structurally-invalid payload. Exported for tests.
+ */
+export function parseSlugRedirect(raw: unknown, base: Cell<unknown>) {
+  try {
+    const link = parseLink(raw, base);
+    return link?.overwrite === "redirect" ? link : undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/runner/src/slug-resolution.ts
+++ b/packages/runner/src/slug-resolution.ts
@@ -1,0 +1,56 @@
+import type { Cell } from "./cell.ts";
+import type { Runtime } from "./runtime.ts";
+import type { URI } from "./sigil-types.ts";
+import type { MemorySpace } from "./storage/interface.ts";
+import { parseLink } from "./link-utils.ts";
+import { slugIdForSpace, validateSlug } from "./slugs.ts";
+
+export class SlugResolutionError extends Error {
+  constructor(
+    message: string,
+    readonly code?:
+      | "invalid"
+      | "missing"
+      | "malformed"
+      | "not-piece"
+      | "missing-piece-id",
+  ) {
+    super(message);
+    this.name = "SlugResolutionError";
+  }
+}
+
+export async function resolveSlugTargetCell(
+  runtime: Runtime,
+  space: MemorySpace,
+  token: string,
+): Promise<Cell<unknown>> {
+  const slug = validateSlug(token);
+  const slugId = slugIdForSpace(space, slug);
+  const slugCell = runtime.getCellFromEntityId(
+    space,
+    { "/": slugId },
+  );
+  await slugCell.sync();
+  const raw = slugCell.getRaw();
+  if (raw === undefined) {
+    throw new SlugResolutionError(`Slug "${slug}" not found.`, "missing");
+  }
+
+  const targetLink = parseLink(raw, slugCell);
+  if (!targetLink || targetLink.overwrite !== "redirect") {
+    throw new SlugResolutionError(
+      `Slug "${slug}" does not contain a valid redirect.`,
+      "malformed",
+    );
+  }
+
+  const target = runtime.getCellFromLink({
+    ...targetLink,
+    id: targetLink.id as URI,
+    space: targetLink.space ?? space,
+    scope: targetLink.scope ?? "space",
+  });
+  await target.sync();
+  return target;
+}

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -11,6 +11,7 @@ import type { CacheableModule } from "../src/harness/types.ts";
 
 import {
   buildSourceDocs,
+  COMPILE_CACHE_RUNTIME_VERSION,
   compiledDocKey,
   compiledIntegrityAtom,
   loadCompiledClosure,
@@ -70,6 +71,56 @@ function toModules(
 
 const identityOf = (program: typeof PROGRAM, path: string) =>
   computeModuleHashes(program).get(path)!;
+
+function fabricLinkedModules(): {
+  modules: CacheableModule[];
+  importerIdentity: string;
+  depIdentity: string;
+  fabricSpecifier: string;
+} {
+  const depProgram = {
+    main: "/dep.ts",
+    files: [
+      { name: "/dep.ts", contents: "export const x = 1;" },
+    ],
+  };
+  const depIdentity = computeModuleHashes(depProgram).get("/dep.ts")!;
+  const fabricSpecifier = `cf:pattern:${depIdentity}`;
+  const importerProgram = {
+    main: "/main.tsx",
+    files: [
+      {
+        name: "/main.tsx",
+        contents:
+          `import { x } from "${fabricSpecifier}";\nexport function y() { return x + 1; }`,
+      },
+    ],
+  };
+  const importerIdentity = computeModuleHashes(importerProgram).get(
+    "/main.tsx",
+  )!;
+  return {
+    importerIdentity,
+    depIdentity,
+    fabricSpecifier,
+    modules: [
+      {
+        identity: importerIdentity,
+        filename: "/main.tsx",
+        source: importerProgram.files[0].contents,
+        js: "/* compiled importer */",
+        imports: [{ specifier: fabricSpecifier, targetIdentity: depIdentity }],
+      },
+      {
+        identity: depIdentity,
+        filename: "/dep.ts",
+        source: depProgram.files[0].contents,
+        js: "/* compiled dependency */",
+        imports: [],
+      },
+    ],
+  };
+}
 
 describe("cell-cache: keys", () => {
   it("formats source and compiled document keys", () => {
@@ -241,13 +292,32 @@ describe("cell-cache: source-set store (per space, link-following)", () => {
     );
     expect(tampered).toBe(undefined);
   });
+
+  it("does not store fabric imports as source links", async () => {
+    const { modules, importerIdentity, fabricSpecifier } =
+      fabricLinkedModules();
+    const tx = runtime.edit();
+    writeSourceDocs(runtime, spaceA, modules, importerIdentity, tx);
+
+    const loaded = await loadVerifiedSourceClosure(
+      runtime,
+      spaceA,
+      importerIdentity,
+      tx,
+    );
+
+    expect(loaded?.size).toBe(1);
+    const importer = loaded?.get(importerIdentity);
+    expect(importer?.imports.map((imp) => imp.specifier)).not.toContain(
+      fabricSpecifier,
+    );
+  });
 });
 
 describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   const spaceA = signer.did();
-  const compilerDid = signer.did();
   const RTVER = "rt-test-1";
 
   beforeEach(() => {
@@ -267,7 +337,10 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     await storageManager?.close();
   });
 
-  const opts = () => ({ runtimeVersion: RTVER, compilerDid });
+  const opts = () => ({
+    runtimeVersion: RTVER,
+    compilerDid: runtime.userIdentityDID,
+  });
 
   it("writes compiled docs with integrity and loads them back (warm hit)", async () => {
     const { modules, entryIdentity } = toModules(PROGRAM);
@@ -366,7 +439,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
 
     const otherDid = "did:key:someone-else";
     expect(compiledIntegrityAtom(otherDid)).not.toBe(
-      compiledIntegrityAtom(compilerDid),
+      compiledIntegrityAtom(opts().compilerDid),
     );
     const rtx = runtime.edit();
     const loaded = await loadCompiledClosure(
@@ -378,5 +451,88 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     );
     rtx.abort?.();
     expect(loaded.size).toBe(0);
+  });
+
+  it("keeps fabric imports as compiled links", async () => {
+    const { modules, importerIdentity, depIdentity, fabricSpecifier } =
+      fabricLinkedModules();
+    const wtx = runtime.edit();
+    writeCompiledDocs(runtime, spaceA, modules, importerIdentity, opts(), wtx);
+    wtx.prepareCfc();
+    await wtx.commit();
+
+    const rtx = runtime.edit();
+    const loaded = await loadCompiledClosure(
+      runtime,
+      spaceA,
+      importerIdentity,
+      opts(),
+      rtx,
+    );
+    rtx.abort?.();
+
+    expect(loaded.has(importerIdentity)).toBe(true);
+    expect(loaded.has(depIdentity)).toBe(true);
+    expect(loaded.get(importerIdentity)?.imports).toContainEqual({
+      specifier: fabricSpecifier,
+      identity: depIdentity,
+    });
+  });
+
+  it("replicates fabric dependencies even though source closures exclude them", async () => {
+    const spaceB = "did:key:z6MkCellCacheFabricReplicationTarget";
+    const { modules, importerIdentity, depIdentity } = fabricLinkedModules();
+    const replicationOpts = {
+      runtimeVersion: COMPILE_CACHE_RUNTIME_VERSION,
+      compilerDid: runtime.userIdentityDID,
+    };
+    const wtx = runtime.edit();
+    writeSourceDocs(runtime, spaceA, modules, importerIdentity, wtx);
+    writeCompiledDocs(
+      runtime,
+      spaceA,
+      modules,
+      importerIdentity,
+      replicationOpts,
+      wtx,
+    );
+    wtx.prepareCfc();
+    await wtx.commit();
+
+    const manager = runtime.patternManager as unknown as {
+      replicateClosures(
+        entryIdentity: string,
+        fromSpace: string,
+        toSpace: string,
+      ): Promise<void>;
+    };
+    await manager.replicateClosures(importerIdentity, spaceA, spaceB);
+
+    const rtx = runtime.edit();
+    const importerSource = await loadVerifiedSourceClosure(
+      runtime,
+      spaceB,
+      importerIdentity,
+      rtx,
+    );
+    const depSource = await loadVerifiedSourceClosure(
+      runtime,
+      spaceB,
+      depIdentity,
+      rtx,
+    );
+    const compiled = await loadCompiledClosure(
+      runtime,
+      spaceB,
+      importerIdentity,
+      replicationOpts,
+      rtx,
+    );
+    rtx.abort?.();
+
+    expect(importerSource?.has(importerIdentity)).toBe(true);
+    expect(depSource?.has(depIdentity)).toBe(true);
+    expect(compiled.has(importerIdentity)).toBe(true);
+    expect(compiled.has(depIdentity)).toBe(true);
   });
 });

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -479,6 +479,43 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     });
   });
 
+  it("refuses to persist modules carrying unpinned fabric edges", () => {
+    // An unpinned specifier folds into the module identity AS TEXT, so the
+    // resolution result (the edge's target) can vary under a fixed identity —
+    // persisting such a module would make cache content key-unstable.
+    const { modules, importerIdentity, depIdentity } = fabricLinkedModules();
+    const unpinned: CacheableModule = {
+      ...modules[0],
+      source:
+        `import { x } from "cf:dep";\nexport function y() { return x + 1; }`,
+      imports: [{ specifier: "cf:dep", targetIdentity: depIdentity }],
+    };
+    const wtx = runtime.edit();
+    try {
+      expect(() =>
+        writeSourceDocs(
+          runtime,
+          spaceA,
+          [unpinned, modules[1]],
+          importerIdentity,
+          wtx,
+        )
+      ).toThrow("unpinned fabric import 'cf:dep'");
+      expect(() =>
+        writeCompiledDocs(
+          runtime,
+          spaceA,
+          [unpinned, modules[1]],
+          importerIdentity,
+          opts(),
+          wtx,
+        )
+      ).toThrow("unpinned fabric import 'cf:dep'");
+    } finally {
+      wtx.abort?.();
+    }
+  });
+
   it("replicates fabric dependencies even though source closures exclude them", async () => {
     const spaceB = "did:key:z6MkCellCacheFabricReplicationTarget";
     const { modules, importerIdentity, depIdentity } = fabricLinkedModules();

--- a/packages/runner/test/fabric-import-specifier.test.ts
+++ b/packages/runner/test/fabric-import-specifier.test.ts
@@ -155,6 +155,9 @@ describe("fabric import specifiers", () => {
       "cf:/",
       "cf://",
       "cf:/kitchen/",
+      "cf:todo-list//x",
+      "cf:todo-list/",
+      "cf:/kitchen/todo-list//deep/x",
     ];
 
     for (const specifier of invalid) {
@@ -175,6 +178,21 @@ describe("fabric import specifiers", () => {
     const pinned = withPin(ref, HASH);
     expect(formatFabricRef(ref)).toBe("cf:/kitchen/todo-list");
     expect(formatFabricRef(pinned)).toBe(`cf:/kitchen/todo-list@${HASH}`);
+  });
+
+  it("withPin on a pattern: URI ref is consistent with the conflicting-pin rule", () => {
+    const ref = parseFabricRef(`cf:pattern:${HASH}`)!;
+    // Equal pin: already content-addressed; no pin is added.
+    expect(formatFabricRef(withPin(ref, HASH))).toBe(`cf:pattern:${HASH}`);
+    // Different pin: contradicts the content address - never representable.
+    expect(() => withPin(ref, HASH_B)).toThrow("conflicting pin");
+  });
+
+  it("formatFabricRef refuses a host-qualified ref without a space", () => {
+    const ref = parseFabricRef("cf://host.example/kitchen/todo-list")!;
+    expect(() => formatFabricRef({ ...ref, space: undefined })).toThrow(
+      "host-qualified refs require a space",
+    );
   });
 
   it("accepts real module identities produced by computeModuleHashes", () => {

--- a/packages/runner/test/fabric-import-specifier.test.ts
+++ b/packages/runner/test/fabric-import-specifier.test.ts
@@ -1,0 +1,203 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { computeModuleHashes } from "../src/harness/module-identity.ts";
+import { createRef } from "../src/create-ref.ts";
+import {
+  formatFabricRef,
+  HASH_RE,
+  isFabricImportSpecifier,
+  parseFabricRef,
+  pinnedIdentity,
+  withPin,
+} from "../src/sandbox/fabric-import-specifier.ts";
+import { isAllowedAuthoredImportSpecifier } from "../src/sandbox/runtime-module-policy.ts";
+import { toURI } from "../src/uri-utils.ts";
+
+const HASH = "Avcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c";
+const HASH_B = "Bvcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c";
+const HEX_LOOKING_HASH = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+describe("fabric import specifiers", () => {
+  it("returns undefined for non-fabric specifiers", () => {
+    for (const specifier of ["./foo.ts", "commonfabric", "npm:x"]) {
+      expect(parseFabricRef(specifier)).toBeUndefined();
+      expect(isFabricImportSpecifier(specifier)).toBe(false);
+    }
+  });
+
+  it("parses valid specifiers and formats canonically", () => {
+    const cases = [
+      {
+        specifier: "cf:todo-list",
+        expected: {
+          ref: { kind: "slug", slug: "todo-list" },
+        },
+      },
+      {
+        specifier: "cf:todo-list/schemas",
+        expected: {
+          ref: { kind: "slug", slug: "todo-list" },
+          subpath: "schemas",
+        },
+      },
+      {
+        specifier: "cf:/kitchen/todo-list",
+        expected: {
+          space: "kitchen",
+          ref: { kind: "slug", slug: "todo-list" },
+        },
+      },
+      {
+        specifier: "cf:/kitchen/todo-list/a/b.ts",
+        expected: {
+          space: "kitchen",
+          ref: { kind: "slug", slug: "todo-list" },
+          subpath: "a/b.ts",
+        },
+      },
+      {
+        specifier: "cf:/did:key:z6MkFabricImportTest/todo-list",
+        expected: {
+          space: "did:key:z6MkFabricImportTest",
+          ref: { kind: "slug", slug: "todo-list" },
+        },
+      },
+      {
+        specifier: "cf://host.example/kitchen/todo-list",
+        expected: {
+          host: "host.example",
+          space: "kitchen",
+          ref: { kind: "slug", slug: "todo-list" },
+        },
+      },
+      {
+        specifier: "cf://host.example:8000/kitchen/todo-list",
+        expected: {
+          host: "host.example:8000",
+          space: "kitchen",
+          ref: { kind: "slug", slug: "todo-list" },
+        },
+      },
+      {
+        specifier: `cf:/kitchen/todo-list@${HASH}`,
+        expected: {
+          space: "kitchen",
+          ref: { kind: "slug", slug: "todo-list" },
+          pin: HASH,
+        },
+      },
+      {
+        specifier: `cf:pattern:${HASH}`,
+        expected: {
+          ref: { kind: "uri", scheme: "pattern", hash: HASH },
+        },
+      },
+      {
+        specifier: `cf:pattern:${HEX_LOOKING_HASH}`,
+        expected: {
+          ref: { kind: "uri", scheme: "pattern", hash: HEX_LOOKING_HASH },
+        },
+      },
+      {
+        specifier: `cf:pattern:${HASH}@${HASH}`,
+        canonical: `cf:pattern:${HASH}`,
+        expected: {
+          ref: { kind: "uri", scheme: "pattern", hash: HASH },
+        },
+      },
+      {
+        specifier: `cf:/kitchen/of:fid1:${HASH}`,
+        expected: {
+          space: "kitchen",
+          ref: { kind: "uri", scheme: "of", hash: HASH },
+        },
+      },
+      {
+        specifier: `cf:of:fid1:${HASH}`,
+        expected: {
+          ref: { kind: "uri", scheme: "of", hash: HASH },
+        },
+      },
+      {
+        specifier: `cf:fid1:${HASH}`,
+        canonical: `cf:of:fid1:${HASH}`,
+        expected: {
+          ref: { kind: "uri", scheme: "of", hash: HASH },
+        },
+      },
+    ];
+
+    for (const { specifier, expected, canonical } of cases) {
+      const parsed = parseFabricRef(specifier);
+      expect(parsed).toEqual(expected);
+      expect(isFabricImportSpecifier(specifier)).toBe(true);
+      expect(isAllowedAuthoredImportSpecifier(specifier)).toBe(true);
+      expect(formatFabricRef(parsed!)).toBe(canonical ?? specifier);
+      expect(parseFabricRef(formatFabricRef(parsed!))).toEqual(parsed);
+    }
+  });
+
+  it("rejects malformed fabric specifiers", () => {
+    const invalid = [
+      "cf://host.example/todo-list",
+      "cf:todo-list@abc",
+      `cf:todo-list@${HASH}=`,
+      `cf:todo-list@${HASH}x`,
+      `cf:pattern:${HASH}@${HASH_B}`,
+      `cf:pattern:${HASH.toUpperCase()}@${HASH}`,
+      `cf:of:${HASH}`,
+      "cf:data:abc",
+      `cf:module/${HASH}`,
+      "cf:cache-root/x",
+      "cf:Has_Upper",
+      "cf:",
+      "cf:/",
+      "cf://",
+      "cf:/kitchen/",
+    ];
+
+    for (const specifier of invalid) {
+      expect(() => parseFabricRef(specifier)).toThrow();
+      expect(isFabricImportSpecifier(specifier)).toBe(false);
+      expect(isAllowedAuthoredImportSpecifier(specifier)).toBe(false);
+    }
+  });
+
+  it("reports pinned identities without resolving mutable pointers", () => {
+    expect(pinnedIdentity(parseFabricRef(`cf:pattern:${HASH}`)!)).toBe(HASH);
+    expect(pinnedIdentity(parseFabricRef(`cf:todo-list@${HASH}`)!)).toBe(HASH);
+    expect(pinnedIdentity(parseFabricRef("cf:todo-list")!)).toBeUndefined();
+  });
+
+  it("adds pins without changing the original ref", () => {
+    const ref = parseFabricRef("cf:/kitchen/todo-list")!;
+    const pinned = withPin(ref, HASH);
+    expect(formatFabricRef(ref)).toBe("cf:/kitchen/todo-list");
+    expect(formatFabricRef(pinned)).toBe(`cf:/kitchen/todo-list@${HASH}`);
+  });
+
+  it("accepts real module identities produced by computeModuleHashes", () => {
+    const hashes = computeModuleHashes({
+      files: [{ name: "/main.ts", contents: "export const value = 1;" }],
+      main: "/main.ts",
+    });
+    const hash = hashes.get("/main.ts")!;
+
+    expect(HASH_RE.test(hash)).toBe(true);
+    expect(parseFabricRef(`cf:pattern:${hash}`)).toEqual({
+      ref: { kind: "uri", scheme: "pattern", hash },
+    });
+  });
+
+  it("accepts real entity URIs produced by createRef and toURI", () => {
+    const uri = toURI(createRef({ x: 1 }, "fabric import canary"));
+    const match = /^of:fid1:([A-Za-z0-9_-]{43})$/.exec(uri);
+
+    expect(match).not.toBeNull();
+    expect(parseFabricRef(`cf:/somespace/${uri}`)).toEqual({
+      space: "somespace",
+      ref: { kind: "uri", scheme: "of", hash: match![1] },
+    });
+  });
+});

--- a/packages/runner/test/fabric-imports-engine.test.ts
+++ b/packages/runner/test/fabric-imports-engine.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import type { Program } from "@commonfabric/js-compiler";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { Engine } from "../src/harness/engine.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { writeSourceDocs } from "../src/compilation-cache/cell-cache.ts";
+import { FABRIC_MOUNT_ROOT } from "../src/sandbox/module-record-compiler.ts";
+
+const signer = await Identity.fromPassphrase("fabric imports engine test");
+const space = signer.did();
+
+describe("Engine fabric imports", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let engine: Engine;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+    engine = runtime.harness as Engine;
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  function dependencyProgram(value: number): RuntimeProgram {
+    return {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: `export const x = ${value};`,
+        },
+      ],
+    };
+  }
+
+  function importerProgram(specifier: string): RuntimeProgram {
+    return {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            `import { pattern } from "commonfabric";`,
+            `import { x } from "${specifier}";`,
+            `export function y() { return x + 1; }`,
+            `export default pattern<{ value: number }>(({ value }) => ({ result: value + x }));`,
+          ].join("\n"),
+        },
+      ],
+    };
+  }
+
+  async function publish(program: RuntimeProgram) {
+    const compiled = await engine.compileToRecordGraph(program);
+    const tx = runtime.edit();
+    writeSourceDocs(
+      runtime,
+      space,
+      compiled.modules,
+      compiled.entryIdentity,
+      tx,
+    );
+    await tx.commit();
+    return compiled;
+  }
+
+  async function runPattern(pattern: unknown, value: number): Promise<unknown> {
+    const tx = runtime.edit();
+    const resultCell = runtime.getCell<{ result: number }>(
+      space,
+      `fabric import result ${value}`,
+      undefined,
+      tx,
+    );
+    // deno-lint-ignore no-explicit-any
+    const result = runtime.run(tx, pattern as any, { value }, resultCell);
+    await tx.commit();
+    await result.pull();
+    return result.getAsQueryResult();
+  }
+
+  it("compiles, type-checks, evaluates, and describes pinned same-space imports", async () => {
+    const dependency = await publish(dependencyProgram(41));
+    const specifier = `cf:pattern:${dependency.entryIdentity}`;
+    const program = importerProgram(specifier);
+
+    const compiled = await engine.compileToRecordGraph(program, {
+      fabricImports: { space },
+    });
+
+    const mountedPath =
+      `${FABRIC_MOUNT_ROOT}${dependency.entryIdentity}/main.tsx`;
+    const mountedSpecifier = compiled.graph.specifierByPath.get(mountedPath);
+    expect(mountedSpecifier).toBe(`cf:module/${dependency.entryIdentity}`);
+    expect(compiled.graph.records.has(`cf:module/${dependency.entryIdentity}`))
+      .toBe(true);
+
+    const importerRecord = compiled.graph.records.get(compiled.mainSpecifier)!;
+    expect(importerRecord.resolutions?.[specifier]).toBe(
+      `cf:module/${dependency.entryIdentity}`,
+    );
+
+    const importedModule = compiled.modules.find((module) =>
+      module.identity === dependency.entryIdentity
+    );
+    expect(importedModule?.filename).toBe("/main.tsx");
+    expect(importedModule?.source).toBe(dependency.modules[0].source);
+
+    const importerModule = compiled.modules.find((module) =>
+      module.identity === compiled.entryIdentity
+    );
+    expect(importerModule?.imports).toContainEqual({
+      specifier,
+      targetIdentity: dependency.entryIdentity,
+    });
+
+    const evaluated = engine.evaluateRecordGraph(
+      compiled.id,
+      compiled.graph,
+      compiled.mainSpecifier,
+      program.files,
+    );
+    expect(evaluated.main?.y()).toBe(42);
+    expect(await runPattern(evaluated.main?.default, 1)).toEqual({
+      result: 42,
+    });
+  });
+
+  it("uses the mounted source for TypeScript diagnostics", async () => {
+    const dependency = await publish(dependencyProgram(1));
+    const specifier = `cf:pattern:${dependency.entryIdentity}`;
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents:
+            `import { missing } from "${specifier}";\nexport const y = missing;`,
+        },
+      ],
+    };
+
+    await expect(
+      engine.compileToRecordGraph(program, { fabricImports: { space } }),
+    ).rejects.toThrow("has no exported member 'missing'");
+  });
+
+  it("rejects fabric imports without a space context before generic resolution errors", async () => {
+    const dependency = await publish(dependencyProgram(1));
+    await expect(
+      engine.compileToRecordGraph(
+        importerProgram(`cf:pattern:${dependency.entryIdentity}`),
+      ),
+    ).rejects.toThrow(
+      "fabric imports require a space context (options.fabricImports)",
+    );
+  });
+
+  it("dedupes mounted files when different specifier texts pin the same identity", async () => {
+    const dependency = await publish(dependencyProgram(2));
+    const direct = `cf:pattern:${dependency.entryIdentity}`;
+    const pinnedSlug = `cf:dep@${dependency.entryIdentity}`;
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            `import { x as a } from "${direct}";`,
+            `import { x as b } from "${pinnedSlug}";`,
+            `export function total() { return a + b; }`,
+          ].join("\n"),
+        },
+      ],
+    };
+
+    const compiled = await engine.compileToRecordGraph(program, {
+      fabricImports: { space },
+    });
+
+    expect(
+      compiled.modules.filter((module) =>
+        module.identity === dependency.entryIdentity
+      ),
+    ).toHaveLength(1);
+    expect(compiled.graph.records.has(`cf:module/${dependency.entryIdentity}`))
+      .toBe(true);
+
+    const evaluated = engine.evaluateRecordGraph(
+      compiled.id,
+      compiled.graph,
+      compiled.mainSpecifier,
+      program.files,
+    );
+    expect(evaluated.main?.total()).toBe(4);
+  });
+
+  it("keeps old pins stable and changes importer identity when the pin text changes", async () => {
+    const oldDependency = await publish(dependencyProgram(3));
+    const oldSpecifier = `cf:pattern:${oldDependency.entryIdentity}`;
+    const oldImporter = await engine.compileToRecordGraph(
+      importerProgram(oldSpecifier),
+      { fabricImports: { space } },
+    );
+
+    const newDependency = await publish(dependencyProgram(4));
+    const oldImporterAgain = await engine.compileToRecordGraph(
+      importerProgram(oldSpecifier),
+      { fabricImports: { space } },
+    );
+    const newImporter = await engine.compileToRecordGraph(
+      importerProgram(`cf:pattern:${newDependency.entryIdentity}`),
+      { fabricImports: { space } },
+    );
+
+    expect(oldImporterAgain.entryIdentity).toBe(oldImporter.entryIdentity);
+    expect(newImporter.entryIdentity).not.toBe(oldImporter.entryIdentity);
+    expect(
+      oldImporterAgain.modules.some((module) =>
+        module.identity === oldDependency.entryIdentity
+      ),
+    ).toBe(true);
+    expect(
+      newImporter.modules.some((module) =>
+        module.identity === newDependency.entryIdentity
+      ),
+    ).toBe(true);
+  });
+
+  it("surfaces mounted files in getTransformedProgram", async () => {
+    const dependency = await publish(dependencyProgram(5));
+    let transformed: Program | undefined;
+
+    await engine.compileToRecordGraph(
+      importerProgram(`cf:pattern:${dependency.entryIdentity}`),
+      {
+        fabricImports: { space },
+        getTransformedProgram: (program) => {
+          transformed = program;
+        },
+      },
+    );
+
+    expect(
+      transformed?.files.some((file) =>
+        file.name === `${FABRIC_MOUNT_ROOT}${dependency.entryIdentity}/main.tsx`
+      ),
+    ).toBe(true);
+  });
+
+  it("compiles already-resolved stored sources with fabric imports", async () => {
+    const dependency = await publish(dependencyProgram(7));
+    const modules = await engine.compileResolvedToRecordGraph(
+      [
+        {
+          name: "/main.tsx",
+          contents:
+            `import { x } from "cf:pattern:${dependency.entryIdentity}";\nexport function y() { return x + 1; }`,
+        },
+      ],
+      "/main.tsx",
+      { fabricImports: { space } },
+    );
+
+    expect(
+      modules.modules.some((module) =>
+        module.identity === dependency.entryIdentity
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/runner/test/fabric-imports-engine.test.ts
+++ b/packages/runner/test/fabric-imports-engine.test.ts
@@ -63,8 +63,11 @@ describe("Engine fabric imports", () => {
     };
   }
 
-  async function publish(program: RuntimeProgram) {
-    const compiled = await engine.compileToRecordGraph(program);
+  async function publish(
+    program: RuntimeProgram,
+    options: Parameters<Engine["compileToRecordGraph"]>[1] = {},
+  ) {
+    const compiled = await engine.compileToRecordGraph(program, options);
     const tx = runtime.edit();
     writeSourceDocs(
       runtime,
@@ -372,6 +375,149 @@ describe("Engine fabric imports", () => {
         file.name === `${FABRIC_MOUNT_ROOT}${dependency.entryIdentity}/main.tsx`
       ),
     ).toBe(true);
+  });
+
+  it("compiles transitive fabric imports and mounts each subtree once", async () => {
+    const base = await publish(dependencyProgram(100));
+    const midProgram: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            `import { x } from "cf:pattern:${base.entryIdentity}";`,
+            `export function p() { return x + 1; }`,
+          ].join("\n"),
+        },
+      ],
+    };
+    const mid = await publish(midProgram, { fabricImports: { space } });
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            `import { p } from "cf:pattern:${mid.entryIdentity}";`,
+            `export function y() { return p() + 1; }`,
+          ].join("\n"),
+        },
+      ],
+    };
+
+    const compiled = await engine.compileToRecordGraph(program, {
+      fabricImports: { space },
+    });
+
+    // Both subtrees are mounted under their PUBLISHED identities, once each.
+    expect(compiled.graph.records.has(`cf:module/${mid.entryIdentity}`))
+      .toBe(true);
+    expect(compiled.graph.records.has(`cf:module/${base.entryIdentity}`))
+      .toBe(true);
+    expect(
+      compiled.modules.filter((m) => m.identity === base.entryIdentity),
+    ).toHaveLength(1);
+    expect(
+      compiled.modules.filter((m) => m.identity === mid.entryIdentity),
+    ).toHaveLength(1);
+
+    // The mounted middle module's own fabric edge resolves in records AND in
+    // write-back form (matching what its own publish produced).
+    const midRecord = compiled.graph.records.get(
+      `cf:module/${mid.entryIdentity}`,
+    )!;
+    expect(midRecord.resolutions?.[`cf:pattern:${base.entryIdentity}`]).toBe(
+      `cf:module/${base.entryIdentity}`,
+    );
+    const midModule = compiled.modules.find((m) =>
+      m.identity === mid.entryIdentity
+    );
+    expect(midModule?.imports).toContainEqual({
+      specifier: `cf:pattern:${base.entryIdentity}`,
+      targetIdentity: base.entryIdentity,
+    });
+
+    const evaluated = engine.evaluateRecordGraph(
+      compiled.id,
+      compiled.graph,
+      compiled.mainSpecifier,
+      program.files,
+    );
+    expect(evaluated.main?.y()).toBe(102);
+  });
+
+  it("skips the TypeScript compile when every module, including mounts, is cached", async () => {
+    const dependency = await publish(dependencyProgram(6));
+    const program = importerProgram(`cf:pattern:${dependency.entryIdentity}`);
+
+    let firstTransformed = 0;
+    const first = await engine.compileToRecordGraph(program, {
+      fabricImports: { space },
+      getTransformedProgram: () => {
+        firstTransformed++;
+      },
+    });
+    expect(firstTransformed).toBe(1);
+
+    const artifacts = new Map(
+      first.modules.map((m) => [m.identity, {
+        js: m.js,
+        ...(m.sourceMap === undefined ? {} : { sourceMap: m.sourceMap }),
+      }]),
+    );
+    let requested: string[] | undefined;
+    let secondTransformed = 0;
+    const second = await engine.compileToRecordGraph(program, {
+      fabricImports: { space },
+      getTransformedProgram: () => {
+        secondTransformed++;
+      },
+      precompiledModulesFor: ({ identities }) => {
+        requested = identities;
+        return Promise.resolve(artifacts);
+      },
+    });
+
+    // The cache was queried for the mounted identity too, and the full hit
+    // skipped the TypeScript compile entirely (the transform callback only
+    // fires inside compileToModules).
+    expect(requested).toContain(dependency.entryIdentity);
+    expect(secondTransformed).toBe(0);
+    expect(second.entryIdentity).toBe(first.entryIdentity);
+
+    const evaluated = engine.evaluateRecordGraph(
+      second.id,
+      second.graph,
+      second.mainSpecifier,
+      program.files,
+    );
+    expect(evaluated.main?.y()).toBe(7);
+  });
+
+  it("refuses to write back modules from an unpinned (dev) compile", async () => {
+    const dependency = await publish(dependencyProgram(8));
+    const { cell } = await writePatternMeta(dependency.entryIdentity);
+    await writeSlug("dep", cell);
+
+    const compiled = await engine.compileToRecordGraph(
+      importerProgram("cf:dep"),
+      { fabricImports: { space, allowUnpinned: true } },
+    );
+
+    const tx = runtime.edit();
+    try {
+      expect(() =>
+        writeSourceDocs(
+          runtime,
+          space,
+          compiled.modules,
+          compiled.entryIdentity,
+          tx,
+        )
+      ).toThrow("unpinned fabric import 'cf:dep'");
+    } finally {
+      tx.abort?.();
+    }
   });
 
   it("compiles already-resolved stored sources with fabric imports", async () => {

--- a/packages/runner/test/fabric-imports-engine.test.ts
+++ b/packages/runner/test/fabric-imports-engine.test.ts
@@ -8,6 +8,12 @@ import { Engine } from "../src/harness/engine.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import { writeSourceDocs } from "../src/compilation-cache/cell-cache.ts";
 import { FABRIC_MOUNT_ROOT } from "../src/sandbox/module-record-compiler.ts";
+import { createRef } from "../src/create-ref.ts";
+import { fromURI, toURI } from "../src/uri-utils.ts";
+import { type PatternMeta, patternMetaSchema } from "../src/pattern-manager.ts";
+import { slugIdForSpace } from "../src/slugs.ts";
+import type { Cell } from "../src/cell.ts";
+import type { URI } from "../src/sigil-types.ts";
 
 const signer = await Identity.fromPassphrase("fabric imports engine test");
 const space = signer.did();
@@ -69,6 +75,54 @@ describe("Engine fabric imports", () => {
     );
     await tx.commit();
     return compiled;
+  }
+
+  function newPatternId(label: string): URI {
+    return toURI(createRef({ pattern: label }, "fabric imports engine test"));
+  }
+
+  function patternMetaCell(patternId: URI): Cell<PatternMeta> {
+    return runtime.getCellFromEntityId(
+      space,
+      { "/": fromURI(patternId) },
+      [],
+      patternMetaSchema,
+    );
+  }
+
+  async function writePatternMeta(
+    entryIdentity: string,
+  ): Promise<{ patternId: URI; cell: Cell<PatternMeta> }> {
+    const patternId = newPatternId(entryIdentity);
+    const cell = patternMetaCell(patternId);
+    await runtime.editWithRetry((tx) => {
+      cell.withTx(tx).set({
+        spec: "pattern",
+        entryIdentity,
+      } as PatternMeta);
+    });
+    return { patternId, cell };
+  }
+
+  async function writeSlug(slug: string, target: Cell<unknown>): Promise<void> {
+    const slugCell = runtime.getCellFromEntityId(space, {
+      "/": slugIdForSpace(space, slug),
+    });
+    await runtime.editWithRetry((tx) => {
+      const slugWithTx = slugCell.withTx(tx);
+      slugWithTx.setRawUntyped(
+        target.withTx(tx).getAsWriteRedirectLink({ base: slugWithTx }),
+      );
+    });
+  }
+
+  async function poisonSlug(slug: string): Promise<void> {
+    const slugCell = runtime.getCellFromEntityId(space, {
+      "/": slugIdForSpace(space, slug),
+    });
+    await runtime.editWithRetry((tx) => {
+      slugCell.withTx(tx).setRawUntyped("not a redirect");
+    });
   }
 
   async function runPattern(pattern: unknown, value: number): Promise<unknown> {
@@ -161,6 +215,71 @@ describe("Engine fabric imports", () => {
     ).rejects.toThrow(
       "fabric imports require a space context (options.fabricImports)",
     );
+  });
+
+  it("rejects unpinned fabric imports unless explicitly allowed", async () => {
+    await expect(
+      engine.compileToRecordGraph(importerProgram("cf:dep"), {
+        fabricImports: { space },
+      }),
+    ).rejects.toThrow(
+      "unpinned fabric import 'cf:dep'; pin it (cf deps update) or deploy to pin",
+    );
+  });
+
+  it("resolves unpinned fabric imports in dev mode and surfaces resolved pins", async () => {
+    const dependency = await publish(dependencyProgram(9));
+    const { patternId, cell } = await writePatternMeta(
+      dependency.entryIdentity,
+    );
+    await writeSlug("dep", cell);
+
+    const compiled = await engine.compileToRecordGraph(
+      importerProgram("cf:dep"),
+      {
+        fabricImports: { space, allowUnpinned: true },
+      },
+    );
+
+    expect(compiled.resolvedPins).toEqual([
+      {
+        specifier: "cf:dep",
+        resolvedIdentity: dependency.entryIdentity,
+        chain: [
+          "slug:dep",
+          `patternMeta:${patternId}`,
+          `entryIdentity:${dependency.entryIdentity}`,
+        ],
+      },
+    ]);
+    const evaluated = engine.evaluateRecordGraph(
+      compiled.id,
+      compiled.graph,
+      compiled.mainSpecifier,
+      importerProgram("cf:dep").files,
+    );
+    expect(evaluated.main?.y()).toBe(10);
+  });
+
+  it("does not chase the slug for already-pinned mutable refs", async () => {
+    const dependency = await publish(dependencyProgram(11));
+    const { cell } = await writePatternMeta(dependency.entryIdentity);
+    await writeSlug("dep", cell);
+    await poisonSlug("dep");
+
+    const compiled = await engine.compileToRecordGraph(
+      importerProgram(`cf:dep@${dependency.entryIdentity}`),
+      { fabricImports: { space } },
+    );
+
+    expect(compiled.resolvedPins).toEqual([]);
+    const evaluated = engine.evaluateRecordGraph(
+      compiled.id,
+      compiled.graph,
+      compiled.mainSpecifier,
+      importerProgram(`cf:dep@${dependency.entryIdentity}`).files,
+    );
+    expect(evaluated.main?.y()).toBe(12);
   });
 
   it("dedupes mounted files when different specifier texts pin the same identity", async () => {

--- a/packages/runner/test/fabric-imports-pattern-manager.test.ts
+++ b/packages/runner/test/fabric-imports-pattern-manager.test.ts
@@ -131,6 +131,15 @@ describe("PatternManager fabric imports", () => {
           "default",
         ),
       ).toBeDefined();
+      // Importer and dependency share the filename `/main.tsx`. The cached
+      // record path must not let one shadow the other in its filename-keyed
+      // side tables — the IMPORTER's exports must be indexed by identity too.
+      expect(
+        rt2.patternManager.artifactFromIdentitySync(
+          importerIdentity,
+          "default",
+        ),
+      ).toBeDefined();
     } finally {
       await rt2.dispose();
       await rt1.dispose();

--- a/packages/runner/test/fabric-imports-pattern-manager.test.ts
+++ b/packages/runner/test/fabric-imports-pattern-manager.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { Engine } from "../src/harness/engine.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import {
+  COMPILE_CACHE_RUNTIME_VERSION,
+  loadCompiledClosure,
+  writeSourceDocs,
+} from "../src/compilation-cache/cell-cache.ts";
+
+const signer = await Identity.fromPassphrase(
+  "fabric imports pattern manager test",
+);
+const space = signer.did();
+
+describe("PatternManager fabric imports", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+  });
+
+  afterEach(async () => {
+    await storageManager?.close();
+  });
+
+  const newRuntime = () =>
+    new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+
+  function dependencyProgram(value: number): RuntimeProgram {
+    return {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            `import { pattern } from "commonfabric";`,
+            `export const x = ${value};`,
+            `export default pattern<{ value: number }>(({ value }) => ({ dep: value + x }));`,
+          ].join("\n"),
+        },
+      ],
+    };
+  }
+
+  function importerProgram(specifier: string): RuntimeProgram {
+    return {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            `import { pattern } from "commonfabric";`,
+            `import dep, { x } from "${specifier}";`,
+            `export function y() { return x + 1; }`,
+            `export default pattern<{ value: number }>(({ value }) => {`,
+            `  const child = dep({ value });`,
+            `  return { result: value + x + 1, child };`,
+            `});`,
+          ].join("\n"),
+        },
+      ],
+    };
+  }
+
+  async function runPattern(
+    runtime: Runtime,
+    pattern: unknown,
+    value: number,
+    cause: string,
+  ): Promise<unknown> {
+    const tx = runtime.edit();
+    const resultCell = runtime.getCell<{
+      result: number;
+      child: { dep: number };
+    }>(space, cause, undefined, tx);
+    // deno-lint-ignore no-explicit-any
+    const result = runtime.run(tx, pattern as any, { value }, resultCell);
+    await tx.commit();
+    await result.pull();
+    return result.getAsQueryResult();
+  }
+
+  it("compiles cache-backed fabric imports and warm-reloads them by identity", async () => {
+    const rt1 = newRuntime();
+    const rt2 = newRuntime();
+    try {
+      const pm1 = rt1.patternManager;
+      const tx1 = rt1.edit();
+      const dependency = await pm1.compilePattern(dependencyProgram(10), {
+        space,
+        tx: tx1,
+      });
+      const dependencyIdentity = pm1.getArtifactEntryRef(dependency)!.identity;
+      await pm1.flushCompileCacheWrites();
+
+      const importer = await pm1.compilePattern(
+        importerProgram(`cf:pattern:${dependencyIdentity}`),
+        { space, tx: tx1 },
+      );
+      const importerIdentity = pm1.getArtifactEntryRef(importer)!.identity;
+      await pm1.flushCompileCacheWrites();
+      await tx1.commit();
+      await rt1.storageManager.synced();
+
+      const loaded = await rt2.patternManager.loadPatternByIdentity(
+        importerIdentity,
+        "default",
+        space,
+      );
+
+      expect(typeof loaded).toBe("function");
+      expect(rt2.patternManager.getCompileCacheStats().byIdentityHits).toBe(1);
+      const out = await runPattern(rt2, loaded, 5, "warm fabric reload") as {
+        result: number;
+        child: { dep: number };
+      };
+      expect(out.result).toBe(16);
+      expect(out.child).toEqual({ dep: 15 });
+      expect(
+        rt2.patternManager.artifactFromIdentitySync(
+          dependencyIdentity,
+          "default",
+        ),
+      ).toBeDefined();
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  it("cold-reloads fabric imports by identity from verified source docs", async () => {
+    const runtime = newRuntime();
+    try {
+      const engine = runtime.harness as Engine;
+      const dependency = await engine.compileToRecordGraph(
+        dependencyProgram(20),
+      );
+      const depTx = runtime.edit();
+      writeSourceDocs(
+        runtime,
+        space,
+        dependency.modules,
+        dependency.entryIdentity,
+        depTx,
+      );
+      await depTx.commit();
+
+      const importer = await engine.compileToRecordGraph(
+        importerProgram(`cf:pattern:${dependency.entryIdentity}`),
+        { fabricImports: { space } },
+      );
+      const importerTx = runtime.edit();
+      writeSourceDocs(
+        runtime,
+        space,
+        importer.modules,
+        importer.entryIdentity,
+        importerTx,
+      );
+      await importerTx.commit();
+
+      const loaded = await runtime.patternManager.loadPatternByIdentity(
+        importer.entryIdentity,
+        "default",
+        space,
+      );
+
+      expect(typeof loaded).toBe("function");
+      const out = await runPattern(
+        runtime,
+        loaded,
+        2,
+        "cold fabric reload",
+      ) as {
+        result: number;
+        child: { dep: number };
+      };
+      expect(out.result).toBe(23);
+      expect(out.child).toEqual({ dep: 22 });
+      expect(
+        runtime.patternManager.artifactFromIdentitySync(
+          dependency.entryIdentity,
+          "default",
+        ),
+      ).toBeDefined();
+
+      await runtime.patternManager.flushCompileCacheWrites();
+      const readTx = runtime.edit();
+      const compiled = await loadCompiledClosure(
+        runtime,
+        space,
+        importer.entryIdentity,
+        {
+          runtimeVersion: COMPILE_CACHE_RUNTIME_VERSION,
+          compilerDid: runtime.userIdentityDID,
+        },
+        readTx,
+      );
+      readTx.abort?.();
+      expect(compiled.has(importer.entryIdentity)).toBe(true);
+      expect(compiled.has(dependency.entryIdentity)).toBe(true);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+});

--- a/packages/runner/test/fabric-imports-pattern-manager.test.ts
+++ b/packages/runner/test/fabric-imports-pattern-manager.test.ts
@@ -8,6 +8,7 @@ import type { RuntimeProgram } from "../src/harness/types.ts";
 import {
   COMPILE_CACHE_RUNTIME_VERSION,
   loadCompiledClosure,
+  loadVerifiedSourceClosure,
   writeSourceDocs,
 } from "../src/compilation-cache/cell-cache.ts";
 
@@ -15,6 +16,7 @@ const signer = await Identity.fromPassphrase(
   "fabric imports pattern manager test",
 );
 const space = signer.did();
+const otherSpace = "did:key:z6MkFabricImportsPatternManagerOther";
 
 describe("PatternManager fabric imports", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
@@ -206,6 +208,56 @@ describe("PatternManager fabric imports", () => {
       readTx.abort?.();
       expect(compiled.has(importer.entryIdentity)).toBe(true);
       expect(compiled.has(dependency.entryIdentity)).toBe(true);
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("copies cross-space fabric imports into the compiling space cache", async () => {
+    const runtime = newRuntime();
+    try {
+      const engine = runtime.harness as Engine;
+      const dependency = await engine.compileToRecordGraph(
+        dependencyProgram(30),
+      );
+      const depTx = runtime.edit();
+      writeSourceDocs(
+        runtime,
+        otherSpace,
+        dependency.modules,
+        dependency.entryIdentity,
+        depTx,
+      );
+      await depTx.commit();
+
+      const importer = await runtime.patternManager.compilePattern(
+        importerProgram(
+          `cf:/${otherSpace}/pattern:${dependency.entryIdentity}`,
+        ),
+        { space },
+      );
+      const importerIdentity = runtime.patternManager.getArtifactEntryRef(
+        importer,
+      )!.identity;
+      await runtime.patternManager.flushCompileCacheWrites();
+
+      const readTx = runtime.edit();
+      const copiedDependency = await loadVerifiedSourceClosure(
+        runtime,
+        space,
+        dependency.entryIdentity,
+        readTx,
+      );
+      const copiedImporter = await loadVerifiedSourceClosure(
+        runtime,
+        space,
+        importerIdentity,
+        readTx,
+      );
+      readTx.abort?.();
+
+      expect(copiedDependency?.has(dependency.entryIdentity)).toBe(true);
+      expect(copiedImporter?.has(importerIdentity)).toBe(true);
     } finally {
       await runtime.dispose();
     }

--- a/packages/runner/test/fabric-imports-snapshot.test.ts
+++ b/packages/runner/test/fabric-imports-snapshot.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { Engine } from "../src/harness/engine.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { writeSourceDocs } from "../src/compilation-cache/cell-cache.ts";
+import { rewriteFabricPins } from "../src/fabric-pin-rewrite.ts";
+import { resolveFabricRefToIdentity } from "../src/fabric-ref-resolution.ts";
+import { createRef } from "../src/create-ref.ts";
+import { fromURI, toURI } from "../src/uri-utils.ts";
+import { type PatternMeta, patternMetaSchema } from "../src/pattern-manager.ts";
+import { slugIdForSpace } from "../src/slugs.ts";
+import type { Cell } from "../src/cell.ts";
+import type { URI } from "../src/sigil-types.ts";
+
+const signer = await Identity.fromPassphrase(
+  "fabric imports snapshot semantics test",
+);
+const space = signer.did();
+
+describe("fabric import snapshot semantics", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let engine: Engine;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+    engine = runtime.harness as Engine;
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  function dependencyProgram(value: number): RuntimeProgram {
+    return {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: `export const x = ${value};`,
+        },
+      ],
+    };
+  }
+
+  function importerProgram(specifier: string): RuntimeProgram {
+    return {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            `import { pattern } from "commonfabric";`,
+            `import { x } from "${specifier}";`,
+            `export default pattern<{ value: number }>(({ value }) => ({ result: value + x }));`,
+          ].join("\n"),
+        },
+      ],
+    };
+  }
+
+  async function publishDependency(value: number) {
+    const compiled = await engine.compileToRecordGraph(
+      dependencyProgram(value),
+    );
+    const tx = runtime.edit();
+    writeSourceDocs(
+      runtime,
+      space,
+      compiled.modules,
+      compiled.entryIdentity,
+      tx,
+    );
+    await tx.commit();
+    return compiled;
+  }
+
+  function newPatternId(label: string): URI {
+    return toURI(createRef({ pattern: label }, "snapshot semantics"));
+  }
+
+  function patternMetaCell(patternId: URI): Cell<PatternMeta> {
+    return runtime.getCellFromEntityId(
+      space,
+      { "/": fromURI(patternId) },
+      [],
+      patternMetaSchema,
+    );
+  }
+
+  async function writePatternMeta(
+    label: string,
+    entryIdentity: string,
+  ): Promise<Cell<PatternMeta>> {
+    const cell = patternMetaCell(newPatternId(label));
+    await runtime.editWithRetry((tx) => {
+      cell.withTx(tx).set({
+        spec: "pattern",
+        entryIdentity,
+      } as PatternMeta);
+    });
+    return cell;
+  }
+
+  async function writeSlug(slug: string, target: Cell<unknown>): Promise<void> {
+    const slugCell = runtime.getCellFromEntityId(space, {
+      "/": slugIdForSpace(space, slug),
+    });
+    await runtime.editWithRetry((tx) => {
+      const slugWithTx = slugCell.withTx(tx);
+      slugWithTx.setRawUntyped(
+        target.withTx(tx).getAsWriteRedirectLink({ base: slugWithTx }),
+      );
+    });
+  }
+
+  async function pinProgram(program: RuntimeProgram): Promise<RuntimeProgram> {
+    const files = [];
+    for (const file of program.files) {
+      const rewritten = await rewriteFabricPins(
+        file.contents,
+        async (ref) =>
+          (await resolveFabricRefToIdentity(runtime, space, ref))
+            .entryIdentity,
+      );
+      files.push({ ...file, contents: rewritten.contents });
+    }
+    return { ...program, files };
+  }
+
+  async function compileAndRun(
+    program: RuntimeProgram,
+    value: number,
+  ): Promise<
+    { entryIdentity: string; moduleIdentities: string[]; result: unknown }
+  > {
+    const compiled = await engine.compileToRecordGraph(program, {
+      fabricImports: { space },
+    });
+    const evaluated = engine.evaluateRecordGraph(
+      compiled.id,
+      compiled.graph,
+      compiled.mainSpecifier,
+      program.files,
+    );
+    const tx = runtime.edit();
+    const resultCell = runtime.getCell<{ result: number }>(
+      space,
+      `snapshot-result-${value}-${compiled.entryIdentity}`,
+      undefined,
+      tx,
+    );
+    // deno-lint-ignore no-explicit-any
+    const result = runtime.run(
+      tx,
+      evaluated.main?.default as any,
+      { value },
+      resultCell,
+    );
+    await tx.commit();
+    await result.pull();
+    return {
+      entryIdentity: compiled.entryIdentity,
+      moduleIdentities: compiled.modules.map((module) => module.identity)
+        .sort(),
+      result: result.getAsQueryResult(),
+    };
+  }
+
+  it("pins mutable refs into stable snapshots and updates only on re-pin", async () => {
+    const depV1 = await publishDependency(10);
+    const metaV1 = await writePatternMeta("dep-v1", depV1.entryIdentity);
+    await writeSlug("dep", metaV1);
+
+    const unpinned = importerProgram("cf:dep");
+    const pinnedV1 = await pinProgram(unpinned);
+    expect(pinnedV1.files[0].contents).toContain(
+      `from "cf:dep@${depV1.entryIdentity}"`,
+    );
+
+    const runV1 = await compileAndRun(pinnedV1, 1);
+    expect(runV1.result).toEqual({ result: 11 });
+
+    const depV2 = await publishDependency(20);
+    const metaV2 = await writePatternMeta("dep-v2", depV2.entryIdentity);
+    await writeSlug("dep", metaV2);
+
+    const rerunV1 = await compileAndRun(pinnedV1, 1);
+    expect(rerunV1.entryIdentity).toBe(runV1.entryIdentity);
+    expect(rerunV1.moduleIdentities).toEqual(runV1.moduleIdentities);
+    expect(rerunV1.result).toEqual({ result: 11 });
+
+    const pinnedV2 = await pinProgram(pinnedV1);
+    const [beforeImport, , afterImport] = pinnedV1.files[0].contents.split(
+      "\n",
+    );
+    const [nextBeforeImport, , nextAfterImport] = pinnedV2.files[0].contents
+      .split("\n");
+    expect(nextBeforeImport).toBe(beforeImport);
+    expect(nextAfterImport).toBe(afterImport);
+    expect(pinnedV2.files[0].contents).toContain(
+      `from "cf:dep@${depV2.entryIdentity}"`,
+    );
+
+    const runV2 = await compileAndRun(pinnedV2, 1);
+    expect(runV2.entryIdentity).not.toBe(runV1.entryIdentity);
+    expect(runV2.result).toEqual({ result: 21 });
+
+    const dataCell = runtime.getCell(space, {
+      space,
+      random: "not-a-pattern",
+    });
+    await runtime.editWithRetry((tx) => {
+      dataCell.withTx(tx).set({ value: 1 });
+    });
+    await writeSlug("dep", dataCell);
+
+    const pinnedAfterBadSlug = await compileAndRun(pinnedV2, 1);
+    expect(pinnedAfterBadSlug.result).toEqual({ result: 21 });
+
+    await expect(
+      engine.compileToRecordGraph(unpinned, {
+        fabricImports: { space, allowUnpinned: true },
+      }),
+    ).rejects.toThrow("cf:dep does not resolve to a pattern");
+  });
+});

--- a/packages/runner/test/fabric-module-identity.test.ts
+++ b/packages/runner/test/fabric-module-identity.test.ts
@@ -1,0 +1,133 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { Source } from "@commonfabric/js-compiler";
+import {
+  computeFabricModuleIdentities,
+  computeModuleIdentities,
+  FABRIC_MOUNT_ROOT,
+  type FabricMount,
+} from "../src/sandbox/module-record-compiler.ts";
+
+const OTHER_HASH = "Bvcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c";
+
+function source(name: string, contents: string): Source {
+  return { name, contents };
+}
+
+function mountPath(entryIdentity: string, filename: string): string {
+  return `${FABRIC_MOUNT_ROOT}${entryIdentity}${filename}`;
+}
+
+function mount(entryIdentity: string): FabricMount {
+  return {
+    entryIdentity,
+    entryPath: mountPath(entryIdentity, "/main.tsx"),
+    specifiers: [`cf:pattern:${entryIdentity}`],
+  };
+}
+
+describe("computeFabricModuleIdentities", () => {
+  it("preserves published subtree identities and keeps pins in authored identity", () => {
+    const subtree = [
+      source(
+        "/main.tsx",
+        `import { value } from "./util.ts";\nexport const imported = value;`,
+      ),
+      source("/util.ts", `export const value = 7;`),
+    ];
+    const standalone = computeModuleIdentities(subtree);
+    const entryIdentity = standalone.get("/main.tsx")!;
+
+    const mounted = [
+      source(
+        "/host.tsx",
+        `import { imported } from "cf:pattern:${entryIdentity}";\nexport const host = imported;`,
+      ),
+      source(mountPath(entryIdentity, "/main.tsx"), subtree[0].contents),
+      source(mountPath(entryIdentity, "/util.ts"), subtree[1].contents),
+    ];
+    const identities = computeFabricModuleIdentities(mounted, [
+      mount(entryIdentity),
+    ]);
+
+    expect(identities.get(mountPath(entryIdentity, "/main.tsx"))).toBe(
+      standalone.get("/main.tsx"),
+    );
+    expect(identities.get(mountPath(entryIdentity, "/util.ts"))).toBe(
+      standalone.get("/util.ts"),
+    );
+
+    const repinned = [
+      source(
+        "/host.tsx",
+        `import { imported } from "cf:pattern:${OTHER_HASH}";\nexport const host = imported;`,
+      ),
+      mounted[1],
+      mounted[2],
+    ];
+    const repinnedIdentities = computeFabricModuleIdentities(repinned, [
+      mount(entryIdentity),
+    ]);
+
+    expect(repinnedIdentities.get("/host.tsx")).not.toBe(
+      identities.get("/host.tsx"),
+    );
+  });
+
+  it("throws when a mounted entry does not hash back to its identity", () => {
+    const subtree = [
+      source("/main.tsx", `export const value = 1;`),
+    ];
+    const entryIdentity = computeModuleIdentities(subtree).get("/main.tsx")!;
+    const tampered = [
+      source("/host.tsx", `export const host = 1;`),
+      source(mountPath(entryIdentity, "/main.tsx"), `export const value = 2;`),
+    ];
+
+    expect(() =>
+      computeFabricModuleIdentities(tampered, [mount(entryIdentity)])
+    )
+      .toThrow("integrity failure");
+  });
+
+  it("throws for files under the fabric mount root with no matching mount", () => {
+    const orphan = [
+      source("/host.tsx", `export const host = 1;`),
+      source(
+        `${FABRIC_MOUNT_ROOT}${OTHER_HASH}/main.tsx`,
+        `export const x = 1;`,
+      ),
+    ];
+
+    expect(() => computeFabricModuleIdentities(orphan, [])).toThrow(
+      "corrupt fabric mount assembly",
+    );
+  });
+
+  it("keeps two mounts with the same stored filenames independent", () => {
+    const first = [source("/main.tsx", `export const value = 1;`)];
+    const second = [source("/main.tsx", `export const value = 2;`)];
+    const firstIdentities = computeModuleIdentities(first);
+    const secondIdentities = computeModuleIdentities(second);
+    const firstEntry = firstIdentities.get("/main.tsx")!;
+    const secondEntry = secondIdentities.get("/main.tsx")!;
+    const mounted = [
+      source("/host.tsx", `export const host = 1;`),
+      source(mountPath(firstEntry, "/main.tsx"), first[0].contents),
+      source(mountPath(secondEntry, "/main.tsx"), second[0].contents),
+    ];
+
+    const identities = computeFabricModuleIdentities(mounted, [
+      mount(firstEntry),
+      mount(secondEntry),
+    ]);
+
+    expect(identities.get(mountPath(firstEntry, "/main.tsx"))).toBe(
+      firstEntry,
+    );
+    expect(identities.get(mountPath(secondEntry, "/main.tsx"))).toBe(
+      secondEntry,
+    );
+  });
+});

--- a/packages/runner/test/fabric-pin-rewrite.test.ts
+++ b/packages/runner/test/fabric-pin-rewrite.test.ts
@@ -17,13 +17,18 @@ describe("rewriteFabricPins", () => {
       'const literal = "cf:not-an-import";',
     ].join("\n");
 
-    const result = await rewriteFabricPins(source, async (_ref, specifier) =>
-      ({
-        "cf:dep": ENTRY_A,
-        "cf:other": ENTRY_B,
-        "cf:types": ENTRY_A,
-        "cf:inline": ENTRY_B,
-      })[specifier] ?? null);
+    const result = await rewriteFabricPins(
+      source,
+      (_ref, specifier) =>
+        Promise.resolve(
+          ({
+            "cf:dep": ENTRY_A,
+            "cf:other": ENTRY_B,
+            "cf:types": ENTRY_A,
+            "cf:inline": ENTRY_B,
+          })[specifier] ?? null,
+        ),
+    );
 
     expect(result.rewrites).toEqual([
       {
@@ -65,9 +70,9 @@ describe("rewriteFabricPins", () => {
       `import skipped from "cf:skipped";`,
     ].join("\n");
 
-    const result = await rewriteFabricPins(source, async (_ref, specifier) => {
-      if (specifier === `cf:dep@${ENTRY_A}`) return ENTRY_A;
-      return null;
+    const result = await rewriteFabricPins(source, (_ref, specifier) => {
+      if (specifier === `cf:dep@${ENTRY_A}`) return Promise.resolve(ENTRY_A);
+      return Promise.resolve(null);
     });
 
     expect(result.contents).toBe(source);

--- a/packages/runner/test/fabric-pin-rewrite.test.ts
+++ b/packages/runner/test/fabric-pin-rewrite.test.ts
@@ -1,0 +1,80 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { rewriteFabricPins } from "../src/fabric-pin-rewrite.ts";
+
+const ENTRY_A = "Avcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c";
+const ENTRY_B = "Bvcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c";
+
+describe("rewriteFabricPins", () => {
+  it("rewrites only import/export string literal spans", async () => {
+    const source = [
+      "import {",
+      "  dep,",
+      '} from "cf:dep";',
+      "export * from 'cf:other';",
+      'import type { RemoteType } from "cf:types";',
+      'type Inline = import("cf:inline").Value;',
+      'const literal = "cf:not-an-import";',
+    ].join("\n");
+
+    const result = await rewriteFabricPins(source, async (_ref, specifier) =>
+      ({
+        "cf:dep": ENTRY_A,
+        "cf:other": ENTRY_B,
+        "cf:types": ENTRY_A,
+        "cf:inline": ENTRY_B,
+      })[specifier] ?? null);
+
+    expect(result.rewrites).toEqual([
+      {
+        specifier: "cf:dep",
+        pinned: `cf:dep@${ENTRY_A}`,
+        line: 3,
+      },
+      {
+        specifier: "cf:other",
+        pinned: `cf:other@${ENTRY_B}`,
+        line: 4,
+      },
+      {
+        specifier: "cf:types",
+        pinned: `cf:types@${ENTRY_A}`,
+        line: 5,
+      },
+      {
+        specifier: "cf:inline",
+        pinned: `cf:inline@${ENTRY_B}`,
+        line: 6,
+      },
+    ]);
+    expect(result.contents).toContain(`} from "cf:dep@${ENTRY_A}";`);
+    expect(result.contents).toContain(`export * from 'cf:other@${ENTRY_B}';`);
+    expect(result.contents).toContain(
+      `import type { RemoteType } from "cf:types@${ENTRY_A}";`,
+    );
+    expect(result.contents).toContain(
+      `type Inline = import("cf:inline@${ENTRY_B}").Value;`,
+    );
+    expect(result.contents).toContain('const literal = "cf:not-an-import";');
+    expect(stripPins(result.contents)).toBe(source);
+  });
+
+  it("leaves already-current pins and null resolutions unchanged", async () => {
+    const source = [
+      `import dep from "cf:dep@${ENTRY_A}";`,
+      `import skipped from "cf:skipped";`,
+    ].join("\n");
+
+    const result = await rewriteFabricPins(source, async (_ref, specifier) => {
+      if (specifier === `cf:dep@${ENTRY_A}`) return ENTRY_A;
+      return null;
+    });
+
+    expect(result.contents).toBe(source);
+    expect(result.rewrites).toEqual([]);
+  });
+});
+
+function stripPins(contents: string): string {
+  return contents.replaceAll(`@${ENTRY_A}`, "").replaceAll(`@${ENTRY_B}`, "");
+}

--- a/packages/runner/test/fabric-ref-resolution.test.ts
+++ b/packages/runner/test/fabric-ref-resolution.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { parseFabricRef } from "../src/sandbox/fabric-import-specifier.ts";
+import { resolveFabricRefToIdentity } from "../src/fabric-ref-resolution.ts";
+import { createRef } from "../src/create-ref.ts";
+import { fromURI, toURI } from "../src/uri-utils.ts";
+import { type PatternMeta, patternMetaSchema } from "../src/pattern-manager.ts";
+import { slugIdForSpace } from "../src/slugs.ts";
+import type { Cell } from "../src/cell.ts";
+import type { URI } from "../src/sigil-types.ts";
+import { getSigilLink } from "../src/runner-utils.ts";
+
+const signer = await Identity.fromPassphrase("fabric ref resolution test");
+const space = signer.did();
+
+const ENTRY_A = "Avcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c";
+const ENTRY_B = "Bvcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c";
+
+describe("fabric ref resolution", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  function parse(specifier: string) {
+    const ref = parseFabricRef(specifier);
+    if (ref === undefined) throw new Error(`not a fabric ref: ${specifier}`);
+    return ref;
+  }
+
+  function newPatternId(label: string): URI {
+    return toURI(createRef({ pattern: label }, "fabric ref resolution"));
+  }
+
+  function hashFromPatternId(patternId: URI): string {
+    return fromURI(patternId).replace(/^fid1:/, "");
+  }
+
+  function patternMetaCell(patternId: URI): Cell<PatternMeta> {
+    return runtime.getCellFromEntityId(
+      space,
+      { "/": fromURI(patternId) },
+      [],
+      patternMetaSchema,
+    );
+  }
+
+  async function writePatternMeta(
+    patternId: URI,
+    meta: Partial<PatternMeta>,
+  ): Promise<Cell<PatternMeta>> {
+    const cell = patternMetaCell(patternId);
+    await runtime.editWithRetry((tx) => {
+      cell.withTx(tx).set({
+        spec: "pattern",
+        patternName: `pattern-${hashFromPatternId(patternId).slice(0, 6)}`,
+        ...meta,
+      } as PatternMeta);
+    });
+    return cell;
+  }
+
+  function pieceCell(label: string): Cell<unknown> {
+    return runtime.getCell(
+      space,
+      { space, random: `piece-${label}` },
+    );
+  }
+
+  async function writeSlug(slug: string, target: Cell<unknown>): Promise<void> {
+    const slugCell = runtime.getCellFromEntityId(space, {
+      "/": slugIdForSpace(space, slug),
+    });
+    await runtime.editWithRetry((tx) => {
+      const slugWithTx = slugCell.withTx(tx);
+      slugWithTx.setRawUntyped(
+        target.withTx(tx).getAsWriteRedirectLink({ base: slugWithTx }),
+      );
+    });
+  }
+
+  it("returns terminal identities for pattern refs", async () => {
+    const result = await resolveFabricRefToIdentity(
+      runtime,
+      space,
+      parse(`cf:pattern:${ENTRY_A}`),
+    );
+
+    expect(result).toEqual({
+      entryIdentity: ENTRY_A,
+      chain: [`pattern:${ENTRY_A}`, `entryIdentity:${ENTRY_A}`],
+    });
+  });
+
+  it("rejects space names until name to DID resolution exists", async () => {
+    await expect(
+      resolveFabricRefToIdentity(runtime, space, parse("cf:/kitchen/todo")),
+    ).rejects.toThrow(
+      "space names require name→DID resolution (open question 2); use a DID",
+    );
+  });
+
+  it("resolves slug to piece patternIdentity metadata", async () => {
+    const patternId = newPatternId("identity-piece");
+    const piece = pieceCell("identity");
+    await runtime.editWithRetry((tx) => {
+      const pieceWithTx = piece.withTx(tx);
+      pieceWithTx.set({ name: "piece" });
+      pieceWithTx.setMetaRaw("pattern", getSigilLink(patternId));
+      pieceWithTx.setMetaRaw("patternIdentity", {
+        identity: ENTRY_A,
+        symbol: "default",
+      });
+    });
+    await writeSlug("dep", piece);
+
+    const result = await resolveFabricRefToIdentity(
+      runtime,
+      space,
+      parse("cf:dep"),
+    );
+
+    expect(result.entryIdentity).toBe(ENTRY_A);
+    expect(result.chain).toEqual([
+      "slug:dep",
+      `piece:${piece.getAsNormalizedFullLink().id}`,
+      `patternIdentity:${ENTRY_A}`,
+      `entryIdentity:${ENTRY_A}`,
+    ]);
+  });
+
+  it("resolves slug directly to a pattern meta cell", async () => {
+    const patternId = newPatternId("direct-meta");
+    const meta = await writePatternMeta(patternId, { entryIdentity: ENTRY_A });
+    await writeSlug("direct-meta", meta);
+
+    const result = await resolveFabricRefToIdentity(
+      runtime,
+      space,
+      parse("cf:direct-meta"),
+    );
+
+    expect(result.entryIdentity).toBe(ENTRY_A);
+    expect(result.chain).toEqual([
+      "slug:direct-meta",
+      `patternMeta:${patternId}`,
+      `entryIdentity:${ENTRY_A}`,
+    ]);
+  });
+
+  it("reports slug to plain data cells with the chain", async () => {
+    const cell = runtime.getCell(space, { space, random: "plain-data" });
+    await runtime.editWithRetry((tx) => {
+      cell.withTx(tx).set({ value: 1 });
+    });
+    await writeSlug("plain", cell);
+
+    await expect(
+      resolveFabricRefToIdentity(runtime, space, parse("cf:plain")),
+    ).rejects.toThrow(
+      `cf:plain does not resolve to a pattern (chain: slug:plain)`,
+    );
+  });
+
+  it("wraps missing slug errors with the chain", async () => {
+    await expect(
+      resolveFabricRefToIdentity(runtime, space, parse("cf:missing")),
+    ).rejects.toThrow(`Slug "missing" not found. (chain: slug:missing)`);
+  });
+
+  it("resolves of: refs directly to pattern meta cells", async () => {
+    const patternId = newPatternId("of-meta");
+    await writePatternMeta(patternId, { entryIdentity: ENTRY_A });
+
+    const result = await resolveFabricRefToIdentity(
+      runtime,
+      space,
+      parse(`cf:of:fid1:${hashFromPatternId(patternId)}`),
+    );
+
+    expect(result.entryIdentity).toBe(ENTRY_A);
+    expect(result.chain).toEqual([
+      `of:${patternId}`,
+      `patternMeta:${patternId}`,
+      `entryIdentity:${ENTRY_A}`,
+    ]);
+  });
+
+  it("resolves pieces with legacy patternId metadata through pattern meta", async () => {
+    const patternId = newPatternId("legacy-pattern-id");
+    await writePatternMeta(patternId, { entryIdentity: ENTRY_B });
+    const piece = pieceCell("legacy");
+    await runtime.editWithRetry((tx) => {
+      const pieceWithTx = piece.withTx(tx);
+      pieceWithTx.set({ name: "legacy" });
+      pieceWithTx.setMetaRaw("pattern", getSigilLink(patternId));
+    });
+    await writeSlug("legacy", piece);
+
+    const result = await resolveFabricRefToIdentity(
+      runtime,
+      space,
+      parse("cf:legacy"),
+    );
+
+    expect(result.entryIdentity).toBe(ENTRY_B);
+    expect(result.chain).toEqual([
+      "slug:legacy",
+      `piece:${piece.getAsNormalizedFullLink().id}`,
+      `patternMeta:${patternId}`,
+      `entryIdentity:${ENTRY_B}`,
+    ]);
+  });
+
+  it("reports legacy pattern meta without entryIdentity", async () => {
+    const patternId = newPatternId("missing-entry-identity");
+    await writePatternMeta(patternId, {});
+
+    await expect(
+      resolveFabricRefToIdentity(
+        runtime,
+        space,
+        parse(`cf:of:fid1:${hashFromPatternId(patternId)}`),
+      ),
+    ).rejects.toThrow(
+      `pattern meta for cf:of:fid1:${
+        hashFromPatternId(patternId)
+      } has no entryIdentity (legacy pattern; re-deploy it)`,
+    );
+  });
+});

--- a/packages/runner/test/fabric-resolver.test.ts
+++ b/packages/runner/test/fabric-resolver.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import {
+  InMemoryProgram,
+  type Program,
+  type Source,
+} from "@commonfabric/js-compiler";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import {
+  computeModuleHashes,
+  resolveModuleImports,
+} from "../src/harness/module-identity.ts";
+import type { CacheableModule } from "../src/harness/types.ts";
+import {
+  sourceDocKey,
+  writeSourceDocs,
+} from "../src/compilation-cache/cell-cache.ts";
+import { FabricAwareResolver } from "../src/harness/fabric-resolver.ts";
+import { FABRIC_MOUNT_ROOT } from "../src/sandbox/module-record-compiler.ts";
+
+const signer = await Identity.fromPassphrase("fabric resolver test");
+const space = signer.did();
+const otherSpace = "did:key:z6MkFabricResolverOtherSpace";
+const MISSING_HASH = "Bvcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c";
+
+const PROGRAM: Program = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        `import { value } from "./dep.ts";`,
+        `export const result = value + 1;`,
+      ].join("\n"),
+    },
+    {
+      name: "/dep.ts",
+      contents: `export const value = 41;`,
+    },
+  ],
+};
+
+function toModules(
+  program: Program,
+): { modules: CacheableModule[]; entryIdentity: string } {
+  const ids = computeModuleHashes(program);
+  const edges = resolveModuleImports(program);
+  const modules = program.files.map((file) => ({
+    identity: ids.get(file.name)!,
+    filename: file.name,
+    source: file.contents,
+    js: `/* compiled */ ${file.name}`,
+    imports: (edges.get(file.name)?.internalDeps ?? []).map((dep) => ({
+      specifier: dep.specifier,
+      targetIdentity: ids.get(dep.target)!,
+    })),
+  }));
+  return { modules, entryIdentity: ids.get(program.main)! };
+}
+
+function innerProgram(source = `export {};`) {
+  return new InMemoryProgram("/importer.tsx", { "/importer.tsx": source });
+}
+
+describe("FabricAwareResolver", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  async function publish(program: Program = PROGRAM): Promise<string> {
+    const { modules, entryIdentity } = toModules(program);
+    const tx = runtime.edit();
+    writeSourceDocs(runtime, space, modules, entryIdentity, tx);
+    await tx.commit();
+    return entryIdentity;
+  }
+
+  it("fetches a pinned same-space pattern and mounts its verified source closure", async () => {
+    const entryIdentity = await publish();
+    const specifier = `cf:pattern:${entryIdentity}`;
+    const resolver = new FabricAwareResolver(innerProgram(), {
+      runtime,
+      space,
+    });
+
+    const entry = await resolver.resolveSource(specifier);
+    const entryPath = `${FABRIC_MOUNT_ROOT}${entryIdentity}/main.tsx`;
+
+    expect(entry).toEqual({
+      name: entryPath,
+      contents: PROGRAM.files[0].contents,
+    });
+    expect(await resolver.resolveSource(entryPath)).toBe(entry);
+    expect(resolver.specifierAliases().get(specifier)).toBe(entryPath);
+    expect(resolver.mounts()).toEqual([
+      { entryIdentity, entryPath, specifiers: [specifier] },
+    ]);
+
+    const depPath = `${FABRIC_MOUNT_ROOT}${entryIdentity}/dep.ts`;
+    expect((await resolver.resolveSource(depPath))?.contents).toBe(
+      PROGRAM.files[1].contents,
+    );
+  });
+
+  it("reports missing or tampered source closures as not found", async () => {
+    const resolver = new FabricAwareResolver(innerProgram(), {
+      runtime,
+      space,
+    });
+    await expect(
+      resolver.resolveSource(`cf:pattern:${MISSING_HASH}`),
+    ).rejects.toThrow(
+      `source for pattern:${MISSING_HASH} not found in space ${space} (or failed integrity verification)`,
+    );
+
+    const entryIdentity = await publish({
+      main: "/main.tsx",
+      files: [
+        { name: "/main.tsx", contents: "export const value = 1;" },
+      ],
+    });
+    const tx = runtime.edit();
+    runtime.getCell(space, sourceDocKey(entryIdentity), undefined, tx).set({
+      kind: "source",
+      identity: entryIdentity,
+      code: "export const value = 2;",
+      filename: "/main.tsx",
+      imports: [],
+    });
+    await tx.commit();
+
+    await expect(
+      resolver.resolveSource(`cf:pattern:${entryIdentity}`),
+    ).rejects.toThrow(
+      `source for pattern:${entryIdentity} not found in space ${space} (or failed integrity verification)`,
+    );
+  });
+
+  it("rejects root-absolute imports inside imported patterns", async () => {
+    const program: Program = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents:
+            `import { value } from "/dep.ts"; export const result = value;`,
+        },
+        { name: "/dep.ts", contents: `export const value = 1;` },
+      ],
+    };
+    const entryIdentity = await publish(program);
+    const resolver = new FabricAwareResolver(innerProgram(), {
+      runtime,
+      space,
+    });
+
+    await expect(
+      resolver.resolveSource(`cf:pattern:${entryIdentity}`),
+    ).rejects.toThrow(
+      `imported pattern ${entryIdentity} uses root-absolute imports; not supported`,
+    );
+  });
+
+  it("dedupes different specifier texts pinned to the same identity", async () => {
+    const entryIdentity = await publish();
+    const direct = `cf:pattern:${entryIdentity}`;
+    const pinnedSlug = `cf:dep@${entryIdentity}`;
+    const resolver = new FabricAwareResolver(innerProgram(), {
+      runtime,
+      space,
+    });
+
+    const first = await resolver.resolveSource(direct);
+    const second = await resolver.resolveSource(pinnedSlug);
+
+    expect(second).toBe(first);
+    expect(resolver.mounts()).toEqual([
+      {
+        entryIdentity,
+        entryPath: `${FABRIC_MOUNT_ROOT}${entryIdentity}/main.tsx`,
+        specifiers: [direct, pinnedSlug],
+      },
+    ]);
+    expect(resolver.specifierAliases()).toEqual(
+      new Map([
+        [direct, `${FABRIC_MOUNT_ROOT}${entryIdentity}/main.tsx`],
+        [pinnedSlug, `${FABRIC_MOUNT_ROOT}${entryIdentity}/main.tsx`],
+      ]),
+    );
+  });
+
+  it("throws M1 scope errors for mutable, cross-space, cross-host, and subpath refs", async () => {
+    const entryIdentity = await publish();
+    const resolver = new FabricAwareResolver(innerProgram(), {
+      runtime,
+      space,
+    });
+    const cases: Array<[string, string]> = [
+      [
+        "cf:dep",
+        "fabric ref requires resolution of a mutable pointer — not yet supported (M2)",
+      ],
+      [
+        `cf:/${otherSpace}/pattern:${entryIdentity}`,
+        "cross-space fabric refs not yet supported (M2)",
+      ],
+      [
+        `cf://example.com/${space}/pattern:${entryIdentity}`,
+        "cross-host fabric refs not yet supported (M3)",
+      ],
+      [
+        `cf:pattern:${entryIdentity}/schema`,
+        "subpaths not yet supported (M4)",
+      ],
+    ];
+
+    for (const [specifier, message] of cases) {
+      await expect(resolver.resolveSource(specifier)).rejects.toThrow(message);
+    }
+  });
+
+  it("delegates non-fabric specifiers and main() to the wrapped resolver", async () => {
+    const source: Source = {
+      name: "/dep.ts",
+      contents: "export const value = 1;",
+    };
+    const resolver = new FabricAwareResolver(
+      new InMemoryProgram("/main.tsx", {
+        "/main.tsx": `import { value } from "./dep.ts";`,
+        "/dep.ts": source.contents,
+      }),
+      { runtime, space },
+    );
+
+    expect(await resolver.main()).toEqual({
+      name: "/main.tsx",
+      contents: `import { value } from "./dep.ts";`,
+    });
+    expect(await resolver.resolveSource(source.name)).toEqual(source);
+  });
+});

--- a/packages/runner/test/fabric-resolver.test.ts
+++ b/packages/runner/test/fabric-resolver.test.ts
@@ -19,6 +19,12 @@ import {
 } from "../src/compilation-cache/cell-cache.ts";
 import { FabricAwareResolver } from "../src/harness/fabric-resolver.ts";
 import { FABRIC_MOUNT_ROOT } from "../src/sandbox/module-record-compiler.ts";
+import { createRef } from "../src/create-ref.ts";
+import { fromURI, toURI } from "../src/uri-utils.ts";
+import { type PatternMeta, patternMetaSchema } from "../src/pattern-manager.ts";
+import { slugIdForSpace } from "../src/slugs.ts";
+import type { URI } from "../src/sigil-types.ts";
+import type { Cell } from "../src/cell.ts";
 
 const signer = await Identity.fromPassphrase("fabric resolver test");
 const space = signer.did();
@@ -78,12 +84,62 @@ describe("FabricAwareResolver", () => {
     await storageManager?.close();
   });
 
-  async function publish(program: Program = PROGRAM): Promise<string> {
+  async function publish(
+    program: Program = PROGRAM,
+    targetSpace = space,
+  ): Promise<string> {
     const { modules, entryIdentity } = toModules(program);
     const tx = runtime.edit();
-    writeSourceDocs(runtime, space, modules, entryIdentity, tx);
+    writeSourceDocs(runtime, targetSpace, modules, entryIdentity, tx);
     await tx.commit();
     return entryIdentity;
+  }
+
+  function newPatternId(label: string): URI {
+    return toURI(createRef({ pattern: label }, "fabric resolver test"));
+  }
+
+  function patternMetaCell(
+    patternId: URI,
+    targetSpace = space,
+  ): Cell<PatternMeta> {
+    return runtime.getCellFromEntityId(
+      targetSpace,
+      { "/": fromURI(patternId) },
+      [],
+      patternMetaSchema,
+    );
+  }
+
+  async function writePatternMeta(
+    entryIdentity: string,
+    targetSpace = space,
+  ): Promise<{ patternId: URI; cell: Cell<PatternMeta> }> {
+    const patternId = newPatternId(entryIdentity);
+    const cell = patternMetaCell(patternId, targetSpace);
+    await runtime.editWithRetry((tx) => {
+      cell.withTx(tx).set({
+        spec: "pattern",
+        entryIdentity,
+      } as PatternMeta);
+    });
+    return { patternId, cell };
+  }
+
+  async function writeSlug(
+    slug: string,
+    target: Cell<unknown>,
+    targetSpace = space,
+  ): Promise<void> {
+    const slugCell = runtime.getCellFromEntityId(targetSpace, {
+      "/": slugIdForSpace(targetSpace, slug),
+    });
+    await runtime.editWithRetry((tx) => {
+      const slugWithTx = slugCell.withTx(tx);
+      slugWithTx.setRawUntyped(
+        target.withTx(tx).getAsWriteRedirectLink({ base: slugWithTx }),
+      );
+    });
   }
 
   it("fetches a pinned same-space pattern and mounts its verified source closure", async () => {
@@ -200,7 +256,52 @@ describe("FabricAwareResolver", () => {
     );
   });
 
-  it("throws M1 scope errors for mutable, cross-space, cross-host, and subpath refs", async () => {
+  it("resolves unpinned refs when allowed and records resolved pins", async () => {
+    const entryIdentity = await publish();
+    const { patternId, cell } = await writePatternMeta(entryIdentity);
+    await writeSlug("dep", cell);
+    const resolver = new FabricAwareResolver(innerProgram(), {
+      runtime,
+      space,
+      allowUnpinned: true,
+    });
+
+    const entry = await resolver.resolveSource("cf:dep");
+
+    expect(entry?.name).toBe(`${FABRIC_MOUNT_ROOT}${entryIdentity}/main.tsx`);
+    expect(resolver.resolvedPins()).toEqual([
+      {
+        specifier: "cf:dep",
+        resolvedIdentity: entryIdentity,
+        chain: [
+          "slug:dep",
+          `patternMeta:${patternId}`,
+          `entryIdentity:${entryIdentity}`,
+        ],
+      },
+    ]);
+  });
+
+  it("loads pinned cross-space refs from the referenced DID space", async () => {
+    const entryIdentity = await publish(PROGRAM, otherSpace);
+    const specifier = `cf:/${otherSpace}/pattern:${entryIdentity}`;
+    const resolver = new FabricAwareResolver(innerProgram(), {
+      runtime,
+      space,
+    });
+
+    const entry = await resolver.resolveSource(specifier);
+
+    expect(entry).toEqual({
+      name: `${FABRIC_MOUNT_ROOT}${entryIdentity}/main.tsx`,
+      contents: PROGRAM.files[0].contents,
+    });
+    expect(resolver.specifierAliases().get(specifier)).toBe(
+      `${FABRIC_MOUNT_ROOT}${entryIdentity}/main.tsx`,
+    );
+  });
+
+  it("throws scope errors for unpinned, cross-host, subpath, and named-space refs", async () => {
     const entryIdentity = await publish();
     const resolver = new FabricAwareResolver(innerProgram(), {
       runtime,
@@ -209,11 +310,7 @@ describe("FabricAwareResolver", () => {
     const cases: Array<[string, string]> = [
       [
         "cf:dep",
-        "fabric ref requires resolution of a mutable pointer — not yet supported (M2)",
-      ],
-      [
-        `cf:/${otherSpace}/pattern:${entryIdentity}`,
-        "cross-space fabric refs not yet supported (M2)",
+        "unpinned fabric import 'cf:dep'; pin it (cf deps update) or deploy to pin",
       ],
       [
         `cf://example.com/${space}/pattern:${entryIdentity}`,
@@ -222,6 +319,10 @@ describe("FabricAwareResolver", () => {
       [
         `cf:pattern:${entryIdentity}/schema`,
         "subpaths not yet supported (M4)",
+      ],
+      [
+        `cf:/kitchen/pattern:${entryIdentity}`,
+        "space names require name→DID resolution (open question 2); use a DID",
       ],
     ];
 

--- a/packages/runner/test/module-record-compiler.test.ts
+++ b/packages/runner/test/module-record-compiler.test.ts
@@ -31,6 +31,8 @@ function files(map: Record<string, string>): Source[] {
   return Object.entries(map).map(([name, contents]) => ({ name, contents }));
 }
 
+const FABRIC_HASH = "Avcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c";
+
 describe("compileSourcesToRecords + importModuleGraphNow (end to end)", () => {
   it("loads a multi-module compiled program through the SES module graph", () => {
     const sources = files({
@@ -89,6 +91,51 @@ describe("compileSourcesToRecords + importModuleGraphNow (end to end)", () => {
       records,
     }) as { run(): number };
     expect(ns.run()).toBe(42);
+  });
+
+  it("resolves specifier aliases to content-addressed module records", () => {
+    const fabricSpecifier = `cf:pattern:${FABRIC_HASH}`;
+    const mountedPath = `/~cf/${FABRIC_HASH}/main.tsx`;
+    const sources = files({
+      "/a.tsx": `import { x } from "${fabricSpecifier}";\nexport const y = x;`,
+      [mountedPath]: `export const x = 1;`,
+    });
+    const { records, specifierByPath } = compileSourcesToRecords(sources, {
+      specifierAliases: new Map([[fabricSpecifier, mountedPath]]),
+      identityByPath: new Map([
+        ["/a.tsx", "importer-identity"],
+        [mountedPath, "mounted-identity"],
+      ]),
+    });
+
+    const record = records.get(specifierByPath.get("/a.tsx")!)!;
+    expect(record.resolutions?.[fabricSpecifier]).toBe(
+      "cf:module/mounted-identity",
+    );
+  });
+
+  it("resolves export-star specifier aliases when collecting exports", () => {
+    const fabricSpecifier = `cf:pattern:${FABRIC_HASH}`;
+    const mountedPath = `/~cf/${FABRIC_HASH}/main.tsx`;
+    const sources = files({
+      "/a.tsx": `export * from "${fabricSpecifier}";\nexport const own = 2;`,
+      [mountedPath]: `export const imported = 1;`,
+    });
+    const { records, specifierByPath } = compileSourcesToRecords(sources, {
+      specifierAliases: new Map([[fabricSpecifier, mountedPath]]),
+      identityByPath: new Map([
+        ["/a.tsx", "importer-identity"],
+        [mountedPath, "mounted-identity"],
+      ]),
+    });
+
+    const record = records.get(specifierByPath.get("/a.tsx")!)!;
+    expect(new Set(record.exports)).toEqual(
+      new Set(["imported", "own", "__esModule"]),
+    );
+    expect(record.resolutions?.[fabricSpecifier]).toBe(
+      "cf:module/mounted-identity",
+    );
   });
 
   it("resolves a default import across modules (esModuleInterop)", () => {

--- a/packages/runner/test/slug-resolution.test.ts
+++ b/packages/runner/test/slug-resolution.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { parseLink } from "../src/link-utils.ts";
+import { slugIdForSpace } from "../src/slugs.ts";
+import { resolveSlugTargetCell } from "../src/slug-resolution.ts";
+
+const signer = await Identity.fromPassphrase("runner slug resolution tests");
+const space = signer.did();
+
+describe("slug resolution", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("resolves slug redirects to arbitrary cells", async () => {
+    const target = runtime.getCell(
+      space,
+      { space, random: "slug-cell-target" },
+    );
+    const slugCell = runtime.getCellFromEntityId(space, {
+      "/": slugIdForSpace(space, "value-link"),
+    });
+
+    await runtime.editWithRetry((tx) => {
+      const targetWithTx = target.withTx(tx);
+      const slugWithTx = slugCell.withTx(tx);
+      targetWithTx.set({ value: 1 });
+      slugWithTx.setRawUntyped(
+        targetWithTx.getAsWriteRedirectLink({ base: slugWithTx }),
+      );
+    });
+
+    await slugCell.sync();
+    const link = parseLink(slugCell.getRaw(), slugCell);
+    expect(link?.overwrite).toBe("redirect");
+
+    const resolved = await resolveSlugTargetCell(runtime, space, "value-link");
+    expect(resolved.getAsNormalizedFullLink().id).toBe(
+      target.getAsNormalizedFullLink().id,
+    );
+    expect(resolved.getAsNormalizedFullLink().path).toEqual([]);
+    expect(resolved.get()).toEqual({ value: 1 });
+  });
+
+  it("reports missing and malformed slug documents", async () => {
+    await expect(
+      resolveSlugTargetCell(runtime, space, "missing"),
+    ).rejects.toThrow(/Slug "missing" not found/);
+
+    const slugCell = runtime.getCellFromEntityId(space, {
+      "/": slugIdForSpace(space, "malformed"),
+    });
+    await runtime.editWithRetry((tx) => {
+      slugCell.withTx(tx).setRawUntyped("not a redirect");
+    });
+
+    await expect(
+      resolveSlugTargetCell(runtime, space, "malformed"),
+    ).rejects.toThrow(/does not contain a valid redirect/);
+  });
+});

--- a/packages/runner/test/slug-resolution.test.ts
+++ b/packages/runner/test/slug-resolution.test.ts
@@ -5,7 +5,10 @@ import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { parseLink } from "../src/link-utils.ts";
 import { slugIdForSpace } from "../src/slugs.ts";
-import { resolveSlugTargetCell } from "../src/slug-resolution.ts";
+import {
+  parseSlugRedirect,
+  resolveSlugTargetCell,
+} from "../src/slug-resolution.ts";
 
 const signer = await Identity.fromPassphrase("runner slug resolution tests");
 const space = signer.did();
@@ -72,5 +75,27 @@ describe("slug resolution", () => {
     await expect(
       resolveSlugTargetCell(runtime, space, "malformed"),
     ).rejects.toThrow(/does not contain a valid redirect/);
+  });
+
+  it("treats parseLink throws as malformed redirects (foreign-written payloads)", () => {
+    // A sigil-SHAPED payload with broken internals (non-array path) makes
+    // parseLink throw a generic TypeError. This runtime's own write path
+    // rejects such values, but foreign clients can persist them over the
+    // memory protocol — the resolver must fold the throw into the typed
+    // "malformed" outcome (SlugResolutionError) instead of leaking a bare
+    // TypeError past callers like the fabric chase's chain wrapping.
+    const base = runtime.getCellFromEntityId(space, {
+      "/": slugIdForSpace(space, "poisoned"),
+    });
+    const poisoned = {
+      "/": {
+        "link@1": { id: "of:abc", path: "not-an-array", overwrite: "redirect" },
+      },
+    };
+    expect(() => parseLink(poisoned, base)).toThrow(); // the hazard is real
+    expect(parseSlugRedirect(poisoned, base)).toBeUndefined();
+    expect(
+      parseSlugRedirect("not a redirect", base),
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
Implements pattern imports (spec + plan: `docs/specs/pattern-imports/`, #4067) through M2: patterns can now `import { … }` from other patterns published in the fabric — typed, content-addressed, and reproducible.

## What you can write

```tsx
// A slug in the current space. The slug may point at a PIECE (meaning: the
// pattern that piece currently runs) or directly at a published pattern.
import { TodoItem, todoSchema } from "cf:todo-list";

// Explicit space (leading slash), space by DID:
import { TodoItem } from "cf:/did:key:z6Mk…/todo-list";

// Content-addressed source, no mutable pointer at all:
import { TodoItem } from "cf:pattern:Avcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c";

// What a DEPLOYED importer actually stores — the mutable ref with its pin:
import { TodoItem } from "cf:/kitchen/todo-list@Avcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c";
```

Imports are real module imports: you get the target's exports (patterns, schemas, types, handlers, helpers), type-checked by TypeScript against the actual fetched source — a wrong member name is a compile error.

## How it works

1. **Resolution is a pointer chase, all ordinary cell reads** (no service endpoints): slug → redirect target → (if it's a piece) `meta("patternIdentity")` → pattern meta → **entry-module identity** — the same content-addressed hash the compile cache and `cf:module/<hash>` already use.
2. **Snapshot at pin time, not compile time.** Deploying rewrites the import specifier in the stored source to carry the resolved hash (`…@<hash>`). After that, compiles never read the slug or piece again — updating the piece's pattern or re-pointing the slug does NOT affect deployed importers until an explicit re-pin. Because module identity already folds the specifier text into its Merkle hash, the pin makes importer identity content-derived with zero changes to hashing.
3. **Fetched source is verified, never trusted**: the closure is re-hashed and must reproduce the requested identity, so any space/host that serves it is integrity-checked by construction.
4. **Imported subtrees keep their published identities** (mounted under `/~cf/<hash>/…`, hashed in their own namespace), so an importer shares compiled cache docs and live module instances with an already-running piece of the imported pattern — the import costs nothing the deployed pattern hasn't paid.
5. **Availability is compile-time only.** Write-back copies the imported source + compiled docs into the compiling space, so warm and cold reloads of a deployed importer are fully local.
6. **Unpinned compiles are never cached** (`assertNoUnpinnedFabricImports`): an unpinned specifier's resolution can vary under a fixed module identity, so persisting it would poison content-addressed cache keys. Unpinned resolution is a dev-only convenience.

## The CLI

**Deploying pins automatically.** `cf piece new` / set-pattern resolve every mutable ref and store the pinned source:

```
$ cf piece new patterns/board.tsx --space did:key:z6Mk…
pinned cf:/kitchen/todo-list -> @Avcny13Rj8q-2ClANy_-k0ikWWQcXx7QTdsiqGfrC1c
```

**`cf deps update` re-pins on demand** — walks the whole local program (sibling files included), rewrites only the import literals, byte-identical elsewhere:

```
$ cf deps update patterns/board.tsx --space did:key:z6Mk…
/Users/me/patterns/schemas.tsx:3 pinned cf:dep -> @Bq9Xw…

# only one import:
$ cf deps update patterns/board.tsx --import cf:dep

# CI freshness gate: exit non-zero if any pin would change, write nothing:
$ cf deps update patterns/board.tsx --check
```

**`cf check` / `cf dev` accept `--space`** to resolve unpinned refs live while iterating:

```
$ cf check patterns/board.tsx --space did:key:z6Mk… --no-run
resolved cf:dep -> @Bq9Xw… (not pinned; deploy or run cf deps update to pin)

# without a space, fabric imports fail with a pointed error instead of a
# generic resolve failure:
$ cf check patterns/board.tsx --no-run
fabric imports require a space context (options.fabricImports)
```

Programmatic equivalent: `fabricImports: { space, allowUnpinned? }` on `TypeScriptHarnessProcessOptions`.

## Scope

In: grammar + policy, pinned `cf:pattern:<hash>` end-to-end, mutable refs (slug / piece / `of:fid1:` URIs) with pinning, cross-space fetch by DID, warm + cold by-identity reload, cross-space closure replication, CLI flows. Out (per plan, M3/M4): host-qualified refs (`cf://host/…`), space *names* (DIDs only for now), subpaths, `cf publish`, npm/esm.sh vendoring.

## Validation

- Full suites green post-rebase: `packages/runner` (609), `packages/js-compiler`, `packages/cli` (45), `packages/piece`.
- New coverage: grammar table incl. real-hash canaries, mount integrity/tamper rejection, transitive imports (I→P→Q), second-compile full cache hit, snapshot-semantics end-to-end (pin → upstream change → byte-identical reload → re-pin), unpinned write-back refusal (red-green), cross-runtime warm/cold resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements `cf:` fabric imports end-to-end across the compiler, runner, and CLI, enabling verified, space-aware dependency loading and reproducible builds. Also fixes cached record graph filename collisions, improves malformed slug errors to typed failures, and stabilizes CLI `deps` command registration.

- **New Features**
  - `@commonfabric/js-compiler`: Specifier aliasing for TypeScript resolution without changing emitted import text.
  - `@commonfabric/runner`: Parse and allow well-formed `cf:` imports; resolve pinned (and dev-only unpinned) refs via space to verified source closures mounted under `/~cf/`; compute fabric-aware module identities; pass specifier aliases into TS and record compilation; record fabric edges; export slug/ref utilities and a pin-rewrite helper; PatternManager reloads pinned deps by identity; refuse cache writes for unpinned compiles to prevent poisoning.
  - CLI: New `deps` command to pin `cf:` imports across the local program; `dev` adds `--space <did>` to resolve unpinned refs; clear, parse-level error when `cf:` imports are used without a space; `deps` command typed as `Command<any>` to fix registration type errors.

- **Migration**
  - Author `cf:` imports in code; resolving them requires a space context.
    - CLI: use `dev --space <did>`.
    - Programmatic: set `fabricImports: { space, allowUnpinned? }` in `TypeScriptHarnessProcessOptions`.
  - Use the `deps` command to pin `cf:` imports for reproducible builds. Unpinned compiles are never persisted to the cache.

<sup>Written for commit f506e417f8612b58bfb3330f0fdf6fb956d20802. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




