### PR TITLE
refactor(ts-transformers): remove unreachable empty-node fallback in capture type building

### DIFF
--- a/packages/ts-transformers/src/ast/type-building.ts
+++ b/packages/ts-transformers/src/ast/type-building.ts
@@ -639,8 +639,15 @@ export function buildTypeElementsFromCaptureTree(
           questionToken = factory.createToken(ts.SyntaxKind.QuestionToken);
         }
       }
-    } else if (childNode.properties.size > 0) {
-      // Intermediate node - need to get type to check optionality
+    } else {
+      // Intermediate node - need to get type to check optionality. Every node
+      // from groupCapturesByRoot carries an expression or at least one child,
+      // so a node without an expression is an intermediate node.
+      if (childNode.properties.size <= 0) {
+        throw new Error(
+          "Invariant violated: child node has neither expression nor child",
+        );
+      }
       if (parentType) {
         // We have a parent type - look up this property
         const propSymbol = parentType.getProperty(propName);
@@ -696,9 +703,6 @@ export function buildTypeElementsFromCaptureTree(
           typeRegistry: context.options.state?.typeRegistry,
         },
       );
-    } else {
-      // Fallback to unknown
-      typeNode = factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
     }
 
     properties.push(


### PR DESCRIPTION
buildTypeElementsFromCaptureTree branched three ways on each capture-tree node: a leaf branch for nodes carrying an expression, an intermediate branch for nodes with children, and a final "// Fallback to unknown" else for nodes with neither. That final branch could only fire for a node with no expression and no children, and no such node can exist. This removes the branch and folds its guarding condition (properties.size > 0) into a plain else, stating the invariant in the comment.

Where the code came from: the fallback was introduced together with the file itself in commit 851a6c89f ("Add handler closure transformation infrastructure", #2001, 2025-11-05). It was defensive from the start: groupCapturesByRoot, the only tree builder (introduced in a5fcd0f8f, #1982, and unchanged since), already could not produce the empty-node shape at that time. git log -L over the fallback lines shows no commit ever modified them after introduction.

How deadness was determined:

- Sole producer. Every tree that reaches this function is built by groupCapturesByRoot. The package contains no hand-built capture trees: no callers of createCaptureTreeNode outside capture-tree.ts, and no object literals of the CaptureTreeNode shape except one in a PatternBuilder test that only reads binding names and never reaches type building. The lift-applied path additionally gates refs through parseCaptureExpression before grouping; refs that fail to parse go to a separate fallback list and never enter the tree.

- Construction invariant. Every node groupCapturesByRoot returns carries an expression or at least one child. A freshly created node receives one or the other before its creating loop iteration ends; the mid-descent break fires only on pre-existing nodes that already carry an expression; and both properties.clear() calls are paired with an expression assignment on the same node, so clearing always yields a leaf, never an empty node.

- No mutation after construction. Nothing outside capture-tree.ts assigns or clears node.expression or node.properties. The one filtering step (filteredCaptureTree in array-method-transform.ts) rebuilds the top-level map by dropping whole root entries and never modifies a node. The recursive call in this function passes the children of nodes already under the invariant.

- Empirical probe. With the fallback body replaced by a throw, the full ts-transformers suite (292 tests, 621 steps) passes against this commit's base with zero hits. Golden fixtures whose expected output contains { type: "unknown" } get it from unknown-typed expressions through the leaf branch, not from this fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the unreachable unknown-type fallback in capture type building and enforce that nodes without an expression must have at least one child. Simplifies control flow and adds a runtime invariant check (throws on empty nodes); no behavior change.

- **Refactors**
  - Fold the “has children” branch into a single else and throw if a node has neither expression nor children.
  - Remove the final fallback to unknown and document the `groupCapturesByRoot` invariant.

<sup>Written for commit 26a99e24d20b88ddb234dca5650fb30dac7cac85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

