### PR TITLE
refactor(runner): scheduler-v2 cutover 3d: read-delta application

### DIFF
--- a/docs/specs/scheduler-v2/implementation/PROGRESS.md
+++ b/docs/specs/scheduler-v2/implementation/PROGRESS.md
@@ -4564,3 +4564,54 @@ ineffective or storming, recorded in memory): rehydration-gate
 status-tolerance; markActionInvalid token-keep; sync-fill invalidation
 suppression at processPullStorageNotification; seed-exclusion of pending-
 rehydration actions (race fixed but render sinks 6x -> 235 runs).
+
+## 07/3d-read-delta-application
+
+- [x] pending — migrated trigger subscription maintenance to per-run read deltas
+  and removed clear/readd trigger replacement churn.
+- Fix shape:
+  - `applyActionReadDelta` now computes recursive and non-recursive read deltas
+    per entity, touching only the trigger index entries whose path sets changed.
+  - The scheduler stores the latest run log in the existing dependency map, so
+    `setSchedulerDependencies` now returns the previous normalized log for the
+    delta primitive. This is the current local equivalent of the work-order's
+    `record.reads` wording.
+  - Subscribe-time, resubscribe-time, and dependency-collection trigger updates
+    all use the same delta primitive; dependency collection still honors
+    `useRawReadsForTriggers` by feeding raw trigger reads into the trigger log.
+  - Trigger cancellation now has one stable cancel per action via
+    `ensureCancelForActionTriggers`; the cancel reads the latest entity set at
+    unsubscribe time and lets the registry own entity cleanup.
+  - Scheduler trigger-index tests cover scope-only read changes and stable
+    cancel behavior after a read delta moves an action between entities.
+- Recordings:
+  - Removed-machinery grep returned no matches:
+
+```text
+$ rg -n "replaceActionTriggerPaths|setCancelForTriggerEntities|lastTriggerReadsByState|addressesEqual" packages/runner/src packages/runner/test
+```
+
+  - `deno fmt` on the touched source/test files: passed.
+  - `deno lint` on the touched source/test files: passed (`Checked 5 files`).
+  - `deno check` on the touched source/test files: passed.
+  - Trigger-index regression check:
+    `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-trigger-index.test.ts`: passed, `2 passed (4 steps)`,
+    `0 failed`.
+  - 3d scheduler pack:
+    `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
+    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler-trigger-index.test.ts test/scheduler-pull.test.ts
+    test/scheduler-events.test.ts test/scheduler-cfc-trigger-reads.test.ts
+    test/scheduler-v2-cutover.test.ts`: passed, `9 passed (60 steps)`,
+    `0 failed`.
+  - `cd packages/runner && deno task test`: passed,
+    `594 passed (3100 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m8s`.
+  - `cd packages/runner && deno bench --allow-ffi --allow-env --allow-read
+    --allow-write=/tmp,/var/folders --allow-run=git
+    test/scheduler.bench.ts`: passed. Steady-state scheduler ops:
+    bare subscribe `1.6ms`, subscribe 100 actions reading same entity `1.6ms`,
+    resubscribe cycle `1.5ms`. Pull with resubscribe `140.5ms`.
+  - `git diff --check`: passed.
+  - Expected noisy passing logs remain: existing write-surface/wish warnings.

