### PR TITLE
fix(runner,cli): fail loudly instead of hanging when a space's default pattern cannot start

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -395,22 +395,26 @@ export async function newPiece(
   );
   const pieces = new PiecesController(manager);
 
-  // Try to ensure default pattern, but don't fail the entire operation
+  // The default pattern is a hard requirement for this command: even when the
+  // user's pattern doesn't use it, registration below (manager.add) sends an
+  // event to the default pattern's addPiece stream. Proceeding past a failure
+  // here can only end in "Cannot add pieces" — fail now, with the real cause.
   try {
     await timeCliPhase(
       "newPiece.ensureDefaultPattern",
       () => pieces.ensureDefaultPattern(),
     );
   } catch (error) {
-    console.warn(
-      `Warning: Could not initialize default pattern: ${
+    throw new Error(
+      `Could not initialize the space's default pattern: ${
         error instanceof Error ? error.message : String(error)
-      }`,
+      }\n` +
+        `The new piece cannot be registered in the space's piece list ` +
+        `without it.\n` +
+        `If this space's root pattern predates a runtime format change, ` +
+        `repair it with: ${cliCommand(["piece", "recreate-root"])}`,
+      { cause: error },
     );
-    console.warn(
-      "Patterns using wish({ query: '#mentionable' }) or wish({ query: '#default' }) may not work.",
-    );
-    // Continue anyway - user's pattern might not need defaultPattern
   }
 
   const program = await timeCliPhase(

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1315,7 +1315,15 @@ export class Runner {
     // Determine initial pattern
     if (givenPattern) {
       currentPatternKey = initialRef ? patternIdentityKey(initialRef) : KEYLESS;
-      instantiatePattern(givenPattern, tx);
+      try {
+        instantiatePattern(givenPattern, tx);
+      } catch (error) {
+        // Without cleanup the piece stays registered in `this.cancels`, so
+        // every later start() reports "already running" for a piece that has
+        // no nodes or event handlers — events sent to it are then dropped.
+        cleanup();
+        throw error;
+      }
       if (!doNotUpdateOnPatternChange) {
         setupPatternWatcher();
       }

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -139,6 +139,38 @@ export interface SchedulerEventQueueState {
   ) => void;
 }
 
+/**
+ * Settle an event that will never be dispatched. The onCommit contract is that
+ * it runs after the final outcome of the event, including failure — a dropped
+ * event is such an outcome. Callers awaiting onCommit (e.g. stream.send with a
+ * commit callback) would otherwise wait forever; that is how a space whose
+ * default pattern fails to instantiate turned `cf piece new` into an
+ * indefinite hang. The callback receives an aborted transaction so
+ * `tx.status()` reports `error` with the drop reason.
+ */
+function notifyEventDropped(
+  state: Pick<SchedulerEventQueueState, "runtime">,
+  args: {
+    readonly eventLink: NormalizedFullLink;
+    readonly onCommit?: QueuedEvent["onCommit"];
+  },
+  reason: string,
+): void {
+  logger.warn("scheduler", reason, { eventLink: args.eventLink });
+  if (!args.onCommit) return;
+  const tx = state.runtime.edit();
+  tx.abort(new Error(reason));
+  try {
+    args.onCommit(tx);
+  } catch (callbackError) {
+    logger.error(
+      "schedule-error",
+      "Error in event commit callback:",
+      callbackError,
+    );
+  }
+}
+
 export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
   readonly eventLink: NormalizedFullLink;
   readonly event: unknown;
@@ -190,12 +222,29 @@ export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
           true,
           { eventId: id, originTx: args.originTx },
         );
+      } else {
+        notifyEventDropped(
+          state,
+          args,
+          `Event dropped: no handler registered for ${args.eventLink.id} ` +
+            `and its piece could not be started`,
+        );
       }
     })();
     state.backgroundTasks.add(startTask);
     startTask.finally(() => {
       state.backgroundTasks.delete(startTask);
     });
+  } else if (!handlerFound) {
+    // Second pass after a piece start that still registered no handler for
+    // this stream (e.g. the piece "started" but its nodes failed to
+    // instantiate). Trying again won't change this, so settle the event now.
+    notifyEventDropped(
+      state,
+      args,
+      `Event dropped: no handler registered for ${args.eventLink.id} ` +
+        `after starting its piece`,
+    );
   }
 }
 
