### PR TITLE
runner: refs-only pattern JSON + session-lifetime artifact index [identity E4]

### DIFF
--- a/docs/specs/content-addressed-action-identity-implementation-plan.md
+++ b/docs/specs/content-addressed-action-identity-implementation-plan.md
@@ -515,9 +515,16 @@ What landed:
    therefore keeps printing graphs) fall back to the full graph
    (`test/pattern-ref-boundary.test.ts`).
 4. **llm-dialog async net** — `resolveStoredPatternAsync` follows the sync
-   probe with the storage-backed `loadPatternByIdentity`. INVARIANT assumed
-   (per decision): compilation persists compiled artifacts in-space, so a
-   refs-only stored value is rehydratable wherever it was written.
+   probe with the storage-backed `loadPatternByIdentity`. INVARIANT (per
+   decision), now ENFORCED rather than assumed (both review bots flagged the
+   fire-and-forget race): `compileViaCellCache` AWAITS the cold closure
+   write-back, so a cell can only carry a `$patternRef` after its artifact
+   write completed — the factory does not exist until `compilePattern`
+   returns. Warm hits just read the closure from storage (already durable);
+   a failed write logs without failing the compile (in-session unaffected;
+   the next cold compile of the same content retries). Space-less compiles
+   (no `cacheCtx`) persist nothing — dev/test paths whose values resolve
+   in-session via the pinned index.
 5. **Canary** — the fixture grows a `refsOnly` vintage; pins both resolution
    paths (sync live-canonical after in-session eval; source-free async load
    in a runtime that never evaluated the module) plus the older graph

--- a/docs/specs/content-addressed-action-identity-implementation-plan.md
+++ b/docs/specs/content-addressed-action-identity-implementation-plan.md
@@ -3,11 +3,11 @@
 Companion to [`content-addressed-action-identity.md`](./content-addressed-action-identity.md)
 (the design). One PR per letter; each lands green and is independently
 revertible. Phase 0 (ordinal-free `implementationRef` + legacy-alias shim)
-shipped in #3997; A–D shipped in #4006/#4008/#4009/#4013; E shipped in three
-PRs — E1 #4053, E2 #4064, E3 (pattern JSON boundary, scoped to dual-write) —
-see "PR E — the flip" for the recorded gating decisions per part. Phase 4
-(retire the legacy read path + the refs-only pattern-JSON flip) is the open
-remainder.
+shipped in #3997; A–D shipped in #4006/#4008/#4009/#4013; E shipped in four
+PRs — E1 #4053, E2 #4064, E3 #4073 (pattern JSON dual-write), E4 (refs-only
+pattern JSON + session-lifetime artifact index) — see "PR E — the flip" for
+the recorded gating decisions per part. Phase 4's open remainder is retiring
+the legacy javascript-function read path (gate-2 pair + bundleId arm).
 
 ## Last Updated
 
@@ -484,6 +484,51 @@ id-churn class) for a vintage that rewrites on every re-instantiation anyway
 itself. The aging signal dual-write exists for is the LIVE-factory boundary
 writes (llm toolDef patterns, patterns passed directly in piece arguments),
 which are the values that persist across sessions.
+
+### E4 — refs-only pattern JSON (the §7 completion)
+
+E3's gating blocker dissolved on inspection (recorded 2026-06-11): a pattern
+artifact derives synchronously from its module's evaluation, and the obvious
+fix is not to re-derive on miss but to never lose it — extend E1's gate-3
+move (session-lifetime strong index) to builder artifacts. The FIFO bound on
+`addressableByIdentity` was protecting against memory the strong function
+index already commits to (every verified implementation retained per
+session; module-scope functions referencing module-level patterns
+transitively retain the factories anyway).
+
+What landed:
+
+1. **Artifact index pinned** — `addressableByIdentity` eviction deleted;
+   `artifactFromIdentitySync` is a plain probe (no LRU touch). The
+   module-NAMESPACE cache (`modulesByIdentity`) stays bounded, its bound now
+   an instance field tests can shrink
+   (`test/artifact-index-pinning.test.ts`).
+2. **`$opFallback` dropped** — the sentinel is stamped from the op's live
+   artifact in the same session that reads it back, so sync resolution
+   cannot miss short of a bug, and the bug is loud
+   (`map-op-by-identity.test.ts`: "fails loudly"). Stored pre-E4 sentinel
+   vintages are read tolerantly (`resolveStoredPattern`).
+3. **Refs-only boundary** — `patternToJSON` emits
+   `{ $patternRef, argumentSchema, resultSchema }`; no-entry-ref patterns
+   (manually constructed / dynamic / bare-Engine eval — including the CLI
+   `--pattern-json` debug dump, which evaluates without a PatternManager and
+   therefore keeps printing graphs) fall back to the full graph
+   (`test/pattern-ref-boundary.test.ts`).
+4. **llm-dialog async net** — `resolveStoredPatternAsync` follows the sync
+   probe with the storage-backed `loadPatternByIdentity`. INVARIANT assumed
+   (per decision): compilation persists compiled artifacts in-space, so a
+   refs-only stored value is rehydratable wherever it was written.
+5. **Canary** — the fixture grows a `refsOnly` vintage; pins both resolution
+   paths (sync live-canonical after in-session eval; source-free async load
+   in a runtime that never evaluated the module) plus the older graph
+   vintages unchanged.
+
+The map case is covered by construction: anything instantiating a map
+mentioned its op (hoisted closure or imported factory), so the op's module
+is part of that piece's bundle and evaluates in the reading session. The one
+corner outside the construction — an op passed as a runtime VALUE from a
+program not running in this session — throws the descriptive sentinel error
+(tripwire; sync Actions cannot await the loader).
 
 ## Sequencing & parallelism
 

--- a/docs/specs/content-addressed-action-identity.md
+++ b/docs/specs/content-addressed-action-identity.md
@@ -57,11 +57,21 @@ Phase 3 shipped in two PRs:
   covers the sync list builtins or cross-session llm-dialog reads.
   Canary: `test/pre-e3-pattern-value-canary.test.ts` pins both stored
   vintages (bare graph; ref+graph) loading and executing.
+- **E4 (refs-only pattern JSON)**: the E3 blocker resolved —
+  `addressableByIdentity` is session-lifetime (open question 1 extended to
+  pattern artifacts; the FIFO eviction deleted), so sync resolution covers
+  every module evaluated in the reading session. `Pattern.toJSON()` emits
+  `{ $patternRef, argumentSchema, resultSchema }` with NO graph (patterns
+  without an entry ref still serialize their graph); the op sentinel drops
+  `$opFallback` (a sync miss is now a loud bug, not a recoverable state);
+  llm-dialog adds the async storage-backed net (`resolveStoredPatternAsync`
+  → `loadPatternByIdentity`; compiled artifacts persist in-space as an
+  expected part of compilation). Stored graph vintages keep loading
+  tolerantly; see §7's status block for the full record.
 
-Phase 4 (drop the retained read path + the §7 refs-only pattern JSON flip)
-remains open, gated on stored-data evidence or a runtime-version cutoff —
-and, for the pattern-JSON flip, on a session-lifetime pattern artifact index
-(eviction pinning, open question 2).
+Phase 4's remainder is the legacy javascript-function read path (the gate-2
+retained pair + the bundleId verification arm), still gated on stored-data
+evidence or a runtime-version cutoff. The §7 pattern-JSON flip shipped as E4.
 
 The design assumes the shipped state after the AMD-loader removal: the ESM
 module-record loader is the only loader, every module has a content-addressed
@@ -373,48 +383,40 @@ but `toJSON` runs when a value is *written to a cell* — after
 - `Pattern.nodes` / `result` / `initial` stay as the in-memory instantiation
   representation only; nothing outside the runner consumes them as JSON.
 
