### PR TITLE
prototype(runtime-client): seq token on cell values to drop stale pushes

### DIFF
--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -624,6 +624,32 @@ export class RuntimeProcessor {
     return ctx;
   }
 
+  // PROTOTYPE: doc confirmed seq for a cell ref, so the client can order/drop
+  // pushes. Returns undefined if unavailable.
+  private docSeq(
+    cellRef: { id: string; space: string; scope?: unknown },
+  ): number | undefined {
+    try {
+      const provider = this.runtime.storageManager.open(
+        cellRef.space as never,
+      ) as unknown as {
+        replica?: {
+          get(e: { id: string; type: string; scope?: unknown }):
+            | { since?: number }
+            | undefined;
+        };
+      };
+      const state = provider.replica?.get({
+        id: cellRef.id,
+        type: "application/json",
+        scope: (cellRef as { scope?: unknown }).scope,
+      });
+      return typeof state?.since === "number" ? state.since : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
   handleCellGet(
     request: CellGetRequest,
   ): JSONValueResponse {
@@ -656,7 +682,7 @@ export class RuntimeProcessor {
       doNotConvertCellResults: true,
       includeCfcLabelView: true,
     });
-    return { value: converted };
+    return { value: converted, seq: this.docSeq(request.cell) };
   }
 
   handleCellSet(request: CellSetRequest): void {
@@ -713,13 +739,15 @@ export class RuntimeProcessor {
       // `.sink` fires synchronously on invocation. Trigger the notification
       // in a microtask so that the subscription response returns
       // before a notification fires.
-      queueMicrotask(() =>
+      const seq = this.docSeq(request.cell);
+      queueMicrotask(() => {
         self.postMessage({
           type: NotificationType.CellUpdate,
           cell: request.cell,
           value: converted,
-        })
-      );
+          seq,
+        });
+      });
     });
 
     this.subscriptions.set(key, cancel);

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -41,6 +41,9 @@ export class CellHandle<T = unknown> {
   #conn: InitializedRuntimeConnection;
   #ref: CellRef;
   #value: T | undefined;
+  // PROTOTYPE: highest doc confirmed seq this handle has applied, so a stale
+  // push (seq <= #lastSeq) can be dropped instead of clobbering a newer value.
+  #lastSeq: number | undefined;
   #callbacks = new Map<number, (value: Readonly<T>) => void>();
   #nextCallbackId = 0;
   #schemaWarned = false;
@@ -228,7 +231,15 @@ export class CellHandle<T = unknown> {
       cell: this.ref(),
     });
 
-    this.#value = CellHandle.deserialize<T>(this, response.value) as T;
+    const synced = CellHandle.deserialize<T>(this, response.value) as T;
+    const seq = response.seq;
+    // PROTOTYPE: don't let an older snapshot clobber a newer pushed value.
+    if (
+      seq === undefined || this.#lastSeq === undefined || seq >= this.#lastSeq
+    ) {
+      this.#value = synced;
+      if (seq !== undefined) this.#lastSeq = seq;
+    }
     return this.#value;
   }
 
