### PR TITLE
refactor(runner): scheduler-v2 cutover 3a: node records

### DIFF
--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -2893,3 +2893,56 @@ Verification:
     - `Scheduler persistent state - clean rehydrate 1000 actions`: 8.2 ms.
     - `Scheduler persistent state - targeted dirty rehydrate 1000 actions`:
       7.6 ms.
+
+## 07/3a-kind
+
+- [x] pending — migrated effect/computation kind tracking to
+  `SchedulerNode` records.
+- Deviations:
+  - None.
+- Choices:
+  - `NodeRegistry` owns action kind registration and the sticky historical
+    effect/computation distinction. Re-registering a known action with a
+    different kind is a hard error.
+  - Existing state bundles that only read active effect/computation membership
+    continue to receive read-only `nodes.effects` / `nodes.computations` views,
+    keeping this family behavior-preserving and tightly scoped.
+  - Mutable classification paths (`updateSchedulerActionType`,
+    `clearActionTypeTracking`) now go through `NodeRegistry`.
+  - Historical-kind checks that previously used `isEffectAction` now use
+    `nodes.isKnownEffect(...)`; test internals expose `registerEffect(...)`
+    instead of the old WeakMap.
+- Recordings:
+  - Contract grep: `grep -rn
+    "isEffectAction\|this\.effects\b\|this\.computations\b"
+    packages/runner/src packages/runner/test/scheduler-test-utils.ts
+    packages/runner/test/scheduler-pull.test.ts`: no matches.
+  - `deno fmt packages/runner/src/scheduler.ts
+    packages/runner/src/scheduler/subscriptions.ts
+    packages/runner/src/scheduler/demand.ts
+    packages/runner/src/scheduler/action-run.ts
+    packages/runner/src/scheduler/node-record.ts
+    packages/runner/test/scheduler-test-utils.ts
+    packages/runner/test/scheduler-pull.test.ts`: passed (`Checked 7 files`).
+  - `deno lint packages/runner/src/scheduler.ts
+    packages/runner/src/scheduler/subscriptions.ts
+    packages/runner/src/scheduler/demand.ts
+    packages/runner/src/scheduler/action-run.ts
+    packages/runner/src/scheduler/node-record.ts
+    packages/runner/test/scheduler-test-utils.ts
+    packages/runner/test/scheduler-pull.test.ts`: passed (`Checked 7 files`).
+  - `deno check packages/runner/src/scheduler.ts
+    packages/runner/src/scheduler/subscriptions.ts
+    packages/runner/src/scheduler/demand.ts
+    packages/runner/src/scheduler/action-run.ts
+    packages/runner/src/scheduler/node-record.ts
+    packages/runner/test/scheduler-test-utils.ts
+    packages/runner/test/scheduler-pull.test.ts`: passed.
+  - Focused scheduler gate:
+    `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-effects.test.ts test/scheduler-pull.test.ts
+    test/scheduler-ordering.test.ts test/scheduler-v2-cutover.test.ts`:
+    passed, `5 passed (70 steps)`, `0 failed`.
+  - `cd packages/runner && deno task test`: passed,
+    `594 passed (3106 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m7s`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -2946,3 +2946,883 @@ Verification:
     passed, `5 passed (70 steps)`, `0 failed`.
   - `cd packages/runner && deno task test`: passed,
     `594 passed (3106 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m7s`.