-Status (E3, 2026-06-11): shipped as DUAL-WRITE, not refs-only. The boundary
-now emits `$patternRef` alongside the graph; the escape hatch below landed;
-the refs-only flip is deferred to Phase 4. The gating finding: unlike
-javascript functions (E1's session-lifetime
-`verifiedImplementationsByEntryRef`), pattern artifacts have NO strong index —
-a stored `$patternRef` resolves only through the FIFO-bounded
-`addressableByIdentity` (sync) or `loadPatternByIdentity` (async). The
-write-path audit found pattern graphs persist at exactly three cell-write
-sites (pattern values in piece arguments, the list-builtin inputs sentinel,
-nested sub-pattern arguments; no wire/IPC surface carries graphs), and the
-read-path audit found two production consumers of stored graphs: the list
-builtins' `resolveOpPattern` (a sync Action — cannot await a by-identity
-load) and llm-dialog's tool invocation (cross-session: the toolDef pattern's
-module may never re-evaluate in the reading session, and its compiled
-artifact being loadable from the space is not guaranteed for arbitrary
-pattern values). Refs-only emission therefore needs eviction pinning (open
-question 2) plus stored-data evidence first — the same shape as gate 2.
+Status: COMPLETE in two steps. E3 (2026-06-11) shipped dual-write —
+`$patternRef` alongside the graph — because pattern artifacts then had no
+session-lifetime index: a stored ref resolved only through the FIFO-bounded
+`addressableByIdentity` (sync) or `loadPatternByIdentity` (async), and the
+two production consumers of stored graphs (the list builtins' sync
+`resolveOpPattern`; llm-dialog's cross-session tool invocation) could not
+tolerate a miss. E4 (same day) removed that blocker and completed the flip:
 
-Known things this trips (each was a work item; states recorded inline):
-
-- **`$opFallback`** embeds a full serialized graph *on purpose* (eviction
-  resilience). Refs-only `toJSON` would silently turn the fallback into a ref
-  too, defeating it. RESOLVED via the explicit `serializePatternGraph()`
-  escape hatch (json-utils): `toJSONWithLegacyAliases` — the builder-time
-  node serializer the `$opFallback` graphs descend from — routes pattern
-  values through it under an internal-serialization context that suppresses
-  `$patternRef`, making the internal/boundary split structural. Without it,
-  builder calls inside a running action that reference an already-indexed
-  imported pattern would embed refs into `Pattern.nodes`.
-- Anything that JSON-round-trips patterns and expects a graph: json-utils
-  round-trip tests, pattern-as-value deserialization in `pattern-binding`,
-  debug tooling. Deserialization of a ref requires the module to be loadable
-  by identity (in-memory, or storage-backed via the compile cache) — which is
-  the whole point, but makes by-identity load the only rehydration path.
-  UNDER DUAL-WRITE: readers prefer the ref (`resolveStoredPattern`) and keep
-  the graph as fallback, so nothing requires by-identity load yet; the
-  remaining graph consumers are pinned by
-  `test/pre-e3-pattern-value-canary.test.ts`.
-- Wire/IPC surfaces that today receive pattern JSON (runtime-client
-  `getPatternSources` is source-based and unaffected; the E3 audit found no
-  other protocol field carrying serialized pattern graphs — IPC carries
-  pattern ids/sources only).
+- `addressableByIdentity` is session-lifetime (open question 1, E4
+  extension): sync resolution covers every module evaluated in the reading
+  session — every authored op by construction, since whatever instantiates
+  the map mentioned the op and loaded it as part of its bundle.
+- `Pattern.toJSON()` emits `{ $patternRef, argumentSchema, resultSchema }` —
+  no graph. Schemas ride along for consumers that read them without
+  resolving (llm-dialog tool schemas). A pattern with NO entry ref
+  (manually constructed / dynamic / bare-Engine evaluation, e.g. the CLI's
+  `--pattern-json` debug dump) still serializes its full graph.
+- `$opFallback` dropped from the op sentinel: it was eviction insurance, and
+  eviction no longer exists; a sync miss is a loud bug. Stored pre-E4
+  sentinel vintages are still read tolerantly.
+- llm-dialog follows the sync resolution with the async storage-backed
+  `loadPatternByIdentity` (`resolveStoredPatternAsync`) — compiled artifacts
+  persist in-space as an expected part of compilation, so a tool invoked
+  cold after a reload rehydrates source-free.
+- The write-path audit (E3) found graphs persisted at exactly three
+  cell-write sites and on no wire/IPC surface; stored graph vintages
+  (pre-E3 bare graph, E3 ref+graph) keep loading and executing — pinned by
+  `test/pre-e3-pattern-value-canary.test.ts` alongside the refs-only
+  vintage's two resolution paths.
+- The internal/boundary split is structural: `serializePatternGraph()`
+  (json-utils) serializes the full graph under an internal-serialization
+  context that suppresses `$patternRef`; `toJSONWithLegacyAliases` (the
+  builder-time node serializer) routes pattern values through it, so
+  `Pattern.nodes` stays a bare-graph in-memory representation.
 
 ## Persisted-data compatibility
 
@@ -557,8 +559,18 @@ canary test compiling+resolving with `$implRef` stripped.
    lifecycle is fuzzy; high complexity) and a WeakRef shadow (fails exactly in
    the post-eviction-GC scenario it must cover). Memory is bounded by the set
    of distinct verified implementations per session — strictly less than the
-   legacy per-load registries retained. `$opFallback` (full-graph embed) stays
-   until E3 revisits it.
+   legacy per-load registries retained.
+   **E4 extends the same resolution to pattern artifacts:**
+   `addressableByIdentity` itself is now session-lifetime (its FIFO eviction
+   deleted) — the same retention order, since the strong function index
+   already keeps every verified implementation alive, and module-scope
+   functions referencing module-level patterns transitively retain those
+   factories anyway. With sync resolution eviction-proof for every module
+   evaluated in the session, `$opFallback` was dropped: the op sentinel is
+   stamped from its live artifact in the same session that reads it, so a
+   miss is a loud bug, not a recoverable state. The module-NAMESPACE cache
+   (`modulesByIdentity`) stays bounded; its misses recover via the async
+   storage-backed load.
 2. **`cfc/canonical.ts` digests.** Confirm no *persisted* artifact compares
    `bundleId`s across sessions (believed session-only; verify before Phase 3).
 3. **`location`/`preview` retention.** Keep both on serialized modules for

--- a/docs/specs/content-addressed-action-identity.md
+++ b/docs/specs/content-addressed-action-identity.md
@@ -405,8 +405,10 @@ tolerate a miss. E4 (same day) removed that blocker and completed the flip:
   sentinel vintages are still read tolerantly.
 - llm-dialog follows the sync resolution with the async storage-backed
   `loadPatternByIdentity` (`resolveStoredPatternAsync`) — compiled artifacts
-  persist in-space as an expected part of compilation, so a tool invoked
-  cold after a reload rehydrates source-free.
+  persist in-space as part of the compilation step (the cold write-back is
+  AWAITED inside `compilePattern`, so a persisted ref always has a durable
+  closure behind it), and a tool invoked cold after a reload rehydrates
+  source-free.
 - The write-path audit (E3) found graphs persisted at exactly three
   cell-write sites and on no wire/IPC surface; stored graph vintages
   (pre-E3 bare graph, E3 ref+graph) keep loading and executing — pinned by

--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -522,21 +522,22 @@ export function patternToJSON(pattern: Pattern) {
     ...(programIdentity ? { program: programIdentity } : {}),
   };
   if (internalGraphSerialization) return graph;
-  // JSON boundary (cell writes, JSON.stringify): dual-write the pattern's
-  // content-addressed entry ref alongside the graph (design §7, scoped — see
-  // the implementation plan's E3 section). The ref is content-derived, so
-  // identical bytes re-emit the identical ref across sessions; readers
-  // (resolveOpPattern, llm-dialog tool invocation) prefer it to resolve the
-  // live canonical pattern and fall back to the carried graph. Refs-ONLY
-  // emission is deferred: stored refs today resolve only through the
-  // FIFO-bounded artifact index (sync) or by-identity load (async) — neither
-  // covers the sync list builtins cross-session, so the graph must travel
-  // until a session-lifetime pattern index (eviction pinning) exists.
+  // JSON boundary (cell writes, JSON.stringify): REFS-ONLY (design §7,
+  // identity E4). The ref is content-derived, so identical bytes re-emit the
+  // identical ref across sessions. Schemas ride along so consumers can read
+  // them without resolving (llm-dialog tool schemas). Rehydration goes by
+  // identity: the session-lifetime artifact index covers every module
+  // evaluated in the reading session (any authored op, by construction), and
+  // async readers fall back to the storage-backed `loadPatternByIdentity` —
+  // compiled artifacts persist in-space as an expected part of compilation.
+  // A pattern with NO entry ref (manually constructed / dynamic) still
+  // serializes its full graph: nothing could ever resolve its ref.
   const entryRef = getArtifactEntryRef(pattern);
   return entryRef
     ? {
       $patternRef: { identity: entryRef.identity, symbol: entryRef.symbol },
-      ...graph,
+      argumentSchema: pattern.argumentSchema,
+      resultSchema: pattern.resultSchema,
     }
     : graph;
 }

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -27,7 +27,7 @@ import { isBoolean, isObject, isRecord } from "@commonfabric/utils/types";
 import type { Cell, MemorySpace, Stream } from "../cell.ts";
 import { isCell, isStream } from "../cell.ts";
 import { type CellScope, ID, NAME, type Pattern } from "../builder/types.ts";
