### PR TITLE
fix(api,schema-generator): carry Default's value in the brand payload

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2373,6 +2373,17 @@ type IsEmptyTuple<T> = T extends readonly unknown[]
 // Nullish-only defaults need a standalone marker because `null & Brand` and
 // `undefined & Brand` collapse to `never`.
 //
+// The brand PAYLOAD carries V — the default VALUE's type — not T (matching
+// DeepDefault<V>). This is load-bearing for schema generation: the alias body
+// never otherwise mentions V, so once the checker resolves the alias away
+// (which it does through every capture/projection/instantiation path), the
+// payload is the ONLY place the default value survives at the type level.
+// Schema generation reads it back from expanded types (see the brand-payload
+// fallback in schema-generator's union formatter); detection everywhere else
+// is payload-agnostic (`{ readonly [DEFAULT_MARKER]: any }`), so the payload
+// choice affects nothing but recoverability. Carrying T instead silently
+// dropped `"default"` from every schema built off a checker type.
+//
 // Empty-tuple special case (CT-1640): for `Default<[]>` we keep ONLY the branded
 // arm and drop the bare `| T` arm. Without this, `Default<[]>` would contribute a
 // bare `[]` (i.e. `never[]`) member; in the documented `T[] | Default<[]>` shape
@@ -2395,10 +2406,10 @@ type IsEmptyTuple<T> = T extends readonly unknown[]
 // field with an empty-ish/seed default and a precise element type should use the
 // two-arg form `Default<string[], []>` (T = the array, not the tuple).
 export type Default<T, V extends T = T> = IsEmptyTuple<T> extends true
-  ? T & DefaultMarker<T>
+  ? T & DefaultMarker<V>
   :
