### PR TITLE
feat(runner): preserve undefined as a real value — make deletion expl…

### DIFF
--- a/docs/specs/sparse-array-preservation.md
+++ b/docs/specs/sparse-array-preservation.md
@@ -126,10 +126,14 @@ so holes survive.
 
 The leaf write itself is one of:
 
-- `parent[slot] = value` for array indices -- the rest of the array
-  (including holes elsewhere) is untouched, so sparseness is preserved.
-- `delete parent[slot]` for array index deletes -- creates a true hole
-  (`i in arr` returns `false` afterwards).
+- `parent[slot] = value` for array index value writes -- the rest of the
+  array (including holes elsewhere) is untouched, so sparseness is
+  preserved. Writing `undefined` stores `undefined` at the slot
+  (present-but-undefined, `i in arr` returns `true`); it does NOT create
+  a hole.
+- `delete parent[slot]` for explicit array index deletes (requested via
+  the write's `delete` option) -- creates a true hole (`i in arr`
+  returns `false` afterwards).
 - `parent.length = effective` for `.length` writes (see
   `applyArrayLengthWrite`) -- JS `length=` truncates the tail, leaving
   holes within the new bound intact.
@@ -176,9 +180,12 @@ for each index:
 | `i in new` | `i in current` | Action |
 |-----------|----------------|--------|
 | No | No | Skip — hole unchanged |
-| No | Yes | Emit delete (attestation interprets `value: undefined` as "create hole") |
-| Yes | No | Diff as new value |
+| No | Yes | Emit explicit delete (`delete: true` on the change; the write layer creates a hole) |
+| Yes | No | Diff as new value (an explicit `undefined` emits a value write, making the slot present-but-undefined) |
 | Yes | Yes | Diff normally |
+
+Note: a change whose `value` is `undefined` WITHOUT the `delete` flag is a
+value write that stores `undefined`; only `delete: true` creates a hole.
 
 The `hasPath` function uses `index in value` (not `value[index] !== undefined`)
 to correctly report that a path through a hole does not exist.

