### PR TITLE
docs: add a two-part system tutorial (contracts, then mechanisms)

### DIFF
--- a/docs/tutorial/01-big-picture.md
+++ b/docs/tutorial/01-big-picture.md
@@ -115,7 +115,7 @@ seven words.
 - **Space** — a store of cells, named by a DID; the unit of sharing and
   access control.
 - **Pattern** — a TypeScript/JSX module that runs once to define a reactive
-  graph over cells. (Legacy name in code: *recipe*.)
+  graph over cells.
 - **Piece** — a deployed instance of a pattern in a space, with its own
   argument and result cells. (Legacy name: *charm*.)
 - **Stream** — a stateless channel; sending to it fires a handler. Event

--- a/docs/tutorial/01-big-picture.md
+++ b/docs/tutorial/01-big-picture.md
@@ -1,0 +1,131 @@
+# Chapter 1 — The Problem and the Big Picture
+
+## The problem
+
+Think about the small programs people actually want: a shared shopping list
+that sorts itself by store aisle, a poll for the group chat, a tracker that
+watches a feed and summarizes it every morning. Today each of those is either
+a SaaS product (someone else's data model, someone else's server, no
+composability) or a script (no UI, no sharing, no durability, dies with the
+terminal).
+
+The structural reasons these are hard to build well:
+
+1. **State is trapped.** Every app owns its own database. Two programs can
+   only cooperate through bespoke APIs, so "wire my todo list into my
+   calendar" is an integration project, not a link.
+2. **Reactivity stops at the process boundary.** Inside one React app, a
+   change propagates automatically. Across two browser tabs, two users, or a
+   browser and a server job, you're back to polling, webhooks, and cache
+   invalidation — hand-rolled every time.
+3. **User programs can't be trusted.** If end users (or LLMs acting for them)
+   write the programs, the platform must run code it didn't review, with
+   real user data, without letting it exfiltrate that data or corrupt it.
+4. **Durability and identity are afterthoughts.** Who owns the data? Where
+   does it live when the tab closes? Can a server keep running my program
+   while I'm offline?
+
+Common Fabric is a runtime built to dissolve all four problems at once: a
+substrate where small reactive programs (**patterns**) operate on durable,
+shared, access-controlled state (**cells** in **spaces**), and where
+reactivity spans processes, machines, and users as naturally as it spans a
+single component tree.
+
+## The shape of the solution
+
+The system's bet is that one abstraction can carry all of this: **a reactive
+cell that is also a durable, addressable, synchronized document.**
+
+- A **cell** is a unit of state. Reading it inside a computation subscribes
+  you; writing it re-runs every computation that read it. So far, that's an
+  ordinary signal, like Solid.js.
+- But a cell is also **durable**: it lives in a **space** (a data store named
+  by a [DID](https://www.w3.org/TR/did-core/) — a cryptographic identifier),
+  persisted server-side in SQLite, and synchronized to every connected
+  client. The "subscription" that drives reactivity is literally a
+  subscription to a query over the store. Two browsers, a CLI, and a
+  background worker observing the same cell are all just subscribers.
+- A **pattern** is a program over cells. Crucially, a pattern is *not* a
+  function that re-renders; it runs **once** to build a reactive graph —
+  nodes for derived values, event handlers, and UI — and then the runtime
+  keeps that graph live forever. (If you know Solid.js: components run once
+  and wire signals. Same idea, but the graph and its state are durable.)
+- A **piece** is a deployed instance of a pattern: the pattern's code plus
+  its argument and result cells, written into a space. Pieces are the things
+  users see, link together, and keep.
+
+Because state and reactivity live in the substrate rather than in any one
+process, the same piece can be driven from a browser UI, poked from a CLI,
+recomputed by a server-side worker, and linked into other pieces — with no
+integration code.
+
+## One trace, end to end
+
+Here is the whole system in one user action. You check off a todo item in
+your browser; your housemate is looking at the same list on their laptop.
+
+1. **UI event.** The checkbox is a `<cf-checkbox $checked={item.done} />` —
+   a two-way binding. Toggling it writes `true` into the `done` cell.
+2. **Local reactivity.** The write goes into a transaction. When it commits,
+   the scheduler finds every computation that read `item.done` — the
+   "remaining items" count, the list partition into active/completed — and
+   re-runs exactly those. Your UI updates immediately (optimistically).
+3. **Sync.** The runtime's storage layer turns the transaction into a
+   *commit* — the operations plus a record of what was read, so the server
+   can detect conflicts — and sends it over a WebSocket to the server
+   (**Toolshed**), which validates it and appends it to the space's SQLite
+   log.
+4. **Fan-out.** The server knows which sessions are watching queries that
+   touch this document. It pushes a delta to your housemate's session.
+5. **Remote reactivity.** Their runtime integrates the delta into its local
+   replica, which fires the same scheduler machinery on their machine: their
+   item count updates, the item moves to "completed". No app code was
+   involved in steps 3–5; the pattern's author wrote only the checkbox
+   binding.
+
+Every chapter of this tutorial is an expansion of one of those five steps.
+
+## The layers, and why each must exist
+
+The repository describes itself in "pace layers" (see `AGENTS.md`); here is
+the same stack with the *why* attached:
+
+| Layer | Packages | Why it has to exist |
+|---|---|---|
+| Foundation | `api`, `runner`, `identity`, `memory` | The cell/pattern abstractions, the scheduler that runs graphs, cryptographic identity, and the durable store. Everything else is expressed in these terms. |
+| System | `schema-generator`, `ts-transformers`, `js-compiler`, `iframe-sandbox` | Patterns are authored as ordinary TypeScript, but the runtime needs *schemas* (to know what to subscribe to) and *graph nodes* (to schedule). A compiler pipeline extracts both. The sandbox exists because pattern code is untrusted. |
+| Capabilities | `piece`, `html`, `llm` | The things patterns can *do* beyond pure computation: be instantiated as pieces, render HTML, call LLMs. |
+| Operation | `background-charm-service`, `cli` | Run pieces with no browser open; drive the system from scripts and agents. |
+| Deployed product | `toolshed`, `shell` | The server (storage, sync, LLM proxy, blobs) and the browser app users actually open. |
+| UI | `ui` | The `cf-*` web-component library patterns build interfaces from. |
+| End-user programs | `patterns`, `home-schemas` | The patterns themselves — the point of the whole exercise. |
+
+A useful way to hold this: **the bottom four rows are one machine** (a
+reactive, durable, secure computer), and patterns are its programs. The
+tutorial's Part I teaches you the machine's instruction set; Part II opens
+the case.
+
+## Vocabulary card
+
+Keep this list at hand; everything else in the tutorial is built from these
+seven words.
+
+- **Cell** — a reactive, durable unit of state, addressed by
+  (space, entity id, path) and described by a schema.
+- **Space** — a store of cells, named by a DID; the unit of sharing and
+  access control.
+- **Pattern** — a TypeScript/JSX module that runs once to define a reactive
+  graph over cells. (Legacy name in code: *recipe*.)
+- **Piece** — a deployed instance of a pattern in a space, with its own
+  argument and result cells. (Legacy name: *charm*.)
+- **Stream** — a stateless channel; sending to it fires a handler. Event
+  handlers and exported actions are streams.
+- **Toolshed** — the server: WebSocket sync endpoint, persistence, LLM
+  proxy, blob store.
+- **Shell** — the browser application that logs you in, boots a runtime, and
+  renders pieces.
+
+---
+
+**Next:** [Chapter 2 — Cells](02-cells.md), the unit everything else is made
+of.

--- a/docs/tutorial/02-cells.md
+++ b/docs/tutorial/02-cells.md
@@ -179,8 +179,9 @@ mechanisms in Chapters 8 and 9:
 - **Reads are subscriptions.** Any value you read inside a `computed()`, a
   JSX expression, or a handler's reactive context re-runs that computation
   when the value changes — even if the change came from another machine.
-- **Writes are transactional.** All writes from one handler invocation
-  commit atomically, or not at all.
+- **Writes are transactional.** All writes from one handler invocation go
+  into one transaction — which targets a single space — and commit
+  atomically, or not at all.
 - **Updates are optimistic but converge.** Your own writes apply locally and
   instantly; if the server detects a conflict with someone else's commit,
   your transaction is rolled back and retried against fresh state. You don't

--- a/docs/tutorial/02-cells.md
+++ b/docs/tutorial/02-cells.md
@@ -1,0 +1,197 @@
+# Chapter 2 — Cells: Reactive, Durable State
+
+Everything in Common Fabric is built from cells, so this chapter is the
+foundation for all the others. The good news: as a pattern author you mostly
+*don't* handle cells explicitly. You declare ordinary-looking types, and the
+framework hands you values that happen to be reactive. The skill is knowing
+when you need more than that.
+
+## The core principle: everything is reactive; `Writable<>` is about writes
+
+This is the single most important rule in the system, and the one newcomers
+trip on (it's the first thing `docs/common/concepts/reactivity.md` says):
+
+> Everything in Common Fabric is reactive by default. The `Writable<>`
+> wrapper in type signatures doesn't enable reactivity — it indicates
+> **write intent**.
+
+A pattern declares its inputs as an interface. Plain types give you reactive
+*read* access; wrapping a field in `Writable<>` additionally gives you the
+mutation methods.
+
+```tsx
+interface ReadOnlyInput {
+  count: number;        // reactive — display it, derive from it
+  items: Item[];        // reactive — .map() over it
+}
+
+interface WritableInput {
+  count: Writable<number>;   // also lets you call count.set(...)
+  items: Writable<Item[]>;   // also lets you call items.push(...)
+}
+```
+
+Why does the type system carry this? Two reasons, one practical and one
+deep:
+
+- Practical: the methods have to come from somewhere. `count.set(1)` only
+  typechecks if `count` is `Writable<number>`.
+- Deep: as Chapter 7 explains, **types are compiled into JSON schemas**, and
+  the schema is what the runtime uses to subscribe to data and to decide
+  what a handler is allowed to touch. Declaring write intent in the type is
+  declaring it to the runtime, not just to the compiler.
+
+The write-capable surface (`docs/common/concepts/writeable.md`):
+
+```ts
+value.get()              // current value (inside computations: also subscribes)
+value.set(next)          // replace
+value.update({ k: v })   // shallow merge into an object
+items.push(item)         // append to an array
+items.remove(item)       // remove (by identity — see below)
+obj.key("field")         // navigate to a sub-cell: a Writable of one field
+```
+
+`.key()` deserves a highlight: it gives you a *cell for a part of a cell*.
+`item.key("title")` is a `Writable<string>` that reads and writes
+`item.title` — which is exactly what you hand to a two-way-bound input
+(Chapter 4). Reactivity is path-granular: a computation that read only
+`item.title` does not re-run when `item.done` changes.
+
+## Defaults: `Default<>`
+
+Cells are durable documents; a brand-new piece has *no* data yet. Any input
+field without a default is `undefined` at runtime until someone writes it.
+So the convention (`docs/common/concepts/types-and-schemas/default.md`) is:
+
+> Use `Default<>` for any field that will be displayed in UI or used in
+> computations.
+
+```ts
+interface TodoItem {
+  title: string;                       // required
+  done: boolean | Default<false>;      // defaults to false
+}
+
+interface TodoListInput {
+  items?: Writable<TodoItem[] | Default<[]>>;
+}
+```
+
+Note the composition in the last line — this is the most common shape for
+mutable collections, and each part earns its place:
+
+- `TodoItem[]` — the value type;
+- `| Default<[]>` — a new piece starts with an empty list instead of
+  `undefined`;
+- `Writable<...>` — the pattern intends to `.push()` to it;
+- `?` — callers may omit it (the default fills it in).
+
+`Default<>` is a *branded type*: it exists only at the type level, and the
+compiler turns it into a `default:` annotation in the generated JSON schema.
+The runtime applies it when the underlying document is missing.
+
+## Where does a cell live? Spaces and scopes
+
+Every cell lives in a **space** — a durable store named by a DID. When a
+piece is instantiated in a space, its argument and result cells are created
+there, and everyone with access to the space shares them. That's the default
+and it's what makes a todo list collaborative with zero effort.
+
+But not all state should be shared that widely. Is the *currently selected
+tab* shared by all users of the space? Obviously not. Common Fabric makes
+this an explicit, declarative choice with **scope wrappers**
+(`skills/pattern-dev/SKILL.md`):
+
+```ts
+interface ChatInput {
+  conversation?: PerSpace<Conversation | Default<typeof DEFAULT_CONVERSATION>>;
+  name?:         PerUser<string | Default<"">>;
+  selectedRoom?: PerSession<SelectedRoom | Default<EMPTY_ROOM>>;
+}
+```
+
+- `PerSpace<T>` — one value shared by everyone in the space (the default
+  semantics; the wrapper makes it explicit).
+- `PerUser<T>` — one value per authenticated user, following them across
+  devices and sessions. Display names, drafts, preferences.
+- `PerSession<T>` — one value per session/tab, ephemeral. Selection,
+  filters, open modals. The litmus test from the skill doc: *"if the user
+  opens the same instance in a new tab, should this state carry over? If
+  not, it is probably `PerSession<>`."*
+
+The crucial discipline: **never simulate isolation by keying ordinary data
+on user or session ids.** The runtime implements scopes by physically
+partitioning storage per principal/session (Chapter 9), which means
+isolation is enforced below your code, not by your code remembering to
+filter.
+
+## Creating cells inside a pattern
+
+Pattern inputs are the normal way state enters a pattern. Occasionally a
+pattern needs private state that isn't part of its interface — say, a
+"currently editing" buffer. You can create a cell directly:
+
+```ts
+const editedName = new Writable("");                    // pattern-scoped
+const selectedItem = new Writable.perSession<string | null>(null);
+const sharedBoard = new Writable.perSpace(DEFAULT_BOARD);
+```
+
+Two rules, both rooted in how patterns execute (Chapter 3 and 8):
+
+1. **This is rare — prefer inputs.** Inputs are visible, linkable, and
+   testable; private cells are not (`docs/common/patterns/new-cells.md`).
+2. **Initialize with static values only.** The pattern body runs once, at
+   graph-construction time, when reactive inputs have no values yet.
+   `new Writable(deck.name)` throws ("reactive reference outside context");
+   instead initialize empty and copy inside an event handler:
+
+```ts
+const editedName = new Writable("");
+const startEditing = action(() => {
+  editedName.set(deck.name);   // fine: handlers run at event time
+});
+```
+
+(You may see `cell()` in older patterns; it's deprecated in favor of
+`new Writable()` — `packages/patterns/DEPRECATED_IDIOMS.md`.)
+
+## Identity: comparing cells, not values
+
+Cells are references into a store, so "is this the same item?" means
+reference identity, not structural equality. When you need to find or remove
+a specific element, use the framework's `equals()`:
+
+```ts
+import { equals } from "commonfabric";
+const idx = items.get().findIndex((el) => equals(item, el));
+```
+
+Don't invent `id` fields to work around this — the reference *is* the
+identity, and it stays correct when two users hold the same item.
+
+## What you can rely on (the contract)
+
+Summarizing the guarantees the rest of the system is built to provide —
+mechanisms in Chapters 8 and 9:
+
+- **Reads are subscriptions.** Any value you read inside a `computed()`, a
+  JSX expression, or a handler's reactive context re-runs that computation
+  when the value changes — even if the change came from another machine.
+- **Writes are transactional.** All writes from one handler invocation
+  commit atomically, or not at all.
+- **Updates are optimistic but converge.** Your own writes apply locally and
+  instantly; if the server detects a conflict with someone else's commit,
+  your transaction is rolled back and retried against fresh state. You don't
+  write merge code; you may occasionally see your write "lose" and re-apply.
+- **Durability is automatic.** There is no save button anywhere in this
+  system. If it committed, it's in SQLite on the server.
+
+---
+
+**Next:** [Chapter 3 — Patterns](03-patterns.md): the programs that give
+cells behavior.
+**Under the hood:** what a cell actually is (a typed link into a space, plus
+a scheduler) — [Chapter 8](08-runtime-internals.md); how durability and sync
+work — [Chapter 9](09-storage-and-sync.md).

--- a/docs/tutorial/03-patterns.md
+++ b/docs/tutorial/03-patterns.md
@@ -1,0 +1,267 @@
+# Chapter 3 — Patterns: Programs as Reactive Graphs
+
+A pattern is where cells get behavior: derived values, event handling, and a
+UI. This chapter builds the mental model that makes everything else in
+pattern authoring fall into place, then walks through a complete real
+pattern from the repository.
+
+## The mental model: the body runs once
+
+If you come from React, unlearn one thing first. A React component is a
+render function that re-runs on every change. A pattern is **not** that. A
+pattern's body runs **once**, at instantiation, to *construct a graph*:
+nodes for each derived value, each handler, and the UI. After that, the
+runtime keeps the graph alive and re-executes individual *nodes* when their
+inputs change. (This is the Solid.js model — components as setup code,
+signals as the living thing — extended to durable state.)
+
+This explains nearly every rule in this chapter before you read it:
+
+- Values in the body are *graph handles*, not data. You can't
+  `if (count > 3)` in the body — `count` has no value yet; the body runs
+  before data flows. Conditional logic lives inside `computed()` or in JSX
+  (which the compiler lowers into graph nodes, Chapter 7).
+- Code that should re-run goes in a node (`computed`, `action`); code in the
+  body runs exactly once, ever.
+- The graph is *data* — it can be serialized, stored in a space, and
+  re-instantiated by a server that never saw your source file.
+
+## Anatomy of a pattern
+
+The skeleton (`docs/common/concepts/pattern.md`):
+
+```tsx
+import { Default, NAME, pattern, Stream, UI, type VNode, Writable } from "commonfabric";
+
+interface CounterInput {
+  value?: Writable<number | Default<0>>;
+}
+
+interface CounterOutput {
+  [NAME]: string;        // display name of the piece
+  [UI]: VNode;           // its rendered interface
+  value: number;         // exposed state — linkable by other pieces
+  increment: Stream<void>;  // exposed behavior — callable by others
+}
+
+export default pattern<CounterInput, CounterOutput>(({ value }) => {
+  // ...build the graph...
+  return { [NAME]: ..., [UI]: ..., value, increment: ... };
+});
+```
+
+The pieces:
+
+- **`pattern<Input, Output>(fn)`** — always supply *both* type parameters in
+  real patterns. They aren't decoration: the compiler turns them into the
+  schemas that drive subscriptions, linking, and tests. Untyped patterns
+  can't have their actions called via `.send()` from tests or the CLI.
+- **`[NAME]`** — a symbol key for the piece's display name. A static string
+  is fine; derive it with `computed()` if it depends on state.
+- **`[UI]`** — a symbol key for the piece's interface (a JSX tree). Chapter 4.
+- **The return object is the public API.** Whatever you return — state,
+  derived values, streams — is what other pieces can link to and what tests
+  can drive. Output types mirror the returned object exactly and never use
+  `Writable<>`; actions appear as `Stream<T>`.
+- **`export default`** — the deployable entry point (the CLI looks for the
+  `default` export).
+
+Name interfaces `<PatternName>Input`/`<PatternName>Output`, not generic
+`Input`/`Output`.
+
+## Derived values: `computed()` (and when to reach for `lift()`)
+
+`computed()` is the workhorse. Give it a closure; it becomes a graph node
+that re-runs whenever anything it read changes:
+
+```ts
+const itemCount = computed(() => items.get().length);
+const activeItems = computed(() => items.get().filter((i) => !i.done));
+const displayName = computed(() => `Counter: ${value.get()}`);
+```
+
+Dependencies are discovered automatically from what the closure actually
+reads — no dependency arrays. Inside the closure you call `.get()`; the
+result of `computed()` is itself a reactive value you can pass to JSX, other
+computeds, or the return object.
+
+`lift()` is the lower-level primitive `computed()` is built on
+(`docs/common/concepts/lift.md`): it turns a pure function into a reusable
+reactive operator, and it must be declared at **module scope**:
+
+```ts
+const addCells = lift(({ a, b }: { a: number; b: number }) => a + b);
+// inside a pattern:
+return { combined: addCells({ a, b }) };
+```
+
+Rule of thumb from the docs: it's almost always better to use `computed()`.
+Reach for `lift()` only for a derivation you want to reuse across patterns
+or call several times. (You'll also see `derive()` in old code — deprecated,
+same meaning as `computed()`.)
+
+One discipline: **`computed()` derives; it never writes.** Calling `.set()`
+on an upstream cell inside a computed creates a reactive cycle — the
+scheduler will re-run it until it hits its iteration limit and gives up
+(Chapter 8).
+
+## Events: `action()` and `handler()`
+
+Cells change because event handlers change them. There are two ways to
+declare a handler, and the difference is purely about *where the data comes
+from*:
+
+**`action(fn)` — defined inside the pattern body, closes over its state.**
+This is the default choice for single-use behavior:
+
+```ts
+const addItem = action((event: { title: string }) => {
+  const trimmed = event.title.trim();
+  if (trimmed) items.push({ title: trimmed, done: false });
+});
+```
+
+**`handler<Event, Context>(fn)` — defined at module scope, bound later.**
+`Event` is the payload `.send()` receives; `Context` is the state you bind
+at the call site:
+
+```ts
+const increment = handler<void, { value: Writable<number> }>(
+  (_, { value }) => value.set(value.get() + 1),
+);
+
+// inside the pattern body:
+const boundIncrement = increment({ value });
+```
+
+The decision rule (`docs/common/ai/pattern-development-guide.md`): *if the
+behavior needs different data at different call sites, use `handler()`;
+otherwise use `action()`.* Handlers shine for per-item behavior bound inside
+`.map()` loops and for logic reused across patterns.
+
+Two hard rules, both consequences of compile-time graph construction:
+
+1. **`handler()` and `lift()` must live at module scope.** The compiler
+   cannot lift a handler that closes over pattern-body variables; you'll get
+   an error if you try. (`action()` exists precisely to make the common
+   closure case ergonomic — the compiler does the capture analysis for you.)
+2. **Type annotations on `handler()` are required.** Without them the event
+   and context are `any` *and* the runtime gets no schema for what the
+   handler may read or write.
+
+Either way, what you get back **is a `Stream`** — a stateless channel.
+`boundIncrement.send()` fires it; JSX event attributes accept a stream
+directly (`onClick={decrement}`) or a closure that sends
+(`onClick={() => boundIncrement.send()}`). Returning a stream from the
+pattern exports the behavior: any other piece, test, or CLI invocation can
+call `counter.increment.send()`.
+
+## A complete real pattern
+
+This is `packages/patterns/counter/counter.tsx`, lightly trimmed. It uses
+every concept above; read it top to bottom.
+
+```tsx
+import {
+  action, computed, Default, handler, NAME, pattern, Stream, UI,
+  type VNode, Writable,
+} from "commonfabric";
+
+interface CounterInput {
+  value?: Writable<number | Default<0>>;
+}
+
+interface CounterOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  value: number;
+  increment: Stream<void>;
+  decrement: Stream<void>;
+}
+
+// Module-scope handler: reusable, bound to context at the call site.
+const increment = handler<void, { value: Writable<number> }>(
+  (_, { value }) => {
+    value.set(value.get() + 1);
+  },
+);
+
+// Plain helper — pure functions are fine anywhere.
+function ordinal(n: number): string {
+  const num = n ?? 0;
+  if (num % 10 === 1 && num % 100 !== 11) return `${num}st`;
+  if (num % 10 === 2 && num % 100 !== 12) return `${num}nd`;
+  if (num % 10 === 3 && num % 100 !== 13) return `${num}rd`;
+  return `${num}th`;
+}
+
+const Counter = pattern<CounterInput, CounterOutput>(({ value }) => {
+  // Bind the module-scope handler to this instance's state.
+  const boundIncrement = increment({ value });
+
+  // Pattern-body action: preferred for single-use behavior.
+  const decrement = action(() => {
+    value.set(value.get() - 1);
+  });
+
+  // Derived values.
+  const displayName = computed(() => `Counter: ${value.get()}`);
+  const ordinalDisplay = computed(() => ordinal(value.get()));
+
+  return {
+    [NAME]: displayName,
+    [UI]: (
+      <cf-screen>
+        <cf-vstack gap="3" style="padding: 2rem; align-items: center;">
+          <div style={{ fontSize: "3rem", fontWeight: "bold" }}>{value}</div>
+          <div>Counter is the {ordinalDisplay} number</div>
+          <cf-hstack gap="2">
+            {/* onClick accepts a Stream directly... */}
+            <cf-button variant="secondary" onClick={decrement}>
+              - Decrement
+            </cf-button>
+            {/* ...or a closure that sends explicitly. */}
+            <cf-button variant="primary" onClick={() => boundIncrement.send()}>
+              + Increment
+            </cf-button>
+          </cf-hstack>
+        </cf-vstack>
+      </cf-screen>
+    ),
+    value,
+    increment: boundIncrement,
+    decrement,
+  };
+});
+
+export default Counter;
+```
+
+Things worth noticing:
+
+- `{value}` appears bare in JSX. No `.get()` — JSX expressions are reactive
+  contexts, and the compiler wires the subscription (Chapter 7).
+- The pure helper `ordinal()` is called *inside* a `computed()`. The
+  computed node is the reactive boundary; the helper stays an ordinary
+  function.
+- `value`, `increment`, and `decrement` are all exported. A test (Chapter 6)
+  drives this counter with `counter.increment.send()` and asserts on
+  `counter.value` — no UI involved.
+
+## What patterns may not do
+
+Pattern code runs sandboxed under SES (hardened JavaScript — Chapter 10), so
+some ambient capabilities are deliberately missing: `Date.now()`,
+`Math.random()`, `setTimeout`, `new Proxy()`. Use the provided
+`safeDateNow()` / `nonPrivateRandom()` from inside actions and handlers, and
+express "later" with reactivity rather than timers. Determinism isn't
+pedantry here: the same graph may be re-executed on a server, in another
+browser, or replayed after a conflict retry — nondeterministic body code
+would diverge.
+
+---
+
+**Next:** [Chapter 4 — UI](04-ui.md): giving the graph a face.
+**Under the hood:** how the body-runs-once trick is implemented, and what
+`computed`/`handler` compile into — [Chapter 7](07-compilation.md); how the
+scheduler decides what to re-run — [Chapter 8](08-runtime-internals.md).

--- a/docs/tutorial/04-ui.md
+++ b/docs/tutorial/04-ui.md
@@ -10,9 +10,11 @@ graph-not-render-function distinction actually bites.
 ## The component library: `cf-*`
 
 Patterns build UI from a library of web components (Lit elements, package
-`packages/ui`), all prefixed `cf-`. The authoritative, type-checked list is
-`packages/patterns/catalog/catalog.tsx`, with live usage examples in
-`packages/patterns/catalog/stories/`. The main families:
+`packages/ui`), all prefixed `cf-`. The component source of truth is
+`packages/ui/src/v2/components/`; the type-checked story catalog
+(`packages/patterns/catalog/catalog.tsx`, with live usage examples in
+`packages/patterns/catalog/stories/`) covers most of them and is the best
+place to see real usage. The main families:
 
 - **Inputs:** `cf-button`, `cf-input`, `cf-textarea`, `cf-checkbox`,
   `cf-select`, `cf-slider`, `cf-switch`, `cf-toggle`, `cf-radio`,
@@ -195,6 +197,7 @@ export default pattern<TodoListInput, TodoListOutput>(({ items }) => {
       </cf-screen>
     ),
     items, addItem, removeItem,
+    // (the real file returns a few more fields: itemCount, summary, ...)
   };
 });
 ```

--- a/docs/tutorial/04-ui.md
+++ b/docs/tutorial/04-ui.md
@@ -1,0 +1,224 @@
+# Chapter 4 — UI: Rendering and Binding
+
+A pattern's `[UI]` is a JSX tree. It looks like React, but the semantics
+follow from Chapter 3's rule — the body runs once — so the JSX you write is
+not "what to render now" but "how the rendering depends on state, forever."
+This chapter covers the component library, two-way binding, events, and the
+two rendering structures (conditionals and lists) where the
+graph-not-render-function distinction actually bites.
+
+## The component library: `cf-*`
+
+Patterns build UI from a library of web components (Lit elements, package
+`packages/ui`), all prefixed `cf-`. The authoritative, type-checked list is
+`packages/patterns/catalog/catalog.tsx`, with live usage examples in
+`packages/patterns/catalog/stories/`. The main families:
+
+- **Inputs:** `cf-button`, `cf-input`, `cf-textarea`, `cf-checkbox`,
+  `cf-select`, `cf-slider`, `cf-switch`, `cf-toggle`, `cf-radio`,
+  `cf-autocomplete`, `cf-tags`, `cf-picker`, `cf-calendar`,
+  `cf-message-input`, `cf-prompt-input`, `cf-image-input`, `cf-code-editor`
+- **Layout:** `cf-screen`, `cf-card`, `cf-vstack`/`cf-hstack`,
+  `cf-vgroup`/`cf-hgroup`, `cf-vscroll`/`cf-hscroll`, `cf-grid`,
+  `cf-list-item`, `cf-modal`, `cf-tab-bar`, `cf-toolbar`
+- **Display:** `cf-heading`, `cf-text`, `cf-label`, `cf-chip`, `cf-badge`,
+  `cf-markdown`, `cf-svg`, `cf-separator`, `cf-kbd`, `cf-copy-button`
+- **Feedback:** `cf-progress`, `cf-loader`, `cf-skeleton`, `cf-alert`,
+  `cf-toast`
+- **Data viz:** `cf-chart` (with `cf-line-mark`, `cf-bar-mark`, ...), `cf-map`
+- **Composition:** `cf-render` (render another piece's UI from a cell —
+  bind with `$cell`), `cf-cell-context`
+
+Why a custom library instead of plain HTML? The next section is the answer.
+
+## Two-way binding: the `$` prefix
+
+The defining feature of the component set is that form components bind
+*directly to cells*. Prefix a property with `$` and the component both reads
+and writes the cell — no handler, no state hook:
+
+```tsx
+<cf-input $value={title} />            // text input ⟷ title cell
+<cf-checkbox $checked={item.done} />   // checkbox ⟷ item.done
+<cf-select $value={category} items={CATEGORIES} />
+<cf-modal $open={dialogOpen}> ... </cf-modal>
+```
+
+Combined with `.key()` from Chapter 2, an entire edit form is bindings:
+
+```tsx
+<cf-input $value={item.key("name")} />
+<cf-input $value={item.key("notes")} />
+```
+
+That's a durable, multi-user, conflict-managed form in two lines — each
+keystroke is a cell write, which is a transaction, which syncs (Chapter 9).
+
+Two rules:
+
+- **Native HTML inputs are one-way only.** `<input value={...}>` displays
+  but never writes back. Always use the `cf-*` form components for editable
+  state.
+- **Don't echo the binding.** Adding an `oncf-change` handler that writes
+  the same value back into the `$value` cell creates feedback; the binding
+  *is* the value path. Use change handlers only for dependent side effects.
+
+## Events
+
+Three conventions, all about exact spelling:
+
+- `onClick` (camelCase) on `cf-button`. It accepts a `Stream` directly
+  (`onClick={decrement}`) or a closure (`onClick={() => stream.send(x)}`).
+- Component-specific events use `oncf-` + kebab-case: `oncf-send`
+  (`cf-message-input`, payload `e.detail.message`), `oncf-change`,
+  `oncf-input`, `oncf-remove`, `oncf-keydown`.
+- Component *properties* are camelCase, exactly as typed in the catalog:
+  `<cf-autocomplete allowCustom={true} />` works; `allow-custom` silently
+  does not.
+
+The single most common UI bug in this system is invoking instead of
+passing:
+
+```tsx
+<cf-button onClick={selectItem.send(index)}>   // ❌ fires during render!
+<cf-button onClick={() => selectItem.send(index)}>  // ✅
+```
+
+The wrong version runs `.send()` while the graph is being built/rendered —
+a write during rendering — and produces the infamous
+`non-idempotent raw:map` / "Too many iterations" errors
+(`docs/development/debugging/gotchas/immediate-event-invocation.md`).
+
+## Conditional rendering
+
+Write plain ternaries; the compiler lowers them into reactive nodes:
+
+```tsx
+{show ? <div>Content</div> : null}
+{score >= 90 ? "A" : score >= 80 ? "B" : "C"}
+```
+
+This is the place to understand *why* the obvious alternative is wrong.
+You might think to gate JSX with `computed()`:
+
+```tsx
+// ❌ WRONG — showForm is a Writable object inside the closure
+{computed(() => {
+  if (!adminMode.get()) return null;
+  return <>{showForm ? <div>This ALWAYS renders!</div> : null}</>;
+})}
+```
+
+Inside a `computed()` closure you are in plain JavaScript: `showForm` there
+is the *cell object*, and objects are always truthy, so the inner ternary
+never works. In JSX proper, the compiler rewrites the ternary so the
+condition is the cell's *value*. Hence the rule: **ternaries in JSX,
+`computed()` for data, never `computed()` around JSX.**
+
+There is also an explicit `ifElse(cond, thenVNode, elseVNode)` operator —
+you'll see it in repo patterns — but you rarely need to write it; the
+ternary lowers to it. One known gotcha: feeding `ifElse` a cell taken
+directly off a *composed sub-pattern* can hang the piece; bridge it through
+a local `computed(() => sub.flag)` first
+(`gotchas/ifelse-composed-pattern-cells.md`).
+
+## List rendering
+
+`.map()` on a reactive array (input or `computed()` result) is reactive list
+rendering — and unlike React, no `key` prop is needed; items have identity
+as cells:
+
+```tsx
+const activeItems = computed(() => items.get().filter((i) => !i.done));
+
+const itemCards = activeItems.map((item: TodoItem) => (
+  <TodoItemPiece item={item} removeItem={removeItem} />
+));
+```
+
+For per-item behavior, bind a module-scope `handler()` inside the map
+(`onClick={deleteItem({ index, items })}`) or use a closure that sends.
+Gotchas that matter in practice:
+
+- Avoid nested cell-reads inside nested maps — pre-compute a top-level
+  `computed()` instead (`gotchas/closure-capture-in-nested-map.md`).
+- Reading a `PerSession` cell inside a `computed()` that's nested in a
+  `.map()` over a computed list is silently blocked; read it once at top
+  level and close over the value
+  (`gotchas/persession-read-in-mapped-computed.md`).
+- Scoped cells are `undefined` until first sync — guard render-path reads
+  with `?? []` (`gotchas/scoped-cell-pitfalls.md`).
+
+## A complete example: the todo list
+
+`packages/patterns/todo-list/todo-list.tsx` exercises everything in this
+chapter. Excerpted (the full file also defines `TodoItemPiece` and a
+completed-item variant as sub-patterns — Chapter 5 covers composition):
+
+```tsx
+export default pattern<TodoListInput, TodoListOutput>(({ items }) => {
+  const addItem = action(({ title }: { title: string }) => {
+    const trimmed = title.trim();
+    if (trimmed) items.push({ title: trimmed, done: false });
+  });
+  const removeItem = action(({ item }: { item: TodoItem }) => {
+    items.remove(item);
+  });
+
+  const activeItems = computed(() => items.get().filter((i) => !i.done));
+  const completedItems = computed(() => items.get().filter((i) => i.done));
+  const hasCompleted = computed(() => completedItems.length > 0);
+
+  const itemCards = activeItems.map((item: TodoItem) => (
+    <TodoItemPiece item={item} removeItem={removeItem} />
+  ));
+
+  return {
+    [NAME]: computed(() => `Todo List (${items.get().length})`),
+    [UI]: (
+      <cf-screen>
+        <cf-vscroll flex showScrollbar fadeEdges>
+          <cf-vstack gap="2" style="padding: 1rem;">
+            {itemCards}
+            {ifElse(hasCompleted, <details>{/* completed section */}</details>, null)}
+          </cf-vstack>
+        </cf-vscroll>
+        <cf-hstack slot="footer" gap="2" style="padding: 1rem;">
+          <cf-message-input
+            placeholder="Add a todo item..."
+            oncf-send={(e: { detail?: { message?: string } }) => {
+              const title = e.detail?.message?.trim();
+              if (title) addItem.send({ title });
+            }}
+          />
+        </cf-hstack>
+      </cf-screen>
+    ),
+    items, addItem, removeItem,
+  };
+});
+```
+
+And the sub-pattern rendering one item is two bindings and a button:
+
+```tsx
+<cf-card>
+  <cf-hstack gap="2" align="center">
+    <cf-checkbox $checked={item.done} />
+    <cf-input $value={item.title} style="flex: 1;" />
+    <cf-button variant="ghost" onClick={() => removeItem.send({ item })}>x</cf-button>
+  </cf-hstack>
+</cf-card>
+```
+
+Trace the checkbox once more, now with full vocabulary: `$checked` writes
+`item.done` → the `activeItems` and `completedItems` computeds re-run → the
+two `.map()`s update → the card moves sections — locally at once, and on
+every other subscribed client after the commit round-trips.
+
+---
+
+**Next:** [Chapter 5 — Composition, pieces, and capabilities](05-composition-and-pieces.md).
+**Under the hood:** how JSX becomes graph nodes and why ternaries lower —
+[Chapter 7](07-compilation.md); how the shell turns VNodes into live DOM —
+[Chapter 11](11-deployed-system.md).

--- a/docs/tutorial/05-composition-and-pieces.md
+++ b/docs/tutorial/05-composition-and-pieces.md
@@ -64,8 +64,7 @@ a human **slug** for URLs. In the shell, `/{spaceName}/{pieceIdOrSlug}` shows
 a piece's UI.
 
 > Legacy naming: pieces are called **charms** in older code
-> (`background-charm-service`), and patterns **recipes** in the builder
-> internals. Same concepts.
+> (`background-charm-service`, `BGCharmEntry`, ...). Same concept.
 
 ## Linking pieces
 
@@ -95,8 +94,8 @@ For drill-down flows (list → detail), a handler can return
 `navigateTo` with a freshly-instantiated pattern creates the detail piece
 and navigates the shell to it; with an existing piece it just navigates.
 The canonical list/detail example is `packages/patterns/reading-list/` —
-the detail pattern receives a `Writable<Item>` and edits fields via
-`.key()` bindings.
+the detail pattern receives each editable field as a `Writable<>` input and
+binds them directly with `$value`.
 
 ## Capability: LLM calls
 
@@ -109,7 +108,8 @@ const response = generateText({
   prompt: userInput,                       // reactive — re-runs when it changes
   system: "You are a helpful assistant.",
 });
-// response: { result: string, error: string, pending: boolean }
+// response: { pending: boolean, result?: string, error?: unknown,
+//             partial?: string /* streaming text so far */ }
 
 {response.pending ? <cf-loader /> : <cf-markdown>{response.result}</cf-markdown>}
 ```
