### PR TITLE
Added a `dataUrl` mode to the fetchDataFunction, which lets us return a base64 data url, and capture binary data.

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2125,7 +2125,7 @@ export type FetchOptions = {
 export type FetchDataFunction = <T>(
   params: Opaque<{
     url: string;
-    mode?: "json" | "text";
+    mode?: "json" | "text" | "dataUrl";
     options?: FetchOptions;
     result?: T;
   }>,

--- a/packages/runner/src/builtins/fetch-data.ts
+++ b/packages/runner/src/builtins/fetch-data.ts
@@ -20,7 +20,7 @@ import { scopedCell } from "./scope-policy.ts";
 /** The shape of fetchData's input cell. */
 type FetchDataInputs = {
   url?: string;
-  mode?: "text" | "json";
+  mode?: "text" | "json" | "dataUrl";
   options?: { body?: any; method?: string; headers?: Record<string, string> };
 };
 
@@ -55,7 +55,8 @@ function snapshotFetchDataInputs(
 ): FetchDataInputs {
   const snapshot = cell.asSchema(fetchDataInputSchema).get() ??
     ({} as FetchDataInputs);
-  const mode = snapshot.mode === "text" || snapshot.mode === "json"
+  const mode = snapshot.mode === "text" || snapshot.mode === "json" ||
+      snapshot.mode === "dataUrl"
     ? snapshot.mode
     : undefined;
   const body = snapshot.options?.body;
@@ -339,7 +340,7 @@ async function startFetch(
   runtime: Runtime,
   inputsCell: Cell<FetchDataInputs>,
   url: string,
-  mode: "text" | "json" | undefined,
+  mode: "text" | "json" | "dataUrl" | undefined,
   options: FetchDataInputs["options"],
   inputHash: string,
   pending: Cell<boolean>,
@@ -352,7 +353,19 @@ async function startFetch(
     if (!r.ok) {
       throw new Error(`HTTP ${r.status}: ${r.statusText}`);
     }
-    return (mode || "json") === "json" ? await r.json() : await r.text();
+    if (mode === "text") return await r.text();
+    if (mode === "dataUrl") {
+      const contentType = r.headers.get("content-type")?.split(";")[0]
+        .trim() || "application/octet-stream";
+      const bytes = new Uint8Array(await r.arrayBuffer());
+      let binary = "";
+      const chunkSize = 0x8000;
+      for (let i = 0; i < bytes.length; i += chunkSize) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+      }
+      return `data:${contentType};base64,${btoa(binary)}`;
+    }
+    return await r.json();
   };
 
   // Body preprocessing (stringify non-string bodies) is handled by the

--- a/packages/runner/test/fetch-data-mutex.test.ts
+++ b/packages/runner/test/fetch-data-mutex.test.ts
@@ -426,6 +426,51 @@ describe("fetch-data mutex mechanism", () => {
     expect(fetchCalls.length).toBeGreaterThan(jsonCallCount);
   });
 
+  it("converts dataUrl mode responses into a serializable data URL", async () => {
+    globalThis.fetch = (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+      fetchCalls.push({ url, init });
+      return Promise.resolve(
+        new Response(new Uint8Array([1, 2, 3, 4]), {
+          status: 200,
+          headers: { "Content-Type": "image/webp" },
+        }),
+      );
+    };
+
+    const fetchData = byRef("fetchData");
+    const testPattern = pattern<{ url: string }>(
+      ({ url }) => fetchData({ url, mode: "dataUrl" }),
+    );
+
+    const resultCell = runtime.getCell(space, "data-url-test", undefined, tx);
+    const result = runtime.run(tx, testPattern, {
+      url: "/api/image",
+    }, resultCell);
+    tx.commit();
+
+    await result.pull();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await result.pull();
+
+    const rawData = result.get() as {
+      pending: boolean;
+      result?: string;
+      error?: unknown;
+    };
+
+    expect(rawData.pending).toBe(false);
+    expect(rawData.error).toBeUndefined();
+    expect(rawData.result).toBe("data:image/webp;base64,AQIDBA==");
+  });
+
   it("should set pending to true during fetch and false after", async () => {
     // Use a longer delay to observe pending state
     const slowFetch = globalThis.fetch;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new `dataUrl` mode to `fetchData` that returns binary responses as base64 data URLs. Default behavior for `json` and `text` is unchanged.

- **New Features**
  - Expanded `FetchDataFunction` mode to include `"dataUrl"`.
  - Runner now handles `"dataUrl"`: reads `arrayBuffer`, base64-encodes, and returns `data:<content-type>;base64,<payload>` (falls back to `application/octet-stream` if missing).
  - Added test to verify correct data URL output and pending/error states.

<sup>Written for commit 43cf9dc7f0cdeaf415f44f26150708287a66a071. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