@@ -312,12 +323,22 @@ export class CellHandle<T = unknown> {
 
   // Called when cell has been updated from the backend with
   // a raw value that may contain CellRefs.
-  [$onCellUpdate](value: unknown): void {
+  [$onCellUpdate](value: unknown, seq?: number): void {
+    // PROTOTYPE: drop a push older than what this handle already holds. This
+    // prevents an in-flight stale push from clobbering a newer (e.g.
+    // optimistic) value when there is no ordering token.
+    if (
+      seq !== undefined && this.#lastSeq !== undefined && seq <= this.#lastSeq
+    ) {
+      return;
+    }
+
     const applied = applyValue(
       value,
       this.#value,
       this as CellHandle<unknown>,
     ) as T;
+    if (seq !== undefined) this.#lastSeq = seq;
     if (valuesEqual(applied, this.#value)) {
       return;
     }

--- a/packages/runtime-client/client/connection.ts
+++ b/packages/runtime-client/client/connection.ts
@@ -331,7 +331,7 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
     const subscribed = this.#subscribed.get(cellRefToKey(cellRef));
     if (subscribed && subscribed.size > 0) {
       for (const instance of subscribed) {
-        instance[$onCellUpdate](value);
+        instance[$onCellUpdate](value, message.seq);
       }
     }
   }

--- a/packages/runtime-client/integration/commit-order-repro.test.ts
+++ b/packages/runtime-client/integration/commit-order-repro.test.ts
@@ -1,0 +1,181 @@
+#!/usr/bin/env -S deno run -A
+// WIP repro for the optimistic-write / stale-push clobber investigation.
+//
+// Needs a local toolshed (memory API) running:
+//   bash scripts/start-local-dev.sh
+//   API_URL=http://localhost:8000/ deno test -A --no-check \
+//     packages/runtime-client/integration/commit-order-repro.test.ts
+//
+// Emits `[repro] ...` lines and a DIVERGENT check. The richer per-hop
+// `[cell-trace]` / `[commit-trace]` output requires the CF_COMMIT_TRACE
+// instrumentation, which is NOT on this branch (it was stripped when the
+// seq-token change was prepared). Re-add that instrumentation in
+// cell-handle.ts / connection.ts / runtime-processor.ts / v2.ts / memory
+// client.ts if you want the per-assignment / per-emit tracing back.
+
+import {
+  createSession,
+  Identity,
+  type IdentityCreateConfig,
+  type Session,
+} from "@commonfabric/identity";
+import { env } from "@commonfabric/integration";
+import {
+  type JSONSchema,
+  RuntimeClient,
+  type RuntimeClientOptions,
+} from "@commonfabric/runtime-client";
+import { WebWorkerRuntimeTransport } from "@commonfabric/runtime-client/transports/web-worker";
+
+const { API_URL } = env;
+const keyConfig: IdentityCreateConfig = { implementation: "noble" };
+const identity = await Identity.fromPassphrase("commit-order repro", keyConfig);
+
+async function createTestSession(): Promise<Session> {
+  return await createSession({
+    identity,
+    spaceName: globalThis.crypto.randomUUID(),
+  });
+}
+
+async function createRuntimeClient(
+  session: Session,
+  extraOptions: Partial<RuntimeClientOptions> = {},
+): Promise<RuntimeClient> {
+  if (session.spaceIdentity && session.spaceName) {
+    session.spaceIdentity = await (
+      await Identity.fromPassphrase("common user", keyConfig)
+    ).derive(session.spaceName, keyConfig);
+  }
+  const transport = await WebWorkerRuntimeTransport.connect();
+  const rt = await RuntimeClient.initialize(transport, {
+    apiUrl: new URL(API_URL),
+    identity: session.as,
+    spaceIdentity: session.spaceIdentity,
+    spaceDid: session.space,
+    spaceName: session.spaceName,
+    ...extraOptions,
+  });
+  await rt.synced(session.space);
+  return rt;
+}
+
+const schema = {
+  type: "object",
+  properties: { x: { type: "string" }, y: { type: "string" } },
+} as const satisfies JSONSchema;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+Deno.test("repro: one client, rapid same-field writes", async () => {
+  const session = await createTestSession();
+  await using rt = await createRuntimeClient(session);
+  const cell = await rt.getCell<{ x: string; y: string }>(
+    session.space,
+    "commit-order-doc-single",
+    schema,
+  );
+  cell.set({ x: "", y: "" });
+  await rt.idle();
+  await cell.sync();
+
+  const x = cell.key("x");
+  console.error("[repro] --- single-client rapid writes: 'B' then 'Bob' ---");
+  x.set("B");
+  x.set("Bob");
+  await rt.idle();
+  await sleep(500);
+});
+
+Deno.test("repro: two clients, contended shared doc (input+change vs sibling)", async () => {
+  const session = await createTestSession();
+  await using rtA = await createRuntimeClient(session);
+  await using rtB = await createRuntimeClient(session);
+  const cellA = await rtA.getCell<{ x: string; y: string }>(
+    session.space,
+    "commit-order-doc-shared",
+    schema,
+  );
+  const cellB = await rtB.getCell<{ x: string; y: string }>(
+    session.space,
+    "commit-order-doc-shared",
+    schema,
+  );
+  cellA.set({ x: "", y: "" });
+  await rtA.idle();
+  await cellA.sync();
+  await cellB.sync();
+
+  const xA = cellA.key("x");
+  const xB = cellB.key("x");
+  // Tight same-path contention, no settling between rounds: A's two rapid
+  // writes (input + change) race B's concurrent write to the SAME field.
+  for (let i = 0; i < 60; i++) {
+    console.error(`[repro] --- round ${i} ---`);
+    xA.set(`B${i}`);
+    xA.set(`Bob${i}`);
+    xB.set(`other${i}`);
+    await sleep(3);
+  }
+  await Promise.all([rtA.idle(), rtB.idle()]);
+  await sleep(800);
+});
+
+Deno.test("repro: SINGLE handle subscribed + optimistic set under contention (clobber)", async () => {
+  const session = await createTestSession();
+  await using rtA = await createRuntimeClient(session);
+  await using rtB = await createRuntimeClient(session);
+  const a = await rtA.getCell<{ x: string; y: string }>(
+    session.space,
+    "clobber-doc",
+    schema,
+  );
+  const b = await rtB.getCell<{ x: string; y: string }>(
+    session.space,
+    "clobber-doc",
+    schema,
+  );
+  await a.set({ x: "init", y: "" });
+  await rtA.idle();
+  await a.sync();
+  await b.sync();
+
+  // Subscribe on the SAME handle we optimistically write to. Record every
+  // value the subscriber observes.
+  const seen: string[] = [];
+  const cancel = a.subscribe((v) => {
+    seen.push(JSON.stringify(v));
+    console.error("[repro] A subscriber sees:", JSON.stringify(v));
+  });
+
+  for (let i = 0; i < 40; i++) {
+    console.error(
+      `[repro] --- round ${i}: B sets remote, A optimistically sets local on the SUBSCRIBED handle ---`,
+    );
+    b.set({ x: `remote${i}`, y: "" }); // contention from the other client
+    a.set({ x: `local${i}`, y: "" }); // optimistic write on the subscribed handle
+    await sleep(15);
+  }
+  await Promise.all([rtA.idle(), rtB.idle()]);
+  await sleep(1000);
+  cancel();
+
+  // Divergence check: the subscribed handle's value vs a FRESH sync of the
+  // SAME client's runtime (rtA). If they differ, the runtime-client handle is
+  // stale relative to its own runtime — the clobber the hypothesis predicts.
+  const freshA = await rtA.getCell<{ x: string; y: string }>(
+    session.space,
+    "clobber-doc",
+    schema,
+  );
+  await freshA.sync();
+  console.error("[repro] subscribed handle a.get() =", JSON.stringify(a.get()));
+  console.error(
+    "[repro] fresh rtA sync (runtime truth) =",
+    JSON.stringify(freshA.get()),
+  );
+  console.error(
+    "[repro] DIVERGENT =",
+    JSON.stringify(a.get()) !== JSON.stringify(freshA.get()),
+  );
+});

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -690,6 +690,9 @@ export interface BooleanResponse {
 
 export interface JSONValueResponse {
   value: JSONValue | undefined;
+  // PROTOTYPE: doc confirmed seq, so a pull (sync) establishes the handle's
+  // baseline seq for dropping stale pushes.
+  seq?: number;
 }
 
 export interface CellResponse {
@@ -723,6 +726,9 @@ export interface CellUpdateNotification {
   type: NotificationType.CellUpdate;
   cell: CellRef;
   value: JSONValue;
+  // PROTOTYPE: doc confirmed seq at emit time, so the client can drop a push
+  // older than what a handle already holds (stale-push clobber fix).
+  seq?: number;
 }
 
 export interface ConsoleNotification {


### PR DESCRIPTION
> **Draft / WIP — set aside.** This is a prototype from an investigation into the optimistic-write clobber on the runtime-client. Opening as a draft to preserve the work and context; not ready for review/merge.

## Problem

A `CellHandle` on the main thread holds an optimistic cached value: `set()` updates `#value` synchronously, ahead of any IPC. Cell update pushes carry **no ordering token** (`CellUpdateNotification` is just `{cell, value}`), so an in-flight push carrying an *older* value can arrive after a newer local `set()` / a newer push and clobber it — the subscriber visibly moves backwards. The runtime (worker) has the right state; the client applies a stale value out of order.

Reproduced (see the included test): under two-client same-path contention, an optimistic `set("local0")` is reverted to a stale `init` push before a later push restores it — repeated across rounds.

## What this does

Give cell values an ordering token so the client can drop stale applies:

- **Worker** attaches the doc's `confirmed.seq` (read via `replica.get`) to `CellUpdate` notifications and `CellGet` responses.
- **Client** `CellHandle` tracks `#lastSeq` (highest seq applied); `$onCellUpdate` drops any push with `seq <= #lastSeq`, and `sync()` won't apply an older snapshot.

In the repro this eliminated the cross-round stale-push clobbers (the majority), and the final state stays convergent.

## What it does NOT do (known gap)

It does **not** close the *optimistic-write-vs-confirmed-catchup* flicker: an unconfirmed optimistic `set()` has no seq, so a higher-seq **confirmed** push that still carries the *pre-set* value (because the optimistic write is pending) is "newer" by seq and still reverts it until the write's own confirmation lands. Fully fixing that needs origin-aware suppression of the transient self-revert (worker knows self vs remote via the storage notification `source`/`type`) and/or making the client mirror the runtime's own `confirmed + optimistic` two-layer model — out of scope here.

## Relationship to #4126

Complementary, different surface. #4126 is writer/handler-side (retry rejected direct writes + a barrier so handler events read-your-writes). This is subscriber/display-side (order pushes, don't clobber). Both are downstream of the same root cause — doc-granular false `stale confirmed read` rejections — which neither fixes.

## Caveats

- **Prototype quality.** `docSeq()` reaches the confirmed seq via an `as`-cast to `replica.get` — needs a real accessor.
- `seq` granularity is per-doc, not per-path.
- The included integration test (`commit-order-repro.test.ts`) needs a local toolshed and emits `[repro]` lines + a `DIVERGENT` check; the per-hop `CF_COMMIT_TRACE` instrumentation it was developed against is intentionally not on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach a per-doc sequence token to cell updates and sync responses so the client can drop stale pushes. This prevents older updates from overwriting newer optimistic values under contention.

- **Bug Fixes**
  - Attach confirmed doc `seq` to `CellUpdateNotification` and `JSONValueResponse`, and forward it through the client.
  - `CellHandle` tracks the highest applied `seq` and ignores pushes or sync snapshots that are older than its current state, avoiding stale clobbers.
  - Known gap: does not eliminate flicker while an optimistic `set()` is unconfirmed; a higher-`seq` confirmed push with the pre-set value can briefly revert it until confirmation.

<sup>Written for commit ab7c04b59d40549b5ba46a42cb49fa5e0b3d61ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

