### PR TITLE
feat(memory): federation PR5 — share session.open verification + bind expiry & audience

### DIFF
--- a/docs/development/federation-pr5-design.md
+++ b/docs/development/federation-pr5-design.md
@@ -1,10 +1,40 @@
 # Federation PR5 — audience-bound `session.open` + space lifecycle
 
-Status: **design / needs Berni's input.** Last of the §14 federation arc
-(PR1–PR4 + site-table v0 landed). This is the *forcing function* for making the
-site table's host hints trustworthy: until the open authorization is
-audience-bound, a host hint is a replay surface, so the site table stays "v0
-unverified hints."
+Status: **Part A mechanism implemented; one decision needs Berni.** Last of the
+§14 federation arc (PR1–PR4 + site-table v0 landed). This is the *forcing
+function* for making the site table's host hints trustworthy: until the open
+authorization is audience-bound, a host hint is a replay surface, so the site
+table stays "v0 unverified hints."
+
+## Implemented in this PR
+
+The `session.open` verification was a byte-identical copy in two places
+(`packages/memory/v2/standalone.ts` and `packages/toolshed/routes/storage/memory.ts`).
+This PR factors it into a single shared helper —
+`packages/memory/v2/session-open-auth.ts` `verifySessionOpenAuthorization()` —
+both now call, and adds two anti-replay checks on top of the signature:
+
+- **Expiry — complete, end-to-end.** The client (`v2-remote-session.ts`) now
+  stamps `iat` + `exp` (a 5-min `SESSION_OPEN_TTL_SECONDS` window) onto every
+  `session.open`; the helper rejects an expired open with a clock-skew grace.
+  Before this the open carried no expiry and was replayable forever. Backward
+  compatible: `exp` rides in the signed invocation hash, older servers ignore
+  it, and an open without `exp` is still accepted.
+- **Audience — mechanism + tests, gated on one decision.** The helper rejects an
+  open whose `aud` ≠ this server's configured `audience` (cross-host replay).
+  Opt-in on both sides (no `aud` or unconfigured server → skip), so it can't
+  break anything today. Covered by `test/session-open-auth-test.ts` (8 cases:
+  valid / tampered / expired / skew-grace / aud-match / aud-replay-rejected /
+  opt-in).
+
+**The one decision for Berni** (everything above is inert without it): the
+`Invocation` `aud` field is typed `DID`, so a proper audience is the memory
+server's **own identity DID** — which the memory server does not have today.
+Decisions: (1) provision a server identity DID; (2) how the client learns it to
+set `aud` (site-table host DID? a `/.well-known` on the host? handshake?); (3)
+when to flip server enforcement from opt-in to required. Once decided, wiring it
+is a config/plumbing change, not a protocol change — the enforcement path and
+tests are already here. Part B (below) is unchanged: still design-only.
 
 ## Two parts
 