+
+## 07/3a-creation-context STOP
+
+- [ ] pending — migrated parent/child creation context to
+  `SchedulerNode.parent` / `SchedulerNode.children`, but stopped before commit.
+- STOP reason:
+  - The required full runner suite failed unexpectedly after the migration.
+  - Failure:
+    `Pattern Runner - Derive returning pattern (CT-1316) ... should not
+    spuriously rerun parent derive when returned child pattern changes`.
+  - Assertion at
+    `packages/runner/test/patterns-derive-return-pattern.test.ts:323`:
+    expected parent derive run count `1`, actual `2`.
+  - This suggests the record-backed parent chain changed a continuation or
+    parent/child scheduling edge in a way that makes the parent derive rerun
+    when only the returned child pattern changes.
+- Recordings before STOP:
+  - Contract grep: `rg -n "actionParent|actionChildren"
+    packages/runner/src`: no matches.
+  - `deno fmt packages/runner/src/scheduler.ts
+    packages/runner/src/scheduler/node-record.ts
+    packages/runner/src/scheduler/subscriptions.ts
+    packages/runner/src/scheduler/demand.ts
+    packages/runner/src/scheduler/pull-subscriptions.ts
+    packages/runner/src/scheduler/action-run.ts
+    packages/runner/src/scheduler/write-propagation.ts
+    packages/runner/src/scheduler/topology.ts
+    packages/runner/src/scheduler/execution.ts
+    packages/runner/src/scheduler/pull-execution.ts
+    packages/runner/src/scheduler/graph-snapshot.ts`: passed
+    (`Checked 11 files`).
+  - `deno lint` on the same 11 files: passed (`Checked 11 files`).
+  - `deno check` on the same 11 files: passed.
+  - Focused parent/graph/cutover gate:
+    `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-ordering.test.ts test/scheduler-effects.test.ts
+    test/scheduler-pull-array.test.ts test/scheduler-v2-cutover.test.ts`:
+    passed, `5 passed (58 steps)`, `0 failed`.
+  - `cd packages/runner && deno task test`: failed,
+    `593 passed (3105 steps)`, `1 failed (1 step)`,
+    `0 ignored (10 steps)`, `2m7s`.
+
+## REVIEWER VERDICT — 07/3a creation-context regression (CT-1316)
+
+Correct stop. `patterns-derive-return-pattern` is a PRODUCT guarantee
+(CT-1316) — it is never eligible for rewrite; the migration must become
+behavior-preserving. The symptom (parent derive reruns when only its
+returned child changes) means the record migration created MORE
+ancestor connectivity than v1 had: the parent-continuation path
+(`write-propagation`'s ancestor-chain check) now finds the parent in a
+child writer's chain where v1 did not.
+
+V1 had two load-bearing WeakMap semantics that are easy to lose:
+
+A. **First assignment wins.** `actionParent` was set at first
+   registration only; the resubscribe path passed
+   `allowExisting: false`. A parent link, once set (or deliberately
+   absent for actions created outside any executing action), was never
+   reassigned.
+B. **Edges survive unsubscribe.** The WeakMaps were intentionally left
+   in place across unsubscribe/resubscribe of the same action object
+   (inventory §2). Your kind-stickiness hard error already implies
+   records persist across remove — parent must persist the same way,
+   and must NOT be recaptured from the CURRENT `executingAction` when a
+   known action re-registers.
+
+Directed investigation, in order:
+
+1. Audit every site that assigns `record.parent`. The likely smoking
+   gun is a get-or-create record helper that stamps
+   `parent = executingAction` when invoked from a NON-registration path
+   (topology, write-propagation, demand, snapshot) or on
+   re-registration of a known action. Parent may be assigned in exactly
+   one place: true first registration of a previously-unknown action,
+   matching v1's `registerParentChildAction` + `allowExisting: false`
+   semantics everywhere else.
+2. Red-first scheduler fixture (goes in
+   `test/scheduler-v2-cutover.test.ts` as an 8th fixture — this is a
+   cutover-preservation property): an action registered parentless at
+   top level, then unsubscribed and re-registered while another action
+   is executing, keeps NO parent; and an action with parent P keeps P
+   when re-registered during Q's run. Paste the red output against the
+   current (broken) tree.
+3. Fix the registry to restore A+B; `rg -n "\.parent\s*=" ` over
+   scheduler src must show only the single sanctioned assignment site.
+4. Gates: the new fixture green; `patterns-derive-return-pattern`
+   passes AS WRITTEN; the focused parent/graph gate you already use;
+   full suite.
+5. If CT-1316 still fails with A+B provably restored (fixture green),
+   STOP with a trace of which ancestor edge the continuation path
+   followed (log `isAncestorAction` inputs for the failing run) — do
+   not attempt a different fix shape without a verdict.
+
+Commit: the creation-context commit as planned plus
+`fixture: parent links are first-assignment-only and survive re-registration`
+folded into it (one commit — the fixture documents the migration's
+invariant).
+
+## IMPLEMENTER FOLLOW-UP — 07/3a creation-context reviewer verdict
+
+- Applied the directed red-first fixture in
+  `packages/runner/test/scheduler-v2-cutover.test.ts`.
+- Red output on the current broken tree:
+  - Command:
+    `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-v2-cutover.test.ts`.
+  - Result: failed in the new fixture
+    `keeps parent links first-assignment-only across re-registration`.
+  - Assertion at `packages/runner/test/scheduler-v2-cutover.test.ts:692`:
+    expected `parentlessChild.parentId` to be `undefined`, actual
+    `"parentQ"`.
+  - Summary: `FAILED | 0 passed (7 steps) | 1 failed (1 step)`.
+
+## IMPLEMENTER STOP — 07/3a creation-context after A+B restoration
+
+- [ ] pending — restored first-assignment-only parent capture and persistent
+  parent edges in `NodeRegistry`, but stopped before commit per reviewer
+  instruction.
+- STOP reason:
+  - The directed parent-link fixture is green and the sanctioned parent
+    assignment grep is clean, but CT-1316 still fails as written.
+  - `patterns-derive-return-pattern.test.ts` failure remains:
+    `should not spuriously rerun parent derive when returned child pattern
+    changes`.
+  - Assertion at
+    `packages/runner/test/patterns-derive-return-pattern.test.ts:323`:
+    expected parent derive run count `1`, actual `2`.
+  - No alternate fix was attempted after A+B restoration.
+- Trace:
+  - Temporary instrumentation logged every `NodeRegistry.isAncestor(...)` call
+    when `SCHEDULER_V2_TRACE_ANCESTOR=1` was set.
+  - Command:
+    `cd packages/runner && ENV=test SCHEDULER_V2_TRACE_ANCESTOR=1 deno test
+    --allow-ffi --allow-env --allow-read
+    --allow-write=/tmp,/var/folders --allow-run=git
+    test/patterns-derive-return-pattern.test.ts >
+    /tmp/scheduler-v2-ct1316-trace.log 2>&1`.
+  - `rg -n "scheduler-v2 ancestor-trace"
+    /tmp/scheduler-v2-ct1316-trace.log`: no matches.
+  - Interpretation: in this failing run, the continuation path does not call
+    `NodeRegistry.isAncestor(...)`; no ancestor-chain edge was followed by that
+    check before the parent derive reran.
+- Recordings after STOP:
+  - `rg -n "\.parent\s*=" packages/runner/src/scheduler`: one match,
+    `packages/runner/src/scheduler/node-record.ts:152: child.parent = parent`.
+  - `rg -n "actionParent|actionChildren" packages/runner/src`: no matches.
+  - `deno fmt packages/runner/src/scheduler.ts
+    packages/runner/src/scheduler/node-record.ts
+    packages/runner/src/scheduler/subscriptions.ts
+    packages/runner/src/scheduler/demand.ts
+    packages/runner/src/scheduler/pull-subscriptions.ts
+    packages/runner/src/scheduler/action-run.ts
+    packages/runner/src/scheduler/write-propagation.ts
+    packages/runner/src/scheduler/topology.ts
+    packages/runner/src/scheduler/execution.ts
+    packages/runner/src/scheduler/pull-execution.ts
+    packages/runner/src/scheduler/graph-snapshot.ts
+    packages/runner/test/scheduler-v2-cutover.test.ts`: passed
+    (`Checked 12 files`).
+  - `deno lint` on the same 12 files: passed (`Checked 12 files`).
+  - `deno check` on the same 12 files: passed.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-v2-cutover.test.ts
+    test/patterns-derive-return-pattern.test.ts`: failed only CT-1316;
+    cutover fixtures passed including
+    `keeps parent links first-assignment-only across re-registration`;
+    summary `FAILED | 1 passed (12 steps) | 1 failed (1 step)`.
+
+## REVIEWER VERDICT — 07/3a creation-context, corrective (my A-rule was wrong)
+
+Root cause found, and it is MY previous verdict: "first assignment
+wins" mis-stated v1. V1's `registerParentChildAction` actually behaves
+as:
+
+  (i)   no executing action → PURE NO-OP: nothing is recorded, and the
+        parent remains assignable by a later call;
+  (ii)  resubscribe path (`allowExisting: false`) → preserves an
+        existing parent, sets it if absent;
+  (iii) subscribe path (`allowExisting: true`, executing action
+        present) → OVERWRITES the parent.
+
+Your `linkParent` instead latches `parentCaptured` on the FIRST CALL —
+including parentless calls — so links v1 would have assigned (or
+reassigned) are now permanently absent. Missing parent edges lose the
+toposort parent-first tie-break, which is exactly the derive-returns-
+pattern shape (child ordered before parent → parent re-dirtied
+mid-pass → the spurious second run).
+
+Corrections:
+
+1. Rewrite `linkParent` as the LITERAL translation of v1:
+
+   - `if (!parentAction || parentAction === childAction) return;` —
+     no latch, no state change.
+   - child/parent records must exist (get; return if either missing).
+   - `if (!allowExisting && child.parent) return;`
+   - assign: if `child.parent` exists and differs, REMOVE child from
+     the old parent's `children` set, then `captureParentRecord`.
+   - Delete `parentCaptured` entirely.
+
+2. REWRITE my 8th cutover fixture (sorry — it encoded the wrong rule)
+   to pin v1's actual semantics, three cases:
+   (a) parentless registration call is a no-op: a later registration
+       under executing Q assigns Q;
+   (b) resubscribe-shaped call (`allowExisting: false`) under executing
+       R preserves an existing parent Q;
+   (c) subscribe-shaped call (`allowExisting: true`) under executing R
+       overwrites Q with R.
+   Run it red against the current latch implementation for case (a)
+   or (c), then green.
+
+3. Gates unchanged: new fixture green, CT-1316 passes AS WRITTEN,
+   focused parent/graph gate, full suite. With literally-equivalent
+   semantics the maps are bisimilar to v1's WeakMaps, so CT-1316 should
+   go green; if it does NOT, stop with a logged call stack for every
+   `markDirectDirty(<parent derive action>)` in the failing run — at
+   that point the divergence is outside the parent family and we need
+   the marking site, not more hypotheses.
+
+4. PROGRESS note: record that the earlier verdict's rule A was
+   reviewer error; the binding definition of creation-context semantics
+   is v1's code, translated literally.
+
+## IMPLEMENTER STOP — 07/3a creation-context after literal v1 parent semantics
+
+- [ ] pending — rewrote the parent-link fixture and `NodeRegistry.linkParent`
+  to match v1 semantics literally, but stopped before commit per reviewer
+  instruction because CT-1316 still fails.
+- Correction recorded:
+  - The earlier "first assignment wins" rule was reviewer error.
+  - The binding definition of creation-context semantics is v1's
+    `registerParentChildAction` behavior translated literally:
+    parentless calls are no-ops, `allowExisting: false` preserves an existing
+    parent, and subscribe-shaped `allowExisting: true` overwrites the parent.
+- Red-first fixture result:
+  - Rewrote the 8th cutover fixture as
+    `matches v1 parent-link semantics across registration paths`.
+  - Red command:
+    `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-v2-cutover.test.ts`.
+  - Red failure on the current latch implementation:
+    assertion at `packages/runner/test/scheduler-v2-cutover.test.ts:697`;
+    expected `"parentQ"`, actual `undefined`.
+- Fix applied:
+  - Removed `parentCaptured`.
+  - `linkParent` now returns without state change when no parent is executing
+    or the parent is the child action.
+  - `allowExisting: false` returns the existing parent without overwrite.
+  - Subscribe-shaped calls overwrite the parent and remove the child from the
+    previous parent's `children` set before linking to the new parent.
+- STOP reason:
+  - The rewritten cutover fixture is green, but CT-1316 still fails as written.
+  - `patterns-derive-return-pattern.test.ts` failure remains:
+    `should not spuriously rerun parent derive when returned child pattern
+    changes`.
+  - Assertion at
+    `packages/runner/test/patterns-derive-return-pattern.test.ts:323`:
+    expected parent derive run count `1`, actual `2`.
+  - No alternate fix was attempted after the reviewer-directed literal
+    translation.
+- Trace:
+  - Temporary instrumentation logged direct dirty marks when
+    `SCHEDULER_V2_TRACE_MARK_DIRECT_DIRTY=1` was set.
+  - Command:
+    `cd packages/runner && ENV=test
+    SCHEDULER_V2_TRACE_MARK_DIRECT_DIRTY=1 deno test --allow-ffi
+    --allow-env --allow-read --allow-write=/tmp,/var/folders
+    --allow-run=git test/patterns-derive-return-pattern.test.ts >
+    /tmp/scheduler-v2-ct1316-mark-direct-dirty.log 2>&1`.
+  - Parent derive action in failing step:
+    `action:/Users/berni/.codex/worktrees/909d/labs/packages/runner/src/builder/pattern.ts:151:21:fid1:Yh9sDtZ`.
+  - Stack for the direct dirty mark:
+    `SchedulerStaleness.markDirectDirty
+    -> markSchedulerDirty (scheduler/staleness.ts:164)
+    -> Object.markDirty (scheduler.ts:1795)
+    -> applyPullTriggeredActionPlan (scheduler/notifications.ts:233)
+    -> processPullStorageNotification (scheduler/pull-notifications.ts:119)
+    -> Scheduler.processStorageNotification (scheduler.ts:1812)
+    -> StorageNotificationRelay.next`.
+  - Interpretation: after literal parent semantics, the parent derive rerun is
+    driven by the storage-notification dirtying path, not by the parent-chain
+    continuation check.
+- Recordings after STOP:
+  - `rg -n
+    "SCHEDULER_V2_TRACE_MARK_DIRECT_DIRTY|scheduler-v2 markDirectDirty|describeAction"
+    packages/runner/src/scheduler/staleness.ts packages/runner/src/scheduler`:
+    no matches.
+  - `rg -n "parentCaptured|\.parent\s*="
+    packages/runner/src/scheduler/node-record.ts packages/runner/src/scheduler`:
+    one assignment site, `packages/runner/src/scheduler/node-record.ts:153:
+    child.parent = parent`; no `parentCaptured` matches.
+  - `deno fmt packages/runner/src/scheduler.ts
+    packages/runner/src/scheduler/node-record.ts
+    packages/runner/src/scheduler/subscriptions.ts
+    packages/runner/src/scheduler/demand.ts
+    packages/runner/src/scheduler/pull-subscriptions.ts
+    packages/runner/src/scheduler/action-run.ts
+    packages/runner/src/scheduler/write-propagation.ts
+    packages/runner/src/scheduler/topology.ts
+    packages/runner/src/scheduler/execution.ts
+    packages/runner/src/scheduler/pull-execution.ts
+    packages/runner/src/scheduler/graph-snapshot.ts
+    packages/runner/test/scheduler-v2-cutover.test.ts`: passed
+    (`Checked 12 files`).
+  - `deno lint` on the same 12 files: passed (`Checked 12 files`).
+  - `deno check` on the same 12 files: passed.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-v2-cutover.test.ts`: passed,
+    `1 passed (8 steps)`, `0 failed`.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-v2-cutover.test.ts
+    test/patterns-derive-return-pattern.test.ts`: failed only CT-1316;
+    cutover fixtures passed including the rewritten v1 parent-link fixture;
+    summary `FAILED | 1 passed (12 steps) | 1 failed (1 step)`.
+
+## REVIEWER VERDICT — 07/3a CT-1316, discriminating experiments (no fix yet)
+
+Keep the literal-v1 `linkParent` and the rewritten fixture — they are
+correct regardless of CT-1316's outcome. The trace says the parent
+derive is dirtied by the TRIGGER-INDEX path, which the creation-context
+migration does not touch directly — so we localize before fixing.
+Run these three experiments and STOP with the results; attempt no fix:
+
+E1. **Did v1-equivalent code mark it too?** Create a scratch worktree
+    at the 3a-kind commit (`git worktree add /tmp/ct1316-base
+    0feccb68d`), apply the SAME `markDirectDirty` instrumentation
+    there (temporary, not committed), run
+    `test/patterns-derive-return-pattern.test.ts`. Record: is the
+    parent derive action marked via the same
+    `processPullStorageNotification` stack there? (If yes → the
+    marking is pre-existing and the regression is in run-gating or
+    demand; if no → the regression is in registered reads or change
+    production.)
+
+E2. **What change dirtied it?** In the CURRENT tree, capture the
+    concrete triggering change for the parent derive: call
+    `runtime.scheduler.setTriggerTraceEnabled(true)` inside the failing
+    test (temporary edit), rerun, and dump the trigger-trace entries
+    whose triggered list contains the parent action id — record
+    entityId, path, before/after summaries, notification type, and the
+    decision. Same capture in the E1 scratch worktree for comparison
+    (even if E1 shows no marking, record the matched-zero fact).
+
+E3. **Close the diff-review gap.** The creation-context diff is ~790
+    lines and only the subscriptions/topology/write-propagation/demand
+    hunks have been reviewed line-by-line. Paste into PROGRESS a list
+    of every hunk in `scheduler.ts`, `action-run.ts`,
+    `pull-subscriptions.ts`, `pull-execution.ts`, `execution.ts`,
+    `graph-snapshot.ts`, and `node-record.ts` classified as
+    [type/bundle-threading only] or [control-flow change], quoting any
+    hunk in the second class in full. Special attention: the order of
+    record creation (`updateSchedulerActionType`/registration) versus
+    `registerParentChildAction` on EVERY path (subscribe, resubscribe,
+    sink resubscribe-first) — `linkParent` silently no-ops when the
+    child record does not exist yet, which is a NEW precondition v1's
+    WeakMap never had. If any path calls parent-linking before record
+    creation, flag it in the E3 list.
+
+Cleanup rule: all instrumentation reverted after capture, as before.
+
+## IMPLEMENTER STOP — 07/3a CT-1316 discriminating experiments
+
+- [ ] pending — ran the reviewer-requested E1/E2/E3 experiments and stopped
+  without attempting a fix.
+- E1 scratch comparison:
+  - Created `/tmp/ct1316-base` at `0feccb68d`:
+    `git worktree add --detach /tmp/ct1316-base 0feccb68d`.
+  - Applied the same temporary `markDirectDirty` instrumentation there and ran:
+    `cd /tmp/ct1316-base/packages/runner && ENV=test
+    SCHEDULER_V2_TRACE_MARK_DIRECT_DIRTY=1 deno test --allow-ffi
+    --allow-env --allow-read --allow-write=/tmp,/var/folders
+    --allow-run=git test/patterns-derive-return-pattern.test.ts >
+    /tmp/scheduler-v2-ct1316-base-mark-direct-dirty.log 2>&1`.
+  - Result: baseline passed, `ok | 1 passed (5 steps) | 0 failed`.
+  - Baseline did mark the CT-1316 parent derive action through the same
+    storage-notification stack:
+    `action:/private/tmp/ct1316-base/packages/runner/src/builder/pattern.ts:151:21:fid1:MjxHd5M`.
+  - Stack:
+    `SchedulerStaleness.markDirectDirty
+    -> markSchedulerDirty (scheduler/staleness.ts:164)
+    -> Object.markDirty (scheduler.ts:1798)
+    -> applyPullTriggeredActionPlan (scheduler/notifications.ts:233)
+    -> processPullStorageNotification (scheduler/pull-notifications.ts:119)
+    -> Scheduler.processStorageNotification (scheduler.ts:1815)
+    -> StorageNotificationRelay.next`.
+  - Interpretation: the parent dirty mark itself is pre-existing at the
+    3a-kind commit; the current CT-1316 regression is in run-gating/demand or
+    later execution behavior, not in whether the trigger-index path marks the
+    parent.
+- E2 trigger-trace comparison:
+  - Current tree command:
+    `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/patterns-derive-return-pattern.test.ts >
+    /tmp/scheduler-v2-ct1316-current-trigger-trace.log 2>&1`.
+  - Current result: failed CT-1316 before the later `double` trace dump.
+    Assertion at
+    `packages/runner/test/patterns-derive-return-pattern.test.ts:352`:
+    expected parent derive run count `1`, actual `2`.
+  - Current trace after `triple` pull:
+    - parent trigger record: `notificationType: "commit"`,
+      `entityId:
+      "of:fid1:jxiSS-u_RdKDipuF4GkyeEJrMaCRL_mI0yKuSWvL6Eg"`, `path:
+      ["value"]`, `before: { kind: "object", size: 1 }`, `after: {
+      kind: "object", size: 1 }`, `matchedActionCount: 1`, triggered
+      parent
+      `action:/Users/berni/.codex/worktrees/909d/labs/packages/runner/src/builder/pattern.ts:151:21:fid1:Yh9sDtZ`,
+      decision `mark-dirty`, `dirtyBefore: false`, `dirtyAfter: true`,
+      `pendingBefore: false`, `pendingAfter: false`, `scheduledEffects: []`.
+    - child-own-commit record: `notificationType: "commit"`, `entityId:
+      "of:fid1:09EamCJB0D_by6ZWjSiEnVtq2ymX-SyO6_Ocu2pypFo"`, `path:
+      ["value"]`, `before: { kind: "object", size: 2 }`, `after: {
+      kind: "object", size: 2 }`, `matchedActionCount: 3`, triggered child
+      `action:/Users/berni/.codex/worktrees/909d/labs/packages/runner/src/builder/pattern.ts:151:21:fid1:kMeW-xi`,
+      decision `skip-own-commit-source`, `dirtyBefore: true`, `dirtyAfter:
+      true`, `pendingBefore: false`, `pendingAfter: false`,
+      `scheduledEffects: []`.
+  - Baseline command:
+    `cd /tmp/ct1316-base/packages/runner && ENV=test deno test --allow-ffi
+    --allow-env --allow-read --allow-write=/tmp,/var/folders
+    --allow-run=git test/patterns-derive-return-pattern.test.ts >
+    /tmp/scheduler-v2-ct1316-base-trigger-trace.log 2>&1`.
+  - Baseline result: passed, `ok | 1 passed (5 steps) | 0 failed`.
+  - Baseline trace after `triple` pull has the same two records and decisions:
+    parent `mark-dirty` for
+    `entityId:
+    "of:fid1:jxiSS-u_RdKDipuF4GkyeEJrMaCRL_mI0yKuSWvL6Eg"`, `path:
+    ["value"]`, before/after `{ kind: "object", size: 1 }`; child
+    `skip-own-commit-source` for
+    `entityId: "of:fid1:09EamCJB0D_by6ZWjSiEnVtq2ymX-SyO6_Ocu2pypFo"`,
+    `path: ["value"]`, before/after `{ kind: "object", size: 2 }`.
+  - Baseline trace after `double` pull repeats those same two trigger records
+    again, and still passes.
+  - Interpretation: E2 does not show a divergent trigger-index change
+    production or decision. The same concrete `commit` changes mark the parent
+    in baseline and current; current diverges after dirtying.
+- E3 hunk classification:
+  - `packages/runner/src/scheduler.ts`: all hunks are
+    `[type/bundle-threading only]`. Removed scheduler-level
+    `actionParent`/`actionChildren` fields, removed old state-bundle entries,
+    and threaded `nodes: this.nodes` where consumers need parent/child lookup.
+  - `packages/runner/src/scheduler/action-run.ts`: all hunks are
+    `[type/bundle-threading only]`. `appendActionRunTrace` now reads
+    `state.nodes.parentOf(args.action)?.action`; state interfaces and callsites
+    no longer thread `actionParent`.
+  - `packages/runner/src/scheduler/execution.ts`: all hunks are
+    `[type/bundle-threading only]`. Added the `NodeRegistry` type import and
+    changed `SchedulerSettleLoopState` from `actionParent` to `nodes`.
+  - `packages/runner/src/scheduler/graph-snapshot.ts`: all hunks are
+    `[type/bundle-threading only]`. Snapshot state now takes `nodes`, and parent
+    and children are read via `nodes.parentOf(...)` / `nodes.childrenOf(...)`.
+  - `packages/runner/src/scheduler/pull-execution.ts`: the only hunk is
+    `[type/bundle-threading only]`. `orderPullWorkSet` receives `state.nodes`
+    instead of `state.actionParent`.
+  - `packages/runner/src/scheduler/pull-subscriptions.ts`: the only direct hunk
+    is `[type/bundle-threading only]`. Demand-first-run logic reads parent via
+    `state.subscriptionState.nodes.parentOf(action)?.action` after
+    `registerParentChildAction`.
+  - Special order check:
+    - Subscribe path: `updateSchedulerActionType(...)` is called at
+      `pull-subscriptions.ts:77-85`; `registerParentChildAction(...)` follows
+      at `pull-subscriptions.ts:88`. The child node record exists before
+      `linkParent`.
+    - Resubscribe path: `updateSchedulerActionType(...)` is called at
+      `pull-subscriptions.ts:215-219`; `registerParentChildAction(...,
+      { allowExisting: false })` follows at `pull-subscriptions.ts:228-230`.
+      The child node record exists before `linkParent`.
+    - Sink resubscribe-first path: `cell.ts` calls
+      `runtime.scheduler.resubscribe(sink.action, log, resubscribeOptions)`,
+      entering the same resubscribe path above. No parent-link-before-record
+      path was found.
+  - `packages/runner/src/scheduler/node-record.ts`: `[control-flow change]`.
+    Quoted hunks:
+
+    ```diff
+    -      if (parent !== undefined) existing.parent = parent;
+           this.activate(existing);
+           return existing;
+    ```
+
+    ```diff
+    -      ...(parent !== undefined ? { parent } : {}),
+           status: "never-ran",
+           invalidCauses: [],
+           liveRefs: 0,
+    @@
+         this.records.set(action, record);
+         this.activate(record);
+    +    if (parent !== undefined) {
+    +      this.captureParentRecord(record, parent);
+    +    }
+         return record;
+    ```
+
+    ```diff
+    +  linkParent(
+    +    childAction: Action,
+    +    parentAction: Action | null | undefined,
+    +    options: { allowExisting?: boolean } = {},
+    +  ): SchedulerNode | undefined {
+    +    const { allowExisting = true } = options;
+    +    if (!parentAction || parentAction === childAction) return undefined;
+    +
+    +    const child = this.records.get(childAction);
+    +    if (!child) return undefined;
+    +    const parent = this.records.get(parentAction);
+    +    if (!parent) return undefined;
+    +    if (!allowExisting && child.parent) return child.parent;
+    +
+    +    if (child.parent && child.parent !== parent) {
+    +      child.parent.children?.delete(child);
+    +    }
+    +    this.captureParentRecord(child, parent);
+    +    return child.parent;
+    +  }
+    +
+    +  parentOf(action: Action): SchedulerNode | undefined {
+    +    return this.records.get(action)?.parent;
+    +  }
+    +
+    +  childrenOf(action: Action): ReadonlySet<SchedulerNode> | undefined {
+    +    return this.records.get(action)?.children;
+    +  }
+    ```
+
+    ```diff
+    +  isAncestor(
+    +    sourceAction: Action,
+    +    candidateAncestor: Action,
+    +  ): boolean {
+    +    let parent = this.records.get(sourceAction)?.parent;
+    +    while (parent) {
+    +      if (parent.action === candidateAncestor) {
+    +        return true;
+    +      }
+    +      parent = parent.parent;
+    +    }
+    +    return false;
+    +  }
+    +
+    +  private captureParentRecord(
+    +    child: SchedulerNode,
+    +    parent: SchedulerNode,
+    +  ): void {
+    +    child.parent = parent;
+    +
+    +    let children = parent.children;
+    +    if (!children) {
+    +      children = new Set();
+    +      parent.children = children;
+    +    }
+    +    children.add(child);
+    +  }
+    ```
+
+- Cleanup after capture:
+  - Reverted all temporary trigger-trace edits in the current tree and scratch
+    worktree.
+  - Reverted the temporary `markDirectDirty` instrumentation in
+    `/tmp/ct1316-base`.
+  - Verification before gates:
+    - current tree:
+      `rg -n
+      "scheduler-v2 trigger-trace|SCHEDULER_V2_TRACE|markDirectDirty\\]|describeAction"
+      packages/runner/test/patterns-derive-return-pattern.test.ts
+      packages/runner/src/scheduler`: no matches.
+    - scratch tree: same grep under `/tmp/ct1316-base`: no matches.
+    - scratch worktree `git status --short`: clean.
+- Gates after STOP recording:
+  - `rg -n "actionParent|actionChildren" packages/runner/src`: no matches.
+  - `rg -n "parentCaptured|\\.parent\\s*="
+    packages/runner/src/scheduler/node-record.ts packages/runner/src/scheduler`:
+    one intentional assignment site,
+    `packages/runner/src/scheduler/node-record.ts:153: child.parent = parent`;
+    no `parentCaptured` matches.
+  - `deno fmt packages/runner/src/scheduler.ts
+    packages/runner/src/scheduler/node-record.ts
+    packages/runner/src/scheduler/subscriptions.ts
+    packages/runner/src/scheduler/demand.ts
+    packages/runner/src/scheduler/pull-subscriptions.ts
+    packages/runner/src/scheduler/action-run.ts
+    packages/runner/src/scheduler/write-propagation.ts
+    packages/runner/src/scheduler/topology.ts
+    packages/runner/src/scheduler/execution.ts
+    packages/runner/src/scheduler/pull-execution.ts
+    packages/runner/src/scheduler/graph-snapshot.ts
+    packages/runner/test/scheduler-v2-cutover.test.ts`: passed
+    (`Checked 12 files`).
+  - `deno lint` on the same 12 files: passed (`Checked 12 files`).
+  - `deno check` on the same 12 files: passed.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-v2-cutover.test.ts`: passed,
+    `1 passed (8 steps) | 0 failed`.
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/patterns-derive-return-pattern.test.ts`: failed CT-1316 as expected
+    for this no-fix stop. Failing step:
+    `should not spuriously rerun parent derive when returned child pattern
+    changes`; assertion at
+    `packages/runner/test/patterns-derive-return-pattern.test.ts:323`;
+    expected parent derive run count `1`, actual `2`.
+
+## REVIEWER VERDICT — 07/3a CT-1316 root-cause localization + bisect protocol
+
+I did hands-on comparative debugging in two scratch worktrees
+(/tmp/ct1316-base = 3a-kind commit, /tmp/ct1316-cur = + your current
+diff; both still exist, instrumented — reuse them). Established facts:
+
+1. The regression is ONE EXTRA RUN OF THE CHILD (not the parent): after
+   parent-run-2's node replacement, base fires 3 child unsubscribes
+   with no further child run; cur fires 2, then the OLD child RUNS
+   (with `record.parent = none` at run time), then the 3rd unsubscribe
+   lands. The extra child run's commit re-dirties the envelope the
+   parent reads → the spurious parent rerun the test catches.
+2. NOT divergent: trigger marking (E1/E2), seed-gate admissions,
+   unsubscribe call-site stacks (identical cancel chains via
+   runner.ts:1234), registry activation/removal code (records persist
+   across remove; only active-set membership drops).
+3. The zombie run's `parent: none` plus the absence of any [SUB] log
+   for it means that child action object's registration never captured
+   a parent — consistent with a different action object (same
+   cause-id) entering via a resubscribe-first or commit-callback-timed
+   path, or with an ordering shift that lets its settle turn land
+   between the second and third cancel.
+
+Stop theorizing; bisect mechanically. The creation-context diff is
+semantically tiny: the node-record parent machinery plus ~10 one-line
+consumer swaps (WeakMap → registry) in demand.ts, topology.ts (2 sites),
+write-propagation.ts, pull-subscriptions.ts, action-run.ts,
+graph-snapshot.ts, subscriptions.ts (registerParentChildAction), and
+execution/pull-execution threading. Protocol:
+
+1. In /tmp/ct1316-cur (or a fresh copy), REVERT consumer swaps one at a
+   time back to a parallel v1 WeakMap: add a temporary
+   `legacyParent = new WeakMap<Action, Action>()` maintained alongside
+   the registry inside `registerParentChildAction` (write BOTH), then
+   point ONE consumer at a time back at `legacyParent` and rerun
+   CT-1316. Order to try: (a) topology.ts both sites, (b)
+   pull-subscriptions first-run-demand parent read, (c) demand.ts
+   hasDemandedParentContext, (d) write-propagation isAncestor, (e)
+   action-run trace read. The first consumer whose reversion flips
+   CT-1316 green is the culprit. (~6 focused runs, no theory required.)
+2. With the culprit known, log that consumer's v1-vs-registry value at
+   the divergence point (the zombie run) — the concrete differing value
+   tells us which registry semantic to fix (likely candidates: parentOf
+   for a NEW object that v1's per-object WeakMap also lacked — meaning
+   the real difference is elsewhere — or an ordering-relevant edge for
+   an action whose record was recreated).
+3. STOP with: culprit consumer, the differing value, and the v1 value's
+   provenance. I will issue the fix verdict; do not fix beyond the
+   instrumentation.
+4. Record in PROGRESS which scratch paths/instrumentation you reused or
+   removed.
+
+Constraint unchanged: CT-1316 passes as written; the 9-fixture cutover
+pack stays green; the literal-v1 linkParent stays.
+
+## IMPLEMENTER STOP — 07/3a CT-1316 topology parent lookup culprit
+
+- [ ] pending — ran the reviewer-requested consumer bisect in scratch and
+  stopped without applying a fix.
+- Scratch paths:
+  - Reused `/tmp/ct1316-cur`, which already contained the current
+    creation-context diff plus reviewer instrumentation (`[RUN]`, `[SUB]`,
+    `[GATE]`, workset logging).
+  - Did not edit `/tmp/ct1316-base` during this pass; it remains reviewer
+    instrumented.
+  - Added scratch-only instrumentation in `/tmp/ct1316-cur`:
+    a temporary `legacyParent: WeakMap<Action, Action>` maintained alongside
+    `NodeRegistry` in `registerParentChildAction`, a
+    `SCHEDULER_V2_LEGACY_PARENT_CONSUMER` selector, and `T_PARENT_DIFF`
+    logging for topology parent lookup mismatches.
+  - No bisect instrumentation was added to the real worktree. Current-tree
+    grep:
+    `rg -n
+    "SCHEDULER_V2_LEGACY_PARENT_CONSUMER|T_PARENT_DIFF|legacyParent|\\[PARENT-DIFF\\]"
+    packages/runner/src packages/runner/test
+    docs/specs/scheduler-v2/implementation/PROGRESS.md` returned only the
+    reviewer verdict / this progress text, no scheduler source matches.
+- Scratch harness check:
+  - `cd /tmp/ct1316-cur && deno check packages/runner/src/scheduler.ts
+    packages/runner/src/scheduler/subscriptions.ts
+    packages/runner/src/scheduler/execution.ts
+    packages/runner/src/scheduler/pull-execution.ts
+    packages/runner/src/scheduler/demand.ts
+    packages/runner/src/scheduler/write-propagation.ts
+    packages/runner/src/scheduler/topology.ts
+    packages/runner/src/scheduler/pull-subscriptions.ts
+    packages/runner/src/scheduler/action-run.ts`: passed.
+- Consumer bisect commands:
+  - Control:
+    `cd /tmp/ct1316-cur/packages/runner && ENV=test deno test --allow-ffi
+    --allow-env --allow-read --allow-write=/tmp,/var/folders
+    --allow-run=git test/patterns-derive-return-pattern.test.ts >
+    /tmp/scheduler-v2-ct1316-bisect-none.log 2>&1`: failed CT-1316.
+  - `SCHEDULER_V2_LEGACY_PARENT_CONSUMER=topology`: passed,
+    `ok | 1 passed (5 steps) | 0 failed`.
+  - `SCHEDULER_V2_LEGACY_PARENT_CONSUMER=pull-subscriptions`: failed CT-1316.
+  - `SCHEDULER_V2_LEGACY_PARENT_CONSUMER=demand`: failed CT-1316.
+  - `SCHEDULER_V2_LEGACY_PARENT_CONSUMER=write-propagation`: failed CT-1316.
+  - `SCHEDULER_V2_LEGACY_PARENT_CONSUMER=action-run`: failed CT-1316.
+- Culprit consumer:
+  - `topology.ts` parent lookup is the first and only tested consumer whose
+    one-at-a-time reversion to the parallel v1 WeakMap flips CT-1316 green.
+- Differing value at the divergence point:
+  - Failing control trace command:
+    `cd /tmp/ct1316-cur/packages/runner && ENV=test T_PARENT_DIFF=1 T_RUN=1
+    deno test --allow-ffi --allow-env --allow-read
+    --allow-write=/tmp,/var/folders --allow-run=git
+    test/patterns-derive-return-pattern.test.ts >
+    /tmp/scheduler-v2-ct1316-topology-parent-diff.log 2>&1`.
+  - At `settleIter: 2`, topology's work set contained:
+    `pull:of:fid1:jnHVX0kdQR3xusRXnBe9QNQasI3aLfr0ZG9XnRaczbw`,
+    `action:/private/tmp/ct1316-cur/packages/runner/src/builder/pattern.ts:151:21:fid1:DbhVmJp`,
+    `sink:did:key:z6Mkkjpx4DvoTk8CG4Sj3NRyvdhKgL66Un5BoA762DStXSG8/of:fid1:5G7oFLrAa2KQk80hXe8xLfH5HQJ8iWwhoNXPrHt5Cgg/pattern`,
+    `pull:of:fid1:Egtel0lLfbT_KUBoQZc9GeZZwLuObL9NHXhPi8x9qjE`.
+  - For the old child action
+    `action:/private/tmp/ct1316-cur/packages/runner/src/builder/pattern.ts:151:21:fid1:DbhVmJp`,
+    registry lookup returned `none`.
+  - The parallel v1 WeakMap lookup returned parent
+    `sink:did:key:z6Mkkjpx4DvoTk8CG4Sj3NRyvdhKgL66Un5BoA762DStXSG8/of:fid1:5G7oFLrAa2KQk80hXe8xLfH5HQJ8iWwhoNXPrHt5Cgg/pattern`.
+  - In the failing control run, `[RUN]` immediately showed that same child run
+    with `parent: none`, matching the reviewer-described zombie run.
+- v1 value provenance:
+  - The WeakMap value was captured by the scratch `registerParentChildAction`
+    mirror with `allowExisting: true`.
+  - Provenance stack:
+    `registerParentChildAction
+    -> subscribePullSchedulerAction (scheduler/pull-subscriptions.ts:88)
+    -> Scheduler.subscribe (scheduler.ts:541)
+    -> Runner.instantiateJavaScriptActionNode (runner.ts:3411)
+    -> Runner.instantiateJavaScriptNode (runner.ts:3459)
+    -> Runner.instantiateNode (runner.ts:1910)
+    -> instantiatePattern (runner.ts:1168)`.
+  - Interpretation: v1's per-action WeakMap preserves a parent edge for this
+    old child action object that the registry no longer exposes to topology.
+    Routing only topology through that v1 parent value orders the second sink
+    before the old child and CT-1316 passes.
+- Confirmation with culprit selector:
+  - Command:
+    `cd /tmp/ct1316-cur/packages/runner && ENV=test
+    SCHEDULER_V2_LEGACY_PARENT_CONSUMER=topology T_PARENT_DIFF=1 T_RUN=1
+    deno test --allow-ffi --allow-env --allow-read
+    --allow-write=/tmp,/var/folders --allow-run=git
+    test/patterns-derive-return-pattern.test.ts >
+    /tmp/scheduler-v2-ct1316-topology-legacy-parent-diff.log 2>&1`.
+  - Result: CT-1316 passed, `ok | 1 passed (5 steps) | 0 failed`.
+  - The same `[PARENT-DIFF]` was logged, but the run order used the WeakMap
+    parent: the second sink ran before the old child, and the failing step
+    passed.
+- STOP reason:
+  - Culprit consumer and value mismatch are identified as requested.
+  - No fix was attempted beyond scratch-only instrumentation.
+
+## REVIEWER VERDICT — 07/3a topology culprit confirmed; one probe, then the fix
+
+Bisect accepted: topology is the only consumer whose reversion flips
+CT-1316, and the differing value is exact (registry `none` vs WeakMap
+`sink` for the old child). The WeakMap capture's provenance proves
+`registerParentChildAction(oldChild)` ran with the SINK executing and
+`allowExisting: true` — so the registry path REFUSED a link v1 took.
+`linkParent` has exactly three refusal points; identify which:
+
+1. Probe (scratch): instrument `linkParent` to log, for child ids
+   matching the test's pattern actions, which branch returns:
+   [no-parent-arg] / [child-record-missing] / [parent-record-missing] /
+   [allowExisting-preserve] / [assigned]. Also tag object identity: a
+   module-scope `WeakMap<object, number>` serial for child and parent
+   objects, logged on every linkParent and registry.register call, so
+   object churn (same id, new object) is visible. One control run of
+   CT-1316; paste the branch + serials for the failing window.
+
+2. Fix, pre-authorized by branch:
+   - **[parent-record-missing]** (most likely — the sink's registration
+     may interleave with churn): change the parent edge to be keyed and
+     valued by ACTION OBJECTS, not records — `SchedulerNode.parent`
+     becomes `parentAction: Action | undefined` (resolve the record
+     lazily in `parentOf`/`isAncestor` via `records.get`, which is
+     correct since records persist), and `children` becomes
+     `Set<Action>` resolved the same way for the snapshot. This is the
+     EXACT WeakMap parity: v1 never required the parent to be
+     registered at link time. Update the 8th fixture's case list to
+     include "parent not yet registered at link time → link still
+     captured".
+   - **[child-record-missing]**: fix the call-order on whichever path
+     skipped registration before linking (name it), keeping
+     register-before-link everywhere.
+   - **[allowExisting-preserve]**: impossible for an
+     `allowExisting: true` call — if the log shows this, the call site
+     passed the wrong flag; fix the call site.
+   - **[no-parent-arg]**: `getExecutingAction()` returned null in the
+     registry call but not the mirror — cannot happen in the same
+     scope; if seen, STOP with the two stacks.
+
+3. Then: apply the fix in the real worktree, drop ALL scratch
+   instrumentation, run the 9-fixture pack + CT-1316 + the focused
+   parent/graph gate + full suite, and commit 3a-creation-context as
+   planned (fixture update included). Record the branch result and fix
+   shape here regardless.
+
+## 07/3a-creation-context
+
+- [x] pending — migrated parent/child creation context to registry-owned
+  action-object edges.
+- Branch result:
+  - Scratch probe log:
+    `/tmp/scheduler-v2-ct1316-link-branch-probe.log`.
+  - Failing window:
+    - child `fid1:DbhVmJp` registered as object serial 23, linked to first
+      sink parent serial 22 with branch `assigned`.
+    - the next child object for the same id registered as serial 24, linked
+      to second sink parent serial 25 with branch `parent-record-missing`;
+      topology then saw registry parent `none` while the v1 mirror had that
+      second sink parent.
+    - after the parent record existed, a later child object serial 26 linked
+      to parent serial 25 with branch `assigned`.
+  - Fix branch taken: `[parent-record-missing]`.
+- Fix shape:
+  - `SchedulerNode.parent` / `children` were replaced with
+    `parentAction?: Action` and `children?: Set<Action>`.
+  - `NodeRegistry` now captures parent and child edges by `Action` object even
+    if the parent record is not registered yet, then resolves parent and child
+    records lazily in `parentOf`, `childrenOf`, and `isAncestor`.
+  - `registerParentChildAction` remains the single edge writer and calls
+    `NodeRegistry.linkParent`.
+  - The cutover parent-link fixture now includes a direct registry case for
+    "parent not yet registered at link time -> link still captured".
+- Scratch cleanup:
+  - Removed scratch worktrees `/tmp/ct1316-cur` and `/tmp/ct1316-base` with
+    `git worktree remove --force`; probe logs remain under `/tmp`.
+  - Real-tree scratch-instrumentation grep:
+    `rg -n
+    "SCHEDULER_V2_LEGACY_PARENT_CONSUMER|T_PARENT_DIFF|\\bT_LINK\\b|\\[LINK-PROBE\\]|\\[PARENT-DIFF\\]|legacyParent"
+    packages/runner/src/scheduler
+    packages/runner/test/scheduler-v2-cutover.test.ts`: no matches.
+- Recordings:
+  - Contract grep:
+    `rg -n "actionParent|actionChildren"
+    packages/runner/src packages/runner/test/scheduler-v2-cutover.test.ts`:
+    no matches.
+  - Parent assignment grep:
+    `rg -n "\\.parent\\s*=|parentCaptured|\\.parentAction\\s*="
+    packages/runner/src/scheduler
+    packages/runner/test/scheduler-v2-cutover.test.ts`:
+    `packages/runner/src/scheduler/node-record.ts:167:
+    child.parentAction = parentAction`.
+  - `deno fmt packages/runner/src/scheduler.ts
+    packages/runner/src/scheduler/node-record.ts
+    packages/runner/src/scheduler/subscriptions.ts
+    packages/runner/src/scheduler/demand.ts
+    packages/runner/src/scheduler/pull-subscriptions.ts
+    packages/runner/src/scheduler/action-run.ts
+    packages/runner/src/scheduler/write-propagation.ts
+    packages/runner/src/scheduler/topology.ts
+    packages/runner/src/scheduler/execution.ts
+    packages/runner/src/scheduler/pull-execution.ts
+    packages/runner/src/scheduler/graph-snapshot.ts
+    packages/runner/test/scheduler-v2-cutover.test.ts`: passed
+    (`Checked 12 files`).
+  - `deno lint` on the same 12 files: passed (`Checked 12 files`).
+  - `deno check` on the same 12 files: passed.
+  - Cutover fixture pack:
+    `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-v2-cutover.test.ts`: passed, `1 passed (8 steps)`,
+    `0 failed`.
+  - CT-1316:
+    `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/patterns-derive-return-pattern.test.ts`: passed,
+    `1 passed (5 steps)`, `0 failed`.
+  - `cd packages/runner && deno task test`: passed,
+    `594 passed (3107 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m6s`.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -2795,7 +2795,7 @@ Verification:
 
 ## 07/3pre
 
-- [x] pending — added the scheduler-v2 cutover fixture pack.
+- [x] 4a607da47 — added the scheduler-v2 cutover fixture pack.
 - Deviations:
   - The cycle-backoff fixture is green on the current v1 cycle-break path with
     a loose bounded-termination assertion (`runCountA + runCountB < 500`) and
@@ -2816,3 +2816,80 @@ Verification:
     `0 failed`.
   - `cd packages/runner && deno task test`: passed,
     `594 passed (3106 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m6s`.
+
+## 07/phase3-baseline
+
+- [x] pending — captured the immediate pre-3a reload and benchmark baselines.
+- Deviations:
+  - `reload-rehydration.test.ts` still emits the fixture's expected action
+    error (`Cannot read properties of undefined (reading 'length')`) while the
+    test passes and asserts the scheduler rehydration counts.
+- Recordings:
+  - `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/reload-rehydration.test.ts`: passed, `1 passed`, `0 failed`;
+    test assertions cover `rehydrate/ok > 0` and
+    `rehydrate/miss/no-snapshot = 0`.
+  - Phase 3 benchmark baseline command passed:
+    `cd packages/runner && deno bench --allow-read --allow-write --allow-net
+    --allow-ffi --allow-env --no-check test/scheduler.bench.ts
+    test/scheduler-demand-roots.bench.ts
+    test/scheduler-stale-propagation.bench.ts
+    test/scheduler-event-preflight.bench.ts
+    test/scheduler-materializer-fanout.bench.ts
+    test/scheduler-persistent-state.bench.ts`.
+  - `test/scheduler.bench.ts`:
+    - `Scheduler - 100 computations, shared entity reads`: 19.0 ms.
+    - `Scheduler - wide graph (1 source, 100 readers)`: 17.6 ms.
+    - `Scheduler - 100 entities, sparse deps`: 17.8 ms.
+    - `Scheduler - deep chain (50 levels)`: 11.0 ms.
+    - `Scheduler - diamond pattern (10 diamonds)`: 9.9 ms.
+    - `Scheduler - repeated dirty marking`: 7.6 ms.
+    - `Scheduler - subscribe/unsubscribe cycle (100x)`: 5.7 ms.
+    - `Scheduler - pull with resubscribe (50 pulls)`: 287.3 ms.
+    - `Overhead - setup/teardown only`: 1.3 ms.
+    - `Overhead - create 100 cells (getCell + set)`: 15.8 ms.
+    - `Overhead - 100x getCell only (no set)`: 1.6 ms.
+    - `Overhead - 100x set on existing cells`: 15.7 ms.
+    - `Overhead - runtime.idle() empty`: 1.2 ms.
+    - `Overhead - commit after 100 sets`: 15.8 ms.
+    - `Overhead - empty commit`: 1.2 ms.
+    - `Overhead - 100 raw tx.write + commit`: 7.2 ms.
+    - `Utility - sortAndCompactPaths (100 paths)`: 21.4 us.
+    - `Utility - sortAndCompactPaths (1000 paths)`: 278.8 us.
+    - `Utility - addressesToPathByEntity (100 paths)`: 15.0 us.
+    - `Utility - addressesToPathByEntity (1000 paths)`: 148.2 us.
+    - `Scheduler - bare subscribe (100x)`: 1.7 ms.
+    - `Scheduler - subscribe 100 actions reading same entity`: 1.6 ms.
+    - `Scheduler - resubscribe cycle (100x)`: 1.3 ms.
+  - `test/scheduler-demand-roots.bench.ts`:
+    - `Scheduler demand roots - effect demand root`: 142.0 ms.
+    - `Scheduler demand roots - event demand root`: 138.0 ms.
+    - `Scheduler demand roots - mixed effect and event roots`: 167.5 ms.
+    - `Scheduler demand roots - parent clears generated children`: 79.4 ms.
+  - `test/scheduler-stale-propagation.bench.ts`:
+    - `Scheduler stale propagation - chain`: 95.6 ms.
+    - `Scheduler stale propagation - diamond`: 95.1 ms.
+    - `Scheduler stale propagation - wide fanout`: 239.6 ms.
+    - `Scheduler stale propagation - dynamic deps`: 78.5 ms.
+    - `Scheduler stale propagation - unchanged recompute`: 77.4 ms.
+  - `test/scheduler-event-preflight.bench.ts`:
+    - `Scheduler event preflight - clean event over broad graph`: 274.6 ms.
+    - `Scheduler event preflight - event waits on transitive stale writer`:
+      27.1 ms.
+    - `Scheduler event preflight - note-shaped 30x7 clean events`: 978.0 ms.
+    - `Scheduler event preflight - deep read-populated handler`: 528.7 ms.
+  - `test/scheduler-materializer-fanout.bench.ts`:
+    - `Scheduler materializer fanout - broad side write with 100 readers`:
+      29.4 ms.
+    - `Scheduler materializer fanout - broad side write with 1000 readers`:
+      94.4 ms.
+    - `Scheduler materializer fanout - static declared write control`:
+      16.4 ms.
+  - `test/scheduler-persistent-state.bench.ts`:
+    - `Scheduler persistent state - clean rehydrate 100 actions`: 2.5 ms.
+    - `Scheduler persistent state - targeted dirty rehydrate 100 actions`:
+      4.0 ms.
+    - `Scheduler persistent state - clean rehydrate 1000 actions`: 8.2 ms.
+    - `Scheduler persistent state - targeted dirty rehydrate 1000 actions`:
+      7.6 ms.

--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -3826,3 +3826,23 @@ CT-1316, and the differing value is exact (registry `none` vs WeakMap
     `1 passed (5 steps)`, `0 failed`.
   - `cd packages/runner && deno task test`: passed,
     `594 passed (3107 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m6s`.
+
+## REVIEWER RESOLUTION — PR #4101 review findings
+
+- [x] pending — computation→effect promotion + raw parent-action access.
+- Findings addressed (Codex/cubic review on PR #4101), red-first:
+  1. Strict kind re-registration threw when an action first subscribed as a
+     computation was re-subscribed with `isEffect: true`. v1's latch allowed
+     that promotion ("once an effect, stays an effect");
+     `NodeRegistry.register` now promotes computation→effect in place and
+     still throws on demotion (cutover fixture "promotes a computation to an
+     effect on re-registration").
+  2. `parentOf(x)?.action` collapsed to undefined while the parent's record
+     was unregistered (registration churn), but demand/trace checks key off
+     action objects (v1 WeakMap parity). Added `parentActionOf()` raw
+     accessor and switched the consumer call sites (demand, action-run
+     trace, graph-snapshot, topology, pull-subscriptions); `parentOf()`
+     record resolution is unchanged for callers that need the record
+     (cutover fixture "keeps captured parent actions reachable before the
+     parent registers").
+- Deviations: none.

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -387,8 +387,6 @@ export class Scheduler {
   // When a child action is created during parent execution, parent must run first
   private executingAction: Action | null = null;
   currentActionId?: string;
-  private actionParent = new WeakMap<Action, Action>();
-  private actionChildren = new WeakMap<Action, Set<Action>>();
   private pullDemandState!: PullDemandState;
   private dependencyGraphState!: DependencyGraphState;
   private dependencyUpdateState!: DependencyUpdateState;
@@ -1681,7 +1679,6 @@ export class Scheduler {
       effects: this.nodes.effects,
       dependents: this.dependents,
       dependencies: this.dependencies,
-      actionParent: this.actionParent,
       nodes: this.nodes,
       pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
       pullDemandedContinuationComputations: this
@@ -1879,7 +1876,7 @@ export class Scheduler {
       effects: this.nodes.effects,
       computations: this.nodes.computations,
       conditionallyScheduledEffects: this.conditionallyScheduledEffects,
-      actionParent: this.actionParent,
+      nodes: this.nodes,
       pending: this.pending,
       markPullDemandContinuation: (action) =>
         this.pullDemandedContinuationComputations.add(action),
@@ -1903,8 +1900,6 @@ export class Scheduler {
       queueExecution: () => this.queueExecution(),
       getActionId: (target) => this.getActionId(target),
       getExecutingAction: () => this.executingAction,
-      actionParent: this.actionParent,
-      actionChildren: this.actionChildren,
     };
   }
 
@@ -1930,7 +1925,6 @@ export class Scheduler {
       pendingDependencyCollection: this.pendingDependencyCollection,
       activePullDemandActions: this.activePullDemandActions,
       pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
-      actionParent: this.actionParent,
       pending: this.pending,
       scheduledFirstTime: this.scheduledFirstTime,
       effects: this.nodes.effects,
@@ -2022,7 +2016,7 @@ export class Scheduler {
       pending: this.pending,
       dirty: this.staleness.dirty,
       dependencies: this.dependencies,
-      actionParent: this.actionParent,
+      nodes: this.nodes,
       dependents: this.dependents,
       conditionallyScheduledEffects: this.conditionallyScheduledEffects,
       filterStats: this.filterStats,
@@ -2239,7 +2233,6 @@ export class Scheduler {
       retries: this.retries,
       pending: this.pending,
       actionRunTrace: this.actionRunTrace,
-      actionParent: this.actionParent,
       nodes: this.nodes,
       diagnosisHistory: this.diagnosisHistory,
       diagnosisNonIdempotent: this.diagnosisNonIdempotent,
@@ -2309,8 +2302,7 @@ export class Scheduler {
       conditionallyScheduledEffects: this.conditionallyScheduledEffects,
       dependencies: this.dependencies,
       dependents: this.dependents,
-      actionParent: this.actionParent,
-      actionChildren: this.actionChildren,
+      nodes: this.nodes,
       actionStats: this.actionStats,
       getDebounce: (action) => this.delays.getDebounce(action),
       getThrottle: (action) => this.delays.getThrottle(action),

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -57,6 +57,7 @@ import {
 import { SchedulerMaterializers } from "./scheduler/materializers.ts";
 import { type DependencyUpdateState } from "./scheduler/dependency-updates.ts";
 import { SchedulerWriteIndex } from "./scheduler/scheduling-writes.ts";
+import { NodeRegistry } from "./scheduler/node-record.ts";
 import {
   SchedulerTriggerIndex,
   SchedulerTriggerSubscriptions,
@@ -285,15 +286,12 @@ export class Scheduler {
   private retries = new WeakMap<Action, number>();
 
   // Effect/computation tracking for pull-based scheduling
-  private effects = new Set<Action>();
-  private computations = new Set<Action>();
+  private nodes = new NodeRegistry();
   private dependents = new WeakMap<Action, Set<Action>>();
   private reverseDependencies = new WeakMap<Action, Set<Action>>();
   private activePullDemandActions = new WeakSet<Action>();
   private pullDemandedFirstRunComputations = new WeakSet<Action>();
   private pullDemandedContinuationComputations = new WeakSet<Action>();
-  // Track which actions are effects persistently (survives unsubscribe/re-subscribe)
-  private isEffectAction = new WeakMap<Action, boolean>();
   // In pull mode, `dirty` means direct dirty. `stale` additionally includes
   // actions with dirty upstream computations.
   private staleness = new SchedulerStaleness({
@@ -365,7 +363,7 @@ export class Scheduler {
   private delayControlState!: SchedulerDelayControlState;
 
   private writeIndex!: SchedulerWriteIndex;
-  private materializers = new SchedulerMaterializers(this.effects);
+  private materializers = new SchedulerMaterializers(this.nodes.effects);
   private dirtyDependencyCollectionState!: DirtyDependencyCollectionState;
   // Track actions scheduled for first time (bypass filter)
   private scheduledFirstTime = new Set<Action>();
@@ -876,13 +874,15 @@ export class Scheduler {
     token: symbol,
   ): boolean {
     return this.initialRehydrationTokens.get(action) === token &&
-      (this.effects.has(action) || this.computations.has(action)) &&
+      (this.nodes.effects.has(action) || this.nodes.computations.has(action)) &&
       !this.pending.has(action) &&
       !this.staleness.dirty.has(action);
   }
 
   private scheduleInitialActionRun(action: Action): void {
-    if (!this.effects.has(action) && !this.computations.has(action)) {
+    if (
+      !this.nodes.effects.has(action) && !this.nodes.computations.has(action)
+    ) {
       return;
     }
 
@@ -892,7 +892,7 @@ export class Scheduler {
     this.scheduledFirstTime.add(action);
 
     if (
-      !this.isEffectAction.get(action) &&
+      !this.nodes.isKnownEffect(action) &&
       this.writeIndex.getSchedulingWrites(action)?.length
     ) {
       this.scheduleAffectedEffects(action);
@@ -1119,8 +1119,8 @@ export class Scheduler {
    */
   getStats(): { effects: number; computations: number; pending: number } {
     return {
-      effects: this.effects.size,
-      computations: this.computations.size,
+      effects: this.nodes.effects.size,
+      computations: this.nodes.computations.size,
       pending: this.pending.size,
     };
   }
@@ -1129,14 +1129,14 @@ export class Scheduler {
    * Returns whether an action is registered as an effect.
    */
   isEffect(action: Action): boolean {
-    return this.effects.has(action);
+    return this.nodes.effects.has(action);
   }
 
   /**
    * Returns whether an action is registered as a computation.
    */
   isComputation(action: Action): boolean {
-    return this.computations.has(action);
+    return this.nodes.computations.has(action);
   }
 
   /**
@@ -1401,7 +1401,7 @@ export class Scheduler {
     return collectInitialExecuteDependenciesState({
       pendingDependencyCollection: this.pendingDependencyCollection,
       populateDependenciesCallbacks: this.populateDependenciesCallbacks,
-      effects: this.effects,
+      effects: this.nodes.effects,
       getSchedulingWrites: (action) =>
         this.writeIndex.getSchedulingWrites(action),
       collectDependenciesForAction: (action, populateDependencies, options) =>
@@ -1435,7 +1435,7 @@ export class Scheduler {
     collectPostEventDependenciesState({
       pendingDependencyCollection: this.pendingDependencyCollection,
       populateDependenciesCallbacks: this.populateDependenciesCallbacks,
-      effects: this.effects,
+      effects: this.nodes.effects,
       getSchedulingWrites: (action) =>
         this.writeIndex.getSchedulingWrites(action),
       collectDependenciesForAction: (action, populateDependencies, options) =>
@@ -1456,7 +1456,7 @@ export class Scheduler {
     return buildPullInitialSeeds({
       pending: this.pending,
       dirty: this.staleness.dirty,
-      effects: this.effects,
+      effects: this.nodes.effects,
       newActionsWithoutDependencies,
       eventBlockingDeps,
       computationDebounceFlushSeeds: this.delays.computationDebounceFlushSeeds,
@@ -1653,7 +1653,7 @@ export class Scheduler {
       diagnosisNonIdempotent: this.diagnosisNonIdempotent,
       causalEdges: this.causalEdges,
       idempotencyViolations: this.idempotencyViolations,
-      computations: this.computations,
+      computations: this.nodes.computations,
       setIdempotencyCheckMode: (enabled) => {
         this.idempotencyCheckMode = enabled;
       },
@@ -1677,12 +1677,12 @@ export class Scheduler {
 
   private createPullDemandState(): PullDemandState {
     return {
-      computations: this.computations,
-      effects: this.effects,
+      computations: this.nodes.computations,
+      effects: this.nodes.effects,
       dependents: this.dependents,
       dependencies: this.dependencies,
       actionParent: this.actionParent,
-      isEffectAction: this.isEffectAction,
+      nodes: this.nodes,
       pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
       pullDemandedContinuationComputations: this
         .pullDemandedContinuationComputations,
@@ -1695,8 +1695,8 @@ export class Scheduler {
   private createDelayControlState(): SchedulerDelayControlState {
     return {
       delays: this.delays,
-      computations: this.computations,
-      effects: this.effects,
+      computations: this.nodes.computations,
+      effects: this.nodes.effects,
       dirty: this.staleness.dirty,
       pending: this.pending,
       queueExecution: () => this.queueExecution(),
@@ -1711,11 +1711,11 @@ export class Scheduler {
       getTrace: () => this.dirtyDependencyTraceContext,
       dirty: this.staleness.dirty,
       pending: this.pending,
-      computations: this.computations,
+      computations: this.nodes.computations,
       reverseDependencies: this.reverseDependencies,
       dependencies: this.dependencies,
       writersByEntity: this.writeIndex.writersByEntity,
-      effects: this.effects,
+      effects: this.nodes.effects,
       materializerIndex: this.materializers,
       isStale: (target) => this.staleness.isStale(target),
       getSchedulingWrites: (target) =>
@@ -1765,7 +1765,7 @@ export class Scheduler {
   private createDirtySchedulingState(): DirtySchedulingState {
     return {
       staleness: this.staleness,
-      computations: this.computations,
+      computations: this.nodes.computations,
       scheduleComputationDebounce: (action) =>
         this.scheduleComputationDebounce(action),
       clearComputationDebounceState: (action) =>
@@ -1788,7 +1788,7 @@ export class Scheduler {
         this.causalEdges.push(edge);
       },
       actionChangeGroups: this.actionChangeGroups,
-      effects: this.effects,
+      effects: this.nodes.effects,
       pending: this.pending,
       dirty: this.staleness.dirty,
       conditionallyScheduledEffects: this.conditionallyScheduledEffects,
@@ -1827,7 +1827,7 @@ export class Scheduler {
 
   private createPendingPullRunnableState(): PendingPullRunnableState {
     return {
-      effects: this.effects,
+      effects: this.nodes.effects,
       isDemandedPullComputation: (action) =>
         this.isDemandedPullComputation(action),
       shouldRunFirstPullComputationInDemandContext: (action) =>
@@ -1837,7 +1837,7 @@ export class Scheduler {
 
   private createDirtyPullRunnableState(): DirtyPullRunnableState {
     return {
-      effects: this.effects,
+      effects: this.nodes.effects,
       isDemandedPullComputation: (action) =>
         this.isDemandedPullComputation(action),
       isThrottled: (action) => this.delays.isThrottled(action),
@@ -1859,7 +1859,7 @@ export class Scheduler {
       dependencies: this.dependencies,
       pending: this.pending,
       dirty: this.staleness.dirty,
-      effects: this.effects,
+      effects: this.nodes.effects,
       materializerIndex: this.materializers,
       dependents: this.dependents,
       pendingPullRunnableState: this.pendingPullRunnableState,
@@ -1876,8 +1876,8 @@ export class Scheduler {
     return {
       triggerIndex: this.triggerIndex,
       changedWritesHistory: this.changedWritesHistory,
-      effects: this.effects,
-      computations: this.computations,
+      effects: this.nodes.effects,
+      computations: this.nodes.computations,
       conditionallyScheduledEffects: this.conditionallyScheduledEffects,
       actionParent: this.actionParent,
       pending: this.pending,
@@ -1898,9 +1898,7 @@ export class Scheduler {
     return {
       actionChangeGroups: this.actionChangeGroups,
       changeGroupToActionId: this.changeGroupToActionId,
-      isEffectAction: this.isEffectAction,
-      effects: this.effects,
-      computations: this.computations,
+      nodes: this.nodes,
       getIdempotencyCheckMode: () => this.idempotencyCheckMode,
       queueExecution: () => this.queueExecution(),
       getActionId: (target) => this.getActionId(target),
@@ -1913,7 +1911,7 @@ export class Scheduler {
   private createPendingDependencyCollectionState(): PendingDependencyCollectionState {
     return {
       pendingDependencyCollection: this.pendingDependencyCollection,
-      effects: this.effects,
+      effects: this.nodes.effects,
       isThrottled: (action) => this.delays.isThrottled(action),
       getSchedulingWrites: (action) =>
         this.writeIndex.getSchedulingWrites(action),
@@ -1935,7 +1933,7 @@ export class Scheduler {
       actionParent: this.actionParent,
       pending: this.pending,
       scheduledFirstTime: this.scheduledFirstTime,
-      effects: this.effects,
+      effects: this.nodes.effects,
       dirty: this.staleness.dirty,
       stale: this.staleness.stale,
       writeIndex: this.writeIndex,
@@ -1979,8 +1977,7 @@ export class Scheduler {
       conditionallyScheduledEffects: this.conditionallyScheduledEffects,
       reverseDependencies: this.reverseDependencies,
       dependents: this.dependents,
-      effects: this.effects,
-      computations: this.computations,
+      nodes: this.nodes,
       pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
       pullDemandedContinuationComputations: this
         .pullDemandedContinuationComputations,
@@ -2000,7 +1997,7 @@ export class Scheduler {
   private createCycleBreakState(): PullCycleBreakState {
     return {
       dirty: this.staleness.dirty,
-      effects: this.effects,
+      effects: this.nodes.effects,
       runsThisExecute: this.runsThisExecute,
       pending: this.pending,
       isThrottled: (action) => this.delays.isThrottled(action),
@@ -2020,8 +2017,8 @@ export class Scheduler {
       getCollectSettleStats: () => this.collectSettleStats,
       pendingDependencyCollection: this.pendingDependencyCollection,
       populateDependenciesCallbacks: this.populateDependenciesCallbacks,
-      effects: this.effects,
-      computations: this.computations,
+      effects: this.nodes.effects,
+      computations: this.nodes.computations,
       pending: this.pending,
       dirty: this.staleness.dirty,
       dependencies: this.dependencies,
@@ -2077,7 +2074,7 @@ export class Scheduler {
     return {
       pending: this.pending,
       dirty: this.staleness.dirty,
-      effects: this.effects,
+      effects: this.nodes.effects,
       eventQueue: this.eventQueue,
       eventQueueWakeState: this.eventQueueWakeState,
       idlePromises: this.idlePromises,
@@ -2243,7 +2240,7 @@ export class Scheduler {
       pending: this.pending,
       actionRunTrace: this.actionRunTrace,
       actionParent: this.actionParent,
-      isEffectAction: this.isEffectAction,
+      nodes: this.nodes,
       diagnosisHistory: this.diagnosisHistory,
       diagnosisNonIdempotent: this.diagnosisNonIdempotent,
       idempotencyViolations: this.idempotencyViolations,
@@ -2282,7 +2279,7 @@ export class Scheduler {
         );
       },
       markReadersDirtyForChangedWrites: (target, changedWrites) => {
-        if (!this.computations.has(target)) return;
+        if (!this.nodes.computations.has(target)) return;
         clearSchedulerDirectDirty(this.dirtySchedulingState, target);
         markReadersDirtyForChangedWrites(
           this.writePropagationState,
@@ -2305,8 +2302,8 @@ export class Scheduler {
   private createGraphSnapshotState(): SchedulerGraphSnapshotState {
     return {
       pullMode: true,
-      effects: this.effects,
-      computations: this.computations,
+      effects: this.nodes.effects,
+      computations: this.nodes.computations,
       pending: this.pending,
       dirty: this.staleness.dirty,
       conditionallyScheduledEffects: this.conditionallyScheduledEffects,

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -169,7 +169,7 @@ export function appendActionRunTrace(state: {
   readonly recordedAt?: number;
   readonly maxHistory?: number;
 }): void {
-  const parentAction = state.nodes.parentOf(args.action)?.action;
+  const parentAction = state.nodes.parentActionOf(args.action);
   const declaredWrites = (state.getSchedulingWrites(args.action) ?? []).map(
     toActionRunTraceAddress,
   );

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -24,6 +24,7 @@ import { toActionRunTraceAddress } from "./diagnostics.ts";
 import { buildSchedulerActionObservation } from "./persistent-observation.ts";
 import { filterIgnoredAddresses, txToReactivityLog } from "./reactivity.ts";
 import { type ActionTimingState, recordActionTime } from "./timing.ts";
+import type { NodeRegistry } from "./node-record.ts";
 import type {
   Action,
   ActionRunTraceEntry,
@@ -156,7 +157,7 @@ export function watchReactiveActionCommit(state: {
 export function appendActionRunTrace(state: {
   readonly actionRunTrace: ActionRunTraceEntry[];
   readonly actionParent: WeakMap<Action, Action>;
-  readonly isEffectAction: WeakMap<Action, boolean>;
+  readonly nodes: NodeRegistry;
   readonly getActionId: (action: Action | EventHandler) => string;
   readonly getSchedulingWrites: (
     action: Action,
@@ -180,7 +181,7 @@ export function appendActionRunTrace(state: {
   state.actionRunTrace.push({
     recordedAt: args.recordedAt ?? performance.now(),
     actionId: args.actionId,
-    actionType: state.isEffectAction.get(args.action)
+    actionType: state.nodes.isKnownEffect(args.action)
       ? "effect"
       : "computation",
     parentActionId: parentAction ? state.getActionId(parentAction) : undefined,
@@ -219,7 +220,7 @@ export interface SchedulerActionRunState {
   readonly pending: Set<Action>;
   readonly actionRunTrace: ActionRunTraceEntry[];
   readonly actionParent: WeakMap<Action, Action>;
-  readonly isEffectAction: WeakMap<Action, boolean>;
+  readonly nodes: NodeRegistry;
   readonly diagnosisHistory: Map<string, DiagnosisRecord[]>;
   readonly diagnosisNonIdempotent: NonIdempotentReport[];
   readonly idempotencyViolations: NonIdempotentReport[];
@@ -512,7 +513,7 @@ function warnOnWriteSurfaceViolations(
   },
   log: ReactivityLog,
 ): void {
-  if (state.isEffectAction.get(args.action)) return;
+  if (state.nodes.isKnownEffect(args.action)) return;
   if ((state.getMaterializerWriteEnvelopes(args.action) ?? []).length > 0) {
     return;
   }
@@ -594,7 +595,7 @@ function attachSchedulerActionObservation(
       schedulerObservationPieceId(args.actionId, telemetry),
     processGeneration: observationIdentity?.processGeneration ?? 0,
     actionId: args.actionId,
-    actionKind: state.isEffectAction.get(args.action)
+    actionKind: state.nodes.isKnownEffect(args.action)
       ? "effect"
       : "computation",
     implementationFingerprint: schedulerImplementationFingerprint(
@@ -720,7 +721,7 @@ function recordOptionalActionRunDiagnostics(
     appendActionRunTrace({
       actionRunTrace: state.actionRunTrace,
       actionParent: state.actionParent,
-      isEffectAction: state.isEffectAction,
+      nodes: state.nodes,
       getActionId: state.getActionId,
       getSchedulingWrites: state.getSchedulingWrites,
     }, {
@@ -749,11 +750,11 @@ function recordOptionalActionRunDiagnostics(
   // Inline idempotency re-run: when the mode is on, every
   // computation gets a second synchronous run against post-commit
   // state. An idempotent computation produces the same writes
-  // both times. Uses isEffectAction (persists past unsubscribe)
+  // both times. Uses the registry's known kind (persists past unsubscribe)
   // since execute() calls unsubscribe() before run().
   if (
     state.getIdempotencyCheckMode() &&
-    !state.isEffectAction.get(args.action)
+    !state.nodes.isKnownEffect(args.action)
   ) {
     logger.timeStart("scheduler", "run", "idempotencyRecheck");
     try {

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -156,7 +156,6 @@ export function watchReactiveActionCommit(state: {
 
 export function appendActionRunTrace(state: {
   readonly actionRunTrace: ActionRunTraceEntry[];
-  readonly actionParent: WeakMap<Action, Action>;
   readonly nodes: NodeRegistry;
   readonly getActionId: (action: Action | EventHandler) => string;
   readonly getSchedulingWrites: (
@@ -170,7 +169,7 @@ export function appendActionRunTrace(state: {
   readonly recordedAt?: number;
   readonly maxHistory?: number;
 }): void {
-  const parentAction = state.actionParent.get(args.action);
+  const parentAction = state.nodes.parentOf(args.action)?.action;
   const declaredWrites = (state.getSchedulingWrites(args.action) ?? []).map(
     toActionRunTraceAddress,
   );
@@ -219,7 +218,6 @@ export interface SchedulerActionRunState {
   readonly retries: WeakMap<Action, number>;
   readonly pending: Set<Action>;
   readonly actionRunTrace: ActionRunTraceEntry[];
-  readonly actionParent: WeakMap<Action, Action>;
   readonly nodes: NodeRegistry;
   readonly diagnosisHistory: Map<string, DiagnosisRecord[]>;
   readonly diagnosisNonIdempotent: NonIdempotentReport[];
@@ -720,7 +718,6 @@ function recordOptionalActionRunDiagnostics(
   if (state.getCollectActionRunTrace()) {
     appendActionRunTrace({
       actionRunTrace: state.actionRunTrace,
-      actionParent: state.actionParent,
       nodes: state.nodes,
       getActionId: state.getActionId,
       getSchedulingWrites: state.getSchedulingWrites,

--- a/packages/runner/src/scheduler/demand.ts
+++ b/packages/runner/src/scheduler/demand.ts
@@ -7,7 +7,6 @@ export interface PullDemandState {
   readonly effects: ReadonlySet<Action>;
   readonly dependents: WeakMap<Action, Set<Action>>;
   readonly dependencies: WeakMap<Action, ReactivityLog>;
-  readonly actionParent: WeakMap<Action, Action>;
   readonly nodes: NodeRegistry;
   readonly pullDemandedFirstRunComputations: WeakSet<Action>;
   readonly pullDemandedContinuationComputations: WeakSet<Action>;
@@ -130,7 +129,7 @@ function hasDemandedParentContext(
   action: Action,
   visited = new Set<Action>(),
 ): boolean {
-  const parent = state.actionParent.get(action);
+  const parent = state.nodes.parentOf(action)?.action;
   if (!parent) return false;
 
   if (isLiveEffect(state, parent)) {

--- a/packages/runner/src/scheduler/demand.ts
+++ b/packages/runner/src/scheduler/demand.ts
@@ -1,4 +1,5 @@
 import type { IMemorySpaceAddress } from "../storage/interface.ts";
+import type { NodeRegistry } from "./node-record.ts";
 import type { Action, ReactivityLog } from "./types.ts";
 
 export interface PullDemandState {
@@ -7,7 +8,7 @@ export interface PullDemandState {
   readonly dependents: WeakMap<Action, Set<Action>>;
   readonly dependencies: WeakMap<Action, ReactivityLog>;
   readonly actionParent: WeakMap<Action, Action>;
-  readonly isEffectAction: WeakMap<Action, boolean>;
+  readonly nodes: NodeRegistry;
   readonly pullDemandedFirstRunComputations: WeakSet<Action>;
   readonly pullDemandedContinuationComputations: WeakSet<Action>;
   readonly hasActionRun: (action: Action) => boolean;
@@ -58,7 +59,7 @@ export function isDemandedPullComputation(
 export function isLiveEffect(
   state: Pick<
     PullDemandState,
-    "effects" | "isEffectAction" | "dependencies"
+    "effects" | "nodes" | "dependencies"
   >,
   action: Action,
 ): boolean {
@@ -67,7 +68,7 @@ export function isLiveEffect(
   // During resubscribe, dependencies can be registered before all effect
   // bookkeeping is restored. Treat only dependency-bearing historical effects
   // as live so unsubscribed effects do not keep old pull graphs demanded.
-  return (state.isEffectAction.get(action) ?? false) &&
+  return state.nodes.isKnownEffect(action) &&
     state.dependencies.has(action);
 }
 

--- a/packages/runner/src/scheduler/demand.ts
+++ b/packages/runner/src/scheduler/demand.ts
@@ -129,7 +129,7 @@ function hasDemandedParentContext(
   action: Action,
   visited = new Set<Action>(),
 ): boolean {
-  const parent = state.nodes.parentOf(action)?.action;
+  const parent = state.nodes.parentActionOf(action);
   if (!parent) return false;
 
   if (isLiveEffect(state, parent)) {

--- a/packages/runner/src/scheduler/execution.ts
+++ b/packages/runner/src/scheduler/execution.ts
@@ -8,6 +8,7 @@ import {
   MAX_ITERATIONS_PER_RUN,
 } from "./constants.ts";
 import type { MaterializerIndexState } from "./materializers.ts";
+import type { NodeRegistry } from "./node-record.ts";
 import type {
   Action,
   PopulateDependenciesEntry,
@@ -310,7 +311,7 @@ export interface SchedulerSettleLoopState {
   readonly pending: Set<Action>;
   readonly dirty: ReadonlySet<Action>;
   readonly dependencies: WeakMap<Action, ReactivityLog>;
-  readonly actionParent: WeakMap<Action, Action>;
+  readonly nodes: NodeRegistry;
   readonly dependents: WeakMap<Action, Set<Action>>;
   readonly conditionallyScheduledEffects: Map<Action, number>;
   readonly filterStats: { filtered: number; executed: number };

--- a/packages/runner/src/scheduler/graph-snapshot.ts
+++ b/packages/runner/src/scheduler/graph-snapshot.ts
@@ -8,6 +8,7 @@ import type {
   SchedulerGraphSnapshot,
 } from "../telemetry.ts";
 import { entityKey } from "./keys.ts";
+import type { NodeRegistry } from "./node-record.ts";
 import type { Action, ReactivityLog } from "./types.ts";
 
 export interface SchedulerGraphSnapshotState {
@@ -19,8 +20,7 @@ export interface SchedulerGraphSnapshotState {
   readonly conditionallyScheduledEffects: ReadonlyMap<Action, number>;
   readonly dependencies: WeakMap<Action, ReactivityLog>;
   readonly dependents: WeakMap<Action, Set<Action>>;
-  readonly actionParent: WeakMap<Action, Action>;
-  readonly actionChildren: WeakMap<Action, Set<Action>>;
+  readonly nodes: NodeRegistry;
   readonly actionStats: ReadonlyMap<string, ActionStats>;
   readonly getDebounce: (action: Action) => number | undefined;
   readonly getThrottle: (action: Action) => number | undefined;
@@ -52,9 +52,9 @@ export function buildSchedulerGraphSnapshot(
     actionById.set(id, action);
 
     // Get parent-child relationships
-    const parent = state.actionParent.get(action);
+    const parent = state.nodes.parentOf(action)?.action;
     const parentId = parent ? state.getActionId(parent) : undefined;
-    const children = state.actionChildren.get(action);
+    const children = state.nodes.childrenOf(action);
     const childCount = children ? children.size : undefined;
 
     // Get reads and writes for diagnostics
@@ -172,7 +172,7 @@ export function buildSchedulerGraphSnapshot(
 
   // Add parent-child edges
   for (const action of actions) {
-    const parent = state.actionParent.get(action);
+    const parent = state.nodes.parentOf(action)?.action;
     if (!parent) continue;
 
     const parentId = state.getActionId(parent);

--- a/packages/runner/src/scheduler/graph-snapshot.ts
+++ b/packages/runner/src/scheduler/graph-snapshot.ts
@@ -52,7 +52,7 @@ export function buildSchedulerGraphSnapshot(
     actionById.set(id, action);
 
     // Get parent-child relationships
-    const parent = state.nodes.parentOf(action)?.action;
+    const parent = state.nodes.parentActionOf(action);
     const parentId = parent ? state.getActionId(parent) : undefined;
     const children = state.nodes.childrenOf(action);
     const childCount = children ? children.size : undefined;
@@ -172,7 +172,7 @@ export function buildSchedulerGraphSnapshot(
 
   // Add parent-child edges
   for (const action of actions) {
-    const parent = state.nodes.parentOf(action)?.action;
+    const parent = state.nodes.parentActionOf(action);
     if (!parent) continue;
 
     const parentId = state.getActionId(parent);

--- a/packages/runner/src/scheduler/node-record.ts
+++ b/packages/runner/src/scheduler/node-record.ts
@@ -6,7 +6,9 @@ export type NodeStatus = "never-ran" | "clean" | "invalid";
 
 export interface SchedulerNode {
   readonly action: Action;
-  readonly kind: NodeKind;
+  // Mutable for the one sanctioned transition: computation → effect
+  // promotion on re-registration ("once an effect, stays an effect").
+  kind: NodeKind;
   parentAction?: Action;
   children?: Set<Action>;
   status: NodeStatus;
@@ -35,9 +37,16 @@ export class NodeRegistry {
     const existing = this.records.get(action);
     if (existing) {
       if (existing.kind !== kind) {
-        throw new Error(
-          `Scheduler action re-registered as ${kind}; was ${existing.kind}`,
-        );
+        // v1 parity: a computation re-subscribed with `isEffect: true` is
+        // promoted ("once an effect, stays an effect"). Demotion has no
+        // sanctioned caller and stays an error.
+        if (existing.kind === "computation" && kind === "effect") {
+          existing.kind = "effect";
+        } else {
+          throw new Error(
+            `Scheduler action re-registered as ${kind}; was ${existing.kind}`,
+          );
+        }
       }
       this.activate(existing);
       return existing;
@@ -102,6 +111,16 @@ export class NodeRegistry {
   parentOf(action: Action): SchedulerNode | undefined {
     const parentAction = this.records.get(action)?.parentAction;
     return parentAction ? this.records.get(parentAction) : undefined;
+  }
+
+  /**
+   * The captured parent ACTION, independent of whether the parent's record
+   * is (still/already) registered — exact parity with the v1 parent WeakMap.
+   * Demand and trace checks key off action objects, so they must see the
+   * parent through registration churn windows where parentOf() is undefined.
+   */
+  parentActionOf(action: Action): Action | undefined {
+    return this.records.get(action)?.parentAction;
   }
 
   childrenOf(action: Action): ReadonlySet<SchedulerNode> | undefined {

--- a/packages/runner/src/scheduler/node-record.ts
+++ b/packages/runner/src/scheduler/node-record.ts
@@ -7,8 +7,8 @@ export type NodeStatus = "never-ran" | "clean" | "invalid";
 export interface SchedulerNode {
   readonly action: Action;
   readonly kind: NodeKind;
-  parent?: SchedulerNode;
-  children?: Set<SchedulerNode>;
+  parentAction?: Action;
+  children?: Set<Action>;
   status: NodeStatus;
   invalidCauses: IMemorySpaceAddress[];
   liveRefs: number;
@@ -19,6 +19,7 @@ export interface SchedulerNode {
 
 export class NodeRegistry {
   private records = new WeakMap<Action, SchedulerNode>();
+  private childActionsByParent = new WeakMap<Action, Set<Action>>();
   private all = new Set<SchedulerNode>();
   private activeEffects = new Set<Action>();
   private activeComputations = new Set<Action>();
@@ -29,7 +30,7 @@ export class NodeRegistry {
   register(
     action: Action,
     kind: NodeKind,
-    parent?: SchedulerNode,
+    parentAction?: Action,
   ): SchedulerNode {
     const existing = this.records.get(action);
     if (existing) {
@@ -38,7 +39,6 @@ export class NodeRegistry {
           `Scheduler action re-registered as ${kind}; was ${existing.kind}`,
         );
       }
-      if (parent !== undefined) existing.parent = parent;
       this.activate(existing);
       return existing;
     }
@@ -46,7 +46,6 @@ export class NodeRegistry {
     const record: SchedulerNode = {
       action,
       kind,
-      ...(parent !== undefined ? { parent } : {}),
       status: "never-ran",
       invalidCauses: [],
       liveRefs: 0,
@@ -55,7 +54,14 @@ export class NodeRegistry {
       retries: 0,
     };
     this.records.set(action, record);
+    const children = this.childActionsByParent.get(action);
+    if (children) {
+      record.children = children;
+    }
     this.activate(record);
+    if (parentAction !== undefined) {
+      this.captureParentAction(record, parentAction);
+    }
     return record;
   }
 
@@ -70,6 +76,44 @@ export class NodeRegistry {
 
   get(action: Action): SchedulerNode | undefined {
     return this.records.get(action);
+  }
+
+  linkParent(
+    childAction: Action,
+    parentAction: Action | null | undefined,
+    options: { allowExisting?: boolean } = {},
+  ): SchedulerNode | undefined {
+    const { allowExisting = true } = options;
+    if (!parentAction || parentAction === childAction) return undefined;
+
+    const child = this.records.get(childAction);
+    if (!child) return undefined;
+    if (!allowExisting && child.parentAction) {
+      return this.parentOf(childAction);
+    }
+
+    if (child.parentAction && child.parentAction !== parentAction) {
+      this.childActionsByParent.get(child.parentAction)?.delete(child.action);
+    }
+    this.captureParentAction(child, parentAction);
+    return this.parentOf(childAction);
+  }
+
+  parentOf(action: Action): SchedulerNode | undefined {
+    const parentAction = this.records.get(action)?.parentAction;
+    return parentAction ? this.records.get(parentAction) : undefined;
+  }
+
+  childrenOf(action: Action): ReadonlySet<SchedulerNode> | undefined {
+    const childActions = this.childActionsByParent.get(action);
+    if (!childActions) return undefined;
+
+    const children = new Set<SchedulerNode>();
+    for (const childAction of childActions) {
+      const child = this.records.get(childAction);
+      if (child) children.add(child);
+    }
+    return children;
   }
 
   isEffect(action: Action): boolean {
@@ -100,6 +144,39 @@ export class NodeRegistry {
     return kind === "effect"
       ? this.activeEffects.size
       : this.activeComputations.size;
+  }
+
+  isAncestor(
+    sourceAction: Action,
+    candidateAncestor: Action,
+  ): boolean {
+    let parentAction = this.records.get(sourceAction)?.parentAction;
+    while (parentAction) {
+      if (parentAction === candidateAncestor) {
+        return true;
+      }
+      parentAction = this.records.get(parentAction)?.parentAction;
+    }
+    return false;
+  }
+
+  private captureParentAction(
+    child: SchedulerNode,
+    parentAction: Action,
+  ): void {
+    child.parentAction = parentAction;
+
+    let children = this.childActionsByParent.get(parentAction);
+    if (!children) {
+      children = new Set();
+      this.childActionsByParent.set(parentAction, children);
+    }
+    children.add(child.action);
+
+    const parent = this.records.get(parentAction);
+    if (parent) {
+      parent.children = children;
+    }
   }
 
   private activate(record: SchedulerNode): void {

--- a/packages/runner/src/scheduler/node-record.ts
+++ b/packages/runner/src/scheduler/node-record.ts
@@ -1,0 +1,115 @@
+import type { IMemorySpaceAddress } from "../storage/interface.ts";
+import type { Action } from "./types.ts";
+
+export type NodeKind = "computation" | "effect";
+export type NodeStatus = "never-ran" | "clean" | "invalid";
+
+export interface SchedulerNode {
+  readonly action: Action;
+  readonly kind: NodeKind;
+  parent?: SchedulerNode;
+  children?: Set<SchedulerNode>;
+  status: NodeStatus;
+  invalidCauses: IMemorySpaceAddress[];
+  liveRefs: number;
+  provisionalDemand: boolean;
+  passRuns: number;
+  retries: number;
+}
+
+export class NodeRegistry {
+  private records = new WeakMap<Action, SchedulerNode>();
+  private all = new Set<SchedulerNode>();
+  private activeEffects = new Set<Action>();
+  private activeComputations = new Set<Action>();
+
+  readonly effects: ReadonlySet<Action> = this.activeEffects;
+  readonly computations: ReadonlySet<Action> = this.activeComputations;
+
+  register(
+    action: Action,
+    kind: NodeKind,
+    parent?: SchedulerNode,
+  ): SchedulerNode {
+    const existing = this.records.get(action);
+    if (existing) {
+      if (existing.kind !== kind) {
+        throw new Error(
+          `Scheduler action re-registered as ${kind}; was ${existing.kind}`,
+        );
+      }
+      if (parent !== undefined) existing.parent = parent;
+      this.activate(existing);
+      return existing;
+    }
+
+    const record: SchedulerNode = {
+      action,
+      kind,
+      ...(parent !== undefined ? { parent } : {}),
+      status: "never-ran",
+      invalidCauses: [],
+      liveRefs: 0,
+      provisionalDemand: false,
+      passRuns: 0,
+      retries: 0,
+    };
+    this.records.set(action, record);
+    this.activate(record);
+    return record;
+  }
+
+  remove(action: Action): SchedulerNode | undefined {
+    const record = this.records.get(action);
+    if (!record) return undefined;
+    this.all.delete(record);
+    this.activeEffects.delete(action);
+    this.activeComputations.delete(action);
+    return record;
+  }
+
+  get(action: Action): SchedulerNode | undefined {
+    return this.records.get(action);
+  }
+
+  isEffect(action: Action): boolean {
+    return this.activeEffects.has(action);
+  }
+
+  isComputation(action: Action): boolean {
+    return this.activeComputations.has(action);
+  }
+
+  isKnownEffect(action: Action): boolean {
+    return this.records.get(action)?.kind === "effect";
+  }
+
+  isKnownComputation(action: Action): boolean {
+    return this.records.get(action)?.kind === "computation";
+  }
+
+  *nodes(kind?: NodeKind): IterableIterator<SchedulerNode> {
+    for (const record of this.all) {
+      if (kind === undefined || record.kind === kind) {
+        yield record;
+      }
+    }
+  }
+
+  size(kind: NodeKind): number {
+    return kind === "effect"
+      ? this.activeEffects.size
+      : this.activeComputations.size;
+  }
+
+  private activate(record: SchedulerNode): void {
+    this.all.add(record);
+    if (record.kind === "effect") {
+      this.activeEffects.add(record.action);
+      this.activeComputations.delete(record.action);
+    } else {
+      this.activeComputations.add(record.action);
+      this.activeEffects.delete(record.action);
+    }
+  }
+}

--- a/packages/runner/src/scheduler/pull-execution.ts
+++ b/packages/runner/src/scheduler/pull-execution.ts
@@ -257,7 +257,7 @@ function orderPullWorkSet(
     workSet,
     state.dependencies,
     state.getSchedulingWritesMap(),
-    state.actionParent,
+    state.nodes,
     state.dependents,
     (action) => state.materializerIndex.getMaterializerWriteEnvelopes(action),
   );

--- a/packages/runner/src/scheduler/pull-subscriptions.ts
+++ b/packages/runner/src/scheduler/pull-subscriptions.ts
@@ -86,7 +86,7 @@ export function subscribePullSchedulerAction(
 
   // Track parent-child relationship if action is created during another action's execution
   registerParentChildAction(state.subscriptionState, action);
-  const parent = state.actionParent.get(action);
+  const parent = state.subscriptionState.nodes.parentOf(action)?.action;
   if (
     !actionIsEffect &&
     parent &&

--- a/packages/runner/src/scheduler/pull-subscriptions.ts
+++ b/packages/runner/src/scheduler/pull-subscriptions.ts
@@ -86,7 +86,7 @@ export function subscribePullSchedulerAction(
 
   // Track parent-child relationship if action is created during another action's execution
   registerParentChildAction(state.subscriptionState, action);
-  const parent = state.subscriptionState.nodes.parentOf(action)?.action;
+  const parent = state.subscriptionState.nodes.parentActionOf(action);
   if (
     !actionIsEffect &&
     parent &&

--- a/packages/runner/src/scheduler/subscriptions.ts
+++ b/packages/runner/src/scheduler/subscriptions.ts
@@ -8,6 +8,7 @@ import {
   readsOverlapWrites,
   type WriterIndexState,
 } from "./scheduling-writes.ts";
+import { type NodeKind, NodeRegistry } from "./node-record.ts";
 import { type TriggerSubscriptionState } from "./trigger-index.ts";
 import { entityKey } from "./keys.ts";
 import type {
@@ -18,9 +19,7 @@ import type {
 } from "./types.ts";
 
 type SchedulerActionTypeState = {
-  readonly isEffectAction: WeakMap<Action, boolean>;
-  readonly effects: Set<Action>;
-  readonly computations: Set<Action>;
+  readonly nodes: NodeRegistry;
   readonly getIdempotencyCheckMode: () => boolean;
   readonly queueExecution: () => void;
 };
@@ -122,7 +121,8 @@ export function markEffectDirtyIfStaleInputs(
   // computations write to what it reads. If so, mark the effect dirty so it can
   // pull those computations and see fresh data.
   // Skip throttled computations - they'll trigger via storage changes when unthrottled.
-  // Use isEffectAction instead of effects because unsubscribe() clears effects before run()
+  // Use the returned action kind instead of active effects because
+  // unsubscribe() clears active membership before run().
   if (!actionIsEffect || state.stale.size === 0) {
     return;
   }
@@ -191,21 +191,18 @@ export function updateSchedulerActionType(
   isEffect: boolean | undefined,
   options: { queueExecution?: boolean; queueComputation?: boolean } = {},
 ): boolean {
-  if (isEffect) {
-    state.isEffectAction.set(action, true);
-  }
-
-  const actionIsEffect = state.isEffectAction.get(action) ?? false;
+  const kind: NodeKind = isEffect === true ||
+      state.nodes.isKnownEffect(action)
+    ? "effect"
+    : "computation";
+  state.nodes.register(action, kind);
+  const actionIsEffect = kind === "effect";
 
   if (actionIsEffect) {
-    state.effects.add(action);
-    state.computations.delete(action);
     if (options.queueExecution) {
       state.queueExecution();
     }
   } else {
-    state.computations.add(action);
-    state.effects.delete(action);
     if (
       options.queueExecution &&
       (options.queueComputation ?? true)
@@ -275,8 +272,7 @@ export interface SchedulerUnsubscribeActionState {
   readonly conditionallyScheduledEffects: Map<Action, number>;
   readonly reverseDependencies: WeakMap<Action, Set<Action>>;
   readonly dependents: WeakMap<Action, Set<Action>>;
-  readonly effects: Set<Action>;
-  readonly computations: Set<Action>;
+  readonly nodes: NodeRegistry;
   readonly pullDemandedFirstRunComputations: WeakSet<Action>;
   readonly pullDemandedContinuationComputations: WeakSet<Action>;
   readonly writeIndex: WriterIndexState;
@@ -379,8 +375,7 @@ function clearActionTypeTracking(
   state: SchedulerUnsubscribeActionState,
   action: Action,
 ): void {
-  state.effects.delete(action);
-  state.computations.delete(action);
+  state.nodes.remove(action);
   state.pullDemandedFirstRunComputations.delete(action);
   state.pullDemandedContinuationComputations.delete(action);
 }

--- a/packages/runner/src/scheduler/subscriptions.ts
+++ b/packages/runner/src/scheduler/subscriptions.ts
@@ -32,8 +32,7 @@ type SchedulerActionChangeGroupState = {
 
 type SchedulerParentChildState = {
   readonly getExecutingAction: () => Action | null;
-  readonly actionParent: WeakMap<Action, Action>;
-  readonly actionChildren: WeakMap<Action, Set<Action>>;
+  readonly nodes: NodeRegistry;
 };
 
 export type SchedulerSubscriptionState =
@@ -75,7 +74,6 @@ export interface SchedulerSubscribeActionState {
   readonly pendingDependencyCollection: Set<Action>;
   readonly activePullDemandActions: WeakSet<Action>;
   readonly pullDemandedFirstRunComputations: WeakSet<Action>;
-  readonly actionParent: WeakMap<Action, Action>;
   readonly pending: Set<Action>;
   readonly scheduledFirstTime: Set<Action>;
   readonly effects: ReadonlySet<Action>;
@@ -247,17 +245,11 @@ export function registerParentChildAction(
 ): void {
   const { allowExisting = true } = options;
   const parent = state.getExecutingAction();
-  if (!parent || parent === action) return;
-  if (!allowExisting && state.actionParent.has(action)) return;
-
-  state.actionParent.set(action, parent);
-
-  let children = state.actionChildren.get(parent);
-  if (!children) {
-    children = new Set();
-    state.actionChildren.set(parent, children);
-  }
-  children.add(action);
+  state.nodes.linkParent(
+    action,
+    parent && parent !== action ? parent : undefined,
+    { allowExisting },
+  );
 }
 
 export interface SchedulerUnsubscribeActionState {

--- a/packages/runner/src/scheduler/topology.ts
+++ b/packages/runner/src/scheduler/topology.ts
@@ -50,7 +50,7 @@ export function topologicalSort(
   actions: Set<Action>,
   dependencies: WeakMap<Action, ReactivityLog>,
   mightWrite: WeakMap<Action, IMemorySpaceAddress[]>,
-  nodes?: Pick<NodeRegistry, "parentOf">,
+  nodes?: Pick<NodeRegistry, "parentActionOf">,
   dependents?: WeakMap<Action, Set<Action>>,
   getAdditionalWrites?: (
     action: Action,
@@ -126,7 +126,7 @@ export function topologicalSort(
   // should win once a parent actually reads a child's result.
   if (nodes) {
     for (const child of actions) {
-      const parent = nodes.parentOf(child)?.action;
+      const parent = nodes.parentActionOf(child);
       if (parent && actions.has(parent)) {
         const graphParent = graph.get(parent)!;
         const graphChild = graph.get(child)!;
@@ -160,8 +160,8 @@ export function topologicalSort(
 
       // Sort by: prefer no unvisited parent, then by in-degree
       unvisited.sort((a, b) => {
-        const aParent = nodes?.parentOf(a)?.action;
-        const bParent = nodes?.parentOf(b)?.action;
+        const aParent = nodes?.parentActionOf(a);
+        const bParent = nodes?.parentActionOf(b);
         const aHasUnvisitedParent = aParent && !visited.has(aParent) &&
           actions.has(aParent);
         const bHasUnvisitedParent = bParent && !visited.has(bParent) &&

--- a/packages/runner/src/scheduler/topology.ts
+++ b/packages/runner/src/scheduler/topology.ts
@@ -5,6 +5,7 @@ import {
 } from "../reactive-dependencies.ts";
 import { normalizeCellScope } from "../scope.ts";
 import type { IMemorySpaceAddress } from "../storage/interface.ts";
+import type { NodeRegistry } from "./node-record.ts";
 import type { Action, ReactivityLog } from "./types.ts";
 
 export function collectTransitiveEffects(state: {
@@ -49,7 +50,7 @@ export function topologicalSort(
   actions: Set<Action>,
   dependencies: WeakMap<Action, ReactivityLog>,
   mightWrite: WeakMap<Action, IMemorySpaceAddress[]>,
-  actionParent?: WeakMap<Action, Action>,
+  nodes?: Pick<NodeRegistry, "parentOf">,
   dependents?: WeakMap<Action, Set<Action>>,
   getAdditionalWrites?: (
     action: Action,
@@ -123,9 +124,9 @@ export function topologicalSort(
   // Add parent-child edges only when no opposing data dependency exists.
   // Structural creation order is a fallback; semantic read/write dependencies
   // should win once a parent actually reads a child's result.
-  if (actionParent) {
+  if (nodes) {
     for (const child of actions) {
-      const parent = actionParent.get(child);
+      const parent = nodes.parentOf(child)?.action;
       if (parent && actions.has(parent)) {
         const graphParent = graph.get(parent)!;
         const graphChild = graph.get(child)!;
@@ -159,8 +160,8 @@ export function topologicalSort(
 
       // Sort by: prefer no unvisited parent, then by in-degree
       unvisited.sort((a, b) => {
-        const aParent = actionParent?.get(a);
-        const bParent = actionParent?.get(b);
+        const aParent = nodes?.parentOf(a)?.action;
+        const bParent = nodes?.parentOf(b)?.action;
         const aHasUnvisitedParent = aParent && !visited.has(aParent) &&
           actions.has(aParent);
         const bHasUnvisitedParent = bParent && !visited.has(bParent) &&

--- a/packages/runner/src/scheduler/write-propagation.ts
+++ b/packages/runner/src/scheduler/write-propagation.ts
@@ -6,6 +6,7 @@ import type {
 } from "../storage/interface.ts";
 import { getTransactionWriteDetails } from "../storage/transaction-inspection.ts";
 import type { MaterializerIndexState } from "./materializers.ts";
+import type { NodeRegistry } from "./node-record.ts";
 import type { TriggerIndexState } from "./trigger-index.ts";
 import type { Action, ReactivityLog } from "./types.ts";
 
@@ -15,7 +16,7 @@ export interface WritePropagationState {
   readonly effects: ReadonlySet<Action>;
   readonly computations: ReadonlySet<Action>;
   readonly conditionallyScheduledEffects: Map<Action, number>;
-  readonly actionParent: WeakMap<Action, Action>;
+  readonly nodes: NodeRegistry;
   readonly pending: Set<Action>;
   readonly markPullDemandContinuation: (action: Action) => void;
   readonly scheduleWithDebounce: (action: Action) => void;
@@ -91,7 +92,7 @@ export function markReadersDirtyForChangedWrites(
       if (state.materializerIndex.isMaterializer(reader)) {
         state.queueExecution();
       }
-      if (isAncestorAction(state.actionParent, sourceAction, reader)) {
+      if (state.nodes.isAncestor(sourceAction, reader)) {
         // Continuations are only for actions in the scheduler parent chain.
         // Dependency edges already schedule ordinary downstream readers; this
         // handles the narrower case where a child created during a pull writes
@@ -103,17 +104,4 @@ export function markReadersDirtyForChangedWrites(
       state.scheduleAffectedEffects(reader);
     }
   }
-}
-
-function isAncestorAction(
-  actionParent: WeakMap<Action, Action>,
-  sourceAction: Action,
-  candidateAncestor: Action,
-): boolean {
-  let parent = actionParent.get(sourceAction);
-  while (parent) {
-    if (parent === candidateAncestor) return true;
-    parent = actionParent.get(parent);
-  }
-  return false;
 }

--- a/packages/runner/test/scheduler-pull.test.ts
+++ b/packages/runner/test/scheduler-pull.test.ts
@@ -656,7 +656,7 @@ describe("pull-based scheduling", () => {
       derived.withTx(actionTx).get();
     };
     const schedulerInternal = getStaleSchedulerInternals(runtime.scheduler);
-    schedulerInternal.isEffectAction.set(effect, true);
+    schedulerInternal.registerEffect(effect);
     const { log } = schedulerInternal.setDependencies(effect, {
       reads: [toMemorySpaceAddress(derived.getAsNormalizedFullLink())],
       shallowReads: [],

--- a/packages/runner/test/scheduler-test-utils.ts
+++ b/packages/runner/test/scheduler-test-utils.ts
@@ -89,7 +89,7 @@ type StaleSchedulerInternals = {
   clearDirectDirty: (action: Action) => boolean;
   markDirectDirty: (action: Action) => boolean;
   markDirty: (action: Action) => void;
-  isEffectAction: WeakMap<Action, boolean>;
+  registerEffect: (action: Action) => void;
   setDependencies: (
     action: Action,
     log: ReactivityLog,
@@ -113,7 +113,9 @@ function getStaleSchedulerInternals(
       & Parameters<typeof markDirectDirtyState>[0];
     dirtySchedulingState: Parameters<typeof markSchedulerDirty>[0];
     dependencyUpdateState: Parameters<typeof setSchedulerDependencies>[0];
-    isEffectAction: WeakMap<Action, boolean>;
+    nodes: {
+      register: (action: Action, kind: "effect" | "computation") => unknown;
+    };
     pullDemandState: PullDemandState;
     updateDependents: StaleSchedulerInternals["updateDependents"];
     collectDirtyDependencies: StaleSchedulerInternals[
@@ -136,7 +138,9 @@ function getStaleSchedulerInternals(
       markDirectDirtyState(internal.staleness, action),
     markDirty: (action) =>
       markSchedulerDirty(internal.dirtySchedulingState, action),
-    isEffectAction: internal.isEffectAction,
+    registerEffect: (action) => {
+      internal.nodes.register(action, "effect");
+    },
     setDependencies: (action, log) =>
       setSchedulerDependencies(internal.dependencyUpdateState, action, log),
     updateDependents: (action, log) => internal.updateDependents(action, log),

--- a/packages/runner/test/scheduler-v2-cutover.test.ts
+++ b/packages/runner/test/scheduler-v2-cutover.test.ts
@@ -792,4 +792,69 @@ describe("scheduler v2 cutover fixtures", () => {
     for (const cancel of stickyCancels) cancel();
     for (const cancel of parentRSubscribeCancels) cancel();
   });
+
+  it("promotes a computation to an effect on re-registration", async () => {
+    // v1 parity: updateSchedulerActionType allowed an action first seen as a
+    // computation to be promoted by a later `isEffect: true` subscription
+    // ("once an effect, stays an effect"). Strict kind re-registration must
+    // not throw on that path.
+    const registry = new NodeRegistry();
+    const promoted: Action = function promotedAction() {};
+    registry.register(promoted, "computation");
+    expect(registry.isComputation(promoted)).toBe(true);
+
+    const record = registry.register(promoted, "effect");
+    expect(record.kind).toBe("effect");
+    expect(registry.isEffect(promoted)).toBe(true);
+    expect(registry.isComputation(promoted)).toBe(false);
+
+    // End-to-end: a live re-subscription with isEffect must not throw.
+    const source = runtime.getCell<number>(
+      space,
+      "cutover-promotion-source",
+      undefined,
+      tx,
+    );
+    source.set(1);
+    await tx.commit();
+    tx = runtime.edit();
+    const sourceAddress = toMemorySpaceAddress(
+      source.getAsNormalizedFullLink(),
+    );
+
+    const reader: Action = function promotionReader(actionTx) {
+      source.withTx(actionTx).get();
+    };
+    const firstCancel = runtime.scheduler.subscribe(reader, {
+      reads: [sourceAddress],
+      shallowReads: [],
+      writes: [],
+    });
+    const promoteCancel = runtime.scheduler.subscribe(reader, {
+      reads: [sourceAddress],
+      shallowReads: [],
+      writes: [],
+    }, { isEffect: true });
+    await runtime.scheduler.idle();
+    firstCancel();
+    promoteCancel();
+  });
+
+  it("keeps captured parent actions reachable before the parent registers", () => {
+    // v1 parity: the parent edge was a WeakMap keyed by action objects, so
+    // demand checks could consult the parent action even when its record was
+    // not (yet) registered. parentActionOf() preserves that raw access.
+    const registry = new NodeRegistry();
+    const lazyParent: Action = function lazyParent() {};
+    const lazyChild: Action = function lazyChild() {};
+    registry.register(lazyChild, "computation");
+    registry.linkParent(lazyChild, lazyParent);
+
+    expect(registry.parentOf(lazyChild)).toBeUndefined();
+    expect(registry.parentActionOf(lazyChild)).toBe(lazyParent);
+
+    registry.register(lazyParent, "effect");
+    expect(registry.parentOf(lazyChild)?.action).toBe(lazyParent);
+    expect(registry.parentActionOf(lazyChild)).toBe(lazyParent);
+  });
 });

--- a/packages/runner/test/scheduler-v2-cutover.test.ts
+++ b/packages/runner/test/scheduler-v2-cutover.test.ts
@@ -15,6 +15,7 @@ import type {
   IExtendedStorageTransaction,
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
+import { NodeRegistry } from "../src/scheduler/node-record.ts";
 
 async function expectSchedulerIdle(runtime: Runtime): Promise<void> {
   const result = await Promise.race([
@@ -611,5 +612,184 @@ describe("scheduler v2 cutover fixtures", () => {
 
     expect(runs).toBe(0);
     expect(output.get()).toBe(0);
+  });
+
+  it("matches v1 parent-link semantics across registration paths", async () => {
+    const parentlessSource = runtime.getCell<number>(
+      space,
+      "v2-cutover-parentless-source",
+      undefined,
+      tx,
+    );
+    const stickySource = runtime.getCell<number>(
+      space,
+      "v2-cutover-sticky-parent-source",
+      undefined,
+      tx,
+    );
+    const parentTrigger = runtime.getCell<number>(
+      space,
+      "v2-cutover-parent-link-trigger",
+      undefined,
+      tx,
+    );
+    parentlessSource.set(1);
+    stickySource.set(1);
+    parentTrigger.set(1);
+    await tx.commit();
+    tx = runtime.edit();
+
+    const parentlessAddress = toMemorySpaceAddress(
+      parentlessSource.getAsNormalizedFullLink(),
+    );
+    const stickyAddress = toMemorySpaceAddress(
+      stickySource.getAsNormalizedFullLink(),
+    );
+    const triggerAddress = toMemorySpaceAddress(
+      parentTrigger.getAsNormalizedFullLink(),
+    );
+
+    const noOpThenAssignChild: Action = function noOpThenAssignChild(
+      actionTx,
+    ) {
+      parentlessSource.withTx(actionTx).get();
+    };
+    const preserveChild: Action = function preserveChild(actionTx) {
+      stickySource.withTx(actionTx).get();
+    };
+    const overwriteChild: Action = function overwriteChild(actionTx) {
+      stickySource.withTx(actionTx).get();
+    };
+    const deferredRegistry = new NodeRegistry();
+    const deferredParent: Action = function deferredParent() {};
+    const deferredChild: Action = function deferredChild() {};
+
+    deferredRegistry.register(deferredChild, "computation");
+    deferredRegistry.linkParent(deferredChild, deferredParent);
+    expect(deferredRegistry.parentOf(deferredChild)).toBeUndefined();
+    deferredRegistry.register(deferredParent, "effect");
+    expect(deferredRegistry.parentOf(deferredChild)?.action).toBe(
+      deferredParent,
+    );
+    expect(
+      deferredRegistry.childrenOf(deferredParent)?.has(
+        deferredRegistry.get(deferredChild)!,
+      ),
+    ).toBe(true);
+
+    const parentlessInitialCancel = runtime.scheduler.subscribe(
+      noOpThenAssignChild,
+      { reads: [parentlessAddress], shallowReads: [], writes: [] },
+      { isEffect: true },
+    );
+    await runtime.scheduler.idle();
+    parentlessInitialCancel();
+    await runtime.scheduler.idle();
+
+    const parentlessNestedCancels: Array<() => void> = [];
+    const parentQ: Action = function parentQ(actionTx) {
+      parentTrigger.withTx(actionTx).get();
+      if (parentlessNestedCancels.length === 0) {
+        parentlessNestedCancels.push(
+          runtime.scheduler.subscribe(
+            noOpThenAssignChild,
+            { reads: [parentlessAddress], shallowReads: [], writes: [] },
+            { isEffect: true },
+          ),
+        );
+      }
+    };
+    const parentQCancel = runtime.scheduler.subscribe(
+      parentQ,
+      { reads: [triggerAddress], shallowReads: [], writes: [] },
+      { isEffect: true },
+    );
+    await runtime.scheduler.idle();
+
+    let graph = runtime.scheduler.getGraphSnapshot();
+    const parentlessNode = graph.nodes.find((node) =>
+      node.id === "noOpThenAssignChild"
+    );
+    expect(parentlessNode).toBeDefined();
+    expect(parentlessNode!.parentId).toBe("parentQ");
+
+    const stickyCancels: Array<() => void> = [];
+    const parentP: Action = function parentP(actionTx) {
+      parentTrigger.withTx(actionTx).get();
+      if (stickyCancels.length === 0) {
+        stickyCancels.push(
+          runtime.scheduler.subscribe(
+            preserveChild,
+            { reads: [stickyAddress], shallowReads: [], writes: [] },
+            { isEffect: true },
+          ),
+        );
+        stickyCancels.push(
+          runtime.scheduler.subscribe(
+            overwriteChild,
+            { reads: [stickyAddress], shallowReads: [], writes: [] },
+            { isEffect: true },
+          ),
+        );
+      }
+    };
+    const parentPCancel = runtime.scheduler.subscribe(
+      parentP,
+      { reads: [triggerAddress], shallowReads: [], writes: [] },
+      { isEffect: true },
+    );
+    await runtime.scheduler.idle();
+
+    graph = runtime.scheduler.getGraphSnapshot();
+    const firstPreserveNode = graph.nodes.find((node) =>
+      node.id === "preserveChild"
+    );
+    const firstOverwriteNode = graph.nodes.find((node) =>
+      node.id === "overwriteChild"
+    );
+    expect(firstPreserveNode?.parentId).toBe("parentP");
+    expect(firstOverwriteNode?.parentId).toBe("parentP");
+
+    const parentRSubscribeCancels: Array<() => void> = [];
+    const parentR: Action = function parentR(actionTx) {
+      parentTrigger.withTx(actionTx).get();
+      runtime.scheduler.resubscribe(
+        preserveChild,
+        { reads: [stickyAddress], shallowReads: [], writes: [] },
+        { isEffect: true },
+      );
+      if (parentRSubscribeCancels.length === 0) {
+        parentRSubscribeCancels.push(
+          runtime.scheduler.subscribe(overwriteChild, {
+            reads: [stickyAddress],
+            shallowReads: [],
+            writes: [],
+          }, { isEffect: true }),
+        );
+      }
+    };
+    const parentRCancel = runtime.scheduler.subscribe(
+      parentR,
+      { reads: [triggerAddress], shallowReads: [], writes: [] },
+      { isEffect: true },
+    );
+    await runtime.scheduler.idle();
+
+    graph = runtime.scheduler.getGraphSnapshot();
+    const secondPreserveNode = graph.nodes.find((node) =>
+      node.id === "preserveChild"
+    );
+    const secondOverwriteNode = graph.nodes.find((node) =>
+      node.id === "overwriteChild"
+    );
+    expect(secondPreserveNode?.parentId).toBe("parentP");
+    expect(secondOverwriteNode?.parentId).toBe("parentR");
+
+    parentQCancel();
+    for (const cancel of parentlessNestedCancels) cancel();
+    parentPCancel();
+    parentRCancel();
+    for (const cancel of stickyCancels) cancel();
+    for (const cancel of parentRSubscribeCancels) cancel();
   });
 });


### PR DESCRIPTION
Stack: 07/3a - based on scheduler-v2/07-3pre (#4100)

## What changed

- Introduces SchedulerNode records for effect/computation kind tracking.
- Migrates scheduler parent/child creation context from WeakMaps to NodeRegistry.
- Preserves v1 parent-link semantics by storing parent and child edges by Action object and resolving records lazily.
- Extends the cutover fixture pack with parent-link registration semantics, including parent-not-yet-registered capture.

## Why

This is the 3a node-record sub-order for scheduler-v2 phase 3. The final reviewer-directed fix addresses the CT-1316 topology regression where a parent link was refused because the parent record was not registered at link time, even though v1 captured that Action parent in a WeakMap.

## Validation

- deno fmt on 12 touched scheduler/test files
- deno lint on 12 touched scheduler/test files
- deno check on 12 touched scheduler/test files
- ENV=test deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git test/scheduler-v2-cutover.test.ts
- ENV=test deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git test/patterns-derive-return-pattern.test.ts
- cd packages/runner && deno task test: 594 passed (3107 steps), 0 failed, 0 ignored (10 steps), 2m6s

See docs/specs/scheduler-v2/implementation/PROGRESS.md for the reviewer probe branch, scratch cleanup, and grep contracts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces WeakMap-based scheduler tracking with a `NodeRegistry` of `SchedulerNode` records keyed by action objects. Restores v1 parent-link semantics, fixes CT-1316’s spurious parent rerun, and allows computation→effect promotion on re-registration.

- **Refactors**
  - Add `packages/runner/src/scheduler/node-record.ts` with `NodeRegistry` and `SchedulerNode`.
  - Move effect/computation membership and kind to the registry; consumers read `nodes.effects` / `nodes.computations`.
  - Replace `actionParent` / `actionChildren` with `nodes.parentOf` / `nodes.childrenOf` / `nodes.isAncestor`; add `nodes.parentActionOf` for raw Action-based lookup parity.
  - Thread `nodes` through scheduler state; remove `isEffectAction` WeakMap.
  - Update topology, demand, write-propagation, subscriptions, execution, pull, graph snapshot, and diagnostics to use the registry.
  - Tests: switch internal helpers to `registerEffect(...)`.
  - Docs: record scheduler-v2 phase 3 baseline in `docs/specs/scheduler-v2/implementation/PROGRESS.md`.

- **Bug Fixes**
  - Parent-linking matches v1: no executing parent → no-op; resubscribe (`allowExisting: false`) preserves parent; subscribe (`allowExisting: true`) overwrites parent; links captured even if the parent isn’t registered yet.
  - Add `parentActionOf(...)` to preserve early-captured parent links at Action granularity; demand and trace call sites use it.
  - Support v1-sanctioned computation→effect promotion on re-registration; still reject demotion.
  - Cutover fixture pins these rules; CT-1316 passes; full suite remains green.

<sup>Written for commit 89e916d7699eca777dba2ce324eb04f4c06c359b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

