### PR TITLE
feat(cf-harness): env-based gateway config + sandbox docker runtime override for local models

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -170,6 +170,48 @@ deno task run -- \
   --print-transcript
 ```
 
+Local open-weight model via any OpenAI-compatible server (llama.cpp shown;
+LM Studio, vLLM, and Ollama's `/v1` endpoint work the same way):
+
+```bash
+# Serve the model locally (downloads on first run, ~63GB):
+llama-server -hf ggml-org/gpt-oss-120b-GGUF --ctx-size 0 --jinja --port 8080
+
+cd packages/cf-harness
+deno task run -- \
+  --workspace ../.. \
+  --gateway-base-url http://localhost:8080/ \
+  --gateway-auth-mode none \
+  --model gpt-oss-120b \
+  --prompt "Summarize the cf-harness package structure." \
+  --print-transcript
+```
+
+The gateway can also be selected via environment, which lets callers (loom,
+pattern-factory) switch to a local model without threading new flags:
+
+```bash
+export CF_HARNESS_GATEWAY_BASE_URL=http://localhost:8080/
+export CF_HARNESS_GATEWAY_AUTH_MODE=none
+export CF_HARNESS_MODEL=gpt-oss-120b
+```
+
+CLI flags take precedence over these variables; `CF_HARNESS_MODEL` is ignored
+on `--resume-run` (the resumed run keeps its recorded model unless `--model`
+is passed explicitly).
+
+On hosts without the `runsc-cfc` Docker runtime (or where the installed CFC
+policy does not label the workspace mount, which makes in-sandbox file reads
+fail with SIGSYS), run with the plain `runc` runtime and observe-mode CFC:
+
+```bash
+export CF_HARNESS_SANDBOX_DOCKER_RUNTIME=runc
+export CF_HARNESS_CFC_ENFORCEMENT_MODE=observe
+```
+
+Tool outputs are then exposed raw with policy warnings recorded in the run
+report instead of being denied for missing trusted mediation metadata.
+
 Interactive chat stdio transport:
 
 ```bash

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -170,8 +170,8 @@ deno task run -- \
   --print-transcript
 ```
 
-Local open-weight model via any OpenAI-compatible server (llama.cpp shown;
-LM Studio, vLLM, and Ollama's `/v1` endpoint work the same way):
+Local open-weight model via any OpenAI-compatible server (llama.cpp shown; LM
+Studio, vLLM, and Ollama's `/v1` endpoint work the same way):
 
 ```bash
 # Serve the model locally (downloads on first run, ~63GB):
@@ -196,9 +196,9 @@ export CF_HARNESS_GATEWAY_AUTH_MODE=none
 export CF_HARNESS_MODEL=gpt-oss-120b
 ```
 
-CLI flags take precedence over these variables; `CF_HARNESS_MODEL` is ignored
-on `--resume-run` (the resumed run keeps its recorded model unless `--model`
-is passed explicitly).
+CLI flags take precedence over these variables; `CF_HARNESS_MODEL` is ignored on
+`--resume-run` (the resumed run keeps its recorded model unless `--model` is
+passed explicitly).
 
 On hosts without the `runsc-cfc` Docker runtime (or where the installed CFC
 policy does not label the workspace mount, which makes in-sandbox file reads

--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -122,6 +122,7 @@ const CLI_STRING_FLAGS = [
   "cfc-result-dir",
   "cfc-invocation-context-dir",
   "sandbox-image",
+  "sandbox-docker-runtime",
   "max-model-turns",
   "fabric-mount",
   "host-mount",
@@ -185,6 +186,7 @@ export interface CfHarnessCliConfig {
   apiKey?: string;
   apiKeySource?: "CF_HARNESS_API_KEY" | "OPENAI_API_KEY";
   sandboxImage?: string;
+  sandboxDockerRuntime?: string;
   fabricMount?: string;
   hostMounts: readonly CfHarnessHostMountConfig[];
 }
@@ -359,6 +361,7 @@ Options:
   --cfc-result-dir <path>       Host dir where runsc writes the CFC result sidecar (required for enforce-* modes)
   --cfc-invocation-context-dir <path> Host dir where the harness writes the CFC invocation-context sidecar (required for enforce-* modes)
   --sandbox-image <image>       Docker image for the runsc-cfc sandbox (default: ${DEFAULT_DOCKER_RUNSC_IMAGE})
+  --sandbox-docker-runtime <n>  Docker runtime for the sandbox (default: runsc-cfc)
   --fabric-mount <path>         Host path for a Fabric FUSE mount (mounted at /fabric in the sandbox)
   --host-mount <spec>           Extra host bind mount (repeatable: name=<id>,source=<host>,target=<sandbox>,mode=readonly|writable)
   --max-model-turns <n>         Maximum model turns before aborting
@@ -369,8 +372,12 @@ Options:
 Environment:
   CF_HARNESS_API_KEY            Preferred API key for the OpenAI-compatible gateway
   OPENAI_API_KEY                Fallback API key if CF_HARNESS_API_KEY is unset
+  CF_HARNESS_GATEWAY_BASE_URL   Default value for --gateway-base-url
+  CF_HARNESS_GATEWAY_AUTH_MODE  Default value for --gateway-auth-mode
+  CF_HARNESS_MODEL              Default value for --model (ignored on --resume-run)
   CF_HARNESS_DOCKER_NETWORK_MODE none | bridge | host (default: bridge)
   CF_HARNESS_SANDBOX_IMAGE      Default value for --sandbox-image
+  CF_HARNESS_SANDBOX_DOCKER_RUNTIME Default value for --sandbox-docker-runtime
   ${CFC_RESULT_DIR_ENV} Fallback for --cfc-result-dir
   ${CFC_INVOCATION_CONTEXT_DIR_ENV} Fallback for --cfc-invocation-context-dir
 `;
