### PR TITLE
fix(runner): diagnose handler stream-marker failures instead of claiming an overwrite

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2572,7 +2572,11 @@ export class Runner {
   }
 
   /**
-   * If the final target of the link chain is a stream, return the first link.
+   * If the final target of the link chain is a stream, return the first link
+   * as `streamLink`. When the inputs carry a `$event` key — i.e. the node was
+   * authored as a handler — but the chain does not end in a stream marker,
+   * return what it resolved to instead (`eventTarget`), so the caller can
+   * report why the node cannot be instantiated as a handler.
    *
    * @param inputs
    * @param base
@@ -2583,21 +2587,27 @@ export class Runner {
     inputs: FabricValue,
     base: NormalizedFullLink,
     tx: IExtendedStorageTransaction,
-  ): NormalizedFullLink | undefined {
-    if (!isRecord(inputs) || !("$event" in inputs)) return undefined;
+  ): {
+    streamLink?: NormalizedFullLink;
+    eventTarget?: { link?: NormalizedFullLink; value: FabricValue };
+  } {
+    if (!isRecord(inputs) || !("$event" in inputs)) return {};
 
     let value: FabricValue = inputs.$event as FabricValue;
+    let lastLink: NormalizedFullLink | undefined;
     while (isWriteRedirectLink(value)) {
-      const maybeStreamLink = resolveLink(
+      lastLink = resolveLink(
         this.runtime,
         tx,
         parseLink(value, base),
         "writeRedirect",
       );
-      value = tx.readValueOrThrow(maybeStreamLink);
+      value = tx.readValueOrThrow(lastLink);
     }
 
-    return isStreamValue(value) ? parseLink(inputs.$event, base) : undefined;
+    return isStreamValue(value)
+      ? { streamLink: parseLink(inputs.$event, base) }
+      : { eventTarget: { link: lastLink, value } };
   }
 
   private createPatternFrame(
@@ -3686,7 +3696,7 @@ export class Runner {
       ...io,
     };
 
-    const streamLink = this.resolveJavaScriptStreamLink(
+    const { streamLink, eventTarget } = this.resolveJavaScriptStreamLink(
       io.inputs,
       processCell.getAsNormalizedFullLink(),
       tx,
@@ -3694,6 +3704,14 @@ export class Runner {
     if (streamLink) {
       this.instantiateJavaScriptHandlerNode({ ...context, streamLink });
       return;
+    }
+    if (eventTarget) {
+      // The node was authored as a handler ($event input), but its stream
+      // marker did not resolve. Report what actually happened instead of
+      // misclassifying the node as a lift.
+      throw new Error(
+        describeHandlerStreamFailure(name, eventTarget, resultCell),
+      );
     }
 
     this.instantiateJavaScriptActionNode(context);
@@ -4311,6 +4329,61 @@ function getTxDebugActionId(
   tx?: IExtendedStorageTransaction,
 ): string | undefined {
   return tx ? (tx.tx as { debugActionId?: string }).debugActionId : undefined;
+}
+
+/**
+ * Explain why a node authored as a handler ($event input) could not be
+ * instantiated as one. The historical error here ("$stream: true was
+ * overwritten") was misleading: the by-far most common cause is that the
+ * marker read returned undefined because nothing was ever written at the
+ * derived location — e.g. piece state persisted before the internal-cell
+ * manifest format (#3911) keeps its markers elsewhere — not that anything
+ * overwrote it.
+ */
+function describeHandlerStreamFailure(
+  name: string | undefined,
+  eventTarget: { link?: NormalizedFullLink; value: FabricValue },
+  resultCell: Cell<any>,
+): string {
+  const prefix = `Handler used as lift: ${
+    name ? `node "${name}"` : "node"
+  }'s $event input`;
+
+  if (eventTarget.link === undefined) {
+    return `${prefix} is not a stream reference (got: ${
+      toCompactDebugString(eventTarget.value, 80)
+    })`;
+  }
+
+  const where = `${eventTarget.link.id}${
+    eventTarget.link.path.length > 0
+      ? ` at path [${eventTarget.link.path.join(", ")}]`
+      : ""
+  }`;
+
+  if (eventTarget.value === undefined) {
+    let hint = "";
+    try {
+      const internalMeta = resultCell.getMetaRaw("internal", {
+        meta: ignoreReadForScheduling,
+      });
+      if (internalMeta !== undefined && !Array.isArray(internalMeta)) {
+        hint = " This piece's internal metadata is a single-cell link " +
+          "(pre-manifest format), so its persisted state predates the " +
+          "current runtime's internal-cell layout; recreate the piece to " +
+          "repair it.";
+      }
+    } catch {
+      // Diagnostic only — never mask the primary error.
+    }
+    return `${prefix} resolves to ${where}, which reads undefined — the ` +
+      `{ "$stream": true } marker was never written there.${hint}`;
+  }
+
+  return `${prefix} resolves to ${where}, whose value is not a stream ` +
+    `marker — { "$stream": true } was overwritten (found: ${
+      toCompactDebugString(eventTarget.value, 80)
+    })`;
 }
 
 /**

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -1160,6 +1160,179 @@ describe("setup/start", () => {
     expect(cellValue).toEqual({ output: 1 });
   });
 
+  it("reports a missing stream marker when a handler's $event reads undefined", async () => {
+    const pattern: Pattern = {
+      argumentSchema: { type: "object", properties: {} },
+      resultSchema: {},
+      result: {},
+      nodes: [
+        {
+          module: { type: "javascript", implementation: () => undefined },
+          inputs: {
+            $event: { $alias: { cell: "argument", path: ["missingStream"] } },
+          },
+          outputs: {},
+        },
+      ],
+    };
+
+    const resultCell = runtime.getCell(
+      space,
+      "handler $event reads undefined",
+    );
+    setupTrusted(runtime, undefined, pattern, {}, resultCell);
+
+    // The node is authored as a handler but its stream marker location was
+    // never written (e.g. state persisted in an older format). The error must
+    // say the marker is missing, not that it was overwritten.
+    const error = await runtime.start(resultCell).then(
+      () => undefined,
+      (e) => e as Error,
+    );
+    expect(error?.message).toContain("was never written");
+    // This piece's internal meta is the modern manifest (an array), so the
+    // pre-manifest hint must not fire on it.
+    expect(error?.message).not.toContain("pre-manifest");
+  });
+
+  it("reports an overwritten stream marker when $event resolves to data", async () => {
+    const pattern: Pattern = {
+      argumentSchema: {
+        type: "object",
+        properties: { ev: { type: "number" } },
+      },
+      resultSchema: {},
+      result: {},
+      nodes: [
+        {
+          module: { type: "javascript", implementation: () => undefined },
+          inputs: { $event: { $alias: { cell: "argument", path: ["ev"] } } },
+          outputs: {},
+        },
+      ],
+    };
+
+    const resultCell = runtime.getCell(
+      space,
+      "handler $event resolves to data",
+    );
+    setupTrusted(runtime, undefined, pattern, { ev: 7 }, resultCell);
+
+    await expect(runtime.start(resultCell)).rejects.toThrow(
+      "was overwritten (found: 7)",
+    );
+  });
+
+  it("reports a non-link $event input on a handler node", async () => {
+    const pattern: Pattern = {
+      argumentSchema: { type: "object", properties: {} },
+      resultSchema: {},
+      result: {},
+      nodes: [
+        {
+          module: { type: "javascript", implementation: () => undefined },
+          inputs: { $event: 42 },
+          outputs: {},
+        },
+      ],
+    };
+
+    const resultCell = runtime.getCell(space, "handler $event is not a link");
+    setupTrusted(runtime, undefined, pattern, {}, resultCell);
+
+    await expect(runtime.start(resultCell)).rejects.toThrow(
+      "is not a stream reference",
+    );
+  });
+
+  it("hints at the pre-manifest format when internal meta is a single-cell link", async () => {
+    const pattern: Pattern = {
+      argumentSchema: { type: "object", properties: {} },
+      resultSchema: {},
+      result: {},
+      nodes: [
+        {
+          module: { type: "javascript", implementation: () => undefined },
+          inputs: {
+            $event: { $alias: { cell: "argument", path: ["missingStream"] } },
+          },
+          outputs: {},
+        },
+      ],
+    };
+
+    const resultCell = runtime.getCell(
+      space,
+      "pre-manifest internal meta hint",
+    );
+    setupTrusted(runtime, undefined, pattern, {}, resultCell);
+
+    // Simulate a piece persisted before the internal-cell manifest format
+    // (#3911): its `internal` meta is a single cell link rather than the
+    // manifest array the modern setup path writes.
+    const legacyInternalCell = runtime.getCell(
+      space,
+      "pre-manifest single internal cell",
+    );
+    const metaTx = runtime.edit();
+    resultCell.withTx(metaTx).setMetaRaw(
+      "internal",
+      legacyInternalCell.getAsWriteRedirectLink({ base: resultCell }),
+    );
+    await metaTx.commit();
+
+    const error = await runtime.start(resultCell).then(
+      () => undefined,
+      (e) => e as Error,
+    );
+    expect(error?.message).toContain("was never written");
+    // The non-array internal meta is the discriminator for the pre-manifest
+    // format; the hint and its remedy must both surface.
+    expect(error?.message).toContain("pre-manifest format");
+    expect(error?.message).toContain("recreate the piece");
+  });
+
+  it("truncates long values in the overwritten-marker diagnostic", async () => {
+    const pattern: Pattern = {
+      argumentSchema: {
+        type: "object",
+        properties: { ev: { type: "string" } },
+      },
+      resultSchema: {},
+      result: {},
+      nodes: [
+        {
+          module: { type: "javascript", implementation: () => undefined },
+          inputs: { $event: { $alias: { cell: "argument", path: ["ev"] } } },
+          outputs: {},
+        },
+      ],
+    };
+
+    const resultCell = runtime.getCell(
+      space,
+      "handler $event resolves to a long value",
+    );
+    setupTrusted(
+      runtime,
+      undefined,
+      pattern,
+      { ev: "x".repeat(200) },
+      resultCell,
+    );
+
+    // The diagnostic prints the offending value but must stay bounded:
+    // toCompactDebugString caps it at 80 characters with an ellipsis, so an
+    // error message never dumps a large payload.
+    const error = await runtime.start(resultCell).then(
+      () => undefined,
+      (e) => e as Error,
+    );
+    expect(error?.message).toContain("was overwritten (found: ");
+    expect(error?.message).toContain("...");
+    expect(error?.message).not.toContain("x".repeat(100));
+  });
+
   it("setup ignores exhausted retry errors and still resolves", async () => {
     const pattern: Pattern = {
       argumentSchema: {


### PR DESCRIPTION
## Summary

When a node authored as a handler (`$event` input) failed stream classification, the runner threw `"Handler used as lift, because $stream: true was overwritten"` with no detail. The message asserts a cause it never checked — and in the wild the by-far most common cause is the opposite of an overwrite: the marker read returns **undefined** because nothing was ever written at the derived location.

Concretely: pieces persisted before the internal-cell manifest format (#3911) keep their `{ "$stream": true }` markers as keys inside the old single internal cell, while the post-#3911 runner derives per-internal cell ids that don't exist in storage. Every load of such a piece fails here — for a space's default pattern that breaks all deploys to the space — with an error blaming data corruption that never happened. (Replaying the affected space's full fact history showed zero stream-marker overwrites.)

Changes:

- `resolveJavaScriptStreamLink` now also reports what the `$event` chain actually resolved to (final link + value) when it does not end in a stream marker.
- `instantiateJavaScriptNode` raises a specific error for each case:
  - the `$event` input is not a stream reference at all (inline value),
  - it resolves to a location that **reads undefined** — marker never written — with an explicit hint when the result cell's `internal` metadata is a pre-manifest single-cell link ("recreate the piece to repair it"),
  - it resolves to a real non-stream value — genuinely overwritten — printing the offending value (rendered fabric-aware and bounded via `toCompactDebugString`, not raw `JSON.stringify`).
- Every variant keeps the `"Handler used as lift"` prefix and names the failing node (including source location for content-addressed modules) and the target entity id.
- The old guard in `instantiateJavaScriptActionNode` remains as a backstop.

## Notes

- This is the diagnostic half; a sibling PR (independent) makes `cf piece new` fail loudly instead of hanging when the default pattern can't start.
- A migration/self-heal for pre-#3911 persisted pieces is deliberately out of scope; with this error, affected pieces are at least identifiable and repairable (`cf piece recreate-root` for space roots).

## Validation

- `deno fmt` / `deno lint` / `deno check` on touched files.
- New unit coverage in `runner.test.ts` for all three variants (missing marker, overwritten marker with value, non-link `$event`), plus: the pre-manifest hint fires on a single-cell-link `internal` meta and stays silent on the modern manifest array, and long offending values are truncated so the diagnostic stays bounded.
- `cd packages/runner && deno task test` (results in PR thread).
- End-to-end against a copy of a space hit by the #3911 format skew, the error is now:
  ```
  Handler used as lift: node "cf:module/vS1c…/api/patterns/system/default-app.tsx:96:3"'s $event input
  resolves to of:fid1:nCG97mOZ…, which reads undefined — the { "$stream": true } marker was never
  written there. This piece's internal metadata is a single-cell link (pre-manifest format), so its
  persisted state predates the current runtime's internal-cell layout; recreate the piece to repair it.
  ```
  instead of the misleading overwrite claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Diagnoses handler $event stream-marker failures by reporting the actual cause (missing marker, overwritten marker, or non-link) instead of always claiming an overwrite. This clarifies “Handler used as lift” errors and makes pre-manifest pieces easy to spot and fix.

- **Bug Fixes**
  - `resolveJavaScriptStreamLink` returns `{ streamLink }` or `{ eventTarget: { link?, value } }` when `$event` doesn’t end in a stream marker.
  - `instantiateJavaScriptNode` throws targeted errors: non-link `$event`; location reads `undefined` (adds a hint for pre-manifest single-cell pieces); non-stream value (prints the found value, truncated via `toCompactDebugString`).
  - Errors keep the “Handler used as lift” prefix and include the node name and resolved link id (with path when present); tests cover missing marker, overwritten marker, non-link, the pre-manifest hint, and value truncation.

<sup>Written for commit 874861c9be279c418faed7f28cd9e4d9c4e2aa09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