@@ -331,6 +380,15 @@ export function preflightQueuedEventDependencies(state: {
   } catch (error) {
     state.eventQueue.shift();
     state.handleError(error as Error, handler);
+    // Dropping the event here is its final outcome — settle the commit
+    // callback like the other drop paths instead of leaving callers that
+    // await it hanging.
+    notifyEventDropped(
+      state,
+      queuedEvent,
+      `Event dropped: populateDependencies threw during dependency ` +
+        `preflight for ${queuedEvent.eventLink.id}`,
+    );
     shouldSkipEvent = true;
   } finally {
     logger.timeEnd(
@@ -640,6 +698,10 @@ export async function dispatchQueuedEvent(state: {
         if (tx.status().status === "ready") {
           tx.abort(error);
         }
+        // A throwing handler is a final outcome for this event — settle the
+        // commit callback (with the aborted tx) instead of leaving callers
+        // that await it hanging.
+        runFinalCommitCallback();
       }
       return;
     }

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -1333,6 +1333,73 @@ describe("setup/start", () => {
     expect(error?.message).not.toContain("x".repeat(100));
   });
 
+  it("start() leaves no running registration when instantiation throws", async () => {
+    // A handler node whose $event input does not resolve to a stream marker
+    // (e.g. persisted state in an older format) makes node instantiation
+    // throw "Handler used as lift".
+    const pattern: Pattern = {
+      argumentSchema: { type: "object", properties: {} },
+      resultSchema: {},
+      result: {},
+      nodes: [
+        {
+          module: { type: "javascript", implementation: () => undefined },
+          inputs: { $event: 42 },
+          outputs: {},
+        },
+      ],
+    };
+
+    const resultCell = runtime.getCell(
+      space,
+      "start cleans up when instantiation throws",
+    );
+    setupTrusted(runtime, undefined, pattern, {}, resultCell);
+
+    await expect(runtime.start(resultCell)).rejects.toThrow(
+      "Handler used as lift",
+    );
+
+    // Regression: the failed start used to leave the piece registered as
+    // running, so a second start() reported success for a piece that had no
+    // nodes or event handlers — events sent to it were silently dropped. It
+    // must fail the same way as the first attempt instead.
+    await expect(runtime.start(resultCell)).rejects.toThrow(
+      "Handler used as lift",
+    );
+  });
+
+  it("run() with a given pattern leaves no running registration when instantiation throws", () => {
+    // Same regression as above, via the fresh-run entry (the path a live
+    // `cf piece new` takes): startCore's givenPattern branch must also clean
+    // up when node instantiation throws.
+    const pattern: Pattern = {
+      argumentSchema: { type: "object", properties: {} },
+      resultSchema: {},
+      result: {},
+      nodes: [
+        {
+          module: { type: "javascript", implementation: () => undefined },
+          inputs: { $event: 42 },
+          outputs: {},
+        },
+      ],
+    };
+
+    const resultCell = runtime.getCell(
+      space,
+      "fresh run cleans up when instantiation throws",
+    );
+
+    expect(() => runTrusted(runtime, undefined, pattern, {}, resultCell))
+      .toThrow("Handler used as lift");
+
+    // A zombie registration would make the second run() short-circuit to
+    // "already running" and return without error. It must throw identically.
+    expect(() => runTrusted(runtime, undefined, pattern, {}, resultCell))
+      .toThrow("Handler used as lift");
+  });
+
   it("setup ignores exhausted retry errors and still resolves", async () => {
     const pattern: Pattern = {
       argumentSchema: {

--- a/packages/runner/test/scheduler-events.test.ts
+++ b/packages/runner/test/scheduler-events.test.ts
@@ -738,6 +738,223 @@ describe("event handling", () => {
     expect(resultCell.get()).toBe(0);
   });
 
+  it("settles the commit callback when no handler is registered", async () => {
+    const eventCell = runtime.getCell<number>(
+      space,
+      "settles commit callback when no handler is registered 1",
+      undefined,
+      tx,
+    );
+    eventCell.set(0);
+    await tx.commit();
+
+    // No handler is registered for this cell, and the cell has no result /
+    // pattern metadata, so the piece-start fallback cannot register one
+    // either. The event can never be dispatched — the commit callback must
+    // still settle (with an errored tx) instead of being dropped silently.
+    const commitStatus = new Promise<string>((resolve) => {
+      runtime.scheduler.queueEvent(
+        eventCell.getAsNormalizedFullLink(),
+        1,
+        undefined,
+        (commitTx) => resolve(commitTx.status().status),
+      );
+    });
+
+    const status = await Promise.race([
+      commitStatus,
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("commit callback never settled")),
+          1_000,
+        )
+      ),
+    ]);
+    expect(status).toBe("error");
+  });
+
+  it("settles the commit callback when the event handler throws", async () => {
+    const eventCell = runtime.getCell<number>(
+      space,
+      "settles commit callback when the event handler throws 1",
+      undefined,
+      tx,
+    );
+    eventCell.set(0);
+    await tx.commit();
+
+    let errors = 0;
+    runtime.scheduler.onError(() => {
+      errors++;
+    });
+
+    const eventHandler: EventHandler = () => {
+      throw new Error("boom");
+    };
+    runtime.scheduler.addEventHandler(
+      eventHandler,
+      eventCell.getAsNormalizedFullLink(),
+    );
+
+    // A throwing handler is the final outcome for the event; the commit
+    // callback must observe it (errored tx) rather than wait forever.
+    const commitStatus = new Promise<string>((resolve) => {
+      runtime.scheduler.queueEvent(
+        eventCell.getAsNormalizedFullLink(),
+        1,
+        undefined,
+        (commitTx) => resolve(commitTx.status().status),
+      );
+    });
+
+    const status = await Promise.race([
+      commitStatus,
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("commit callback never settled")),
+          1_000,
+        )
+      ),
+    ]);
+    expect(status).toBe("error");
+    expect(errors).toBe(1);
+  });
+
+  it("settles the commit callback when populateDependencies throws", async () => {
+    const eventCell = runtime.getCell<number>(
+      space,
+      "settles commit callback when populateDependencies throws 1",
+      undefined,
+      tx,
+    );
+    eventCell.set(0);
+    await tx.commit();
+
+    let errors = 0;
+    runtime.scheduler.onError(() => {
+      errors++;
+    });
+
+    let handlerRan = false;
+    const eventHandler: EventHandler = () => {
+      handlerRan = true;
+    };
+    runtime.scheduler.addEventHandler(
+      eventHandler,
+      eventCell.getAsNormalizedFullLink(),
+      () => {
+        throw new Error("boom in populateDependencies");
+      },
+    );
+
+    // A dependency-preflight throw drops the event before dispatch; that is
+    // its final outcome, so the commit callback must observe it (errored tx)
+    // rather than wait forever.
+    const commitStatus = new Promise<string>((resolve) => {
+      runtime.scheduler.queueEvent(
+        eventCell.getAsNormalizedFullLink(),
+        1,
+        undefined,
+        (commitTx) => resolve(commitTx.status().status),
+      );
+    });
+
+    const status = await Promise.race([
+      commitStatus,
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("commit callback never settled")),
+          1_000,
+        )
+      ),
+    ]);
+    expect(status).toBe("error");
+    expect(errors).toBe(1);
+    expect(handlerRan).toBe(false);
+  });
+
+  it("settles the commit callback when piece loading is disabled and no handler exists", async () => {
+    const eventCell = runtime.getCell<number>(
+      space,
+      "settles commit callback with doNotLoadPieceIfNotRunning 1",
+      undefined,
+      tx,
+    );
+    eventCell.set(0);
+    await tx.commit();
+
+    // This is the second-pass situation: after a piece start, events are
+    // re-queued with doNotLoadPieceIfNotRunning=true; if the piece still
+    // registered no handler for this stream, the event can never dispatch.
+    // That is a final outcome, so the commit callback must settle instead of
+    // vanishing with the event.
+    const commitStatus = new Promise<string>((resolve) => {
+      runtime.scheduler.queueEvent(
+        eventCell.getAsNormalizedFullLink(),
+        1,
+        undefined,
+        (commitTx) => resolve(commitTx.status().status),
+        true,
+      );
+    });
+
+    const status = await Promise.race([
+      commitStatus,
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("commit callback never settled")),
+          1_000,
+        )
+      ),
+    ]);
+    expect(status).toBe("error");
+  });
+
+  it("contains a throwing commit callback when settling a dropped event", async () => {
+    const eventCell = runtime.getCell<number>(
+      space,
+      "contains throwing commit callback on drop 1",
+      undefined,
+      tx,
+    );
+    eventCell.set(0);
+    await tx.commit();
+
+    // A misbehaving commit callback must not break the caller or the queue:
+    // the drop-settle path catches it, and a subsequent event on the same
+    // (still handlerless) stream settles its own callback normally.
+    runtime.scheduler.queueEvent(
+      eventCell.getAsNormalizedFullLink(),
+      1,
+      undefined,
+      () => {
+        throw new Error("boom in commit callback");
+      },
+      true,
+    );
+
+    const commitStatus = new Promise<string>((resolve) => {
+      runtime.scheduler.queueEvent(
+        eventCell.getAsNormalizedFullLink(),
+        2,
+        undefined,
+        (commitTx) => resolve(commitTx.status().status),
+        true,
+      );
+    });
+
+    const status = await Promise.race([
+      commitStatus,
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("commit callback never settled")),
+          1_000,
+        )
+      ),
+    ]);
+    expect(status).toBe("error");
+  });
+
   it("should trigger recomputation of dependent cells", async () => {
     const eventCell = runtime.getCell<number>(
       space,


### PR DESCRIPTION
## Summary

When a space's default pattern fails node instantiation, `cf piece new` hung forever, then exited **code 0 with empty stdout** once the server closed the idle websocket (Deno event-loop drain with an unsettled top-level await). Downstream tooling saw only a generic timeout. Observed in the wild on a space whose root pattern predates the internal-cell manifest format of #3911 — every deploy to the space hung.

Four stacked defects produced the hang; this PR fixes each layer so the failure is loud and immediate:

- **runner** (`startCore`): the piece was registered in `this.cancels` *before* node instantiation, and an instantiation throw skipped the `cleanup()` helper used by the neighboring error paths. The piece became a zombie — every later `start()` short-circuited to "already running" (`doStart` step 2) for a piece with no nodes and no event handlers. Instantiation throws now run `cleanup()` before propagating, so a second `start()` fails the same way as the first instead of reporting success. (The wrap is on the `givenPattern` instantiation site — the only one reachable via current callers: post-#4156, `doStart`/`setupInternal` always resolve the pattern before calling `startCore`, so the patternless sync branch is deliberately left untouched.)
- **scheduler** (`queueSchedulerEvent` / `dispatchQueuedEvent` / `preflightQueuedEventDependencies`): four paths ended an event's life without ever invoking its `onCommit` callback, violating the documented contract ("runs after the final commit result, including exhausted failure") and leaving callers that await the commit hanging:
  1. no handler registered and `ensurePieceRunning` could not start the owning piece;
  2. no handler registered on the re-queue after a piece start (piece "started" but registered no handler for the stream);
  3. the handler threw synchronously (`finalize`'s error branch returned without `runFinalCommitCallback()`);
  4. `populateDependencies` threw during dependency preflight, dropping the event before dispatch (same class, found in a later review pass — not part of the observed hang chain).
  All four now settle the callback with an aborted transaction, so `tx.status()` reports `error` with the drop reason (this is what `PieceManager.add` already checks).
- **cli** (`newPiece`): an `ensureDefaultPattern` failure was downgraded to a warning ("user's pattern might not need defaultPattern") — but the unconditional `manager.add()` below hard-requires the default pattern, so proceeding could only end in an error or, before the fixes above, the hang. The failure is now fatal, reports the underlying error, and points at `cf piece recreate-root` for format-skew repairs.

## Notes

- Root-cause chain was confirmed by reproducing against a copy of the affected space's toolshed store: `ensureDefaultPattern` rejects (warned, swallowed) → `pieces.create` succeeds in ~80ms → `manager.add` pulls the `addPiece` stream fine, then `send()`'s `onCommit` never fires; no timer is pending, so the event loop drains and Deno exits 0.
- Sibling PR (independent): makes the underlying "Handler used as lift, because $stream: true was overwritten" error diagnose what actually happened (in the observed case nothing was overwritten — the marker location was never written because the persisted state predates #3911's manifest format).
- Coverage: every added runner line is test-covered. The cli fatal-error block (9 lines) is exercised end-to-end (see Validation) but not unit-reachable — `newPiece` builds its session and runtime from a single `apiUrl`, so there is no seam to fail only the ensure step without refactoring the function for testability's sake. Accepting that narrow debt:

NEW_PERF_BASELINE: coverage-debt: packages/cli uncovered lines = 4852 lines

## Validation

- `deno fmt` / `deno lint` / `deno check` on touched files.
- New unit coverage:
  - `runner.test.ts`: a pattern whose handler node fails instantiation leaves no "running" registration — a second `start()` rejects identically instead of resolving `true`; same assertion via the fresh-run entry (`run()` with a given pattern — the path `cf piece new` takes).
  - `scheduler-events.test.ts`: `onCommit` settles with an errored tx when no handler is registered for the event, when the handler throws, when `populateDependencies` throws during preflight (verified red without the fix, green with it), and when `doNotLoadPieceIfNotRunning` is set with no handler registered (the internal re-queue's second pass); a throwing commit callback is contained by the drop-settle path and does not affect later events.
- `cd packages/runner && deno task test` and `cd packages/cli && deno task test` (results in PR thread).
- End-to-end against a copy of the affected store: previously hang → exit 0 with empty stdout after ~6 min; now exit 1 in under a second with:
  ```
  Could not initialize the space's default pattern: Handler used as lift, because $stream: true was overwritten
  The new piece cannot be registered in the space's piece list without it.
  If this space's root pattern predates a runtime format change, repair it with: cf piece recreate-root
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hang in `cf piece new` by failing fast when a space’s default pattern can’t start. The CLI now exits immediately with a clear error (code 1) instead of timing out.

- **Bug Fixes**
  - `runner`: run cleanup on node instantiation errors to avoid zombie “already running” pieces; later `start()` calls now fail the same way as the first.
  - `scheduler`: always settle `onCommit` with an aborted tx when an event can’t dispatch: no handler and piece can’t start, still no handler after a start, handler throws, or dependency preflight throws.
  - `cli`: make `ensureDefaultPattern` failure fatal; include the underlying error and suggest `cf piece recreate-root`.

<sup>Written for commit 52b51233d1cf28eaab0ba451f3e59d9352e0fc0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

