### PR TITLE
fix(patterns): preserve item entity identity in update handlers (CT-1715)

### DIFF
--- a/packages/patterns/budget-tracker/expense-form.test.tsx
+++ b/packages/patterns/budget-tracker/expense-form.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Test Pattern: Budget Tracker — Expense Form
+ *
+ * Exercises the budget streams' identity contract (CT-1715):
+ * - setBudget creates a budget for a new category
+ * - setBudget UPDATES the limit for an existing category
+ * - held-reference survival: a reference stashed in a cell BEFORE a limit
+ *   update must still `equals()`-match and still drive a subsequent
+ *   equals()-located removal AFTER the update. The update writes through
+ *   the element's cell; replacing the array slot with a fresh object
+ *   literal would re-mint the budget's entity identity and orphan every
+ *   held reference.
+ * - removeBudget removes by category
+ *
+ * Run: deno task cf test packages/patterns/budget-tracker/expense-form.test.tsx --verbose
+ */
+import {
+  action,
+  computed,
+  equals,
+  handler,
+  pattern,
+  Writable,
+} from "commonfabric";
+import ExpenseForm from "./expense-form.tsx";
+import type { CategoryBudget, Expense } from "./schemas.tsx";
+
+// Test plumbing: remove the budget the held reference points at, locating
+// it with equals() — proves a reference held across a limit update still
+// drives operations (it would silently no-op if the update had re-minted
+// the budget's entity identity).
+const removeHeldBudget = handler<
+  void,
+  { budgets: Writable<CategoryBudget[]>; held: Writable<CategoryBudget> }
+>((_event, { budgets, held }) => {
+  const cur = budgets.get();
+  const idx = cur.findIndex((b) => equals(held, b));
+  if (idx >= 0) {
+    budgets.set(cur.toSpliced(idx, 1));
+  }
+});
+
+export default pattern(() => {
+  const expensesCell = new Writable<Expense[]>([]);
+  const budgetsCell = new Writable<CategoryBudget[]>([]);
+
+  const form = ExpenseForm({
+    expenses: expensesCell,
+    budgets: budgetsCell,
+  });
+
+  // Simulates an external holder (a dashboard row / selection cell) that
+  // read a budget once and keeps the reference across later mutations.
+  // Typed non-null (placeholder initial value) so the cell can be bound
+  // directly as handler state.
+  const heldBudget = new Writable<CategoryBudget>({
+    category: "",
+    limit: 0,
+  });
+
+  // ==========================================================================
+  // Actions
+  // ==========================================================================
+
+  const action_set_food_budget = action(() => {
+    form.setBudget.send({ category: "Food", limit: 100 });
+  });
+
+  const action_stash_held = action(() => {
+    const b = budgetsCell.get()[0];
+    if (b) heldBudget.set(b);
+  });
+
+  const action_update_food_budget = action(() => {
+    form.setBudget.send({ category: "Food", limit: 250 });
+  });
+
+  const action_remove_via_held = removeHeldBudget({
+    budgets: budgetsCell,
+    held: heldBudget,
+  });
+
+  // ==========================================================================
+  // Assertions
+  // ==========================================================================
+
+  const assert_food_created = computed(() => {
+    const cur = budgetsCell.get();
+    return cur.length === 1 && cur[0]?.category === "Food" &&
+      cur[0]?.limit === 100;
+  });
+
+  const assert_held_stashed = computed(() => {
+    const h = heldBudget.get();
+    return h.category === "Food" && equals(budgetsCell.get()[0], h);
+  });
+
+  const assert_food_updated_in_place = computed(() => {
+    const cur = budgetsCell.get();
+    return cur.length === 1 && cur[0]?.category === "Food" &&
+      cur[0]?.limit === 250;
+  });
+  // KEY: the stale-but-once-valid reference still equals()-matches the
+  // budget AFTER setBudget updated its limit.
+  const assert_held_survives_update = computed(() => {
+    const h = heldBudget.get();
+    return equals(budgetsCell.get()[0], h);
+  });
+  // The held reference also READS the update (it would show the stale,
+  // orphaned entity if setBudget had re-minted identity).
+  const assert_held_reads_update = computed(() =>
+    heldBudget.get().limit === 250
+  );
+
+  // KEY: the held reference still DRIVES an equals()-located removal.
+  const assert_removed_via_held = computed(() =>
+    budgetsCell.get().length === 0
+  );
+
+  // ==========================================================================
+  // Test Sequence
+  // ==========================================================================
+  return {
+    tests: [
+      // Create
+      { action: action_set_food_budget },
+      { assertion: assert_food_created },
+
+      // Held-reference survival: stash → update limit → the old reference
+      // still matches, reads the update, and still drives removal.
+      { action: action_stash_held },
+      { assertion: assert_held_stashed },
+      { action: action_update_food_budget },
+      { assertion: assert_food_updated_in_place },
+      { assertion: assert_held_survives_update },
+      { assertion: assert_held_reads_update },
+      { action: action_remove_via_held },
+      { assertion: assert_removed_via_held },
+    ],
+    form,
+  };
+});

--- a/packages/patterns/budget-tracker/expense-form.tsx
+++ b/packages/patterns/budget-tracker/expense-form.tsx
@@ -71,9 +71,11 @@ const setBudgetHandler = handler<
   );
 
   if (existingIndex >= 0) {
-    budgets.set(
-      current.map((b, i) => (i === existingIndex ? { ...b, limit } : b)),
-    );
+    // Write through the element's cell — rebuilding the array with a fresh
+    // object literal for the matched budget would re-mint its entity identity
+    // and orphan previously-held references (see
+    // packages/patterns/primitives/editable-list.tsx).
+    budgets.key(existingIndex).key("limit").set(limit);
   } else {
     budgets.push({ category: category.trim(), limit });
   }
