### PR TITLE
Annotation primitive — prototype (design + Phase-0 spike)

### DIFF
--- a/docs/development/connectors/annotations-prototype-plan.md
+++ b/docs/development/connectors/annotations-prototype-plan.md
@@ -1,0 +1,206 @@
+# Annotation Primitive — Prototype Implementation Plan (labs-4)
+
+Status: **planning → building** · Branch: `proto/annotation-primitive`
+
+This document plans a labs-4 prototype of the annotation primitive proposed in
+loom **PR #2707** (`docs/development/connectors/annotations-*.md` in the loom
+repo). That PR is a *design-doc* PR (eight markdown files, ~4.5k lines, no
+implementation). This plan grounds its spec vocabulary in **real labs-4 code**
+and lays out a phased build.
+
+---
+
+## 1. What the primitive is
+
+An **annotation** is a statement that one entity is *about* another, attachable
+to any target **from the author's own scope without write access to the
+target**. The design's single true runtime ask is a **reverse index** — the
+ability to answer *"what is attached to X?"* — with a thin pattern-space API on
+top.
+
+The author-facing API (latest loom revision, "collapse to ONE verb"):
+
+```ts
+// Library convention type
+type Annotation<T> = { about: Cell<unknown> | EntityRef; rel?: string } & T;
+
+// Authoring verb — identity is OPTIONAL
+annotate<T>(
+  target: Cell<unknown> | EntityRef,
+  { rel, identity, ...data }: { rel?: string; identity?: unknown[] } & T,
+): Cell<Annotation<T>>;
+
+// THE runtime primitive — the reverse index
+annotationsOf<T>(
+  target: Cell<unknown> | EntityRef,
+  schema?: JSONSchema,
+): Cell<Annotation<T>[]>;
+
+// Virtual home entries for entities with no document
+anchorRef(type: string, naturalKey: object): EntityRef;
+
+// Fold annotations through a resolution policy into a home doc
+materialize<T>(target: EntityRef, policy: ResolutionPolicy<T>): Cell<T>;
+```
+
+**Identity semantics (critical).** Omit `identity` → **accreting**: each call is
+a distinct act (append; two identical comments stay distinct). Provide
+`identity` → **converging**: idempotent/toggle-able, keyed by
+`(author, target, rel, identity)`. Default-accrete was chosen late in loom
+review because the earlier default-converge silently overwrote data (two
+comments collapsing into one). Forgetting `identity` should over-accrete
+(recoverable), never overwrite (data loss). `identity` is validated to reject
+non-deterministic values (timestamps, randoms).
+
+---
+
+## 2. Grounding: loom vocabulary → real labs-4 code
+
+Verified against the working tree. ✅ = exists and is our hook point;
+❌ = does not exist, must be built.
+
+| loom concept | labs-4 reality | status |
+| --- | --- | --- |
+| commit boundary / "prepare boundary" | `applyCommitTransaction()` @ `packages/memory/v2/engine.ts:3091`; after `materializeSnapshots()` @ `:3249` each `revision.document` is fully materialized | ✅ hook point |
+| derived index maintained at commit | `scheduler_read_index` / `scheduler_write_index` DDL @ `engine.ts:263–309`, maintained by diff/reconcile `reconcileSchedulerReadRows()` @ `engine.ts:2690`, invoked inside the commit txn | ✅ exact precedent for `link_index` |
+| sigil link encoding | `{"/":{"link@1":{id,path,space,scope,schema,overwrite}}}` — `packages/runner/src/sigil-types.ts:16–32`; parse `link-types.ts:191`; resolve `link-resolution.ts:124`. Links are stored **inline** in documents | ✅ exists |
+| `linkRole:"about"` keyword | schema keywords parsed in `packages/runner/src/cfc.ts` (`getAsCellValues` `:591–633`); no notion of link *role* | ❌ build |
+| `link_index` reverse table | — | ❌ build |
+| `LinkReference` atom (both endpoints minted at commit) | not present (loom spec item SC-10) | ❌ synthesized at the index walker |
+| per-reader read-time label filtering ("op-views") | **NOT PRESENT** — only egress-time LLM observation ceilings | ❌ large separate effort — **deferred** (see §4) |
+| reactive query delivery | scheduler `subscribe()` + trigger index (`packages/runner/src/scheduler/pull-subscriptions.ts:35+`, `trigger-index.ts`); `wish` builtin `builtins/wish.ts:1383+` is tag-based only | ✅ reuse, keyed on target-id |
+| authorship/provenance on write | `TransformedBy` minted at prepare `packages/runner/src/cfc/prepare.ts:1340` | ✅ rides annotation writes for free |
+| entity identity / scope | `(branch, id, scope_key, seq, op_index)`; space is implicit per-DB; `resolveScopeKey()` @ `engine.ts:46` | ✅ |
+| migrations | no versioning; `CREATE TABLE IF NOT EXISTS` + manual `ALTER TABLE` in the INIT string is the convention | ✅ additive DDL is safe |
+
+**Architecture decision (locked).** An annotation is **its own document** in the
+author's space whose `about` field is a sigil link tagged `linkRole:"about"` at
+the target. The commit walker indexes `from = annotationDoc → to = target
+(role=about)`. `annotationsOf(target)` reads `link_index` for **incoming**
+about-edges. **Nothing is ever written into the target** — that is the entire
+point of the primitive, and the reason we reject storing annotations as
+`setMetaRaw` cell-metadata on the target (that is the write-inversion tax the
+primitive exists to remove).
+
+---
+
+## 3. Phased build
+
+De-risks the deepest layer first.
+
+### Phase 0 — commit-boundary index spike (highest risk first)
+- Add `link_index` DDL to the INIT string near `engine.ts:332`
+  (`CREATE TABLE IF NOT EXISTS`, additive; idempotent guards are the
+  convention — no migration system exists).
+- Columns:
+  `(branch, from_id, from_scope_key, from_path JSON, to_space, to_id,
+  to_scope, role, seq, op_index, removed_seq)` plus a lookup index on
+  `(branch, to_id, to_scope, role)` for incoming-edge queries.
+- Add `reconcileLinkRows()` mirroring `reconcileSchedulerReadRows`, called
+  immediately after `materializeSnapshots()` @ `engine.ts:3249`, inside the
+  same SQLite transaction (atomic with the revision write).
+- Walker scans each `revision.document` JSON for sigil `link@1` objects
+  (**not** `SourceLink {"/" : string}` — that shape is content-addressed
+  source, not a sigil link) and emits rows. Diff/reconcile so updates and
+  deletes retract rows (`removed_seq`).
+- **Gate:** a runner test commits an annotation doc and reads index rows back.
+
+### Phase 1 — `linkRole` keyword
+- Add `linkRole?: string` to `LinkV1Inner` (`sigil-types.ts:16–32`).
+- Add a `getLinkRole` accessor alongside `getAsCellValues` in `cfc.ts`.
+- Keep `linkRole` on the **stored** sigil during serialization
+  (`link-utils.ts:222–287`) — unlike `asCell` (stripped at write), `linkRole`
+  is link-semantics, not cell-semantics, so it persists.
+- Walker filters to `role === "about"`.
+
+### Phase 2 — reactive reverse read + `annotationsOf` builtin
+- Engine query "incoming about-edges to X" (`server.ts` graphQuery analog) +
+  runner wiring in `storage/v2.ts`.
+- **Key new wiring / main runtime risk:** make `incoming-edges-to(target)` a
+  subscribable synthetic address in the trigger index, dirtied whenever
+  `reconcileLinkRows` touches a row with `to_id = target`, so subscribed result
+  cells update.
+- Add `builtins/annotations-of.ts` (modeled on `builtins/wish.ts`), the api
+  type in `packages/api/index.ts`, and builder wiring in
+  `builder/factory.ts`.
+- **Gate:** subscribe to `annotationsOf(target)`, commit an annotation in a
+  separate txn, observe the result cell update + schema projection.
+
+### Phase 3 — library verbs
+- `annotate(target, { rel, identity?, ...data })`:
+  - accreting (no `identity`) = read-modify-write append against the author's
+    **live** per-target list — replay-safe, **never a bare ordinal counter**.
+  - converging (`identity`) = stable cause from
+    `createRef(author, target, rel, identity)`.
+  - identity-determinism guard: reject `Date`/random with a loud error.
+- `anchorRef(type, naturalKey) = createRef({ type, naturalKey },
+  ["anchor", type])`.
+- `materialize(target, policy)` = `computed` fold over `annotationsOf`.
+- Pattern-level tests: accreting-distinct, converging-idempotent-toggle,
+  no-write-to-target invariant.
+
+### Phase 4 — migrate two existing patterns
+- `packages/patterns/system/backlinks-index.tsx` — delete the
+  write-into-target scan; backlinks become `annotationsOf(target)`.
+- `packages/patterns/annotation.tsx` — re-express on `annotate` /
+  `annotationsOf`.
+
+### Phase 5 — docs + stress pass
+- `docs/common/concepts/annotation.md` + glossary entry.
+- Devil's-advocate sub-agent review of robustness / regret-in-6-months / ideal
+  UX before presenting.
+
+---
+
+## 4. Scope cuts (decided)
+
+The "full" design leans on two subsystems that **do not exist in labs-4 and are
+each large efforts**. Both are **deferred** for the prototype; the reverse-index
+core ships without them.
+
+1. **Per-reader read-time label filtering — DEFERRED.** No server-side op-view
+   filtering exists today. v1: annotation docs carry authorship labels
+   (`TransformedBy` at prepare, free) and `annotationsOf` does a best-effort
+   label check at the runner read layer. True per-reader server-side filtering
+   is future work (new memory-server machinery).
+2. **Cross-space discovery — DEFERRED.** Each space is a separate SQLite DB, so
+   `link_index` is naturally per-space. v1: `annotationsOf` finds annotations
+   authored in the **same space** as the target — covers all migration targets
+   and demos. Cross-space index federation is future work.
+
+Other intentional simplifications:
+- **Identity stability** (stable per-event id for accreting replay-safety): the
+  loom design names this as a runtime gap. We sidestep it by desugaring
+  accreting to read-modify-write against the live per-target list.
+
+---
+
+## 5. Risks
+
+- **Reactive invalidation of the reverse read (Phase 2)** is the principal
+  novelty — existing trigger-index subscriptions key on reads of concrete
+  addresses; we must dirty a *synthetic* "incoming-edges-to(target)" key from
+  the commit-side reconcile. This is the most likely place to get subtle
+  missed-update or over-invalidation bugs; it gets a dedicated test matrix.
+- **Walker cost at commit.** Walking every committed document for sigil links
+  adds commit-path work. Mirror the scheduler index's diff/reconcile so steady
+  state is cheap; benchmark before/after on a large commit.
+- **Transformer surface.** `linkRole` is set explicitly by the annotation
+  library (schema keyword), **not** inferred from TS types, to avoid touching
+  `ts-transformers`. Revisit only if ergonomics demand type-inferred roles.
+
+---
+
+## 6. Migration targets (why these)
+
+These are labs' own hand-rolled reimplementations of the primitive, named in the
+loom design:
+- `system/backlinks-index.tsx` — the marquee anti-pattern: it iterates
+  `allPieces` and writes a `backlinks` array **into** each target
+  (write-inversion + O(N) rescan). Becomes a reverse-index read.
+- `annotation.tsx` / `annotation-manager.tsx` — discover via
+  `wish({ query: "#annotation" })` and rely on the backlinks hack for reverse
+  lookup.
+- `experimental/folksonomy-aggregator.tsx` — a central collector standing in
+  for a missing reverse index (out of scope for v1 migration; candidate for a
+  follow-up).