-    | ([T] extends [null | undefined] ? DefaultMarker<T>
-      : T & DefaultMarker<T>)
+    | ([T] extends [null | undefined] ? DefaultMarker<V>
+      : T & DefaultMarker<V>)
     | T;
 
 /**

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -18,6 +18,7 @@ import type { GenerationContext, TypeFormatter } from "../interface.ts";
 import type { SchemaGenerator } from "../schema-generator.ts";
 import {
   detectWrapperViaNode,
+  extractDefaultBrandPayloadValue,
   getArrayElementInfo,
   getPropertyNameText,
   resolveWrapperNode,
@@ -251,7 +252,7 @@ export class CommonFabricFormatter implements TypeFormatter {
         : resolvedWrapper.node; // Direct reference or fallback
 
       if (nodeForDefault && ts.isTypeReferenceNode(nodeForDefault)) {
-        return this.formatDefaultType(nodeForDefault, context);
+        return this.formatDefaultType(nodeForDefault, context, type);
       }
     }
 
@@ -950,6 +951,7 @@ export class CommonFabricFormatter implements TypeFormatter {
   private formatDefaultType(
     typeRefNode: ts.TypeReferenceNode,
     context: GenerationContext,
+    pairedType?: ts.Type,
   ): JSONSchemaMutable {
     const typeArgs = typeRefNode.typeArguments;
     if (!typeArgs || typeArgs.length < 1 || typeArgs.length > 2) {
@@ -979,10 +981,22 @@ export class CommonFabricFormatter implements TypeFormatter {
     );
 
     // Extract default value from the default type node (this can handle complex literals)
-    const defaultValue = this.extractDefaultValueFromNode(
+    let defaultValue = this.extractDefaultValueFromNode(
       defaultTypeNode,
       context,
     );
+
+    // Node-based extraction fails when V is not spelled literally at this
+    // declaration — e.g. a generic-substituted V (`Default<string, P>` inside
+    // an instantiated `Tagged<"x">`). The instantiated TYPE's brand payload
+    // carries the substituted V (see Default<> in packages/api), so read it
+    // back from there.
+    if (defaultValue === undefined && pairedType) {
+      defaultValue = extractDefaultBrandPayloadValue(
+        pairedType,
+        context.typeChecker,
+      )?.value;
+    }
 
     if (defaultValue !== undefined) {
       // JSON Schema Draft 2020-12 allows default as a sibling of $ref

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -8,9 +8,10 @@ import type { SchemaGenerator } from "../schema-generator.ts";
 import {
   cloneSchemaDefinition,
   detectWrapperViaNode,
-  extractDefaultBrandPayloadValue,
+  extractDefaultValueFromBrandedMembers,
   getNativeTypeSchema,
   getPropertyNameText,
+  isDefaultBrandedMember,
   resolveWrapperNode,
   TypeWithInternals,
 } from "../type-utils.ts";
@@ -274,17 +275,17 @@ export class UnionFormatter implements TypeFormatter {
     context: GenerationContext,
   ): JSONSchemaMutable | undefined {
     const checker = context.typeChecker;
-    const branded = members.filter(
-      (m) =>
-        this.hasDefaultBrand(m, checker) ||
-        this.isBrandOnlyMarker(m, checker),
-    );
-    if (branded.length !== 1) return undefined;
+    const branded = members.filter((m) => isDefaultBrandedMember(m, checker));
+    if (branded.length === 0) return undefined;
 
-    const extracted = extractDefaultBrandPayloadValue(branded[0]!, checker);
+    // A union-valued default (`Default<boolean, true>`,
+    // `Default<"a" | "b", "a">`) distributes the brand across SEVERAL members,
+    // all carrying the same payload — extract the agreed value across all of
+    // them, and exclude all of them from the formatted remainder.
+    const extracted = extractDefaultValueFromBrandedMembers(branded, checker);
     if (!extracted) return undefined;
 
-    const rest = members.filter((m) => m !== branded[0]);
+    const rest = members.filter((m) => !isDefaultBrandedMember(m, checker));
     if (rest.length === 0) return undefined;
     const schemas = rest.map((m) => {
       const memberNode = orderedMemberNodes?.[members.indexOf(m)];

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -8,6 +8,7 @@ import type { SchemaGenerator } from "../schema-generator.ts";
 import {
   cloneSchemaDefinition,
   detectWrapperViaNode,
+  extractDefaultBrandPayloadValue,
   getNativeTypeSchema,
   getPropertyNameText,
   resolveWrapperNode,
@@ -129,6 +130,20 @@ export class UnionFormatter implements TypeFormatter {
       return expandedEmptyDefault;
     }
 
+    // General expanded-Default recovery: when Default<T, V> reaches us
+    // already resolved away by the checker (no intact alias node anywhere),
+    // the union is `T | (T & DefaultMarker<V>)` and the brand payload
+    // carries V. Format the unbranded members and attach the extracted
+    // default — no authored AST required.
+    const expandedDefault = this.tryFormatExpandedDefaultViaBrandPayload(
+      members,
+      orderedMemberNodes,
+      context,
+    );
+    if (expandedDefault !== undefined) {
+      return expandedDefault;
+    }
+
     // Detect presence of null
     const hasNull = members.some((m) => (m.flags & ts.TypeFlags.Null) !== 0);
     // nonNull excludes only null; undefined members are kept because undefined is
@@ -235,6 +250,57 @@ export class UnionFormatter implements TypeFormatter {
     }
 
     return { anyOf };
+  }
+
+  /**
+   * Recover `"default"` from the DEFAULT_MARKER brand payload when the union
+   * reaches us with the `Default<>` alias already resolved away — the general
+   * case behind every "defaults dropped from injected schemas" regression:
+   * capture shrinking, path lowering, projection, and generic instantiation
+   * all rebuild types from the checker, where the authored alias node is
+   * gone. The brand payload carries V (see Default<> in packages/api), so no
+   * authored AST is required.
+   *
+   * Authored-node handling stays primary: tryFormatDefaultUnion runs first
+   * and also covers non-literal V forms (e.g. `typeof CONST`) via
+   * declaration reads. This fallback fires only when the alias node is
+   * unavailable, and bails (returning undefined) when the union carries no
+   * brand, more than one brand, or a payload that is not literal-shaped —
+   * preserving prior behavior exactly in those cases.
+   */
+  private tryFormatExpandedDefaultViaBrandPayload(
+    members: readonly ts.Type[],
+    orderedMemberNodes: ReadonlyArray<ts.TypeNode | undefined> | undefined,
+    context: GenerationContext,
+  ): JSONSchemaMutable | undefined {
+    const checker = context.typeChecker;
+    const branded = members.filter(
+      (m) =>
+        this.hasDefaultBrand(m, checker) ||
+        this.isBrandOnlyMarker(m, checker),
+    );
+    if (branded.length !== 1) return undefined;
+
+    const extracted = extractDefaultBrandPayloadValue(branded[0]!, checker);
+    if (!extracted) return undefined;
+
+    const rest = members.filter((m) => m !== branded[0]);
+    if (rest.length === 0) return undefined;
+    const schemas = rest.map((m) => {
+      const memberNode = orderedMemberNodes?.[members.indexOf(m)];
+      const native = detectWrapperViaNode(memberNode, context.typeChecker) ===
+          undefined
+        ? getNativeTypeSchema(m, context.typeChecker)
+        : undefined;
+      if (native !== undefined) {
+        return cloneSchemaDefinition(native) as JSONSchemaMutable;
+      }
+      return this.schemaGenerator.formatChildType(m, context, memberNode);
+    });
+    return this.applySchemaDefault(
+      this.combineUnionSchemas(schemas, context),
+      extracted.value,
+    );
   }
 
   private tryFormatDefaultUnion(

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -983,24 +983,25 @@ export function isBrandOnlyMarkerType(
  * literal-shaped. The payload is the only place V survives once the checker
  * resolves the alias away — see Default<> in packages/api/index.ts.
  */
-export function extractDefaultBrandPayloadValue(
-  type: ts.Type,
+export function isDefaultBrandedMember(
+  member: ts.Type,
+  typeChecker: ts.TypeChecker,
+): boolean {
+  if (isBrandOnlyMarkerType(member, typeChecker)) return true;
+  if ((member.flags & ts.TypeFlags.Intersection) === 0) return false;
+  const parts = (member as ts.IntersectionType).types ?? [];
+  return parts.some((part) => isBrandOnlyMarkerType(part, typeChecker));
+}
+
+function extractPayloadFromBrandedMember(
+  member: ts.Type,
   typeChecker: ts.TypeChecker,
 ): { value: unknown } | undefined {
-  const members = type.isUnion() ? type.types : [type];
-  const branded = members.filter((member) => {
-    if (isBrandOnlyMarkerType(member, typeChecker)) return true;
-    if ((member.flags & ts.TypeFlags.Intersection) === 0) return false;
-    const parts = (member as ts.IntersectionType).types ?? [];
-    return parts.some((part) => isBrandOnlyMarkerType(part, typeChecker));
-  });
-  if (branded.length !== 1) return undefined;
-
-  const brandParts = (branded[0]!.flags & ts.TypeFlags.Intersection) !== 0
-    ? ((branded[0] as ts.IntersectionType).types ?? []).filter((part) =>
+  const brandParts = (member.flags & ts.TypeFlags.Intersection) !== 0
+    ? ((member as ts.IntersectionType).types ?? []).filter((part) =>
       isBrandOnlyMarkerType(part, typeChecker)
     )
-    : [branded[0]!];
+    : [member];
   const markerProp = brandParts
     .flatMap((part) => typeChecker.getPropertiesOfType(part))
     .find((prop) =>
@@ -1011,4 +1012,46 @@ export function extractDefaultBrandPayloadValue(
   const extracted = extractValueFromLiteralType(payload, typeChecker);
   if (!extracted || extracted.value === undefined) return undefined;
   return extracted;
+}
+
+/**
+ * Extract the agreed default value from one or more branded members.
+ *
+ * A union-valued default distributes the brand across several members that
+ * all carry the SAME payload — `Default<boolean, true>` expands to
+ * `true & DefaultMarker<true> | false & DefaultMarker<true> | boolean`, two
+ * branded members both paying `true`; likewise `Default<"a" | "b", "a">`.
+ * Require every branded member to yield the same literal value and return it;
+ * bail (undefined) on genuine disagreement — two distinct defaults in one
+ * union is ambiguous and must never resolve to a guess.
+ */
+export function extractDefaultValueFromBrandedMembers(
+  branded: readonly ts.Type[],
+  typeChecker: ts.TypeChecker,
+): { value: unknown } | undefined {
+  if (branded.length === 0) return undefined;
+  let agreed: { value: unknown } | undefined;
+  for (const member of branded) {
+    const extracted = extractPayloadFromBrandedMember(member, typeChecker);
+    if (!extracted) return undefined;
+    if (agreed === undefined) {
+      agreed = extracted;
+    } else if (
+      JSON.stringify(agreed.value) !== JSON.stringify(extracted.value)
+    ) {
+      return undefined;
+    }
+  }
+  return agreed;
+}
+
+export function extractDefaultBrandPayloadValue(
+  type: ts.Type,
+  typeChecker: ts.TypeChecker,
+): { value: unknown } | undefined {
+  const members = type.isUnion() ? type.types : [type];
+  const branded = members.filter((member) =>
+    isDefaultBrandedMember(member, typeChecker)
+  );
+  return extractDefaultValueFromBrandedMembers(branded, typeChecker);
 }

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -887,3 +887,128 @@ function followAliasToWrapperNode(
 
   return undefined;
 }
+
+/**
+ * Convert a purely literal-shaped Type to its JSON value: string/number/
+ * boolean literals, null, literal tuples, and object-literal types whose
+ * members are themselves literal-shaped. Returns the value wrapped (so a
+ * legitimate `null` is distinguishable from "not extractable") or undefined
+ * when any part of the type is not a literal.
+ *
+ * Used to read `Default<T, V>`'s V back out of the DEFAULT_MARKER brand
+ * payload once the checker has resolved the alias away — the payload is the
+ * only place V survives at the type level (see Default<> in
+ * packages/api/index.ts). Deliberately type-structural only: payloads that
+ * resolve to non-literal types (e.g. a widened `typeof CONST`) bail to
+ * undefined, and the caller falls back to existing behavior.
+ */
+export function extractValueFromLiteralType(
+  type: ts.Type,
+  typeChecker: ts.TypeChecker,
+): { value: unknown } | undefined {
+  if (type.flags & ts.TypeFlags.StringLiteral) {
+    return { value: (type as ts.StringLiteralType).value };
+  }
+  if (type.flags & ts.TypeFlags.NumberLiteral) {
+    return { value: (type as ts.NumberLiteralType).value };
+  }
+  if (type.flags & ts.TypeFlags.BooleanLiteral) {
+    return {
+      value: (type as unknown as { intrinsicName?: string }).intrinsicName ===
+        "true",
+    };
+  }
+  if (type.flags & ts.TypeFlags.Null) {
+    return { value: null };
+  }
+
+  if (typeChecker.isTupleType(type)) {
+    const elements = typeChecker.getTypeArguments(type as ts.TypeReference);
+    const values: unknown[] = [];
+    for (const element of elements) {
+      const extracted = extractValueFromLiteralType(element, typeChecker);
+      if (!extracted) return undefined;
+      values.push(extracted.value);
+    }
+    return { value: values };
+  }
+
+  if (
+    (type.flags & ts.TypeFlags.Object) !== 0 &&
+    !typeChecker.isArrayType(type) &&
+    type.getCallSignatures().length === 0 &&
+    type.getConstructSignatures().length === 0
+  ) {
+    const props = typeChecker.getPropertiesOfType(type);
+    const result: Record<string, unknown> = {};
+    for (const prop of props) {
+      const name = String(prop.escapedName as string);
+      // Symbol-keyed members (`__@...`) mean this is a brand, not data.
+      if (name.startsWith("__@")) return undefined;
+      const propType = typeChecker.getTypeOfSymbol(prop);
+      const extracted = extractValueFromLiteralType(propType, typeChecker);
+      if (!extracted) return undefined;
+      result[name] = extracted.value;
+    }
+    return { value: result };
+  }
+
+  return undefined;
+}
+
+/**
+ * True for a "brand-only" object type that carries only symbol-keyed markers
+ * (e.g. `{ readonly [DEFAULT_MARKER]: V }`) — no string-keyed data
+ * properties. TypeScript encodes unique-symbol property names as "__@..."
+ * internally; a type with only such properties is a brand, not data.
+ */
+export function isBrandOnlyMarkerType(
+  type: ts.Type,
+  typeChecker: ts.TypeChecker,
+): boolean {
+  if ((type.flags & ts.TypeFlags.Object) === 0) return false;
+  const props = typeChecker.getPropertiesOfType(type);
+  if (props.length === 0) return true;
+  return props.every((prop) =>
+    String(prop.escapedName as string).startsWith("__@")
+  );
+}
+
+/**
+ * Read `Default<T, V>`'s V back out of the DEFAULT_MARKER brand payload of an
+ * expanded type: `T | (T & DefaultMarker<V>)`, a bare `T & DefaultMarker<V>`
+ * intersection, or a standalone `DefaultMarker<V>` (the nullish arm). Returns
+ * the extracted JSON value wrapped, or undefined when the type carries no
+ * brand, more than one branded member, or a payload that is not
+ * literal-shaped. The payload is the only place V survives once the checker
+ * resolves the alias away — see Default<> in packages/api/index.ts.
+ */
+export function extractDefaultBrandPayloadValue(
+  type: ts.Type,
+  typeChecker: ts.TypeChecker,
+): { value: unknown } | undefined {
+  const members = type.isUnion() ? type.types : [type];
+  const branded = members.filter((member) => {
+    if (isBrandOnlyMarkerType(member, typeChecker)) return true;
+    if ((member.flags & ts.TypeFlags.Intersection) === 0) return false;
+    const parts = (member as ts.IntersectionType).types ?? [];
+    return parts.some((part) => isBrandOnlyMarkerType(part, typeChecker));
+  });
+  if (branded.length !== 1) return undefined;
+
+  const brandParts = (branded[0]!.flags & ts.TypeFlags.Intersection) !== 0
+    ? ((branded[0] as ts.IntersectionType).types ?? []).filter((part) =>
+      isBrandOnlyMarkerType(part, typeChecker)
+    )
+    : [branded[0]!];
+  const markerProp = brandParts
+    .flatMap((part) => typeChecker.getPropertiesOfType(part))
+    .find((prop) =>
+      String(prop.escapedName as string).startsWith("__@DEFAULT_MARKER")
+    );
+  if (!markerProp) return undefined;
+  const payload = typeChecker.getTypeOfSymbol(markerProp);
+  const extracted = extractValueFromLiteralType(payload, typeChecker);
+  if (!extracted || extracted.value === undefined) return undefined;
+  return extracted;
+}

--- a/packages/schema-generator/test/brand-payload-defaults.test.ts
+++ b/packages/schema-generator/test/brand-payload-defaults.test.ts
@@ -1,0 +1,107 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSchemaTransformerV2 } from "../src/plugin.ts";
+import { asObjectSchema, getTypeFromCode } from "./utils.ts";
+
+// The DEFAULT_MARKER brand payload carries V (the default VALUE's type) — see
+// Default<> in packages/api/index.ts. These tests generate schemas from bare
+// checker TYPES (no typeNode), the situation every capture/projection/
+// instantiation path puts the generator in: the authored `Default<…>` alias
+// node is gone, and the payload is the only surviving source of the value.
+// A local replica of the alias is declared in each snippet — brand detection
+// is name-based (`__@DEFAULT_MARKER…` escaped names), matching the formatters.
+const DEFAULT_PRELUDE = `
+  declare const DEFAULT_MARKER: unique symbol;
+  type DefaultMarker<T> = { readonly [DEFAULT_MARKER]: T };
+  type Default<T, V extends T = T> = (T & DefaultMarker<V>) | T;
+`;
+
+describe("brand-payload default recovery (expanded Default<T, V>)", () => {
+  const transformer = createSchemaTransformerV2();
+
+  it("recovers string literal defaults from the payload", async () => {
+    const code = `${DEFAULT_PRELUDE}
+      interface Settings {
+        note: Default<string, "n/a">;
+      }
+    `;
+    const { type, checker } = await getTypeFromCode(code, "Settings");
+    const schema = asObjectSchema(transformer.generateSchema(type, checker));
+
+    expect(schema.properties?.note).toEqual({
+      type: "string",
+      default: "n/a",
+    });
+  });
+
+  it("recovers number and boolean literal defaults", async () => {
+    const code = `${DEFAULT_PRELUDE}
+      interface Settings {
+        count: Default<number, 3>;
+        flag: Default<boolean, true>;
+      }
+    `;
+    const { type, checker } = await getTypeFromCode(code, "Settings");
+    const schema = asObjectSchema(transformer.generateSchema(type, checker));
+
+    expect(schema.properties?.count).toEqual({ type: "number", default: 3 });
+    expect(schema.properties?.flag).toEqual({
+      type: "boolean",
+      default: true,
+    });
+  });
+
+  it("recovers defaults through generic instantiation", async () => {
+    // The case no authored-AST recovery can serve: V is substituted through
+    // a type parameter, so no declaration anywhere spells the literal next
+    // to this property.
+    const code = `${DEFAULT_PRELUDE}
+      interface Tagged<V extends string> {
+        note: Default<string, V>;
+      }
+      interface Holder {
+        tagged: Tagged<"from-generic">;
+      }
+    `;
+    const { type, checker } = await getTypeFromCode(code, "Holder");
+    const schema = asObjectSchema(transformer.generateSchema(type, checker));
+
+    const tagged = asObjectSchema(
+      (schema.properties?.tagged ?? {}) as Record<string, unknown>,
+    );
+    expect(tagged.properties?.note).toEqual({
+      type: "string",
+      default: "from-generic",
+    });
+  });
+
+  it("recovers tuple and object literal payloads", async () => {
+    const code = `${DEFAULT_PRELUDE}
+      interface Settings {
+        tags: Default<string[], ["a", "b"]>;
+        config: Default<{ retries: number }, { retries: 2 }>;
+      }
+    `;
+    const { type, checker } = await getTypeFromCode(code, "Settings");
+    const schema = asObjectSchema(transformer.generateSchema(type, checker));
+
+    expect((schema.properties?.tags as Record<string, unknown>).default)
+      .toEqual(["a", "b"]);
+    expect((schema.properties?.config as Record<string, unknown>).default)
+      .toEqual({ retries: 2 });
+  });
+
+  it("bails to plain formatting for non-literal payloads", async () => {
+    // One-arg form: V = T = string, which is not a literal — no default can
+    // or should be emitted.
+    const code = `${DEFAULT_PRELUDE}
+      interface Settings {
+        note: Default<string>;
+      }
+    `;
+    const { type, checker } = await getTypeFromCode(code, "Settings");
+    const schema = asObjectSchema(transformer.generateSchema(type, checker));
+
+    expect(schema.properties?.note).toEqual({ type: "string" });
+  });
+});

--- a/packages/schema-generator/test/brand-payload-defaults.test.ts
+++ b/packages/schema-generator/test/brand-payload-defaults.test.ts
@@ -105,3 +105,90 @@ describe("brand-payload default recovery (expanded Default<T, V>)", () => {
     expect(schema.properties?.note).toEqual({ type: "string" });
   });
 });
+
+// The tests above generate from the INTERFACE, so each property carries its
+// authored typeNode and flows through the node-based formatter. The cases
+// below generate from the property TYPE with no node — forcing the expanded
+// brand-payload path that capture shrinking / path lowering / projection put
+// the generator in. A union-VALUED default (`boolean`, a literal union, a
+// nullable) distributes the brand across several members; the path must agree
+// the payload across all of them. Uses a faithful Default replica incl. the
+// nullish arm.
+const FAITHFUL_PRELUDE = `
+  declare const DEFAULT_MARKER: unique symbol;
+  type DefaultMarker<T> = { readonly [DEFAULT_MARKER]: T };
+  type IsEmptyTuple<T> = T extends readonly unknown[]
+    ? number extends T["length"] ? false
+    : T["length"] extends 0 ? true
+    : false
+    : false;
+  type Default<T, V extends T = T> = IsEmptyTuple<T> extends true
+    ? T & DefaultMarker<V>
+    : ([T] extends [null | undefined] ? DefaultMarker<V> : T & DefaultMarker<V>) | T;
+`;
+
+describe("brand-payload recovery on the expanded path (no typeNode)", () => {
+  const transformer = createSchemaTransformerV2();
+
+  async function schemaOfPropertyType(
+    body: string,
+  ): Promise<Record<string, unknown>> {
+    const { type, checker } = await getTypeFromCode(
+      `${FAITHFUL_PRELUDE}\n${body}`,
+      "S",
+    );
+    const propType = checker.getTypeOfSymbol(type.getProperty("x")!);
+    return transformer.generateSchema(propType, checker) as Record<
+      string,
+      unknown
+    >;
+  }
+
+  it("recovers a boolean default whose brand distributes across true|false", async () => {
+    // `Default<boolean, true>` expands to two branded members
+    // (`true & marker<true>`, `false & marker<true>`); both pay `true`.
+    // Regression: the single-branded guard dropped this entirely.
+    const schema = await schemaOfPropertyType(
+      `interface S { x: Default<boolean, true>; }`,
+    );
+    expect(schema).toEqual({ type: "boolean", default: true });
+  });
+
+  it("recovers a default whose value type is a literal union", async () => {
+    const schema = await schemaOfPropertyType(
+      `interface S { x: Default<"a" | "b", "a">; }`,
+    );
+    expect(schema.default).toBe("a");
+    expect(schema.enum).toEqual(["a", "b"]);
+  });
+
+  it("recovers a null default on a nullable value type", async () => {
+    const schema = await schemaOfPropertyType(
+      `interface S { x: Default<string | null, null>; }`,
+    );
+    expect(schema.default).toBe(null);
+  });
+
+  it("recovers a non-null default on a nullable value type", async () => {
+    const schema = await schemaOfPropertyType(
+      `interface S { x: Default<string | null, "y">; }`,
+    );
+    expect(schema.default).toBe("y");
+  });
+
+  it("recovers the default when combined with another union member", async () => {
+    const schema = await schemaOfPropertyType(
+      `interface S { x: Default<string, "a"> | number; }`,
+    );
+    expect(schema.default).toBe("a");
+  });
+
+  it("bails (no default) when two distinct defaults disagree in one union", async () => {
+    // `Default<"a">` and `Default<"b">` each contribute a branded member with
+    // a DIFFERENT payload — ambiguous, must never resolve to a guess.
+    const schema = await schemaOfPropertyType(
+      `interface S { x: Default<"a"> | Default<"b">; }`,
+    );
+    expect(schema.default).toBeUndefined();
+  });
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param-no-name.expected.jsx
@@ -75,7 +75,8 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                     type: "array",
                     items: {
                         $ref: "#/$defs/Item"
-                    }
+                    },
+                    "default": []
                 }
             },
             required: ["items"]

--- a/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
@@ -74,7 +74,8 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                     type: "array",
                     items: {
                         $ref: "#/$defs/Item"
-                    }
+                    },
+                    "default": []
                 }
             },
             required: ["items"]

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.expected.jsx
@@ -1,0 +1,223 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { computed, type Default, type Default as RenamedDefault, pattern, } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+// FIXTURE: default-survives-capture-shrink
+// Verifies: Default<…> annotations on properties survive capture shrinking
+// as alias references, so the injected capture schemas keep their
+// `"default"` values. When the shrunken type node expands the alias
+// structurally (`boolean | (false & { [DEFAULT_MARKER]: false })`), the
+// schema generator no longer recognizes the spelling and silently drops
+// the default — and literal default values can widen away entirely
+// (`Default<string, "">` → `{ [DEFAULT_MARKER]: string }`).
+interface Item {
+    done: boolean | Default<false>;
+    label: Default<string, "">;
+    // Renamed import: detection is symbol-verified, not name-gated.
+    rank: RenamedDefault<number, 7>;
+}
+// GENERIC reference: a capture through `Tagged<number>[]` can never be
+// projected node-driven (recovering the declared type of a generic by
+// symbol would leak unsubstituted type parameters) and no authored-AST
+// recovery can serve it. The `"default"` survives because the
+// DEFAULT_MARKER brand payload carries V through instantiation and the
+// schema generator reads it back from the expanded type.
+interface Tagged<T> {
+    value: T;
+    note: Default<string, "n/a">;
+}
+interface Input {
+    items: Item[];
+    boxes: Tagged<number>[];
+}
+const __cfLift_1 = __cfHelpers.lift<{
+    items: {
+        done: boolean | (false & { readonly [DEFAULT_MARKER]: false; });
+    }[];
+}, boolean>(({ items }) => items[0]?.done === true, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    done: {
+                        type: "boolean",
+                        "default": false
+                    }
+                },
+                required: ["done"]
+            }
+        }
+    },
+    required: ["items"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_2 = __cfHelpers.lift<{
+    items: {
+        label: string | (string & { readonly [DEFAULT_MARKER]: ""; });
+    }[];
+}, boolean>(({ items }) => items[0]?.label === "", {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    label: {
+                        type: "string",
+                        "default": ""
+                    }
+                },
+                required: ["label"]
+            }
+        }
+    },
+    required: ["items"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_3 = __cfHelpers.lift<{
+    items: {
+        rank: number | (number & { readonly [DEFAULT_MARKER]: 7; });
+    }[];
+}, boolean>(({ items }) => items[0]?.rank === 7, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    rank: {
+                        type: "number",
+                        "default": 7
+                    }
+                },
+                required: ["rank"]
+            }
+        }
+    },
+    required: ["items"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_4 = __cfHelpers.lift<{
+    boxes: {
+        note: string | (string & { readonly [DEFAULT_MARKER]: "n/a"; });
+    }[];
+}, boolean>(({ boxes }) => boxes[0]?.note === "n/a", {
+    type: "object",
+    properties: {
+        boxes: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    note: {
+                        type: "string",
+                        "default": "n/a"
+                    }
+                },
+                required: ["note"]
+            }
+        }
+    },
+    required: ["boxes"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+export default pattern((__cf_pattern_input) => {
+    const items = __cf_pattern_input.key("items");
+    const boxes = __cf_pattern_input.key("boxes");
+    const firstDone = __cfLift_1({ items: items }).for("firstDone", true);
+    const firstLabelEmpty = __cfLift_2({ items: items }).for("firstLabelEmpty", true);
+    const firstRank = __cfLift_3({ items: items }).for("firstRank", true);
+    const firstBoxNote = __cfLift_4({ boxes: boxes }).for("firstBoxNote", true);
+    return { firstDone, firstLabelEmpty, firstRank, firstBoxNote };
+}, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Item"
+            }
+        },
+        boxes: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    value: {
+                        type: "number"
+                    },
+                    note: {
+                        type: "string",
+                        "default": "n/a"
+                    }
+                },
+                required: ["value", "note"]
+            }
+        }
+    },
+    required: ["items", "boxes"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean",
+                    "default": false
+                },
+                label: {
+                    type: "string",
+                    "default": ""
+                },
+                rank: {
+                    type: "number",
+                    "default": 7
+                }
+            },
+            required: ["done", "label", "rank"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        firstDone: {
+            type: "boolean"
+        },
+        firstLabelEmpty: {
+            type: "boolean"
+        },
+        firstRank: {
+            type: "boolean"
+        },
+        firstBoxNote: {
+            type: "boolean"
+        }
+    },
+    required: ["firstDone", "firstLabelEmpty", "firstRank", "firstBoxNote"]
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4
+});

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-capture-shrink.input.tsx
@@ -1,0 +1,45 @@
+import {
+  computed,
+  type Default,
+  type Default as RenamedDefault,
+  pattern,
+} from "commonfabric";
+
+// FIXTURE: default-survives-capture-shrink
+// Verifies: Default<…> annotations on properties survive capture shrinking
+// as alias references, so the injected capture schemas keep their
+// `"default"` values. When the shrunken type node expands the alias
+// structurally (`boolean | (false & { [DEFAULT_MARKER]: false })`), the
+// schema generator no longer recognizes the spelling and silently drops
+// the default — and literal default values can widen away entirely
+// (`Default<string, "">` → `{ [DEFAULT_MARKER]: string }`).
+interface Item {
+  done: boolean | Default<false>;
+  label: Default<string, "">;
+  // Renamed import: detection is symbol-verified, not name-gated.
+  rank: RenamedDefault<number, 7>;
+}
+
+// GENERIC reference: a capture through `Tagged<number>[]` can never be
+// projected node-driven (recovering the declared type of a generic by
+// symbol would leak unsubstituted type parameters) and no authored-AST
+// recovery can serve it. The `"default"` survives because the
+// DEFAULT_MARKER brand payload carries V through instantiation and the
+// schema generator reads it back from the expanded type.
+interface Tagged<T> {
+  value: T;
+  note: Default<string, "n/a">;
+}
+
+interface Input {
+  items: Item[];
+  boxes: Tagged<number>[];
+}
+
+export default pattern<Input>(({ items, boxes }) => {
+  const firstDone = computed(() => items[0]?.done === true);
+  const firstLabelEmpty = computed(() => items[0]?.label === "");
+  const firstRank = computed(() => items[0]?.rank === 7);
+  const firstBoxNote = computed(() => boxes[0]?.note === "n/a");
+  return { firstDone, firstLabelEmpty, firstRank, firstBoxNote };
+});

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-path-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-path-lowering.expected.jsx
@@ -23,6 +23,10 @@ const __cfAmdHooks = undefined;
 interface Settings {
     note: Default<string, "n/a">;
     count: Default<number, 3>;
+    // Union-VALUED default: `boolean` distributes the brand across true|false,
+    // so the expanded type carries two branded members both paying `true`.
+    // The payload recovery must agree across them (regression: dropped before).
+    enabled: Default<boolean, true>;
 }
 interface Input {
     settings: Settings;
@@ -71,6 +75,28 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_3 = __cfHelpers.lift<{
+    settings: {
+        enabled: boolean | (false & { readonly [DEFAULT_MARKER]: true; }) | (true & { readonly [DEFAULT_MARKER]: true; });
+    };
+}, boolean>(({ settings }) => settings.enabled === true, {
+    type: "object",
+    properties: {
+        settings: {
+            type: "object",
+            properties: {
+                enabled: {
+                    type: "boolean",
+                    "default": true
+                }
+            },
+            required: ["enabled"]
+        }
+    },
+    required: ["settings"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const settings = __cf_pattern_input.key("settings");
     const noteIsUnset = __cfLift_1({ settings: {
@@ -79,7 +105,10 @@ export default pattern((__cf_pattern_input) => {
     const countTimesTwo = __cfLift_2({ settings: {
             count: settings.key("count")
         } }).for("countTimesTwo", true);
-    return { noteIsUnset, countTimesTwo };
+    const isEnabled = __cfLift_3({ settings: {
+            enabled: settings.key("enabled")
+        } }).for("isEnabled", true);
+    return { noteIsUnset, countTimesTwo, isEnabled };
 }, {
     type: "object",
     properties: {
@@ -99,9 +128,13 @@ export default pattern((__cf_pattern_input) => {
                 count: {
                     type: "number",
                     "default": 3
+                },
+                enabled: {
+                    type: "boolean",
+                    "default": true
                 }
             },
-            required: ["note", "count"]
+            required: ["note", "count", "enabled"]
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, {
@@ -112,14 +145,18 @@ export default pattern((__cf_pattern_input) => {
         },
         countTimesTwo: {
             type: "number"
+        },
+        isEnabled: {
+            type: "boolean"
         }
     },
-    required: ["noteIsUnset", "countTimesTwo"]
+    required: ["noteIsUnset", "countTimesTwo", "isEnabled"]
 } as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
     __cfLift_1,
-    __cfLift_2
+    __cfLift_2,
+    __cfLift_3
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-path-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-path-lowering.expected.jsx
@@ -1,0 +1,125 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { computed, type Default, pattern } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+// FIXTURE: default-survives-path-lowering
+// Verifies: Default<…> annotations survive PATH-LOWERED captures. A scalar
+// property access (`settings.note`) lowers to `settings.key("note")` with a
+// leaf type node rebuilt from the checker type, so the injected lift
+// capture schema silently dropped `"default"` for years (the
+// destructured-binding form `({ note })` preserved the authored node and
+// kept its default; the access-chain form did not). The DEFAULT_MARKER
+// brand payload carries V through the rebuild and the schema generator
+// reads it back from the expanded type.
+interface Settings {
+    note: Default<string, "n/a">;
+    count: Default<number, 3>;
+}
+interface Input {
+    settings: Settings;
+}
+const __cfLift_1 = __cfHelpers.lift<{
+    settings: {
+        note: string | (string & { readonly [DEFAULT_MARKER]: "n/a"; });
+    };
+}, boolean>(({ settings }) => settings.note === "n/a", {
+    type: "object",
+    properties: {
+        settings: {
+            type: "object",
+            properties: {
+                note: {
+                    type: "string",
+                    "default": "n/a"
+                }
+            },
+            required: ["note"]
+        }
+    },
+    required: ["settings"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_2 = __cfHelpers.lift<{
+    settings: {
+        count: number | (number & { readonly [DEFAULT_MARKER]: 3; });
+    };
+}, number>(({ settings }) => settings.count * 2, {
+    type: "object",
+    properties: {
+        settings: {
+            type: "object",
+            properties: {
+                count: {
+                    type: "number",
+                    "default": 3
+                }
+            },
+            required: ["count"]
+        }
+    },
+    required: ["settings"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema);
+export default pattern((__cf_pattern_input) => {
+    const settings = __cf_pattern_input.key("settings");
+    const noteIsUnset = __cfLift_1({ settings: {
+            note: settings.key("note")
+        } }).for("noteIsUnset", true);
+    const countTimesTwo = __cfLift_2({ settings: {
+            count: settings.key("count")
+        } }).for("countTimesTwo", true);
+    return { noteIsUnset, countTimesTwo };
+}, {
+    type: "object",
+    properties: {
+        settings: {
+            $ref: "#/$defs/Settings"
+        }
+    },
+    required: ["settings"],
+    $defs: {
+        Settings: {
+            type: "object",
+            properties: {
+                note: {
+                    type: "string",
+                    "default": "n/a"
+                },
+                count: {
+                    type: "number",
+                    "default": 3
+                }
+            },
+            required: ["note", "count"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        noteIsUnset: {
+            type: "boolean"
+        },
+        countTimesTwo: {
+            type: "number"
+        }
+    },
+    required: ["noteIsUnset", "countTimesTwo"]
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-path-lowering.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-path-lowering.input.tsx
@@ -12,6 +12,10 @@ import { computed, type Default, pattern } from "commonfabric";
 interface Settings {
   note: Default<string, "n/a">;
   count: Default<number, 3>;
+  // Union-VALUED default: `boolean` distributes the brand across true|false,
+  // so the expanded type carries two branded members both paying `true`.
+  // The payload recovery must agree across them (regression: dropped before).
+  enabled: Default<boolean, true>;
 }
 
 interface Input {
@@ -21,5 +25,6 @@ interface Input {
 export default pattern<Input>(({ settings }) => {
   const noteIsUnset = computed(() => settings.note === "n/a");
   const countTimesTwo = computed(() => settings.count * 2);
-  return { noteIsUnset, countTimesTwo };
+  const isEnabled = computed(() => settings.enabled === true);
+  return { noteIsUnset, countTimesTwo, isEnabled };
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/default-survives-path-lowering.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/default-survives-path-lowering.input.tsx
@@ -1,0 +1,25 @@
+import { computed, type Default, pattern } from "commonfabric";
+
+// FIXTURE: default-survives-path-lowering
+// Verifies: Default<…> annotations survive PATH-LOWERED captures. A scalar
+// property access (`settings.note`) lowers to `settings.key("note")` with a
+// leaf type node rebuilt from the checker type, so the injected lift
+// capture schema silently dropped `"default"` for years (the
+// destructured-binding form `({ note })` preserved the authored node and
+// kept its default; the access-chain form did not). The DEFAULT_MARKER
+// brand payload carries V through the rebuild and the schema generator
+// reads it back from the expanded type.
+interface Settings {
+  note: Default<string, "n/a">;
+  count: Default<number, 3>;
+}
+
+interface Input {
+  settings: Settings;
+}
+
+export default pattern<Input>(({ settings }) => {
+  const noteIsUnset = computed(() => settings.note === "n/a");
+  const countTimesTwo = computed(() => settings.count * 2);
+  return { noteIsUnset, countTimesTwo };
+});


### PR DESCRIPTION
**Holistic fix for the `Default<T, V>` schema-loss family — supersedes the Default-recovery purpose of #4077 and would-be follow-ups; #4078's projection/cloning core stands on its own merits (see "Relationship to open PRs"). @seefeldb for review.**

## The one-sentence diagnosis

`Default<T, V>`'s alias body never mentioned `V` — the brand carried `T`:

```ts
export type Default<T, V extends T = T> = … T & DefaultMarker<T> … | T;
```

So the default value existed **only in the authored AST**, and every pipeline stage that rebuilds a type from the checker — capture shrinking, path lowering, projection, handler/map context synthesis, generic instantiation — necessarily dropped `"default"` from injected schemas. Each loss has historically been patched with a bespoke authored-AST recovery: the destructured-binding node preservation, `getStaticDefaultTypeNode`, `tryFormatDefaultUnion` + the CT-1639/CT-1640 special cases, #4077's capture-shrink graft, #4078's named-ref recovery, and a path-lowering graft for a further longstanding loss found this week (`settings.note` → `settings.key("note")` captures: runtime-verified to read `undefined` instead of the default; predates #4017). All of them re-derive the same fact from declarations, none can serve generic substitution, and the node-reuse variants carry cross-file printing hazards.

## The fix

**Carry V in the brand** (one line in `api`, matching `DeepDefault<V>`, which already works this way):

```ts
export type Default<T, V extends T = T> = … T & DefaultMarker<V> … | T;
```

Brand detection is payload-agnostic everywhere (`{ readonly [DEFAULT_MARKER]: any }` in `RequireDefaults`/`StripDefaultBrand`; `__@`-name checks in the formatters; name-list in js-compiler diagnostics) — audited and empirically confirmed (the full repo typechecks and every suite passes with zero behavioral fallout). The payload choice affects nothing but recoverability: **V now survives every checker operation**, including generic substitution, which no AST read can ever serve.

**Read it back in the schema generator** (the only consumer that needs V):

- `type-utils`: `extractValueFromLiteralType` (literal/null/tuple/object-literal types → JSON values; non-literal payloads bail) and `extractDefaultBrandPayloadValue` (find the single branded member, read the marker property's type).
- `union-formatter`: general expanded-`Default` recovery when the alias node is gone. Authored-node handling stays primary — it also covers non-literal `V` forms like `typeof CONST` via declaration reads. The fallback fires **only** where the value was previously lost.
- `formatDefaultType`: payload fallback when `V` is not spelled literally at the declaration (generic-substituted `V`, e.g. `Default<string, P>` inside an instantiated `Tagged<"x">`).

## What this buys

| previously lost in | now |
|---|---|
| type-driven capture shrink (#4017 regression, #4077's target) | ✅ recovered from payload (fixture ported from #4077, incl. renamed-import + widening cases) |
| path-lowered captures (`x.key("y")`; longstanding, runtime-verified wrong values) | ✅ recovered (new fixture; failing runtime probes flip to passing) |
| generic refs / instantiated generics (unreachable by ANY authored-AST recovery) | ✅ recovered (fixture case + unit test with `V` substituted through a type parameter) |
| `Default<Item[], []>` through map/handler capture synthesis | ✅ two existing closure goldens re-pin, gaining the `"default": []` their inputs always declared |

## Relationship to open PRs

- **#4077** and the stacked `fix/default-survives-path-lowering` branch fix real subsets of this tactically (graft the value back at specific sites). This PR subsumes both — their fixtures are ported here as the regression suite proving it. Recommend closing them in favor of this if review goes well.
- **#4078** is two things: the Default motivation (subsumed here) and a general projection-precision + cross-file-printing fix (`tryGetDeclaredTypeFromSynthesizedName`, `cloneTypeNodeDeepForEmission`) that fixes non-Default losses (e.g. the `pattern-preserve-opaque-input` narrowing) — that core is orthogonal and still worth landing, reframed.

## Visible consequences / caveats

- Emitted lift annotations show the payload: `string | (string & { readonly [DEFAULT_MARKER]: "n/a" })` — same shape as before, now self-documenting (previously `DEFAULT_MARKER]: string`). Schemas are what changed materially.
- Type-display in user-facing errors likewise shows `V` in the marker — arguably more informative, but it is a visible change.
- Mixed compile units across the api change aren't mutually assignable when `V ≠ T`; the api ships with the repo, so this is transient.
- Non-literal payloads (e.g. widened `typeof CONST`) bail to prior behavior — strictly better or equal everywhere.

## Follow-ups (now on `cleanup/default-payload-followups`, stacked on this PR)

- ✅ Remove CT-1639's `tryFormatExpandedEmptyArrayDefault` (subsumed; its degenerate-empty collapse moves into the general fallback, behavior pinned by CT-1639's own tests).
- ✅ Fix the longstanding cross-file printing corruption for preserved destructured bindings (`note: Default<string, .ts";` when the interface lives in another file) via a position-stripped deep clone in `expressionToTypeNode` (mirrors #4078's `cloneTypeNodeDeepForEmission`).
- ⚠️ Correction to an earlier claim: dropping `Default` from `shouldPreserveBindingDeclaredTypeNode`'s preserve list is NOT unlocked by this PR. `RequireDefaults` strips the DEFAULT_MARKER brand from top-level pattern-body types, so the payload cannot serve top-level destructured `Default` bindings — the authored node remains their only source (verified: removal loses `"default"` in three fixtures).
- Optional annotation polish (`__cfHelpers.Default<T, V>` spelling for rebuilt leaves) — left to #4078's qualification machinery.

## Verification

- schema-generator 25/25 (5 new unit tests: literals, generic substitution, tuple/object payloads, non-literal bail)
- ts-transformers 292/292; only the two closure goldens above re-pin, both strictly gaining declared defaults
- full repo `deno task check` green; fmt/lint clean
- `deno task integration pattern-tests` all green
- runtime probes: a lift over an unset `Default<string, "n/a">` property materializes `"n/a"` (read `undefined` before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Carry `Default<T, V>`’s value in the brand (`DefaultMarker<V>`) and read it during schema generation to restore `"default"` in injected schemas across capture shrinking, path lowering, projection, and generic instantiation. Also recovers union-valued defaults (e.g., `boolean`) by aggregating branded members and requiring payload agreement.

- **Bug Fixes**
  - `packages/api`: switch brand to `DefaultMarker<V>` (incl. nullish/empty-tuple arms) so `V` survives checker ops and generic substitution.
  - `packages/schema-generator`:
    - Add helpers to turn literal/null/tuple/object payload types into JSON values and read the brand payload; bail on non-literals.
    - Union formatter: recover defaults from expanded `T | (T & DefaultMarker<V>)`; collect all branded members (boolean, literal-union, nullable), require identical payloads, exclude them from the remainder; bail on disagreement.
    - `formatDefaultType`: pass the paired type and fall back to the brand payload when `V` isn’t spelled in the node (e.g., generic substitution).
  - Tests/fixtures: new unit tests for literals, tuples/objects, generics, union-valued defaults, and non-literal bail; add schema-injection fixtures for capture shrinking and path lowering; re-pin two closure goldens to include `"default": []`.

<sup>Written for commit 92d831d68bf687a655d38590f4657f7402773e62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