@@ -215,12 +217,10 @@ export default pattern<Input>(({ expenses, budgets }) => {
                 );
 
                 if (existingIndex >= 0) {
-                  budgets.set(
-                    current.map((
-                      b,
-                      i,
-                    ) => (i === existingIndex ? { ...b, limit: limitVal } : b)),
-                  );
+                  // In-place element-cell write — a fresh literal would
+                  // re-mint the budget's entity identity (see
+                  // setBudgetHandler above).
+                  budgets.key(existingIndex).key("limit").set(limitVal);
                 } else {
                   budgets.push({ category: cat, limit: limitVal });
                 }

--- a/packages/patterns/budget-tracker/schemas.tsx
+++ b/packages/patterns/budget-tracker/schemas.tsx
@@ -3,7 +3,7 @@
  *
  * Type definitions used across all budget tracker sub-patterns.
  */
-import { Default } from "commonfabric";
+import { Default, safeDateNow } from "commonfabric";
 
 // ============ CORE TYPES ============
 
@@ -29,6 +29,8 @@ export interface BudgetStatusItem {
 
 // ============ HELPER FUNCTIONS ============
 
+// `new Date()` with no arguments throws in the secure pattern sandbox —
+// derive "today" from safeDateNow() instead.
 export const getTodayDate = (): string => {
-  return new Date().toISOString().split("T")[0];
+  return new Date(safeDateNow()).toISOString().split("T")[0];
 };

--- a/packages/patterns/do-list/do-list.test.tsx
+++ b/packages/patterns/do-list/do-list.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * Test Pattern: Do List
+ *
+ * Exercises the do-list contract via runSynced:
+ * - empty initial state
+ * - add items via addItem
+ * - reference-addressed update (updateItem matched with equals())
+ * - title-addressed update (updateItemByTitle, case-insensitive, updates ALL
+ *   matching titles — the legacy-but-consumed omnibox API)
+ * - reference-addressed remove (removeItem)
+ * - held-reference survival (CT-1715): a reference stashed in a cell BEFORE
+ *   an update (a selection cell, a caller that read the item earlier) must
+ *   still `equals()`-match and still drive a subsequent operation AFTER the
+ *   item is updated — both for the reference-addressed updateItem and the
+ *   title-addressed updateItemByTitle. This guards the update-in-place
+ *   contract: updates write through the element's cells; replacing the array
+ *   slot with a fresh object literal would re-mint the entity identity and
+ *   orphan every held reference.
+ *
+ * Run: deno task cf test packages/patterns/do-list/do-list.test.tsx --verbose
+ */
+import { action, computed, equals, pattern, Writable } from "commonfabric";
+import DoList, { type DoItem } from "./do-list.tsx";
+
+export default pattern(() => {
+  const doList = DoList({});
+
+  // Simulates an external holder (selection cell / attachment source) that
+  // read an item once and keeps the reference across later mutations.
+  const held = new Writable<DoItem | null>(null);
+  const heldByTitle = new Writable<DoItem | null>(null);
+
+  // ==========================================================================
+  // Actions
+  // ==========================================================================
+
+  const add_alpha = action(() => {
+    doList.addItem.send({ title: "Alpha" });
+  });
+  const add_beta = action(() => {
+    doList.addItem.send({ title: "Beta" });
+  });
+  const add_gamma = action(() => {
+    doList.addItem.send({ title: "Gamma" });
+  });
+
+  // Reference-addressed: read the live item from the list, then send it.
+  const done_first_by_ref = action(() => {
+    const item = doList.items[0];
+    if (item) doList.updateItem.send({ item, done: true });
+  });
+  const rename_first_by_ref = action(() => {
+    const item = doList.items[0];
+    if (item) doList.updateItem.send({ item, title: "Alpha!" });
+  });
+
+  // Title-addressed (LLM/omnibox API), case-insensitive.
+  const rename_beta_by_title = action(() => {
+    doList.updateItemByTitle.send({
+      title: "BETA",
+      newTitle: "Beta2",
+      done: true,
+    });
+  });
+
+  // Duplicate titles: the title-addressed handler updates ALL matches (the
+  // original `.map()` semantics, preserved by the in-place rewrite).
+  const add_dup_a = action(() => {
+    doList.addItem.send({ title: "Dup" });
+  });
+  const add_dup_b = action(() => {
+    doList.addItem.send({ title: "Dup" });
+  });
+  const done_all_dups_by_title = action(() => {
+    doList.updateItemByTitle.send({ title: "dup", done: true });
+  });
+
+  // Held-reference survival across the reference-addressed updateItem.
+  const add_held_target = action(() => {
+    doList.addItem.send({ title: "Held" });
+  });
+  const stash_held = action(() => {
+    const item = doList.items[5];
+    if (item) held.set(item);
+  });
+  const rename_held_target = action(() => {
+    const item = doList.items[5];
+    if (item) doList.updateItem.send({ item, title: "HeldRenamed" });
+  });
+  const done_via_held = action(() => {
+    const h = held.get();
+    if (h) doList.updateItem.send({ item: h, done: true });
+  });
+  const remove_via_held = action(() => {
+    const h = held.get();
+    if (h) doList.removeItem.send({ item: h });
+  });
+
+  // Held-reference survival across the TITLE-addressed updateItemByTitle.
+  const add_title_held_target = action(() => {
+    doList.addItem.send({ title: "TitleHeld" });
+  });
+  const stash_title_held = action(() => {
+    const item = doList.items[5];
+    if (item) heldByTitle.set(item);
+  });
+  const rename_title_held_by_title = action(() => {
+    doList.updateItemByTitle.send({
+      title: "titleheld",
+      newTitle: "TitleHeldRenamed",
+      done: true,
+    });
+  });
+  const remove_via_title_held = action(() => {
+    const h = heldByTitle.get();
+    if (h) doList.removeItem.send({ item: h });
+  });
+
+  // ==========================================================================
+  // Assertions
+  // ==========================================================================
+
+  const assert_initial_empty = computed(() => doList.itemCount === 0);
+
+  const assert_three = computed(() => doList.itemCount === 3);
+  const assert_titles = computed(() =>
+    doList.items[0]?.title === "Alpha" &&
+    doList.items[1]?.title === "Beta" &&
+    doList.items[2]?.title === "Gamma"
+  );
+
+  const assert_first_done = computed(() => doList.items[0]?.done === true);
+  const assert_first_renamed = computed(() =>
+    doList.items[0]?.title === "Alpha!" && doList.items[0]?.done === true
+  );
+  const assert_others_untouched = computed(() =>
+    doList.items[1]?.title === "Beta" && doList.items[1]?.done === false &&
+    doList.items[2]?.title === "Gamma" && doList.items[2]?.done === false
+  );
+
+  const assert_beta_renamed_done = computed(() =>
+    doList.items[1]?.title === "Beta2" && doList.items[1]?.done === true
+  );
+
+  const assert_five = computed(() => doList.itemCount === 5);
+  const assert_all_dups_done = computed(() => {
+    const dups = doList.items.filter((i: DoItem) => i.title === "Dup");
+    return dups.length === 2 && dups.every((i: DoItem) => i.done === true);
+  });
+
+  // Held-reference survival (reference-addressed update).
+  const assert_six = computed(() => doList.itemCount === 6);
+  const assert_held_stashed = computed(() => {
+    const h = held.get();
+    return h !== null && equals(doList.items[5], h);
+  });
+  const assert_held_renamed = computed(() =>
+    doList.items[5]?.title === "HeldRenamed"
+  );
+  // KEY: the stale-but-once-valid reference still equals()-matches the item
+  // AFTER updateItem patched it.
+  const assert_held_survives_update = computed(() => {
+    const h = held.get();
+    return h !== null && equals(doList.items[5], h);
+  });
+  // KEY: the held reference still DRIVES mutations after the update.
+  const assert_done_via_held = computed(() => doList.items[5]?.done === true);
+  const assert_removed_via_held = computed(() =>
+    doList.itemCount === 5 &&
+    doList.items.find((i: DoItem) => i.title === "HeldRenamed") === undefined
+  );
+
+  // Held-reference survival (title-addressed update).
+  const assert_six_again = computed(() => doList.itemCount === 6);
+  const assert_title_held_stashed = computed(() => {
+    const h = heldByTitle.get();
+    return h !== null && equals(doList.items[5], h);
+  });
+  const assert_title_held_renamed = computed(() =>
+    doList.items[5]?.title === "TitleHeldRenamed" &&
+    doList.items[5]?.done === true
+  );
+  const assert_title_held_survives_update = computed(() => {
+    const h = heldByTitle.get();
+    return h !== null && equals(doList.items[5], h);
+  });
+  const assert_removed_via_title_held = computed(() =>
+    doList.itemCount === 5 &&
+    doList.items.find((i: DoItem) => i.title === "TitleHeldRenamed") ===
+      undefined
+  );
+
+  // ==========================================================================
+  // Test Sequence
+  // ==========================================================================
+  return {
+    tests: [
+      // Initial empty
+      { assertion: assert_initial_empty },
+
+      // Add three items
+      { action: add_alpha },
+      { action: add_beta },
+      { action: add_gamma },
+      { assertion: assert_three },
+      { assertion: assert_titles },
+
+      // Reference-addressed update (equals() identity)
+      { action: done_first_by_ref },
+      { assertion: assert_first_done },
+      { action: rename_first_by_ref },
+      { assertion: assert_first_renamed },
+      { assertion: assert_others_untouched },
+
+      // Title-addressed update (case-insensitive)
+      { action: rename_beta_by_title },
+      { assertion: assert_beta_renamed_done },
+
+      // Title-addressed update hits ALL matching titles
+      { action: add_dup_a },
+      { action: add_dup_b },
+      { assertion: assert_five },
+      { action: done_all_dups_by_title },
+      { assertion: assert_all_dups_done },
+
+      // Held-reference survival: stash → reference-addressed update → the old
+      // reference still matches and still drives done/remove.
+      { action: add_held_target },
+      { assertion: assert_six },
+      { action: stash_held },
+      { assertion: assert_held_stashed },
+      { action: rename_held_target },
+      { assertion: assert_held_renamed },
+      { assertion: assert_held_survives_update },
+      { action: done_via_held },
+      { assertion: assert_done_via_held },
+      { action: remove_via_held },
+      { assertion: assert_removed_via_held },
+
+      // Held-reference survival: stash → TITLE-addressed update → the old
+      // reference still matches and still drives removal.
+      { action: add_title_held_target },
+      { assertion: assert_six_again },
+      { action: stash_title_held },
+      { assertion: assert_title_held_stashed },
+      { action: rename_title_held_by_title },
+      { assertion: assert_title_held_renamed },
+      { assertion: assert_title_held_survives_update },
+      { action: remove_via_title_held },
+      { assertion: assert_removed_via_title_held },
+    ],
+    doList,
+  };
+});

--- a/packages/patterns/do-list/do-list.tsx
+++ b/packages/patterns/do-list/do-list.tsx
@@ -209,8 +209,9 @@ const updateItemByTitleHandler = handler<
   // the entity identity and orphans every previously-held item reference
   // (see updateItemHandler above). All case-insensitive matches are updated,
   // matching the original `.map()` semantics.
+  const needle = title.toLowerCase();
   for (let index = 0; index < currentItems.length; index++) {
-    if (currentItems[index].title?.toLowerCase() !== title.toLowerCase()) {
+    if (currentItems[index].title?.toLowerCase() !== needle) {
       continue;
     }
     const element = items.key(index);

--- a/packages/patterns/do-list/do-list.tsx
+++ b/packages/patterns/do-list/do-list.tsx
@@ -122,17 +122,18 @@ const updateItemHandler = handler<
   { items: Writable<DoItem[]> }
 >(({ item, title, done }, { items }) => {
   const currentItems = items.get();
-  const newItems = currentItems.map((i) => {
-    if (!equals(i, item)) return i;
+  const index = currentItems.findIndex((i) => equals(i, item));
+  if (index < 0) return;
 
-    return {
-      ...i,
-      ...(title !== undefined ? { title } : {}),
-      ...(done !== undefined ? { done } : {}),
-    };
-  });
-
-  items.set(newItems);
+  // Write THROUGH the element's cells (`items.key(index)` resolves through the
+  // slot's link into the entity doc) — never replace the slot with a fresh
+  // object literal: a fresh literal re-mints the entity identity, so every
+  // previously-held reference to the item (a selection cell, a caller that
+  // read it earlier) stops equals()-matching and later mutations with it
+  // silently no-op. See packages/patterns/primitives/editable-list.tsx.
+  const element = items.key(index);
+  if (title !== undefined) element.key("title").set(title);
+  if (done !== undefined) element.key("done").set(done);
 });
 
 const addItemsHandler = handler<
@@ -202,20 +203,25 @@ const updateItemByTitleHandler = handler<
   { items: Writable<DoItem[]> }
 >(({ title, newTitle, done, attachments }, { items }) => {
   const currentItems = items.get();
-  const newItems = currentItems.map((i) => {
-    if (i.title?.toLowerCase() !== title.toLowerCase()) return i;
-
-    return {
-      ...i,
-      ...(newTitle !== undefined ? { title: newTitle } : {}),
-      ...(done !== undefined ? { done } : {}),
-      ...(attachments !== undefined
-        ? { attachments: [...(i.attachments ?? []), ...attachments] }
-        : {}),
-    };
-  });
-
-  items.set(newItems);
+  // Title matching stays the addressing mechanism (LLM-friendly API), but the
+  // update itself writes through each matched element's cells instead of
+  // replacing the array slot with a fresh literal — slot replacement re-mints
+  // the entity identity and orphans every previously-held item reference
+  // (see updateItemHandler above). All case-insensitive matches are updated,
+  // matching the original `.map()` semantics.
+  for (let index = 0; index < currentItems.length; index++) {
+    if (currentItems[index].title?.toLowerCase() !== title.toLowerCase()) {
+      continue;
+    }
+    const element = items.key(index);
+    if (newTitle !== undefined) element.key("title").set(newTitle);
+    if (done !== undefined) element.key("done").set(done);
+    if (attachments !== undefined) {
+      for (const attachment of attachments) {
+        element.key("attachments").push(attachment);
+      }
+    }
+  }
 });
 
 const addAttachment = handler<

--- a/packages/patterns/fair-share/main.test.tsx
+++ b/packages/patterns/fair-share/main.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Test Pattern: Fair Share — joinWithProfile identity preservation
+ *
+ * Exercises the exported joinWithProfile handler (the participant/roster
+ * "join with your profile" idiom) against test-owned cells:
+ * - joining as a new person pushes a {name, avatar?} snapshot and selects
+ *   them as "you" (myName)
+ * - joining as an existing avatar-less person BACKFILLS the avatar
+ * - the avatar backfill must preserve the person's entity identity
+ *   (CT-1715): it writes through the element's cell; replacing the array
+ *   slot with a fresh object literal would re-mint the entity and orphan
+ *   every previously-held reference (selection cells, rows read earlier)
+ * - an existing avatar is NOT overwritten by a later join
+ * - held-reference survival: a reference stashed BEFORE the backfill still
+ *   `equals()`-matches the person and still drives a subsequent
+ *   equals()-located removal AFTER the backfill
+ *
+ * The full Fair Share pattern is not instantiated here: its UI resolves
+ * `wish()` queries, and the ledger handler under test is module-scope state
+ * bound, so the contract is exercised directly on the cells.
+ *
+ * Run: deno task cf test packages/patterns/fair-share/main.test.tsx --verbose
+ */
+import {
+  action,
+  computed,
+  equals,
+  handler,
+  pattern,
+  Writable,
+} from "commonfabric";
+import { joinWithProfile } from "./main.tsx";
+
+interface Person {
+  name: string;
+  avatar?: string;
+}
+
+// Test plumbing: remove the person the held reference points at, locating it
+// with equals() — proves a reference held across the avatar backfill still
+// drives operations (it would silently no-op if the backfill had re-minted
+// the person's entity identity).
+const removeHeldPerson = handler<
+  void,
+  { people: Writable<Person[]>; held: Writable<Person> }
+>((_event, { people, held }) => {
+  const cur = people.get();
+  const idx = cur.findIndex((p) => equals(held, p));
+  if (idx >= 0) {
+    people.set(cur.toSpliced(idx, 1));
+  }
+});
+
+export default pattern(() => {
+  const peopleCell = new Writable<Person[]>([]);
+  const myNameCell = new Writable<string>("");
+
+  // Simulates an external holder (selection cell / balance row) that read a
+  // person once and keeps the reference across later mutations. Typed
+  // non-null (placeholder initial value) so the cell can be bound directly
+  // as handler state.
+  const held = new Writable<Person>({ name: "" });
+
+  // ==========================================================================
+  // Actions
+  // ==========================================================================
+
+  // Ann is added by hand first (no avatar) — the backfill target.
+  const action_join_ann_no_avatar = joinWithProfile({
+    people: peopleCell,
+    myName: myNameCell,
+    name: "Ann",
+    avatar: "",
+  });
+
+  const action_stash_held = action(() => {
+    const p = peopleCell.get()[0];
+    if (p) held.set(p);
+  });
+
+  // Ann joins again with a profile avatar — exercises the backfill branch.
+  const action_join_ann_with_avatar = joinWithProfile({
+    people: peopleCell,
+    myName: myNameCell,
+    name: "Ann",
+    avatar: "🙂",
+  });
+
+  // A later join must NOT clobber an existing avatar snapshot.
+  const action_join_ann_other_avatar = joinWithProfile({
+    people: peopleCell,
+    myName: myNameCell,
+    name: "Ann",
+    avatar: "🦊",
+  });
+
+  // New person with avatar — the push branch.
+  const action_join_bob = joinWithProfile({
+    people: peopleCell,
+    myName: myNameCell,
+    name: "Bob",
+    avatar: "🐱",
+  });
+
+  const action_remove_via_held = removeHeldPerson({
+    people: peopleCell,
+    held,
+  });
+
+  // ==========================================================================
+  // Assertions
+  // ==========================================================================
+
+  const assert_ann_added = computed(() => {
+    const cur = peopleCell.get();
+    return cur.length === 1 && cur[0]?.name === "Ann" && !cur[0]?.avatar;
+  });
+  const assert_my_name_ann = computed(() => myNameCell.get() === "Ann");
+
+  const assert_held_stashed = computed(() => {
+    const h = held.get();
+    return h.name === "Ann" && equals(peopleCell.get()[0], h);
+  });
+
+  const assert_avatar_backfilled = computed(() =>
+    peopleCell.get()[0]?.avatar === "🙂"
+  );
+  // KEY: the stale-but-once-valid reference still equals()-matches the
+  // person AFTER the backfill wrote through the element's cell.
+  const assert_held_survives_backfill = computed(() => {
+    const h = held.get();
+    return equals(peopleCell.get()[0], h);
+  });
+  // The held reference also READS the update (it would show the stale,
+  // orphaned entity if the backfill had re-minted identity).
+  const assert_held_reads_backfill = computed(() => held.get().avatar === "🙂");
+
+  const assert_avatar_not_clobbered = computed(() =>
+    peopleCell.get()[0]?.avatar === "🙂"
+  );
+
+  const assert_bob_added_with_avatar = computed(() => {
+    const cur = peopleCell.get();
+    return cur.length === 2 && cur[1]?.name === "Bob" &&
+      cur[1]?.avatar === "🐱";
+  });
+  const assert_my_name_bob = computed(() => myNameCell.get() === "Bob");
+
+  // KEY: the held reference still DRIVES an equals()-located removal.
+  const assert_removed_via_held = computed(() => {
+    const cur = peopleCell.get();
+    return cur.length === 1 && cur[0]?.name === "Bob";
+  });
+
+  // ==========================================================================
+  // Test Sequence
+  // ==========================================================================
+  return {
+    tests: [
+      // Join as a new (avatar-less) person
+      { action: action_join_ann_no_avatar },
+      { assertion: assert_ann_added },
+      { assertion: assert_my_name_ann },
+
+      // Stash an external reference BEFORE the backfill
+      { action: action_stash_held },
+      { assertion: assert_held_stashed },
+
+      // Avatar backfill preserves identity
+      { action: action_join_ann_with_avatar },
+      { assertion: assert_avatar_backfilled },
+      { assertion: assert_held_survives_backfill },
+      { assertion: assert_held_reads_backfill },
+
+      // Existing avatar is not overwritten
+      { action: action_join_ann_other_avatar },
+      { assertion: assert_avatar_not_clobbered },
+
+      // New person push branch
+      { action: action_join_bob },
+      { assertion: assert_bob_added_with_avatar },
+      { assertion: assert_my_name_bob },
+
+      // The held reference still drives removal after the backfill
+      { action: action_remove_via_held },
+      { assertion: assert_removed_via_held },
+    ],
+    peopleCell,
+  };
+});

--- a/packages/patterns/fair-share/main.tsx
+++ b/packages/patterns/fair-share/main.tsx
@@ -126,7 +126,8 @@ const computeSettlements = (balances: Balance[]): Settlement[] => {
 // idiom: each viewer contributes their own #profile snapshot on join, rather
 // than the app querying everyone's private profile state (see
 // docs/specs/shared-profile-rosters.md). `name` stays the natural key.
-const joinWithProfile = handler<
+// Exported for tests.
+export const joinWithProfile = handler<
   unknown,
   {
     people: Writable<Person[]>;
@@ -144,7 +145,11 @@ const joinWithProfile = handler<
     people.push(av ? { name: n, avatar: av } : { name: n });
   } else if (av && !cur[idx].avatar) {
     // Backfill the avatar snapshot if this name was added by hand earlier.
-    people.set(cur.toSpliced(idx, 1, { ...cur[idx], avatar: av }));
+    // Write through the element's cell — replacing the array slot with a
+    // fresh object literal would re-mint the person's entity identity and
+    // orphan previously-held references (selection cells, expense rows read
+    // earlier). See packages/patterns/primitives/editable-list.tsx.
+    people.key(idx).key("avatar").set(av);
   }
   myName.set(n);
 });
@@ -337,25 +342,34 @@ export default pattern<State>(({ people, expenses, myName }) => {
                       const name = { ...cur[idx] }.name;
                       // Cascade-clean so balances stay zero-sum: drop expenses
                       // they paid (money has no creditor now) and remove them
-                      // from every other split. Built with a plain for-loop and
-                      // explicit array spreads — chaining .filter()/.map() on the
-                      // reactive .get() array makes the transformer rewrite them
-                      // to .filterWithPattern()/.mapWithPattern(), which throw at
-                      // runtime here.
+                      // from every other split. Built with a plain for-loop —
+                      // chaining .filter()/.map() on the reactive .get() array
+                      // makes the transformer rewrite them to
+                      // .filterWithPattern()/.mapWithPattern(), which throw at
+                      // runtime here. Kept expenses are pushed by REFERENCE
+                      // (not `{ ...e }` clones) and split changes are written
+                      // through the element's cell — fresh literals would
+                      // re-mint every kept expense's entity identity and
+                      // orphan previously-held references.
+                      const allExpenses = expenses.get();
                       const cleaned: Expense[] = [];
-                      for (const e of expenses.get()) {
+                      for (let i = 0; i < allExpenses.length; i++) {
+                        const e = allExpenses[i];
                         if (e.paidBy === name) continue;
                         const had = [...(e.sharedBy ?? [])];
                         // Empty sharedBy means "split among everyone" — it stays
                         // implicit-everyone (now a smaller group), so keep it as-is.
                         if (had.length === 0) {
-                          cleaned.push({ ...e });
+                          cleaned.push(e);
                           continue;
                         }
                         const shared = had.filter((s) => s !== name);
                         // An explicit split emptied by this removal is dropped.
                         if (shared.length === 0) continue;
-                        cleaned.push({ ...e, sharedBy: shared });
+                        if (shared.length !== had.length) {
+                          expenses.key(i).key("sharedBy").set(shared);
+                        }
+                        cleaned.push(e);
                       }
                       people.set(cur.toSpliced(idx, 1));
                       expenses.set(cleaned);

--- a/packages/patterns/habit-tracker/habit-tracker.test.tsx
+++ b/packages/patterns/habit-tracker/habit-tracker.test.tsx
@@ -7,6 +7,12 @@
  * - Toggling habit completion
  * - Deleting habits
  * - Default values
+ * - held-reference survival (CT-1715): a log reference stashed in a cell
+ *   BEFORE a toggle must still `equals()`-match and still drive a
+ *   subsequent equals()-located removal AFTER the toggle. The toggle writes
+ *   through the element's cell; replacing the array slot with a fresh
+ *   object literal would re-mint the log's entity identity and orphan every
+ *   held reference.
  *
  * Run: deno task cf test packages/patterns/habit-tracker/habit-tracker.test.tsx --verbose
  *
@@ -14,15 +20,48 @@
  * a reactivity tracking bug where direct .length access doesn't register
  * dependencies. See packages/patterns/gideon-tests/array-length-repro.test.tsx
  */
-import { action, computed, pattern } from "commonfabric";
+import {
+  action,
+  computed,
+  equals,
+  handler,
+  pattern,
+  Writable,
+} from "commonfabric";
 import HabitTracker from "./habit-tracker.tsx";
 import type { Habit, HabitLog } from "./schemas.tsx";
 
 // Helper to get array length with proper reactivity tracking
 const len = <T,>(arr: T[]): number => arr.filter(() => true).length;
 
+// Test plumbing: remove the log the held reference points at, locating it
+// with equals() — proves a reference held across a toggle still drives
+// operations (it would silently no-op if the toggle had re-minted the log's
+// entity identity).
+const removeHeldLog = handler<
+  void,
+  { logs: Writable<HabitLog[]>; held: Writable<HabitLog> }
+>((_event, { logs, held }) => {
+  const cur = logs.get();
+  const idx = cur.findIndex((l) => equals(held, l));
+  if (idx >= 0) {
+    logs.set(cur.toSpliced(idx, 1));
+  }
+});
+
 export default pattern(() => {
-  const subject = HabitTracker({ habits: [], logs: [] });
+  const logsCell = new Writable<HabitLog[]>([]);
+  const subject = HabitTracker({ habits: [], logs: logsCell });
+
+  // Simulates an external holder (a stats panel / selection cell) that read
+  // a log once and keeps the reference across later mutations. Typed
+  // non-null (placeholder initial value) so the cell can be bound directly
+  // as handler state.
+  const heldLog = new Writable<HabitLog>({
+    habitName: "",
+    date: "",
+    completed: false,
+  });
 
   // === Actions ===
 
@@ -60,6 +99,16 @@ export default pattern(() => {
     subject.deleteHabit.send({
       habit: { name: "NonExistent", icon: "?", color: "#000" },
     });
+  });
+
+  // === Held-reference survival actions (CT-1715) ===
+  const action_stash_held_log = action(() => {
+    const log = logsCell.get()[0];
+    if (log) heldLog.set(log);
+  });
+  const action_remove_via_held = removeHeldLog({
+    logs: logsCell,
+    held: heldLog,
   });
 
   // === Assertions ===
@@ -170,6 +219,30 @@ export default pattern(() => {
     () => len(subject.habits) === 2,
   );
 
+  // === Held-reference survival assertions (CT-1715) ===
+  const assert_held_log_stashed = computed(() => {
+    const h = heldLog.get();
+    return h.habitName === "Exercise" && equals(logsCell.get()[0], h);
+  });
+  const assert_log_completed_again = computed(
+    () => logsCell.get()[0]?.completed === true,
+  );
+  // KEY: the stale-but-once-valid reference still equals()-matches the log
+  // AFTER the toggle updated it.
+  const assert_held_log_survives_toggle = computed(() => {
+    const h = heldLog.get();
+    return equals(logsCell.get()[0], h);
+  });
+  // The held reference also READS the update (it would show the stale,
+  // orphaned entity if the toggle had re-minted identity).
+  const assert_held_log_reads_toggle = computed(
+    () => heldLog.get().completed === true,
+  );
+  // KEY: the held reference still DRIVES an equals()-located removal.
+  const assert_removed_via_held = computed(
+    () => len(subject.logs) === 0,
+  );
+
   return {
     tests: [
       // Initial state
@@ -221,6 +294,18 @@ export default pattern(() => {
       // Delete nonexistent habit
       { action: action_delete_nonexistent },
       { assertion: assert_still_two_habits },
+
+      // Held-reference survival: stash → toggle → the old reference still
+      // matches, reads the update, and still drives removal.
+      // (After the earlier toggles the Exercise log exists, completed=false.)
+      { action: action_stash_held_log },
+      { assertion: assert_held_log_stashed },
+      { action: action_toggle_exercise },
+      { assertion: assert_log_completed_again },
+      { assertion: assert_held_log_survives_toggle },
+      { assertion: assert_held_log_reads_toggle },
+      { action: action_remove_via_held },
+      { assertion: assert_removed_via_held },
     ],
     subject,
   };

--- a/packages/patterns/habit-tracker/habit-tracker.tsx
+++ b/packages/patterns/habit-tracker/habit-tracker.tsx
@@ -53,10 +53,13 @@ export default pattern<HabitTrackerInput, HabitTrackerOutput>(
         (log) => log.habitName === habitName && log.date === todayDate,
       );
       if (existingIdx >= 0) {
-        const updated = currentLogs.map((log, i) =>
-          i === existingIdx ? { ...log, completed: !log.completed } : log
+        // Write through the element's cell — replacing the array slot with a
+        // fresh object literal would re-mint the log's entity identity and
+        // orphan previously-held references (see
+        // packages/patterns/primitives/editable-list.tsx).
+        logs.key(existingIdx).key("completed").set(
+          !currentLogs[existingIdx].completed,
         );
-        logs.set(updated);
       } else {
         logs.push({ habitName, date: todayDate, completed: true });
       }

--- a/packages/patterns/map-demo.tsx
+++ b/packages/patterns/map-demo.tsx
@@ -137,10 +137,11 @@ const markerDragHandler = handler<
 >(({ detail: { index, position } }, { stops }) => {
   const currentStops = stops.get();
   if (index >= 0 && index < currentStops.length) {
-    const updated = currentStops.map((stop, i) =>
-      i === index ? { ...stop, position } : stop
-    );
-    stops.set(updated);
+    // Write through the element's cell — rebuilding the array with a fresh
+    // object literal for the dragged stop would re-mint its entity identity
+    // and orphan previously-held references (see
+    // packages/patterns/primitives/editable-list.tsx).
+    stops.key(index).key("position").set(position);
   }
 });
 

--- a/packages/patterns/project-list/main.test.tsx
+++ b/packages/patterns/project-list/main.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Test Pattern: Project List
+ *
+ * Exercises the toggle handler's identity contract (CT-1715):
+ * - toggling flips `done` on the addressed item only
+ * - held-reference survival: a reference stashed in a cell BEFORE a toggle
+ *   must still `equals()`-match and still drive a subsequent
+ *   equals()-located removal AFTER the toggle. The toggle writes through
+ *   the element's cell; replacing the array slot with a fresh object
+ *   literal would re-mint the item's entity identity and orphan every held
+ *   reference.
+ *
+ * Run: deno task cf test packages/patterns/project-list/main.test.tsx --verbose
+ */
+import {
+  action,
+  computed,
+  equals,
+  handler,
+  pattern,
+  Writable,
+} from "commonfabric";
+import ProjectList, { toggleItem } from "./main.tsx";
+
+interface ProjectItem {
+  id: string;
+  title: string;
+  done: boolean;
+}
+
+// Seed the list with fresh literals so each item becomes an entity doc with
+// its own identity (the same shape the pattern's addItem action produces).
+const seedItems = handler<void, { items: Writable<ProjectItem[]> }>(
+  (_event, { items }) => {
+    items.push({ id: "a", title: "First", done: false });
+    items.push({ id: "b", title: "Second", done: false });
+  },
+);
+
+// Test plumbing: remove the item the held reference points at, locating it
+// with equals() — proves a reference held across a toggle still drives
+// operations (it would silently no-op if the toggle had re-minted the
+// item's entity identity).
+const removeHeldItem = handler<
+  void,
+  { items: Writable<ProjectItem[]>; held: Writable<ProjectItem> }
+>((_event, { items, held }) => {
+  const cur = items.get();
+  const idx = cur.findIndex((i) => equals(held, i));
+  if (idx >= 0) {
+    items.set(cur.toSpliced(idx, 1));
+  }
+});
+
+export default pattern(() => {
+  const itemsCell = new Writable<ProjectItem[]>([]);
+  const list = ProjectList({ items: itemsCell });
+
+  // Simulates an external holder (selection cell) that read an item once
+  // and keeps the reference across later mutations. Typed non-null
+  // (placeholder initial value) so the cell can be bound as handler state.
+  const heldItem = new Writable<ProjectItem>({
+    id: "",
+    title: "",
+    done: false,
+  });
+
+  // ==========================================================================
+  // Actions
+  // ==========================================================================
+
+  const action_seed = seedItems({ items: itemsCell });
+
+  const action_stash_held = action(() => {
+    const item = itemsCell.get()[0];
+    if (item) heldItem.set(item);
+  });
+
+  // The REAL exported toggle handler, bound exactly as the row UI binds it.
+  const action_toggle_first = toggleItem({ index: 0, items: itemsCell });
+
+  const action_remove_via_held = removeHeldItem({
+    items: itemsCell,
+    held: heldItem,
+  });
+
+  // ==========================================================================
+  // Assertions
+  // ==========================================================================
+
+  const assert_seeded = computed(() => {
+    const cur = itemsCell.get();
+    return cur.length === 2 && cur[0]?.title === "First" &&
+      cur[1]?.title === "Second";
+  });
+
+  const assert_held_stashed = computed(() => {
+    const h = heldItem.get();
+    return h.title === "First" && equals(itemsCell.get()[0], h);
+  });
+
+  const assert_first_done = computed(() => itemsCell.get()[0]?.done === true);
+  const assert_second_untouched = computed(() =>
+    itemsCell.get()[1]?.done === false
+  );
+  // KEY: the stale-but-once-valid reference still equals()-matches the item
+  // AFTER the toggle updated it.
+  const assert_held_survives_toggle = computed(() => {
+    const h = heldItem.get();
+    return equals(itemsCell.get()[0], h);
+  });
+  // The held reference also READS the update (it would show the stale,
+  // orphaned entity if the toggle had re-minted identity).
+  const assert_held_reads_toggle = computed(() => heldItem.get().done === true);
+
+  const assert_toggled_back = computed(() =>
+    itemsCell.get()[0]?.done === false
+  );
+
+  // KEY: the held reference still DRIVES an equals()-located removal.
+  const assert_removed_via_held = computed(() => {
+    const cur = itemsCell.get();
+    return cur.length === 1 && cur[0]?.title === "Second";
+  });
+
+  // ==========================================================================
+  // Test Sequence
+  // ==========================================================================
+  return {
+    tests: [
+      { action: action_seed },
+      { assertion: assert_seeded },
+
+      // Held-reference survival: stash → toggle → the old reference still
+      // matches, reads the update, and still drives removal.
+      { action: action_stash_held },
+      { assertion: assert_held_stashed },
+      { action: action_toggle_first },
+      { assertion: assert_first_done },
+      { assertion: assert_second_untouched },
+      { assertion: assert_held_survives_toggle },
+      { assertion: assert_held_reads_toggle },
+
+      // Toggling again flips back (still through the element's cell).
+      { action: action_toggle_first },
+      { assertion: assert_toggled_back },
+
+      { action: action_remove_via_held },
+      { assertion: assert_removed_via_held },
+    ],
+    list,
+  };
+});

--- a/packages/patterns/project-list/main.tsx
+++ b/packages/patterns/project-list/main.tsx
@@ -28,15 +28,18 @@ export interface ProjectListOutput {
   items: Writable<ProjectItem[]>;
 }
 
-const toggleItem = handler<
+// Exported for tests. Writes through the element's cell (`.key(index)`) —
+// rebuilding the array with a fresh object literal for the toggled item would
+// re-mint its entity identity and orphan previously-held references (see
+// packages/patterns/primitives/editable-list.tsx).
+export const toggleItem = handler<
   void,
   { index: number; items: Writable<ProjectItem[]> }
 >(
   (_, { index, items }) => {
     const list = items.get();
-    items.set(
-      list.map((item, i) => i === index ? { ...item, done: !item.done } : item),
-    );
+    if (index < 0 || index >= list.length) return;
+    items.key(index).key("done").set(!list[index].done);
   },
 );
 

--- a/packages/patterns/shopping-list.test.tsx
+++ b/packages/patterns/shopping-list.test.tsx
@@ -7,11 +7,24 @@
  * - Marking items as done
  * - Removing items
  * - Statistics (totalCount, doneCount, remainingCount)
+ * - held-reference survival (CT-1715): a reference stashed in a cell BEFORE
+ *   an aisle correction (selectAisle) must still `equals()`-match and still
+ *   drive a subsequent equals()-located removal AFTER the correction. The
+ *   correction writes through the element's cell; replacing the array slot
+ *   with a fresh object literal would re-mint the entity identity and
+ *   orphan every held reference.
  *
  * Run: deno task cf test packages/patterns/shopping-list.test.tsx --verbose
  */
-import { computed, handler, pattern, Writable } from "commonfabric";
-import ShoppingList from "./shopping-list.tsx";
+import {
+  action,
+  computed,
+  equals,
+  handler,
+  pattern,
+  Writable,
+} from "commonfabric";
+import ShoppingList, { removeItem, selectAisle } from "./shopping-list.tsx";
 
 interface ShoppingItem {
   title: string;
@@ -20,14 +33,21 @@ interface ShoppingItem {
   aisleOverride: string;
 }
 
-// Handler to set items
+// Handler to set items. Builds fresh literals (not copies of the
+// state-bound data proxies) so each item becomes an entity doc with its own
+// identity — the same shape the pattern's own add handlers produce. Entity
+// identity is what the held-reference tests below exercise.
 const setItems = handler<
   void,
   { items: Writable<ShoppingItem[]>; data: ShoppingItem[] }
 >(
   (_event, { items, data }) => {
-    // Copy to make mutable
-    items.set([...data]);
+    items.set(data.map((d) => ({
+      title: d.title,
+      done: d.done,
+      aisleSeed: d.aisleSeed,
+      aisleOverride: d.aisleOverride,
+    })));
   },
 );
 
@@ -51,6 +71,18 @@ export default pattern(() => {
     items: itemsCell,
     storeLayout: layoutCell,
   });
+
+  // Held-reference survival plumbing: an external holder (selection cell)
+  // that read an item once and keeps the reference across later mutations.
+  // Typed non-null (placeholder initial value) so the cell can be bound
+  // directly as handler state.
+  const heldItem = new Writable<ShoppingItem>({
+    title: "",
+    done: false,
+    aisleSeed: 0,
+    aisleOverride: "",
+  });
+  const correctionIndexCell = new Writable<number>(-1);
 
   // ==========================================================================
   // Actions - bind handlers with hardcoded data
@@ -105,6 +137,28 @@ Fresh vegetables and fruits
     layout: "",
   });
 
+  // === Held-reference survival actions (CT-1715) ===
+  // After test 5 the list is [Bread, Eggs]; stash a reference to Bread.
+  const action_stash_held_item = action(() => {
+    const item = itemsCell.get()[0];
+    if (item) heldItem.set(item);
+  });
+  const action_open_correction = action(() => {
+    correctionIndexCell.set(0);
+  });
+  // The REAL exported selectAisle handler, bound to the test-owned cells.
+  const action_select_aisle = selectAisle({
+    items: itemsCell,
+    correctionIndex: correctionIndexCell,
+    selectedAisle: "Aisle 2",
+  });
+  // The REAL exported removeItem handler, driven by the held reference
+  // (removeItem locates the item with equals()).
+  const action_remove_via_held = removeItem({
+    items: itemsCell,
+    item: heldItem,
+  });
+
   // ==========================================================================
   // Assertions
   // ==========================================================================
@@ -155,6 +209,33 @@ Fresh vegetables and fruits
     String(list.storeLayout).trim().length === 0
   );
 
+  // === Held-reference survival assertions (CT-1715) ===
+  const assert_held_stashed = computed(() => {
+    const h = heldItem.get();
+    return h.title === "Bread" && equals(itemsCell.get()[0], h);
+  });
+  const assert_override_set = computed(() =>
+    itemsCell.get()[0]?.aisleOverride === "Aisle 2"
+  );
+  const assert_correction_closed = computed(() =>
+    correctionIndexCell.get() === -1
+  );
+  // KEY: the stale-but-once-valid reference still equals()-matches the item
+  // AFTER selectAisle updated it.
+  const assert_held_survives_correction = computed(() => {
+    const h = heldItem.get();
+    return equals(itemsCell.get()[0], h);
+  });
+  // The held reference also READS the update (it would show the stale,
+  // orphaned entity if selectAisle had re-minted identity).
+  const assert_held_reads_correction = computed(() =>
+    heldItem.get().aisleOverride === "Aisle 2"
+  );
+  // KEY: the held reference still DRIVES an equals()-located removal.
+  const assert_removed_via_held = computed(() =>
+    list.totalCount === 1 && list.items[0]?.title === "Eggs"
+  );
+
   // ==========================================================================
   // Test Sequence
   // ==========================================================================
@@ -199,6 +280,18 @@ Fresh vegetables and fruits
       { assertion: assert_has_layout },
       { action: action_clear_store_layout },
       { assertion: assert_layout_cleared },
+
+      // === Test 7: Held-reference survival across an aisle correction ===
+      { action: action_stash_held_item },
+      { assertion: assert_held_stashed },
+      { action: action_open_correction },
+      { action: action_select_aisle },
+      { assertion: assert_override_set },
+      { assertion: assert_correction_closed },
+      { assertion: assert_held_survives_correction },
+      { assertion: assert_held_reads_correction },
+      { action: action_remove_via_held },
+      { assertion: assert_removed_via_held },
     ],
     list,
   };

--- a/packages/patterns/shopping-list.tsx
+++ b/packages/patterns/shopping-list.tsx
@@ -251,7 +251,8 @@ const openStoreMapper = handler<unknown, Record<string, never>>(
 );
 
 // Handler for removing an item
-const removeItem = handler<
+// Exported for tests.
+export const removeItem = handler<
   unknown,
   { items: Writable<ShoppingItem[]>; item: ShoppingItem }
 >((_event, { items, item }) => {
@@ -289,7 +290,11 @@ const closeCorrection = handler<
 });
 
 // Handler for selecting an aisle correction
-const selectAisle = handler<
+// Exported for tests. Writes through the element's cell (`.key(idx)`) —
+// rebuilding the array with a fresh object literal for the corrected item
+// would re-mint its entity identity and orphan previously-held references
+// (see packages/patterns/primitives/editable-list.tsx).
+export const selectAisle = handler<
   unknown,
   {
     items: Writable<ShoppingItem[]>;
@@ -302,15 +307,8 @@ const selectAisle = handler<
     const itemsList = items.get();
     const item = itemsList[idx];
     if (item) {
-      const updated = itemsList.map((i, index) =>
-        index === idx
-          ? {
-            ...i,
-            aisleOverride: selectedAisle, // Store user's selection
-          }
-          : i
-      );
-      items.set(updated);
+      // Store user's selection
+      items.key(idx).key("aisleOverride").set(selectedAisle);
     }
   }
   correctionIndex.set(-1);

--- a/packages/patterns/store-mapper.test.tsx
+++ b/packages/patterns/store-mapper.test.tsx
@@ -13,17 +13,33 @@
  * - AI photo import: addExtractedAisle with null products (graceful handling)
  * - AI photo import: addExtractedAisle duplicate prevention
  * - AI photo import: mergeExtractedAisle product merging
+ * - held-reference survival (CT-1715): a reference stashed in a cell BEFORE
+ *   setDepartmentLocation / mergeExtractedAisle must still `equals()`-match
+ *   and still drive a subsequent operation AFTER the update. Updates write
+ *   through the element's cells; replacing the array slot with a fresh
+ *   object literal would re-mint the entity identity and orphan every held
+ *   reference.
+ *
+ * The AI-import and location handlers are the REAL exported handlers from
+ * store-mapper.tsx (not local mirrors), bound to the test-owned cells.
  *
  * Run: deno task cf test packages/patterns/store-mapper.test.tsx --verbose
  */
 import {
+  action,
   computed,
+  equals,
   handler,
   pattern,
   safeDateNow,
   Writable,
 } from "commonfabric";
-import StoreMapper from "./store-mapper.tsx";
+import StoreMapper, {
+  addExtractedAisle,
+  mergeExtractedAisle,
+  removeAisle,
+  setDepartmentLocation,
+} from "./store-mapper.tsx";
 
 interface Aisle {
   name: string;
@@ -68,13 +84,21 @@ const setAisles = handler<void, { aisles: Writable<Aisle[]>; data: Aisle[] }>(
   },
 );
 
-// Handler to set departments
+// Handler to set departments. Builds fresh literals (not copies of the
+// state-bound data proxies) so each department becomes an entity doc with
+// its own identity — the same shape the pattern's default-department init
+// produces. Entity identity is what the held-reference tests below exercise.
 const setDepts = handler<
   void,
   { departments: Writable<Department[]>; data: Department[] }
 >(
   (_event, { departments, data }) => {
-    departments.set([...data]);
+    departments.set(data.map((d) => ({
+      name: d.name,
+      icon: d.icon,
+      location: d.location,
+      description: d.description,
+    })));
   },
 );
 
@@ -98,61 +122,6 @@ const setStoreName = handler<
   },
 );
 
-// Types for AI photo import testing
-interface ExtractedAisle {
-  name: string;
-  products: string[] | null;
-}
-
-// Handler to simulate addExtractedAisle (mirrors store-mapper.tsx implementation)
-const addExtractedAisle = handler<
-  void,
-  { aisles: Writable<Aisle[]>; extracted: ExtractedAisle }
->((_event, { aisles, extracted }) => {
-  const current = aisles.get() || [];
-  const exists = current.some(
-    (a: Aisle) => a.name.toLowerCase() === extracted.name.toLowerCase(),
-  );
-  if (!exists) {
-    aisles.push({
-      name: extracted.name,
-      description: (extracted.products || []).map((p: string) => `- ${p}`).join(
-        "\n",
-      ),
-    });
-  }
-});
-
-// Handler to simulate mergeExtractedAisle (mirrors store-mapper.tsx implementation)
-const mergeExtractedAisle = handler<
-  void,
-  { aisles: Writable<Aisle[]>; extracted: ExtractedAisle }
->((_event, { aisles, extracted }) => {
-  const current = aisles.get() || [];
-  const idx = current.findIndex(
-    (a: Aisle) => a.name.toLowerCase() === extracted.name.toLowerCase(),
-  );
-  if (idx >= 0) {
-    const existing = current[idx];
-    const existingItems = (existing.description || "")
-      .split("\n")
-      .map((l) => l.replace(/^-\s*/, "").trim().toLowerCase())
-      .filter(Boolean);
-    const newProducts = (extracted.products || []).filter(
-      (p) => !existingItems.includes(p.toLowerCase()),
-    );
-    if (newProducts.length > 0) {
-      const newDesc = existing.description
-        ? existing.description + "\n" +
-          newProducts.map((p) => `- ${p}`).join("\n")
-        : newProducts.map((p) => `- ${p}`).join("\n");
-      aisles.set(
-        current.toSpliced(idx, 1, { ...existing, description: newDesc }),
-      );
-    }
-  }
-});
-
 export default pattern(() => {
   // Create writable cells that we control
   const storeNameCell = new Writable("Test Store");
@@ -169,6 +138,18 @@ export default pattern(() => {
     entrances: entrancesCell,
     itemLocations: itemLocationsCell,
   });
+
+  // Simulate external holders (selection cells) that read an item once and
+  // keep the reference across later mutations (held-reference survival).
+  // Typed non-null (placeholder initial value) so the cells can be bound
+  // directly as handler state (`Opaque<T>` accepts `Cell<T>`, not `T | null`).
+  const heldDept = new Writable<Department>({
+    name: "",
+    icon: "",
+    location: "unassigned",
+    description: "",
+  });
+  const heldAisle = new Writable<Aisle>({ name: "", description: "" });
 
   // ==========================================================================
   // Actions
@@ -343,6 +324,45 @@ export default pattern(() => {
   });
 
   // ==========================================================================
+  // Held-reference survival actions (CT-1715)
+  // ==========================================================================
+
+  // Test 13: setDepartmentLocation must preserve the department's entity
+  // identity. Stash a reference, relocate the department, then relocate it
+  // AGAIN driving the handler with the stashed reference.
+  const action_stash_held_dept = action(() => {
+    const d = store.departments[0];
+    if (d) heldDept.set(d);
+  });
+  const action_relocate_first_dept = setDepartmentLocation({
+    departments: departmentsCell,
+    dept: departmentsCell.key(0),
+    location: "back-center",
+  });
+  const action_relocate_via_held_dept = setDepartmentLocation({
+    departments: departmentsCell,
+    dept: heldDept,
+    location: "right-back",
+  });
+
+  // Test 14: mergeExtractedAisle must preserve the aisle's entity identity.
+  // Stash a reference to aisle "8" (index 3: 1, 2, 5, 8, 9), merge more
+  // products into it, then REMOVE it driving removeAisle with the stashed
+  // reference (removeAisle locates the aisle with equals()).
+  const action_stash_held_aisle = action(() => {
+    const a = store.aisles[3];
+    if (a) heldAisle.set(a);
+  });
+  const action_merge_into_held_aisle = mergeExtractedAisle({
+    aisles: aislesCell,
+    extracted: { name: "8", products: ["Honey"] },
+  });
+  const action_remove_via_held_aisle = removeAisle({
+    aisles: aislesCell,
+    aisle: heldAisle,
+  });
+
+  // ==========================================================================
   // AI Photo Import Handler Assertions
   // ==========================================================================
 
@@ -397,6 +417,46 @@ export default pattern(() => {
     const matches = String(aisle8.description).match(/Coffee/g);
     return matches && matches.length === 1;
   });
+
+  // ==========================================================================
+  // Held-reference survival assertions (CT-1715)
+  // ==========================================================================
+
+  const assert_held_dept_stashed = computed(() => {
+    const h = heldDept.get();
+    return h.name !== "" && equals(store.departments[0], h);
+  });
+  const assert_dept_relocated = computed(() =>
+    store.departments[0]?.location === "back-center"
+  );
+  // KEY: the stale-but-once-valid reference still equals()-matches the
+  // department AFTER setDepartmentLocation updated it.
+  const assert_held_dept_survives = computed(() => {
+    const h = heldDept.get();
+    return h.name !== "" && equals(store.departments[0], h);
+  });
+  // KEY: the held reference still DRIVES the handler after the update.
+  const assert_dept_relocated_via_held = computed(() =>
+    store.departments[0]?.location === "right-back"
+  );
+
+  const assert_held_aisle_stashed = computed(() => {
+    const h = heldAisle.get();
+    return h.name !== "" && equals(store.aisles[3], h);
+  });
+  const assert_aisle_8_has_honey = computed(() => {
+    const aisle8 = store.aisles.find((a: Aisle) => a.name === "8");
+    return aisle8 !== undefined &&
+      String(aisle8.description).includes("Honey");
+  });
+  const assert_held_aisle_survives = computed(() => {
+    const h = heldAisle.get();
+    return h.name !== "" && equals(store.aisles[3], h);
+  });
+  const assert_aisle_8_removed_via_held = computed(() =>
+    Number(store.aisleCount) === 4 &&
+    store.aisles.find((a: Aisle) => a.name === "8") === undefined
+  );
 
   // ==========================================================================
   // Test Sequence
@@ -468,6 +528,24 @@ export default pattern(() => {
       { action: action_merge_extracted_aisle_8 },
       { assertion: assert_aisle_8_merged },
       { assertion: assert_aisle_8_no_duplicate_coffee },
+
+      // === Test 13: Held-reference survival — setDepartmentLocation ===
+      { action: action_stash_held_dept },
+      { assertion: assert_held_dept_stashed },
+      { action: action_relocate_first_dept },
+      { assertion: assert_dept_relocated },
+      { assertion: assert_held_dept_survives },
+      { action: action_relocate_via_held_dept },
+      { assertion: assert_dept_relocated_via_held },
+
+      // === Test 14: Held-reference survival — mergeExtractedAisle ===
+      { action: action_stash_held_aisle },
+      { assertion: assert_held_aisle_stashed },
+      { action: action_merge_into_held_aisle },
+      { assertion: assert_aisle_8_has_honey },
+      { assertion: assert_held_aisle_survives },
+      { action: action_remove_via_held_aisle },
+      { assertion: assert_aisle_8_removed_via_held },
     ],
     store,
   };

--- a/packages/patterns/store-mapper.tsx
+++ b/packages/patterns/store-mapper.tsx
@@ -116,9 +116,10 @@ const appendUploadedPhotos = handler<
   ]);
 });
 
-interface ExtractedAisle {
+export interface ExtractedAisle {
   name: string;
-  products: string[];
+  // The AI extraction may omit or null the products list.
+  products?: string[] | null;
 }
 
 // Default departments to load
@@ -150,7 +151,8 @@ const addAisle = handler<
   });
 });
 
-const removeAisle = handler<
+// Exported for tests.
+export const removeAisle = handler<
   unknown,
   { aisles: Writable<Aisle[]>; aisle: Aisle }
 >((_event, { aisles, aisle }) => {
@@ -184,7 +186,11 @@ const removeEntrance = handler<
 });
 
 // Department location handler
-const setDepartmentLocation = handler<
+// Exported for tests. Writes through the element's cell (`.key(index)`) —
+// replacing the array slot with a fresh object literal would re-mint the
+// department's entity identity and orphan previously-held references
+// (see packages/patterns/primitives/editable-list.tsx).
+export const setDepartmentLocation = handler<
   unknown,
   {
     departments: Writable<Department[]>;
@@ -195,14 +201,13 @@ const setDepartmentLocation = handler<
   const current = departments.get();
   const index = current.findIndex((el) => equals(dept, el));
   if (index >= 0) {
-    departments.set(
-      current.toSpliced(index, 1, { ...current[index], location }),
-    );
+    departments.key(index).key("location").set(location);
   }
 });
 
 // Handlers for AI photo import
