### PR TITLE
refactor(runner): static write surface; remove write-set discovery (scheduler-v2 phase 1)

### DIFF
--- a/docs/specs/scheduler-v2/implementation/05-phase1-static-write-surface.md
+++ b/docs/specs/scheduler-v2/implementation/05-phase1-static-write-surface.md
@@ -187,9 +187,31 @@ justification: "asserted v1 write-set learning; v2 surface is static"):
   surface.
 - `test/scheduler-effects.test.ts:451-459` — membership-style check;
   likely passes unchanged; verify.
+- `test/scheduler-core.test.ts` / action-run trace expectation — effects now
+  have no scheduler-visible output, so trace `declaredWrites` is empty for
+  effects.
+- `test/scheduler-pull-handlers.test.ts` / dynamic lift seeding — seed the
+  computation's static surface through subscribe-with-log (the registration
+  declaration channel) or an annotation, not post-run `resubscribe`.
+- `test/scheduler-pull.test.ts` / unrelated pending dependency collection —
+  v2 §5.3 arrives early here: computations created during a live effect's run
+  get provisional first-run demand; the v1 exception keyed on run-learned
+  effect writes no longer exists.
+
+Auto-debounce cleanup in the same commit:
+
+1. `src/cell.ts` `pull()`: subscribe the ephemeral pull-root effect with
+   `noDebounce: true`. Pull-root debounce protection is explicit rather than
+   inferred from a write-surface proxy.
+2. The auto-debounce eligibility gate (`canAutomaticallyDebounce` in
+   delay-control): remove the `isPullDemandRootEffect` exemption. Keep the
+   effect-only requirement, explicit `noDebounce` opt-out, and existing timing
+   thresholds. Keep `isPullDemandRootEffect` itself and its other call sites
+   unchanged in this phase.
 
 Failures in ANY other file: apply the decision tree in step 4 if they are
-ordering-related; otherwise STOP.
+ordering-related. If timing/throttle tests fail after the auto-debounce cleanup,
+STOP and list the failing names. Otherwise STOP.
 
 Commit: `refactor(runner): scheduling writes are the static declared surface (scheduler-v2 phase 1)`
 
@@ -248,6 +270,8 @@ better; regressions >10%: STOP).
 - [ ] Observation payload still carries both write fields (compat), equal
       to the surface.
 - [ ] Fixtures A/B green; behavior change (if any) documented.
-- [ ] Test rewrites confined to the three named files (or decision-tree
-      fallback applied and marked).
+- [ ] Test rewrites confined to the named files: ordering, observations,
+      effects, core trace expectation, pull single §5.3 test, and
+      pull-handlers seeding form (or decision-tree fallback applied and
+      marked).
 - [ ] Bench deltas recorded; none worse than 10%.

--- a/docs/specs/scheduler-v2/implementation/05-phase1-static-write-surface.md
+++ b/docs/specs/scheduler-v2/implementation/05-phase1-static-write-surface.md
@@ -60,27 +60,29 @@ becomes the unconditional surface registration:
 ```typescript
 // Static write surface (spec scheduler-v2 P4): the action's writes are
 // fixed at registration — declared outputs plus statically resolved
-// redirect targets, already computed by the runner. Nothing about the
+// redirect targets, already computed by the runner, or a registration-time
+// ReactivityLog supplied by direct scheduler callers. Nothing about the
 // surface is learned from runs.
-const surface = (action as Partial<TelemetryAnnotations>).writes ?? [];
+const annotatedSurface = (action as Partial<TelemetryAnnotations>).writes ?? [];
+const surface = annotatedSurface.length > 0
+  ? annotatedSurface.map(toMemorySpaceAddress)
+  : (immediateLog?.writes ?? []);
 if (!actionIsEffect && surface.length > 0) {
-  setSchedulerDependencies(
-    state.dependencyUpdateState,
-    action,
-    {
-      reads: [],
-      shallowReads: [],
-      writes: surface.map(toMemorySpaceAddress),
-    },
-  );
+  state.writeIndex.setSurface(action, surface);
+  state.registerWriterDependents(action, surface);
 }
 ```
 
 (Identical to today's block minus the `!immediateLog` condition and with
 the comment replaced; with an `immediateLog` the subsequent
 `setSchedulerDependencies(state..., immediateLog)` call now must NOT
-clobber the surface — that is handled by step 3's rewrite, which ignores
-log writes. Order the calls so the surface registration runs first.)
+clobber the surface — that is handled by step 3's rewrite, which keeps
+surface registration out of dependency updates. Order the calls so the
+surface registration runs first.)
+
+Surface resolution is a registration-time declaration, in priority order:
+non-empty annotated `action.writes`, then `immediateLog.writes`, then empty.
+`resubscribe(action, runLog)` never changes the surface.
 
 Commit with step 3 (single commit; this step alone is incoherent).
 
@@ -101,28 +103,20 @@ export function setSchedulerDependencies(
 } {
   const reads = sortAndCompactPaths(log.reads);
   const shallowReads = sortAndCompactPaths(log.shallowReads, false);
-  const ignoredSchedulingWrites =
-    (action as Partial<TelemetryAnnotations>).ignoredSchedulingWrites ?? [];
-  // Static write surface (spec scheduler-v2 P4): scheduling writes are the
-  // declared surface, never the transaction's observed writes.
-  const surface = sortAndCompactPaths(
-    filterIgnoredAddresses(
-      ((action as Partial<TelemetryAnnotations>).writes ?? []).map(
-        toMemorySpaceAddress,
-      ),
-      ignoredSchedulingWrites,
-    ),
-  );
   const schedulingLog: ReactivityLog = {
     reads,
     shallowReads,
-    writes: surface,
+    writes: state.writeIndex.getSchedulingWrites(action) ?? [],
   };
   state.dependencies.set(action, schedulingLog);
-  state.writeIndex.setSurface(action, surface);
   return { reads, shallowReads, log: schedulingLog };
 }
 ```
+
+`setSchedulerDependencies` must not register, update, derive, or rederive the
+write surface. Registration sites own `state.writeIndex.setSurface(...)`;
+dependency updates only refresh reads and return the already-registered
+scheduling writes for compatibility with existing graph/telemetry payloads.
 
 Deletions in the same commit:
 

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -2342,8 +2342,139 @@ the settled-origin note).
 
 ## REVIEWER RESOLUTION — 05/step-3 declaration-rule docs
 
-- [x] pending — WO05 step 2/3 amended so registration-time `ReactivityLog`
+- [x] 13e6f09a7 — WO05 step 2/3 amended so registration-time `ReactivityLog`
   writes declare the static surface when annotations are absent, while
   resubscribe/run logs never change the surface.
+- Recordings: docs-only commit; no `deno fmt`/`deno lint`/`deno check`
+  required.
+
+## IMPLEMENTER STOP — 05/step-3 declaration-rule implementation residuals
+
+Implemented the reviewer verdict narrowly:
+
+- `subscribePullSchedulerAction` resolves the registration-time surface once:
+  non-empty annotated `action.writes` first, else `immediateLog.writes`, else
+  empty; effects still do not register a scheduling surface.
+- `setSchedulerDependencies` no longer reads `log.writes` or writes to the
+  write index; it refreshes reads and returns the already-registered surface.
+- `rehydrateActionFromObservation` now registers the live annotated surface
+  before resubscribing reads, so persisted `currentKnownWrites` never restores
+  the surface by itself.
+- Named test rewrites stayed confined to `scheduler-ordering.test.ts`,
+  `scheduler-observations.test.ts`, and `scheduler-effects.test.ts`.
+
+Verification:
+
+- `deno fmt packages/runner/src/scheduler/pull-subscriptions.ts
+  packages/runner/src/scheduler/dependency-updates.ts
+  packages/runner/src/scheduler/scheduling-writes.ts
+  packages/runner/src/scheduler/dependency-graph.ts
+  packages/runner/src/scheduler/action-run.ts
+  packages/runner/src/scheduler/subscriptions.ts packages/runner/src/scheduler.ts
+  packages/runner/src/runtime.ts packages/runner/test/experimental-options.test.ts
+  packages/runner/test/scheduler-ordering.test.ts
+  packages/runner/test/scheduler-observations.test.ts
+  packages/runner/test/scheduler-effects.test.ts
+  packages/runner/test/scheduler-static-writes.test.ts`: passed
+  (`Checked 13 files`).
+- `deno lint` on the same 13 files: passed (`Checked 13 files`).
+- `deno check` on the same 13 files: passed.
+- `grep -rn "backfillDependentsForNewWrites\|pruneDependentsForCurrentWrites"
+  packages/runner/src/`: no matches.
+- `grep -rn "schedulerHistoricalMightWrite\|historicalMightWrite" packages
+  --include="*.ts"`: no matches.
+- `grep -rn
+  "buildKnownSchedulingWrites\|historicalMightWrite\|diffSchedulingWrites\|pruneStructuralAncestorWrites"
+  packages/runner/src`: no matches.
+- Focused tests passed:
+  - `test/scheduler-static-writes.test.ts`: `1 passed (2 steps)`.
+  - `test/scheduler-ordering.test.ts`: `2 passed (17 steps)`.
+  - `test/scheduler-observations.test.ts`: `1 passed (22 steps)`.
+  - `test/scheduler-effects.test.ts`: `1 passed (20 steps)`.
+  - `test/experimental-options.test.ts`: `1 passed (11 steps)`.
+
+Full suite failure:
+
+- `cd packages/runner && deno task test`: failed, `588 passed
+  (3091 steps)`, `4 failed (4 steps)`, `0 ignored (10 steps)`, `2m5s`.
+- Per-test classification required by the reviewer verdict:
+  - `test/scheduler-core.test.ts` / `captures exact action runs for one
+    reactive update`: (b) not run-log surface evolution. The action-run trace
+    still expects an effect's `declaredWrites` length to be 1, but effects now
+    have no registered scheduling surface.
+  - `test/scheduler-pull-handlers.test.ts` / `should wait for dynamically
+    created lift before dispatching to downstream handler`: (a) asserts
+    run-log surface evolution/setup. The test seeds the lift surface through
+    `resubscribe(liftAction, log)`, which v2 now forbids.
+  - `test/scheduler-pull.test.ts` / `should not re-run an effect for unrelated
+    pending dependency collection`: (b) not run-log surface evolution. With
+    effects now empty-surface demand roots, a child computation subscribed
+    while the effect runs is demanded and runs once.
+  - `test/scheduler-timing.test.ts` / `should auto-debounce slow writeful
+    effects after threshold runs`: (b) not run-log surface evolution. The test
+    classifies a writeful effect by its old scheduling writes; effects now have
+    an empty scheduling surface and are treated as pull demand roots.
+
+Stopped per the reviewer verdict because three residual failures are class
+(b). No rewrites outside the three named files were attempted.
+
+## REVIEWER VERDICT — 05/step-3 residuals (effect-surface proxy)
+
+Effects being surface-less is CORRECT (spec §4.2: no scheduler-visible
+output) and stays. The three class-(b) residuals are v1's
+"writes==0 ⇒ pull-demand-root" PROXY breaking, not your change being
+wrong. Per-test rulings:
+
+1. `scheduler-core` / "captures exact action runs ...": authorized
+   rewrite (add to named files): an effect's `declaredWrites` in the
+   action-run trace is now 0 — that is the v2 truth, the test encoded
+   the v1 run-learned surface.
+2. `scheduler-pull-handlers` / dynamic-lift seeding: your class-(a)
+   call is right — authorized rewrite, minimal form: seed the lift's
+   surface through subscribe-with-log (the declaration channel) or an
+   annotation, not post-run `resubscribe`.
+3. `scheduler-pull` / "unrelated pending dependency collection": the
+   new behavior IS spec §5.3 arriving early — a computation created
+   during any LIVE node's run (every effect is live) gets one
+   provisional first run. Authorized rewrite of this single test to the
+   v2 expectation, with this comment above the changed assertion:
+   `// v2 (spec §5.3): children created during a live effect's run get`
+   `// provisional first-run demand; the v1 writeful-effect exception`
+   `// keyed on run-learned writes, which no longer exist.`
+4. `scheduler-timing` / auto-debounce: NO test rewrite — the mechanism
+   must be fixed, or every ordinary sink loses auto-debounce (violates
+   spec §8.2). Two edits:
+   - `cell.ts` `pull()`: subscribe its ephemeral effect with
+     `noDebounce: true` (the pull-root protection becomes EXPLICIT
+     instead of riding the writes proxy);
+   - the auto-debounce eligibility gate (`canAutomaticallyDebounce` in
+     delay-control): drop the `isPullDemandRootEffect` exemption,
+     keeping effect-only + `noDebounce` opt-out + thresholds.
+   Keep `isPullDemandRootEffect` itself and its OTHER call sites
+   (demand context, snapshot) unchanged in this phase — with effects
+   surface-less it now returns true for all effects, which matches the
+   §5.3 semantics accepted in (3); the predicate dissolves entirely in
+   phase 3b.
+   The failing timing test must then pass AS WRITTEN. If any other
+   timing/throttle test fails after this (e.g. one asserting pull
+   roots never debounce via the proxy), STOP with the name.
+
+Bookkeeping: named-rewrite list for this work order now reads:
+ordering, observations, effects, core (trace expectation), pull
+(single §5.3 test), pull-handlers (seeding form). Docs amendment —
+`docs(specs): scheduler-v2 WO05 — effect surfaces, pull-root opt-out, §5.3 early`
+— before the code commit. Deferred spec notes now three: immediate-log
+declaration channel (P4), settled-origin rule (§7.6), and §8.2's
+exemption being noDebounce/pull-root-by-option rather than a writes
+proxy.
+
+Then: full suite green → commit step 2+3 (one commit, message from
+step 3), then steps 4-6 as written.
+
+## REVIEWER RESOLUTION — 05/step-3 residual-rule docs
+
+- [x] pending — WO05 step 3 amended for effect-empty-surface trace
+  expectations, subscribe-time seeding of dynamic lifts, early §5.3 provisional
+  child demand, and explicit `noDebounce` pull-root auto-debounce opt-out.
 - Recordings: docs-only commit; no `deno fmt`/`deno lint`/`deno check`
   required.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -2187,7 +2187,7 @@ packages/runner/src/scheduler/events.ts:654:            permanent: isPermanentRe
 
 ## 05/step-1
 
-- [x] pending — static write surface demand fixtures added.
+- [x] ca77bc16e — static write surface demand fixtures added.
 - Deviations: both fixtures already pass on current code, so they pin existing
   behavior; no behavior-change red case was observed.
 - Recordings:
@@ -2200,3 +2200,150 @@ packages/runner/src/scheduler/events.ts:654:            permanent: isPermanentRe
     --allow-read --allow-write=/tmp,/var/folders --allow-run=git
     test/scheduler-static-writes.test.ts`: passed, `1 passed (2 steps)`,
     `0 failed`.
+
+## IMPLEMENTER STOP — 05/step-3 static write surface sweep
+
+Stopped after implementing the step 2/3 static-surface rewrite locally because
+the full runner suite produced failures outside the three work-order-named
+rewrite files. Continuing would require either changing public scheduler API
+compatibility for direct `subscribe(..., ReactivityLog)` callers, or widening
+test rewrites beyond the allowed files.
+
+Local changes currently include:
+
+- `pull-subscriptions.ts`: unconditional static surface registration from
+  action annotations before `immediateLog` setup.
+- `dependency-updates.ts`: scheduling writes are derived only from the
+  annotated static surface, never `log.writes`.
+- `scheduling-writes.ts`: deleted dynamic write discovery helpers and
+  historical might-write mode; `SchedulerWriteIndex` now stores the current
+  static surface.
+- `dependency-graph.ts`/`subscriptions.ts`/`scheduler.ts`: added static
+  registration-time dependent edge attachment so existing readers can see a
+  newly registered static writer without resurrecting dynamic write-growth
+  diffing.
+- `action-run.ts`: persisted observations keep both write fields populated
+  from the static surface.
+- `runtime.ts` and experimental-option tests: removed
+  `schedulerHistoricalMightWrite`.
+- Named test rewrites in `scheduler-ordering.test.ts`,
+  `scheduler-observations.test.ts`, and `scheduler-effects.test.ts` assert
+  static surfaces instead of v1 write-set learning. The step-1 fixture was
+  also corrected to express declared writes through `action.writes`, because
+  v2 ignores direct `log.writes` as scheduler surface.
+
+Verification before the full-suite STOP:
+
+- `deno fmt packages/runner/src/scheduler/pull-subscriptions.ts
+  packages/runner/src/scheduler/dependency-updates.ts
+  packages/runner/src/scheduler/scheduling-writes.ts
+  packages/runner/src/scheduler/dependency-graph.ts
+  packages/runner/src/scheduler/action-run.ts
+  packages/runner/src/scheduler/subscriptions.ts packages/runner/src/scheduler.ts
+  packages/runner/src/runtime.ts packages/runner/test/experimental-options.test.ts
+  packages/runner/test/scheduler-ordering.test.ts
+  packages/runner/test/scheduler-observations.test.ts
+  packages/runner/test/scheduler-effects.test.ts
+  packages/runner/test/scheduler-static-writes.test.ts`: passed
+  (`Checked 13 files`).
+- `deno lint` on the same 13 files: passed (`Checked 13 files`).
+- `deno check` on the same 13 files: passed.
+- `grep -rn "backfillDependentsForNewWrites\|pruneDependentsForCurrentWrites"
+  packages/runner/src/`: no matches.
+- `grep -rn "schedulerHistoricalMightWrite\|historicalMightWrite" packages
+  --include="*.ts"`: no matches.
+- `grep -rn
+  "buildKnownSchedulingWrites\|historicalMightWrite\|diffSchedulingWrites\|pruneStructuralAncestorWrites"
+  packages/runner/src`: no matches.
+- Focused tests passed:
+  - `test/scheduler-static-writes.test.ts`: `1 passed (2 steps)`.
+  - `test/scheduler-ordering.test.ts`: `2 passed (17 steps)`.
+  - `test/scheduler-observations.test.ts`: `1 passed (22 steps)`.
+  - `test/scheduler-effects.test.ts`: `1 passed (20 steps)`.
+  - `test/experimental-options.test.ts`: `1 passed (11 steps)`.
+
+Full suite failure:
+
+- `cd packages/runner && deno task test`: failed, `580 passed
+  (3032 steps)`, `12 failed (63 steps)`, `0 ignored (10 steps)`, `2m5s`.
+- Failure groups:
+  - `test/cell-callbacks.test.ts`: persistent effect after `pull()` cleanup.
+  - `test/memory-v2-pull-reactivity.test.ts`: 2 pull reactivity failures.
+  - `test/scheduler-convergence.test.ts`: 6 convergence/cycle/stat failures.
+  - `test/scheduler-core.test.ts`: 5 scheduler core/trace/cancel failures.
+  - `test/scheduler-events.test.ts`: 2 event recomputation/in-flight demand
+    failures.
+  - `test/scheduler-pull-array.test.ts`: 7 array/demand/navigation failures.
+  - `test/scheduler-pull-handlers.test.ts`: 7 handler dependency pulling
+    failures.
+  - `test/scheduler-pull-references.test.ts`: reference propagation failure.
+  - `test/scheduler-pull.test.ts`: broad pull scheduling/staleness failures,
+    including the explicit legacy assertion
+    `should preserve writes when collecting dependencies from ReactivityLog`.
+  - `test/scheduler-retries.test.ts`: retry dependency preservation failure.
+  - `test/scheduler-throttle.test.ts`: 4 throttle/staleness failures.
+  - `test/scheduler-timing.test.ts`: 7 debounce/auto-debounce/cycle-debounce
+    failures.
+
+Reviewer question: should the scheduler keep a compatibility path where a
+direct `ReactivityLog` passed to `subscribe`/`resubscribe` seeds a static
+surface for unannotated actions, or should the work order explicitly authorize
+widening rewrites/annotations across the additional direct-scheduler tests?
+
+## REVIEWER VERDICT — 05/step-3 subscribe-time logs are declarations
+
+Keep the compatibility path — and not as a concession: it is the
+P4-correct reading. A `ReactivityLog` passed to `subscribe(...)` is a
+REGISTRATION-TIME declaration (the caller saying "this action reads X,
+writes Y"), the same rank as runner annotations. What P4 forbids is the
+surface changing from RUN logs. Do NOT widen test rewrites beyond the
+three named files.
+
+The rule:
+
+1. Surface resolution at REGISTRATION, in priority order:
+   annotated `action.writes` (non-empty) → else `immediateLog.writes`
+   (subscribe-with-log path) → else empty. Applied once.
+2. `resubscribe(action, runLog)` NEVER touches the surface — for
+   annotated and unannotated actions alike. This is the only intended
+   v1→v2 semantic change, and the three named files' rewrites already
+   express it.
+3. Architectural placement: move surface registration OUT of
+   `setSchedulerDependencies` entirely — registration sites own it
+   (`subscribePullSchedulerAction` for both the annotation and
+   immediate-log cases; the rehydration path keeps using the annotation
+   as you already have it). `setSchedulerDependencies` becomes
+   reads/edges only and never writes to the write index. This matches
+   the v2 component split (registration owns the surface) and makes the
+   resubscribe path structurally unable to clobber it.
+4. Populate-callback subscribers with no log and no annotation (e.g.
+   `cell.pull()`'s ephemeral effect) keep an empty surface — correct,
+   they are effects.
+
+Expected effect: the direct-subscribe test population (the 12 failing
+files) declares writes in their initial logs, so their surfaces, writer
+edges, demand, and ordering come back without any test edits —
+including the explicitly-legacy
+`should preserve writes when collecting dependencies from ReactivityLog`
+(subscribe-time, so it must pass unchanged) and the retry-preservation
+test (retry resubscribes with the captured log; surface stays the
+registration-time one).
+
+After implementing: run the full suite. If failures remain, list them
+per-test in PROGRESS with a one-line classification — (a) asserts
+run-log surface EVOLUTION (rewrite authorized, name it), (b) anything
+else (STOP with the failure). Do not bulk-rewrite.
+
+Docs: amend WO05 step 2/3 with the declaration rule — own commit:
+`docs(specs): scheduler-v2 WO05 — subscribe-time logs declare the surface`.
+Deferred spec note recorded: P4's text should gain one sentence naming
+the immediate-log declaration channel (rides the later docs change with
+the settled-origin note).
+
+## REVIEWER RESOLUTION — 05/step-3 declaration-rule docs
+
+- [x] pending — WO05 step 2/3 amended so registration-time `ReactivityLog`
+  writes declare the static surface when annotations are absent, while
+  resubscribe/run logs never change the surface.
+- Recordings: docs-only commit; no `deno fmt`/`deno lint`/`deno check`
+  required.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -2473,8 +2473,112 @@ step 3), then steps 4-6 as written.
 
 ## REVIEWER RESOLUTION — 05/step-3 residual-rule docs
 
-- [x] pending — WO05 step 3 amended for effect-empty-surface trace
+- [x] 315a34866 — WO05 step 3 amended for effect-empty-surface trace
   expectations, subscribe-time seeding of dynamic lifts, early §5.3 provisional
   child demand, and explicit `noDebounce` pull-root auto-debounce opt-out.
 - Recordings: docs-only commit; no `deno fmt`/`deno lint`/`deno check`
   required.
+
+## IMPLEMENTER STOP — 05/step-3 residual-rule timing proxy follow-up
+
+Applied the reviewer verdict narrowly:
+
+- `cell.ts` `pull()` subscribes its ephemeral effect with `noDebounce: true`.
+- Auto-debounce eligibility no longer exempts `isPullDemandRootEffect`; it keeps
+  effect-only eligibility and explicit `noDebounce` opt-out.
+- `scheduler-core.test.ts` action-run trace now expects effect
+  `declaredWrites` to be empty while preserving the actual write assertion.
+- `scheduler-pull-handlers.test.ts` seeds the dynamic lift surface through
+  `subscribe(..., ReactivityLog)` rather than `resubscribe(...)`.
+- `scheduler-pull.test.ts` rewrites the single §5.3 provisional child-demand
+  expectation with the reviewer-specified comment.
+
+Verification before STOP:
+
+- `deno fmt` on the 20 touched TS/test files: passed (`Checked 20 files`).
+- `deno lint` on the same 20 files: passed (`Checked 20 files`).
+- `deno check` on the same 20 files: passed.
+- Focused residual reruns:
+  - `test/scheduler-core.test.ts`: `1 passed (25 steps)`.
+  - `test/scheduler-pull-handlers.test.ts`: `1 passed (11 steps)`.
+  - `test/scheduler-pull.test.ts`: `1 passed (26 steps)`.
+  - `test/scheduler-timing.test.ts`: failed, `0 passed (20 steps)`,
+    `1 failed (1 step)`.
+
+STOP condition from reviewer verdict:
+
+- `test/scheduler-timing.test.ts` / `should not auto-debounce write-less pull
+  demand root effects` still asserts the old proxy behavior. After removing the
+  `isPullDemandRootEffect` auto-debounce exemption, it observes debounce `100`
+  instead of `undefined` at `scheduler-timing.test.ts:396`.
+
+No rewrite was attempted because the reviewer explicitly said to STOP if any
+other timing/throttle test fails after the auto-debounce cleanup.
+
+## REVIEWER VERDICT — 05/step-3 timing-proxy companion test
+
+Correct stop; this is the companion assertion of the same dead proxy,
+from the other side. "Write-less effect" no longer means "pull root" —
+it means an ordinary read-only sink, which is precisely what §8.2 wants
+auto-debounced when slow. The pull-root protection is now the explicit
+`noDebounce: true` that `pull()` sets.
+
+Authorized rewrite of this single test (added to the named list):
+
+1. Rename `should not auto-debounce write-less pull demand root effects`
+   → `auto-debounces slow write-less effects; pull roots opt out via noDebounce`.
+2. Flip the main assertion: after threshold runs, the bare write-less
+   slow effect HAS debounce 100 (the value your run already observed).
+3. In the same test (or a sibling `it` if cleaner), assert the
+   protected case explicitly: an identical slow effect subscribed with
+   `noDebounce: true` keeps debounce `undefined` after the same number
+   of runs. Skip this half only if an existing test in the file already
+   covers the `noDebounce` opt-out for effects — check first and note
+   which.
+4. Comment above the flipped assertion:
+   `// v2 (spec §8.2): the auto-debounce exemption is the explicit`
+   `// noDebounce opt-out (pull() sets it); v1 exempted any write-less`
+   `// effect via the demand-root writes proxy, which no longer exists.`
+
+Then full suite; if green, proceed with the commit sequence from the
+prior verdict (steps 2+3 commit, then 4-6). Any further failure of any
+shape: STOP as usual.
+
+## IMPLEMENTER RESOLUTION — 05/step-3 timing companion rewrite
+
+Applied the verdict:
+
+- `scheduler-timing.test.ts` renamed the write-less effect test and now asserts
+  that a bare slow write-less effect gets auto-debounce `100`.
+- The same test asserts an identical slow effect subscribed with
+  `noDebounce: true` keeps debounce `undefined`.
+- Existing `noDebounce` coverage in this file was cycle-aware debounce only, so
+  the explicit effect auto-debounce opt-out assertion was added here.
+
+Verification:
+
+- `deno fmt` on the 20 touched TS/test files: passed (`Checked 20 files`).
+- `deno lint` on the same 20 files: passed (`Checked 20 files`).
+- `deno check` on the same 20 files: passed.
+- Contract greps:
+  - `grep -rn "backfillDependentsForNewWrites\|pruneDependentsForCurrentWrites"
+    packages/runner/src/`: no matches.
+  - `grep -rn "schedulerHistoricalMightWrite\|historicalMightWrite" packages
+    --include="*.ts"`: no matches.
+  - `grep -rn
+    "buildKnownSchedulingWrites\|historicalMightWrite\|diffSchedulingWrites\|pruneStructuralAncestorWrites"
+    packages/runner/src`: no matches.
+- Focused named rewrites passed:
+  - `ENV=test deno test --allow-ffi --allow-env --allow-read
+    --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-static-writes.test.ts test/scheduler-ordering.test.ts
+    test/scheduler-observations.test.ts test/scheduler-effects.test.ts
+    test/experimental-options.test.ts`: `6 passed (72 steps)`,
+    `0 failed`.
+  - `ENV=test deno test --allow-ffi --allow-env --allow-read
+    --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-core.test.ts test/scheduler-pull-handlers.test.ts
+    test/scheduler-pull.test.ts test/scheduler-timing.test.ts`:
+    `4 passed (83 steps)`, `0 failed`.
+- `cd packages/runner && deno task test`: `ok | 592 passed (3095 steps) |
+  0 failed | 0 ignored (10 steps) (2m4s)`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -2706,3 +2706,21 @@ Verification:
     `0 failed`.
   - Test rewrites were confined to the reviewer-approved named files; step 4
     clean removal held without the decision-tree fallback.
