### PR TITLE
test(memory): pin replay-before-precondition ordering for receipt commits

### DIFF
--- a/packages/memory/test/v2-commit-preconditions.test.ts
+++ b/packages/memory/test/v2-commit-preconditions.test.ts
@@ -696,3 +696,94 @@ Deno.test("entity-absent failures keep receipt-exists through client round trip"
     await server.close();
   }
 });
+
+Deno.test("replayed receipt commit returns the stored result instead of an entity-absent rejection", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    const commit = {
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      preconditions: [{
+        kind: "entity-absent" as const,
+        id: "entity:receipt",
+      }],
+      operations: [{
+        op: "set" as const,
+        id: "entity:receipt",
+        value: toEntityDocument({ receipt: 1 }),
+      }],
+    };
+
+    const first = applyCommit(engine, {
+      sessionId: "session:replay-receipt",
+      commit,
+    });
+
+    // Identical same-session resend (same localSeq): replay detection runs
+    // BEFORE precondition validation, so the stored result comes back.
+    // Re-validating entity-absent here would check against the state the
+    // first application created and wrongly reject the idempotent replay.
+    const replayed = applyCommit(engine, {
+      sessionId: "session:replay-receipt",
+      commit,
+    });
+
+    assertEquals(replayed.seq, first.seq);
+    assertEquals(replayed.branch, first.branch);
+    assertEquals(read(engine, { id: "entity:receipt" }), {
+      value: { receipt: 1 },
+    });
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("replayed localSeq with different content still fails as a replay mismatch", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:replay-mismatch",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        preconditions: [{
+          kind: "entity-absent",
+          id: "entity:receipt",
+        }],
+        operations: [{
+          op: "set",
+          id: "entity:receipt",
+          value: toEntityDocument({ receipt: 1 }),
+        }],
+      },
+    });
+
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:replay-mismatch",
+          commit: {
+            localSeq: 1,
+            reads: { confirmed: [], pending: [] },
+            preconditions: [{
+              kind: "entity-absent",
+              id: "entity:receipt",
+            }],
+            operations: [{
+              op: "set",
+              id: "entity:receipt",
+              value: toEntityDocument({ receipt: 2 }),
+            }],
+          },
+        }),
+      ProtocolError,
+      "commit replay mismatch",
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});


### PR DESCRIPTION
Follow-up to [#4096](https://github.com/commontoolsinc/labs/pull/4096) (reviewer ask that didn't land before merge): the replay-detect hoist above `validateCommitPreconditions` in `applyCommitTransaction` is load-bearing for receipt semantics — re-validating `entity-absent` on a same-session resend would check against the state the first application created and reject the idempotent replay. No test pinned that ordering.

Two fixtures, both **verified red** against the inverted ordering (validation moved back above replay detection) and green on main:
- identical same-session resend (same `localSeq`) → stored result, same `seq`/`branch`, value unchanged
- content-mismatched resend of the same `localSeq` → still `ProtocolError` replay mismatch (not a precondition rejection)

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests in `packages/memory` to pin replay-before-precondition ordering for receipt commits using the `entity-absent` precondition. Identical same-session resends (same `localSeq`) return the stored result with unchanged `seq`/`branch`, and content-mismatched resends of the same `localSeq` fail with `ProtocolError` replay mismatch; test-only, no production code changed.

<sup>Written for commit cfc157f9896914fbcdd60852400a59a18a64fa44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