--- a/packages/runner/src/scheduler/dependency-collection.ts
+++ b/packages/runner/src/scheduler/dependency-collection.ts
@@ -6,8 +6,8 @@ import {
   setSchedulerDependencies,
 } from "./dependency-updates.ts";
 import {
-  replaceActionTriggerPaths,
-  setCancelForTriggerEntities,
+  applyActionReadDelta,
+  ensureCancelForActionTriggers,
   type TriggerSubscriptionState,
 } from "./trigger-index.ts";
 import type {
@@ -49,11 +49,12 @@ export function collectDependenciesForAction(
     options,
   );
 
-  const { reads, shallowReads, log: schedulingLog } = setSchedulerDependencies(
-    state.dependencyUpdateState,
-    action,
-    log,
-  );
+  const { previousLog, reads, shallowReads, log: schedulingLog } =
+    setSchedulerDependencies(
+      state.dependencyUpdateState,
+      action,
+      log,
+    );
   if (options.updateDependents ?? true) {
     state.updateDependents(action, schedulingLog);
   }
@@ -62,16 +63,19 @@ export function collectDependenciesForAction(
   const shallowReadsForTriggers = options.useRawReadsForTriggers
     ? log.shallowReads
     : shallowReads;
-  const { entities } = replaceActionTriggerPaths(
+  const nextTriggerLog = {
+    reads: readsForTriggers,
+    shallowReads: shallowReadsForTriggers,
+  };
+  const { entities } = applyActionReadDelta(
     state.triggerSubscriptionState,
     action,
-    readsForTriggers,
-    shallowReadsForTriggers,
+    previousLog,
+    nextTriggerLog,
   );
-  setCancelForTriggerEntities(
+  ensureCancelForActionTriggers(
     state.triggerSubscriptionState,
     action,
-    entities,
   );
 
   return { log, entities };

--- a/packages/runner/src/scheduler/dependency-updates.ts
+++ b/packages/runner/src/scheduler/dependency-updates.ts
@@ -13,10 +13,16 @@ export function setSchedulerDependencies(
   action: Action,
   log: ReactivityLog,
 ): {
+  previousLog: ReactivityLog;
   reads: IMemorySpaceAddress[];
   shallowReads: IMemorySpaceAddress[];
   log: ReactivityLog;
 } {
+  const previousLog = state.dependencies.get(action) ?? {
+    reads: [],
+    shallowReads: [],
+    writes: [],
+  };
   const reads = sortAndCompactPaths(log.reads);
   const shallowReads = sortAndCompactPaths(log.shallowReads, false);
   const schedulingLog: ReactivityLog = {
@@ -25,5 +31,5 @@ export function setSchedulerDependencies(
     writes: state.writeIndex.getSchedulingWrites(action) ?? [],
   };
   state.dependencies.set(action, schedulingLog);
-  return { reads, shallowReads, log: schedulingLog };
+  return { previousLog, reads, shallowReads, log: schedulingLog };
 }

--- a/packages/runner/src/scheduler/pull-subscriptions.ts
+++ b/packages/runner/src/scheduler/pull-subscriptions.ts
@@ -7,8 +7,8 @@ import { setSchedulerDependencies } from "./dependency-updates.ts";
 import { isLive } from "./dependency-graph.ts";
 import { filterIgnoredAddresses } from "./reactivity.ts";
 import {
-  replaceActionTriggerPaths,
-  setCancelForTriggerEntities,
+  applyActionReadDelta,
+  ensureCancelForActionTriggers,
 } from "./trigger-index.ts";
 import type {
   Action,
@@ -127,25 +127,21 @@ export function subscribePullSchedulerAction(
   // If a ReactivityLog was provided directly, set up dependencies immediately.
   // This ensures writes are tracked right away for reverse dependency graph.
   if (immediateLog) {
-    const { reads, shallowReads, log: schedulingLog } =
-      setSchedulerDependencies(
-        state.dependencyUpdateState,
-        action,
-        immediateLog,
-      );
-    state.updateDependents(action, schedulingLog);
-    const { entities } = replaceActionTriggerPaths(
-      state.triggerSubscriptionState,
+    const { previousLog, log: schedulingLog } = setSchedulerDependencies(
+      state.dependencyUpdateState,
       action,
-      reads,
-      shallowReads,
+      immediateLog,
     );
-
-    // Register the cancel function for the latest trigger set.
-    setCancelForTriggerEntities(
+    state.updateDependents(action, schedulingLog);
+    applyActionReadDelta(
       state.triggerSubscriptionState,
       action,
-      entities,
+      previousLog,
+      schedulingLog,
+    );
+    ensureCancelForActionTriggers(
+      state.triggerSubscriptionState,
+      action,
     );
   } else if (!deferInitialExecution) {
     // Mark action for dependency collection before first run
@@ -196,11 +192,12 @@ export function resubscribePullSchedulerAction(
     options,
   );
 
-  const { reads, shallowReads, log: schedulingLog } = setSchedulerDependencies(
-    state.dependencyUpdateState,
-    action,
-    log,
-  );
+  const { previousLog, reads, shallowReads, log: schedulingLog } =
+    setSchedulerDependencies(
+      state.dependencyUpdateState,
+      action,
+      log,
+    );
 
   // Track action type for pull-based scheduling
   // Once an action is marked as an effect, it stays an effect
@@ -225,11 +222,11 @@ export function resubscribePullSchedulerAction(
     allowExisting: false,
   });
 
-  const { entities, triggerPathsByEntity } = replaceActionTriggerPaths(
+  const { triggerPathsByEntity } = applyActionReadDelta(
     state.triggerSubscriptionState,
     action,
-    reads,
-    shallowReads,
+    previousLog,
+    schedulingLog,
   );
 
   logger.debug("schedule-resubscribe", () => [
@@ -238,10 +235,9 @@ export function resubscribePullSchedulerAction(
     `Reads: ${reads.length}`,
   ]);
 
-  setCancelForTriggerEntities(
+  ensureCancelForActionTriggers(
     state.triggerSubscriptionState,
     action,
-    entities,
   );
 
   markEffectDirtyIfStaleInputs(

--- a/packages/runner/src/scheduler/trigger-index.ts
+++ b/packages/runner/src/scheduler/trigger-index.ts
@@ -12,7 +12,7 @@ import type {
   IMemorySpaceAddress,
 } from "../storage/interface.ts";
 import { entityKey } from "./keys.ts";
-import type { Action, SpaceScopeAndURI } from "./types.ts";
+import type { Action, ReactivityLog, SpaceScopeAndURI } from "./types.ts";
 
 export interface TriggerIndexState {
   readonly triggers: Map<
@@ -23,6 +23,7 @@ export interface TriggerIndexState {
     SpaceScopeAndURI,
     Map<Action, SortedAndCompactPaths>
   >;
+  readonly actionTriggerEntities: WeakMap<Action, Set<SpaceScopeAndURI>>;
   addActionReads(
     action: Action,
     reads: IMemorySpaceAddress[],
@@ -104,6 +105,10 @@ export class SchedulerTriggerSubscriptions implements TriggerSubscriptionState {
     return this.state.triggerIndex.nonRecursiveTriggers;
   }
 
+  get actionTriggerEntities(): TriggerIndexState["actionTriggerEntities"] {
+    return this.state.triggerIndex.actionTriggerEntities;
+  }
+
   get cancels(): WeakMap<Action, Cancel> {
     return this.state.cancels;
   }
@@ -176,6 +181,10 @@ export class SchedulerTriggerIndex implements TriggerIndexState {
     SpaceScopeAndURI,
     Map<Action, SortedAndCompactPaths>
   >();
+  readonly actionTriggerEntities = new WeakMap<
+    Action,
+    Set<SpaceScopeAndURI>
+  >();
 
   addActionReads(
     action: Action,
@@ -213,6 +222,8 @@ export class SchedulerTriggerIndex implements TriggerIndexState {
       }
       pathsByAction.set(action, paths);
     }
+
+    this.actionTriggerEntities.set(action, entities);
 
     return { entities, triggerPathsByEntity };
   }
@@ -342,96 +353,107 @@ export function addTriggerPathsToIndex(
   return state.addActionReads(action, reads, shallowReads);
 }
 
-// Last-registered reads per (subscription state, action), so a re-run whose
-// read set is unchanged — the overwhelmingly common case for steady-state
-// sinks and settle re-runs — skips the O(read-entities) clear + re-add of
-// the trigger index. Keyed by the state's `cancels` map (stable identity per
-// scheduler) so actions never cross-contaminate between runtimes.
-const lastTriggerReadsByState = new WeakMap<
-  object,
-  WeakMap<Action, {
-    reads: IMemorySpaceAddress[];
-    shallowReads: IMemorySpaceAddress[];
-    result: {
-      entities: Set<SpaceScopeAndURI>;
-      triggerPathsByEntity: Map<SpaceScopeAndURI, SortedAndCompactPaths>;
-    };
-  }>
->();
-
-const addressesEqual = (
-  a: readonly IMemorySpaceAddress[],
-  b: readonly IMemorySpaceAddress[],
-): boolean => {
-  if (a === b) return true;
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    const x = a[i], y = b[i];
-    if (
-      x.space !== y.space || x.id !== y.id || x.type !== y.type ||
-      x.scope !== y.scope || x.path.length !== y.path.length
-    ) {
-      return false;
-    }
-    for (let j = 0; j < x.path.length; j++) {
-      if (x.path[j] !== y.path[j]) return false;
-    }
-  }
-  return true;
-};
-
-export function replaceActionTriggerPaths(
-  state: TriggerSubscriptionState,
+export function applyActionReadDelta(
+  state: TriggerIndexState,
   action: Action,
-  reads: IMemorySpaceAddress[],
-  shallowReads: IMemorySpaceAddress[],
+  prevLog: Pick<ReactivityLog, "reads" | "shallowReads">,
+  nextLog: Pick<ReactivityLog, "reads" | "shallowReads">,
 ): {
   entities: Set<SpaceScopeAndURI>;
   triggerPathsByEntity: Map<SpaceScopeAndURI, SortedAndCompactPaths>;
 } {
-  let byAction = lastTriggerReadsByState.get(state.cancels);
-  // Only skip while the action is still registered: an unsubscribe runs the
-  // cancel (removing the action from the entity index), so a later
-  // re-subscribe must re-add even with identical reads.
-  const prev = state.cancels.has(action) ? byAction?.get(action) : undefined;
-  if (
-    prev !== undefined &&
-    addressesEqual(prev.reads, reads) &&
-    addressesEqual(prev.shallowReads, shallowReads)
-  ) {
-    return prev.result;
-  }
-  clearActionTriggers(state, action);
-  const result = addTriggerPathsToIndex(state, action, reads, shallowReads);
-  if (byAction === undefined) {
-    byAction = new WeakMap();
-    lastTriggerReadsByState.set(state.cancels, byAction);
-  }
-  byAction.set(action, { reads, shallowReads, result });
-  return result;
+  const prevPathsByEntity = addressesToPathByEntity(prevLog.reads);
+  const nextPathsByEntity = addressesToPathByEntity(nextLog.reads);
+  const prevNonRecursivePathsByEntity = addressesToPathByEntity(
+    prevLog.shallowReads,
+  );
+  const nextNonRecursivePathsByEntity = addressesToPathByEntity(
+    nextLog.shallowReads,
+  );
+
+  applyActionReadDeltaToMap(
+    state.triggers,
+    action,
+    prevPathsByEntity,
+    nextPathsByEntity,
+  );
+  applyActionReadDeltaToMap(
+    state.nonRecursiveTriggers,
+    action,
+    prevNonRecursivePathsByEntity,
+    nextNonRecursivePathsByEntity,
+  );
+
+  const entities = new Set<SpaceScopeAndURI>([
+    ...nextPathsByEntity.keys(),
+    ...nextNonRecursivePathsByEntity.keys(),
+  ]);
+  state.actionTriggerEntities.set(action, entities);
+
+  return { entities, triggerPathsByEntity: nextPathsByEntity };
 }
 
-export function clearActionTriggers(
+export function ensureCancelForActionTriggers(
   state: TriggerSubscriptionState,
   action: Action,
 ): void {
-  const cancel = state.cancels.get(action);
-  if (!cancel) return;
+  if (state.cancels.has(action)) return;
 
-  cancel();
-  state.cancels.delete(action);
-}
-
-export function setCancelForTriggerEntities(
-  state: TriggerSubscriptionState,
-  action: Action,
-  entities: Set<SpaceScopeAndURI>,
-): void {
   const actionId = state.getActionId(action);
   state.cancels.set(action, () => {
+    const entities = state.actionTriggerEntities.get(action) ?? new Set();
     state.onTriggerUnsubscribe?.(actionId, entities.size);
     state.removeActionFromEntities(action, entities);
+    state.actionTriggerEntities.delete(action);
   });
+}
+
+function applyActionReadDeltaToMap(
+  triggerMap: Map<SpaceScopeAndURI, Map<Action, SortedAndCompactPaths>>,
+  action: Action,
+  prevPathsByEntity: Map<SpaceScopeAndURI, SortedAndCompactPaths>,
+  nextPathsByEntity: Map<SpaceScopeAndURI, SortedAndCompactPaths>,
+): void {
+  const entities = new Set<SpaceScopeAndURI>([
+    ...prevPathsByEntity.keys(),
+    ...nextPathsByEntity.keys(),
+  ]);
+
+  for (const entity of entities) {
+    const prevPaths = prevPathsByEntity.get(entity);
+    const nextPaths = nextPathsByEntity.get(entity);
+    if (pathsEqual(prevPaths, nextPaths)) continue;
+
+    if (nextPaths === undefined) {
+      removeActionFromTriggerMap(triggerMap, entity, action);
+      continue;
+    }
+
+    let pathsByAction = triggerMap.get(entity);
+    if (!pathsByAction) {
+      pathsByAction = new Map();
+      triggerMap.set(entity, pathsByAction);
+    }
+    pathsByAction.set(action, nextPaths);
+  }
+}
+
+function pathsEqual(
+  a: SortedAndCompactPaths | undefined,
+  b: SortedAndCompactPaths | undefined,
+): boolean {
+  if (a === b) return true;
+  if (a === undefined || b === undefined || a.length !== b.length) {
+    return false;
+  }
+
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].length !== b[i].length) return false;
+    for (let j = 0; j < a[i].length; j++) {
+      if (a[i][j] !== b[i][j]) return false;
+    }
+  }
+  return true;
 }
 
 export function removeActionFromTriggerIndex(

--- a/packages/runner/test/scheduler-trigger-index.test.ts
+++ b/packages/runner/test/scheduler-trigger-index.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "./scheduler-test-utils.ts";
-import { SchedulerTriggerIndex } from "../src/scheduler/trigger-index.ts";
-import type { Action } from "../src/scheduler/types.ts";
+import {
+  applyActionReadDelta,
+  ensureCancelForActionTriggers,
+  SchedulerTriggerIndex,
+  SchedulerTriggerSubscriptions,
+} from "../src/scheduler/trigger-index.ts";
+import type { Action, ReactivityLog } from "../src/scheduler/types.ts";
 import type { IMemorySpaceAddress } from "../src/storage/interface.ts";
 
 describe("SchedulerTriggerIndex", () => {
@@ -51,13 +56,10 @@ describe("SchedulerTriggerIndex", () => {
   });
 });
 
-describe("replaceActionTriggerPaths unchanged-reads skip", () => {
-  it("re-registers triggers when only the read scope changes", async () => {
-    const { replaceActionTriggerPaths, setCancelForTriggerEntities } =
-      await import("../src/scheduler/trigger-index.ts");
-    const { SchedulerTriggerSubscriptions } = await import(
-      "../src/scheduler/trigger-index.ts"
-    );
+describe("applyActionReadDelta", () => {
+  const emptyLog: ReactivityLog = { reads: [], shallowReads: [], writes: [] };
+
+  it("updates triggers when only the read scope changes", () => {
     const triggerIndex = new SchedulerTriggerIndex();
     const state = new SchedulerTriggerSubscriptions({
       triggerIndex,
@@ -72,18 +74,77 @@ describe("replaceActionTriggerPaths unchanged-reads skip", () => {
     } as const;
     const spaceRead = { ...base, scope: "space" } as IMemorySpaceAddress;
     const userRead = { ...base, scope: "user" } as IMemorySpaceAddress;
+    const firstLog: ReactivityLog = {
+      reads: [spaceRead],
+      shallowReads: [],
+      writes: [],
+    };
+    const secondLog: ReactivityLog = {
+      reads: [userRead],
+      shallowReads: [],
+      writes: [],
+    };
 
-    const first = replaceActionTriggerPaths(state, action, [spaceRead], []);
-    setCancelForTriggerEntities(state, action, first.entities);
+    applyActionReadDelta(state, action, emptyLog, firstLog);
+    ensureCancelForActionTriggers(state, action);
 
     // Same space/id/path, different scope: must NOT be treated as unchanged.
-    const second = replaceActionTriggerPaths(state, action, [userRead], []);
-    setCancelForTriggerEntities(state, action, second.entities);
+    applyActionReadDelta(state, action, firstLog, secondLog);
 
     expect(triggerIndex.collectReadersForWrite(userRead).has(action)).toBe(
       true,
     );
     expect(triggerIndex.collectReadersForWrite(spaceRead).has(action)).toBe(
+      false,
+    );
+  });
+
+  it("keeps one cancel that removes the latest trigger entities", () => {
+    const triggerIndex = new SchedulerTriggerIndex();
+    const cancels = new WeakMap<Action, () => void>();
+    const state = new SchedulerTriggerSubscriptions({
+      triggerIndex,
+      cancels,
+      getActionId: () => "test-action",
+    });
+    const action: Action = () => {};
+    const firstRead: IMemorySpaceAddress = {
+      space: "did:key:trigger-index-cancel-a",
+      scope: "space",
+      id: "of:cell",
+      path: ["value"],
+    };
+    const secondRead: IMemorySpaceAddress = {
+      space: "did:key:trigger-index-cancel-b",
+      scope: "space",
+      id: "of:cell",
+      path: ["value"],
+    };
+    const firstLog: ReactivityLog = {
+      reads: [firstRead],
+      shallowReads: [],
+      writes: [],
+    };
+    const secondLog: ReactivityLog = {
+      reads: [secondRead],
+      shallowReads: [],
+      writes: [],
+    };
+
+    applyActionReadDelta(state, action, emptyLog, firstLog);
+    ensureCancelForActionTriggers(state, action);
+    const firstCancel = cancels.get(action);
+    applyActionReadDelta(state, action, firstLog, secondLog);
+    ensureCancelForActionTriggers(state, action);
+
+    expect(cancels.get(action)).toBe(firstCancel);
+
+    cancels.get(action)?.();
+
+    expect(triggerIndex.collectReadersForWrite(firstRead).has(action)).toBe(
+      false,
+    );
+    expect(triggerIndex.collectReadersForWrite(secondRead).has(action)).toBe(
       false,
     );
   });


### PR DESCRIPTION
Stack: 07/3d — based on scheduler-v2/07-3c (#4103)

## 07/3d-read-delta-application

- [x] pending — migrated trigger subscription maintenance to per-run read deltas
  and removed clear/readd trigger replacement churn.
- Fix shape:
  - `applyActionReadDelta` now computes recursive and non-recursive read deltas
    per entity, touching only the trigger index entries whose path sets changed.
  - The scheduler stores the latest run log in the existing dependency map, so
    `setSchedulerDependencies` now returns the previous normalized log for the
    delta primitive. This is the current local equivalent of the work-order's
    `record.reads` wording.
  - Subscribe-time, resubscribe-time, and dependency-collection trigger updates
    all use the same delta primitive; dependency collection still honors
    `useRawReadsForTriggers` by feeding raw trigger reads into the trigger log.
  - Trigger cancellation now has one stable cancel per action via
    `ensureCancelForActionTriggers`; the cancel reads the latest entity set at
    unsubscribe time and lets the registry own entity cleanup.
  - Scheduler trigger-index tests cover scope-only read changes and stable
    cancel behavior after a read delta moves an action between entities.
- Recordings:
  - Removed-machinery grep returned no matches:

```text
$ rg -n "replaceActionTriggerPaths|setCancelForTriggerEntities|lastTriggerReadsByState|addressesEqual" packages/runner/src packages/runner/test
```

  - `deno fmt` on the touched source/test files: passed.
  - `deno lint` on the touched source/test files: passed (`Checked 5 files`).
  - `deno check` on the touched source/test files: passed.
  - Trigger-index regression check:
    `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
    test/scheduler-trigger-index.test.ts`: passed, `2 passed (4 steps)`,
    `0 failed`.
  - 3d scheduler pack:
    `cd packages/runner && ENV=test deno test --allow-ffi --allow-env
    --allow-read --allow-write=/tmp,/var/folders --allow-run=git
    test/scheduler-trigger-index.test.ts test/scheduler-pull.test.ts
    test/scheduler-events.test.ts test/scheduler-cfc-trigger-reads.test.ts
    test/scheduler-v2-cutover.test.ts`: passed, `9 passed (60 steps)`,
    `0 failed`.
  - `cd packages/runner && deno task test`: passed,
    `594 passed (3100 steps)`, `0 failed`, `0 ignored (10 steps)`, `2m8s`.
  - `cd packages/runner && deno bench --allow-ffi --allow-env --allow-read
    --allow-write=/tmp,/var/folders --allow-run=git
    test/scheduler.bench.ts`: passed. Steady-state scheduler ops:
    bare subscribe `1.6ms`, subscribe 100 actions reading same entity `1.6ms`,
    resubscribe cycle `1.5ms`. Pull with resubscribe `140.5ms`.
  - `git diff --check`: passed.
  - Expected noisy passing logs remain: existing write-surface/wish warnings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches scheduler trigger maintenance to per-run read deltas to remove clear/re-add churn and keep a single stable cancel per action. Improves correctness on scope-only read changes and reduces trigger index work.

- **Refactors**
  - Added `applyActionReadDelta` that computes per-entity deltas for recursive and non-recursive reads using `previousLog` and the next log, updating only changed path sets.
  - `setSchedulerDependencies` now stores the latest run log and returns `previousLog` for delta calculation.
  - Unified subscribe, resubscribe, and dependency-collection updates on the same delta primitive; `useRawReadsForTriggers` still feeds raw reads into the trigger log.
  - Introduced per-action `actionTriggerEntities` and `ensureCancelForActionTriggers` to register one cancel per action; removed `replaceActionTriggerPaths` and `setCancelForTriggerEntities`.

- **Bug Fixes**
  - Correctly updates triggers when only the read scope changes.
  - Unsubscribe uses a single stable cancel that removes the latest entity set.

<sup>Written for commit f3e0041dc4fb0c5f5c16614b1d6dc29230e0a567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