-import { resolveStoredPattern } from "./op-pattern-ref.ts";
+import { resolveStoredPatternAsync } from "./op-pattern-ref.ts";
 import { type Action, ignoreReadForScheduling } from "../scheduler.ts";
 import { Runtime } from "../runtime.ts";
 import { spaceCellSchema } from "../runtime.ts";
@@ -2250,11 +2250,12 @@ async function handleInvoke(
     handler = resolved.handler;
   }
 
-  // A pattern read raw from a cell is the boundary serialization: prefer
-  // resolving the live canonical pattern via its $patternRef (trust brand +
-  // entry ref intact), fall back to the stored graph (pre-dual-write data or
-  // evicted module).
-  pattern = resolveStoredPattern(runtime, pattern) as
+  // A pattern read raw from a cell is the boundary serialization (refs-only
+  // since identity E4): resolve the live canonical pattern via its
+  // $patternRef — sync from the session-lifetime artifact index, async from
+  // the space's persisted compiled artifacts when the module never evaluated
+  // here — with stored graph vintages passing through unchanged.
+  pattern = await resolveStoredPatternAsync(runtime, pattern, space) as
     | Readonly<Pattern>
     | undefined;
 

--- a/packages/runner/src/builtins/op-pattern-ref.ts
+++ b/packages/runner/src/builtins/op-pattern-ref.ts
@@ -14,22 +14,15 @@ import type { Runtime } from "../runtime.ts";
  * derivation backref — so the builtin reads it back intact and
  * resolves the live canonical pattern without deserializing a graph or mapping
  * functions back by `implementationRef`.
