### PR TITLE
Add cfcheck pattern verification task

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -43,6 +43,9 @@ jobs:
       - name: 🔎 Type check codebase
         run: deno task check
 
+      - name: 🔎 Check Common Fabric patterns
+        run: deno task cfcheck
+
       - name: 🧭 Check cf-review skill facts
         run: deno task check-skill-facts
 

--- a/deno.json
+++ b/deno.json
@@ -38,6 +38,7 @@
   ],
   "tasks": {
     "check": "./tasks/check.sh",
+    "cfcheck": "deno run -A ./tasks/cfcheck.ts",
     "check-skill-facts": "deno test --allow-read skills/cf-review/check-facts.ts",
     "cf": "deno run --allow-run --allow-env --allow-read ./packages/cli/launcher.ts",
     "test": "./tasks/test.ts",

--- a/packages/patterns/airtable/airtable-importer.tsx
+++ b/packages/patterns/airtable/airtable-importer.tsx
@@ -72,7 +72,7 @@ const fetchBases = handler<
   loading.set(true);
   error.set("");
   try {
-    const client = new AirtableClient(auth);
+    const client = AirtableClient(auth);
     const result = await client.listBases();
     bases.set(result.map((b) => ({ id: b.id, name: b.name })));
   } catch (e) {
@@ -96,7 +96,7 @@ const fetchTables = handler<
   loading.set(true);
   error.set("");
   try {
-    const client = new AirtableClient(auth);
+    const client = AirtableClient(auth);
     const result = await client.listTables(baseId);
     tables.set(result.map((t) => ({ id: t.id, name: t.name })));
   } catch (e) {
@@ -121,7 +121,7 @@ const fetchRecords = handler<
   loading.set(true);
   error.set("");
   try {
-    const client = new AirtableClient(auth);
+    const client = AirtableClient(auth);
     const result = await client.listRecords(baseId, tableId, {
       maxRecords: 500,
     });

--- a/packages/patterns/airtable/core/util/airtable-client.ts
+++ b/packages/patterns/airtable/core/util/airtable-client.ts
@@ -5,15 +5,13 @@
  * ```typescript
  * import { AirtableClient } from "./util/airtable-client.ts";
  *
- * const client = new AirtableClient(authCell, { debugMode: true });
+ * const client = AirtableClient(authCell, { debugMode: true });
  * const bases = await client.listBases();
  * const tables = await client.listTables(baseId);
  * const records = await client.listRecords(baseId, tableId);
  * ```
  */
 import { getPatternEnvironment, Writable } from "commonfabric";
-
-const env = getPatternEnvironment();
 
 import type { AirtableAuth as AirtableAuthType } from "../airtable-auth.tsx";
 
@@ -83,40 +81,41 @@ function debugLog(debugMode: boolean, ...args: unknown[]) {
 const AIRTABLE_API_BASE = "https://api.airtable.com/v0";
 const AIRTABLE_META_BASE = "https://api.airtable.com/v0/meta";
 
-export class AirtableClient {
-  private authCell: Writable<AirtableAuthType>;
-  private retries: number;
-  private delay: number;
-  private debugMode: boolean;
-  private onRefresh?: () => Promise<void>;
+export interface AirtableClient {
+  listBases(): Promise<AirtableBase[]>;
+  listTables(baseId: string): Promise<AirtableTable[]>;
+  listRecords(
+    baseId: string,
+    tableIdOrName: string,
+    options?: ListRecordsOptions,
+  ): Promise<AirtableRecord[]>;
+}
 
-  constructor(
-    authCell: Writable<AirtableAuthType>,
-    config: AirtableClientConfig = {},
-  ) {
-    this.authCell = authCell;
-    this.retries = config.retries ?? 2;
-    this.delay = config.delay ?? 1000;
-    this.debugMode = config.debugMode ?? false;
-    this.onRefresh = config.onRefresh;
-  }
+export function AirtableClient(
+  authCell: Writable<AirtableAuthType>,
+  config: AirtableClientConfig = {},
+): AirtableClient {
+  const retries = config.retries ?? 2;
+  const delay = config.delay ?? 1000;
+  const debugMode = config.debugMode ?? false;
+  const onRefresh = config.onRefresh;
 
-  private getToken(): string {
-    const auth = this.authCell.get();
+  function getToken(): string {
+    const auth = authCell.get();
     return auth?.accessToken || "";
   }
 
   /**
    * Make an authenticated API request with retry and token refresh.
    */
-  private async request<T>(
+  async function request<T>(
     url: string,
     options: RequestInit = {},
   ): Promise<T> {
     let lastError: Error | null = null;
 
-    for (let attempt = 0; attempt <= this.retries; attempt++) {
-      const token = this.getToken();
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      const token = getToken();
       if (!token) {
         throw new Error("No access token available");
       }
@@ -132,19 +131,17 @@ export class AirtableClient {
         });
 
         if (response.status === 401) {
-          debugLog(this.debugMode, "Got 401, attempting token refresh...");
-          await this.refreshToken();
+          debugLog(debugMode, "Got 401, attempting token refresh...");
+          await refreshToken();
           continue;
         }
 
         if (response.status === 429) {
           const retryAfter = response.headers.get("Retry-After");
           const parsed = retryAfter ? parseInt(retryAfter, 10) : NaN;
-          const waitMs = !isNaN(parsed)
-            ? parsed * 1000
-            : this.delay * (attempt + 1);
+          const waitMs = !isNaN(parsed) ? parsed * 1000 : delay * (attempt + 1);
           debugLog(
-            this.debugMode,
+            debugMode,
             `Rate limited, waiting ${waitMs}ms...`,
           );
           await sleep(waitMs);
@@ -161,13 +158,13 @@ export class AirtableClient {
         return (await response.json()) as T;
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
-        if (attempt < this.retries) {
+        if (attempt < retries) {
           debugLog(
-            this.debugMode,
-            `Request failed (attempt ${attempt + 1}/${this.retries + 1}):`,
+            debugMode,
+            `Request failed (attempt ${attempt + 1}/${retries + 1}):`,
             lastError.message,
           );
-          await sleep(this.delay);
+          await sleep(delay);
         }
       }
     }
@@ -178,18 +175,19 @@ export class AirtableClient {
   /**
    * Refresh the access token via the server endpoint.
    */
-  private async refreshToken(): Promise<void> {
-    if (this.onRefresh) {
-      await this.onRefresh();
+  async function refreshToken(): Promise<void> {
+    if (onRefresh) {
+      await onRefresh();
       return;
     }
 
-    const auth = this.authCell.get();
+    const auth = authCell.get();
     const refreshToken = auth?.refreshToken;
     if (!refreshToken) {
       throw new Error("No refresh token available");
     }
 
+    const env = getPatternEnvironment();
     const res = await fetch(
       new URL("/api/integrations/airtable-oauth/refresh", env.apiUrl),
       {
@@ -208,12 +206,12 @@ export class AirtableClient {
       throw new Error("Invalid refresh response");
     }
 
-    this.authCell.update({
+    authCell.update({
       ...json.tokenInfo,
       user: auth.user,
     });
 
-    debugLog(this.debugMode, "Token refreshed successfully");
+    debugLog(debugMode, "Token refreshed successfully");
   }
 
   // ==========================================================================
@@ -223,8 +221,8 @@ export class AirtableClient {
   /**
    * List all accessible bases.
    */
-  async listBases(): Promise<AirtableBase[]> {
-    debugLog(this.debugMode, "Listing bases...");
+  async function listBases(): Promise<AirtableBase[]> {
+    debugLog(debugMode, "Listing bases...");
 
     const bases: AirtableBase[] = [];
     let offset: string | undefined;
@@ -233,7 +231,7 @@ export class AirtableClient {
       const url = new URL(`${AIRTABLE_META_BASE}/bases`);
       if (offset) url.searchParams.set("offset", offset);
 
-      const response = await this.request<{
+      const response = await request<{
         bases: AirtableBase[];
         offset?: string;
       }>(url.toString());
@@ -242,34 +240,36 @@ export class AirtableClient {
       offset = response.offset;
     } while (offset);
 
-    debugLog(this.debugMode, `Found ${bases.length} bases`);
+    debugLog(debugMode, `Found ${bases.length} bases`);
     return bases;
   }
 
   /**
    * List all tables in a base.
    */
-  async listTables(baseId: string): Promise<AirtableTable[]> {
-    debugLog(this.debugMode, `Listing tables for base ${baseId}...`);
+  async function listTables(
+    baseId: string,
+  ): Promise<AirtableTable[]> {
+    debugLog(debugMode, `Listing tables for base ${baseId}...`);
 
-    const response = await this.request<{ tables: AirtableTable[] }>(
+    const response = await request<{ tables: AirtableTable[] }>(
       `${AIRTABLE_META_BASE}/bases/${baseId}/tables`,
     );
 
-    debugLog(this.debugMode, `Found ${response.tables.length} tables`);
+    debugLog(debugMode, `Found ${response.tables.length} tables`);
     return response.tables;
   }
 
   /**
    * List records from a table with pagination.
    */
-  async listRecords(
+  async function listRecords(
     baseId: string,
     tableIdOrName: string,
     options: ListRecordsOptions = {},
   ): Promise<AirtableRecord[]> {
     debugLog(
-      this.debugMode,
+      debugMode,
       `Listing records from ${baseId}/${tableIdOrName}...`,
     );
 
@@ -310,7 +310,7 @@ export class AirtableClient {
         }
       }
 
-      const response = await this.request<{
+      const response = await request<{
         records: AirtableRecord[];
         offset?: string;
       }>(url.toString());
@@ -324,7 +324,9 @@ export class AirtableClient {
     } while (offset);
 
     const result = records.slice(0, maxRecords);
-    debugLog(this.debugMode, `Fetched ${result.length} records`);
+    debugLog(debugMode, `Fetched ${result.length} records`);
     return result;
   }
+
+  return { listBases, listTables, listRecords };
 }

--- a/packages/patterns/tools/importer-prompt.ts
+++ b/packages/patterns/tools/importer-prompt.ts
@@ -1078,15 +1078,13 @@ const AIRTABLE_CLIENT_SOURCE = `/**
  * \\\`\\\`\\\`typescript
  * import { AirtableClient } from "./util/airtable-client.ts";
  *
- * const client = new AirtableClient(authCell, { debugMode: true });
+ * const client = AirtableClient(authCell, { debugMode: true });
  * const bases = await client.listBases();
  * const tables = await client.listTables(baseId);
  * const records = await client.listRecords(baseId, tableId);
  * \\\`\\\`\\\`
  */
 import { getPatternEnvironment, Writable } from "commonfabric";
-
-const env = getPatternEnvironment();
 
 import type { AirtableAuth as AirtableAuthType } from "../airtable-auth.tsx";
 
@@ -1156,40 +1154,41 @@ function debugLog(debugMode: boolean, ...args: unknown[]) {
 const AIRTABLE_API_BASE = "https://api.airtable.com/v0";
 const AIRTABLE_META_BASE = "https://api.airtable.com/v0/meta";
 
-export class AirtableClient {
-  private authCell: Writable<AirtableAuthType>;
-  private retries: number;
-  private delay: number;
-  private debugMode: boolean;
-  private onRefresh?: () => Promise<void>;
+export interface AirtableClient {
+  listBases(): Promise<AirtableBase[]>;
+  listTables(baseId: string): Promise<AirtableTable[]>;
+  listRecords(
+    baseId: string,
+    tableIdOrName: string,
+    options?: ListRecordsOptions,
+  ): Promise<AirtableRecord[]>;
+}
 
-  constructor(
-    authCell: Writable<AirtableAuthType>,
-    config: AirtableClientConfig = {},
-  ) {
-    this.authCell = authCell;
-    this.retries = config.retries ?? 2;
-    this.delay = config.delay ?? 1000;
-    this.debugMode = config.debugMode ?? false;
-    this.onRefresh = config.onRefresh;
-  }
+export function AirtableClient(
+  authCell: Writable<AirtableAuthType>,
+  config: AirtableClientConfig = {},
+): AirtableClient {
+  const retries = config.retries ?? 2;
+  const delay = config.delay ?? 1000;
+  const debugMode = config.debugMode ?? false;
+  const onRefresh = config.onRefresh;
 
-  private getToken(): string {
-    const auth = this.authCell.get();
+  function getToken(): string {
+    const auth = authCell.get();
     return auth?.accessToken || "";
   }
 
   /**
    * Make an authenticated API request with retry and token refresh.
    */
-  private async request<T>(
+  async function request<T>(
     url: string,
     options: RequestInit = {},
   ): Promise<T> {
     let lastError: Error | null = null;
 
-    for (let attempt = 0; attempt <= this.retries; attempt++) {
-      const token = this.getToken();
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      const token = getToken();
       if (!token) {
         throw new Error("No access token available");
       }
@@ -1205,8 +1204,8 @@ export class AirtableClient {
         });
 
         if (response.status === 401) {
-          debugLog(this.debugMode, "Got 401, attempting token refresh...");
-          await this.refreshToken();
+          debugLog(debugMode, "Got 401, attempting token refresh...");
+          await refreshToken();
           continue;
         }
 
@@ -1214,9 +1213,9 @@ export class AirtableClient {
           const retryAfter = response.headers.get("Retry-After");
           const waitMs = retryAfter
             ? parseInt(retryAfter) * 1000
-            : this.delay * (attempt + 1);
+            : delay * (attempt + 1);
           debugLog(
-            this.debugMode,
+            debugMode,
             \\\`Rate limited, waiting \\\${waitMs}ms...\\\`,
           );
           await sleep(waitMs);
@@ -1233,13 +1232,13 @@ export class AirtableClient {
         return (await response.json()) as T;
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
-        if (attempt < this.retries) {
+        if (attempt < retries) {
           debugLog(
-            this.debugMode,
-            \\\`Request failed (attempt \\\${attempt + 1}/\\\${this.retries + 1}):\\\`,
+            debugMode,
+            \\\`Request failed (attempt \\\${attempt + 1}/\\\${retries + 1}):\\\`,
             lastError.message,
           );
-          await sleep(this.delay);
+          await sleep(delay);
         }
       }
     }
@@ -1250,18 +1249,19 @@ export class AirtableClient {
   /**
    * Refresh the access token via the server endpoint.
    */
-  private async refreshToken(): Promise<void> {
-    if (this.onRefresh) {
-      await this.onRefresh();
+  async function refreshToken(): Promise<void> {
+    if (onRefresh) {
+      await onRefresh();
       return;
     }
 
-    const auth = this.authCell.get();
+    const auth = authCell.get();
     const refreshToken = auth?.refreshToken;
     if (!refreshToken) {
       throw new Error("No refresh token available");
     }
 
+    const env = getPatternEnvironment();
     const res = await fetch(
       new URL("/api/integrations/airtable-oauth/refresh", env.apiUrl),
       {
@@ -1280,12 +1280,12 @@ export class AirtableClient {
       throw new Error("Invalid refresh response");
     }
 
-    this.authCell.update({
+    authCell.update({
       ...json.tokenInfo,
       user: auth.user,
     });
 
-    debugLog(this.debugMode, "Token refreshed successfully");
+    debugLog(debugMode, "Token refreshed successfully");
   }
 
   // ==========================================================================
@@ -1295,8 +1295,8 @@ export class AirtableClient {
   /**
    * List all accessible bases.
    */
-  async listBases(): Promise<AirtableBase[]> {
-    debugLog(this.debugMode, "Listing bases...");
+  async function listBases(): Promise<AirtableBase[]> {
+    debugLog(debugMode, "Listing bases...");
 
     const bases: AirtableBase[] = [];
     let offset: string | undefined;
@@ -1305,7 +1305,7 @@ export class AirtableClient {
       const url = new URL(\\\`\\\${AIRTABLE_META_BASE}/bases\\\`);
       if (offset) url.searchParams.set("offset", offset);
 
-      const response = await this.request<{
+      const response = await request<{
         bases: AirtableBase[];
         offset?: string;
       }>(url.toString());
@@ -1314,34 +1314,36 @@ export class AirtableClient {
       offset = response.offset;
     } while (offset);
 
-    debugLog(this.debugMode, \\\`Found \\\${bases.length} bases\\\`);
+    debugLog(debugMode, \\\`Found \\\${bases.length} bases\\\`);
     return bases;
   }
 
   /**
    * List all tables in a base.
    */
-  async listTables(baseId: string): Promise<AirtableTable[]> {
-    debugLog(this.debugMode, \\\`Listing tables for base \\\${baseId}...\\\`);
+  async function listTables(
+    baseId: string,
+  ): Promise<AirtableTable[]> {
+    debugLog(debugMode, \\\`Listing tables for base \\\${baseId}...\\\`);
 
-    const response = await this.request<{ tables: AirtableTable[] }>(
+    const response = await request<{ tables: AirtableTable[] }>(
       \\\`\\\${AIRTABLE_META_BASE}/bases/\\\${baseId}/tables\\\`,
     );
 
-    debugLog(this.debugMode, \\\`Found \\\${response.tables.length} tables\\\`);
+    debugLog(debugMode, \\\`Found \\\${response.tables.length} tables\\\`);
     return response.tables;
   }
 
   /**
    * List records from a table with pagination.
    */
-  async listRecords(
+  async function listRecords(
     baseId: string,
     tableIdOrName: string,
     options: ListRecordsOptions = {},
   ): Promise<AirtableRecord[]> {
     debugLog(
-      this.debugMode,
+      debugMode,
       \\\`Listing records from \\\${baseId}/\\\${tableIdOrName}...\\\`,
     );
 
@@ -1382,7 +1384,7 @@ export class AirtableClient {
         }
       }
 
-      const response = await this.request<{
+      const response = await request<{
         records: AirtableRecord[];
         offset?: string;
       }>(url.toString());
@@ -1396,10 +1398,13 @@ export class AirtableClient {
     } while (offset);
 
     const result = records.slice(0, maxRecords);
-    debugLog(this.debugMode, \\\`Fetched \\\${result.length} records\\\`);
+    debugLog(debugMode, \\\`Fetched \\\${result.length} records\\\`);
     return result;
   }
-}`;
+
+  return { listBases, listTables, listRecords };
+}
+`;
 
 // Read from: packages/patterns/airtable/airtable-importer.tsx
 const AIRTABLE_IMPORTER_SOURCE = `import {
@@ -1476,7 +1481,7 @@ const fetchBases = handler<
   loading.set(true);
   error.set("");
   try {
-    const client = new AirtableClient(auth);
+    const client = AirtableClient(auth);
     const result = await client.listBases();
     bases.set(result.map((b) => ({ id: b.id, name: b.name })));
   } catch (e) {
@@ -1500,7 +1505,7 @@ const fetchTables = handler<
   loading.set(true);
   error.set("");
   try {
-    const client = new AirtableClient(auth);
+    const client = AirtableClient(auth);
     const result = await client.listTables(baseId);
     tables.set(result.map((t) => ({ id: t.id, name: t.name })));
   } catch (e) {
@@ -1525,7 +1530,7 @@ const fetchRecords = handler<
   loading.set(true);
   error.set("");
   try {
-    const client = new AirtableClient(auth);
+    const client = AirtableClient(auth);
     const result = await client.listRecords(baseId, tableId, {
       maxRecords: 500,
     });
@@ -2376,14 +2381,17 @@ Auth manager utility pattern. Wraps the shared \`AuthManagerBase\` pattern — f
 
 ## File 3: \`packages/patterns/${providerName}/core/util/${providerName}-client.ts\`
 
-Typed API client class. Follow the Airtable client reference:
+Typed API client function. Follow the Airtable client reference:
 
 - Import \`getPatternEnvironment\` and \`Writable\` from "commonfabric"
 - Import auth type from the auth pattern
 - Base URL: \`${api.baseUrl}\`
+- Export a client function named \`${pascalName}Client(...)\` that returns the
+  public methods
+- Keep \`getPatternEnvironment()\` inside the refresh helper, not at module scope
 - Implement:
-  - \`private request<T>(url, options)\` with:
-    - Bearer token auth from \`this.authCell.get().accessToken\`
+  - \`request<T>(url, options)\` with:
+    - Bearer token auth from the auth writable's current access token
     - Retry logic (default 2 retries)
     - 401 -> auto refresh token via \`/api/integrations/${providerName}-oauth/refresh\`
     - 429 -> respect Retry-After header${
@@ -2391,7 +2399,7 @@ Typed API client class. Follow the Airtable client reference:
       ? `, max ${api.rateLimit.requestsPerSecond} req/s`
       : ""
   }
-  - \`private refreshToken()\` — calls the server refresh endpoint
+  - \`refreshToken()\` — calls the server refresh endpoint
   - Public methods for each key API endpoint, with proper TypeScript types
   - Pagination support using the ${api.pagination?.style ?? "detected"} pattern:
 ${
@@ -2412,7 +2420,7 @@ Main importer pattern. Follow the Airtable importer reference:
 - Define module-scope \`handler()\` functions for each API call:
   - Each handler takes \`auth\`, relevant state cells (\`loading\`, \`error\`, result cells)
   - Each uses \`try/catch/finally\` with \`loading.set(true/false)\`
-  - Creates a client instance: \`new ${pascalName}Client(auth)\`
+  - Creates a client instance: \`${pascalName}Client(auth)\`
 - The pattern function:
   1. Creates auth manager: \`const { auth, isReady, fullUI: authUI } = ${pascalName}AuthManager({ requiredScopes: [...] })\`
   2. Defines Writable cells for mutable state (lists, loading, error)

--- a/tasks/cfcheck.ts
+++ b/tasks/cfcheck.ts
@@ -1,0 +1,148 @@
+import { process } from "../packages/cli/lib/dev.ts";
+
+const PATTERNS_DIR = "packages/patterns";
+const CHECK_BATCH_SIZE = 8;
+
+const NON_PATTERN_PREFIXES = [
+  "packages/patterns/integration/",
+  "packages/patterns/tools/",
+];
+
+// deno-lint-ignore ban-untagged-todo
+// TODO: Drive this list to zero so cfcheck covers every authored pattern file.
+const EXCLUDED_PATTERN_FILES = new Set<string>([
+  "packages/patterns/base/contacts.tsx",
+  "packages/patterns/base/family-member.tsx",
+  "packages/patterns/base/person.tsx",
+  "packages/patterns/battleship/multiplayer/repro-minimal.tsx",
+  "packages/patterns/cfc-agent-prompt-injection-demo/main.tsx",
+  "packages/patterns/cfc/prompt-injection/atoms.ts",
+  "packages/patterns/cfc/prompt-injection/mod.ts",
+  "packages/patterns/cfc/prompt-injection/schemas.ts",
+  "packages/patterns/cfc/prompt-injection/tools.ts",
+  "packages/patterns/deprecated/calendar-v512.tsx",
+  "packages/patterns/deprecated/charm-ref-in-cell.tsx",
+  "packages/patterns/deprecated/charms-ref-in-cell.tsx",
+  "packages/patterns/deprecated/linkedlist-in-cell.tsx",
+  "packages/patterns/examples/write-and-run.tsx",
+  "packages/patterns/experimental/email-task-engine.tsx",
+  "packages/patterns/google/WIP/google-docs-importer.tsx",
+  "packages/patterns/google/core/bill-extractor/index.tsx",
+  "packages/patterns/google/core/experimental/calendar-event-manager.tsx",
+  "packages/patterns/google/core/experimental/gmail-label-manager.tsx",
+  "packages/patterns/google/core/experimental/gmail-sender.tsx",
+  "packages/patterns/google/core/experimental/google-docs-comment-confirm.ts",
+  "packages/patterns/google/core/experimental/google-docs-comment-orchestrator.tsx",
+  "packages/patterns/google/core/gmail-extractor.tsx",
+  "packages/patterns/google/core/imported-calendar.tsx",
+  "packages/patterns/google/core/util/agentic-tools.ts",
+  "packages/patterns/google/core/util/calendar-write-client.ts",
+  "packages/patterns/google/core/util/gmail-send-client.ts",
+  "packages/patterns/google/core/util/google-docs-client.ts",
+  "packages/patterns/google/extractors/bam-school-dashboard.tsx",
+  "packages/patterns/google/extractors/berkeley-library.tsx",
+  "packages/patterns/google/extractors/bofa-bill-tracker.tsx",
+  "packages/patterns/google/extractors/calendar-change-detector.tsx",
+  "packages/patterns/google/extractors/chase-bill-tracker.tsx",
+  "packages/patterns/google/extractors/email-notes.tsx",
+  "packages/patterns/google/extractors/email-pattern-dreamer.tsx",
+  "packages/patterns/google/extractors/email-pattern-launcher.tsx",
+  "packages/patterns/google/extractors/email-style-extractor.tsx",
+  "packages/patterns/google/extractors/email-ticket-finder.tsx",
+  "packages/patterns/google/extractors/expect-response-followup.tsx",
+  "packages/patterns/google/extractors/favorite-foods-gmail-agent.tsx",
+  "packages/patterns/google/extractors/hotel-membership-gmail-agent.tsx",
+  "packages/patterns/google/extractors/pge-bill-tracker.tsx",
+  "packages/patterns/google/extractors/united-flight-tracker.tsx",
+  "packages/patterns/google/extractors/usps-informed-delivery.tsx",
+  "packages/patterns/mod.ts",
+  "packages/patterns/scrabble/scrabble-words.ts",
+  "packages/patterns/test/webhook-test.tsx",
+  "packages/patterns/weekly-calendar/weekly-calendar.tsx",
+]);
+
+async function collectPatternFiles(dir: string): Promise<string[]> {
+  const files: string[] = [];
+
+  async function walk(current: string) {
+    for await (const entry of Deno.readDir(current)) {
+      const path = `${current}/${entry.name}`;
+      if (entry.isDirectory) {
+        await walk(path);
+        continue;
+      }
+      if (!entry.isFile) continue;
+      if (!isPatternSource(path)) continue;
+      files.push(path);
+    }
+  }
+
+  await walk(dir);
+  return files.sort();
+}
+
+function isPatternSource(path: string): boolean {
+  if (!path.endsWith(".ts") && !path.endsWith(".tsx")) return false;
+  if (path.endsWith(".test.ts") || path.endsWith(".test.tsx")) return false;
+  return !NON_PATTERN_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+const allFiles = await collectPatternFiles(PATTERNS_DIR);
+const filesToCheck = allFiles.filter((file) =>
+  !EXCLUDED_PATTERN_FILES.has(file)
+);
+const excludedPresent = allFiles.filter((file) =>
+  EXCLUDED_PATTERN_FILES.has(file)
+);
+const staleExclusions = [...EXCLUDED_PATTERN_FILES].filter((file) =>
+  !allFiles.includes(file)
+);
+
+if (staleExclusions.length > 0) {
+  console.error("Stale cfcheck exclusions:");
+  for (const file of staleExclusions) console.error(`  ${file}`);
+  Deno.exit(1);
+}
+
+console.log(
+  `Common Fabric checking ${filesToCheck.length} pattern files` +
+    ` (${excludedPresent.length} excluded).`,
+);
+
+const failures: Array<{ file: string; error: string }> = [];
+
+for (let i = 0; i < filesToCheck.length; i += CHECK_BATCH_SIZE) {
+  const batch = filesToCheck.slice(i, i + CHECK_BATCH_SIZE);
+  await Promise.all(
+    batch.map(async (file) => {
+      try {
+        await process({
+          main: `${Deno.cwd()}/${file}`,
+          rootPath: Deno.cwd(),
+          check: true,
+          run: false,
+        });
+      } catch (error) {
+        failures.push({
+          file,
+          error: formatError(error),
+        });
+      }
+    }),
+  );
+}
+
+if (failures.length > 0) {
+  failures.sort((a, b) => a.file.localeCompare(b.file));
+  console.error("Common Fabric pattern checks failed:");
+  for (const failure of failures) {
+    console.error(`\n${failure.file}`);
+    console.error(failure.error);
+  }
+  Deno.exit(1);
+}


### PR DESCRIPTION
Add deno task cfcheck, which runs the Common Fabric compiler and Secure ECMAScript verifier over non-test pattern source files. The task keeps an explicit exclusion list for files that do not pass yet, with a TODO marker to drive that list to zero.

Do the first burn-down fix for that task by removing Airtable from the failing set. Move the Airtable pattern environment lookup into refreshToken, expose AirtableClient as a Secure ECMAScript-compatible function, and update the importer call sites and prompt references to use the client function.

Update continuous integration to run deno task cfcheck.

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: job: Check = 269s
---END COPY-PASTE---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `cfcheck` task that compiles and Secure ECMAScript-verifies all non-test pattern files, and runs it in CI. Refactors the Airtable client to a SES-safe factory function and updates importer and prompt usage; removes Airtable from the failing set.

- **New Features**
  - Added `deno task cfcheck` to compile and SES-verify pattern sources (skips tests and `integration/` and `tools/`).
  - Explicit exclusion list with stale-entry checks; processes files in small batches.
  - CI runs `cfcheck` via `.github/workflows/deno.yml`.

- **Refactors**
  - Converted Airtable client to `AirtableClient(auth, config?)` returning methods; added `AirtableClient` interface.
  - Moved `getPatternEnvironment()` into `refreshToken()` for SES.
  - Updated importer call sites and the importer prompt to use the function form.

<sup>Written for commit 24a68bf79f7ffa28b0c09d7ed697c790aa74def4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