--- a/docs/development/connectors/annotations-prototype-plan.md
+++ b/docs/development/connectors/annotations-prototype-plan.md
@@ -1,52 +1,23 @@
 # Annotation Primitive — Prototype Implementation Plan (labs-4)
 
-Status: **under review — altitude in question** · Branch: `proto/annotation-primitive`
-
-> **⚠️ Adversarial review outcome (2026-06-14).** Three independent critics
-> reviewed this plan and the Phase-0 spike. Headline findings (detail in the PR
-> description):
->
-> - **Altitude is likely wrong for a prototype.** Phase 0 put the reverse index
->   in the memory engine — the hardest, least-reversible layer — to retire the
->   *easy* risk (walk JSON, write rows), while **Phase 2 (reactive delivery) —
->   the genuinely hard part — is not credible as written.** The scheduler
->   trigger index keys only on concrete `space/scope/id`; a committed annotation
->   doc `D` never writes its target `X`, so the change-notification path carries
->   `D`'s id only and a reader watching `X` is never woken. Making
->   `annotationsOf` reactive would require a cross-layer change-notification
->   protocol extension (memory-server + runner-storage + scheduler) this plan
->   does not scope or budget.
-> - **`wish()` already solves the analogous problem** (reactive over a changing
->   set of entities) by reading a *concrete materialized index cell* and riding
->   the ordinary trigger index — no synthetic subscription. **Recommended
->   pivot:** build `annotationsOf` as a `computed` over
->   `wish({ query: "#annotation" })` filtered by the `about` target — zero engine
->   code, reactive on day one, exercises every ergonomic question and both
->   migrations. Only if that demonstrably doesn't scale, promote the index to a
->   concrete commit-written cell (the wish model) — never a SQLite side-table
->   plus a net-new synthetic-subscription protocol.
-> - **Two correctness blockers in the Phase-0 spike** (were the engine path
->   kept): (1) **branch inheritance** — the reverse read misses every annotation
->   committed on a parent branch before a fork; `scheduler_read_index` is an
->   *anti*-precedent (it is branch-local because it tracks live ephemeral
->   readers, not inheritable content). (2) **scope encoding** — `to_scope` stores
->   the raw `LinkScope` token (`"user"`/`"session"`/`"inherit"`) while a target's
->   real identity is a *resolved* `scope_key` (`"user:<principal>"`, …); they
->   coincide only for `"space"`, so non-space targets silently return nothing.
->   Plus a reconcile bug: borrowing `reconcileSchedulerIndexRows` freezes
->   `seq`/`op_index` on converging re-sets, which would silently defeat the very
->   Phase-2 invalidation the engine path exists to enable.
->
-> The Phase-0 engine spike below is retained as a **reference artifact** proving
-> the commit-boundary mechanism *works mechanically*, not as the recommended
-> path. The §2 claim that `scheduler_read_index` is an "exact precedent" is
-> **withdrawn**.
+Status: **revised per adversarial review — wish-backed altitude** · Branch:
+`proto/annotation-primitive` · PR: commontoolsinc/labs#4132
 
 This document plans a labs-4 prototype of the annotation primitive proposed in
 loom **PR #2707** (`docs/development/connectors/annotations-*.md` in the loom
 repo). That PR is a *design-doc* PR (eight markdown files, ~4.5k lines, no
 implementation). This plan grounds its spec vocabulary in **real labs-4 code**
 and lays out a phased build.
+
+> **Revision note (2026-06-14).** v1 of this plan put the reverse index in the
+> memory engine (a `link_index` table maintained at the commit boundary) and
+> built a Phase-0 spike of it. Three independent adversarial critics converged on
+> the same verdict: **that is the wrong altitude for a prototype, and its
+> reactive layer (the actually-hard part) is not credible without a cross-layer
+> protocol change.** This revision adopts their recommended path — a wish-backed
+> library `annotationsOf` that is reactive for free — and demotes the engine
+> index to a properly-specified *future optimization*. The full reasoning is in
+> §6; the engine spike is preserved as a reference artifact in §5.
 
 ---
 
@@ -70,7 +41,7 @@ annotate<T>(
   { rel, identity, ...data }: { rel?: string; identity?: unknown[] } & T,
 ): Cell<Annotation<T>>;
 
-// THE runtime primitive — the reverse index
+// THE reverse lookup
 annotationsOf<T>(
   target: Cell<unknown> | EntityRef,
   schema?: JSONSchema,
@@ -92,155 +63,179 @@ comments collapsing into one). Forgetting `identity` should over-accrete
 (recoverable), never overwrite (data loss). `identity` is validated to reject
 non-deterministic values (timestamps, randoms).
 
+**Invariant that defines the whole primitive:** an annotation is its **own
+document** in the author's space; **nothing is ever written into the target.**
+(This is why we reject storing annotations as `setMetaRaw` cell-metadata on the
+target — that is the write-inversion tax the primitive exists to remove.)
+
 ---
 
 ## 2. Grounding: loom vocabulary → real labs-4 code
 
-Verified against the working tree. ✅ = exists and is our hook point;
-❌ = does not exist, must be built.
+Verified against the working tree. ✅ = exists and is usable as-is;
+🔶 = exists but the prototype builds *on top of* it; ❌ = does not exist.
 
 | loom concept | labs-4 reality | status |
 | --- | --- | --- |
-| commit boundary / "prepare boundary" | `applyCommitTransaction()` @ `packages/memory/v2/engine.ts:3091`; after `materializeSnapshots()` @ `:3249` each `revision.document` is fully materialized | ✅ hook point |
-| derived index maintained at commit | `scheduler_read_index` / `scheduler_write_index` DDL @ `engine.ts:263–309`, maintained by diff/reconcile `reconcileSchedulerReadRows()` @ `engine.ts:2690`, invoked inside the commit txn | ✅ exact precedent for `link_index` |
-| sigil link encoding | `{"/":{"link@1":{id,path,space,scope,schema,overwrite}}}` — `packages/runner/src/sigil-types.ts:16–32`; parse `link-types.ts:191`; resolve `link-resolution.ts:124`. Links are stored **inline** in documents | ✅ exists |
-| `linkRole:"about"` keyword | schema keywords parsed in `packages/runner/src/cfc.ts` (`getAsCellValues` `:591–633`); no notion of link *role* | ❌ build |
-| `link_index` reverse table | — | ❌ build |
-| `LinkReference` atom (both endpoints minted at commit) | not present (loom spec item SC-10) | ❌ synthesized at the index walker |
-| per-reader read-time label filtering ("op-views") | **NOT PRESENT** — only egress-time LLM observation ceilings | ❌ large separate effort — **deferred** (see §4) |
-| reactive query delivery | scheduler `subscribe()` + trigger index (`packages/runner/src/scheduler/pull-subscriptions.ts:35+`, `trigger-index.ts`); `wish` builtin `builtins/wish.ts:1383+` is tag-based only | ✅ reuse, keyed on target-id |
-| authorship/provenance on write | `TransformedBy` minted at prepare `packages/runner/src/cfc/prepare.ts:1340` | ✅ rides annotation writes for free |
-| entity identity / scope | `(branch, id, scope_key, seq, op_index)`; space is implicit per-DB; `resolveScopeKey()` @ `engine.ts:46` | ✅ |
-| migrations | no versioning; `CREATE TABLE IF NOT EXISTS` + manual `ALTER TABLE` in the INIT string is the convention | ✅ additive DDL is safe |
+| reactive discovery of a changing entity set | `wish({ query: "#tag" })` — reads a **concrete materialized index cell** (`…backlinksIndex.mentionable`) and rides the ordinary trigger index; re-runs when that cell is written. `builtins/wish.ts` | ✅ **the reactivity engine for `annotationsOf`** |
+| author-space annotation doc + `about` edge | a normal pattern doc with an `about` field (a sigil link or `EntityRef`) and a discovery tag (`#annotation`); existing `annotation.tsx` already does this | ✅ |
+| sigil link encoding | `{"/":{"link@1":{id,path,space,scope,schema,overwrite}}}` — `packages/runner/src/sigil-types.ts:16–32`; parse `link-types.ts:191`; resolve `link-resolution.ts:124` | ✅ |
+| authorship/provenance on write | `TransformedBy` minted at prepare `cfc/prepare.ts:1340` | ✅ rides annotation writes for free |
+| `createRef` for stable/anchor identity | `createRef(value, path)` | ✅ backs `anchorRef` + converging identity |
+| reverse index maintained at commit | `scheduler_read_index` exists but is **not** a precedent — it is fed from live scheduler *observations* and is branch-local *because* it tracks ephemeral readers, the opposite of inheritable content (see §6) | ❌ for content; do **not** mirror it |
+| per-reader read-time label filtering ("op-views") | **NOT PRESENT** — only egress-time LLM ceilings | ❌ deferred (§4) |
+| `linkRole` on a link | added in `sigil-types.ts` this branch; **only needed by the future engine index** (§7), not by the library path | 🔶 forward-compat |
 