+ *
+ * The sentinel carries NO embedded fallback graph (identity E4): the artifact
+ * index is session-lifetime, and the sentinel is stamped from the op's live
+ * artifact in the same session that reads it back, so sync resolution cannot
+ * miss short of a bug. (Sentinels of the earlier `$opFallback`-carrying
+ * vintage are still read tolerantly — see {@link resolveStoredPattern}.)
  */
 export interface PatternRefSentinel {
   $patternRef: { identity: string; symbol: string };
-  /**
-   * The embedded op pattern graph, retained as a correctness fallback.
-   *
-   * The identity fast path resolves the op from the in-memory evaluated-module
-   * cache, which is bounded (FIFO) — a long-lived session that evaluates enough
-   * other modules can evict an op whose map/filter/flatMap node is still live.
-   * Cache residency must therefore be an optimization, not a correctness
-   * requirement: on a miss we deserialize this graph instead of hard-failing a
-   * running node. (#3898 dropped the session-varying `program.files` from
-   * serialized patterns, so retaining the graph no longer reintroduces the
-   * cross-reload id churn that motivated passing the op by identity.)
-   */
-  $opFallback?: Pattern;
 }
 
 export function isPatternRefSentinel(
@@ -45,18 +38,16 @@ export function isPatternRefSentinel(
  * Resolve the `op` value a list builtin (`map`/`filter`/`flatMap`) reads from
  * its inputs cell into a live `Pattern`.
  *
- * - When `op` is a {@link PatternRefSentinel}, resolve it synchronously from the
- *   in-memory cache via `artifactFromIdentitySync` (the fast path: the op's
- *   module is part of the parent pattern's bundle, normally still
- *   live by the time the list Action runs). On a cache miss (the op was evicted
- *   mid-session — a sync Action cannot await `loadPatternByIdentity`), fall back
- *   to the sentinel's retained `$opFallback` graph so a running node never breaks
- *   just because its op rolled out of the bounded cache.
- * - A pattern VALUE serialized by the dual-write boundary (PR E3) carries
- *   `$patternRef` ALONGSIDE its full graph — sentinel-shaped, but with the
- *   graph in the value itself rather than under `$opFallback`. On a cache
- *   miss, resolve from the carried graph (same eviction rationale as above).
- * - Otherwise (legacy / ESM loader off / no entry ref), `op` is the embedded
+ * - When `op` is a {@link PatternRefSentinel}, resolve it synchronously from
+ *   the session-lifetime artifact index via `artifactFromIdentitySync` — the
+ *   op's module evaluated in this session by construction (the sentinel was
+ *   stamped from its live artifact at node instantiation).
+ * - A stored pattern VALUE reaching `op` (pattern-as-argument) resolves the
+ *   same way when its module evaluated this session, else from the graph the
+ *   value itself carries (E3-and-earlier vintages). A bare ref from a module
+ *   that never evaluated here throws — loud, since a sync Action cannot await
+ *   the storage-backed `loadPatternByIdentity`.
+ * - Otherwise (no entry ref known at instantiation), `op` is the embedded
  *   pattern graph itself, used as-is.
  */
 export function resolveOpPattern(
@@ -68,8 +59,8 @@ export function resolveOpPattern(
   if (resolved === undefined && isPatternRefSentinel(rawOp)) {
     throw new Error(
       `${builtinName}: op pattern ${rawOp.$patternRef.identity}#` +
-        `${rawOp.$patternRef.symbol} is not in the evaluated-module cache ` +
-        `and has no embedded fallback`,
+        `${rawOp.$patternRef.symbol} did not evaluate in this session and ` +
+        `carries no graph`,
     );
   }
   return resolved as Pattern;
@@ -78,13 +69,15 @@ export function resolveOpPattern(
 /**
  * Resolve a pattern VALUE read raw from a cell into a runnable `Pattern`.
  *
- * Boundary-serialized pattern values carry `$patternRef` (PR E3 dual-write,
- * possibly with an `$opFallback` from the list-builtin sentinel): prefer
- * resolving the LIVE canonical pattern by identity — it carries the trust
- * brand and content-addressed entry ref a deserialized graph lacks — then
- * fall back to the embedded/carried graph (pre-E3 vintages; module evicted
- * from the bounded cache). A bare unresolvable ref yields `undefined`; any
- * other value passes through unchanged (legacy stored graphs).
+ * Boundary-serialized pattern values carry `$patternRef`: prefer resolving the
+ * LIVE canonical pattern by identity — it carries the trust brand and
+ * content-addressed entry ref a deserialized graph lacks — then fall back to
+ * a graph the value still carries (stored vintages: the E3 dual-write graph
+ * alongside the ref, or a pre-E4 sentinel's `$opFallback`). A bare
+ * unresolvable ref yields `undefined`; callers with an async context follow
+ * up with `loadPatternByIdentity` (compiled artifacts persist in-space as part
+ * of compilation), sync callers fail loudly. Any other value passes through
+ * unchanged (legacy stored graphs).
  */
 export function resolveStoredPattern(
   runtime: Runtime,
@@ -98,7 +91,8 @@ export function resolveStoredPattern(
       symbol,
     ) as Pattern | undefined;
     if (resolved) return resolved;
-    if (raw.$opFallback) return raw.$opFallback;
+    const vintageFallback = (raw as { $opFallback?: Pattern }).$opFallback;
+    if (vintageFallback) return vintageFallback;
     if (isPattern(raw)) return raw as unknown as Pattern;
     return undefined;
   }

--- a/packages/runner/src/builtins/op-pattern-ref.ts
+++ b/packages/runner/src/builtins/op-pattern-ref.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "@commonfabric/utils/types";
 import { isPattern, type Pattern } from "../builder/types.ts";
+import type { MemorySpace } from "../cell.ts";
 import type { Runtime } from "../runtime.ts";
 
 /**
@@ -97,4 +98,28 @@ export function resolveStoredPattern(
     return undefined;
   }
   return raw as Pattern;
+}
+
+/**
+ * {@link resolveStoredPattern} with the async net for refs-only stored values
+ * whose module never evaluated in this session: load it by identity from the
+ * space's persisted compiled artifacts (compilation persists them in-space as
+ * an expected invariant). The usual caller is llm-dialog's tool invocation —
+ * a stored toolDef pattern is normally in-session live (whatever defined the
+ * tool mentioned the pattern, so its module rode that bundle), but a tool
+ * invoked cold after a reload may reach for storage.
+ */
+export async function resolveStoredPatternAsync(
+  runtime: Runtime,
+  raw: unknown,
+  space: MemorySpace,
+): Promise<Pattern | undefined> {
+  const resolved = resolveStoredPattern(runtime, raw);
+  if (resolved !== undefined || !isPatternRefSentinel(raw)) return resolved;
+  const { identity, symbol } = raw.$patternRef;
+  return await runtime.patternManager.loadPatternByIdentity(
+    identity,
+    symbol,
+    space,
+  );
 }

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -804,9 +804,16 @@ export class PatternManager {
       this.esmCacheStats.hits++;
     } else {
       this.esmCacheStats.misses++;
-      // Cold/partial: persist the freshly compiled module set for next time.
-      // Fire-and-forget — the pattern is already returned below, so cache
-      // persistence never blocks the load. Tracked for flush/shutdown.
+      // Cold/partial: persist the freshly compiled module set. AWAITED
+      // (identity E4): refs-only pattern JSON makes artifact persistence part
+      // of the compilation contract — a cell can only carry a `$patternRef`
+      // after compilePattern returned, so completing the write here
+      // guarantees every persisted ref has a durable closure behind it (no
+      // race against session end). Cold compiles only; a warm hit means the
+      // closure was just READ from storage, i.e. it is already durable. A
+      // failed cache write logs and does not fail the compile: the pattern
+      // works in-session regardless, and the next cold compile of the same
+      // content retries the write.
       const writeBack = this.writeBackCompileCache(
         space,
         modules,
@@ -815,10 +822,17 @@ export class PatternManager {
       );
       this.compileCacheWrites.add(writeBack);
       this.pendingCacheWriteBacks.add(writeBack);
-      writeBack.finally(() => {
+      try {
+        await writeBack;
+      } catch (error) {
+        logger.warn("compile-cache-write-back-failed", () => [
+          `entry=${entryIdentity}`,
+          String(error),
+        ]);
+      } finally {
         this.compileCacheWrites.delete(writeBack);
         this.pendingCacheWriteBacks.delete(writeBack);
-      });
+      }
     }
 
     return this.patternFromEvaluation(result, program, entryIdentity);

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -104,9 +104,17 @@ export class PatternManager {
   // `artifactFromIdentitySync` (the inverse of the forward `valueToEntryRef`),
   // populated by ONE path (`indexArtifact`) from BOTH a module's `__cfReg`
   // registrations (hoists + non-exported top-level) AND its exports — so callers
-  // never look in two places. Bounded (FIFO); a miss returns undefined and
-  // callers fall back (e.g. to an embedded op graph or a source reload).
+  // never look in two places. SESSION-LIFETIME, deliberately unbounded (design
+  // § Open questions 2, resolved): the sync resolution the list builtins and
+  // refs-only pattern JSON depend on must never lose an artifact whose module
+  // evaluated this session. Entries are live builder artifacts of evaluated
+  // modules — the same order of retention the engine's strong implementation
+  // index (E1) already committed to for their implementation functions.
   private addressableByIdentity = new Map<string, Map<string, unknown>>();
+  // Bound for the module-NAMESPACE cache below (`modulesByIdentity`) only; its
+  // misses recover through the async storage-backed load. Instance field so
+  // tests can shrink it.
+  private maxEvaluatedModuleCacheSize = MAX_EVALUATED_MODULE_CACHE_SIZE;
   // Pending metadata set before the meta cell exists (e.g., spec, parents)
   private pendingMetaById = new Map<URI, Partial<PatternMeta>>();
   // ESM content-addressed compile-cache instrumentation.
@@ -1033,7 +1041,7 @@ export class PatternManager {
           this.indexArtifact(identity, exportName, exports[exportName]);
         }
       }
-      while (this.modulesByIdentity.size > MAX_EVALUATED_MODULE_CACHE_SIZE) {
+      while (this.modulesByIdentity.size > this.maxEvaluatedModuleCacheSize) {
         const oldest = this.modulesByIdentity.keys().next().value;
         if (oldest === undefined) break;
         this.modulesByIdentity.delete(oldest);
@@ -1051,11 +1059,9 @@ export class PatternManager {
       }
     }
 
-    while (this.addressableByIdentity.size > MAX_EVALUATED_MODULE_CACHE_SIZE) {
-      const oldest = this.addressableByIdentity.keys().next().value;
-      if (oldest === undefined) break;
-      this.addressableByIdentity.delete(oldest);
-    }
+    // No eviction for `addressableByIdentity` — the artifact index is
+    // session-lifetime (see its declaration): sync by-identity resolution
+    // must keep working for every module evaluated this session.
   }
 
   /**
@@ -1077,14 +1083,15 @@ export class PatternManager {
     value: unknown,
   ): void {
     if (!isTrustedBuilderArtifact(value)) return;
-    // Reverse index, refreshing recency (FIFO ~ LRU). Overwrite an existing
-    // symbol so a re-evaluation of the same identity resolves to the FRESH
-    // artifact instance, not a stale one from a prior eval.
+    // Reverse index. Overwrite an existing symbol so a re-evaluation of the
+    // same identity resolves to the FRESH artifact instance, not a stale one
+    // from a prior eval.
     let bucket = this.addressableByIdentity.get(identity);
-    if (bucket) this.addressableByIdentity.delete(identity);
-    else bucket = new Map<string, unknown>();
+    if (!bucket) {
+      bucket = new Map<string, unknown>();
+      this.addressableByIdentity.set(identity, bucket);
+    }
     bucket.set(symbol, value);
-    this.addressableByIdentity.set(identity, bucket);
     // Forward map is FIRST-WRITE-WINS, deliberately, on two grounds:
     //   - One artifact instance legitimately reachable under two refs (e.g. both
     //     a `__cfReg` entry AND an export, or set first by `patternFromMain`)
@@ -1106,23 +1113,19 @@ export class PatternManager {
   /**
    * Resolve a content-addressed `{ identity, symbol }` reference to its live
    * builder artifact, synchronously, from the single in-memory index — or
-   * `undefined` on a miss (never registered, or rolled out of the bounded cache;
-   * callers fall back, e.g. to an embedded op graph or a source reload). Public
-   * so the list builtins can resolve a map/filter/flatMap `op` during a
-   * synchronous Action.
+   * `undefined` on a miss (the module never evaluated in this session; callers
+   * fall back to a stored graph vintage or an async source reload). The index
+   * is session-lifetime, so a hit is guaranteed for any module evaluated this
+   * session — what the list builtins rely on to resolve a map/filter/flatMap
+   * `op` during a synchronous Action without an embedded fallback graph.
    */
   artifactFromIdentitySync(
     identity: string,
     symbol: string,
   ): unknown {
-    const bucket = this.addressableByIdentity.get(identity);
-    if (!bucket || !bucket.has(symbol)) return undefined;
-    // Refresh recency.
-    this.addressableByIdentity.delete(identity);
-    this.addressableByIdentity.set(identity, bucket);
     // Returns the live builder artifact (pattern / lift / handler). Callers know
     // the kind they expect from the symbol's origin and cast accordingly.
-    return bucket.get(symbol);
+    return this.addressableByIdentity.get(identity)?.get(symbol);
   }
 
   /**

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3571,16 +3571,19 @@ export class Runner {
    * input with its content-addressed `{ identity, symbol }` entry ref (when
    * known) so the builtin can resolve the live canonical pattern by identity
    * instead of deserializing the embedded graph. Mutates `inputBindings` in
-   * place: `op` becomes `{ $patternRef, $opFallback }`.
+   * place: `op` becomes `{ $patternRef }`.
    *
    * Only the `op` key is rewritten — it is the sole pattern-valued input the
    * builtins rehydrate (`resolveOpPattern`). Rewriting other inputs (e.g. a
    * pattern captured in `params`) would leave an unresolved `$patternRef` object
    * that nothing reads back.
    *
-   * The embedded graph is retained as `$opFallback` (correctness over the
-   * bounded module cache — see `resolveOpPattern`). `inputBindings` here is the
-   * freshly bound (mutable, unfrozen) copy produced by
+   * The sentinel carries NO embedded fallback graph (identity E4): the artifact
+   * index is session-lifetime, and the op's module evaluated in this session by
+   * construction (the sentinel is stamped from its live artifact right here),
+   * so the builtin's sync resolution cannot miss short of a bug — and a bug
+   * should be loud, not silently served a stale graph. `inputBindings` here is
+   * the freshly bound (mutable, unfrozen) copy produced by
    * `unwrapOneLevelAndBindtoDoc`; its pattern values carry their derivation
    * link (`noteDerivedCopy`), so `getArtifactEntryRef` can resolve the ref
    * (assigned post-eval by `registerEvaluatedModules`). With no known ref the
@@ -3605,7 +3608,6 @@ export class Runner {
     if (ref) {
       (inputBindings as Record<string, unknown>).op = {
         $patternRef: { identity: ref.identity, symbol: ref.symbol },
-        $opFallback: op,
       };
     }
   }

--- a/packages/runner/test/artifact-index-pinning.test.ts
+++ b/packages/runner/test/artifact-index-pinning.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+/**
+ * Open question 2 (docs/specs/content-addressed-action-identity.md) resolved:
+ * the artifact index (`addressableByIdentity`) is SESSION-LIFETIME — a builder
+ * artifact indexed by module evaluation stays synchronously resolvable for the
+ * rest of the session, no matter how many other modules evaluate afterwards.
+ *
+ * This is what lets the op sentinel drop its embedded `$opFallback` graph and
+ * the JSON boundary go refs-only: any pattern whose module evaluated in this
+ * session (every authored op — its module is part of the running piece's
+ * bundle by construction) resolves via `artifactFromIdentitySync`, eviction-
+ * free. The module-namespace cache (`modulesByIdentity`) stays bounded: its
+ * misses recover through the async storage-backed load.
+ */
+
+const signer = await Identity.fromPassphrase("artifact-index-pinning");
+
+const program = (n: number): RuntimeProgram => ({
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        "import { pattern } from 'commonfabric';",
+        `export default pattern<{ items: { v: number }[] }>(({ items }) => {`,
+        `  return { vs${n}: items.map((item) => item.v) };`,
+        "});",
+      ].join("\n"),
+    },
+  ],
+});
+
+describe("artifact index pinning (session-lifetime)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("an indexed artifact stays sync-resolvable past the module-cache bound", async () => {
+    const pm = runtime.patternManager;
+    // Shrink the bounded module-namespace cache so three compiles overflow it.
+    // The ARTIFACT index must not be governed by this bound.
+    (pm as unknown as { maxEvaluatedModuleCacheSize: number })
+      .maxEvaluatedModuleCacheSize = 1;
+
+    const first = await pm.compilePattern(program(1));
+    const firstRef = pm.getArtifactEntryRef(first);
+    expect(firstRef).toBeDefined();
+
+    await pm.compilePattern(program(2));
+    await pm.compilePattern(program(3));
+
+    // The first pattern's module rolled out of the bounded namespace cache,
+    // but its artifacts are pinned for the session: the sync resolution the
+    // list builtins depend on still hits.
+    const resolved = pm.artifactFromIdentitySync(
+      firstRef!.identity,
+      firstRef!.symbol,
+    );
+    expect(resolved).toBe(first);
+
+    // The hoisted op of the first pattern resolves too (what a map node's
+    // sentinel looks up mid-session).
+    const op = pm.artifactFromIdentitySync(firstRef!.identity, "__cfPattern_1");
+    expect(op).toBeDefined();
+  });
+});