-const addExtractedAisle = handler<
+// Exported for tests.
+export const addExtractedAisle = handler<
   unknown,
   { aisles: Writable<Aisle[]>; extracted: ExtractedAisle }
 >((_event, { aisles, extracted }) => {
@@ -247,7 +252,10 @@ const addAllExtractedAisles = handler<
   }
 });
 
-const mergeExtractedAisle = handler<
+// Exported for tests. Writes the merged description through the element's
+// cell instead of replacing the array slot — slot replacement re-mints the
+// aisle's entity identity and orphans previously-held references.
+export const mergeExtractedAisle = handler<
   unknown,
   { aisles: Writable<Aisle[]>; extracted: ExtractedAisle }
 >((_event, { aisles, extracted }) => {
@@ -269,9 +277,7 @@ const mergeExtractedAisle = handler<
         ? existing.description + "\n" +
           newProducts.map((p) => `- ${p}`).join("\n")
         : newProducts.map((p) => `- ${p}`).join("\n");
-      aisles.set(
-        current.toSpliced(idx, 1, { ...existing, description: newDesc }),
-      );
+      aisles.key(idx).key("description").set(newDesc);
     }
   }
 });


### PR DESCRIPTION
## Mechanism

Patterns updated array items by replacing the array slot with a fresh object literal — `items.set(current.toSpliced(i, 1, { ...old, ...changes }))`, or a `.map()` returning `{ ...i, changed }` for the matched item. Spreading a read proxy drops link provenance, so `recursivelyAddIDIfNeeded` (packages/runner/src/cell.ts) assigns the literal a fresh `[ID]` and `normalizeAndDiff` (data-updating.ts) derives a NEW entity doc: the item's entity identity is re-minted on every update. Any previously-held reference (a selection cell, a ref read before the mutation) stops `equals()`-matching, and later operations sent with it silently no-op. The fix is the idiom established by `packages/patterns/primitives/editable-list.tsx` (#4082) and documented in `docs/common/patterns/primitives.md` (Identity) and `docs/common/ai/pattern-critique-guide.md` §15: locate the element (preserving each site's existing match semantics exactly), then write through the element's cells — `items.key(i).key(field).set(value)`. Structural ops (remove/insert/filter/reorder) legitimately rebuild the array and were left alone.

