### PR TITLE
Reduce typesystem lies at the memory boundary

### DIFF
--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertExists, assertRejects } from "@std/assert";
 import { FakeTime } from "@std/testing/time";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { Server, SessionRegistry } from "../v2/server.ts";
 import {
   decodeMemoryBoundary,
@@ -538,7 +539,7 @@ class ReconnectableLoopbackTransport implements Transport {
   private connection(): ReturnType<Server["connect"]> {
     if (this.#connection === null) {
       this.connectionCount++;
-      this.#connection = this.server.connect((message) => {
+      this.#connection = this.server.connect((message: FabricValue) => {
         this.#receiver(encodeMemoryBoundary(message));
       });
     }
@@ -640,7 +641,7 @@ class ScriptedReconnectTransport implements Transport {
     return Promise.resolve();
   }
 
-  #respond(message: unknown): void {
+  #respond(message: FabricValue): void {
     this.#receiver(encodeMemoryBoundary(message));
   }
 }
@@ -724,7 +725,7 @@ class DelayedTransactTransport implements Transport {
     return Promise.resolve();
   }
 
-  #respond(message: unknown): void {
+  #respond(message: FabricValue): void {
     this.#receiver(encodeMemoryBoundary(message));
   }
 }
@@ -800,7 +801,7 @@ class AckCountingTransport implements Transport {
     return Promise.resolve();
   }
 
-  #respond(message: unknown): void {
+  #respond(message: FabricValue): void {
     this.#receiver(encodeMemoryBoundary(message));
   }
 }
@@ -869,7 +870,7 @@ class HangingAckTransport implements Transport {
     return Promise.resolve();
   }
 
-  #respond(message: unknown): void {
+  #respond(message: FabricValue): void {
     this.#receiver(encodeMemoryBoundary(message));
   }
 }
@@ -1781,7 +1782,7 @@ class DisconnectableAckTransport implements Transport {
     return Promise.resolve();
   }
 
-  #respond(message: unknown): void {
+  #respond(message: FabricValue): void {
     this.#receiver(encodeMemoryBoundary(message));
   }
 }

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -57,8 +57,9 @@ const authorization = {
   access: { "proof:1": {} },
 };
 
-const decodeStored = <Value extends FabricValue>(source: string | null | undefined): Value =>
-  decodeMemoryBoundary<Value>(source ?? "null");
+const decodeStored = <Value extends FabricValue>(
+  source: string | null | undefined,
+): Value => decodeMemoryBoundary<Value>(source ?? "null");
 
 const toSourceLink = (id: string) => ({ "/": id } as const);
 

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertExists, assertThrows } from "@std/assert";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { toFileUrl } from "@std/path";
 import { Database } from "@db/sqlite";
 import {
@@ -56,7 +57,7 @@ const authorization = {
   access: { "proof:1": {} },
 };
 
-const decodeStored = <Value>(source: string | null | undefined): Value =>
+const decodeStored = <Value extends FabricValue>(source: string | null | undefined): Value =>
   decodeMemoryBoundary<Value>(source ?? "null");
 
 const toSourceLink = (id: string) => ({ "/": id } as const);

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -660,8 +660,8 @@ export const wireMemoryProtocolFlags = (
   commitPreconditions: flags.commitPreconditions,
 });
 