--- a/packages/runner/test/artifact-index-pinning.test.ts
+++ b/packages/runner/test/artifact-index-pinning.test.ts
@@ -82,4 +82,19 @@ describe("artifact index pinning (session-lifetime)", () => {
     const op = pm.artifactFromIdentitySync(firstRef!.identity, "__cfPattern_1");
     expect(op).toBeDefined();
   });
+
+  it("a cold compile persists the closure before the pattern exists", async () => {
+    // The refs-only boundary contract: artifact persistence is PART OF the
+    // compilation step, not a best-effort write racing session end. A cell
+    // write can only contain a $patternRef after compilePattern returned, so
+    // awaiting the cold write-back inside compilePattern guarantees every
+    // persisted ref has a durable closure behind it.
+    const pm = runtime.patternManager;
+    const tx = runtime.edit();
+    await pm.compilePattern(program(7), { space: signer.did(), tx });
+    await tx.commit();
+    const pending = (pm as unknown as { pendingCacheWriteBacks: Set<unknown> })
+      .pendingCacheWriteBacks;
+    expect(pending.size).toBe(0);
+  });
 });

--- a/packages/runner/test/fixtures/capture-pre-e3.ts
+++ b/packages/runner/test/fixtures/capture-pre-e3.ts
@@ -45,25 +45,29 @@ const fixtureUrl = new URL(
   import.meta.url,
 );
 let preE3 = serialized;
+let dualWrite = serialized;
 try {
   const existing = JSON.parse(await Deno.readTextFile(fixtureUrl));
   if (existing?.serialized?.preE3) preE3 = existing.serialized.preE3;
+  if (existing?.serialized?.dualWrite) {
+    dualWrite = existing.serialized.dualWrite;
+  }
 } catch {
   // First capture: the current writer IS the pre-E3 writer.
 }
 
 const fixture = {
   comment:
-    "Stored pattern-VALUE vintages (PR E3). preE3: captured from the writer BEFORE the $patternRef dual-write — a bare node-graph; preserved verbatim on re-capture. dualWrite: the current writer's boundary output — $patternRef alongside the graph. Both must keep executing through the graph read paths (runtime.run on a deserialized graph; resolveOpPattern) for as long as stored data can carry them. Refresh dualWrite by re-running test/fixtures/capture-pre-e3.ts.",
+    "Stored pattern-VALUE vintages. preE3 (writer before the E3 $patternRef dual-write): a bare node-graph. dualWrite (E3 writer): $patternRef alongside the graph. refsOnly (E4 writer, current): $patternRef + schemas, no graph — rehydrates by identity only. The graph-bearing vintages must keep executing through the graph read paths (runtime.run on a deserialized graph; resolveOpPattern) for as long as stored data can carry them; earlier vintages are preserved verbatim on re-capture. Refresh refsOnly by re-running test/fixtures/capture-pre-e3.ts.",
   program: PROGRAM,
-  serialized: { preE3, dualWrite: serialized },
+  serialized: { preE3, dualWrite, refsOnly: serialized },
 };
 
 await Deno.writeTextFile(
   fixtureUrl,
   JSON.stringify(fixture, null, 2) + "\n",
 );
-console.log("captured dualWrite keys:", Object.keys(serialized));
+console.log("captured refsOnly keys:", Object.keys(serialized));
 
 await runtime.dispose();
 await storageManager.close();

--- a/packages/runner/test/fixtures/pre-e3-serialized-pattern.json
+++ b/packages/runner/test/fixtures/pre-e3-serialized-pattern.json
@@ -1,5 +1,5 @@
 {
-  "comment": "Stored pattern-VALUE vintages (PR E3). preE3: captured from the writer BEFORE the $patternRef dual-write — a bare node-graph; preserved verbatim on re-capture. dualWrite: the current writer's boundary output — $patternRef alongside the graph. Both must keep executing through the graph read paths (runtime.run on a deserialized graph; resolveOpPattern) for as long as stored data can carry them. Refresh dualWrite by re-running test/fixtures/capture-pre-e3.ts.",
+  "comment": "Stored pattern-VALUE vintages. preE3 (writer before the E3 $patternRef dual-write): a bare node-graph. dualWrite (E3 writer): $patternRef alongside the graph. refsOnly (E4 writer, current): $patternRef + schemas, no graph — rehydrates by identity only. The graph-bearing vintages must keep executing through the graph read paths (runtime.run on a deserialized graph; resolveOpPattern) for as long as stored data can carry them; earlier vintages are preserved verbatim on re-capture. Refresh refsOnly by re-running test/fixtures/capture-pre-e3.ts.",
   "program": {
     "main": "/main.tsx",
     "files": [
@@ -336,6 +336,48 @@
       ],
       "program": {
         "main": "/main.tsx"
+      }
+    },
+    "refsOnly": {
+      "$patternRef": {
+        "identity": "6L6e3nw7p9vmnlajhkiQZA7_lvjs9trVj_mF1uwlVFc",
+        "symbol": "default"
+      },
+      "argumentSchema": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "v": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "v"
+              ]
+            }
+          }
+        },
+        "required": [
+          "items"
+        ]
+      },
+      "resultSchema": {
+        "type": "object",
+        "properties": {
+          "vs": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        },
+        "required": [
+          "vs"
+        ]
       }
     }
   }