## Per-site changes

| File / handler | Before | After | Test |
|---|---|---|---|
| `do-list/do-list.tsx` `updateItemHandler` | `.map()` returning `{ ...i, title?, done? }` for the `equals()` match, then `items.set` | `findIndex(equals)` + `items.key(i).key("title"/"done").set` | **new** `do-list/do-list.test.tsx` — held-ref stash → update → toggle/remove via held |
| `do-list/do-list.tsx` `updateItemByTitleHandler` | `.map()` spread for every case-insensitive title match (title-addressed omnibox API — API unchanged) | per-match `items.key(i)` field writes; attachments merged via `element.key("attachments").push(...)` | same file — held-ref across a title-addressed rename, plus all-matches semantics guard (two "Dup" items both updated) |
| `store-mapper.tsx` `setDepartmentLocation` (:199) | `toSpliced(index, 1, { ...dept, location })` | `departments.key(index).key("location").set(location)` | `store-mapper.test.tsx` Test 13 — stash → relocate → relocate again with the handler driven BY the held cell |
| `store-mapper.tsx` `mergeExtractedAisle` (:273) | `toSpliced(idx, 1, { ...existing, description })` | `aisles.key(idx).key("description").set(newDesc)` | `store-mapper.test.tsx` Test 14 — stash → merge → remove via held through the real `removeAisle` |
| `fair-share/main.tsx` `joinWithProfile` (:147) | avatar backfill via `toSpliced(idx, 1, { ...person, avatar })` | `people.key(idx).key("avatar").set(av)` | **new** `fair-share/main.test.tsx` — stash → backfill → equals + live-read + equals()-located removal via held |
| `fair-share/main.tsx` person-chip remove cascade (inline `oncf-remove`) | kept expenses cloned (`cleaned.push({ ...e })`, `{ ...e, sharedBy }`) — re-minted EVERY kept expense on each person removal | kept expenses pushed **by reference**; split shrink written via `expenses.key(i).key("sharedBy").set(shared)` | inline UI closure — not driveable from the test harness; declared here instead of a fake test |
| `shopping-list.tsx` `selectAisle` (:305) | `.map()` spread at the correction index | `items.key(idx).key("aisleOverride").set(selectedAisle)` | `shopping-list.test.tsx` Test 7 — stash → correction → equals + live-read + removal via held through the real `removeItem` |
| `habit-tracker/habit-tracker.tsx` `toggleHabit` (:56) | `.map()` spread flipping `completed` | `logs.key(existingIdx).key("completed").set(!...)` | `habit-tracker.test.tsx` held sequence — stash → toggle → equals + live-read + equals()-located removal |
| `project-list/main.tsx` `toggleItem` (:38) | `.map()` spread at index | `items.key(index).key("done").set(!list[index].done)` (+ bounds guard) | **new** `project-list/main.test.tsx` |
| `map-demo.tsx` `markerDragHandler` (:140) | `.map()` spread at index for `position` | `stops.key(index).key("position").set(position)` | not tested — drag-event map demo, handler not exposed; mechanism identical to project-list's tested index-addressed fix |
| `budget-tracker/expense-form.tsx` `setBudgetHandler` (:75) and inline "Set Budget" onClick (:219) | `.map()` spread updating `limit` | `budgets.key(i).key("limit").set(limit)` in both | **new** `budget-tracker/expense-form.test.tsx` drives the `setBudget` stream (covers the handler); the inline closure shares the exact mechanism but is not driveable from the harness |

