### PR TITLE
Add parameters to getImage endpoint to enable specifying size

### DIFF
--- a/packages/toolshed/routes/ai/img/img.handlers.ts
+++ b/packages/toolshed/routes/ai/img/img.handlers.ts
@@ -22,9 +22,10 @@ export const generateImage: AppRouteHandler<GenerateImageRoute> = async (c) => {
     ? { width, height }
     : undefined;
 
-  const cacheKey = customSize === undefined
-    ? prompt
-    : JSON.stringify({ prompt, ...customSize });
+  const cacheKey = JSON.stringify({
+    prompt,
+    image_size: customSize ?? "square",
+  });
   const promptSha = await sha256(cacheKey);
   const cachePath = `${CACHE_DIR}/${promptSha}.webp`;
 

--- a/packages/toolshed/routes/ai/img/img.handlers.ts
+++ b/packages/toolshed/routes/ai/img/img.handlers.ts
@@ -16,11 +16,22 @@ const CACHE_DIR = `${env.CACHE_DIR}/ai-img`;
 export const generateImage: AppRouteHandler<GenerateImageRoute> = async (c) => {
   const logger = c.get("logger");
   const { prompt } = c.req.query();
+  const width = Number(c.req.query("width"));
+  const height = Number(c.req.query("height"));
+  const customSize = Number.isInteger(width) && Number.isInteger(height)
+    ? { width, height }
+    : undefined;
 
-  const promptSha = await sha256(prompt);
+  const cacheKey = customSize === undefined
+    ? prompt
+    : JSON.stringify({ prompt, ...customSize });
+  const promptSha = await sha256(cacheKey);
   const cachePath = `${CACHE_DIR}/${promptSha}.webp`;
 
-  logger.info({ prompt, promptSha }, "Starting image generation");
+  logger.info(
+    { prompt, promptSha, image_size: customSize ?? "square" },
+    "Starting image generation",
+  );
 
   // Check cache first
   try {
@@ -47,7 +58,7 @@ export const generateImage: AppRouteHandler<GenerateImageRoute> = async (c) => {
     const result = await fal.subscribe("fal-ai/flux/schnell", {
       input: {
         prompt,
-        image_size: "square",
+        image_size: customSize ?? "square",
         num_images: 1,
       },
       logs: true,

--- a/packages/toolshed/routes/ai/img/img.routes.ts
+++ b/packages/toolshed/routes/ai/img/img.routes.ts
@@ -86,6 +86,10 @@ export const generateImage = createRoute({
         .openapi({
           example: "cat with a hat",
         }),
+      width: z.coerce.number().int().min(64).max(1024).optional()
+        .describe("Optional generated image width in pixels"),
+      height: z.coerce.number().int().min(64).max(1024).optional()
+        .describe("Optional generated image height in pixels"),
     }),
   },
   responses: {


### PR DESCRIPTION
Not really sure why the performance regression, but shouldn't be related

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-trusted-component-examples/process-examples.test.tsx = 14s
NEW_PERF_BASELINE: step: Type check = 65s
---END COPY-PASTE---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added optional width and height query params to the image generation endpoint so clients can request custom image sizes. Caching and logs now account for size; default remains square.

- **New Features**
  - Accepts optional width and height (64–1024 px) with `z.coerce.number().int()`; uses custom size only when both are provided.
  - Cache key includes prompt + `image_size` to serve the correct cached variant.
  - Forwards `image_size` to `fal-ai/flux/schnell`; logs include `image_size`.

<sup>Written for commit d4a7de6a1c20c79dee39ca6fe251112381f0da7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



