### PR TITLE
refactor(runner): tx-carried source action for self-suppression (scheduler-v2 phase 2)

### DIFF
--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -2625,7 +2625,7 @@ Verification:
 
 ## 05/phase-end
 
-- [x] pending — WO05 exit checklist self-check complete.
+- [x] 606cf649b — WO05 exit checklist self-check complete.
 - Deviations: none.
 - Recordings:
   - `cd packages/runner && deno task test`: passed,
@@ -2724,3 +2724,15 @@ Verification:
     (`test/scheduler-observations.test.ts` "persists and rehydrates
     immediate-log write surfaces").
 - Deviations: none.
+
+## 06/step-1
+
+- [x] pending — storage transactions now carry `sourceAction`, stamped by
+  scheduler action runs and event dispatches.
+- Deviations: none.
+- Recordings:
+  - `deno fmt packages/runner/src/storage/interface.ts
+    packages/runner/src/scheduler/action-run.ts
+    packages/runner/src/scheduler/events.ts`: passed (`Checked 3 files`).
+  - `deno lint` on the same three files: passed (`Checked 3 files`).
+  - `deno check` on the same three files: passed.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -2739,7 +2739,7 @@ Verification:
 
 ## 06/step-2+3
 
-- [x] pending — scheduler self-suppression now uses tx-carried object identity
+- [x] a94e779bc — scheduler self-suppression now uses tx-carried object identity
   and the in-flight source bookkeeping is deleted.
 - Deviations: none.
 - Recordings:
@@ -2779,3 +2779,16 @@ Verification:
     the focused test command above.
   - `runSchedulerAction` and `dispatchQueuedEvent` both stamp
     `tx.tx.sourceAction`.
+
+## 06/phase-end
+
+- [x] pending — WO06 exit checklist self-check complete.
+- Deviations: none.
+- Recordings:
+  - `cd packages/runner && deno task test`: passed,
+    `593 passed (3099 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m6s`.
+  - No phase-specific benchmarks are listed for WO06.
+  - Exit checklist greps and inspections are recorded in `06/step-2+3` above;
+    rerun after the commit confirmed `grep -rn "inFlightSources"
+    packages/runner/src` has no matches and suppression remains
+    `notification.source.sourceAction === action`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -2727,7 +2727,7 @@ Verification:
 
 ## 06/step-1
 
-- [x] pending — storage transactions now carry `sourceAction`, stamped by
+- [x] 5c9cb3c31 — storage transactions now carry `sourceAction`, stamped by
   scheduler action runs and event dispatches.
 - Deviations: none.
 - Recordings:
@@ -2736,3 +2736,46 @@ Verification:
     packages/runner/src/scheduler/events.ts`: passed (`Checked 3 files`).
   - `deno lint` on the same three files: passed (`Checked 3 files`).
   - `deno check` on the same three files: passed.
+
+## 06/step-2+3
+
+- [x] pending — scheduler self-suppression now uses tx-carried object identity
+  and the in-flight source bookkeeping is deleted.
+- Deviations: none.
+- Recordings:
+  - Fixture pre-swap check after adding `scheduler-tx-identity.test.ts` on the
+    step-1 state: `cd packages/runner && ENV=test deno test --allow-ffi
+    --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-tx-identity.test.ts`: passed, `1 passed (3 steps)`,
+    `0 failed`.
+  - Contract grep:
+    `grep -rn
+    "inFlightSources\|InFlightSourceState\|addInFlightSource\|removeInFlightSource"
+    packages/runner/src packages/runner/test/scheduler-cfc-trigger-reads.test.ts`:
+    no matches.
+  - `deno fmt packages/runner/src/scheduler/pull-notifications.ts
+    packages/runner/src/scheduler/action-run.ts packages/runner/src/scheduler.ts
+    packages/runner/src/scheduler/notifications.ts
+    packages/runner/test/scheduler-cfc-trigger-reads.test.ts
+    packages/runner/test/scheduler-tx-identity.test.ts`: passed
+    (`Checked 6 files`).
+  - `deno lint` on the same six files: passed (`Checked 6 files`).
+  - `deno check` on the same six files: passed.
+  - Focused tests:
+    `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-tx-identity.test.ts test/scheduler-cfc-trigger-reads.test.ts
+    test/scheduler-retries.test.ts`: passed, `6 passed (13 steps)`,
+    `0 failed`.
+  - `cd packages/runner && deno task test`: passed,
+    `593 passed (3099 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m6s`.
+- Exit checklist:
+  - `grep -rn "inFlightSources" packages/runner/src`: no matches.
+  - Suppression compares `notification.source.sourceAction === action` in
+    `pull-notifications.ts`; the diagnostic `actionId` is used only for
+    diagnostics around the check.
+  - `changeGroup` skip remains intact with the required explanatory comment.
+  - The three tx identity fixtures and `scheduler-retries.test.ts` are green in
+    the focused test command above.
+  - `runSchedulerAction` and `dispatchQueuedEvent` both stamp
+    `tx.tx.sourceAction`.

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -14,7 +14,6 @@ import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
   IStorageSubscription,
-  IStorageTransaction,
   MemorySpace,
   StorageNotification,
 } from "./storage/interface.ts";
@@ -76,7 +75,6 @@ import {
   snapshotDirtyDependencyTraceContext,
 } from "./scheduler/dirty-dependencies.ts";
 import {
-  type InFlightSourceState,
   runSchedulerAction,
   type SchedulerActionRunState,
   schedulerImplementationFingerprint,
@@ -365,9 +363,6 @@ export class Scheduler {
     getActionId: (action) => this.getActionId(action),
   });
   private delayControlState!: SchedulerDelayControlState;
-  private inFlightSourceState: InFlightSourceState = {
-    inFlightSources: new WeakMap<Action, Set<IStorageTransaction>>(),
-  };
 
   private writeIndex!: SchedulerWriteIndex;
   private materializers = new SchedulerMaterializers(this.effects);
@@ -1796,7 +1791,6 @@ export class Scheduler {
       effects: this.effects,
       pending: this.pending,
       dirty: this.staleness.dirty,
-      inFlightSources: this.inFlightSourceState.inFlightSources,
       conditionallyScheduledEffects: this.conditionallyScheduledEffects,
       getActionId: (target) => this.getActionId(target),
       recordCellUpdate: (change) =>
@@ -2241,7 +2235,6 @@ export class Scheduler {
         }
       },
       actionChangeGroups: this.actionChangeGroups,
-      inFlightSourceState: this.inFlightSourceState,
       actionTimingState: this.actionTimingState,
       pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
       pullDemandedContinuationComputations: this

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -7,7 +7,6 @@ import type {
   ChangeGroup,
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
-  IStorageTransaction,
 } from "../storage/interface.ts";
 import { isPermanentRejection } from "../storage/rejection.ts";
 import { sortAndCompactPaths } from "../reactive-dependencies.ts";
@@ -42,36 +41,6 @@ const logger = getLogger("scheduler", {
 export type ActionInvocationResult =
   | { ok: true; result: any }
   | { ok: false; error: unknown };
-
-export interface InFlightSourceState {
-  readonly inFlightSources: WeakMap<Action, Set<IStorageTransaction>>;
-}
-
-export function addInFlightSource(
-  state: InFlightSourceState,
-  action: Action,
-  source: IStorageTransaction,
-): void {
-  let sources = state.inFlightSources.get(action);
-  if (!sources) {
-    sources = new Set<IStorageTransaction>();
-    state.inFlightSources.set(action, sources);
-  }
-  sources.add(source);
-}
-
-export function removeInFlightSource(
-  state: InFlightSourceState,
-  action: Action,
-  source: IStorageTransaction,
-): void {
-  const sources = state.inFlightSources.get(action);
-  if (!sources) return;
-  sources.delete(source);
-  if (sources.size === 0) {
-    state.inFlightSources.delete(action);
-  }
-}
 
 export function invokeReactiveAction(state: {
   readonly runtime: Runtime;
@@ -138,10 +107,6 @@ export function watchReactiveActionCommit(state: {
   readonly resubscribe: (action: Action, log: ReactivityLog) => void;
   readonly markDirectDirty: (action: Action) => void;
   readonly queueExecution: () => void;
-  readonly removeInFlightSource: (
-    action: Action,
-    tx: IExtendedStorageTransaction["tx"],
-  ) => void;
   readonly restoreCfcTriggerReads: () => void;
 }): void {
   state.commitPromise.then(({ error }) => {
@@ -179,8 +144,6 @@ export function watchReactiveActionCommit(state: {
       // Clear retries after successful commit.
       state.retries.delete(state.action);
     }
-  }).finally(() => {
-    state.removeInFlightSource(state.action, state.tx.tx);
   }).catch((error) => {
     logger.error(
       "schedule-error",
@@ -249,7 +212,6 @@ export interface SchedulerActionRunState {
     addresses: readonly IMemorySpaceAddress[],
   ) => void;
   readonly actionChangeGroups: WeakMap<Action, ChangeGroup>;
-  readonly inFlightSourceState: InFlightSourceState;
   readonly actionTimingState: ActionTimingState;
   readonly pullDemandedFirstRunComputations: WeakSet<Action>;
   readonly pullDemandedContinuationComputations: WeakSet<Action>;
@@ -333,7 +295,6 @@ export async function runSchedulerAction(
   }
   (tx.tx as { debugActionId?: string }).debugActionId = actionId;
   tx.tx.sourceAction = action;
-  addInFlightSource(state.inFlightSourceState, action, tx.tx);
   const actionStartTime = performance.now();
 
   let result: any;
@@ -435,7 +396,6 @@ function rescheduleActionForImmediateRetry(
   },
 ): void {
   if (args.tx.status().status === "ready") args.tx.abort(args.error);
-  removeInFlightSource(state.inFlightSourceState, args.action, args.tx.tx);
   const retries = (state.retries.get(args.action) ?? 0) + 1;
   state.retries.set(args.action, retries);
   if (retries < MAX_RETRIES_FOR_REACTIVE) {
@@ -513,12 +473,6 @@ function finalizeReactiveActionCommit(
     resubscribe: state.resubscribe,
     markDirectDirty: state.markDirectDirty,
     queueExecution: state.queueExecution,
-    removeInFlightSource: (target, source) =>
-      removeInFlightSource(
-        state.inFlightSourceState,
-        target,
-        source,
-      ),
     restoreCfcTriggerReads: () => {
       if (
         args.cfcTriggerReads !== undefined && args.cfcTriggerReads.length > 0

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -332,6 +332,7 @@ export async function runSchedulerAction(
     tx.addCfcTriggerReads(cfcTriggerReads);
   }
   (tx.tx as { debugActionId?: string }).debugActionId = actionId;
+  tx.tx.sourceAction = action;
   addInFlightSource(state.inFlightSourceState, action, tx.tx);
   const actionStartTime = performance.now();
 

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -509,6 +509,7 @@ export async function dispatchQueuedEvent(state: {
   const tx = state.runtime.edit();
   tx.dispatchedEventId = queuedEvent.id;
   tx.tx.immediate = true;
+  tx.tx.sourceAction = action;
   if (queuedEvent.originTx !== undefined) {
     const originLocalSeq = state.getOriginLocalSeq(
       queuedEvent.originTx,

--- a/packages/runner/src/scheduler/notifications.ts
+++ b/packages/runner/src/scheduler/notifications.ts
@@ -3,7 +3,6 @@ import type {
   ChangeGroup,
   IMemoryChange,
   IMemorySpaceAddress,
-  IStorageTransaction,
 } from "../storage/interface.ts";
 import type { TriggerIndexState } from "./trigger-index.ts";
 import type { MaterializerIndexState } from "./materializers.ts";
@@ -135,6 +134,10 @@ function planSkippedTriggeredAction(
     return { decision: "skip-own-commit-source", operation: "none" };
   }
 
+  // changeGroup is a user-facing suppression feature: external
+  // subscribers (e.g. cf-code-editor sinks) group their own writes so
+  // their subscription ignores them. It is NOT scheduler-internal
+  // self-suppression — that is tx.sourceAction (spec scheduler-v2 P5).
   if (
     state.hasSourceChangeGroup &&
     state.actionChangeGroup !== undefined &&
@@ -263,7 +266,6 @@ export interface StorageNotificationState {
   readonly effects: ReadonlySet<Action>;
   readonly pending: ReadonlySet<Action>;
   readonly dirty: ReadonlySet<Action>;
-  readonly inFlightSources: WeakMap<Action, Set<IStorageTransaction>>;
   readonly conditionallyScheduledEffects: Map<Action, number>;
   readonly getActionId: (action: Action) => string;
   readonly recordCellUpdate: (change: IMemoryChange) => void;

--- a/packages/runner/src/scheduler/pull-notifications.ts
+++ b/packages/runner/src/scheduler/pull-notifications.ts
@@ -99,7 +99,7 @@ export function processPullStorageNotification(
       const dirtyBefore = state.dirty.has(action);
       const isOwnCommitSource = notification.type === "commit" &&
         notification.source !== undefined &&
-        state.inFlightSources.get(action)?.has(notification.source) === true;
+        notification.source.sourceAction === action;
       const plan = planPullTriggeredAction({
         isEffect: actionIsEffect,
         dirtyBefore,

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -519,6 +519,13 @@ export interface IStorageTransaction {
    */
   immediate?: boolean;
   /**
+   * The scheduler action whose run opened this transaction (spec scheduler-v2
+   * P5). Change records derived from this transaction must not re-trigger this
+   * action. Compared by OBJECT IDENTITY — diagnostic action ids may collide
+   * across instances.
+   */
+  sourceAction?: object;
+  /**
    * Opt the transaction into writing to more than one memory space. By default
    * a transaction may write to a single space only. When enabled, commit()
    * commits each written space's changes as a separate per-space commit, in the

--- a/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
+++ b/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
@@ -83,7 +83,6 @@ describe("recordCfcTriggerRead dedup keys", () => {
 function makeNotificationState(args: {
   action: Action;
   triggerIndex: SchedulerTriggerIndex;
-  inFlightSources?: WeakMap<Action, Set<IStorageTransaction>>;
   actionChangeGroups?: WeakMap<Action, ChangeGroup>;
 }): StorageNotificationState {
   return {
@@ -97,7 +96,6 @@ function makeNotificationState(args: {
     effects: new Set([args.action]),
     pending: new Set(),
     dirty: new Set(),
-    inFlightSources: args.inFlightSources ?? new WeakMap(),
     conditionallyScheduledEffects: new Map(),
     getActionId: () => "test-action",
     recordCellUpdate: () => {},
@@ -156,13 +154,10 @@ describe("trigger reads follow the scheduling decision", () => {
   ) {
     it(`${mode}: skip-own-commit-source records no trigger read`, () => {
       const action: Action = () => {};
-      const sourceTx = {} as IStorageTransaction;
-      const inFlightSources = new WeakMap<Action, Set<IStorageTransaction>>();
-      inFlightSources.set(action, new Set([sourceTx]));
+      const sourceTx = { sourceAction: action } as IStorageTransaction;
       const state = makeNotificationState({
         action,
         triggerIndex: makeTriggerIndexFor(action),
-        inFlightSources,
       });
 
       process(state, makeCommitNotification(sourceTx));
@@ -216,25 +211,24 @@ describe("trigger reads survive failed runs", () => {
   }): Promise<void> {
     const action: Action = () => {};
     const tx = { tx: {} } as IExtendedStorageTransaction;
-    return new Promise((resolve) => {
-      watchReactiveActionCommit({
-        action,
-        tx,
-        log: { reads: [], shallowReads: [], writes: [] },
-        retries: args.retries ?? new WeakMap(),
-        pending: new Set(),
-        commitPromise: Promise.resolve(
-          { error: args.error } as Awaited<
-            ReturnType<IExtendedStorageTransaction["commit"]>
-          >,
-        ),
-        resubscribe: () => {},
-        markDirectDirty: () => {},
-        queueExecution: () => {},
-        removeInFlightSource: () => resolve(),
-        restoreCfcTriggerReads: args.onRestore,
-      });
+    const commitPromise = Promise.resolve(
+      { error: args.error } as Awaited<
+        ReturnType<IExtendedStorageTransaction["commit"]>
+      >,
+    );
+    watchReactiveActionCommit({
+      action,
+      tx,
+      log: { reads: [], shallowReads: [], writes: [] },
+      retries: args.retries ?? new WeakMap(),
+      pending: new Set(),
+      commitPromise,
+      resubscribe: () => {},
+      markDirectDirty: () => {},
+      queueExecution: () => {},
+      restoreCfcTriggerReads: args.onRestore,
     });
+    return commitPromise.then(() => undefined);
   }
 
   it("restores consumed trigger reads when a commit conflict re-runs", async () => {

--- a/packages/runner/test/scheduler-tx-identity.test.ts
+++ b/packages/runner/test/scheduler-tx-identity.test.ts
@@ -1,0 +1,175 @@
+import {
+  afterEach,
+  beforeEach,
+  createSchedulerTestRuntime,
+  describe,
+  disposeSchedulerTestRuntime,
+  expect,
+  it,
+  Runtime,
+  space,
+  toMemorySpaceAddress,
+} from "./scheduler-test-utils.ts";
+import type {
+  Action,
+  IExtendedStorageTransaction,
+  SchedulerTestStorageManager,
+} from "./scheduler-test-utils.ts";
+import type { ChangeGroup } from "../src/storage/interface.ts";
+
+describe("tx-carried source action identity", () => {
+  let storageManager: SchedulerTestStorageManager;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
+      import.meta.url,
+    ));
+  });
+
+  afterEach(async () => {
+    await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
+  });
+
+  it("suppresses a computation's own commit by transaction source action", async () => {
+    const value = runtime.getCell<number>(
+      space,
+      "tx-identity-self-value",
+      undefined,
+      tx,
+    );
+    value.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let runs = 0;
+    const valueAddress = toMemorySpaceAddress(value.getAsNormalizedFullLink());
+    const action = Object.assign(
+      ((actionTx: IExtendedStorageTransaction) => {
+        runs++;
+        const current = value.withTx(actionTx).get();
+        value.withTx(actionTx).set(current);
+      }) as Action,
+      {
+        writes: [value.getAsNormalizedFullLink()],
+      },
+    );
+
+    runtime.scheduler.subscribe(
+      action,
+      {
+        reads: [valueAddress],
+        shallowReads: [],
+        writes: [valueAddress],
+      },
+      {},
+    );
+
+    const cancel = value.withTx(tx).sink(() => {});
+    try {
+      value.withTx(tx).set(1);
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.scheduler.idle();
+      expect(runs).toBe(1);
+
+      value.withTx(tx).set(2);
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.scheduler.idle();
+      expect(runs).toBe(2);
+    } finally {
+      cancel();
+    }
+  });
+
+  it("does not starve sibling pull effects that share a diagnostic id", async () => {
+    const source = runtime.getCell<number>(
+      space,
+      "tx-identity-shared-id-source",
+      undefined,
+      tx,
+    );
+    const output = runtime.getCell<number>(
+      space,
+      "tx-identity-shared-id-output",
+      undefined,
+      tx,
+    );
+    source.set(1);
+    output.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    const outputLink = output.getAsNormalizedFullLink();
+    const writer = Object.assign(
+      ((actionTx: IExtendedStorageTransaction) => {
+        const next = source.withTx(actionTx).get();
+        output.withTx(actionTx).set(next * 10);
+      }) as Action,
+      {
+        writes: [outputLink],
+      },
+    );
+    runtime.scheduler.subscribe(
+      writer,
+      {
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(outputLink)],
+      },
+      {},
+    );
+
+    source.withTx(tx).set(2);
+    await tx.commit();
+    tx = runtime.edit();
+
+    // Guards P5's object-identity rule: these two actions share the
+    // diagnostic id "pull:<uri>"; id-based suppression would starve one.
+    const [first, second] = await Promise.all([
+      output.pull(),
+      output.pull(),
+    ]);
+
+    expect(first).toBe(20);
+    expect(second).toBe(20);
+  });
+
+  it("keeps changeGroup suppression for external subscribers", async () => {
+    const value = runtime.getCell<number>(
+      space,
+      "tx-identity-change-group",
+      undefined,
+      tx,
+    );
+    value.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    const changeGroup = {} as ChangeGroup;
+    const values: number[] = [];
+    const cancel = value.sink((next) => {
+      values.push(next);
+    }, { changeGroup });
+    try {
+      await runtime.scheduler.idle();
+      expect(values).toEqual([0]);
+
+      const sameGroupTx = runtime.edit({ changeGroup });
+      value.withTx(sameGroupTx).set(1);
+      await sameGroupTx.commit();
+      await runtime.scheduler.idle();
+      expect(values).toEqual([0]);
+
+      const noGroupTx = runtime.edit();
+      value.withTx(noGroupTx).set(2);
+      await noGroupTx.commit();
+      await runtime.scheduler.idle();
+      expect(values).toEqual([0, 2]);
+    } finally {
+      cancel();
+    }
+  });
+});


### PR DESCRIPTION
Stack: 06/phase2 - based on scheduler-v2/05-phase1 (#4098)

PROGRESS excerpt:

## 06/step-1

- [x] 5c9cb3c31 — storage transactions now carry `sourceAction`, stamped by
  scheduler action runs and event dispatches.
- Deviations: none.
- Recordings:
  - `deno fmt packages/runner/src/storage/interface.ts
    packages/runner/src/scheduler/action-run.ts
    packages/runner/src/scheduler/events.ts`: passed (`Checked 3 files`).
  - `deno lint` on the same three files: passed (`Checked 3 files`).
  - `deno check` on the same three files: passed.

## 06/step-2+3

- [x] a94e779bc — scheduler self-suppression now uses tx-carried object identity
  and the in-flight source bookkeeping is deleted.
- Deviations: none.
- Recordings:
  - Fixture pre-swap check after adding `scheduler-tx-identity.test.ts` on the
    step-1 state: `cd packages/runner && ENV=test deno test --allow-ffi
    --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git
    test/scheduler-tx-identity.test.ts`: passed, `1 passed (3 steps)`,
    `0 failed`.
  - Contract grep:
    `grep -rn
    "inFlightSources\|InFlightSourceState\|addInFlightSource\|removeInFlightSource"
    packages/runner/src packages/runner/test/scheduler-cfc-trigger-reads.test.ts`:
    no matches.
  - `deno fmt packages/runner/src/scheduler/pull-notifications.ts
    packages/runner/src/scheduler/action-run.ts packages/runner/src/scheduler.ts
    packages/runner/src/scheduler/notifications.ts
    packages/runner/test/scheduler-cfc-trigger-reads.test.ts
    packages/runner/test/scheduler-tx-identity.test.ts`: passed
    (`Checked 6 files`).
  - `deno lint` on the same six files: passed (`Checked 6 files`).
  - `deno check` on the same six files: passed.
  - Focused tests:
    `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
    test/scheduler-tx-identity.test.ts test/scheduler-cfc-trigger-reads.test.ts
    test/scheduler-retries.test.ts`: passed, `6 passed (13 steps)`,
    `0 failed`.
  - `cd packages/runner && deno task test`: passed,
    `593 passed (3099 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m6s`.
- Exit checklist:
  - `grep -rn "inFlightSources" packages/runner/src`: no matches.
  - Suppression compares `notification.source.sourceAction === action` in
    `pull-notifications.ts`; the diagnostic `actionId` is used only for
    diagnostics around the check.
  - `changeGroup` skip remains intact with the required explanatory comment.
  - The three tx identity fixtures and `scheduler-retries.test.ts` are green in
    the focused test command above.
  - `runSchedulerAction` and `dispatchQueuedEvent` both stamp
    `tx.tx.sourceAction`.

## 06/phase-end

- [x] pending — WO06 exit checklist self-check complete.
- Deviations: none.
- Recordings:
  - `cd packages/runner && deno task test`: passed,
    `593 passed (3099 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m6s`.
  - No phase-specific benchmarks are listed for WO06.
  - Exit checklist greps and inspections are recorded in `06/step-2+3` above;
    rerun after the commit confirmed `grep -rn "inFlightSources"
    packages/runner/src` has no matches and suppression remains
    `notification.source.sourceAction === action`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch scheduler self-suppression to transaction-carried action identity. Each storage transaction now stamps `tx.sourceAction`, removing in-flight source tracking and avoiding starvation when sibling pull effects share a diagnostic id.

- **Refactors**
  - Add `sourceAction` to `IStorageTransaction`; set in `runSchedulerAction` and `dispatchQueuedEvent`.
  - Self-suppress by checking `notification.source.sourceAction === action` in `pull-notifications.ts`.
  - Remove `InFlightSourceState` and in-flight bookkeeping; drop `inFlightSources` from notification state.
  - Keep `changeGroup` suppression for external subscribers (commented in `notifications.ts`).
  - Add `scheduler-tx-identity.test.ts`; update related tests; all `packages/runner` tests pass.

<sup>Written for commit b8d5deda0935344d169f238d8904fe0f14cac024. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