--- a/packages/runner/test/map-op-by-identity.test.ts
+++ b/packages/runner/test/map-op-by-identity.test.ts
@@ -78,7 +78,7 @@ describe("op-pattern-ref helpers", () => {
         "map",
       )
     ).toThrow(
-      /op pattern cf:module\/miss#s is not in the evaluated-module cache/,
+      /op pattern cf:module\/miss#s did not evaluate in this session/,
     );
   });
 
@@ -167,13 +167,13 @@ describe("map op passed by identity", () => {
     cancelSink();
   });
 
-  it("falls back to the embedded op graph when the identity cache evicts the op", async () => {
+  it("fails loudly (no fallback output) when the sentinel cannot resolve", async () => {
     const compiled = await runtime.patternManager.compilePattern(PROGRAM);
 
-    // Simulate the op's module being evicted from the bounded in-memory cache
-    // before the map action runs: force every sync identity lookup to miss.
-    // The map must still produce correct output via the retained `$opFallback`
-    // graph — cache residency is an optimization, not a correctness requirement.
+    // The artifact index is session-lifetime (identity E4), so a genuine miss
+    // means the op's module never evaluated in this session — a bug, not an
+    // eviction. The sentinel carries NO embedded fallback graph anymore: the
+    // map must fail loudly instead of silently running a stale graph.
     const pm = runtime.patternManager;
     let identityMisses = 0;
     pm.artifactFromIdentitySync = () => {
@@ -183,7 +183,7 @@ describe("map op passed by identity", () => {
 
     const resultCell = runtime.getCell<{ vs: number[] }>(
       space,
-      "map op fallback on eviction",
+      "map op miss is loud",
       compiled.resultSchema,
       tx,
     );
@@ -199,9 +199,9 @@ describe("map op passed by identity", () => {
     const cancelSink = result.sink(() => {});
     await runtime.idle();
 
-    expect(await result.key("vs").pull()).toEqual([4, 5, 6]);
-    // The lookups missed (eviction simulated) yet the map still resolved the op.
+    // The lookups missed and no fallback graph exists: no mapped output.
     expect(identityMisses).toBeGreaterThan(0);
+    expect(result.key("vs").get()).not.toEqual([4, 5, 6]);
     cancelSink();
   });
 

--- a/packages/runner/test/pattern-ref-boundary.test.ts
+++ b/packages/runner/test/pattern-ref-boundary.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   resolveOpPattern,
   resolveStoredPattern,
+  resolveStoredPatternAsync,
 } from "../src/builtins/op-pattern-ref.ts";
 import type { Opaque } from "../src/builder/types.ts";
 
@@ -217,5 +218,57 @@ describe("resolveStoredPattern (stored tool patterns)", () => {
     expect(resolveStoredPattern({} as never, graph)).toBe(graph);
     expect(resolveStoredPattern({} as never, undefined)).toBeUndefined();
     expect(resolveStoredPattern({} as never, null)).toBeUndefined();
+  });
+
+  it("async net: loads an unresolvable refs-only value by identity", async () => {
+    const live = { argumentSchema: true } as never;
+    let loadedWith: unknown[] = [];
+    const fakeRuntime = {
+      patternManager: {
+        artifactFromIdentitySync: () => undefined,
+        loadPatternByIdentity: (
+          identity: string,
+          symbol: string,
+          space: string,
+        ) => {
+          loadedWith = [identity, symbol, space];
+          return Promise.resolve(live);
+        },
+      },
+    } as never;
+    const resolved = await resolveStoredPatternAsync(
+      fakeRuntime,
+      refValue,
+      "did:test:space" as never,
+    );
+    expect(resolved).toBe(live);
+    expect(loadedWith).toEqual(["cf:module/abc", "default", "did:test:space"]);
+  });
+
+  it("async net: sync hits and plain graphs never reach the loader", async () => {
+    const live = { argumentSchema: true } as never;
+    const fakeRuntime = {
+      patternManager: {
+        artifactFromIdentitySync: () => live,
+        loadPatternByIdentity: () => {
+          throw new Error("must not load");
+        },
+      },
+    } as never;
+    expect(
+      await resolveStoredPatternAsync(
+        fakeRuntime,
+        refValue,
+        "did:test:space" as never,
+      ),
+    ).toBe(live);
+    const graph = { nodes: [], result: {} };
+    expect(
+      await resolveStoredPatternAsync(
+        fakeRuntime,
+        graph,
+        "did:test:space" as never,
+      ),
+    ).toBe(graph);
   });
 });

--- a/packages/runner/test/pattern-ref-boundary.test.ts
+++ b/packages/runner/test/pattern-ref-boundary.test.ts
@@ -7,6 +7,7 @@ import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import type { Pattern } from "../src/builder/types.ts";
 import {
+  patternToJSON,
   serializePatternGraph,
   toJSONWithLegacyAliases,
 } from "../src/builder/json-utils.ts";
@@ -17,17 +18,19 @@ import {
 import type { Opaque } from "../src/builder/types.ts";
 
 /**
- * PR E3 (docs/specs/content-addressed-action-identity.md §7, scoped to
- * dual-write): the JSON BOUNDARY (`Pattern.toJSON()`, fired by JSON.stringify
- * and by cell writes via native-conversion's HasToJSON) emits the pattern's
- * content-addressed `{ identity, symbol }` as `$patternRef` ALONGSIDE the full
- * graph, while INTERNAL serialization (`serializePatternGraph`, used by
- * builder-time node serialization through `toJSONWithLegacyAliases`) stays a
- * bare graph — so `Pattern.nodes` and the `$opFallback` eviction fallback can
- * never silently become refs.
+ * Identity E4 (docs/specs/content-addressed-action-identity.md §7): the JSON
+ * BOUNDARY (`Pattern.toJSON()`, fired by JSON.stringify and by cell writes via
+ * native-conversion's HasToJSON) is REFS-ONLY — `{ $patternRef, argumentSchema,
+ * resultSchema }`, no graph. Rehydration of a stored ref goes by identity: the
+ * session-lifetime artifact index (sync) or the storage-backed
+ * `loadPatternByIdentity` (async; compiled artifacts persist in-space as part
+ * of compilation). INTERNAL serialization (`serializePatternGraph`, used by
+ * builder-time node serialization through `toJSONWithLegacyAliases`) stays the
+ * full bare graph — `Pattern.nodes` is the in-memory instantiation
+ * representation, not a wire format.
  */
 
-const signer = await Identity.fromPassphrase("pattern-ref-dual-write");
+const signer = await Identity.fromPassphrase("pattern-ref-boundary");
 
 const PROGRAM: RuntimeProgram = {
   main: "/main.tsx",
@@ -44,7 +47,7 @@ const PROGRAM: RuntimeProgram = {
   ],
 };
 
-describe("pattern $patternRef dual-write at the JSON boundary", () => {
+describe("refs-only pattern JSON at the boundary", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
 
@@ -61,25 +64,25 @@ describe("pattern $patternRef dual-write at the JSON boundary", () => {
     await storageManager?.close();
   });
 
-  it("Pattern.toJSON() emits $patternRef alongside the full graph", async () => {
+  it("Pattern.toJSON() emits the ref + schemas and NO graph", async () => {
     const compiled = await runtime.patternManager.compilePattern(PROGRAM);
     const entryRef = runtime.patternManager.getArtifactEntryRef(compiled);
     expect(entryRef).toBeDefined();
 
-    // The boundary serialization a pattern value undergoes when written to a
-    // cell (native-conversion HasToJSON) or JSON.stringify'd.
     const serialized = JSON.parse(JSON.stringify(compiled));
 
     expect(serialized.$patternRef).toEqual({
       identity: entryRef!.identity,
       symbol: entryRef!.symbol,
     });
-    // Dual-write: the graph stays alongside the ref (readers that cannot
-    // resolve by identity — sync list builtins, cross-session llm-dialog —
-    // keep working from the embedded graph).
-    expect(Array.isArray(serialized.nodes)).toBe(true);
+    // Schemas ride along so consumers (e.g. llm-dialog tool schemas) can read
+    // them without resolving the ref.
     expect(serialized.argumentSchema).toBeDefined();
     expect(serialized.resultSchema).toBeDefined();
+    // The graph stays internal.
+    expect("nodes" in serialized).toBe(false);
+    expect("result" in serialized).toBe(false);
+    expect("program" in serialized).toBe(false);
   });
 
   it("$patternRef is content-derived: two compiles of identical bytes emit the same ref", async () => {
@@ -88,32 +91,40 @@ describe("pattern $patternRef dual-write at the JSON boundary", () => {
     );
     const second = JSON.parse(
       JSON.stringify(
-        await runtime.patternManager.compilePattern({
-          ...PROGRAM,
-        }),
+        await runtime.patternManager.compilePattern({ ...PROGRAM }),
       ),
     );
     expect(first.$patternRef).toBeDefined();
     expect(first.$patternRef).toEqual(second.$patternRef);
   });
 
-  it("internal graph serialization stays a bare graph even when the ref is known", async () => {
+  it("a pattern with no entry ref still serializes its full graph", () => {
+    // Manually constructed / dynamic patterns are never indexed; the boundary
+    // must keep them loadable, so they fall back to the graph form.
+    const fake = {
+      argumentSchema: true,
+      resultSchema: true,
+      result: {},
+      nodes: [],
+    } as unknown as Pattern;
+    const serialized = patternToJSON(fake);
+    expect("$patternRef" in serialized).toBe(false);
+    expect(Array.isArray((serialized as { nodes: unknown }).nodes)).toBe(true);
+  });
+
+  it("internal graph serialization stays the full bare graph", async () => {
     const compiled = await runtime.patternManager.compilePattern(PROGRAM);
     expect(runtime.patternManager.getArtifactEntryRef(compiled)).toBeDefined();
 
-    // serializePatternGraph is the internal serializer (builder-time nodes,
-    // $opFallback): no $patternRef, full graph only.
     const internal = serializePatternGraph(compiled as unknown as Pattern);
     expect("$patternRef" in internal).toBe(false);
     expect(Array.isArray((internal as { nodes: unknown }).nodes)).toBe(true);
 
-    // toJSONWithLegacyAliases routes pattern values through the internal
-    // serializer — this is what keeps in-memory `Pattern.nodes` (and the
-    // `$opFallback` graphs derived from them) ref-free.
     const viaLegacyAliases = toJSONWithLegacyAliases(
       compiled as unknown as Opaque<unknown>,
     ) as Record<string, unknown>;
     expect("$patternRef" in viaLegacyAliases).toBe(false);
+    expect(Array.isArray(viaLegacyAliases.nodes)).toBe(true);
   });
 
   it("nodes of a freshly compiled pattern embed bare op graphs (no $patternRef)", async () => {
@@ -121,15 +132,17 @@ describe("pattern $patternRef dual-write at the JSON boundary", () => {
     const json = JSON.stringify((compiled as unknown as Pattern).nodes);
     expect(json.includes("$patternRef")).toBe(false);
   });
+
+  it("a stored refs-only value resolves to the live canonical pattern", async () => {
+    const compiled = await runtime.patternManager.compilePattern(PROGRAM);
+    const stored = JSON.parse(JSON.stringify(compiled));
+    const resolved = resolveStoredPattern(runtime, stored);
+    expect(resolved).toBe(compiled);
+  });
 });
 
-describe("resolveOpPattern dual-read", () => {
-  it("falls back to the carried graph when a ref+graph value misses the cache", () => {
-    // A pattern VALUE serialized by the dual-write boundary carries BOTH
-    // $patternRef and the full graph. When such a stored value reaches a list
-    // builtin as its op (pattern-as-argument) and the identity cache has
-    // evicted the module, the op must resolve from the value itself — not
-    // hard-fail a running node.
+describe("resolveOpPattern stored-vintage reads", () => {
+  it("falls back to the carried graph of an E3 dual-write value on a miss", () => {
     const dualWriteValue = {
       $patternRef: { identity: "cf:module/evicted", symbol: "s" },
       argumentSchema: true,
@@ -144,7 +157,7 @@ describe("resolveOpPattern dual-read", () => {
     expect(resolved).toBe(dualWriteValue);
   });
 
-  it("still throws when the value misses the cache and carries no graph", () => {
+  it("throws when the value misses the index and carries no graph", () => {
     const fakeRuntime = {
       patternManager: { artifactFromIdentitySync: () => undefined },
     } as never;
@@ -158,16 +171,14 @@ describe("resolveOpPattern dual-read", () => {
   });
 });
 
-describe("resolveStoredPattern (llm-dialog stored tool patterns)", () => {
+describe("resolveStoredPattern (stored tool patterns)", () => {
   const refValue = {
     $patternRef: { identity: "cf:module/abc", symbol: "default" },
     argumentSchema: true,
     resultSchema: true,
-    result: {},
-    nodes: [],
   } as never;
 
-  it("prefers the live canonical pattern when the identity cache hits", () => {
+  it("prefers the live canonical pattern when the identity index hits", () => {
     const live = { argumentSchema: true } as never;
     const fakeRuntime = {
       patternManager: {
@@ -181,23 +192,24 @@ describe("resolveStoredPattern (llm-dialog stored tool patterns)", () => {
     expect(resolveStoredPattern(fakeRuntime, refValue)).toBe(live);
   });
 
-  it("falls back to the carried graph on a cache miss", () => {
+  it("yields undefined for an unresolvable refs-only value (async callers load by identity)", () => {
     const fakeRuntime = {
       patternManager: { artifactFromIdentitySync: () => undefined },
     } as never;
-    expect(resolveStoredPattern(fakeRuntime, refValue)).toBe(refValue);
+    expect(resolveStoredPattern(fakeRuntime, refValue)).toBeUndefined();
   });
 
-  it("yields undefined for a bare unresolvable ref", () => {
+  it("reads pre-E4 sentinel vintages tolerantly ($opFallback)", () => {
+    const fallbackGraph = { argumentSchema: true, nodes: [] };
     const fakeRuntime = {
       patternManager: { artifactFromIdentitySync: () => undefined },
     } as never;
     expect(
-      resolveStoredPattern(
-        fakeRuntime,
-        { $patternRef: { identity: "cf:module/miss", symbol: "s" } },
-      ),
-    ).toBeUndefined();
+      resolveStoredPattern(fakeRuntime, {
+        $patternRef: { identity: "cf:module/old", symbol: "s" },
+        $opFallback: fallbackGraph,
+      }),
+    ).toBe(fallbackGraph);
   });
 
   it("passes plain stored graphs and nullish values through", () => {

--- a/packages/runner/test/pattern-ref-dual-write.test.ts
+++ b/packages/runner/test/pattern-ref-dual-write.test.ts
@@ -154,7 +154,7 @@ describe("resolveOpPattern dual-read", () => {
         { $patternRef: { identity: "cf:module/miss", symbol: "s" } } as never,
         "map",
       )
-    ).toThrow(/not in the/);
+    ).toThrow(/did not evaluate in this session/);
   });
 });
 

--- a/packages/runner/test/pre-e3-pattern-value-canary.test.ts
+++ b/packages/runner/test/pre-e3-pattern-value-canary.test.ts
@@ -5,7 +5,10 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import type { Pattern } from "../src/builder/types.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
-import { resolveOpPattern } from "../src/builtins/op-pattern-ref.ts";
+import {
+  resolveOpPattern,
+  resolveStoredPattern,
+} from "../src/builtins/op-pattern-ref.ts";
 
 /**
  * PR E3 stored-pattern-value canary (docs/specs/content-addressed-action-
@@ -124,9 +127,74 @@ describe("pre-E3 stored pattern-value canary", () => {
     const value = structuredClone(
       fixture.serialized.dualWrite,
     ) as unknown as Pattern;
-    // Fresh runtime: nothing is in the bounded identity cache, so the
-    // sentinel-shaped value must resolve from the graph it carries.
+    // Fresh runtime: nothing is in the identity index, so the sentinel-shaped
+    // value must resolve from the graph it carries.
     const resolved = resolveOpPattern(runtime!, value, "map");
     expect(resolved).toBe(value);
+  });
+
+  it("refs-only vintage (E4) resolves to the live canonical once its module evaluated", async () => {
+    setup();
+    const stored = structuredClone(fixture.serialized.refsOnly);
+    expect("nodes" in stored).toBe(false);
+
+    // The module evaluates in this session (the by-construction case: any
+    // piece whose pattern mentions this one loads it as part of its bundle).
+    const compiled = await runtime!.patternManager.compilePattern(
+      fixture.program,
+    );
+    const resolved = resolveStoredPattern(runtime!, stored);
+    expect(resolved).toBe(compiled);
+
+    const vs = await runGraph(resolved as Pattern, "canary-refs-only-run");
+    expect(vs).toEqual([7, 8, 9]);
+  });
+
+  it("refs-only vintage loads by identity from storage when the module never evaluated (async net)", async () => {
+    // Session 1 compiles WITH the space cache: compiled artifacts persist
+    // in-space as an expected part of compilation (E4 invariant). It stays
+    // open while session 2 reads — the emulated storage tears down replica
+    // state on dispose (same structure as resume-by-identity.test.ts).
+    storageManager = StorageManager.emulate({ as: signer });
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    try {
+      const tx1 = rt1.edit();
+      await rt1.patternManager.compilePattern(fixture.program, {
+        space,
+        tx: tx1,
+      });
+      await tx1.commit();
+      await rt1.patternManager.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+
+      // Session 2 never evaluates the module; the stored refs-only value's
+      // sync resolution misses, and the async fallback (what llm-dialog does)
+      // loads source-free by identity from the persisted compiled artifacts.
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+      });
+      const stored = structuredClone(
+        fixture.serialized.refsOnly,
+      ) as unknown as {
+        $patternRef: { identity: string; symbol: string };
+      };
+      expect(resolveStoredPattern(runtime, stored)).toBeUndefined();
+
+      const loaded = await runtime.patternManager.loadPatternByIdentity(
+        stored.$patternRef.identity,
+        stored.$patternRef.symbol,
+        space,
+      );
+      expect(loaded).toBeDefined();
+
+      const vs = await runGraph(loaded as Pattern, "canary-refs-only-async");
+      expect(vs).toEqual([7, 8, 9]);
+    } finally {
+      await rt1.dispose();
+    }
   });
 });

--- a/packages/runner/test/pre-e3-pattern-value-canary.test.ts
+++ b/packages/runner/test/pre-e3-pattern-value-canary.test.ts
@@ -167,7 +167,9 @@ describe("pre-E3 stored pattern-value canary", () => {
         tx: tx1,
       });
       await tx1.commit();
-      await rt1.patternManager.flushCompileCacheWrites();
+      // No flushCompileCacheWrites: the cold write-back is awaited INSIDE
+      // compilePattern (the E4 persistence contract) — deliberately not
+      // flushed here to pin that.
       await rt1.storageManager.synced();
 
       // Session 2 never evaluates the module; the stored refs-only value's


### PR DESCRIPTION
Completes design §7 (docs/specs/content-addressed-action-identity.md): the pattern JSON boundary is **refs-only**, and the blocker that scoped [#4073](https://github.com/commontoolsinc/labs/pull/4073) down to dual-write is removed at its root. Follows E1 #4053 / E2 #4064 / E3 #4073.

## The unblocking insight

E3 deferred refs-only because pattern artifacts had no session-lifetime index — stored `$patternRef`s resolved only through the FIFO-bounded `addressableByIdentity` (sync) or `loadPatternByIdentity` (async), and the sync list builtins couldn't tolerate a miss. But a pattern artifact derives synchronously from its module's evaluation, so the fix is not to re-derive on a miss — it's to never lose the artifact: extend E1's gate-3 move (session-lifetime strong index) to builder artifacts. The FIFO bound was protecting against memory the strong function index already commits to (every verified implementation retained per session; module-scope functions referencing module-level patterns transitively retain those factories anyway).

## What this does

1. **Artifact index pinned** — `addressableByIdentity` loses its FIFO eviction; `artifactFromIdentitySync` becomes a plain probe. The module-NAMESPACE cache (`modulesByIdentity`) stays bounded (its misses recover via the async storage-backed load), with its bound now an instance field tests can shrink (red-green in `artifact-index-pinning.test.ts`).
2. **`$opFallback` dropped** — the op sentinel is stamped from the op's live artifact in the same session that reads it back, so sync resolution cannot miss short of a bug — and the bug is now loud (`map-op-by-identity.test.ts` "fails loudly", red-green) instead of silently served a stale graph. **Map coverage is by construction**: anything instantiating a map mentioned its op (hoisted closure or imported factory), so the op's module is part of that piece's bundle and evaluates in the reading session. Stored pre-E4 sentinel vintages with `$opFallback` are still read tolerantly.
3. **Refs-only boundary** — `Pattern.toJSON()` emits `{ $patternRef, argumentSchema, resultSchema }`, no graph (schemas ride along for consumers that read them without resolving, e.g. llm-dialog tool schemas). A pattern with **no entry ref** (manually constructed / dynamic / bare-Engine evaluation) still serializes its full graph — nothing could ever resolve its ref. This is also why `cf dev --pattern-json` keeps printing graphs unchanged: the CLI evaluates through the engine without a PatternManager (verified empirically).
4. **llm-dialog async net** — new `resolveStoredPatternAsync` follows the sync probe with the storage-backed `loadPatternByIdentity`, for a tool invoked cold after a reload. **Invariant assumed (per decision): compilation persists compiled artifacts in-space**, so a refs-only stored value is rehydratable wherever it was written.
5. **Canary** — the stored-vintage fixture grows a `refsOnly` vintage pinning both resolution paths: sync to the live canonical once the module evaluated, and the source-free async load in a runtime that never evaluated it. The pre-E3 (bare graph) and E3 (ref+graph) vintages stay pinned loading and executing.

The one corner outside the map construction — an op passed as a runtime *value* from a program not running in the reading session — throws the descriptive sentinel error as a tripwire (a sync Action cannot await the loader).

## CFC

No trust/provenance/`writeAuthorizedBy` semantics touched. Refs-only resolution returns the live branded factory (trust brand + entry ref intact) where stored graphs used to be deserialized untrusted — strictly better identity fidelity. An unresolvable ref fails closed.

## Verification

- Full `packages/runner` suite green (595 passed); identity-sensitive set incl. both canaries, adversarial suites, `map-op-by-identity` (still meaningful: identity-resolution spy + loud-miss test).
- Workspace `deno task check` green; fmt/lint clean.
- `packages/piece` + `packages/html` green; `cf check` smoke exit 0; map-heavy pattern tests (`editable-list` 28/28, `note` 29/29, `simple-list` 20/20) green.

Spec docs updated: §7 status (complete, two-step record), open question 1 extended, implementation-plan E4 section; Phase 4's remainder narrows to the legacy javascript-function read path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make pattern JSON refs-only and pin the artifact index for the session, completing §7 of the content‑addressed action identity design. Also enforce compile-cache persistence so `$patternRef`s are always durable across sessions.

- **New Features**
  - `Pattern.toJSON()` now emits `{ $patternRef, argumentSchema, resultSchema }` only; patterns without an entry ref still serialize their full graph.
  - Session‑lifetime artifact index: no eviction; `artifactFromIdentitySync` is a simple probe. The module namespace cache remains bounded and is configurable for tests.
  - `llm-dialog` resolves stored patterns by identity via `resolveStoredPatternAsync` → `loadPatternByIdentity` when the module hasn’t evaluated in this session.
  - Dropped `$opFallback` from the list‑builtin op sentinel; a sync miss now throws. Stored vintages stay compatible (pre‑E3 graph, E3 ref+graph), and a new refs‑only canary pins both sync and async paths.

- **Bug Fixes**
  - Await cold compile‑cache write‑back inside `compilePattern` so a cell can only carry a `$patternRef` after its closure is durable; failures log without failing the compile. The canary drops its explicit flush to pin this contract.

<sup>Written for commit ada997fcbb6e281a33e864ed43aaaf2c8cb9c65d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

