### PR TITLE
Fix port-offset toolshed API_URL and MEMORY_URL

### DIFF
--- a/docs/development/LOCAL_DEV_SERVERS.md
+++ b/docs/development/LOCAL_DEV_SERVERS.md
@@ -126,6 +126,10 @@ This checks both process presence and HTTP health, exiting non-zero if
 anything is wrong. It supports the same `--port-offset`, `--shell-port`, and
 `--toolshed-port` flags as the other scripts.
 
+When `--port-offset` changes the toolshed port, `start-local-dev.sh` also sets
+toolshed's internal `API_URL` and `MEMORY_URL` to the offset toolshed URL unless
+those variables are already exported in the shell environment.
+
 ### Common Issues
 
 | Symptom | Cause | Fix |

--- a/scripts/start-local-dev.sh
+++ b/scripts/start-local-dev.sh
@@ -109,6 +109,9 @@ INSPECT_PORT=${INSPECT_PORT:-$((BASE_INSPECTOR_PORT + PORT_OFFSET))}
 export SHELL_PORT
 export TOOLSHED_PORT
 
+TOOLSHED_API_URL=${API_URL:-"http://localhost:$TOOLSHED_PORT"}
+TOOLSHED_MEMORY_URL=${MEMORY_URL:-"$TOOLSHED_API_URL"}
+
 require_command "deno" \
     "Run 'mise install' from the repo root or install Deno before starting local dev."
 require_command "curl" \
@@ -301,6 +304,8 @@ if [[ "$INSPECT" == "true" ]]; then
     fi
 fi
 SHELL_URL="http://localhost:$SHELL_PORT" \
+    API_URL="$TOOLSHED_API_URL" \
+    MEMORY_URL="$TOOLSHED_MEMORY_URL" \
     deno run --unstable-otel -A $INSPECT_FLAG $WATCH_FLAG \
         --env-file=.env index.ts --port="$TOOLSHED_PORT" \
         > "$TOOLSHED_LOG" 2>&1 &


### PR DESCRIPTION
When start-local-dev.sh runs with --port-offset, it now starts toolshed with API_URL and MEMORY_URL set to the offset toolshed URL unless the caller has already exported those variables. This keeps the toolshed runtime, pattern environment, and remote memory client on the same local port as the server that was started.

The failure reproduced while running with --port-offset=1. Google redirected back to localhost:8001 during the Open Authorization callback, but toolshed crashed while persisting the token because its runtime still used the default MEMORY_URL on localhost:8000. After the change, logs show the Google provider route registered and remote storage configured as http://localhost:8001.

Also document that port-offset startup updates the internal toolshed URLs so local development setup matches the script behavior.

Evidence: bash -n scripts/start-local-dev.sh; git diff --check; ./scripts/check-local-dev.sh --port-offset 1; an HTTP POST to /api/integrations/google-oauth/login on localhost:8001 reaches the registered route and returns request validation for an intentionally incomplete payload.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes local dev port mismatches by starting toolshed with offset-aware internal URLs. Prevents OAuth callback crashes by keeping the runtime, pattern environment, and remote memory client on the same offset port.

- **Bug Fixes**
  - With `--port-offset`, set `API_URL` and `MEMORY_URL` to `http://localhost:$TOOLSHED_PORT` unless already exported.
  - Google OAuth now completes on the offset port (e.g., 8001) without memory URL conflicts.
  - Updated docs to note the new port-offset behavior.

<sup>Written for commit 8c30be454719047cd42fd5e17b363fe36ea6b159. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

