### PR TITLE
feat(runner): federation PR5 Part B — StorageManager.closeSpace (per-space teardown)

### DIFF
--- a/docs/development/federation-pr5-design.md
+++ b/docs/development/federation-pr5-design.md
@@ -81,27 +81,43 @@ the pre-audience-binding hole flagged when PR1 landed.
 
 ### Part B — space lifecycle: make `space` required, drop implicit spaces
 
-**Today.** PR2/PR2.5 made page-ops carry an optional `space?` and bound
-`RuntimeInternals` to `(identity, host)` with space-first methods. Berni's
-review ask (acknowledged on #3995): *"make every `space?` required, remove the
-implicit spaces"* — i.e. a space is always part of the address, never inferred.
-Plus a **refcount / lifecycle**: when is a space's per-space context
-(`PieceManager`/`PiecesController`, storage session) created and, crucially,
-**torn down**? Today opened spaces accumulate; nothing closes them.
+**Make-`space`-required: essentially done.** Verified against current main:
+#3995 already made all page-op protocol types, the `RuntimeProcessor` handlers,
+`lib-shell/runtime.ts`, and `RuntimeClient` methods take a required `space: DID`
+and ripped out the implicit current-space. The only remaining "optional" sites
+are (a) the **link/data-model layer** (`runner/link-types.ts`
+`NormalizedLink.space?`, sigil-link `space ?? from.space` in `cell-handle.ts`),
+which is **intentional relative-link inheritance** — making it required would
+break relative links — and (b) a couple of defensive runtime fallbacks
+(`pieceCreatedCallback`'s home-manager fallback, the redirect-link
+`space ?? requesting`). Those aren't the implicit-space Berni meant; forcing
+them strict risks breaking existing data, so leave as-is unless Berni wants them
+tightened.
 
-**Proposed shape (for Berni to confirm).**
-- Make `space` required across the page-op protocol + `RuntimeProcessor.spaces`
-  entry points; delete the home-defaulting fallbacks.
-- Add refcounted space contexts: open on first use, dispose when the last
-  page/cell referencing the space goes away (with a grace window to avoid
-  thrash on navigation). Ties into audience-binding: a closed space re-opens
-  with a fresh audience-bound handshake.
+**The real gap is teardown — and the labs code already flags it.**
+`v2.ts` `registerSpaceHost` says an opened space can't be re-pointed because
+"re-pointing requires an explicit close, *which is lifecycle follow-up work*"
+(v2.ts:~587). Today `StorageManager` holds a per-space `#providers` map and only
+ever closes *all* of them (`close()`/`closeNow()`); per-space contexts
+accumulate for the worker's lifetime.
 
-**Open questions for Berni**
-- Refcount granularity (per page? per cell subscription?) and the
-  close grace-window.
-- Does "remove implicit spaces" land as one mechanical PR, or staged behind the
-  refcount work?
+**Implemented in this PR — `StorageManager.closeSpace(space)`** (the named
+follow-up): the per-space counterpart to `close()` — flush, `provider.destroy()`,
+forget; a later `open(space)` re-establishes a fresh provider; other spaces
+untouched; no-op when not open. (`PieceManager`/`PiecesController` hold no
+persistent `.sink` of their own — just a one-shot `spaceCell.sync()` — so the
+`RuntimeProcessor` `SpaceContext` is GC-safe to drop; the storage *connection*
+was the only real per-space resource needing an explicit close.) Tests in
+`storage-close.test.ts`.
+
+**Remaining — the refcount that drives it (a separate, design-gated step).** A
+`RuntimeProcessor` refcount retains a space on `PageStart` + `CellSubscribe`,
+releases on `PageStop` + `CellUnsubscribe`, and on zero-after-grace evicts the
+`SpaceContext` + calls `closeSpace`. **Open questions for Berni** (why this is
+split out): refcount granularity (per page? per cell subscription? a
+combination?) and the close grace-window — getting them wrong prematurely tears
+down a live space. The teardown primitive is now in; the policy is the call to
+make.
 
 ## Sequencing
 - **A before B**: audience-binding is the security gate that lets the site

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -654,6 +654,32 @@ export class StorageManager implements IStorageManager {
     this.#providers.clear();
   }
 
+  /**
+   * Close a SINGLE space's storage connection — the per-space counterpart to
+   * `close()`, and the "lifecycle follow-up work" `registerSpaceHost` refers to.
+   * Flushes the space's pending writes, destroys its provider, and forgets it,
+   * leaving every other space's connection untouched. A later `open(space)`
+   * re-establishes a fresh provider (at which point a re-pointed host hint can
+   * take effect). No-op when the space isn't open.
+   *
+   * The provider is removed from the map FIRST so a concurrent `open(space)`
+   * gets a fresh provider rather than the one being torn down; the detached
+   * provider still flushes its own pending writes before it is destroyed.
+   *
+   * This is the teardown primitive a space refcount drives (federation §14
+   * PR5 Part B) — long-lived workers that visit many federated spaces can
+   * release the ones no page or subscription references anymore.
+   */
+  async closeSpace(space: MemorySpace): Promise<void> {
+    const provider = this.#providers.get(space);
+    if (!provider) {
+      return;
+    }
+    this.#providers.delete(space);
+    await provider.synced();
+    await provider.destroy();
+  }
+
   edit(): IStorageTransaction {
     return V2Transaction.V2StorageTransaction.create(this);
   }

--- a/packages/runner/test/storage-close.test.ts
+++ b/packages/runner/test/storage-close.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import type {
   MemorySpace,
@@ -106,4 +106,51 @@ Deno.test("Provider.destroyNow force-closes after destroy is already pending", a
 
   assertEquals(result, "closed");
   assertEquals(closeNowCalls, 1);
+});
+
+Deno.test("StorageManager.closeSpace tears down one space, leaves others", async () => {
+  const signer = await Identity.fromPassphrase("storage-close-space");
+  const storage = TestStorageManager.create({
+    as: signer,
+    memoryHost: new URL("http://localhost:65535"),
+  }, new PendingSessionFactory());
+
+  const spaceA = (await Identity.fromPassphrase("close-space-A")).did();
+  const spaceB = (await Identity.fromPassphrase("close-space-B")).did();
+
+  const a1 = storage.open(spaceA);
+  const b1 = storage.open(spaceB);
+  // The session never resolves, so let the graceful flush/destroy complete
+  // without blocking (same technique as the destroyNow test above).
+  if (hasDestroyNowProvider(a1)) {
+    a1.replica.synced = () => Promise.resolve();
+    a1.replica.close = () => Promise.resolve();
+  }
+
+  await storage.closeSpace(spaceA);
+
+  // spaceA is forgotten — a fresh open re-establishes a NEW provider.
+  // spaceB's connection is untouched (same provider instance).
+  assert(
+    storage.open(spaceA) !== a1,
+    "closeSpace should drop spaceA's provider so it re-opens fresh",
+  );
+  assertEquals(
+    storage.open(spaceB),
+    b1,
+    "closeSpace(spaceA) must not touch spaceB",
+  );
+});
+
+Deno.test("StorageManager.closeSpace is a no-op for an unopened space", async () => {
+  const signer = await Identity.fromPassphrase("storage-close-space-noop");
+  const storage = TestStorageManager.create({
+    as: signer,
+    memoryHost: new URL("http://localhost:65535"),
+  }, new PendingSessionFactory());
+
+  // Must not throw or hang when nothing is open for the space.
+  await storage.closeSpace(
+    (await Identity.fromPassphrase("never-opened")).did(),
+  );
 });


### PR DESCRIPTION
Federation §14 PR5 **Part B**, first slice. The labs code already names this gap — `v2.ts` `registerSpaceHost` refuses to re-point an opened space because *"re-pointing requires an explicit close, which is lifecycle follow-up work."* Today `StorageManager` only closes **all** per-space providers at once; per-space connections accumulate for a worker's lifetime, which matters for long-lived workers that visit many federated spaces.

## What's here
- **`StorageManager.closeSpace(space)`** — the per-space counterpart to `close()`: flush the space's pending writes, `destroy()` its provider, forget it (removed from the map first so a concurrent `open` gets a fresh provider). A later `open(space)` re-establishes a clean connection — and a re-pointed host hint can then take effect. Other spaces untouched; no-op when not open.
- Tests in `storage-close.test.ts` (tear-down + leaves-others + no-op).

## On the rest of Part B (for you, @seefeldb)
I verified against current main and updated `docs/development/federation-pr5-design.md`:
- **"Make `space` required" is already done** (#3995 — all page-ops/handlers/lib-shell/RuntimeClient require `space`). The only remaining "optional" `space` sites are **intentional relative-link inheritance** in the data-model layer (`NormalizedLink.space?`, sigil-link `?? from.space`) — making those required would break relative links — plus a couple defensive runtime fallbacks. Not the implicit spaces you meant; left as-is.
- **The refcount that *drives* `closeSpace`** (retain on PageStart/CellSubscribe, release on PageStop/CellUnsubscribe, evict on zero-after-grace) is split out as the next step because the **granularity + grace-window are your call** — getting them wrong prematurely tears down a live space. The teardown primitive is now in; the policy is yours.

Verification: `v2.ts` type-checks; `storage-close.test.ts` 4/4 (2 new + 2 existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-space teardown via `StorageManager.closeSpace` to release a single space’s storage connection without touching others. This prevents connection buildup in long-lived workers and allows host re-pointing to take effect on re-open.

- **New Features**
  - API: `StorageManager.closeSpace(space)` in `packages/runner/src/storage/v2.ts`.
  - Behavior: remove provider from the map first, then `synced()` and `destroy()`; no-op if unopened; a later `open(space)` gets a fresh provider.
  - Tests: added coverage for per-space teardown, isolation from other spaces, and no-op behavior.
  - Docs: updated federation PR5 Part B notes; “make space required” already done; a refcount policy to call `closeSpace` will follow.

<sup>Written for commit ac3afa0d3150110df0275b73fe34ddb0e9ad3d37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

