### PR TITLE
feat(runner): durable event ids + permanent-rejection taxonomy (scheduler-v2 E0)

### DIFF
--- a/docs/specs/scheduler-v2/implementation/02-phaseE0-event-identity.md
+++ b/docs/specs/scheduler-v2/implementation/02-phaseE0-event-identity.md
@@ -8,6 +8,10 @@
 Spec: §7.5 (event identity), §7.6 (taxonomy), decisions 7/8.
 Paths relative to `packages/runner/` unless noted.
 
+Execution correction: Step 3 must be completed before Step 2, because Step 2
+sets `tx.dispatchedEventId` and Step 3 declares that transaction field. Execute
+this order: Step 1 → Step 3 → Step 2 → Step 4.
+
 ## Step 1 — Event identity module
 
 New file: `src/scheduler/event-identity.ts`

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1039,6 +1039,17 @@ Implementer resolution: updated work order 02 to record the execution
 correction: Step 3 precedes Step 2 because Step 2 assigns the transaction field
 that Step 3 declares.
 
+## 02/step-3
+
+- [x] pending — dispatchedEventId transaction field
+- Deviations: executed before Step 2 per reviewer verdict; no concrete class
+  property was required.
+- Recordings:
+  - `deno fmt packages/runner/src/storage/interface.ts`: passed
+    (`Checked 1 file`).
+  - `deno check src/storage/interface.ts
+    src/storage/extended-storage-transaction.ts`: passed.
+
 ## REVIEWER VERDICT — PR #4087 CI failures (review feedback, stacked-PR protocol)
 
 PR #4087's diff and exit contracts verified good (I re-ran the greps at

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -972,3 +972,12 @@ packages/runtime-client/runtime-client.ts:322:      pullMode,
     `0 failed`, `1 ignored`, `18s`.
   - `cd packages/runtime-client && deno task test`: passed,
     `15 passed (61 steps)`, `0 failed`, `628ms`.
+
+## 02/step-1
+
+- [x] pending — event-id minting helper
+- Deviations: none.
+- Recordings:
+  - `deno fmt packages/runner/src/scheduler/event-identity.ts`: passed
+    (`Checked 1 file`).
+  - `deno check src/scheduler/event-identity.ts`: passed.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1141,7 +1141,7 @@ Then `git merge scheduler-v2/01-phase0` into `scheduler-v2/02-e0`
 
 ## 02/step-4
 
-- [x] pending — permanent-rejection taxonomy; retry paths skip precondition
+- [x] d7ac43b43 — permanent-rejection taxonomy; retry paths skip precondition
   failures
 - Deviations: `deno check` exposed that `PushError` in
   `src/storage/interface.ts` also needed `IPreconditionFailedError`, because
@@ -1170,3 +1170,41 @@ Then `git merge scheduler-v2/01-phase0` into `scheduler-v2/02-e0`
     `1 passed (3 steps)`, `0 failed`.
   - `cd packages/runner && deno task test`: passed,
     `588 passed (3074 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m3s`.
+
+## 02/phase-end self-check
+
+- Full runner suite:
+  `cd packages/runner && deno task test` → `588 passed (3074 steps)`,
+  `0 failed`, `0 ignored (10 steps)`, `2m3s`.
+- Benchmarks: work order 02 lists no phase-specific benchmarks; no benchmark
+  command was run.
+- Exit checklist greps and inspections:
+  - `grep -rn "eventQueue\.push\|eventQueue\.unshift"
+    packages/runner/src/scheduler/events.ts`:
+
+```text
+packages/runner/src/scheduler/events.ts:141:      state.eventQueue.push({
+packages/runner/src/scheduler/events.ts:485:        state.eventQueue.unshift({
+packages/runner/src/scheduler/events.ts:557:        state.eventQueue.unshift({
+```
+
+  - Code inspection of those three sites shows the push includes `id` and
+    `originTx`, and both unshift requeues preserve `id: queuedEvent.id` and
+    `originTx: queuedEvent.originTx`.
+  - `grep -rn "isPermanentRejection" packages/runner/src --include="*.ts"`:
+
+```text
+packages/runner/src/scheduler/action-run.ts:11:import { isPermanentRejection } from "../storage/rejection.ts";
+packages/runner/src/scheduler/action-run.ts:165:        retries < MAX_RETRIES_FOR_REACTIVE && !isPermanentRejection(error)
+packages/runner/src/scheduler/events.ts:14:import { isPermanentRejection } from "../storage/rejection.ts";
+packages/runner/src/scheduler/events.ts:550:        !isPermanentRejection(result.error)
+packages/runner/src/scheduler/events.ts:578:            permanent: isPermanentRejection(result.error),
+packages/runner/src/storage/rejection.ts:6:export function isPermanentRejection(
+```
+
+  - `git diff --name-only scheduler-v2/01-phase0...HEAD -- packages/memory`:
+    no matches.
+  - New test/helper files present:
+    `packages/runner/test/scheduler-event-identity.test.ts`,
+    `packages/runner/test/scheduler-rejection-taxonomy.test.ts`,
+    `packages/runner/src/storage/rejection.ts`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1041,7 +1041,7 @@ that Step 3 declares.
 
 ## 02/step-3
 
