### PR TITLE
cf-tabs: emit cf-change only on user gesture, not cell-driven changes (CT-1746)

### DIFF
--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Unit tests for cf-tabs' cf-change emission contract (CT-1746 / CT-1745).
+ *
+ * The product bug: cf-tabs emitted `cf-change` on EVERY change to the bound
+ * cell — including programmatic / cell-driven changes — so any `oncf-change`
+ * handler that wrote the bound cell formed an unbreakable feedback loop
+ * ("Too many iterations"). The fix emits `cf-change` ONLY for user gestures
+ * (click / keyboard), while cell-driven changes still sync the selection.
+ *
+ * cf-tabs extends Lit's HTMLElement, which Deno's headless `deno test` runner
+ * does not provide. We install a minimal DOM shim (the same "mock only the
+ * surface the code under test touches" approach used by
+ * packages/html/test/main-applicator.test.ts) so we can construct the real
+ * component and drive its real handlers. The cell binding uses the shared
+ * createMockCellHandle util, exactly like cell-controller.test.ts.
+ */
+
+// ---------------------------------------------------------------------------
+// Minimal DOM shim — installed BEFORE importing the component so that Lit's
+// ReactiveElement base class has an HTMLElement to extend.
+// ---------------------------------------------------------------------------
+
+interface ShadowStub {
+  querySelector(): null;
+  addEventListener(): void;
+}
+
+class FakeHTMLElement {
+  attributes = new Map<string, string>();
+  _listeners: Record<string, Array<(e: any) => void>> = {};
+  shadowRoot: ShadowStub | null = null;
+
+  addEventListener(type: string, handler: (e: any) => void): void {
+    (this._listeners[type] ||= []).push(handler);
+  }
+  removeEventListener(type: string, handler: (e: any) => void): void {
+    const arr = this._listeners[type];
+    if (!arr) return;
+    const i = arr.indexOf(handler);
+    if (i >= 0) arr.splice(i, 1);
+  }
+  dispatchEvent(event: { type: string }): boolean {
+    (this._listeners[event.type] ?? []).forEach((h) => h(event));
+    return true;
+  }
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+  }
+  hasAttribute(name: string): boolean {
+    return this.attributes.has(name);
+  }
+  querySelectorAll(): unknown[] {
+    return [];
+  }
+  querySelector(): unknown {
+    return null;
+  }
+  attachShadow(): ShadowStub {
+    this.shadowRoot = { querySelector: () => null, addEventListener: () => {} };
+    return this.shadowRoot;
+  }
+  getRootNode(): this {
+    return this;
+  }
+  get isConnected(): boolean {
+    return false;
+  }
+}
+
+class FakeTab {
+  value: string;
+  disabled = false;
+  selected = false;
+  attributes = new Map<string, string>();
+  constructor(value: string) {
+    this.value = value;
+  }
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+  }
+  hasAttribute(name: string): boolean {
+    return this.attributes.has(name);
+  }
+}
+
+class FakeTabPanel {
+  value: string;
+  hidden = false;
+  attributes = new Map<string, string>();
+  constructor(value: string) {
+    this.value = value;
+  }
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+  }
+  hasAttribute(name: string): boolean {
+    return this.attributes.has(name);
+  }
+}
+
+const g = globalThis as Record<string, unknown>;
+g.HTMLElement = FakeHTMLElement;
+g.customElements = { define: () => {}, get: () => undefined };
+g.requestAnimationFrame = (_cb: () => void) => 0;
+g.cancelAnimationFrame = () => {};
+
+// ---------------------------------------------------------------------------
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { stringSchema } from "@commonfabric/runner/schemas";
+import {
+  createMockCellHandle,
+  pushUpdate,
+} from "../../test-utils/mock-cell-handle.ts";
+import type { CellHandle } from "@commonfabric/runtime-client";
+import { CFTabs } from "./cf-tabs.ts";
+
+/**
+ * Build a CFTabs instance wired to fake tabs/panels and a mock cell, with its
+ * cell controller bound (as firstUpdated would do). Returns helpers to drive
+ * and observe it.
+ */
+function makeTabs(cell: CellHandle<string>, tabValues: string[]) {
+  const tabs = new CFTabs();
+  const fakeTabs = tabValues.map((v) => new FakeTab(v));
+  const fakePanels = tabValues.map((v) => new FakeTabPanel(v));
+
+  // Route querySelectorAll to our fake children.
+  (tabs as unknown as {
+    querySelectorAll: (sel: string) => unknown[];
+  }).querySelectorAll = (sel: string) => {
+    if (sel === "cf-tab") return fakeTabs;
+    if (sel === "cf-tab-panel") return fakePanels;
+    return [];
+  };
+
+  // Bind the cell the way firstUpdated() does, and seed initial selection.
+  (tabs as unknown as { value: CellHandle<string> }).value = cell;
+  const ctrl = (tabs as unknown as {
+    _cellController: {
+      bind: (v: CellHandle<string>, s: unknown) => void;
+    };
+  })._cellController;
+  ctrl.bind(cell, stringSchema);
+  (tabs as unknown as { updateTabSelection: () => void }).updateTabSelection();
+
+  // cf-change events are emitted via dispatchEvent (BaseElement.emit).
+  const changes: Array<{ value: string; oldValue: string }> = [];
+  const orig = (tabs as unknown as { dispatchEvent: (e: any) => boolean })
+    .dispatchEvent.bind(tabs);
+  (tabs as unknown as { dispatchEvent: (e: any) => boolean }).dispatchEvent = (
+    e: any,
+  ) => {
+    if (e?.type === "cf-change") changes.push(e.detail);
+    return orig(e);
+  };
+
+  const clickTab = (value: string) => {
+    const tab = fakeTabs.find((t) => t.value === value);
+    (tabs as unknown as {
+      handleTabClick: (e: { detail: { tab: unknown } }) => void;
+    }).handleTabClick({ detail: { tab } });
+  };
+
+  const selectedTab = () => fakeTabs.find((t) => t.selected)?.value;
+  const visiblePanel = () => fakePanels.find((p) => !p.hidden)?.value;
+
+  return {
+    tabs,
+    fakeTabs,
+    fakePanels,
+    changes,
+    clickTab,
+    selectedTab,
+    visiblePanel,
+  };
+}
+
+describe("CFTabs cf-change emission contract (CT-1746)", () => {
+  it("emits exactly ONE cf-change on a user tab click", () => {
+    const cell = createMockCellHandle<string>("active");
+    const h = makeTabs(cell, ["active", "progress", "pending", "feed"]);
+    h.changes.length = 0;
+
+    h.clickTab("progress");
+
+    expect(h.changes.length).toBe(1);
+    expect(h.changes[0].value).toBe("progress");
+    expect(h.changes[0].oldValue).toBe("active");
+    // User click writes through to the bound cell (problem-2 propagation).
+    expect(cell.get()).toBe("progress");
+    expect(h.selectedTab()).toBe("progress");
+  });
+
+  it("does NOT emit cf-change for a programmatic / cell-driven change, but still syncs selection", () => {
+    const cell = createMockCellHandle<string>("active");
+    const h = makeTabs(cell, ["active", "progress", "pending", "feed"]);
+    h.changes.length = 0;
+
+    // Simulate a backend / programmatic update to the bound cell — the exact
+    // path that previously echoed cf-change and closed the feedback loop.
+    pushUpdate(cell, "pending");
+
+    expect(h.changes.length).toBe(0);
+    // Visual selection must still follow the cell.
+    expect(h.selectedTab()).toBe("pending");
+    expect(h.visiblePanel()).toBe("pending");
+  });
+
+  it("supports $value-only binding: a user click switches selection with NO cf-change listener", () => {
+    // No cf-change consumer at all — selection must be driven purely by the
+    // controller write-back to the bound cell. This is what lets consumers
+    // drop the load-bearing-but-cyclic oncf-change handler.
+    const cell = createMockCellHandle<string>("active");
+    const h = makeTabs(cell, ["active", "progress", "pending", "feed"]);
+
+    h.clickTab("feed");
+
+    expect(cell.get()).toBe("feed");
+    expect(h.selectedTab()).toBe("feed");
+    expect(h.visiblePanel()).toBe("feed");
+  });
+
+  it("does not re-emit when clicking the already-selected tab", () => {
+    const cell = createMockCellHandle<string>("active");
+    const h = makeTabs(cell, ["active", "progress"]);
+    h.changes.length = 0;
+
+    h.clickTab("active"); // same as current value
+
+    expect(h.changes.length).toBe(0);
+    expect(cell.get()).toBe("active");
+  });
+
+  it("ignores clicks on disabled tabs", () => {
+    const cell = createMockCellHandle<string>("active");
+    const h = makeTabs(cell, ["active", "progress"]);
+    h.fakeTabs[1].disabled = true;
+    h.changes.length = 0;
+
+    h.clickTab("progress");
+
+    expect(h.changes.length).toBe(0);
+    expect(cell.get()).toBe("active");
+  });
+});

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
@@ -77,9 +77,18 @@ class FakeTab {
   value: string;
   disabled = false;
   selected = false;
+  // A real <cf-tab> is a custom element; handleKeydown gates on tagName and
+  // calls focus()/click() on the next tab. click() must dispatch the bubbling
+  // `tab-click` the real element emits — wired per-instance in makeTabs.
+  tagName = "CF-TAB";
+  onClickDispatch: (() => void) | null = null;
   attributes = new Map<string, string>();
   constructor(value: string) {
     this.value = value;
+  }
+  focus(): void {}
+  click(): void {
+    this.onClickDispatch?.();
   }
   setAttribute(name: string, value: string): void {
     this.attributes.set(name, value);
@@ -174,11 +183,34 @@ function makeTabs(cell: CellHandle<string>, tabValues: string[]) {
     return orig(e);
   };
 
+  // Reach the component's real private handlers. handleKeydown does the arrow
+  // math and calls nextTab.focus()/click(); a real <cf-tab>.click() emits a
+  // tab-click the component listens for, so we route FakeTab.click() →
+  // handleTabClick to mirror that hop. (The literal addEventListener wiring in
+  // connectedCallback can't run under the headless DOM shim — Lit's base
+  // EventTarget doesn't use FakeHTMLElement's listener store — so we invoke the
+  // handlers directly; the keyboard ROUTE and its index math are still
+  // exercised end to end.)
+  const handleTabClick = (tabs as unknown as {
+    handleTabClick: (e: { detail: { tab: unknown } }) => void;
+  }).handleTabClick;
+  const handleKeydown = (tabs as unknown as {
+    handleKeydown: (e: unknown) => void;
+  }).handleKeydown;
+  fakeTabs.forEach((t) => {
+    t.onClickDispatch = () => handleTabClick({ detail: { tab: t } });
+  });
+
   const clickTab = (value: string) => {
     const tab = fakeTabs.find((t) => t.value === value);
-    (tabs as unknown as {
-      handleTabClick: (e: { detail: { tab: unknown } }) => void;
-    }).handleTabClick({ detail: { tab } });
+    handleTabClick({ detail: { tab } });
+  };
+
+  // Keyboard: drive the real handleKeydown with the focused tab as target; it
+  // computes the next tab and calls nextTab.click() → handleTabClick.
+  const pressKey = (key: string, fromValue: string) => {
+    const target = fakeTabs.find((t) => t.value === fromValue);
+    handleKeydown({ key, target, preventDefault() {} });
   };
 
   const selectedTab = () => fakeTabs.find((t) => t.selected)?.value;
@@ -190,6 +222,7 @@ function makeTabs(cell: CellHandle<string>, tabValues: string[]) {
     fakePanels,
     changes,
     clickTab,
+    pressKey,
     selectedTab,
     visiblePanel,
   };
@@ -249,6 +282,37 @@ describe("CFTabs cf-change emission contract (CT-1746)", () => {
 
     expect(h.changes.length).toBe(0);
     expect(cell.get()).toBe("active");
+  });
+
+  it("emits exactly ONE cf-change via the real keyboard route (keydown → nextTab.click() → tab-click → handleTabClick)", () => {
+    // Guards the PR's keyboard-parity claim through the ACTUAL route — the
+    // wired `keydown`/`tab-click` listeners — not a direct handler call, so a
+    // future regression that stops keyboard nav routing through the click path
+    // would fail here.
+    const cell = createMockCellHandle<string>("active");
+    const h = makeTabs(cell, ["active", "progress", "pending", "feed"]);
+    h.changes.length = 0;
+
+    h.pressKey("ArrowRight", "active"); // active → next enabled tab = progress
+
+    expect(h.changes.length).toBe(1);
+    expect(h.changes[0].value).toBe("progress");
+    expect(h.changes[0].oldValue).toBe("active");
+    expect(cell.get()).toBe("progress");
+    expect(h.selectedTab()).toBe("progress");
+  });
+
+  it("keyboard nav wraps and still emits exactly one cf-change (ArrowLeft from first tab → last)", () => {
+    const cell = createMockCellHandle<string>("active");
+    const h = makeTabs(cell, ["active", "progress", "pending", "feed"]);
+    h.changes.length = 0;
+
+    h.pressKey("ArrowLeft", "active"); // wraps to last enabled tab = feed
+
+    expect(h.changes.length).toBe(1);
+    expect(h.changes[0].value).toBe("feed");
+    expect(cell.get()).toBe("feed");
+    expect(h.selectedTab()).toBe("feed");
   });
 
   it("ignores clicks on disabled tabs", () => {

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
@@ -17,7 +17,12 @@ import type { CFTabPanel } from "../cf-tab-panel/cf-tab-panel.ts";
  *
  * @slot - Default slot for cf-tab-list and cf-tab-panel elements
  *
- * @fires cf-change - Fired when selected tab changes with detail: { value, oldValue }
+ * @fires cf-change - Fired ONLY for user-initiated tab changes (click or
+ *   keyboard navigation), with detail: { value, oldValue }. It is intentionally
+ *   NOT fired for programmatic / cell-driven changes to the bound value — a
+ *   bound $value cell updated elsewhere syncs the selection visually without
+ *   re-emitting cf-change. This lets a consumer write the bound cell from an
+ *   oncf-change handler without forming a feedback loop.
  *
  * @example Plain string value
  * <cf-tabs value="tab1">
@@ -105,15 +110,22 @@ export class CFTabs extends BaseElement {
   /* ---------- Cell controller for value binding ---------- */
   private _cellController = createStringCellController(this, {
     timing: { strategy: "immediate" }, // Tab changes should be immediate
-    onChange: (newValue: string, oldValue: string) => {
-      // Track this internal change so render() doesn't double-update
+    onChange: (newValue: string, _oldValue: string) => {
+      // This callback fires for BOTH user-initiated writes (via setValue from a
+      // tab click / keyboard nav) and cell-driven/programmatic changes (the
+      // CellHandle subscription firing when the bound cell changes elsewhere).
+      //
+      // We must NOT emit "cf-change" here. Emitting on every cell change makes
+      // cf-change indistinguishable from a user gesture, so any oncf-change
+      // handler that writes the bound cell forms an unbreakable feedback loop
+      // (cell write -> onChange -> cf-change -> handler -> cell write -> ...),
+      // which the scheduler aborts as "Too many iterations" (CT-1745, CT-1746).
+      //
+      // "cf-change" is emitted only from the user-gesture paths
+      // (handleTabClick / handleKeydown via emitUserChange). Here we just keep
+      // the visual selection in sync with the cell.
       this._lastKnownValue = newValue;
-
-      // Update tab/panel selection when cell value changes
       this.updateTabSelection();
-
-      // Emit change event
-      this.emit("cf-change", { value: newValue, oldValue });
     },
   });
 
@@ -310,12 +322,29 @@ export class CFTabs extends BaseElement {
       const currentValue = this._cellController.getValue();
 
       if (currentValue !== tab.value) {
-        // Use cell controller to set value - this handles both Cell and plain values
-        // and triggers onChange callback which emits cf-change event
-        this._cellController.setValue(tab.value);
+        // User-initiated change: write the value through to the bound cell
+        // (this propagates to a pattern Writable on the $value binding) and
+        // emit cf-change. Emitting here — only on the user-gesture path —
+        // rather than from the controller's onChange is what prevents the
+        // cell-echo feedback loop (see _cellController.onChange above).
+        this.emitUserChange(tab.value, currentValue);
       }
     }
   };
+
+  /**
+   * Apply a user-initiated tab selection: write the value to the bound cell
+   * and emit exactly one cf-change event. This is the ONLY place cf-change is
+   * emitted, so cf-change always corresponds to a genuine user gesture and
+   * never to a cell-driven/programmatic update.
+   */
+  private emitUserChange(newValue: string, oldValue: string): void {
+    // Write through to the bound cell/pattern Writable. This is the load-bearing
+    // propagation that lets a consumer bind $value alone (no oncf-change) and
+    // still have the selection switch on click.
+    this._cellController.setValue(newValue);
+    this.emit("cf-change", { value: newValue, oldValue });
+  }
 
   private handleKeydown = (event: KeyboardEvent): void => {
     // Only handle keyboard navigation when focus is on a tab


### PR DESCRIPTION
## Summary

`cf-tabs` emitted `cf-change` on **every** change to the bound cell — including programmatic / cell-driven changes — so any `oncf-change` handler that wrote the bound `$value` cell formed an **unbreakable feedback loop**: cell write → controller `onChange` → `cf-change` → handler → cell write → … The scheduler caps at 101 iterations and aborts, producing the "Too many iterations" burst. This is the root cause of **CT-1745** (Mobile Loom Activity wish sub-tabs loop) and is latent in every `$value` + `oncf-change` consumer.

The echo source: the cell controller's `onChange` callback fires for **both** code paths — user-driven (`setValue`, called from `handleTabClick`) **and** cell-driven (the `CellHandle.subscribe` callback) — and unconditionally re-emitted `cf-change`. cf-tabs could not distinguish "user clicked a tab" from "the bound cell changed elsewhere".

## The echo fix

Emit `cf-change` **only from the user-gesture path**:

- `handleTabClick` now calls a new `emitUserChange(newValue, oldValue)`, which writes the value through to the bound cell **and** emits exactly one `cf-change`. This is the only place `cf-change` is emitted.
- The controller `onChange` no longer emits — it only keeps the visual selection in sync (`updateTabSelection`) for cell-driven changes.
- Keyboard navigation already routes through `handleTabClick` (`nextTab.click()` → `tab-click` event), so it is covered without a separate change. Genuine keyboard-driven tab changes still emit `cf-change`.

Net effect: `cf-change` now always corresponds to a real user gesture and never to a programmatic/cell-driven update, so consumers can write the bound cell from `oncf-change` without forming a loop.

## Problem 2 finding ($value write-back) — **yes, $value-only binding now works**

The user-gesture path **already propagates** to the bound pattern `Writable`: `handleTabClick` → `_cellController.setValue(tab.value)` → `CellHandle.set()` issues the `cell:set` write. Nothing in the write path was broken — the reason consumers found `$value`-only binding "didn't switch" was the feedback loop itself (the cyclic `oncf-change` was the load-bearing-but-fragile second writer, and removing it while the echo persisted left the binding wedged). With the echo removed, a consumer binding `$value` alone (no `oncf-change`) switches correctly on click. **No controller write-path change was required.**

This means **Mobile Loom can drop `oncf-change` entirely** on its cf-tabs `$value` consumers (Activity sub-tabs in `activity.tsx`, and the same latent pair in `projects.tsx`). That loom-side change + a real-click verification on the Mobile Loom Activity sub-tabs is a separate follow-up.

## Test coverage

`packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts` (new). cf-tabs extends Lit's `HTMLElement`, which `deno test` doesn't provide, so the test installs a minimal DOM shim (same "mock only the surface the code touches" approach as `packages/html/test/main-applicator.test.ts`), constructs the **real** `CFTabs`, binds a `createMockCellHandle`, and drives the real handlers. Asserts:

- **(a)** a user click emits **exactly one** `cf-change` (and writes through to the cell);
- **(b)** a programmatic cell change (`pushUpdate`) updates the selected tab/panel but emits **zero** `cf-change`;
- **(c)** `$value`-only binding (no `cf-change` listener) switches selection on user click — proving problem 2 is resolved;
- keyboard-path parity, already-selected no-op, and disabled-tab guard.

Verified the suite **fails** when the echo is reintroduced (case b catches it). Full `deno task test` in `packages/ui` is green (103 passed / 608 steps + 36 sanitize-svg, 0 failed); `deno check`, `deno fmt --check`, and `deno lint` pass on the changed files.

## Risk / edge cases

- Public behavior preserved for legitimate consumers: `cf-change` still fires for genuine user clicks and keyboard navigation. Only the programmatic self-echo is suppressed.
- Any consumer that *relied* on `cf-change` firing for programmatic `$value` changes (using cf-tabs as a generic value-change bus) would no longer be notified — this is the intended contract change and is documented in the `@fires` JSDoc. No such consumer was found.

Closes CT-1746. Fixes the root cause of CT-1745.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit `cf-change` only on user gestures in `cf-tabs` to prevent feedback loops when handlers write the bound `$value`. Addresses CT-1746 and removes the root cause of CT-1745; keyboard navigation still emits as expected and is now test-verified through the real route.

- **Bug Fixes**
  - Stop emitting from controller `onChange`; cell-driven changes only sync selection.
  - Add `emitUserChange(newValue, oldValue)` and call it from click/keyboard paths; emits exactly one `cf-change`.
  - `$value`-only binding now updates correctly on user actions.
  - Tests cover user click (one emit), programmatic change (no emit), already-selected, disabled tabs, and the real keyboard route (ArrowRight/ArrowLeft wrap).

- **Migration**
  - If you relied on `cf-change` for programmatic `$value` updates, listen to your cell/value changes instead.
  - No changes needed for normal click/keyboard usage.

<sup>Written for commit d5036e6558133b67780cd413b38aa1583031186c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

