### PR TITLE
feat(runner,memory): exactly-once event handling via result-cell receipts (scheduler-v2 E2)

### DIFF
--- a/docs/specs/scheduler-v2/implementation/04-phaseE2-receipts.md
+++ b/docs/specs/scheduler-v2/implementation/04-phaseE2-receipts.md
@@ -72,27 +72,32 @@ determinism: STOP.
 
 Commit: `feat(runner): handler frame causes derive from the event id (scheduler-v2 E2)`
 
-## Step 3 — Engine: create-only entity precondition
+## Step 3 — Engine: entity-absent receipt precondition
 
 Files: `packages/memory/v2/engine.ts` plus the commit-operation type
 located in work order 03 step 2.1.
 
-1. Extend the `set` commit operation type with optional
-   `createOnly?: true` (wire-compatible optional field).
-2. In `applyCommitTransaction`, where `set` operations are applied: if
-   `createOnly` and a head revision already exists for that
-   (id, scope, branch), reject the whole commit via the same route as the
-   origin-committed rejection (work order 03 step 3), with
-   `{ name: "PreconditionFailedError", precondition: "receipt-exists" }`.
-   "Head exists" must use the same existence notion the engine uses for
-   conflict detection — locate the head lookup used by `findConflictSeq`
-   and reuse it; if ambiguous (tombstones/deletes), STOP and ask the
-   memory owner whether a deleted head counts as existing (record the
-   answer in PROGRESS.md and as a code comment).
-3. Engine tests (extend `v2-commit-preconditions.test.ts` from work order
-   03): create-only on a fresh entity applies; second create-only commit
-   for the same entity rejects with `receipt-exists`; a normal `set`
-   without the flag still overwrites.
+1. Extend the commit precondition type with
+   `{ kind: "entity-absent", id, scope? }` (wire-compatible optional
+   precondition kind). Do not use an operation-level `createOnly` flag;
+   receipts are commit-level preconditions independent of surviving writes.
+2. In `validateCommitPreconditions`: if `entity-absent` and a head revision
+   already exists for that (id, scope, branch), reject the whole commit via
+   the same route as the origin-committed rejection (work order 03 step 3),
+   with `{ name: "PreconditionFailedError", precondition: "receipt-exists" }`.
+   "Head exists" includes deleted/tombstoned heads and must use the same
+   scope-key resolution and delete-aware existence semantics as the engine's
+   set/delete conflict checks.
+3. Allow commits with no operations when preconditions are present, and write
+   the commit row for localSeq continuity. This is required so a duplicate
+   handling whose writes are fully elided still reaches the engine and fails
+   the receipt precondition instead of succeeding locally as a no-op.
+4. Engine tests (extend `v2-commit-preconditions.test.ts` from work order
+   03): entity-absent on a fresh entity applies; second entity-absent commit
+   for the same entity rejects with `receipt-exists`; normal `set` without the
+   precondition still overwrites; create → delete → entity-absent for the same
+   entity rejects with `receipt-exists`; precondition-only commits pass/fail
+   correctly for absent/present entities.
 
 Commit: `feat(memory): create-only set precondition for event receipts (scheduler-v2 E2)`
 
