### PR TITLE
Reduce pull request deployment spam in tests

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -149,7 +149,6 @@ jobs:
   generated-patterns-integration-test:
     name: "Generated Patterns Integration Tests (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
-    environment: ci
     strategy:
       fail-fast: false
       matrix:
@@ -200,7 +199,6 @@ jobs:
     name: "Package Integration Tests (${{ matrix.suite_name }})"
     runs-on: ubuntu-latest
     needs: ["build-binaries"]
-    environment: ci
     strategy:
       fail-fast: false
       matrix:
@@ -273,7 +271,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ matrix.timeout_minutes }}
     needs: ["build-binaries"]
-    environment: ci
     strategy:
       fail-fast: false
       matrix:
@@ -395,7 +392,6 @@ jobs:
     name: "Pattern Integration Tests (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
     needs: ["build-binaries"]
-    environment: ci
     strategy:
       fail-fast: false
       matrix:
@@ -449,7 +445,6 @@ jobs:
     name: "Pattern Reload Integration Tests"
     runs-on: ubuntu-latest
     needs: ["build-binaries"]
-    environment: ci
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
GitHub Actions creates a deployment record for every job that declares an environment. The affected pull request test jobs used the ci environment, so every separate copy created by the test matrix added a timeline entry that looked like a temporary deployment to ci.

This removes the environment declaration from the pull request test jobs only. It does not change the pull_request or push triggers, job names, required job dependencies, test matrix values, runner choices, steps, test commands, uploaded artifacts, or performance gate dependencies. The same tests still run for pull requests and for pushes to main.

The affected test jobs do not read secrets or variables from the ci environment. They use local environment values, built binaries, and explicit fake keys where needed. The main-only jobs that do need protected secrets or environment variables still declare the ci environment, including binary signing and shell staging deployment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the environment declaration from pull request test jobs to stop GitHub from creating deployment entries for each test matrix shard. All tests, matrices, steps, artifacts, and gates remain the same; main-only jobs that need secrets still use the `ci` environment.

<sup>Written for commit 380c48e8c0c25330432d2ba0c301440c3041ab9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