Every new/extended held-reference test was also run against the **pre-fix** implementation to prove it guards the regression: do-list 14/6 failed, store-mapper 34/4 failed, fair-share 7/3 failed, shopping-list 25/3 failed, habit-tracker 25/3 failed, project-list 5/3 failed, budget-tracker 3/3 failed — all failures exactly the held-survival / driven-via-held assertions.

## Grep sweep results

Swept `packages/patterns` for `toSpliced(i, 1, {...})` replacements and `.map()` callbacks returning `{ ...matched }` spreads inside handlers/actions that `.set()` the array (excluding `deprecated/`, fixture tiers `gideon-tests/`/`test/`/`integration/`/scope-bug dirs, and `record/`). All replace-style hits are either fixed above or deliberately left:

**Deliberately NOT fixed:**
- `scrabble/scrabble.tsx:847` (move placed tile `{ ...tile, row, col }`) and `:1085` (player score `{ ...player, score }` by name) — game state is value-oriented (tiles are rebuilt as fresh value objects when returning to the rack via `returnedLetters`; players are addressed by name throughout). No reference-holding consumers; converting score/tile state to in-place writes would touch turn-submission invariants disproportionate to the risk. Left noted.
- `base/contacts.tsx:134` (`removeContact` rewrites every group `{ ...g, contactIndices }`) — the whole file is index-addressed (user-land `contactIndices` + `selectedIndex`, itself the anti-pattern per docs/common/concepts/identity.md), and the groups UI is explicitly deferred. Patching the spread alone would not restore identity guarantees while indices remain the addressing scheme; needs the data-model redesign, not this mechanical fix.
- `factory-outputs/parking-coordinator/main.tsx` (`editPerson` people/requests/adminRegistry rewrites) — factory-output tier; the app addresses people by name strings everywhere (selection cells hold names, renames cascade by string), so entity identity is not part of its addressing contract.
- Derived-view spreads in `computed()` (google extractors `calendar-change-detector.tsx:250`, `united-flight-tracker.tsx:503`, `gmail-agentic-search.tsx:1094`, scrabble `rackTiles`) — display projections, not array mutations; spreading there is correct.
- Structural ops everywhere (`toSpliced(i, 1)` removals, filter-rebuilds, `aisles.set([...current, ...newAisles])` appends) — rebuilding the array is correct for genuine adds/drops; array spreads keep element references, only object spreads re-mint.

