### PR TITLE
Isolate nested Deno test lockfiles

### DIFF
--- a/.agents/skills/isolated-test-processes
+++ b/.agents/skills/isolated-test-processes
@@ -1,0 +1,1 @@
+../../skills/isolated-test-processes

--- a/.claude/skills/isolated-test-processes
+++ b/.claude/skills/isolated-test-processes
@@ -1,0 +1,1 @@
+../../skills/isolated-test-processes

--- a/packages/patterns/scoped-group-chat/schema.test.ts
+++ b/packages/patterns/scoped-group-chat/schema.test.ts
@@ -1,18 +1,31 @@
 import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
+
+const ROOT = join(import.meta.dirname!, "..", "..", "..");
 
 Deno.test("scoped group chat pattern schema generates scoped input cells", async () => {
-  const command = new Deno.Command(Deno.execPath(), {
-    args: [
-      "task",
-      "cf",
+  const output = await runDenoCommandWithTemporaryLock({
+    root: ROOT,
+    cwd: ROOT,
+    args: (lockPath) => [
+      "run",
+      "--config",
+      join(ROOT, "deno.json"),
+      "--lock",
+      lockPath,
+      "--allow-net",
+      "--allow-ffi",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "--allow-run",
+      join(ROOT, "packages/cli/mod.ts"),
       "check",
       "packages/patterns/scoped-group-chat/main-with-writable-inputs.tsx",
       "--pattern-json",
     ],
-    stdout: "piped",
-    stderr: "piped",
   });
-  const output = await command.output();
   assertEquals(output.code, 0);
 
   const stdout = new TextDecoder().decode(output.stdout);

--- a/packages/shell/test/standard-decorators-entrypoint.test.ts
+++ b/packages/shell/test/standard-decorators-entrypoint.test.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import { join } from "@std/path";
+import { runDenoCheckWithTemporaryConfig } from "@commonfabric/test-support/isolated-deno";
 
 const ROOT = join(import.meta.dirname!, "..", "..", "..");
 
@@ -22,20 +23,12 @@ Deno.test("shell entrypoint type-checks under standard decorators", async () => 
     ...(packageConfig.imports ?? {}),
   };
 
-  const tempConfig = join(
-    ROOT,
-    ".deno.standard-decorators.shell-entrypoint.json",
-  );
-  await Deno.writeTextFile(tempConfig, JSON.stringify(rootConfig, null, 2));
-
-  const output = await new Deno.Command(Deno.execPath(), {
-    cwd: ROOT,
-    args: ["check", "--config", tempConfig, "packages/shell/src/index.ts"],
-    stdout: "piped",
-    stderr: "piped",
-  }).output();
-
-  await Deno.remove(tempConfig);
+  const output = await runDenoCheckWithTemporaryConfig({
+    root: ROOT,
+    config: rootConfig,
+    files: ["packages/shell/src/index.ts"],
+    tempConfigPrefix: "deno.standard-decorators.shell-entrypoint",
+  });
 
   if (!output.success) {
     console.error(decode(output.stdout));

--- a/packages/shell/test/standard-decorators-shell-phase2.test.ts
+++ b/packages/shell/test/standard-decorators-shell-phase2.test.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import { join } from "@std/path";
+import { runDenoCheckWithTemporaryConfig } from "@commonfabric/test-support/isolated-deno";
 
 const ROOT = join(import.meta.dirname!, "..", "..", "..");
 
@@ -14,9 +15,6 @@ Deno.test("shell component slice type-checks under standard decorators", async (
   rootConfig.compilerOptions ??= {};
   rootConfig.compilerOptions.experimentalDecorators = false;
 
-  const tempConfig = join(ROOT, ".deno.standard-decorators.shell-phase2.json");
-  await Deno.writeTextFile(tempConfig, JSON.stringify(rootConfig, null, 2));
-
   const files = [
     "packages/shell/src/components/Button.ts",
     "packages/shell/src/components/CFLogo.ts",
@@ -27,14 +25,12 @@ Deno.test("shell component slice type-checks under standard decorators", async (
     "packages/shell/src/components/PieceList.ts",
   ];
 
-  const output = await new Deno.Command(Deno.execPath(), {
-    cwd: ROOT,
-    args: ["check", "--config", tempConfig, ...files],
-    stdout: "piped",
-    stderr: "piped",
-  }).output();
-
-  await Deno.remove(tempConfig);
+  const output = await runDenoCheckWithTemporaryConfig({
+    root: ROOT,
+    config: rootConfig,
+    files,
+    tempConfigPrefix: "deno.standard-decorators.shell-phase2",
+  });
 
   if (!output.success) {
     console.error(decode(output.stdout));

--- a/packages/shell/test/standard-decorators-shell-views-phase3.test.ts
+++ b/packages/shell/test/standard-decorators-shell-views-phase3.test.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import { join } from "@std/path";
+import { runDenoCheckWithTemporaryConfig } from "@commonfabric/test-support/isolated-deno";
 
 const ROOT = join(import.meta.dirname!, "..", "..", "..");
 
@@ -13,9 +14,6 @@ Deno.test("shell view slice type-checks under standard decorators", async () => 
 
   rootConfig.compilerOptions ??= {};
   rootConfig.compilerOptions.experimentalDecorators = false;
-
-  const tempConfig = join(ROOT, ".deno.standard-decorators.shell-views.json");
-  await Deno.writeTextFile(tempConfig, JSON.stringify(rootConfig, null, 2));
 
   const files = [
     "packages/iframe-sandbox/src/common-iframe-sandbox.ts",
@@ -32,14 +30,12 @@ Deno.test("shell view slice type-checks under standard decorators", async () => 
     "packages/shell/src/views/_PieceView.ts",
   ];
 
-  const output = await new Deno.Command(Deno.execPath(), {
-    cwd: ROOT,
-    args: ["check", "--config", tempConfig, ...files],
-    stdout: "piped",
-    stderr: "piped",
-  }).output();
-
-  await Deno.remove(tempConfig);
+  const output = await runDenoCheckWithTemporaryConfig({
+    root: ROOT,
+    config: rootConfig,
+    files,
+    tempConfigPrefix: "deno.standard-decorators.shell-views",
+  });
 
   if (!output.success) {
     console.error(decode(output.stdout));

--- a/packages/test-support/deno.json
+++ b/packages/test-support/deno.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "exports": {
     ".": "./src/mod.ts",
-    "./fixture-runner": "./src/fixture-runner.ts"
+    "./fixture-runner": "./src/fixture-runner.ts",
+    "./isolated-deno": "./src/isolated-deno.ts"
   },
   "imports": {
     "typescript": "npm:typescript"

--- a/packages/test-support/src/isolated-deno.ts
+++ b/packages/test-support/src/isolated-deno.ts
@@ -1,0 +1,85 @@
+import { join } from "@std/path";
+
+export interface DenoCommandWithTemporaryLockOptions {
+  root: string;
+  cwd?: string;
+  args: (lockPath: string) => string[];
+  env?: Record<string, string>;
+}
+
+export interface DenoCheckWithTemporaryConfigOptions {
+  root: string;
+  config: unknown;
+  files: string[];
+  tempConfigPrefix: string;
+}
+
+async function removeIfPresent(path: string, options?: Deno.RemoveOptions) {
+  try {
+    await Deno.remove(path, options);
+  } catch (error) {
+    if (!(error instanceof Deno.errors.NotFound)) {
+      throw error;
+    }
+  }
+}
+
+export async function runDenoCommandWithTemporaryLock(
+  options: DenoCommandWithTemporaryLockOptions,
+): Promise<Deno.CommandOutput> {
+  const tempDir = await Deno.makeTempDir({
+    prefix: "commonfabric-deno-lock-",
+  });
+  const tempLock = join(tempDir, "deno.lock");
+
+  try {
+    await Deno.copyFile(join(options.root, "deno.lock"), tempLock);
+    const commandOptions: Deno.CommandOptions = {
+      cwd: options.cwd ?? options.root,
+      args: options.args(tempLock),
+      stdout: "piped",
+      stderr: "piped",
+    };
+    if (options.env) {
+      commandOptions.env = options.env;
+    }
+    return await new Deno.Command(Deno.execPath(), commandOptions).output();
+  } finally {
+    await removeIfPresent(tempDir, { recursive: true });
+  }
+}
+
+export async function runDenoCheckWithTemporaryConfig(
+  options: DenoCheckWithTemporaryConfigOptions,
+): Promise<Deno.CommandOutput> {
+  const safePrefix = options.tempConfigPrefix.replaceAll(
+    /[^a-zA-Z0-9._-]/g,
+    "-",
+  );
+  const tempConfig = join(
+    options.root,
+    `.${safePrefix}.${Deno.pid}.${crypto.randomUUID()}.json`,
+  );
+
+  try {
+    await Deno.writeTextFile(
+      tempConfig,
+      JSON.stringify(options.config, null, 2),
+    );
+
+    return await runDenoCommandWithTemporaryLock({
+      root: options.root,
+      cwd: options.root,
+      args: (tempLock) => [
+        "check",
+        "--config",
+        tempConfig,
+        "--lock",
+        tempLock,
+        ...options.files,
+      ],
+    });
+  } finally {
+    await removeIfPresent(tempConfig);
+  }
+}

--- a/packages/test-support/src/mod.ts
+++ b/packages/test-support/src/mod.ts
@@ -3,9 +3,15 @@ export {
   defineFixtureSuite,
   shouldUpdateGoldens,
 } from "./fixture-runner.ts";
+export {
+  runDenoCheckWithTemporaryConfig,
+  runDenoCommandWithTemporaryLock,
+} from "./isolated-deno.ts";
 export type {
   Fixture,
   FixtureContext,
   FixtureGroup,
   FixtureSuiteConfig,
 } from "./fixture-runner.ts";
+export type { DenoCheckWithTemporaryConfigOptions } from "./isolated-deno.ts";
+export type { DenoCommandWithTemporaryLockOptions } from "./isolated-deno.ts";

--- a/packages/ui/test/standard-decorators-entrypoint.test.ts
+++ b/packages/ui/test/standard-decorators-entrypoint.test.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import { join } from "@std/path";
+import { runDenoCheckWithTemporaryConfig } from "@commonfabric/test-support/isolated-deno";
 
 const ROOT = join(import.meta.dirname!, "..", "..", "..");
 
@@ -22,20 +23,12 @@ Deno.test("ui entrypoint type-checks under standard decorators", async () => {
     ...(packageConfig.imports ?? {}),
   };
 
-  const tempConfig = join(
-    ROOT,
-    ".deno.standard-decorators.ui-entrypoint.json",
-  );
-  await Deno.writeTextFile(tempConfig, JSON.stringify(rootConfig, null, 2));
-
-  const output = await new Deno.Command(Deno.execPath(), {
-    cwd: ROOT,
-    args: ["check", "--config", tempConfig, "packages/ui/src/index.ts"],
-    stdout: "piped",
-    stderr: "piped",
-  }).output();
-
-  await Deno.remove(tempConfig);
+  const output = await runDenoCheckWithTemporaryConfig({
+    root: ROOT,
+    config: rootConfig,
+    files: ["packages/ui/src/index.ts"],
+    tempConfigPrefix: "deno.standard-decorators.ui-entrypoint",
+  });
 
   if (!output.success) {
     console.error(decode(output.stdout));

--- a/packages/ui/test/standard-decorators-phase1.test.ts
+++ b/packages/ui/test/standard-decorators-phase1.test.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import { join } from "@std/path";
+import { runDenoCheckWithTemporaryConfig } from "@commonfabric/test-support/isolated-deno";
 
 const ROOT = join(import.meta.dirname!, "..", "..", "..");
 
@@ -14,9 +15,6 @@ Deno.test("phase 1 files type-check under standard decorators", async () => {
   rootConfig.compilerOptions ??= {};
   rootConfig.compilerOptions.experimentalDecorators = false;
 
-  const tempConfig = join(ROOT, ".deno.standard-decorators.phase1.json");
-  await Deno.writeTextFile(tempConfig, JSON.stringify(rootConfig, null, 2));
-
   const files = [
     "packages/shell/src/components/Button.ts",
     "packages/shell/src/components/CFLogo.ts",
@@ -28,14 +26,12 @@ Deno.test("phase 1 files type-check under standard decorators", async () => {
     "packages/ui/src/v2/components/cf-tile/cf-tile.ts",
   ];
 
-  const output = await new Deno.Command(Deno.execPath(), {
-    cwd: ROOT,
-    args: ["check", "--config", tempConfig, ...files],
-    stdout: "piped",
-    stderr: "piped",
-  }).output();
-
-  await Deno.remove(tempConfig);
+  const output = await runDenoCheckWithTemporaryConfig({
+    root: ROOT,
+    config: rootConfig,
+    files,
+    tempConfigPrefix: "deno.standard-decorators.phase1",
+  });
 
   if (!output.success) {
     console.error(decode(output.stdout));

--- a/packages/ui/test/standard-decorators-phase4.test.ts
+++ b/packages/ui/test/standard-decorators-phase4.test.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import { join } from "@std/path";
+import { runDenoCheckWithTemporaryConfig } from "@commonfabric/test-support/isolated-deno";
 
 const ROOT = join(import.meta.dirname!, "..", "..", "..");
 
@@ -14,9 +15,6 @@ Deno.test("transitive ui slice type-checks under standard decorators", async () 
   rootConfig.compilerOptions ??= {};
   rootConfig.compilerOptions.experimentalDecorators = false;
 
-  const tempConfig = join(ROOT, ".deno.standard-decorators.ui-phase4.json");
-  await Deno.writeTextFile(tempConfig, JSON.stringify(rootConfig, null, 2));
-
   const files = [
     "packages/ui/src/v2/components/cf-audio-visualizer/cf-audio-visualizer.ts",
     "packages/ui/src/v2/components/cf-autocomplete/cf-autocomplete.ts",
@@ -27,14 +25,12 @@ Deno.test("transitive ui slice type-checks under standard decorators", async () 
     "packages/ui/src/v2/components/form/cf-form.ts",
   ];
 
-  const output = await new Deno.Command(Deno.execPath(), {
-    cwd: ROOT,
-    args: ["check", "--config", tempConfig, ...files],
-    stdout: "piped",
-    stderr: "piped",
-  }).output();
-
-  await Deno.remove(tempConfig);
+  const output = await runDenoCheckWithTemporaryConfig({
+    root: ROOT,
+    config: rootConfig,
+    files,
+    tempConfigPrefix: "deno.standard-decorators.ui-phase4",
+  });
 
   if (!output.success) {
     console.error(decode(output.stdout));

--- a/packages/ui/test/standard-decorators-phase5.test.ts
+++ b/packages/ui/test/standard-decorators-phase5.test.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import { join } from "@std/path";
+import { runDenoCheckWithTemporaryConfig } from "@commonfabric/test-support/isolated-deno";
 
 const ROOT = join(import.meta.dirname!, "..", "..", "..");
 
@@ -13,9 +14,6 @@ Deno.test("secondary transitive ui slice type-checks under standard decorators",
 
   rootConfig.compilerOptions ??= {};
   rootConfig.compilerOptions.experimentalDecorators = false;
-
-  const tempConfig = join(ROOT, ".deno.standard-decorators.ui-phase5.json");
-  await Deno.writeTextFile(tempConfig, JSON.stringify(rootConfig, null, 2));
 
   const files = [
     "packages/ui/src/v2/components/cf-cell-link/cf-cell-link.ts",
@@ -33,14 +31,12 @@ Deno.test("secondary transitive ui slice type-checks under standard decorators",
     "packages/ui/src/v2/components/cf-tool-call/cf-tool-call.ts",
   ];
 
-  const output = await new Deno.Command(Deno.execPath(), {
-    cwd: ROOT,
-    args: ["check", "--config", tempConfig, ...files],
-    stdout: "piped",
-    stderr: "piped",
-  }).output();
-
-  await Deno.remove(tempConfig);
+  const output = await runDenoCheckWithTemporaryConfig({
+    root: ROOT,
+    config: rootConfig,
+    files,
+    tempConfigPrefix: "deno.standard-decorators.ui-phase5",
+  });
 
   if (!output.success) {
     console.error(decode(output.stdout));

--- a/packages/ui/test/standard-decorators-phase6.test.ts
+++ b/packages/ui/test/standard-decorators-phase6.test.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import { join } from "@std/path";
+import { runDenoCheckWithTemporaryConfig } from "@commonfabric/test-support/isolated-deno";
 
 const ROOT = join(import.meta.dirname!, "..", "..", "..");
 
@@ -14,9 +15,6 @@ Deno.test("third transitive ui slice type-checks under standard decorators", asy
   rootConfig.compilerOptions ??= {};
   rootConfig.compilerOptions.experimentalDecorators = false;
 
-  const tempConfig = join(ROOT, ".deno.standard-decorators.ui-phase6.json");
-  await Deno.writeTextFile(tempConfig, JSON.stringify(rootConfig, null, 2));
-
   const files = [
     "packages/ui/src/v2/components/cf-chevron-button/cf-chevron-button.ts",
     "packages/ui/src/v2/components/cf-drag-source/cf-drag-source.ts",
@@ -28,14 +26,12 @@ Deno.test("third transitive ui slice type-checks under standard decorators", asy
     "packages/ui/src/v2/components/cf-select/cf-select.ts",
   ];
 
-  const output = await new Deno.Command(Deno.execPath(), {
-    cwd: ROOT,
-    args: ["check", "--config", tempConfig, ...files],
-    stdout: "piped",
-    stderr: "piped",
-  }).output();
-
-  await Deno.remove(tempConfig);
+  const output = await runDenoCheckWithTemporaryConfig({
+    root: ROOT,
+    config: rootConfig,
+    files,
+    tempConfigPrefix: "deno.standard-decorators.ui-phase6",
+  });
 
   if (!output.success) {
     console.error(decode(output.stdout));

--- a/packages/ui/test/standard-decorators-phase7.test.ts
+++ b/packages/ui/test/standard-decorators-phase7.test.ts
@@ -1,5 +1,6 @@
 import { assert } from "@std/assert";
 import { join } from "@std/path";
+import { runDenoCheckWithTemporaryConfig } from "@commonfabric/test-support/isolated-deno";
 
 const ROOT = join(import.meta.dirname!, "..", "..", "..");
 
@@ -14,9 +15,6 @@ Deno.test("fourth transitive ui slice type-checks under standard decorators", as
   rootConfig.compilerOptions ??= {};
   rootConfig.compilerOptions.experimentalDecorators = false;
 
-  const tempConfig = join(ROOT, ".deno.standard-decorators.ui-phase7.json");
-  await Deno.writeTextFile(tempConfig, JSON.stringify(rootConfig, null, 2));
-
   const files = [
     "packages/ui/src/v2/components/cf-file-download/cf-file-download.ts",
     "packages/ui/src/v2/components/cf-file-input/cf-file-input.ts",
@@ -27,14 +25,12 @@ Deno.test("fourth transitive ui slice type-checks under standard decorators", as
     "packages/ui/src/v2/components/cf-message-beads/cf-message-beads.ts",
   ];
 
-  const output = await new Deno.Command(Deno.execPath(), {
-    cwd: ROOT,
-    args: ["check", "--config", tempConfig, ...files],
-    stdout: "piped",
-    stderr: "piped",
-  }).output();
-
-  await Deno.remove(tempConfig);
+  const output = await runDenoCheckWithTemporaryConfig({
+    root: ROOT,
+    config: rootConfig,
+    files,
+    tempConfigPrefix: "deno.standard-decorators.ui-phase7",
+  });
 
   if (!output.success) {
     console.error(decode(output.stdout));

--- a/skills/isolated-test-processes/SKILL.md
+++ b/skills/isolated-test-processes/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: isolated-test-processes
+description: Guide for writing side-effect-free tests that spawn child processes, especially Deno commands. Use when adding or reviewing tests that call Deno.Command, run deno check/test/run/task/install, generate temporary deno.json files, update goldens, write build artifacts, or otherwise risk changing deno.lock or files in the repository workspace.
+---
+
+# Isolated Test Processes
+
+Tests that spawn Deno can update the repository even when the test only means to
+verify behavior. Deno commands resolve dependencies and may refresh `deno.lock`
+metadata. Generated configs, output files, and golden updates can also leave
+workspace files behind if cleanup is not tied to failure paths.
+
+## Repo Map
+
+Use `@commonfabric/test-support/isolated-deno` for nested Deno commands that
+need lockfile isolation.
+
+For nested Deno checks that need a generated config:
+
+```ts
+import {
+  runDenoCheckWithTemporaryConfig,
+} from "@commonfabric/test-support/isolated-deno";
+```
+
+That helper keeps the generated Deno workspace config in the repository root,
+where Deno requires workspace members to be nested under the config directory.
+It points Deno at a temporary copy of `deno.lock`, so dependency metadata writes
+do not touch the real lockfile. It also removes the generated root config in a
+`finally` block.
+
+For nested Deno commands that do not need a generated config:
+
+```ts
+import {
+  runDenoCommandWithTemporaryLock,
+} from "@commonfabric/test-support/isolated-deno";
+```
+
+Pass an argument builder and place the temporary lock path in the child Deno
+command's `--lock` flag.
+
+## Values
+
+- A verification test must not change `deno.lock` or repository files.
+- If a test needs mutable inputs or outputs, put them under `Deno.makeTempDir()`
+  or an explicit test fixture copy.
+- If a generated file must briefly live in the repository root for tool
+  semantics, give it a unique dot-prefixed name and remove it in `finally`.
+- If a test intentionally updates fixtures or goldens, gate the write behind an
+  explicit environment variable such as `UPDATE_GOLDENS=1`.
+- Treat `Deno.Command(Deno.execPath())` as a side-effect boundary. The child
+  Deno process does not inherit the parent test runner's lockfile flags.
+
+## Common Tells
+
+Risky tests often contain `Deno.Command(Deno.execPath())`, `deno check`,
+`deno task`, `deno install`, generated `deno.json` files, generated build
+outputs, or direct writes to paths under the repository root.


### PR DESCRIPTION
Some tests spawn child Deno commands that use the repository lockfile as writable state. When Deno refreshes dependency metadata during verification, it can dirty deno.lock even though no source dependency changed. The standard decorator checks also created root-level temporary configs that could remain if a failure interrupted cleanup.

Add shared test support helpers that copy deno.lock to a temporary lockfile for child Deno commands and remove generated files in finally blocks. Use the helpers in the standard decorator checks and the scoped group chat schema test, and add a repository skill documenting the pattern for tests that spawn child processes without workspace side effects.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents tests from mutating the repo lockfile by running nested Deno commands with a temporary `deno.lock`, and ensures temp configs are always cleaned up. Adds `@commonfabric/test-support/isolated-deno` helpers and updates affected tests to use them.

- **New Features**
  - Added `runDenoCommandWithTemporaryLock` and `runDenoCheckWithTemporaryConfig` in `@commonfabric/test-support/isolated-deno`.
  - Exported new helpers via `packages/test-support/deno.json` and `src/mod.ts`.
  - Added `skills/isolated-test-processes` with guidance for side‑effect‑free tests.

- **Bug Fixes**
  - Updated standard decorator test suites and the scoped group chat schema test to use a temp lockfile and unique, auto‑cleaned root configs.
  - Eliminates accidental `deno.lock` writes and leftover `.deno.*.json` files when tests spawn Deno.

<sup>Written for commit b285d5062d70edb13dbe375dc3d69346de3bc92e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