@@ -1172,18 +1179,39 @@ export const parseCfHarnessCliArgs = async (
   const runManifestPath = typeof args["run-manifest"] === "string"
     ? resolve(cwd, args["run-manifest"])
     : undefined;
+  const env = deps.env ??
+    {
+      CF_HARNESS_API_KEY: Deno.env.get("CF_HARNESS_API_KEY"),
+      OPENAI_API_KEY: Deno.env.get("OPENAI_API_KEY"),
+      CF_HARNESS_GATEWAY_BASE_URL: Deno.env.get("CF_HARNESS_GATEWAY_BASE_URL"),
+      CF_HARNESS_GATEWAY_AUTH_MODE: Deno.env.get(
+        "CF_HARNESS_GATEWAY_AUTH_MODE",
+      ),
+      CF_HARNESS_MODEL: Deno.env.get("CF_HARNESS_MODEL"),
+      CF_HARNESS_CFC_ENFORCEMENT_MODE: Deno.env.get(
+        "CF_HARNESS_CFC_ENFORCEMENT_MODE",
+      ),
+      CF_CFC_MODE: Deno.env.get("CF_CFC_MODE"),
+      CF_HARNESS_SANDBOX_IMAGE: Deno.env.get("CF_HARNESS_SANDBOX_IMAGE"),
+      CF_HARNESS_SANDBOX_DOCKER_RUNTIME: Deno.env.get(
+        "CF_HARNESS_SANDBOX_DOCKER_RUNTIME",
+      ),
+      [CFC_RESULT_DIR_ENV]: Deno.env.get(CFC_RESULT_DIR_ENV),
+      [CFC_INVOCATION_CONTEXT_DIR_ENV]: Deno.env.get(
+        CFC_INVOCATION_CONTEXT_DIR_ENV,
+      ),
+    };
   const gatewayBaseUrl = typeof args["gateway-base-url"] === "string"
     ? args["gateway-base-url"]
-    : DEFAULT_GATEWAY_BASE_URL;
+    : nonEmptyEnvValue(env.CF_HARNESS_GATEWAY_BASE_URL) ??
+      DEFAULT_GATEWAY_BASE_URL;
+  const rawGatewayAuthMode = typeof args["gateway-auth-mode"] === "string"
+    ? args["gateway-auth-mode"]
+    : nonEmptyEnvValue(env.CF_HARNESS_GATEWAY_AUTH_MODE);
   const parsedGatewayAuthMode = parseHarnessGatewayAuthMode(
-    typeof args["gateway-auth-mode"] === "string"
-      ? args["gateway-auth-mode"]
-      : undefined,
+    rawGatewayAuthMode,
   );
-  if (
-    args["gateway-auth-mode"] !== undefined &&
-    parsedGatewayAuthMode === undefined
-  ) {
+  if (rawGatewayAuthMode !== undefined && parsedGatewayAuthMode === undefined) {
     throw new Error("gateway auth mode must be one of bearer, none");
   }
   const gatewayAuthMode = parsedGatewayAuthMode ?? "bearer";
@@ -1210,20 +1238,6 @@ export const parseCfHarnessCliArgs = async (
       });
     }),
   );