--- a/packages/generated-patterns/integration/patterns/library-checkout-system.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/library-checkout-system.pattern.ts
@@ -261,12 +261,18 @@ const computeAvailability = (
   const loansByItem = new Map<string, LoanRecord[]>();
   for (const loan of loans) {
     const bucket = loansByItem.get(loan.itemId) ?? [];
+    // FIXME(@ubik2) - workaround for transformer removing unused memberId
+    // from bucket contents, which makes the result invalid.
+    const _memberId = loan.memberId;
     bucket.push(loan);
     loansByItem.set(loan.itemId, bucket);
   }
   const holdsByItem = new Map<string, HoldRecord[]>();
   for (const hold of holds) {
     const bucket = holdsByItem.get(hold.itemId) ?? [];
+    // FIXME(@ubik2) - workaround for transformer removing unused memberId
+    // from bucket contents, which makes the result invalid.
+    const _memberId = hold.memberId;
     bucket.push(hold);
     holdsByItem.set(hold.itemId, bucket);
   }

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -343,6 +343,14 @@ export function diffAndUpdate(
 export type ChangeSet = {
   location: NormalizedFullLink;
   value: FabricValue;
+  /**
+   * When true, the change removes the slot at `location` (object key
+   * removal or array hole) instead of writing a value; `value` is
+   * `undefined`. Without this flag, a change whose `value` is `undefined`
+   * stores `undefined` as a real value — present-but-undefined is distinct
+   * from absent.
+   */
+  delete?: boolean;
 }[];
 
 /**
@@ -931,7 +939,8 @@ export function normalizeAndDiff(
       if (!inNew && !inCur) continue; // hole→hole: no change
 
       if (!inNew && inCur) {
-        // value→hole: emit delete (set to undefined)
+        // value→hole: emit an explicit delete (a plain `undefined` write
+        // would store `undefined` rather than punching a hole)
         changes.push({
           location: {
             ...link,
@@ -939,6 +948,7 @@ export function normalizeAndDiff(
             schema: runtime.cfc.getSchemaAtPath(link.schema, [i.toString()]),
           },
           value: undefined,
+          delete: true,
         });
         continue;
       }
@@ -947,6 +957,22 @@ export function normalizeAndDiff(
       const childSchema = runtime.cfc.getSchemaAtPath(link.schema, [
         i.toString(),
       ]);
+
+      // hole→explicit-undefined: a real change (the slot becomes
+      // present-but-undefined) that the value diff below can't see, since
+      // both sides read as `undefined`. Emit the write directly.
+      if (newValue[i] === undefined && !inCur) {
+        changes.push({
+          location: {
+            ...link,
+            path: [...link.path, i.toString()],
+            schema: childSchema,
+          },
+          value: undefined,
+        });
+        continue;
+      }
+
       const nestedChanges = normalizeAndDiff(
         runtime,
         tx,
@@ -1073,6 +1099,19 @@ export function normalizeAndDiff(
       });
 
       const childSchema = runtime.cfc.getSchemaAtPath(link.schema, [key]);
+
+      // An explicit `undefined` for a key the current object doesn't have is
+      // a real change — the slot becomes present-but-undefined — but the
+      // value diff below sees `undefined === undefined` and would emit
+      // nothing. `undefined` is a leaf, so emit the write directly.
+      if (newValue[key] === undefined && !(key in currentRecord)) {
+        changes.push({
+          location: { ...link, path: [...link.path, key], schema: childSchema },
+          value: undefined,
+        });
+        continue;
+      }
+
       const nestedChanges = normalizeAndDiff(
         runtime,
         tx,
@@ -1141,12 +1180,14 @@ export function normalizeAndDiff(
       }
     }
 
-    // Handle removed keys
+    // Handle removed keys: explicit deletes, so a key the new value omits is
+    // removed rather than left behind as present-but-undefined.
     for (const key in currentRecord) {
       if (!(key in newValue) && !eagerScopedKeys.has(key)) {
         changes.push({
           location: { ...link, path: [...link.path, key] },
           value: undefined,
+          delete: true,
         });
       }
     }
@@ -1172,12 +1213,15 @@ export function normalizeAndDiff(
           i < Math.max(currentLength, newLength);
           i++
         ) {
+          // Slots beyond the shorter length are removed (or, on growth,
+          // were never present): explicit deletes, not `undefined` values.
           changes.push({
             location: {
               ...link,
               path: [...link.path.slice(0, -1), i.toString()],
             },
             value: undefined,
+            delete: true,
           });
         }
         return changes;
@@ -1232,7 +1276,8 @@ function hasPath(value: unknown, path: readonly string[]): boolean {
  *
  * Key rules:
  * - Empty objects `{}` or arrays `[]` do NOT subsume children (children populate them)
- * - Parent deletions (`value: undefined`) DO subsume child changes
+ * - Parent deletions (`delete: true`) and parent writes of `undefined` DO
+ *   subsume child changes (either way the subtree at the parent is gone)
  * - Parent must actually CONTAIN the child's path for subsumption to occur
  *
  * @param changes - The original change set
@@ -1261,8 +1306,9 @@ export function compactChangeSet(changes: ChangeSet): ChangeSet {
 
     // Track parent paths that can subsume children
     // Empty {} or [] don't subsume - children populate them!
-    const subsumingPaths: Array<{ path: readonly string[]; value: unknown }> =
-      [];
+    const subsumingPaths: Array<
+      { path: readonly string[]; value: unknown; delete?: boolean }
+    > = [];
 
     for (const change of sorted) {
       const path = change.location.path;
@@ -1284,17 +1330,22 @@ export function compactChangeSet(changes: ChangeSet): ChangeSet {
         return hasPath(parentVal, relativePath);
       });
 
-      // Also check: is this child subsumed by a DELETION of parent?
+      // Also check: is this child subsumed by a parent whose subtree is gone
+      // (explicit delete, or overwritten with `undefined`)?
       const isDeletedByParent = subsumingPaths.some((parent) => {
         if (parent.path.length >= path.length) return false;
         if (!parent.path.every((seg, i) => seg === path[i])) return false;
-        return parent.value === undefined; // Parent deletion subsumes child
+        return parent.delete === true || parent.value === undefined;
       });
 
       if (!isSubsumed && !isDeletedByParent) {
         result.push(change);
         // Track this path for potential child subsumption
-        subsumingPaths.push({ path, value: change.value });
+        subsumingPaths.push({
+          path,
+          value: change.value,
+          delete: change.delete,
+        });
       }
     }
   }
@@ -1326,6 +1377,7 @@ export function applyChangeSet(
       changes.map((change) => ({
         address: change.location,
         value: change.value,
+        delete: change.delete,
       })),
     );
     return;
@@ -1333,7 +1385,11 @@ export function applyChangeSet(
   for (const change of changes) {
     // `diffAndUpdate()` establishes attempted-target coverage before we get
     // here, so these direct writes preserve the phase-1 `attemptedWrites` view.
-    tx.writeValueOrThrow(change.location, change.value);
+    tx.writeValueOrThrow(
+      change.location,
+      change.value,
+      change.delete ? { delete: true } : undefined,
+    );
   }
 }
 

--- a/packages/runner/src/path-utils.ts
+++ b/packages/runner/src/path-utils.ts
@@ -17,15 +17,10 @@ export function setValueAtPath(
 
   if (deepEqual(parent[path[path.length - 1]], value)) return false;
 
-  if (value === undefined) {
-    delete parent[path[path.length - 1]];
-    // Truncate array from the end for undefined values
-    if (Array.isArray(parent)) {
-      while (parent.length > 0 && parent[parent.length - 1] === undefined) {
-        parent.pop();
-      }
-    }
-  } else parent[path[path.length - 1]] = value;
+  // We just set the values here. If you need to delete elements from an
+  // array or object, set it to another array or object without those elements.
+  // We can set value to undefined here without issue
+  parent[path[path.length - 1]] = value;
 
   return true;
 }
@@ -47,7 +42,7 @@ export function hasValueAtPath(obj: any, path: PropertyKey[]): boolean {
     }
     current = current[key];
   }
-  return current !== undefined;
+  return true;
 }
 
 export function arrayEqual(

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -19,6 +19,7 @@ import type {
   IReadOptions,
   IStorageTransaction,
   ITransactionJournal,
+  IWriteOptions,
   MemorySpace,
   Metadata,
   ReadError,
@@ -662,6 +663,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   write(
     address: IMemorySpaceAddress,
     value: FabricValue,
+    options?: IWriteOptions,
   ): Result<IAttestation, WriteError | WriterError> {
     this.assertWritable("write()");
     this.noteSystemWrite(address);
@@ -670,12 +672,13 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       this.invalidateCfc("write-after-prepare");
     }
     this.invalidateReadResultCache();
-    return this.tx.write(address, value);
+    return this.tx.write(address, value, options);
   }
 
   writeOrThrow(
     address: IMemorySpaceAddress,
     value: FabricValue,
+    options?: IWriteOptions,
   ): void {
     this.assertWritable("writeOrThrow()");
     this.noteSystemWrite(address);
@@ -684,11 +687,16 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       this.invalidateCfc("write-after-prepare");
     }
     this.invalidateReadResultCache();
-    const writeResult = this.tx.write(address, value);
+    const writeResult = this.tx.write(address, value, options);
     if (
       writeResult.error &&
       (writeResult.error.name === "NotFoundError")
     ) {
+      if (options?.delete) {
+        // Deleting a slot whose path doesn't exist is a no-op; don't
+        // materialize intermediates just to remove nothing.
+        return;
+      }
       // Create parent entries if needed.
       // errorPath includes the missing key (consistent with read errors).
       // lastExistingPath is one level up - the actual last existing parent.
@@ -755,13 +763,16 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   writeValueOrThrow(
     address: NormalizedFullLink,
     value: FabricValue,
+    options?: IWriteOptions,
   ): void {
     this.assertWritable("writeValueOrThrow()");
-    this.writeOrThrow(toMemorySpaceAddress(address), value);
+    this.writeOrThrow(toMemorySpaceAddress(address), value, options);
   }
 
   writeValuesOrThrow(
-    writes: Iterable<{ address: NormalizedFullLink; value: FabricValue }>,
+    writes: Iterable<
+      { address: NormalizedFullLink; value: FabricValue; delete?: boolean }
+    >,
   ): void {
     this.assertWritable("writeValuesOrThrow()");
     this.invalidateReadResultCache();
@@ -782,7 +793,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
             const address = toMemorySpaceAddress(write.address);
             noteSystemWrite(address);
             noteWriteIdentity();
-            yield { address, value: write.value };
+            yield { address, value: write.value, delete: write.delete };
           }
         })(),
       );
@@ -793,7 +804,11 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     }
 
     for (const write of writes) {
-      this.writeValueOrThrow(write.address, write.value);
+      this.writeValueOrThrow(
+        write.address,
+        write.value,
+        write.delete ? { delete: true } : undefined,
+      );
     }
   }
 
@@ -1205,32 +1220,41 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
   write(
     address: IMemorySpaceAddress,
     value: FabricValue,
+    options?: IWriteOptions,
   ): Result<IAttestation, WriteError | WriterError> {
-    return this.wrapped.write(address, value);
+    return this.wrapped.write(address, value, options);
   }
 
   writeOrThrow(
     address: IMemorySpaceAddress,
     value: FabricValue,
+    options?: IWriteOptions,
   ): void {
-    return this.wrapped.writeOrThrow(address, value);
+    return this.wrapped.writeOrThrow(address, value, options);
   }
 
   writeValueOrThrow(
     address: NormalizedFullLink,
     value: FabricValue,
+    options?: IWriteOptions,
   ): void {
-    return this.wrapped.writeValueOrThrow(address, value);
+    return this.wrapped.writeValueOrThrow(address, value, options);
   }
 
   writeValuesOrThrow(
-    writes: Iterable<{ address: NormalizedFullLink; value: FabricValue }>,
+    writes: Iterable<
+      { address: NormalizedFullLink; value: FabricValue; delete?: boolean }
+    >,
   ): void {
     if (this.wrapped.writeValuesOrThrow) {
       return this.wrapped.writeValuesOrThrow(writes);
     }
     for (const write of writes) {
-      this.wrapped.writeValueOrThrow(write.address, write.value);
+      this.wrapped.writeValueOrThrow(
+        write.address,
+        write.value,
+        write.delete ? { delete: true } : undefined,
+      );
     }
   }
 

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -465,9 +465,25 @@ export interface IResetNotification {
 export interface IMergedChanges extends Iterable<IMemoryChange> {
 }
 
+/**
+ * Options accepted by transaction write operations.
+ */
+export interface IWriteOptions {
+  /**
+   * When true, the write removes the slot at the address path — deleting an
+   * object key or punching an array hole — instead of storing a value.
+   * `value` must be `undefined`. Without this flag, writing `undefined`
+   * stores `undefined` as a real value: present-but-undefined is distinct
+   * from absent. A root-path delete retracts the document.
+   */
+  delete?: boolean;
+}
+
 export interface ITransactionWriteRequest {
   address: IMemorySpaceAddress;
   value: FabricValue;
+  /** See {@link IWriteOptions.delete}. */
+  delete?: boolean;
 }
 
 export interface IMemoryChange {
@@ -655,11 +671,13 @@ export interface IStorageTransaction {
    *
    * @param address - Memory address to write to.
    * @param value - Value to write.
+   * @param options - Optional write options (e.g. explicit delete intent).
    * @returns Result containing the written value or an error.
    */
   write(
     address: IMemorySpaceAddress,
     value?: FabricValue,
+    options?: IWriteOptions,
   ): Result<IAttestation, WriterError | WriteError>;
 
   /**
@@ -891,10 +909,12 @@ export interface IExtendedStorageTransaction
    *
    * @param address - Memory address to write to.
    * @param value - Value to write.
+   * @param options - Optional write options (e.g. explicit delete intent).
    */
   writeOrThrow(
     address: IMemorySpaceAddress,
     value: FabricValue,
+    options?: IWriteOptions,
   ): void;
 
   /**
@@ -911,10 +931,12 @@ export interface IExtendedStorageTransaction
    *
    * @param address - Memory address to write to.
    * @param value - Value to write.
+   * @param options - Optional write options (e.g. explicit delete intent).
    */
   writeValueOrThrow(
     address: NormalizedFullLink,
     value: FabricValue,
+    options?: IWriteOptions,
   ): void;
 
   /**
@@ -922,7 +944,9 @@ export interface IExtendedStorageTransaction
    * `["value", ...path]` helper semantics on top of `writeBatch`.
    */
   writeValuesOrThrow?(
-    writes: Iterable<{ address: NormalizedFullLink; value: FabricValue }>,
+    writes: Iterable<
+      { address: NormalizedFullLink; value: FabricValue; delete?: boolean }
+    >,
   ): void;
 
   /**
@@ -1007,6 +1031,7 @@ export interface ITransactionWriter extends ITransactionReader {
   write(
     address: IMemoryAddress,
     value?: FabricValue,
+    options?: IWriteOptions,
   ): Result<IAttestation, WriteError>;
 }
 

--- a/packages/runner/src/storage/transaction.ts
+++ b/packages/runner/src/storage/transaction.ts
@@ -14,6 +14,7 @@ import type {
   IStorageTransactionWriteIsolationError,
   ITransactionReader,
   ITransactionWriter,
+  IWriteOptions,
   MemorySpace,
   ReaderError,
   Result,
@@ -122,8 +123,12 @@ class StorageTransaction implements IStorageTransaction {
     return read(this, address, options);
   }
 
-  write(address: IMemorySpaceAddress, value?: FabricValue) {
-    return write(this, address, value);
+  write(
+    address: IMemorySpaceAddress,
+    value?: FabricValue,
+    options?: IWriteOptions,
+  ) {
+    return write(this, address, value, options);
   }
 
   abort(reason?: unknown): Result<Unit, InactiveTransactionError> {
@@ -267,13 +272,14 @@ export const write = (
   transaction: StorageTransaction,
   address: IMemorySpaceAddress,
   value?: FabricValue,
+  options?: IWriteOptions,
 ): Result<IAttestation, WriterError | WriteError> => {
   const { ok: space, error } = writer(transaction, address.space);
   if (error) {
     return { error };
   } else {
     const { space: _, ...memoryAddress } = address;
-    const result = space.write(memoryAddress, value);
+    const result = space.write(memoryAddress, value, options);
     if (!result.error) {
       recordWriteStackTrace(address, value, {
         scopeId:

--- a/packages/runner/src/storage/transaction/chronicle.ts
+++ b/packages/runner/src/storage/transaction/chronicle.ts
@@ -13,6 +13,7 @@ import type {
   ITransaction,
   ITypeMismatchError,
   IUnsupportedMediaTypeError,
+  IWriteOptions,
   MemorySpace,
   Result,
   State,
@@ -57,16 +58,18 @@ const applyWriteToAttestation = (
   source: IAttestation,
   address: IMemoryAddress,
   value: FabricValue | undefined,
+  options?: IWriteOptions,
 ): Result<IAttestation, INotFoundError | ITypeMismatchError> => {
   const relativePath = address.path.slice(source.address.path.length);
 
   // Root write: pure replacement; bypass `applyMutablePathWrite` to
   // avoid forcing a deep-equal comparison (we know nothing here is
   // structurally equal to the new root unless it's literally the
-  // same reference).
+  // same reference). A root delete retracts (root becomes undefined).
   if (relativePath.length === 0) {
-    if (source.value === value) return { ok: source };
-    return { ok: { ...source, value } };
+    const nextValue = options?.delete === true ? undefined : value;
+    if (source.value === nextValue) return { ok: source };
+    return { ok: { ...source, value: nextValue } };
   }
 
   if (source.value === undefined) {
@@ -76,7 +79,12 @@ const applyWriteToAttestation = (
   }
 
   const relativeAddress = { ...address, path: relativePath };
-  const result = applyMutablePathWrite(source.value, relativeAddress, value);
+  const result = applyMutablePathWrite(
+    source.value,
+    relativeAddress,
+    value,
+    options,
+  );
   if (result.error) {
     return { error: result.error };
   }
@@ -198,6 +206,7 @@ export class Chronicle {
   write(
     address: IMemoryAddress,
     value?: FabricValue,
+    options?: IWriteOptions,
   ): Result<
     IAttestation,
     | IStorageTransactionInconsistent
@@ -239,7 +248,7 @@ export class Chronicle {
     }
 
     // Apply the write directly to the working copy - O(1) instead of O(N)
-    return changes.applyWrite(address, value);
+    return changes.applyWrite(address, value, options);
   }
 
   read(
@@ -564,6 +573,7 @@ class Changes {
   applyWrite(
     address: IMemoryAddress,
     value: FabricValue,
+    options?: IWriteOptions,
   ): Result<
     IAttestation,
     IStorageTransactionInconsistent | INotFoundError | ITypeMismatchError
@@ -590,12 +600,17 @@ class Changes {
       this.#workingCopy,
       address,
       value,
+      options,
     );
     if (result.ok) {
       this.#workingCopy = result.ok;
-      // Store individual path attestation for novelty() iterator
+      // Store individual path attestation for novelty() iterator. A delete
+      // records `undefined` at the path, matching the post-write state.
       const pathKey = JSON.stringify(address.path);
-      this.#pathAttestations.set(pathKey, { address, value });
+      this.#pathAttestations.set(pathKey, {
+        address,
+        value: options?.delete === true ? undefined : value,
+      });
     }
     return result;
   }

--- a/packages/runner/src/storage/transaction/journal.ts
+++ b/packages/runner/src/storage/transaction/journal.ts
@@ -12,6 +12,7 @@ import type {
   ITransactionJournal,
   ITransactionReader,
   ITransactionWriter,
+  IWriteOptions,
   JournalArchive,
   MemorySpace,
   ReadError,
@@ -155,12 +156,13 @@ export const write = (
   space: MemorySpace,
   address: IMemoryAddress,
   value?: FabricValue,
+  options?: IWriteOptions,
 ): Result<IAttestation, WriteError> => {
   const { ok: branch, error } = checkout(journal, space);
   if (error) {
     return { error };
   } else {
-    const result = branch.write(address, value);
+    const result = branch.write(address, value, options);
     if (result.error) {
       return { error: result.error.from(space) };
     } else {
@@ -366,8 +368,9 @@ export class TransactionWriter implements ITransactionWriter {
   write(
     address: IMemoryAddress,
     value?: FabricValue,
+    options?: IWriteOptions,
   ) {
-    return write(this.#journal, this.#space, address, value);
+    return write(this.#journal, this.#space, address, value, options);
   }
 }
 

--- a/packages/runner/src/storage/transaction/mutable-path-write.ts
+++ b/packages/runner/src/storage/transaction/mutable-path-write.ts
@@ -32,6 +32,17 @@ export type MutableWriteResult = {
   changed: boolean;
 };
 
+export type MutablePathWriteOptions = {
+  /**
+   * When true, the write removes the slot at the address path — deleting an
+   * object key or punching an array hole — instead of storing a value.
+   * `value` is ignored (callers pass `undefined`). Without this flag,
+   * writing `undefined` stores `undefined` as a real value:
+   * present-but-undefined is distinct from absent.
+   */
+  delete?: boolean;
+};
+
 export const isContainerValue = (
   value: FabricValue | undefined,
 ): value is Record<string, FabricValue> | FabricValue[] =>
@@ -55,12 +66,21 @@ export const getValueTypeName = (value: FabricValue | undefined): string => {
  * Delegates spine descent + thaw + missing-intermediate creation to
  * `cloneForMutation` (with `createMissing: true`), which exposes the
  * parent container at `address.path.slice(0, -1)` as a mutable handle.
- * The function then performs the leaf write -- a property set/delete on
- * an object, an element set/delete on an array, or the legacy
- * length-write coercion when the parent is an array and the leaf key is
- * `"length"`. Subtrees off the spine are preserved by identity, so a
- * subsequent re-freeze short-circuits on everything except the freshly
- * thawed spine.
+ * The function then performs the leaf write -- a property set on an
+ * object, an element set on an array, or the legacy length-write
+ * coercion when the parent is an array and the leaf key is `"length"`.
+ * Subtrees off the spine are preserved by identity, so a subsequent
+ * re-freeze short-circuits on everything except the freshly thawed
+ * spine.
+ *
+ * Writing `undefined` stores `undefined` (present-but-undefined is a
+ * real state, distinct from absent) and materializes missing
+ * intermediates like any other value. Removal is requested explicitly
+ * via `options.delete`, which deletes the leaf slot (object key removal
+ * or array hole) and never materializes intermediates for a slot that
+ * wasn't there. A delete with leaf key `"length"` funnels through the
+ * legacy length coercion (undefined → NaN → truncate), matching the
+ * historical `tx.write(path/length, undefined)` behavior.
  *
  * `force: false` is passed to `cloneForMutation` because the root, by
  * this point, is either (a) freshly allocated by us (in the
@@ -72,19 +92,25 @@ export const applyMutablePathWrite = (
   currentRoot: FabricValue | undefined,
   address: IMemoryAddress,
   value: FabricValue | undefined,
+  options?: MutablePathWriteOptions,
 ): Result<MutableWriteResult, ITypeMismatchError> => {
+  const isDelete = options?.delete === true;
   if (address.path.length === 0) {
+    const nextRoot = isDelete ? undefined : value;
     return {
       ok: {
-        root: value,
+        root: nextRoot,
         previousValue: currentRoot,
-        changed: !deepEqual(currentRoot, value),
+        changed: !deepEqual(currentRoot, nextRoot),
       },
     };
   }
 
   if (currentRoot === undefined) {
-    if (value === undefined) {
+    if (isDelete) {
+      // Delete-of-nonexistent stays a no-op: don't materialize intermediates
+      // just to remove a slot that wasn't there. A non-delete write — even of
+      // `undefined` — materializes the path below.
       return {
         ok: {
           root: currentRoot,
@@ -157,28 +183,37 @@ export const applyMutablePathWrite = (
     }
     const slot = Number(leafKey);
     const previousValue = parent[slot];
-    if (deepEqual(previousValue, value)) {
+    if (isDelete) {
+      if (!(slot in parent)) {
+        return { ok: { root: newRoot, previousValue, changed: false } };
+      }
+      delete parent[slot];
+      return { ok: { root: newRoot, previousValue, changed: true } };
+    }
+    // Presence-aware no-op detection: a hole and a stored `undefined` are
+    // different states, so equal values only short-circuit when the slot
+    // actually exists.
+    if (slot in parent && deepEqual(previousValue, value)) {
       return { ok: { root: newRoot, previousValue, changed: false } };
     }
-    if (value === undefined) {
-      delete parent[slot];
-    } else {
-      parent[slot] = value;
-    }
+    parent[slot] = value;
     return { ok: { root: newRoot, previousValue, changed: true } };
   }
 
   // Object branch.
   const obj = parent as Record<string, FabricValue>;
   const previousValue = obj[leafKey];
-  if (deepEqual(previousValue, value)) {
+  if (isDelete) {
+    if (!(leafKey in obj)) {
+      return { ok: { root: newRoot, previousValue, changed: false } };
+    }
+    delete obj[leafKey];
+    return { ok: { root: newRoot, previousValue, changed: true } };
+  }
+  if (leafKey in obj && deepEqual(previousValue, value)) {
     return { ok: { root: newRoot, previousValue, changed: false } };
   }
-  if (value === undefined) {
-    delete obj[leafKey];
-  } else {
-    obj[leafKey] = value;
-  }
+  obj[leafKey] = value as FabricValue;
   return { ok: { root: newRoot, previousValue, changed: true } };
 };
 

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -25,6 +25,7 @@ import type {
   ITransactionReader,
   ITransactionWriter,
   ITransactionWriteRequest,
+  IWriteOptions,
   MediaType,
   MemorySpace,
   NativeStorageCommit,
@@ -65,7 +66,7 @@ import {
   isReadIgnoredForScheduling,
   isReadMarkedAsAttemptedWrite,
 } from "./reactivity-log.ts";
-import { readValueAtPath } from "./v2-path.ts";
+import { hasValueAtPath, readValueAtPath } from "./v2-path.ts";
 import { recordWriteStackTrace } from "./write-stack-trace.ts";
 import { normalizeCellScope } from "../scope.ts";
 import type { CellScope } from "../builder/types.ts";
@@ -340,9 +341,11 @@ const schedulerObservationCommitSpace = (
 const findMaterializedParentPath = (
   currentRoot: FabricValue | undefined,
   path: readonly string[],
-  value: FabricValue | undefined,
+  isDelete: boolean,
 ): readonly string[] | undefined => {
-  if (value === undefined) {
+  // Deletes never materialize intermediates; value writes (including
+  // explicit `undefined`) do.
+  if (isDelete) {
     return undefined;
   }
 
@@ -434,24 +437,38 @@ const findDeepestArrayPath = (
     : path.slice(0, firstArrayLikeSegment);
 };
 
+/**
+ * Builds a patch op from before/after state at `path`. Presence (slot
+ * exists) is distinct from value: a slot holding `undefined` is present,
+ * so add/remove are chosen from presence transitions, and a stored
+ * `undefined` travels as a `replace`/`add` whose value is `undefined`.
+ * When presence flags are omitted they are inferred from value
+ * definedness (legacy callers in the array fast-path, where presence
+ * parity was already established via `in` checks).
+ */
 const buildValuePatchCandidate = (
   path: readonly string[],
   value: FabricValue | undefined,
   previousValue: FabricValue | undefined,
+  valuePresent: boolean = value !== undefined,
+  previousPresent: boolean = previousValue !== undefined,
 ): PatchDraftCandidate | null => {
-  if (deepEqual(value, previousValue)) {
+  if (valuePresent === previousPresent && deepEqual(value, previousValue)) {
     return null;
   }
 
   const pointer = encodePointer(path);
-  if (value === undefined) {
+  if (!valuePresent) {
+    if (!previousPresent) {
+      return null;
+    }
     return {
       patch: { op: "remove", path: pointer },
       path,
       coversDescendants: true,
     };
   }
-  if (previousValue === undefined) {
+  if (!previousPresent) {
     return {
       patch: { op: "add", path: pointer, value },
       path,
@@ -481,26 +498,42 @@ const buildArrayPatchCandidates = (
   path: readonly string[],
   before: FabricValue | undefined,
   after: FabricValue | undefined,
+  beforePresent: boolean = before !== undefined,
+  afterPresent: boolean = after !== undefined,
 ): PatchDraftCandidate[] => {
-  if (deepEqual(before, after)) {
+  if (beforePresent === afterPresent && deepEqual(before, after)) {
     return [];
   }
 
   if (!Array.isArray(before) || !Array.isArray(after)) {
-    const candidate = buildValuePatchCandidate(path, after, before);
+    const candidate = buildValuePatchCandidate(
+      path,
+      after,
+      before,
+      afterPresent,
+      beforePresent,
+    );
     return candidate ? [candidate] : [];
   }
 
+  // Both sides are arrays from here on, so the array slot itself is present
+  // in both states; fallbacks below replace the whole array.
   const overlappingLength = Math.min(before.length, after.length);
   for (let index = 0; index < overlappingLength; index += 1) {
     if ((index in before) !== (index in after)) {
-      const fallback = buildValuePatchCandidate(path, after, before);
+      const fallback = buildValuePatchCandidate(
+        path,
+        after,
+        before,
+        true,
+        true,
+      );
       return fallback ? [fallback] : [];
     }
   }
 
   if (after.length > before.length && !arrayTailIsDense(after, before.length)) {
-    const fallback = buildValuePatchCandidate(path, after, before);
+    const fallback = buildValuePatchCandidate(path, after, before, true, true);
     return fallback ? [fallback] : [];
   }
 
@@ -556,7 +589,7 @@ const buildArrayPatchCandidates = (
   }
 
   if (candidates.length === 0) {
-    const fallback = buildValuePatchCandidate(path, after, before);
+    const fallback = buildValuePatchCandidate(path, after, before, true, true);
     return fallback ? [fallback] : [];
   }
 
@@ -725,8 +758,9 @@ class V2Writer extends V2Reader implements ITransactionWriter {
   write(
     address: IMemoryAddress,
     value?: FabricValue,
+    options?: IWriteOptions,
   ): Result<IAttestation, WriteError> {
-    return this.tx.writeWithinSpace(this.did(), address, value);
+    return this.tx.writeWithinSpace(this.did(), address, value, options);
   }
 }
 
@@ -1058,12 +1092,19 @@ export class V2StorageTransaction implements IStorageTransaction {
   write(
     address: IMemorySpaceAddress,
     value?: FabricValue,
+    options?: IWriteOptions,
   ): Result<IAttestation, WriterError | WriteError> {
     const ready = this.prepareWriteSpace(address.space);
     if (ready.error) {
       return { error: ready.error };
     }
-    return this.writeWithinBranch(ready.ok, address.space, address, value);
+    return this.writeWithinBranch(
+      ready.ok,
+      address.space,
+      address,
+      value,
+      options,
+    );
   }
 
   writeBatch(
@@ -1116,9 +1157,16 @@ export class V2StorageTransaction implements IStorageTransaction {
     space: MemorySpace,
     address: IMemoryAddress,
     value?: FabricValue,
+    options?: IWriteOptions,
   ): Result<IAttestation, WriteError> {
     this.assertWritable("write()");
-    return this.writeWithinBranch(this.branch(space), space, address, value);
+    return this.writeWithinBranch(
+      this.branch(space),
+      space,
+      address,
+      value,
+      options,
+    );
   }
 
   /**
@@ -1129,34 +1177,44 @@ export class V2StorageTransaction implements IStorageTransaction {
    * subtrees stay deep-frozen and structurally shared with the prior
    * `doc.current.value`.
    *
-   * No-op short-circuits:
-   *   - If the leaf is already deep-equal to `value`, return the unchanged
-   *     attestation.
-   *   - If `value === undefined` and the leaf doesn't exist (path not
-   *     found), return the unchanged attestation -- don't allocate
-   *     intermediate containers just to delete a slot that wasn't there.
+   * No-op short-circuits (presence-aware: a stored `undefined` is a real
+   * state, distinct from an absent slot):
+   *   - For a value write, if the leaf exists and is already deep-equal to
+   *     `value`, return the unchanged attestation. A write of `undefined`
+   *     to an absent leaf is NOT a no-op — it stores `undefined`,
+   *     materializing intermediates if needed.
+   *   - For a delete (`options.delete`), if the leaf doesn't exist —
+   *     whether the leaf slot is absent or an intermediate is missing —
+   *     return the unchanged attestation; don't allocate intermediate
+   *     containers just to delete a slot that wasn't there.
    */
   private writeWithinBranch(
     branch: SpaceBranch,
     space: MemorySpace,
     address: IMemoryAddress,
     value?: FabricValue,
+    options?: IWriteOptions,
   ): Result<IAttestation, WriteError> {
     if (address.id.startsWith("data:")) {
       return { error: ReadOnlyAddressError(address).from(space) };
     }
+    const isDelete = options?.delete === true;
 
     const { doc: readDoc } = this.document(branch, address);
     const doc = ensureWritableDocument(readDoc);
     const current = doc.current;
     const previous = inspectPath(current.value, address.path);
-    if (previous.kind === "ok" && deepEqual(previous.value, value)) {
-      return { ok: current };
+    if (previous.kind === "ok") {
+      const present = hasValueAtPath(current.value, address.path, {
+        allowArrayLength: true,
+      });
+      if (
+        isDelete ? !present : (present && deepEqual(previous.value, value))
+      ) {
+        return { ok: current };
+      }
     }
-    // Delete-of-nonexistent: don't create intermediate containers just to
-    // express "remove a slot that wasn't there." This preserves the
-    // previous `writeWithinSpaceCreatingParents` short-circuit.
-    if (previous.kind === "notFound" && value === undefined) {
+    if (previous.kind === "notFound" && isDelete) {
       return { ok: current };
     }
 
@@ -1179,7 +1237,7 @@ export class V2StorageTransaction implements IStorageTransaction {
     const activityPath = findMaterializedParentPath(
       current.value,
       address.path,
-      isolatedValue,
+      isDelete,
     ) ?? address.path;
     const previousActivityValue = cloneIfNecessary(
       readValueAtPath(current.value, activityPath, {
@@ -1191,6 +1249,7 @@ export class V2StorageTransaction implements IStorageTransaction {
       current.value,
       address,
       isolatedValue,
+      isDelete ? { delete: true } : undefined,
     );
     if (result.error) {
       return { error: result.error.from(space) };
@@ -1240,8 +1299,13 @@ export class V2StorageTransaction implements IStorageTransaction {
       // Singleton-batch / data:URI fallback: route each write through the
       // unified single-write entry, which itself handles
       // create-missing-intermediates.
-      for (const { address, value } of writes) {
-        const result = this.writeWithinSpace(space, address, value);
+      for (const { address, value, delete: isDelete } of writes) {
+        const result = this.writeWithinSpace(
+          space,
+          address,
+          value,
+          isDelete ? { delete: true } : undefined,
+        );
         if (result.error) {
           return { error: result.error };
         }
@@ -1271,27 +1335,42 @@ export class V2StorageTransaction implements IStorageTransaction {
     // reading it AFTER the call would observe the post-write state.
     // (See `writeWithinBranch` for the same invariant and a regression
     // test.)
-    for (const { address, value } of writes) {
+    for (const { address, value, delete: isDelete } of writes) {
       const isolatedValue = value === undefined
         ? undefined
         : cloneIfNecessary(value) as FabricValue;
       const previousValue = readValueAtPath(nextRoot, address.path, {
         allowArrayLength: true,
       });
-      if (deepEqual(previousValue, isolatedValue)) {
+      // Presence-aware no-op detection (also keeps no-op deletes from
+      // reaching `applyMutablePathWrite`, which would materialize
+      // intermediates into `nextRoot` before the changed check).
+      const present = hasValueAtPath(nextRoot, address.path, {
+        allowArrayLength: true,
+      });
+      if (
+        isDelete
+          ? !present
+          : (present && deepEqual(previousValue, isolatedValue))
+      ) {
         continue;
       }
       const activityPath = findMaterializedParentPath(
         nextRoot,
         address.path,
-        isolatedValue,
+        isDelete === true,
       ) ?? address.path;
       const previousActivityValue = cloneIfNecessary(
         readValueAtPath(nextRoot, activityPath, {
           allowArrayLength: true,
         }) as FabricValue,
       ) as FabricValue | undefined;
-      const result = applyMutablePathWrite(nextRoot, address, isolatedValue);
+      const result = applyMutablePathWrite(
+        nextRoot,
+        address,
+        isolatedValue,
+        isDelete ? { delete: true } : undefined,
+      );
       if (result.error) {
         if (changed) {
           doc.current = {
@@ -1915,6 +1994,8 @@ export class V2StorageTransaction implements IStorageTransaction {
       path: readonly string[];
       value: FabricValue | undefined;
       previousValue: FabricValue | undefined;
+      valuePresent: boolean;
+      previousPresent: boolean;
     }>();
     const arrayGroups = new Map<string, readonly string[]>();
     for (const detail of details) {
@@ -1928,7 +2009,22 @@ export class V2StorageTransaction implements IStorageTransaction {
         detail.address.path,
         { allowArrayLength: true },
       );
-      if (deepEqual(value, previousValue)) {
+      // Presence-aware change detection: present-but-undefined and absent
+      // both read as `undefined`, but transitions between them are real
+      // changes (add/remove of an `undefined`-valued slot).
+      const valuePresent = hasValueAtPath(
+        doc.current.value,
+        detail.address.path,
+        { allowArrayLength: true },
+      );
+      const previousPresent = hasValueAtPath(
+        doc.initial.value,
+        detail.address.path,
+        { allowArrayLength: true },
+      );
+      if (
+        valuePresent === previousPresent && deepEqual(value, previousValue)
+      ) {
         continue;
       }
 
@@ -1946,6 +2042,8 @@ export class V2StorageTransaction implements IStorageTransaction {
         path: detail.address.path,
         value,
         previousValue,
+        valuePresent,
+        previousPresent,
       });
     }
 
@@ -1955,6 +2053,8 @@ export class V2StorageTransaction implements IStorageTransaction {
         detail.path,
         detail.value,
         detail.previousValue,
+        detail.valuePresent,
+        detail.previousPresent,
       );
       if (candidate) {
         fullCoverCandidates.push(candidate);
@@ -1974,6 +2074,12 @@ export class V2StorageTransaction implements IStorageTransaction {
           arrayPath,
           beforeValue,
           afterValue,
+          hasValueAtPath(doc.initial.value, arrayPath, {
+            allowArrayLength: true,
+          }),
+          hasValueAtPath(doc.current.value, arrayPath, {
+            allowArrayLength: true,
+          }),
         )
       ) {
         if (candidate.coversDescendants) {

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -3434,19 +3434,6 @@ export class SchemaObjectTraverser<V extends FabricValue>
         schema: itemSchema,
       };
       this.tx.read(curDoc.address, READ_NON_RECURSIVE_FOR_SCHEDULING);
-      // TODO(danfuzz): Sparse array holes should be preserved by the data
-      // model, but they currently come back as `null` from the storage
-      // boundary — that's a bug. As a stopgap, when the item schema expects
-      // cells/streams, or the schema rejects both `null` and `undefined`, treat
-      // that committed `null` as a missing slot so array consumers still see
-      // hole semantics. Fix the hole densification at its source and remove
-      // this.
-      if (
-        item === null &&
-        this.shouldTreatNullArrayEntryAsHole(curSelector.schema)
-      ) {
-        return true;
-      }
       // We follow the first link in array elements so we don't have
       // strangeness with setting item at 0 to item at 1. If the element on
       // the array is a link, we follow that link so the returned object is
@@ -3590,25 +3577,6 @@ export class SchemaObjectTraverser<V extends FabricValue>
       return true;
     });
     return valid ? arrayObj : undefined;
-  }
-
-  private shouldTreatNullArrayEntryAsHole(
-    schema: JSONSchema | undefined,
-  ): boolean {
-    if (
-      schema === undefined ||
-      ContextualFlowControl.isTrueSchema(schema) ||
-      ContextualFlowControl.isFalseSchema(schema)
-    ) {
-      return false;
-    }
-
-    if (SchemaObjectTraverser.hasAsCell(schema)) {
-      return true;
-    }
-
-    return this.isValidType(schema, "null") === TypeValidity.False &&
-      this.isValidType(schema, "undefined") === TypeValidity.False;
   }
 
   /**

--- a/packages/runner/test/memory-v2-envelope-delete.test.ts
+++ b/packages/runner/test/memory-v2-envelope-delete.test.ts
@@ -6,7 +6,7 @@ import * as Chronicle from "../src/storage/transaction/chronicle.ts";
 const signer = await Identity.fromPassphrase("memory v2 envelope delete");
 const space = signer.did();
 
-Deno.test("memory v2 chronicle retracts an empty JSON envelope", async () => {
+Deno.test("memory v2 chronicle retracts when the envelope value is deleted", async () => {
   const storage = StorageManager.emulate({
     as: signer,
   });
@@ -26,8 +26,54 @@ Deno.test("memory v2 chronicle retracts an empty JSON envelope", async () => {
     });
 
     const chronicle = Chronicle.open(replica);
+    // Explicit delete of the envelope's `value` key empties the envelope,
+    // which commits as a retraction.
+    chronicle.write(
+      {
+        id: "test:delete-envelope",
+        type: "application/json",
+        path: ["value"],
+      },
+      undefined,
+      { delete: true },
+    );
+
+    const commitResult = chronicle.commit();
+    const transaction = commitResult.ok!;
+
+    assertEquals(commitResult.error, undefined);
+    assertEquals(transaction.facts.length, 1);
+    assertEquals(transaction.facts[0].of, "test:delete-envelope");
+    assertEquals(transaction.facts[0].is, undefined);
+  } finally {
+    await storage.close();
+  }
+});
+
+Deno.test("memory v2 chronicle preserves an envelope whose value is written as undefined", async () => {
+  const storage = StorageManager.emulate({
+    as: signer,
+  });
+
+  try {
+    const replica = storage.open(space).replica;
+    if (!replica.commitNative) {
+      throw new Error("Expected memory v2 replica to support commitNative()");
+    }
+    await replica.commitNative({
+      operations: [{
+        op: "set",
+        id: "test:set-undefined-envelope",
+        type: "application/json",
+        value: { value: { name: "ToClear", active: true } },
+      }],
+    });
+
+    const chronicle = Chronicle.open(replica);
+    // A plain write of `undefined` stores `undefined` as the envelope value;
+    // the fact stays asserted (present-but-undefined, not retracted).
     chronicle.write({
-      id: "test:delete-envelope",
+      id: "test:set-undefined-envelope",
       type: "application/json",
       path: ["value"],
     }, undefined);
@@ -37,8 +83,13 @@ Deno.test("memory v2 chronicle retracts an empty JSON envelope", async () => {
 
     assertEquals(commitResult.error, undefined);
     assertEquals(transaction.facts.length, 1);
-    assertEquals(transaction.facts[0].of, "test:delete-envelope");
-    assertEquals(transaction.facts[0].is, undefined);
+    assertEquals(transaction.facts[0].of, "test:set-undefined-envelope");
+    const is = transaction.facts[0].is as
+      | Record<string, unknown>
+      | undefined;
+    assertEquals(is !== undefined, true);
+    assertEquals(Object.hasOwn(is!, "value"), true);
+    assertEquals(is!.value, undefined);
   } finally {
     await storage.close();
   }

--- a/packages/runner/test/memory-v2-native-commit.test.ts
+++ b/packages/runner/test/memory-v2-native-commit.test.ts
@@ -242,12 +242,16 @@ Deno.test("memory v2 transactions emit add and remove patch drafts for safe obje
     drafts.length = 0;
 
     const removeTx = storage.edit();
-    const removeWrite = removeTx.write({
-      space,
-      id: "of:memory-v2-native-add-remove",
-      type,
-      path: ["value", "profile", "title"],
-    }, undefined);
+    const removeWrite = removeTx.write(
+      {
+        space,
+        id: "of:memory-v2-native-add-remove",
+        type,
+        path: ["value", "profile", "title"],
+      },
+      undefined,
+      { delete: true },
+    );
     assert(removeWrite.ok);
     const removeCommit = await removeTx.commit();
     assert(removeCommit.ok);
@@ -390,12 +394,16 @@ Deno.test("memory v2 transactions drop same-tx add-then-remove paths from patch 
       path: ["value", "profile", "subtitle"],
     }, "Analyst");
     assert(addWrite.ok);
-    const removeWrite = tx.write({
-      space,
-      id: "of:memory-v2-native-elide-noop-remove",
-      type,
-      path: ["value", "profile", "subtitle"],
-    }, undefined);
+    const removeWrite = tx.write(
+      {
+        space,
+        id: "of:memory-v2-native-elide-noop-remove",
+        type,
+        path: ["value", "profile", "subtitle"],
+      },
+      undefined,
+      { delete: true },
+    );
     assert(removeWrite.ok);
     const renameWrite = tx.write({
       space,

--- a/packages/runner/test/memory-v2-transaction-path.test.ts
+++ b/packages/runner/test/memory-v2-transaction-path.test.ts
@@ -179,7 +179,7 @@ describe("memory v2 transaction path semantics", () => {
     await tx.commit();
   });
 
-  it("delete-of-nonexistent: writing undefined at a missing path is a no-op (does not create intermediates)", () => {
+  it("delete-of-nonexistent: an explicit delete at a missing path is a no-op (does not create intermediates)", () => {
     const tx = runtime.edit();
     tx.writeValueOrThrow({
       space,
@@ -190,14 +190,18 @@ describe("memory v2 transaction path semantics", () => {
       kept: "intact",
     });
 
-    // Attempt to "delete" a slot that doesn't exist. Should leave the doc
-    // unchanged -- no `details` container materialized, `kept` preserved.
-    tx.writeValueOrThrow({
-      space,
-      scope: "space",
-      id: "of:path-delete-nonexistent",
-      path: ["details", "profile", "name"],
-    }, undefined);
+    // Delete a slot that doesn't exist. Should leave the doc unchanged --
+    // no `details` container materialized, `kept` preserved.
+    tx.writeValueOrThrow(
+      {
+        space,
+        scope: "space",
+        id: "of:path-delete-nonexistent",
+        path: ["details", "profile", "name"],
+      },
+      undefined,
+      { delete: true },
+    );
 
     expect(
       tx.readValueOrThrow({
@@ -216,6 +220,39 @@ describe("memory v2 transaction path semantics", () => {
         path: ["details"],
       }).ok?.value,
     ).toBeUndefined();
+
+    tx.abort();
+  });
+
+  it("writing undefined at a missing path materializes intermediates and stores undefined", () => {
+    const tx = runtime.edit();
+    tx.writeValueOrThrow({
+      space,
+      scope: "space",
+      id: "of:path-set-undefined-nonexistent",
+      path: [],
+    }, {
+      kept: "intact",
+    });
+
+    // A plain write of `undefined` is a value write: intermediates are
+    // created and the leaf slot becomes present-but-undefined.
+    tx.writeValueOrThrow({
+      space,
+      scope: "space",
+      id: "of:path-set-undefined-nonexistent",
+      path: ["details", "profile", "name"],
+    }, undefined);
+
+    const root = tx.readValueOrThrow({
+      space,
+      scope: "space",
+      id: "of:path-set-undefined-nonexistent",
+      path: [],
+    }) as { kept: string; details: { profile: Record<string, unknown> } };
+    expect(root.kept).toBe("intact");
+    expect("name" in root.details.profile).toBe(true);
+    expect(root.details.profile.name).toBeUndefined();
 
     tx.abort();
   });

--- a/packages/runner/test/path-utils.test.ts
+++ b/packages/runner/test/path-utils.test.ts
@@ -63,13 +63,35 @@ describe("Path operations", () => {
     });
   });
 
-  describe("hasValueAtPath for default values", () => {
+  describe("hasValueAtPath for undefined values", () => {
     const store = {
       defaultValue: undefined,
     };
 
-    it("should return false if the default value is undefined", () => {
-      expect(hasValueAtPath(store, ["defaultValue"])).toBe(false);
+    it("should return true for a present key whose value is undefined", () => {
+      expect(hasValueAtPath(store, ["defaultValue"])).toBe(true);
+    });
+
+    it("should return false for an absent key", () => {
+      expect(hasValueAtPath(store, ["missing"])).toBe(false);
+    });
+  });
+
+  describe("setValueAtPath with undefined", () => {
+    it("should store undefined as a value, keeping the key present", () => {
+      const obj: Record<string, unknown> = { a: 1, b: 2 };
+      setValueAtPath(obj, ["a"], undefined);
+      expect("a" in obj).toBe(true);
+      expect(obj.a).toBeUndefined();
+      expect(Object.keys(obj)).toEqual(["a", "b"]);
+    });
+
+    it("should not truncate arrays when setting undefined", () => {
+      const obj: { list: unknown[] } = { list: [1, 2, 3] };
+      setValueAtPath(obj, ["list", 2], undefined);
+      expect(obj.list.length).toBe(3);
+      expect(2 in obj.list).toBe(true);
+      expect(obj.list[2]).toBeUndefined();
     });
   });
 });

--- a/packages/runner/test/undefined-values.test.ts
+++ b/packages/runner/test/undefined-values.test.ts
@@ -1,0 +1,148 @@
+import { assertEquals } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("undefined values");
+const space = signer.did();
+
+Deno.test("explicit undefined object properties are preserved", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+
+  let tx: IExtendedStorageTransaction = runtime.edit();
+
+  try {
+    const cell = runtime.getCell<{ a?: number; b: number }>(
+      space,
+      "undefined-values-object",
+      undefined,
+      tx,
+    );
+
+    cell.set({ a: undefined, b: 2 });
+    await tx.commit();
+    tx = runtime.edit();
+
+    const value = cell.get() as Record<string, unknown>;
+    assertEquals(Object.hasOwn(value, "a"), true);
+    assertEquals(value.a, undefined);
+    assertEquals(value.b, 2);
+  } finally {
+    await tx.commit();
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("removed keys are deleted, not left as undefined", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+
+  let tx: IExtendedStorageTransaction = runtime.edit();
+
+  try {
+    const cell = runtime.getCell<{ a?: number; b: number }>(
+      space,
+      "undefined-values-removed-key",
+      undefined,
+      tx,
+    );
+
+    cell.set({ a: 1, b: 2 });
+    await tx.commit();
+    tx = runtime.edit();
+
+    cell.withTx(tx).set({ b: 2 });
+    await tx.commit();
+    tx = runtime.edit();
+
+    const value = cell.get() as Record<string, unknown>;
+    assertEquals(Object.hasOwn(value, "a"), false);
+    assertEquals(Object.keys(value), ["b"]);
+  } finally {
+    await tx.commit();
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("overwriting a value with undefined keeps the key present", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+
+  let tx: IExtendedStorageTransaction = runtime.edit();
+
+  try {
+    const cell = runtime.getCell<{ a?: number; b: number }>(
+      space,
+      "undefined-values-overwrite",
+      undefined,
+      tx,
+    );
+
+    cell.set({ a: 1, b: 2 });
+    await tx.commit();
+    tx = runtime.edit();
+
+    cell.withTx(tx).set({ a: undefined, b: 2 });
+    await tx.commit();
+    tx = runtime.edit();
+
+    const value = cell.get() as Record<string, unknown>;
+    assertEquals(Object.hasOwn(value, "a"), true);
+    assertEquals(value.a, undefined);
+  } finally {
+    await tx.commit();
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("array elements set to undefined stay present-but-undefined", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+
+  let tx: IExtendedStorageTransaction = runtime.edit();
+
+  try {
+    const cell = runtime.getCell<{ list: (number | undefined)[] }>(
+      space,
+      "undefined-values-array",
+      undefined,
+      tx,
+    );
+
+    cell.set({ list: [1, 2, 3] });
+    await tx.commit();
+    tx = runtime.edit();
+
+    cell.withTx(tx).set({ list: [1, undefined, 3] });
+    await tx.commit();
+    tx = runtime.edit();
+
+    const value = cell.get() as { list: (number | undefined)[] };
+    assertEquals(value.list.length, 3);
+    assertEquals(1 in value.list, true);
+    assertEquals(value.list[1], undefined);
+    assertEquals(value.list[0], 1);
+    assertEquals(value.list[2], 3);
+  } finally {
+    await tx.commit();
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});


### PR DESCRIPTION
## Summary

`undefined` is now a real, preserved value throughout the runtime. Previously a
write of `undefined` doubled as the deletion signal, so `{a: undefined}` and
`{}` collapsed to the same state and explicitly-set undefineds were silently
dropped — but users of the system expect them to be preserved. Deletion is now
a separate, explicit write intent.

No storage format change was needed: the fvj1 codec already round-trips
undefined as `/Undefined@1` (distinct from `/hole`), and `deepEqual`,
value-clone, and value hashing were already presence-correct. The work is
confined to the runner's write pipeline, where `undefined` was overloaded.

## Semantics

| Operation | Before | After |
|---|---|---|
| `write(addr, undefined)` | deletes the slot | stores `undefined` (slot stays present), materializing intermediates like any other value |
| `write(addr, undefined, { delete: true })` | — | removes the slot (object key removal / array hole); no-op if the path doesn't exist |
| `cell.set({a: undefined})` | key dropped | key preserved, reads back as present-but-undefined |
| `cell.set(undefined)` at root | retracts the document | stores `{value: undefined}` in the envelope; retraction remains expressible at the transaction level (envelope-value delete), and a `cell.delete()` can expose it later if needed |

**Unchanged by design** (per discussion):
- Schema defaults still apply when the value is undefined — if a schema allows
  undefined as a valid value, it shouldn't declare a default.
- `map`/`filter` builtins keep the undefined-means-not-ready convention; they
  expect an array, so undefined remains a meaningful "input not available" state.

## How it works

- **Write primitives** (`mutable-path-write.ts`): `applyMutablePathWrite` takes
  a `delete` option. No-op detection is presence-aware (`in`-based): setting
  `undefined` on an absent key is a real change; deleting an absent key is a
  no-op that never materializes intermediates.
- **Transaction API** (`interface.ts` + both stacks): `write`/`writeOrThrow`/
  `writeValueOrThrow` accept `IWriteOptions { delete?: boolean }`; batch
  entries and `ChangeSet` entries carry `delete?: boolean` as a field. Includes
  a fix in `writeBatchRun` where a no-op delete could have leaked materialized
  intermediates into the working root before the changed-check.
- **Diff engine** (`data-updating.ts`): the three removal sites (removed object
  keys, value→hole, length shrink) emit `delete: true`. Two transitions the old
  diff couldn't see now emit value writes: absent-key→explicit-undefined and
  hole→explicit-undefined.
- **Patch generation** (`v2-transaction.ts`): add/remove/replace are chosen
  from before/after slot *presence* rather than `value === undefined`, so a
  stored undefined travels as replace/add with an undefined value. The
  server-side patch applier needed no changes.

## Testing

- New `test/undefined-values.test.ts`: undefined properties round-trip through
  commit; removed keys actually disappear (no `key: undefined` residue);
  overwrite-with-undefined keeps the key; array elements stay
  present-but-undefined.
- Flipped per the new semantics: writing undefined at a missing path now
  materializes intermediates (`memory-v2-transaction-path`); envelope tests
  split into delete-retracts vs. set-undefined-preserves
  (`memory-v2-envelope-delete`); native-commit remove tests pass
  `{ delete: true }`.
- `docs/specs/sparse-array-preservation.md` updated: only `delete: true`
  creates holes.
- Full runner suite: 605 passed, 0 failed. Type-check and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves undefined as a real stored value and makes deletion explicit via a write option, instead of overloading `undefined` as “delete”. Also removes the old null-as-hole array traversal stopgap and adds a small pattern workaround.

- **New Features**
  - Writing `undefined` stores it (materializes intermediates); deletion uses `{ delete: true }` and does not materialize missing paths. Root delete retracts the document; `cell.set(undefined)` now stores `{ value: undefined }`.
  - Write APIs accept `IWriteOptions.delete` across both stacks (`write`/`writeOrThrow`/`writeValueOrThrow`, batch writes, `ChangeSet`); delete of a non-existent path is a no-op. Presence-aware no-op checks distinguish holes from present-but-undefined.
  - Diff/Patch: deletes are flagged (`delete: true`); add/remove/replace are chosen from slot presence, so a stored `undefined` emits add/replace and holes are created only by deletes. Change-set compaction treats parent deletes and parent writes of `undefined` as subsuming children.
  - Utilities/Docs: `setValueAtPath` stores `undefined` without removing keys; `hasValueAtPath` returns true for present-but-undefined; sparse-array spec updated.
  - Traversal: removed the null-as-hole stopgap; arrays now rely on true holes via the fvj1 `/hole` encoding. Literal `null` is validated per schema.
  - Patterns: added a small workaround in `library-checkout-system` to keep `memberId` from being stripped by a transformer.

- **Migration**
  - Replace “write `undefined` to delete” with `{ delete: true }` (e.g., `tx.write(addr, undefined, { delete: true })`).
  - To retract a JSON envelope/root, delete the slot (e.g., delete `["value"]`); `cell.set(undefined)` preserves the envelope with `{ value: undefined }`.
  - Update tests that assumed `undefined` removes keys/holes; use explicit delete and expect `hasValueAtPath(...) === true` for present `undefined`.

<sup>Written for commit 8971d41c46a478dd501649bd21dcc359b32521df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

