### PR TITLE
fix(runner): fail closed on unevaluable CFC policy $refs in value matching

### DIFF
--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2392,7 +2392,13 @@ const verifyInputRequirements = (
 
   for (const entry of walkIfcSchema(schema)) {
     if (
-      !ifcEntryAppliesToAttemptedWrite(tx, target, entry.path, entry.schema, entry.root)
+      !ifcEntryAppliesToAttemptedWrite(
+        tx,
+        target,
+        entry.path,
+        entry.schema,
+        entry.root,
+      )
     ) {
       continue;
     }

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1463,7 +1463,15 @@ const walkIfcSchema = (
   schema: JSONSchema,
   path: readonly string[] = [],
   entries: Array<
-    { path: readonly string[]; label: IFCLabel; schema: JSONSchema }
+    {
+      path: readonly string[];
+      label: IFCLabel;
+      schema: JSONSchema;
+      // Document carrying the `$defs` that resolves refs inside `schema`.
+      // `schema` is the bare ifc node (no `$defs` of its own), so value-condition
+      // refs only resolve against this root — thread it to the policy matcher.
+      root: JSONSchema;
+    }
   > = [],
   root: JSONSchema = schema,
   active: Set<JSONSchema> = new Set(),
@@ -1498,6 +1506,7 @@ const walkIfcSchema = (
             : undefined,
         },
         schema: resolved,
+        root: childRoot,
       });
     }
 
@@ -2096,17 +2105,26 @@ export const wildcardPolicyMatchesValue = (
   },
   schema: JSONSchema | undefined,
   value: unknown,