--- a/docs/development/federation-pr5-design.md
+++ b/docs/development/federation-pr5-design.md
@@ -1,0 +1,95 @@
+# Federation PR5 — audience-bound `session.open` + space lifecycle
+
+Status: **design / needs Berni's input.** Last of the §14 federation arc
+(PR1–PR4 + site-table v0 landed). This is the *forcing function* for making the
+site table's host hints trustworthy: until the open authorization is
+audience-bound, a host hint is a replay surface, so the site table stays "v0
+unverified hints."
+
+## Two parts
+
+### Part A — audience-bind the open authorization (security-critical)
+
+**Today (the replay surface).** `packages/memory/access.ts`:
+
+- `authorize(access, as)` (≈L110) builds `proof = { [invocationHash]: {} }` and
+  signs `hashOf(proof).bytes` — *only* the invocation hashes. There is **no
+  audience, no nonce, no expiry** in the signed payload.
+- `claim(access, authorization, serviceDid, acl)` (≈L26) verifies that signature
+  over `hashOf(authorization.access)` and checks issuer = space owner / service
+  DID / ACL — but never checks *who the authorization was for*.
+
+So a captured `{signature, access}` is valid at **any** host that serves the
+space, **forever**, and can be **replayed**. With site-table host hints (PR3′),
+a hostile or compromised host hint can route a client's signed open to an
+attacker, who replays it to the real host and acts as the user. This is exactly
+the pre-audience-binding hole flagged when PR1 landed.
+
+**Proposed shape (for Berni to confirm).**
+
+1. Bind the audience into the signed payload:
+   `sign(hashOf({ proof, aud, nonce, exp }))` where
+   - `aud` = the target provider/service DID (the host the client *intends* to
+     talk to),
+   - `nonce` = per-open random,
+   - `exp` = short expiry (open is a live handshake, not a durable grant).
+2. `claim` additionally enforces `aud === thisProviderDid`, `exp > now`, and
+   nonce-not-seen (a small bounded replay cache, TTL = `exp` window).
+3. Wire-format/version: this changes the `Authorization` shape over the wire.
+   Need a compat story — version tag + dual-accept window, or a hard cut keyed
+   to a memory-protocol version. **Decision for Berni.**
+
+**Open questions for Berni**
+- Is `aud` the **service/provider DID** (the toolshed's identity) or the
+  **host URL**? DID is replay-proof across URL changes; URL is what the site
+  table stores. (Likely DID, with the site table resolving URL→DID.)
+- Expiry window + clock-skew tolerance for `exp`.
+- Compat: dual-accept window vs. hard protocol-version cut. Any non-loom
+  consumers of `authorize`/`claim` to migrate?
+- Where does the provider's expected `aud` come from — config, or derived from
+  the connection's own identity?
+
+### Part B — space lifecycle: make `space` required, drop implicit spaces
+
+**Today.** PR2/PR2.5 made page-ops carry an optional `space?` and bound
+`RuntimeInternals` to `(identity, host)` with space-first methods. Berni's
+review ask (acknowledged on #3995): *"make every `space?` required, remove the
+implicit spaces"* — i.e. a space is always part of the address, never inferred.
+Plus a **refcount / lifecycle**: when is a space's per-space context
+(`PieceManager`/`PiecesController`, storage session) created and, crucially,
+**torn down**? Today opened spaces accumulate; nothing closes them.
+
+**Proposed shape (for Berni to confirm).**
+- Make `space` required across the page-op protocol + `RuntimeProcessor.spaces`
+  entry points; delete the home-defaulting fallbacks.
+- Add refcounted space contexts: open on first use, dispose when the last
+  page/cell referencing the space goes away (with a grace window to avoid
+  thrash on navigation). Ties into audience-binding: a closed space re-opens
+  with a fresh audience-bound handshake.
+
+**Open questions for Berni**
+- Refcount granularity (per page? per cell subscription?) and the
+  close grace-window.
+- Does "remove implicit spaces" land as one mechanical PR, or staged behind the
+  refcount work?
+
+## Sequencing
+- **A before B**: audience-binding is the security gate that lets the site
+  table graduate from "unverified hints" to a trustable lookup; it's also
+  smaller and self-contained. B (lifecycle) is the cleanup Berni wants and
+  pairs naturally with the re-open-with-fresh-audience flow.
+- Loom side: once A lands and the site table is trustable, the loom
+  `registerSpaceHost` "never silently re-point" guard can soften (a verified
+  host hint is no longer a replay surface). No loom change needed for A itself.
+
+## Test plan (A)
+- Unit: `claim` rejects an authorization whose `aud` ≠ provider DID, whose `exp`
+  is past, and a replayed nonce. `authorize`→`claim` round-trip passes only for
+  the intended audience.
+- Integration: two memory providers; an open authorized for provider 1 is
+  rejected by provider 2 (the replay that works today).
+
+---
+_Grounded in `packages/memory/access.ts` (authorize/claim) on labs main
+`4d22dcdc5`. Filed from the loom federation workstream; pairs with the loom
+site-table v0 (PR3′) and CommonTools CT-1731 context._

--- a/packages/memory/deno.json
+++ b/packages/memory/deno.json
@@ -37,6 +37,7 @@
     "./v2/engine": "./v2/engine.ts",
     "./v2/server": "./v2/server.ts",
     "./v2/standalone": "./v2/standalone.ts",
+    "./v2/session-open-auth": "./v2/session-open-auth.ts",
     "./v2/storage-path": "./v2/storage-path.ts",
     "./commit": "./commit.ts",
     "./codec": "./codec.ts",

--- a/packages/memory/test/session-open-auth-test.ts
+++ b/packages/memory/test/session-open-auth-test.ts
@@ -1,0 +1,116 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { alice, bob, mallory, space } from "./principal.ts";
+import { MEMORY_PROTOCOL } from "../v2.ts";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { verifySessionOpenAuthorization } from "../v2/session-open-auth.ts";
+
+// Build a signed session.open authorization the same way the production client
+// (v2-remote-session.ts) does, with optional aud/iat/exp for the PR5 checks.
+const buildOpen = async (
+  extra: { aud?: string; iat?: number; exp?: number } = {},
+  identity = alice,
+) => {
+  const session = {};
+  const sub = space.did();
+  const invocation: Record<string, unknown> = {
+    iss: identity.did(),
+    cmd: "session.open",
+    sub,
+    args: { protocol: MEMORY_PROTOCOL, session },
+    ...extra,
+  };
+  const signature = await identity.sign(hashOf(invocation).bytes);
+  if (signature.error) throw signature.error;
+  return {
+    space: sub,
+    session,
+    invocation,
+    authorization: { signature: new FabricBytes(signature.ok) },
+  };
+};
+
+describe("verifySessionOpenAuthorization", () => {
+  it("accepts a valid signed open and returns the issuer principal", async () => {
+    assertEquals(
+      await verifySessionOpenAuthorization(await buildOpen()),
+      alice.did(),
+    );
+  });
+
+  it("rejects a malformed/unauthorized open", async () => {
+    const msg = await buildOpen();
+    // Tamper with the issuer after signing — the signature no longer verifies.
+    msg.invocation.iss = bob.did();
+    await assertRejects(() => verifySessionOpenAuthorization(msg));
+  });
+
+  // --- expiry (no audience identity needed) ---
+
+  it("accepts an unexpired open", async () => {
+    const now = 1_000_000;
+    const msg = await buildOpen({ iat: now, exp: now + 300 });
+    assertEquals(
+      await verifySessionOpenAuthorization(msg, { nowSeconds: now + 10 }),
+      alice.did(),
+    );
+  });
+
+  it("rejects an expired open (beyond the skew grace)", async () => {
+    const now = 1_000_000;
+    const msg = await buildOpen({ iat: now - 1000, exp: now - 500 });
+    await assertRejects(
+      () =>
+        verifySessionOpenAuthorization(msg, {
+          nowSeconds: now,
+          clockSkewSeconds: 120,
+        }),
+      Error,
+      "expired",
+    );
+  });
+
+  it("tolerates clock skew within the grace window", async () => {
+    const now = 1_000_000;
+    const msg = await buildOpen({ iat: now, exp: now - 30 }); // just expired
+    assertEquals(
+      await verifySessionOpenAuthorization(msg, {
+        nowSeconds: now,
+        clockSkewSeconds: 120,
+      }),
+      alice.did(),
+    );
+  });
+
+  // --- audience binding (the cross-host replay fix) ---
+
+  it("accepts an audience-bound open at the matching host", async () => {
+    const aud = bob.did(); // stand-in for the host's audience identity
+    assertEquals(
+      await verifySessionOpenAuthorization(await buildOpen({ aud }), {
+        audience: aud,
+      }),
+      alice.did(),
+    );
+  });
+
+  it("rejects an audience-bound open replayed to a different host", async () => {
+    const msg = await buildOpen({ aud: bob.did() });
+    await assertRejects(
+      () => verifySessionOpenAuthorization(msg, { audience: mallory.did() }),
+      Error,
+      "audience mismatch",
+    );
+  });
+
+  it("ignores aud when the server configures no audience (opt-in rollout)", async () => {
+    // Until the memory server has an audience identity, an aud-bearing open is
+    // still accepted (no audience option passed) — so the client change can
+    // land before the server one.
+    assertEquals(
+      await verifySessionOpenAuthorization(await buildOpen({ aud: bob.did() })),
+      alice.did(),
+    );
+  });
+});

--- a/packages/memory/v2/session-open-auth.ts
+++ b/packages/memory/v2/session-open-auth.ts
@@ -1,0 +1,140 @@
+/**
+ * Shared verification for the signed `session.open` invocation.
+ *
+ * The memory server authenticates a client by verifying the signature on its
+ * `session.open` invocation; the verified issuer becomes the session principal
+ * that storage partitioning keys off. Toolshed's `/api/storage/memory` route
+ * and the standalone test server both performed this verification with
+ * byte-identical copies — this is the single source of truth they now share.
+ *
+ * Federation §14 PR5 adds two anti-replay checks on top of the signature:
+ *
+ *  - **expiry** (`exp`): a `session.open` is a live handshake, not a durable
+ *    grant. When the invocation carries an `exp` (the client now stamps one),
+ *    reject it once expired (with a clock-skew grace). Bounds how long a
+ *    captured open can be replayed.
+ *
+ *  - **audience** (`aud`): when the invocation is bound to an audience AND this
+ *    server is configured with its own `audience` identity, require they match
+ *    — so an open signed for host A cannot be replayed to host B. This is the
+ *    cross-host replay fix that lets the site table's host hints become
+ *    trustable. Both halves are opt-in (absent `aud` or unconfigured server →
+ *    skip) so the check rolls out without a flag day. NOTE: the `Invocation`
+ *    `aud` field is typed `DID`, so a *proper* audience is the server's own
+ *    identity DID — which the memory server does not have today. Provisioning
+ *    that identity (and letting the client discover it, e.g. via the site
+ *    table) is the open architectural decision tracked in
+ *    docs/development/federation-pr5-design.md; until it lands no client sets
+ *    `aud` and this stays inert. The mechanism + tests are here so that
+ *    decision is a wiring change, not a protocol change.
+ */
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { fromDID } from "../util.ts";
+import { MEMORY_PROTOCOL } from "../v2.ts";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+export const authorizationError = (message: string): Error =>
+  Object.assign(new Error(message), { name: "AuthorizationError" });
+
+const sameSessionDescriptor = (
+  left: Record<string, unknown>,
+  right: { sessionId?: string; seenSeq?: number },
+): boolean =>
+  (typeof left.sessionId === "string" ? left.sessionId : undefined) ===
+    right.sessionId &&
+  (typeof left.seenSeq === "number" ? left.seenSeq : undefined) ===
+    right.seenSeq;
+
+export type SessionOpenMessage = {
+  space: string;
+  session: { sessionId?: string; seenSeq?: number };
+  invocation?: Record<string, unknown>;
+  authorization?: unknown;
+};
+
+export type VerifySessionOpenOptions = {
+  /** This server's own audience identity (a DID). When set, an invocation that
+   * carries an `aud` must match it. Unset → audience is not enforced. */
+  audience?: string;
+  /** Current unix time in seconds (defaults to now). Injectable for tests. */
+  nowSeconds?: number;
+  /** Grace window for `exp` to tolerate client/server clock skew. */
+  clockSkewSeconds?: number;
+};
+
+const DEFAULT_CLOCK_SKEW_SECONDS = 120;
+
+/**
+ * Verify a `session.open` authorization. Returns the verified issuer DID (the
+ * session principal) or throws an AuthorizationError. Behaviour matches the
+ * prior inline copies exactly, plus the opt-in expiry/audience checks above.
+ */
+export const verifySessionOpenAuthorization = async (
+  message: SessionOpenMessage,
+  options: VerifySessionOpenOptions = {},
+): Promise<string> => {
+  const rawSignature = isRecord(message.authorization)
+    ? message.authorization.signature
+    : undefined;
+  const signature = rawSignature instanceof FabricBytes
+    ? rawSignature.slice()
+    : null;
+  if (!isRecord(message.invocation) || signature === null) {
+    throw authorizationError("memory session.open requires authorization");
+  }
+
+  const invocation = message.invocation;
+  if (
+    typeof invocation.iss !== "string" ||
+    invocation.cmd !== "session.open" ||
+    invocation.sub !== message.space ||
+    !isRecord(invocation.args) ||
+    invocation.args.protocol !== MEMORY_PROTOCOL ||
+    !isRecord(invocation.args.session) ||
+    !sameSessionDescriptor(invocation.args.session, message.session)
+  ) {
+    throw authorizationError("memory session.open authorization mismatch");
+  }
+
+  // Audience binding: an open bound to a *different* audience must not be
+  // accepted here (replay across hosts). Opt-in on both sides.
+  if (
+    options.audience !== undefined &&
+    invocation.aud !== undefined &&
+    invocation.aud !== options.audience
+  ) {
+    throw authorizationError(
+      "memory session.open audience mismatch (replayed to the wrong host)",
+    );
+  }
+
+  // Expiry: a captured open must not be replayable forever.
+  if (invocation.exp !== undefined) {
+    if (typeof invocation.exp !== "number") {
+      throw authorizationError("memory session.open has a malformed exp");
+    }
+    const now = options.nowSeconds ?? Math.floor(Date.now() / 1000);
+    const skew = options.clockSkewSeconds ?? DEFAULT_CLOCK_SKEW_SECONDS;
+    if (invocation.exp < now - skew) {
+      throw authorizationError("memory session.open authorization expired");
+    }
+  }
+
+  const issuer = await fromDID(invocation.iss);
+  if (issuer.error) {
+    throw issuer.error;
+  }
+
+  const verified = await issuer.ok.verify({
+    payload: hashOf(invocation).bytes,
+    signature,
+  });
+  if (verified.error) {
+    throw verified.error;
+  }
+
+  return invocation.iss;
+};

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -12,77 +12,16 @@
  * bundles.
  */
 
-import { encodeMemoryBoundary, MEMORY_PROTOCOL } from "../v2.ts";
+import { encodeMemoryBoundary } from "../v2.ts";
 import * as MemoryServer from "./server.ts";
-import { hashOf } from "@commonfabric/data-model/value-hash";
-import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import { fromDID } from "../util.ts";
+import { verifySessionOpenAuthorization } from "./session-open-auth.ts";
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  value !== null && typeof value === "object" && !Array.isArray(value);
-
-const authorizationError = (message: string): Error =>
-  Object.assign(new Error(message), { name: "AuthorizationError" });
-
-const sameSessionDescriptor = (
-  left: Record<string, unknown>,
-  right: { sessionId?: string; seenSeq?: number },
-): boolean =>
-  (typeof left.sessionId === "string" ? left.sessionId : undefined) ===
-    right.sessionId &&
-  (typeof left.seenSeq === "number" ? left.seenSeq : undefined) ===
-    right.seenSeq;
-
-// Same verification as toolshed's memory route: the session principal is the
-// verified issuer of the signed session.open invocation. User/session scoped
-// storage partitioning keys off this principal, so clients exercise real
-// authentication, not a trusted-client shortcut.
-const authorizeSessionOpen = async (
-  message: {
-    space: string;
-    session: { sessionId?: string; seenSeq?: number };
-    invocation?: Record<string, unknown>;
-    authorization?: unknown;
-  },
-): Promise<string> => {
-  const rawSignature = isRecord(message.authorization)
-    ? message.authorization.signature
-    : undefined;
-  const signature = rawSignature instanceof FabricBytes
-    ? rawSignature.slice()
-    : null;
-  if (!isRecord(message.invocation) || signature === null) {
-    throw authorizationError("memory session.open requires authorization");
-  }
-
-  const invocation = message.invocation;
-  if (
-    typeof invocation.iss !== "string" ||
-    invocation.cmd !== "session.open" ||
-    invocation.sub !== message.space ||
-    !isRecord(invocation.args) ||
-    invocation.args.protocol !== MEMORY_PROTOCOL ||
-    !isRecord(invocation.args.session) ||
-    !sameSessionDescriptor(invocation.args.session, message.session)
-  ) {
-    throw authorizationError("memory session.open authorization mismatch");
-  }
-
-  const issuer = await fromDID(invocation.iss);
-  if (issuer.error) {
-    throw issuer.error;
-  }
-
-  const verified = await issuer.ok.verify({
-    payload: hashOf(invocation).bytes,
-    signature,
-  });
-  if (verified.error) {
-    throw verified.error;
-  }
-
-  return invocation.iss;
-};
+// Session.open verification is shared with toolshed's memory route — see
+// session-open-auth.ts. The standalone test server does not configure an
+// audience (audience binding is opt-in), so this enforces signature + expiry.
+const authorizeSessionOpen = (
+  message: Parameters<typeof verifySessionOpenAuthorization>[0],
+): Promise<string> => verifySessionOpenAuthorization(message);
 
 let nextConnectionTag = 0;
 

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -34,6 +34,15 @@ export const toSpaceWebSocketAddress = (
 export const MEMORY_STORAGE_PATH = "/api/storage/memory";
 
 /**
+ * Validity window stamped onto each signed `session.open` (federation PR5).
+ * `session.open` is a live handshake sent the instant a connection opens, so a
+ * few minutes is ample for clock skew and round-trip while bounding how long a
+ * captured open stays replayable (the server adds its own skew grace). Was
+ * effectively infinite before this — the open carried no `exp` at all.
+ */
+export const SESSION_OPEN_TTL_SECONDS = 300;
+
+/**
  * Build the per-space storage-endpoint resolver: a space present in
  * `spaceHostMap` resolves against that host's base URL, everything else
  * against `defaultHost`. Host selection lives here, next to the
@@ -181,6 +190,11 @@ export class RemoteSessionFactory implements SessionFactory {
     space: MemorySpace,
     session: MemoryClient.MountOptions,
   ): Promise<MemoryClient.SessionOpenAuth> {
+    // Stamp a short validity window so a captured session.open can't be
+    // replayed forever (federation PR5). `exp` rides inside the signed
+    // invocation hash and is enforced server-side in session-open-auth.ts;
+    // servers that don't yet check it simply ignore the extra fields.
+    const iat = Math.floor(Date.now() / 1000);
     const invocation = {
       iss: signer.did(),
       cmd: "session.open",
@@ -189,6 +203,8 @@ export class RemoteSessionFactory implements SessionFactory {
         protocol: MEMORY_PROTOCOL,
         session,
       },
+      iat,
+      exp: iat + SESSION_OPEN_TTL_SECONDS,
     };
     const signature = await signer.sign(hashOf(invocation).bytes);
     if (signature.error) {

--- a/packages/toolshed/routes/storage/memory.ts
+++ b/packages/toolshed/routes/storage/memory.ts
@@ -1,77 +1,17 @@
-import { MEMORY_PROTOCOL } from "@commonfabric/memory/v2";
 import * as MemoryServer from "@commonfabric/memory/v2/server";
-import { hashOf } from "@commonfabric/data-model/value-hash";
-import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { verifySessionOpenAuthorization } from "@commonfabric/memory/v2/session-open-auth";
 import * as FS from "@std/fs";
 import * as Path from "@std/path";
 import env from "@/env.ts";
 import { resolveMemoryEngineStoreRootUrl } from "./memory-path.ts";
-import { fromDID } from "../../../memory/util.ts";
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  value !== null && typeof value === "object" && !Array.isArray(value);
-
-const authorizationError = (message: string): Error =>
-  Object.assign(new Error(message), { name: "AuthorizationError" });
-
-const sameSessionDescriptor = (
-  left: Record<string, unknown>,
-  right: { sessionId?: string; seenSeq?: number },
-): boolean =>
-  (typeof left.sessionId === "string" ? left.sessionId : undefined) ===
-    right.sessionId &&
-  (typeof left.seenSeq === "number" ? left.seenSeq : undefined) ===
-    right.seenSeq;
-
-const authorizeSessionOpen = async (
-  message: {
-    space: string;
-    session: { sessionId?: string; seenSeq?: number };
-    invocation?: Record<string, unknown>;
-    authorization?: unknown;
-  },
-): Promise<string> => {
-  // The session signature travels as a `FabricBytes` (emitted by the client in
-  // `v2-remote-session.ts`), which decodes to one here. A non-null `signature`
-  // implies a well-formed `authorization`, so it needn't be checked separately.
-  const rawSignature = isRecord(message.authorization)
-    ? message.authorization.signature
-    : undefined;
-  const signature = rawSignature instanceof FabricBytes
-    ? rawSignature.slice()
-    : null;
-  if (!isRecord(message.invocation) || signature === null) {
-    throw authorizationError("memory session.open requires authorization");
-  }
-
-  const invocation = message.invocation;
-  if (
-    typeof invocation.iss !== "string" ||
-    invocation.cmd !== "session.open" ||
-    invocation.sub !== message.space ||
-    !isRecord(invocation.args) ||
-    invocation.args.protocol !== MEMORY_PROTOCOL ||
-    !isRecord(invocation.args.session) ||
-    !sameSessionDescriptor(invocation.args.session, message.session)
-  ) {
-    throw authorizationError("memory session.open authorization mismatch");
-  }
-
-  const issuer = await fromDID(invocation.iss);
-  if (issuer.error) {
-    throw issuer.error;
-  }
-
-  const verified = await issuer.ok.verify({
-    payload: hashOf(invocation).bytes,
-    signature,
-  });
-  if (verified.error) {
-    throw verified.error;
-  }
-
-  return invocation.iss;
-};
+// Session.open verification is shared with the standalone server — see
+// @commonfabric/memory/v2/session-open-auth. Audience binding is opt-in; the
+// toolshed does not yet configure an audience identity (federation PR5 design
+// doc), so this enforces signature + expiry today.
+const authorizeSessionOpen = (
+  message: Parameters<typeof verifySessionOpenAuthorization>[0],
+): Promise<string> => verifySessionOpenAuthorization(message);
 
 // Determine store URL: DB_PATH (single-file mode) or MEMORY_DIR (directory mode)
 let storeUrl: URL;


### PR DESCRIPTION
Last of the §14 federation arc (Part A). `session.open` is the signed handshake that authenticates a client to a memory host — and today it carries **no expiry and no audience**, so a captured open replays to any host serving the space, forever. With the site table's host hints (PR3′), that's a live replay surface; this is the forcing function that lets those hints become trustable.

## What's here
- **Factored** the byte-identical `session.open` verification from `v2/standalone.ts` *and* `toolshed/routes/storage/memory.ts` into one shared `verifySessionOpenAuthorization` (`packages/memory/v2/session-open-auth.ts`).
- **Expiry — complete, end-to-end.** The client (`runner/.../v2-remote-session.ts`) now stamps `iat`+`exp` (`SESSION_OPEN_TTL_SECONDS`, 5 min) on every open; the helper rejects expired opens with a clock-skew grace. Backward compatible (rides in the signed hash; older servers ignore it; opens without `exp` still accepted).
- **Audience — mechanism + tests, opt-in.** The helper rejects an open whose `aud` ≠ the server's configured `audience` (cross-host replay). Inert until both sides are configured, so it can't break anything today. 8 tests (`test/session-open-auth-test.ts`): valid / tampered / expired / skew-grace / aud-match / aud-replay-rejected / opt-in.

## The one decision for you, @seefeldb
The audience mechanism is inert until: (1) the memory server gets an **identity DID** (`Invocation.aud` is typed `DID`; the server has none today), (2) the client can **discover** it to set `aud` (site-table host DID? a host `/.well-known`? handshake?), and (3) we flip enforcement opt-in→required. Once you decide, wiring it is config/plumbing — the enforcement path + tests are already in. Full write-up + Part B (make `space` required + refcounted lifecycle, still design-only) in `docs/development/federation-pr5-design.md`.

Tests: new helper suite green (8); existing toolshed `memory.test.ts` green (14) through the refactor; all touched files type-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share `session.open` verification across memory servers and add expiry and optional audience binding to block cross-host replays. The client now stamps `iat/exp`; servers enforce expiry and, when configured, audience — fully backward compatible.

- **New Features**
  - Expiry: client adds `iat` and `exp` (`SESSION_OPEN_TTL_SECONDS = 300`); server rejects expired opens with clock-skew grace.
  - Audience (opt-in): rejects opens when `invocation.aud` ≠ server `audience`, preventing cross-host replay. Skipped if either side is unset.
  - Tests: added a focused suite covering valid, tampered, expired, skew-grace, audience match/mismatch, and opt-in behavior.

- **Refactors**
  - Deduped verification into `verifySessionOpenAuthorization` (`packages/memory/v2/session-open-auth.ts`) and replaced inline copies in the standalone server and toolshed route.
  - Exported the helper via `packages/memory/deno.json`; no other behavior changes beyond the new expiry check.

<sup>Written for commit 2b468356b157f9d6255801abc900f926a2ae4672. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