-**Architecture decision (locked).** An annotation is **its own document** in the
-author's space whose `about` field is a sigil link tagged `linkRole:"about"` at
-the target. The commit walker indexes `from = annotationDoc → to = target
-(role=about)`. `annotationsOf(target)` reads `link_index` for **incoming**
-about-edges. **Nothing is ever written into the target** — that is the entire
-point of the primitive, and the reason we reject storing annotations as
-`setMetaRaw` cell-metadata on the target (that is the write-inversion tax the
-primitive exists to remove).
+**Architecture decision (revised).** `annotationsOf(target)` is a **`computed`
+over `wish({ query: "#annotation" })`** that keeps the candidates whose `about`
+resolves to `target`. It reuses wish's existing reactivity wholesale: when a new
+annotation doc is authored (and tagged), wish re-runs through the normal trigger
+index and the computed re-filters. **Zero engine code.** Its only known weakness
+is O(N) candidate scanning per target — a *performance* property a prototype is
+allowed to have and should measure before paying engine surface to fix.
 
 ---
 
-## 3. Phased build
+## 3. Phased build (right altitude — library first)
 
-De-risks the deepest layer first.
+Each phase ships value and is independently reversible. No foundation
+(pace-layer 1) code is touched.
 
-### Phase 0 — commit-boundary index spike (highest risk first)
-- Add `link_index` DDL to the INIT string near `engine.ts:332`
-  (`CREATE TABLE IF NOT EXISTS`, additive; idempotent guards are the
-  convention — no migration system exists).
-- Columns:
-  `(branch, from_id, from_scope_key, from_path JSON, to_space, to_id,
-  to_scope, role, seq, op_index, removed_seq)` plus a lookup index on
-  `(branch, to_id, to_scope, role)` for incoming-edge queries.
-- Add `reconcileLinkRows()` mirroring `reconcileSchedulerReadRows`, called
-  immediately after `materializeSnapshots()` @ `engine.ts:3249`, inside the
-  same SQLite transaction (atomic with the revision write).
-- Walker scans each `revision.document` JSON for sigil `link@1` objects
-  (**not** `SourceLink {"/" : string}` — that shape is content-addressed
-  source, not a sigil link) and emits rows. Diff/reconcile so updates and
-  deletes retract rows (`removed_seq`).
-- **Gate:** a runner test commits an annotation doc and reads index rows back.
-
-### Phase 1 — `linkRole` keyword
-- Add `linkRole?: string` to `LinkV1Inner` (`sigil-types.ts:16–32`).
-- Add a `getLinkRole` accessor alongside `getAsCellValues` in `cfc.ts`.
-- Keep `linkRole` on the **stored** sigil during serialization
-  (`link-utils.ts:222–287`) — unlike `asCell` (stripped at write), `linkRole`
-  is link-semantics, not cell-semantics, so it persists.
-- Walker filters to `role === "about"`.
-
-### Phase 2 — reactive reverse read + `annotationsOf` builtin
-- Engine query "incoming about-edges to X" (`server.ts` graphQuery analog) +
-  runner wiring in `storage/v2.ts`.
-- **Key new wiring / main runtime risk:** make `incoming-edges-to(target)` a
-  subscribable synthetic address in the trigger index, dirtied whenever
-  `reconcileLinkRows` touches a row with `to_id = target`, so subscribed result
-  cells update.
-- Add `builtins/annotations-of.ts` (modeled on `builtins/wish.ts`), the api
-  type in `packages/api/index.ts`, and builder wiring in
-  `builder/factory.ts`.
-- **Gate:** subscribe to `annotationsOf(target)`, commit an annotation in a
-  separate txn, observe the result cell update + schema projection.
-
-### Phase 3 — library verbs
-- `annotate(target, { rel, identity?, ...data })`:
+### Phase A — `annotate` + `annotationsOf` (library)
+- `annotate(target, { rel, identity?, ...data })` authors an annotation doc in
+  the author's space carrying `about` (a link/ref to `target`), `rel`, the data,
+  and the discovery tag so `wish` finds it. **No write to target.**
   - accreting (no `identity`) = read-modify-write append against the author's
     **live** per-target list — replay-safe, **never a bare ordinal counter**.
-  - converging (`identity`) = stable cause from
+  - converging (`identity`) = stable cause via
     `createRef(author, target, rel, identity)`.
   - identity-determinism guard: reject `Date`/random with a loud error.
-- `anchorRef(type, naturalKey) = createRef({ type, naturalKey },
-  ["anchor", type])`.
-- `materialize(target, policy)` = `computed` fold over `annotationsOf`.
-- Pattern-level tests: accreting-distinct, converging-idempotent-toggle,
-  no-write-to-target invariant.
+- `annotationsOf(target, schema?)` = `computed` filtering
+  `wish({ query: "#annotation" })` by resolved `about === target`, schema-
+  projected, with `.filter(a => a.rel === …)` ergonomics.
+- **Gate:** author two comments on a doc → both appear distinct (accrete);
+  a tag toggles (converge); the target document is never mutated (assert no
+  revision on the target); the result updates reactively when a new annotation
+  is authored.
 
-### Phase 4 — migrate two existing patterns
-- `packages/patterns/system/backlinks-index.tsx` — delete the
-  write-into-target scan; backlinks become `annotationsOf(target)`.
+### Phase B — `anchorRef` + `materialize`
+- `anchorRef(type, naturalKey) = createRef({ type, naturalKey }, ["anchor", type])`
+  — per-source identity for home-less entities (a phone is *evidence*, not the
+  key).
+- `materialize(target, policy)` = `computed` fold of `annotationsOf(target)`
+  through a resolution policy into a home doc.
+
+### Phase C — migrate two existing patterns
+- `packages/patterns/system/backlinks-index.tsx` — delete the write-into-target
+  scan; backlinks become `annotationsOf(target)`.
 - `packages/patterns/annotation.tsx` — re-express on `annotate` /
-  `annotationsOf`.
+  `annotationsOf` (it already discovers via `wish({ query: "#annotation" })`).
 
-### Phase 5 — docs + stress pass
+### Phase D — docs
 - `docs/common/concepts/annotation.md` + glossary entry.
-- Devil's-advocate sub-agent review of robustness / regret-in-6-months / ideal
-  UX before presenting.
+
+### Phase E — *deferred optimization*: engine-backed index (only if needed)
+Pursue **only if** the wish-scan in Phase A demonstrably doesn't scale at demo
+size. When pursued, do it the way the runtime wants (see §6): a **concrete
+materialized "incoming" cell** written at the commit boundary, so reads ride the
+existing concrete-address trigger index — **not** a SQLite side-table plus a
+net-new synthetic-subscription protocol. Required correctness checklist before
+any such index ships (all are gaps the Phase-0 spike had — §5):
+1. **Branch inheritance** — reads must honor `readRowForBranch`-style parent-chain
+   inheritance, or be explicitly scoped to `DEFAULT_BRANCH` with a loud comment
+   and a test encoding the gap.
+2. **Scope identity** — key on the *resolved* `scope_key`
+   (`"user:<principal>"`, …) via `resolveScopeKey`, resolving `"inherit"` against
+   the source doc's scope_key — never the raw `LinkScope` token.
+3. **Freshness** — replace-all-for-source reconcile (delete-all + insert) so
+   `seq`/`op_index` are always current; do **not** borrow
+   `reconcileSchedulerIndexRows` (its key drops the freshness columns, so
+   converging re-sets mutate zero rows).
+4. **Edge feed** — prefer carrying role-bearing edges as *commit metadata* (the
+   way `schedulerObservation` rides the commit, reusing the `CfcAddress` the
+   runner already computes at `link-resolution.ts:46`); keep the document walk
+   only as a server-authoritative verifier, and *state* the server-authoritative
+   justification.
+5. **Link semantics** — index the link's target `path` (sub-path targets), skip
+   `overwrite:"redirect"` links, and pre-filter with a cheap `"link@1"` substring
+   check before the recursive walk.
+6. **Shared tag** — decide deliberately where `"link@1"` lives (memory can't
+   import runner; `@commonfabric/api` is a foundation both could depend on) — do
+   not silently fork the constant.
 
 ---
 
-## 4. Scope cuts (decided)
-
-The "full" design leans on two subsystems that **do not exist in labs-4 and are
-each large efforts**. Both are **deferred** for the prototype; the reverse-index
-core ships without them.
+## 4. Scope cuts (unchanged)
 
 1. **Per-reader read-time label filtering — DEFERRED.** No server-side op-view