## Incidental changes (documented intentionally)

- **Test-harness discovery:** held-reference tests require entity-bearing items. Test setter helpers that copy state-bound proxies (`items.set([...data])`) produce identity-less rows for which `equals()` stashing can never match — `setDepts` (store-mapper.test) and `setItems` (shopping-list.test) now mint fresh literals per row, matching what the patterns' own add paths produce.
- **Exports for testability** (no behavior change): store-mapper `addExtractedAisle`/`mergeExtractedAisle`/`removeAisle`/`setDepartmentLocation` (+ `ExtractedAisle.products` loosened to `string[] | null | undefined`, which the implementations already tolerated — the old test passed `products: null`); shopping-list `selectAisle`/`removeItem`; fair-share `joinWithProfile`; project-list `toggleItem`. The store-mapper test's hand-rolled mirror handlers were replaced by the real exported ones.
- **budget-tracker `schemas.tsx` `getTodayDate`**: bare `new Date()` throws in the secure pattern sandbox ("Calling new %SharedDate%() with no arguments throws"), which made the pattern impossible to instantiate under `cf test`; now `new Date(safeDateNow())`, the same idiom fair-share uses.
- The held cells bound as handler state are typed non-null with placeholder initial values because the CTS rejects `as unknown as` casts and `Opaque<T>` accepts `Cell<T>` but not `Cell<T | null>`.