-  const env = deps.env ??
-    {
-      CF_HARNESS_API_KEY: Deno.env.get("CF_HARNESS_API_KEY"),
-      OPENAI_API_KEY: Deno.env.get("OPENAI_API_KEY"),
-      CF_HARNESS_CFC_ENFORCEMENT_MODE: Deno.env.get(
-        "CF_HARNESS_CFC_ENFORCEMENT_MODE",
-      ),
-      CF_CFC_MODE: Deno.env.get("CF_CFC_MODE"),
-      CF_HARNESS_SANDBOX_IMAGE: Deno.env.get("CF_HARNESS_SANDBOX_IMAGE"),
-      [CFC_RESULT_DIR_ENV]: Deno.env.get(CFC_RESULT_DIR_ENV),
-      [CFC_INVOCATION_CONTEXT_DIR_ENV]: Deno.env.get(
-        CFC_INVOCATION_CONTEXT_DIR_ENV,
-      ),
-    };
   const rawSandboxImage = typeof args["sandbox-image"] === "string"
     ? args["sandbox-image"].trim()
     : undefined;
@@ -1232,6 +1246,17 @@ export const parseCfHarnessCliArgs = async (
   }
   const sandboxImage = rawSandboxImage ??
     nonEmptyEnvValue(env.CF_HARNESS_SANDBOX_IMAGE);
+  const rawSandboxDockerRuntime =
+    typeof args["sandbox-docker-runtime"] === "string"
+      ? args["sandbox-docker-runtime"].trim()
+      : undefined;
+  if (rawSandboxDockerRuntime !== undefined && rawSandboxDockerRuntime === "") {
+    throw new Error(
+      "--sandbox-docker-runtime requires a non-empty runtime name",
+    );
+  }
+  const sandboxDockerRuntime = rawSandboxDockerRuntime ??
+    nonEmptyEnvValue(env.CF_HARNESS_SANDBOX_DOCKER_RUNTIME);
   const explicitCfcMode = typeof args["cfc-enforcement-mode"] === "string"
     ? args["cfc-enforcement-mode"]
     : undefined;
