### PR TITLE
refactor(schema-generator,ts-transformers): Default payload follow-ups — fold CT-1639, fix cross-file annotation corruption

### DIFF
--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -276,6 +276,13 @@ export class UnionFormatter implements TypeFormatter {
     // split the real array's schema into anyOf branches, dropping
     // per-element capabilities like asCell:["comparable"] from the
     // consumer's view. Collapse them into the real member.
+    //
+    // Safety: dropping the `[]`/`never[]` arm never narrows the accepted set
+    // because ArrayFormatter emits array/tuple schemas with no length bound
+    // (no minItems/prefixItems) — so `[]` is always a valid instance of the
+    // surviving real member, and a recovered `default: []` validates against
+    // it. If array length constraints are ever emitted, gate this pruning to
+    // the expanded-empty-default shape before relying on it.
     const hasRealArray = rest.some((m) =>
       (checker.isArrayType(m) || checker.isTupleType(m)) &&
       !this.isEmptyArrayType(m, checker)

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -114,23 +114,6 @@ export class UnionFormatter implements TypeFormatter {
       return defaultUnionSchema;
     }
 
-    // CT-1639: when Default<[]> reaches us already EXPANDED by the checker (no
-    // intact `Default<>` alias node — e.g. via a synthesized handler/map context
-    // schema), the union looks like `RealArray | ([] & DefaultMarker<[]>) | []`.
-    // tryFormatDefaultUnion can't recognize it (no Default node), so it would
-    // fall through to a multi-branch anyOf that splits the real array from the
-    // empty-array branch — dropping per-element capabilities like
-    // asCell:["comparable"] from the consumer's view. Collapse the degenerate
-    // empty-array members into the real array member and carry an empty default.
-    const expandedEmptyDefault = this.tryFormatExpandedEmptyArrayDefault(
-      members,
-      orderedMemberNodes,
-      context,
-    );
-    if (expandedEmptyDefault !== undefined) {
-      return expandedEmptyDefault;
-    }
-
     // General expanded-Default recovery: when Default<T, V> reaches us
     // already resolved away by the checker (no intact alias node anywhere),
     // the union is `T | (T & DefaultMarker<V>)` and the brand payload
@@ -285,7 +268,21 @@ export class UnionFormatter implements TypeFormatter {
     const extracted = extractDefaultValueFromBrandedMembers(branded, checker);
     if (!extracted) return undefined;
 
-    const rest = members.filter((m) => !isDefaultBrandedMember(m, checker));
+    let rest = members.filter((m) => !isDefaultBrandedMember(m, checker));
+    // Degenerate empty-array members (the empty tuple `[]` / `never[]`) ride
+    // along with expanded array Defaults (historically the unbranded arm of
+    // `Default<[]>`, see CT-1639/CT-1640). When a real array member is
+    // present they contribute nothing — but formatted as members they would
+    // split the real array's schema into anyOf branches, dropping
+    // per-element capabilities like asCell:["comparable"] from the
+    // consumer's view. Collapse them into the real member.
+    const hasRealArray = rest.some((m) =>
+      (checker.isArrayType(m) || checker.isTupleType(m)) &&
+      !this.isEmptyArrayType(m, checker)
+    );
+    if (hasRealArray) {
+      rest = rest.filter((m) => !this.isEmptyArrayType(m, checker));
+    }
     if (rest.length === 0) return undefined;
     const schemas = rest.map((m) => {
       const memberNode = orderedMemberNodes?.[members.indexOf(m)];
@@ -376,93 +373,6 @@ export class UnionFormatter implements TypeFormatter {
     );
   }
 
-  /**
-   * CT-1639: collapse an EXPANDED `Default<[]>` array union.
-   *
-   * When `Default<[]>` is expanded by the checker (the intact alias node is
-   * gone), the union is `RealArray | ([] & DefaultMarker<[]>) | []` — one real
-   * (possibly element-capability-bearing) array member plus one or more
-   * degenerate empty-array members (the empty tuple `[]`/`never[]`, optionally
-   * intersected with the Default brand). Emitting these as separate `anyOf`
-   * branches loses the real array's per-element annotations from a consumer's
-   * view. Instead, format only the real array member and attach `default: []`.
-   *
-   * Returns undefined when the pattern doesn't apply (so the caller proceeds
-   * with its normal union handling) — notably when there is more than one real
-   * array member, or a non-array member is present.
-   */
-  private tryFormatExpandedEmptyArrayDefault(
-    members: readonly ts.Type[],
-    orderedMemberNodes: ReadonlyArray<ts.TypeNode | undefined> | undefined,
-    context: GenerationContext,
-  ): JSONSchemaMutable | undefined {
-    const checker = context.typeChecker;
-
-    let realArrayIndex = -1;
-    // Only the BRANDED empty member (`[] & DefaultMarker<[]>`) proves this is an
-    // expanded `Default<[]>`. A bare `[]` / `never[]` is the *unbranded* arm of
-    // that same Default union — but it also appears in ordinary unions like
-    // `string[] | []` that have nothing to do with defaults. So we require at
-    // least one branded empty member before collapsing + attaching `default:[]`;
-    // a bare empty member alone is left to normal union handling. (CT-1639)
-    let sawBrandedEmpty = false;
-
-    for (let i = 0; i < members.length; i++) {
-      const member = members[i]!;
-      if (this.isDegenerateEmptyArrayMember(member, checker)) {
-        if (this.hasDefaultBrand(member, checker)) {
-          sawBrandedEmpty = true;
-        }
-        continue;
-      }
-      if (!checker.isArrayType(member) && !checker.isTupleType(member)) {
-        // A non-array, non-degenerate member means this isn't the
-        // `RealArray | Default<[]>` shape we collapse here.
-        return undefined;
-      }
-      if (realArrayIndex === -1) {
-        realArrayIndex = i;
-      } else {
-        // More than one real array member — not the Default<[]> collapse shape.
-        return undefined;
-      }
-    }
-
-    if (realArrayIndex === -1 || !sawBrandedEmpty) {
-      return undefined;
-    }
-
-    const realArraySchema = this.schemaGenerator.formatChildType(
-      members[realArrayIndex]!,
-      context,
-      orderedMemberNodes?.[realArrayIndex],
-    );
-    return this.applySchemaDefault(realArraySchema, []);
-  }
-
-  /**
-   * True for a member that contributes only an empty array to the union: the
-   * empty tuple `[]` / `never[]`, optionally intersected with the Default brand
-   * (`[] & DefaultMarker<[]>`). For the intersection form we strip the brand
-   * constituents and check that the substantive remainder is an empty array.
-   */
-  private isDegenerateEmptyArrayMember(
-    member: ts.Type,
-    checker: ts.TypeChecker,
-  ): boolean {
-    if ((member.flags & ts.TypeFlags.Intersection) !== 0) {
-      const parts = (member as ts.IntersectionType).types ?? [];
-      const substantive = parts.filter(
-        (p) => !this.isBrandOnlyMarker(p, checker),
-      );
-      // Brand intersected with exactly one empty-array part (e.g.
-      // `[] & DefaultMarker<[]>`).
-      return substantive.length === 1 &&
-        this.isEmptyArrayType(substantive[0]!, checker);
-    }
-    return this.isEmptyArrayType(member, checker);
-  }
-
   /** Empty tuple `[]`, or `never[]`. */
   private isEmptyArrayType(type: ts.Type, checker: ts.TypeChecker): boolean {
     if (checker.isTupleType(type)) {
@@ -475,34 +385,6 @@ export class UnionFormatter implements TypeFormatter {
       return !!elementType && (elementType.flags & ts.TypeFlags.Never) !== 0;
     }
     return false;
-  }
-
-  /**
-   * True if `member` carries the Default brand — i.e. it is an intersection with
-   * a brand-only marker constituent (`X & DefaultMarker<V>`). This is what
-   * distinguishes the unbranded `[]` arm of an *expanded* `Default<[]>` union
-   * from a bare `[]` in an ordinary union like `string[] | []`.
-   */
-  private hasDefaultBrand(member: ts.Type, checker: ts.TypeChecker): boolean {
-    if ((member.flags & ts.TypeFlags.Intersection) === 0) return false;
-    const parts = (member as ts.IntersectionType).types ?? [];
-    return parts.some((p) => this.isBrandOnlyMarker(p, checker));
-  }
-
-  /**
-   * True for a "brand-only" object type that carries only symbol-keyed markers
-   * (e.g. `{ readonly [DEFAULT_MARKER]: T }`) — no string-keyed data properties.
-   * TypeScript encodes unique-symbol property names as "__@..." internally; a
-   * type with only such properties is a brand, not data. (Mirrors the same
-   * convention used by IntersectionFormatter.isBrandOnlyOrEmpty.)
-   */
-  private isBrandOnlyMarker(type: ts.Type, checker: ts.TypeChecker): boolean {
-    if ((type.flags & ts.TypeFlags.Object) === 0) return false;
-    const props = checker.getPropertiesOfType(type);
-    if (props.length === 0) return true; // empty object `{}`
-    return props.every((prop) =>
-      String(prop.escapedName as string).startsWith("__@")
-    );
   }
 
   private getUnionTypeNode(

--- a/packages/ts-transformers/src/ast/type-building.ts
+++ b/packages/ts-transformers/src/ast/type-building.ts
@@ -442,7 +442,14 @@ export function expressionToTypeNode(
   );
   if (declaredTypeNode) {
     const type = context.checker.getTypeFromTypeNode(declaredTypeNode);
-    const clonedTypeNode = cloneTypeNode(declaredTypeNode);
+    // Deep position-stripped clone: the declaration may live in another
+    // source file, and a shallow clone keeps child positions — the printer
+    // would slice the EMIT file's text at those offsets, corrupting literal
+    // type arguments (`Default<string, .ts";`).
+    const clonedTypeNode = cloneTypeNodeDeepForEmission(
+      declaredTypeNode,
+      context.options.state?.typeRegistry,
+    );
     context.options.state?.typeRegistry?.set(clonedTypeNode, type);
     return clonedTypeNode;
   }
@@ -587,6 +594,60 @@ export function cloneTypeNode<T extends ts.TypeNode>(typeNode: T): T {
   return (ts.factory as typeof ts.factory & {
     cloneNode<TNode extends ts.Node>(node: TNode): TNode;
   }).cloneNode(typeNode);
+}
+
+/**
+ * Deep-clones a TypeNode for emission, stripping source positions throughout.
+ *
+ * An authored declaration's type node may live in a different source file
+ * than the one being emitted (e.g. a pattern destructuring an interface
+ * imported from a sibling module). The printer extracts literal text (the
+ * `"n/a"` in `Default<string, "n/a">`) by source position from the file it
+ * is currently printing, so reusing such nodes verbatim emits garbage tokens
+ * sliced from the wrong file. A position-free deep clone makes every node
+ * synthetic, forcing the printer to print structurally (literals fall back
+ * to their `.text`).
+ *
+ * Pass `typeRegistry` to carry each node's registered Type onto its clone.
+ *
+ * (Mirrors the helper of the same name on the lift-capture-shrink branch,
+ * #4078 — whichever lands second keeps one copy.)
+ */
+export function cloneTypeNodeDeepForEmission<T extends ts.TypeNode>(
+  typeNode: T,
+  typeRegistry?: WeakMap<ts.Node, ts.Type>,
+): T {
+  const nullContext = (ts as typeof ts & {
+    nullTransformationContext?: ts.TransformationContext;
+  }).nullTransformationContext;
+  if (!nullContext) return typeNode;
+  const cloneShallow = (ts.factory as typeof ts.factory & {
+    cloneNode<TNode extends ts.Node>(node: TNode): TNode;
+  }).cloneNode;
+
+  const visit = <N extends ts.Node>(node: N): N => {
+    // Post-order: children first, so leaf nodes (identifiers, literals,
+    // keywords) get cloned explicitly while composite nodes are recreated by
+    // visitEachChild's update calls when any child changed.
+    let result = ts.visitEachChild(
+      node,
+      (child) => visit(child),
+      nullContext,
+    ) as N;
+    if (result === node) {
+      result = cloneShallow(node);
+    }
+    // update* calls copy the original's text range for source maps; strip it
+    // so the printer treats the node as synthesized everywhere.
+    ts.setTextRange(result, { pos: -1, end: -1 });
+    const registered = typeRegistry?.get(node);
+    if (registered) {
+      typeRegistry!.set(result, registered);
+    }
+    return result;
+  };
+
+  return visit(typeNode);
 }
 
 /**

--- a/packages/ts-transformers/test/ast/type-building.test.ts
+++ b/packages/ts-transformers/test/ast/type-building.test.ts
@@ -1,0 +1,58 @@
+import { assertEquals, assertStrictEquals } from "@std/assert";
+import ts from "typescript";
+
+import { cloneTypeNodeDeepForEmission } from "../../src/ast/type-building.ts";
+
+// The printer extracts literal text by source position from the file it is
+// printing. A declaration member's type node reused in ANOTHER file therefore
+// emits garbage tokens for literal types (e.g. the `"n/a"` in
+// `Default<string, "n/a">` printed as whatever sits at those offsets in the
+// emit file). cloneTypeNodeDeepForEmission strips positions throughout so
+// literals print from their own `.text`. (Same guarantee as the helper of
+// this name on the #4078 branch.)
+Deno.test("cloneTypeNodeDeepForEmission prints cross-file literal types from their own text", () => {
+  const declarationFile = ts.createSourceFile(
+    "declaration.ts",
+    `interface I { label: Default<string, "default-text">; }`,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+  );
+  const iface = declarationFile.statements[0] as ts.InterfaceDeclaration;
+  const member = iface.members[0] as ts.PropertySignature;
+  const typeNode = member.type!;
+
+  // A different, shorter emit file: position-based extraction cannot
+  // reproduce the literal from here.
+  const emitFile = ts.createSourceFile(
+    "emit.ts",
+    "export {};",
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+  );
+  const printer = ts.createPrinter({ removeComments: true });
+
+  const cloned = cloneTypeNodeDeepForEmission(typeNode);
+  const printed = printer.printNode(ts.EmitHint.Unspecified, cloned, emitFile);
+
+  assertEquals(printed, `Default<string, "default-text">`);
+});
+
+Deno.test("cloneTypeNodeDeepForEmission carries typeRegistry entries onto clones", () => {
+  const declarationFile = ts.createSourceFile(
+    "declaration.ts",
+    `interface I { label: Default<string, "x">; }`,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+  );
+  const iface = declarationFile.statements[0] as ts.InterfaceDeclaration;
+  const member = iface.members[0] as ts.PropertySignature;
+  const typeNode = member.type!;
+
+  const fakeType = { flags: ts.TypeFlags.String } as ts.Type;
+  const typeRegistry = new WeakMap<ts.Node, ts.Type>();
+  typeRegistry.set(typeNode, fakeType);
+
+  const cloned = cloneTypeNodeDeepForEmission(typeNode, typeRegistry);
+
+  assertStrictEquals(typeRegistry.get(cloned), fakeType);
+});


### PR DESCRIPTION
**Stacked on #4123** (first commit is that PR's; review the top two). The follow-ups its body promised, with one honest correction discovered while doing them.

## 1. CT-1639's special case folds into the general payload fallback

`tryFormatExpandedEmptyArrayDefault` existed to recover ONE expanded-`Default` shape (`RealArray | ([] & DefaultMarker<[]>) | []`) before the brand payload carried V. The general brand-payload fallback now serves it. The one behavior it had that the fallback lacked — collapsing degenerate empty-array members (`[]`/`never[]`) so the real array's per-element capabilities (`asCell:["comparable"]`) survive as a single schema instead of splitting into `anyOf` branches — moves into the fallback as a documented pruning step. Net −90 lines; CT-1639's own tests (which explicitly pin the three-member shape including the bare `[]`) pass unchanged.

## 2. Cross-file annotation corruption for preserved bindings, fixed

`expressionToTypeNode` reuses the authored declared type node for preserved bindings (`Default`/`Per*`/`Writable`-of-those) via a SHALLOW clone that keeps child positions. When the declaration lives in a different source file than the pattern, the printer slices the emit file's text at those foreign offsets — a cross-file `Default<string, "n/a">` binding printed as `Default<string, .ts";` (longstanding; cosmetic at runtime since types are erased, corrupt in goldens/`--show-transformed`/debugging). Now deep-cloned position-free via `cloneTypeNodeDeepForEmission`, so literals print from their own text. Mirrors #4078's helper of the same name — whichever lands second keeps one copy (trivial conflict). Zero golden churn: same-file output is textually identical. Unit tests pin the cross-file print and typeRegistry carry-over.

## ⚠️ Correction: the preserve list is NOT removable

#4123's body originally listed "drop `Default` from `shouldPreserveBindingDeclaredTypeNode`" as unlocked. It is not, and this PR deliberately does not do it: **`RequireDefaults` strips the DEFAULT_MARKER brand from top-level pattern-body fields**, so for a top-level destructured binding (`({ count })` with `count: Default<number, 0>`) the use-site checker type is plain `number` — no brand, no payload, nothing for #4123's mechanism to read. The authored declared node is the only remaining source for those bindings. Verified empirically: removing the entry loses `"default"` in `event-handler-no-compute-wrap`, `nested-default-optional`, and `map-ternary-inside-nested-map`. (The payload serves *nested* properties because the stripping is one level deep.) #4123's body has been updated; the underlying `RequireDefaults` question is being raised separately.

Annotation polish (`__cfHelpers.Default<T, V>` spelling for rebuilt leaves) is deliberately left to #4078's qualification machinery.

## Verification

- ts-transformers 294/294 (two new unit tests); schema-generator 25/25; zero golden churn across both commits
- full repo `deno task check` green; fmt/lint clean; `deno task integration pattern-tests` all green
- runtime probes (lift over unset `Default` properties) pass
- cross-file repro: `Default<string, .ts";` → `Default<string, "n/a">`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors union default handling in `schema-generator` and fixes cross‑file type printing in `ts-transformers`. CT‑1639’s expanded `Default<[]>` now folds into the general payload fallback with safe empty‑array pruning; preserved bindings use position‑free deep clones to prevent corrupted output.

- **Refactors**
  - Fold the expanded `Default<[]>` case into the payload fallback; when a real array exists, prune `[]`/`never[]` so per‑element capabilities stay in one schema. Safe because we emit no array length constraints; gate if that changes.
  - Keep `Default` in the preserve list: `RequireDefaults` strips the brand on top‑level destructuring, so the declared node is still required.

- **Bug Fixes**
  - Cross‑file printing: use `cloneTypeNodeDeepForEmission` to deep‑clone preserved declared type nodes with positions stripped and `typeRegistry` carried over, so literals like `Default<string, "n/a">` print correctly.
  - Add unit tests for cross‑file printing and registry carry‑over.

<sup>Written for commit 4cba92f83cb91ed61fd8103aa900b221d49f9606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