@@ -113,10 +118,12 @@ handlers that launch nothing.
    ```
 
    Store marked (space, scope, id) tuples; in `storage/v2.ts`
-   `commitOperations`, set `createOnly: true` on the matching `set`
-   operations (match on id + normalized scope). Only when the
-   `commitPreconditions` flag is on (same gate as work order 03; when the
-   flag is off the mark is recorded but not emitted).
+   `commitOperations`, emit a matching
+   `{ kind: "entity-absent", id, scope }` commit precondition for each mark.
+   This must happen even when no semantic operations survive elision. Only
+   emit these preconditions when the `commitPreconditions` flag is on (same
+   gate as work order 03; when the flag is off the mark is recorded but not
+   emitted).
 2. `src/runner.ts` `handleJavaScriptHandlerResult`: this function must now
    ALWAYS materialize the result cell. Restructure the head of the
    function:

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1757,7 +1757,7 @@ is green on top of the fix.
 
 ## 04/step-4
 
-- [x] pending — every event handling result cell is marked as a create-only
+- [x] ee9b3c89e — every event handling result cell is marked as a create-only
   receipt when the commit-preconditions protocol flag is enabled.
 - Deviations: none. Preserved existing cross-space handler-result
   materialization: launched result cells still live in the resolved result
@@ -1818,3 +1818,151 @@ packages/runner/src/storage/v2-transaction.ts:865:    this.assertWritable("markC
     `scheduler-test-utils.ts` default of `commitPreconditions: true`: passed,
     `590 passed (3091 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m5s`.
     The helper toggle was reverted before commit.
+
+## MEMORY-OWNER REVIEW — PR #4090 engine changes: APPROVED + two E2 rulings
+
+Engine review of the origin-committed precondition (acting memory
+owner):
+
+- APPROVED. Check placement is inside the engine's SQLite transaction,
+  before read validation; `SELECT_PENDING_RESOLUTION` row-presence is
+  valid committed-evidence because rejected commits throw BEFORE the
+  commit-row insert (rolled back), and it is the exact statement/
+  semantics pending-read resolution already trusts — the precondition
+  inherits the session/localSeq continuity the system already depends
+  on, so no new reconnect failure mode. ProtocolError on unknown kinds
+  is the right strict posture. Client round-trip test shape verified.
+
+Two rulings WO04 (E2) must apply — do not stop for these:
+
+1. **Tombstones count as existing.** For the create-only receipt
+   precondition, "head exists" includes DELETED/tombstoned heads: a
+   receipt that was created and later deleted still witnesses that the
+   event was handled (I11 is exactly-once EVER, not exactly-once-while-
+   retained). Use the same head/delete-aware existence notion the
+   set/delete conflict detection uses (`selectSetDeleteConflict`
+   neighborhood), and add an engine test: create → delete → create-only
+   commit for the same entity → `PreconditionFailedError`
+   ("receipt-exists"). Retention/GC interplay is spec open question 2 —
+   out of scope.
+2. **Version the precondition capability.** The engine throws
+   ProtocolError on unknown precondition kinds, so an E2 client sending
+   `receipt-exists` to an E1-only server that advertises
+   `commitPreconditions` would loop on a retryable error. In WO04:
+   change the handshake flag to a LEVEL — servers advertise
+   `commitPreconditions: 2` once receipt-exists ships (E1-only code
+   advertises 1, or keep boolean=origin-committed-only); the client
+   attaches `origin-committed` at level ≥1 and `receipt-exists` /
+   `createOnly` ops at level ≥2. Since E1 has not deployed anywhere
+   yet, you may instead simply ship E1+E2 with the boolean flag meaning
+   BOTH — but then the E1 commit range must never be deployed alone:
+   record whichever you implement; the level scheme is preferred.
+
+## IMPLEMENTER STOP — 04/step-5 receipt fixtures expose runner receipt gap
+
+Step 5 fixture work is uncommitted in
+`packages/runner/test/scheduler-event-receipts.test.ts`. The focused fixture
+currently demonstrates that the Step 4 runner implementation does not yet
+enforce receipt exactly-once for handler frames with opaque refs or already
+materialized launched results:
+
+```text
+$ cd packages/runner && ENV=test deno test --allow-ffi --allow-env --allow-read \
+  --allow-write=/tmp,/var/folders --allow-run=git \
+  test/scheduler-event-receipts.test.ts
+Check test/scheduler-event-receipts.test.ts
+running 1 test from ./test/scheduler-event-receipts.test.ts
+scheduler event receipts ...
+  deduplicates redelivered events by create-only receipt ... FAILED
+  deduplicates redelivered pattern launches by receipt ... FAILED
+  retries transient conflicts with the same receipt id ... FAILED
+  creates a receipt document for handlers that launch nothing ... ok
+  allows redelivered events to commit twice while receipts are disabled ... FAILED
+FAILED | 0 passed (1 step) | 1 failed (4 steps)
+```
+
+Key failure excerpts:
+
+```text
+deduplicates redelivered events by create-only receipt:
+expected effectsTotal 1, actual 2
+
+deduplicates redelivered pattern launches by receipt:
+expected a scheduler.event.commit marker with permanentRejection
+"receipt-exists", actual false
+```
+
+Inference: the no-props/no-launch receipt-only path is green because it writes
+`{}` directly, but stateful handlers and duplicate pattern launches go through
+the launching/materialization branch. In duplicate cases that branch can avoid a
+fresh `set` on the existing result cell, so `markCreateOnly` has no matching
+commit operation to tag and no `receipt-exists` precondition reaches memory.
+
+Fixing this appears to require touching `packages/runner/src/runner.ts` or the
+runner storage receipt-marking path to force a create-only receipt operation for
+already-materialized result cells. Work order 04 step 5 names only
+`test/scheduler-event-receipts.test.ts`, so per 00-README G4 I am stopping for
+reviewer direction rather than widening the step.
+
+Additional memory-owner rulings above are acknowledged: tombstones already
+count as existing in 04/step-3, and the current implementation records the
+transitional boolean `commitPreconditions` flag as E1+E2 together rather than
+introducing a numeric level in this unmerged stack.
+
+## REVIEWER RESOLUTION — 04/step-5 entity-absent docs amendment
+
+- [x] pending — documented the reviewer-approved replacement of op-level
+  `createOnly` receipts with commit-level `entity-absent` preconditions.
+- Deviations: none. Progress also backfills 04/step-4 to `ee9b3c89e`.
+
+## REVIEWER + MEMORY-OWNER VERDICT — 04/step-5 receipt gap (design correction)
+
+Your inference is right and the flaw is in MY step-4 design: tagging
+`createOnly` on a SET OPERATION makes the witness disappear whenever the
+duplicate handling's writes are elided as no-ops — and in the limit a
+fully-elided transaction short-circuits client-side without reaching the
+engine at all. The receipt must be a COMMIT-LEVEL precondition,
+independent of operations. Authorized redesign (touches runner storage +
+memory engine; G4 scope granted):
+
+1. **New precondition kind** alongside origin-committed:
+   `{ kind: "entity-absent", id, scope? }` — evaluated in
+   `validateCommitPreconditions`, scope resolved exactly as head lookups
+   resolve it; "exists" INCLUDES tombstoned heads (standing ruling — use
+   the `selectSetDeleteConflict`-style delete-aware lookup); violation →
+   `PreconditionFailedError("receipt-exists", ...)`.
+2. **Drop the op-level `createOnly` flag** (revert that part of
+   1b0395f1b's surface) — one mechanism, not two. Engine tests retarget
+   to the precondition, keeping the tombstone case
+   (create → delete → entity-absent commit → receipt-exists).
+3. **Client plumbing** (`markCreateOnly` keeps its name/signature):
+   marked entities emit an `entity-absent` precondition for their space
+   in `commitOperations`, regardless of what operations survive
+   elision.
+4. **Kill the zero-op escape**: a transaction carrying preconditions
+   must NOT take the no-op short-circuit — locate the early-return in
+   `commitOperations` (the path that returns ok without calling the
+   engine when no semantic ops exist) and exempt precondition-bearing
+   commits. Engine side: accept ops-empty commits when
+   `preconditions` is non-empty (mirror how observation-only commits
+   relaxed the zero-op rule), writing the commit row for localSeq
+   continuity. Engine test: precondition-only commit, both pass and
+   receipt-exists outcomes.
+5. **Fixture to add** (the corner that motivates 4): an IDEMPOTENT
+   handler (all writes elided on redelivery) — duplicate delivery must
+   still be rejected receipt-exists, not silently "succeed" locally.
+6. Sequence: docs amendment to WO04 step 3/4 describing the
+   entity-absent design
+   (`docs(specs): scheduler-v2 WO04 — receipt is a commit-level entity-absent precondition`),
+   then `feat(memory): entity-absent commit precondition replaces op-level createOnly`,
+   then the runner plumbing commit, then step 5's fixtures (all green)
+   as planned.
+
+Flag acknowledgment ACCEPTED: transitional boolean = E1+E2 ship
+together; constraint recorded — `commitPreconditions` stays default-off
+until the 04 PR merges (already true; experimental flags default off).
+
+Memory-owner note for the engine commit: keep the entity-absent lookup
+inside the same transaction scope as the other validations, and reuse
+the existing scope-key resolution helpers rather than re-deriving scope
+semantics.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1911,7 +1911,7 @@ introducing a numeric level in this unmerged stack.
 
 ## REVIEWER RESOLUTION — 04/step-5 entity-absent docs amendment
 
-- [x] pending — documented the reviewer-approved replacement of op-level
+- [x] 67a160c2c — documented the reviewer-approved replacement of op-level
   `createOnly` receipts with commit-level `entity-absent` preconditions.
 - Deviations: none. Progress also backfills 04/step-4 to `ee9b3c89e`.
 
@@ -1966,3 +1966,23 @@ Memory-owner note for the engine commit: keep the entity-absent lookup
 inside the same transaction scope as the other validations, and reuse
 the existing scope-key resolution helpers rather than re-deriving scope
 semantics.
+
+## REVIEWER RESOLUTION — 04/step-5 entity-absent memory engine
+
+- [x] pending — memory now uses commit-level `entity-absent` preconditions
+  instead of op-level `createOnly`, including precondition-only commits.
+- Deviations: widened the runner storage interface precondition type to the
+  memory `CommitPrecondition` union in this commit so the workspace
+  type-checks; runner emission logic remains for the next reviewer-requested
+  commit.
+- Recordings:
+  - `deno fmt packages/memory/v2.ts packages/memory/v2/engine.ts
+    packages/memory/test/v2-commit-preconditions.test.ts
+    packages/runner/src/storage/interface.ts`: passed (`Checked 4 files`).
+  - `deno lint` on the same four files: passed (`Checked 4 files`).
+  - `deno check` on the same four files: passed.
+  - `cd packages/memory && deno test --allow-ffi --allow-env --allow-read
+    --allow-write=/tmp,/var/folders test/v2-commit-preconditions.test.ts`:
+    passed, `10 passed`, `0 failed`.
+  - `cd packages/memory && deno task test`: passed, `211 passed
+    (95 steps)`, `0 failed`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1732,7 +1732,7 @@ is green on top of the fix.
 
 ## 04/step-3
 
-- [x] pending — memory v2 create-only `set` operations reject when the target
+- [x] 1b0395f1b — memory v2 create-only `set` operations reject when the target
   entity head already exists.
 - Deviations: added an extra deleted-head fixture because the engine `head`
   table is upserted by `delete`; tombstoned heads therefore count as existing
@@ -1754,3 +1754,67 @@ is green on top of the fix.
     passed, `8 passed`, `0 failed`.
   - `cd packages/memory && deno task test`: passed, `211 passed
     (95 steps)`, `0 failed`.
+
+## 04/step-4
+
+- [x] pending — every event handling result cell is marked as a create-only
+  receipt when the commit-preconditions protocol flag is enabled.
+- Deviations: none. Preserved existing cross-space handler-result
+  materialization: launched result cells still live in the resolved result
+  space; receipt-only no-launch handlers create `{}` in `processCell.space`.
+- Recordings:
+  - Constraint grep:
+
+```text
+$ grep -n "handleJavaScriptHandlerResult" packages/runner/src/runner.ts
+2502:  private handleJavaScriptHandlerResult(
+2981:            return this.handleJavaScriptHandlerResult(
+```
+
+  - `crypto.randomUUID()` fallback grep:
+
+```text
+$ rg -n "crypto\.randomUUID\(\)" packages/runner/src/runner.ts
+2884:        $event: tx.dispatchedEventId ?? crypto.randomUUID(),
+```
+
+  - Receipt mark site grep:
+
+```text
+$ rg -n "markCreateOnly" packages/runner/src
+packages/runner/src/runner.ts:1460:    markCreateOnlyResult: boolean = false,
+packages/runner/src/runner.ts:1476:        if (markCreateOnlyResult) {
+packages/runner/src/runner.ts:1477:          startTx.markCreateOnly?.(
+packages/runner/src/runner.ts:1517:    markCreateOnlyResult = false,
+packages/runner/src/runner.ts:1531:        if (markCreateOnlyResult) {
+packages/runner/src/runner.ts:1532:          startTx.markCreateOnly?.(
+packages/runner/src/runner.ts:2528:        tx.markCreateOnly?.(receiptCell.getAsNormalizedFullLink());
+packages/runner/src/runner.ts:2611:      tx.markCreateOnly?.(receiptCell.getAsNormalizedFullLink());
+packages/runner/src/runner.ts:2675:    markCreateOnlyResult = false,
+packages/runner/src/runner.ts:2696:        markCreateOnlyResult,
+packages/runner/src/storage/extended-storage-transaction.ts:563:  markCreateOnly(
+packages/runner/src/storage/extended-storage-transaction.ts:566:    this.assertWritable("markCreateOnly");
+packages/runner/src/storage/extended-storage-transaction.ts:573:    this.tx.markCreateOnly?.(link);
+packages/runner/src/storage/extended-storage-transaction.ts:1109:  markCreateOnly(
+packages/runner/src/storage/extended-storage-transaction.ts:1112:    this.wrapped.markCreateOnly?.(link);
+packages/runner/src/storage/interface.ts:587:  markCreateOnly?(
+packages/runner/src/storage/interface.ts:764:  markCreateOnly?(
+packages/runner/src/storage/v2-transaction.ts:862:  markCreateOnly(
+packages/runner/src/storage/v2-transaction.ts:865:    this.assertWritable("markCreateOnly()");
+```
+
+  - `deno fmt packages/runner/src/storage/interface.ts
+    packages/runner/src/storage/extended-storage-transaction.ts
+    packages/runner/src/storage/v2-transaction.ts
+    packages/runner/src/storage/v2.ts packages/runner/src/runner.ts
+    packages/runner/src/scheduler/events.ts packages/runner/src/telemetry.ts`:
+    passed (`Checked 7 files`).
+  - `deno lint` on the same seven files: passed (`Checked 7 files`).
+  - `deno check` on the same seven files: passed.
+  - `cd packages/runner && deno task test` with default
+    `commitPreconditions` off: passed, `590 passed (3091 steps)`,
+    `0 failed`, `0 ignored (10 steps)`, `2m5s`.
+  - `cd packages/runner && deno task test` with a temporary
+    `scheduler-test-utils.ts` default of `commitPreconditions: true`: passed,
+    `590 passed (3091 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m5s`.
+    The helper toggle was reverted before commit.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -2015,7 +2015,7 @@ semantics.
 
 ## 04/step-5
 
-- [x] pending — receipt exactly-once fixtures cover redelivery, launches,
+- [x] 5fdd5375a — receipt exactly-once fixtures cover redelivery, launches,
   transient retry, precondition-only idempotent redelivery, receipt-only
   handling, and flag-off transitional behavior.
 - Deviations: includes the reviewer-requested idempotent handler fixture where
@@ -2032,3 +2032,83 @@ semantics.
     --allow-read --allow-write=/tmp,/var/folders --allow-run=git
     test/scheduler-event-receipts.test.ts`: passed, `1 passed (6 steps)`,
     `0 failed`.
+
+## 04/phase-end self-check
+
+- [x] pending — work order 04 phase-end verification recorded.
+- Deviations: work order 04 lists no phase-specific benchmarks beyond the
+  full suites and exit-checklist greps. The flag-on runner pass used a
+  temporary local edit to `packages/runner/test/scheduler-test-utils.ts` to
+  default `commitPreconditions: true`; that edit was reverted before this
+  record was written, and `git status --short` was clean.
+- Recordings:
+  - `cd packages/memory && deno task test`: passed, `211 passed
+    (95 steps)`, `0 failed`.
+  - `cd packages/runner && deno task test` with default
+    `commitPreconditions` off: passed, `591 passed (3097 steps)`,
+    `0 failed`, `0 ignored (10 steps)`, `2m5s`.
+  - `cd packages/runner && deno task test` with a temporary
+    `scheduler-test-utils.ts` default of `commitPreconditions: true`: passed,
+    `591 passed (3097 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m5s`.
+    The helper toggle was reverted before recording.
+  - `grep -n "handleJavaScriptHandlerResult" packages/runner/src/runner.ts`:
+
+```text
+2502:  private handleJavaScriptHandlerResult(
+2981:            return this.handleJavaScriptHandlerResult(
+```
+
+  - `rg -n "crypto\.randomUUID\(\)" packages/runner/src/runner.ts`:
+
+```text
+2884:        $event: tx.dispatchedEventId ?? crypto.randomUUID(),
+```
+
+  - `rg -n "markCreateOnly" packages/runner/src`:
+
+```text
+packages/runner/src/runner.ts:1460:    markCreateOnlyResult: boolean = false,
+packages/runner/src/runner.ts:1476:        if (markCreateOnlyResult) {
+packages/runner/src/runner.ts:1477:          startTx.markCreateOnly?.(
+packages/runner/src/runner.ts:1517:    markCreateOnlyResult = false,
+packages/runner/src/runner.ts:1531:        if (markCreateOnlyResult) {
+packages/runner/src/runner.ts:1532:          startTx.markCreateOnly?.(
+packages/runner/src/runner.ts:2528:        tx.markCreateOnly?.(receiptCell.getAsNormalizedFullLink());
+packages/runner/src/runner.ts:2611:      tx.markCreateOnly?.(receiptCell.getAsNormalizedFullLink());
+packages/runner/src/runner.ts:2675:    markCreateOnlyResult = false,
+packages/runner/src/runner.ts:2696:        markCreateOnlyResult,
+packages/runner/src/storage/v2-transaction.ts:865:  markCreateOnly(
+packages/runner/src/storage/v2-transaction.ts:868:    this.assertWritable("markCreateOnly()");
+packages/runner/src/storage/extended-storage-transaction.ts:563:  markCreateOnly(
+packages/runner/src/storage/extended-storage-transaction.ts:566:    this.assertWritable("markCreateOnly");
+packages/runner/src/storage/extended-storage-transaction.ts:573:    this.tx.markCreateOnly?.(link);
+packages/runner/src/storage/extended-storage-transaction.ts:1109:  markCreateOnly(
+packages/runner/src/storage/extended-storage-transaction.ts:1112:    this.wrapped.markCreateOnly?.(link);
+packages/runner/src/storage/interface.ts:587:  markCreateOnly?(
+packages/runner/src/storage/interface.ts:764:  markCreateOnly?(
+```
+
+  - `rg -n "event-handler-replaced|Exactly one handler per event|event-lost-race|permanentRejection|isPermanentRejection|receipt-exists" packages/runner/src/scheduler/events.ts packages/runner/src/telemetry.ts packages/runner/src/storage/rejection.ts`:
+
+```text
+packages/runner/src/storage/rejection.ts:4: * for `receipt-exists` a retry would double-handle an event.
+packages/runner/src/storage/rejection.ts:6:export function isPermanentRejection(
+packages/runner/src/telemetry.ts:170:  permanentRejection?: "origin-committed" | "receipt-exists";
+packages/runner/src/scheduler/events.ts:16:import { isPermanentRejection } from "../storage/rejection.ts";
+packages/runner/src/scheduler/events.ts:162:      // Exactly one handler per event (spec scheduler-v2 decision 12).
+packages/runner/src/scheduler/events.ts:210:    logger.warn("event-handler-replaced", () => [
+packages/runner/src/scheduler/events.ts:594:      const permanentRejection =
+packages/runner/src/scheduler/events.ts:595:        result.error && isPermanentRejection(result.error)
+packages/runner/src/scheduler/events.ts:613:        ...(permanentRejection !== undefined ? { permanentRejection } : {}),
+packages/runner/src/scheduler/events.ts:617:        !isPermanentRejection(result.error)
+packages/runner/src/scheduler/events.ts:639:        if (permanentRejection === "receipt-exists") {
+packages/runner/src/scheduler/events.ts:641:            "event-lost-race",
+packages/runner/src/scheduler/events.ts:654:            permanent: isPermanentRejection(result.error),
+```
+
+  - `rg -n "entity-absent|PreconditionFailedError|receipt-exists" packages/memory/v2.ts packages/memory/v2/engine.ts packages/memory/v2/server.ts packages/runner/src/storage/interface.ts packages/runner/src/storage/v2-transaction.ts packages/runner/src/storage/v2.ts`: entity-absent precondition type, engine validation,
+    memory server typed-error mapping, runner native precondition emission, and
+    runner permanent rejection mapping all present.
+  - `rg -n "createOnly" packages/memory packages/runner/src packages/runner/test/scheduler-event-receipts.test.ts`: no op-level
+    `createOnly` operation surface remains; remaining matches are
+    `markCreateOnly` API/helper names and local mark maps.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -2112,3 +2112,29 @@ packages/runner/src/scheduler/events.ts:654:            permanent: isPermanentRe
   - `rg -n "createOnly" packages/memory packages/runner/src packages/runner/test/scheduler-event-receipts.test.ts`: no op-level
     `createOnly` operation surface remains; remaining matches are
     `markCreateOnly` API/helper names and local mark maps.
+
+## REVIEWER RESOLUTION — PR #4096 review findings
+
+- [x] pending — deferred-navigate receipt placement + rejection-normalization
+  hardening.
+- Findings addressed (Codex/cubic review on PR #4096), red-first where
+  applicable:
+  1. `setupDeferredHandlerResultPattern` created the result-cell head in the
+     handler transaction (`setupInternal`) but the create-only receipt mark
+     rode the deferred start transaction — the first delivery's deferred
+     start saw an existing head and died as `receipt-exists`, while
+     redeliveries went unguarded. The mark now rides the handler transaction
+     that performs the create; `startAfterSuccessfulCommit` loses its unused
+     `markCreateOnlyResult` parameter
+     (`test/scheduler-event-receipts.test.ts` "navigateTo handler results
+     navigate once and deduplicate redelivery", red-first: first delivery
+     never navigated).
+  2. `toRejectedError` accessed `.precondition` without optional chaining;
+     a primitive/null rejection would throw while normalizing a commit
+     failure and mask the real error.
+- Rebase note: main now validates preconditions ahead of every commit shape
+  (#4090 resolution); the entity-absent precondition made re-validation on
+  commit replays unsafe, so the generic same-session replay check is hoisted
+  ABOVE precondition validation (still before the observation fast paths,
+  which keep their own replay table and never hit the generic check).
+- Deviations: none.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1989,7 +1989,7 @@ semantics.
 
 ## REVIEWER RESOLUTION — 04/step-5 entity-absent runner plumbing
 
-- [x] pending — runner storage now turns `markCreateOnly` into commit-level
+- [x] c6e33b303 — runner storage now turns `markCreateOnly` into commit-level
   `entity-absent` preconditions independent of surviving operations.
 - Deviations: includes memory server/client error mapping so
   `PreconditionFailedError("receipt-exists")` survives the remote storage
@@ -2008,6 +2008,26 @@ semantics.
     --allow-write=/tmp,/var/folders
     packages/memory/test/v2-commit-preconditions.test.ts`: passed,
     `11 passed`, `0 failed`.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-event-receipts.test.ts`: passed, `1 passed (6 steps)`,
+    `0 failed`.
+
+## 04/step-5
+
+- [x] pending — receipt exactly-once fixtures cover redelivery, launches,
+  transient retry, precondition-only idempotent redelivery, receipt-only
+  handling, and flag-off transitional behavior.
+- Deviations: includes the reviewer-requested idempotent handler fixture where
+  duplicate delivery's semantic writes are elided, leaving the receipt
+  precondition as the only surviving commit guard. Red output for the
+  fixture-first cases is recorded above in the IMPLEMENTER STOP section.
+- Recordings:
+  - `deno fmt packages/runner/test/scheduler-event-receipts.test.ts`: passed
+    (`Checked 1 file`).
+  - `deno lint packages/runner/test/scheduler-event-receipts.test.ts`: passed
+    (`Checked 1 file`).
+  - `deno check packages/runner/test/scheduler-event-receipts.test.ts`: passed.
   - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
     --allow-read --allow-write=/tmp,/var/folders --allow-run=git
     test/scheduler-event-receipts.test.ts`: passed, `1 passed (6 steps)`,

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1693,7 +1693,7 @@ is green on top of the fix.
 
 ## 04/step-1
 
-- [x] pending — one handler per event link; replacement warns and the last
+- [x] 364e86ad4 — one handler per event link; replacement warns and the last
   registration wins.
 - Deviations: used `scheduler-events.test.ts` because the file now type-checks
   cleanly; asserted the warn through `getLoggerCountsBreakdown`.
@@ -1714,3 +1714,18 @@ is green on top of the fix.
     `0 failed`.
   - `cd packages/runner && deno task test`: passed,
     `590 passed (3091 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m5s`.
+
+## 04/step-2
+
+- [x] pending — handler-frame causes derive from the durable event id, falling
+  back to `crypto.randomUUID()` only for non-dispatch invocations.
+- Deviations: none.
+- Recordings:
+  - No baked per-attempt-id failures observed.
+  - `deno fmt packages/runner/src/runner.ts`: passed (`Checked 1 file`).
+  - `deno lint packages/runner/src/runner.ts`: passed (`Checked 1 file`).
+  - `deno check packages/runner/src/runner.ts`: passed.
+  - `cd packages/runner && deno task test`: passed,
+    `590 passed (3091 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m5s`.
+  - `cd packages/patterns && deno task test`: passed; package test task is
+    currently a stub (`No tests defined.`).

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1717,7 +1717,7 @@ is green on top of the fix.
 
 ## 04/step-2
 
-- [x] pending — handler-frame causes derive from the durable event id, falling
+- [x] 729618409 — handler-frame causes derive from the durable event id, falling
   back to `crypto.randomUUID()` only for non-dispatch invocations.
 - Deviations: none.
 - Recordings:
@@ -1729,3 +1729,28 @@ is green on top of the fix.
     `590 passed (3091 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m5s`.
   - `cd packages/patterns && deno task test`: passed; package test task is
     currently a stub (`No tests defined.`).
+
+## 04/step-3
+
+- [x] pending — memory v2 create-only `set` operations reject when the target
+  entity head already exists.
+- Deviations: added an extra deleted-head fixture because the engine `head`
+  table is upserted by `delete`; tombstoned heads therefore count as existing
+  under the same head-exists semantics used here.
+- Red-first recordings:
+  - `cd packages/memory && deno test --allow-ffi --allow-env --allow-read
+    --allow-write=/tmp,/var/folders test/v2-commit-preconditions.test.ts`:
+    failed as expected before the engine check, `6 passed`, `2 failed`;
+    duplicate create-only and deleted-head create-only fixtures both failed
+    with `AssertionError: Expected function to throw.`
+- Recordings:
+  - `deno fmt packages/memory/v2.ts packages/memory/v2/engine.ts
+    packages/memory/test/v2-commit-preconditions.test.ts`: passed
+    (`Checked 3 files`).
+  - `deno lint` on the same three files: passed (`Checked 3 files`).
+  - `deno check` on the same three files: passed.
+  - `cd packages/memory && deno test --allow-ffi --allow-env --allow-read
+    --allow-write=/tmp,/var/folders test/v2-commit-preconditions.test.ts`:
+    passed, `8 passed`, `0 failed`.
+  - `cd packages/memory && deno task test`: passed, `211 passed
+    (95 steps)`, `0 failed`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1634,7 +1634,7 @@ is green on top of the fix.
 
 ## 03/phase-end
 
-- [x] pending — WO03 exit checklist self-check complete.
+- [x] 6ebfbff2d — WO03 exit checklist self-check complete.
 - Benchmarks: none listed in WO03.
 - Recordings:
   - `cd packages/runner && deno task test`: passed,
@@ -1690,3 +1690,27 @@ is green on top of the fix.
      preconditions on storage that cannot enforce them
      (`test/storage-commit-preconditions.test.ts`).
 - Deviations: none.
+
+## 04/step-1
+
+- [x] pending — one handler per event link; replacement warns and the last
+  registration wins.
+- Deviations: used `scheduler-events.test.ts` because the file now type-checks
+  cleanly; asserted the warn through `getLoggerCountsBreakdown`.
+- Red-first recordings:
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-events.test.ts`: failed as expected before the fix:
+    replacement fixture expected first handler count `0`, actual `1`.
+- Recordings:
+  - `deno fmt packages/runner/src/scheduler/events.ts
+    packages/runner/test/scheduler-events.test.ts`: passed
+    (`Checked 2 files`).
+  - `deno lint` on the same two files: passed (`Checked 2 files`).
+  - `deno check` on the same two files: passed.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-events.test.ts`: passed, `1 passed (15 steps)`,
+    `0 failed`.
+  - `cd packages/runner && deno task test`: passed,
+    `590 passed (3091 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m5s`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -1969,7 +1969,7 @@ semantics.
 
 ## REVIEWER RESOLUTION — 04/step-5 entity-absent memory engine
 
-- [x] pending — memory now uses commit-level `entity-absent` preconditions
+- [x] 83d0c2d22 — memory now uses commit-level `entity-absent` preconditions
   instead of op-level `createOnly`, including precondition-only commits.
 - Deviations: widened the runner storage interface precondition type to the
   memory `CommitPrecondition` union in this commit so the workspace
@@ -1986,3 +1986,29 @@ semantics.
     passed, `10 passed`, `0 failed`.
   - `cd packages/memory && deno task test`: passed, `211 passed
     (95 steps)`, `0 failed`.
+
+## REVIEWER RESOLUTION — 04/step-5 entity-absent runner plumbing
+
+- [x] pending — runner storage now turns `markCreateOnly` into commit-level
+  `entity-absent` preconditions independent of surviving operations.
+- Deviations: includes memory server/client error mapping so
+  `PreconditionFailedError("receipt-exists")` survives the remote storage
+  round trip and reaches runner scheduling as a permanent rejection. Drops the
+  op-level `createOnly` surface from runner native commit operations.
+- Recordings:
+  - `deno fmt packages/runner/src/storage/interface.ts
+    packages/runner/src/storage/v2-transaction.ts
+    packages/runner/src/storage/v2.ts packages/memory/v2/server.ts
+    packages/memory/test/v2-commit-preconditions.test.ts
+    packages/runner/test/scheduler-event-receipts.test.ts`: passed
+    (`Checked 6 files`).
+  - `deno lint` on the same six files: passed (`Checked 6 files`).
+  - `deno check` on the same six files: passed.
+  - `deno test --allow-ffi --allow-env --allow-read
+    --allow-write=/tmp,/var/folders
+    packages/memory/test/v2-commit-preconditions.test.ts`: passed,
+    `11 passed`, `0 failed`.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-event-receipts.test.ts`: passed, `1 passed (6 steps)`,
+    `0 failed`.

--- a/packages/memory/test/v2-commit-preconditions.test.ts
+++ b/packages/memory/test/v2-commit-preconditions.test.ts
@@ -650,3 +650,49 @@ Deno.test("precondition failures keep name and precondition through client round
     await server.close();
   }
 });
+
+Deno.test("entity-absent failures keep receipt-exists through client round trip", async () => {
+  const server = new Server({
+    store: new URL("memory://memory-v2-entity-absent-client"),
+  });
+  const client = await connect({ transport: loopback(server) });
+  const session = await client.mount(
+    "did:key:z6Mk-memory-v2-entity-absent-client",
+  );
+
+  try {
+    await session.transact({
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: "entity:receipt",
+        value: toEntityDocument({ receipt: 1 }),
+      }],
+    });
+
+    const error = await assertRejects(
+      () =>
+        session.transact({
+          localSeq: 2,
+          reads: { confirmed: [], pending: [] },
+          preconditions: [{
+            kind: "entity-absent",
+            id: "entity:receipt",
+          }],
+          operations: [],
+        }),
+      Error,
+      "entity-absent precondition target already exists",
+    );
+
+    assertEquals(error.name, "PreconditionFailedError");
+    assertEquals(
+      (error as Error & { precondition?: unknown }).precondition,
+      "receipt-exists",
+    );
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});

--- a/packages/memory/test/v2-commit-preconditions.test.ts
+++ b/packages/memory/test/v2-commit-preconditions.test.ts
@@ -187,6 +187,184 @@ Deno.test("commits without preconditions are unaffected", async () => {
   }
 });
 
+Deno.test("create-only set applies on a fresh entity", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    const applied = applyCommit(engine, {
+      sessionId: "session:create-only-fresh",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:receipt",
+          createOnly: true,
+          value: toEntityDocument({ receipt: 1 }),
+        }],
+      },
+    });
+
+    assertEquals(applied.seq, 1);
+    assertEquals(read(engine, { id: "entity:receipt" }), {
+      value: { receipt: 1 },
+    });
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("create-only set rejects when the entity head already exists", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:create-only-existing",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:receipt",
+          createOnly: true,
+          value: toEntityDocument({ receipt: 1 }),
+        }],
+      },
+    });
+
+    const rejected = assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:create-only-existing",
+          commit: {
+            localSeq: 2,
+            reads: { confirmed: [], pending: [] },
+            operations: [
+              {
+                op: "set",
+                id: "entity:receipt",
+                createOnly: true,
+                value: toEntityDocument({ receipt: 2 }),
+              },
+              {
+                op: "set",
+                id: "entity:side-effect",
+                value: toEntityDocument({ shouldNotCommit: true }),
+              },
+            ],
+          },
+        }),
+      PreconditionFailedError,
+      "create-only set target already exists",
+    );
+
+    assertEquals(rejected.name, "PreconditionFailedError");
+    assertEquals(rejected.precondition, "receipt-exists");
+    assertEquals(read(engine, { id: "entity:receipt" }), {
+      value: { receipt: 1 },
+    });
+    assertEquals(read(engine, { id: "entity:side-effect" }), null);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("set without createOnly overwrites an existing entity", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:create-only-normal-set",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:receipt",
+          createOnly: true,
+          value: toEntityDocument({ receipt: 1 }),
+        }],
+      },
+    });
+
+    const applied = applyCommit(engine, {
+      sessionId: "session:create-only-normal-set",
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:receipt",
+          value: toEntityDocument({ receipt: 2 }),
+        }],
+      },
+    });
+
+    assertEquals(applied.seq, 2);
+    assertEquals(read(engine, { id: "entity:receipt" }), {
+      value: { receipt: 2 },
+    });
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("create-only set treats a deleted head as existing", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:create-only-delete-head",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:receipt",
+          value: toEntityDocument({ receipt: 1 }),
+        }],
+      },
+    });
+    applyCommit(engine, {
+      sessionId: "session:create-only-delete-head",
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{ op: "delete", id: "entity:receipt" }],
+      },
+    });
+
+    assertEquals(read(engine, { id: "entity:receipt" }), null);
+
+    const rejected = assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:create-only-delete-head",
+          commit: {
+            localSeq: 3,
+            reads: { confirmed: [], pending: [] },
+            operations: [{
+              op: "set",
+              id: "entity:receipt",
+              createOnly: true,
+              value: toEntityDocument({ receipt: 3 }),
+            }],
+          },
+        }),
+      PreconditionFailedError,
+      "create-only set target already exists",
+    );
+
+    assertEquals(rejected.precondition, "receipt-exists");
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
 const observationOnlyFixture = (
   localSeq: number,
 ): SchedulerActionObservation => ({

--- a/packages/memory/test/v2-commit-preconditions.test.ts
+++ b/packages/memory/test/v2-commit-preconditions.test.ts
@@ -187,19 +187,22 @@ Deno.test("commits without preconditions are unaffected", async () => {
   }
 });
 
-Deno.test("create-only set applies on a fresh entity", async () => {
+Deno.test("entity-absent precondition applies on a fresh entity", async () => {
   const { engine, path } = await createEngine();
 
   try {
     const applied = applyCommit(engine, {
-      sessionId: "session:create-only-fresh",
+      sessionId: "session:entity-absent-fresh",
       commit: {
         localSeq: 1,
         reads: { confirmed: [], pending: [] },
+        preconditions: [{
+          kind: "entity-absent",
+          id: "entity:receipt",
+        }],
         operations: [{
           op: "set",
           id: "entity:receipt",
-          createOnly: true,
           value: toEntityDocument({ receipt: 1 }),
         }],
       },
@@ -215,19 +218,22 @@ Deno.test("create-only set applies on a fresh entity", async () => {
   }
 });
 
-Deno.test("create-only set rejects when the entity head already exists", async () => {
+Deno.test("entity-absent precondition rejects when the entity head already exists", async () => {
   const { engine, path } = await createEngine();
 
   try {
     applyCommit(engine, {
-      sessionId: "session:create-only-existing",
+      sessionId: "session:entity-absent-existing",
       commit: {
         localSeq: 1,
         reads: { confirmed: [], pending: [] },
+        preconditions: [{
+          kind: "entity-absent",
+          id: "entity:receipt",
+        }],
         operations: [{
           op: "set",
           id: "entity:receipt",
-          createOnly: true,
           value: toEntityDocument({ receipt: 1 }),
         }],
       },
@@ -236,15 +242,18 @@ Deno.test("create-only set rejects when the entity head already exists", async (
     const rejected = assertThrows(
       () =>
         applyCommit(engine, {
-          sessionId: "session:create-only-existing",
+          sessionId: "session:entity-absent-existing",
           commit: {
             localSeq: 2,
             reads: { confirmed: [], pending: [] },
+            preconditions: [{
+              kind: "entity-absent",
+              id: "entity:receipt",
+            }],
             operations: [
               {
                 op: "set",
                 id: "entity:receipt",
-                createOnly: true,
                 value: toEntityDocument({ receipt: 2 }),
               },
               {
@@ -256,7 +265,7 @@ Deno.test("create-only set rejects when the entity head already exists", async (
           },
         }),
       PreconditionFailedError,
-      "create-only set target already exists",
+      "entity-absent precondition target already exists",
     );
 
     assertEquals(rejected.name, "PreconditionFailedError");
@@ -271,26 +280,29 @@ Deno.test("create-only set rejects when the entity head already exists", async (
   }
 });
 
-Deno.test("set without createOnly overwrites an existing entity", async () => {
+Deno.test("set without entity-absent precondition overwrites an existing entity", async () => {
   const { engine, path } = await createEngine();
 
   try {
     applyCommit(engine, {
-      sessionId: "session:create-only-normal-set",
+      sessionId: "session:entity-absent-normal-set",
       commit: {
         localSeq: 1,
         reads: { confirmed: [], pending: [] },
+        preconditions: [{
+          kind: "entity-absent",
+          id: "entity:receipt",
+        }],
         operations: [{
           op: "set",
           id: "entity:receipt",
-          createOnly: true,
           value: toEntityDocument({ receipt: 1 }),
         }],
       },
     });
 
     const applied = applyCommit(engine, {
-      sessionId: "session:create-only-normal-set",
+      sessionId: "session:entity-absent-normal-set",
       commit: {
         localSeq: 2,
         reads: { confirmed: [], pending: [] },
@@ -312,12 +324,12 @@ Deno.test("set without createOnly overwrites an existing entity", async () => {
   }
 });
 
-Deno.test("create-only set treats a deleted head as existing", async () => {
+Deno.test("entity-absent precondition treats a deleted head as existing", async () => {
   const { engine, path } = await createEngine();
 
   try {
     applyCommit(engine, {
-      sessionId: "session:create-only-delete-head",
+      sessionId: "session:entity-absent-delete-head",
       commit: {
         localSeq: 1,
         reads: { confirmed: [], pending: [] },
@@ -329,7 +341,7 @@ Deno.test("create-only set treats a deleted head as existing", async () => {
       },
     });
     applyCommit(engine, {
-      sessionId: "session:create-only-delete-head",
+      sessionId: "session:entity-absent-delete-head",
       commit: {
         localSeq: 2,
         reads: { confirmed: [], pending: [] },
@@ -342,20 +354,91 @@ Deno.test("create-only set treats a deleted head as existing", async () => {
     const rejected = assertThrows(
       () =>
         applyCommit(engine, {
-          sessionId: "session:create-only-delete-head",
+          sessionId: "session:entity-absent-delete-head",
           commit: {
             localSeq: 3,
             reads: { confirmed: [], pending: [] },
+            preconditions: [{
+              kind: "entity-absent",
+              id: "entity:receipt",
+            }],
             operations: [{
               op: "set",
               id: "entity:receipt",
-              createOnly: true,
               value: toEntityDocument({ receipt: 3 }),
             }],
           },
         }),
       PreconditionFailedError,
-      "create-only set target already exists",
+      "entity-absent precondition target already exists",
+    );
+
+    assertEquals(rejected.precondition, "receipt-exists");
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("entity-absent precondition-only commit applies for an absent entity", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    const applied = applyCommit(engine, {
+      sessionId: "session:entity-absent-only-fresh",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        preconditions: [{
+          kind: "entity-absent",
+          id: "entity:receipt",
+        }],
+        operations: [],
+      },
+    });
+
+    assertEquals(applied.seq, 1);
+    assertEquals(applied.revisions, []);
+    assertEquals(read(engine, { id: "entity:receipt" }), null);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("entity-absent precondition-only commit rejects for an existing entity", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:entity-absent-only-existing",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:receipt",
+          value: toEntityDocument({ receipt: 1 }),
+        }],
+      },
+    });
+
+    const rejected = assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:entity-absent-only-existing",
+          commit: {
+            localSeq: 2,
+            reads: { confirmed: [], pending: [] },
+            preconditions: [{
+              kind: "entity-absent",
+              id: "entity:receipt",
+            }],
+            operations: [],
+          },
+        }),
+      PreconditionFailedError,
+      "entity-absent precondition target already exists",
     );
 
     assertEquals(rejected.precondition, "receipt-exists");

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -71,6 +71,7 @@ export interface SetOperation {
   id: EntityId;
   scope?: CellScope;
   value: EntityDocument;
+  createOnly?: true;
 }
 
 export interface PatchOperation {

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -71,7 +71,6 @@ export interface SetOperation {
   id: EntityId;
   scope?: CellScope;
   value: EntityDocument;
-  createOnly?: true;
 }
 
 export interface PatchOperation {
@@ -130,11 +129,17 @@ export interface SchedulerObservationCommit {
   schedulerObservation: unknown;
 }
 
-export interface CommitPrecondition {
-  kind: "origin-committed";
-  /** localSeq of a commit from the SAME session in this space. */
-  originLocalSeq: number;
-}
+export type CommitPrecondition =
+  | {
+    kind: "origin-committed";
+    /** localSeq of a commit from the SAME session in this space. */
+    originLocalSeq: number;
+  }
+  | {
+    kind: "entity-absent";
+    id: EntityId;
+    scope?: CellScope;
+  };
 
 export interface ClientCommit {
   localSeq: number;

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -3124,10 +3124,35 @@ const applyCommitTransaction = (
   const branch = commit.branch ?? DEFAULT_BRANCH;
   ensureActiveBranch(engine, branch);
 
+  // Replay detection first: a commit this session already applied returns
+  // its stored result without re-validating preconditions — re-checking
+  // entity-absent against the state the original application created would
+  // wrongly reject the replay. Observation-only commits keep their own
+  // replay table and never insert here, so this is a no-op for them.
+  const existing = engine.statements.selectExistingCommit.get({
+    session_id: sessionKey,
+    local_seq: commit.localSeq,
+  }) as CommitRow | undefined;
+  if (existing) {
+    if (!sameStoredOriginal(existing.original, commit)) {
+      throw new ProtocolError(
+        `commit replay mismatch for session ${sessionId} localSeq ${commit.localSeq}`,
+      );
+    }
+    return {
+      seq: existing.seq,
+      branch: existing.branch,
+      revisions: selectCommitRevisions(engine, existing.seq),
+    };
+  }
+
   // Preconditions gate every commit shape, including the observation-only
   // fast paths below — a descendant of an uncommitted origin must not
   // persist anything, observations included.
-  validateCommitPreconditions(engine, sessionKey, commit);
+  validateCommitPreconditions(engine, sessionKey, branch, commit, {
+    principal,
+    sessionId,
+  });
 
   if (commit.operations.length === 0 && hasSchedulerObservationBatch) {
     return applySchedulerObservationBatchCommit(engine, {
@@ -3151,23 +3176,6 @@ const applyCommitTransaction = (
       reads: commit.reads,
       schedulerObservation,
     });
-  }
-
-  const existing = engine.statements.selectExistingCommit.get({
-    session_id: sessionKey,
-    local_seq: commit.localSeq,
-  }) as CommitRow | undefined;
-  if (existing) {
-    if (!sameStoredOriginal(existing.original, commit)) {
-      throw new ProtocolError(
-        `commit replay mismatch for session ${sessionId} localSeq ${commit.localSeq}`,
-      );
-    }
-    return {
-      seq: existing.seq,
-      branch: existing.branch,
-      revisions: selectCommitRevisions(engine, existing.seq),
-    };
   }
 
   validateConfirmedReads(engine, branch, commit, { principal, sessionId });
@@ -3325,21 +3333,6 @@ const writeOperation = (
           "memory v2 set operations require explicit document objects",
         );
       }
-      if (operation.createOnly) {
-        const existingHead = engine.statements.selectHead.get({
-          branch,
-          id: operation.id,
-          scope_key: scopeKey,
-        }) as HeadRow | undefined;
-        // The head table keeps the latest set or delete revision; either means
-        // this entity id has already been claimed for create-only receipts.
-        if (existingHead !== undefined) {
-          throw new PreconditionFailedError(
-            "receipt-exists",
-            `create-only set target already exists: ${operation.id}`,
-          );
-        }
-      }
       engine.statements.insertRevision.run({
         branch,
         id: operation.id,
@@ -3431,7 +3424,9 @@ const writeOperation = (
 const validateCommitPreconditions = (
   engine: Engine,
   sessionKey: string,
+  branch: BranchName,
   commit: ClientCommit,
+  scopeContext: { principal?: string; sessionId: SessionId },
 ): void => {
   for (const precondition of commit.preconditions ?? []) {
     // Wire input: validate the shape deterministically so malformed entries
@@ -3442,30 +3437,50 @@ const validateCommitPreconditions = (
     ) {
       throw new ProtocolError("malformed commit precondition: not an object");
     }
-    if (precondition.kind !== "origin-committed") {
-      throw new ProtocolError(
-        `unsupported commit precondition: ${
-          String((precondition as { kind?: unknown }).kind)
-        }`,
-      );
-    }
-    if (!Number.isInteger(precondition.originLocalSeq)) {
-      throw new ProtocolError(
-        "malformed origin-committed precondition: originLocalSeq must be an integer",
-      );
-    }
-
-    // Same-session commits are applied in order, so the origin's fate is
-    // decided when the follow-up arrives; an absent origin means rejection.
-    const row = engine.statements.selectPendingResolution.get({
-      session_id: sessionKey,
-      local_seq: precondition.originLocalSeq,
-    }) as { seq: number } | undefined;
-    if (!row) {
-      throw new PreconditionFailedError(
-        "origin-committed",
-        `origin commit not committed: localSeq ${precondition.originLocalSeq}`,
-      );
+    switch (precondition.kind) {
+      case "origin-committed": {
+        if (!Number.isInteger(precondition.originLocalSeq)) {
+          throw new ProtocolError(
+            "malformed origin-committed precondition: originLocalSeq must be an integer",
+          );
+        }
+        // Same-session commits are applied in order, so the origin's fate is
+        // decided when the follow-up arrives; an absent origin means rejection.
+        const row = engine.statements.selectPendingResolution.get({
+          session_id: sessionKey,
+          local_seq: precondition.originLocalSeq,
+        }) as { seq: number } | undefined;
+        if (!row) {
+          throw new PreconditionFailedError(
+            "origin-committed",
+            `origin commit not committed: localSeq ${precondition.originLocalSeq}`,
+          );
+        }
+        break;
+      }
+      case "entity-absent": {
+        const scopeKey = resolveScopeKey(precondition.scope, scopeContext);
+        const existingSetOrDelete = engine.statements.selectSetDeleteConflict
+          .get({
+            branch,
+            id: precondition.id,
+            scope_key: scopeKey,
+            after_seq: 0,
+          }) as { seq: number } | undefined;
+        if (existingSetOrDelete !== undefined) {
+          throw new PreconditionFailedError(
+            "receipt-exists",
+            `entity-absent precondition target already exists: ${precondition.id}`,
+          );
+        }
+        break;
+      }
+      default:
+        throw new ProtocolError(
+          `unsupported commit precondition: ${
+            String((precondition as { kind?: unknown }).kind)
+          }`,
+        );
     }
   }
 };

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -3325,6 +3325,21 @@ const writeOperation = (
           "memory v2 set operations require explicit document objects",
         );
       }
+      if (operation.createOnly) {
+        const existingHead = engine.statements.selectHead.get({
+          branch,
+          id: operation.id,
+          scope_key: scopeKey,
+        }) as HeadRow | undefined;
+        // The head table keeps the latest set or delete revision; either means
+        // this entity id has already been claimed for create-only receipts.
+        if (existingHead !== undefined) {
+          throw new PreconditionFailedError(
+            "receipt-exists",
+            `create-only set target already exists: ${operation.id}`,
+          );
+        }
+      }
       engine.statements.insertRevision.run({
         branch,
         id: operation.id,

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -192,6 +192,26 @@ const toError = (name: string, message: string): V2Error => ({
   message,
 });
 
+const toPreconditionFailedError = (
+  error: unknown,
+  message: string,
+): V2Error | undefined => {
+  if (
+    error instanceof Engine.PreconditionFailedError ||
+    (error instanceof Error &&
+      error.name === "PreconditionFailedError" &&
+      typeof (error as { precondition?: unknown }).precondition === "string")
+  ) {
+    return {
+      name: "PreconditionFailedError",
+      message,
+      precondition: (error as unknown as { precondition: string })
+        .precondition,
+    };
+  }
+  return undefined;
+};
+
 export type MemoryAclMode = "off" | "observe" | "enforce";
 
 /** Engine doc id of a space's ACL document: the doc whose entity id is the
@@ -1535,22 +1555,17 @@ export class Server {
       const messageText = error instanceof Error
         ? error.message
         : String(error);
+      const preconditionError = toPreconditionFailedError(error, messageText);
       return respondTypedError<Engine.AppliedCommit>(
         message.requestId,
-        error instanceof Engine.PreconditionFailedError
-          ? {
-            name: "PreconditionFailedError",
-            message: messageText,
-            precondition: error.precondition,
-          }
-          : toError(
-            error instanceof Engine.ConflictError
-              ? "ConflictError"
-              : error instanceof Engine.ProtocolError
-              ? "ProtocolError"
-              : "TransactionError",
-            messageText,
-          ),
+        preconditionError ? preconditionError : toError(
+          error instanceof Engine.ConflictError
+            ? "ConflictError"
+            : error instanceof Engine.ProtocolError
+            ? "ProtocolError"
+            : "TransactionError",
+          messageText,
+        ),
       );
     }
   }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1455,7 +1455,6 @@ export class Runner {
     givenPattern?: Pattern,
     options: RunnerRunOptions = {},
     pullOnceAfterStart: boolean = false,
-    markCreateOnlyResult: boolean = false,
   ): void {
     const resultLink = resultCell.getAsNormalizedFullLink();
     tx.addCommitCallback((_committedTx, result) => {
@@ -1471,11 +1470,6 @@ export class Runner {
       );
       try {
         this.startWithTx(startTx, committedResultCell, givenPattern, options);
-        if (markCreateOnlyResult) {
-          startTx.markCreateOnly?.(
-            committedResultCell.getAsNormalizedFullLink(),
-          );
-        }
         this.runtime.prepareTxForCommit(startTx);
         startTx.commit().then(({ error }) => {
           if (error) {
@@ -2707,6 +2701,14 @@ export class Runner {
       undefined,
       resultCell,
     );
+    // The receipt mark must ride the transaction that creates the result
+    // cell's head — setupInternal just wrote it into the handler tx. Marking
+    // the deferred start tx instead would see the already-committed head and
+    // reject the FIRST delivery as receipt-exists, while redeliveries (whose
+    // own handler tx re-creates the cell) would go unguarded.
+    if (markCreateOnlyResult) {
+      tx.markCreateOnly?.(resultCell.getAsNormalizedFullLink());
+    }
     if (resultSetup.needsStart) {
       this.startAfterSuccessfulCommit(
         tx,
@@ -2714,7 +2716,6 @@ export class Runner {
         resultSetup.pattern,
         {},
         this.patternNeedsOneShotPull(resultSetup.pattern),
-        markCreateOnlyResult,
       );
     }
     return resultCell;

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1455,6 +1455,7 @@ export class Runner {
     givenPattern?: Pattern,
     options: RunnerRunOptions = {},
     pullOnceAfterStart: boolean = false,
+    markCreateOnlyResult: boolean = false,
   ): void {
     const resultLink = resultCell.getAsNormalizedFullLink();
     tx.addCommitCallback((_committedTx, result) => {
@@ -1470,6 +1471,11 @@ export class Runner {
       );
       try {
         this.startWithTx(startTx, committedResultCell, givenPattern, options);
+        if (markCreateOnlyResult) {
+          startTx.markCreateOnly?.(
+            committedResultCell.getAsNormalizedFullLink(),
+          );
+        }
         this.runtime.prepareTxForCommit(startTx);
         startTx.commit().then(({ error }) => {
           if (error) {
@@ -1506,6 +1512,7 @@ export class Runner {
     pattern: Pattern,
     inputs: FabricValue,
     pullOnceAfterStart = false,
+    markCreateOnlyResult = false,
   ): void {
     const resultLink = resultCell.getAsNormalizedFullLink();
     tx.addCommitCallback((_committedTx, result) => {
@@ -1519,6 +1526,11 @@ export class Runner {
       );
       try {
         this.run(startTx, pattern, inputs, committedResultCell);
+        if (markCreateOnlyResult) {
+          startTx.markCreateOnly?.(
+            committedResultCell.getAsNormalizedFullLink(),
+          );
+        }
         this.runtime.prepareTxForCommit(startTx);
         startTx.commit().then(({ error }) => {
           if (error) {
@@ -2517,10 +2529,25 @@ export class Runner {
     addCancel: AddCancel,
     cause: Record<string, any>,
   ): any {
+    let receiptCell = this.runtime.getCell(
+      processCell.space,
+      { resultFor: cause },
+      undefined,
+      tx,
+    );
+    const receiptsEnabled =
+      this.runtime.experimental.commitPreconditions === true;
     if (
       !validateAndCheckOpaqueRefs(result, name) &&
       frame.opaqueRefs.size === 0
     ) {
+      if (receiptsEnabled) {
+        // Receipt-only handling (spec scheduler-v2 §7.6): nothing was
+        // launched, but the result cell is still created — its create is the
+        // exactly-once witness for this event id.
+        receiptCell.withTx(tx).setRaw({});
+        tx.markCreateOnly?.(receiptCell.getAsNormalizedFullLink());
+      }
       return result;
     }
 
@@ -2539,6 +2566,14 @@ export class Runner {
       resultPattern,
     );
     const crossSpace = resultSpace !== processCell.space;
+    if (crossSpace) {
+      receiptCell = this.runtime.getCell(
+        resultSpace,
+        { resultFor: cause },
+        undefined,
+        tx,
+      );
+    }
 
     // CT-1687: a handler that materializes a child piece in another space
     // (`Factory.inSpace(...)`) leaves a piece that a fresh runtime must load
@@ -2563,20 +2598,17 @@ export class Runner {
     }
 
     if (deferForNavigate && result === undefined) {
-      const resultCell = this.runtime.getCell(
-        resultSpace,
-        { resultFor: cause },
-        undefined,
-        tx,
-      );
+      // navigateTo results are commit-gated (startAfterSuccessfulCommit);
+      // the receipt precondition rides the deferred start's own create.
       this.runPatternAfterSuccessfulCommit(
         tx,
-        resultCell,
+        receiptCell,
         resultPattern,
         undefined,
         true,
+        true,
       );
-      addCancel(() => this.stop(resultCell));
+      addCancel(() => this.stop(receiptCell));
       return result;
     }
 
@@ -2592,18 +2624,13 @@ export class Runner {
         resultPattern,
         resultSpace,
         cause,
+        true,
       )
-      : this.run(
-        tx,
-        resultPattern,
-        undefined,
-        this.runtime.getCell(
-          resultSpace,
-          { resultFor: cause },
-          undefined,
-          tx,
-        ),
-      );
+      : this.run(tx, resultPattern, undefined, receiptCell);
+
+    if (!deferForNavigate) {
+      tx.markCreateOnly?.(receiptCell.getAsNormalizedFullLink());
+    }
 
     addCancel(() => this.stop(resultCell));
 
@@ -2666,6 +2693,7 @@ export class Runner {
     resultPattern: Pattern,
     resultSpace: MemorySpace,
     cause: Record<string, any>,
+    markCreateOnlyResult = false,
   ): Cell<any> {
     const resultCell = this.runtime.getCell(
       resultSpace,
@@ -2686,6 +2714,7 @@ export class Runner {
         resultSetup.pattern,
         {},
         this.patternNeedsOneShotPull(resultSetup.pattern),
+        markCreateOnlyResult,
       );
     }
     return resultCell;

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2866,9 +2866,14 @@ export class Runner {
         ...(inputs as Record<string, any>),
         $event: event,
       };
+      // Spec scheduler-v2 §7.6 / decision 13: the handler's result cell — and
+      // every id minted in this frame — derives from the durable event id, so
+      // retries of the same event reuse the same ids and duplicate handlings
+      // collide on the receipt. The fallback covers non-dispatch invocations
+      // (tests calling the handler directly).
       const cause = {
         ...(inputs as Record<string, any>),
-        $event: crypto.randomUUID(),
+        $event: tx.dispatchedEventId ?? crypto.randomUUID(),
       };
       const policyFacingIdentity = resolvePolicyFacingImplementationIdentity(
         module,

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -158,6 +158,8 @@ export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
       if (args.originTx !== undefined) {
         state.recordLineageEvent(args.originTx, queuedEvent);
       }
+      // Exactly one handler per event (spec scheduler-v2 decision 12).
+      break;
     }
   }
 
@@ -198,6 +200,16 @@ export function addSchedulerEventHandler(state: {
 }): Cancel {
   if (args.populateDependencies) {
     args.handler.populateDependencies = args.populateDependencies;
+  }
+  const existingIndex = state.eventHandlers.findIndex(([existing]) =>
+    areNormalizedLinksSame(existing, args.ref)
+  );
+  if (existingIndex !== -1) {
+    state.eventHandlers.splice(existingIndex, 1);
+    logger.warn("event-handler-replaced", () => [
+      "Replacing existing event handler for link",
+      { linkId: args.ref.id },
+    ]);
   }
   state.eventHandlers.push([args.ref, args.handler]);
   return () => {

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -10,6 +10,7 @@ import type { Runtime } from "../runtime.ts";
 import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
+  IPreconditionFailedError,
   MemorySpace,
 } from "../storage/interface.ts";
 import { isPermanentRejection } from "../storage/rejection.ts";
@@ -612,6 +613,10 @@ export async function dispatchQueuedEvent(state: {
     // the commit, dependent speculative transactions are rejected as well and
     // the normal retry path reruns the event.
     tx.commit().then((result) => {
+      const permanentRejection =
+        result.error && isPermanentRejection(result.error)
+          ? (result.error as IPreconditionFailedError).precondition
+          : undefined;
       if (!result.error && changedWrites.length > 0) {
         state.onEventCommitWrites?.(action, changedWrites);
       }
@@ -627,6 +632,7 @@ export async function dispatchQueuedEvent(state: {
           ? { writesTruncated: true }
           : {}),
         ...(result.error ? { error: result.error.message } : {}),
+        ...(permanentRejection !== undefined ? { permanentRejection } : {}),
       });
       if (
         result.error && retriesLeft > 0 &&
@@ -642,6 +648,15 @@ export async function dispatchQueuedEvent(state: {
       }
       runFinalCommitCallback();
       if (result.error) {
+        if (permanentRejection === "receipt-exists") {
+          logger.warn(
+            "event-lost-race",
+            () => [
+              "Event handling lost the receipt race",
+              { eventId: queuedEvent.id, handlerId },
+            ],
+          );
+        }
         logger.error(
           "schedule-error",
           "Event handler transaction failed after exhausting all retries",

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -83,6 +83,11 @@ const logger = getLogger("extended-storage-transaction", {
   level: "error",
 });
 
+const createOnlyMarkKey = (
+  link: { id: string; scope?: unknown },
+): string =>
+  `${normalizeCellScope(link.scope as CellScope | undefined)}\0${link.id}`;
+
 type CfcInstrumentationHooks = {
   onRelevantTx?(): void;
   onPreparedTx?(): void;
@@ -105,6 +110,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   private statusOverride?: StorageTransactionStatus;
   private commitCallbacksDispatched = false;
   private commitPreconditions = new Map<MemorySpace, CommitPrecondition[]>();
+  private createOnlyMarks = new Map<MemorySpace, Set<string>>();
   private outboxIdempotencyKeys = new Set<string>();
   private readOnlySource?: string;
   private narrowestReadScope: CellScope = "space";
@@ -617,6 +623,19 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   ): readonly CommitPrecondition[] | undefined {
     return this.tx.getCommitPreconditions?.(space) ??
       this.commitPreconditions.get(space);
+  }
+
+  markCreateOnly(
+    link: { space: MemorySpace; id: string; scope?: unknown },
+  ): void {
+    this.assertWritable("markCreateOnly");
+    let marks = this.createOnlyMarks.get(link.space);
+    if (!marks) {
+      marks = new Set();
+      this.createOnlyMarks.set(link.space, marks);
+    }
+    marks.add(createOnlyMarkKey(link));
+    this.tx.markCreateOnly?.(link);
   }
 
   recordSqliteWrite(space: MemorySpace, op: SqliteOperation): void {
@@ -1190,6 +1209,12 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
     space: MemorySpace,
   ): readonly CommitPrecondition[] | undefined {
     return this.wrapped.getCommitPreconditions?.(space);
+  }
+
+  markCreateOnly(
+    link: { space: MemorySpace; id: string; scope?: unknown },
+  ): void {
+    this.wrapped.markCreateOnly?.(link);
   }
 
   recordSqliteWrite(space: MemorySpace, op: SqliteOperation): void {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -589,6 +589,15 @@ export interface IStorageTransaction {
   ): readonly CommitPrecondition[] | undefined;
 
   /**
+   * Mark an entity this transaction creates as create-only: the commit fails
+   * with PreconditionFailedError("receipt-exists") if the entity already has a
+   * head (scheduler-v2 §7.6 receipts).
+   */
+  markCreateOnly?(
+    link: { space: MemorySpace; id: string; scope?: unknown },
+  ): void;
+
+  /**
    * Optional: record a folded SQLite write onto this transaction so it commits
    * ATOMICALLY with the cell ops targeting `space` (one commit = cell ops + a
    * `sqlite` op; on SQL failure the whole commit aborts). Claims `space` as a
@@ -755,6 +764,15 @@ export interface IExtendedStorageTransaction
   getCommitPreconditions?(
     space: MemorySpace,
   ): readonly CommitPrecondition[] | undefined;
+
+  /**
+   * Mark an entity this transaction creates as create-only: the commit fails
+   * with PreconditionFailedError("receipt-exists") if the entity already has a
+   * head (scheduler-v2 §7.6 receipts).
+   */
+  markCreateOnly?(
+    link: { space: MemorySpace; id: string; scope?: unknown },
+  ): void;
 
   getCfcState(): Readonly<CfcTxState>;
   setCfcEnforcementMode(mode: CfcEnforcementMode): void;
@@ -1312,6 +1330,7 @@ export type NativeStorageCommitOperation =
     type: MediaType;
     scope?: CellScope;
     value: FabricValue;
+    createOnly?: true;
   }
   | {
     op: "delete";

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -759,7 +759,7 @@ export interface IExtendedStorageTransaction
    */
   addCommitPrecondition?(
     space: MemorySpace,
-    precondition: { kind: "origin-committed"; originLocalSeq: number },
+    precondition: CommitPrecondition,
   ): void;
   getCommitPreconditions?(
     space: MemorySpace,

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1330,7 +1330,6 @@ export type NativeStorageCommitOperation =
     type: MediaType;
     scope?: CellScope;
     value: FabricValue;
-    createOnly?: true;
   }
   | {
     op: "delete";

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -128,6 +128,11 @@ const logger = getLogger("storage.v2.transaction", {
   level: "error",
 });
 
+const createOnlyMarkKey = (
+  id: string,
+  scope?: unknown,
+): string => `${normalizeCellScope(scope as CellScope | undefined)}\0${id}`;
+
 // Enabled so cross-space partial-commit failures (no rollback) are visible.
 const multiSpaceCommitLogger = getLogger("storage.v2.multi-space-commit", {
   enabled: true,
@@ -746,6 +751,7 @@ export class V2StorageTransaction implements IStorageTransaction {
   #reactivityLogCache?: TransactionReactivityLog;
   #schedulerObservation?: unknown;
   #commitPreconditions = new Map<MemorySpace, CommitPrecondition[]>();
+  #createOnlyMarks = new Map<MemorySpace, Set<string>>();
   // Folded SQLite write ops per space, applied in the same commit as cell ops.
   #sqliteOps = new Map<MemorySpace, SqliteOperation[]>();
   #writeSpace?: MemorySpace;
@@ -860,6 +866,22 @@ export class V2StorageTransaction implements IStorageTransaction {
     return this.#commitPreconditions.get(space);
   }
 
+  markCreateOnly(
+    link: { space: MemorySpace; id: string; scope?: unknown },
+  ): void {
+    this.assertWritable("markCreateOnly()");
+    const ready = this.editable();
+    if (ready.error) {
+      throw ready.error;
+    }
+    let marks = this.#createOnlyMarks.get(link.space);
+    if (!marks) {
+      marks = new Set();
+      this.#createOnlyMarks.set(link.space, marks);
+    }
+    marks.add(createOnlyMarkKey(link.id, link.scope));
+  }
+
   recordSqliteWrite(space: MemorySpace, op: SqliteOperation): void {
     this.assertWritable("recordSqliteWrite()");
     const ready = this.editable();
@@ -886,6 +908,7 @@ export class V2StorageTransaction implements IStorageTransaction {
       space,
     );
     const preconditions = this.#commitPreconditions.get(space);
+    const createOnlyMarks = this.#createOnlyMarks.get(space);
     const sqliteOps = this.#sqliteOps.get(space);
     if (
       !branch && schedulerObservation === undefined &&
@@ -914,9 +937,16 @@ export class V2StorageTransaction implements IStorageTransaction {
       }
 
       operations.push(
-        doc.current.value === undefined
-          ? { op: "delete", id, type, scope }
-          : { op: "set", id, type, scope, value: doc.current.value },
+        doc.current.value === undefined ? { op: "delete", id, type, scope } : {
+          op: "set",
+          id,
+          type,
+          scope,
+          value: doc.current.value,
+          ...(createOnlyMarks?.has(createOnlyMarkKey(id, scope))
+            ? { createOnly: true as const }
+            : {}),
+        },
       );
     }
 

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -751,7 +751,10 @@ export class V2StorageTransaction implements IStorageTransaction {
   #reactivityLogCache?: TransactionReactivityLog;
   #schedulerObservation?: unknown;
   #commitPreconditions = new Map<MemorySpace, CommitPrecondition[]>();
-  #createOnlyMarks = new Map<MemorySpace, Set<string>>();
+  #createOnlyMarks = new Map<
+    MemorySpace,
+    Map<string, { id: string; scope: CellScope }>
+  >();
   // Folded SQLite write ops per space, applied in the same commit as cell ops.
   #sqliteOps = new Map<MemorySpace, SqliteOperation[]>();
   #writeSpace?: MemorySpace;
@@ -874,12 +877,20 @@ export class V2StorageTransaction implements IStorageTransaction {
     if (ready.error) {
       throw ready.error;
     }
+    const claim = this.claimWriteSpace(link.space);
+    if (claim.error) {
+      throw claim.error;
+    }
     let marks = this.#createOnlyMarks.get(link.space);
     if (!marks) {
-      marks = new Set();
+      marks = new Map();
       this.#createOnlyMarks.set(link.space, marks);
     }
-    marks.add(createOnlyMarkKey(link.id, link.scope));
+    const scope = normalizeCellScope(link.scope as CellScope | undefined);
+    marks.set(createOnlyMarkKey(link.id, scope), {
+      id: link.id,
+      scope,
+    });
   }
 
   recordSqliteWrite(space: MemorySpace, op: SqliteOperation): void {
@@ -909,10 +920,21 @@ export class V2StorageTransaction implements IStorageTransaction {
     );
     const preconditions = this.#commitPreconditions.get(space);
     const createOnlyMarks = this.#createOnlyMarks.get(space);
+    const createOnlyPreconditions = [...(createOnlyMarks?.values() ?? [])].map(
+      ({ id, scope }) => ({
+        kind: "entity-absent" as const,
+        id,
+        scope,
+      }),
+    );
+    const nativePreconditions = [
+      ...(preconditions ?? []),
+      ...createOnlyPreconditions,
+    ];
     const sqliteOps = this.#sqliteOps.get(space);
     if (
       !branch && schedulerObservation === undefined &&
-      !preconditions?.length && !sqliteOps?.length
+      nativePreconditions.length === 0 && !sqliteOps?.length
     ) {
       return undefined;
     }
@@ -943,9 +965,6 @@ export class V2StorageTransaction implements IStorageTransaction {
           type,
           scope,
           value: doc.current.value,
-          ...(createOnlyMarks?.has(createOnlyMarkKey(id, scope))
-            ? { createOnly: true as const }
-            : {}),
         },
       );
     }
@@ -953,7 +972,9 @@ export class V2StorageTransaction implements IStorageTransaction {
     return {
       operations,
       ...(schedulerObservation !== undefined ? { schedulerObservation } : {}),
-      ...(preconditions?.length ? { preconditions: [...preconditions] } : {}),
+      ...(nativePreconditions.length
+        ? { preconditions: nativePreconditions }
+        : {}),
       ...(sqliteOps?.length ? { sqliteOps: [...sqliteOps] } : {}),
     };
   }

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -57,6 +57,7 @@ import * as Differential from "./differential.ts";
 import type {
   IMemoryAddress,
   IMergedChanges,
+  IPreconditionFailedError,
   IRemoteStorageProviderSettings,
   ISpaceReplica,
   IStorageManager,
@@ -1009,7 +1010,6 @@ type NativeCommitOperation =
     id: URI;
     scope?: CellScope;
     value: EntityDocument;
-    createOnly?: true;
   }
   | {
     op: "patch";
@@ -1400,7 +1400,6 @@ class SpaceReplica implements ISpaceReplica {
                 id: operation.id,
                 scope: operation.scope,
                 value: toExplicitDocument(operation.value),
-                ...(operation.createOnly ? { createOnly: true as const } : {}),
               }
           ),
     );
@@ -1708,9 +1707,6 @@ class SpaceReplica implements ISpaceReplica {
                   id: operation.id,
                   scope: operation.scope,
                   value: operation.value,
-                  ...(emitCommitPreconditions && operation.createOnly
-                    ? { createOnly: true as const }
-                    : {}),
                 };
             }
           }),
@@ -2222,8 +2218,22 @@ const toRejectedError = (
   commit: unknown,
 ): StorageTransactionRejected => {
   const message = error instanceof Error ? error.message : String(error);
+  const name = error instanceof Error
+    ? error.name
+    : (error as { name?: unknown })?.name;
+  const precondition = (error as { precondition?: unknown }).precondition;
   if (
-    (error instanceof Error && error.name === "ConflictError") ||
+    name === "PreconditionFailedError" &&
+    (precondition === "origin-committed" || precondition === "receipt-exists")
+  ) {
+    return {
+      name: "PreconditionFailedError",
+      message,
+      precondition,
+    } as IPreconditionFailedError;
+  }
+  if (
+    name === "ConflictError" ||
     message.includes("stale confirmed read") ||
     message.includes("pending dependency")
   ) {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2221,7 +2221,9 @@ const toRejectedError = (
   const name = error instanceof Error
     ? error.name
     : (error as { name?: unknown })?.name;
-  const precondition = (error as { precondition?: unknown }).precondition;
+  // `error` may be a primitive or null — never throw while normalizing a
+  // commit failure, that would mask the real rejection.
+  const precondition = (error as { precondition?: unknown })?.precondition;
   if (
     name === "PreconditionFailedError" &&
     (precondition === "origin-committed" || precondition === "receipt-exists")

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1004,7 +1004,13 @@ type WatchRefreshBatch = {
 };
 
 type NativeCommitOperation =
-  | { op: "set"; id: URI; scope?: CellScope; value: EntityDocument }
+  | {
+    op: "set";
+    id: URI;
+    scope?: CellScope;
+    value: EntityDocument;
+    createOnly?: true;
+  }
   | {
     op: "patch";
     id: URI;
@@ -1394,6 +1400,7 @@ class SpaceReplica implements ISpaceReplica {
                 id: operation.id,
                 scope: operation.scope,
                 value: toExplicitDocument(operation.value),
+                ...(operation.createOnly ? { createOnly: true as const } : {}),
               }
           ),
     );
@@ -1655,7 +1662,8 @@ class SpaceReplica implements ISpaceReplica {
     preconditions: readonly CommitPrecondition[] = [],
     sqliteOps: readonly SqliteOperation[] = [],
   ): Promise<Result<Unit, StorageTransactionRejected>> {
-    const activePreconditions = getCommitPreconditionsConfig()
+    const emitCommitPreconditions = getCommitPreconditionsConfig();
+    const activePreconditions = emitCommitPreconditions
       ? (preconditions ?? [])
       : [];
     if (
@@ -1700,6 +1708,9 @@ class SpaceReplica implements ISpaceReplica {
                   id: operation.id,
                   scope: operation.scope,
                   value: operation.value,
+                  ...(emitCommitPreconditions && operation.createOnly
+                    ? { createOnly: true as const }
+                    : {}),
                 };
             }
           }),

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -167,6 +167,7 @@ export type RuntimeTelemetryMarker = {
   writes: string[];
   writesTruncated?: boolean;
   error?: string;
+  permanentRejection?: "origin-committed" | "receipt-exists";
 } | {
   type: "scheduler.event.preflight";
   handlerId: string;

--- a/packages/runner/test/scheduler-event-receipts.test.ts
+++ b/packages/runner/test/scheduler-event-receipts.test.ts
@@ -1,0 +1,541 @@
+import {
+  afterEach,
+  beforeEach,
+  createSchedulerTestRuntime,
+  describe,
+  disposeSchedulerTestRuntime,
+  expect,
+  it,
+  Runtime,
+  space,
+} from "./scheduler-test-utils.ts";
+import type {
+  Cell,
+  IExtendedStorageTransaction,
+  RuntimeTelemetryMarker,
+  SchedulerTestStorageManager,
+} from "./scheduler-test-utils.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { resolveLink } from "../src/link-resolution.ts";
+
+type TransactMessage = { requestId: string };
+type TransactResponse = {
+  type: "response";
+  requestId: string;
+  ok?: unknown;
+  error?: { name: string; message: string };
+};
+type TestMemoryServer = {
+  transact(message: TransactMessage): Promise<TransactResponse>;
+};
+
+function emulatedServer(
+  storageManager: SchedulerTestStorageManager,
+): TestMemoryServer {
+  return (storageManager as unknown as { server(): TestMemoryServer }).server();
+}
+
+function rejectNextServerTransact(
+  storageManager: SchedulerTestStorageManager,
+): () => void {
+  const server = emulatedServer(storageManager);
+  const original = server.transact.bind(server);
+  let shouldReject = true;
+  server.transact = async (message) => {
+    if (shouldReject) {
+      shouldReject = false;
+      return {
+        type: "response",
+        requestId: message.requestId,
+        error: {
+          name: "ConflictError",
+          message: "forced scheduler receipt test conflict",
+        },
+      };
+    }
+    return await original(message);
+  };
+
+  return () => {
+    server.transact = original;
+  };
+}
+
+async function waitForSchedulerCondition(
+  runtime: Runtime,
+  condition: () => boolean,
+  message: string,
+): Promise<void> {
+  const deadline = performance.now() + 1_000;
+  while (!condition() && performance.now() < deadline) {
+    await runtime.idle();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  if (!condition()) {
+    throw new Error(message);
+  }
+}
+
+function collectEventCommitMarkers(runtime: Runtime): {
+  markers: RuntimeTelemetryMarker[];
+  dispose(): void;
+} {
+  const markers: RuntimeTelemetryMarker[] = [];
+  const listener = (event: Event) => {
+    const marker = (event as CustomEvent<{
+      marker: RuntimeTelemetryMarker;
+    }>).detail.marker;
+    if (marker.type === "scheduler.event.commit") {
+      markers.push(marker);
+    }
+  };
+  runtime.telemetry.addEventListener("telemetry", listener);
+  return {
+    markers,
+    dispose: () => runtime.telemetry.removeEventListener("telemetry", listener),
+  };
+}
+
+function permanentRejection(
+  marker: RuntimeTelemetryMarker,
+): string | undefined {
+  return (marker as { permanentRejection?: string }).permanentRejection;
+}
+
+function receiptCellForEvent<T>(
+  runtime: Runtime,
+  eventId: string,
+): Cell<T> {
+  return runtime.getCell<T>(
+    space,
+    { resultFor: { $ctx: {}, $event: eventId } },
+  );
+}
+
+function resolvedStreamLink(streamCell: Cell<unknown>, runtime: Runtime) {
+  return resolveLink(
+    runtime,
+    runtime.readTx(),
+    streamCell.getAsNormalizedFullLink(),
+  );
+}
+
+describe("scheduler event receipts", () => {
+  let storageManager: SchedulerTestStorageManager;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
+      import.meta.url,
+      { experimental: { commitPreconditions: true } },
+    ));
+  });
+
+  afterEach(async () => {
+    await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
+  });
+
+  it("deduplicates redelivered events by create-only receipt", async () => {
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { cell, handler, lift, pattern } = commonfabric;
+    let handlerInvocations = 0;
+    const recordEvent = handler<
+      { value: number },
+      { effects: { total: number } }
+    >(
+      (event, { effects }) => {
+        handlerInvocations++;
+        effects.total += event.value;
+      },
+      { proxy: true },
+    );
+    const rootPattern = pattern(() => {
+      const effects = cell({ total: 0 });
+      const effectsTotal = lift(({ total }: { total: number }) => total)(
+        effects,
+      );
+      return { effectsTotal, stream: recordEvent({ effects }) };
+    });
+    const rootCell = runtime.getCell<
+      { effectsTotal: number; stream: unknown }
+    >(
+      space,
+      "receipts redelivery root",
+      undefined,
+      tx,
+    );
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await root.pull();
+
+    const commitTelemetry = collectEventCommitMarkers(runtime);
+    const eventId = "evt:receipt-redelivery:0:receipts-redelivery-root";
+    try {
+      const streamLink = resolvedStreamLink(root.key("stream"), runtime);
+      runtime.scheduler.queueEvent(
+        streamLink,
+        { value: 1 },
+        undefined,
+        undefined,
+        false,
+        { eventId },
+      );
+      runtime.scheduler.queueEvent(
+        streamLink,
+        { value: 1 },
+        undefined,
+        undefined,
+        false,
+        { eventId },
+      );
+
+      await waitForSchedulerCondition(
+        runtime,
+        () => handlerInvocations === 2 && commitTelemetry.markers.length >= 2,
+        "redelivered event did not settle",
+      );
+      await root.key("effectsTotal").pull();
+
+      expect(handlerInvocations).toBe(2);
+      expect(root.key("effectsTotal").get()).toBe(1);
+      expect(
+        commitTelemetry.markers.some((marker) =>
+          permanentRejection(marker) === "receipt-exists"
+        ),
+      ).toBe(true);
+    } finally {
+      commitTelemetry.dispose();
+    }
+  });
+
+  it("deduplicates redelivered pattern launches by receipt", async () => {
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { handler, pattern } = commonfabric;
+    const childPattern = pattern<{ value: number }>(({ value }) => {
+      return { value };
+    });
+    let handlerInvocations = 0;
+    const launchChild = handler<{ value: number }, Record<string, never>>(
+      (event) => {
+        handlerInvocations++;
+        return childPattern({ value: event.value });
+      },
+      { proxy: true },
+    );
+    const rootPattern = pattern(() => {
+      return { stream: launchChild({}) };
+    });
+    const rootCell = runtime.getCell<{ stream: unknown }>(
+      space,
+      "receipts launch root",
+      undefined,
+      tx,
+    );
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await root.pull();
+
+    const commitTelemetry = collectEventCommitMarkers(runtime);
+    const eventId = "evt:receipt-launch:0:receipts-launch-root";
+    try {
+      const streamLink = resolvedStreamLink(root.key("stream"), runtime);
+      runtime.scheduler.queueEvent(
+        streamLink,
+        { value: 7 },
+        undefined,
+        undefined,
+        false,
+        { eventId },
+      );
+      runtime.scheduler.queueEvent(
+        streamLink,
+        { value: 7 },
+        undefined,
+        undefined,
+        false,
+        { eventId },
+      );
+
+      const resultCell = receiptCellForEvent<{ value: number }>(
+        runtime,
+        eventId,
+      );
+      await waitForSchedulerCondition(
+        runtime,
+        () => handlerInvocations === 2 && commitTelemetry.markers.length >= 2,
+        "redelivered launch event did not settle",
+      );
+      await resultCell.pull();
+
+      expect(handlerInvocations).toBe(2);
+      expect(resultCell.get()).toEqual({ value: 7 });
+      expect(
+        commitTelemetry.markers.some((marker) =>
+          permanentRejection(marker) === "receipt-exists"
+        ),
+      ).toBe(true);
+    } finally {
+      commitTelemetry.dispose();
+    }
+  });
+
+  it("retries transient conflicts with the same receipt id", async () => {
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { cell, handler, lift, pattern } = commonfabric;
+    let handlerInvocations = 0;
+    const recordEvent = handler<
+      { value: number },
+      { effects: { total: number } }
+    >(
+      (event, { effects }) => {
+        handlerInvocations++;
+        effects.total += event.value;
+      },
+      { proxy: true },
+    );
+    const rootPattern = pattern(() => {
+      const effects = cell({ total: 0 });
+      const effectsTotal = lift(({ total }: { total: number }) => total)(
+        effects,
+      );
+      return { effectsTotal, stream: recordEvent({ effects }) };
+    });
+    const rootCell = runtime.getCell<
+      { effectsTotal: number; stream: unknown }
+    >(
+      space,
+      "receipts retry root",
+      undefined,
+      tx,
+    );
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await root.pull();
+
+    const commitTelemetry = collectEventCommitMarkers(runtime);
+    const restoreTransact = rejectNextServerTransact(storageManager);
+    const eventId = "evt:receipt-retry:0:receipts-retry-root";
+    try {
+      runtime.scheduler.queueEvent(
+        resolvedStreamLink(root.key("stream"), runtime),
+        { value: 3 },
+        undefined,
+        undefined,
+        false,
+        { eventId },
+      );
+
+      await waitForSchedulerCondition(
+        runtime,
+        () => handlerInvocations === 2,
+        "retrying receipt event did not commit",
+      );
+      await root.key("effectsTotal").pull();
+
+      expect(handlerInvocations).toBe(2);
+      expect(root.key("effectsTotal").get()).toBe(3);
+      expect(
+        commitTelemetry.markers.some((marker) =>
+          permanentRejection(marker) === "receipt-exists"
+        ),
+      ).toBe(false);
+    } finally {
+      restoreTransact();
+      commitTelemetry.dispose();
+    }
+  });
+
+  it("rejects redelivered idempotent handlers when all writes elide", async () => {
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { cell, handler, lift, pattern } = commonfabric;
+    let handlerInvocations = 0;
+    const setHandled = handler<
+      unknown,
+      { effects: { handled: boolean } }
+    >(
+      (_event, { effects }) => {
+        handlerInvocations++;
+        effects.handled = true;
+      },
+      { proxy: true },
+    );
+    const rootPattern = pattern(() => {
+      const effects = cell({ handled: false });
+      const handled = lift(({ handled }: { handled: boolean }) => handled)(
+        effects,
+      );
+      return { handled, stream: setHandled({ effects }) };
+    });
+    const rootCell = runtime.getCell<{ handled: boolean; stream: unknown }>(
+      space,
+      "receipts idempotent root",
+      undefined,
+      tx,
+    );
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await root.pull();
+
+    const commitTelemetry = collectEventCommitMarkers(runtime);
+    const eventId = "evt:receipt-idempotent:0:receipts-idempotent-root";
+    try {
+      const streamLink = resolvedStreamLink(root.key("stream"), runtime);
+      runtime.scheduler.queueEvent(
+        streamLink,
+        {},
+        undefined,
+        undefined,
+        false,
+        { eventId },
+      );
+      runtime.scheduler.queueEvent(
+        streamLink,
+        {},
+        undefined,
+        undefined,
+        false,
+        { eventId },
+      );
+
+      await waitForSchedulerCondition(
+        runtime,
+        () => handlerInvocations === 2 && commitTelemetry.markers.length >= 2,
+        "idempotent redelivered event did not settle",
+      );
+      await root.key("handled").pull();
+
+      expect(handlerInvocations).toBe(2);
+      expect(root.key("handled").get()).toBe(true);
+      expect(
+        commitTelemetry.markers.some((marker) =>
+          permanentRejection(marker) === "receipt-exists"
+        ),
+      ).toBe(true);
+    } finally {
+      commitTelemetry.dispose();
+    }
+  });
+
+  it("creates a receipt document for handlers that launch nothing", async () => {
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { handler, pattern } = commonfabric;
+    let handlerInvocations = 0;
+    const noLaunch = handler<unknown, Record<string, never>>(
+      () => {
+        handlerInvocations++;
+      },
+      { proxy: true },
+    );
+    const rootPattern = pattern(() => {
+      return { stream: noLaunch({}) };
+    });
+    const rootCell = runtime.getCell<{ stream: unknown }>(
+      space,
+      "receipts no launch root",
+      undefined,
+      tx,
+    );
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await root.pull();
+
+    const eventId = "evt:receipt-empty:0:receipts-empty-root";
+    runtime.scheduler.queueEvent(
+      resolvedStreamLink(root.key("stream"), runtime),
+      {},
+      undefined,
+      undefined,
+      false,
+      { eventId },
+    );
+
+    await waitForSchedulerCondition(
+      runtime,
+      () => handlerInvocations === 1,
+      "receipt-only event did not run",
+    );
+    const resultCell = receiptCellForEvent<Record<string, never>>(
+      runtime,
+      eventId,
+    );
+    await resultCell.pull();
+
+    expect(resultCell.get()).toEqual({});
+  });
+
+  it("allows redelivered events to commit twice while receipts are disabled", async () => {
+    await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
+    ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
+      import.meta.url,
+      { experimental: { commitPreconditions: false } },
+    ));
+
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { cell, handler, lift, pattern } = commonfabric;
+    let handlerInvocations = 0;
+    const recordEvent = handler<
+      { value: number },
+      { effects: { total: number } }
+    >(
+      (event, { effects }) => {
+        handlerInvocations++;
+        effects.total += event.value;
+      },
+      { proxy: true },
+    );
+    const rootPattern = pattern(() => {
+      const effects = cell({ total: 0 });
+      const effectsTotal = lift(({ total }: { total: number }) => total)(
+        effects,
+      );
+      return { effectsTotal, stream: recordEvent({ effects }) };
+    });
+    const rootCell = runtime.getCell<
+      { effectsTotal: number; stream: unknown }
+    >(
+      space,
+      "receipts flag off root",
+      undefined,
+      tx,
+    );
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await root.pull();
+
+    const eventId = "evt:receipt-flag-off:0:receipts-flag-off-root";
+    const streamLink = resolvedStreamLink(root.key("stream"), runtime);
+    runtime.scheduler.queueEvent(
+      streamLink,
+      { value: 5 },
+      undefined,
+      undefined,
+      false,
+      { eventId },
+    );
+    runtime.scheduler.queueEvent(
+      streamLink,
+      { value: 5 },
+      undefined,
+      undefined,
+      false,
+      { eventId },
+    );
+
+    await waitForSchedulerCondition(
+      runtime,
+      () => handlerInvocations === 2,
+      "flag-off redelivery did not commit twice",
+    );
+    await root.key("effectsTotal").pull();
+
+    expect(handlerInvocations).toBe(2);
+    expect(root.key("effectsTotal").get()).toBe(10);
+  });
+});

--- a/packages/runner/test/scheduler-event-receipts.test.ts
+++ b/packages/runner/test/scheduler-event-receipts.test.ts
@@ -17,6 +17,8 @@ import type {
 } from "./scheduler-test-utils.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { resolveLink } from "../src/link-resolution.ts";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
 
 type TransactMessage = { requestId: string };
 type TransactResponse = {
@@ -538,4 +540,102 @@ describe("scheduler event receipts", () => {
     expect(handlerInvocations).toBe(2);
     expect(root.key("effectsTotal").get()).toBe(10);
   });
+});
+
+Deno.test("navigateTo handler results navigate once and deduplicate redelivery", async () => {
+  const navSigner = await Identity.fromPassphrase(
+    "receipts navigate operator",
+  );
+  const navSpace = navSigner.did();
+  const storageManager = StorageManager.emulate({ as: navSigner });
+  const navigations: string[] = [];
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+    experimental: { commitPreconditions: true },
+    navigateCallback: (target) => {
+      navigations.push(target.entityId?.["/"] ?? "");
+    },
+  });
+  let tx = runtime.edit();
+
+  try {
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { NAME, handler, navigateTo, pattern } = commonfabric;
+
+    const Target = pattern(() => ({
+      [NAME]: "receipts navigate target",
+    }));
+    let handlerInvocations = 0;
+    const openTarget = handler<Record<string, never>, Record<string, never>>(
+      () => {
+        handlerInvocations++;
+        return navigateTo(Target({}));
+      },
+      { proxy: true },
+    );
+    const rootPattern = pattern(() => {
+      return { stream: openTarget({}) };
+    });
+    const rootCell = runtime.getCell<{ stream: unknown }>(
+      navSpace,
+      "receipts navigate root",
+      undefined,
+      tx,
+    );
+    const root = runtime.run(tx, rootPattern, {}, rootCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await root.pull();
+
+    const eventId = "evt:receipt-navigate:0:receipts-navigate-root";
+    const streamLink = resolveLink(
+      runtime,
+      runtime.readTx(),
+      root.key("stream").getAsNormalizedFullLink(),
+    );
+
+    // First delivery: the receipt must not strangle the launch itself —
+    // the deferred navigateTo start has to survive its own receipt mark.
+    runtime.scheduler.queueEvent(
+      streamLink,
+      {},
+      undefined,
+      undefined,
+      false,
+      { eventId },
+    );
+    await waitForSchedulerCondition(
+      runtime,
+      () => navigations.length >= 1,
+      "first navigateTo delivery did not navigate",
+    );
+    expect(handlerInvocations).toBe(1);
+    expect(navigations.length).toBe(1);
+
+    // Redelivery of the same event id: the receipt dedupes; no second
+    // navigation.
+    runtime.scheduler.queueEvent(
+      streamLink,
+      {},
+      undefined,
+      undefined,
+      false,
+      { eventId },
+    );
+    await waitForSchedulerCondition(
+      runtime,
+      () => handlerInvocations === 2,
+      "redelivered navigateTo event did not run",
+    );
+    await runtime.idle();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await runtime.idle();
+
+    expect(navigations.length).toBe(1);
+  } finally {
+    await tx.commit();
+    await runtime.dispose();
+    await storageManager.close();
+  }
 });

--- a/packages/runner/test/scheduler-events.test.ts
+++ b/packages/runner/test/scheduler-events.test.ts
@@ -1,6 +1,10 @@
 // Scheduler event handling tests.
 
 import {
+  getLoggerCountsBreakdown,
+  resetAllLoggerCounts,
+} from "@commonfabric/utils/logger";
+import {
   afterEach,
   beforeEach,
   createSchedulerTestRuntime,
@@ -218,6 +222,61 @@ describe("event handling", () => {
 
     expect(eventCount).toBe(1);
     expect(eventCell.get()).toBe(1);
+  });
+
+  it("replaces an existing handler for the same event link", async () => {
+    resetAllLoggerCounts();
+    const eventCell = runtime.getCell<number>(
+      space,
+      "single handler per link event",
+      undefined,
+      tx,
+    );
+    const payloads = runtime.getCell<string[]>(
+      space,
+      "single handler per link payloads",
+      undefined,
+      tx,
+    );
+    eventCell.set(0);
+    payloads.set([]);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let firstCount = 0;
+    let secondCount = 0;
+    const firstHandler: EventHandler = (handlerTx, event) => {
+      firstCount++;
+      const current = payloads.withTx(handlerTx).get();
+      payloads.withTx(handlerTx).set([...current, `first:${event}`]);
+    };
+    const secondHandler: EventHandler = (handlerTx, event) => {
+      secondCount++;
+      const current = payloads.withTx(handlerTx).get();
+      payloads.withTx(handlerTx).set([...current, `second:${event}`]);
+    };
+
+    runtime.scheduler.addEventHandler(
+      firstHandler,
+      eventCell.getAsNormalizedFullLink(),
+    );
+    runtime.scheduler.addEventHandler(
+      secondHandler,
+      eventCell.getAsNormalizedFullLink(),
+    );
+    runtime.scheduler.queueEvent(eventCell.getAsNormalizedFullLink(), 42);
+
+    await waitForSignal(
+      runtime.idle(),
+      "replacement handler event did not settle",
+    );
+
+    expect(firstCount).toBe(0);
+    expect(secondCount).toBe(1);
+    expect(payloads.get()).toEqual(["second:42"]);
+    expect(
+      getLoggerCountsBreakdown().scheduler?.["event-handler-replaced"]?.warn,
+    ).toBe(1);
   });
 
   it("should handle events with nested paths", async () => {


### PR DESCRIPTION
Stack: 04/E2 — based on scheduler-v2/03-e1 (#4090)

## Summary

Implements scheduler-v2 E2 result-cell receipts for exactly-once event handling. This adds single-handler event dispatch, event-derived handler frame causes, receipt creation for handled events, permanent lost-race handling, and receipt fixtures.

After reviewer/memory-owner feedback, receipts now use commit-level `entity-absent` preconditions rather than op-level `createOnly`. `markCreateOnly` keeps its runner API but emits commit preconditions independent of surviving semantic operations, so duplicate idempotent handlers still reach memory and fail with `receipt-exists` instead of locally succeeding as no-ops.

## Validation

- `cd packages/memory && deno task test`: passed, `211 passed (95 steps)`, `0 failed`
- `cd packages/runner && deno task test` with default `commitPreconditions` off: passed, `591 passed (3097 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m5s`
- `cd packages/runner && deno task test` with temporary `scheduler-test-utils.ts` default `commitPreconditions: true`: passed, `591 passed (3097 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m5s`
- Focused receipt fixture: `cd packages/runner && ENV=test deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git test/scheduler-event-receipts.test.ts`: passed, `1 passed (6 steps)`, `0 failed`
- Focused memory preconditions: `deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders packages/memory/test/v2-commit-preconditions.test.ts`: passed, `11 passed`, `0 failed`

See `docs/specs/scheduler-v2/implementation/PROGRESS.md` for the full work-order recordings, reviewer stop/resolution notes, and exit-check greps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scheduler-v2 E2 receipts to guarantee exactly-once event handling. The runner writes a receipt per handled event and memory enforces a commit-level `entity-absent` precondition, rejecting duplicates with `PreconditionFailedError("receipt-exists")`.

- **New Features**
  - Exactly-once via result-cell receipts: memory `entity-absent` precondition (tombstones count), allows precondition-only commits, and bypasses zero-op short-circuit when preconditions exist.
  - Runner marks the handler’s result cell as the receipt across spaces and for deferred `navigateTo`; no-launch handlers write `{}`; idempotent replays still emit preconditions even if writes elide.
  - Scheduler treats `receipt-exists` as permanent (logs “event-lost-race”); transient conflicts still retry with the same receipt id.
  - One handler per event link; last registration wins with a warn marker.
  - Handler frame causes derive from the durable event id; fallback to `crypto.randomUUID()` for non-dispatch calls.
  - Typed precondition failures propagate through remote memory so the scheduler sees `PreconditionFailedError("receipt-exists")`.

- **Migration**
  - Receipts are gated by the experimental `commitPreconditions` flag (default off). Enable to activate exactly-once.
  - Update `packages/memory` and `packages/runner` together; no data migration required.

<sup>Written for commit 3d6505f18a03c21cf300a2e81f8188f5518fce84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

