### PR TITLE
fix(runner): persist derived Writable seeds — materialize initial values at cell serialization (CT-1645)

### DIFF
--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -612,6 +612,7 @@ const writeIsSeedMaterialization = (
   }
   return [...(tx.getWriteDetails?.(target.space) ?? [])].some((detail) =>
     detail.address.id === target.id &&
+    normalizeCellScope(detail.address.scope) === target.scope &&
     detail.address.path.length <= 1 &&
     detail.previousValue === undefined
   );

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -42,6 +42,7 @@ import { canonicalizeLogicalPath } from "./canonical.ts";
 import { uniqueCfcAtoms } from "./observation.ts";
 import { mergeCfcSchemaEnvelopes } from "./schema-merge.ts";
 import {
+  CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
   CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION,
   type CfcMetadata,
   type IFCLabel,
@@ -576,6 +577,46 @@ const setupProjectionSourceMatchesValue = (
 // re-writes, and later field edits therefore remain fully enforced; the slot the
 // pattern result is placed into is independently gated by its own
 // `writeAuthorizedBy`, and the owner binding by `currentPrincipalIntegrityReason`.
+// `writeAuthorizedBy` gates *modification* of an existing owner-protected
+// value (§8.15.10); the runtime materializing a runtime-constructed cell's
+// initial value (`Writable(initialValue)` in a lift/handler frame — the CTS
+// wraps derived initializers this way) is the trusted initialization step
+// (§8.15.4), like the projection-marker case above. It is not (and cannot be)
+// the claim-referenced edit handler. Recognize it by BOTH signals together:
+// the seed-materialization marker — recorded ONLY by the runtime's
+// cell-serialization path (data-updating.ts BRANCH_CELL), never reachable
+// from arbitrary `cell.set` — AND the write creating the doc (a root-level
+// write whose previousValue is undefined, the same signal
+// `derivePersistedLinkLabel` uses for same-tx child docs). Edits to existing
+// docs and direct unmarked writes stay fully enforced; ownerPrincipal /
+// integrity minting is gated separately (`currentPrincipalIntegrityReason`
+// runs before this).
+const writeIsSeedMaterialization = (
+  tx: IExtendedStorageTransaction,
+  target: {
+    space: MemorySpace;
+    id: URI;
+    scope: ReturnType<typeof normalizeCellScope>;
+  },
+): boolean => {
+  const marked = tx.getCfcState().writePolicyInputs.some((input) =>
+    input.kind === "structural-provenance" &&
+    input.claim === CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION &&
+    input.sources.some((source) =>
+      source.space === target.space && source.id === target.id &&
+      normalizeCellScope(source.scope) === target.scope
+    )
+  );
+  if (!marked) {
+    return false;
+  }
+  return [...(tx.getWriteDetails?.(target.space) ?? [])].some((detail) =>
+    detail.address.id === target.id &&
+    detail.address.path.length <= 1 &&
+    detail.previousValue === undefined
+  );
+};
+
 const writeIsPatternSetupInitialization = (
   tx: IExtendedStorageTransaction,
   target: {
@@ -2324,7 +2365,8 @@ const verifyInputRequirements = (
       tx,
       target,
       entry.path,
-    ) || writeIsPatternSetupInitialization(tx, target, entry.path);
+    ) || writeIsPatternSetupInitialization(tx, target, entry.path) ||
+      writeIsSeedMaterialization(tx, target);
     if (writeAuthorizedByFailure !== undefined && !setupProjection) {
       return writeAuthorizedByFailure;
     }

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -10,6 +10,15 @@ export type { CfcLabelView, IFCLabel } from "./label-view-core.ts";
 export const CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION =
   "runtime.setup.result-projection";
 
+// Recorded ONLY by the runtime's cell-serialization path (data-updating.ts
+// BRANCH_CELL) when it materializes a runtime-constructed cell's initial
+// value into the brand-new doc the cell points at. The prepare gate accepts a
+// protected write only when this marker covers the target AND the write
+// creates the doc — arbitrary `cell.set` calls record no marker and stay
+// fully enforced.
+export const CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION =
+  "runtime.setup.seed-materialization";
+
 export type CfcEnforcementMode =
   | "disabled"
   | "observe"

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -52,6 +52,7 @@ import {
   allowMutableTransactionRead,
   markReadAsAttemptedWrite,
 } from "./scheduler.ts";
+import { ignoreReadForScheduling } from "./storage/reactivity-log.ts";
 import {
   readStoredCfcMetadata,
   storedCfcMetadataAppliesToPath,
@@ -534,14 +535,25 @@ export function normalizeAndDiff(
     // and leave user edits alone.
     const cellSchema = newValue.schema;
     const seedDefault = isRecord(cellSchema) ? cellSchema.default : undefined;
+    const seedTarget = seedDefault !== undefined
+      ? newValue.getAsNormalizedFullLink()
+      : undefined;
     if (
       seedDefault !== undefined &&
+      // Only root-linked cells: those are the runtime-constructed
+      // `Writable(value)` cells whose doc the default describes in full. A
+      // sub-path cell (e.g. via `.key()`) carries a FIELD default — writing
+      // that over the doc root would clobber the document.
+      seedTarget !== undefined && seedTarget.path.length === 0 &&
       !(isRecord(seedDefault) &&
         (seedDefault as Record<string, unknown>).$stream === true)
     ) {
-      const targetLink = newValue.getAsNormalizedFullLink();
-      const targetRoot: NormalizedFullLink = { ...targetLink, path: [] };
-      if (tx.readValueOrThrow(targetRoot, options) === undefined) {
+      // Don't subscribe the serializing action to the seed doc — mirror
+      // materializeDerivedInternalCells' read for the same check.
+      const absent = tx.readValueOrThrow(seedTarget, {
+        meta: ignoreReadForScheduling,
+      }) === undefined;
+      if (absent) {
         try {
           // The marker is what authorizes this write past an owner-protected
           // schema's `writeAuthorizedBy` (cfc/prepare.ts requires marker AND
@@ -550,20 +562,23 @@ export function normalizeAndDiff(
           tx.recordCfcWritePolicyInput({
             kind: "structural-provenance",
             target: {
-              space: targetRoot.space,
-              id: targetRoot.id,
-              scope: targetRoot.scope,
+              space: seedTarget.space,
+              id: seedTarget.id,
+              scope: seedTarget.scope,
               path: [],
             },
             claim: CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
             sources: [{
-              space: targetRoot.space,
-              id: targetRoot.id,
-              scope: targetRoot.scope,
+              space: seedTarget.space,
+              id: seedTarget.id,
+              scope: seedTarget.scope,
               path: [],
             }],
           });
-          tx.writeValueOrThrow(targetRoot, seedDefault as FabricValue);
+          tx.writeValueOrThrow(
+            seedTarget,
+            fabricFromNativeValue(seedDefault) as FabricValue,
+          );
         } catch (error) {
           // Fail open: a seed-materialization failure must not abort the
           // serialization that references the cell — the link (with its
@@ -572,7 +587,7 @@ export function normalizeAndDiff(
             "diff",
             () => [
               `[BRANCH_CELL] seed materialization failed for`,
-              targetRoot.id,
+              seedTarget.id,
               error,
             ],
           );

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -77,6 +77,21 @@ const diffLogger = getLogger("normalizeAndDiff", {
 // Sentinel value to distinguish "no precomputed value" from "precomputed value is undefined"
 const NO_PRECOMPUTED = Symbol("no-precomputed");
 
+// Docs whose seed-materialization absence check found a PRESENT value, keyed
+// `space/id`, per runtime so tests with multiple runtimes stay isolated. A
+// doc can't become un-created, so a settled entry can never suppress a needed
+// seed; pending writes are deliberately not memoized (an aborted tx must
+// re-seed). See the BRANCH_CELL seed materialization below.
+const seedCheckSettled = new WeakMap<Runtime, Set<string>>();
+const seededDocs = (runtime: Runtime): Set<string> => {
+  let docs = seedCheckSettled.get(runtime);
+  if (docs === undefined) {
+    docs = new Set();
+    seedCheckSettled.set(runtime, docs);
+  }
+  return docs;
+};
+
 const cfcAddressFromLink = (link: NormalizedFullLink): CfcAddress => ({
   space: link.space,
   id: link.id,
@@ -535,7 +550,9 @@ export function normalizeAndDiff(
     // and leave user edits alone.
     const cellSchema = newValue.schema;
     const seedDefault = isRecord(cellSchema) ? cellSchema.default : undefined;
-    const seedTarget = seedDefault !== undefined
+    const seedTarget = seedDefault !== undefined &&
+        !(isRecord(seedDefault) &&
+          (seedDefault as Record<string, unknown>).$stream === true)
       ? newValue.getAsNormalizedFullLink()
       : undefined;
     if (
@@ -545,14 +562,21 @@ export function normalizeAndDiff(
       // sub-path cell (e.g. via `.key()`) carries a FIELD default — writing
       // that over the doc root would clobber the document.
       seedTarget !== undefined && seedTarget.path.length === 0 &&
-      !(isRecord(seedDefault) &&
-        (seedDefault as Record<string, unknown>).$stream === true)
+      // Each doc needs the absence check at most once per runtime: once
+      // found present (or seeded here), later serializations of the same
+      // cell skip it — the check would otherwise run on EVERY defaulted-cell
+      // serialization, a measurable hot-path cost (the CI perf check caught
+      // +22–36% on the CLI integration suites for the unmemoized version).
+      !seededDocs(runtime).has(`${seedTarget.space}/${seedTarget.id}`)
     ) {
       // Don't subscribe the serializing action to the seed doc — mirror
       // materializeDerivedInternalCells' read for the same check.
       const absent = tx.readValueOrThrow(seedTarget, {
         meta: ignoreReadForScheduling,
       }) === undefined;
+      if (!absent) {
+        seededDocs(runtime).add(`${seedTarget.space}/${seedTarget.id}`);
+      }
       if (absent) {
         try {
           // The marker is what authorizes this write past an owner-protected
@@ -579,6 +603,9 @@ export function normalizeAndDiff(
             seedTarget,
             fabricFromNativeValue(seedDefault) as FabricValue,
           );
+          // Deliberately NOT memoized here: if this tx aborts, the doc stays
+          // absent and the next serialization must seed again. Once the
+          // write commits, the next check finds the doc present and settles.
         } catch (error) {
           // Fail open: a seed-materialization failure must not abort the
           // serialization that references the cell — the link (with its

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -62,7 +62,10 @@ import {
   cloneCfcLabelView,
   getCarriedCfcLabelView,
 } from "./cfc/label-view-state.ts";
-import type { CfcAddress } from "./cfc/types.ts";
+import {
+  CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
+  type CfcAddress,
+} from "./cfc/types.ts";
 import { LINK_V1_TAG } from "./sigil-types.ts";
 
 const diffLogger = getLogger("normalizeAndDiff", {
@@ -519,6 +522,63 @@ export function normalizeAndDiff(
     );
     linkOriginFromCell = true;
     const carriedCfcLabelView = getCarriedCfcLabelView(newValue);
+    // Materialize a runtime-constructed cell's initial value: a
+    // `Writable(initialValue)` built inside a lift/handler frame (the CTS
+    // wraps derived initials this way) carries its seed only as the link
+    // schema's `default` — nothing else ever writes the backing doc, so a
+    // fresh session reads the field as undefined (and a `required` field
+    // collapses the whole result; the blank-profile-name bug). This is the
+    // first point where the cell's identity is settled AND a live tx covers
+    // the write, so seed the target doc here, only if it has no value yet —
+    // re-derivations serialize the same cell again but find the doc present
+    // and leave user edits alone.
+    const cellSchema = newValue.schema;
+    const seedDefault = isRecord(cellSchema) ? cellSchema.default : undefined;
+    if (
+      seedDefault !== undefined &&
+      !(isRecord(seedDefault) &&
+        (seedDefault as Record<string, unknown>).$stream === true)
+    ) {
+      const targetLink = newValue.getAsNormalizedFullLink();
+      const targetRoot: NormalizedFullLink = { ...targetLink, path: [] };
+      if (tx.readValueOrThrow(targetRoot, options) === undefined) {
+        try {
+          // The marker is what authorizes this write past an owner-protected
+          // schema's `writeAuthorizedBy` (cfc/prepare.ts requires marker AND
+          // doc-creation); it is recorded only here, by the runtime, never
+          // from arbitrary cell.set calls.
+          tx.recordCfcWritePolicyInput({
+            kind: "structural-provenance",
+            target: {
+              space: targetRoot.space,
+              id: targetRoot.id,
+              scope: targetRoot.scope,
+              path: [],
+            },
+            claim: CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
+            sources: [{
+              space: targetRoot.space,
+              id: targetRoot.id,
+              scope: targetRoot.scope,
+              path: [],
+            }],
+          });
+          tx.writeValueOrThrow(targetRoot, seedDefault as FabricValue);
+        } catch (error) {
+          // Fail open: a seed-materialization failure must not abort the
+          // serialization that references the cell — the link (with its
+          // schema default) still gets written below.
+          diffLogger.warn(
+            "diff",
+            () => [
+              `[BRANCH_CELL] seed materialization failed for`,
+              targetRoot.id,
+              error,
+            ],
+          );
+        }
+      }
+    }
     newValue = attachCfcLabelViewToSigilLink(
       newValue.getAsLink({ includeSchema: true }),
       carriedCfcLabelView,

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -91,6 +91,11 @@ const seededDocs = (runtime: Runtime): Set<string> => {
   }
   return docs;
 };
+// Scope is part of the key: per-user/per-session instances share an id with
+// the space-scoped doc, and one scope's presence must not suppress another's
+// seed.
+const seedMemoKey = (link: NormalizedFullLink): string =>
+  `${link.space}/${link.scope ?? "space"}/${link.id}`;
 
 const cfcAddressFromLink = (link: NormalizedFullLink): CfcAddress => ({
   space: link.space,
@@ -567,7 +572,7 @@ export function normalizeAndDiff(
       // cell skip it — the check would otherwise run on EVERY defaulted-cell
       // serialization, a measurable hot-path cost (the CI perf check caught
       // +22–36% on the CLI integration suites for the unmemoized version).
-      !seededDocs(runtime).has(`${seedTarget.space}/${seedTarget.id}`)
+      !seededDocs(runtime).has(seedMemoKey(seedTarget))
     ) {
       // Don't subscribe the serializing action to the seed doc — mirror
       // materializeDerivedInternalCells' read for the same check.
@@ -575,14 +580,22 @@ export function normalizeAndDiff(
         meta: ignoreReadForScheduling,
       }) === undefined;
       if (!absent) {
-        seededDocs(runtime).add(`${seedTarget.space}/${seedTarget.id}`);
+        seededDocs(runtime).add(seedMemoKey(seedTarget));
       }
       if (absent) {
         try {
-          // The marker is what authorizes this write past an owner-protected
-          // schema's `writeAuthorizedBy` (cfc/prepare.ts requires marker AND
-          // doc-creation); it is recorded only here, by the runtime, never
-          // from arbitrary cell.set calls.
+          tx.writeValueOrThrow(
+            seedTarget,
+            fabricFromNativeValue(seedDefault) as FabricValue,
+          );
+          // The marker is what authorizes the write above past an
+          // owner-protected schema's `writeAuthorizedBy` (cfc/prepare.ts
+          // requires marker AND doc-creation; both are checked at commit,
+          // so in-tx ordering is immaterial there). Record it only AFTER
+          // the write succeeds: a thrown write must not leave a stray
+          // marker that could authorize an unrelated same-doc write later
+          // in this transaction. It is recorded only here, by the runtime,
+          // never from arbitrary cell.set calls.
           tx.recordCfcWritePolicyInput({
             kind: "structural-provenance",
             target: {
@@ -599,10 +612,6 @@ export function normalizeAndDiff(
               path: [],
             }],
           });
-          tx.writeValueOrThrow(
-            seedTarget,
-            fabricFromNativeValue(seedDefault) as FabricValue,
-          );
           // Deliberately NOT memoized here: if this tx aborts, the doc stays
           // absent and the next serialization must seed again. Once the
           // write commits, the next check finds the doc present and settles.

--- a/packages/runner/test/inspace-child-owner-seed.test.ts
+++ b/packages/runner/test/inspace-child-owner-seed.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("inspace-child-owner-seed");
+const spaceA = signer.did(); // "home" — runs the parent, holds the list
+const spaceB = (await Identity.fromPassphrase("owner seed child B")).did();
+
+// Same two-manager shape as cross-space-value-read.test.ts: each session has
+// its OWN per-space replicas, loopback-connected to one shared in-process
+// memory server — the real browser/CLI session split. A single emulate
+// manager's shared replicas would mask any "writer never committed X /
+// reader never fetched X" gap.
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager.sharedServer = server;
+    return manager;
+  }
+
+  private sharedServer!: MemoryV2Server.Server;
+
+  protected override server(): MemoryV2Server.Server {
+    return this.sharedServer;
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+  });
+
+// The profile-create flow in miniature: a handler pushes an `inSpace` child
+// whose pattern seeds an OWNER-PROTECTED field from its input —
+// `new Writable<OwnerProtected<...>>(initialName).for("name")`, exactly
+// profile-home.tsx's `name`. The CTS wraps the derived initializer in a lift,
+// so the seed value only exists at runtime; it must still be persisted to the
+// child space like a static initial value. Regression (found 2026-06-11): the
+// runtime-constructed cell's seed survived only as the link schema `default`
+// — its backing doc was never written — so a fresh session read `name` as
+// undefined, and `name` being required collapsed the whole result (blank
+// profile pages). The fix materializes the seed when the cell is first
+// serialized to a link (data-updating.ts BRANCH_CELL), authorized by the
+// doc-creation hatch in cfc/prepare.ts (`writeCreatesProtectedDoc` —
+// writeAuthorizedBy gates modification, not trusted initialization).
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        "import {",
+        "  Cfc,",
+        "  handler,",
+        "  pattern,",
+        "  RepresentsCurrentUser,",
+        "  Stream,",
+        "  Writable,",
+        "  WriteAuthorizedBy,",
+        "} from 'commonfabric';",
+        "",
+        "type CurrentPrincipal = { readonly __ctCurrentPrincipal: true };",
+        "",
+        "type OwnerProtected<T, Binding> = RepresentsCurrentUser<",
+        "  Cfc<",
+        "    WriteAuthorizedBy<T, Binding>,",
+        "    { ownerPrincipal: CurrentPrincipal }",
+        "  >",
+        ">;",
+        "",
+        "type SetNameEvent = { name?: string };",
+        "",
+        "const setName = handler<SetNameEvent, { name: Writable<string> }>(",
+        "  (event, state) => {",
+        "    state.name.set(event.name ?? '');",
+        "  },",
+        ");",
+        "",
+        "interface ChildOutput {",
+        "  name: OwnerProtected<string, typeof setName>;",
+        "  setName: Stream<SetNameEvent>;",
+        "}",
+        "",
+        "export const child = pattern<{ initialName?: string }, ChildOutput>(",
+        "  ({ initialName }) => {",
+        "    const name = new Writable<OwnerProtected<string, typeof setName>>(",
+        "      initialName ?? '',",
+        "    ).for('name');",
+        "    return {",
+        "      name,",
+        "      setName: setName({ name }),",
+        "    };",
+        "  },",
+        ");",
+        "",
+        "const create = handler<",
+        "  { name?: string },",
+        "  { items: Writable<ChildOutput[]> }",
+        ">((event, { items }) => {",
+        `  items.push(child.inSpace("${spaceB}")({`,
+        "    initialName: event.name ?? 'hi',",
+        "  }) as ChildOutput);",
+        "});",
+        "",
+        "export default pattern(() => {",
+        "  const items = new Writable<ChildOutput[]>([]).for('items');",
+        "  return { items, create: create({ items }) };",
+        "});",
+      ].join("\n"),
+    },
+  ],
+};
+
+const RESULT_CAUSE = "inspace child owner seed parent";
+
+const childLinkListSchema = {
+  type: "array",
+  items: { type: "unknown", asCell: ["cell"] },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+describe("inSpace child owner-protected seed value (profile name)", () => {
+  let server: MemoryV2Server.Server;
+  let managerA: SharedServerStorageManager;
+  let managerB: SharedServerStorageManager;
+
+  beforeEach(() => {
+    server = newSharedServer();
+    managerA = SharedServerStorageManager.connectTo(server, { as: signer });
+    managerB = SharedServerStorageManager.connectTo(server, { as: signer });
+  });
+
+  afterEach(async () => {
+    await managerA?.close();
+    await managerB?.close();
+    await server?.close();
+  });
+
+  it("a fresh session reads the seeded owner-protected name", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: managerA,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: managerB,
+    });
+    try {
+      // Session 1: run the parent in space A; the handler creates the child
+      // in space B with a seeded owner-protected `name` (profile creation).
+      const tx1 = rt1.edit();
+      const parent = await rt1.patternManager.compilePattern(PROGRAM, {
+        space: spaceA,
+        tx: tx1,
+      });
+      const resultCell1 = rt1.getCell<Record<string, unknown>>(
+        spaceA,
+        RESULT_CAUSE,
+        undefined,
+        tx1,
+      );
+      // deno-lint-ignore no-explicit-any
+      const r1 = rt1.run(tx1, parent as any, {}, resultCell1);
+      // The runtime's own commit paths (scheduler, editWithRetry) prepare;
+      // an unprepared CFC-relevant tx is rejected wholesale at commit, so a
+      // manual test tx must prepare too.
+      rt1.prepareTxForCommit(tx1);
+      const commit1 = await tx1.commit();
+      expect(commit1.error).toBeUndefined();
+      await r1.pull();
+
+      // Fresh tx for the event send: the ifc-carrying schema makes send()
+      // read CFC metadata through the cell's tx, and tx1 is already done.
+      const tx2 = rt1.edit();
+      r1.withTx(tx2).key("create").send({ name: "hi" });
+      const commit2 = await tx2.commit();
+      expect(commit2.error).toBeUndefined();
+      await r1.pull();
+      await rt1.idle();
+
+      await r1.pull();
+      const links = r1.key("items").asSchema(childLinkListSchema)
+        // deno-lint-ignore no-explicit-any
+        .get() as any[];
+      expect(links.length).toBe(1);
+      const childLink = links[0].getAsNormalizedFullLink();
+      expect(childLink.space).toBe(spaceB);
+
+      // The creating session itself sees the seed.
+      expect(links[0].key("name").get()).toBe("hi");
+
+      await rt1.patternManager.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+      await rt1.idle();
+      await rt1.storageManager.synced();
+
+      // Session 2 (own replicas): the single-field read resolves the seed
+      // from the PERSISTED terminal doc — before the fix the doc was absent
+      // (only the link schema `default` existed) and this read depended on
+      // the default annotation.
+      const childCell = rt2.getCellFromLink(childLink);
+      await childCell.sync();
+      const nameCell = childCell.key("name");
+      await nameCell.sync();
+      await nameCell.pull();
+      expect(nameCell.get()).toBe("hi");
+
+      // The full result resolves after the piece starts (the shell's piece
+      // view always starts; the deferred result doc materializes on run) —
+      // with `name` populated. Before the fix `name` stayed undefined here
+      // even after start, because the lift re-run still never wrote the doc.
+      const started = await rt2.start(childCell);
+      expect(started).toBe(true);
+      await rt2.idle();
+      await childCell.pull();
+      const value = childCell.getAsQueryResult() as
+        | { name?: string }
+        | undefined;
+      expect(value).toBeDefined();
+      expect(value?.name).toBe("hi");
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

A `new Writable(initialValue)` whose initializer is **derived** (any non-literal expression — e.g. profile-home's `initialName ?? ""`) is wrapped in a lift by the CTS transformer and constructed at runtime. The constructor captures the seed **only as the cell's link-schema `default`** (the `setInitialValue()` path referenced by the stale TODO in cell.ts no longer exists) — **the backing doc is never written**.

Consequences, as seen in the field (CT-1645 profile work):
- A fresh session reads the field as `undefined`; a `required` field collapses the **whole result** to `undefined`.
- Every freshly created profile rendered a blank name (and no dynamic content at all); the field only healed when an explicit handler write (e.g. `setName`) later created the doc — which is why profiles that had been renamed read fine and the gap masqueraded as a recent regression.
- Static literal seeds were unaffected (descriptor defaults are written by `materializeDerivedInternalCells`), which is why this hid for so long.

Deterministic repro: the new test in this PR (red without the fix).

## Fix

1. **`data-updating.ts`** (`normalizeAndDiff` BRANCH_CELL): when serializing a **root-linked** cell whose schema carries a non-`$stream` `default` and whose target doc has no value, write the default to the target root in the same transaction — the first point where the cell's identity is settled AND a live tx covers the write. Write-if-absent: re-derivations find the doc present and leave user edits alone. Fail-open (logged warning) so a seed failure can't abort the serialization referencing the cell. Sub-path cells are excluded (their default describes a field, not the doc).

2. **`cfc/prepare.ts` + `cfc/types.ts`**: the seed write to an owner-protected field comes from the runtime's serialization path, not the claim-referenced edit handler, so `writeAuthorizedBy` (a *modification* gate, CFC §8.15.10) would reject it. New setup hatch `writeIsSeedMaterialization` accepts the write only when **both** hold:
   - a `CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION` marker recorded by the seeding site itself covers the target, and
   - the write **creates** the doc (root write, `previousValue === undefined`).

   Arbitrary `cell.set` calls record no marker and stay fully enforced — the cfc-boundary forged-provenance suite pins this (an earlier creation-only version of the hatch was correctly rejected by 5 of those tests).

## Test

`packages/runner/test/inspace-child-owner-seed.test.ts` — the profile-create flow in miniature: two-manager shared-server harness (per-session replicas), a handler pushes an `inSpace` child whose pattern seeds an owner-protected `name` from its input. Asserts the creating session's read, a fresh session's single-field read, and the fresh session's **full result** after `start()`.

## Verification

- runner suite **599 passed / 0 failed** (full `deno task test`, twice — before and after self-review hardening)
- `traverse-replay` golden oracles unchanged
- cfc-boundary / cfc-schema-merge / cfc-nonexported-binding-identity ✓
- inspace-child-reload (CT-1687) and cross-space-value-read (CT-1667) ✓
- `pattern-tests profile-home` ✓
- Live in the shell: a freshly created profile **renders its name for the first time** and survives a cold reload.

Part of CT-1645. Found and root-caused via the investigation log in `.claude/investigation-fresh-piece-reads.md` (not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist derived `Writable(initialValue)` seeds by writing the initial value to the target doc during cell serialization so fresh sessions read seeded fields correctly. Adds scope-aware authorization and memoization; fixes CT-1645 (blank names/undefined required fields on new profiles).

- **Bug Fixes**
  - Seed materialization: in `normalizeAndDiff` (BRANCH_CELL), for root-linked cells with a non-`$stream` schema `default` and an absent target doc, write the default to the doc root in the same tx (write-if-absent, `fabricFromNativeValue`, `ignoreReadForScheduling`, fail-open with a warning).
  - Performance: memoize the absence check per doc+scope per runtime once a PRESENT value is seen; pending writes aren’t memoized to allow re-seeding after aborted txs.
  - CFC authorization: add `CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION` and `writeIsSeedMaterialization` to allow this protected write only when marked and creating the doc at the same scope (root write, `previousValue === undefined`); record the marker only after a successful write; arbitrary `cell.set` remains fully enforced.
  - Test: `inspace-child-owner-seed.test.ts` ensures a fresh session sees the seeded `name` and the full result after `start()`.

<sup>Written for commit 5fbe494949cf3e23dc1724781d1a807bbee97349. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