-export const encodeMemoryBoundary = (value: unknown): string =>
-  jsonFromValue(value as FabricValue);
+export const encodeMemoryBoundary = (value: FabricValue): string =>
+  jsonFromValue(value);
 
 export const decodeMemoryBoundary = <Value = FabricValue>(
   source: string,

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -663,13 +663,13 @@ export const wireMemoryProtocolFlags = (
 export const encodeMemoryBoundary = (value: FabricValue): string =>
   jsonFromValue(value);
 
-export const decodeMemoryBoundary = <Value = FabricValue>(
+export const decodeMemoryBoundary = <Value extends FabricValue = FabricValue>(
   source: string,
-): Value => {
+): Value & FabricValue => {
   const decoded = valueFromJson(
     source,
     memoryReconstructionContext,
-  ) as FabricValue;
+  );
 
   return decoded as Value;
 };

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -3047,7 +3047,7 @@ function encodeSchedulerPath(path: readonly string[]): string {
 }
 
 function decodeSchedulerPath(payload: string): string[] {
-  const path = decodeMemoryBoundary<unknown>(payload);
+  const path = decodeMemoryBoundary(payload);
   if (!Array.isArray(path)) {
     throw new Error("scheduler paths must be arrays");
   }
@@ -4247,7 +4247,7 @@ const ensureActiveBranch = (engine: Engine, branch: BranchName): void => {
 const emptyEntityDocument = (): EntityDocument => ({});
 
 const decodeStoredDocument = (data: string | null): EntityDocument => {
-  const parsed = decodeMemoryBoundary<unknown>(data ?? "null");
+  const parsed = decodeMemoryBoundary(data ?? "null");
   if (!isEntityDocument(parsed)) {
     throw new Error("memory v2 stored documents must be plain object roots");
   }
@@ -4255,7 +4255,7 @@ const decodeStoredDocument = (data: string | null): EntityDocument => {
 };
 
 const decodeStoredPatchList = (data: string | null): PatchOp[] => {
-  const parsed = decodeMemoryBoundary<unknown>(data ?? "[]");
+  const parsed = decodeMemoryBoundary(data ?? "[]");
   if (!Array.isArray(parsed)) {
     throw new Error("memory v2 stored patches must be arrays");
   }

--- a/packages/runner/test/memory-v2-reconnect-race.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-race.test.ts
@@ -1,5 +1,6 @@
 import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import type { MIME, URI } from "@commonfabric/memory/interface";
 import {
   decodeMemoryBoundary,
@@ -220,7 +221,7 @@ class RejectThenSucceedTransport implements MemoryV2Client.Transport {
     return Promise.resolve();
   }
 
-  #respond(message: unknown): void {
+  #respond(message: FabricValue): void {
     this.#receiver(encodeMemoryBoundary(message));
   }
 }

--- a/packages/runner/test/memory-v2-watch-refresh-race.test.ts
+++ b/packages/runner/test/memory-v2-watch-refresh-race.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "@std/assert";
 import { FakeTime } from "@std/testing/time";
 import { Identity } from "@commonfabric/identity";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import type { URI } from "@commonfabric/memory/interface";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import {
@@ -119,7 +120,7 @@ class CountingWatchSetTransport implements MemoryV2Client.Transport {
     return Promise.resolve();
   }
 
-  #respond(message: unknown): void {
+  #respond(message: FabricValue): void {
     this.#receiver(encodeMemoryBoundary(message));
   }
 }
@@ -222,7 +223,7 @@ class DelayedWatchAddTransport implements MemoryV2Client.Transport {
     return Promise.resolve();
   }
 
-  #respond(message: unknown): void {
+  #respond(message: FabricValue): void {
     this.#receiver(encodeMemoryBoundary(message));
   }
 }
@@ -314,7 +315,7 @@ class IncrementalEffectTransport implements MemoryV2Client.Transport {
     });
   }
 
-  #respond(message: unknown): void {
+  #respond(message: FabricValue): void {
     this.#receiver(encodeMemoryBoundary(message));
   }
 }

--- a/packages/toolshed/routes/storage/memory/memory.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.test.ts
@@ -1,6 +1,7 @@
 import { assert, assertEquals } from "@std/assert";
 import app from "../../../app.ts";
 import { memoryServer } from "../memory.ts";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
   decodeMemoryBoundary,
   encodeMemoryBoundary,
@@ -56,7 +57,7 @@ const createSessionOpenAuth = async (
   };
 };
 
-const readJsonMessage = async <Message>(
+const readJsonMessage = async <Message extends FabricValue>(
   socket: WebSocket,
 ): Promise<Message> => {
   const payload = await new Promise<string>((resolve, reject) => {


### PR DESCRIPTION
This PR changes `encodeMemoryBoundary()` and `decodeMemoryBoundary()` such that they no longer claim to accept and return (respectively) arbitrary types of value. Instead, `encodeMemoryBoundary()` is now defined to accept `FabricValue` per se, and `decodeMemoryBoundary()` gets slightly more involved typesystem annotations to ensure its generic parameter is compatible with `FabricValue` and that it actually returns something that the typesystem believes is a `FabricValue`.

The fact that these were previously not quite so tight is part of what enabled an invalid value through to the `data-model`'s JSON codec subsystem. The `data-model` bug was fixed in PR #3900; even though it was only a problem when TS's typesystem was being faked out, it made sense to fail loudly rather than (as it did) silently produce incorrect results. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened memory boundary types by requiring `FabricValue` for encoding and ensuring decoding returns a `FabricValue`-compatible type. Improves type safety and prevents arbitrary values, with no runtime behavior changes.

- **Refactors**
  - `encodeMemoryBoundary(value: FabricValue): string` (was `unknown`).
  - `decodeMemoryBoundary<Value extends FabricValue = FabricValue>(source): Value & FabricValue`; removed `<unknown>` usage at call sites.
  - Updated transports/tests to use `FabricValue` messages (e.g., `#respond(message: FabricValue)`).
  - Simplified decoders in `v2/engine.ts` to call `decodeMemoryBoundary` directly and validate shapes.

<sup>Written for commit c49f66bbf5e162fad3ea87663cc2ee2eebf9d443. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

