### PR TITLE
feat(runner,memory): speculation lineage for event-launched work (scheduler-v2 E1)

### DIFF
--- a/docs/specs/scheduler-v2/implementation/03-phaseE1-speculation-lineage.md
+++ b/docs/specs/scheduler-v2/implementation/03-phaseE1-speculation-lineage.md
@@ -206,8 +206,18 @@ export class SpeculationLineage {
   private recordFor(origin: IExtendedStorageTransaction): OriginRecord {
     let record = this.byOrigin.get(origin);
     if (!record) {
-      record = { status: "pending", events: new Set(), pieceStops: [] };
+      const originStatus = origin.status().status;
+      record = {
+        status: originStatus === "done"
+          ? "confirmed"
+          : originStatus === "error"
+          ? "failed"
+          : "pending",
+        events: new Set(),
+        pieceStops: [],
+      };
       this.byOrigin.set(origin, record);
+      if (record.status !== "pending") return record;
       origin.addCommitCallback((_tx, result) => {
         const settled = this.byOrigin.get(origin);
         if (!settled) return;
@@ -282,7 +292,9 @@ Caveat to verify while implementing: `addCommitCallback` must fire even
 for read-only/no-op commits (the origin handler may have made no writes).
 Read `extended-storage-transaction.ts` `addCommitCallback` + commit (~line
 841-857) and confirm callbacks run on every commit() resolution path; if
-any early-return path skips callbacks, STOP and report it.
+any early-return path skips callbacks, STOP and report it. Commit callbacks do
+not fire retroactively for already-settled transactions; `recordFor()` must
+inspect `origin.status()` before registering a callback.
 
 Unit tests: `test/scheduler-lineage.test.ts` — record/fail cancels events
 (removeQueuedEvent called) and runs pieceStops; record/confirm does NOT
@@ -290,7 +302,10 @@ remove events and drops pieceStops; **two recorded events, origin
 confirms, first release()s → second still reads `"confirmed"`** (the
 stranded-sibling regression); release() of the last event after
 settlement deletes the record; originStatus of an unknown origin returns
-`"confirmed"`; double-settle safe.
+`"confirmed"`; double-settle safe; record on an already-committed origin
+reports `"confirmed"` without registering a commit callback; record on an
+already-failed/aborted origin reports `"failed"` without registering a commit
+callback.
 
 Commit: `feat(runner): speculation lineage registry (scheduler-v2 E1)`
 
@@ -316,8 +331,8 @@ Commit: `feat(runner): speculation lineage registry (scheduler-v2 E1)`
    ```
    if (head.originTx) {
      status = lineage.originStatus(head.originTx)
-     if (status === "failed") { /* unreachable: failure removes it from the
-        queue synchronously in the commit callback; assert + drop + release */ }
+     if (status === "failed") { /* drop + release + debug-log; already-failed
+        settled origins reach this path and must not dispatch */ }
      sameSpace = getCommitLocalSeq(head.originTx.tx, head.eventLink.space) !== undefined
      if (!sameSpace && status === "pending") {
        // Cross-space: park until origin confirmation (spec decision 11).

--- a/docs/specs/scheduler-v2/implementation/03-phaseE1-speculation-lineage.md
+++ b/docs/specs/scheduler-v2/implementation/03-phaseE1-speculation-lineage.md
@@ -146,10 +146,15 @@ File: `packages/memory/v2/engine.ts`.
    `localSeq`. If none exists, reject the whole commit with an error whose
    wire shape reaches the client as
    `{ name: "PreconditionFailedError", precondition: "origin-committed", message: ... }`
-   — trace how the conflict error's `name` reaches
-   `StorageTransactionRejected` on the client and make this error take
-   the same route. If the existing route normalizes names, STOP and
-   report the route before inventing a new one.
+   — the existing route normalizes errors, so extend it end to end:
+   add an `Engine.PreconditionFailedError` sibling to `Engine.ConflictError`
+   with `precondition: "origin-committed" | "receipt-exists"`, map it in
+   `packages/memory/v2/server.ts` before the `TransactionError` catch-all,
+   add optional `precondition?: string` to `V2Error`, and copy that property
+   onto the reconstructed client `Error` in `packages/memory/v2/client.ts`.
+   Do not encode this through `ConflictError` or `TransactionError`; the
+   runner's permanent-rejection taxonomy is name-keyed and already recognizes
+   `PreconditionFailedError`.
 3. Same-session ordering note (add as a comment at the check): commits
    from one session are applied in order, so the origin's fate is decided
    when the follow-up arrives; an absent origin means it was rejected.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1335,3 +1335,31 @@ Concrete route, end to end:
    `docs(specs): scheduler-v2 WO03 — precondition error wire route`.
 
 Then continue step 3 as written.
+
+## REVIEWER RESOLUTION — 03/step-3 precondition error wire route docs
+
+- [x] 5f180b852 — documented the reviewer-approved
+  `PreconditionFailedError` wire route in WO03 Step 3 before implementation.
+- Deviations: none.
+
+## 03/step-3
+
+- [x] pending — origin-committed commit precondition
+- Deviations: implemented the reviewer verdict by adding the
+  `PreconditionFailedError` route through the memory server/client wire path;
+  no runner changes were needed. The new test file uses the memory
+  server/client path, so its direct test run needs the same env/read/write/ffi
+  permissions as other server-backed memory tests.
+- Recordings:
+  - `deno fmt packages/memory/v2/engine.ts packages/memory/v2/server.ts
+    packages/memory/v2/client.ts packages/memory/v2.ts
+    packages/memory/test/v2-commit-preconditions.test.ts`: passed
+    (`Checked 5 files`).
+  - `deno lint` on the same five files: passed (`Checked 5 files`).
+  - `deno check` on the same five files: passed.
+  - `cd packages/memory && deno test test/v2-commit-preconditions.test.ts`:
+    failed before execution because importing the server/client path requires
+    env access for `TSC_WATCHFILE`.
+  - `cd packages/memory && deno test --allow-ffi --allow-env --allow-read
+    --allow-write=/tmp,/var/folders test/v2-commit-preconditions.test.ts`:
+    passed, `4 passed`, `0 failed`, `26ms`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1231,7 +1231,7 @@ packages/runner/src/storage/rejection.ts:6:export function isPermanentRejection(
 
 ## 03/step-2
 
-- [x] pending — commit precondition plumbing behind `commitPreconditions`
+- [x] fa9711c19 — commit precondition plumbing behind `commitPreconditions`
   flag
 - Deviations: updated the narrow memory/runtime flag tests because the new
   protocol flag makes their exact object assertions stale. Implemented the
@@ -1260,3 +1260,78 @@ packages/runner/src/storage/rejection.ts:6:export function isPermanentRejection(
     `0 failed`.
   - `cd packages/runner && deno task test`: passed,
     `588 passed (3075 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m4s`.
+
+## IMPLEMENTER STOP — 03/step-3 precondition error wire route
+
+Step 3 requires a precondition rejection whose wire shape reaches the client as
+`{ name: "PreconditionFailedError", precondition: "origin-committed",
+message: ... }`, and explicitly says to STOP if the existing route normalizes
+error names.
+
+Findings:
+
+- `packages/memory/v2/engine.ts` `applyCommitTransaction` has the same-session
+  identity needed for the check: it computes `sessionKey =
+  resolveCommitSessionKey(sessionId, principal)` before read validation.
+- Existing stale-read conflict rejection throws `Engine.ConflictError` from
+  `validateConfirmedReads` / `resolvePendingReads`.
+- `packages/memory/v2/server.ts` `MemoryServer.transact` catches engine errors
+  and normalizes names through `toError(...)`:
+  `Engine.ConflictError` → `"ConflictError"`, `Engine.ProtocolError` →
+  `"ProtocolError"`, all other errors → `"TransactionError"`.
+- `packages/memory/v2.ts` `V2Error` currently has only `{ name, message }`.
+  There is no `precondition` field on the wire error type.
+- `packages/memory/v2/client.ts` `Client.request` reconstructs an `Error` from
+  `response.error.message` and `response.error.name` only.
+
+Therefore, adding an engine-side `PreconditionFailedError` now would reach the
+runner as `TransactionError`, and its `precondition: "origin-committed"`
+metadata would be dropped. No Step 3 implementation or test edits were applied.
+Need reviewer direction: extend the v2 wire error surface and server/client
+mapping for `PreconditionFailedError`, or encode the precondition failure
+through an existing normalized route.
+
+## REVIEWER VERDICT — 03/step-3 precondition error wire route
+
+Excellent trace; the route is exactly the normalize-and-drop case the
+step anticipated. Ruling: EXTEND THE WIRE SURFACE — the taxonomy is a
+real new error class (E0's whole point, and E2 receipts need the same
+route). Do NOT encode through ConflictError or TransactionError: name
+is what `isPermanentRejection` keys on, and ConflictError means
+retryable — overloading either poisons the taxonomy.
+
+Concrete route, end to end:
+
+1. Engine (`packages/memory/v2/engine.ts` or wherever
+   `Engine.ConflictError` is defined — same module): add a sibling
+   error class `PreconditionFailedError` with
+   `name = "PreconditionFailedError"` and a
+   `precondition: "origin-committed" | "receipt-exists"` field. Throw
+   it from the `applyCommitTransaction` origin-committed check (using
+   the `sessionKey` you located).
+2. Server (`packages/memory/v2/server.ts` `toError`): add the branch
+   mapping `Engine.PreconditionFailedError` →
+   `{ name: "PreconditionFailedError", message, precondition }` —
+   BEFORE the catch-all TransactionError arm.
+3. Wire type (`packages/memory/v2.ts` `V2Error`): add optional
+   `precondition?: string`. JSON-additive; old peers ignore it.
+4. Client (`packages/memory/v2/client.ts` `Client.request`): when
+   reconstructing the Error, copy `response.error.precondition` onto
+   the object as a plain property when present. Name/message handling
+   otherwise unchanged.
+5. Runner: NO changes — `IPreconditionFailedError` and
+   `isPermanentRejection` (name-keyed) already match this shape.
+6. Compat: no flag gating on the ERROR path. Safety comes from the
+   ATTACH side already being gated on the negotiated
+   `commitPreconditions` flag — an old client never attaches
+   preconditions, so it can never receive this error.
+7. Tests: in `v2-commit-preconditions.test.ts`, assert the
+   CLIENT-VISIBLE shape (name + precondition survive the full
+   server→client round trip) if the harness runs through server+client;
+   if the existing engine tests hit the engine directly, add one
+   focused `toError` mapping test for the server instead, plus keep the
+   engine-level assertions.
+8. Amend WO03 step 3 in-branch with this route — own docs commit first:
+   `docs(specs): scheduler-v2 WO03 — precondition error wire route`.
+
+Then continue step 3 as written.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1662,3 +1662,31 @@ is green on top of the fix.
     `eventQueue.push`, processing remains head-only, retry uses the existing
     `unshift` path for the same event id, and lineage failure only removes
     failed descendants or shifts a failed head without reordering survivors.
+
+## REVIEWER RESOLUTION — PR #4090 review findings
+
+- [x] pending — engine precondition reachability + lineage retry
+  re-registration + fail-closed precondition plumbing.
+- Findings addressed (Codex/cubic review on PR #4090), red-first fixtures
+  recorded for each:
+  1. Engine empty-commit guard rejected precondition-only commits
+     (`operations: []` from a descendant with only no-op writes) before
+     `validateCommitPreconditions` could run, and the observation-only
+     fast paths returned before validation. Preconditions now make a
+     commit non-empty and validate ahead of every commit shape; malformed
+     entries surface as deterministic `ProtocolError`
+     (`packages/memory/test/v2-commit-preconditions.test.ts`).
+  2. Retry requeues (`RetryImmediately`, non-permanent commit failure)
+     created fresh `QueuedEvent` objects the lineage registry never saw, so
+     an origin failing while the retry was queued could not remove it and
+     the post-settlement `originStatus()` fallback let it run. Requeues now
+     re-record with the registry
+     (`test/scheduler-event-lineage.test.ts` "keeps retried same-space
+     follow-ups lineage-gated").
+  3. `V2StorageTransaction.addCommitPrecondition` did not claim a write
+     space, so a precondition-only transaction resolved ok without sending
+     a commit; it now claims the space like `recordSqliteWrite`. Both
+     transaction wrappers now throw instead of silently dropping
+     preconditions on storage that cannot enforce them
+     (`test/storage-commit-preconditions.test.ts`).
+- Deviations: none.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1609,7 +1609,7 @@ is green on top of the fix.
 
 ## 03/step-6
 
-- [x] pending — handler-launched piece registrations are stopped when the
+- [x] 7a50fba4b — handler-launched piece registrations are stopped when the
   launching handler transaction fails permanently.
 - Deviations: restored the reviewer-approved Step 6 work after the
   settled-origin fixup; stash conflict resolution in
@@ -1631,3 +1631,34 @@ is green on top of the fix.
     `0 failed`.
   - `cd packages/runner && deno task test`: passed,
     `590 passed (3090 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m4s`.
+
+## 03/phase-end
+
+- [x] pending — WO03 exit checklist self-check complete.
+- Benchmarks: none listed in WO03.
+- Recordings:
+  - `cd packages/runner && deno task test`: passed,
+    `590 passed (3090 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m4s`.
+  - `cd packages/memory && deno task test`: passed, `211 passed
+    (95 steps)`, `0 failed`.
+- Exit checklist:
+  - All event-lineage fixtures green:
+    `test/scheduler-event-lineage.test.ts` passed, `1 passed (7 steps)`,
+    `0 failed`; duplication fixture red-first output is recorded under
+    03/step-5.
+  - Preconditions inspection passed: `dispatchQueuedEvent` attaches
+    `origin-committed` only when `originLocalSeq !== undefined`, lineage
+    status is `"pending"`, and
+    `runtime.experimental.commitPreconditions === true`.
+  - Cross-space park inspection passed: `pull-events.ts` only examines the
+    head event, parks by returning before preflight, `idle()` waits on
+    `hasPendingLineageHeadEvent()`, and `continuation.ts` documents that the
+    wake source is the lineage commit callback rather than a timer.
+  - Renderer/ingress events inspection passed: `queueSchedulerEvent` takes no
+    lineage branch unless `args.originTx !== undefined`.
+  - Engine tests green; flag PR for memory-owner review because WO03 touches
+    `packages/memory`.
+  - FIFO inspection passed: surviving events are appended with
+    `eventQueue.push`, processing remains head-only, retry uses the existing
+    `unshift` path for the same event id, and lineage failure only removes
+    failed descendants or shifts a failed head without reordering survivors.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1366,7 +1366,7 @@ Then continue step 3 as written.
 
 ## 03/step-4
 
-- [x] pending — speculation lineage registry
+- [x] 7891f157 — speculation lineage registry
 - Deviations: none. Verified the work-order caveat in
   `extended-storage-transaction.ts`: `commit()` always attaches the storage
   commit promise to `runCommitCallbacks(result)`, including read-only/no-op
@@ -1379,6 +1379,60 @@ Then continue step 3 as written.
   - `deno lint` on the same two files: passed (`Checked 2 files`).
   - `deno check packages/runner/src/scheduler/lineage.ts
     packages/runner/test/scheduler-lineage.test.ts`: passed.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-lineage.test.ts`: passed, `1 passed (6 steps)`,
+    `0 failed`.
+
+## 03/step-5
+
+- [x] pending — lineage gating for handler-sent events
+- Deviations: no shared conflict-forcing helper exists in
+  `test/scheduler-retries.test.ts`; existing scheduler retry fixtures force
+  aborts directly. For the same-space red fixture, patched the emulated memory
+  server's next `transact()` after setup to return `ConflictError`, which
+  rejects after the client has built the origin commit/localSeq. The event
+  fixture calls `scheduler.queueEvent(..., { originTx })` at the same scheduler
+  boundary used by stream `Cell.set()` so the test stays focused on lineage
+  behavior. The handler-result piece-stop assertion is left for 03/step-6,
+  where the work order wires `runner.ts`.
+- Red-first recordings:
+  - Initial `cd packages/runner && ENV=test deno test --allow-ffi
+    --allow-env --allow-read --allow-write=/tmp,/var/folders
+    --allow-run=git test/scheduler-event-lineage.test.ts`: failed as
+    expected:
+    - same-space retry expected one committed descendant, actual `2`;
+    - permanent origin failure expected `[]`, actual two committed
+      descendants;
+    - both cross-space tests expected `idle()` to remain `pending`, actual
+      `resolved`.
+- Recordings:
+  - `deno fmt packages/runner/src/scheduler.ts
+    packages/runner/src/scheduler/events.ts
+    packages/runner/src/scheduler/pull-events.ts
+    packages/runner/src/scheduler/continuation.ts
+    packages/runner/src/scheduler/pull-continuation.ts
+    packages/runner/test/scheduler-event-lineage.test.ts
+    packages/runner/test/scheduler-event-identity.test.ts`: passed
+    (`Checked 7 files`).
+  - `deno lint` on the same seven files: passed (`Checked 7 files`).
+  - `deno check` on the same seven files: passed.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-event-lineage.test.ts`: passed, `1 passed (4 steps)`,
+    `0 failed`.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-event-identity.test.ts`: passed, `1 passed (4 steps)`,
+    `0 failed`.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-events.test.ts`: passed, `1 passed (14 steps)`,
+    `0 failed`.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-pull-handlers.test.ts`: passed, `1 passed (11 steps)`,
+    `0 failed`.
   - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
     --allow-read --allow-write=/tmp,/var/folders --allow-run=git
     test/scheduler-lineage.test.ts`: passed, `1 passed (6 steps)`,

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1344,7 +1344,7 @@ Then continue step 3 as written.
 
 ## 03/step-3
 
-- [x] pending — origin-committed commit precondition
+- [x] 8406bda91 — origin-committed commit precondition
 - Deviations: implemented the reviewer verdict by adding the
   `PreconditionFailedError` route through the memory server/client wire path;
   no runner changes were needed. The new test file uses the memory
@@ -1363,3 +1363,23 @@ Then continue step 3 as written.
   - `cd packages/memory && deno test --allow-ffi --allow-env --allow-read
     --allow-write=/tmp,/var/folders test/v2-commit-preconditions.test.ts`:
     passed, `4 passed`, `0 failed`, `26ms`.
+
+## 03/step-4
+
+- [x] pending — speculation lineage registry
+- Deviations: none. Verified the work-order caveat in
+  `extended-storage-transaction.ts`: `commit()` always attaches the storage
+  commit promise to `runCommitCallbacks(result)`, including read-only/no-op
+  commits that still call `this.tx.commit()`, and `rejectCommitBeforeStorage`
+  also invokes `runCommitCallbacks(result)` for pre-storage CFC rejection.
+- Recordings:
+  - `deno fmt packages/runner/src/scheduler/lineage.ts
+    packages/runner/test/scheduler-lineage.test.ts`: passed (`Checked 2
+    files`).
+  - `deno lint` on the same two files: passed (`Checked 2 files`).
+  - `deno check packages/runner/src/scheduler/lineage.ts
+    packages/runner/test/scheduler-lineage.test.ts`: passed.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-lineage.test.ts`: passed, `1 passed (6 steps)`,
+    `0 failed`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1561,6 +1561,48 @@ is green on top of the fix.
 
 ## REVIEWER RESOLUTION — 03/step-6 stale-origin lineage docs
 
-- [x] pending — documented the reviewer-approved settled-origin lineage record
-  behavior in WO03 before implementation.
+- [x] 024dfb38f — documented the reviewer-approved settled-origin lineage
+  record behavior in WO03 before implementation.
 - Deviations: none.
+
+## REVIEWER RESOLUTION — 03/step-6 stale-origin lineage fix
+
+- [x] pending — lineage now initializes records from already-settled origin
+  transaction status before registering commit callbacks.
+- Deviations: none. Verified the missing caveat from 03/step-4 empirically:
+  `addCommitCallback` does not fire retroactively for already-settled
+  transactions, so record creation must inspect `origin.status()`.
+- Red-first recordings:
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-lineage.test.ts`: failed as expected before the fix:
+    already-committed origin actual `pending`, expected `confirmed`; already
+    failed origin actual `pending`, expected `failed`.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-event-lineage.test.ts`: failed as expected before the fix
+    on the already-committed origin fixture:
+    `error: Promise resolution is still pending but the event loop has already resolved`.
+- Recordings:
+  - `deno fmt packages/runner/src/scheduler/lineage.ts
+    packages/runner/src/scheduler/pull-events.ts
+    packages/runner/test/scheduler-lineage.test.ts
+    packages/runner/test/scheduler-event-lineage.test.ts`: passed
+    (`Checked 4 files`).
+  - `deno lint` on the same four files: passed (`Checked 4 files`).
+  - `deno check` on the same four files: passed.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-lineage.test.ts`: passed, `1 passed (8 steps)`,
+    `0 failed`.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-event-lineage.test.ts`: passed, `1 passed (6 steps)`,
+    `0 failed`.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/llm-dialog-outbox.test.ts`: passed, `1 passed (1 step)`,
+    `0 failed`.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/llm-dialog.test.ts`: passed, `1 passed (17 steps)`, `0 failed`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1208,3 +1208,23 @@ packages/runner/src/storage/rejection.ts:6:export function isPermanentRejection(
     `packages/runner/test/scheduler-event-identity.test.ts`,
     `packages/runner/test/scheduler-rejection-taxonomy.test.ts`,
     `packages/runner/src/storage/rejection.ts`.
+
+## 03/step-1
+
+- [x] pending — record per-space commit localSeq on source transactions
+- Deviations: selected `test/memory-v2-transaction-commit-rejection.test.ts`
+  as the storage transaction test from the work-order inventory.
+- Recordings:
+  - `deno fmt packages/runner/src/storage/commit-identity.ts
+    packages/runner/src/storage/v2.ts`: passed (`Checked 2 files`).
+  - `deno lint packages/runner/src/storage/commit-identity.ts
+    packages/runner/src/storage/v2.ts`: passed (`Checked 2 files`).
+  - `deno check src/storage/v2.ts`: passed.
+  - `ENV=test deno test --allow-ffi --allow-env --allow-read
+    --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-retries.test.ts`: passed, `1 passed (2 steps)`,
+    `0 failed`.
+  - `ENV=test deno test --allow-ffi --allow-env --allow-read
+    --allow-write=/tmp,/var/folders --allow-run=git
+    test/memory-v2-transaction-commit-rejection.test.ts`: passed,
+    `1 passed`, `0 failed`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1567,7 +1567,7 @@ is green on top of the fix.
 
 ## REVIEWER RESOLUTION — 03/step-6 stale-origin lineage fix
 
-- [x] pending — lineage now initializes records from already-settled origin
+- [x] e9a27d0a4 — lineage now initializes records from already-settled origin
   transaction status before registering commit callbacks.
 - Deviations: none. Verified the missing caveat from 03/step-4 empirically:
   `addCommitCallback` does not fire retroactively for already-settled
@@ -1606,3 +1606,28 @@ is green on top of the fix.
   - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
     --allow-read --allow-write=/tmp,/var/folders --allow-run=git
     test/llm-dialog.test.ts`: passed, `1 passed (17 steps)`, `0 failed`.
+
+## 03/step-6
+
+- [x] pending — handler-launched piece registrations are stopped when the
+  launching handler transaction fails permanently.
+- Deviations: restored the reviewer-approved Step 6 work after the
+  settled-origin fixup; stash conflict resolution in
+  `scheduler-event-lineage.test.ts` kept both settled-origin fixtures and the
+  Step 6 piece-stop fixture.
+- Red-first recordings:
+  - Before the Step 6 hook, `runtime.runner.cancels.size` expected the pre-send
+    baseline `1`, actual `13`, after the handler exhausted retries.
+- Recordings:
+  - `deno fmt packages/runner/src/runner.ts
+    packages/runner/src/scheduler/action-run.ts
+    packages/runner/test/scheduler-event-lineage.test.ts`: passed
+    (`Checked 3 files`).
+  - `deno lint` on the same three files: passed (`Checked 3 files`).
+  - `deno check` on the same three files: passed.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-event-lineage.test.ts`: passed, `1 passed (7 steps)`,
+    `0 failed`.
+  - `cd packages/runner && deno task test`: passed,
+    `590 passed (3090 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m4s`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1211,7 +1211,7 @@ packages/runner/src/storage/rejection.ts:6:export function isPermanentRejection(
 
 ## 03/step-1
 
-- [x] pending — record per-space commit localSeq on source transactions
+- [x] 72ad97869 — record per-space commit localSeq on source transactions
 - Deviations: selected `test/memory-v2-transaction-commit-rejection.test.ts`
   as the storage transaction test from the work-order inventory.
 - Recordings:
@@ -1228,3 +1228,35 @@ packages/runner/src/storage/rejection.ts:6:export function isPermanentRejection(
     --allow-write=/tmp,/var/folders --allow-run=git
     test/memory-v2-transaction-commit-rejection.test.ts`: passed,
     `1 passed`, `0 failed`.
+
+## 03/step-2
+
+- [x] pending — commit precondition plumbing behind `commitPreconditions`
+  flag
+- Deviations: updated the narrow memory/runtime flag tests because the new
+  protocol flag makes their exact object assertions stale. Implemented the
+  source-readable precondition metadata on the native v2 transaction as well as
+  the extended wrapper, matching the existing scheduler-observation handoff
+  path into `commitNative`.
+- Recordings:
+  - `grep -rn "ClientCommit" ../../packages/memory
+    ../../packages/runner/src/storage --include="*.ts" |
+    grep -i "interface\|type\|="` located `ClientCommit` in
+    `packages/memory/v2.ts`.
+  - `deno fmt packages/memory/v2.ts packages/memory/test/v2-test.ts
+    packages/runner/src/runtime.ts packages/runner/src/storage/interface.ts
+    packages/runner/src/storage/extended-storage-transaction.ts
+    packages/runner/src/storage/v2-transaction.ts
+    packages/runner/src/storage/v2.ts
+    packages/runner/test/experimental-options.test.ts`: passed
+    (`Checked 8 files`).
+  - `deno lint` on the same eight files: passed (`Checked 8 files`).
+  - `deno check` on the same eight files: passed.
+  - `cd packages/memory && deno test test/v2-test.ts`: passed,
+    `7 passed (13 steps)`, `0 failed`.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/experimental-options.test.ts`: passed, `1 passed (12 steps)`,
+    `0 failed`.
+  - `cd packages/runner && deno task test`: passed,
+    `588 passed (3075 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m4s`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1386,7 +1386,7 @@ Then continue step 3 as written.
 
 ## 03/step-5
 
-- [x] pending — lineage gating for handler-sent events
+- [x] b443cef48 — lineage gating for handler-sent events
 - Deviations: no shared conflict-forcing helper exists in
   `test/scheduler-retries.test.ts`; existing scheduler retry fixtures force
   aborts directly. For the same-space red fixture, patched the emulated memory
@@ -1437,3 +1437,130 @@ Then continue step 3 as written.
     --allow-read --allow-write=/tmp,/var/folders --allow-run=git
     test/scheduler-lineage.test.ts`: passed, `1 passed (6 steps)`,
     `0 failed`.
+
+## IMPLEMENTER STOP — 03/step-6 full runner suite blocked by stale-origin lineage
+
+Step 6's focused implementation was applied locally but NOT committed. The
+piece-stop fixture was red/green as required:
+
+- Red before implementation:
+  `runtime.runner.cancels.size` expected the pre-send baseline `1`, actual
+  `13`, after the handler exhausted retries.
+- Green after adding the non-deferred `recordPieceStop(...)` hook and the two
+  action-run WATCH comments:
+  `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+  --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+  test/scheduler-event-lineage.test.ts` passed, `1 passed (5 steps)`,
+  `0 failed`.
+- File verification passed:
+  `deno fmt`, `deno lint`, and `deno check` on
+  `packages/runner/src/runner.ts`,
+  `packages/runner/src/scheduler/action-run.ts`, and
+  `packages/runner/test/scheduler-event-lineage.test.ts`.
+
+Full runner suite then failed twice despite all visible tests passing:
+
+```text
+$ cd packages/runner && deno task test
+ok | 586 passed (3063 steps) | 0 failed | 0 ignored (10 steps) (2m19s)
+error: Promise resolution is still pending but the event loop has already resolved
+```
+
+Isolated failing tests:
+
+```text
+$ cd packages/runner && ENV=test deno test --allow-ffi --allow-env --allow-read \
+  --allow-write=/tmp,/var/folders --allow-run=git test/llm-dialog-outbox.test.ts
+running 1 test from ./test/llm-dialog-outbox.test.ts
+llmDialog outbox mechanism ...
+  enqueues llmDialog work behind the post-commit outbox ...
+ok | 0 passed | 0 failed (5s)
+error: Promise resolution is still pending but the event loop has already resolved
+
+$ cd packages/runner && ENV=test deno test --allow-ffi --allow-env --allow-read \
+  --allow-write=/tmp,/var/folders --allow-run=git test/llm-dialog.test.ts
+running 1 test from ./test/llm-dialog.test.ts
+llmDialog ...
+  should support a multi-turn conversation via addMessage ...
+ok | 0 passed | 0 failed (5s)
+error: Promise resolution is still pending but the event loop has already resolved
+```
+
+The same isolated failures reproduce at Step 5's committed SHA `b443cef48`
+in a detached comparison worktree, so this is not caused by the Step 6
+`runner.ts` compensation hook.
+
+Temporary diagnostics (reverted; not left in the worktree) showed the
+`llm-dialog-outbox` test reaches `addMessage.send(...)`, and the scheduler
+queue contains a head event with `originTx !== undefined` for the already
+committed setup transaction. Inference: Step 5's
+`queueSchedulerEvent -> recordLineageEvent` can create a fresh pending lineage
+record after the origin transaction has already committed, so the commit
+callback that would confirm/release the origin will never fire and the head
+event parks forever.
+
+Need reviewer direction: allow a follow-up/fixup touching
+`packages/runner/src/scheduler/lineage.ts` (and likely a narrow regression
+fixture) so already-settled origins are treated as confirmed/failed instead of
+registered as pending, or provide a different ruling.
+
+## REVIEWER VERDICT — 03/step-6 stale-origin lineage hang
+
+Your inference is confirmed as the root cause, and it is a bug in MY
+reference implementation: `recordFor()` assumes the origin is in flight.
+An event sent with an ALREADY-SETTLED origin tx (normal for sends from
+test/framework code whose cells are bound to committed transactions)
+creates a record frozen at "pending" — `addCommitCallback` never fires
+for settled transactions — so the head gate parks forever. An
+already-settled successful origin is semantically NO speculation: it
+must behave as confirmed on arrival.
+
+Authorized fixup, on the 03 branch:
+
+1. `src/scheduler/lineage.ts` — in `recordFor(origin)`, before creating
+   the record, inspect `origin.status()`. Use the transaction's actual
+   status vocabulary (read the `IStorageTransactionStatus` type and the
+   existing `status().status === "ready"` checks for the open-state
+   name):
+   - settled successfully → create the record with status "confirmed"
+     and DO NOT register a commit callback;
+   - settled failed/aborted → status "failed", no callback (and no
+     cancellation sweep — there is nothing speculative to cancel from a
+     pre-settled failure; the head gate handles the queued event);
+   - open/in-flight → register the callback exactly as today.
+2. Head gate: the "failed origin at head" branch I marked unreachable
+   is now reachable (failed-before-record origins are never removed by
+   a callback). Replace the assert with: shift + drop the event +
+   `release()` + log debug. A FAILED settled origin must not dispatch
+   its event (I10).
+3. Red-first regression fixtures:
+   - unit (`scheduler-lineage.test.ts`): `recordFor` on a
+     committed-settled tx → originStatus "confirmed", no callback
+     registered; on an aborted tx → "failed".
+   - integration (`scheduler-event-lineage.test.ts`): send to a stream
+     via a cell bound to an ALREADY-COMMITTED tx → event dispatches,
+     `idle()` resolves; same with an aborted tx → event dropped,
+     `idle()` resolves. Paste the red (hang→timeout or assertion) for
+     the committed case from the pre-fix tree.
+   - the two llm-dialog tests are the integration witnesses: both must
+     pass untouched.
+4. Commit: `fix(runner): lineage treats already-settled origins as settled (scheduler-v2 E1)`
+   — separate from the step-6 commit; land it FIRST, then re-run and
+   commit step 6 as planned.
+5. Amend WO03's reference code block + unit-test list in-branch to
+   match — docs commit before the fix commit:
+   `docs(specs): scheduler-v2 WO03 — settled-origin lineage records`.
+6. Note for phase-end: this case also justifies a one-line addition to
+   the step-4 "caveat to verify" — record in PROGRESS that
+   `addCommitCallback` does NOT fire for already-settled transactions
+   (you have now verified it empirically).
+
+Your red/green discipline and the detached-worktree bisect were exactly
+right; the step-6 runner.ts hook itself is approved as-is once the suite
+is green on top of the fix.
+
+## REVIEWER RESOLUTION — 03/step-6 stale-origin lineage docs
+
+- [x] pending — documented the reviewer-approved settled-origin lineage record
+  behavior in WO03 before implementation.
+- Deviations: none.

--- a/packages/memory/test/v2-commit-preconditions.test.ts
+++ b/packages/memory/test/v2-commit-preconditions.test.ts
@@ -1,0 +1,226 @@
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { toFileUrl } from "@std/path";
+import {
+  applyCommit,
+  close,
+  type Engine,
+  open,
+  PreconditionFailedError,
+  read,
+} from "../v2/engine.ts";
+import { Server } from "../v2/server.ts";
+import { connect, loopback } from "../v2/client.ts";
+import { type EntityDocument, toDocumentPath } from "../v2.ts";
+import type { FabricValue } from "../interface.ts";
+
+const createEngine = async (): Promise<{
+  engine: Engine;
+  path: string;
+}> => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const engine = await open({ url: toFileUrl(path) });
+  return { engine, path };
+};
+
+const toEntityDocument = (value: FabricValue): EntityDocument => ({ value });
+
+Deno.test("origin-committed precondition accepts a committed same-session origin", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:lineage",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:origin",
+          value: toEntityDocument({ ok: true }),
+        }],
+      },
+    });
+
+    const followUp = applyCommit(engine, {
+      sessionId: "session:lineage",
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        preconditions: [{
+          kind: "origin-committed",
+          originLocalSeq: 1,
+        }],
+        operations: [{
+          op: "set",
+          id: "entity:follow-up",
+          value: toEntityDocument({ released: true }),
+        }],
+      },
+    });
+
+    assertEquals(followUp.seq, 2);
+    assertEquals(read(engine, { id: "entity:follow-up" }), {
+      value: { released: true },
+    });
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("origin-committed precondition rejects a rejected origin localSeq", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:setup",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:source",
+          value: toEntityDocument({ version: 1 }),
+        }],
+      },
+    });
+
+    applyCommit(engine, {
+      sessionId: "session:other",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id: "entity:source",
+          patches: [{
+            op: "replace",
+            path: "/value/version",
+            value: 2,
+          }],
+        }],
+      },
+    });
+
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:lineage",
+          commit: {
+            localSeq: 1,
+            reads: {
+              confirmed: [{
+                id: "entity:source",
+                path: toDocumentPath(["value", "version"]),
+                seq: 1,
+              }],
+              pending: [],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:origin-attempt",
+              value: toEntityDocument({ shouldNotCommit: true }),
+            }],
+          },
+        }),
+      Error,
+      "stale confirmed read",
+    );
+
+    const rejected = assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:lineage",
+          commit: {
+            localSeq: 2,
+            reads: { confirmed: [], pending: [] },
+            preconditions: [{
+              kind: "origin-committed",
+              originLocalSeq: 1,
+            }],
+            operations: [{
+              op: "set",
+              id: "entity:descendant",
+              value: toEntityDocument({ shouldNotCommit: true }),
+            }],
+          },
+        }),
+      PreconditionFailedError,
+      "origin commit not committed",
+    );
+
+    assertEquals(rejected.name, "PreconditionFailedError");
+    assertEquals(rejected.precondition, "origin-committed");
+    assertEquals(read(engine, { id: "entity:descendant" }), null);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("commits without preconditions are unaffected", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    const applied = applyCommit(engine, {
+      sessionId: "session:no-preconditions",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:plain",
+          value: toEntityDocument({ ok: true }),
+        }],
+      },
+    });
+
+    assertEquals(applied.seq, 1);
+    assertEquals(read(engine, { id: "entity:plain" }), {
+      value: { ok: true },
+    });
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("precondition failures keep name and precondition through client round trip", async () => {
+  const server = new Server({
+    store: new URL("memory://memory-v2-commit-preconditions-client"),
+  });
+  const client = await connect({ transport: loopback(server) });
+  const session = await client.mount(
+    "did:key:z6Mk-memory-v2-commit-preconditions-client",
+  );
+
+  try {
+    const error = await assertRejects(
+      () =>
+        session.transact({
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          preconditions: [{
+            kind: "origin-committed",
+            originLocalSeq: 99,
+          }],
+          operations: [{
+            op: "set",
+            id: "entity:descendant",
+            value: toEntityDocument({ shouldNotCommit: true }),
+          }],
+        }),
+      Error,
+      "origin commit not committed",
+    );
+
+    assertEquals(error.name, "PreconditionFailedError");
+    assertEquals(
+      (error as Error & { precondition?: unknown }).precondition,
+      "origin-committed",
+    );
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});

--- a/packages/memory/test/v2-commit-preconditions.test.ts
+++ b/packages/memory/test/v2-commit-preconditions.test.ts
@@ -6,7 +6,9 @@ import {
   type Engine,
   open,
   PreconditionFailedError,
+  ProtocolError,
   read,
+  type SchedulerActionObservation,
 } from "../v2/engine.ts";
 import { Server } from "../v2/server.ts";
 import { connect, loopback } from "../v2/client.ts";
@@ -179,6 +181,169 @@ Deno.test("commits without preconditions are unaffected", async () => {
     assertEquals(read(engine, { id: "entity:plain" }), {
       value: { ok: true },
     });
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+const observationOnlyFixture = (
+  localSeq: number,
+): SchedulerActionObservation => ({
+  version: 1,
+  ownerSpace: undefined,
+  branch: "main",
+  pieceId: "piece:preconditions",
+  processGeneration: 1,
+  actionId: "pattern.tsx:handler:precondition-test",
+  actionKind: "event-handler",
+  implementationFingerprint: "impl:preconditions",
+  runtimeFingerprint: "runtime:test",
+  observedAtSeq: 0,
+  observedAtLocalSeq: localSeq,
+  transactionKind: "action-run",
+  reads: [],
+  shallowReads: [],
+  actualChangedWrites: [],
+  currentKnownWrites: [],
+  declaredWrites: [],
+  materializerWriteEnvelopes: [],
+  status: "success",
+});
+
+Deno.test("precondition-only commit validates and records against a committed origin", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:lineage",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:origin",
+          value: toEntityDocument({ ok: true }),
+        }],
+      },
+    });
+
+    // A descendant handler that performed no semantic writes still commits
+    // its origin-committed precondition: the engine must validate it and
+    // record the localSeq instead of rejecting the commit as empty.
+    const followUp = applyCommit(engine, {
+      sessionId: "session:lineage",
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        preconditions: [{
+          kind: "origin-committed",
+          originLocalSeq: 1,
+        }],
+        operations: [],
+      },
+    });
+
+    assertEquals(followUp.seq, 2);
+    assertEquals(followUp.revisions, []);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("precondition-only commit rejects a missing origin with PreconditionFailedError", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    const rejected = assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:lineage",
+          commit: {
+            localSeq: 1,
+            reads: { confirmed: [], pending: [] },
+            preconditions: [{
+              kind: "origin-committed",
+              originLocalSeq: 99,
+            }],
+            operations: [],
+          },
+        }),
+      PreconditionFailedError,
+      "origin commit not committed",
+    );
+    assertEquals(rejected.precondition, "origin-committed");
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("observation-only commit still validates preconditions", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    // Preconditions must be validated before the observation-only fast path;
+    // otherwise a descendant of an uncommitted origin can persist its
+    // scheduler observation.
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:lineage",
+          commit: {
+            localSeq: 1,
+            reads: { confirmed: [], pending: [] },
+            preconditions: [{
+              kind: "origin-committed",
+              originLocalSeq: 99,
+            }],
+            operations: [],
+            schedulerObservation: observationOnlyFixture(1),
+          },
+        }),
+      PreconditionFailedError,
+      "origin commit not committed",
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("malformed preconditions are rejected with ProtocolError", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    const malformed: unknown[] = [
+      null,
+      "origin-committed",
+      { kind: 42 },
+      { kind: "origin-committed", originLocalSeq: "1" },
+      { kind: "origin-committed", originLocalSeq: 1.5 },
+      { kind: "origin-committed" },
+    ];
+    for (const precondition of malformed) {
+      assertThrows(
+        () =>
+          applyCommit(engine, {
+            sessionId: "session:lineage",
+            commit: {
+              localSeq: 1,
+              reads: { confirmed: [], pending: [] },
+              // deno-lint-ignore no-explicit-any
+              preconditions: [precondition as any],
+              operations: [{
+                op: "set",
+                id: "entity:should-not-commit",
+                value: toEntityDocument({ ok: false }),
+              }],
+            },
+          }),
+        ProtocolError,
+      );
+    }
+    assertEquals(read(engine, { id: "entity:should-not-commit" }), null);
   } finally {
     close(engine);
     await Deno.remove(path);

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -13,7 +13,9 @@ import {
   isSourceLink,
   MEMORY_PROTOCOL,
   parseMemoryProtocolFlags,
+  resetCommitPreconditionsConfig,
   resetPersistentSchedulerStateConfig,
+  setCommitPreconditionsConfig,
   setPersistentSchedulerStateConfig,
   toDocumentPath,
   toDocumentSelector,
@@ -112,24 +114,30 @@ describe("memory v2 flags", () => {
   it("reflects the active runtime storage flags", () => {
     resetModernCellRepConfig();
     resetPersistentSchedulerStateConfig();
+    resetCommitPreconditionsConfig();
     setModernCellRepConfig(false);
     setPersistentSchedulerStateConfig(false);
+    setCommitPreconditionsConfig(false);
 
     assertEquals(getMemoryProtocolFlags(), {
       modernCellRep: false,
       persistentSchedulerState: false,
+      commitPreconditions: false,
     });
 
     setModernCellRepConfig(true);
     setPersistentSchedulerStateConfig(true);
+    setCommitPreconditionsConfig(true);
 
     assertEquals(getMemoryProtocolFlags(), {
       modernCellRep: true,
       persistentSchedulerState: true,
+      commitPreconditions: true,
     });
 
     resetModernCellRepConfig();
     resetPersistentSchedulerStateConfig();
+    resetCommitPreconditionsConfig();
   });
 
   it("treats scheduler-state persistence as an optional capability", () => {
@@ -137,10 +145,12 @@ describe("memory v2 flags", () => {
       {
         modernCellRep: true,
         persistentSchedulerState: true,
+        commitPreconditions: true,
       },
       {
         modernCellRep: true,
         persistentSchedulerState: false,
+        commitPreconditions: false,
       },
     ));
   });
@@ -151,10 +161,12 @@ describe("parseMemoryProtocolFlags", () => {
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: true }), {
       modernCellRep: true,
       persistentSchedulerState: false,
+      commitPreconditions: false,
     });
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: false }), {
       modernCellRep: false,
       persistentSchedulerState: false,
+      commitPreconditions: false,
     });
   });
 
@@ -166,6 +178,20 @@ describe("parseMemoryProtocolFlags", () => {
       {
         modernCellRep: false,
         persistentSchedulerState: true,
+        commitPreconditions: false,
+      },
+    );
+  });
+
+  it("accepts the canonical commitPreconditions key", () => {
+    assertEquals(
+      parseMemoryProtocolFlags({
+        commitPreconditions: true,
+      }),
+      {
+        modernCellRep: false,
+        persistentSchedulerState: false,
+        commitPreconditions: true,
       },
     );
   });
@@ -180,6 +206,13 @@ describe("parseMemoryProtocolFlags", () => {
       parseMemoryProtocolFlags({
         modernCellRep: true,
         persistentSchedulerState: "true",
+      }),
+      null,
+    );
+    assertEquals(
+      parseMemoryProtocolFlags({
+        modernCellRep: true,
+        commitPreconditions: "true",
       }),
       null,
     );

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -512,6 +512,7 @@ export interface SessionRevokedMessage {
 export interface V2Error {
   name: string;
   message: string;
+  precondition?: string;
 }
 
 export type V2Result<Value> = { ok: Value } | { error: V2Error };

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -129,6 +129,12 @@ export interface SchedulerObservationCommit {
   schedulerObservation: unknown;
 }
 
+export interface CommitPrecondition {
+  kind: "origin-committed";
+  /** localSeq of a commit from the SAME session in this space. */
+  originLocalSeq: number;
+}
+
 export interface ClientCommit {
   localSeq: number;
   reads: {
@@ -136,6 +142,7 @@ export interface ClientCommit {
     pending: PendingRead[];
   };
   operations: Operation[];
+  preconditions?: CommitPrecondition[];
   schedulerObservation?: unknown;
   schedulerObservationBatch?: SchedulerObservationCommit[];
   codeCID?: Reference;
@@ -172,6 +179,7 @@ export interface SessionOpenResult {
 export interface MemoryProtocolFlags {
   modernCellRep: boolean;
   persistentSchedulerState: boolean;
+  commitPreconditions: boolean;
 }
 
 /**
@@ -180,6 +188,7 @@ export interface MemoryProtocolFlags {
 export type WireMemoryProtocolFlags = {
   modernCellRep?: boolean;
   persistentSchedulerState?: boolean;
+  commitPreconditions?: boolean;
 };
 
 export interface HelloMessage {
@@ -539,6 +548,7 @@ const memoryReconstructionContext = new EmptyReconstructionContext(
 );
 
 let persistentSchedulerStateEnabled = false;
+let commitPreconditionsEnabled = false;
 
 /**
  * Ambient runtime flag for persistent scheduler observations and rehydration.
@@ -557,16 +567,33 @@ export function resetPersistentSchedulerStateConfig(): void {
   persistentSchedulerStateEnabled = false;
 }
 
+/**
+ * Ambient runtime flag for commit preconditions. The runner owns the feature,
+ * but the memory protocol needs the value during client/server handshakes.
+ */
+export function setCommitPreconditionsConfig(enabled?: boolean): void {
+  commitPreconditionsEnabled = enabled ?? false;
+}
+
+export function getCommitPreconditionsConfig(): boolean {
+  return commitPreconditionsEnabled;
+}
+
+export function resetCommitPreconditionsConfig(): void {
+  commitPreconditionsEnabled = false;
+}
+
 export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   modernCellRep: getModernCellRepConfig(),
   persistentSchedulerState: getPersistentSchedulerStateConfig(),
+  commitPreconditions: getCommitPreconditionsConfig(),
 });
 
 /**
- * Scheduler-state persistence is an optional capability, not a data-model wire
- * contract. Peers with different scheduler flags can still share memory data;
- * the server's flag controls whether scheduler observation rows are accepted
- * and served on that connection.
+ * Scheduler-state persistence and commit preconditions are optional
+ * capabilities, not data-model wire contracts. Peers with different scheduler
+ * flags can still share memory data; the server's flags control whether
+ * scheduler rows and precondition checks are accepted on that connection.
  */
 export const compatibleMemoryProtocolFlags = (
   left: MemoryProtocolFlags,
@@ -592,6 +619,14 @@ export const parseMemoryProtocolFlags = (
     return null;
   }
 
+  const commitPreconditions = value.commitPreconditions;
+  if (
+    commitPreconditions !== undefined &&
+    typeof commitPreconditions !== "boolean"
+  ) {
+    return null;
+  }
+
   const modernCellRep = value.modernCellRep;
   if (
     modernCellRep !== undefined &&
@@ -603,6 +638,7 @@ export const parseMemoryProtocolFlags = (
   return {
     modernCellRep: modernCellRep === true,
     persistentSchedulerState: persistentSchedulerState === true,
+    commitPreconditions: commitPreconditions === true,
   };
 };
 
@@ -614,6 +650,7 @@ export const wireMemoryProtocolFlags = (
 ): WireMemoryProtocolFlags => ({
   modernCellRep: flags.modernCellRep,
   persistentSchedulerState: flags.persistentSchedulerState,
+  commitPreconditions: flags.commitPreconditions,
 });
 
 export const encodeMemoryBoundary = (value: unknown): string =>

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -156,6 +156,10 @@ export class Client {
     if (result.error) {
       const error = new Error(result.error.message);
       error.name = result.error.name;
+      if (result.error.precondition !== undefined) {
+        (error as Error & { precondition?: string }).precondition =
+          result.error.precondition;
+      }
       throw error;
     }
     return result.ok as Result;

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -3113,15 +3113,21 @@ const applyCommitTransaction = (
       "memory v2 schedulerObservationBatch commits must not include semantic operations",
     );
   }
+  const hasPreconditions = (commit.preconditions?.length ?? 0) > 0;
   if (
     commit.operations.length === 0 && !schedulerObservation &&
-    !hasSchedulerObservationBatch
+    !hasSchedulerObservationBatch && !hasPreconditions
   ) {
     throw new Error("memory v2 commit requires at least one operation");
   }
 
   const branch = commit.branch ?? DEFAULT_BRANCH;
   ensureActiveBranch(engine, branch);
+
+  // Preconditions gate every commit shape, including the observation-only
+  // fast paths below — a descendant of an uncommitted origin must not
+  // persist anything, observations included.
+  validateCommitPreconditions(engine, sessionKey, commit);
 
   if (commit.operations.length === 0 && hasSchedulerObservationBatch) {
     return applySchedulerObservationBatchCommit(engine, {
@@ -3164,7 +3170,6 @@ const applyCommitTransaction = (
     };
   }
 
-  validateCommitPreconditions(engine, sessionKey, commit);
   validateConfirmedReads(engine, branch, commit, { principal, sessionId });
   const resolvedPendingReads = resolvePendingReads(
     engine,
@@ -3414,11 +3419,24 @@ const validateCommitPreconditions = (
   commit: ClientCommit,
 ): void => {
   for (const precondition of commit.preconditions ?? []) {
+    // Wire input: validate the shape deterministically so malformed entries
+    // surface as ProtocolError instead of a TypeError-turned-TransactionError.
+    if (
+      precondition === null || typeof precondition !== "object" ||
+      Array.isArray(precondition)
+    ) {
+      throw new ProtocolError("malformed commit precondition: not an object");
+    }
     if (precondition.kind !== "origin-committed") {
       throw new ProtocolError(
         `unsupported commit precondition: ${
           String((precondition as { kind?: unknown }).kind)
         }`,
+      );
+    }
+    if (!Number.isInteger(precondition.originLocalSeq)) {
+      throw new ProtocolError(
+        "malformed origin-committed precondition: originLocalSeq must be an integer",
       );
     }
 

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -676,6 +676,19 @@ export class ConflictError extends Error {
   }
 }
 
+export class PreconditionFailedError extends Error {
+  readonly precondition: "origin-committed" | "receipt-exists";
+
+  constructor(
+    precondition: PreconditionFailedError["precondition"],
+    message: string,
+  ) {
+    super(message);
+    this.name = "PreconditionFailedError";
+    this.precondition = precondition;
+  }
+}
+
 export class ProtocolError extends Error {
   constructor(message: string) {
     super(message);
@@ -3151,6 +3164,7 @@ const applyCommitTransaction = (
     };
   }
 
+  validateCommitPreconditions(engine, sessionKey, commit);
   validateConfirmedReads(engine, branch, commit, { principal, sessionId });
   const resolvedPendingReads = resolvePendingReads(
     engine,
@@ -3390,6 +3404,35 @@ const writeOperation = (
         commitSeq: seq,
         op: "delete",
       };
+    }
+  }
+};
+
+const validateCommitPreconditions = (
+  engine: Engine,
+  sessionKey: string,
+  commit: ClientCommit,
+): void => {
+  for (const precondition of commit.preconditions ?? []) {
+    if (precondition.kind !== "origin-committed") {
+      throw new ProtocolError(
+        `unsupported commit precondition: ${
+          String((precondition as { kind?: unknown }).kind)
+        }`,
+      );
+    }
+
+    // Same-session commits are applied in order, so the origin's fate is
+    // decided when the follow-up arrives; an absent origin means rejection.
+    const row = engine.statements.selectPendingResolution.get({
+      session_id: sessionKey,
+      local_seq: precondition.originLocalSeq,
+    }) as { seq: number } | undefined;
+    if (!row) {
+      throw new PreconditionFailedError(
+        "origin-committed",
+        `origin commit not committed: localSeq ${precondition.originLocalSeq}`,
+      );
     }
   }
 };

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1532,16 +1532,25 @@ export class Server {
         this.stageConflictRefreshDirtyIds(message.space, message.commit);
         await this.flushSessions([message.space]);
       }
+      const messageText = error instanceof Error
+        ? error.message
+        : String(error);
       return respondTypedError<Engine.AppliedCommit>(
         message.requestId,
-        toError(
-          error instanceof Engine.ConflictError
-            ? "ConflictError"
-            : error instanceof Engine.ProtocolError
-            ? "ProtocolError"
-            : "TransactionError",
-          error instanceof Error ? error.message : String(error),
-        ),
+        error instanceof Engine.PreconditionFailedError
+          ? {
+            name: "PreconditionFailedError",
+            message: messageText,
+            precondition: error.precondition,
+          }
+          : toError(
+            error instanceof Engine.ConflictError
+              ? "ConflictError"
+              : error instanceof Engine.ProtocolError
+              ? "ProtocolError"
+              : "TransactionError",
+            messageText,
+          ),
       );
     }
   }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2607,6 +2607,16 @@ export class Runner {
 
     addCancel(() => this.stop(resultCell));
 
+    if (!deferForNavigate) {
+      // Spec scheduler-v2 §7.6 rule 2: the launch is speculative; if this
+      // handler's transaction ultimately fails, stop the piece (data writes
+      // roll back with the transaction; registrations do not).
+      this.runtime.scheduler.lineage.recordPieceStop(
+        tx,
+        () => this.stop(resultCell),
+      );
+    }
+
     return result;
   }
 

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -20,8 +20,11 @@ import {
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
 import {
+  getCommitPreconditionsConfig,
   getPersistentSchedulerStateConfig,
+  resetCommitPreconditionsConfig,
   resetPersistentSchedulerStateConfig,
+  setCommitPreconditionsConfig,
   setPersistentSchedulerStateConfig,
 } from "@commonfabric/memory/v2";
 import { PatternEnvironment, setPatternEnvironment } from "./builder/env.ts";
@@ -183,6 +186,8 @@ export interface ExperimentalOptions {
   modernCellRep?: boolean | undefined;
   /** Persist scheduler observations and use them for scheduler rehydration. */
   persistentSchedulerState?: boolean | undefined;
+  /** Attach origin-committed preconditions to scheduler-v2 lineage commits. */
+  commitPreconditions?: boolean | undefined;
   /** Preserve cumulative scheduler write history instead of using current-known writes. */
   schedulerHistoricalMightWrite?: boolean | undefined;
 }
@@ -350,6 +355,7 @@ export class Runtime {
     this.experimental = {
       modernCellRep: undefined,
       persistentSchedulerState: undefined,
+      commitPreconditions: undefined,
       schedulerHistoricalMightWrite: undefined,
       ...options.experimental,
     };
@@ -376,6 +382,8 @@ export class Runtime {
     );
     this.experimental.persistentSchedulerState =
       getPersistentSchedulerStateConfig();
+    setCommitPreconditionsConfig(this.experimental.commitPreconditions);
+    this.experimental.commitPreconditions = getCommitPreconditionsConfig();
 
     this.id = options.storageManager.id;
     this.apiUrl = new URL(options.apiUrl);
@@ -582,6 +590,7 @@ export class Runtime {
     // Reset experimental config to defaults.
     resetModernCellRepConfig();
     resetPersistentSchedulerStateConfig();
+    resetCommitPreconditionsConfig();
 
     // Clear the current runtime reference
     // Removed setCurrentRuntime call - no longer using singleton pattern

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -169,6 +169,7 @@ import {
   type ActionTimingState,
   getActionStats as getActionStatsFromState,
 } from "./scheduler/timing.ts";
+import { getCommitLocalSeq } from "./storage/commit-identity.ts";
 import {
   addSchedulerEventHandler,
   cancelEventQueueWake as cancelEventQueueWakeState,
@@ -180,6 +181,7 @@ import {
   type SchedulerEventExecutionState,
   type SchedulerEventQueueState,
 } from "./scheduler/events.ts";
+import { SpeculationLineage } from "./scheduler/lineage.ts";
 import { processPullQueuedEventDuringExecute } from "./scheduler/pull-events.ts";
 import {
   buildSchedulerGraphSnapshot,
@@ -261,6 +263,14 @@ export {
 export class Scheduler {
   private eventQueue: QueuedEvent[] = [];
   private eventHandlers: [NormalizedFullLink, EventHandler][] = [];
+  readonly lineage = new SpeculationLineage({
+    removeQueuedEvent: (event) => {
+      const index = this.eventQueue.indexOf(event);
+      if (index >= 0) this.eventQueue.splice(index, 1);
+    },
+    queueExecution: () => this.queueExecution(),
+    onError: (error) => logger.error("lineage", () => [error]),
+  });
 
   private pending = new Set<Action>();
   private dependencies = new WeakMap<Action, ReactivityLog>();
@@ -908,6 +918,10 @@ export class Scheduler {
       ) {
         // A queued event is parked behind a throttled dependency. Wait for the
         // wake timer to re-schedule the queue and then re-check.
+        this.idlePromises.push(resolve);
+      } else if (this.hasPendingLineageHeadEvent()) {
+        // A cross-space lineage head has no timer; its origin commit callback
+        // is the wake source, so idle must stay open until that callback runs.
         this.idlePromises.push(resolve);
       } else if (!this.scheduled) {
         if (this.hasRunnablePullWork()) {
@@ -2080,6 +2094,7 @@ export class Scheduler {
       getNextDebounceRunTime: (action) => this.getNextDebounceRunTime(action),
       getNextEligibleRunTime: (action) =>
         this.delays.getNextEligibleRunTime(action),
+      hasPendingLineageHeadEvent: () => this.hasPendingLineageHeadEvent(),
       resetLoopCounter: () => {
         this.loopCounter = new WeakMap();
       },
@@ -2119,6 +2134,9 @@ export class Scheduler {
           targetDoNotLoad,
           targetOpts,
         ),
+      recordLineageEvent: (originTx, queuedEvent) => {
+        this.lineage.recordEvent(originTx, queuedEvent);
+      },
     };
   }
 
@@ -2157,6 +2175,12 @@ export class Scheduler {
         this.delays.getNextEligibleRunTime(target),
       scheduleEventQueueWake: (notBefore) =>
         scheduleEventQueueWakeState(this.eventQueueWakeState, notBefore),
+      lineageStatus: (originTx) => this.lineage.originStatus(originTx),
+      releaseLineageEvent: (originTx, queuedEvent) => {
+        this.lineage.release(originTx, queuedEvent);
+      },
+      getOriginLocalSeq: (originTx, targetSpace) =>
+        getCommitLocalSeq(originTx.tx, targetSpace),
       snapshotDirtyDependencyTraceContext: (trace) =>
         snapshotDirtyDependencyTraceContext(
           this.dirtyDependencyCollectionState,
@@ -2413,6 +2437,14 @@ export class Scheduler {
 
   private hasDeferredDirtyEffectWork(): boolean {
     return hasDeferredDirtyEffectWorkState(this.pullSchedulingState);
+  }
+
+  private hasPendingLineageHeadEvent(): boolean {
+    const head = this.eventQueue[0];
+    if (head?.originTx === undefined) return false;
+    if (this.lineage.originStatus(head.originTx) !== "pending") return false;
+    return getCommitLocalSeq(head.originTx.tx, head.eventLink.space) ===
+      undefined;
   }
 
   private scheduleAffectedEffects(

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -2179,6 +2179,9 @@ export class Scheduler {
       releaseLineageEvent: (originTx, queuedEvent) => {
         this.lineage.release(originTx, queuedEvent);
       },
+      recordLineageEvent: (originTx, queuedEvent) => {
+        this.lineage.recordEvent(originTx, queuedEvent);
+      },
       getOriginLocalSeq: (originTx, targetSpace) =>
         getCommitLocalSeq(originTx.tx, targetSpace),
       snapshotDirtyDependencyTraceContext: (trace) =>

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -174,6 +174,9 @@ export function watchReactiveActionCommit(state: {
         state.markDirectDirty(state.action);
         state.pending.add(state.action);
         state.queueExecution();
+      } else {
+        // WATCH(scheduler-v2): exhausted retries can leave a piece registered
+        // against rolled-back data (accepted zombie — spec §15 decision 9).
       }
     } else {
       // Clear retries after successful commit.
@@ -453,6 +456,8 @@ function rescheduleActionForImmediateRetry(
     state.pending.add(args.action);
     state.queueExecution();
   } else {
+    // WATCH(scheduler-v2): exhausted retries can leave a piece registered
+    // against rolled-back data (accepted zombie — spec §15 decision 9).
     state.retries.delete(args.action);
     logger.error(
       "schedule-error",

--- a/packages/runner/src/scheduler/continuation.ts
+++ b/packages/runner/src/scheduler/continuation.ts
@@ -26,6 +26,7 @@ export interface ExecuteContinuationState {
   readonly isDebouncedComputationWaiting: (action: Action) => boolean;
   readonly getNextDebounceRunTime: (action: Action) => number | undefined;
   readonly getNextEligibleRunTime: (action: Action) => number | undefined;
+  readonly hasPendingLineageHeadEvent: () => boolean;
   readonly resetLoopCounter: () => void;
   readonly setScheduled: (scheduled: boolean) => void;
   readonly resetSettlingTracker: () => void;
@@ -65,6 +66,15 @@ export function applyQuiescentContinuation(
 
     // Waiting on a future wake is quiescent from the scheduler's perspective,
     // so reset the non-settling tracker.
+    state.resetSettlingTracker();
+    return;
+  }
+
+  if (continuation.hasParkedHeadEvent) {
+    markNotScheduled(state);
+
+    // A lineage-parked head has no timer; the origin transaction's commit
+    // callback is the wake source.
     state.resetSettlingTracker();
     return;
   }

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -243,6 +243,10 @@ export interface SchedulerEventExecutionState {
     originTx: IExtendedStorageTransaction,
     event: QueuedEvent,
   ) => void;
+  readonly recordLineageEvent: (
+    originTx: IExtendedStorageTransaction,
+    event: QueuedEvent,
+  ) => void;
   readonly getOriginLocalSeq: (
     originTx: IExtendedStorageTransaction,
     space: MemorySpace,
@@ -450,6 +454,10 @@ export async function dispatchQueuedEvent(state: {
     originTx: IExtendedStorageTransaction,
     event: QueuedEvent,
   ) => void;
+  readonly recordLineageEvent: (
+    originTx: IExtendedStorageTransaction,
+    event: QueuedEvent,
+  ) => void;
   readonly getOriginLocalSeq: (
     originTx: IExtendedStorageTransaction,
     space: MemorySpace,
@@ -506,6 +514,30 @@ export async function dispatchQueuedEvent(state: {
     state.releaseLineageEvent(queuedEvent.originTx, queuedEvent);
   }
   const actionId = state.getActionId(action);
+
+  // Requeue a retry of this event. Dispatch released the lineage
+  // registration above, so the fresh QueuedEvent object must be re-recorded:
+  // otherwise an origin that fails while the retry is queued cannot remove
+  // it, and the post-settlement originStatus() fallback ("confirmed") would
+  // let a descendant of a failed origin run.
+  const requeueForRetry = () => {
+    const retry: QueuedEvent = {
+      id: queuedEvent.id,
+      originTx: queuedEvent.originTx,
+      action,
+      eventLink: queuedEvent.eventLink,
+      handler,
+      event: eventValue,
+      retriesLeft: retriesLeft - 1,
+      onCommit,
+    };
+    state.eventQueue.unshift(retry);
+    if (retry.originTx !== undefined) {
+      state.recordLineageEvent(retry.originTx, retry);
+    }
+    state.queueExecution();
+  };
+
   const runFinalCommitCallback = () => {
     if (!onCommit) {
       return;
@@ -531,17 +563,7 @@ export async function dispatchQueuedEvent(state: {
         tx.abort(error);
       }
       if (retriesLeft > 0) {
-        state.eventQueue.unshift({
-          id: queuedEvent.id,
-          originTx: queuedEvent.originTx,
-          action,
-          eventLink: queuedEvent.eventLink,
-          handler,
-          event: eventValue,
-          retriesLeft: retriesLeft - 1,
-          onCommit,
-        });
-        state.queueExecution();
+        requeueForRetry();
       } else {
         logger.error(
           "scheduler",
@@ -603,17 +625,7 @@ export async function dispatchQueuedEvent(state: {
           `Event handler transaction failed, retrying (${retriesLeft} retries left)`,
           { error: result.error, handlerId },
         );
-        state.eventQueue.unshift({
-          id: queuedEvent.id,
-          originTx: queuedEvent.originTx,
-          action,
-          eventLink: queuedEvent.eventLink,
-          handler,
-          event: eventValue,
-          retriesLeft: retriesLeft - 1,
-          onCommit,
-        });
-        state.queueExecution();
+        requeueForRetry();
         return;
       }
       runFinalCommitCallback();

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -10,6 +10,7 @@ import type { Runtime } from "../runtime.ts";
 import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
+  MemorySpace,
 } from "../storage/interface.ts";
 import { isPermanentRejection } from "../storage/rejection.ts";
 import type {
@@ -19,6 +20,7 @@ import type {
 import { createDirtyDependencyTraceContext } from "./diagnostics.ts";
 import { mintEventId } from "./event-identity.ts";
 import { planEventDirtyDependencyScheduling } from "./execution.ts";
+import type { OriginStatus } from "./lineage.ts";
 import { RetryImmediately } from "./retry-immediately.ts";
 import {
   hasAnnotatedWrites,
@@ -120,6 +122,10 @@ export interface SchedulerEventQueueState {
     doNotLoadPieceIfNotRunning: boolean,
     opts?: { eventId?: string; originTx?: IExtendedStorageTransaction },
   ) => void;
+  readonly recordLineageEvent: (
+    originTx: IExtendedStorageTransaction,
+    event: QueuedEvent,
+  ) => void;
 }
 
 export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
@@ -138,7 +144,7 @@ export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
     if (areNormalizedLinksSame(link, args.eventLink)) {
       handlerFound = true;
       state.queueExecution();
-      state.eventQueue.push({
+      const queuedEvent: QueuedEvent = {
         id,
         originTx: args.originTx,
         eventLink: args.eventLink,
@@ -147,7 +153,11 @@ export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
         event: args.event,
         retriesLeft: args.retries,
         onCommit: args.onCommit,
-      });
+      };
+      state.eventQueue.push(queuedEvent);
+      if (args.originTx !== undefined) {
+        state.recordLineageEvent(args.originTx, queuedEvent);
+      }
     }
   }
 
@@ -226,6 +236,17 @@ export interface SchedulerEventExecutionState {
   readonly getNextDebounceRunTime: (action: Action) => number | undefined;
   readonly getNextEligibleRunTime: (action: Action) => number | undefined;
   readonly scheduleEventQueueWake: (notBefore: number) => void;
+  readonly lineageStatus: (
+    originTx: IExtendedStorageTransaction,
+  ) => OriginStatus;
+  readonly releaseLineageEvent: (
+    originTx: IExtendedStorageTransaction,
+    event: QueuedEvent,
+  ) => void;
+  readonly getOriginLocalSeq: (
+    originTx: IExtendedStorageTransaction,
+    space: MemorySpace,
+  ) => number | undefined;
   readonly snapshotDirtyDependencyTraceContext: (
     trace: DirtyDependencyTraceContext,
   ) => SchedulerEventPreflightStats;
@@ -422,6 +443,17 @@ export async function dispatchQueuedEvent(state: {
   ) => SchedulerActionInfo | undefined;
   readonly handleError: (error: Error, action: Action) => void;
   readonly queueExecution: () => void;
+  readonly lineageStatus: (
+    originTx: IExtendedStorageTransaction,
+  ) => OriginStatus;
+  readonly releaseLineageEvent: (
+    originTx: IExtendedStorageTransaction,
+    event: QueuedEvent,
+  ) => void;
+  readonly getOriginLocalSeq: (
+    originTx: IExtendedStorageTransaction,
+    space: MemorySpace,
+  ) => number | undefined;
   readonly onEventCommitWrites?: (
     sourceAction: Action,
     writes: readonly IMemorySpaceAddress[],
@@ -456,6 +488,23 @@ export async function dispatchQueuedEvent(state: {
   const tx = state.runtime.edit();
   tx.dispatchedEventId = queuedEvent.id;
   tx.tx.immediate = true;
+  if (queuedEvent.originTx !== undefined) {
+    const originLocalSeq = state.getOriginLocalSeq(
+      queuedEvent.originTx,
+      queuedEvent.eventLink.space,
+    );
+    if (
+      originLocalSeq !== undefined &&
+      state.lineageStatus(queuedEvent.originTx) === "pending" &&
+      state.runtime.experimental.commitPreconditions === true
+    ) {
+      tx.addCommitPrecondition?.(queuedEvent.eventLink.space, {
+        kind: "origin-committed",
+        originLocalSeq,
+      });
+    }
+    state.releaseLineageEvent(queuedEvent.originTx, queuedEvent);
+  }
   const actionId = state.getActionId(action);
   const runFinalCommitCallback = () => {
     if (!onCommit) {

--- a/packages/runner/src/scheduler/lineage.ts
+++ b/packages/runner/src/scheduler/lineage.ts
@@ -31,7 +31,13 @@ export class SpeculationLineage {
   private recordFor(origin: IExtendedStorageTransaction): OriginRecord {
     let record = this.byOrigin.get(origin);
     if (!record) {
-      const originStatus = origin.status().status;
+      // A read-only transaction (cell.send() forwards its tx as the origin,
+      // which in read contexts is runtime.readTx()) never commits: it is not
+      // a speculative launch. Treat it as confirmed — "pending" would park
+      // cross-space events forever and addCommitCallback() throws on it.
+      const originStatus = origin.isReadOnly?.()
+        ? "done"
+        : origin.status().status;
       record = {
         status: originStatus === "done"
           ? "confirmed"

--- a/packages/runner/src/scheduler/lineage.ts
+++ b/packages/runner/src/scheduler/lineage.ts
@@ -1,0 +1,103 @@
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import type { QueuedEvent } from "./types.ts";
+
+export type OriginStatus = "pending" | "confirmed" | "failed";
+
+interface OriginRecord {
+  status: OriginStatus;
+  events: Set<QueuedEvent>;
+  pieceStops: Array<() => void>;
+}
+
+/**
+ * Speculation lineage (scheduler-v2 §7.6 / I10): tracks work launched by a
+ * transaction so it can be released on commit success or cancelled on
+ * failure. Records are created lazily on first launch and removed when the
+ * origin settles and its launches are flushed.
+ */
+export class SpeculationLineage {
+  private byOrigin = new Map<IExtendedStorageTransaction, OriginRecord>();
+
+  constructor(
+    private readonly hooks: {
+      /** Remove a not-yet-dispatched event from the queue. */
+      removeQueuedEvent: (event: QueuedEvent) => void;
+      /** Wake the scheduler (parked cross-space events become ready). */
+      queueExecution: () => void;
+      onError: (error: unknown) => void;
+    },
+  ) {}
+
+  private recordFor(origin: IExtendedStorageTransaction): OriginRecord {
+    let record = this.byOrigin.get(origin);
+    if (!record) {
+      record = { status: "pending", events: new Set(), pieceStops: [] };
+      this.byOrigin.set(origin, record);
+      origin.addCommitCallback((_tx, result) => {
+        const settled = this.byOrigin.get(origin);
+        if (!settled) return;
+        settled.status = result.error ? "failed" : "confirmed";
+        if (result.error) {
+          for (const event of settled.events) {
+            try {
+              this.hooks.removeQueuedEvent(event);
+            } catch (error) {
+              this.hooks.onError(error);
+            }
+          }
+          settled.events.clear();
+          for (const stop of settled.pieceStops) {
+            try {
+              stop();
+            } catch (error) {
+              this.hooks.onError(error);
+            }
+          }
+          settled.pieceStops.length = 0;
+          this.byOrigin.delete(origin);
+        } else {
+          // Success: compensation is moot, but the EVENTS must stay
+          // registered — still-queued descendants (e.g. cross-space parked
+          // ones) keep asking originStatus() until they dispatch and
+          // release(). Clearing them here would let the first release()
+          // delete the record and strand the rest.
+          settled.pieceStops.length = 0;
+        }
+        this.hooks.queueExecution();
+      });
+    }
+    return record;
+  }
+
+  recordEvent(origin: IExtendedStorageTransaction, event: QueuedEvent): void {
+    this.recordFor(origin).events.add(event);
+  }
+
+  recordPieceStop(origin: IExtendedStorageTransaction, stop: () => void): void {
+    this.recordFor(origin).pieceStops.push(stop);
+  }
+
+  /** Called when an event is dispatched or dropped. */
+  release(origin: IExtendedStorageTransaction, event: QueuedEvent): void {
+    const record = this.byOrigin.get(origin);
+    if (!record) return;
+    record.events.delete(event);
+    if (
+      record.status !== "pending" && record.events.size === 0 &&
+      record.pieceStops.length === 0
+    ) {
+      this.byOrigin.delete(origin);
+    }
+  }
+
+  originStatus(origin: IExtendedStorageTransaction): OriginStatus {
+    return this.byOrigin.get(origin)?.status ??
+      // Unknown origin ⇒ the record was settled and fully released. A
+      // still-queued event always finds its record (failure removes the
+      // event synchronously; success keeps the record until release()),
+      // so this fallback is only reachable after settlement — and it must
+      // be "confirmed": "pending" would park a cross-space event forever,
+      // since the commit callback that wakes it has already fired.
+      "confirmed";
+  }
+}

--- a/packages/runner/src/scheduler/lineage.ts
+++ b/packages/runner/src/scheduler/lineage.ts
@@ -31,8 +31,19 @@ export class SpeculationLineage {
   private recordFor(origin: IExtendedStorageTransaction): OriginRecord {
     let record = this.byOrigin.get(origin);
     if (!record) {
-      record = { status: "pending", events: new Set(), pieceStops: [] };
+      const originStatus = origin.status().status;
+      record = {
+        status: originStatus === "done"
+          ? "confirmed"
+          : originStatus === "error"
+          ? "failed"
+          : "pending",
+        events: new Set(),
+        pieceStops: [],
+      };
       this.byOrigin.set(origin, record);
+      if (record.status !== "pending") return record;
+
       origin.addCommitCallback((_tx, result) => {
         const settled = this.byOrigin.get(origin);
         if (!settled) return;
@@ -92,11 +103,11 @@ export class SpeculationLineage {
 
   originStatus(origin: IExtendedStorageTransaction): OriginStatus {
     return this.byOrigin.get(origin)?.status ??
-      // Unknown origin ⇒ the record was settled and fully released. A
-      // still-queued event always finds its record (failure removes the
-      // event synchronously; success keeps the record until release()),
-      // so this fallback is only reachable after settlement — and it must
-      // be "confirmed": "pending" would park a cross-space event forever,
+      // Unknown origin ⇒ no active lineage record remains. A still-queued
+      // event with an already-failed origin creates a failed record and is
+      // dropped before release; successful origins keep the record until
+      // release(). This fallback is therefore after settlement/release — and
+      // must be "confirmed": "pending" would park a cross-space event forever,
       // since the commit callback that wakes it has already fired.
       "confirmed";
   }

--- a/packages/runner/src/scheduler/pull-continuation.ts
+++ b/packages/runner/src/scheduler/pull-continuation.ts
@@ -11,10 +11,13 @@ export function applyPullExecuteContinuation(
 ): void {
   // In pull mode, we consider ourselves done when there are no effects or
   // effect-demanded computations to execute.
+  const hasPendingLineageHeadEvent = state.hasPendingLineageHeadEvent();
   const hasQueuedEventReadyNow = state.eventQueue.length > 0 &&
-    !isHeadEventParked(state.eventQueueWakeState);
+    !isHeadEventParked(state.eventQueueWakeState) &&
+    !hasPendingLineageHeadEvent;
   const hasParkedHeadEvent = state.eventQueue.length > 0 &&
-    isHeadEventParked(state.eventQueueWakeState);
+    (isHeadEventParked(state.eventQueueWakeState) ||
+      hasPendingLineageHeadEvent);
   const shouldRerunAfterCurrentExecute = state
     .consumeRerunAfterCurrentExecute();
 

--- a/packages/runner/src/scheduler/pull-events.ts
+++ b/packages/runner/src/scheduler/pull-events.ts
@@ -120,6 +120,8 @@ export async function processPullQueuedEventDuringExecute(
     lineageStatus: (originTx) => state.lineageStatus(originTx),
     releaseLineageEvent: (originTx, event) =>
       state.releaseLineageEvent(originTx, event),
+    recordLineageEvent: (originTx, event) =>
+      state.recordLineageEvent(originTx, event),
     getOriginLocalSeq: (originTx, space) =>
       state.getOriginLocalSeq(originTx, space),
     onEventCommitWrites: (sourceAction, writes) =>

--- a/packages/runner/src/scheduler/pull-events.ts
+++ b/packages/runner/src/scheduler/pull-events.ts
@@ -1,9 +1,15 @@
+import { getLogger } from "@commonfabric/utils/logger";
 import {
   dispatchQueuedEvent,
   preflightQueuedEventDependencies,
   type SchedulerEventExecutionState,
 } from "./events.ts";
 import type { Action } from "./types.ts";
+
+const logger = getLogger("scheduler", {
+  enabled: true,
+  level: "warn",
+});
 
 export async function processPullQueuedEventDuringExecute(
   state: SchedulerEventExecutionState,
@@ -22,10 +28,10 @@ export async function processPullQueuedEventDuringExecute(
     if (originStatus === "failed") {
       state.eventQueue.shift();
       state.releaseLineageEvent(queuedEvent.originTx, queuedEvent);
-      state.handleError(
-        new Error("failed lineage origin remained queued"),
-        queuedEvent.action,
-      );
+      logger.debug("scheduler-lineage", () => [
+        "Dropping event from failed lineage origin",
+        { eventId: queuedEvent.id },
+      ]);
       return;
     }
     if (!sameSpace && originStatus === "pending") {

--- a/packages/runner/src/scheduler/pull-events.ts
+++ b/packages/runner/src/scheduler/pull-events.ts
@@ -13,6 +13,26 @@ export async function processPullQueuedEventDuringExecute(
   const queuedEvent = state.eventQueue[0];
   if (!queuedEvent) return;
 
+  if (queuedEvent.originTx !== undefined) {
+    const originStatus = state.lineageStatus(queuedEvent.originTx);
+    const sameSpace = state.getOriginLocalSeq(
+      queuedEvent.originTx,
+      queuedEvent.eventLink.space,
+    ) !== undefined;
+    if (originStatus === "failed") {
+      state.eventQueue.shift();
+      state.releaseLineageEvent(queuedEvent.originTx, queuedEvent);
+      state.handleError(
+        new Error("failed lineage origin remained queued"),
+        queuedEvent.action,
+      );
+      return;
+    }
+    if (!sameSpace && originStatus === "pending") {
+      return;
+    }
+  }
+
   if (
     queuedEvent.notBefore !== undefined &&
     queuedEvent.notBefore > performance.now()
@@ -91,6 +111,11 @@ export async function processPullQueuedEventDuringExecute(
     getActionTelemetryInfo: (target) => state.getActionTelemetryInfo(target),
     handleError: (error, target) => state.handleError(error, target),
     queueExecution: () => state.queueExecution(),
+    lineageStatus: (originTx) => state.lineageStatus(originTx),
+    releaseLineageEvent: (originTx, event) =>
+      state.releaseLineageEvent(originTx, event),
+    getOriginLocalSeq: (originTx, space) =>
+      state.getOriginLocalSeq(originTx, space),
     onEventCommitWrites: (sourceAction, writes) =>
       state.onEventCommitWrites?.(sourceAction, writes),
   }, queuedEvent);

--- a/packages/runner/src/storage/commit-identity.ts
+++ b/packages/runner/src/storage/commit-identity.ts
@@ -1,0 +1,28 @@
+import type { IStorageTransaction, MemorySpace } from "./interface.ts";
+
+// Per-space client commit sequence numbers recorded for a source
+// transaction at commit-build time (storage/v2.ts). Used by speculation
+// lineage (scheduler-v2 §7.6) to express the `origin-committed`
+// precondition for follow-up work.
+const localSeqBySource = new WeakMap<object, Map<MemorySpace, number>>();
+
+export function recordCommitLocalSeq(
+  source: IStorageTransaction,
+  space: MemorySpace,
+  localSeq: number,
+): void {
+  let bySpace = localSeqBySource.get(source);
+  if (!bySpace) {
+    bySpace = new Map();
+    localSeqBySource.set(source, bySpace);
+  }
+  bySpace.set(space, localSeq);
+}
+
+export function getCommitLocalSeq(
+  source: IStorageTransaction | undefined,
+  space: MemorySpace,
+): number | undefined {
+  if (!source) return undefined;
+  return localSeqBySource.get(source)?.get(space);
+}

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -596,13 +596,20 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     precondition: CommitPrecondition,
   ): void {
     this.assertWritable("addCommitPrecondition");
+    // Fail closed: a precondition is a commit gate, so silently ignoring it
+    // on storage that cannot enforce it would let the gated commit through.
+    if (!this.tx.addCommitPrecondition) {
+      throw new Error(
+        "storage transaction does not support addCommitPrecondition()",
+      );
+    }
     const preconditions = this.commitPreconditions.get(space);
     if (preconditions) {
       preconditions.push(precondition);
     } else {
       this.commitPreconditions.set(space, [precondition]);
     }
-    this.tx.addCommitPrecondition?.(space, precondition);
+    this.tx.addCommitPrecondition(space, precondition);
   }
 
   getCommitPreconditions(
@@ -1169,7 +1176,14 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
     space: MemorySpace,
     precondition: CommitPrecondition,
   ): void {
-    this.wrapped.addCommitPrecondition?.(space, precondition);
+    // Fail closed, like ExtendedStorageTransaction: a precondition is a
+    // commit gate and must not be silently dropped.
+    if (!this.wrapped.addCommitPrecondition) {
+      throw new Error(
+        "storage transaction does not support addCommitPrecondition()",
+      );
+    }
+    this.wrapped.addCommitPrecondition(space, precondition);
   }
 
   getCommitPreconditions(

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -32,7 +32,10 @@ import type {
   WriterError,
 } from "./interface.ts";
 import { createReadOnlyTransactionError, toThrowable } from "./interface.ts";
-import type { SqliteOperation } from "@commonfabric/memory/v2";
+import type {
+  CommitPrecondition,
+  SqliteOperation,
+} from "@commonfabric/memory/v2";
 import {
   getDirectTransactionReactivityLog,
   getTransactionReadActivities,
@@ -101,6 +104,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   >();
   private statusOverride?: StorageTransactionStatus;
   private commitCallbacksDispatched = false;
+  private commitPreconditions = new Map<MemorySpace, CommitPrecondition[]>();
   private outboxIdempotencyKeys = new Set<string>();
   private readOnlySource?: string;
   private narrowestReadScope: CellScope = "space";
@@ -585,6 +589,27 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
 
   getSchedulerObservation(): unknown {
     return this.tx.getSchedulerObservation?.();
+  }
+
+  addCommitPrecondition(
+    space: MemorySpace,
+    precondition: CommitPrecondition,
+  ): void {
+    this.assertWritable("addCommitPrecondition");
+    const preconditions = this.commitPreconditions.get(space);
+    if (preconditions) {
+      preconditions.push(precondition);
+    } else {
+      this.commitPreconditions.set(space, [precondition]);
+    }
+    this.tx.addCommitPrecondition?.(space, precondition);
+  }
+
+  getCommitPreconditions(
+    space: MemorySpace,
+  ): readonly CommitPrecondition[] | undefined {
+    return this.tx.getCommitPreconditions?.(space) ??
+      this.commitPreconditions.get(space);
   }
 
   recordSqliteWrite(space: MemorySpace, op: SqliteOperation): void {
@@ -1138,6 +1163,19 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
 
   getSchedulerObservation(): unknown {
     return this.wrapped.getSchedulerObservation?.();
+  }
+
+  addCommitPrecondition(
+    space: MemorySpace,
+    precondition: CommitPrecondition,
+  ): void {
+    this.wrapped.addCommitPrecondition?.(space, precondition);
+  }
+
+  getCommitPreconditions(
+    space: MemorySpace,
+  ): readonly CommitPrecondition[] | undefined {
+    return this.wrapped.getCommitPreconditions?.(space);
   }
 
   recordSqliteWrite(space: MemorySpace, op: SqliteOperation): void {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1,6 +1,7 @@
 import type { Immutable } from "@commonfabric/utils/types";
 import type { CellScope } from "@commonfabric/api";
 import type {
+  CommitPrecondition,
   EntityDocument,
   PatchOp,
   SchedulerActionSnapshotQuery,
@@ -575,6 +576,19 @@ export interface IStorageTransaction {
   getSchedulerObservation?(): unknown;
 
   /**
+   * Optional commit-time preconditions attached to this transaction's commit in
+   * the given space. Storage backends that support v2 native commits read these
+   * during commit construction.
+   */
+  addCommitPrecondition?(
+    space: MemorySpace,
+    precondition: CommitPrecondition,
+  ): void;
+  getCommitPreconditions?(
+    space: MemorySpace,
+  ): readonly CommitPrecondition[] | undefined;
+
+  /**
    * Optional: record a folded SQLite write onto this transaction so it commits
    * ATOMICALLY with the cell ops targeting `space` (one commit = cell ops + a
    * `sqlite` op; on SQL failure the whole commit aborts). Claims `space` as a
@@ -728,6 +742,19 @@ export interface IExtendedStorageTransaction
    * runner to derive the handler result cell's cause (spec §7.6).
    */
   dispatchedEventId?: string;
+
+  /**
+   * Commit-time preconditions attached to this transaction's commit in
+   * the given space (scheduler-v2 §7.6). Violations surface as
+   * IPreconditionFailedError (permanent — never retried).
+   */
+  addCommitPrecondition?(
+    space: MemorySpace,
+    precondition: { kind: "origin-committed"; originLocalSeq: number },
+  ): void;
+  getCommitPreconditions?(
+    space: MemorySpace,
+  ): readonly CommitPrecondition[] | undefined;
 
   getCfcState(): Readonly<CfcTxState>;
   setCfcEnforcementMode(mode: CfcEnforcementMode): void;
@@ -1304,6 +1331,7 @@ export type NativeStorageCommitOperation =
 export interface NativeStorageCommit {
   operations: readonly NativeStorageCommitOperation[];
   schedulerObservation?: unknown;
+  preconditions?: readonly CommitPrecondition[];
   /**
    * Folded SQLite write ops, applied in the same wire commit as `operations`
    * (appended last). They are NOT entity revisions and stay out of the

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -839,6 +839,13 @@ export class V2StorageTransaction implements IStorageTransaction {
     if (ready.error) {
       throw ready.error;
     }
+    // Claim `space` as a write target (sets #writeSpace, enforces single-space
+    // write isolation) so a precondition-only commit is still sent and
+    // validated instead of resolving ok without a write space.
+    const claimed = this.claimWriteSpace(space);
+    if (claimed.error) {
+      throw claimed.error;
+    }
     const preconditions = this.#commitPreconditions.get(space);
     if (preconditions) {
       preconditions.push(precondition);

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1,7 +1,11 @@
 import { cloneIfNecessary } from "@commonfabric/data-model/fabric-value";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { unclaimed } from "@commonfabric/memory/fact";
-import type { PatchOp, SqliteOperation } from "@commonfabric/memory/v2";
+import type {
+  CommitPrecondition,
+  PatchOp,
+  SqliteOperation,
+} from "@commonfabric/memory/v2";
 import { encodePointer, pathsOverlap } from "../../../memory/v2/path.ts";
 import { PathKeyMap } from "@commonfabric/utils/path-key-map";
 import type { FabricValue } from "@commonfabric/memory/interface";
@@ -741,6 +745,7 @@ export class V2StorageTransaction implements IStorageTransaction {
   #readActivities: IReadActivity[] = [];
   #reactivityLogCache?: TransactionReactivityLog;
   #schedulerObservation?: unknown;
+  #commitPreconditions = new Map<MemorySpace, CommitPrecondition[]>();
   // Folded SQLite write ops per space, applied in the same commit as cell ops.
   #sqliteOps = new Map<MemorySpace, SqliteOperation[]>();
   #writeSpace?: MemorySpace;
@@ -825,6 +830,29 @@ export class V2StorageTransaction implements IStorageTransaction {
     return this.#schedulerObservation;
   }
 
+  addCommitPrecondition(
+    space: MemorySpace,
+    precondition: CommitPrecondition,
+  ): void {
+    this.assertWritable("addCommitPrecondition()");
+    const ready = this.editable();
+    if (ready.error) {
+      throw ready.error;
+    }
+    const preconditions = this.#commitPreconditions.get(space);
+    if (preconditions) {
+      preconditions.push(precondition);
+    } else {
+      this.#commitPreconditions.set(space, [precondition]);
+    }
+  }
+
+  getCommitPreconditions(
+    space: MemorySpace,
+  ): readonly CommitPrecondition[] | undefined {
+    return this.#commitPreconditions.get(space);
+  }
+
   recordSqliteWrite(space: MemorySpace, op: SqliteOperation): void {
     this.assertWritable("recordSqliteWrite()");
     const ready = this.editable();
@@ -850,8 +878,12 @@ export class V2StorageTransaction implements IStorageTransaction {
     const schedulerObservation = this.schedulerObservationForNativeCommit(
       space,
     );
+    const preconditions = this.#commitPreconditions.get(space);
     const sqliteOps = this.#sqliteOps.get(space);
-    if (!branch && schedulerObservation === undefined && !sqliteOps?.length) {
+    if (
+      !branch && schedulerObservation === undefined &&
+      !preconditions?.length && !sqliteOps?.length
+    ) {
       return undefined;
     }
 
@@ -884,6 +916,7 @@ export class V2StorageTransaction implements IStorageTransaction {
     return {
       operations,
       ...(schedulerObservation !== undefined ? { schedulerObservation } : {}),
+      ...(preconditions?.length ? { preconditions: [...preconditions] } : {}),
       ...(sqliteOps?.length ? { sqliteOps: [...sqliteOps] } : {}),
     };
   }
@@ -1465,8 +1498,12 @@ export class V2StorageTransaction implements IStorageTransaction {
     );
     const operations = native?.operations ?? [];
     const hasSchedulerObservation = native?.schedulerObservation !== undefined;
+    const hasCommitPreconditions = (native?.preconditions?.length ?? 0) > 0;
     const hasSqliteOps = (native?.sqliteOps?.length ?? 0) > 0;
-    if (operations.length === 0 && !hasSchedulerObservation && !hasSqliteOps) {
+    if (
+      operations.length === 0 && !hasSchedulerObservation &&
+      !hasCommitPreconditions && !hasSqliteOps
+    ) {
       const result = { ok: {} } satisfies Result<Unit, CommitError>;
       this.#state = { status: "done", result };
       return result;
@@ -1520,10 +1557,12 @@ export class V2StorageTransaction implements IStorageTransaction {
       const operations = native?.operations ?? [];
       const hasSchedulerObservation =
         native?.schedulerObservation !== undefined;
+      const hasCommitPreconditions = (native?.preconditions?.length ?? 0) > 0;
       const hasSqliteOps = (native?.sqliteOps?.length ?? 0) > 0;
       if (
         !native ||
-        (operations.length === 0 && !hasSchedulerObservation && !hasSqliteOps)
+        (operations.length === 0 && !hasSchedulerObservation &&
+          !hasCommitPreconditions && !hasSqliteOps)
       ) {
         continue;
       }

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -50,6 +50,7 @@ import {
   parseLinkPrimitive,
 } from "../link-types.ts";
 import type { Cancel } from "../cancel.ts";
+import { recordCommitLocalSeq } from "./commit-identity.ts";
 import * as Differential from "./differential.ts";
 import type {
   IMemoryAddress,
@@ -1657,6 +1658,9 @@ class SpaceReplica implements ISpaceReplica {
     }
 
     const localSeq = this.#nextLocalSeq++;
+    if (source !== undefined) {
+      recordCommitLocalSeq(source, this.#space, localSeq);
+    }
     const commit = withCommitTiming(
       ["commitOperations", "buildCommit"],
       (): ClientCommit => ({

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -19,8 +19,10 @@ import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import {
   type CellScope,
   type ClientCommit,
+  type CommitPrecondition,
   type DocumentPath,
   type EntityDocument,
+  getCommitPreconditionsConfig,
   getPersistentSchedulerStateConfig,
   type PatchOp,
   type SchedulerActionSnapshotQuery,
@@ -1364,6 +1366,9 @@ class SpaceReplica implements ISpaceReplica {
     const schedulerObservation = getPersistentSchedulerStateConfig()
       ? transaction.schedulerObservation
       : undefined;
+    const preconditions = getCommitPreconditionsConfig()
+      ? transaction.preconditions
+      : undefined;
     const operations = withCommitTiming(
       ["commitNative", "normalize"],
       () =>
@@ -1397,6 +1402,7 @@ class SpaceReplica implements ISpaceReplica {
 
     if (
       operations.length === 0 && schedulerObservation === undefined &&
+      !preconditions?.length &&
       sqliteOps.length === 0
     ) {
       return { ok: {} };
@@ -1409,6 +1415,7 @@ class SpaceReplica implements ISpaceReplica {
           operations,
           source,
           schedulerObservation,
+          preconditions,
           sqliteOps,
         ),
     );
@@ -1645,9 +1652,16 @@ class SpaceReplica implements ISpaceReplica {
     operations: NativeCommitOperation[],
     source?: IStorageTransaction,
     schedulerObservation?: unknown,
+    preconditions: readonly CommitPrecondition[] = [],
     sqliteOps: readonly SqliteOperation[] = [],
   ): Promise<Result<Unit, StorageTransactionRejected>> {
-    if (operations.length === 0 && sqliteOps.length === 0) {
+    const activePreconditions = getCommitPreconditionsConfig()
+      ? (preconditions ?? [])
+      : [];
+    if (
+      operations.length === 0 && sqliteOps.length === 0 &&
+      activePreconditions.length === 0
+    ) {
       if (schedulerObservation === undefined) {
         return { ok: {} };
       }
@@ -1692,6 +1706,9 @@ class SpaceReplica implements ISpaceReplica {
           ...sqliteOps,
         ],
         ...(schedulerObservation !== undefined ? { schedulerObservation } : {}),
+        ...(activePreconditions.length > 0
+          ? { preconditions: [...activePreconditions] }
+          : {}),
       }),
     );
     const touched = operations.map((operation) => ({

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -8,7 +8,9 @@ import {
   resetModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
 import {
+  getCommitPreconditionsConfig,
   getPersistentSchedulerStateConfig,
+  resetCommitPreconditionsConfig,
   resetPersistentSchedulerStateConfig,
 } from "@commonfabric/memory/v2";
 
@@ -22,6 +24,7 @@ const signer = await Identity.fromPassphrase("test experimental");
 describe("ExperimentalOptions", () => {
   afterEach(() => {
     resetModernCellRepConfig();
+    resetCommitPreconditionsConfig();
     resetPersistentSchedulerStateConfig();
   });
 
@@ -38,6 +41,7 @@ describe("ExperimentalOptions", () => {
       expect(runtime.experimental).toEqual({
         modernCellRep: false,
         persistentSchedulerState: false,
+        commitPreconditions: false,
         schedulerHistoricalMightWrite: undefined,
       });
       await runtime.dispose();
@@ -56,6 +60,7 @@ describe("ExperimentalOptions", () => {
       expect(runtime.experimental).toEqual({
         modernCellRep: true,
         persistentSchedulerState: false,
+        commitPreconditions: false,
         schedulerHistoricalMightWrite: undefined,
       });
       await runtime.dispose();
@@ -72,6 +77,7 @@ describe("ExperimentalOptions", () => {
       expect(runtime.experimental).toEqual({
         modernCellRep: false,
         persistentSchedulerState: false,
+        commitPreconditions: false,
         schedulerHistoricalMightWrite: undefined,
       });
       await runtime.dispose();
@@ -126,6 +132,22 @@ describe("ExperimentalOptions", () => {
       await sm.close();
     });
 
+    it("constructing Runtime with commitPreconditions sets global config", async () => {
+      const sm = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: sm,
+        experimental: {
+          commitPreconditions: true,
+        },
+      });
+
+      expect(getCommitPreconditionsConfig()).toBe(true);
+
+      await runtime.dispose();
+      await sm.close();
+    });
+
     it("constructing Runtime with explicit false sets config to false", async () => {
       const sm = StorageManager.emulate({ as: signer });
       const runtime = new Runtime({
@@ -172,6 +194,7 @@ describe("ExperimentalOptions", () => {
 
       expect(getModernCellRepConfig()).toBe(initial);
       expect(getPersistentSchedulerStateConfig()).toBe(false);
+      expect(getCommitPreconditionsConfig()).toBe(false);
     });
   });
 });

--- a/packages/runner/test/scheduler-event-identity.test.ts
+++ b/packages/runner/test/scheduler-event-identity.test.ts
@@ -58,6 +58,7 @@ describe("scheduler event identity", () => {
       backgroundTasks: new Set(),
       queueExecution: () => {},
       queueEvent: () => {},
+      recordLineageEvent: () => {},
     }, {
       eventLink,
       event: { value: 1 },

--- a/packages/runner/test/scheduler-event-lineage.test.ts
+++ b/packages/runner/test/scheduler-event-lineage.test.ts
@@ -1,0 +1,481 @@
+import { Identity } from "@commonfabric/identity";
+import {
+  afterEach,
+  beforeEach,
+  createSchedulerTestRuntime,
+  describe,
+  disposeSchedulerTestRuntime,
+  expect,
+  it,
+  Runtime,
+  space,
+} from "./scheduler-test-utils.ts";
+import type {
+  EventHandler,
+  IExtendedStorageTransaction,
+  SchedulerTestStorageManager,
+} from "./scheduler-test-utils.ts";
+
+const secondSigner = await Identity.fromPassphrase(
+  "scheduler event lineage second space",
+);
+const secondSpace = secondSigner.did();
+
+type TransactMessage = { requestId: string };
+type TransactResponse = {
+  type: "response";
+  requestId: string;
+  ok?: unknown;
+  error?: { name: string; message: string };
+};
+type TestMemoryServer = {
+  transact(message: TransactMessage): Promise<TransactResponse>;
+};
+
+function emulatedServer(
+  storageManager: SchedulerTestStorageManager,
+): TestMemoryServer {
+  return (storageManager as unknown as { server(): TestMemoryServer }).server();
+}
+
+function rejectNextServerTransact(
+  storageManager: SchedulerTestStorageManager,
+): () => void {
+  const server = emulatedServer(storageManager);
+  const original = server.transact.bind(server);
+  let shouldReject = true;
+  server.transact = async (message) => {
+    if (shouldReject) {
+      shouldReject = false;
+      return {
+        type: "response",
+        requestId: message.requestId,
+        error: {
+          name: "ConflictError",
+          message: "forced scheduler lineage test conflict",
+        },
+      };
+    }
+    return await original(message);
+  };
+
+  return () => {
+    server.transact = original;
+  };
+}
+
+function delayNextServerTransact(
+  storageManager: SchedulerTestStorageManager,
+) {
+  const server = emulatedServer(storageManager);
+  const original = server.transact.bind(server);
+  const started = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<"confirm" | "fail">();
+  let shouldDelay = true;
+
+  server.transact = async (message) => {
+    if (!shouldDelay) {
+      return await original(message);
+    }
+    shouldDelay = false;
+    started.resolve();
+    const outcome = await release.promise;
+    if (outcome === "fail") {
+      return {
+        type: "response",
+        requestId: message.requestId,
+        error: {
+          name: "ConflictError",
+          message: "forced scheduler lineage test conflict",
+        },
+      };
+    }
+    return await original(message);
+  };
+
+  return {
+    started: started.promise,
+    confirm: () => release.resolve("confirm"),
+    fail: () => release.resolve("fail"),
+    restore: () => {
+      server.transact = original;
+    },
+  };
+}
+
+async function waitForSchedulerCondition(
+  runtime: Runtime,
+  condition: () => boolean,
+  message: string,
+): Promise<void> {
+  const deadline = performance.now() + 1_000;
+  while (!condition() && performance.now() < deadline) {
+    await runtime.idle();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  if (!condition()) {
+    throw new Error(message);
+  }
+}
+
+async function waitForSignal(
+  signal: Promise<void>,
+  message: string,
+): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      signal,
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error(message)), 1_000);
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}
+
+async function expectIdlePending(
+  idlePromise: Promise<void>,
+): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const result = await Promise.race([
+      idlePromise.then(() => "resolved" as const),
+      new Promise<"pending">((resolve) => {
+        timeoutId = setTimeout(() => resolve("pending"), 100);
+      }),
+    ]);
+    expect(result).toBe("pending");
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}
+
+describe("scheduler event lineage", () => {
+  let storageManager: SchedulerTestStorageManager;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
+      import.meta.url,
+      { experimental: { commitPreconditions: true } },
+    ));
+  });
+
+  afterEach(async () => {
+    await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
+  });
+
+  it("commits only the retried origin attempt's same-space follow-up", async () => {
+    const streamA = runtime.getCell<unknown>(
+      space,
+      "lineage duplication stream a",
+      undefined,
+      tx,
+    );
+    const streamB = runtime.getCell<unknown>(
+      space,
+      "lineage duplication stream b",
+      undefined,
+      tx,
+    );
+    const originWrites = runtime.getCell<number>(
+      space,
+      "lineage duplication origin writes",
+      undefined,
+      tx,
+    );
+    const payloads = runtime.getCell<unknown[]>(
+      space,
+      "lineage duplication payloads",
+      undefined,
+      tx,
+    );
+    streamA.set({ $stream: true });
+    streamB.set({ $stream: true });
+    originWrites.set(0);
+    payloads.set([]);
+    await tx.commit();
+    tx = runtime.edit();
+
+    const restoreTransact = rejectNextServerTransact(storageManager);
+    let originAttempts = 0;
+    const handlerA: EventHandler = (handlerTx) => {
+      originAttempts++;
+      originWrites.withTx(handlerTx).set(originAttempts);
+      runtime.scheduler.queueEvent(
+        streamB.getAsNormalizedFullLink(),
+        originAttempts,
+        undefined,
+        undefined,
+        false,
+        { originTx: handlerTx },
+      );
+    };
+    const handlerB: EventHandler = (handlerTx, event: unknown) => {
+      const current = payloads.withTx(handlerTx).get();
+      payloads.withTx(handlerTx).set([...current, event]);
+    };
+
+    runtime.scheduler.addEventHandler(
+      handlerA,
+      streamA.getAsNormalizedFullLink(),
+    );
+    runtime.scheduler.addEventHandler(
+      handlerB,
+      streamB.getAsNormalizedFullLink(),
+    );
+
+    try {
+      runtime.scheduler.queueEvent(streamA.getAsNormalizedFullLink(), {});
+      await waitForSchedulerCondition(
+        runtime,
+        () => originAttempts >= 2 && payloads.get().length >= 1,
+        "same-space follow-up did not commit",
+      );
+
+      expect(originAttempts).toBe(2);
+      expect(payloads.get().length).toBe(1);
+    } finally {
+      restoreTransact();
+    }
+  });
+
+  it("drops payload-only same-space follow-ups from permanently failed origins", async () => {
+    const streamA = runtime.getCell<unknown>(
+      space,
+      "lineage permanent stream a",
+      undefined,
+      tx,
+    );
+    const streamB = runtime.getCell<unknown>(
+      space,
+      "lineage permanent stream b",
+      undefined,
+      tx,
+    );
+    const originWrites = runtime.getCell<number>(
+      space,
+      "lineage permanent origin writes",
+      undefined,
+      tx,
+    );
+    const payloads = runtime.getCell<unknown[]>(
+      space,
+      "lineage permanent payloads",
+      undefined,
+      tx,
+    );
+    streamA.set({ $stream: true });
+    streamB.set({ $stream: true });
+    originWrites.set(0);
+    payloads.set([]);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let originAttempts = 0;
+    const handlerA: EventHandler = (handlerTx) => {
+      originAttempts++;
+      originWrites.withTx(handlerTx).set(originAttempts);
+      runtime.scheduler.queueEvent(
+        streamB.getAsNormalizedFullLink(),
+        originAttempts,
+        undefined,
+        undefined,
+        false,
+        { originTx: handlerTx },
+      );
+      handlerTx.abort("force lineage permanent failure");
+    };
+    const handlerB: EventHandler = (handlerTx, event: unknown) => {
+      const current = payloads.withTx(handlerTx).get();
+      payloads.withTx(handlerTx).set([...current, event]);
+    };
+
+    runtime.scheduler.addEventHandler(
+      handlerA,
+      streamA.getAsNormalizedFullLink(),
+    );
+    runtime.scheduler.addEventHandler(
+      handlerB,
+      streamB.getAsNormalizedFullLink(),
+    );
+
+    runtime.scheduler.queueEvent(streamA.getAsNormalizedFullLink(), {}, 1);
+    await waitForSchedulerCondition(
+      runtime,
+      () => originAttempts >= 2,
+      "permanent origin did not exhaust retries",
+    );
+    await runtime.idle();
+
+    expect(originAttempts).toBe(2);
+    expect(payloads.get()).toEqual([]);
+  });
+
+  it("parks cross-space follow-ups until the origin confirms", async () => {
+    const streamA = runtime.getCell<unknown>(
+      space,
+      "lineage cross confirm stream a",
+      undefined,
+      tx,
+    );
+    const streamB = runtime.getCell<unknown>(
+      secondSpace,
+      "lineage cross confirm stream b",
+      undefined,
+      tx,
+    );
+    const originWrites = runtime.getCell<number>(
+      space,
+      "lineage cross confirm origin writes",
+      undefined,
+      tx,
+    );
+    const payloads = runtime.getCell<unknown[]>(
+      secondSpace,
+      "lineage cross confirm payloads",
+      undefined,
+      tx,
+    );
+    streamA.set({ $stream: true });
+    originWrites.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+    streamB.withTx(tx).set({ $stream: true });
+    payloads.withTx(tx).set([]);
+    await tx.commit();
+    tx = runtime.edit();
+
+    const gate = delayNextServerTransact(storageManager);
+    const handlerA: EventHandler = (handlerTx) => {
+      originWrites.withTx(handlerTx).set(1);
+      runtime.scheduler.queueEvent(
+        streamB.getAsNormalizedFullLink(),
+        1,
+        undefined,
+        undefined,
+        false,
+        { originTx: handlerTx },
+      );
+    };
+    const handlerB: EventHandler = (handlerTx, event: unknown) => {
+      const current = payloads.withTx(handlerTx).get();
+      payloads.withTx(handlerTx).set([...current, event]);
+    };
+    let idlePromise: Promise<void> | undefined;
+
+    runtime.scheduler.addEventHandler(
+      handlerA,
+      streamA.getAsNormalizedFullLink(),
+    );
+    runtime.scheduler.addEventHandler(
+      handlerB,
+      streamB.getAsNormalizedFullLink(),
+    );
+
+    try {
+      runtime.scheduler.queueEvent(streamA.getAsNormalizedFullLink(), {});
+      await waitForSignal(gate.started, "origin commit did not start");
+      idlePromise = runtime.idle();
+      await expectIdlePending(idlePromise);
+
+      expect(payloads.get()).toEqual([]);
+
+      gate.confirm();
+      await idlePromise;
+      await waitForSchedulerCondition(
+        runtime,
+        () => payloads.get().length === 1,
+        "cross-space follow-up did not dispatch after origin confirmation",
+      );
+      expect(payloads.get().length).toBe(1);
+    } finally {
+      gate.confirm();
+      gate.restore();
+      await idlePromise?.catch(() => {});
+    }
+  });
+
+  it("drops cross-space follow-ups when the origin fails", async () => {
+    const streamA = runtime.getCell<unknown>(
+      space,
+      "lineage cross fail stream a",
+      undefined,
+      tx,
+    );
+    const streamB = runtime.getCell<unknown>(
+      secondSpace,
+      "lineage cross fail stream b",
+      undefined,
+      tx,
+    );
+    const originWrites = runtime.getCell<number>(
+      space,
+      "lineage cross fail origin writes",
+      undefined,
+      tx,
+    );
+    const payloads = runtime.getCell<unknown[]>(
+      secondSpace,
+      "lineage cross fail payloads",
+      undefined,
+      tx,
+    );
+    streamA.set({ $stream: true });
+    originWrites.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+    streamB.withTx(tx).set({ $stream: true });
+    payloads.withTx(tx).set([]);
+    await tx.commit();
+    tx = runtime.edit();
+
+    const gate = delayNextServerTransact(storageManager);
+    const handlerA: EventHandler = (handlerTx) => {
+      originWrites.withTx(handlerTx).set(1);
+      runtime.scheduler.queueEvent(
+        streamB.getAsNormalizedFullLink(),
+        1,
+        undefined,
+        undefined,
+        false,
+        { originTx: handlerTx },
+      );
+    };
+    const handlerB: EventHandler = (handlerTx, event: unknown) => {
+      const current = payloads.withTx(handlerTx).get();
+      payloads.withTx(handlerTx).set([...current, event]);
+    };
+    let idlePromise: Promise<void> | undefined;
+
+    runtime.scheduler.addEventHandler(
+      handlerA,
+      streamA.getAsNormalizedFullLink(),
+    );
+    runtime.scheduler.addEventHandler(
+      handlerB,
+      streamB.getAsNormalizedFullLink(),
+    );
+
+    try {
+      runtime.scheduler.queueEvent(streamA.getAsNormalizedFullLink(), {}, 0);
+      await waitForSignal(gate.started, "origin commit did not start");
+      idlePromise = runtime.idle();
+      await expectIdlePending(idlePromise);
+
+      expect(payloads.get()).toEqual([]);
+
+      gate.fail();
+      await idlePromise;
+      await runtime.idle();
+      expect(payloads.get()).toEqual([]);
+    } finally {
+      gate.fail();
+      gate.restore();
+      await idlePromise?.catch(() => {});
+    }
+  });
+});

--- a/packages/runner/test/scheduler-event-lineage.test.ts
+++ b/packages/runner/test/scheduler-event-lineage.test.ts
@@ -15,6 +15,7 @@ import type {
   IExtendedStorageTransaction,
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 const secondSigner = await Identity.fromPassphrase(
   "scheduler event lineage second space",
@@ -57,6 +58,27 @@ function rejectNextServerTransact(
       };
     }
     return await original(message);
+  };
+
+  return () => {
+    server.transact = original;
+  };
+}
+
+function rejectServerTransacts(
+  storageManager: SchedulerTestStorageManager,
+): () => void {
+  const server = emulatedServer(storageManager);
+  const original = server.transact.bind(server);
+  server.transact = (message) => {
+    return Promise.resolve({
+      type: "response",
+      requestId: message.requestId,
+      error: {
+        name: "ConflictError",
+        message: "forced scheduler lineage test conflict",
+      },
+    });
   };
 
   return () => {
@@ -555,5 +577,63 @@ describe("scheduler event lineage", () => {
     );
 
     expect(payloads.get()).toEqual([]);
+  });
+
+  it("stops handler-result pieces when the handler commit fails permanently", async () => {
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { cell, handler, lift, pattern } = commonfabric;
+    const childPattern = pattern<{ source: number }>(({ source }) => {
+      const observed = lift((value: number) => value)(source);
+      return { observed };
+    });
+    let handlerAttempts = 0;
+    const launchChild = handler(
+      {},
+      {
+        type: "object",
+        properties: {
+          source: { type: "number", asCell: ["cell"] },
+        },
+        required: ["source"],
+      },
+      (_event, { source }) => {
+        handlerAttempts++;
+        source.set((source.get() ?? 0) + 1);
+        return childPattern({ source });
+      },
+    );
+    const rootPattern = pattern(() => {
+      const source = cell(0);
+      return {
+        launch: launchChild({ source }),
+        source,
+      };
+    });
+    const rootCell = runtime.getCell<{ launch: unknown; source: number }>(
+      space,
+      "lineage handler-result piece stop root",
+      undefined,
+      tx,
+    );
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await root.pull();
+
+    const runningBefore = runtime.runner.cancels.size;
+    const restoreTransact = rejectServerTransacts(storageManager);
+    try {
+      root.key("launch").send({});
+      await waitForSchedulerCondition(
+        runtime,
+        () => handlerAttempts >= 6,
+        "handler did not exhaust retries",
+      );
+      await runtime.idle();
+
+      expect(runtime.runner.cancels.size).toBe(runningBefore);
+    } finally {
+      restoreTransact();
+    }
   });
 });

--- a/packages/runner/test/scheduler-event-lineage.test.ts
+++ b/packages/runner/test/scheduler-event-lineage.test.ts
@@ -428,6 +428,54 @@ describe("scheduler event lineage", () => {
     }
   });
 
+  it("treats read-only origin transactions as settled", async () => {
+    const stream = runtime.getCell<unknown>(
+      space,
+      "lineage read-only origin stream",
+      undefined,
+      tx,
+    );
+    const payloads = runtime.getCell<unknown[]>(
+      space,
+      "lineage read-only origin payloads",
+      undefined,
+      tx,
+    );
+    stream.set({ $stream: true });
+    payloads.set([]);
+    await tx.commit();
+    tx = runtime.edit();
+
+    const handler: EventHandler = (handlerTx, event: unknown) => {
+      const current = payloads.withTx(handlerTx).get();
+      payloads.withTx(handlerTx).set([...current, event]);
+    };
+    runtime.scheduler.addEventHandler(
+      handler,
+      stream.getAsNormalizedFullLink(),
+    );
+
+    // cell.send() forwards its transaction as the lineage origin; in read
+    // contexts that is a read-only readTx() which never commits. Such events
+    // are not speculative launches and must dispatch unconditionally instead
+    // of throwing from addCommitCallback() or parking forever.
+    runtime.scheduler.queueEvent(
+      stream.getAsNormalizedFullLink(),
+      "from-read-context",
+      undefined,
+      undefined,
+      false,
+      { originTx: runtime.readTx() },
+    );
+    await waitForSchedulerCondition(
+      runtime,
+      () => payloads.get().length >= 1,
+      "read-only-origin event did not dispatch",
+    );
+
+    expect(payloads.get()).toEqual(["from-read-context"]);
+  });
+
   it("parks cross-space follow-ups until the origin confirms", async () => {
     const streamA = runtime.getCell<unknown>(
       space,

--- a/packages/runner/test/scheduler-event-lineage.test.ts
+++ b/packages/runner/test/scheduler-event-lineage.test.ts
@@ -478,4 +478,82 @@ describe("scheduler event lineage", () => {
       await idlePromise?.catch(() => {});
     }
   });
+
+  it("dispatches stream events whose origin transaction already committed", async () => {
+    const stream = runtime.getCell<unknown>(
+      space,
+      "lineage committed-origin stream",
+      undefined,
+      tx,
+    );
+    const payloads = runtime.getCell<unknown[]>(
+      space,
+      "lineage committed-origin payloads",
+      undefined,
+      tx,
+    );
+    stream.set({ $stream: true });
+    payloads.set([]);
+    await tx.commit();
+
+    const originTx = runtime.edit();
+    await originTx.commit();
+    tx = runtime.edit();
+
+    const handler: EventHandler = (handlerTx, event: unknown) => {
+      const current = payloads.withTx(handlerTx).get();
+      payloads.withTx(handlerTx).set([...current, event]);
+    };
+    runtime.scheduler.addEventHandler(
+      handler,
+      stream.getAsNormalizedFullLink(),
+    );
+
+    stream.withTx(originTx).send("settled origin payload");
+    await waitForSignal(
+      runtime.idle(),
+      "already-committed origin event did not reach idle",
+    );
+
+    expect(payloads.get()).toEqual(["settled origin payload"]);
+  });
+
+  it("drops stream events whose origin transaction already failed", async () => {
+    const stream = runtime.getCell<unknown>(
+      space,
+      "lineage failed-origin stream",
+      undefined,
+      tx,
+    );
+    const payloads = runtime.getCell<unknown[]>(
+      space,
+      "lineage failed-origin payloads",
+      undefined,
+      tx,
+    );
+    stream.set({ $stream: true });
+    payloads.set([]);
+    await tx.commit();
+
+    const originTx = runtime.edit();
+    originTx.abort("already failed lineage origin");
+    tx = runtime.edit();
+
+    const handler: EventHandler = (handlerTx, event: unknown) => {
+      const current = payloads.withTx(handlerTx).get();
+      payloads.withTx(handlerTx).set([...current, event]);
+    };
+    runtime.scheduler.addEventHandler(
+      handler,
+      stream.getAsNormalizedFullLink(),
+    );
+
+    stream.withTx(originTx).send("dropped origin payload");
+    await waitForSignal(
+      runtime.idle(),
+      "already-failed origin event did not reach idle",
+    );
+
+    expect(payloads.get()).toEqual([]);
+  });
 });

--- a/packages/runner/test/scheduler-event-lineage.test.ts
+++ b/packages/runner/test/scheduler-event-lineage.test.ts
@@ -16,6 +16,7 @@ import type {
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { RetryImmediately } from "../src/scheduler/retry-immediately.ts";
 
 const secondSigner = await Identity.fromPassphrase(
   "scheduler event lineage second space",
@@ -335,6 +336,96 @@ describe("scheduler event lineage", () => {
 
     expect(originAttempts).toBe(2);
     expect(payloads.get()).toEqual([]);
+  });
+
+  it("keeps retried same-space follow-ups lineage-gated", async () => {
+    const streamA = runtime.getCell<unknown>(
+      space,
+      "lineage retry stream a",
+      undefined,
+      tx,
+    );
+    const streamB = runtime.getCell<unknown>(
+      space,
+      "lineage retry stream b",
+      undefined,
+      tx,
+    );
+    const originWrites = runtime.getCell<number>(
+      space,
+      "lineage retry origin writes",
+      undefined,
+      tx,
+    );
+    const payloads = runtime.getCell<unknown[]>(
+      space,
+      "lineage retry payloads",
+      undefined,
+      tx,
+    );
+    streamA.set({ $stream: true });
+    streamB.set({ $stream: true });
+    originWrites.set(0);
+    payloads.set([]);
+    await tx.commit();
+    tx = runtime.edit();
+
+    const handlerA: EventHandler = (handlerTx) => {
+      originWrites.withTx(handlerTx).set(1);
+      runtime.scheduler.queueEvent(
+        streamB.getAsNormalizedFullLink(),
+        1,
+        undefined,
+        undefined,
+        false,
+        { originTx: handlerTx },
+      );
+    };
+    let descendantAttempts = 0;
+    const handlerB: EventHandler = (handlerTx, event: unknown) => {
+      descendantAttempts++;
+      if (descendantAttempts === 1) {
+        // Simulate the inSpace("name") resolution path: the run aborts and
+        // the scheduler requeues the same event locally.
+        throw new RetryImmediately();
+      }
+      const current = payloads.withTx(handlerTx).get();
+      payloads.withTx(handlerTx).set([...current, event]);
+    };
+
+    runtime.scheduler.addEventHandler(
+      handlerA,
+      streamA.getAsNormalizedFullLink(),
+    );
+    runtime.scheduler.addEventHandler(
+      handlerB,
+      streamB.getAsNormalizedFullLink(),
+    );
+
+    // Interleaving: the origin commit is held in flight while the descendant
+    // dispatches speculatively and requeues itself locally (RetryImmediately).
+    // The requeued retry must stay lineage-gated: when the origin then fails,
+    // the retry must not run and commit.
+    const gate = delayNextServerTransact(storageManager);
+
+    try {
+      runtime.scheduler.queueEvent(streamA.getAsNormalizedFullLink(), {}, 0);
+      await waitForSignal(gate.started, "origin commit did not start");
+      await waitForSchedulerCondition(
+        runtime,
+        () => descendantAttempts >= 1,
+        "descendant did not dispatch while the origin was pending",
+      );
+      gate.fail();
+      await runtime.idle();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await runtime.idle();
+
+      expect(payloads.get()).toEqual([]);
+    } finally {
+      gate.fail();
+      gate.restore();
+    }
   });
 
   it("parks cross-space follow-ups until the origin confirms", async () => {

--- a/packages/runner/test/scheduler-lineage.test.ts
+++ b/packages/runner/test/scheduler-lineage.test.ts
@@ -1,0 +1,178 @@
+import type { NormalizedFullLink } from "../src/link-utils.ts";
+import { SpeculationLineage } from "../src/scheduler/lineage.ts";
+import type { QueuedEvent } from "../src/scheduler/types.ts";
+import type {
+  CommitError,
+  IExtendedStorageTransaction,
+  MemorySpace,
+  Result,
+  Unit,
+} from "../src/storage/interface.ts";
+import { describe, expect, it } from "./scheduler-test-utils.ts";
+
+type CommitCallback = Parameters<
+  IExtendedStorageTransaction["addCommitCallback"]
+>[0];
+
+type TestOriginTx = IExtendedStorageTransaction & {
+  settle(result: Result<Unit, CommitError>): void;
+};
+
+const eventLink: NormalizedFullLink = {
+  id: "of:event-stream",
+  space: "did:key:z6MkLineage" as MemorySpace,
+  scope: "space",
+  path: [],
+};
+
+const okResult: Result<Unit, CommitError> = { ok: {} };
+const errorResult: Result<Unit, CommitError> = {
+  error: {
+    name: "StorageTransactionAborted",
+    message: "failed",
+    reason: new Error("failed"),
+  },
+};
+
+function createOriginTx(): TestOriginTx {
+  const callbacks: CommitCallback[] = [];
+  const origin = {
+    tx: {},
+    addCommitCallback(callback: CommitCallback): void {
+      callbacks.push(callback);
+    },
+    settle(result: Result<Unit, CommitError>): void {
+      for (const callback of callbacks) {
+        callback(origin as TestOriginTx, result);
+      }
+    },
+  };
+
+  return origin as TestOriginTx;
+}
+
+function queuedEvent(
+  id: string,
+  originTx?: IExtendedStorageTransaction,
+): QueuedEvent {
+  return {
+    id,
+    originTx,
+    eventLink,
+    action: () => {},
+    handler: () => {},
+    event: { id },
+    retriesLeft: 0,
+  };
+}
+
+function createLineageHooks() {
+  const removed: QueuedEvent[] = [];
+  const errors: unknown[] = [];
+  let queueExecutions = 0;
+  const lineage = new SpeculationLineage({
+    removeQueuedEvent: (event) => removed.push(event),
+    queueExecution: () => queueExecutions++,
+    onError: (error) => errors.push(error),
+  });
+
+  return {
+    lineage,
+    removed,
+    errors,
+    queueExecutions: () => queueExecutions,
+  };
+}
+
+describe("SpeculationLineage", () => {
+  it("cancels recorded events and runs piece stops when the origin fails", () => {
+    const origin = createOriginTx();
+    const event = queuedEvent("evt:failed", origin);
+    const { lineage, removed, errors, queueExecutions } = createLineageHooks();
+    let stops = 0;
+
+    lineage.recordEvent(origin, event);
+    lineage.recordPieceStop(origin, () => stops++);
+    origin.settle(errorResult);
+
+    expect(removed).toEqual([event]);
+    expect(stops).toBe(1);
+    expect(queueExecutions()).toBe(1);
+    expect(errors).toEqual([]);
+    expect(lineage.originStatus(origin)).toBe("confirmed");
+  });
+
+  it("keeps recorded events and drops piece stops when the origin confirms", () => {
+    const origin = createOriginTx();
+    const event = queuedEvent("evt:confirmed", origin);
+    const { lineage, removed, errors, queueExecutions } = createLineageHooks();
+    let stops = 0;
+
+    lineage.recordEvent(origin, event);
+    lineage.recordPieceStop(origin, () => stops++);
+    origin.settle(okResult);
+
+    expect(removed).toEqual([]);
+    expect(stops).toBe(0);
+    expect(queueExecutions()).toBe(1);
+    expect(errors).toEqual([]);
+    expect(lineage.originStatus(origin)).toBe("confirmed");
+  });
+
+  it("keeps confirmed siblings visible after the first event releases", () => {
+    const origin = createOriginTx();
+    const first = queuedEvent("evt:first", origin);
+    const second = queuedEvent("evt:second", origin);
+    const { lineage } = createLineageHooks();
+
+    lineage.recordEvent(origin, first);
+    lineage.recordEvent(origin, second);
+    origin.settle(okResult);
+    lineage.release(origin, first);
+
+    expect(lineage.originStatus(origin)).toBe("confirmed");
+    lineage.release(origin, second);
+    expect(lineage.originStatus(origin)).toBe("confirmed");
+  });
+
+  it("deletes the record when the last settled event releases", () => {
+    const origin = createOriginTx();
+    const event = queuedEvent("evt:last", origin);
+    const { lineage, removed, queueExecutions } = createLineageHooks();
+    let stops = 0;
+
+    lineage.recordEvent(origin, event);
+    lineage.recordPieceStop(origin, () => stops++);
+    origin.settle(okResult);
+    lineage.release(origin, event);
+    origin.settle(errorResult);
+
+    expect(removed).toEqual([]);
+    expect(stops).toBe(0);
+    expect(queueExecutions()).toBe(1);
+    expect(lineage.originStatus(origin)).toBe("confirmed");
+  });
+
+  it("treats an unknown origin as confirmed", () => {
+    const origin = createOriginTx();
+    const { lineage } = createLineageHooks();
+
+    expect(lineage.originStatus(origin)).toBe("confirmed");
+  });
+
+  it("ignores duplicate settlement callbacks after failure cleanup", () => {
+    const origin = createOriginTx();
+    const event = queuedEvent("evt:double-fail", origin);
+    const { lineage, removed, queueExecutions } = createLineageHooks();
+    let stops = 0;
+
+    lineage.recordEvent(origin, event);
+    lineage.recordPieceStop(origin, () => stops++);
+    origin.settle(errorResult);
+    origin.settle(errorResult);
+
+    expect(removed).toEqual([event]);
+    expect(stops).toBe(1);
+    expect(queueExecutions()).toBe(1);
+  });
+});

--- a/packages/runner/test/scheduler-lineage.test.ts
+++ b/packages/runner/test/scheduler-lineage.test.ts
@@ -16,6 +16,7 @@ type CommitCallback = Parameters<
 
 type TestOriginTx = IExtendedStorageTransaction & {
   settle(result: Result<Unit, CommitError>): void;
+  callbackCount(): number;
 };
 
 const eventLink: NormalizedFullLink = {
@@ -34,17 +35,34 @@ const errorResult: Result<Unit, CommitError> = {
   },
 };
 
-function createOriginTx(): TestOriginTx {
+function createOriginTx(
+  initialStatus: "ready" | "done" | "error" = "ready",
+): TestOriginTx {
   const callbacks: CommitCallback[] = [];
+  let status = initialStatus;
   const origin = {
     tx: {},
+    status() {
+      if (status === "error") {
+        return {
+          status,
+          journal: {},
+          error: errorResult.error,
+        };
+      }
+      return { status, journal: {} };
+    },
     addCommitCallback(callback: CommitCallback): void {
       callbacks.push(callback);
     },
     settle(result: Result<Unit, CommitError>): void {
+      status = result.error ? "error" : "done";
       for (const callback of callbacks) {
         callback(origin as TestOriginTx, result);
       }
+    },
+    callbackCount(): number {
+      return callbacks.length;
     },
   };
 
@@ -158,6 +176,32 @@ describe("SpeculationLineage", () => {
     const { lineage } = createLineageHooks();
 
     expect(lineage.originStatus(origin)).toBe("confirmed");
+  });
+
+  it("treats already-committed origins as confirmed without callbacks", () => {
+    const origin = createOriginTx("done");
+    const event = queuedEvent("evt:already-committed", origin);
+    const { lineage, removed, queueExecutions } = createLineageHooks();
+
+    lineage.recordEvent(origin, event);
+
+    expect(lineage.originStatus(origin)).toBe("confirmed");
+    expect(origin.callbackCount()).toBe(0);
+    expect(removed).toEqual([]);
+    expect(queueExecutions()).toBe(0);
+  });
+
+  it("treats already-failed origins as failed without callbacks", () => {
+    const origin = createOriginTx("error");
+    const event = queuedEvent("evt:already-failed", origin);
+    const { lineage, removed, queueExecutions } = createLineageHooks();
+
+    lineage.recordEvent(origin, event);
+
+    expect(lineage.originStatus(origin)).toBe("failed");
+    expect(origin.callbackCount()).toBe(0);
+    expect(removed).toEqual([]);
+    expect(queueExecutions()).toBe(0);
   });
 
   it("ignores duplicate settlement callbacks after failure cleanup", () => {

--- a/packages/runner/test/storage-commit-preconditions.test.ts
+++ b/packages/runner/test/storage-commit-preconditions.test.ts
@@ -1,0 +1,87 @@
+import { assert, assertEquals, assertExists, assertThrows } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import {
+  resetCommitPreconditionsConfig,
+  setCommitPreconditionsConfig,
+} from "@commonfabric/memory/v2";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
+import type {
+  IStorageTransaction,
+  NativeStorageCommit,
+  Result,
+  StorageTransactionRejected,
+  Unit,
+} from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("storage-commit-preconditions");
+const space = signer.did();
+
+const captureNativeDrafts = () => {
+  const storage = StorageManager.emulate({
+    as: signer,
+  });
+  const provider = storage.open(space);
+  const replica = provider.replica as typeof provider.replica & {
+    commitNative(
+      transaction: NativeStorageCommit,
+      source?: unknown,
+    ): Promise<Result<Unit, StorageTransactionRejected>>;
+  };
+  const originalCommitNative = replica.commitNative?.bind(replica);
+  assertExists(originalCommitNative);
+
+  const drafts: NativeStorageCommit[] = [];
+  replica.commitNative = async (transaction, source) => {
+    drafts.push(structuredClone(transaction));
+    return await originalCommitNative(transaction, source);
+  };
+
+  return { storage, drafts };
+};
+
+Deno.test("precondition-only transactions send and validate their commit", async () => {
+  setCommitPreconditionsConfig(true);
+  const { storage, drafts } = captureNativeDrafts();
+
+  try {
+    // A transaction whose only staged work is an origin-committed
+    // precondition must still send a commit: silently resolving ok would
+    // drop the lineage gate.
+    const tx = storage.edit();
+    tx.addCommitPrecondition?.(space, {
+      kind: "origin-committed",
+      originLocalSeq: 99,
+    });
+    const result = await tx.commit();
+
+    assertEquals(drafts.length, 1);
+    assertEquals(drafts[0].operations, []);
+    assertEquals(drafts[0].preconditions, [{
+      kind: "origin-committed",
+      originLocalSeq: 99,
+    }]);
+    // The referenced origin never committed, so the engine must reject.
+    assert(result.error, "missing-origin precondition must reject the commit");
+  } finally {
+    resetCommitPreconditionsConfig();
+    await storage.close();
+  }
+});
+
+Deno.test("extended transaction refuses preconditions the storage cannot enforce", () => {
+  // The wrapper must fail closed: silently ignoring a gating precondition
+  // because the inner transaction does not support it would let a
+  // descendant of an unconfirmed origin commit ungated.
+  const innerWithoutSupport = {} as IStorageTransaction;
+  const tx = new ExtendedStorageTransaction(innerWithoutSupport);
+  assertThrows(
+    () =>
+      tx.addCommitPrecondition(space, {
+        kind: "origin-committed",
+        originLocalSeq: 1,
+      }),
+    Error,
+    "does not support",
+  );
+});


### PR DESCRIPTION
Stack: 03/E1 — based on scheduler-v2/02-e0 (#4088).

## Summary

Implements scheduler-v2 E1 speculation lineage for work launched by event handlers:

- records per-space origin commit localSeqs and threads `origin-committed` preconditions through runner and memory v2 behind `experimental.commitPreconditions`;
- adds memory engine validation and wire propagation for `PreconditionFailedError`;
- adds a scheduler lineage registry and event gating so same-space descendants carry preconditions, cross-space descendants park until origin confirmation, and failed-origin descendants are dropped;
- compensates handler-result piece launches by stopping pieces if the launching handler transaction fails;
- documents the reviewer-approved already-settled-origin lineage behavior and records WO03 progress/evidence.

## Validation

- `deno fmt`, `deno lint`, and `deno check` on touched TypeScript files before each implementation commit.
- `cd packages/runner && ENV=test deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git test/scheduler-event-lineage.test.ts` passed: `1 passed (7 steps)`, `0 failed`.
- `cd packages/runner && ENV=test deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git test/scheduler-lineage.test.ts` passed: `1 passed (8 steps)`, `0 failed`.
- `cd packages/runner && deno task test` passed: `590 passed (3090 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m4s`.
- `cd packages/memory && deno task test` passed: `211 passed (95 steps)`, `0 failed`.

## Review Notes

This work order touches `packages/memory`; please include memory-owner review. `docs/specs/scheduler-v2/implementation/PROGRESS.md` contains the red-first outputs, reviewer stop/resolution notes, and the WO03 exit-checklist self-check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements scheduler‑v2 E1 speculation lineage for event‑launched work. Descendants are gated by their origin: same‑space commits carry an `origin-committed` precondition, cross‑space events park until the origin settles, and read‑only origins are treated as settled to avoid parking or errors in read contexts. Adds commit preconditions to `@commonfabric/memory` v2 (behind `commitPreconditions`) with a wired `PreconditionFailedError`, and stops handler‑launched pieces when the origin fails.

- New Features
  - Runner: lineage registry; attach same‑space `origin-committed` preconditions, park cross‑space descendants, drop on failed origins, stop handler‑launched pieces; retries re‑register with lineage.
  - Memory v2: commit preconditions with engine validation; `PreconditionFailedError` carries `precondition` on the wire.
  - Storage/Scheduler: record per‑space origin `localSeq` and attach preconditions to native commits; event queue and pull‑mode continuation respect lineage‑parked heads; expose `commitPreconditions` in runtime and `MemoryProtocolFlags`.

- Bug Fixes
  - Preconditions make a commit non‑empty; observation‑only and precondition‑only commits validate; malformed entries raise `ProtocolError`.
  - Read‑only origin transactions are treated as confirmed so read‑context sends do not park or throw.
  - Lineage initializes from already‑settled origins; requeues stay lineage‑registered so failed origins can drop them.
  - Commit preconditions claim their space and throw if a backend cannot record them (fail closed).

<sup>Written for commit bb01e32800719e28e152347983157cbe936295e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