-- [x] pending — dispatchedEventId transaction field
+- [x] e28a7782e — dispatchedEventId transaction field
 - Deviations: executed before Step 2 per reviewer verdict; no concrete class
   property was required.
 - Recordings:
@@ -1049,6 +1049,46 @@ that Step 3 declares.
     (`Checked 1 file`).
   - `deno check src/storage/interface.ts
     src/storage/extended-storage-transaction.ts`: passed.
+
+## 02/step-2
+
+- [x] pending — thread event ids and origin tx through the event queue
+- Deviations: executed after Step 3 per reviewer verdict. Caller sweep included
+  non-test benchmark callers; none forwards events between schedulers.
+- Recordings:
+  - `deno fmt packages/runner/src/scheduler/types.ts
+    packages/runner/src/scheduler.ts packages/runner/src/scheduler/events.ts
+    packages/runner/src/cell.ts
+    packages/runner/test/scheduler-event-identity.test.ts`: passed
+    (`Checked 5 files`).
+  - `deno check src/scheduler.ts src/scheduler/events.ts
+    src/scheduler/types.ts src/cell.ts
+    test/scheduler-event-identity.test.ts`: passed.
+  - `ENV=test deno test --allow-ffi --allow-env --allow-read
+    --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-event-identity.test.ts`: passed, `1 passed (4 steps)`,
+    `0 failed`.
+  - Caller sweep:
+
+```text
+$ cd packages/runner
+$ grep -rn "queueEvent(" ../../packages --include="*.ts" | grep -v "\.test\.ts"
+../../packages/runner/test/scheduler-demand-roots.bench.ts:197:          graph.env.runtime.scheduler.queueEvent(
+../../packages/runner/test/scheduler-demand-roots.bench.ts:253:          graph.env.runtime.scheduler.queueEvent(
+../../packages/runner/test/default-app-note-create.bench.ts:214:  env.runtime.scheduler.queueEvent(link, { kind: "create" });
+../../packages/runner/test/default-app-note-create.bench.ts:216:    env.runtime.scheduler.queueEvent(link, { kind: "remove" });
+../../packages/runner/test/scheduler-event-preflight.bench.ts:184:        graph.env.runtime.scheduler.queueEvent(
+../../packages/runner/test/scheduler-event-preflight.bench.ts:212:        graph.env.runtime.scheduler.queueEvent(
+../../packages/runner/test/scheduler-event-preflight.bench.ts:274:            graph.env.runtime.scheduler.queueEvent(
+../../packages/runner/test/scheduler-event-preflight.bench.ts:406:        runtime.scheduler.queueEvent(eventStream.getAsNormalizedFullLink(), 1);
+../../packages/runner/src/scheduler.ts:944:  queueEvent(
+../../packages/runner/src/scheduler.ts:2114:        this.queueEvent(
+../../packages/runner/src/scheduler/events.ts:161:        state.queueEvent(
+../../packages/runner/src/cell.ts:1167:      this.runtime.scheduler.queueEvent(
+```
+
+  - `cd packages/runner && deno task test`: passed,
+    `587 passed (3071 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m3s`.
 
 ## REVIEWER VERDICT — PR #4087 CI failures (review feedback, stacked-PR protocol)
 

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1138,3 +1138,35 @@ Message: `docs(specs): scheduler-v2 — lint in G3; repo-wide mode-API exit grep
 
 Then `git merge scheduler-v2/01-phase0` into `scheduler-v2/02-e0`
 (merge, never rebase), push both, and continue WO02 step 4.
+
+## 02/step-4
+
+- [x] pending — permanent-rejection taxonomy; retry paths skip precondition
+  failures
+- Deviations: `deno check` exposed that `PushError` in
+  `src/storage/interface.ts` also needed `IPreconditionFailedError`, because
+  v2 storage `send()` returns `commitOperations(...)` whose error surface is
+  `StorageTransactionRejected`. Added it in the same named file; no extra
+  implementation file was touched.
+- Recordings:
+  - Initial `deno check src/storage/interface.ts src/storage/rejection.ts
+    src/scheduler/events.ts src/scheduler/action-run.ts
+    test/scheduler-rejection-taxonomy.test.ts`: failed with
+    `Type 'IPreconditionFailedError' is not assignable to type 'PushError'`
+    at `src/storage/v2.ts:1068:5`.
+  - `deno fmt packages/runner/src/storage/interface.ts
+    packages/runner/src/storage/rejection.ts
+    packages/runner/src/scheduler/events.ts
+    packages/runner/src/scheduler/action-run.ts
+    packages/runner/test/scheduler-rejection-taxonomy.test.ts`: passed
+    (`Checked 5 files`).
+  - `deno lint` on the same five files: passed (`Checked 5 files`).
+  - `deno check src/storage/interface.ts src/storage/rejection.ts
+    src/scheduler/events.ts src/scheduler/action-run.ts
+    test/scheduler-rejection-taxonomy.test.ts`: passed.
+  - `ENV=test deno test --allow-ffi --allow-env --allow-read
+    --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-rejection-taxonomy.test.ts`: passed,
+    `1 passed (3 steps)`, `0 failed`.
+  - `cd packages/runner && deno task test`: passed,
+    `588 passed (3074 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m3s`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -975,9 +975,115 @@ packages/runtime-client/runtime-client.ts:322:      pullMode,
 
 ## 02/step-1
 
-- [x] pending — event-id minting helper
+- [x] 722bd082f — event-id minting helper
 - Deviations: none.
 - Recordings:
   - `deno fmt packages/runner/src/scheduler/event-identity.ts`: passed
     (`Checked 1 file`).
   - `deno check src/scheduler/event-identity.ts`: passed.
+
+## IMPLEMENTER STOP — 02/step-2 transaction-field sequencing
+
+Applied the Step 2 event-id threading edits through `QueuedEvent`,
+`Scheduler.queueEvent`, `queueSchedulerEvent`, the event requeue sites, and
+the `Cell.set` stream-send origin option. Formatting passed:
+
+```text
+$ deno fmt packages/runner/src/scheduler/types.ts \
+  packages/runner/src/scheduler.ts \
+  packages/runner/src/scheduler/events.ts packages/runner/src/cell.ts
+Checked 4 files
+```
+
+The Step 2 instruction also says to set `tx.dispatchedEventId =
+queuedEvent.id` in `dispatchQueuedEvent`, but the field is introduced only in
+Step 3. The Step 2 compile check therefore fails before the Step 2 test file
+can be added or the full suite can run:
+
+```text
+$ cd packages/runner
+$ deno check src/scheduler.ts src/scheduler/events.ts src/scheduler/types.ts src/cell.ts
+Check src/scheduler.ts
+Check src/scheduler/events.ts
+Check src/scheduler/types.ts
+Check src/cell.ts
+TS2339 [ERROR]: Property 'dispatchedEventId' does not exist on type 'IExtendedStorageTransaction'.
+  tx.dispatchedEventId = queuedEvent.id;
+     ~~~~~~~~~~~~~~~~~
+    at file:///.../packages/runner/src/scheduler/events.ts:456:6
+
+error: Type checking failed.
+```
+
+No Step 3 transaction-interface edit was pulled forward, and no workaround cast
+was added.
+
+## REVIEWER VERDICT — 02/step-2 field-before-declaration
+
+Correct stop; work-order sequencing flaw (step 2 uses
+`tx.dispatchedEventId`, step 3 declares it). Resolution: execute step 3
+BEFORE step 2 — it is small and standalone. Order becomes 1 → 3 → 2 → 4.
+
+1. Do step 3 now exactly as written (interface field on
+   `IExtendedStorageTransaction` with its doc comment; plain optional
+   property on any concrete class deno check requires), commit with
+   step 3's message.
+2. Then finish step 2 (your current tree) including its test file and
+   full-suite verification, commit with step 2's message.
+3. Amend the work order in-branch to note the execution reorder — own
+   docs commit before the step-3 commit:
+   `docs(specs): scheduler-v2 WO02 — step 3 precedes step 2 (field before use)`.
+4. Continue with step 4.
+
+Implementer resolution: updated work order 02 to record the execution
+correction: Step 3 precedes Step 2 because Step 2 assigns the transaction field
+that Step 3 declares.
+
+## REVIEWER VERDICT — PR #4087 CI failures (review feedback, stacked-PR protocol)
+
+PR #4087's diff and exit contracts verified good (I re-ran the greps at
+the PR head independently). CI surfaced four misses that were OUTSIDE
+every sweep the work order ordered — two are work-order gaps, none are
+judgment errors of yours. Handle per the stacked-PR protocol: finish
+your current WO02 stop-7 sequence first (docs reorder commit, step-3
+commit, step-2 commit — clean tree), THEN fix on
+`scheduler-v2/01-phase0`, push, merge 01 forward into 02, continue.
+
+Fixes on the 01 branch, one commit
+(`fix(runner,cli,piece): phase-0 leftovers outside the runner sweep`):
+
+1. `packages/runner/src/runner.ts` lint (the Check job): remove the
+   now-unused `internalVerifierRead` import (line 69 — confirm single
+   use first) and remove the now-unused `schedulerRehydration`
+   PARAMETER from `handleJavaScriptHandlerResult`'s signature and its
+   single call site (grep to confirm exactly one caller).
+2. `packages/piece/test/pull-materialization.test.ts:138`: delete the
+   `enablePullMode()` line (rule E no-op).
+3. `packages/cli`: the cf test runner exposes a `schedulerMode` option
+   whose "push" arm calls the deleted API (test-runner.ts:884-888).
+   Remove the option END-TO-END: run the untruncated inventory
+   `grep -rn "schedulerMode\|scheduler-mode" packages/cli` and delete
+   the option type, the if/else branch, the CLI flag parsing/help, and
+   any multi-user-runner passthrough it shows. Pull is the only
+   behavior. STOP only if the inventory shows a use that is not mode
+   selection.
+4. Closing contract for the commit:
+   `git grep -n "enablePullMode\|disablePullMode\|isPullModeEnabled" -- ':!docs'`
+   → zero matches.
+
+Verification for the commit: `deno lint` + `deno check` on every
+touched file; run `packages/piece` tests and the cli test-runner's own
+test task; runner suite unchanged (not required again). Push 01 —
+PR #4087 reruns; Check / Test / runtime-client / Pattern-Reload /
+Pattern-Integration should clear. Pattern Unit Tests 3/5+4/5 may still
+fail: known PRE-EXISTING main breakage (profile-create.tsx :8000
+connection refused) — record, do not chase.
+
+Process amendments (docs commit on 01, before the fix commit):
+- 00-README G3 gains `deno lint <touched files>` alongside fmt/check.
+- WO01 exit checklist gains the repo-wide mode-API grep from item 4
+  (scoped `':!docs'`).
+Message: `docs(specs): scheduler-v2 — lint in G3; repo-wide mode-API exit grep`.
+
+Then `git merge scheduler-v2/01-phase0` into `scheduler-v2/02-e0`
+(merge, never rebase), push both, and continue WO02 step 4.

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1169,6 +1169,8 @@ export class CellImpl<T extends FabricValue>
         event,
         undefined,
         onCommit,
+        false,
+        { originTx: this.tx ?? undefined },
       );
 
       this.cleanup?.();

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -950,6 +950,7 @@ export class Scheduler {
     // effects. Use the post-commit outbox for success-only effect release.
     onCommit?: (tx: IExtendedStorageTransaction) => void,
     doNotLoadPieceIfNotRunning: boolean = false,
+    opts: { eventId?: string; originTx?: IExtendedStorageTransaction } = {},
   ): void {
     queueSchedulerEvent(this.eventQueueState, {
       eventLink,
@@ -957,6 +958,8 @@ export class Scheduler {
       retries,
       onCommit,
       doNotLoadPieceIfNotRunning,
+      eventId: opts.eventId,
+      originTx: opts.originTx,
     });
   }
 
@@ -2106,6 +2109,7 @@ export class Scheduler {
         targetRetries,
         targetOnCommit,
         targetDoNotLoad,
+        targetOpts,
       ) =>
         this.queueEvent(
           targetEventLink,
@@ -2113,6 +2117,7 @@ export class Scheduler {
           targetRetries,
           targetOnCommit,
           targetDoNotLoad,
+          targetOpts,
         ),
     };
   }

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -8,6 +8,7 @@ import type {
   IMemorySpaceAddress,
   IStorageTransaction,
 } from "../storage/interface.ts";
+import { isPermanentRejection } from "../storage/rejection.ts";
 import { sortAndCompactPaths } from "../reactive-dependencies.ts";
 import {
   MAX_ACTION_RUN_TRACE_HISTORY,
@@ -160,7 +161,9 @@ export function watchReactiveActionCommit(state: {
 
       const retries = (state.retries.get(state.action) ?? 0) + 1;
       state.retries.set(state.action, retries);
-      if (retries < MAX_RETRIES_FOR_REACTIVE) {
+      if (
+        retries < MAX_RETRIES_FOR_REACTIVE && !isPermanentRejection(error)
+      ) {
         // Re-schedule the action to run again on conflict failure.
         // Use resubscribe to set up dependencies/triggers from the log,
         // then mark as dirty/pending to ensure it runs again.

--- a/packages/runner/src/scheduler/event-identity.ts
+++ b/packages/runner/src/scheduler/event-identity.ts
@@ -1,0 +1,34 @@
+import type { NormalizedFullLink } from "../link-utils.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+
+// Per-origin-transaction state for minting causally-derived event ids:
+// a stable random key for the transaction plus a send counter. Both live
+// only as long as the transaction object; retries of the sending handler
+// run in a NEW transaction and therefore mint fresh ids (spec §7.6: each
+// attempt's launches are tied to that attempt).
+const txEventKeys = new WeakMap<object, { key: string; counter: number }>();
+
+function originStateFor(tx: object): { key: string; counter: number } {
+  let state = txEventKeys.get(tx);
+  if (!state) {
+    state = { key: crypto.randomUUID(), counter: 0 };
+    txEventKeys.set(tx, state);
+  }
+  return state;
+}
+
+/**
+ * Mints the durable id for an event at send time (spec §7.5). Ingress
+ * callers that already own a durable delivery id pass it through instead.
+ */
+export function mintEventId(
+  eventLink: NormalizedFullLink,
+  originTx?: IExtendedStorageTransaction,
+): string {
+  if (originTx) {
+    const state = originStateFor(originTx);
+    const seq = state.counter++;
+    return `evt:${state.key}:${seq}:${eventLink.id}`;
+  }
+  return `evt:${crypto.randomUUID()}:${eventLink.id}`;
+}

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -8,10 +8,15 @@ import {
 } from "../link-utils.ts";
 import type { Runtime } from "../runtime.ts";
 import type {
+  IExtendedStorageTransaction,
+  IMemorySpaceAddress,
+} from "../storage/interface.ts";
+import type {
   SchedulerActionInfo,
   SchedulerEventPreflightStats,
 } from "../telemetry.ts";
 import { createDirtyDependencyTraceContext } from "./diagnostics.ts";
+import { mintEventId } from "./event-identity.ts";
 import { planEventDirtyDependencyScheduling } from "./execution.ts";
 import { RetryImmediately } from "./retry-immediately.ts";
 import {
@@ -27,7 +32,6 @@ import type {
   QueuedEvent,
   ReactivityLog,
 } from "./types.ts";
-import type { IMemorySpaceAddress } from "../storage/interface.ts";
 
 const logger = getLogger("scheduler", {
   enabled: true,
@@ -113,6 +117,7 @@ export interface SchedulerEventQueueState {
     retries: number,
     onCommit: QueuedEvent["onCommit"] | undefined,
     doNotLoadPieceIfNotRunning: boolean,
+    opts?: { eventId?: string; originTx?: IExtendedStorageTransaction },
   ) => void;
 }
 
@@ -122,7 +127,10 @@ export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
   readonly retries: number;
   readonly onCommit?: QueuedEvent["onCommit"];
   readonly doNotLoadPieceIfNotRunning: boolean;
+  readonly eventId?: string;
+  readonly originTx?: IExtendedStorageTransaction;
 }): void {
+  const id = args.eventId ?? mintEventId(args.eventLink, args.originTx);
   let handlerFound = false;
 
   for (const [link, handler] of state.eventHandlers) {
@@ -130,6 +138,8 @@ export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
       handlerFound = true;
       state.queueExecution();
       state.eventQueue.push({
+        id,
+        originTx: args.originTx,
         eventLink: args.eventLink,
         action: (tx) => handler(tx, args.event),
         handler,
@@ -154,6 +164,7 @@ export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
           args.retries,
           args.onCommit,
           true,
+          { eventId: id, originTx: args.originTx },
         );
       }
     })();
@@ -442,6 +453,7 @@ export async function dispatchQueuedEvent(state: {
   }
 
   const tx = state.runtime.edit();
+  tx.dispatchedEventId = queuedEvent.id;
   tx.tx.immediate = true;
   const actionId = state.getActionId(action);
   const runFinalCommitCallback = () => {
@@ -470,6 +482,8 @@ export async function dispatchQueuedEvent(state: {
       }
       if (retriesLeft > 0) {
         state.eventQueue.unshift({
+          id: queuedEvent.id,
+          originTx: queuedEvent.originTx,
           action,
           eventLink: queuedEvent.eventLink,
           handler,
@@ -537,6 +551,8 @@ export async function dispatchQueuedEvent(state: {
           { error: result.error, handlerId },
         );
         state.eventQueue.unshift({
+          id: queuedEvent.id,
+          originTx: queuedEvent.originTx,
           action,
           eventLink: queuedEvent.eventLink,
           handler,

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -11,6 +11,7 @@ import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
 } from "../storage/interface.ts";
+import { isPermanentRejection } from "../storage/rejection.ts";
 import type {
   SchedulerActionInfo,
   SchedulerEventPreflightStats,
@@ -544,7 +545,10 @@ export async function dispatchQueuedEvent(state: {
           : {}),
         ...(result.error ? { error: result.error.message } : {}),
       });
-      if (result.error && retriesLeft > 0) {
+      if (
+        result.error && retriesLeft > 0 &&
+        !isPermanentRejection(result.error)
+      ) {
         logger.warn(
           "scheduler",
           `Event handler transaction failed, retrying (${retriesLeft} retries left)`,
@@ -568,7 +572,11 @@ export async function dispatchQueuedEvent(state: {
         logger.error(
           "schedule-error",
           "Event handler transaction failed after exhausting all retries",
-          { error: result.error, handlerId },
+          {
+            error: result.error,
+            handlerId,
+            permanent: isPermanentRejection(result.error),
+          },
         );
       }
     }).catch((error) => {

--- a/packages/runner/src/scheduler/types.ts
+++ b/packages/runner/src/scheduler/types.ts
@@ -188,6 +188,10 @@ export interface TriggerTraceEntry {
 }
 
 export type QueuedEvent = {
+  /** Durable event id minted at send (spec §7.5). */
+  readonly id: string;
+  /** The transaction whose handler sent this event, when transactional. */
+  readonly originTx?: IExtendedStorageTransaction;
   eventLink: NormalizedFullLink;
   action: Action;
   handler: EventHandler;

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -722,6 +722,13 @@ export interface IExtendedStorageTransaction
   extends Omit<IStorageTransaction, "reader" | "writer"> {
   tx: IStorageTransaction;
 
+  /**
+   * The durable id of the event whose dispatch opened this transaction
+   * (spec §7.5). Set by the scheduler's event dispatch; consumed by the
+   * runner to derive the handler result cell's cause (spec §7.6).
+   */
+  dispatchedEventId?: string;
+
   getCfcState(): Readonly<CfcTxState>;
   setCfcEnforcementMode(mode: CfcEnforcementMode): void;
   setCfcFlowLabelsMode(mode: CfcFlowLabelsMode): void;

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1042,6 +1042,18 @@ export interface IStorageTransactionInconsistent extends IStorageError {
 }
 
 /**
+ * A commit-time precondition failed (spec scheduler-v2 §7.6). Unlike
+ * optimistic conflicts, this class is PERMANENT: the client must not
+ * retry. `origin-committed` — the transaction that caused this work
+ * never committed. `receipt-exists` — another handling of the same
+ * event already committed (lost race).
+ */
+export interface IPreconditionFailedError extends Error {
+  name: "PreconditionFailedError";
+  precondition: "origin-committed" | "receipt-exists";
+}
+
+/**
  * Error that indicating that no change could be made to a transaction is it is
  * no longer active.
  */
@@ -1056,6 +1068,7 @@ export type StorageTransactionFailed =
 
 export type StorageTransactionRejected =
   | IConflictError
+  | IPreconditionFailedError
   | IStoreError
   | TransactionError
   | IConnectionError
@@ -1218,6 +1231,7 @@ export type PushError =
   | IStoreError
   | IConnectionError
   | IConflictError
+  | IPreconditionFailedError
   | TransactionError
   | IAuthorizationError;
 

--- a/packages/runner/src/storage/rejection.ts
+++ b/packages/runner/src/storage/rejection.ts
@@ -1,0 +1,10 @@
+/**
+ * Permanent rejections are commit-time precondition failures (spec
+ * scheduler-v2 §7.6): retrying can never succeed and MUST not happen —
+ * for `receipt-exists` a retry would double-handle an event.
+ */
+export function isPermanentRejection(
+  error: { name?: string } | undefined | null,
+): boolean {
+  return error?.name === "PreconditionFailedError";
+}

--- a/packages/runner/test/scheduler-event-identity.test.ts
+++ b/packages/runner/test/scheduler-event-identity.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "./scheduler-test-utils.ts";
+import { mintEventId } from "../src/scheduler/event-identity.ts";
+import { queueSchedulerEvent } from "../src/scheduler/events.ts";
+import type { NormalizedFullLink } from "../src/link-utils.ts";
+import type { Runtime } from "../src/runtime.ts";
+import type { QueuedEvent } from "../src/scheduler/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+
+const eventLink: NormalizedFullLink = {
+  id: "of:event-stream",
+  space: "did:key:z6MkEventIdentity" as MemorySpace,
+  scope: "space",
+  path: [],
+};
+
+function eventKey(id: string): string {
+  return id.split(":")[1];
+}
+
+describe("scheduler event identity", () => {
+  it("mints sequential ids from the same origin transaction", () => {
+    const originTx = {} as IExtendedStorageTransaction;
+
+    const first = mintEventId(eventLink, originTx);
+    const second = mintEventId(eventLink, originTx);
+
+    expect(first).toMatch(/^evt:[^:]+:0:of:event-stream$/);
+    expect(second).toMatch(/^evt:[^:]+:1:of:event-stream$/);
+    expect(eventKey(first)).toBe(eventKey(second));
+  });
+
+  it("mints different keys for different origin transactions", () => {
+    const first = mintEventId(eventLink, {} as IExtendedStorageTransaction);
+    const second = mintEventId(eventLink, {} as IExtendedStorageTransaction);
+
+    expect(eventKey(first)).not.toBe(eventKey(second));
+  });
+
+  it("mints distinct ids without an origin transaction", () => {
+    const first = mintEventId(eventLink);
+    const second = mintEventId(eventLink);
+
+    expect(first).toMatch(/^evt:[^:]+:of:event-stream$/);
+    expect(second).toMatch(/^evt:[^:]+:of:event-stream$/);
+    expect(first).not.toBe(second);
+  });
+
+  it("threads explicit event ids into queued events", () => {
+    const eventQueue: QueuedEvent[] = [];
+    const originTx = {} as IExtendedStorageTransaction;
+    const handler = () => {};
+
+    queueSchedulerEvent({
+      runtime: {} as Runtime,
+      eventHandlers: [[eventLink, handler]],
+      eventQueue,
+      backgroundTasks: new Set(),
+      queueExecution: () => {},
+      queueEvent: () => {},
+    }, {
+      eventLink,
+      event: { value: 1 },
+      retries: 1,
+      doNotLoadPieceIfNotRunning: false,
+      eventId: "evt:provided:0:of:event-stream",
+      originTx,
+    });
+
+    expect(eventQueue.length).toBe(1);
+    expect(eventQueue[0].id).toBe("evt:provided:0:of:event-stream");
+    expect(eventQueue[0].originTx).toBe(originTx);
+  });
+});

--- a/packages/runner/test/scheduler-rejection-taxonomy.test.ts
+++ b/packages/runner/test/scheduler-rejection-taxonomy.test.ts
@@ -1,0 +1,22 @@
+// Integration coverage for no-retry behavior lands in work orders 03/04,
+// where the engine can actually emit precondition failures.
+import { describe, expect, it } from "./scheduler-test-utils.ts";
+import { isPermanentRejection } from "../src/storage/rejection.ts";
+
+describe("scheduler rejection taxonomy", () => {
+  it("classifies precondition failures as permanent", () => {
+    expect(isPermanentRejection({
+      name: "PreconditionFailedError",
+    })).toBe(true);
+  });
+
+  it("does not classify conflicts as permanent", () => {
+    expect(isPermanentRejection({
+      name: "ConflictError",
+    })).toBe(false);
+  });
+
+  it("does not classify missing errors as permanent", () => {
+    expect(isPermanentRejection(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
Stack: 02/E0 — based on scheduler-v2/01-phase0 (#4087)

## Summary

Implements scheduler-v2 work order 02:

- Adds durable event id minting and threads event ids/origin transactions through queued events and requeues.
- Adds `dispatchedEventId` on runner storage transactions for event dispatch causality.
- Adds permanent-rejection taxonomy and gates event/reactive commit retry paths on `PreconditionFailedError`.
- Adds focused unit coverage for event identity and rejection taxonomy.

## Notes

- Step 3 was executed before Step 2 per reviewer verdict because Step 2 assigns `tx.dispatchedEventId` and Step 3 declares that field.
- Parent PR #4087 review feedback was fixed on `scheduler-v2/01-phase0`, pushed, and merged forward into this branch with a normal merge.
- Work order 02 lists no phase-specific benchmark command; none was run.

## Validation

- `deno fmt` / `deno lint` / `deno check` on touched Step 4 files.
- `ENV=test deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git test/scheduler-event-identity.test.ts`
- `ENV=test deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git test/scheduler-rejection-taxonomy.test.ts`
- `cd packages/runner && deno task test` → `588 passed (3074 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m3s`.
- Exit checklist greps recorded in `docs/specs/scheduler-v2/implementation/PROGRESS.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds durable event IDs to scheduler events and threads them through dispatch and requeues for clear causality. Introduces a permanent-rejection taxonomy so retries skip `PreconditionFailedError`, and exposes `dispatchedEventId` on transactions.

- New Features
  - Mint durable IDs with `mintEventId()`; stable per origin transaction via counter, or random when no origin.
  - `Scheduler.queueEvent()` accepts `opts` with `eventId` and `originTx`; requeues preserve `id` and `originTx`; cell stream sends pass `originTx` automatically.
  - Dispatcher sets `tx.dispatchedEventId` to the queued event ID for handler-result causality.
  - Retry paths in event handling and reactive commits skip when `isPermanentRejection(error)` (`PreconditionFailedError`).

- Migration
  - `QueuedEvent` now includes `id` and optional `originTx`.
  - `Scheduler.queueEvent()` adds an optional `opts: { eventId?: string; originTx?: IExtendedStorageTransaction }`.
  - Storage interface adds `dispatchedEventId?` on `IExtendedStorageTransaction`, introduces `IPreconditionFailedError`, and includes it in `StorageTransactionRejected`/`PushError`. Use `isPermanentRejection()` to gate retries.

<sup>Written for commit 22f1a7a4332b7fc6a5688bb5335a5ac95574a063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

