### PR TITLE
Add support for providing the mutex timeout to a fetchData call.

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2112,6 +2112,7 @@ export type GenerateTextFunction = (
 export type FetchOptions = {
   body?: JSONValue;
   headers?: Record<string, string>;
+  mutexTimeoutMs?: number;
   cache?:
     | "default"
     | "no-store"

--- a/packages/runner/src/builtins/fetch-data.ts
+++ b/packages/runner/src/builtins/fetch-data.ts
@@ -18,10 +18,19 @@ import { setPatternCell, setResultCell } from "../result-utils.ts";
 import { scopedCell } from "./scope-policy.ts";
 
 /** The shape of fetchData's input cell. */
+type FetchDataOptions = {
+  body?: any;
+  method?: string;
+  headers?: Record<string, string>;
+  mutexTimeoutMs?: number;
+};
+
+type FetchRequestOptions = Omit<FetchDataOptions, "mutexTimeoutMs">;
+
 type FetchDataInputs = {
   url?: string;
   mode?: "text" | "json" | "dataUrl";
-  options?: { body?: any; method?: string; headers?: Record<string, string> };
+  options?: FetchDataOptions;
 };
 
 /**
@@ -40,6 +49,7 @@ const fetchDataInputSchema = internSchema(
         properties: {
           body: {},
           method: { type: "string" },
+          mutexTimeoutMs: { type: "number" },
           headers: {
             type: "object",
             additionalProperties: { type: "string" },
@@ -59,16 +69,34 @@ function snapshotFetchDataInputs(
       snapshot.mode === "dataUrl"
     ? snapshot.mode
     : undefined;
-  const body = snapshot.options?.body;
-  const options = snapshot.options
+  const { mutexTimeoutMs: _mutexTimeoutMs, ...requestOptions } =
+    snapshot.options ?? {};
+  const body = requestOptions.body;
+  const options = Object.keys(requestOptions).length > 0
     ? {
-      ...snapshot.options,
+      ...requestOptions,
       body: body !== undefined && typeof body !== "string"
         ? JSON.stringify(body)
         : body,
     }
     : undefined;
   return createFrozenRequestSnapshot({ url: snapshot.url, mode, options });
+}
+
+function snapshotFetchDataConfig(
+  cell: Cell<FetchDataInputs>,
+): { inputs: FetchDataInputs; mutexTimeoutMs?: number } {
+  const snapshot = cell.asSchema(fetchDataInputSchema).get() ??
+    ({} as FetchDataInputs);
+  const inputs = snapshotFetchDataInputs(cell);
+  const mutexTimeoutMs = snapshot.options?.mutexTimeoutMs;
+  return {
+    inputs,
+    ...(typeof mutexTimeoutMs === "number" && Number.isFinite(mutexTimeoutMs) &&
+        mutexTimeoutMs > 0
+      ? { mutexTimeoutMs }
+      : {}),
+  };
 }
 
 /**
@@ -128,7 +156,9 @@ export function fetchData(
 
   return (tx: IExtendedStorageTransaction) => {
     tx.resetNarrowestReadScope();
-    const inputsSnapshot = snapshotFetchDataInputs(inputsCell.withTx(tx));
+    const { inputs: inputsSnapshot, mutexTimeoutMs } = snapshotFetchDataConfig(
+      inputsCell.withTx(tx),
+    );
     const outputScope = tx.getNarrowestReadScope();
 
     if (!cellsInitialized || cellScope !== outputScope) {
@@ -278,6 +308,7 @@ export function fetchData(
             // after commit.
             snapshotFetchDataInputs,
             inputHash,
+            mutexTimeoutMs,
           ).then(
             ({ claimed }) => {
               if (!claimed) {
@@ -341,7 +372,7 @@ async function startFetch(
   inputsCell: Cell<FetchDataInputs>,
   url: string,
   mode: "text" | "json" | "dataUrl" | undefined,
-  options: FetchDataInputs["options"],
+  options: FetchRequestOptions | undefined,
   inputHash: string,
   pending: Cell<boolean>,
   result: Cell<any | undefined>,

--- a/packages/runner/src/builtins/fetch-data.ts
+++ b/packages/runner/src/builtins/fetch-data.ts
@@ -60,17 +60,17 @@ const fetchDataInputSchema = internSchema(
   },
 );
 
-function snapshotFetchDataInputs(
-  cell: Cell<FetchDataInputs>,
+function normalizedFetchDataInputs(
+  url: string | undefined,
+  rawMode: string | undefined,
+  rawOptions: Readonly<FetchDataOptions> | undefined,
 ): FetchDataInputs {
-  const snapshot = cell.asSchema(fetchDataInputSchema).get() ??
-    ({} as FetchDataInputs);
-  const mode = snapshot.mode === "text" || snapshot.mode === "json" ||
-      snapshot.mode === "dataUrl"
-    ? snapshot.mode
+  const mode = rawMode === "text" || rawMode === "json" ||
+      rawMode === "dataUrl"
+    ? rawMode
     : undefined;
-  const { mutexTimeoutMs: _mutexTimeoutMs, ...requestOptions } =
-    snapshot.options ?? {};
+  const { mutexTimeoutMs: _mutexTimeoutMs, ...requestOptions } = rawOptions ??
+    {};
   const body = requestOptions.body;
   const options = Object.keys(requestOptions).length > 0
     ? {
@@ -80,7 +80,19 @@ function snapshotFetchDataInputs(
         : body,
     }
     : undefined;
-  return createFrozenRequestSnapshot({ url: snapshot.url, mode, options });
+  return createFrozenRequestSnapshot({ url, mode, options });
+}
+
+function snapshotFetchDataInputs(
+  cell: Cell<FetchDataInputs>,
+): FetchDataInputs {
+  const snapshot = cell.asSchema(fetchDataInputSchema).get() ??
+    ({} as FetchDataInputs);
+  return normalizedFetchDataInputs(
+    snapshot.url,
+    snapshot.mode,
+    snapshot.options,
+  );
 }
 
 function snapshotFetchDataConfig(
@@ -88,10 +100,13 @@ function snapshotFetchDataConfig(
 ): { inputs: FetchDataInputs; mutexTimeoutMs?: number } {
   const snapshot = cell.asSchema(fetchDataInputSchema).get() ??
     ({} as FetchDataInputs);
-  const inputs = snapshotFetchDataInputs(cell);
   const mutexTimeoutMs = snapshot.options?.mutexTimeoutMs;
   return {
-    inputs,
+    inputs: normalizedFetchDataInputs(
+      snapshot.url,
+      snapshot.mode,
+      snapshot.options,
+    ),
     ...(typeof mutexTimeoutMs === "number" && Number.isFinite(mutexTimeoutMs) &&
         mutexTimeoutMs > 0
       ? { mutexTimeoutMs }

--- a/packages/runner/src/builtins/fetch-utils.ts
+++ b/packages/runner/src/builtins/fetch-utils.ts
@@ -54,8 +54,7 @@ export function computeInputHashFromValue<T extends Record<string, any>>(
   const options = inputsOnly.options;
   if (
     options !== null && typeof options === "object" &&
-    !Array.isArray(options) &&
-    Object.hasOwn(options, "mutexTimeoutMs")
+    !Array.isArray(options)
   ) {
     const {
       mutexTimeoutMs: _mutexTimeoutMs,
@@ -65,13 +64,11 @@ export function computeInputHashFromValue<T extends Record<string, any>>(
       string,
       unknown
     >;
-    const normalizedInputs = { ...inputsOnly };
     if (Object.keys(normalizedOptions).length > 0) {
-      normalizedInputs.options = normalizedOptions;
+      inputsOnly.options = normalizedOptions;
     } else {
-      delete normalizedInputs.options;
+      delete inputsOnly.options;
     }
-    return hashStringOf(stripUndefinedProps(normalizedInputs));
   }
   return hashStringOf(stripUndefinedProps(inputsOnly));
 }

--- a/packages/runner/src/builtins/fetch-utils.ts
+++ b/packages/runner/src/builtins/fetch-utils.ts
@@ -27,9 +27,10 @@ export const internalSchema = internSchema(
  *
  * Two normalizations are applied before hashing:
  *
- * (1) The top-level `result` property is dropped. It exists only as a
- *     TypeScript type hint at call sites, never as a real fetch parameter,
- *     and so must not influence the hash.
+ * (1) The top-level `result` property and `options.mutexTimeoutMs` property
+ *     are dropped. `result` exists only as a TypeScript type hint at call
+ *     sites, and `mutexTimeoutMs` is a local scheduling knob. Neither is a
+ *     real fetch parameter, so neither must influence the hash.
  *
  * (2) `undefined`-valued object properties are dropped, recursively.
  *     Callers commonly materialize snapshots via unconditional object
@@ -50,6 +51,28 @@ export function computeInputHashFromValue<T extends Record<string, any>>(
     string,
     unknown
   >;
+  const options = inputsOnly.options;
+  if (
+    options !== null && typeof options === "object" &&
+    !Array.isArray(options) &&
+    Object.hasOwn(options, "mutexTimeoutMs")
+  ) {
+    const {
+      mutexTimeoutMs: _mutexTimeoutMs,
+      ...requestOptions
+    } = options as Record<string, unknown>;
+    const normalizedOptions = stripUndefinedProps(requestOptions) as Record<
+      string,
+      unknown
+    >;
+    const normalizedInputs = { ...inputsOnly };
+    if (Object.keys(normalizedOptions).length > 0) {
+      normalizedInputs.options = normalizedOptions;
+    } else {
+      delete normalizedInputs.options;
+    }
+    return hashStringOf(stripUndefinedProps(normalizedInputs));
+  }
   return hashStringOf(stripUndefinedProps(inputsOnly));
 }
 

--- a/packages/runner/test/fetch-data-mutex.test.ts
+++ b/packages/runner/test/fetch-data-mutex.test.ts
@@ -201,7 +201,8 @@ describe("fetch-data mutex mechanism", () => {
   it("uses a stable fetchData idempotency key for identical inputs", async () => {
     const fetchData = byRef("fetchData");
     const testPattern = pattern<{ url: string }>(
-      ({ url }) => fetchData({ url, mode: "json" }),
+      ({ url }) =>
+        fetchData({ url, mode: "json", options: { mutexTimeoutMs: 30_000 } }),
     );
 
     const txPrototype = ExtendedStorageTransaction.prototype;
@@ -238,6 +239,11 @@ describe("fetch-data mutex mechanism", () => {
         mode: "json",
       });
 
+      expect(computeInputHashFromValue({
+        url: "http://mock-test-server.local/api/idempotency",
+        mode: "json",
+        options: { mutexTimeoutMs: 30_000 },
+      })).toBe(expectedHash);
       expect(outboxIds.length).toBeGreaterThan(0);
       expect(outboxIds[0]).toBe(`fetchData:${expectedHash}`);
     } finally {


### PR DESCRIPTION
## Motivation
In some places, we were triggering another fetch before the first finished, since it took longer than the timeout.
This lets these calls provide a different mutex timeout.

There's a performance regression, but it's fairly minor.

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/main.test.tsx = 24s
---END COPY-PASTE---

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a per-call `mutexTimeoutMs` option to `fetchData` to control how long to wait for the fetch mutex. Idempotency keys stay the same for identical requests; the timeout does not affect them.

- **New Features**
  - Added `mutexTimeoutMs?: number` to `FetchOptions` and `fetchData` options.
  - Excluded `options.mutexTimeoutMs` from the input hash and request options; it is only used in the mutex-claim path and ignored if not a positive number.
  - Updated tests to verify stable hashing and idempotency keys with `mutexTimeoutMs`.

<sup>Written for commit 64cb08af250fe1d8f77c7b1f2fb0a78704128601. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