+  // Schema document that resolves `$ref`s inside `schema`. walkIfcSchema
+  // captures an ifc node WITHOUT the document's `$defs` (those live on the
+  // outer root), so a value-condition ref like `items: {$ref: "#/$defs/X"}`
+  // only resolves when the root carrying `$defs` is threaded in. Without it the
+  // ref is spuriously unevaluable and the entry would fail closed on a perfectly
+  // valid policy. Defaults to `schema` for callers whose schema is already
+  // self-contained (e.g. the unit-test surface).
+  root?: JSONSchema,
 ): boolean => {
   if (schema === undefined) {
     return true;
   }
+  const resolutionRoot = root ?? schema;
 
   // An unevaluable policy `$ref` (UnevaluablePolicyRefError) fails closed:
   // treat the entry as applying rather than letting a broken/poisoned schema
   // envelope silently exclude its writeAuthorizedBy/maxConfidentiality checks.
   const matches = (candidate: unknown): boolean => {
     try {
-      return policySchemaMatchesValue(schema, candidate);
+      return policySchemaMatchesValue(schema, candidate, resolutionRoot);
     } catch (error) {
       if (error instanceof UnevaluablePolicyRefError) {
         return true;
@@ -2140,6 +2158,10 @@ const ifcEntryAppliesToAttemptedWrite = (
   },
   path: readonly string[],
   schema?: JSONSchema,
+  // Document root that resolves `$ref`s inside `schema` (see
+  // wildcardPolicyMatchesValue). Threaded from walkIfcSchema entries, whose
+  // captured ifc node lacks the document's `$defs`.
+  root?: JSONSchema,
 ): boolean => {
   const wildcardIndex = path.indexOf("*");
   if (wildcardIndex === -1) {
@@ -2190,13 +2212,13 @@ const ifcEntryAppliesToAttemptedWrite = (
     })();
     if (path.length === 0) {
       return value === undefined ||
-        wildcardPolicyMatchesValue(tx, target, schema, value);
+        wildcardPolicyMatchesValue(tx, target, schema, value, root);
     }
     if (value === undefined) {
       return previousWriteValueForTarget(tx, pathTarget) !== undefined;
     }
     return value !== undefined &&
-      wildcardPolicyMatchesValue(tx, target, schema, value);
+      wildcardPolicyMatchesValue(tx, target, schema, value, root);
   }
 
   const exactAttemptedPaths = [
@@ -2219,6 +2241,7 @@ const ifcEntryAppliesToAttemptedWrite = (
         target,
         schema,
         writeValueForTarget(tx, { ...target, path: writePath }),
+        root,
       )
     );
   }
@@ -2234,7 +2257,7 @@ const ifcEntryAppliesToAttemptedWrite = (
     const writePath = write.address.path.slice(1).map((entry) => String(entry));
     if (pathPatternMatches(path, writePath)) {
       return !deepEqual(write.value, write.previousValue) &&
-        wildcardPolicyMatchesValue(tx, target, schema, write.value);
+        wildcardPolicyMatchesValue(tx, target, schema, write.value, root);
     }
     if (concretePathHasPrefix(prefix, writePath)) {
       const relativePrefix = prefix.slice(writePath.length);
@@ -2249,7 +2272,7 @@ const ifcEntryAppliesToAttemptedWrite = (
       );
       if (
         matches.some((match) =>
-          wildcardPolicyMatchesValue(tx, target, schema, match)
+          wildcardPolicyMatchesValue(tx, target, schema, match, root)
         )
       ) {
         return true;
@@ -2267,7 +2290,7 @@ const ifcEntryAppliesToAttemptedWrite = (
   }
   const matches = valuesAtPatternPath(value, path.slice(wildcardIndex));
   return matches.some((match) =>
-    wildcardPolicyMatchesValue(tx, target, schema, match)
+    wildcardPolicyMatchesValue(tx, target, schema, match, root)
   );
 };
 
@@ -2369,7 +2392,7 @@ const verifyInputRequirements = (
 
   for (const entry of walkIfcSchema(schema)) {
     if (
-      !ifcEntryAppliesToAttemptedWrite(tx, target, entry.path, entry.schema)
+      !ifcEntryAppliesToAttemptedWrite(tx, target, entry.path, entry.schema, entry.root)
     ) {
       continue;
     }
@@ -2496,7 +2519,13 @@ const verifyExactCopyRequirements = (
     // Without this gate an untouched entry compares undefined to undefined and
     // passes vacuously, accepting the claim (and copying its label) unverified.
     if (
-      !ifcEntryAppliesToAttemptedWrite(tx, target, entry.path, entry.schema)
+      !ifcEntryAppliesToAttemptedWrite(
+        tx,
+        target,
+        entry.path,
+        entry.schema,
+        entry.root,
+      )
     ) {
       continue;
     }
@@ -3246,7 +3275,13 @@ export const prepareBoundaryCommit = (
     const persistedLabelEntries: LabelMapEntry[] = mergedSchemaEntries
       .flatMap((entry) => {
         if (
-          !ifcEntryAppliesToAttemptedWrite(tx, target, entry.path, entry.schema)
+          !ifcEntryAppliesToAttemptedWrite(
+            tx,
+            target,
+            entry.path,
+            entry.schema,
+            entry.root,
+          )
         ) {
           return [];
         }

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1998,6 +1998,14 @@ const schemaTypeMatchesValue = (
   });
 };
 
+// Thrown when a policy `$ref` cannot be resolved against its own document, so
+// the value condition cannot be evaluated. It propagates past the matcher's
+// boolean combinators (notably `oneOf`'s exactly-one count, where neither
+// `true` nor `false` reliably biases toward "applies") and is caught at the
+// `wildcardPolicyMatchesValue` boundary, which fails closed by treating the
+// ifc entry as applying — mirroring the unresolvable-LINK branch (audit S17).
+class UnevaluablePolicyRefError extends Error {}
+
 const policySchemaMatchesValue = (
   schema: JSONSchema,
   value: unknown,
@@ -2019,12 +2027,16 @@ const policySchemaMatchesValue = (
       schema,
       schemaRoot,
     );
-    if (resolved === undefined) {
-      return false;
+    // An unresolvable policy ref (missing/dropped `$def`, or a ref that
+    // resolves to itself with no progress) leaves the condition unevaluable.
+    // Unlike S17's author-controlled LINK schema, this schema IS the policy we
+    // enforce, but the same rule holds: an unevaluable condition must never
+    // silently exclude the entry (fail open) — signal it so the boundary fails
+    // closed.
+    if (resolved === undefined || resolved === schema) {
+      throw new UnevaluablePolicyRefError(schema.$ref);
     }
-    return resolved !== schema
-      ? policySchemaMatchesValue(resolved, value, schemaRoot)
-      : false;
+    return policySchemaMatchesValue(resolved, value, schemaRoot);
   }
   if (schema.const !== undefined && !deepEqual(schema.const, value)) {
     return false;
@@ -2089,13 +2101,27 @@ export const wildcardPolicyMatchesValue = (
     return true;
   }
 
+  // An unevaluable policy `$ref` (UnevaluablePolicyRefError) fails closed:
+  // treat the entry as applying rather than letting a broken/poisoned schema
+  // envelope silently exclude its writeAuthorizedBy/maxConfidentiality checks.
+  const matches = (candidate: unknown): boolean => {
+    try {
+      return policySchemaMatchesValue(schema, candidate);
+    } catch (error) {
+      if (error instanceof UnevaluablePolicyRefError) {
+        return true;
+      }
+      throw error;
+    }
+  };
+
   if (!isPrimitiveCellLink(value)) {
-    return policySchemaMatchesValue(schema, value);
+    return matches(value);
   }
 
   const linkedValue = linkedWriteValueForPolicy(tx, target, value);
   if (linkedValue !== undefined) {
-    return policySchemaMatchesValue(schema, linkedValue);
+    return matches(linkedValue);
   }
 
   // The link's target value is unresolvable, so the policy's value condition

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -375,6 +375,13 @@ const mergeSchemaNode = (
     mergedItems = right.items;
   }
 
+  // `$defs` is not merged: `{...left, ...right}` lets a `right` envelope that
+  // declares its own `$defs` replace `left`'s wholesale, which can leave a
+  // surviving `items`/`properties` `$ref` (e.g. `#/$defs/Element`) pointing at
+  // a dropped def. The merged envelope's ifc (incl. writeAuthorizedBy) still
+  // rides on the node, so the policy matcher must not let the now-unresolvable
+  // value-condition ref exclude the entry — `policySchemaMatchesValue` in
+  // prepare.ts fails closed on unevaluable refs for exactly this reason.
   return {
     ...left,
     ...right,

--- a/packages/runner/test/cfc-policy-schema-ref-resolution.test.ts
+++ b/packages/runner/test/cfc-policy-schema-ref-resolution.test.ts
@@ -114,6 +114,54 @@ describe("CFC writeAuthorizedBy policy applies when its value-condition $ref is 
     ).toBe(true);
   });
 
+  it("resolves a value-condition $ref against the threaded document root", () => {
+    // The real walkIfcSchema shape: the captured ifc node is the bare array
+    // envelope WITHOUT `$defs` (those live on the outer document the walk
+    // descended from). The policy matcher only resolves `#/$defs/Element` when
+    // that document root is threaded in (the `root` argument), so a legitimate
+    // generated policy must NOT be treated as unevaluable. Without the threaded
+    // root the same ref is spuriously unresolvable and the entry would fail
+    // closed on a perfectly valid write (the default-app notebook reload
+    // regression).
+    const ifcNode = {
+      type: "array",
+      items: { $ref: "#/$defs/Element" },
+      ifc: { writeAuthorizedBy: ["trusted-handler"] },
+    } as const satisfies JSONSchema;
+    const documentRoot = {
+      type: "object",
+      properties: { elements: ifcNode },
+      $defs: {
+        Element: {
+          type: "object",
+          properties: { cell: true, tag: { type: "string" } },
+        },
+      },
+    } as const satisfies JSONSchema;
+
+    // Threaded root => ref resolves => the matcher evaluates the real items and
+    // the entry applies for a matching value.
+    expect(
+      wildcardPolicyMatchesValue(tx, target, ifcNode, [
+        { cell: { some: "link" }, tag: "note" },
+      ], documentRoot),
+    ).toBe(true);
+    // A value that violates the resolved items schema does NOT match — proving
+    // the ref actually resolved (rather than short-circuiting to "applies").
+    expect(
+      wildcardPolicyMatchesValue(tx, target, ifcNode, [
+        { cell: { some: "link" }, tag: 42 },
+      ], documentRoot),
+    ).toBe(false);
+    // Same node WITHOUT the threaded root: the bare node has no `$defs`, so the
+    // ref is genuinely unevaluable and the entry fails closed (applies).
+    expect(
+      wildcardPolicyMatchesValue(tx, target, ifcNode, [
+        { cell: { some: "link" }, tag: 42 },
+      ]),
+    ).toBe(true);
+  });
+
   it("does not let an unresolvable branch suppress a matched oneOf entry", () => {
     // Regression guard for the matcher's oneOf arm specifically: returning a
     // plain `true` for the unresolvable branch would make two branches "match"

--- a/packages/runner/test/cfc-policy-schema-ref-resolution.test.ts
+++ b/packages/runner/test/cfc-policy-schema-ref-resolution.test.ts
@@ -59,7 +59,13 @@ describe("CFC policy value matching resolves $refs against the schema root", () 
     })).toBe(false);
   });
 
-  it("still fails closed on a genuinely unresolvable nested $ref", () => {
+  it("fails closed (entry applies) on a genuinely unresolvable nested $ref", () => {
+    // A value-condition ref that cannot be resolved against its own document
+    // leaves the policy unevaluable. The policy schema is the authority we are
+    // enforcing, so an unevaluable condition must NOT silently exclude the ifc
+    // entry — that would skip its writeAuthorizedBy/maxConfidentiality checks
+    // (fail open). `wildcardPolicyMatchesValue` returning true here means the
+    // entry applies, mirroring the unresolvable-LINK branch (audit S17).
     const schema = {
       type: "array",
       items: { $ref: "#/$defs/Missing" },
@@ -69,6 +75,58 @@ describe("CFC policy value matching resolves $refs against the schema root", () 
     } as const satisfies JSONSchema;
 
     expect(wildcardPolicyMatchesValue(tx, target, schema, [{ x: 1 }]))
-      .toBe(false);
+      .toBe(true);
+  });
+});
+
+// A write-authority policy whose value condition is carried by a `$ref` (the
+// generated array-items shape) must still apply when that ref is unresolvable.
+// Otherwise `ifcEntryAppliesToAttemptedWrite` treats the `writeAuthorizedBy`
+// entry as not applying and the protected write is accepted unverified — a
+// fail-open direction the nearby comment ("must fail closed on unresolved
+// refs") and the S17 link branch both forbid.
+describe("CFC writeAuthorizedBy policy applies when its value-condition $ref is unresolvable", () => {
+  const space = "did:key:policy-schema-refs" as const;
+  const target = { space, id: "of:guarded" as const, scope: "space" as const };
+  const tx = {
+    getWriteDetails: () => [],
+    readValueOrThrow: () => undefined,
+  } as unknown as IExtendedStorageTransaction;
+
+  it("applies (fail closed) when the items $ref names a dropped $def", () => {
+    // The shape a poisoned merge produces: the writeAuthorizedBy-bearing array
+    // envelope still references `#/$defs/Element`, but `$defs` no longer carries
+    // it (a candidate envelope replaced `$defs` wholesale via the
+    // `{...left, ...right}` spread in mergeSchemaNode).
+    const schema = {
+      type: "array",
+      items: { $ref: "#/$defs/Element" },
+      ifc: { writeAuthorizedBy: ["trusted-handler"] },
+      $defs: {
+        SomethingElse: { type: "object" },
+      },
+    } as const satisfies JSONSchema;
+
+    expect(
+      wildcardPolicyMatchesValue(tx, target, schema, [
+        { cell: { some: "link" } },
+      ]),
+    ).toBe(true);
+  });
+
+  it("does not let an unresolvable branch suppress a matched oneOf entry", () => {
+    // Regression guard for the matcher's oneOf arm specifically: returning a
+    // plain `true` for the unresolvable branch would make two branches "match"
+    // and flip `filter(...).length === 1` to false (fail open). The
+    // unevaluable-ref signal must short-circuit the whole match to "applies".
+    const schema = {
+      oneOf: [
+        { type: "object", properties: { kind: { const: "a" } } },
+        { $ref: "#/$defs/Missing" },
+      ],
+    } as const satisfies JSONSchema;
+
+    expect(wildcardPolicyMatchesValue(tx, target, schema, { kind: "a" }))
+      .toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Closes a fail-open direction in CFC write-policy applicability.

`policySchemaMatchesValue` returned `false` when a policy schema's value-condition `$ref` was **genuinely unresolvable** (missing/dropped `$def`, or a self-resolving ref). That `false` propagates up through `wildcardPolicyMatchesValue` → `ifcEntryAppliesToAttemptedWrite` as **"entry does not apply"**, so `verifyInputRequirements` skips the entry — silently dropping its `writeAuthorizedBy` / `maxConfidentiality` enforcement. This is **fail-open**, contradicting:

- the matcher's own comment ("CFC policy checks must fail closed on unresolved refs"), and
- the unresolvable-**LINK** branch (audit **S17**) in the same function, which returns `true` (entry applies = fail closed).

The previous test even mislabeled this: it asserted the matcher returns `false` and called that "fails closed" — but `false` here is fail-**open**. Corrected.

Builds on the root-threading base fix (#4121, now merged).

## How an unresolvable policy ref can arise

`mergeCfcSchemaEnvelopes` can produce exactly this poisoned shape. `mergeSchemaNode` spreads `{...left, ...right}`, so a candidate envelope that declares its **own** `$defs` replaces the existing `$defs` **wholesale**, while a surviving `items`/`properties` `$ref` (and the `writeAuthorizedBy` ifc) still ride on the node:

```
existing: { type:"array", items:{$ref:"#/$defs/Element"}, ifc:{writeAuthorizedBy:["trusted-handler"]}, $defs:{ Element: {...} } }
candidate:{ type:"array", items:{$ref:"#/$defs/Element"}, $defs:{ SomethingElse: {...} } }
merged:   { type:"array", items:{$ref:"#/$defs/Element"}, ifc:{writeAuthorizedBy:["trusted-handler"]}, $defs:{ SomethingElse: {...} } }  // Element ref now unresolvable
```

(A candidate **without** `$defs` does *not* drop the existing `$defs` — the spread preserves the left key — so that specific direction is unfounded.)

## Fix

- `policySchemaMatchesValue`: an unresolvable ref now throws `UnevaluablePolicyRefError` instead of returning `false`. Throwing (rather than returning `true`) is deliberate — a plain `true` would mis-bias `oneOf`'s exactly-one count and could *itself* re-introduce a fail-open. The throw short-circuits past all boolean combinators.
- `wildcardPolicyMatchesValue`: catches the sentinel and returns `true` (entry applies = fail closed), mirroring the S17 link branch. This is the chokepoint — it covers *any* cause of an unresolvable policy ref, not only the merge.
- `schema-merge.ts`: comment documenting the wholesale `$defs` replacement and the matcher's fail-closed reliance.

Resolvable refs are unaffected (root threading from #4121 is intact); only genuinely broken policy schemas now **enforce** instead of silently skipping.

## Tests

- Updated the mislabeled regression to expect `true` (genuine fail-closed).
- Added a `writeAuthorizedBy`-bearing test for the dropped-`$def` shape, plus a `oneOf` guard ensuring the unevaluable signal doesn't suppress a matched branch.
- Red → green confirmed; all 59 CFC runner test files (289 steps) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- Perf-check noise overrides: marginal multi-user pattern-test wall-time
variance (lunch-poll), unrelated to this runner-only CFC change. The job:Check
spike was pure deps-install runner variance and is being refreshed via job rerun
rather than baselined. -->
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/main.test.tsx = 27s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/multi-user.test.tsx = 52s