-   filtering exists today. v1: annotation docs carry authorship labels
-   (`TransformedBy` at prepare, free) and `annotationsOf` does a best-effort
-   label check at the runner read layer. True per-reader server-side filtering
-   is future work (new memory-server machinery).
-2. **Cross-space discovery — DEFERRED.** Each space is a separate SQLite DB, so
-   `link_index` is naturally per-space. v1: `annotationsOf` finds annotations
-   authored in the **same space** as the target — covers all migration targets
-   and demos. Cross-space index federation is future work.
-
-Other intentional simplifications:
-- **Identity stability** (stable per-event id for accreting replay-safety): the
-  loom design names this as a runtime gap. We sidestep it by desugaring
-  accreting to read-modify-write against the live per-target list.
+   filtering exists. v1: annotation docs carry authorship labels (`TransformedBy`
+   at prepare, free); `annotationsOf` does a best-effort label check at the
+   read layer. True per-reader server-side filtering is future work.
+2. **Cross-space discovery — DEFERRED.** v1 is single-space (the space of the
+   target), which covers all migration targets and demos.
+3. **Identity stability** — accreting desugars to read-modify-write against the
+   live per-target list, sidestepping the loom "stable per-event id" runtime gap.
 
 ---
 
-## 5. Risks
+## 5. Reference artifact: the Phase-0 engine spike
 
-- **Reactive invalidation of the reverse read (Phase 2)** is the principal
-  novelty — existing trigger-index subscriptions key on reads of concrete
-  addresses; we must dirty a *synthetic* "incoming-edges-to(target)" key from
-  the commit-side reconcile. This is the most likely place to get subtle
-  missed-update or over-invalidation bugs; it gets a dedicated test matrix.
-- **Walker cost at commit.** Walking every committed document for sigil links
-  adds commit-path work. Mirror the scheduler index's diff/reconcile so steady
-  state is cheap; benchmark before/after on a large commit.
-- **Transformer surface.** `linkRole` is set explicitly by the annotation
-  library (schema keyword), **not** inferred from TS types, to avoid touching
-  `ts-transformers`. Revisit only if ergonomics demand type-inferred roles.
+Committed on this branch (`feat(memory): annotation primitive — Phase 0
+link_index spike`). It adds a `link_index` table to `packages/memory/v2/engine.ts`,
+maintained at the commit boundary by walking each materialized revision for
+role-bearing sigil links, plus `readIncomingLinks()`. **8 gate tests + the
+existing engine suites pass.**
+
+It is retained **only** as proof the commit-boundary mechanism works
+mechanically. It is **not** the recommended path, and as a general reverse index
+it has two correctness **blockers** and several should-fixes (all enumerated as
+the §3 Phase-E checklist): branch inheritance, scope encoding, the borrowed-
+reconcile freshness bug, dropped target `path`, redirect links, the post-SELECT
+cost gate, speculative cross-space columns, and a gate test that injects sigils
+literally (so it does not prove an annotation written *through the runner* lands
+a `linkRole` in storage). If Phase E is ever pursued, prefer the concrete-cell
+model over reviving this side-table.
 
 ---
 
-## 6. Migration targets (why these)
+## 6. Why the altitude changed (the load-bearing reasoning)
 