@@ -1299,7 +1324,7 @@ export const parseCfHarnessCliArgs = async (
     ...(typeof args.model === "string"
       ? { model: args.model }
       : resumeRun === undefined
-      ? { model: DEFAULT_MODEL }
+      ? { model: nonEmptyEnvValue(env.CF_HARNESS_MODEL) ?? DEFAULT_MODEL }
       : {}),
     gatewayBaseUrl,
     gatewayAuthMode,
@@ -1325,6 +1350,7 @@ export const parseCfHarnessCliArgs = async (
     ...(apiKey !== undefined ? { apiKey } : {}),
     ...(apiKeySource !== undefined ? { apiKeySource } : {}),
     ...(sandboxImage !== undefined ? { sandboxImage } : {}),
+    ...(sandboxDockerRuntime !== undefined ? { sandboxDockerRuntime } : {}),
     ...(fabricMount !== undefined ? { fabricMount } : {}),
     hostMounts,
   };
@@ -1930,6 +1956,9 @@ export const runCfHarnessCli = async (
         ...(parsed.sandboxImage !== undefined
           ? { sandboxImage: parsed.sandboxImage }
           : {}),
+        ...(parsed.sandboxDockerRuntime !== undefined
+          ? { sandboxDockerRuntime: parsed.sandboxDockerRuntime }
+          : {}),
         ...(parsed.cfcResultDir !== undefined
           ? { cfcResultDir: parsed.cfcResultDir }
           : {}),
@@ -2008,6 +2037,9 @@ export const runCfHarnessCli = async (
         artifactRoot: parsed.artifactRoot,
         ...(parsed.sandboxImage !== undefined
           ? { sandboxImage: parsed.sandboxImage }
+          : {}),
+        ...(parsed.sandboxDockerRuntime !== undefined
+          ? { sandboxDockerRuntime: parsed.sandboxDockerRuntime }
           : {}),
         ...(parsed.cfcResultDir !== undefined
           ? { cfcResultDir: parsed.cfcResultDir }

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -169,6 +169,7 @@ export interface CreateHarnessEngineOptions
   runState?: HarnessRunState;
   workspaceHostPath?: string;
   sandboxImage?: string;
+  sandboxDockerRuntime?: string;
   additionalMounts?: readonly DockerRunscAdditionalMountConfig[];
   cfcResultDir?: string;
   cfcInvocationContextDir?: string;
@@ -195,6 +196,7 @@ const isToolOutputWithId = (value: unknown): value is ToolOutputWithId =>
 interface ResolveSandboxConfigOptions {
   workspaceHostPath?: string;
   sandboxImage?: string;
+  sandboxDockerRuntime?: string;
   additionalMounts?: readonly DockerRunscAdditionalMountConfig[];
   cfcResultDir?: string;
   cfcInvocationContextDir?: string;
@@ -216,6 +218,9 @@ const resolveSandboxConfig = (
     workspaceHostPath: options.workspaceHostPath,
     ...(options.sandboxImage !== undefined
       ? { image: options.sandboxImage }
+      : {}),
+    ...(options.sandboxDockerRuntime !== undefined
+      ? { runtimeName: options.sandboxDockerRuntime }
       : {}),
     ...(options.additionalMounts !== undefined &&
         options.additionalMounts.length > 0
@@ -314,6 +319,7 @@ export class CfHarnessEngine {
       ? resolveSandboxConfig(this.config, {
         workspaceHostPath: options.workspaceHostPath,
         sandboxImage: options.sandboxImage,
+        sandboxDockerRuntime: options.sandboxDockerRuntime,
         additionalMounts: options.additionalMounts,
         cfcResultDir: options.cfcResultDir,
         cfcInvocationContextDir: options.cfcInvocationContextDir,

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -327,6 +327,135 @@ Deno.test("parseCfHarnessCliArgs supports gateway auth mode override", async () 
   assertEquals(parsed.gatewayAuthMode, "none");
 });
 
+Deno.test("parseCfHarnessCliArgs resolves sandbox docker runtime from flag and environment", async () => {
+  const fromFlag = await parseCfHarnessCliArgs(
+    ["--prompt", "hi", "--sandbox-docker-runtime", "runc"],
+    {
+      cwd: "/tmp/project",
+      env: { CF_HARNESS_SANDBOX_DOCKER_RUNTIME: "runsc-cfc" },
+    },
+  );
+  if ("help" in fromFlag) {
+    throw new Error("expected config result");
+  }
+  assertEquals(fromFlag.sandboxDockerRuntime, "runc");
+
+  const fromEnv = await parseCfHarnessCliArgs(
+    ["--prompt", "hi"],
+    {
+      cwd: "/tmp/project",
+      env: { CF_HARNESS_SANDBOX_DOCKER_RUNTIME: "runc" },
+    },
+  );
+  if ("help" in fromEnv) {
+    throw new Error("expected config result");
+  }
+  assertEquals(fromEnv.sandboxDockerRuntime, "runc");
+
+  const unset = await parseCfHarnessCliArgs(
+    ["--prompt", "hi"],
+    { cwd: "/tmp/project", env: {} },
+  );
+  if ("help" in unset) {
+    throw new Error("expected config result");
+  }
+  assertEquals(unset.sandboxDockerRuntime, undefined);
+
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        ["--prompt", "hi", "--sandbox-docker-runtime", "  "],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "--sandbox-docker-runtime requires a non-empty runtime name",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs resolves gateway config from environment", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    ["--prompt", "hi"],
+    {
+      cwd: "/tmp/project",
+      env: {
+        CF_HARNESS_GATEWAY_BASE_URL: "http://localhost:8080/",
+        CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+        CF_HARNESS_MODEL: "gpt-oss-120b",
+      },
+    },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.gatewayBaseUrl, "http://localhost:8080/");
+  assertEquals(parsed.gatewayAuthMode, "none");
+  assertEquals(parsed.model, "gpt-oss-120b");
+});
+
+Deno.test("parseCfHarnessCliArgs prefers gateway flags over environment", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    [
+      "--prompt",
+      "hi",
+      "--gateway-base-url",
+      "https://llm.example.test/",
+      "--gateway-auth-mode",
+      "bearer",
+      "--model",
+      "gpt-5.5",
+    ],
+    {
+      cwd: "/tmp/project",
+      env: {
+        CF_HARNESS_GATEWAY_BASE_URL: "http://localhost:8080/",
+        CF_HARNESS_GATEWAY_AUTH_MODE: "none",
+        CF_HARNESS_MODEL: "gpt-oss-120b",
+      },
+    },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.gatewayBaseUrl, "https://llm.example.test/");
+  assertEquals(parsed.gatewayAuthMode, "bearer");
+  assertEquals(parsed.model, "gpt-5.5");
+});
+
+Deno.test("parseCfHarnessCliArgs rejects invalid gateway auth mode from environment", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(["--prompt", "hi"], {
+        cwd: "/tmp/project",
+        env: { CF_HARNESS_GATEWAY_AUTH_MODE: "token" },
+      }),
+    Error,
+    "gateway auth mode must be one of bearer, none",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs ignores blank gateway environment values", async () => {
+  const parsed = await parseCfHarnessCliArgs(
+    ["--prompt", "hi"],
+    {
+      cwd: "/tmp/project",
+      env: {
+        CF_HARNESS_GATEWAY_BASE_URL: "  ",
+        CF_HARNESS_GATEWAY_AUTH_MODE: "",
+        CF_HARNESS_MODEL: " ",
+      },
+    },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.gatewayBaseUrl, "https://llm.stage.commontools.dev/");
+  assertEquals(parsed.gatewayAuthMode, "bearer");
+  assertEquals(parsed.model, "gpt-5.5");
+});
+
 Deno.test("parseCfHarnessCliArgs supports batch output mode override", async () => {
   const parsed = await parseCfHarnessCliArgs(
     ["--prompt", "hi", "--output-mode", "batch"],


### PR DESCRIPTION
### What

Makes local open-weight models (any OpenAI-compatible server — llama-server, LM Studio, vLLM, Ollama `/v1`) a first-class cf-harness target, configurable purely through the environment:

- **`CF_HARNESS_GATEWAY_BASE_URL` / `CF_HARNESS_GATEWAY_AUTH_MODE` / `CF_HARNESS_MODEL`** — env defaults for `--gateway-base-url`, `--gateway-auth-mode`, `--model`. Flags take precedence; blank env values are ignored; `CF_HARNESS_MODEL` does not apply on `--resume-run` (resumed runs keep their recorded model unless `--model` is explicit).
- **`--sandbox-docker-runtime` / `CF_HARNESS_SANDBOX_DOCKER_RUNTIME`** — selects the Docker runtime for the tool sandbox (default unchanged: `runsc-cfc`). Threads the `runtimeName` option that `resolveDockerRunscSandboxConfig` already had out to the CLI/engine.

### Why

The gateway client was already a generic OpenAI-compatible client, but base URL was flag-only, so every consumer needed forwarding code. Loom's `harness_batch.py` and pattern-factory's `run-factory.sh` had each independently started honoring these exact env names at their own layers — this PR moves the contract into cf-harness itself, so consumers get local-model support with zero plumbing (verified: pattern-factory and loom need no code changes, just env + their existing model settings).

The runtime override exists because dev laptops without a registered `runsc-cfc` runtime — or with a CFC policy that doesn't label the workspace mount — can't execute `read_file` in-sandbox at all (gVisor SIGSYS-kills content reads of unlabeled ⊤-confidentiality files). The documented escape hatch is `runc` + observe-mode CFC.

### Security posture (the part that wants your eyes, wilk)

`--sandbox-docker-runtime runc` drops gVisor isolation for tool execution, but it does **not** weaken CFC enforce modes: outputs from a non-CFC runtime carry no trusted mediation metadata and are still denied at the harness layer (verified — that denial is how this gap was found). Observe mode remains the explicit opt-out, and the README documents the pairing. Open questions for you:

1. Should the harness warn (or refuse) when a non-`runsc-cfc` runtime is combined with an enforce-mode CFC config, rather than letting every tool call fail with denials?
2. Is the better long-term fix to ship a `/workspace/**` path label in the dev CFC policy so `runsc-cfc` works out of the box on laptops and this knob stays rare? (Happy to file that separately.)

### Verification

- `deno task test`: 406/406.
- End-to-end on macOS: llama-server serving **gpt-oss-120b** (Apache 2.0) on `:8080`, all five env vars set, no flags — 4-turn tool loop through the `runc` sandbox, `read_file` executed, correct final answer, observe-mode warnings recorded in the run report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds env-based gateway config and a sandbox Docker runtime override so local OpenAI-compatible models are first-class in `cf-harness`. Callers can switch to local servers via env, and use `runc` for the tool sandbox on dev machines.

- New Features
  - Env defaults: `CF_HARNESS_GATEWAY_BASE_URL`, `CF_HARNESS_GATEWAY_AUTH_MODE`, `CF_HARNESS_MODEL`. Flags win; blank env is ignored; `CF_HARNESS_MODEL` is ignored on `--resume-run` unless `--model` is set.
  - Sandbox runtime: `--sandbox-docker-runtime` and `CF_HARNESS_SANDBOX_DOCKER_RUNTIME` (default `runsc-cfc`), threaded through the CLI and engine.
  - Validation: rejects invalid gateway auth mode; `--sandbox-docker-runtime` requires a non-empty name.
  - Safety: using `runc` does not weaken CFC enforce modes; pair with observe mode if you need to bypass mediation on dev.

<sup>Written for commit e3dfadbbd7a102ad870fcbbc3cf7756d22163233. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