@@ -133,7 +133,8 @@ const itemsWithAisles = items.map((item) => {
 
 Model names must be `vendor:model` (e.g. `"anthropic:claude-sonnet-4-5"`,
 `"openai:gpt-4o"`); a malformed name fails with an unhelpful `TypeError`.
-Pass `cache: false` to force regeneration.
+`generateObject` accepts `cache: false` to force regeneration
+(`generateText` is always cached per distinct input).
 
 Think about what this composition means: an LLM call whose *prompt is a
 reactive function of durable shared state*, whose result is durable shared

--- a/docs/tutorial/05-composition-and-pieces.md
+++ b/docs/tutorial/05-composition-and-pieces.md
@@ -1,0 +1,159 @@
+# Chapter 5 — Composition, Pieces, and Capabilities
+
+So far we've built single programs. The point of Common Fabric, though, is
+*networks* of programs: patterns composing into bigger patterns, and
+deployed pieces linking to each other through shared cells. This chapter
+covers composition inside one source file, the piece lifecycle, linking
+across pieces, navigation, and the built-in LLM capability.
+
+## Composing patterns in source
+
+A pattern instantiates another pattern by calling it — as a function or as
+JSX (equivalent; the runtime extracts `[UI]` from the result):
+
+```tsx
+{items.map((item) => ItemCard({ item }))}
+{items.map((item) => <ItemCard item={item} />)}
+```
+
+What gets passed down is **the cell, not a copy**. In the todo list
+(Chapter 4), `TodoItemPiece` receives the `item` cell; when its checkbox
+writes `item.done`, the parent's computeds see it — there is no
+prop-drilling/state-lifting dance because there is no ownership boundary:
+both patterns are graphs over the same cells. Streams pass the same way
+(`removeItem` is sent down so the child can ask the parent to remove it).
+
+The contract for a composable child: its `Output` must include
+`[NAME]: string` and `[UI]: VNode` if the parent will render it. And the
+wiring is **by exact field name** — the child's input names must match what
+you pass; there is no automatic mapping.
+
+Two cautions, both compiler-rooted (Chapter 7):
+
+- Pattern inputs are cell proxies, so spreading them (`{...extraTools}`) is
+  a silent no-op; merge inside a `computed()` instead.
+- If a value passed to a child came from *another* composed pattern, bridge
+  it through a local `computed()` before using it in `ifElse` (Chapter 4's
+  gotcha).
+
+Passing a plain value to a child input creates fresh state owned by that
+instance; passing a cell shares state. The same `Counter` pattern can be ten
+independent counters or ten views of one counter, depending only on what the
+parent passes.
+
+## Pieces: patterns, deployed
+
+A **pattern** is source code — a template. A **piece** is an instance of a
+pattern living in a space. Instantiation (via `cf piece new`, the shell, or
+another piece) does roughly this (see `packages/piece/src/manager.ts`):
+
+1. The pattern source is compiled and registered, so the space knows the
+   program (not just its output).
+2. An **argument cell** is created to hold the piece's inputs, and a
+   **result cell** to hold what the pattern returns; metadata links the
+   piece to its pattern source.
+3. The piece is added to the space's piece list (the space's default
+   pattern maintains `allPieces` and exposes an `addPiece` stream — note,
+   even space management is "just a pattern").
+4. From then on, any runtime that opens the space can load the piece: the
+   pattern graph is re-instantiated over the argument cell, and the result
+   (including `[UI]`) flows from there.
+
+A piece is identified by an entity id (a hash, e.g. `bafy...`) and can carry
+a human **slug** for URLs. In the shell, `/{spaceName}/{pieceIdOrSlug}` shows
+a piece's UI.
+
+> Legacy naming: pieces are called **charms** in older code
+> (`background-charm-service`), and patterns **recipes** in the builder
+> internals. Same concepts.
+
+## Linking pieces
+
+Because a piece's inputs and outputs are cells, you can wire *deployed*
+pieces together after the fact:
+
+```bash
+deno task cf piece link <editor-piece-id>/items <viewer-piece-id>/items
+```
+
+This points the viewer's `items` input at the editor's `items` output — the
+same cell-sharing as in-source composition, but done at runtime between
+independently deployed programs. Under the hood it writes a **link** (a
+serialized cell reference) into the viewer's argument cell; the runtime
+resolves links transparently on read (Chapter 8). This is the payoff of the
+whole design: integration between programs is a pointer, not an API project.
+
+## Navigation
+
+For drill-down flows (list → detail), a handler can return
+`navigateTo(somePiece)`:
+
+```tsx
+<cf-button onClick={() => navigateTo(ItemDetail({ item }))}>Edit</cf-button>
+```
+
+`navigateTo` with a freshly-instantiated pattern creates the detail piece
+and navigates the shell to it; with an existing piece it just navigates.
+The canonical list/detail example is `packages/patterns/reading-list/` —
+the detail pattern receives a `Writable<Item>` and edits fields via
+`.key()` bindings.
+
+## Capability: LLM calls
+
+Patterns can call language models declaratively — `generateText` /
+`generateObject` are *reactive nodes*, not awaited promises
+(`docs/common/capabilities/llm.md`):
+
+```tsx
+const response = generateText({
+  prompt: userInput,                       // reactive — re-runs when it changes
+  system: "You are a helpful assistant.",
+});
+// response: { result: string, error: string, pending: boolean }
+
+{response.pending ? <cf-loader /> : <cf-markdown>{response.result}</cf-markdown>}
+```
+
+The request flows through the server's LLM proxy (Toolshed — Chapter 11),
+results are cached per distinct input, and `pending`/`error`/`result` are
+just cells your UI binds to. A real use from
+`packages/patterns/shopping-list.tsx` — note it's *inside a `.map()`*, one
+cached classification per item:
+
+```tsx
+const itemsWithAisles = items.map((item) => {
+  const aisleResult = generateObject<AisleResult>({
+    system: "You are a grocery store assistant. ...respond with one of the exact locations...",
+    prompt: `Store layout:\n${effectiveLayout}\n\nItem: ${item.title}\n...`,
+    model: "anthropic:claude-haiku-4-5",
+  });
+  return { item, aisle: aisleResult };
+});
+```
+
+Model names must be `vendor:model` (e.g. `"anthropic:claude-sonnet-4-5"`,
+`"openai:gpt-4o"`); a malformed name fails with an unhelpful `TypeError`.
+Pass `cache: false` to force regeneration.
+
+Think about what this composition means: an LLM call whose *prompt is a
+reactive function of durable shared state*, whose result is durable shared
+state, inside a list comprehension, synced to every user of the space. That
+sentence is the product.
+
+## Background execution
+
+A piece can keep working with no browser open. A pattern that exposes a
+`bgUpdater` stream (or registers via the `cf-updater` component) gets picked
+up by the **background piece service**, which polls registered pieces (every
+60 s by default) and sends to that stream server-side — same graph, same
+cells, headless executor (details in Chapter 11). This is how "summarize my
+feed every morning" works without anyone keeping a tab open.
+
+---
+
+**Next:** [Chapter 6 — The development workflow](06-workflow.md): actually
+building, deploying, and testing.
+**Under the hood:** what links physically are and how cross-piece reactivity
+syncs — [Chapters 8](08-runtime-internals.md) and
+[9](09-storage-and-sync.md); how the server runs pieces —
+[Chapter 11](11-deployed-system.md).

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -1,0 +1,160 @@
+# Chapter 6 — The Development Workflow
+
+You now know the language; this chapter is the toolchain. The loop is:
+**sketch → check → deploy → drive → test**, all through the `cf` CLI
+(run as `deno task cf ...` from the repo root). Keep this chapter open while
+you build your first pattern.
+
+## Check: the fast inner loop
+
+```bash
+deno task cf check pattern.tsx                 # compile + execute once (quiet on success)
+deno task cf check pattern.tsx --no-run        # typecheck only (fastest)
+deno task cf check pattern.tsx --show-transformed   # print the compiled output
+deno task cf check pattern.tsx --verbose-errors     # more error context
+```
+
+`cf check` runs the full compiler pipeline (Chapter 7) and instantiates the
+pattern once, so it catches both type errors and graph-construction errors
+("reactive reference outside context", handlers in the wrong scope, ...).
+`--show-transformed` is your X-ray: when behavior is mysterious, look at
+what your source actually compiled into before theorizing.
+
+## Set up identity and server
+
+You need a running server and a key. For a local server, see
+`docs/development/LOCAL_DEV_SERVERS.md` (short version: there's a task that
+runs Toolshed on `localhost:8000`; use `dev-local` for the shell, not
+`dev`). Then:
+
+```bash
+# Derive a deterministic dev key. Use `id derive`, NOT `id new > file` —
+# the latter pollutes the key file with ANSI output.
+deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
+
+export CF_IDENTITY=./cf.key
+export CF_API_URL=http://localhost:8000
+```
+
+Every piece command below takes `-i/--identity`, `-a/--api-url`,
+`-s/--space` — or reads them from `CF_IDENTITY`, `CF_API_URL`, and a `-s`
+space name. (What the key actually is, and how a space name becomes a DID,
+is Chapter 10.)
+
+## Deploy and iterate
+
+```bash
+# First deploy only — SAVE THE PRINTED PIECE ID
+deno task cf piece new pattern.tsx -s myspace
+
+# Every iteration after that: update the SAME piece in place
+deno task cf piece setsrc pattern.tsx --piece bafyreia... -s myspace
+```
+
+The most common workflow mistake is rerunning `piece new` after each edit —
+that creates a new piece every time, and your space fills with stale
+duplicates. `new` once, `setsrc` forever after.
+
+## Drive a deployed piece from the CLI
+
+Everything a pattern exports (Chapter 3) is drivable without a browser:
+
+```bash
+deno task cf piece ls -s myspace                       # list pieces
+deno task cf piece inspect --piece <ID>                # dump structure/state
+deno task cf piece get --piece <ID> items              # read one exported field
+deno task cf piece call addItem '{"title": "Test"}' --piece <ID>   # send to a stream
+echo '"hello"' | deno task cf piece set --piece <ID> title          # write a field
+deno task cf piece step --piece <ID>                   # force recompute
+deno task cf piece view --piece <ID>                   # render the UI in the terminal
+deno task cf piece link <srcID>/items <dstID>/items    # wire two pieces
+deno task cf piece set-slug myslug <ID>                # pretty URL
+```
+
+One subtlety: `piece set` writes the cell but doesn't trigger recompute —
+follow it with `piece step`. (`piece call` does both.)
+
+This CLI surface is also exactly how *agents* drive the system — same
+streams, same cells. The browser shell is just one more client.
+
+## Testing patterns
+
+Tests are patterns that test patterns: instantiate the subject, alternate
+`action` steps and `computed(() => boolean)` assertions, and return them as
+a `tests` array. From `packages/patterns/counter/counter.test.tsx`:
+
+```tsx
+import { action, computed, pattern } from "commonfabric";
+import Counter from "./counter.tsx";
+
+export default pattern(() => {
+  const counter = Counter({});
+
+  const action_increment = action(() => {
+    counter.increment.send();
+  });
+
+  const assert_initial_value_is_0 = computed(() => counter.value === 0);
+  const assert_value_is_1 = computed(() => counter.value === 1);
+
+  return {
+    tests: [
+      { assertion: assert_initial_value_is_0 },
+      { action: action_increment },
+      { assertion: assert_value_is_1 },
+    ],
+    counter, // exposed for debugging
+  };
+});
+```
+
+```bash
+deno task cf test packages/patterns/counter/counter.test.tsx --verbose
+deno task cf test packages/patterns/my-pattern/      # all tests in a directory
+```
+
+Notice what makes the subject *testable*: dual type parameters on
+`pattern<Input, Output>()` and exported `Stream<T>` actions. That's why
+Chapter 3 insisted on them. Keep assertions deterministic — no
+`safeDateNow()` or randomness inside them. The guidance from the canonical
+guide: primary verification is still runtime behavior; write tests for
+logic that's awkward or expensive to verify by clicking.
+
+## The gotcha checklist
+
+Before your first deploy, scan your pattern against the ten most common
+failures (each links to a full writeup under
+`docs/development/debugging/gotchas/` or the development guide):
+
+1. **`computed()` gating JSX** — cells are truthy objects inside the
+   closure; use ternaries in JSX instead.
+2. **Writing upstream cells inside `computed()`** — reactive cycle;
+   derivation in computeds, mutation in actions.
+3. **Echoing a `$value` binding from its own change handler** — feedback
+   loop; the binding is the value path.
+4. **`handler()`/`lift()` inside the pattern body** — must be module scope;
+   use `action()` for closures.
+5. **`new Writable(reactiveValue)`** — initialize with statics; copy from
+   inputs inside an action.
+6. **`onClick={stream.send(x)}`** — invokes during render; pass
+   `() => stream.send(x)`.
+7. **Storing a cell reference to mark selection** — link resolution makes
+   `.set()` write *through* to the item; box it: `selected.set({ item })`.
+8. **`ifElse` on a composed pattern's cell** — hangs; bridge through a local
+   `computed()`.
+9. **`Date.now()` / `Math.random()` / `setTimeout` / `new Proxy()`** — not
+   available under SES; use `safeDateNow()` / `nonPrivateRandom()` in
+   handlers only.
+10. **Unguarded scoped-cell reads while rendering** — `PerSession` cells are
+    `undefined` until first sync; guard with `?? []`.
+
+When something still goes wrong: `docs/development/debugging/` has the error
+reference, and the repo-local `pattern-critic` agent/skill reviews a pattern
+against the full rule list mechanically.
+
+---
+
+This closes Part I — you can now build, deploy, link, and test patterns.
+**Part II begins with [Chapter 7 — From TypeScript to a runnable
+graph](07-compilation.md):** what actually happens when `cf check` compiles
+your file.

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -71,8 +71,13 @@ deno task cf piece link <srcID>/items <dstID>/items    # wire two pieces
 deno task cf piece set-slug myslug <ID>                # pretty URL
 ```
 
-One subtlety: `piece set` writes the cell but doesn't trigger recompute —
-follow it with `piece step`. (`piece call` does both.)
+One subtlety: neither `piece set` nor `piece call` refreshes *computed*
+outputs. `set` writes the cell without running anything; `call` runs the
+handler (so the handler's own writes land and sync), but the scheduler is
+lazy — derived values recompute only when something observes them
+(Chapter 8), and nothing in the ephemeral CLI session does. Run
+`cf piece step --piece <ID>` — which pulls the piece, forcing
+recomputation — before inspecting computed fields with `get`/`inspect`.
 
 This CLI surface is also exactly how *agents* drive the system — same
 streams, same cells. The browser shell is just one more client.

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -138,13 +138,14 @@ failures (each links to a full writeup under
    inputs inside an action.
 6. **`onClick={stream.send(x)}`** — invokes during render; pass
    `() => stream.send(x)`.
-7. **Storing a cell reference to mark selection** — link resolution makes
-   `.set()` write *through* to the item; box it: `selected.set({ item })`.
+7. **Storing a cell reference to mark selection** — later writes can land on
+   the referenced item (sub-path writes and pattern bindings follow links)
+   instead of changing the selection; box it: `selected.set({ item })`.
 8. **`ifElse` on a composed pattern's cell** — hangs; bridge through a local
    `computed()`.
 9. **`Date.now()` / `Math.random()` / `setTimeout` / `new Proxy()`** — not
    available under SES; use `safeDateNow()` / `nonPrivateRandom()` in
-   handlers only.
+   handlers or one-time initialization, never in `computed()`/`lift()`.
 10. **Unguarded scoped-cell reads while rendering** — `PerSession` cells are
     `undefined` until first sync; guard with `?? []`.
 

--- a/docs/tutorial/07-compilation.md
+++ b/docs/tutorial/07-compilation.md
@@ -43,7 +43,9 @@ expression like `{price - discount}` is rewritten into a module-scope
 `lift()` node (`__cfLift_1`) with schemas for its inputs and output — this
 is precisely why plain ternaries in JSX "just work" reactively (Chapter 4)
 while the same ternary inside a `computed()` body is plain JavaScript: the
-transformer rewrites JSX sites, not closure bodies.
+transformer lowers JSX expression sites into reactive nodes, while a
+closure's body logic stays plain JavaScript (only its captures are
+rewritten, as described next).
 
 **Closure reification** (`ClosureTransformer`,
 `PatternCallbackLowering`, `BuilderCallbackHoisting`,
@@ -82,10 +84,10 @@ one handles the branded wrapper types:
 |---|---|
 | `number` | `{ type: "number" }` |
 | `Cell<T>` / `Writable<T>` | schema of `T` + `asCell: ["cell"]` |
-| `Stream<T>` | schema of `T` + `asCell: ["stream", "cell"]` |
+| `Stream<T>` | schema of `T` + `asCell: ["stream"]` |
 | `OpaqueRef<T>` | schema of `T` + `asCell: ["opaque"]` |
 | `T \| Default<V>` | schema of `T` + `default: V` |
-| `PerSpace<T>` / `PerUser<T>` / `PerSession<T>` | schema of `T` + `scope: "space" \| "user" \| "session"` |
+| `PerSpace<T>` / `PerUser<T>` / `PerSession<T>` | schema of `T` + `scope: "space" \| "user" \| "session"` (folded into the `asCell` entry when the inner type is cell-wrapped) |
 
 So the "phantom" types of Part I are real after all — each becomes a schema
 annotation the runtime reads: `asCell` tells the runtime to pass a cell
@@ -153,15 +155,17 @@ placeholder, not a number.
 
 ## Identity and caching: `implementationRef`
 
-Each node's code carries an `implementationRef` — a stable identity for the
-implementation (e.g. `"main.tsx#000:handler"`: file, position, export). It
-serves three masters:
+Each node's code carries an `implementationRef` — a stable, content-derived
+identity for the implementation (minted from the function's source, kind,
+and position; trusted host functions get reserved refs). It serves three
+masters:
 
 - **Caching**: compiled functions are cached by ref
   (`packages/runner/src/function-cache.ts`), so re-loading a piece doesn't
   recompile unchanged nodes.
 - **Stable scheduling**: the scheduler identifies actions across re-runs by
-  ref.
+  a content-addressed implementation fingerprint (the implementation hash,
+  falling back to source location).
 - **Provenance**: verified-source tracking ties running code back to the
   exact source that produced it (this also feeds the CFC
   confidential-computing work you'll see in `packages/patterns/cfc-*`).

--- a/docs/tutorial/07-compilation.md
+++ b/docs/tutorial/07-compilation.md
@@ -1,0 +1,190 @@
+# Chapter 7 — From TypeScript to a Runnable Graph
+
+Part I kept repeating two suspicious claims: "the body runs once" and "your
+types matter at runtime." Neither is something stock TypeScript can do —
+types are erased at compile time, and closures don't survive serialization.
+This chapter explains the machinery that makes both true: a custom compiler
+pipeline that rewrites pattern source before it ever executes.
+
+## Why a compiler is non-negotiable
+
+Recall what the runtime needs from a pattern (Chapters 1–3):
+
+1. **Schemas.** Reactivity is *subscription to queries defined by schemas*.
+   When a piece loads, the runtime must know which documents and which paths
+   inside them to sync — before running any user code. That information is
+   in your TypeScript types (`Writable<number | Default<0>>`), which
+   ordinarily vanish at compile time.
+2. **A serializable graph.** A piece's program must be re-instantiable by a
+   server or another browser from stored data. Closures over local variables
+   can't be stored; graph nodes with explicit inputs can.
+3. **Safety.** Pattern code is untrusted; the emitted code must be amenable
+   to sandboxing (frozen functions, no ambient authority — Chapter 10).
+
+So the pipeline's job is: **reify types into JSON schemas, reify closures
+into explicit graph nodes, and harden the result.**
+
+## The pipeline
+
+`packages/ts-transformers/src/cf-pipeline.ts` defines ~19 transformer stages
+that run in strict order over the TypeScript AST. You don't need to know
+all of them; you need the five jobs they implement:
+
+**Validation** (early stages — `CastValidation`, `OpaqueGetValidation`,
+`PatternContextValidation`, ...): reject things that cannot work at
+runtime, at compile time — e.g. `.get()` calls in invalid positions, or
+malformed pattern context usage. Many "framework rules" from Part I are
+enforced here, which is why violations are compile errors rather than weird
+runtime behavior.
+
+**JSX lowering** (`JsxExpressionSiteRouter`, `LiftLowering`): every dynamic
+expression site in JSX is routed to a lowering strategy. A multi-value
+expression like `{price - discount}` is rewritten into a module-scope
+`lift()` node (`__cfLift_1`) with schemas for its inputs and output — this
+is precisely why plain ternaries in JSX "just work" reactively (Chapter 4)
+while the same ternary inside a `computed()` body is plain JavaScript: the
+transformer rewrites JSX sites, not closure bodies.
+
+**Closure reification** (`ClosureTransformer`,
+`PatternCallbackLowering`, `BuilderCallbackHoisting`,
+`BuilderCallHoisting`): callbacks that conceptually close over pattern
+state — `action()` bodies, `.map()` callbacks — are analyzed; their
+captured variables become explicit, schema-described inputs, and the
+callbacks are hoisted to module scope. A `.map()` over items becomes a
+mapping *node* whose closure travels with a schema of what it captures.
+This is the trick behind `action()`: you write a closure, the compiler
+turns it into the same shape as a module-scope `handler()`.
+
+**Schema injection** (`SchemaInjection`, `SchemaGenerator`): type arguments
+on `pattern<I, O>()`, `handler<E, C>()`, and the lowered lifts are replaced
+by generated JSON schemas (next section). A `TypeRegistry`
+(`WeakMap<Node, Type>`) threads type information across stages so that
+schemas can still be generated for synthetic nodes the earlier stages
+created.
+
+**Hardening** (`ModuleScopeFunctionHardening` and friends): emitted
+module-scope functions get `Object.freeze()` and the module is shaped for
+the SES sandbox.
+
+You can watch all of this on any file:
+
+```bash
+deno task cf check pattern.tsx --show-transformed --no-run
+```
+
+## Types → JSON schemas
+
+The `schema-generator` package walks TypeScript types with a chain of
+formatters (`packages/schema-generator/src/`); the Common Fabric–specific
+one handles the branded wrapper types:
+
+| You write | Schema emitted |
+|---|---|
+| `number` | `{ type: "number" }` |
+| `Cell<T>` / `Writable<T>` | schema of `T` + `asCell: ["cell"]` |
+| `Stream<T>` | schema of `T` + `asCell: ["stream", "cell"]` |
+| `OpaqueRef<T>` | schema of `T` + `asCell: ["opaque"]` |
+| `T \| Default<V>` | schema of `T` + `default: V` |
+| `PerSpace<T>` / `PerUser<T>` / `PerSession<T>` | schema of `T` + `scope: "space" \| "user" \| "session"` |
+
+So the "phantom" types of Part I are real after all — each becomes a schema
+annotation the runtime reads: `asCell` tells the runtime to pass a cell
+handle (write-capable) instead of a plain value; `default` fills missing
+documents; `scope` selects the storage partition (Chapter 9).
+
+A real before/after, from the transformer test fixtures
+(`packages/ts-transformers/test/fixtures/handler-schema/simple-handler.input.tsx`
+and its `.expected.jsx`):
+
+```tsx
+// You write:
+const myHandler = handler<CounterEvent, CounterState>((event, state) => {
+  state.value.set(state.value.get() + event.increment);
+});
+
+// The compiler emits:
+const myHandler = handler({
+  type: "object",
+  properties: { increment: { type: "number" } },
+  required: ["increment"],
+}, {
+  type: "object",
+  properties: { value: { type: "number", asCell: ["cell"] } },
+  required: ["value"],
+}, (event, state) => {
+  state.value.set(state.value.get() + event.increment);
+});
+```
+
+The generics are gone; in their place are two schemas — what the event looks
+like, and what state the handler touches (with `asCell` marking write
+access). At runtime these schemas are the handler's *capability
+declaration*: they bound what gets subscribed, what gets passed in, and what
+it can write.
+
+## What `pattern()` builds: the graph object
+
+After transformation, executing the module is cheap and safe: calling
+`pattern(inputSchema, outputSchema, fn)` and then instantiating it runs the
+body **once** inside a tracking frame (`packages/runner/src/builder/`).
+Every `computed`/`lift`/`handler`/sub-pattern call registers a node; the
+result is a frozen, serializable description
+(`packages/runner/src/builder/types.ts`):
+
+```ts
+Pattern {
+  argumentSchema, resultSchema,   // the generated schemas
+  nodes: Node[],                  // the graph
+  result,                         // shape of the output, with links into nodes
+}
+Node {
+  module: { type: "javascript" | "pattern" | "raw" | "isolated" | ...,
+            implementation, implementationRef, ... },
+  inputs, outputs,                // value trees containing cell links
+}
+```
+
+During body execution your "values" are `OpaqueRef`s — proxies that record
+operations like `.key()` chains instead of performing them. That's the
+body-runs-once trick demystified: the body manipulates *placeholders*, and
+real data only flows later, when the scheduler executes nodes (Chapter 8).
+It's also why `if (count > 3)` in the body can't work — `count` is a
+placeholder, not a number.
+
+## Identity and caching: `implementationRef`
+
+Each node's code carries an `implementationRef` — a stable identity for the
+implementation (e.g. `"main.tsx#000:handler"`: file, position, export). It
+serves three masters:
+
+- **Caching**: compiled functions are cached by ref
+  (`packages/runner/src/function-cache.ts`), so re-loading a piece doesn't
+  recompile unchanged nodes.
+- **Stable scheduling**: the scheduler identifies actions across re-runs by
+  ref.
+- **Provenance**: verified-source tracking ties running code back to the
+  exact source that produced it (this also feeds the CFC
+  confidential-computing work you'll see in `packages/patterns/cfc-*`).
+
+The `js-compiler` package does the actual TypeScript-to-JS emission in two
+modes: **bundle** (one AMD bundle — how pattern programs are packaged for
+execution) and **modules** (per-file CommonJS — used by the module-record
+loader/verifier). Compilation results are cached server-side too (Toolshed's
+compilation cache), so opening a piece doesn't recompile it per client.
+
+## Where compiled code runs
+
+Compiled pattern code executes inside an SES (hardened JavaScript)
+environment in the runtime's process — that's the "no `Date.now()`" rule
+from Chapter 3. For fully untrusted *rendered* content there's a second,
+stronger boundary: `packages/iframe-sandbox` runs guest HTML/JS inside a
+double iframe (an outer `srcdoc` iframe that pins a strict
+Content-Security-Policy, enclosing an inner iframe with the guest code),
+with all data access mediated by a postMessage IPC protocol
+(read/write/subscribe/LLM request). Chapter 10 covers the security model in
+full.
+
+---
+
+**Next:** [Chapter 8 — The reactive runtime](08-runtime-internals.md): how
+the graph the compiler built actually executes.

--- a/docs/tutorial/08-runtime-internals.md
+++ b/docs/tutorial/08-runtime-internals.md
@@ -1,0 +1,144 @@
+# Chapter 8 — The Reactive Runtime
+
+Chapter 7 ended with a frozen graph object. This chapter is about the
+machine that runs it: what a `Cell` really is, how the scheduler decides
+what to re-execute, and how writes become transactions. This is the heart of
+the system — `packages/runner` (with public types in `packages/api`).
+
+## What a Cell actually is
+
+A `Cell` (`packages/runner/src/cell.ts`) holds no data. It is a **typed
+pointer plus a transaction context**:
+
+```
+Cell = {
+  link: { space, id, path, schema },   // a NormalizedLink — WHERE and WHAT SHAPE
+  tx,                                  // which transaction reads/writes go through
+  ...                                  // kind: cell | stream | readonly | ...
+}
+```
+
+- `space` — the DID of the space the document lives in.
+- `id` — the entity id (`of:<hash>` URI) of the document.
+- `path` — a property path *within* the document (`["items", 2, "title"]`).
+- `schema` — the JSON schema (from Chapter 7) describing what's expected at
+  that path — including `asCell`/`default`/`scope` annotations.
+
+Every cell operation is now obvious from the shape: `.key("title")` returns
+a sibling cell with one more path segment and the narrowed schema.
+`.asSchema()` reinterprets the same location under a different schema.
+`.get()` resolves the link against the local replica of the space *through
+the current transaction*. Path-granular reactivity (Chapter 2) falls out:
+dependencies are recorded as (id, path) pairs, so writing `item.done`
+doesn't disturb readers of `item.title`.
+
+Entity ids are content-derived: `createRef(source, cause)` hashes the
+creation context (`packages/runner/src/create-ref.ts`), so the "same" cell
+created by the same graph node gets the same id deterministically — which is
+what lets a server re-instantiate a piece and arrive at the same cells.
+
+**Links between documents** are stored as serializable references (sigil
+links: `{ "/": { documentId, path, ... } }`). When a read encounters one, it
+resolves through to the target — transparently crossing documents and even
+spaces. This is the mechanism behind `cf piece link` (Chapter 5), and also
+behind the "selection" gotcha (Chapter 6, #7): writing to a cell that
+*contains* a link writes through to the link's target, by design.
+
+## The scheduler: reads are subscriptions, literally
+
+The runtime's event loop is the scheduler
+(`packages/runner/src/scheduler.ts`). Every graph node — each `computed`,
+`lift`, handler, render binding — is an **action**. The cycle:
+
+1. **Run inside a transaction.** Each action executes with a fresh
+   transaction whose journal records every (space, id, path) it read — the
+   *reactivity log*. No annotations needed; reading through the transaction
+   is what subscribes you.
+2. **Commit.** The transaction's writes are applied (next section).
+3. **Re-subscribe.** The action's actual read-set replaces its old one. The
+   scheduler maintains a reverse index — "this (id, path) is read by these
+   actions" — so dependencies follow the data the action *really* touched
+   this run, branch by branch.
+4. **React.** When any write lands (locally, or arriving from the server —
+   the scheduler doesn't care), the index marks the affected actions dirty
+   and queues them.
+
+Two execution strategies exist (`scheduler/pull-execution.ts`,
+`push-execution.ts`): **push** re-runs anything dirty immediately; **pull**
+(the default) is lazy — only computations that something observable (a UI
+sink, an effect, an explicit `.pull()`) depends on get re-run, so an
+unobserved derived value costs nothing.
+
+Cycles and pathologies are contained by bounded iteration — an action that
+keeps dirtying itself (e.g. a `computed` that writes upstream, gotcha #2)
+gets cut off with the "Too many iterations" error rather than hanging the
+runtime.
+
+The dirtying machinery is also why *remote* changes feel local: a synced
+update from another user lands in the replica as a write notification, hits
+the same trigger index, and re-runs the same actions. The pattern code
+cannot tell the difference.
+
+## Transactions: atomicity and optimism
+
+Every action runs in an `IExtendedStorageTransaction`
+(`packages/runner/src/storage/`):
+
+- **Reads** go through the transaction so they (a) see a consistent
+  snapshot plus the transaction's own pending writes, and (b) get journaled
+  for reactivity and conflict detection.
+- **Writes** are buffered in the journal, not applied. A transaction may
+  write to **one space** (reads may span spaces).
+- **Commit** applies the writes to the local replica *optimistically* —
+  subscribers re-run immediately — and ships them to the server
+  asynchronously (Chapter 9).
+
+If the server later rejects the commit (someone else won a race), the
+replica rolls the optimistic writes back, emits a `revert` notification
+(dependents re-run with the restored state), and the runtime retries the
+action against fresh data (`Runtime.editWithRetry`; the scheduler retries
+reactive actions a bounded number of times). This is the mechanism behind
+the Part I promise "optimistic but converge; you may see a write lose and
+re-apply."
+
+Note the layering discipline: the scheduler only knows "transactions commit
+or conflict"; *how* conflicts are detected is entirely the storage layer's
+business (Chapter 9). That separation is what lets the same runtime run
+against an in-process store (tests, CLI) or a remote server, unchanged.
+
+## Executing a pattern graph
+
+Instantiating a piece (`packages/runner/src/runner.ts` and `builder/`) ties
+the previous three sections together:
+
+1. The pattern's `argumentSchema` is applied to the argument cell — this is
+   where `default:` values materialize and `asCell` decides whether a node
+   receives a value or a writable handle.
+2. Each `Node` in the graph becomes a scheduled action: `javascript` nodes
+   (lifts/computeds/handlers) wrap their compiled implementation (fetched
+   via the `implementationRef` function cache); `pattern` nodes recurse into
+   sub-patterns; `isolated` nodes run in the stronger sandbox.
+3. Handler nodes register as **stream** consumers: nothing runs until
+   something `.send()`s to the stream; then the handler executes as a
+   one-shot action with the event as input, in its own transaction.
+4. The `result` tree is written so the piece's result cell contains links to
+   the right internal cells — which is why other pieces can link to a
+   piece's outputs (Chapter 5): the outputs *are* addressable cells.
+
+There's no diffing and no re-render pass anywhere in this story. The UI
+(Chapter 11) is just one more subscriber: a VNode tree whose dynamic slots
+are cells, with a renderer that patches the DOM when those cells change.
+
+## Spaces in the runtime
+
+The runtime's `StorageManager` opens one **provider per space**, each
+wrapping a local **replica** (confirmed state + pending optimistic
+versions per document). All cells with the same `space` share that replica;
+cross-space links just mean an action's read-set spans replicas. Identity
+and authorization for opening a space session are Chapter 10's subject; the
+sync protocol that keeps replicas honest is next.
+
+---
+
+**Next:** [Chapter 9 — Storage and sync](09-storage-and-sync.md): what
+happens to a commit after it leaves the replica.

--- a/docs/tutorial/08-runtime-internals.md
+++ b/docs/tutorial/08-runtime-internals.md
@@ -29,8 +29,8 @@ a sibling cell with one more path segment and the narrowed schema.
 `.asSchema()` reinterprets the same location under a different schema.
 `.get()` resolves the link against the local replica of the space *through
 the current transaction*. Path-granular reactivity (Chapter 2) falls out:
-dependencies are recorded as (id, path) pairs, so writing `item.done`
-doesn't disturb readers of `item.title`.
+dependencies are recorded as (space, id, path) addresses, so writing
+`item.done` doesn't disturb readers of `item.title`.
 
 Entity ids are content-derived: `createRef(source, cause)` hashes the
 creation context (`packages/runner/src/create-ref.ts`), so the "same" cell
@@ -38,11 +38,16 @@ created by the same graph node gets the same id deterministically — which is
 what lets a server re-instantiate a piece and arrive at the same cells.
 
 **Links between documents** are stored as serializable references (sigil
-links: `{ "/": { documentId, path, ... } }`). When a read encounters one, it
-resolves through to the target — transparently crossing documents and even
-spaces. This is the mechanism behind `cf piece link` (Chapter 5), and also
-behind the "selection" gotcha (Chapter 6, #7): writing to a cell that
-*contains* a link writes through to the link's target, by design.
+links: `{ "/": { "link@1": { id, path, space } } }`). When a read encounters
+one, it resolves through to the target — transparently crossing documents
+and even spaces. This is the mechanism behind `cf piece link` (Chapter 5).
+Writes are subtler, and worth stating precisely: a write whose path
+continues *past* a link (`selected.key("title").set(...)`) follows the link
+and lands on the target, as does a write through a *write-redirect* link
+(the kind pattern argument/output bindings use) — but writing a plain value
+at the exact location of an ordinary link simply **replaces the link**.
+This asymmetry is what makes the "selection" gotcha (Chapter 6, #7)
+confusing in practice, and why the rule there is to box stored references.
 
 ## The scheduler: reads are subscriptions, literally
 
@@ -56,7 +61,7 @@ The runtime's event loop is the scheduler
    is what subscribes you.
 2. **Commit.** The transaction's writes are applied (next section).
 3. **Re-subscribe.** The action's actual read-set replaces its old one. The
-   scheduler maintains a reverse index — "this (id, path) is read by these
+   scheduler maintains a reverse index — "this (space, id, path) is read by these
    actions" — so dependencies follow the data the action *really* touched
    this run, branch by branch.
 4. **React.** When any write lands (locally, or arriving from the server —
@@ -116,8 +121,10 @@ the previous three sections together:
    receives a value or a writable handle.
 2. Each `Node` in the graph becomes a scheduled action: `javascript` nodes
    (lifts/computeds/handlers) wrap their compiled implementation (fetched
-   via the `implementationRef` function cache); `pattern` nodes recurse into
-   sub-patterns; `isolated` nodes run in the stronger sandbox.
+   via the `implementationRef` function cache) and run in the SES sandbox;
+   `pattern` nodes recurse into sub-patterns; `ref`/`raw`/`passthrough`
+   cover builtins and plumbing. (An `isolated` module type is declared in
+   the API but not currently implemented by the runner.)
 3. Handler nodes register as **stream** consumers: nothing runs until
    something `.send()`s to the stream; then the handler executes as a
    one-shot action with the event as input, in its own transaction.

--- a/docs/tutorial/09-storage-and-sync.md
+++ b/docs/tutorial/09-storage-and-sync.md
@@ -19,7 +19,8 @@ The code is `packages/memory` (the store and protocol) plus
 ## The data model: documents in spaces
 
 The unit of storage is an **entity document**: a JSON document named by a
-content-derived id (`of:<hash>`), living in a space, with the cell's payload
+hash id (`of:<hash>`, derived from the cell's creation context — the
+document itself mutates while its id stays stable), living in a space, with the cell's payload
 under its `value` field plus metadata (e.g. a `source` link to the owning
 piece). Cells (Chapter 8) address `(space, id, path)`; the path is resolved
 inside the document.
@@ -120,7 +121,8 @@ blob_store(hash PK, data BLOB, content_type, size)
 
 Reading a document means: find its head revision; if it's a `set`, decode
 it; if a `patch`, replay patches forward from the nearest snapshot
-(snapshots are written every N revisions to bound replay cost). So the store
+(a snapshot is written once enough patch revisions — 10 by default —
+accumulate since the last full value, bounding replay cost). So the store
 is an **event log with materialized checkpoints** — history is retained,
 heads are fast, and the conflict checks in the commit protocol are simple
 indexed queries over `revision`.
@@ -136,7 +138,7 @@ Patterns can also declare cells that *are* SQLite databases (the
 `sqlite-builtin`, `docs/specs/sqlite-builtin`): the cell's entity id names a
 per-`(space, id)` database file. The design is asymmetric, deliberately:
 
-- **Writes** ride inside ordinary commits as `{op: "sqlite", sql, params}`
+- **Writes** ride inside ordinary commits as `{op: "sqlite", db, sql, params}`
   operations — atomic with cell writes in the same transaction, conflict-
   checked like everything else. There is no standalone SQL-write RPC.
 - **Reads** (`sqlite.query`) bypass the engine connection entirely and go
@@ -146,7 +148,7 @@ per-`(space, id)` database file. The design is asymmetric, deliberately:
   read-only is enforced by the OS-level open flag, not by parsing alone.
 
 A server-side registry can also map a handle to an external on-disk
-database (`cf piece link <piece>/<field> sqlite:/abs/path`) — read-only —
+database (`cf piece link sqlite:/abs/path <piece>/<field>`) — read-only —
 which is how local datasets get exposed to patterns.
 
 ## The local/remote symmetry

--- a/docs/tutorial/09-storage-and-sync.md
+++ b/docs/tutorial/09-storage-and-sync.md
@@ -1,0 +1,167 @@
+# Chapter 9 — Storage and Sync
+
+Chapter 8 ended with an optimistic commit leaving the local replica. This
+chapter follows it: the wire protocol, how the server detects conflicts
+without locks, how other clients hear about it, and what's actually on disk.
+The code is `packages/memory` (the store and protocol) plus
+`packages/runner/src/storage/` (the client side).
+
+> **Historical note, because you'll see it in the code.** The package
+> contains two generations. The original ("v1") modeled storage as a chain
+> of immutable *facts* `{the, of, is, cause}` with per-fact compare-and-swap
+> — its types still shape the public vocabulary (`URI`, `ConflictError`,
+> entity ids like `of:<hash>`). The current engine ("v2",
+> `packages/memory/v2/`) keeps the spirit — optimistic concurrency over
+> append-only history — but moves the unit of conflict from single facts to
+> **commits with read-set validation**, which is what's described below.
+> Toolshed and the runtime speak only v2.
+
+## The data model: documents in spaces
+
+The unit of storage is an **entity document**: a JSON document named by a
+content-derived id (`of:<hash>`), living in a space, with the cell's payload
+under its `value` field plus metadata (e.g. a `source` link to the owning
+piece). Cells (Chapter 8) address `(space, id, path)`; the path is resolved
+inside the document.
+
+Documents also carry a **scope key**. `PerUser`/`PerSession` cells
+(Chapter 2) aren't filtered by queries — the engine physically partitions
+revisions by `scope_key` derived from the session's principal
+(`v2/engine.ts`). Isolation by partition, not by discipline.
+
+## The commit protocol: optimistic concurrency via read sets
+
+A client ships each transaction as a `ClientCommit`
+(`packages/memory/v2.ts`):
+
+```ts
+ClientCommit {
+  localSeq,                       // client-session-local sequence number
+  reads: {
+    confirmed: [{ id, path, seq }],      // "I read X at server commit seq N"
+    pending:   [{ id, path, localSeq }], // "I read my own unconfirmed commit"
+  },
+  operations: [ set | patch | delete | sqlite ],
+}
+```
+
+The `reads` field is the concurrency-control token, built automatically from
+the transaction journal (Chapter 8). The protocol is *optimistic*: no locks,
+no leases — the client asserts what it saw, and the server validates that
+assertion at commit time (`v2/engine.ts`, inside a single SQLite
+transaction):
+
+1. **Idempotence.** A commit is keyed by `(sessionId, localSeq)`. A replay
+   returns the recorded result; a *different* payload under the same
+   `localSeq` is a protocol error. This makes retry-after-disconnect safe.
+2. **Read validation.** For each confirmed read, the engine checks whether
+   any later revision touched it. Full-document `set`/`delete` conflicts
+   with any read of that document; a `patch` conflicts **only if its patched
+   paths overlap the read path**. Two users patching disjoint fields of the
+   same document both succeed — this path-granular rule is what makes
+   field-level two-way bindings (Chapter 4) practical under concurrency.
+3. **Pending resolution.** Pipelined commits (a client needn't wait for ack
+   to keep committing) have their pending reads mapped to the server
+   sequence numbers their dependencies actually landed at, then validated
+   the same way.
+4. **Append.** The commit gets the next global `seq`; each operation becomes
+   a revision row; per-document heads advance.
+
+On conflict, the loser gets a `ConflictError` *and* the server immediately
+pushes fresh state for the contested documents to that session — so the
+client-side story from Chapter 8 (revert, re-run, retry) starts from
+current data, not after another round trip.
+
+Client-side resilience details worth knowing
+(`packages/memory/v2/client.ts`): unacknowledged commits are kept and
+**replayed on reconnect** (safe by idempotence), and a connection drop
+leaves commits queued rather than failed. Offline-tolerant by construction,
+within a session's lifetime.
+
+## Subscriptions: watches over schema-shaped graphs
+
+The read side mirrors the reactive model. Over one WebSocket, a client opens
+a session per space (`hello` → `session.open`, then `transact` /
+`graph.query` / `session.watch.set` / `session.watch.add` / `session.ack`).
+
+A **watch** is a set of graph queries: roots (`{id, selector}`) where the
+selector is a *schema path selector* — the same schemas from Chapter 7,
+acting as a query language. The server traverses each root document,
+**following links reachable under the schema**, and records which documents
+the traversal touched. That set is the subscription. So "subscribe to this
+piece" means: walk its argument/result documents as shaped by its schemas,
+across link boundaries, and watch everything you saw. (This is the precise
+sense of the tagline from Chapter 1 — *reactivity is subscription to the
+result of a query defined by schemas*.)
+
+After every commit the server marks the written ids dirty and, on a
+debounced tick, re-walks only the affected graphs per session, diffs against
+what that session already has, and pushes a `session/effect` carrying a
+`SessionSync` — upserts (id, seq, document) and removals. The originating
+session is skipped (it already applied the change optimistically). The
+client integrates the delta into its replica and notifies cell sinks —
+re-entering Chapter 8's trigger index, completing the loop from the
+Chapter 1 trace.
+
+## On disk: one SQLite database per space
+
+Each space is one SQLite file (`<store>/engine-v3/<space-did>.sqlite`),
+WAL-mode. The core tables (`v2/engine.ts` INIT script, abridged):
+
+```sql
+"commit"  (seq PK, session_id, local_seq, original JSON, resolution JSON, ...)
+           -- the full history of commits; UNIQUE (session_id, local_seq)
+revision  (id, scope_key, seq, op, data JSON, ...)   -- one row per operation
+head      (id, scope_key → seq)                      -- current tip per document
+snapshot  (id, scope_key, seq, value JSON)           -- periodic materializations
+branch    (name, parent_branch, fork_seq, head_seq, ...)
+blob_store(hash PK, data BLOB, content_type, size)
+```
+
+Reading a document means: find its head revision; if it's a `set`, decode
+it; if a `patch`, replay patches forward from the nearest snapshot
+(snapshots are written every N revisions to bound replay cost). So the store
+is an **event log with materialized checkpoints** — history is retained,
+heads are fast, and the conflict checks in the commit protocol are simple
+indexed queries over `revision`.
+
+The schema also reveals features at the edge of this tutorial's scope:
+`branch` (commits can target named branches forked from main, with merge
+records), and persisted scheduler state (tables that let server-side
+executors rehydrate action read/write indexes across processes).
+
+## The SQLite capability (cells as databases)
+
+Patterns can also declare cells that *are* SQLite databases (the
+`sqlite-builtin`, `docs/specs/sqlite-builtin`): the cell's entity id names a
+per-`(space, id)` database file. The design is asymmetric, deliberately:
+
+- **Writes** ride inside ordinary commits as `{op: "sqlite", sql, params}`
+  operations — atomic with cell writes in the same transaction, conflict-
+  checked like everything else. There is no standalone SQL-write RPC.
+- **Reads** (`sqlite.query`) bypass the engine connection entirely and go
+  through a pooled set of *read-only* connections opened directly on the
+  database file (`v2/sqlite/read-pool.ts`), with a statement guard
+  (SELECT-only, no ATTACH/PRAGMA). Reads scale without touching the writer;
+  read-only is enforced by the OS-level open flag, not by parsing alone.
+
+A server-side registry can also map a handle to an external on-disk
+database (`cf piece link <piece>/<field> sqlite:/abs/path`) — read-only —
+which is how local datasets get exposed to patterns.
+
+## The local/remote symmetry
+
+One detail with outsized architectural value: the *same* client and server
+classes run in-process. `EmulatedStorageManager`
+(`packages/runner/src/storage/v2-emulate.ts`) constructs a real
+`MemoryServer` and connects the real client over a loopback transport — no
+sockets, identical protocol. Tests and CLI runs exercise the genuine commit
+and watch machinery, and "local vs deployed" differs only in transport and
+authentication. When debugging sync behavior, you can usually reproduce it
+entirely in-process.
+
+---
+
+**Next:** [Chapter 10 — Identity, authorization, and
+isolation](10-identity-and-security.md): who is allowed to do all of the
+above, and how untrusted code is contained.

--- a/docs/tutorial/10-identity-and-security.md
+++ b/docs/tutorial/10-identity-and-security.md
@@ -56,7 +56,7 @@ current (v2) protocol, authorization happens at **session open**
 `packages/toolshed/routes/storage/memory.ts`):
 
 1. The client builds an invocation
-   `{ iss: <user did>, cmd: "session.open", sub: <space did>, args: {session} }`
+   `{ iss: <user did>, cmd: "session.open", sub: <space did>, args: {protocol, session} }`
    and signs its hash with the user's key.
 2. The server verifies the signature against the issuer DID and that the
    signed invocation matches *this exact* session-open request (no replay

--- a/docs/tutorial/10-identity-and-security.md
+++ b/docs/tutorial/10-identity-and-security.md
@@ -1,0 +1,124 @@
+# Chapter 10 — Identity, Authorization, and Isolation
+
+Two trust problems run through everything so far. *Who* is writing to a
+space — across browsers, CLIs, and servers, with no accounts database
+anywhere in the design? And how can the platform run *user-authored
+programs* against real user data? This chapter covers both: cryptographic
+identity, session authorization, and the layered sandboxing of pattern
+code. Code: `packages/identity`, the auth hooks in `packages/toolshed` and
+`packages/memory`, and `packages/iframe-sandbox`.
+
+## Identity: keypairs all the way down
+
+There are no usernames or server-side accounts. An identity *is* an Ed25519
+keypair, named by its public key as a DID:
+`did:key:z6Mk...` (`packages/identity/src/identity.ts`). Everything that
+acts or is acted upon — users, services, spaces — is a DID.
+
+Two derivation tricks give the system its shape:
+
+- **Passphrase derivation.** `Identity.fromPassphrase(s)` hashes a string
+  into a keypair deterministically.
+- **Hierarchical derivation.** `identity.derive(name)` deterministically
+  derives a child keypair from a parent and a label.
+
+A **space DID** is just `someIdentity.derive(spaceName).did()`. No
+registration step, no central registry: knowing the derivation inputs *is*
+knowing the space. (Dev environments lean on this hard — the CLI's
+`id derive "implicit trust"` from Chapter 6 reproduces the standard dev
+identity, and named dev spaces derive from a well-known passphrase, which
+is why two local setups agree on what `did:key:...` a space name means.)
+
+## Passkeys: the browser login
+
+The shell never asks for a password and never stores a private key on a
+server. Login (`packages/identity/src/pass-key.ts`):
+
+1. `navigator.credentials.create()` makes a WebAuthn **passkey** (resident
+   key, e.g. in iCloud Keychain or a security key), requesting the **PRF
+   extension**.
+2. The PRF extension lets the authenticator evaluate a pseudo-random
+   function; its 32-byte output becomes the seed for the user's root
+   Ed25519 key (`Identity.fromRaw(seed)`).
+3. The root identity is cached in IndexedDB (`common-key-store`) for the
+   session; user spaces are `derive()`d from it.
+
+So the user's "account" is reconstructible from their passkey alone, on any
+device, with the actual signing key never leaving the authenticator's
+control path. The CLI does the equivalent with a key file (`cf id derive`,
+`CF_IDENTITY`).
+
+## Authorizing the connection
+
+How does the server know a WebSocket client may touch a space? In the
+current (v2) protocol, authorization happens at **session open**
+(`packages/runner/src/storage/v2-remote-session.ts`,
+`packages/toolshed/routes/storage/memory.ts`):
+
+1. The client builds an invocation
+   `{ iss: <user did>, cmd: "session.open", sub: <space did>, args: {session} }`
+   and signs its hash with the user's key.
+2. The server verifies the signature against the issuer DID and that the
+   signed invocation matches *this exact* session-open request (no replay
+   onto other sessions).
+3. The issuer becomes the session's pinned **principal**: reopening the
+   session as someone else fails, a stolen stale token is revoked, and —
+   importantly — the principal is what keys the `user:`/`session:` scope
+   partitions from Chapter 9. `PerUser` isolation is cryptographic
+   identity, enforced in the storage engine.
+
+The package also contains a fuller capability system from the v1 design —
+UCAN-signed per-invocation proofs and per-space ACLs
+(`packages/memory/access.ts`, `acl.ts`, surfaced as `cf acl ...`). **An
+honest caveat for the current code:** in the v2 path as deployed, what's
+verified is the signature and principal binding; the v1-style space-level
+ACL check is not wired into the v2 server (the v2 session-open hook
+authenticates rather than authorizes against an ACL). Treat per-space
+access control as an evolving area and check the code before relying on a
+specific enforcement property.
+
+## Running untrusted code: three rings
+
+Patterns are arbitrary user (often LLM-written) code operating on private
+data. The containment is layered:
+
+**Ring 1 — the compiler (Chapter 7).** Validation stages reject hostile or
+unworkable constructs; emitted module-scope functions are frozen; every
+handler/lift carries a schema that *declares* what it reads and writes. The
+schema is a capability manifest: the runtime passes a handler exactly the
+cells its context schema names — with write handles only where the schema
+says `asCell` — rather than ambient access to the space. (The
+`cfc-*` patterns and the verified-source `implementationRef` machinery
+extend this into data-classification policies — flow tracking of which code
+touched which classified data — beyond this tutorial's scope.)
+
+**Ring 2 — SES.** Compiled pattern code executes inside SES (Secure
+ECMAScript) compartments: hardened intrinsics, no ambient authority. This
+is why authored code has no `Date.now()`, `Math.random()`, `setTimeout`, or
+`new Proxy()` (Chapter 3) — nondeterminism and timing channels are denied
+at the platform layer, and the blessed substitutes (`safeDateNow()`,
+`nonPrivateRandom()`) are injected capabilities rather than globals.
+
+**Ring 3 — the iframe sandbox.** For fully untrusted rendered content,
+`packages/iframe-sandbox` adds a process-level browser boundary with a
+clever double-iframe construction: an **outer** iframe loaded via `srcdoc`
+carries a strict Content-Security-Policy meta tag
+(`default-src 'none'`, no form posts, no child frames, connections limited
+to the host); per the CSP spec, a nested `srcdoc` document *must inherit*
+those policies — so the **inner** iframe, which holds the guest code,
+cannot shed them. The guest gets no direct data access at all: reads,
+writes, subscriptions, and LLM calls cross the boundary as a postMessage
+IPC protocol mediated by the host (`src/ipc.ts`), which applies policy per
+request. The package README is candid that exfiltration hardening (e.g.
+covert channels via permitted fetches) is ongoing work.
+
+The rings compose with the data layer: even code that breaks ergonomics
+rules still acts *as* its session's principal, inside one space's replica,
+through schema-bounded handles, with every commit journaled in the
+append-only history of Chapter 9. Damage is scoped and auditable by
+construction.
+
+---
+
+**Next:** [Chapter 11 — The deployed system](11-deployed-system.md): all
+the layers assembled into the thing users actually run.

--- a/docs/tutorial/11-deployed-system.md
+++ b/docs/tutorial/11-deployed-system.md
@@ -1,0 +1,129 @@
+# Chapter 11 — The Deployed System, End to End
+
+Every previous chapter examined one layer. This one assembles them: the
+server, the browser app, the headless executor, and the CLI — then re-runs
+Chapter 1's trace with all the machinery visible.
+
+## Toolshed: the server
+
+Toolshed (`packages/toolshed`) is a single Deno server that hosts everything
+the product needs server-side. Its route groups (`app.ts`) tell the story:
+
+- `storage/memory` — **the** sync endpoint: `GET /api/storage/memory` with a
+  WebSocket upgrade, bridging each socket to the memory server of Chapter 9
+  (one SQLite engine per space, sessions, watches).
+- `ai/llm` (+ `ai/img`, `ai/voice`, `ai/webreader`) — the LLM proxy behind
+  `generateText`/`generateObject` (Chapter 5): model routing, caching,
+  feedback. Patterns never hold API keys; the capability is mediated
+  server-side.
+- `blobs` — content-addressed binary storage (images etc., 10 MB cap),
+  per-space.
+- `patterns` — the pattern registry/discovery API.
+- `integrations/*` — OAuth flows (Google, Discord, ...) so pieces can hold
+  third-party credentials server-side; `webhooks` for inbound events.
+- `whoami`, `meta`, `health` — introspection; `shell` — serves the web app
+  itself.
+
+It boots its own `Runtime` instance too — the server is also a client of the
+fabric, which is what server-side piece execution rides on. Configuration is
+environment-driven (`HOST`, `PORT`, `MEMORY_DIR`/`DB_PATH`, compilation
+cache toggles); `docs/development/LOCAL_DEV_SERVERS.md` covers running it
+locally.
+
+## Shell: the browser client
+
+The shell (`packages/shell`) is deliberately thin — a login screen, a
+header, and a piece renderer around the runtime:
+
+- **Boot.** The page loads, opens the IndexedDB key store, and either runs
+  the passkey flow (Chapter 10) or restores the cached identity. The
+  Runtime itself — scheduler, replicas, compiled pattern execution — runs in
+  a **Web Worker** (`src/lib/runtime.ts`); the DOM thread talks to it
+  through a `RuntimeClient` transport. UI jank and pattern execution are
+  isolated from each other.
+- **Routing.** `/{spaceName}` shows the space's default pattern;
+  `/{spaceName}/{pieceIdOrSlug}` a specific piece; `/.embed/...` the same
+  without shell chrome. Navigation is an event (`cf-navigate`) kept in sync
+  with browser history — and `navigateTo()` from Chapter 5 bottoms out
+  here.
+- **Rendering.** To show a piece, the shell asks the runtime for the
+  piece's result cell, takes its `[UI]` VNode tree, and materializes it as
+  DOM: `cf-*` tags become the Lit web components of Chapter 4, whose
+  reactive slots are bound to cells via sinks. Updates flow cell → sink →
+  component re-render; there is no app-level render loop.
+
+## Background execution
+
+The background piece service (`packages/background-charm-service` — charm =
+piece, Chapter 1) is the proof that a piece is *not* a UI artifact. It runs
+as a headless process with an operator identity, connects to the same
+WebSocket endpoint, and maintains a registry cell of pieces that asked for
+background updates (the `bgUpdater` convention from Chapter 5; registration
+via the `cf-updater` component or the integrations API). Per space it
+spawns a worker that, on each poll tick (default 60 s), sends an event to
+each registered piece's `bgUpdater` stream — and from there it's just
+Chapter 8: the handler runs, transactions commit, watchers (including any
+open browsers) sync. Same graph, third kind of executor.
+
+## The CLI, revisited
+
+With the architecture visible, Chapter 6's CLI needs one sentence: `cf` is a
+fourth client — key file instead of passkey, terminal instead of DOM,
+loopback or remote transport — driving the identical runtime. That all four
+executors (shell, toolshed, background service, CLI) are *the same machine
+with different transports* is the architectural payoff of the local/remote
+symmetry noted in Chapter 9.
+
+## The full trace
+
+Chapter 1's checkbox, one last time — every step now has a chapter behind
+it. Alice and Bob both have `/{space}/todo-list` open; Alice's browser also
+ran `cf piece link` long ago to feed the list into a dashboard piece.
+
+1. **Click** (Ch. 4). Alice toggles `<cf-checkbox $checked={item.done} />`.
+   The Lit component writes `true` through the binding into the cell — a
+   `Writable` whose link is `(space, item-doc-id, ["value", ..., "done"])`.
+2. **Transaction** (Ch. 8). The write lands in a transaction journal in the
+   worker-hosted runtime. On commit, the replica applies it optimistically;
+   the trigger index dirties the `activeItems`/`completedItems` computeds;
+   pull-execution re-runs them; UI sinks fire; the row moves to "Completed"
+   in Alice's DOM — all before any network round trip.
+3. **Commit** (Ch. 9). The storage manager emits a `ClientCommit` — a
+   `patch` op on the item document plus the journal's read set — over the
+   session opened at login (signed `session.open`, Ch. 10). Toolshed's
+   engine validates the reads against the space's SQLite history inside one
+   write transaction, appends commit + revision rows, advances the head.
+   Had Bob concurrently patched the same item's `title`, both commits would
+   land — disjoint paths don't conflict; had he patched `done`, the loser
+   would revert and retry (Ch. 8/9).
+4. **Fan-out** (Ch. 9). The engine marks the item document dirty. The
+   debounced refresh re-walks affected watch graphs per session — Bob's
+   watch covers the list's documents via its schema selectors, as does the
+   dashboard's (the link from `cf piece link` is just a sigil link the
+   traversal follows). Each gets a `session/effect` with the new document
+   state; Alice's session is skipped as origin.
+5. **Remote update** (Ch. 8/11). Bob's worker integrates the upsert into
+   his replica; the notification hits his trigger index; the same computeds
+   re-run on his machine; his DOM updates. The dashboard piece — possibly
+   currently being recomputed by the background service rather than any
+   browser — sees the same change the same way.
+
+Total pattern-author code involved: one `$checked` binding and two
+`computed()` lines. Everything else — atomicity, conflict detection,
+sync, multi-client reactivity, auth, persistence — is the substrate doing
+its job. That ratio, more than any single mechanism, is the thesis of
+Common Fabric.
+
+## Where to go from here
+
+- **Build something**: re-read [Chapter 6](06-workflow.md) and start from
+  `packages/patterns/counter/`; the catalog stories
+  (`packages/patterns/catalog/stories/`) are the best UI reference.
+- **Runtime work**: `docs/development/DEVELOPMENT.md` for style and
+  principles, `docs/development/debugging/` for the error reference; the
+  scheduler (`packages/runner/src/scheduler.ts`) and the v2 engine
+  (`packages/memory/v2/engine.ts`) are the two files most worth reading
+  end to end.
+- **Open questions to watch in the code**: v2 space-level access control
+  (Ch. 10 caveat), branches/merge in the storage engine (Ch. 9), and the
+  CFC data-classification work (`packages/patterns/cfc-*`).

--- a/docs/tutorial/11-deployed-system.md
+++ b/docs/tutorial/11-deployed-system.md
@@ -18,7 +18,8 @@ the product needs server-side. Its route groups (`app.ts`) tell the story:
   server-side.
 - `blobs` — content-addressed binary storage (images etc., 10 MB cap),
   per-space.
-- `patterns` — the pattern registry/discovery API.
+- `patterns` — serves the built-in pattern sources
+  (`GET /api/patterns/:filename`).
 - `integrations/*` — OAuth flows (Google, Discord, ...) so pieces can hold
   third-party credentials server-side; `webhooks` for inbound events.
 - `whoami`, `meta`, `health` — introspection; `shell` — serves the web app

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -53,8 +53,8 @@ also read "vertically": learn a concept, then immediately open the hood on it.
   repository root and are the ground truth; when this tutorial and the code
   disagree, the code wins.
 - Code in patterns imports from the `commonfabric` module.
-- You will meet some legacy names in the code: a *pattern* is sometimes called
-  a *recipe* (the builder code), and a *piece* is sometimes called a *charm*
-  (e.g. `background-charm-service`). This tutorial uses the current names —
-  **pattern** and **piece** — and flags the old ones where you'll encounter
-  them.
+- You will meet one legacy name in the code: a *piece* is called a *charm* in
+  older identifiers and package names (e.g. `background-charm-service`). This
+  tutorial uses the current names — **pattern** and **piece** — and flags the
+  old one where you'll encounter it. (An even older name for pattern,
+  *recipe*, survives only in a few stale comments and test fixtures.)

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -1,0 +1,60 @@
+# The Common Fabric Tutorial
+
+This is a guided tour of the Common Fabric system for an engineer who is
+comfortable with programming and technical systems but has never seen this
+codebase. It is written to be read in order, but it is split into two parts so
+you can stop at the depth you need.
+
+**Part I — Using the system (the contract).** What problem Common Fabric
+solves, the concepts you program against, and everything you need to write,
+test, and deploy patterns. After Part I you can build real things without
+knowing how any of it is implemented.
+
+**Part II — How it works (the mechanism).** The same system revisited
+subsystem by subsystem: the compiler pipeline, the reactive scheduler, the
+storage and sync protocol, identity and isolation, and the deployed topology.
+After Part II you can reason about behavior, performance, and failure modes,
+and debug surprises.
+
+Each Part I chapter ends with a pointer to its Part II counterpart, so you can
+also read "vertically": learn a concept, then immediately open the hood on it.
+
+## Reading map
+
+| | Chapter | You'll learn |
+|---|---|---|
+| **Part I** | [1. The problem and the big picture](01-big-picture.md) | Why this exists; the five-layer shape of the solution; core vocabulary |
+| | [2. Cells: reactive, durable state](02-cells.md) | The unit of state; `Writable<>`, `Default<>`, scoped state |
+| | [3. Patterns: programs as reactive graphs](03-patterns.md) | `pattern()`, `computed()`, `action()`/`handler()`; a full working example |
+| | [4. UI: rendering and binding](04-ui.md) | JSX, the `cf-*` component library, two-way binding, lists and conditionals |
+| | [5. Composition, pieces, and capabilities](05-composition-and-pieces.md) | Sub-patterns, deployed pieces, linking, navigation, built-in LLM calls |
+| | [6. The development workflow](06-workflow.md) | `cf check`/`piece new`/`call`/`test`; the gotcha checklist |
+| **Part II** | [7. From TypeScript to a runnable graph](07-compilation.md) | The transformer pipeline; how types become JSON schemas |
+| | [8. The reactive runtime](08-runtime-internals.md) | What a Cell really is; the scheduler; transactions and retries |
+| | [9. Storage and sync](09-storage-and-sync.md) | The commit protocol, conflict detection, subscriptions, SQLite layout |
+| | [10. Identity, authorization, and isolation](10-identity-and-security.md) | DIDs, passkeys, signed sessions, sandboxing untrusted code |
+| | [11. The deployed system, end to end](11-deployed-system.md) | Toolshed, the shell, background execution; one click traced through every layer |
+
+## How to choose your path
+
+- **"I want to build a pattern this afternoon."** Read chapters 1–6, keep
+  [chapter 6](06-workflow.md) open while you work, and skim the gotchas list
+  before your first deploy. The repo-local skill `skills/pattern-dev/SKILL.md`
+  is the operational companion to this tutorial.
+- **"I'm joining the runtime team."** Read all of Part I quickly for
+  vocabulary (don't skip it — Part II assumes it), then read Part II
+  carefully. Chapter 11 ties the layers back together.
+- **"I just need to evaluate the architecture."** Read chapters 1, 8, 9,
+  and 11.
+
+## Conventions in this tutorial
+
+- File references like `packages/runner/src/scheduler.ts` are relative to the
+  repository root and are the ground truth; when this tutorial and the code
+  disagree, the code wins.
+- Code in patterns imports from the `commonfabric` module.
+- You will meet some legacy names in the code: a *pattern* is sometimes called
+  a *recipe* (the builder code), and a *piece* is sometimes called a *charm*
+  (e.g. `background-charm-service`). This tutorial uses the current names —
+  **pattern** and **piece** — and flags the old ones where you'll encounter
+  them.


### PR DESCRIPTION
## Why

There is no single document that takes an engineer who is new to this codebase from "what problem does this solve" to "I can build patterns and reason about the runtime." The existing docs are excellent but fragmented by audience: concept references under `docs/common/`, debugging gotchas, skills, and package-level internals — with nothing connecting cells → patterns → compiler → scheduler → sync protocol into one motivated narrative. New teammates (and agents) currently reconstruct that map by spelunking.

This adds a guided tutorial that builds the map once: each section is motivated by why the system needs it, and the layers are bound back together with an end-to-end trace (a checkbox click followed from `$checked` binding through scheduler, commit protocol, SQLite, and fan-out to another browser).

## What Changed

12 documents under `docs/tutorial/`, entry point `docs/tutorial/README.md`:

- **Part I — Using the system (chapters 1–6):** the problem and big picture, cells (`Writable<>`/`Default<>`/scopes), patterns (`computed`/`action`/`handler`, body-runs-once model), UI (`cf-*` components, bindings, conditional/list rendering), composition/pieces/linking/LLM, and the `cf` CLI workflow with a top-10 gotcha checklist. Contract-level: enough to build, deploy, and test patterns.
- **Part II — How it works (chapters 7–11):** the transformer pipeline (types → JSON schemas, closure reification), the reactive runtime (Cell as typed link, scheduler, optimistic transactions), storage and sync (v2 `ClientCommit` read-set validation, watches, per-space SQLite), identity/authorization/sandboxing, and the deployed topology (toolshed, shell, background service) ending with a full-stack trace.
- Each Part I chapter cross-links its Part II counterpart so the tutorial can be read straight through or vertically per concept.

Notes for reviewers:
- The tutorial teaches the **v2** memory engine and flags `packages/memory/README.md` as describing the legacy v1 fact store.
- Chapter 10 contains an explicit caveat that v1-style per-space ACL checks do not appear to be wired into the v2 `session.open` path (it authenticates and pins the principal). If that's wrong or has landed elsewhere, that paragraph is the one to correct.
- Uses current terminology (pattern/piece) and flags legacy names (recipe/charm) where readers will hit them in code.

## Test plan

- Docs-only change; no code paths affected.
- Every repo file path referenced in the tutorial was checked to exist (scripted sweep over all `packages/`, `docs/`, `skills/` references).
- Code excerpts are copied verbatim from `packages/patterns/counter/`, `packages/patterns/todo-list/`, `packages/patterns/shopping-list.tsx`, and transformer test fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a two-part tutorial that teaches how to build with patterns and explains how the system works, improving onboarding and architectural understanding. A follow-up fact-checking pass aligned the docs with actual runtime, compiler, and storage behavior.

- **New Features**
  - 12 chapters under `docs/tutorial/`: Part I (1–6) using the system—cells, patterns (`computed`/`action`/`handler`), UI (`cf-*` bindings), composition/pieces, CLI workflow, and top gotchas; Part II (7–11) how it works—transformers and schemas, runtime/scheduler/transactions, v2 storage+sync, identity/sandboxing, deployed topology and background execution.
  - Cross-links between matching chapters to support straight-through or vertical reading.
  - Notes the v2 memory engine and flags legacy v1 references and names (recipe/charm).
  - Docs-only; no runtime or API changes.

- **Bug Fixes**
  - Corrected schemas and runtime details: `Stream<T>` maps to `asCell: ["stream"]`; `implementationRef` is content-derived; `session.open` includes protocol and pins the principal.
  - Clarified link semantics: a plain `.set()` at a link replaces the link; only sub-path and write-redirect writes follow links.
  - Noted that the `isolated` module type is declared but not implemented in the runner.
  - Updated LLM docs: `cache: false` applies to `generateObject` only; `generateText` result shape documented precisely.
  - Storage/sync and routing fixes: per-space transaction atomicity; sigil link shape and `(space, id, path)` addressing; SQLite snapshot cadence and disk-source link arg order; corrected `patterns` route and legacy naming notes.
  - Clarified CLI behavior: `cf piece call` does not refresh computed outputs; use `cf piece step` to force recomputation.

<sup>Written for commit c6a266c3effb6e9bc06a1dfb77bfa344eee700de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