-These are labs' own hand-rolled reimplementations of the primitive, named in the
-loom design:
-- `system/backlinks-index.tsx` — the marquee anti-pattern: it iterates
-  `allPieces` and writes a `backlinks` array **into** each target
-  (write-inversion + O(N) rescan). Becomes a reverse-index read.
+- **The hard part is reactive delivery, and the engine path can't do it cheaply.**
+  The scheduler trigger index keys only on **concrete** `space/scope/id`
+  (`scheduler/keys.ts`, `trigger-index.ts:240`). A committed annotation doc `D`
+  never writes its target `X` (that's the point), so the change-notification path
+  (`schedulerWriteAddressesForRevisions`, built only from `revision.id`) carries
+  `D`'s id and never `X`. A reader watching `X` is never woken. Making the
+  SQLite-side-table index reactive would require a **cross-layer change-
+  notification protocol extension** (memory-server + runner-storage + scheduler) —
+  weeks of work, and exactly the kind of distributed cache-invalidation change
+  that breeds subtle missed-update/over-invalidation bugs.
+- **`wish()` already solves the analogous problem — without any of that.** It is
+  reactive over a changing entity set by reading a *concrete materialized index
+  cell* and riding the ordinary trigger index. The grain-following design either
+  (a) reuses wish directly (Phase A), or (b) if an index is truly warranted,
+  makes that index a *concrete cell written on commit* so reads subscribe through
+  the existing mechanism (Phase E). A SQLite side-table is invisible to the
+  reactive graph, which is precisely why it would force a parallel invalidation
+  path.
+- **Risk ordering was inverted.** Phase 0 retired the *easy, certain* risk (walk
+  JSON, write rows) in the *least-reversible* layer, while the *uncertain* risk
+  (reactive delivery) was deferred. The prototype's actual purpose — validating
+  `annotate`/`annotationsOf` ergonomics and deleting the write-inversion hacks —
+  sits entirely on top of `annotationsOf` and treats its implementation as a
+  black box. So implement the cheap, reversible version first.
+
+---
+
+## 7. Migration targets (why these)
+
+labs' own hand-rolled reimplementations of the primitive, named in the loom
+design:
+- `system/backlinks-index.tsx` — the marquee anti-pattern: iterates `allPieces`
+  and writes a `backlinks` array **into** each target (write-inversion + O(N)
+  rescan). Becomes a reverse-index read.
 - `annotation.tsx` / `annotation-manager.tsx` — discover via
   `wish({ query: "#annotation" })` and rely on the backlinks hack for reverse
-  lookup.
-- `experimental/folksonomy-aggregator.tsx` — a central collector standing in
-  for a missing reverse index (out of scope for v1 migration; candidate for a
-  follow-up).
+  lookup. The library path subsumes this directly.
+- `experimental/folksonomy-aggregator.tsx` — a central collector standing in for
+  a missing reverse index (follow-up candidate).

--- a/docs/development/connectors/annotations-prototype-plan.md
+++ b/docs/development/connectors/annotations-prototype-plan.md
@@ -1,6 +1,46 @@
 # Annotation Primitive — Prototype Implementation Plan (labs-4)
 
-Status: **planning → building** · Branch: `proto/annotation-primitive`
+Status: **under review — altitude in question** · Branch: `proto/annotation-primitive`
+
+> **⚠️ Adversarial review outcome (2026-06-14).** Three independent critics
+> reviewed this plan and the Phase-0 spike. Headline findings (detail in the PR
+> description):
+>
+> - **Altitude is likely wrong for a prototype.** Phase 0 put the reverse index
+>   in the memory engine — the hardest, least-reversible layer — to retire the
+>   *easy* risk (walk JSON, write rows), while **Phase 2 (reactive delivery) —
+>   the genuinely hard part — is not credible as written.** The scheduler
+>   trigger index keys only on concrete `space/scope/id`; a committed annotation
+>   doc `D` never writes its target `X`, so the change-notification path carries
+>   `D`'s id only and a reader watching `X` is never woken. Making
+>   `annotationsOf` reactive would require a cross-layer change-notification
+>   protocol extension (memory-server + runner-storage + scheduler) this plan
+>   does not scope or budget.
+> - **`wish()` already solves the analogous problem** (reactive over a changing
+>   set of entities) by reading a *concrete materialized index cell* and riding
+>   the ordinary trigger index — no synthetic subscription. **Recommended
+>   pivot:** build `annotationsOf` as a `computed` over
+>   `wish({ query: "#annotation" })` filtered by the `about` target — zero engine
+>   code, reactive on day one, exercises every ergonomic question and both
+>   migrations. Only if that demonstrably doesn't scale, promote the index to a
+>   concrete commit-written cell (the wish model) — never a SQLite side-table
+>   plus a net-new synthetic-subscription protocol.
+> - **Two correctness blockers in the Phase-0 spike** (were the engine path
+>   kept): (1) **branch inheritance** — the reverse read misses every annotation
+>   committed on a parent branch before a fork; `scheduler_read_index` is an
+>   *anti*-precedent (it is branch-local because it tracks live ephemeral
+>   readers, not inheritable content). (2) **scope encoding** — `to_scope` stores
+>   the raw `LinkScope` token (`"user"`/`"session"`/`"inherit"`) while a target's
+>   real identity is a *resolved* `scope_key` (`"user:<principal>"`, …); they
+>   coincide only for `"space"`, so non-space targets silently return nothing.
+>   Plus a reconcile bug: borrowing `reconcileSchedulerIndexRows` freezes
+>   `seq`/`op_index` on converging re-sets, which would silently defeat the very
+>   Phase-2 invalidation the engine path exists to enable.
+>
+> The Phase-0 engine spike below is retained as a **reference artifact** proving
+> the commit-boundary mechanism *works mechanically*, not as the recommended
+> path. The §2 claim that `scheduler_read_index` is an "exact precedent" is
+> **withdrawn**.
 
 This document plans a labs-4 prototype of the annotation primitive proposed in
 loom **PR #2707** (`docs/development/connectors/annotations-*.md` in the loom

--- a/packages/memory/test/v2-link-index.test.ts
+++ b/packages/memory/test/v2-link-index.test.ts
@@ -1,0 +1,193 @@
+import { assertEquals } from "@std/assert";
+import { toFileUrl } from "@std/path";
+import {
+  applyCommit,
+  close,
+  type Engine,
+  open,
+  readIncomingLinks,
+} from "../v2/engine.ts";
+import { type EntityDocument } from "../v2.ts";
+
+// Annotation primitive (prototype) — Phase 0 gate: the commit boundary walks
+// each revised document for sigil links carrying a `linkRole` and maintains the
+// reverse `link_index`. These tests exercise population, idempotence,
+// retargeting, deletion, the patch path, and the negative cases (plain links
+// and SourceLinks must not be indexed).
+
+const createEngine = async (): Promise<{ engine: Engine; path: string }> => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const engine = await open({ url: toFileUrl(path) });
+  return { engine, path };
+};
+
+const aboutLink = (id: string, role = "about") => ({
+  "/": { "link@1": { id, linkRole: role } },
+});
+
+const plainLink = (id: string) => ({ "/": { "link@1": { id } } });
+
+const toDoc = (value: unknown, extra: Record<string, unknown> = {}):
+  EntityDocument => ({ ...extra, value } as EntityDocument);
+
+const commitSet = (
+  engine: Engine,
+  localSeq: number,
+  id: string,
+  document: EntityDocument,
+) =>
+  applyCommit(engine, {
+    sessionId: "session:alice",
+    principal: "did:key:alice",
+    commit: {
+      localSeq,
+      reads: { confirmed: [], pending: [] },
+      operations: [{ op: "set", id, value: document }],
+    },
+  });
+
+Deno.test("link_index: indexes an annotation about-edge at commit", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    commitSet(
+      engine,
+      1,
+      "annotation:1",
+      toDoc({ rel: "comment", body: "Great work!", about: aboutLink("doc:1") }),
+    );
+
+    const incoming = readIncomingLinks(engine, { toId: "doc:1", role: "about" });
+    assertEquals(incoming.length, 1);
+    assertEquals(incoming[0].fromId, "annotation:1");
+    assertEquals(incoming[0].role, "about");
+    assertEquals(incoming[0].toId, "doc:1");
+    assertEquals(incoming[0].fromPath, ["value", "about"]);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("link_index: ignores sigil links without a linkRole", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    commitSet(
+      engine,
+      1,
+      "doc:2",
+      toDoc({ ref: plainLink("doc:1") }),
+    );
+    assertEquals(readIncomingLinks(engine, { toId: "doc:1" }).length, 0);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("link_index: ignores SourceLink (string under '/')", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    // `source` is a SourceLink `{ "/": "<hash>" }` — a string under "/", which
+    // must not be mistaken for a sigil link.
+    commitSet(
+      engine,
+      1,
+      "doc:3",
+      toDoc({ note: "x" }, { source: { "/": "doc:1" } }),
+    );
+    assertEquals(readIncomingLinks(engine, { toId: "doc:1" }).length, 0);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("link_index: converging re-set is idempotent", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    const doc = toDoc({ rel: "tag", tag: "#alex", about: aboutLink("doc:1") });
+    commitSet(engine, 1, "annotation:tag", doc);
+    commitSet(engine, 2, "annotation:tag", doc);
+    assertEquals(readIncomingLinks(engine, { toId: "doc:1", role: "about" }).length, 1);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("link_index: retargeting moves the edge", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    commitSet(engine, 1, "annotation:1", toDoc({ about: aboutLink("doc:A") }));
+    commitSet(engine, 2, "annotation:1", toDoc({ about: aboutLink("doc:B") }));
+    assertEquals(readIncomingLinks(engine, { toId: "doc:A", role: "about" }).length, 0);
+    assertEquals(readIncomingLinks(engine, { toId: "doc:B", role: "about" }).length, 1);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("link_index: delete clears edges", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    commitSet(engine, 1, "annotation:1", toDoc({ about: aboutLink("doc:1") }));
+    applyCommit(engine, {
+      sessionId: "session:alice",
+      principal: "did:key:alice",
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{ op: "delete", id: "annotation:1" }],
+      },
+    });
+    assertEquals(readIncomingLinks(engine, { toId: "doc:1", role: "about" }).length, 0);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("link_index: patch adding an about-edge is indexed", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    commitSet(engine, 1, "annotation:1", toDoc({ rel: "comment" }));
+    assertEquals(readIncomingLinks(engine, { toId: "doc:1", role: "about" }).length, 0);
+    applyCommit(engine, {
+      sessionId: "session:alice",
+      principal: "did:key:alice",
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id: "annotation:1",
+          patches: [{ op: "add", path: "/value/about", value: aboutLink("doc:1") }],
+        }],
+      },
+    });
+    const incoming = readIncomingLinks(engine, { toId: "doc:1", role: "about" });
+    assertEquals(incoming.length, 1);
+    assertEquals(incoming[0].fromId, "annotation:1");
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("link_index: multiple annotations on the same target accrete", async () => {
+  const { engine, path } = await createEngine();
+  try {
+    commitSet(engine, 1, "annotation:1", toDoc({ body: "one", about: aboutLink("doc:1") }));
+    commitSet(engine, 2, "annotation:2", toDoc({ body: "two", about: aboutLink("doc:1") }));
+    const incoming = readIncomingLinks(engine, { toId: "doc:1", role: "about" });
+    assertEquals(incoming.length, 2);
+    assertEquals(
+      incoming.map((l) => l.fromId).sort(),
+      ["annotation:1", "annotation:2"],
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -26,6 +26,14 @@ const DEFAULT_SCOPE_KEY = "space" as const;
 const DEFAULT_SCHEDULER_SNAPSHOT_LIST_LIMIT = 500;
 const MAX_SCHEDULER_SNAPSHOT_LIST_LIMIT = 1_000;
 
+// Annotation primitive (prototype): structural tag of a sigil link. The memory
+// engine must not depend on the runner, so we re-declare the tag here rather
+// than importing it. A sigil link is `{ "/": { "link@1": { id, ..., linkRole? } } }`;
+// the reserved "/" key makes links detectable in any committed value without
+// schema knowledge. Keep in sync with packages/runner/src/sigil-types.ts
+// (LINK_V1_TAG).
+const SIGIL_LINK_TAG = "link@1";
+
 const normalizeScope = (scope: CellScope | undefined): CellScope =>
   scope ?? DEFAULT_SCOPE;
 
@@ -328,6 +336,30 @@ CREATE TABLE IF NOT EXISTS scheduler_action_state (
   FOREIGN KEY (latest_observation_id)
     REFERENCES scheduler_observation(observation_id)
 );
+
+-- Annotation primitive (prototype): reverse index of "about" edges.
+-- Populated at the commit boundary by walking each revised document for sigil
+-- links that carry a linkRole (see SIGIL_LINK_TAG). A row records that the
+-- source document (from_*) links to a target (to_*) under a role, so a reverse
+-- lookup (what is attached to X?) is a single indexed read.
+-- Per-space (each space is its own database); cross-space federation is future.
+CREATE TABLE IF NOT EXISTS link_index (
+  branch      TEXT    NOT NULL DEFAULT '',
+  from_space  TEXT    NOT NULL DEFAULT '',
+  from_id     TEXT    NOT NULL,
+  from_scope  TEXT    NOT NULL,
+  from_path   JSON    NOT NULL,
+  to_space    TEXT    NOT NULL DEFAULT '',
+  to_id       TEXT    NOT NULL,
+  to_scope    TEXT    NOT NULL,
+  role        TEXT    NOT NULL,
+  seq         INTEGER NOT NULL,
+  op_index    INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_link_index_incoming
+  ON link_index (branch, to_id, to_scope, role);
+CREATE INDEX IF NOT EXISTS idx_link_index_source
+  ON link_index (branch, from_id, from_scope);
 
 COMMIT;
 `;
@@ -1451,6 +1483,57 @@ export const readState = (
     scope: declaredScope,
     scopeKey,
   });
+};
+
+// Annotation primitive (prototype): the reverse-index read. Returns the
+// incoming role-bearing links (e.g. annotation about-edges) targeting `toId`,
+// optionally filtered by `role`. Backs `annotationsOf(target)`.
+export interface IncomingLink {
+  fromSpace: string;
+  fromId: EntityId;
+  fromScope: string;
+  fromPath: string[];
+  toSpace: string;
+  toId: EntityId;
+  toScope: string;
+  role: string;
+  seq: number;
+  opIndex: number;
+}
+
+export const readIncomingLinks = (
+  engine: Engine,
+  { toId, toScope = DEFAULT_SCOPE_KEY, role, branch = DEFAULT_BRANCH }: {
+    toId: EntityId;
+    toScope?: string;
+    role?: string;
+    branch?: BranchName;
+  },
+): IncomingLink[] => {
+  const rows = (role !== undefined
+    ? engine.database.prepare(`
+        SELECT * FROM link_index
+        WHERE branch = :branch AND to_id = :to_id
+          AND to_scope = :to_scope AND role = :role
+        ORDER BY seq, op_index
+      `).all({ branch, to_id: toId, to_scope: toScope, role })
+    : engine.database.prepare(`
+        SELECT * FROM link_index
+        WHERE branch = :branch AND to_id = :to_id AND to_scope = :to_scope
+        ORDER BY seq, op_index
+      `).all({ branch, to_id: toId, to_scope: toScope })) as LinkIndexRow[];
+  return rows.map((row) => ({
+    fromSpace: row.from_space,
+    fromId: row.from_id,
+    fromScope: row.from_scope,
+    fromPath: JSON.parse(row.from_path) as string[],
+    toSpace: row.to_space,
+    toId: row.to_id,
+    toScope: row.to_scope,
+    role: row.role,
+    seq: row.seq,
+    opIndex: row.op_index,
+  }));
 };
 
 const readStateForScopeKey = (
@@ -3088,6 +3171,240 @@ function schedulerActionKey(entry: {
   }\0${entry.pieceId}\0${entry.processGeneration}\0${entry.actionId}`;
 }
 
+// ---------------------------------------------------------------------------
+// Annotation primitive (prototype): link_index maintenance at the commit
+// boundary. Mirrors the scheduler_read_index reconcile pattern. See
+// docs/development/connectors/annotations-prototype-plan.md
+// ---------------------------------------------------------------------------
+
+interface LinkIndexRow {
+  branch: string;
+  from_space: string;
+  from_id: string;
+  from_scope: string;
+  from_path: string;
+  to_space: string;
+  to_id: string;
+  to_scope: string;
+  role: string;
+  seq: number;
+  op_index: number;
+}
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+// A sigil link is `{ "/": { "link@1": {...} } }`. A SourceLink is `{ "/": "<hash>" }`
+// (string under "/"), so the object-vs-string check at the "/" key disambiguates
+// the two without any schema knowledge.
+const sigilLinkInner = (value: unknown): Record<string, unknown> | undefined => {
+  if (!isPlainRecord(value)) return undefined;
+  const slash = value["/"];
+  if (!isPlainRecord(slash)) return undefined;
+  const inner = slash[SIGIL_LINK_TAG];
+  return isPlainRecord(inner) ? inner : undefined;
+};
+
+// Walk a committed document collecting every sigil link that carries a
+// `linkRole`. Only role-bearing links are indexed, keeping link_index scoped to
+// annotation edges rather than the entire link graph.
+const collectRoleLinks = (
+  document: EntityDocument,
+): Array<{ path: string[]; inner: Record<string, unknown> }> => {
+  const found: Array<{ path: string[]; inner: Record<string, unknown> }> = [];
+  const walk = (value: unknown, path: string[]): void => {
+    const inner = sigilLinkInner(value);
+    if (inner !== undefined) {
+      if (typeof inner.linkRole === "string" && inner.linkRole.length > 0) {
+        found.push({ path, inner });
+      }
+      // A link's inner fields (schema, etc.) are not document content; do not
+      // descend into them.
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => walk(item, [...path, String(index)]));
+      return;
+    }
+    if (isPlainRecord(value)) {
+      for (const [key, child] of Object.entries(value)) {
+        walk(child, [...path, key]);
+      }
+    }
+  };
+  walk(document as unknown, []);
+  return found;
+};
+
+const linkIndexRowsForDocument = (
+  options: {
+    branch: BranchName;
+    fromSpace: string;
+    fromId: EntityId;
+    fromScope: string;
+    seq: number;
+    opIndex: number;
+    document: EntityDocument | null;
+  },
+): LinkIndexRow[] => {
+  if (options.document === null) return [];
+  return collectRoleLinks(options.document)
+    .filter(({ inner }) => typeof inner.id === "string")
+    .map(({ path, inner }) => ({
+      branch: options.branch,
+      from_space: options.fromSpace,
+      from_id: options.fromId,
+      from_scope: options.fromScope,
+      from_path: JSON.stringify(path),
+      to_space: typeof inner.space === "string"
+        ? inner.space
+        : options.fromSpace,
+      to_id: inner.id as string,
+      to_scope: typeof inner.scope === "string" ? inner.scope : DEFAULT_SCOPE_KEY,
+      role: inner.linkRole as string,
+      seq: options.seq,
+      op_index: options.opIndex,
+    }));
+};
+
+const linkIndexRowKey = (row: LinkIndexRow): string =>
+  [
+    row.branch,
+    row.from_space,
+    row.from_id,
+    row.from_scope,
+    row.from_path,
+    row.to_space,
+    row.to_id,
+    row.to_scope,
+    row.role,
+  ].join("\0");
+
+// Reconcile all link_index rows for a single revised source document. Existing
+// rows for (branch, from_id, from_scope) are diffed against the links currently
+// in the document; removed links are deleted, new links inserted. A `delete`
+// revision yields no next rows, which clears the source's edges.
+const reconcileLinkRowsForSource = (
+  engine: Engine,
+  options: {
+    branch: BranchName;
+    fromSpace: string;
+    fromId: EntityId;
+    fromScope: string;
+    seq: number;
+    opIndex: number;
+    document: EntityDocument | null;
+  },
+): void => {
+  const sourceParams = {
+    branch: options.branch,
+    from_id: options.fromId,
+    from_scope: options.fromScope,
+  };
+  const existingRows = engine.database.prepare(`
+    SELECT
+      branch, from_space, from_id, from_scope, from_path,
+      to_space, to_id, to_scope, role, seq, op_index
+    FROM link_index
+    WHERE branch = :branch
+      AND from_id = :from_id
+      AND from_scope = :from_scope
+  `).all(sourceParams) as LinkIndexRow[];
+  const nextRows = linkIndexRowsForDocument(options);
+
+  // Nothing here and nothing coming: avoid preparing delete/insert statements
+  // for the overwhelmingly common non-annotation commit.
+  if (existingRows.length === 0 && nextRows.length === 0) return;
+
+  const deleteRowStmt = engine.database.prepare(`
+    DELETE FROM link_index
+    WHERE branch = :branch
+      AND from_space = :from_space
+      AND from_id = :from_id
+      AND from_scope = :from_scope
+      AND from_path = :from_path
+      AND to_space = :to_space
+      AND to_id = :to_id
+      AND to_scope = :to_scope
+      AND role = :role
+  `);
+  const insertRowStmt = engine.database.prepare(`
+    INSERT INTO link_index (
+      branch, from_space, from_id, from_scope, from_path,
+      to_space, to_id, to_scope, role, seq, op_index
+    ) VALUES (
+      :branch, :from_space, :from_id, :from_scope, :from_path,
+      :to_space, :to_id, :to_scope, :role, :seq, :op_index
+    )
+  `);
+  reconcileSchedulerIndexRows<LinkIndexRow>({
+    existingRows,
+    nextRows,
+    keyForRow: linkIndexRowKey,
+    deleteAllRows: () => {
+      engine.database.prepare(`
+        DELETE FROM link_index
+        WHERE branch = :branch
+          AND from_id = :from_id
+          AND from_scope = :from_scope
+      `).run(sourceParams);
+    },
+    deleteRow: (row) => {
+      deleteRowStmt.run({
+        branch: row.branch,
+        from_space: row.from_space,
+        from_id: row.from_id,
+        from_scope: row.from_scope,
+        from_path: row.from_path,
+        to_space: row.to_space,
+        to_id: row.to_id,
+        to_scope: row.to_scope,
+        role: row.role,
+      });
+    },
+    insertRow: (row) => insertRowStmt.run({ ...row }),
+  });
+};
+
+// Entry point called from applyCommitTransaction after snapshots materialize.
+const reconcileLinkIndexForRevisions = (
+  engine: Engine,
+  options: {
+    branch: BranchName;
+    space: string | undefined;
+    seq: number;
+    revisions: AppliedRevision[];
+  },
+): void => {
+  for (const revision of options.revisions) {
+    const fromScope = revision.scopeKey ?? DEFAULT_SCOPE_KEY;
+    let document: EntityDocument | null;
+    if (revision.op === "delete") {
+      document = null;
+    } else if (revision.op === "set") {
+      document = revision.document ?? null;
+    } else {
+      // patch: AppliedRevision carries only the patches, so read the freshly
+      // materialized full document to recompute outgoing edges.
+      document = readStateForScopeKey(engine, {
+        id: revision.id,
+        scopeKey: fromScope,
+        branch: options.branch,
+        seq: options.seq,
+      })?.document ?? null;
+    }
+    reconcileLinkRowsForSource(engine, {
+      branch: options.branch,
+      fromSpace: options.space ?? "",
+      fromId: revision.id,
+      fromScope,
+      seq: options.seq,
+      opIndex: revision.opIndex,
+      document,
+    });
+  }
+};
+
 const applyCommitTransaction = (
   engine: Engine,
   {
@@ -3247,6 +3564,10 @@ const applyCommitTransaction = (
 
   engine.statements.updateBranchHead.run({ branch, seq });
   materializeSnapshots(engine, branch, revisions);
+
+  // Annotation primitive (prototype): maintain the reverse link_index from the
+  // freshly materialized documents, atomically within this commit transaction.
+  reconcileLinkIndexForRevisions(engine, { branch, space, seq, revisions });
 
   const changedSchedulerWrites = space
     ? schedulerWriteAddressesForRevisions(space, revisions)

--- a/packages/patterns/annotations/annotations.tsx
+++ b/packages/patterns/annotations/annotations.tsx
@@ -1,0 +1,245 @@
+// deno-lint-ignore-file no-explicit-any
+/**
+ * Annotation primitive (prototype) — backlinks-index-backed library.
+ *
+ * An **annotation** is a statement that one entity is *about* another. It is
+ * authored as its **own document** in the author's space, pointing at the
+ * target through an `about` link (and the target's plain entity id, `aboutId`,
+ * for robust matching). **Nothing is ever written into the target** — that is
+ * the whole point of the primitive.
+ *
+ * The reverse lookup `annotationsOf` reads the space's concrete mentionable
+ * index — `wish({ query: "#default" }).result.backlinksIndex.mentionable`,
+ * which the default app maintains reactively — and keeps the annotations whose
+ * `aboutId` equals the target's id. Reactive for free (an ordinary cell read),
+ * works for ANY target (no `backlinks`-field cooperation required), and avoids
+ * the favorites/schema fragility of hashtag discovery.
+ *
+ * One verb (`annotate`); `identity` alone switches accrete vs. converge.
+ * Accreting works in pure pattern-space; converging (toggle/idempotent) needs a
+ * content-independent piece identity — the surgical runtime affordance tracked
+ * as plan §A.2.
+ *
+ * SES note: builder calls (pattern/lift/handler/wish) may not live in standalone
+ * functions, so `annotate` is a module-scope handler and `annotationsOf` a
+ * module-scope lift; the pattern body owns the `wish` call.
+ *
+ * See docs/development/connectors/annotations-prototype-plan.md
+ */
+import {
+  Cell,
+  computed,
+  type Default,
+  getEntityId,
+  handler,
+  lift,
+  NAME,
+  pattern,
+  type Stream,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+import type { MentionablePiece } from "../system/backlinks-index.tsx";
+
+// ===== Types =====
+
+/**
+ * A persisted annotation document. `about` is a link to the target; `aboutId`
+ * is the target's plain entity id (the matching key); `rel` is the relationship
+ * ("comment", "tag", "verdict", …); the remaining fields are the annotation's
+ * own data.
+ */
+export interface AnnotationPiece {
+  [NAME]?: string;
+  about?: MentionablePiece | null;
+  aboutId?: string;
+  rel?: string;
+  body?: string;
+  isAnnotation?: boolean;
+  isMentionable?: boolean;
+  mentioned?: MentionablePiece[];
+}
+
+export interface AnnotationInput {
+  about?: Writable<MentionablePiece | null | Default<null>>;
+  aboutId?: string | Default<"">;
+  rel?: Writable<string | Default<"comment">>;
+  body?: Writable<string | Default<"">>;
+  isAnnotation?: boolean | Default<true>;
+  isMentionable?: boolean | Default<true>;
+}
+
+/**
+ * An #annotation document that points at a target via `about`. (The `#annotation`
+ * hashtag here keeps the piece nominally tag-discoverable too, but the reverse
+ * lookup does not depend on hashtag discovery.)
+ */
+export interface AnnotationOutput extends AnnotationPiece {
+  [NAME]: string;
+  [UI]: VNode;
+  about: MentionablePiece | null;
+  aboutId: string;
+  rel: string;
+  body: string;
+  isAnnotation: boolean;
+  isMentionable: boolean;
+  mentioned: MentionablePiece[];
+}
+
+// ===== The annotation document pattern =====
+
+export const Annotation = pattern<AnnotationInput, AnnotationOutput>(
+  ({ about, aboutId, rel, body, isAnnotation, isMentionable }) => {
+    const name = computed(() => {
+      const r = (rel.get() || "comment").trim();
+      const b = (body.get() ?? "").trim();
+      return b ? `💬 ${r}: ${b.slice(0, 48)}` : `💬 ${r}`;
+    });
+
+    // `mentioned` feeds the backlinks/mentionable system for free, so the
+    // annotation is discoverable and the about-edge is visible to tooling —
+    // without writing anything back into the target.
+    const mentioned = computed<MentionablePiece[]>(() => {
+      const t = about.get();
+      return t ? [t] : [];
+    });
+
+    return {
+      [NAME]: name,
+      [UI]: (
+        <cf-vstack
+          gap="1"
+          style={{
+            padding: "8px 10px",
+            border: "1px solid #e5e7eb",
+            borderRadius: "8px",
+            background: "white",
+          }}
+        >
+          <span
+            style={{ fontSize: "11px", color: "#6b7280", fontWeight: "600" }}
+          >
+            {rel}
+          </span>
+          <span style={{ fontSize: "14px" }}>{body}</span>
+        </cf-vstack>
+      ),
+      about,
+      aboutId,
+      rel,
+      body,
+      isAnnotation,
+      isMentionable,
+      mentioned,
+    };
+  },
+);
+
+export default Annotation;
+
+// ===== Authoring: the single verb (handler) =====
+
+/**
+ * The single annotation verb. Bind it to a UI event with the `target` and
+ * (optionally) a draft cell for the body. `identity` alone switches accrete vs.
+ * converge — there is no second API surface.
+ *
+ * ```tsx
+ * // accreting comment from a draft cell (cleared on post):
+ * <cf-button onClick={annotate({ addPiece, target: doc, rel: "comment", body: draft })}>
+ *   Post
+ * </cf-button>
+ * // converging tag toggle (idempotent, keyed by identity):
+ * <cf-button onClick={annotate({ addPiece, target: rec, rel: "tag", identity: "#alex", body: "#alex" })}>
+ *   #alex
+ * </cf-button>
+ * ```
+ */
+export const annotate = handler<
+  unknown,
+  {
+    addPiece: Stream<{ piece: MentionablePiece }>;
+    /**
+     * The target. Declared as a Cell so the handler receives a cell *link* (not
+     * a plain value): the link is stored as `about`, and its entity id as
+     * `aboutId` — the key `annotationsOf` matches on.
+     */
+    target: Cell<MentionablePiece>;
+    rel?: string;
+    identity?: unknown;
+    /** A literal, or a Writable draft that is cleared after posting. */
+    body?: string | Writable<string>;
+  }
+>((_event, { addPiece, target, rel, identity, body }) => {
+  const draft = isWritable(body) ? body : undefined;
+  const text = (draft ? (draft.get() ?? "") : ((body as string) ?? "")).trim();
+  if (identity === undefined && !text) return; // accreting text needs content
+  if (identity !== undefined) assertDeterministicIdentity(identity);
+  const aboutId = getEntityId(target)?.["/"] ?? "";
+  // Accreting (no identity): a fresh distinct piece per call.
+  // Converging (identity): must mint with a content-independent cause keyed by
+  // (target, rel, identity) so re-runs update in place and addPiece's equals()
+  // dedup keeps exactly one — the surgical runtime affordance (plan §A.2).
+  const piece = Annotation(
+    { about: target as any, aboutId, rel: rel ?? "comment", body: text },
+  );
+  addPiece.send({ piece: piece as any });
+  draft?.set("");
+});
+
+function isWritable(v: unknown): v is Writable<string> {
+  return !!v && typeof (v as { get?: unknown }).get === "function";
+}
+
+/** Reject non-deterministic identity (timestamps, randoms) loudly, per the design. */
+function assertDeterministicIdentity(identity: unknown): void {
+  if (JSON.stringify(identity) === undefined) {
+    throw new Error(
+      "annotate(): `identity` must be JSON-serializable and deterministic",
+    );
+  }
+}
+
+// ===== Reverse lookup: annotationsOf =====
+
+/**
+ * Reactive reverse lookup, as a lift: every annotation about `target`,
+ * optionally filtered by `rel`. The pattern body supplies `all` from the
+ * default app's mentionable index and `targetId` from `getEntityId(target)`.
+ *
+ * ```tsx
+ * const dflt = wish<{
+ *   addPiece: Stream<{ piece: MentionablePiece }>;
+ *   backlinksIndex: { mentionable: AnnotationPiece[] | undefined };
+ * }>({ query: "#default" }).result!;
+ * const targetId = getEntityId(doc)?.["/"];
+ * const comments = annotationsOf({ all: dflt.backlinksIndex.mentionable, targetId, rel: "comment" });
+ * ```
+ *
+ * NOTE: `all` is typed `AnnotationPiece[]`, not `MentionablePiece[]`, on
+ * purpose. A lift projects its inputs through the schema derived from this
+ * declared type, *stripping undeclared fields*. Typed as `MentionablePiece[]`
+ * (which has no `isAnnotation`/`aboutId`) those fields arrive `undefined` and
+ * the filter silently returns nothing. Consumers' `wish` types must be widened
+ * the same way. (A `computed` would not strip — it auto-tracks cell proxies.)
+ *
+ * O(N) over the space's mentionable pieces — a deliberate prototype trade-off;
+ * plan Phase E promotes this to a concrete per-target reverse index.
+ */
+export const annotationsOf = lift<
+  {
+    all: AnnotationPiece[] | undefined;
+    targetId: string | undefined;
+    rel?: string;
+  },
+  AnnotationPiece[]
+>(({ all, targetId, rel }) => {
+  if (!targetId) return [];
+  return (all ?? []).filter((a) =>
+    !!a &&
+    a.isAnnotation === true &&
+    a.aboutId === targetId &&
+    (rel === undefined || a.rel === rel)
+  );
+});

--- a/packages/patterns/annotations/comment-thread.tsx
+++ b/packages/patterns/annotations/comment-thread.tsx
@@ -1,0 +1,78 @@
+// deno-lint-ignore-file no-explicit-any
+/**
+ * CommentThread — demo of the annotation primitive (accreting mode).
+ *
+ * Renders all #annotation comments about `doc` via `annotationsOf`, plus a
+ * composer that posts a new comment with the single `annotate` verb. Each
+ * comment is its **own document** in the space — `doc` is never written.
+ *
+ * This is the canonical loom example, realised on the backlinks-index-backed
+ * library: `annotationsOf` reads the default app's mentionable index and keeps
+ * the annotations whose `aboutId` is this doc.
+ */
+import {
+  getEntityId,
+  NAME,
+  pattern,
+  type Stream,
+  UI,
+  type VNode,
+  wish,
+  Writable,
+} from "commonfabric";
+import type { MentionablePiece } from "../system/backlinks-index.tsx";
+import { annotate, type AnnotationPiece, annotationsOf } from "./annotations.tsx";
+
+interface CommentThreadInput {
+  /** The target being commented on. Never written by this pattern. */
+  doc: Writable<MentionablePiece>;
+}
+
+interface CommentThreadOutput {
+  [NAME]: string;
+  [UI]: VNode;
+}
+
+export default pattern<CommentThreadInput, CommentThreadOutput>(({ doc }) => {
+  // `mentionable` is typed `AnnotationPiece[]` (not `MentionablePiece[]`) so the
+  // wish schema projection passes `isAnnotation`/`aboutId` through to
+  // `annotationsOf` — see the note on `annotationsOf` in annotations.tsx.
+  const dflt = wish<{
+    addPiece: Stream<{ piece: MentionablePiece }>;
+    backlinksIndex: { mentionable: AnnotationPiece[] | undefined };
+  }>({ query: "#default" }).result!;
+
+  const draft = new Writable<string>("");
+  const targetId = getEntityId(doc)?.["/"];
+  const comments = annotationsOf({
+    all: dflt.backlinksIndex.mentionable,
+    targetId,
+    rel: "comment",
+  });
+
+  return {
+    [NAME]: "💬 Comments",
+    [UI]: (
+      <cf-vstack gap="2" style={{ padding: "12px", maxWidth: "520px" }}>
+        {comments.map((c: AnnotationPiece) => (
+          <cf-card style={{ padding: "8px 10px" }}>
+            <span style={{ fontSize: "14px" }}>{c.body}</span>
+          </cf-card>
+        ))}
+        <cf-hstack gap="2" style={{ alignItems: "center" }}>
+          <cf-input $value={draft} placeholder="Add a comment…" />
+          <cf-button
+            onClick={annotate({
+              addPiece: dflt.addPiece,
+              target: doc,
+              rel: "comment",
+              body: draft,
+            })}
+          >
+            Post
+          </cf-button>
+        </cf-hstack>
+      </cf-vstack>
+    ),
+  };
+});

--- a/packages/runner/src/sigil-types.ts
+++ b/packages/runner/src/sigil-types.ts
@@ -25,6 +25,12 @@ export type LinkV1Inner = {
   scope?: LinkScope;
   schema?: JSONSchema;
   overwrite?: "redirect" | "this"; // default is "this"
+  // Annotation primitive (prototype): marks this link as an annotation's
+  // about-edge. When present, the memory engine indexes the link in
+  // `link_index` at the commit boundary so `annotationsOf(target)` can find
+  // incoming edges. Persisted on the stored sigil (link-semantics, not
+  // cell-semantics). See docs/development/connectors/annotations-prototype-plan.md
+  linkRole?: string;
 };
 
 export type LinkV1 = {


### PR DESCRIPTION
## Annotation primitive — prototype (design + Phase-0 spike)

Prototypes the **annotation primitive** from loom **PR #2707** in labs-4. An
*annotation* is a statement that one entity is *about* another, attachable to any
target **from the author's own scope without write access to the target**. The
design's one true runtime ask is a **reverse index** — "what is attached to X?"

This PR is intentionally a **draft for discussion**, @seefeldb — it contains the
design doc and a working Phase-0 engine spike, but an adversarial review (below)
raised a **fundamental altitude question** and **two correctness blockers** that
I'd like your call on before building further.

### What's here

- **`docs/development/connectors/annotations-prototype-plan.md`** — the full
  plan: loom-spec vocabulary grounded in real labs-4 code, a 5-phase build, and
  the decided scope cuts (label-filtering + cross-space deferred; single-space
  v1). Now topped with a status banner reflecting the review.
- **`packages/runner/src/sigil-types.ts`** — optional `linkRole` on `LinkV1Inner`
  so a sigil link can be tagged an annotation about-edge.
- **`packages/memory/v2/engine.ts`** — a `link_index` reverse table maintained at
  the commit boundary (`applyCommitTransaction` → `reconcileLinkIndexForRevisions`
  after `materializeSnapshots`), by walking each materialized revision for
  role-bearing sigil links; plus exported `readIncomingLinks()` as the reverse
  read.
- **`packages/memory/test/v2-link-index.test.ts`** — 8 gate tests (population,
  idempotence, retarget, delete, the patch path, and the SourceLink / plain-link
  negative cases). All pass; existing engine + precondition suites still green.

The Phase-0 mechanism works mechanically. The review's point is that *working* is
not the question that mattered.

---

## Adversarial review — three independent critics

### 🔴 Strategic: the altitude is likely wrong for a prototype

The stated goal is **prototype + migrate patterns** (validate the ergonomics of
`annotate`/`annotationsOf`, delete the write-inversion hacks in
`backlinks-index.tsx` and `annotation.tsx`). None of that requires touching the
memory engine. Phase 0 front-loaded the **hardest, least-reversible layer** to
retire the *easy* risk (walk JSON, write rows — a mechanical mirror of
`reconcileSchedulerReadRows` that was never going to fail), and deferred the part
that is actually uncertain.

**Phase 2 (reactive delivery) is not credible as written.** Three independent
code facts:
1. The scheduler trigger index keys only on **concrete** `space/scope/id`
   (`scheduler/keys.ts`, `trigger-index.ts:240`). There is no representation for
   a synthetic "incoming-edges-to(X)" key.
2. Commit notifications are built only from `revision.id`
   (`schedulerWriteAddressesForRevisions`, `engine.ts:~4251`). When annotation
   doc `D` is committed, target `X` is in *no* revision (X is never written —
   that's the point), so the notify path carries `D`'s id only; a reader watching
   `X` is never woken.
3. `annotationsOf(X)` reads a *derived query result*, touching no concrete
   address a future annotation's commit will write.

Making it reactive needs a **cross-layer change-notification protocol extension**
(memory-server + runner-storage + scheduler) — weeks of work the plan compresses
to one sentence ("make it a subscribable synthetic address").

**The tell:** `wish()` already solves the analogous problem (reactive over a
changing set of entities) and does it **without** a synthetic subscription — it
reads a *concrete materialized index cell* (`…backlinksIndex.mentionable`) and
rides the ordinary trigger index. Our `link_index` is a SQLite side-table
**invisible to the reactive graph**, which is exactly why Phase 2 would have to
bolt a parallel invalidation path back on.

**Recommended pivot:** build `annotationsOf` as a `computed` over
`wish({ query: "#annotation" })` filtered by the `about` target. Zero engine
code, reactive on day one, exercises 100% of the ergonomics and both migrations.
*Only if* that doesn't scale, promote the reverse index to a **concrete
commit-written cell** (the wish model) so reads ride the existing trigger index —
never a SQLite side-table plus a net-new synthetic-subscription protocol.

### 🔴 Blocker 1 — branch inheritance

`readIncomingLinks` on a child branch **misses every annotation committed on the
parent before the fork**: it does a flat `WHERE branch = :branch` and never walks
the parent chain the way `readRowForBranch` does, and `createBranch` copies no
index rows. Forward content reads (`read(doc, branch=child)`) *do* inherit, so
the reverse index would contradict the forward view.

The plan's claim that `scheduler_read_index` is an **"exact precedent" is
withdrawn — it's an anti-precedent.** That index is branch-local *because* it
tracks live, ephemeral scheduler readers (correct by construction); `link_index`
indexes **durable, inheritable content** and must honor inheritance.

### 🔴 Blocker 2 — scope encoding baked into storage shape

`to_scope` stores the raw `LinkScope` token (`"user"` / `"session"` /
`"inherit"`), but a target's real identity is a **resolved `scope_key`**
(`"user:<principal>"`, `"session:<principal>:<sessionId>"`, via `resolveScopeKey`).
They coincide only for `"space"`, so any non-space target silently returns zero
rows the moment Phase 2 wires it. This is a storage-format decision — the worst
kind to get wrong late.

### 🟠 Should-fix

- **Don't borrow `reconcileSchedulerIndexRows`.** Its key excludes
  `seq`/`op_index`, so a *converging* re-set (same edge, new seq) produces **zero
  row mutations** — `seq` freezes at first commit. Any Phase-2 invalidation hung
  off "did reconcile touch a row for `to_id`" would miss converging updates.
  Replace with a replace-all-for-source reconcile (delete-all + insert), so `seq`
  is always fresh.
- **Reuse vs reinvention.** The runner already computes link endpoints
  (`recordCfcWritePolicyInput` → `CfcAddress` at `link-resolution.ts:46`). The
  grain-following feed is role-bearing edges carried as **commit metadata** (the
  way `schedulerObservation` rides the commit), with the document walk kept only
  as a server-authoritative verifier. The plan never made the
  server-authoritative argument; it should, or use the existing signal.
- **`SIGIL_LINK_TAG` drift.** `"link@1"` is now forked into 3 places. Memory
  genuinely can't import runner (circular), but `@commonfabric/api` is a
  foundation both could depend on — a deliberate decision worth making vs.
  re-declaring.
- **Dropping the link `path`** (sub-path targets), **redirect links carrying
  `linkRole`**, **cost gate runs after the unconditional SELECT + full walk** (add
  a `"link@1"` substring pre-filter), **speculative cross-space columns**,
  **set-vs-patch provenance asymmetry**, and **missing tests** (branches, scope,
  partial-edge-delete, redirect).
- The gate test injects sigils literally, so it does **not** prove an annotation
  written *through the runner* lands a `linkRole` in storage (Phase 0/1
  sequencing).

The Phase-0 craftsmanship was assessed as clean ("the problem is the altitude,
not the craftsmanship").

---

## What I'd like from review

1. **Altitude call:** pivot to the wish-backed library `annotationsOf` for the
   prototype, or keep the engine path and pay down the blockers? This is the
   load-bearing decision.
2. If we keep an engine index eventually: **concrete commit-written cell** (wish
   model) vs **SQLite side-table + synthetic subscription**?
3. Sanity-check the Phase-2 reactivity analysis — is a synthetic dirtied-key in
   the change-notification protocol as large as the critics make it sound?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prototype the annotation primitive with a wish-backed `annotationsOf` and a single `annotate` verb, plus a comment-thread demo. Keep the commit-time `link_index` reverse index as a Phase‑0 spike for reference and future optimization.

- **New Features**
  - `packages/patterns/annotations/annotations.tsx`: add `Annotation` piece, `annotate` handler (accrete/converge by `identity`), and `annotationsOf` lift backed by the default app’s mentionable index; never writes the target.
  - `packages/patterns/annotations/comment-thread.tsx`: simple CommentThread that uses `annotate` and `annotationsOf` to post and render comments.
  - `packages/runner/src/sigil-types.ts`: add optional `linkRole` to `LinkV1Inner` so `link@1` edges can be marked as annotations.
  - `packages/memory/v2/engine.ts`: add `link_index` and populate it at commit by walking materialized docs for `link@1` with `linkRole`; expose `readIncomingLinks(...)`.
  - `packages/memory/test/v2-link-index.test.ts`: gate tests for population, idempotence, retarget, delete, and patch; ignores `SourceLink` and plain links.
  - `docs/development/connectors/annotations-prototype-plan.md`: revise plan to the wish-backed altitude for `annotationsOf` and defer the engine index to a future optimization; keep the Phase‑0 spike as a reference.

<sup>Written for commit 9a003b8052bc5196e795a823444afc46967964eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

