### PR TITLE
fix(shell): treat runtime disposal as cancellation; drop piece.test.ts console-error allowlist

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1799,6 +1799,7 @@
     },
     "uuid@9.0.1": {
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": true,
       "bin": true
     },
     "w3c-keyname@2.2.8": {

--- a/deno.lock
+++ b/deno.lock
@@ -1799,7 +1799,6 @@
     },
     "uuid@9.0.1": {
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": true,
       "bin": true
     },
     "w3c-keyname@2.2.8": {

--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -105,6 +105,11 @@ export class Page extends EventTarget {
       for (const method of methods) {
         newConsole[method] = (...args: unknown[]) => {
           const formatted = args.map((value) => {
+            if (value instanceof Error) {
+              // Error properties are non-enumerable — JSON.stringify yields
+              // "{}". The stack includes name + message.
+              return value.stack ?? `${value.name}: ${value.message}`;
+            }
             if (value && typeof value === "object") {
               try {
                 return JSON.stringify(value);

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -4,12 +4,14 @@ import { NameSchema } from "@commonfabric/runner/schemas";
 import {
   CellHandle,
   FavoritesManager,
+  isRuntimeDisposedError,
   JSONValue,
   PageHandle,
   Program,
   RuntimeClient,
   RuntimeClientEvents,
   RuntimeClientOptions,
+  RuntimeDisposedError,
   RuntimeTelemetryMarkerResult,
 } from "@commonfabric/runtime-client";
 import { WebWorkerRuntimeTransport } from "@commonfabric/runtime-client/transports/web-worker";
@@ -344,6 +346,7 @@ export class RuntimeInternals extends EventTarget {
       if (!page) return;
       await (trackRecent as any).send({ piece: page.cell() });
     } catch (e) {
+      if (isRuntimeDisposedError(e)) return;
       console.error("[RuntimeInternals] Failed to track recent piece:", e);
     }
   }
@@ -359,6 +362,7 @@ export class RuntimeInternals extends EventTarget {
       await (addPiece as any).send({ piece: cell });
       await spaceRoot.cell().sync();
     } catch (e) {
+      if (isRuntimeDisposedError(e)) return;
       console.error(
         "[RuntimeInternals] Failed to register navigated piece:",
         e,
@@ -425,7 +429,7 @@ export class RuntimeInternals extends EventTarget {
 
   #check() {
     if (this.#disposed) {
-      throw new Error("RuntimeInternals disposed.");
+      throw new RuntimeDisposedError("RuntimeInternals disposed.");
     }
   }
 

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -16,6 +16,7 @@ import {
   rebaseCfcLabelView,
 } from "@commonfabric/runner/cfc/label-view-core";
 import { $conn, type RuntimeClient } from "./runtime-client.ts";
+import { isRuntimeDisposedError } from "./shared/disposed-error.ts";
 import {
   type CellRef,
   type CfcLabelView,
@@ -119,7 +120,9 @@ export class CellHandle<T = unknown> {
       cell: this.ref(),
       value: CellHandle.serialize(value),
     }).catch((error) => {
-      console.error("[CellHandle] Set failed:", error);
+      if (!isRuntimeDisposedError(error)) {
+        console.error("[CellHandle] Set failed:", error);
+      }
     });
   }
 
@@ -129,7 +132,9 @@ export class CellHandle<T = unknown> {
       cell: this.ref(),
       event: CellHandle.serialize(event),
     }).catch((error) => {
-      console.error("[CellHandle] Send failed:", error);
+      if (!isRuntimeDisposedError(error)) {
+        console.error("[CellHandle] Send failed:", error);
+      }
     });
   }
 

--- a/packages/runtime-client/client/connection.test.ts
+++ b/packages/runtime-client/client/connection.test.ts
@@ -1,0 +1,71 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { RuntimeConnection } from "./connection.ts";
+import { EventEmitter } from "./emitter.ts";
+import { isRuntimeDisposedError } from "../shared/disposed-error.ts";
+import {
+  type InitializationData,
+  type IPCClientMessage,
+  RequestType,
+} from "../protocol/mod.ts";
+import type { RuntimeTransport, RuntimeTransportEvents } from "./transport.ts";
+
+/**
+ * Transport that auto-acknowledges every request except the types in
+ * `holdTypes`, which are left pending (simulating in-flight work).
+ */
+class FakeTransport extends EventEmitter<RuntimeTransportEvents>
+  implements RuntimeTransport {
+  constructor(private holdTypes: RequestType[] = []) {
+    super();
+  }
+
+  send(message: IPCClientMessage): void {
+    if (this.holdTypes.includes(message.data.type)) return;
+    // Acknowledge asynchronously, like a real worker round-trip.
+    queueMicrotask(() => {
+      this.emit("message", { msgId: message.msgId, data: undefined });
+    });
+  }
+
+  dispose(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+async function initializedConnection(
+  transport: FakeTransport,
+): Promise<RuntimeConnection> {
+  const connection = new RuntimeConnection(transport);
+  await connection.initialize({} as InitializationData);
+  return connection;
+}
+
+describe("RuntimeConnection disposal", () => {
+  it("rejects in-flight requests with RuntimeDisposedError on dispose", async () => {
+    const transport = new FakeTransport([RequestType.Idle]);
+    const connection = await initializedConnection(transport);
+
+    const inFlight = connection.request<RequestType.Idle>({
+      type: RequestType.Idle,
+    });
+    // Avoid an unhandled rejection between dispose() and the assertion.
+    const settled = inFlight.then(() => undefined, (error) => error);
+
+    await connection.dispose();
+
+    const error = await settled;
+    expect(isRuntimeDisposedError(error)).toBe(true);
+  });
+
+  it("rejects requests issued after dispose with RuntimeDisposedError", async () => {
+    const transport = new FakeTransport();
+    const connection = await initializedConnection(transport);
+    await connection.dispose();
+
+    const error = await connection
+      .request<RequestType.Idle>({ type: RequestType.Idle })
+      .then(() => undefined, (e) => e);
+    expect(isRuntimeDisposedError(error)).toBe(true);
+  });
+});

--- a/packages/runtime-client/client/connection.ts
+++ b/packages/runtime-client/client/connection.ts
@@ -26,6 +26,10 @@ import { RuntimeTransport } from "./transport.ts";
 import { EventEmitter } from "./emitter.ts";
 import { $onCellUpdate, CellHandle } from "../cell-handle.ts";
 import { cellRefToKey } from "../shared/utils.ts";
+import {
+  isRuntimeDisposedError,
+  RuntimeDisposedError,
+} from "../shared/disposed-error.ts";
 
 const ipcLogger = getLogger("runtime-client");
 
@@ -104,6 +108,15 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
     if (!this.#initialized && data.type !== RequestType.Initialize) {
       throw new Error("RuntimeConnection is uninitialized.");
     }
+    if (this.#disposed && data.type !== RequestType.Dispose) {
+      // Reject instead of sending into a (soon-to-be) dead transport,
+      // where the request would only ever time out.
+      return Promise.reject(
+        new RuntimeDisposedError(
+          `RuntimeConnection is disposed (request: ${data.type})`,
+        ),
+      );
+    }
     const timeout = timeoutMs ?? this.#timeoutMs;
     const msgId = this.#nextMsgId++;
     const message = { msgId, data };
@@ -166,7 +179,9 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
       type: RequestType.CellSubscribe,
       cell: cell.ref(),
     }).catch((error) => {
-      console.error("[RuntimeClient] Subscription failed:", error);
+      if (!isRuntimeDisposedError(error)) {
+        console.error("[RuntimeClient] Subscription failed:", error);
+      }
       this.#subscribed.delete(key);
     });
     return;
@@ -192,7 +207,9 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
       type: RequestType.CellUnsubscribe,
       cell: cell.ref(),
     }).catch((error) => {
-      console.error("[RuntimeClient] Unsubscription failed:", error);
+      if (!isRuntimeDisposedError(error)) {
+        console.error("[RuntimeClient] Unsubscription failed:", error);
+      }
     });
     return;
   }
@@ -201,7 +218,9 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
     this.#disposed = true;
     for (const pending of this.#pendingRequests.values()) {
       clearTimeout(pending.timeoutId);
-      pending.deferred.reject(new Error("Disposing runtime connection"));
+      pending.deferred.reject(
+        new RuntimeDisposedError("Disposing runtime connection"),
+      );
     }
     this.#pendingRequests.clear();
 
@@ -374,11 +393,13 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
       event,
       nodeId,
     }).catch((error) => {
-      console.error(
-        "[RuntimeClient] VDom event dispatch failed:",
-        error instanceof Error ? error.message : String(error),
-        error,
-      );
+      if (!isRuntimeDisposedError(error)) {
+        console.error(
+          "[RuntimeClient] VDom event dispatch failed:",
+          error instanceof Error ? error.message : String(error),
+          error,
+        );
+      }
     });
   }
 