+
+## REVIEWER RESOLUTION — PR #4098 review findings
+
+- [x] pending — immediate-log write surfaces survive persistence and
+  rehydration.
+- Findings addressed (Codex/cubic review on PR #4098), red-first:
+  - Actions whose static surface came from `subscribe(action,
+    ReactivityLog)` (no `.writes` annotation) persisted
+    `currentKnownWrites: []` (annotation-only `declaredWrites`), and
+    `rehydrateActionFromObservation` resolved the surface with no
+    immediate log, so a restored action read as writing nothing.
+    Observations now persist the live registered surface
+    (`getSchedulingWrites(action) ?? declaredWrites`) and rehydration
+    resolves through `resolveRegistrationSurface(action, { writes:
+    observation.currentKnownWrites })`, mirroring registration
+    (`test/scheduler-observations.test.ts` "persists and rehydrates
+    immediate-log write surfaces").
+- Deviations: none.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -2582,3 +2582,43 @@ Verification:
     `4 passed (83 steps)`, `0 failed`.
 - `cd packages/runner && deno task test`: `ok | 592 passed (3095 steps) |
   0 failed | 0 ignored (10 steps) (2m4s)`.
+
+## 05/step-2+3
+
+- [x] 6a9377bbe — scheduling writes are static declared surfaces registered at
+  subscribe time.
+- Deviations: reviewer-authorized residual rewrites documented above; effects
+  have no scheduler-visible write surface, and pull-root debounce protection is
+  the explicit `noDebounce` opt-out.
+- Recordings: see the `IMPLEMENTER RESOLUTION — 05/step-3 timing companion
+  rewrite` verification above.
+
+## 05/step-4
+
+- [x] no commit — clean removal held; no ordering-only effect write fallback
+  was needed.
+- Deviations: none.
+- Recordings:
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-ordering.test.ts test/scheduler-convergence.test.ts`:
+    passed, `3 passed (32 steps)`, `0 failed`.
+
+## 05/step-5
+
+- [x] pending — added a dev warning for computation writes outside the declared
+  static surface.
+- Deviations: none.
+- Recordings:
+  - `deno fmt packages/runner/src/scheduler/action-run.ts
+    packages/runner/test/scheduler-static-writes.test.ts`: passed
+    (`Checked 2 files`).
+  - `deno lint packages/runner/src/scheduler/action-run.ts
+    packages/runner/test/scheduler-static-writes.test.ts`: passed
+    (`Checked 2 files`).
+  - `deno check packages/runner/src/scheduler/action-run.ts
+    packages/runner/test/scheduler-static-writes.test.ts`: passed.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-static-writes.test.ts`: passed, `1 passed (3 steps)`,
+    `0 failed`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -2606,8 +2606,8 @@ Verification:
 
 ## 05/step-5
 
-- [x] pending — added a dev warning for computation writes outside the declared
-  static surface.
+- [x] 088100973 — added a dev warning for computation writes outside the
+  declared static surface.
 - Deviations: none.
 - Recordings:
   - `deno fmt packages/runner/src/scheduler/action-run.ts
@@ -2622,3 +2622,87 @@ Verification:
     --allow-read --allow-write=/tmp,/var/folders --allow-run=git
     test/scheduler-static-writes.test.ts`: passed, `1 passed (3 steps)`,
     `0 failed`.
+
+## 05/phase-end
+
+- [x] pending — WO05 exit checklist self-check complete.
+- Deviations: none.
+- Recordings:
+  - `cd packages/runner && deno task test`: passed,
+    `592 passed (3096 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m4s`.
+  - Phase benchmark command passed:
+    `cd packages/runner && deno bench --allow-read --allow-write --allow-net
+    --allow-ffi --allow-env --no-check test/scheduler.bench.ts
+    test/scheduler-demand-roots.bench.ts
+    test/scheduler-stale-propagation.bench.ts`.
+  - Benchmark deltas vs 05/step-0 baseline:
+    - `test/scheduler.bench.ts`:
+      - `Scheduler - 100 computations, shared entity reads`: 19.4 ms -> 19.7
+        ms (+1.5%).
+      - `Scheduler - wide graph (1 source, 100 readers)`: 17.9 ms -> 17.3 ms
+        (-3.4%).
+      - `Scheduler - 100 entities, sparse deps`: 17.3 ms -> 17.7 ms (+2.3%).
+      - `Scheduler - deep chain (50 levels)`: 11.5 ms -> 11.2 ms (-2.6%).
+      - `Scheduler - diamond pattern (10 diamonds)`: 9.6 ms -> 9.7 ms
+        (+1.0%).
+      - `Scheduler - repeated dirty marking`: 7.7 ms -> 7.7 ms (+0.0%).
+      - `Scheduler - subscribe/unsubscribe cycle (100x)`: 5.8 ms -> 5.6 ms
+        (-3.4%).
+      - `Scheduler - pull with resubscribe (50 pulls)`: 291.3 ms -> 288.4 ms
+        (-1.0%).
+      - `Overhead - setup/teardown only`: 1.3 ms -> 1.4 ms (+7.7%).
+      - `Overhead - create 100 cells (getCell + set)`: 15.4 ms -> 15.5 ms
+        (+0.6%).
+      - `Overhead - 100x getCell only (no set)`: 1.6 ms -> 1.6 ms (+0.0%).
+      - `Overhead - 100x set on existing cells`: 15.7 ms -> 15.5 ms (-1.3%).
+      - `Overhead - runtime.idle() empty`: 1.3 ms -> 1.2 ms (-7.7%).
+      - `Overhead - commit after 100 sets`: 15.9 ms -> 16.1 ms (+1.3%).
+      - `Overhead - empty commit`: 1.3 ms -> 1.2 ms (-7.7%).
+      - `Overhead - 100 raw tx.write + commit`: 7.1 ms -> 7.6 ms (+7.0%).
+      - `Utility - sortAndCompactPaths (100 paths)`: 21.7 us -> 21.1 us
+        (-2.8%).
+      - `Utility - sortAndCompactPaths (1000 paths)`: 280.5 us -> 281.3 us
+        (+0.3%).
+      - `Utility - addressesToPathByEntity (100 paths)`: 14.9 us -> 14.8 us
+        (-0.7%).
+      - `Utility - addressesToPathByEntity (1000 paths)`: 150.3 us -> 152.1
+        us (+1.2%).
+      - `Scheduler - bare subscribe (100x)`: 1.7 ms -> 1.6 ms (-5.9%).
+      - `Scheduler - subscribe 100 actions reading same entity`: 1.7 ms -> 1.6
+        ms (-5.9%).
+      - `Scheduler - resubscribe cycle (100x)`: 1.4 ms -> 1.3 ms (-7.1%).
+    - `test/scheduler-demand-roots.bench.ts`:
+      - `Scheduler demand roots - effect demand root`: 147.1 ms -> 144.1 ms
+        (-2.0%).
+      - `Scheduler demand roots - event demand root`: 131.8 ms -> 129.4 ms
+        (-1.8%).
+      - `Scheduler demand roots - mixed effect and event roots`: 169.0 ms ->
+        172.8 ms (+2.2%).
+      - `Scheduler demand roots - parent clears generated children`: 81.3 ms ->
+        82.6 ms (+1.6%).
+    - `test/scheduler-stale-propagation.bench.ts`:
+      - `Scheduler stale propagation - chain`: 105.5 ms -> 97.3 ms (-7.8%).
+      - `Scheduler stale propagation - diamond`: 94.7 ms -> 89.4 ms (-5.6%).
+      - `Scheduler stale propagation - wide fanout`: 244.0 ms -> 248.0 ms
+        (+1.6%).
+      - `Scheduler stale propagation - dynamic deps`: 82.9 ms -> 74.7 ms
+        (-9.9%).
+      - `Scheduler stale propagation - unchanged recompute`: 74.7 ms -> 73.2
+        ms (-2.0%).
+  - No benchmark regression exceeded 10%.
+- Exit checklist:
+  - `grep -rn
+    "buildKnownSchedulingWrites\|historicalMightWrite\|diffSchedulingWrites\|pruneStructuralAncestorWrites"
+    packages/runner/src`: no matches.
+  - `grep -rn "log\.writes"
+    packages/runner/src/scheduler/dependency-updates.ts`: no matches;
+    inspection confirms `setSchedulerDependencies` reads only `log.reads` and
+    `log.shallowReads`, and returns `state.writeIndex.getSchedulingWrites`.
+  - Observation payload compatibility held: `attachSchedulerActionObservation`
+    still sets both `currentKnownWrites` and `declaredWrites` to the registered
+    static surface.
+  - Static write fixtures A/B and the new surface-violation fixture are green:
+    `test/scheduler-static-writes.test.ts` passed, `1 passed (3 steps)`,
+    `0 failed`.
+  - Test rewrites were confined to the reviewer-approved named files; step 4
+    clean removal held without the decision-tree fallback.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -2035,7 +2035,7 @@ semantics.
 
 ## 04/phase-end self-check
 
-- [x] pending — work order 04 phase-end verification recorded.
+- [x] a49811102 — work order 04 phase-end verification recorded.
 - Deviations: work order 04 lists no phase-specific benchmarks beyond the
   full suites and exit-checklist greps. The flag-on runner pass used a
   temporary local edit to `packages/runner/test/scheduler-test-utils.ts` to
@@ -2138,3 +2138,65 @@ packages/runner/src/scheduler/events.ts:654:            permanent: isPermanentRe
   ABOVE precondition validation (still before the observation fast paths,
   which keep their own replay table and never hit the generic check).
 - Deviations: none.
+
+## 05/step-0
+
+- [x] no commit — phase 1 benchmark baseline captured before static write
+  surface changes.
+- Deviations: none.
+- Recordings:
+  - `cd packages/runner && deno bench --allow-read --allow-write
+    --allow-net --allow-ffi --allow-env --no-check test/scheduler.bench.ts
+    test/scheduler-demand-roots.bench.ts
+    test/scheduler-stale-propagation.bench.ts`: passed.
+  - `test/scheduler.bench.ts`:
+    - `Scheduler - 100 computations, shared entity reads`: 19.4 ms
+    - `Scheduler - wide graph (1 source, 100 readers)`: 17.9 ms
+    - `Scheduler - 100 entities, sparse deps`: 17.3 ms
+    - `Scheduler - deep chain (50 levels)`: 11.5 ms
+    - `Scheduler - diamond pattern (10 diamonds)`: 9.6 ms
+    - `Scheduler - repeated dirty marking`: 7.7 ms
+    - `Scheduler - subscribe/unsubscribe cycle (100x)`: 5.8 ms
+    - `Scheduler - pull with resubscribe (50 pulls)`: 291.3 ms
+    - `Overhead - setup/teardown only`: 1.3 ms
+    - `Overhead - create 100 cells (getCell + set)`: 15.4 ms
+    - `Overhead - 100x getCell only (no set)`: 1.6 ms
+    - `Overhead - 100x set on existing cells`: 15.7 ms
+    - `Overhead - runtime.idle() empty`: 1.3 ms
+    - `Overhead - commit after 100 sets`: 15.9 ms
+    - `Overhead - empty commit`: 1.3 ms
+    - `Overhead - 100 raw tx.write + commit`: 7.1 ms
+    - `Utility - sortAndCompactPaths (100 paths)`: 21.7 us
+    - `Utility - sortAndCompactPaths (1000 paths)`: 280.5 us
+    - `Utility - addressesToPathByEntity (100 paths)`: 14.9 us
+    - `Utility - addressesToPathByEntity (1000 paths)`: 150.3 us
+    - `Scheduler - bare subscribe (100x)`: 1.7 ms
+    - `Scheduler - subscribe 100 actions reading same entity`: 1.7 ms
+    - `Scheduler - resubscribe cycle (100x)`: 1.4 ms
+  - `test/scheduler-demand-roots.bench.ts`:
+    - `Scheduler demand roots - effect demand root`: 147.1 ms
+    - `Scheduler demand roots - event demand root`: 131.8 ms
+    - `Scheduler demand roots - mixed effect and event roots`: 169.0 ms
+    - `Scheduler demand roots - parent clears generated children`: 81.3 ms
+  - `test/scheduler-stale-propagation.bench.ts`:
+    - `Scheduler stale propagation - chain`: 105.5 ms
+    - `Scheduler stale propagation - diamond`: 94.7 ms
+    - `Scheduler stale propagation - wide fanout`: 244.0 ms
+    - `Scheduler stale propagation - dynamic deps`: 82.9 ms
+    - `Scheduler stale propagation - unchanged recompute`: 74.7 ms
+
+## 05/step-1
+
+- [x] pending — static write surface demand fixtures added.
+- Deviations: both fixtures already pass on current code, so they pin existing
+  behavior; no behavior-change red case was observed.
+- Recordings:
+  - `deno fmt packages/runner/test/scheduler-static-writes.test.ts`: passed
+    (`Checked 1 file`).
+  - `deno lint packages/runner/test/scheduler-static-writes.test.ts`: passed
+    (`Checked 1 file`).
+  - `deno check packages/runner/test/scheduler-static-writes.test.ts`: passed.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-static-writes.test.ts`: passed, `1 passed (2 steps)`,
+    `0 failed`.

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -982,6 +982,7 @@ export class CellImpl<T extends FabricValue>
       // Subscribe as an effect so it runs in the next cycle.
       const cancel = this.runtime.scheduler.subscribe(action, action, {
         isEffect: true,
+        noDebounce: true,
       });
 
       // Wait for the scheduler to process all pending work, then resolve.

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -188,8 +188,6 @@ export interface ExperimentalOptions {
   persistentSchedulerState?: boolean | undefined;
   /** Attach origin-committed preconditions to scheduler-v2 lineage commits. */
   commitPreconditions?: boolean | undefined;
-  /** Preserve cumulative scheduler write history instead of using current-known writes. */
-  schedulerHistoricalMightWrite?: boolean | undefined;
 }
 
 export interface RuntimeOptions {
@@ -356,7 +354,6 @@ export class Runtime {
       modernCellRep: undefined,
       persistentSchedulerState: undefined,
       commitPreconditions: undefined,
-      schedulerHistoricalMightWrite: undefined,
       ...options.experimental,
     };
 

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -597,7 +597,14 @@ export class Scheduler {
       return false;
     }
 
-    const surface = resolveRegistrationSurface(action, undefined);
+    // Annotation first; otherwise restore the persisted live surface —
+    // mirroring registration, where subscribe's ReactivityLog supplies the
+    // surface for annotation-less actions.
+    const surface = resolveRegistrationSurface(action, {
+      reads: [],
+      shallowReads: [],
+      writes: observation.currentKnownWrites,
+    });
     if (observation.actionKind !== "effect" && surface.length > 0) {
       this.writeIndex.setSurface(action, surface);
       registerDependentsForWriterSurface(

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -51,8 +51,8 @@ import {
   stopSchedulerDiagnosis,
 } from "./scheduler/diagnosis.ts";
 import {
-  backfillDependentsForNewWrites,
   type DependencyGraphState,
+  registerDependentsForWriterSurface,
   updateDependentEdgesForLog,
 } from "./scheduler/dependency-graph.ts";
 import { SchedulerMaterializers } from "./scheduler/materializers.ts";
@@ -162,6 +162,7 @@ import {
   type WritePropagationState,
 } from "./scheduler/write-propagation.ts";
 import {
+  resolveRegistrationSurface,
   resubscribePullSchedulerAction,
   subscribePullSchedulerAction,
 } from "./scheduler/pull-subscriptions.ts";
@@ -596,9 +597,20 @@ export class Scheduler {
       return false;
     }
 
+    const surface = resolveRegistrationSurface(action, undefined);
+    if (observation.actionKind !== "effect" && surface.length > 0) {
+      this.writeIndex.setSurface(action, surface);
+      registerDependentsForWriterSurface(
+        this.dependencyGraphState,
+        action,
+        surface,
+      );
+    }
+
     this.resubscribe(action, {
       reads: observation.reads,
       shallowReads: observation.shallowReads,
+      // Static dependency setup ignores this in favor of the live annotation.
       writes: observation.currentKnownWrites,
     }, {
       isEffect: observation.actionKind === "effect",
@@ -1152,9 +1164,7 @@ export class Scheduler {
   // ============================================================
 
   /**
-   * Returns the active scheduling write set for an action. By default this is
-   * the current-known write set; experimental historical mode returns the
-   * cumulative legacy view instead.
+   * Returns the action's static write surface.
    */
   getMightWrite(action: Action): IMemorySpaceAddress[] | undefined {
     return this.writeIndex.getSchedulingWrites(action);
@@ -1660,10 +1670,7 @@ export class Scheduler {
   }
 
   private createWriteIndex(): SchedulerWriteIndex {
-    return new SchedulerWriteIndex({
-      useHistoricalMightWrite: () =>
-        this.runtime.experimental.schedulerHistoricalMightWrite === true,
-    });
+    return new SchedulerWriteIndex();
   }
 
   private createPullDemandState(): PullDemandState {
@@ -1690,7 +1697,6 @@ export class Scheduler {
       effects: this.effects,
       dirty: this.staleness.dirty,
       pending: this.pending,
-      isPullDemandRootEffect: (action) => this.isPullDemandRootEffect(action),
       queueExecution: () => this.queueExecution(),
       logDebounce: (message) =>
         logger.debug("schedule-debounce", () => [message]),
@@ -1737,14 +1743,6 @@ export class Scheduler {
     return {
       writeIndex: this.writeIndex,
       dependencies: this.dependencies,
-      dependencyGraph: this.dependencyGraphState,
-      backfillDependentsForNewWrites: (action, addedWrites) => {
-        backfillDependentsForNewWrites(
-          this.dependencyGraphState,
-          action,
-          addedWrites,
-        );
-      },
     };
   }
 
@@ -1953,6 +1951,12 @@ export class Scheduler {
       markEffectConditionallyScheduled: (action) =>
         this.markEffectConditionallyScheduled(action),
       updateDependents: (action, log) => this.updateDependents(action, log),
+      registerWriterDependents: (action, writes) =>
+        registerDependentsForWriterSurface(
+          this.dependencyGraphState,
+          action,
+          writes,
+        ),
       scheduleAffectedEffects: (action) => this.scheduleAffectedEffects(action),
       queueExecution: () => this.queueExecution(),
       getActionId: (action) => this.getActionId(action),
@@ -2256,10 +2260,6 @@ export class Scheduler {
         getSchedulerActionTelemetryInfo(target),
       getSchedulingWrites: (target) =>
         this.writeIndex.getSchedulingWrites(target),
-      getCurrentKnownSchedulingWrites: (target) =>
-        this.writeIndex.currentKnownWrites.get(target),
-      getHistoricalMightWrite: (target) =>
-        this.writeIndex.historicalMightWrite.get(target),
       getMaterializerWriteEnvelopes: (target) =>
         this.materializers.getMaterializerWriteEnvelopes(target),
       getDebounce: (target) => this.delays.getDebounce(target),

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -639,7 +639,11 @@ function attachSchedulerActionObservation(
     observedAtSeq: 0,
     transactionKind: "action-run",
     transactionLog: log,
-    currentKnownWrites: declaredWrites,
+    // The live registered surface — for actions without a `.writes`
+    // annotation it came from subscribe's ReactivityLog, which
+    // declaredWrites (annotation-only) does not capture.
+    currentKnownWrites: state.getSchedulingWrites(args.action) ??
+      declaredWrites,
     declaredWrites,
     materializerWriteEnvelopes:
       state.getMaterializerWriteEnvelopes(args.action) ?? [],

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -2,6 +2,7 @@ import { getLogger } from "@commonfabric/utils/logger";
 import { getPersistentSchedulerStateConfig } from "@commonfabric/memory/v2";
 import type { Runtime } from "../runtime.ts";
 import { toMemorySpaceAddress } from "../link-utils.ts";
+import { normalizeCellScope } from "../scope.ts";
 import type {
   ChangeGroup,
   IExtendedStorageTransaction,
@@ -488,6 +489,7 @@ function finalizeReactiveActionCommit(
   }, {
     beforeCommit: () => {
       log = txToReactivityLog(args.tx);
+      warnOnWriteSurfaceViolations(state, args, log);
       attachSchedulerActionObservation(state, args, log);
     },
   });
@@ -545,6 +547,44 @@ function finalizeReactiveActionCommit(
     changedComputationWrites,
   );
   args.resolve(args.result);
+}
+
+function warnOnWriteSurfaceViolations(
+  state: SchedulerActionRunState,
+  args: {
+    readonly action: Action;
+    readonly actionId: string;
+  },
+  log: ReactivityLog,
+): void {
+  if (state.isEffectAction.get(args.action)) return;
+  if ((state.getMaterializerWriteEnvelopes(args.action) ?? []).length > 0) {
+    return;
+  }
+
+  const surface = state.getSchedulingWrites(args.action) ?? [];
+  for (const write of log.writes) {
+    if (
+      surface.some((surfaceWrite) => surfaceCoversWrite(surfaceWrite, write))
+    ) {
+      continue;
+    }
+    logger.warn("write-surface-violation", () => [
+      `Action ${args.actionId} wrote outside its declared surface`,
+      write,
+    ]);
+  }
+}
+
+function surfaceCoversWrite(
+  surface: IMemorySpaceAddress,
+  write: IMemorySpaceAddress,
+): boolean {
+  return surface.space === write.space &&
+    surface.id === write.id &&
+    normalizeCellScope(surface.scope) === normalizeCellScope(write.scope) &&
+    surface.path.length <= write.path.length &&
+    surface.path.every((segment, index) => segment === write.path[index]);
 }
 
 function attachSchedulerActionObservation(

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -23,10 +23,6 @@ import { RetryImmediately } from "./retry-immediately.ts";
 import { toActionRunTraceAddress } from "./diagnostics.ts";
 import { buildSchedulerActionObservation } from "./persistent-observation.ts";
 import { filterIgnoredAddresses, txToReactivityLog } from "./reactivity.ts";
-import {
-  buildKnownSchedulingWrites,
-  pruneStructuralAncestorWrites,
-} from "./scheduling-writes.ts";
 import { type ActionTimingState, recordActionTime } from "./timing.ts";
 import type {
   Action,
@@ -275,12 +271,6 @@ export interface SchedulerActionRunState {
     action: Action | EventHandler,
   ) => SchedulerActionInfo | undefined;
   readonly getSchedulingWrites: (
-    action: Action,
-  ) => readonly IMemorySpaceAddress[] | undefined;
-  readonly getCurrentKnownSchedulingWrites: (
-    action: Action,
-  ) => readonly IMemorySpaceAddress[] | undefined;
-  readonly getHistoricalMightWrite: (
     action: Action,
   ) => readonly IMemorySpaceAddress[] | undefined;
   readonly getMaterializerWriteEnvelopes: (
@@ -584,23 +574,6 @@ function attachSchedulerActionObservation(
     (annotated.writes ?? []).map(toMemorySpaceAddress),
     ignoredSchedulingWrites,
   ));
-  const { newCurrentKnownWrites } = buildKnownSchedulingWrites({
-    writes: pruneStructuralAncestorWrites(
-      sortAndCompactPaths(
-        filterIgnoredAddresses(log.writes, ignoredSchedulingWrites),
-        false,
-      ),
-    ),
-    declaredWrites,
-    existingCurrentWrites: filterIgnoredAddresses(
-      state.getCurrentKnownSchedulingWrites(args.action) ?? [],
-      ignoredSchedulingWrites,
-    ),
-    existingHistoricalWrites: filterIgnoredAddresses(
-      state.getHistoricalMightWrite(args.action) ?? [],
-      ignoredSchedulingWrites,
-    ),
-  });
   const telemetry = state.getActionTelemetryInfo(args.action);
   const actionOptions = schedulerActionOptions(state, args.action);
   const observationIdentity = annotated.schedulerObservationIdentity;
@@ -626,7 +599,7 @@ function attachSchedulerActionObservation(
     observedAtSeq: 0,
     transactionKind: "action-run",
     transactionLog: log,
-    currentKnownWrites: newCurrentKnownWrites,
+    currentKnownWrites: declaredWrites,
     declaredWrites,
     materializerWriteEnvelopes:
       state.getMaterializerWriteEnvelopes(args.action) ?? [],

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -577,7 +577,12 @@ function warnOnWriteSurfaceViolations(
     ) {
       continue;
     }
-    logger.warn("write-surface-violation", () => [
+    // Declaration-gap diagnostics, not enforcement (work order 05 step 5) —
+    // debug level because known gaps remain (builtins minting cause-keyed
+    // internal docs inside their run, e.g. ifElse/unless/fetchData) and
+    // cf test fails tests on console warnings. Counted regardless of level:
+    // assert via getLoggerCountsBreakdown().scheduler["write-surface-violation"].
+    logger.debug("write-surface-violation", () => [
       `Action ${args.actionId} wrote outside its declared surface`,
       write,
     ]);

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -564,6 +564,14 @@ function warnOnWriteSurfaceViolations(
 
   const surface = state.getSchedulingWrites(args.action) ?? [];
   for (const write of log.writes) {
+    // Per-user/per-session slots are runtime-mediated writes (scope-default
+    // initialization, UI state) that authored surfaces do not declare —
+    // exempt them so this declaration-gap diagnostic tracks authored
+    // space-scoped writes only.
+    // WATCH(scheduler-v2): re-include once scoped-slot writes are declared.
+    if (normalizeCellScope(write.scope) !== "space") {
+      continue;
+    }
     if (
       surface.some((surfaceWrite) => surfaceCoversWrite(surfaceWrite, write))
     ) {

--- a/packages/runner/src/scheduler/delay-control.ts
+++ b/packages/runner/src/scheduler/delay-control.ts
@@ -7,7 +7,6 @@ export interface SchedulerDelayControlState {
   readonly effects: ReadonlySet<Action>;
   readonly dirty: ReadonlySet<Action>;
   readonly pending: Set<Action>;
-  readonly isPullDemandRootEffect: (action: Action) => boolean;
   readonly queueExecution: () => void;
   readonly logDebounce: (message: string) => void;
 }
@@ -18,7 +17,6 @@ export function canAutomaticallyDebounce(
 ): boolean {
   return state.delays.canAutomaticallyDebounce(action, {
     effects: state.effects,
-    isPullDemandRootEffect: state.isPullDemandRootEffect,
   });
 }
 

--- a/packages/runner/src/scheduler/delays.ts
+++ b/packages/runner/src/scheduler/delays.ts
@@ -74,12 +74,10 @@ export class SchedulerDelays {
     action: Action,
     context: {
       readonly effects: ReadonlySet<Action>;
-      readonly isPullDemandRootEffect: (action: Action) => boolean;
     },
   ): boolean {
     if (this.noDebounce.get(action)) return false;
-    if (!context.effects.has(action)) return false;
-    return !context.isPullDemandRootEffect(action);
+    return context.effects.has(action);
   }
 
   maybeAutoDebounce(

--- a/packages/runner/src/scheduler/dependency-graph.ts
+++ b/packages/runner/src/scheduler/dependency-graph.ts
@@ -198,6 +198,24 @@ export function registerDependentEdge(
   }
 }
 
+export function registerDependentsForWriterSurface(
+  state: DependencyGraphState,
+  writer: Action,
+  writes: readonly IMemorySpaceAddress[],
+): void {
+  const readers = new Set<Action>();
+  for (const write of writes) {
+    for (const action of state.triggerIndex.collectReadersForWrite(write)) {
+      readers.add(action);
+    }
+  }
+  readers.delete(writer);
+
+  for (const action of readers) {
+    registerDependentEdge(state, writer, action);
+  }
+}
+
 export function unregisterDependentEdge(
   state: DependencyGraphState,
   writer: Action,
@@ -217,49 +235,6 @@ export function unregisterDependentEdge(
 
   if (hadDependent) {
     state.staleness.removeStaleUpstream(writer, dependent);
-  }
-}
-
-export function backfillDependentsForNewWrites(
-  state: DependencyGraphState,
-  writer: Action,
-  writes: readonly IMemorySpaceAddress[],
-): void {
-  // Caller must ensure writes is non-empty.
-  if (writes.length === 0) {
-    throw new Error("backfillDependentsForNewWrites requires non-empty writes");
-  }
-  const readers = new Set<Action>();
-  for (const write of writes) {
-    for (const action of state.triggerIndex.collectReadersForWrite(write)) {
-      readers.add(action);
-    }
-  }
-  readers.delete(writer);
-
-  for (const action of readers) {
-    registerDependentEdge(state, writer, action);
-  }
-}
-
-export function pruneDependentsForCurrentWrites(
-  state: DependencyGraphState,
-  writer: Action,
-  writes: readonly IMemorySpaceAddress[],
-): void {
-  const dependents = state.dependents.get(writer);
-  if (!dependents) return;
-
-  for (const dependent of [...dependents]) {
-    const log = state.dependencies.get(dependent);
-    if (
-      log &&
-      readsOverlapWrites(log.reads, log.shallowReads, writes)
-    ) {
-      continue;
-    }
-
-    unregisterDependentEdge(state, writer, dependent);
   }
 }
 

--- a/packages/runner/src/scheduler/dependency-updates.ts
+++ b/packages/runner/src/scheduler/dependency-updates.ts
@@ -1,27 +1,11 @@
 import { sortAndCompactPaths } from "../reactive-dependencies.ts";
-import { toMemorySpaceAddress } from "../link-utils.ts";
 import type { IMemorySpaceAddress } from "../storage/interface.ts";
-import {
-  type DependencyGraphState,
-  pruneDependentsForCurrentWrites,
-} from "./dependency-graph.ts";
-import { filterIgnoredAddresses } from "./reactivity.ts";
-import {
-  buildKnownSchedulingWrites,
-  diffSchedulingWrites,
-  pruneStructuralAncestorWrites,
-  type SchedulerWriteIndex,
-} from "./scheduling-writes.ts";
-import type { Action, ReactivityLog, TelemetryAnnotations } from "./types.ts";
+import { type SchedulerWriteIndex } from "./scheduling-writes.ts";
+import type { Action, ReactivityLog } from "./types.ts";
 
 export interface DependencyUpdateState {
   readonly writeIndex: SchedulerWriteIndex;
   readonly dependencies: WeakMap<Action, ReactivityLog>;
-  readonly dependencyGraph: DependencyGraphState;
-  readonly backfillDependentsForNewWrites: (
-    action: Action,
-    addedWrites: readonly IMemorySpaceAddress[],
-  ) => void;
 }
 
 export function setSchedulerDependencies(
@@ -35,78 +19,11 @@ export function setSchedulerDependencies(
 } {
   const reads = sortAndCompactPaths(log.reads);
   const shallowReads = sortAndCompactPaths(log.shallowReads, false);
-  const ignoredSchedulingWrites =
-    (action as Partial<TelemetryAnnotations>).ignoredSchedulingWrites ?? [];
-  const writes = pruneStructuralAncestorWrites(
-    sortAndCompactPaths(
-      filterIgnoredAddresses(log.writes, ignoredSchedulingWrites),
-      false,
-    ),
-  );
-  const declaredWrites = sortAndCompactPaths(
-    filterIgnoredAddresses(
-      ((action as Partial<TelemetryAnnotations>).writes ?? []).map(
-        toMemorySpaceAddress,
-      ),
-      ignoredSchedulingWrites,
-    ),
-  );
   const schedulingLog: ReactivityLog = {
     reads,
     shallowReads,
-    writes,
+    writes: state.writeIndex.getSchedulingWrites(action) ?? [],
   };
   state.dependencies.set(action, schedulingLog);
-
-  // Rebuild the current scheduling view from the latest writes plus
-  // declared writes. Keep the cumulative legacy union separately
-  // so it can be enabled behind an experimental flag.
-  const rawExistingCurrentWrites =
-    state.writeIndex.currentKnownWrites.get(action) ?? [];
-  const existingCurrentWrites = filterIgnoredAddresses(
-    rawExistingCurrentWrites,
-    ignoredSchedulingWrites,
-  );
-  const existingHistoricalWrites = filterIgnoredAddresses(
-    state.writeIndex.historicalMightWrite.get(action) ?? [],
-    ignoredSchedulingWrites,
-  );
-  const { newCurrentKnownWrites, newHistoricalMightWrite } =
-    buildKnownSchedulingWrites({
-      writes,
-      declaredWrites,
-      existingCurrentWrites,
-      existingHistoricalWrites,
-    });
-  state.writeIndex.currentKnownWrites.set(action, newCurrentKnownWrites);
-  state.writeIndex.historicalMightWrite.set(action, newHistoricalMightWrite);
-
-  const previousSchedulingWrites = state.writeIndex.useHistoricalMightWrite()
-    ? existingHistoricalWrites
-    : existingCurrentWrites;
-  const nextSchedulingWrites = state.writeIndex.useHistoricalMightWrite()
-    ? newHistoricalMightWrite
-    : newCurrentKnownWrites;
-
-  const { addedWrites, removedWrites } = diffSchedulingWrites(
-    previousSchedulingWrites,
-    nextSchedulingWrites,
-  );
-
-  state.writeIndex.updateWriterIndex(action, nextSchedulingWrites);
-
-  if (removedWrites.length > 0) {
-    pruneDependentsForCurrentWrites(
-      state.dependencyGraph,
-      action,
-      nextSchedulingWrites,
-    );
-  }
-
-  if (addedWrites.length > 0) {
-    // Backfill reverse edges when new writers appear after readers are already subscribed.
-    state.backfillDependentsForNewWrites(action, addedWrites);
-  }
-
   return { reads, shallowReads, log: schedulingLog };
 }

--- a/packages/runner/src/scheduler/pull-subscriptions.ts
+++ b/packages/runner/src/scheduler/pull-subscriptions.ts
@@ -1,7 +1,10 @@
 import { getLogger } from "@commonfabric/utils/logger";
 import { toMemorySpaceAddress } from "../link-utils.ts";
 import type { Cancel } from "../cancel.ts";
+import { sortAndCompactPaths } from "../reactive-dependencies.ts";
+import type { IMemorySpaceAddress } from "../storage/interface.ts";
 import { setSchedulerDependencies } from "./dependency-updates.ts";
+import { filterIgnoredAddresses } from "./reactivity.ts";
 import {
   replaceActionTriggerPaths,
   setCancelForTriggerEntities,
@@ -107,23 +110,15 @@ export function subscribePullSchedulerAction(
   // Store the populateDependencies callback for use in execute()
   state.populateDependenciesCallbacks.set(action, populateDependenciesEntry);
 
-  // Newly subscribed computations can be the replacement for an already-running
-  // child graph (for example after a $TYPE change). Seed any statically
-  // declared writes immediately so existing effects can discover the new writer
-  // before the first execute() cycle.
-  if (!actionIsEffect && !immediateLog) {
-    const declaredWrites = (action as Partial<TelemetryAnnotations>).writes;
-    if (declaredWrites && declaredWrites.length > 0) {
-      setSchedulerDependencies(
-        state.dependencyUpdateState,
-        action,
-        {
-          reads: [],
-          shallowReads: [],
-          writes: declaredWrites.map(toMemorySpaceAddress),
-        },
-      );
-    }
+  // Static write surface (spec scheduler-v2 P4): the action's writes are
+  // fixed at registration — declared outputs plus statically resolved
+  // redirect targets, already computed by the runner, or a registration-time
+  // ReactivityLog supplied by direct scheduler callers. Nothing about the
+  // surface is learned from runs.
+  const surface = resolveRegistrationSurface(action, immediateLog);
+  if (!actionIsEffect && surface.length > 0) {
+    state.writeIndex.setSurface(action, surface);
+    state.registerWriterDependents(action, surface);
   }
 
   // If a ReactivityLog was provided directly, set up dependencies immediately.
@@ -179,6 +174,20 @@ export function subscribePullSchedulerAction(
   });
 
   return () => state.unsubscribe(action);
+}
+
+export function resolveRegistrationSurface(
+  action: Action,
+  immediateLog: ReactivityLog | undefined,
+): IMemorySpaceAddress[] {
+  const annotated = action as Partial<TelemetryAnnotations>;
+  const annotatedSurface = annotated.writes ?? [];
+  const surface = annotatedSurface.length > 0
+    ? annotatedSurface.map(toMemorySpaceAddress)
+    : (immediateLog?.writes ?? []);
+  return sortAndCompactPaths(
+    filterIgnoredAddresses(surface, annotated.ignoredSchedulingWrites ?? []),
+  );
 }
 
 export function resubscribePullSchedulerAction(

--- a/packages/runner/src/scheduler/scheduling-writes.ts
+++ b/packages/runner/src/scheduler/scheduling-writes.ts
@@ -1,19 +1,16 @@
 import {
   arraysOverlap,
   nonRecursiveReadMayOverlapWrite,
-  sortAndCompactPaths,
 } from "../reactive-dependencies.ts";
 import { normalizeCellScope } from "../scope.ts";
-import type {
-  IMemorySpaceAddress,
-  MemoryAddressPathComponent,
-} from "../storage/interface.ts";
+import type { IMemorySpaceAddress } from "../storage/interface.ts";
 import { entityKey } from "./keys.ts";
 import type { Action, SpaceScopeAndURI } from "./types.ts";
 
 export interface WriterIndexState {
   readonly writersByEntity: Map<SpaceScopeAndURI, Set<Action>>;
   readonly actionWriteEntities: WeakMap<Action, Set<SpaceScopeAndURI>>;
+  setSurface(action: Action, surface: IMemorySpaceAddress[]): void;
   updateWriterIndex(
     action: Action,
     nextSchedulingWrites: readonly IMemorySpaceAddress[],
@@ -27,20 +24,14 @@ export interface WriterIndexState {
 
 export interface SchedulingWriteState {
   readonly currentKnownWrites: WeakMap<Action, IMemorySpaceAddress[]>;
-  readonly historicalMightWrite: WeakMap<Action, IMemorySpaceAddress[]>;
-  readonly useHistoricalMightWrite: () => boolean;
   getSchedulingWrites(action: Action): IMemorySpaceAddress[] | undefined;
   getSchedulingWritesMap(): WeakMap<Action, IMemorySpaceAddress[]>;
 }
 
 export class SchedulerWriteIndex
   implements WriterIndexState, SchedulingWriteState {
-  // Current-known writes are rebuilt on each dependency update from actual
-  // writes plus declared writes. This is the default scheduling view.
+  // Current-known writes are the action's static declared write surface.
   readonly currentKnownWrites = new WeakMap<Action, IMemorySpaceAddress[]>();
-  // Historical writes preserve the legacy cumulative union and are only used
-  // when the experimental historical-write mode is enabled.
-  readonly historicalMightWrite = new WeakMap<Action, IMemorySpaceAddress[]>();
   // Index: entity -> actions that write to it (for fast dependency lookup).
   // Updated from the active scheduling write set.
   readonly writersByEntity = new Map<SpaceScopeAndURI, Set<Action>>();
@@ -50,26 +41,18 @@ export class SchedulerWriteIndex
     Set<SpaceScopeAndURI>
   >();
 
-  constructor(
-    private readonly state: {
-      readonly useHistoricalMightWrite: () => boolean;
-    },
-  ) {}
-
-  useHistoricalMightWrite(): boolean {
-    return this.state.useHistoricalMightWrite();
-  }
-
   getSchedulingWrites(action: Action): IMemorySpaceAddress[] | undefined {
-    return this.useHistoricalMightWrite()
-      ? this.historicalMightWrite.get(action)
-      : this.currentKnownWrites.get(action);
+    return this.currentKnownWrites.get(action);
   }
 
   getSchedulingWritesMap(): WeakMap<Action, IMemorySpaceAddress[]> {
-    return this.useHistoricalMightWrite()
-      ? this.historicalMightWrite
-      : this.currentKnownWrites;
+    return this.currentKnownWrites;
+  }
+
+  /** Registers the action's static write surface (idempotent). */
+  setSurface(action: Action, surface: IMemorySpaceAddress[]): void {
+    this.currentKnownWrites.set(action, surface);
+    this.updateWriterIndex(action, surface);
   }
 
   updateWriterIndex(
@@ -161,70 +144,6 @@ export function updateWriterIndex(
   return state.updateWriterIndex(action, nextSchedulingWrites);
 }
 
-export function buildKnownSchedulingWrites(state: {
-  readonly writes: readonly IMemorySpaceAddress[];
-  readonly declaredWrites: readonly IMemorySpaceAddress[];
-  readonly existingCurrentWrites: readonly IMemorySpaceAddress[];
-  readonly existingHistoricalWrites: readonly IMemorySpaceAddress[];
-}): {
-  newCurrentKnownWrites: IMemorySpaceAddress[];
-  newHistoricalMightWrite: IMemorySpaceAddress[];
-} {
-  const observedWrites = state.writes.length > 0
-    ? state.writes
-    : state.existingCurrentWrites;
-  const dynamicParentWrites = deriveDynamicCollectionParentWrites(
-    state.writes,
-    state.declaredWrites,
-  );
-  const declaredAncestorWrites = deriveDeclaredAncestorWrites(
-    state.writes,
-    state.declaredWrites,
-  );
-  const newCurrentKnownWrites = sortAndCompactPaths([
-    ...state.declaredWrites,
-    ...observedWrites,
-    ...dynamicParentWrites,
-    ...declaredAncestorWrites,
-  ]);
-  const newHistoricalMightWrite = sortAndCompactPaths([
-    ...state.existingHistoricalWrites,
-    ...newCurrentKnownWrites,
-  ]);
-  return { newCurrentKnownWrites, newHistoricalMightWrite };
-}
-
-export function diffSchedulingWrites(
-  previousSchedulingWrites: readonly IMemorySpaceAddress[],
-  nextSchedulingWrites: readonly IMemorySpaceAddress[],
-): {
-  addedWrites: IMemorySpaceAddress[];
-  removedWrites: IMemorySpaceAddress[];
-} {
-  const addedWrites = nextSchedulingWrites.filter((write) =>
-    !previousSchedulingWrites.some((existing) =>
-      schedulingWriteSubsumes(existing, write)
-    )
-  );
-  const removedWrites = previousSchedulingWrites.filter((write) =>
-    !nextSchedulingWrites.some((existing) =>
-      schedulingWriteSubsumes(existing, write)
-    )
-  );
-  return { addedWrites, removedWrites };
-}
-
-function schedulingWriteSubsumes(
-  existing: IMemorySpaceAddress,
-  write: IMemorySpaceAddress,
-): boolean {
-  return existing.space === write.space &&
-    existing.id === write.id &&
-    normalizeCellScope(existing.scope) === normalizeCellScope(write.scope) &&
-    existing.path.length <= write.path.length &&
-    arraysOverlap(existing.path, write.path);
-}
-
 export function readsOverlapWrites(
   reads: readonly IMemorySpaceAddress[],
   shallowReads: readonly IMemorySpaceAddress[],
@@ -259,89 +178,4 @@ export function readsOverlapWrites(
   }
 
   return false;
-}
-
-export function pruneStructuralAncestorWrites(
-  writes: readonly IMemorySpaceAddress[],
-): IMemorySpaceAddress[] {
-  // Transaction reactivity logs include ancestor paths when a child write
-  // changes shallow structure. For scheduling writes, the descendant path is
-  // precise enough; keeping the ancestor would make unrelated shallow root
-  // readers depend on this action.
-  return writes.filter((write) =>
-    !writes.some((other) =>
-      other !== write &&
-      other.space === write.space &&
-      other.id === write.id &&
-      other.type === write.type &&
-      write.path.length < other.path.length &&
-      arraysOverlap(write.path, other.path)
-    )
-  );
-}
-
-export function deriveDynamicCollectionParentWrites(
-  writes: readonly IMemorySpaceAddress[],
-  declaredWrites: readonly IMemorySpaceAddress[],
-): IMemorySpaceAddress[] {
-  return deriveDeclaredAncestorWritesMatching(
-    writes,
-    declaredWrites,
-    (declaredWrite, write) =>
-      isDynamicCollectionSegment(write.path[declaredWrite.path.length]),
-  );
-}
-
-export function deriveDeclaredAncestorWrites(
-  writes: readonly IMemorySpaceAddress[],
-  declaredWrites: readonly IMemorySpaceAddress[],
-): IMemorySpaceAddress[] {
-  return deriveDeclaredAncestorWritesMatching(
-    writes,
-    declaredWrites,
-    () => true,
-  );
-}
-
-function deriveDeclaredAncestorWritesMatching(
-  writes: readonly IMemorySpaceAddress[],
-  declaredWrites: readonly IMemorySpaceAddress[],
-  predicate: (
-    declaredWrite: IMemorySpaceAddress,
-    write: IMemorySpaceAddress,
-  ) => boolean,
-): IMemorySpaceAddress[] {
-  const ancestorWrites: IMemorySpaceAddress[] = [];
-  for (const declaredWrite of declaredWrites) {
-    for (const write of writes) {
-      if (
-        declaredWriteIsAncestorOfWrite(declaredWrite, write) &&
-        predicate(declaredWrite, write)
-      ) {
-        ancestorWrites.push(declaredWrite);
-        break;
-      }
-    }
-  }
-  return ancestorWrites;
-}
-
-function declaredWriteIsAncestorOfWrite(
-  declaredWrite: IMemorySpaceAddress,
-  write: IMemorySpaceAddress,
-): boolean {
-  return declaredWrite.space === write.space &&
-    declaredWrite.id === write.id &&
-    declaredWrite.type === write.type &&
-    normalizeCellScope(declaredWrite.scope) ===
-      normalizeCellScope(write.scope) &&
-    declaredWrite.path.length < write.path.length &&
-    arraysOverlap(declaredWrite.path, write.path);
-}
-
-function isDynamicCollectionSegment(
-  segment: MemoryAddressPathComponent | undefined,
-): boolean {
-  if (typeof segment === "number") return Number.isInteger(segment);
-  return typeof segment === "string" && /^(0|[1-9]\d*)$/.test(segment);
 }

--- a/packages/runner/src/scheduler/subscriptions.ts
+++ b/packages/runner/src/scheduler/subscriptions.ts
@@ -94,6 +94,10 @@ export interface SchedulerSubscribeActionState {
   readonly markDirectDirty: (action: Action) => void;
   readonly markEffectConditionallyScheduled: (action: Action) => void;
   readonly updateDependents: (action: Action, log: ReactivityLog) => void;
+  readonly registerWriterDependents: (
+    action: Action,
+    writes: readonly IMemorySpaceAddress[],
+  ) => void;
   readonly scheduleAffectedEffects: (action: Action) => void;
   readonly queueExecution: () => void;
   readonly getActionId: (action: Action) => string;

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -42,7 +42,6 @@ describe("ExperimentalOptions", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: false,
-        schedulerHistoricalMightWrite: undefined,
       });
       await runtime.dispose();
       await sm.close();
@@ -61,7 +60,6 @@ describe("ExperimentalOptions", () => {
         modernCellRep: true,
         persistentSchedulerState: false,
         commitPreconditions: false,
-        schedulerHistoricalMightWrite: undefined,
       });
       await runtime.dispose();
       await sm.close();
@@ -78,22 +76,7 @@ describe("ExperimentalOptions", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: false,
-        schedulerHistoricalMightWrite: undefined,
       });
-      await runtime.dispose();
-      await sm.close();
-    });
-
-    it("preserves the schedulerHistoricalMightWrite flag", async () => {
-      const sm = StorageManager.emulate({ as: signer });
-      const runtime = new Runtime({
-        apiUrl: new URL(import.meta.url),
-        storageManager: sm,
-        experimental: {
-          schedulerHistoricalMightWrite: true,
-        },
-      });
-      expect(runtime.experimental.schedulerHistoricalMightWrite).toBe(true);
       await runtime.dispose();
       await sm.close();
     });

--- a/packages/runner/test/scheduler-core.test.ts
+++ b/packages/runner/test/scheduler-core.test.ts
@@ -494,19 +494,17 @@ describe("scheduler", () => {
     expect(computeRuns.at(-1)?.actionType).toBe("computation");
     expect(effectRuns.at(-1)?.actionType).toBe("effect");
     expect(computeRuns.at(-1)?.declaredWrites.length).toBe(1);
-    expect(effectRuns.at(-1)?.declaredWrites.length).toBe(1);
+    expect(effectRuns.at(-1)?.declaredWrites.length).toBe(0);
     expect(computeRuns.at(-1)?.actualWrites).toEqual(
       computeRuns.at(-1)?.declaredWrites,
     );
-    expect(effectRuns.at(-1)?.actualWrites).toEqual(
-      effectRuns.at(-1)?.declaredWrites,
-    );
+    expect(effectRuns.at(-1)?.actualWrites.length).toBe(1);
     expect(computeRuns.at(-1)?.declaredWrites[0]).toMatchObject({
       space,
       entityId: expect.stringMatching(/^of:/),
       path: ["value"],
     });
-    expect(effectRuns.at(-1)?.declaredWrites[0]).toMatchObject({
+    expect(effectRuns.at(-1)?.actualWrites[0]).toMatchObject({
       space,
       entityId: expect.stringMatching(/^of:/),
       path: ["value"],

--- a/packages/runner/test/scheduler-effects.test.ts
+++ b/packages/runner/test/scheduler-effects.test.ts
@@ -270,16 +270,28 @@ describe("effect/computation tracking", () => {
     tx = runtime.edit();
 
     // Action 1: reads source, writes intermediate
-    const action1: Action = (actionTx) => {
-      const val = source.withTx(actionTx).get();
-      intermediate.withTx(actionTx).send(val * 10);
-    };
+    const intermediateLink = intermediate.getAsNormalizedFullLink();
+    const action1 = Object.assign(
+      ((actionTx: IExtendedStorageTransaction) => {
+        const val = source.withTx(actionTx).get();
+        intermediate.withTx(actionTx).send(val * 10);
+      }) as Action,
+      {
+        writes: [intermediateLink],
+      },
+    );
 
     // Action 2: reads intermediate, writes output
-    const action2: Action = (actionTx) => {
-      const val = intermediate.withTx(actionTx).get();
-      output.withTx(actionTx).send(val + 5);
-    };
+    const outputLink = output.getAsNormalizedFullLink();
+    const action2 = Object.assign(
+      ((actionTx: IExtendedStorageTransaction) => {
+        const val = intermediate.withTx(actionTx).get();
+        output.withTx(actionTx).send(val + 5);
+      }) as Action,
+      {
+        writes: [outputLink],
+      },
+    );
 
     // Subscribe action1 first (writes to intermediate)
     runtime.scheduler.subscribe(
@@ -287,7 +299,7 @@ describe("effect/computation tracking", () => {
       {
         reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [toMemorySpaceAddress(intermediate.getAsNormalizedFullLink())],
+        writes: [toMemorySpaceAddress(intermediateLink)],
       },
       {},
     );
@@ -299,7 +311,7 @@ describe("effect/computation tracking", () => {
       {
         reads: [toMemorySpaceAddress(intermediate.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
+        writes: [toMemorySpaceAddress(outputLink)],
       },
       {},
     );
@@ -328,16 +340,22 @@ describe("effect/computation tracking", () => {
     runtime.scheduler.subscribe(effect, effect, { isEffect: true });
     await runtime.scheduler.idle();
 
-    const computation: Action = (actionTx) => {
-      data.withTx(actionTx).key("foo").set(2);
-    };
+    const fooLink = data.key("foo").getAsNormalizedFullLink();
+    const computation = Object.assign(
+      ((actionTx: IExtendedStorageTransaction) => {
+        data.withTx(actionTx).key("foo").set(2);
+      }) as Action,
+      {
+        writes: [fooLink],
+      },
+    );
     runtime.scheduler.subscribe(
       computation,
       {
         reads: [],
         shallowReads: [],
         writes: [
-          toMemorySpaceAddress(data.key("foo").getAsNormalizedFullLink()),
+          toMemorySpaceAddress(fooLink),
         ],
       },
       {},
@@ -347,7 +365,7 @@ describe("effect/computation tracking", () => {
     expect(dependents.has(effect)).toBe(true);
   });
 
-  it("should backfill only when new writer paths overlap existing reads", async () => {
+  it("should keep writer paths fixed over resubscribe logs", async () => {
     const data = runtime.getCell<{ foo: number; bar: number }>(
       space,
       "backfill-writer-paths",
@@ -365,16 +383,22 @@ describe("effect/computation tracking", () => {
     runtime.scheduler.subscribe(effect, effect, { isEffect: true });
     await runtime.scheduler.idle();
 
-    const computation: Action = (actionTx) => {
-      data.withTx(actionTx).key("foo").set(2);
-    };
+    const fooLink = data.key("foo").getAsNormalizedFullLink();
+    const computation = Object.assign(
+      ((actionTx: IExtendedStorageTransaction) => {
+        data.withTx(actionTx).key("foo").set(2);
+      }) as Action,
+      {
+        writes: [fooLink],
+      },
+    );
     runtime.scheduler.subscribe(
       computation,
       {
         reads: [],
         shallowReads: [],
         writes: [
-          toMemorySpaceAddress(data.key("foo").getAsNormalizedFullLink()),
+          toMemorySpaceAddress(fooLink),
         ],
       },
       {},
@@ -393,7 +417,7 @@ describe("effect/computation tracking", () => {
     });
 
     const updatedDependents = runtime.scheduler.getDependents(computation);
-    expect(updatedDependents.has(effect)).toBe(true);
+    expect(updatedDependents.has(effect)).toBe(false);
   });
 
   it("should prune ignored scheduling writes from mightWrite and dependents", async () => {
@@ -415,7 +439,10 @@ describe("effect/computation tracking", () => {
     await tx.commit();
     tx = runtime.edit();
 
+    const outputLink = output.getAsNormalizedFullLink();
+    const childProcessLink = childProcess.getAsNormalizedFullLink();
     const action: Action & {
+      writes?: ReturnType<typeof output.getAsNormalizedFullLink>[];
       ignoredSchedulingWrites?: ReturnType<
         typeof childProcess.getAsNormalizedFullLink
       >[];
@@ -425,28 +452,28 @@ describe("effect/computation tracking", () => {
         pattern: getSigilLink("of:child-pattern"),
       });
     };
+    action.writes = [outputLink, childProcessLink];
+    action.ignoredSchedulingWrites = [childProcessLink];
 
     runtime.scheduler.subscribe(
       action,
       {
         reads: [],
         shallowReads: [],
-        writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
+        writes: [toMemorySpaceAddress(outputLink)],
       },
       {},
     );
 
     await runtime.scheduler.run(action);
 
-    const childProcessId = childProcess.getAsNormalizedFullLink().id;
+    const outputId = outputLink.id;
+    const childProcessId = childProcessLink.id;
     expect(
       runtime.scheduler.getMightWrite(action)?.some((write) =>
-        write.id === childProcessId
+        write.id === outputId
       ),
     ).toBe(true);
-    action.ignoredSchedulingWrites = [childProcess.getAsNormalizedFullLink()];
-    await runtime.scheduler.run(action);
-
     expect(
       runtime.scheduler.getMightWrite(action)?.some((write) =>
         write.id === childProcessId
@@ -454,7 +481,7 @@ describe("effect/computation tracking", () => {
     ).toBe(false);
   });
 
-  it("should drop stale dependents when writes move to a different cell", async () => {
+  it("should keep dependents when resubscribe logs move outside the static surface", async () => {
     const cellA = runtime.getCell<number>(
       space,
       "write-switch-cell-a",
@@ -478,13 +505,16 @@ describe("effect/computation tracking", () => {
     runtime.scheduler.subscribe(effect, effect, { isEffect: true });
     await runtime.scheduler.idle();
 
-    const computation: Action = () => {};
+    const cellALink = cellA.getAsNormalizedFullLink();
+    const computation = Object.assign((() => {}) as Action, {
+      writes: [cellALink],
+    });
     runtime.scheduler.subscribe(
       computation,
       {
         reads: [],
         shallowReads: [],
-        writes: [toMemorySpaceAddress(cellA.getAsNormalizedFullLink())],
+        writes: [toMemorySpaceAddress(cellALink)],
       },
       {},
     );
@@ -497,9 +527,7 @@ describe("effect/computation tracking", () => {
       writes: [toMemorySpaceAddress(cellB.getAsNormalizedFullLink())],
     });
 
-    expect(runtime.scheduler.getDependents(computation).has(effect)).toBe(
-      false,
-    );
+    expect(runtime.scheduler.getDependents(computation).has(effect)).toBe(true);
   });
 
   it("should ignore attemptedWrites as scheduler dependency evidence", async () => {
@@ -633,9 +661,11 @@ describe("effect/computation tracking", () => {
         sideTarget.withTx(actionTx).set({ value });
       },
       {
+        writes: [output.getAsNormalizedFullLink()],
         materializerWriteEnvelopes: [sideTarget.getAsNormalizedFullLink()],
       },
     ) as Action & {
+      writes: ReturnType<typeof output.getAsNormalizedFullLink>[];
       materializerWriteEnvelopes: ReturnType<
         typeof sideTarget.getAsNormalizedFullLink
       >[];
@@ -684,7 +714,7 @@ describe("effect/computation tracking", () => {
     );
   });
 
-  it("should not make broad attempted writes into materializer dependents", async () => {
+  it("should keep broad materializer envelopes out of ordinary dependents", async () => {
     const source = runtime.getCell<number>(
       space,
       "materializer-fanout-source",
@@ -734,7 +764,7 @@ describe("effect/computation tracking", () => {
     await runtime.idle();
 
     expect(runtime.scheduler.getDependents(materializer).has(changedEffect))
-      .toBe(true);
+      .toBe(false);
     expect(runtime.scheduler.getDependents(materializer).has(stableEffect))
       .toBe(false);
   });
@@ -1003,14 +1033,20 @@ describe("effect/computation tracking", () => {
     tx = runtime.edit();
 
     let computationRuns = 0;
-    const computation: Action = (actionTx) => {
-      computationRuns++;
-      target.withTx(actionTx).set(source.withTx(actionTx).get());
-    };
+    const targetLink = target.getAsNormalizedFullLink();
+    const computation = Object.assign(
+      ((actionTx: IExtendedStorageTransaction) => {
+        computationRuns++;
+        target.withTx(actionTx).set(source.withTx(actionTx).get());
+      }) as Action,
+      {
+        writes: [targetLink],
+      },
+    );
     runtime.scheduler.subscribe(computation, {
       reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
       shallowReads: [],
-      writes: [toMemorySpaceAddress(target.getAsNormalizedFullLink())],
+      writes: [toMemorySpaceAddress(targetLink)],
     });
     await runtime.idle();
     expect(computationRuns).toBe(0);

--- a/packages/runner/test/scheduler-observations.test.ts
+++ b/packages/runner/test/scheduler-observations.test.ts
@@ -364,6 +364,82 @@ describe("persistent scheduler observations", () => {
     }
   });
 
+  it("persists and rehydrates immediate-log write surfaces", async () => {
+    // An action whose static surface came from subscribe's ReactivityLog
+    // (no `.writes` annotation) must persist that live surface and restore
+    // it on rehydration — otherwise a restored action reads as writing
+    // nothing.
+    const testRuntime = createSchedulerTestRuntime("https://example.test", {});
+    try {
+      const { runtime, tx } = testRuntime;
+      const source = runtime.getCell<number>(
+        space,
+        "scheduler-observation-immediate-log-source",
+        undefined,
+        tx,
+      );
+      const target = runtime.getCell<number>(
+        space,
+        "scheduler-observation-immediate-log-target",
+        undefined,
+        tx,
+      );
+      source.set(0);
+      target.set(0);
+      await tx.commit();
+
+      const observations: SchedulerActionObservation[] = [];
+      const originalEdit = runtime.edit.bind(runtime);
+      runtime.edit = ((...args: Parameters<typeof originalEdit>) => {
+        const actionTx = originalEdit(...args);
+        const originalSetSchedulerObservation = actionTx
+          .setSchedulerObservation?.bind(actionTx);
+        actionTx.setSchedulerObservation = (observation: unknown) => {
+          if (isSchedulerActionObservation(observation)) {
+            observations.push(observation);
+          }
+          originalSetSchedulerObservation?.(observation);
+        };
+        return actionTx;
+      }) as typeof runtime.edit;
+
+      const surface = [
+        toMemorySpaceAddress(target.getAsNormalizedFullLink()),
+      ];
+      let runs = 0;
+      const logSurfaceWriter = function logSurfaceWriter(
+        actionTx: IExtendedStorageTransaction,
+      ) {
+        runs++;
+        source.withTx(actionTx).get();
+        target.withTx(actionTx).set(runs);
+      } as Action;
+
+      runtime.scheduler.subscribe(logSurfaceWriter, {
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+        shallowReads: [],
+        writes: surface,
+      });
+
+      await runtime.scheduler.run(logSurfaceWriter);
+      expect(observations.at(-1)?.currentKnownWrites).toEqual(surface);
+
+      const restoredWriter = (() => {}) as Action;
+      (restoredWriter as { src?: string }).src = "logSurfaceWriter";
+      expect(
+        runtime.scheduler.rehydrateActionFromObservation(
+          restoredWriter,
+          { observation: observations.at(-1)! },
+        ),
+      ).toBe(true);
+      expect(runtime.scheduler.getMightWrite(restoredWriter)).toEqual(
+        surface,
+      );
+    } finally {
+      await disposeSchedulerTestRuntime(testRuntime);
+    }
+  });
+
   it("rehydrates failed scheduler observations as runnable work", async () => {
     const testRuntime = createSchedulerTestRuntime("https://example.test", {});
     try {

--- a/packages/runner/test/scheduler-observations.test.ts
+++ b/packages/runner/test/scheduler-observations.test.ts
@@ -60,6 +60,13 @@ const writeAddress = {
   path: ["value", "output"],
 };
 
+const writeLink = {
+  space: writeAddress.space,
+  scope: writeAddress.scope,
+  id: writeAddress.id,
+  path: writeAddress.path.slice(1),
+};
+
 const declaredWrite = {
   space: "did:key:space" as const,
   scope: "space" as const,
@@ -208,7 +215,10 @@ describe("persistent scheduler observations", () => {
   it("rehydrates clean scheduler observations without rerun pressure", async () => {
     const testRuntime = createSchedulerTestRuntime("https://example.test", {});
     try {
-      const persistedAction = () => {};
+      const persistedAction = Object.assign(
+        function persistedAction() {},
+        { writes: [writeLink] },
+      );
       testRuntime.runtime.scheduler.subscribe(persistedAction, {
         reads: [],
         shallowReads: [],
@@ -251,7 +261,7 @@ describe("persistent scheduler observations", () => {
     }
   });
 
-  it("persists the post-run scheduling writes when an action write path changes", async () => {
+  it("persists the static scheduling surface when an action write path changes", async () => {
     const testRuntime = createSchedulerTestRuntime("https://example.test", {});
     try {
       const { runtime, tx } = testRuntime;
@@ -294,14 +304,24 @@ describe("persistent scheduler observations", () => {
       }) as typeof runtime.edit;
 
       let runs = 0;
-      const changingWriter: Action = (
-        actionTx: IExtendedStorageTransaction,
-      ) => {
-        runs++;
-        const writeSecondTarget = selector.withTx(actionTx).get();
-        const target = writeSecondTarget ? secondTarget : firstTarget;
-        target.withTx(actionTx).set(runs);
-      };
+      const staticSurface = [
+        toMemorySpaceAddress(firstTarget.getAsNormalizedFullLink()),
+        toMemorySpaceAddress(secondTarget.getAsNormalizedFullLink()),
+      ];
+      const changingWriter = Object.assign(
+        function changingWriter(actionTx: IExtendedStorageTransaction) {
+          runs++;
+          const writeSecondTarget = selector.withTx(actionTx).get();
+          const target = writeSecondTarget ? secondTarget : firstTarget;
+          target.withTx(actionTx).set(runs);
+        },
+        {
+          writes: [
+            firstTarget.getAsNormalizedFullLink(),
+            secondTarget.getAsNormalizedFullLink(),
+          ],
+        },
+      ) as Action;
 
       runtime.scheduler.subscribe(changingWriter, {
         reads: [toMemorySpaceAddress(selector.getAsNormalizedFullLink())],
@@ -310,9 +330,7 @@ describe("persistent scheduler observations", () => {
       });
 
       await runtime.scheduler.run(changingWriter);
-      expect(observations.at(-1)?.currentKnownWrites).toEqual([
-        toMemorySpaceAddress(firstTarget.getAsNormalizedFullLink()),
-      ]);
+      expect(observations.at(-1)?.currentKnownWrites).toEqual(staticSurface);
 
       const triggerTx = runtime.edit();
       selector.withTx(triggerTx).set(true);
@@ -323,11 +341,14 @@ describe("persistent scheduler observations", () => {
       expect(changedObservation?.actualChangedWrites).toEqual([
         toMemorySpaceAddress(secondTarget.getAsNormalizedFullLink()),
       ]);
-      expect(changedObservation?.currentKnownWrites).toEqual([
-        toMemorySpaceAddress(secondTarget.getAsNormalizedFullLink()),
-      ]);
+      expect(changedObservation?.currentKnownWrites).toEqual(staticSurface);
 
-      const restoredChangingWriter: Action = () => {};
+      const restoredChangingWriter = Object.assign((() => {}) as Action, {
+        writes: [
+          firstTarget.getAsNormalizedFullLink(),
+          secondTarget.getAsNormalizedFullLink(),
+        ],
+      });
       (restoredChangingWriter as { src?: string }).src = "changingWriter";
       expect(
         runtime.scheduler.rehydrateActionFromObservation(
@@ -335,9 +356,9 @@ describe("persistent scheduler observations", () => {
           { observation: changedObservation! },
         ),
       ).toBe(true);
-      expect(runtime.scheduler.getMightWrite(restoredChangingWriter)).toEqual([
-        toMemorySpaceAddress(secondTarget.getAsNormalizedFullLink()),
-      ]);
+      expect(runtime.scheduler.getMightWrite(restoredChangingWriter)).toEqual(
+        staticSurface,
+      );
     } finally {
       await disposeSchedulerTestRuntime(testRuntime);
     }
@@ -455,9 +476,12 @@ describe("persistent scheduler observations", () => {
     const testRuntime = createSchedulerTestRuntime("https://example.test", {});
     try {
       let runs = 0;
-      const autoPersistedAction = () => {
-        runs++;
-      };
+      const autoPersistedAction = Object.assign(
+        function autoPersistedAction() {
+          runs++;
+        },
+        { writes: [writeLink] },
+      );
       const actionId = "autoPersistedAction";
       const provider = testRuntime.runtime.storageManager.open(space) as {
         listSchedulerActionSnapshots?: (
@@ -550,7 +574,10 @@ describe("persistent scheduler observations", () => {
         });
 
       let populateCalls = 0;
-      const rehydratingAction = () => {};
+      const rehydratingAction = Object.assign(
+        function rehydratingAction() {},
+        { writes: [writeLink] },
+      );
       runtime.scheduler.subscribe(rehydratingAction, () => {
         populateCalls++;
       }, {
@@ -1266,12 +1293,15 @@ describe("persistent scheduler observations", () => {
     }
   });
 
-  it("backfills dependents when rehydrated currentKnownWrites restore a no-op writer", async () => {
+  it("backfills dependents when the live surface restores a no-op writer", async () => {
     const testRuntime = createSchedulerTestRuntime("https://example.test", {});
     try {
       const { runtime } = testRuntime;
       const persistedReader = () => {};
-      const persistedWriter = () => {};
+      const persistedWriter = Object.assign(
+        function persistedWriter() {},
+        { writes: [writeLink] },
+      );
 
       runtime.scheduler.subscribe(persistedReader, {
         reads: [writeAddress],
@@ -1407,9 +1437,8 @@ describe("persistent scheduler observations", () => {
       });
       await runtime.idle();
 
-      expect(runtime.scheduler.getMightWrite(canceledBeforeRehydrate)).toEqual(
-        [],
-      );
+      expect(runtime.scheduler.getMightWrite(canceledBeforeRehydrate))
+        .toBeUndefined();
       expect(
         runtime.scheduler.getGraphSnapshot().nodes.some((node) =>
           node.id === "canceledBeforeRehydrate"
@@ -1487,9 +1516,8 @@ describe("persistent scheduler observations", () => {
       await runtime.idle();
 
       expect(runtime.scheduler.isDirty(dirtyBeforeRehydrate)).toBe(true);
-      expect(runtime.scheduler.getMightWrite(dirtyBeforeRehydrate)).toEqual(
-        [],
-      );
+      expect(runtime.scheduler.getMightWrite(dirtyBeforeRehydrate))
+        .toBeUndefined();
     } finally {
       await disposeSchedulerTestRuntime(testRuntime);
     }
@@ -1553,7 +1581,7 @@ describe("persistent scheduler observations", () => {
 
       expect(runs).toBe(1);
       expect(testRuntime.runtime.scheduler.getMightWrite(stalePersistedAction))
-        .toEqual([writeAddress]);
+        .toBeUndefined();
     } finally {
       await disposeSchedulerTestRuntime(testRuntime);
     }

--- a/packages/runner/test/scheduler-ordering.test.ts
+++ b/packages/runner/test/scheduler-ordering.test.ts
@@ -17,11 +17,6 @@ import type {
   IExtendedStorageTransaction,
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
-import {
-  buildKnownSchedulingWrites,
-  deriveDeclaredAncestorWrites,
-  deriveDynamicCollectionParentWrites,
-} from "../src/scheduler/scheduling-writes.ts";
 import { topologicalSort } from "../src/scheduler/topology.ts";
 import type { IMemorySpaceAddress } from "../src/storage/interface.ts";
 
@@ -55,7 +50,7 @@ describe("push-triggered filtering", () => {
     await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
   });
 
-  it("should track mightWrite from actual writes", async () => {
+  it("should track mightWrite from the static surface at subscribe", async () => {
     const cell = runtime.getCell<number>(
       space,
       "mightwrite-test",
@@ -66,32 +61,33 @@ describe("push-triggered filtering", () => {
     await tx.commit();
     tx = runtime.edit();
 
-    const action: Action = (actionTx) => {
-      cell.withTx(actionTx).send(42);
-    };
+    const declaredWrite = cell.getAsNormalizedFullLink();
+    const action = Object.assign(
+      ((actionTx: IExtendedStorageTransaction) => {
+        cell.withTx(actionTx).send(42);
+      }) as Action,
+      {
+        writes: [declaredWrite],
+      },
+    );
 
-    // Initially no mightWrite
     expect(runtime.scheduler.getMightWrite(action)).toBeUndefined();
-
-    // Run action
     runtime.scheduler.subscribe(
       action,
       {
         reads: [],
         shallowReads: [],
-        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
+        writes: [toMemorySpaceAddress(declaredWrite)],
       },
       {},
     );
-    await cell.pull();
 
-    // mightWrite should now include the cell
-    const mightWrite = runtime.scheduler.getMightWrite(action);
-    expect(mightWrite).toBeDefined();
-    expect(mightWrite!.length).toBeGreaterThan(0);
+    expect(runtime.scheduler.getMightWrite(action)).toEqual([
+      toMemorySpaceAddress(declaredWrite),
+    ]);
   });
 
-  it("should replace current-known writes over multiple resubscriptions by default", async () => {
+  it("should keep the static surface over multiple resubscriptions", async () => {
     const cell1 = runtime.getCell<number>(space, "mw-accum-1", undefined, tx);
     const cell2 = runtime.getCell<number>(space, "mw-accum-2", undefined, tx);
     cell1.set(0);
@@ -99,19 +95,22 @@ describe("push-triggered filtering", () => {
     await tx.commit();
     tx = runtime.edit();
 
-    const action: Action = () => {};
+    const declaredWrite = cell1.getAsNormalizedFullLink();
+    const action = Object.assign((() => {}) as Action, {
+      writes: [declaredWrite],
+    });
     runtime.scheduler.subscribe(
       action,
       {
         reads: [],
         shallowReads: [],
-        writes: [toMemorySpaceAddress(cell1.getAsNormalizedFullLink())],
+        writes: [toMemorySpaceAddress(declaredWrite)],
       },
       {},
     );
 
     expect(runtime.scheduler.getMightWrite(action)).toEqual([
-      toMemorySpaceAddress(cell1.getAsNormalizedFullLink()),
+      toMemorySpaceAddress(declaredWrite),
     ]);
 
     runtime.scheduler.resubscribe(action, {
@@ -121,67 +120,8 @@ describe("push-triggered filtering", () => {
     });
 
     expect(runtime.scheduler.getMightWrite(action)).toEqual([
-      toMemorySpaceAddress(cell2.getAsNormalizedFullLink()),
+      toMemorySpaceAddress(declaredWrite),
     ]);
-  });
-
-  it("should preserve historical mightWrite behind the experimental flag", async () => {
-    await runtime.dispose();
-    await storageManager.close();
-
-    /*
-     * This one test opts into the legacy cumulative write-history flag after
-     * the default fixture has already been disposed.
-     */
-    ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
-      import.meta.url,
-      {
-        experimental: {
-          schedulerHistoricalMightWrite: true,
-        },
-      },
-    ));
-
-    const cell1 = runtime.getCell<number>(
-      space,
-      "mw-experimental-1",
-      undefined,
-      tx,
-    );
-    const cell2 = runtime.getCell<number>(
-      space,
-      "mw-experimental-2",
-      undefined,
-      tx,
-    );
-    cell1.set(0);
-    cell2.set(0);
-    await tx.commit();
-    tx = runtime.edit();
-
-    const action: Action = () => {};
-    runtime.scheduler.subscribe(
-      action,
-      {
-        reads: [],
-        shallowReads: [],
-        writes: [toMemorySpaceAddress(cell1.getAsNormalizedFullLink())],
-      },
-      {},
-    );
-
-    runtime.scheduler.resubscribe(action, {
-      reads: [],
-      shallowReads: [],
-      writes: [toMemorySpaceAddress(cell2.getAsNormalizedFullLink())],
-    });
-
-    expect(
-      runtime.scheduler.getMightWrite(action)?.map((write) => write.id).sort(),
-    ).toEqual([
-      cell1.getAsNormalizedFullLink().id,
-      cell2.getAsNormalizedFullLink().id,
-    ].sort());
   });
 
   it("should keep declared writes in current-known writes after empty resubscribe", async () => {
@@ -221,34 +161,53 @@ describe("push-triggered filtering", () => {
     ]);
   });
 
-  it("should keep declared writes when a run only writes metadata", () => {
-    const declaredWrite = scopedAddress("user", [
-      "value",
-      "currentUserIsAdmin",
+  it("should keep the declared surface when a run only writes metadata", async () => {
+    const declared = runtime.getCell<number>(
+      space,
+      "mw-declared-surface-output",
+      undefined,
+      tx,
+    );
+    const metadata = runtime.getCell<number>(
+      space,
+      "mw-observed-metadata-write",
+      undefined,
+      tx,
+    );
+    declared.set(0);
+    metadata.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    const declaredWrite = declared.getAsNormalizedFullLink();
+    const metadataWrite = metadata.getAsNormalizedFullLink();
+    const action = Object.assign(
+      ((actionTx: IExtendedStorageTransaction) => {
+        metadata.withTx(actionTx).set(1);
+      }) as Action,
+      {
+        writes: [declaredWrite],
+      },
+    );
+
+    runtime.scheduler.subscribe(
+      action,
+      {
+        reads: [],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(declaredWrite)],
+      },
+      {},
+    );
+
+    await runtime.scheduler.run(action);
+
+    expect(runtime.scheduler.getMightWrite(action)).toEqual([
+      toMemorySpaceAddress(declaredWrite),
     ]);
-    const metadataWrite = scopedAddress("user", ["cfc"]);
-
-    const { newCurrentKnownWrites } = buildKnownSchedulingWrites({
-      writes: [metadataWrite],
-      declaredWrites: [declaredWrite],
-      existingCurrentWrites: [],
-      existingHistoricalWrites: [],
-    });
-
-    expect(
-      newCurrentKnownWrites.some((write) =>
-        write.scope === declaredWrite.scope &&
-        write.id === declaredWrite.id &&
-        write.path.join("/") === declaredWrite.path.join("/")
-      ),
-    ).toBe(true);
-    expect(
-      newCurrentKnownWrites.some((write) =>
-        write.scope === metadataWrite.scope &&
-        write.id === metadataWrite.id &&
-        write.path.join("/") === metadataWrite.path.join("/")
-      ),
-    ).toBe(true);
+    expect(runtime.scheduler.getMightWrite(action)).not.toEqual([
+      toMemorySpaceAddress(metadataWrite),
+    ]);
   });
 
   it("should not broaden current-known writes to structural parent paths", async () => {
@@ -333,24 +292,6 @@ describe("push-triggered filtering", () => {
     ]);
   });
 
-  it("should not derive declared ancestor writes across scopes", () => {
-    const spaceAncestor = scopedAddress("space", ["items"]);
-    const sessionChild = scopedAddress("session", ["items", "details"]);
-
-    expect(
-      deriveDeclaredAncestorWrites([sessionChild], [spaceAncestor]),
-    ).toEqual([]);
-  });
-
-  it("should not derive dynamic collection parent writes across scopes", () => {
-    const spaceCollection = scopedAddress("space", ["items"]);
-    const sessionItem = scopedAddress("session", ["items", "0"]);
-
-    expect(
-      deriveDynamicCollectionParentWrites([sessionItem], [spaceCollection]),
-    ).toEqual([]);
-  });
-
   it("should not order materializer writes before readers in other scopes", () => {
     const materializer: Action = () => {};
     const reader: Action = () => {};
@@ -418,10 +359,16 @@ describe("push-triggered filtering", () => {
     tx = runtime.edit();
 
     let runCount = 0;
-    const action: Action = (actionTx) => {
-      runCount++;
-      cell.withTx(actionTx).send(runCount);
-    };
+    const cellLink = cell.getAsNormalizedFullLink();
+    const action = Object.assign(
+      ((actionTx: IExtendedStorageTransaction) => {
+        runCount++;
+        cell.withTx(actionTx).send(runCount);
+      }) as Action,
+      {
+        writes: [cellLink],
+      },
+    );
 
     // First run with default scheduling should work
     runtime.scheduler.subscribe(
@@ -429,7 +376,7 @@ describe("push-triggered filtering", () => {
       {
         reads: [],
         shallowReads: [],
-        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
+        writes: [toMemorySpaceAddress(cellLink)],
       },
       {},
     );
@@ -500,10 +447,16 @@ describe("push-triggered filtering", () => {
     tx = runtime.edit();
 
     let runCount = 0;
-    const action: Action = (actionTx) => {
-      runCount++;
-      cell.withTx(actionTx).send(runCount);
-    };
+    const cellLink = cell.getAsNormalizedFullLink();
+    const action = Object.assign(
+      ((actionTx: IExtendedStorageTransaction) => {
+        runCount++;
+        cell.withTx(actionTx).send(runCount);
+      }) as Action,
+      {
+        writes: [cellLink],
+      },
+    );
 
     // Run once to establish mightWrite
     runtime.scheduler.subscribe(
@@ -511,7 +464,7 @@ describe("push-triggered filtering", () => {
       {
         reads: [],
         shallowReads: [],
-        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
+        writes: [toMemorySpaceAddress(cellLink)],
       },
       {},
     );
@@ -526,7 +479,7 @@ describe("push-triggered filtering", () => {
       {
         reads: [],
         shallowReads: [],
-        writes: [toMemorySpaceAddress(cell.getAsNormalizedFullLink())],
+        writes: [toMemorySpaceAddress(cellLink)],
       },
       {},
     );

--- a/packages/runner/test/scheduler-pull-handlers.test.ts
+++ b/packages/runner/test/scheduler-pull-handlers.test.ts
@@ -1048,10 +1048,9 @@ describe("handler dependency pulling", () => {
       liftOutput.withTx(actionTx).send(input * 2);
     };
 
-    // Resubscribe the lift - NOT scheduled immediately
+    // Subscribe the lift with a registration-time surface - NOT scheduled immediately
     // This tests that the lift is pulled when handler B needs it
-    // Use resubscribe to set up triggers without scheduling immediate execution
-    runtime.scheduler.resubscribe(liftAction, {
+    runtime.scheduler.subscribe(liftAction, {
       reads: [toMemorySpaceAddress(liftInput.getAsNormalizedFullLink())],
       shallowReads: [],
       writes: [toMemorySpaceAddress(liftOutput.getAsNormalizedFullLink())],

--- a/packages/runner/test/scheduler-pull.test.ts
+++ b/packages/runner/test/scheduler-pull.test.ts
@@ -260,7 +260,10 @@ describe("pull-based scheduling", () => {
 
     expect(effectRuns).toBe(1);
     expect(effectResult.get()).toBe(1);
-    expect(unrelatedRuns).toBe(0);
+    // v2 (spec §5.3): children created during a live effect's run get
+    // provisional first-run demand; the v1 writeful-effect exception
+    // keyed on run-learned writes, which no longer exist.
+    expect(unrelatedRuns).toBe(1);
   });
 
   it("should re-run an effect for transitively related pending dependency collection", async () => {

--- a/packages/runner/test/scheduler-static-writes.test.ts
+++ b/packages/runner/test/scheduler-static-writes.test.ts
@@ -50,18 +50,24 @@ describe("static write surface demand", () => {
     tx = runtime.edit();
 
     let runs = 0;
-    const writer: Action = (actionTx) => {
-      runs++;
-      const value = source.withTx(actionTx).get();
-      output.withTx(actionTx).send(value * 10);
-    };
+    const outputLink = output.getAsNormalizedFullLink();
+    const writer = Object.assign(
+      ((actionTx: IExtendedStorageTransaction) => {
+        runs++;
+        const value = source.withTx(actionTx).get();
+        output.withTx(actionTx).send(value * 10);
+      }) as Action,
+      {
+        writes: [outputLink],
+      },
+    );
 
     runtime.scheduler.subscribe(
       writer,
       {
         reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
+        writes: [toMemorySpaceAddress(outputLink)],
       },
       {},
     );
@@ -94,18 +100,24 @@ describe("static write surface demand", () => {
     tx = runtime.edit();
 
     let runs = 0;
-    const writer: Action = (actionTx) => {
-      runs++;
-      const value = source.withTx(actionTx).get();
-      output.withTx(actionTx).send(value * 10);
-    };
+    const outputLink = output.getAsNormalizedFullLink();
+    const writer = Object.assign(
+      ((actionTx: IExtendedStorageTransaction) => {
+        runs++;
+        const value = source.withTx(actionTx).get();
+        output.withTx(actionTx).send(value * 10);
+      }) as Action,
+      {
+        writes: [outputLink],
+      },
+    );
 
     runtime.scheduler.subscribe(
       writer,
       {
         reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
         shallowReads: [],
-        writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
+        writes: [toMemorySpaceAddress(outputLink)],
       },
       {},
     );

--- a/packages/runner/test/scheduler-static-writes.test.ts
+++ b/packages/runner/test/scheduler-static-writes.test.ts
@@ -209,7 +209,7 @@ describe("static write surface demand", () => {
       expect(runs).toBe(1);
       expect(
         getLoggerCountsBreakdown().scheduler?.["write-surface-violation"]
-          ?.warn ?? 0,
+          ?.debug ?? 0,
       ).toBe(0);
     } finally {
       cancel();
@@ -277,7 +277,7 @@ describe("static write surface demand", () => {
       expect(undeclared.get()).toBe(2);
       expect(
         getLoggerCountsBreakdown().scheduler?.["write-surface-violation"]
-          ?.warn,
+          ?.debug,
       ).toBe(1);
     } finally {
       cancel();

--- a/packages/runner/test/scheduler-static-writes.test.ts
+++ b/packages/runner/test/scheduler-static-writes.test.ts
@@ -1,0 +1,129 @@
+import {
+  afterEach,
+  beforeEach,
+  createSchedulerTestRuntime,
+  describe,
+  disposeSchedulerTestRuntime,
+  expect,
+  it,
+  Runtime,
+  space,
+  toMemorySpaceAddress,
+} from "./scheduler-test-utils.ts";
+import type {
+  Action,
+  IExtendedStorageTransaction,
+  SchedulerTestStorageManager,
+} from "./scheduler-test-utils.ts";
+
+describe("static write surface demand", () => {
+  let storageManager: SchedulerTestStorageManager;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
+      import.meta.url,
+    ));
+  });
+
+  afterEach(async () => {
+    await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
+  });
+
+  it("keeps a declared writer dormant while its output has no demand", async () => {
+    const source = runtime.getCell<number>(
+      space,
+      "static-writes-dormant-source",
+      undefined,
+      tx,
+    );
+    const output = runtime.getCell<number>(
+      space,
+      "static-writes-dormant-output",
+      undefined,
+      tx,
+    );
+    source.set(1);
+    output.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let runs = 0;
+    const writer: Action = (actionTx) => {
+      runs++;
+      const value = source.withTx(actionTx).get();
+      output.withTx(actionTx).send(value * 10);
+    };
+
+    runtime.scheduler.subscribe(
+      writer,
+      {
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
+      },
+      {},
+    );
+
+    source.withTx(tx).send(2);
+    await tx.commit();
+    tx = runtime.edit();
+    await runtime.scheduler.idle();
+
+    expect(runs).toBe(0);
+    expect(output.get()).toBe(0);
+  });
+
+  it("runs a declared writer when demand arrives at its output", async () => {
+    const source = runtime.getCell<number>(
+      space,
+      "static-writes-demand-source",
+      undefined,
+      tx,
+    );
+    const output = runtime.getCell<number>(
+      space,
+      "static-writes-demand-output",
+      undefined,
+      tx,
+    );
+    source.set(1);
+    output.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let runs = 0;
+    const writer: Action = (actionTx) => {
+      runs++;
+      const value = source.withTx(actionTx).get();
+      output.withTx(actionTx).send(value * 10);
+    };
+
+    runtime.scheduler.subscribe(
+      writer,
+      {
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
+      },
+      {},
+    );
+
+    source.withTx(tx).send(3);
+    await tx.commit();
+    tx = runtime.edit();
+    await runtime.scheduler.idle();
+    expect(runs).toBe(0);
+
+    const cancel = output.withTx(tx).sink(() => {});
+    try {
+      await runtime.scheduler.idle();
+
+      expect(runs).toBe(1);
+      expect(output.get()).toBe(30);
+    } finally {
+      cancel();
+    }
+  });
+});

--- a/packages/runner/test/scheduler-static-writes.test.ts
+++ b/packages/runner/test/scheduler-static-writes.test.ts
@@ -1,4 +1,8 @@
 import {
+  getLogger,
+  getLoggerCountsBreakdown,
+} from "@commonfabric/utils/logger";
+import {
   afterEach,
   beforeEach,
   createSchedulerTestRuntime,
@@ -136,6 +140,74 @@ describe("static write surface demand", () => {
       expect(output.get()).toBe(30);
     } finally {
       cancel();
+    }
+  });
+
+  it("warns when a computation writes outside its declared surface", async () => {
+    getLogger("scheduler").resetCounts();
+    const source = runtime.getCell<number>(
+      space,
+      "static-writes-violation-source",
+      undefined,
+      tx,
+    );
+    const declared = runtime.getCell<number>(
+      space,
+      "static-writes-violation-declared",
+      undefined,
+      tx,
+    );
+    const undeclared = runtime.getCell<number>(
+      space,
+      "static-writes-violation-undeclared",
+      undefined,
+      tx,
+    );
+    source.set(1);
+    declared.set(0);
+    undeclared.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let runs = 0;
+    const declaredLink = declared.getAsNormalizedFullLink();
+    const writer = Object.assign(
+      ((actionTx: IExtendedStorageTransaction) => {
+        runs++;
+        const value = source.withTx(actionTx).get();
+        undeclared.withTx(actionTx).send(value);
+      }) as Action,
+      {
+        writes: [declaredLink],
+      },
+    );
+
+    runtime.scheduler.subscribe(
+      writer,
+      {
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(declaredLink)],
+      },
+      {},
+    );
+
+    const cancel = declared.withTx(tx).sink(() => {});
+    try {
+      source.withTx(tx).send(2);
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.scheduler.idle();
+
+      expect(runs).toBe(1);
+      expect(undeclared.get()).toBe(2);
+      expect(
+        getLoggerCountsBreakdown().scheduler?.["write-surface-violation"]
+          ?.warn,
+      ).toBe(1);
+    } finally {
+      cancel();
+      getLogger("scheduler").resetCounts();
     }
   });
 });

--- a/packages/runner/test/scheduler-static-writes.test.ts
+++ b/packages/runner/test/scheduler-static-writes.test.ts
@@ -143,6 +143,80 @@ describe("static write surface demand", () => {
     }
   });
 
+  it("does not warn for scoped-slot writes outside the declared surface", async () => {
+    getLogger("scheduler").resetCounts();
+    const source = runtime.getCell<number>(
+      space,
+      "static-writes-scoped-source",
+      undefined,
+      tx,
+    );
+    const declared = runtime.getCell<number>(
+      space,
+      "static-writes-scoped-declared",
+      undefined,
+      tx,
+    );
+    const scopedTarget = runtime.getCell<number>(
+      space,
+      "static-writes-scoped-target",
+      undefined,
+      tx,
+    );
+    source.set(1);
+    declared.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    // Per-user/per-session slots are runtime-mediated (scope defaults,
+    // UI state) and not part of the authored surface; the declaration-gap
+    // diagnostic must not flag them.
+    const scopedLink = {
+      ...scopedTarget.getAsNormalizedFullLink(),
+      scope: "session" as const,
+    };
+    let runs = 0;
+    const declaredLink = declared.getAsNormalizedFullLink();
+    const writer = Object.assign(
+      ((actionTx: IExtendedStorageTransaction) => {
+        runs++;
+        const value = source.withTx(actionTx).get();
+        runtime.getCellFromLink<number>(scopedLink, undefined, actionTx)
+          .send(value);
+      }) as Action,
+      {
+        writes: [declaredLink],
+      },
+    );
+
+    runtime.scheduler.subscribe(
+      writer,
+      {
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(declaredLink)],
+      },
+      {},
+    );
+
+    const cancel = declared.withTx(tx).sink(() => {});
+    try {
+      source.withTx(tx).send(2);
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.scheduler.idle();
+
+      expect(runs).toBe(1);
+      expect(
+        getLoggerCountsBreakdown().scheduler?.["write-surface-violation"]
+          ?.warn ?? 0,
+      ).toBe(0);
+    } finally {
+      cancel();
+      getLogger("scheduler").resetCounts();
+    }
+  });
+
   it("warns when a computation writes outside its declared surface", async () => {
     getLogger("scheduler").resetCounts();
     const source = runtime.getCell<number>(

--- a/packages/runner/test/scheduler-timing.test.ts
+++ b/packages/runner/test/scheduler-timing.test.ts
@@ -374,7 +374,7 @@ describe("debounce and throttling", () => {
     expect(runtime.scheduler.getDebounce(effect)).toBe(100);
   });
 
-  it("should not auto-debounce write-less pull demand root effects", () => {
+  it("auto-debounces slow write-less effects; pull roots opt out via noDebounce", () => {
     const effect: Action = () => {};
     runtime.scheduler.subscribe(effect, {
       reads: [],
@@ -393,7 +393,29 @@ describe("debounce and throttling", () => {
 
     scheduler.maybeAutoDebounce(effect);
 
-    expect(runtime.scheduler.getDebounce(effect)).toBeUndefined();
+    // v2 (spec §8.2): the auto-debounce exemption is the explicit
+    // noDebounce opt-out (pull() sets it); v1 exempted any write-less
+    // effect via the demand-root writes proxy, which no longer exists.
+    expect(runtime.scheduler.getDebounce(effect)).toBe(100);
+
+    const protectedEffect: Action = () => {};
+    runtime.scheduler.subscribe(protectedEffect, {
+      reads: [],
+      shallowReads: [],
+      writes: [],
+    }, { isEffect: true, noDebounce: true });
+
+    scheduler.actionStats.set(scheduler.getActionId(protectedEffect), {
+      runCount: 3,
+      totalTime: 180,
+      averageTime: 60,
+      lastRunTime: 60,
+      lastRunTimestamp: performance.now(),
+    });
+
+    scheduler.maybeAutoDebounce(protectedEffect);
+
+    expect(runtime.scheduler.getDebounce(protectedEffect)).toBeUndefined();
   });
 
   it("should not auto-debounce fast actions", async () => {


### PR DESCRIPTION
Stack: 05/phase1 — based on scheduler-v2/04-e2 (#4096)

PROGRESS excerpt:

## 05/step-0

- [x] no commit — phase 1 benchmark baseline captured before static write
  surface changes.
- Deviations: none.
- Recordings:
  - `cd packages/runner && deno bench --allow-read --allow-write
    --allow-net --allow-ffi --allow-env --no-check test/scheduler.bench.ts
    test/scheduler-demand-roots.bench.ts
    test/scheduler-stale-propagation.bench.ts`: passed.
  - `test/scheduler.bench.ts`:
    - `Scheduler - 100 computations, shared entity reads`: 19.4 ms
    - `Scheduler - wide graph (1 source, 100 readers)`: 17.9 ms
    - `Scheduler - 100 entities, sparse deps`: 17.3 ms
    - `Scheduler - deep chain (50 levels)`: 11.5 ms
    - `Scheduler - diamond pattern (10 diamonds)`: 9.6 ms
    - `Scheduler - repeated dirty marking`: 7.7 ms
    - `Scheduler - subscribe/unsubscribe cycle (100x)`: 5.8 ms
    - `Scheduler - pull with resubscribe (50 pulls)`: 291.3 ms
    - `Overhead - setup/teardown only`: 1.3 ms
    - `Overhead - create 100 cells (getCell + set)`: 15.4 ms
    - `Overhead - 100x getCell only (no set)`: 1.6 ms
    - `Overhead - 100x set on existing cells`: 15.7 ms
    - `Overhead - runtime.idle() empty`: 1.3 ms
    - `Overhead - commit after 100 sets`: 15.9 ms
    - `Overhead - empty commit`: 1.3 ms
    - `Overhead - 100 raw tx.write + commit`: 7.1 ms
    - `Utility - sortAndCompactPaths (100 paths)`: 21.7 us
    - `Utility - sortAndCompactPaths (1000 paths)`: 280.5 us
    - `Utility - addressesToPathByEntity (100 paths)`: 14.9 us
    - `Utility - addressesToPathByEntity (1000 paths)`: 150.3 us
    - `Scheduler - bare subscribe (100x)`: 1.7 ms
    - `Scheduler - subscribe 100 actions reading same entity`: 1.7 ms
    - `Scheduler - resubscribe cycle (100x)`: 1.4 ms
  - `test/scheduler-demand-roots.bench.ts`:
    - `Scheduler demand roots - effect demand root`: 147.1 ms
    - `Scheduler demand roots - event demand root`: 131.8 ms
    - `Scheduler demand roots - mixed effect and event roots`: 169.0 ms
    - `Scheduler demand roots - parent clears generated children`: 81.3 ms
  - `test/scheduler-stale-propagation.bench.ts`:
    - `Scheduler stale propagation - chain`: 105.5 ms
    - `Scheduler stale propagation - diamond`: 94.7 ms
    - `Scheduler stale propagation - wide fanout`: 244.0 ms
    - `Scheduler stale propagation - dynamic deps`: 82.9 ms
    - `Scheduler stale propagation - unchanged recompute`: 74.7 ms

## 05/step-1

- [x] ca77bc16e — static write surface demand fixtures added.
- Deviations: both fixtures already pass on current code, so they pin existing
  behavior; no behavior-change red case was observed.
- Recordings:
  - `deno fmt packages/runner/test/scheduler-static-writes.test.ts`: passed
    (`Checked 1 file`).
  - `deno lint packages/runner/test/scheduler-static-writes.test.ts`: passed
    (`Checked 1 file`).
  - `deno check packages/runner/test/scheduler-static-writes.test.ts`: passed.
  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
    test/scheduler-static-writes.test.ts`: passed, `1 passed (2 steps)`,
    `0 failed`.

## IMPLEMENTER STOP — 05/step-3 static write surface sweep

Stopped after implementing the step 2/3 static-surface rewrite locally because
the full runner suite produced failures outside the three work-order-named
rewrite files. Continuing would require either changing public scheduler API
compatibility for direct `subscribe(..., ReactivityLog)` callers, or widening
test rewrites beyond the allowed files.

Local changes currently include:

- `pull-subscriptions.ts`: unconditional static surface registration from
  action annotations before `immediateLog` setup.
- `dependency-updates.ts`: scheduling writes are derived only from the
  annotated static surface, never `log.writes`.
- `scheduling-writes.ts`: deleted dynamic write discovery helpers and
  historical might-write mode; `SchedulerWriteIndex` now stores the current
  static surface.
- `dependency-graph.ts`/`subscriptions.ts`/`scheduler.ts`: added static
  registration-time dependent edge attachment so existing readers can see a
  newly registered static writer without resurrecting dynamic write-growth
  diffing.
- `action-run.ts`: persisted observations keep both write fields populated
  from the static surface.
- `runtime.ts` and experimental-option tests: removed
  `schedulerHistoricalMightWrite`.
- Named test rewrites in `scheduler-ordering.test.ts`,
  `scheduler-observations.test.ts`, and `scheduler-effects.test.ts` assert
  static surfaces instead of v1 write-set learning. The step-1 fixture was
  also corrected to express declared writes through `action.writes`, because
  v2 ignores direct `log.writes` as scheduler surface.

Verification before the full-suite STOP:

- `deno fmt packages/runner/src/scheduler/pull-subscriptions.ts
  packages/runner/src/scheduler/dependency-updates.ts
  packages/runner/src/scheduler/scheduling-writes.ts
  packages/runner/src/scheduler/dependency-graph.ts
  packages/runner/src/scheduler/action-run.ts
  packages/runner/src/scheduler/subscriptions.ts packages/runner/src/scheduler.ts
  packages/runner/src/runtime.ts packages/runner/test/experimental-options.test.ts
  packages/runner/test/scheduler-ordering.test.ts
  packages/runner/test/scheduler-observations.test.ts
  packages/runner/test/scheduler-effects.test.ts
  packages/runner/test/scheduler-static-writes.test.ts`: passed
  (`Checked 13 files`).
- `deno lint` on the same 13 files: passed (`Checked 13 files`).
- `deno check` on the same 13 files: passed.
- `grep -rn "backfillDependentsForNewWrites\|pruneDependentsForCurrentWrites"
  packages/runner/src/`: no matches.
- `grep -rn "schedulerHistoricalMightWrite\|historicalMightWrite" packages
  --include="*.ts"`: no matches.
- `grep -rn
  "buildKnownSchedulingWrites\|historicalMightWrite\|diffSchedulingWrites\|pruneStructuralAncestorWrites"
  packages/runner/src`: no matches.
- Focused tests passed:
  - `test/scheduler-static-writes.test.ts`: `1 passed (2 steps)`.
  - `test/scheduler-ordering.test.ts`: `2 passed (17 steps)`.
  - `test/scheduler-observations.test.ts`: `1 passed (22 steps)`.
  - `test/scheduler-effects.test.ts`: `1 passed (20 steps)`.
  - `test/experimental-options.test.ts`: `1 passed (11 steps)`.

Full suite failure:

- `cd packages/runner && deno task test`: failed, `580 passed
  (3032 steps)`, `12 failed (63 steps)`, `0 ignored (10 steps)`, `2m5s`.
- Failure groups:
  - `test/cell-callbacks.test.ts`: persistent effect after `pull()` cleanup.
  - `test/memory-v2-pull-reactivity.test.ts`: 2 pull reactivity failures.
  - `test/scheduler-convergence.test.ts`: 6 convergence/cycle/stat failures.
  - `test/scheduler-core.test.ts`: 5 scheduler core/trace/cancel failures.
  - `test/scheduler-events.test.ts`: 2 event recomputation/in-flight demand
    failures.
  - `test/scheduler-pull-array.test.ts`: 7 array/demand/navigation failures.
  - `test/scheduler-pull-handlers.test.ts`: 7 handler dependency pulling
    failures.
  - `test/scheduler-pull-references.test.ts`: reference propagation failure.
  - `test/scheduler-pull.test.ts`: broad pull scheduling/staleness failures,
    including the explicit legacy assertion
    `should preserve writes when collecting dependencies from ReactivityLog`.
  - `test/scheduler-retries.test.ts`: retry dependency preservation failure.
  - `test/scheduler-throttle.test.ts`: 4 throttle/staleness failures.
  - `test/scheduler-timing.test.ts`: 7 debounce/auto-debounce/cycle-debounce
    failures.

Reviewer question: should the scheduler keep a compatibility path where a
direct `ReactivityLog` passed to `subscribe`/`resubscribe` seeds a static
surface for unannotated actions, or should the work order explicitly authorize
widening rewrites/annotations across the additional direct-scheduler tests?

## REVIEWER VERDICT — 05/step-3 subscribe-time logs are declarations

Keep the compatibility path — and not as a concession: it is the
P4-correct reading. A `ReactivityLog` passed to `subscribe(...)` is a
REGISTRATION-TIME declaration (the caller saying "this action reads X,
writes Y"), the same rank as runner annotations. What P4 forbids is the
surface changing from RUN logs. Do NOT widen test rewrites beyond the
three named files.

The rule:

1. Surface resolution at REGISTRATION, in priority order:
   annotated `action.writes` (non-empty) → else `immediateLog.writes`
   (subscribe-with-log path) → else empty. Applied once.
2. `resubscribe(action, runLog)` NEVER touches the surface — for
   annotated and unannotated actions alike. This is the only intended
   v1→v2 semantic change, and the three named files' rewrites already
   express it.
3. Architectural placement: move surface registration OUT of
   `setSchedulerDependencies` entirely — registration sites own it
   (`subscribePullSchedulerAction` for both the annotation and
   immediate-log cases; the rehydration path keeps using the annotation
   as you already have it). `setSchedulerDependencies` becomes
   reads/edges only and never writes to the write index. This matches
   the v2 component split (registration owns the surface) and makes the
   resubscribe path structurally unable to clobber it.
4. Populate-callback subscribers with no log and no annotation (e.g.
   `cell.pull()`'s ephemeral effect) keep an empty surface — correct,
   they are effects.

Expected effect: the direct-subscribe test population (the 12 failing
files) declares writes in their initial logs, so their surfaces, writer
edges, demand, and ordering come back without any test edits —
including the explicitly-legacy
`should preserve writes when collecting dependencies from ReactivityLog`
(subscribe-time, so it must pass unchanged) and the retry-preservation
test (retry resubscribes with the captured log; surface stays the
registration-time one).

After implementing: run the full suite. If failures remain, list them
per-test in PROGRESS with a one-line classification — (a) asserts
run-log surface EVOLUTION (rewrite authorized, name it), (b) anything
else (STOP with the failure). Do not bulk-rewrite.

Docs: amend WO05 step 2/3 with the declaration rule — own commit:
`docs(specs): scheduler-v2 WO05 — subscribe-time logs declare the surface`.
Deferred spec note recorded: P4's text should gain one sentence naming
the immediate-log declaration channel (rides the later docs change with
the settled-origin note).

## REVIEWER RESOLUTION — 05/step-3 declaration-rule docs

- [x] 13e6f09a7 — WO05 step 2/3 amended so registration-time `ReactivityLog`
  writes declare the static surface when annotations are absent, while
  resubscribe/run logs never change the surface.
- Recordings: docs-only commit; no `deno fmt`/`deno lint`/`deno check`
  required.

## IMPLEMENTER STOP — 05/step-3 declaration-rule implementation residuals

Implemented the reviewer verdict narrowly:

- `subscribePullSchedulerAction` resolves the registration-time surface once:
  non-empty annotated `action.writes` first, else `immediateLog.writes`, else
  empty; effects still do not register a scheduling surface.
- `setSchedulerDependencies` no longer reads `log.writes` or writes to the
  write index; it refreshes reads and returns the already-registered surface.
- `rehydrateActionFromObservation` now registers the live annotated surface
  before resubscribing reads, so persisted `currentKnownWrites` never restores
  the surface by itself.
- Named test rewrites stayed confined to `scheduler-ordering.test.ts`,
  `scheduler-observations.test.ts`, and `scheduler-effects.test.ts`.

Verification:

- `deno fmt packages/runner/src/scheduler/pull-subscriptions.ts
  packages/runner/src/scheduler/dependency-updates.ts
  packages/runner/src/scheduler/scheduling-writes.ts
  packages/runner/src/scheduler/dependency-graph.ts
  packages/runner/src/scheduler/action-run.ts
  packages/runner/src/scheduler/subscriptions.ts packages/runner/src/scheduler.ts
  packages/runner/src/runtime.ts packages/runner/test/experimental-options.test.ts
  packages/runner/test/scheduler-ordering.test.ts
  packages/runner/test/scheduler-observations.test.ts
  packages/runner/test/scheduler-effects.test.ts
  packages/runner/test/scheduler-static-writes.test.ts`: passed
  (`Checked 13 files`).
- `deno lint` on the same 13 files: passed (`Checked 13 files`).
- `deno check` on the same 13 files: passed.
- `grep -rn "backfillDependentsForNewWrites\|pruneDependentsForCurrentWrites"
  packages/runner/src/`: no matches.
- `grep -rn "schedulerHistoricalMightWrite\|historicalMightWrite" packages
  --include="*.ts"`: no matches.
- `grep -rn
  "buildKnownSchedulingWrites\|historicalMightWrite\|diffSchedulingWrites\|pruneStructuralAncestorWrites"
  packages/runner/src`: no matches.
- Focused tests passed:
  - `test/scheduler-static-writes.test.ts`: `1 passed (2 steps)`.
  - `test/scheduler-ordering.test.ts`: `2 passed (17 steps)`.
  - `test/scheduler-observations.test.ts`: `1 passed (22 steps)`.
  - `test/scheduler-effects.test.ts`: `1 passed (20 steps)`.
  - `test/experimental-options.test.ts`: `1 passed (11 steps)`.

Full suite failure:

- `cd packages/runner && deno task test`: failed, `588 passed
  (3091 steps)`, `4 failed (4 steps)`, `0 ignored (10 steps)`, `2m5s`.
- Per-test classification required by the reviewer verdict:
  - `test/scheduler-core.test.ts` / `captures exact action runs for one
    reactive update`: (b) not run-log surface evolution. The action-run trace
    still expects an effect's `declaredWrites` length to be 1, but effects now
    have no registered scheduling surface.
  - `test/scheduler-pull-handlers.test.ts` / `should wait for dynamically
    created lift before dispatching to downstream handler`: (a) asserts
    run-log surface evolution/setup. The test seeds the lift surface through
    `resubscribe(liftAction, log)`, which v2 now forbids.
  - `test/scheduler-pull.test.ts` / `should not re-run an effect for unrelated
    pending dependency collection`: (b) not run-log surface evolution. With
    effects now empty-surface demand roots, a child computation subscribed
    while the effect runs is demanded and runs once.
  - `test/scheduler-timing.test.ts` / `should auto-debounce slow writeful
    effects after threshold runs`: (b) not run-log surface evolution. The test
    classifies a writeful effect by its old scheduling writes; effects now have
    an empty scheduling surface and are treated as pull demand roots.

Stopped per the reviewer verdict because three residual failures are class
(b). No rewrites outside the three named files were attempted.

## REVIEWER VERDICT — 05/step-3 residuals (effect-surface proxy)

Effects being surface-less is CORRECT (spec §4.2: no scheduler-visible
output) and stays. The three class-(b) residuals are v1's
"writes==0 ⇒ pull-demand-root" PROXY breaking, not your change being
wrong. Per-test rulings:

1. `scheduler-core` / "captures exact action runs ...": authorized
   rewrite (add to named files): an effect's `declaredWrites` in the
   action-run trace is now 0 — that is the v2 truth, the test encoded
   the v1 run-learned surface.
2. `scheduler-pull-handlers` / dynamic-lift seeding: your class-(a)
   call is right — authorized rewrite, minimal form: seed the lift's
   surface through subscribe-with-log (the declaration channel) or an
   annotation, not post-run `resubscribe`.
3. `scheduler-pull` / "unrelated pending dependency collection": the
   new behavior IS spec §5.3 arriving early — a computation created
   during any LIVE node's run (every effect is live) gets one
   provisional first run. Authorized rewrite of this single test to the
   v2 expectation, with this comment above the changed assertion:
   `// v2 (spec §5.3): children created during a live effect's run get`
   `// provisional first-run demand; the v1 writeful-effect exception`
   `// keyed on run-learned writes, which no longer exist.`
4. `scheduler-timing` / auto-debounce: NO test rewrite — the mechanism
   must be fixed, or every ordinary sink loses auto-debounce (violates
   spec §8.2). Two edits:
   - `cell.ts` `pull()`: subscribe its ephemeral effect with
     `noDebounce: true` (the pull-root protection becomes EXPLICIT
     instead of riding the writes proxy);
   - the auto-debounce eligibility gate (`canAutomaticallyDebounce` in
     delay-control): drop the `isPullDemandRootEffect` exemption,
     keeping effect-only + `noDebounce` opt-out + thresholds.
   Keep `isPullDemandRootEffect` itself and its OTHER call sites
   (demand context, snapshot) unchanged in this phase — with effects
   surface-less it now returns true for all effects, which matches the
   §5.3 semantics accepted in (3); the predicate dissolves entirely in
   phase 3b.
   The failing timing test must then pass AS WRITTEN. If any other
   timing/throttle test fails after this (e.g. one asserting pull
   roots never debounce via the proxy), STOP with the name.

Bookkeeping: named-rewrite list for this work order now reads:
ordering, observations, effects, core (trace expectation), pull
(single §5.3 test), pull-handlers (seeding form). Docs amendment —
`docs(specs): scheduler-v2 WO05 — effect surfaces, pull-root opt-out, §5.3 early`
— before the code commit. Deferred spec notes now three: immediate-log
declaration channel (P4), settled-origin rule (§7.6), and §8.2's
exemption being noDebounce/pull-root-by-option rather than a writes
proxy.

Then: full suite green → commit step 2+3 (one commit, message from
step 3), then steps 4-6 as written.

## REVIEWER RESOLUTION — 05/step-3 residual-rule docs

- [x] 315a34866 — WO05 step 3 amended for effect-empty-surface trace
  expectations, subscribe-time seeding of dynamic lifts, early §5.3 provisional
  child demand, and explicit `noDebounce` pull-root auto-debounce opt-out.
- Recordings: docs-only commit; no `deno fmt`/`deno lint`/`deno check`
  required.

## IMPLEMENTER STOP — 05/step-3 residual-rule timing proxy follow-up

Applied the reviewer verdict narrowly:

- `cell.ts` `pull()` subscribes its ephemeral effect with `noDebounce: true`.
- Auto-debounce eligibility no longer exempts `isPullDemandRootEffect`; it keeps
  effect-only eligibility and explicit `noDebounce` opt-out.
- `scheduler-core.test.ts` action-run trace now expects effect
  `declaredWrites` to be empty while preserving the actual write assertion.
- `scheduler-pull-handlers.test.ts` seeds the dynamic lift surface through
  `subscribe(..., ReactivityLog)` rather than `resubscribe(...)`.
- `scheduler-pull.test.ts` rewrites the single §5.3 provisional child-demand
  expectation with the reviewer-specified comment.

Verification before STOP:

- `deno fmt` on the 20 touched TS/test files: passed (`Checked 20 files`).
- `deno lint` on the same 20 files: passed (`Checked 20 files`).
- `deno check` on the same 20 files: passed.
- Focused residual reruns:
  - `test/scheduler-core.test.ts`: `1 passed (25 steps)`.
  - `test/scheduler-pull-handlers.test.ts`: `1 passed (11 steps)`.
  - `test/scheduler-pull.test.ts`: `1 passed (26 steps)`.
  - `test/scheduler-timing.test.ts`: failed, `0 passed (20 steps)`,
    `1 failed (1 step)`.

STOP condition from reviewer verdict:

- `test/scheduler-timing.test.ts` / `should not auto-debounce write-less pull
  demand root effects` still asserts the old proxy behavior. After removing the
  `isPullDemandRootEffect` auto-debounce exemption, it observes debounce `100`
  instead of `undefined` at `scheduler-timing.test.ts:396`.

No rewrite was attempted because the reviewer explicitly said to STOP if any
other timing/throttle test fails after the auto-debounce cleanup.

## REVIEWER VERDICT — 05/step-3 timing-proxy companion test

Correct stop; this is the companion assertion of the same dead proxy,
from the other side. "Write-less effect" no longer means "pull root" —
it means an ordinary read-only sink, which is precisely what §8.2 wants
auto-debounced when slow. The pull-root protection is now the explicit
`noDebounce: true` that `pull()` sets.

Authorized rewrite of this single test (added to the named list):

1. Rename `should not auto-debounce write-less pull demand root effects`
   → `auto-debounces slow write-less effects; pull roots opt out via noDebounce`.
2. Flip the main assertion: after threshold runs, the bare write-less
   slow effect HAS debounce 100 (the value your run already observed).
3. In the same test (or a sibling `it` if cleaner), assert the
   protected case explicitly: an identical slow effect subscribed with
   `noDebounce: true` keeps debounce `undefined` after the same number
   of runs. Skip this half only if an existing test in the file already
   covers the `noDebounce` opt-out for effects — check first and note
   which.
4. Comment above the flipped assertion:
   `// v2 (spec §8.2): the auto-debounce exemption is the explicit`
   `// noDebounce opt-out (pull() sets it); v1 exempted any write-less`
   `// effect via the demand-root writes proxy, which no longer exists.`

Then full suite; if green, proceed with the commit sequence from the
prior verdict (steps 2+3 commit, then 4-6). Any further failure of any
shape: STOP as usual.

## IMPLEMENTER RESOLUTION — 05/step-3 timing companion rewrite

Applied the verdict:

- `scheduler-timing.test.ts` renamed the write-less effect test and now asserts
  that a bare slow write-less effect gets auto-debounce `100`.
- The same test asserts an identical slow effect subscribed with
  `noDebounce: true` keeps debounce `undefined`.
- Existing `noDebounce` coverage in this file was cycle-aware debounce only, so
  the explicit effect auto-debounce opt-out assertion was added here.

Verification:

- `deno fmt` on the 20 touched TS/test files: passed (`Checked 20 files`).
- `deno lint` on the same 20 files: passed (`Checked 20 files`).
- `deno check` on the same 20 files: passed.
- Contract greps:
  - `grep -rn "backfillDependentsForNewWrites\|pruneDependentsForCurrentWrites"
    packages/runner/src/`: no matches.
  - `grep -rn "schedulerHistoricalMightWrite\|historicalMightWrite" packages
    --include="*.ts"`: no matches.
  - `grep -rn
    "buildKnownSchedulingWrites\|historicalMightWrite\|diffSchedulingWrites\|pruneStructuralAncestorWrites"
    packages/runner/src`: no matches.
- Focused named rewrites passed:
  - `ENV=test deno test --allow-ffi --allow-env --allow-read
    --allow-write=/tmp,/var/folders --allow-run=git
    test/scheduler-static-writes.test.ts test/scheduler-ordering.test.ts
    test/scheduler-observations.test.ts test/scheduler-effects.test.ts
    test/experimental-options.test.ts`: `6 passed (72 steps)`,
    `0 failed`.
  - `ENV=test deno test --allow-ffi --allow-env --allow-read
    --allow-write=/tmp,/var/folders --allow-run=git
    test/scheduler-core.test.ts test/scheduler-pull-handlers.test.ts
    test/scheduler-pull.test.ts test/scheduler-timing.test.ts`:
    `4 passed (83 steps)`, `0 failed`.
- `cd packages/runner && deno task test`: `ok | 592 passed (3095 steps) |
  0 failed | 0 ignored (10 steps) (2m4s)`.

## 05/step-2+3

- [x] 6a9377bbe — scheduling writes are static declared surfaces registered at
  subscribe time.
- Deviations: reviewer-authorized residual rewrites documented above; effects
  have no scheduler-visible write surface, and pull-root debounce protection is
  the explicit `noDebounce` opt-out.
- Recordings: see the `IMPLEMENTER RESOLUTION — 05/step-3 timing companion
  rewrite` verification above.

## 05/step-4

- [x] no commit — clean removal held; no ordering-only effect write fallback
  was needed.
- Deviations: none.
- Recordings:
  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
    test/scheduler-ordering.test.ts test/scheduler-convergence.test.ts`:
    passed, `3 passed (32 steps)`, `0 failed`.

## 05/step-5

- [x] 088100973 — added a dev warning for computation writes outside the
  declared static surface.
- Deviations: none.
- Recordings:
  - `deno fmt packages/runner/src/scheduler/action-run.ts
    packages/runner/test/scheduler-static-writes.test.ts`: passed
    (`Checked 2 files`).
  - `deno lint packages/runner/src/scheduler/action-run.ts
    packages/runner/test/scheduler-static-writes.test.ts`: passed
    (`Checked 2 files`).
  - `deno check packages/runner/src/scheduler/action-run.ts
    packages/runner/test/scheduler-static-writes.test.ts`: passed.
  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
    test/scheduler-static-writes.test.ts`: passed, `1 passed (3 steps)`,
    `0 failed`.

## 05/phase-end

- [x] pending — WO05 exit checklist self-check complete.
- Deviations: none.
- Recordings:
  - `cd packages/runner && deno task test`: passed,
    `592 passed (3096 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m4s`.
  - Phase benchmark command passed:
    `cd packages/runner && deno bench --allow-read --allow-write --allow-net
    --allow-ffi --allow-env --no-check test/scheduler.bench.ts
    test/scheduler-demand-roots.bench.ts
    test/scheduler-stale-propagation.bench.ts`.
  - Benchmark deltas vs 05/step-0 baseline:
    - `test/scheduler.bench.ts`:
      - `Scheduler - 100 computations, shared entity reads`: 19.4 ms -> 19.7
        ms (+1.5%).
      - `Scheduler - wide graph (1 source, 100 readers)`: 17.9 ms -> 17.3 ms
        (-3.4%).
      - `Scheduler - 100 entities, sparse deps`: 17.3 ms -> 17.7 ms (+2.3%).
      - `Scheduler - deep chain (50 levels)`: 11.5 ms -> 11.2 ms (-2.6%).
      - `Scheduler - diamond pattern (10 diamonds)`: 9.6 ms -> 9.7 ms
        (+1.0%).
      - `Scheduler - repeated dirty marking`: 7.7 ms -> 7.7 ms (+0.0%).
      - `Scheduler - subscribe/unsubscribe cycle (100x)`: 5.8 ms -> 5.6 ms
        (-3.4%).
      - `Scheduler - pull with resubscribe (50 pulls)`: 291.3 ms -> 288.4 ms
        (-1.0%).
      - `Overhead - setup/teardown only`: 1.3 ms -> 1.4 ms (+7.7%).
      - `Overhead - create 100 cells (getCell + set)`: 15.4 ms -> 15.5 ms
        (+0.6%).
      - `Overhead - 100x getCell only (no set)`: 1.6 ms -> 1.6 ms (+0.0%).
      - `Overhead - 100x set on existing cells`: 15.7 ms -> 15.5 ms (-1.3%).
      - `Overhead - runtime.idle() empty`: 1.3 ms -> 1.2 ms (-7.7%).
      - `Overhead - commit after 100 sets`: 15.9 ms -> 16.1 ms (+1.3%).
      - `Overhead - empty commit`: 1.3 ms -> 1.2 ms (-7.7%).
      - `Overhead - 100 raw tx.write + commit`: 7.1 ms -> 7.6 ms (+7.0%).
      - `Utility - sortAndCompactPaths (100 paths)`: 21.7 us -> 21.1 us
        (-2.8%).
      - `Utility - sortAndCompactPaths (1000 paths)`: 280.5 us -> 281.3 us
        (+0.3%).
      - `Utility - addressesToPathByEntity (100 paths)`: 14.9 us -> 14.8 us
        (-0.7%).
      - `Utility - addressesToPathByEntity (1000 paths)`: 150.3 us -> 152.1
        us (+1.2%).
      - `Scheduler - bare subscribe (100x)`: 1.7 ms -> 1.6 ms (-5.9%).
      - `Scheduler - subscribe 100 actions reading same entity`: 1.7 ms -> 1.6
        ms (-5.9%).
      - `Scheduler - resubscribe cycle (100x)`: 1.4 ms -> 1.3 ms (-7.1%).
    - `test/scheduler-demand-roots.bench.ts`:
      - `Scheduler demand roots - effect demand root`: 147.1 ms -> 144.1 ms
        (-2.0%).
      - `Scheduler demand roots - event demand root`: 131.8 ms -> 129.4 ms
        (-1.8%).
      - `Scheduler demand roots - mixed effect and event roots`: 169.0 ms ->
        172.8 ms (+2.2%).
      - `Scheduler demand roots - parent clears generated children`: 81.3 ms ->
        82.6 ms (+1.6%).
    - `test/scheduler-stale-propagation.bench.ts`:
      - `Scheduler stale propagation - chain`: 105.5 ms -> 97.3 ms (-7.8%).
      - `Scheduler stale propagation - diamond`: 94.7 ms -> 89.4 ms (-5.6%).
      - `Scheduler stale propagation - wide fanout`: 244.0 ms -> 248.0 ms
        (+1.6%).
      - `Scheduler stale propagation - dynamic deps`: 82.9 ms -> 74.7 ms
        (-9.9%).
      - `Scheduler stale propagation - unchanged recompute`: 74.7 ms -> 73.2
        ms (-2.0%).
  - No benchmark regression exceeded 10%.
- Exit checklist:
  - `grep -rn
    "buildKnownSchedulingWrites\|historicalMightWrite\|diffSchedulingWrites\|pruneStructuralAncestorWrites"
    packages/runner/src`: no matches.
  - `grep -rn "log\.writes"
    packages/runner/src/scheduler/dependency-updates.ts`: no matches;
    inspection confirms `setSchedulerDependencies` reads only `log.reads` and
    `log.shallowReads`, and returns `state.writeIndex.getSchedulingWrites`.
  - Observation payload compatibility held: `attachSchedulerActionObservation`
    still sets both `currentKnownWrites` and `declaredWrites` to the registered
    static surface.
  - Static write fixtures A/B and the new surface-violation fixture are green:
    `test/scheduler-static-writes.test.ts` passed, `1 passed (3 steps)`,
    `0 failed`.
  - Test rewrites were confined to the reviewer-approved named files; step 4
    clean removal held without the decision-tree fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make scheduler writes a static surface fixed at subscribe time for deterministic scheduling. Persist the live surface through rehydration and add a debug-level diagnostic for out-of-surface writes (scoped-slot writes ignored).

- **Refactors**
  - Resolve writer surface once at subscription: from `action.writes` (if non-empty), else from the subscribe-time `ReactivityLog`, else empty.
  - Remove dynamic write discovery/history and related diff/backfill/prune paths; drop `schedulerHistoricalMightWrite`.
  - Attach writer edges at registration; `setSchedulerDependencies` now refreshes reads only.
  - Effects register no scheduler-visible writes; auto-debounce applies to effects unless opted out with `noDebounce`.
  - `cell.pull()` subscribes its ephemeral effect with `noDebounce: true`.
  - Persist and rehydrate the live registered surface: observations store the surface; rehydration resolves it like registration (annotation first, else persisted).
  - Add a debug-level diagnostic when a run writes outside its declared surface; ignore scoped-slot writes; logger counters still increment.

- **Migration**
  - Declare writes via `action.writes` or by passing a `ReactivityLog` to `subscribe(action, log)`.
  - Stop using `resubscribe(action, runLog)` to seed or change the surface.
  - For pull roots that must not debounce, subscribe with `{ noDebounce: true }`.
  - If you see the diagnostic, align your declared surface with actual writes.

<sup>Written for commit e7bae94ce4e54e7832a384cbbd20e11bf7f58d57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