## Verification

`deno task cf check <file> --no-run` — exit 0 for every touched pattern:

```
packages/patterns/do-list/do-list.tsx EXIT=0
packages/patterns/store-mapper.tsx EXIT=0
packages/patterns/fair-share/main.tsx EXIT=0
packages/patterns/shopping-list.tsx EXIT=0
packages/patterns/habit-tracker/habit-tracker.tsx EXIT=0
packages/patterns/project-list/main.tsx EXIT=0
packages/patterns/map-demo.tsx EXIT=0
packages/patterns/budget-tracker/expense-form.tsx EXIT=0
packages/patterns/system/default-app-ben.tsx EXIT=0   (do-list omnibox consumer)
```

`deno task cf test` — all green, full suites including the new held-reference sequences:

```
=== do-list ===            20 passed, 0 failed (2310ms)   [--root packages/patterns]
=== store-mapper ===       38 passed, 0 failed (3467ms)
=== fair-share ===         10 passed, 0 failed (941ms)
=== shopping-list ===      28 passed, 0 failed (3143ms)
=== habit-tracker ===      28 passed, 0 failed (1160ms)
=== project-list ===        8 passed, 0 failed (606ms)
=== budget-tracker ===      6 passed, 0 failed (697ms)
=== editable-list (reference, untouched) === 34 passed, 0 failed (1486ms)
```