--- a/packages/runtime-client/client/connection.ts
+++ b/packages/runtime-client/client/connection.ts
@@ -413,11 +413,13 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
       mountId,
       batchId,
     }).catch((error) => {
-      console.error(
-        "[RuntimeClient] VDom batch acknowledgement failed:",
-        error instanceof Error ? error.message : String(error),
-        error,
-      );
+      if (!isRuntimeDisposedError(error)) {
+        console.error(
+          "[RuntimeClient] VDom batch acknowledgement failed:",
+          error instanceof Error ? error.message : String(error),
+          error,
+        );
+      }
     });
   }
 

--- a/packages/runtime-client/favorites-manager.ts
+++ b/packages/runtime-client/favorites-manager.ts
@@ -15,6 +15,7 @@ import {
   Home,
   homeSchema,
 } from "@commonfabric/home-schemas";
+import { isRuntimeDisposedError } from "./shared/disposed-error.ts";
 
 type HandlerName = "addFavorite" | "removeFavorite";
 
@@ -100,6 +101,9 @@ export class FavoritesManager {
 
     // Start the subscription process
     setupSubscription().catch((error) => {
+      // A subscriber tearing down or the runtime being disposed while
+      // setup is in flight is an expected race, not a failure.
+      if (isDisposed || isRuntimeDisposedError(error)) return;
       const err = error instanceof Error ? error : new Error(String(error));
       if (onError) {
         onError(err);
@@ -109,9 +113,7 @@ export class FavoritesManager {
           err,
         );
       }
-      if (!isDisposed) {
-        callback([]);
-      }
+      callback([]);
     });
 
     // Return cleanup function

--- a/packages/runtime-client/mod.ts
+++ b/packages/runtime-client/mod.ts
@@ -10,6 +10,7 @@ export * from "./client/emitter.ts";
 export * from "./client/transport.ts";
 export * from "./client/connection.ts";
 export { cellRefToKey } from "./shared/utils.ts";
+export * from "./shared/disposed-error.ts";
 export * from "./protocol/mod.ts";
 export * from "./vnode-types.ts";
 export * from "@commonfabric/runner/shared";

--- a/packages/runtime-client/shared/disposed-error.ts
+++ b/packages/runtime-client/shared/disposed-error.ts
@@ -1,0 +1,19 @@
+/**
+ * Rejection for operations that cannot complete because the runtime
+ * (connection) is disposed or mid-disposal. Expected whenever async work
+ * races a teardown — logout, worker replacement, page navigation — so
+ * callers should treat it as a cancellation, not a failure.
+ */
+export class RuntimeDisposedError extends Error {
+  override name = "RuntimeDisposedError";
+}
+
+/**
+ * Matches by `name` rather than `instanceof` so the check survives
+ * duplicate bundled copies of this module.
+ */
+export function isRuntimeDisposedError(
+  error: unknown,
+): error is RuntimeDisposedError {
+  return error instanceof Error && error.name === "RuntimeDisposedError";
+}

--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -120,17 +120,7 @@ async function waitForSpaceRootPattern(
 }
 
 describe("shell piece tests", () => {
-  const shell = new ShellIntegration({
-    // TODO(shell-console-errors): pre-existing shell noise surfaced by the
-    // fail-on-console-error default — both fire during normal piece-view
-    // navigation in this suite and log an empty serialized error. Fix the
-    // underlying paths (favorites-manager.ts setupSubscription, AppView
-    // refreshSlugTarget), then drop these entries.
-    allowedConsoleErrors: [
-      "[FavoritesManager] Failed to setup favorites subscription",
-      "[AppView] Failed to refresh slug target",
-    ],
-  });
+  const shell = new ShellIntegration();
   shell.bindLifecycle();
 
   it("can view and interact with a piece", async () => {

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -15,7 +15,12 @@ import {
   updatePageTitle,
 } from "../../shared/mod.ts";
 import { KeyboardController } from "../lib/keyboard-router.ts";
-import { type Cancel, NAME, PageHandle } from "@commonfabric/runtime-client";
+import {
+  type Cancel,
+  isRuntimeDisposedError,
+  NAME,
+  PageHandle,
+} from "@commonfabric/runtime-client";
 
 export class XAppView extends BaseView {
   static override styles = css`
@@ -91,7 +96,9 @@ export class XAppView extends BaseView {
       try {
         return await rt.getSpaceRootPattern(space);
       } catch (err) {
-        console.error("[AppView] Failed to load space root pattern:", err);
+        if (!isRuntimeDisposedError(err)) {
+          console.error("[AppView] Failed to load space root pattern:", err);
+        }
         throw err;
       }
     },
@@ -232,7 +239,9 @@ export class XAppView extends BaseView {
         void this.#refreshSlugTarget(rt, space, slug, token, key, true);
       });
     }).catch((error) => {
-      if (this.slugSubscriptionToken === token) {
+      if (
+        this.slugSubscriptionToken === token && !isRuntimeDisposedError(error)
+      ) {
         console.error("[AppView] Failed to watch slug cell:", error);
       }
     });
@@ -273,6 +282,18 @@ export class XAppView extends BaseView {
       );
       targetKey = pattern.id();
     } catch (error) {
+      if (isRuntimeDisposedError(error)) {
+        // The runtime this subscription polls was disposed (logout,
+        // teardown, worker replacement) — stop polling it; a new runtime
+        // re-subscribes via #syncSlugSubscription.
+        if (
+          this.slugSubscriptionToken === token &&
+          this.slugSubscriptionKey === key
+        ) {
+          this.#clearSlugSubscription();
+        }
+        return;
+      }
       if (notify) {
         console.error("[AppView] Failed to refresh slug target:", error);
       }

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -239,11 +239,14 @@ export class XAppView extends BaseView {
         void this.#refreshSlugTarget(rt, space, slug, token, key, true);
       });
     }).catch((error) => {
-      if (
-        this.slugSubscriptionToken === token && !isRuntimeDisposedError(error)
-      ) {
-        console.error("[AppView] Failed to watch slug cell:", error);
+      if (this.slugSubscriptionToken !== token) return;
+      if (isRuntimeDisposedError(error)) {
+        // Reset the subscription key so a replacement runtime for the
+        // same space/slug re-subscribes instead of matching the stale key.
+        this.#clearSlugSubscription();
+        return;
       }
+      console.error("[AppView] Failed to watch slug cell:", error);
     });
   }
 


### PR DESCRIPTION
## Problem

`packages/shell/integration/piece.test.ts` carried a `TODO(shell-console-errors)` allowlist for two console errors that fired during normal piece-view navigation, both logging an empty serialized error:

- `[FavoritesManager] Failed to setup favorites subscription: {}`
- `[AppView] Failed to refresh slug target: {}`

## Root causes

**The `{}`** was a harness artifact: `applyConsoleFormatter` (packages/integration/page.ts) JSON.stringifies object console args, and `Error` properties are non-enumerable. Errors now format as their stack — this improves diagnosability for every integration suite.

**The errors themselves** were teardown races. With the formatter fixed, the favorites error reproduced locally as `Error: Disposing runtime connection` rejecting the in-flight `ensureHomePatternRunning` request exactly when the test disposes the runtime mid-flight (the AppView slug-poll error is the same dispose race, landing in the 1s poll window). Disposal racing async consumers is expected during logout/worker replacement/teardown and should not log `console.error`.

## Fix

- New `RuntimeDisposedError` + `isRuntimeDisposedError` (name-based guard, survives duplicate bundles) in runtime-client. Used when dispose rejects in-flight requests, when requests are issued after dispose, and by `RuntimeInternals`' disposed check.
- Requests issued after dispose previously went into the dead transport and could only hit the 60s timeout; they now reject immediately.
- Consumers treat disposal as cancellation: favorites subscription setup returns silently, AppView's slug poll **stops polling** the dead runtime, and the identically-shaped fire-and-forget catch sites (connection subscribe/unsubscribe/vdom events, CellHandle set/send, track-recent, register-navigated, space-root load) skip the error log. Genuine failures still log, now with real stacks.
- Allowlist + TODO removed from piece.test.ts — the suite runs under full fail-on-console-error enforcement.

## Verification

- New unit tests for the disposal-rejection contract (`connection.test.ts`): both fail against the old behavior (plain `Error` rejection; post-dispose silent send).
- Full shell integration suite (local dev stack) green twice with the allowlist removed; the favorites error reproduced before the fix and is gone after.
- Workspace-wide `deno task check` green; runtime-client/lib-shell/shell unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat runtime disposal as cancellation and show real error stacks in integration logs. Removes the shell test console-error allowlist, stops teardown noise (including VDOM batch ack), and ensures slug subscriptions recover after runtime replacement.

- **Bug Fixes**
  - Added `RuntimeDisposedError` + `isRuntimeDisposedError`; in-flight requests reject on dispose and post-dispose requests reject immediately; `RuntimeInternals` uses it for disposed checks.
  - Gated disposal noise: `CellHandle` set/send, subscription/unsubscription, VDOM events and batch ack, `trackRecent`, `registerNavigated`, and space-root pattern load skip `console.error` on disposal; real errors still log with stacks.
  - `AppView`: stop slug-target polling on disposal; silence slug watch/setup errors; clear slug subscription state on both watch and refresh paths so a replacement runtime re-subscribes.
  - `FavoritesManager`: treat setup races as cancellation and return without logging.
  - Integration console formatter now prints `Error.stack` instead of `{}`; removed the allowlist in shell `piece.test.ts`; added `RuntimeConnection` disposal tests.

- **Dependencies**
  - Reverted incidental `deno.lock` metadata churn.

<sup>Written for commit 22d08b1a9f68e6bb2e4879a6ba569b25d2b1d422. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



---

## Performance baseline overrides

The `Check` job's perf regression is structural, not from this PR (zero
`deno.yml` diff): PR #4138 (merged to main 2026-06-15) added the
"Check Common Fabric patterns" CI step (~215s), which lands after the
perf baseline window. Every PR on current main shows `Check` as regressed
until post-#4138 main runs shift the baseline. The two borderline subtests
move with the same slow-runner window. Accepting the emitted baselines:

```
NEW_PERF_BASELINE: job: Check = 299s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/main.test.tsx = 26s
NEW_PERF_BASELINE: job: CLI Integration Tests (core-piece-values) = 76s
```