Pre-fix implementations fail the new guards (run with handlers exported onto the origin/main bodies):

```
do-list:       14 passed, 6 failed   store-mapper:  34 passed, 4 failed
fair-share:     7 passed, 3 failed   shopping-list: 25 passed, 3 failed
habit-tracker: 25 passed, 3 failed   project-list:   5 passed, 3 failed
budget-tracker: 3 passed, 3 failed
```

`deno lint` (16 touched files): `Checked 16 files` — clean. `deno fmt --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves item entity identity across updates by switching spread-based array rewrites to in-place element-cell writes, preventing stale references and no-op actions. Addresses CT-1715 across multiple `packages/patterns` handlers and adds strong regression coverage.

- **Bug Fixes**
  - Replaced `{ ...item, change }`/`toSpliced` updates with `items.key(i).key(field).set(...)` in: do-list (item/title updates), store-mapper (setDepartmentLocation, mergeExtractedAisle), fair-share (avatar backfill; removal keeps expense references), shopping-list (selectAisle), habit-tracker (toggleHabit), project-list (toggleItem), map-demo (markerDragHandler), budget-tracker (setBudget).
  - Preserved existing lookup semantics (equals/title/index). Left structural ops (add/remove/reorder) unchanged.
  - Updated budget-tracker `getTodayDate` to use `safeDateNow()` for sandbox compatibility.

- **Refactors**
  - Exported handlers for testability: store-mapper (`addExtractedAisle`, `mergeExtractedAisle`, `removeAisle`, `setDepartmentLocation`), shopping-list (`selectAisle`, `removeItem`), fair-share (`joinWithProfile`), project-list (`toggleItem`). Loosened `store-mapper` `ExtractedAisle.products` to `string[] | null | undefined`.
  - Added held-reference tests that stash a pre-update ref, perform the update, then assert equals()-match, live read of changes, and ability to drive follow-up actions.
  - Minor perf: hoisted `toLowerCase()` out of the title-match loop in do-list’s `updateItemByTitle`.

<sup>Written for commit 4b10eae322e4bb8e62974540291d7db5934f96e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

