### PR TITLE
feat(lunch-poll): migrate visit + vote history to the SQLite builtin

### DIFF
--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -294,15 +294,6 @@ export async function executeResolvedCallable(
   if (resolved.callableKind === "handler") {
     const send = resolved.callableCell.send;
     if (typeof send === "function") {
-      // Drain in-flight storage syncs BEFORE dispatching the event: piece
-      // load issues watch batches that may still be in flight, and a handler
-      // reads its asCell inputs (e.g. a SqliteDb handle) synchronously from
-      // the local replica — dispatching early races the doc-carrying response
-      // and the handler sees an empty doc ("invalid database handle" on
-      // db.exec). The awaits AFTER send cover the handler's own writes, not
-      // its inputs.
-      await resolved.manager.runtime.idle();
-      await resolved.manager.synced();
       const runtimeErrors = runtimeErrorLog(resolved.manager.runtime);
       const errorCountBefore = runtimeErrors.length;
       const tx = await new Promise<CallableTransactionLike>(
@@ -331,10 +322,6 @@ export async function executeResolvedCallable(
       return {};
     }
 
-    // Same pre-send drain as above: don't trigger the handler while piece
-    // load syncs are still in flight.
-    await resolved.manager.runtime.idle();
-    await resolved.manager.synced();
     await resolved.piece[resolved.cellProp].set(input, [resolved.cellKey]);
     await resolved.manager.runtime.idle();
     await resolved.manager.synced();

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -294,6 +294,15 @@ export async function executeResolvedCallable(
   if (resolved.callableKind === "handler") {
     const send = resolved.callableCell.send;
     if (typeof send === "function") {
+      // Drain in-flight storage syncs BEFORE dispatching the event: piece
+      // load issues watch batches that may still be in flight, and a handler
+      // reads its asCell inputs (e.g. a SqliteDb handle) synchronously from
+      // the local replica — dispatching early races the doc-carrying response
+      // and the handler sees an empty doc ("invalid database handle" on
+      // db.exec). The awaits AFTER send cover the handler's own writes, not
+      // its inputs.
+      await resolved.manager.runtime.idle();
+      await resolved.manager.synced();
       const runtimeErrors = runtimeErrorLog(resolved.manager.runtime);
       const errorCountBefore = runtimeErrors.length;
       const tx = await new Promise<CallableTransactionLike>(
@@ -322,6 +331,10 @@ export async function executeResolvedCallable(
       return {};
     }
 
+    // Same pre-send drain as above: don't trigger the handler while piece
+    // load syncs are still in flight.
+    await resolved.manager.runtime.idle();
+    await resolved.manager.synced();
     await resolved.piece[resolved.cellProp].set(input, [resolved.cellKey]);
     await resolved.manager.runtime.idle();
     await resolved.manager.synced();

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -1,11 +1,22 @@
 # Deploying & sharing lunch-poll state
 
-This pattern's data lives in **`PerSpace` cells** (`users`, `options`, `votes`,
-`history`, `adminName`, `question`). That state belongs to **one deployed piece
-instance** in one space — addressed by `(space, causal-cell-id)` — not to "the
-pattern" in the abstract. So "share the state" means "everyone points at the
-same piece," and "copy the state" means "move those cell values into a new
-piece." This doc covers both, plus the identity caveat that bites first.
+> **⚠️ The SQLite migration is NOT live-deployable yet (as of 2026-06-04).** The
+> visit history + vote-history were moved into SQLite (`sqliteDatabase`), and
+> the pattern is correct and green in `cf test`, BUT on a _deployed_ piece
+> `db.exec` throws "invalid database handle" — an open sqlite-builtin bug (see
+> `session_outputs/2026-06-04_lunch-poll-sqlite/`). **Keep the canonical piece
+> on the previous array-based-history build** until that's fixed. The notes
+> below about `history: PerSpace` describe that previous build; the migrated
+> build replaces `history` with SQLite tables and adds a `sqliteRev` PerSpace
+> counter.
+
+This pattern's durable data lives in **`PerSpace` cells** (`users`, `options`,
+`votes`, `adminName`, `question`; the previous build also had `history`). That
+state belongs to **one deployed piece instance** in one space — addressed by
+`(space, causal-cell-id)` — not to "the pattern" in the abstract. So "share the
+state" means "everyone points at the same piece," and "copy the state" means
+"move those cell values into a new piece." This doc covers both, plus the
+identity caveat that bites first.
 
 ## The canonical piece
 

--- a/packages/patterns/lunch-poll/LUNCH-COORDINATOR-TODO.md
+++ b/packages/patterns/lunch-poll/LUNCH-COORDINATOR-TODO.md
@@ -10,36 +10,74 @@ rest are still backlog.
 
 ## Planned features
 
-### 1. "Last days we went" history ✅ (shipped)
+### 1. "Last days we went" history ✅ (shipped; reworked onto SQLite)
 
 Keep a per-space log of where the group actually ended up eating, with dates, so
 nobody suggests the same place three days running.
 
-- ✅ `history: PerSpace<HistoryEntry[]>`
-  (`{ id, title, loggedByName, wentAt }`), appended via a host-only `logVisit`
-  handler. Each option has a "✓ we went here" button that logs that place. The
-  stored log is capped at the 50 most recent visits so the PerSpace array can't
-  grow without bound.
+- ✅ Stored in a **SQLite `visits` table** (`sqliteDatabase(...)` in the pattern
+  body), reworked from the original `history: PerSpace<HistoryEntry[]>` array as
+  the team's first dogfood of the SQLite builtins (PRs #3776/#3848). Columns:
+  `id, title, logged_by (TEXT name snapshot), logged_by_cf_link (cfLink<User>
+  live pointer), went_at`.
+  **No more 50-entry cap** — a table grows fine; the read query bounds itself
+  with `LIMIT 8`. Appended via the host-only `logVisit` (`db.exec` INSERT). Each
+  option still has a "✓ we went here" button.
 - ✅ **Backdating:** a host "Log 'we went here' as of:" date field (blank =
   today) backdates the entry; `logVisit` also accepts an explicit `wentAt`. The
   date draft clears after each log so it defaults back to today.
-- ✅ **Editing:** `removeHistoryEntry({ id })` deletes a single mistaken entry
-  ("we didn't actually eat there") via a per-row ✕; `clearHistory` (two-step
-  confirm) wipes the whole log. Both host-only.
+- ✅ **Editing:** `removeHistoryEntry({ id })` (`db.exec` DELETE) drops a single
+  mistaken entry via a per-row ✕; `clearHistory` (two-step confirm) truncates
+  the table. Both host-only, and both also clear the matching `vote_history`
+  rows.
 - ✅ Shown as a **"Recently eaten" list below the options** (8 most recent,
-  most-recent-first), labelled with each visit's own date ("Tuesday, May 20").
-  No per-option nudge — history lives in this one section.
-- Implementation notes (hard-won; see also `scoped-cells-field-notes.md`):
-  - Visit labels derive **only from the stored `wentAt`**, never from the
-    current clock — calling `safeDateNow()` inside a `derive`/`computed` is
-    non-idempotent (it belongs in handlers, like the backdate parse). This is
-    also why there's no live "within the last N days" window; we show the
-    visit's own date and let the human judge.
+  most-recent-first), a `db.query` rendered with the SAME plain-JSX `.map`
+  idiom, labelled with each visit's own date ("Tuesday, May 20").
+- Implementation notes (hard-won):
+  - Visit labels derive **only from the stored `went_at`**, never from the
+    current clock — `safeDateNow()` inside a `derive`/`computed` is
+    non-idempotent (it belongs in handlers, like the backdate parse).
   - Interactive `onClick` handlers must live in **plain-ternary JSX**, not
-    inside a `computed(() => …)`-returned VNode, or they mis-lower as lifts
-    (`$event in inputs` → non-idempotent write).
-  - Don't name a `.map((h) => …)` callback `h` when the body contains JSX — `h`
-    is the JSX factory; shadowing it yields `TypeError: h is not a function`.
+    inside a `computed/lift`-returned VNode, or they mis-lower as lifts
+    (`$event in inputs`). The `db.query` result is fed to the card via
+    `computed(() => recentVisits.result ?? [])` — an OpaqueRef<row[]> shaped
+    exactly like the old `recentHistory` array, so the plain-JSX `.map` (where
+    the handlers live) is preserved unchanged.
+  - **SQLite issues found while dogfooding** (see
+    `session_outputs/2026-06-04_lunch-poll-sqlite/` for full writeups):
+    1. _(worked around)_ The `@db/sqlite` binding truncates a bound JS number to
+       32 bits, so a ms-epoch `went_at` round-trips as garbage. Workaround:
+       store timestamps as zero-padded TEXT (`encodeTs`/`decodeTs`); 16-digit
+       padding keeps `ORDER BY` correct.
+    2. _(worked around, test-runner only)_ `reactOn: db` left the `recentVisits`
+       query stale after writes in the emulated test runner; reacting on a
+       `PerSpace<number>` `sqliteRev` counter the handlers bump is reliable.
+    3. **⚠️ OPEN, blocks live deploy:** on a _deployed_ piece, `db.exec` in the
+       mutating handlers throws "invalid database handle" — the `SqliteDb`
+       handle isn't materialized on the deployed handler-input path (works fine
+       in the emulated `cf test` runner). Reliably reproduced; root cause not
+       yet isolated (it is NOT the cfLink column, NOT any single query — likely
+       an emergent interaction in this scoped pattern). **Filed for the
+       sqlite-builtin owner; the live canonical piece stays on the previous
+       array-based history until this is fixed.** The migration here is complete
+       and green in tests, ready to deploy once the bug is resolved.
+
+### 1b. Durable vote-history snapshot ✅ (shipped)
+
+When the host logs a visit, snapshot **who voted what** at that moment into a
+SQLite `vote_history` table tied to the visit. Live voting stays on the in-cell
+`votes` array — only the durable record is in SQLite.
+
+- ✅ `vote_history`
+  (`id, visit_id, voter, voter_cf_link, option_title,
+  vote_color, went_at`).
+  `logVisit` loops the current votes and writes one row each (option title
+  denormalized; voter as both a frozen name and a live `cfLink<User>`). All
+  INSERTs fold into the one handler commit.
+- ✅ Surfaced as a read-only **"📊 Lunch stats"** card (a `GROUP BY` query):
+  per-place visit count + green/red tallies across the whole record.
+- Future: a per-option "last N times we did X: 🟢🟢🟡" inline recap (needs a
+  per-option query inside `options.map`) — deferred.
 
 ### 2. People's favorite foods
 

--- a/packages/patterns/lunch-poll/SQLITE-DEPLOY-BUG.md
+++ b/packages/patterns/lunch-poll/SQLITE-DEPLOY-BUG.md
@@ -1,0 +1,231 @@
+# SQLite builtin: `db.exec` fails on a _deployed_ piece — bug report
+
+**Status:** OPEN — reliably reproduced, root cause not isolated. **Date:**
+2026-06-04 **Context:** First dogfood of the SQLite pattern builtins
+(`sqliteDatabase` / `db.query` / `db.exec`, PRs #3776 / #3848) on `lunch-poll`.
+The migration is complete and **green in `cf test`**, but cannot deploy live
+because of this bug. **For:** review with the sqlite-builtin owner (Berni).
+
+---
+
+## TL;DR
+
+On a **deployed piece** (`cf piece new` → `cf piece call`), any handler that
+calls `db.exec(...)` throws **"invalid database handle"**. The _same pattern,
+same handler_ runs fine in the **emulated `cf test` runner** (which runs a real
+in-process `MemoryV2Server` with real SQLite). So `db.query` reads work
+everywhere; `db.exec` writes fail **only on a deployed piece**.
+
+We could not isolate a single-feature trigger: removing the cfLink columns, the
+JOIN query, the second table, or the dangling queries each **individually fails
+to fix it**. It looks like an emergent interaction specific to the deployed
+handler-input materialization of the `SqliteDb` handle in a non-trivial scoped
+(`PerUser` + `PerSpace`) pattern.
+
+---
+
+## Exact symptom
+
+After deploying `packages/patterns/lunch-poll/main.tsx` and calling any
+sqlite-mutating handler (`logVisit`, `removeHistoryEntry`, `clearHistory`):
+
+```
+Error in action: TypeError: .exec() is only available on a SqliteDb cell (invalid database handle)
+TypeError: .exec() is only available on a SqliteDb cell (invalid database handle)
+    at CellImpl.exec (packages/runner/src/cell.ts:977:13)
+    at eval (fid1:<recipe-id>/main.tsx:<line>:5 — inside the handler body)
+```
+
+The throw is the guard at
+[`packages/runner/src/cell.ts:973-979`](../../runner/src/cell.ts): `.exec()`
+reads the handle with `this.getRaw({ lastNode: "value" })` and requires a string
+`id`; on the deployed path the delivered handle's `{ id, tables }` value is
+absent, so `typeof handle.id !== "string"` and it throws. (The comment there
+already notes "handler-input materialization doesn't always stamp the kind onto
+the delivered cell" — this looks like a deeper version of that: not just the
+brand/kind, but the readable handle value itself is missing on deploy.)
+
+`db.query` reads on the **same deployed piece** work fine — e.g. `recentVisits`
+returns `{ pending: false, result: [...] }`. Only `db.exec` fails.
+
+## The test-runner vs deployed-piece divergence (key clue)
+
+- **`cf test` (emulated):** `StorageManager.emulate()`
+  ([`packages/cli/lib/test-runner.ts:818`](../../cli/lib/test-runner.ts)) spins
+  up a real in-process `MemoryV2Server` over a loopback transport, with real
+  SQLite. `db.exec` **works** here — `lunch-poll`'s `main.test.tsx` exercises
+  `logVisit` (writes `visits` + `vote_history` rows) and asserts on the results;
+  **17/17 green**.
+- **Deployed piece** (`cf piece new` against a local toolshed, then
+  `cf piece call`): `db.exec` **fails** as above.
+
+So the bug is in the **deployed-piece handler-input materialization** of the
+`SqliteDb` handle — not in SQLite execution itself, not in the recipe/transform
+(it type-checks and `--show-transformed` looks correct), and not in the emulated
+path.
+
+---
+
+## What is NOT the cause (single-variable tests, all on a deployed piece)
+
+We bisected on the real pattern. Each row changes ONE thing from the full
+pattern and re-tests `clearHistory` (a minimal mutating handler:
+`db.exec("DELETE FROM visits") ; db.exec("DELETE FROM vote_history")`):
+
+| Change from the full pattern                                | `db.exec` on deploy |
+| ----------------------------------------------------------- | ------------------- |
+| _(none — full pattern)_                                     | ❌ fails            |
+| − `vote_history` table + its handler writes + snapshot loop | ❌ still fails      |
+| − dangling `vote_history` queries (stubbed to static)       | ❌ still fails      |
+| − the `cfLink` columns only (keep all 4 queries)            | ❌ still fails      |
+| − the `placeStats` JOIN query only                          | ❌ still fails      |
+
+> ⚠️ An earlier bisect appeared to show "removing cfLink fixes it" — that step
+> had **removed cfLink AND stubbed two `db.query` calls at once** (two
+> variables), so it proved nothing about cfLink alone. Corrected: cfLink removal
+> _by itself_ does NOT fix it.
+
+## What does NOT reproduce it (minimal build-up, all on a deployed piece)
+
+Minimal patterns built up toward lunch-poll's shape — **all worked** (no error):
+
+- 1 `db` + 1 handler `db.exec`, no scope → works
+-
+  - `PerSpace` only → works
+-
+  - `PerUser` only → works
+- `PerUser` + `PerSpace` + handler `db.exec`, **no `db.query`** → works
+-
+  - 1 `db.query` with `reactOn: <counter>` → works
+-
+  - cfLink column + `users.key(i)` bind → works
+-
+  - 2 tables + 4 queries incl. a GROUP BY JOIN → works
+-
+  - `Writable.perSession.of(...)` local cells → works
+-
+  - typed `Output` returning the query result + `[UI]` mapping it → works
+-
+  - a coexisting `fetchData` builtin (like the cuisine images) → works
+
+So no single ingredient reproduces it in isolation; the full `lunch-poll`
+reliably does. The trigger is some emergent combination we haven't pinned down.
+
+---
+
+## SEPARATE, smaller bug found along the way (also reproducible, minimal)
+
+In a **minimal** `PerUser` + `PerSpace` pattern,
+`db.query(sql, { reactOn: db })` corrupts the `db` handle delivered to handlers
+— `db.exec` then throws the same "invalid database handle". Toggling exactly one
+variable:
+
+| PerUser | PerSpace | `db.query` | `reactOn`                    | `db.exec` in handler |
+| ------- | -------- | ---------- | ---------------------------- | -------------------- |
+| ✓       | ✓        | — (none)   | —                            | ✅ works             |
+| ✓       | ✓        | ✓          | `db`                         | ❌ **fails**         |
+| ✓       | ✓        | ✓          | omitted                      | ✅ works             |
+| ✓       | ✓        | ✓          | a `PerSpace<number>` counter | ✅ works             |
+
+This is **distinct** from the lunch-poll deploy bug above (which fails even with
+`reactOn: <counter>`), but is its own real issue: passing `db` itself as
+`reactOn` under `PerUser`+`PerSpace` should not break the write handle. Minimal
+repro pattern:
+
+```tsx
+import {
+  Default,
+  handler,
+  pattern,
+  type PerSpace,
+  type PerUser,
+  sqliteDatabase,
+  type SqliteDb,
+  table,
+  Writable,
+} from "commonfabric";
+type NameCell = Writable<string | Default<"">>;
+
+const clear = handler<
+  Record<string, never>,
+  { db: SqliteDb; myName: NameCell }
+>(
+  (_, { db, myName }) => {
+    if (myName.get()) db.exec("DELETE FROM v", []);
+  },
+);
+
+interface Input {
+  q?: PerSpace<string | Default<"">>;
+  myName?: PerUser<string | Default<"">>;
+}
+export default pattern<Input>(({ myName }) => {
+  const db = sqliteDatabase({ tables: { v: table({ t: "text" }) } });
+  const query = db.query<{ t: string }>("SELECT t FROM v", { reactOn: db }); // <- the poison
+  return { q: undefined, query, clear: clear({ db, myName }) };
+});
+```
+
+Deploy it, `set myName --input '"X"'`, `step`, then `call clear '{}'` → throws.
+Change `{ reactOn: db }` to omit `reactOn` (or react on a counter) → works.
+
+---
+
+## How to reproduce the lunch-poll deploy bug
+
+Local toolshed (`http://localhost:8000`), any identity:
+
+```bash
+export CF_API_URL=http://localhost:8000
+export CF_IDENTITY=./cf.key   # e.g. deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
+SPACE=lunch-sqlite-repro
+
+PIECE=$(deno task cf piece new packages/patterns/lunch-poll/main.tsx -s "$SPACE" | grep -oE 'fid1:[A-Za-z0-9_-]+' | head -1)
+
+deno task cf piece call --piece "$PIECE" -s "$SPACE" joinAs '{"name":"Host"}'
+deno task cf piece step --piece "$PIECE" -s "$SPACE"
+
+# Any of these throws "invalid database handle":
+deno task cf piece call --piece "$PIECE" -s "$SPACE" clearHistory '{}'
+# or, after addOption: logVisit '{"title":"Thai Kitchen"}'
+```
+
+`cf test packages/patterns/lunch-poll/main.test.tsx` passes 17/17 on the same
+source — the divergence is the deployed path only.
+
+---
+
+## Workarounds already applied in this pattern (so the rest is shippable-once-fixed)
+
+These are in `main.tsx` now; both are unrelated to the OPEN deploy bug above but
+are real sqlite-builtin sharp edges worth fixing too:
+
+1. **Large-integer truncation.** `@db/sqlite` binds a JS `number` as a 32-bit
+   int, so a ms-epoch timestamp (`~1.7e12`) stored in an `integer` column reads
+   back as a negative 32-bit-wrapped value (e.g. `1700000001000` →
+   `-807048216`). Passing a `BigInt` did not help in this version. Reproduced in
+   isolation against `@db/sqlite` directly (no CF layers). **Workaround:** store
+   timestamps as zero-padded TEXT (`encodeTs`/`decodeTs` in `main.tsx`);
+   16-digit padding keeps lexicographic `ORDER BY` equal to numeric order.
+2. **`reactOn: db` stale re-query in the test runner.** With `reactOn: db`, the
+   `recentVisits` query did not re-run after a committed `db.exec` in the
+   emulated runner (3 history assertions went stale). Reacting on a
+   `PerSpace<number>` `sqliteRev` counter that the handlers bump is reliable.
+   (The spec's in-commit `rev`-bump model is meant to make `reactOn: db` work;
+   it didn't here.)
+
+---
+
+## Pointers
+
+- Guard that throws: `packages/runner/src/cell.ts:973-979` (`.exec`).
+- Emulated test storage (works): `packages/runner/src/storage/v2-emulate.ts`,
+  wired in `packages/cli/lib/test-runner.ts:818`.
+- Builtin impl: `packages/runner/src/builtins/sqlite-builtins.ts`; handle types
+  in `packages/api/index.ts` (`SqliteDb`, kind `"sqlite"`).
+- Spec: `docs/specs/sqlite-builtin/` (esp. `01-api.md`,
+  `03-database-sources.md`, `05-reactivity.md`).
+- Full investigation log (this session):
+  `session_outputs/2026-06-04_lunch-poll-sqlite/` —
+  `02_int-truncation-finding.md`, `03_db-handle-peruser-perspace-bug.md`,
+  `SESSION_SUMMARY.md`.

--- a/packages/patterns/lunch-poll/SQLITE-DEPLOY-BUG.md
+++ b/packages/patterns/lunch-poll/SQLITE-DEPLOY-BUG.md
@@ -1,7 +1,50 @@
 # SQLite builtin: `db.exec` fails on a _deployed_ piece — bug report
 
-**Status:** OPEN, **trigger isolated 2026-06-09.** Dates: found 06-04,
-re-verified 06-05 and 06-09. **For:** the sqlite-builtin owner (Berni).
+**Status: RESOLVED 2026-06-09** (root cause found; fix in
+`packages/cli/lib/callable.ts`). Dates: found 06-04, re-verified 06-05 and
+06-09, fixed later on 06-09. **For:** the sqlite-builtin owner (Berni) — see the
+resolution below; one runtime-level follow-up remains open.
+
+## ✅ RESOLUTION 2026-06-09 — a client-side dispatch race, fully explained
+
+**Root cause:** `cf piece call` dispatched the handler event while the watch
+batches issued during piece load were still in flight. The `SqliteDb` handle is
+an asCell handler input read _synchronously_ inside the handler
+(`getRaw({ lastNode: "value" })`, cell.ts `.exec`); when the watch response
+carrying the handle doc hadn't landed in the local replica yet, the read saw an
+empty doc and the guard threw "invalid database handle". Verified by tracing the
+handle doc id through both sides of the sync boundary (session-attributed): the
+server returned the doc correctly in the CLI session's own piece-load batch —
+the response simply arrived _after_ the handler had already run.
+
+**The "emergent (query-count × pattern bulk)" trigger was the race's loss
+condition**, not a property of any SQL construct: each query node adds watch
+entries, and the per-session watch batches are answered serially, so bulk
+deterministically pushes the doc-carrying response past the dispatch. The
+emulated `cf test` runner never fails because loopback storage always wins the
+race. The `lph-*` table, the P1–P8 build-ups, and the day-to-day flakiness of
+the minimal repros are all explained by this.
+
+**Fix:** in `executeResolvedCallable` (`packages/cli/lib/callable.ts`), await
+`runtime.idle()` + `manager.synced()` **before** dispatching the event (both the
+`send()` path and the `.set()` fallback). The pre-existing awaits after `send`
+cover the handler's writes, not its inputs.
+
+**Verified:** full unmodified lunch-poll on a freshly deployed piece —
+`clearHistory`, `logVisit`, `addOption` all succeed across repeated fresh CLI
+sessions; rows land in (and are deleted from) the per-piece sqlite file;
+`cf test` 17/17; cli suite 43/43.
+
+**Remaining follow-up (runtime owners):** the invariant "a handler's asCell
+input docs are locally synced before the handler body runs" is still unguarded
+in the scheduler/event dispatch itself — the CLI was the only cold-start surface
+poking handlers immediately, but other surfaces (e.g. bg-piece-service
+delivering a queued event right after starting a piece) could in principle hit
+the same race. Also untested against this fix: the separate minimal
+`reactOn: db` repro below. Full investigation log:
+`session_outputs/2026-06-09_lunch-poll-sqlite-fresh-eyes/`.
+
+---
 
 ## ⭐ Update 2026-06-09 — isolated the trigger (post Berni's #3896 fix)
 

--- a/packages/patterns/lunch-poll/SQLITE-DEPLOY-BUG.md
+++ b/packages/patterns/lunch-poll/SQLITE-DEPLOY-BUG.md
@@ -1,11 +1,28 @@
 # SQLite builtin: `db.exec` fails on a _deployed_ piece — bug report
 
-**Status: RESOLVED 2026-06-09** (root cause found; fix in
-`packages/cli/lib/callable.ts`). Dates: found 06-04, re-verified 06-05 and
-06-09, fixed later on 06-09. **For:** the sqlite-builtin owner (Berni) — see the
-resolution below; one runtime-level follow-up remains open.
+**Status: RESOLVED 2026-06-10 by runtime PR #3967** (Berni-approved; handler
+asCell-input presync at dispatch plus a `pull()` covered-in-flight contract fix
+in `packages/runner`). Dates: found 06-04, re-verified 06-05 and 06-09, root
+cause and both fixes 06-09/10.
 
-## ✅ RESOLUTION 2026-06-09 — a client-side dispatch race, fully explained
+## ⚠️ Reviving this branch — checklist (written 2026-06-10)
+
+1. **Rebase onto main once #3967 is merged.** The runtime fix alone makes
+   lunch-poll work on deploy — verified on a testbed of main + this pattern with
+   NO local workaround.
+2. **Drop the `packages/cli/lib/callable.ts` hunk from commit `82ced8cee`**
+   (keep that commit's doc changes). It was the interim CLI-only drain (PR
+   #3962, closed as superseded — Berni: blanket "wait for everything to be
+   synced" is the wrong general shape). It is harmless but redundant under
+   #3967, and it adds a global drain to every `cf piece call`.
+3. **Re-test the separate minimal `reactOn: db` repro below** against the merged
+   runtime fix before carrying it forward as its own issue — it was never
+   re-tested after either fix and may or may not share the cause.
+4. Design discussion (options A/B/C, open questions: per-surface opt-out,
+   `isQueryResultProxy` predicate, the `synced`-flag inheritance white lie)
+   lives in PR #3967's description and comments.
+
+## ✅ RESOLUTION 2026-06-09/10 — a client-side dispatch race, fully explained
 
 **Root cause:** `cf piece call` dispatched the handler event while the watch
 batches issued during piece load were still in flight. The `SqliteDb` handle is
@@ -25,24 +42,30 @@ emulated `cf test` runner never fails because loopback storage always wins the
 race. The `lph-*` table, the P1–P8 build-ups, and the day-to-day flakiness of
 the minimal repros are all explained by this.
 
-**Fix:** in `executeResolvedCallable` (`packages/cli/lib/callable.ts`), await
-`runtime.idle()` + `manager.synced()` **before** dispatching the event (both the
-`send()` path and the `.set()` fallback). The pre-existing awaits after `send`
-cover the handler's writes, not its inputs.
+**Fix (the durable one — PR #3967, merged):** three coordinated runtime changes.
+(1) `storage/v2 pull()`: entries covered by an already-registered selector now
+AWAIT the covering watch's in-flight promise — restoring `cell.sync()`'s
+contract that resolved ⇒ data locally available (also fixed for concurrent
+same-key deduped pulls). (2) `EventHandler.presyncInputs`: the handler argument
+is materialized via the existing machinery (asCell fields surface as Cells
+without reading their docs) and every collected Cell's `sync()` is awaited. (3)
+`dispatchQueuedEvent` awaits presync before invoking the handler, fail-open.
+Targeted, not global: a handler waits only on ITS OWN input docs; steady-state
+coverage resolves in a microtask.
+
+(An interim CLI-only drain in `executeResolvedCallable` — PR #3962 — was
+verified first and then closed as superseded; a copy of it rides this branch in
+`82ced8cee` and should be dropped on rebase, see checklist above.)
 
 **Verified:** full unmodified lunch-poll on a freshly deployed piece —
 `clearHistory`, `logVisit`, `addOption` all succeed across repeated fresh CLI
 sessions; rows land in (and are deleted from) the per-piece sqlite file;
-`cf test` 17/17; cli suite 43/43.
+`cf test` 17/17; runner suite 553/553; cli suite 43/43.
 
-**Remaining follow-up (runtime owners):** the invariant "a handler's asCell
-input docs are locally synced before the handler body runs" is still unguarded
-in the scheduler/event dispatch itself — the CLI was the only cold-start surface
-poking handlers immediately, but other surfaces (e.g. bg-piece-service
-delivering a queued event right after starting a piece) could in principle hit
-the same race. Also untested against this fix: the separate minimal
-`reactOn: db` repro below. Full investigation log:
-`session_outputs/2026-06-09_lunch-poll-sqlite-fresh-eyes/`.
+**Still untested:** the separate minimal `reactOn: db` repro below was never
+re-tested against the merged fix. Full investigation log:
+`session_outputs/2026-06-09_lunch-poll-sqlite-fresh-eyes/` (01 = root cause +
+CLI fix, 02 = runtime prototype, pitfalls, design discussion).
 
 ---
 

--- a/packages/patterns/lunch-poll/SQLITE-DEPLOY-BUG.md
+++ b/packages/patterns/lunch-poll/SQLITE-DEPLOY-BUG.md
@@ -1,10 +1,83 @@
 # SQLite builtin: `db.exec` fails on a _deployed_ piece — bug report
 
-**Status:** OPEN. **Dates:** found 2026-06-04, re-verified 2026-06-05.
-**Context:** First dogfood of the SQLite pattern builtins (`sqliteDatabase` /
-`db.query` / `db.exec`, PRs #3776 / #3848) on `lunch-poll`. The migration is
-complete and **green in `cf test`**, but cannot deploy live because of this bug.
-**For:** review with the sqlite-builtin owner (Berni).
+**Status:** OPEN, **trigger isolated 2026-06-09.** Dates: found 06-04,
+re-verified 06-05 and 06-09. **For:** the sqlite-builtin owner (Berni).
+
+## ⭐ Update 2026-06-09 — isolated the trigger (post Berni's #3896 fix)
+
+**Two facts, both verified against a server running Berni's scope fix (#3896,
+`a6b6e14a8`):**
+
+1. **#3896 fixes the minimal case but NOT the full pattern.** A _minimal_
+   `PerUser`+`PerSpace` pattern with `db.query` + `db.exec` now works end-to-end
+   on a deployed piece (write lands, `reactOn: db` re-queries). ✅ The full
+   lunch-poll still fails: every `db.exec` (even an unrelated `clearHistory`
+   doing a plain `DELETE`) throws `invalid database handle`. ❌
+2. **The remaining trigger is EMERGENT — `db.query` count × pattern bulk — not
+   any single SQL construct.** This is the honest, hard-won conclusion (I twice
+   over-narrowed to a single cause and was wrong; the data below is what
+   actually holds).
+
+### The data (single-variable tests on the fixed #3896 server)
+
+Two axes, neither sufficient alone:
+
+**(A) Minimal build-up — add features to a tiny pattern: ALL pass.** P1–P8 each
+WORK: `reactOn:<counter>`, cf-link col + `users.key()` bind, 2 tables, **4
+db.query incl. a GROUP BY JOIN (P4)**, async `fetchData` handler, ~13 bound
+handlers + big output contract, 11 `perSession` cells, many nodes between `db`
+and its consumers. So no individual feature — _including 4 queries with a JOIN_
+— triggers it on a minimal skeleton.
+
+**(B) Strip-down from the real (failing) lunch-poll skeleton (`lph-*`):**
+
+| Variant (on the full lunch-poll body, UI stripped)                            | `db.exec` on deploy |
+| ----------------------------------------------------------------------------- | ------------------- |
+| `lph-b` — only the `recentVisits` query (1 query)                             | ✅ works            |
+| `lph-e` — `recentVisits` + a `count(*)` JOIN (2 queries)                      | ✅ works            |
+| `lph-d` — `recentVisits` + the full aggregate `placeStats` (2 queries)        | ❌ fails            |
+| `lph-k` — `recentVisits` + 3 more **plain** queries (4 queries, NO aggregate) | ❌ fails            |
+
+**The contradiction that pins it down:** P4 (4 queries incl. JOIN) on a
+_minimal_ skeleton WORKS, but `lph-k` (4 plain queries) on the _full lunch-poll_
+skeleton FAILS. And `lph-b` (full skeleton, 1 query) WORKS. So it is the
+**combination of (several `db.query` calls) × (the full pattern's bulk)** that
+trips it — not the query count alone, not the pattern bulk alone, and not the
+complex aggregate alone (`lph-d` shows the aggregate _can_ trip it at just 2
+queries, but `lph-k` shows plain queries also trip it at 4 — so the aggregate is
+an aggravating factor, not THE cause).
+
+### Why a _read_ query breaks the _write_ handle (hypothesis for Berni)
+
+Symptom is on `db.exec` (cell.ts:977 — the delivered `SqliteDb` handle's
+`{id,tables}` value is absent on the deployed path), but the trigger is the
+presence of _enough_ `db.query` nodes in a bulky pattern. Each `db.query` builds
+a `sqliteQuery` node sharing the one `db` handle cell; their request-hashing /
+`rowSchema` lowering / scope-stamping appears to perturb that shared handle so
+its ref isn't stamped on the deployed path — only server-side, never in the
+emulated `cf test` runner. Possibly a cause-identity / output-spot collision
+among multiple query nodes + the write op that scales with pattern size.
+(Speculative — Berni knows the internals; the `lph-*` table is the ground
+truth.)
+
+### Reproduce
+
+`packages/patterns/lunch-poll/main.tsx` on this branch, deployed via
+`cf piece
+new` against a local toolshed **running #3896**, then
+`cf piece call … clearHistory` (or `logVisit`) → throws. Reducing to a single
+`db.query` makes all `db.exec` work. The `lph-b`/`lph-e`/`lph-d`/`lph-k`
+skeletons above bracket the trigger.
+
+### ⚠️ No clean pattern-side workaround found yet
+
+Replacing the aggregate `placeStats` with JS aggregation did NOT unblock it
+(that still leaves 4 `db.query` calls → `lph-k` shows that fails). A real
+unblock needs either Berni's fix, or collapsing lunch-poll down to ~1 `db.query`
+(possible but loses the separate count/stats reads). **Live cutover stays on
+hold.**
+
+---
 
 ## Update 2026-06-05 — reconciling with Berni's diagnosis
 

--- a/packages/patterns/lunch-poll/SQLITE-DEPLOY-BUG.md
+++ b/packages/patterns/lunch-poll/SQLITE-DEPLOY-BUG.md
@@ -1,10 +1,39 @@
 # SQLite builtin: `db.exec` fails on a _deployed_ piece — bug report
 
-**Status:** OPEN — reliably reproduced, root cause not isolated. **Date:**
-2026-06-04 **Context:** First dogfood of the SQLite pattern builtins
-(`sqliteDatabase` / `db.query` / `db.exec`, PRs #3776 / #3848) on `lunch-poll`.
-The migration is complete and **green in `cf test`**, but cannot deploy live
-because of this bug. **For:** review with the sqlite-builtin owner (Berni).
+**Status:** OPEN. **Dates:** found 2026-06-04, re-verified 2026-06-05.
+**Context:** First dogfood of the SQLite pattern builtins (`sqliteDatabase` /
+`db.query` / `db.exec`, PRs #3776 / #3848) on `lunch-poll`. The migration is
+complete and **green in `cf test`**, but cannot deploy live because of this bug.
+**For:** review with the sqlite-builtin owner (Berni).
+
+## Update 2026-06-05 — reconciling with Berni's diagnosis
+
+Berni's hypothesis: the `"sqlite"` cell should be **forced per-space** (the
+cell-derived DB file is per-space), or scope folded into the DB id for per-user
+DBs. Our follow-up confirms the diagnosis is in the right place — the handle's
+scope — and adds two concrete data points:
+
+1. **The bug is deterministic on the real `lunch-poll`** — re-verified on a
+   fresh deploy on 2026-06-05; `clearHistory`/`logVisit` still throw. (A
+   _minimal_ `reactOn: db` repro that failed on 06-04 happened to pass on 06-05
+   — environment-sensitive — but the full pattern fails robustly. Use the full
+   pattern as the reproducer, not that minimal one.)
+2. **The author-side `.asScope("space")` lever is a no-op for `sqliteDatabase`,
+   and does NOT fix it.** `sqliteDatabase` is a `raw()` builtin whose handle is
+   allocated in its own action via
+   `makeResultCell → runtime.getCell(parentCell.space, …, undefined, tx)`
+   ([`packages/runner/src/builtins/sqlite-builtins.ts:41-58,138`](../../runner/src/builtins/sqlite-builtins.ts))
+   — it never consults `module.defaultScope`. (Only the _pattern-node_ path
+   reads `module.defaultScope`, [`runner.ts:3821`](../../runner/src/runner.ts).)
+   So a pattern author cannot pin the handle's scope today, and pinning it via
+   `.asScope` does nothing. **The per-space fix has to live inside the builtin /
+   `makeResultCell`** — give the handle cell an explicit `"space"` scope at
+   allocation (or fold scope into the DB id). Verified: adding
+   `.asScope("space")` to lunch-poll's `db` left `clearHistory` still failing.
+
+This narrows it nicely: the **write-handle materialization on the deployed path
+needs the handle to carry a definite (space) scope**, which the current builtin
+allocation doesn't give it in a `PerUser`+`PerSpace` pattern.
 
 ---
 

--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -90,7 +90,15 @@ export default pattern(() => {
     if (first) poll.removeOption.send({ optionId: first.id });
   });
 
-  // Log a specific place by title (defaults wentAt to today).
+  // Cast a green vote on the surviving option (Thai) so that the next
+  // logVisit captures a non-empty vote snapshot into vote_history.
+  const action_vote_green_thai = action(() => {
+    const first = poll.options[0]; // Thai Kitchen (the only survivor)
+    if (first) poll.castVote.send({ optionId: first.id, voteType: "green" });
+  });
+
+  // Log a specific place by title (defaults wentAt to today). With a live
+  // green vote on Thai, this also writes one vote_history row.
   const action_log_thai = action(() => {
     poll.logVisit.send({ title: "Thai Kitchen" });
   });
@@ -101,8 +109,10 @@ export default pattern(() => {
     poll.logVisit.send({ title: "Chipotle", wentAt: PAST_VISIT + 1000 });
   });
 
+  // Most-recent visit is recentVisits[0] (ORDER BY went_at DESC). Thai is
+  // logged "today" so it sorts ahead of the backdated Chipotle.
   const action_remove_first_history = action(() => {
-    const first = poll.history[0];
+    const first = poll.recentVisits.result?.[0];
     if (first) poll.removeHistoryEntry.send({ id: first.id });
   });
 
@@ -186,31 +196,54 @@ export default pattern(() => {
     poll.adminName === "Alex" && poll.isAdmin === true
   );
 
-  // Winner logged via logVisit({}) — the only remaining option (Thai Kitchen)
-  // has the sole vote, so it's the top choice. Attributed to the host. If the
-  // pre-join attempt ("Sneaky") had not been gated, history[0] would be
-  // "Sneaky" — so this implicitly verifies the host gate too.
-  const assert_thai_logged = computed(() =>
-    poll.history.length === 1 &&
-    poll.history[0]?.title === "Thai Kitchen" &&
-    poll.history[0]?.loggedByName === "Alex"
-  );
+  // History now lives in a SQLite `visits` table; we assert on the
+  // `recentVisits` query result (ORDER BY went_at DESC). The `historyCount` /
+  // `mostRecentTitle` scalars are exposed as a belt-and-suspenders signal — the
+  // most reliable values out of the emulated test runner.
 
-  // Second entry is the backdated Chipotle log, with the exact wentAt we
-  // passed (proves backdating).
-  const assert_two_history = computed(() =>
-    poll.history.length === 2 &&
-    poll.history[1]?.title === "Chipotle" &&
-    poll.history[1]?.wentAt === PAST_VISIT + 1000
-  );
+  // Logged the surviving option (Thai Kitchen) by title → one row, attributed
+  // to the host (the frozen `logged_by` name snapshot). If the pre-join attempt
+  // ("Sneaky") had not been gated, a row would exist before this — so this
+  // implicitly verifies the host gate too.
+  const assert_thai_logged = computed(() => {
+    const rows = poll.recentVisits.result ?? [];
+    return rows.length === 1 &&
+      rows[0]?.title === "Thai Kitchen" &&
+      rows[0]?.logged_by === "Alex" &&
+      poll.historyCount === 1 &&
+      poll.mostRecentTitle === "Thai Kitchen";
+  });
 
-  // After deleting history[0] (Thai), only the Chipotle entry remains.
-  const assert_one_history_after_remove = computed(() =>
-    poll.history.length === 1 &&
-    poll.history[0]?.title === "Chipotle"
-  );
+  // The live green vote on Thai was snapshotted into vote_history when Thai was
+  // logged → exactly one snapshot row.
+  const assert_vote_snapshot = computed(() => poll.voteHistoryCount === 1);
 
-  const assert_history_cleared = computed(() => poll.history.length === 0);
+  // Second row is the backdated Chipotle log; under went_at DESC it sorts after
+  // today's Thai, so it's rows[1]. went_at is stored as zero-padded TEXT (the
+  // @db/sqlite integer-truncation workaround), so we compare via Number(...) —
+  // proving the backdated value round-trips exactly.
+  const assert_two_history = computed(() => {
+    const rows = poll.recentVisits.result ?? [];
+    return rows.length === 2 &&
+      rows[1]?.title === "Chipotle" &&
+      Number(rows[1]?.went_at) === PAST_VISIT + 1000 &&
+      poll.historyCount === 2;
+  });
+
+  // After deleting rows[0] (Thai, the most recent), only Chipotle remains.
+  const assert_one_history_after_remove = computed(() => {
+    const rows = poll.recentVisits.result ?? [];
+    return rows.length === 1 &&
+      rows[0]?.title === "Chipotle" &&
+      poll.historyCount === 1;
+  });
+
+  // Clearing visits also clears the vote_history snapshots.
+  const assert_history_cleared = computed(() =>
+    (poll.recentVisits.result ?? []).length === 0 &&
+    poll.historyCount === 0 &&
+    poll.voteHistoryCount === 0
+  );
 
   return {
     tests: [
@@ -273,16 +306,21 @@ export default pattern(() => {
 
       // "We went here" history. The pre-join attempt above ("Sneaky") must
       // have left no trace.
-      // Log the surviving option by title → one entry, attributed to host.
+      // Cast a live green vote on the surviving option (Thai) so the next
+      // logVisit snapshots it into vote_history.
+      { action: action_vote_green_thai },
+      // Log the surviving option by title → one visit row, attributed to host,
+      // plus one vote_history snapshot row for the green vote.
       { action: action_log_thai },
       { assertion: assert_thai_logged },
+      { assertion: assert_vote_snapshot },
       // A second, backdated, explicit log → two entries (proves backdating).
       { action: action_log_visit_chipotle_backdated },
       { assertion: assert_two_history },
       // Delete a single entry (host) → the other remains.
       { action: action_remove_first_history },
       { assertion: assert_one_history_after_remove },
-      // Clear all → empty.
+      // Clear all → empty (visits AND vote_history).
       { action: action_clear_history },
       { assertion: assert_history_cleared },
     ],

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -22,14 +22,29 @@
  * "We went here" history (Lunch Coordinator roadmap #1): the host logs where
  * the group actually ate via each option's "we went here" button. A host date
  * field backdates the next log (blank = today; `logVisit` also takes an
- * explicit `wentAt`). Each entry is a per-space `HistoryEntry` (place + date);
- * the stored log is capped at the MAX_HISTORY most recent. The log shows as a
- * "Recently eaten" list below the options (8 most recent); the host can delete
- * a single mistaken entry (`removeHistoryEntry`) or clear the whole log.
+ * explicit `wentAt`). The log shows as a "Recently eaten" list below the
+ * options (8 most recent); the host can delete a single mistaken entry
+ * (`removeHistoryEntry`) or clear the whole log.
+ *
+ * Storage (dogfooding the SQLite builtins, PRs #3776/#3848): visits live in a
+ * SQLite `visits` table — not the former `PerSpace<HistoryEntry[]>` array — so
+ * there's no MAX_HISTORY cap and "Recently eaten" is a `db.query` (the read
+ * bounds itself with LIMIT). Each `logVisit` also snapshots everyone's current
+ * vote into a `vote_history` table tied to that visit; the "📊 Lunch stats"
+ * card surfaces per-place visit + green/red tallies from it. Live voting stays
+ * on the in-cell `votes` array — only the durable record is in SQLite. Both
+ * tables carry a frozen TEXT name plus a `cfLink<User>` live profile pointer.
+ *
+ * KNOWN ISSUE (open): correct + green in the emulated `cf test` runner, but on a
+ * *deployed* piece `db.exec` throws "invalid database handle" (a sqlite-builtin
+ * × scoped-pattern interaction, reliably reproduced, root cause still open —
+ * see the session finding doc). Don't cut over the live canonical piece yet.
  * See `LUNCH-COORDINATOR-TODO.md`.
  */
 
 import {
+  type Cell,
+  cfLink,
   computed,
   Default,
   fetchData,
@@ -41,7 +56,10 @@ import {
   type PerSpace,
   type PerUser,
   safeDateNow,
+  sqliteDatabase,
+  type SqliteDb,
   Stream,
+  table,
   UI,
   type VNode,
   wish,
@@ -136,12 +154,49 @@ export interface CastVoteEvent {
 
 export type ResetVotesEvent = Record<PropertyKey, never>;
 
-/** A place the group actually ate, logged by the host. */
+/**
+ * A place the group actually ate, logged by the host. Persisted in the SQLite
+ * `visits` table (replacing the former `history: PerSpace<HistoryEntry[]>`
+ * array). Column names are snake_case to read naturally in SQL; this interface
+ * documents the logical shape.
+ */
 export interface HistoryEntry {
   id: string;
   title: string;
   loggedByName: string;
   wentAt: number;
+}
+
+/**
+ * A row of the `visits` query result. `logged_by` is a frozen name snapshot
+ * (what the "Recently eaten" card renders); `logged_by_cf_link` is a live
+ * pointer to the logging user's profile (dogfoods the cfLink feature). See the
+ * KNOWN ISSUE note on the `sqliteDatabase(...)` call about deployed pieces.
+ */
+export interface VisitRow {
+  id: string;
+  title: string;
+  logged_by: string;
+  logged_by_cf_link: Cell<User>;
+  // Stored as zero-padded TEXT (see encodeTs) — decode with Number() / decodeTs.
+  went_at: string;
+}
+
+/**
+ * A row of the `vote_history` table — a snapshot of one person's vote at the
+ * moment a visit was logged. `option_title` is denormalized (options get
+ * removed; the title is the meaningful record). `voter` is a frozen name (no
+ * cfLink — same deployed-piece reason as VisitRow).
+ */
+export interface VoteHistoryRow {
+  id: string;
+  visit_id: string;
+  voter: string;
+  voter_cf_link: Cell<User>;
+  option_title: string;
+  vote_color: VoteColor;
+  // Stored as zero-padded TEXT (see encodeTs) — decode with Number() / decodeTs.
+  went_at: string;
 }
 
 /**
@@ -167,9 +222,15 @@ type LinkTargetCell = Writable<string | null>;
 type OptionsCell = Writable<Option[] | Default<[]>>;
 type VotesCell = Writable<Vote[] | Default<[]>>;
 type UsersCell = Writable<User[] | Default<[]>>;
-type HistoryCell = Writable<HistoryEntry[] | Default<[]>>;
 type NameCell = Writable<string | Default<"">>;
 type HomePageRefreshCell = Writable<number>;
+// A monotonic write counter bumped by the sqlite-mutating handlers; the
+// db.query calls react on THIS rather than on `db`. In the test runner,
+// `reactOn: db` does not reliably re-run a query after a committed db.exec,
+// whereas bumping a plain PerSpace counter and reacting on it does. (The spec's
+// in-commit `rev`-bump model is meant to make `reactOn: db` work; until it does
+// here, the counter is the dependable trigger.)
+type RevCell = Writable<number | Default<0>>;
 
 const PLAYER_COLORS = [
   "#2f8a64",
@@ -325,10 +386,6 @@ const DAY_NAMES = [
   "Saturday",
 ];
 
-// Cap on the stored visit log so a long-lived poll's PerSpace array can't grow
-// without bound. The "Recently eaten" card shows fewer (the 8 most recent).
-const MAX_HISTORY = 50;
-
 const newHistoryId = () =>
   `h_${safeDateNow().toString(36)}_${
     Math.floor(nonPrivateRandom() * 1e6).toString(36)
@@ -343,6 +400,20 @@ const parseVisitDate = (draft: string | undefined): number => {
   const t = new Date(`${s}T00:00:00`).getTime();
   return Number.isNaN(t) ? safeDateNow() : t;
 };
+
+// We store ms-epoch timestamps as zero-padded TEXT, not as SQLite `integer`.
+// Why: the @db/sqlite binding the runtime uses truncates a bound JS number to
+// 32 bits, so a real ms-epoch (~1.7e12) round-trips as a negative garbage value
+// (and passing a BigInt doesn't help in this version). TEXT round-trips the
+// value losslessly; 16-digit zero-padding keeps lexicographic ORDER BY equal to
+// numeric order for every non-negative timestamp (covers dates well past 3000).
+// If/when the integer-binding bug is fixed upstream, this can revert to a plain
+// `integer` column. (Surfaced while dogfooding the SQLite builtin — worth
+// reporting upstream.)
+const TS_WIDTH = 16;
+const encodeTs = (ms: number): string =>
+  Math.max(0, Math.trunc(ms)).toString().padStart(TS_WIDTH, "0");
+const decodeTs = (s: string | undefined): number => Number(s ?? 0);
 
 // Label for a visit derived purely from its own timestamp — never from the
 // current clock, so it stays idempotent inside reactive computations (timestamps
@@ -607,17 +678,25 @@ const clearMyVote = handler<ClearVoteEvent, {
 });
 
 // Host-only, same gate as the other mutating admin actions. Logs where the
-// group actually ate — by option id (resolved to its title) or a free title.
+// group actually ate — by option id (resolved to its title) or a free title —
+// into the SQLite `visits` table, and snapshots everyone's current vote into
+// `vote_history`. All db.exec writes here fold into the one handler commit.
+//
+// SQLite carries the cap that the old in-cell array needed: no MAX_HISTORY
+// pruning — the table grows fine, and the read query bounds what's shown.
 const logVisit = handler<LogVisitEvent, {
-  history: HistoryCell;
+  db: SqliteDb;
   options: OptionsCell;
+  votes: VotesCell;
+  users: UsersCell;
   myName: NameCell;
   adminName: NameCell;
   visitDate: NameCell;
+  rev: RevCell;
 }>(
   (
     { optionId, title, wentAt },
-    { history, options, myName, adminName, visitDate },
+    { db, options, votes, users, myName, adminName, visitDate, rev },
   ) => {
     const me = trimmedName(myName.get());
     const admin = trimmedName(adminName.get());
@@ -631,44 +710,79 @@ const logVisit = handler<LogVisitEvent, {
     const when = typeof wentAt === "number"
       ? wentAt
       : parseVisitDate(visitDate.get());
-    const entry: HistoryEntry = {
-      id: newHistoryId(),
-      title: place,
-      loggedByName: me,
-      wentAt: when,
+    const whenText = encodeTs(when); // see encodeTs: timestamps stored as TEXT
+    const visitId = newHistoryId();
+
+    // Resolve a name → that user's live Cell<User> in the directory, for the
+    // `*_cf_link` columns. users.key(i) is a stable, toCell-bearing cell; a
+    // cell may only be bound to a _cf_link column (binding elsewhere throws).
+    const us = users.get();
+    const cellForName = (name: string): Cell<User> | null => {
+      const idx = us.findIndex((u) => u.name === name);
+      return idx >= 0 ? users.key(idx) : null;
     };
-    // Cap the stored log at the MAX_HISTORY most recent visits (by date).
-    const next = [...history.get(), entry];
-    history.set(
-      next.length > MAX_HISTORY
-        ? [...next].sort((a, b) => b.wentAt - a.wentAt).slice(0, MAX_HISTORY)
-        : next,
+    const hostCell = cellForName(me);
+
+    db.exec(
+      "INSERT INTO visits (id, title, logged_by, logged_by_cf_link, went_at) VALUES (?, ?, ?, ?, ?)",
+      // a _cf_link param must never be undefined; pass null for an absent cell.
+      [visitId, place, me, hostCell ?? null, whenText],
     );
+
+    // Snapshot the current live votes tied to this visit. Denormalize the
+    // option title (options can be removed later; the title is the record).
+    const titleById = new Map(options.get().map((o) => [o.id, o.title]));
+    for (const v of votes.get()) {
+      const optTitle = trimmedName(titleById.get(v.optionId));
+      if (!optTitle) continue; // vote for an already-removed option → skip
+      db.exec(
+        "INSERT INTO vote_history (id, visit_id, voter, voter_cf_link, option_title, vote_color, went_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [
+          `${visitId}_${v.voterName}_${v.optionId}`,
+          visitId,
+          v.voterName,
+          cellForName(v.voterName) ?? null,
+          optTitle,
+          v.voteType,
+          whenText,
+        ],
+      );
+    }
+
     // Reset the date draft so the next log defaults back to today.
     visitDate.set("");
+    // Bump the write counter so the reactOn:rev queries re-run (see RevCell).
+    rev.set((rev.get() ?? 0) + 1);
   },
 );
 
 const removeHistoryEntry = handler<RemoveHistoryEntryEvent, {
-  history: HistoryCell;
+  db: SqliteDb;
   myName: NameCell;
   adminName: NameCell;
-}>(({ id }, { history, myName, adminName }) => {
+  rev: RevCell;
+}>(({ id }, { db, myName, adminName, rev }) => {
   const me = trimmedName(myName.get());
   const admin = trimmedName(adminName.get());
   if (!me || me !== admin) return;
-  history.set(history.get().filter((h) => h.id !== id));
+  db.exec("DELETE FROM visits WHERE id = ?", [id]);
+  // Drop the vote snapshot for that visit too, so the two tables stay aligned.
+  db.exec("DELETE FROM vote_history WHERE visit_id = ?", [id]);
+  rev.set((rev.get() ?? 0) + 1);
 });
 
 const clearHistory = handler<ClearHistoryEvent, {
-  history: HistoryCell;
+  db: SqliteDb;
   myName: NameCell;
   adminName: NameCell;
-}>((_, { history, myName, adminName }) => {
+  rev: RevCell;
+}>((_, { db, myName, adminName, rev }) => {
   const me = trimmedName(myName.get());
   const admin = trimmedName(adminName.get());
   if (!me || me !== admin) return;
-  history.set([]);
+  db.exec("DELETE FROM visits", []);
+  db.exec("DELETE FROM vote_history", []);
+  rev.set((rev.get() ?? 0) + 1);
 });
 
 interface OptionTally {
@@ -724,10 +838,14 @@ export interface CozyPollInput {
   options?: PerSpace<Option[] | Default<[]>>;
   votes?: PerSpace<Vote[] | Default<[]>>;
   users?: PerSpace<User[] | Default<[]>>;
-  history?: PerSpace<HistoryEntry[] | Default<[]>>;
   adminName?: PerSpace<string | Default<"">>;
   myName?: PerUser<string | Default<"">>;
   webSearchUrl?: PerSpace<string | Default<typeof WEB_SEARCH_URL>>;
+  // Write counter bumped by the sqlite-mutating handlers; the db.query calls
+  // react on this rather than on `db` directly (see RevCell for why).
+  sqliteRev?: PerSpace<number | Default<0>>;
+  // Visit history + the vote-history snapshots now live in a SQLite database
+  // owned by the pattern body (`sqliteDatabase(...)`), not a PerSpace input.
   // optionDraft etc. are internal form drafts, declared as local
   // per-session cells in the pattern body (parking-coordinator idiom).
 }
@@ -740,13 +858,20 @@ export interface CozyPollOutput {
   options: readonly Option[];
   votes: readonly Vote[];
   users: readonly User[];
-  history: readonly HistoryEntry[];
   adminName: string;
   myName: string;
   userCount: number;
   optionCount: number;
   voteCount: number;
   historyCount: number;
+  // The "Recently eaten" SQLite query result ({ pending, result, error }).
+  // Exposed so tests and consumers can read the durable visit log.
+  recentVisits: { pending: boolean; result?: VisitRow[]; error?: unknown };
+  // Title of the most-recent visit ("" when empty) — a plain scalar that's the
+  // most reliable signal for tests (vs. asserting on the result array shape).
+  mostRecentTitle: string;
+  // Count of rows in the vote_history snapshot table.
+  voteHistoryCount: number;
   isJoined: boolean;
   isAdmin: boolean;
   homePageLookupUrls: readonly string[];
@@ -770,7 +895,6 @@ export interface CozyPollOutput {
 const EMPTY_OPTIONS: Option[] = [];
 const EMPTY_VOTES: Vote[] = [];
 const EMPTY_USERS: User[] = [];
-const EMPTY_HISTORY: HistoryEntry[] = [];
 
 export default pattern<CozyPollInput, CozyPollOutput>(
   (
@@ -780,12 +904,46 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       options,
       votes,
       users,
-      history,
       adminName,
       myName,
       webSearchUrl,
+      sqliteRev,
     },
   ) => {
+    // SQLite database owned by this pattern (default cell-derived source). The
+    // visit log and the per-visit vote snapshots live here; the runtime owns
+    // table creation/migration from this declaration. `*_cf_link` columns store
+    // a live Cell<User> reference alongside the frozen TEXT name.
+    //
+    // KNOWN ISSUE (open): on a *deployed* piece (not the emulated test runner),
+    // `db.exec` in these handlers throws "invalid database handle". It is NOT
+    // the cf-link alone (removing it didn't fix it) — it's a subtler interaction
+    // of this scoped (PerUser+PerSpace) pattern's multiple db.query calls with
+    // the write handle. Reliably reproduced; root cause still open; filed for
+    // the sqlite-builtin owner. The pattern is correct + green in `cf test`
+    // (emulated MemoryV2Server). Do NOT cut over the live canonical piece until
+    // it's fixed. See session_outputs/2026-06-04_lunch-poll-sqlite/.
+    const db = sqliteDatabase({
+      tables: {
+        visits: table({
+          id: "text primary key",
+          title: "text",
+          logged_by: "text",
+          logged_by_cf_link: cfLink<User>(),
+          // ms-epoch as zero-padded TEXT, not integer — see encodeTs.
+          went_at: "text",
+        }),
+        vote_history: table({
+          id: "text primary key",
+          visit_id: "text",
+          voter: "text",
+          voter_cf_link: cfLink<User>(),
+          option_title: "text",
+          vote_color: "text",
+          went_at: "text",
+        }),
+      },
+    });
     // Internal per-session form drafts — local to each browser session,
     // not exposed as pattern inputs. Uses the scoped-constructor idiom
     // introduced by parking-coordinator (PR #3610).
@@ -854,18 +1012,27 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     const boundClearMyVote = clearMyVote({ votes, myName });
     const boundResetVotes = resetVotes({ votes, myName, adminName });
     const boundLogVisit = logVisit({
-      history,
+      db,
       options,
+      votes,
+      users,
       myName,
       adminName,
       visitDate,
+      rev: sqliteRev,
     });
     const boundRemoveHistoryEntry = removeHistoryEntry({
-      history,
+      db,
       myName,
       adminName,
+      rev: sqliteRev,
     });
-    const boundClearHistory = clearHistory({ history, myName, adminName });
+    const boundClearHistory = clearHistory({
+      db,
+      myName,
+      adminName,
+      rev: sqliteRev,
+    });
     const boundSetCity = setCity({ city, myName, adminName, cityDraft });
     const boundEnrichHomePages = enrichHomePages({
       myName,
@@ -891,13 +1058,55 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     const userCount = users.length;
     const optionCount = options.length;
     const voteCount = votes.length;
-    const historyCount = history.length;
-    const hasHistory = history.length > 0;
-    // Most-recent-first, capped — the "Recently eaten" card stays compact.
-    // Whole-array transform over a reactive array → computed (a single lift
-    // over the array), not bare; see 04-finding-map-on-reactive-array.md.
-    const recentHistory = computed(() =>
-      [...history].sort((a, b) => b.wentAt - a.wentAt).slice(0, 8)
+    // The "Recently eaten" card, now a SQLite query. It re-runs when the
+    // sqliteRev counter changes — the mutating handlers bump it after each
+    // db.exec (we react on the counter, not `db`; see RevCell). The read bounds
+    // itself with LIMIT 8 — no stored cap needed.
+    const recentVisits = db.query<VisitRow>(
+      "SELECT id, title, logged_by, logged_by_cf_link, went_at FROM visits ORDER BY went_at DESC LIMIT 8",
+      { reactOn: sqliteRev },
+    );
+    // `recentVisits.result` is `VisitRow[] | undefined`. Coercing with `?? []`
+    // inside a computed yields an OpaqueRef<VisitRow[]> structurally identical
+    // to the old `recentHistory` array — so the "Recently eaten" card keeps its
+    // existing plain-JSX `.map(...)` with interactive onClick handlers, which
+    // must NOT live inside a lift-returned VNode (they'd mis-lower as lifts —
+    // "$event in inputs" / non-idempotent write). This is the key to migrating
+    // the card without reintroducing that bug.
+    const recentRows = computed(() => recentVisits.result ?? []);
+    const visitCount = db.query<{ n: number }>(
+      "SELECT count(*) AS n FROM visits",
+      { reactOn: sqliteRev },
+    );
+    const historyCount = computed(() => visitCount.result?.[0]?.n ?? 0);
+    const hasHistory = computed(() => (visitCount.result?.[0]?.n ?? 0) > 0);
+    const mostRecentTitle = computed(() =>
+      recentVisits.result?.[0]?.title ?? ""
+    );
+    // 📊 Lunch stats: per-place visit count + green/red tallies across the
+    // whole durable record, joining visits to their vote snapshots. Read-only
+    // (no handlers), so it's free of the lift hazard above.
+    const placeStats = db.query<
+      { title: string; visits: number; greens: number; reds: number }
+    >(
+      `SELECT v.title AS title,
+              count(DISTINCT v.id) AS visits,
+              sum(CASE WHEN vh.vote_color = 'green' THEN 1 ELSE 0 END) AS greens,
+              sum(CASE WHEN vh.vote_color = 'red' THEN 1 ELSE 0 END) AS reds
+       FROM visits v
+       LEFT JOIN vote_history vh ON vh.visit_id = v.id
+       GROUP BY v.title
+       ORDER BY visits DESC, greens DESC
+       LIMIT 5`,
+      { reactOn: sqliteRev },
+    );
+    const placeStatsRows = computed(() => placeStats.result ?? []);
+    const voteHistoryCountQuery = db.query<{ n: number }>(
+      "SELECT count(*) AS n FROM vote_history",
+      { reactOn: sqliteRev },
+    );
+    const voteHistoryCount = computed(() =>
+      voteHistoryCountQuery.result?.[0]?.n ?? 0
     );
     // Resolve the viewer's name ONCE here at the top level. PerUser `myName`
     // resolves in this scope, but NOT inside the per-option `options.map(...)`
@@ -1997,7 +2206,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                             ))
                           : null}
                       </div>
-                      {recentHistory.map((entry) => {
+                      {recentRows.map((entry) => {
                         const entryId = entry.id;
                         return (
                           <div
@@ -2024,7 +2233,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                               <span
                                 style={{ fontSize: "12px", color: "#a08552" }}
                               >
-                                {visitLabel(entry.wentAt)}
+                                {visitLabel(decodeTs(entry.went_at))}
                               </span>
                               {isAdmin
                                 ? (
@@ -2054,6 +2263,74 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                           </div>
                         );
                       })}
+                    </div>
+                  )
+                  : null}
+
+                {
+                  /* Lunch stats — a read-only recap from the vote_history
+                  snapshots: per-place visit count + how the group leaned
+                  (greens / reds) across every logged visit. Shown to everyone
+                  whenever there's any history. No interactive handlers, so the
+                  whole-array `.map` is plain and free of the lift hazard the
+                  "Recently eaten" card has to dodge. */
+                }
+                {hasHistory
+                  ? (
+                    <div
+                      style={{
+                        marginBottom: "16px",
+                        padding: "12px 16px",
+                        backgroundColor: "#f3f0fb",
+                        border: "1px solid #ddd2f0",
+                        borderRadius: "8px",
+                      }}
+                    >
+                      <div
+                        style={{
+                          fontSize: "11px",
+                          fontWeight: 700,
+                          letterSpacing: "0.05em",
+                          textTransform: "uppercase",
+                          color: "#5b3fa3",
+                          marginBottom: "10px",
+                        }}
+                      >
+                        📊 Lunch stats
+                      </div>
+                      {placeStatsRows.map((stat) => (
+                        <div
+                          style={{
+                            display: "flex",
+                            alignItems: "baseline",
+                            justifyContent: "space-between",
+                            gap: "8px",
+                            padding: "4px 0",
+                            fontSize: "13px",
+                            color: "#473266",
+                          }}
+                        >
+                          <span style={{ fontWeight: 500 }}>{stat.title}</span>
+                          <span
+                            style={{
+                              display: "inline-flex",
+                              alignItems: "baseline",
+                              gap: "10px",
+                              fontSize: "12px",
+                            }}
+                          >
+                            <span style={{ color: "#8a7bb0" }}>
+                              {stat.visits}×
+                            </span>
+                            <span style={{ color: "#2f8a64" }}>
+                              🟢 {stat.greens}
+                            </span>
+                            <span style={{ color: "#a33b35" }}>
+                              🔴 {stat.reds}
+                            </span>
+                          </span>
+                        </div>
+                      ))}
                     </div>
                   )
                   : null}
@@ -2190,17 +2467,21 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       // didn't write them, and a computed that RETURNS undefined is
       // indistinguishable from "not yet computed" for cross-runtime readers —
       // so every snapshot yields a real, stable value (the shared EMPTY
-      // constants keep the fallback idempotent across recomputes).
+      // constants keep the fallback idempotent across recomputes). The visit
+      // history is no longer a PerSpace input — it lives in SQLite now and is
+      // surfaced via `recentVisits`/`mostRecentTitle` below.
       options: computed(() => options ?? EMPTY_OPTIONS),
       votes: computed(() => votes ?? EMPTY_VOTES),
       users: computed(() => users ?? EMPTY_USERS),
-      history: computed(() => history ?? EMPTY_HISTORY),
       adminName: computed(() => trimmedName(adminName)),
       myName: computed(() => trimmedName(myName)),
       userCount,
       optionCount,
       voteCount,
       historyCount,
+      recentVisits,
+      mostRecentTitle,
+      voteHistoryCount,
       isJoined,
       isAdmin,
       homePageLookupUrls,


### PR DESCRIPTION
## Summary

Migrates the lunch-poll's **visit history** and **per-visit vote snapshots** off in-cell `PerSpace` arrays and into the **SQLite builtin** (`sqliteDatabase` + `db.query`/`db.exec`). Adds a durable visit log, vote-history snapshots, and a "Lunch stats" aggregate — none of which need an in-cell `MAX_HISTORY` cap anymore (the read queries bound what's shown).

Pattern-only change: 5 files under `packages/patterns/lunch-poll/`, no runtime/CLI changes.

## ✅ Deploy status (important — historical commit messages are stale)

The first commit is labelled *"NOT live-deployable yet"* because of the `db.exec` "invalid database handle" bug on deployed pieces. **That bug is now RESOLVED by runtime PR #3967 (merged to main).** Verified end-to-end: deployed to a production toolshed, `db.exec` INSERT/DELETE land in the per-piece SQLite file, and the reactive queries resolve under a subscribed runtime. So this branch **is** live-deployable on current main, with no pattern-side workaround.

Full root-cause investigation (a client-side dispatch race) is written up in `SQLITE-DEPLOY-BUG.md`.

## What's included

- `visits` + `vote_history` SQLite tables; `*_cf_link` columns carry a live `Cell<User>` alongside the frozen TEXT name.
- Reactive reads (`recentVisits`, `placeStats`, counts) that re-run on a `sqliteRev` PerSpace counter the mutating handlers bump (the dependable trigger until in-commit `rev`-bump `reactOn: db` is solid).
- Timestamps stored as zero-padded TEXT (`encodeTs`/`decodeTs`) — works around `@db/sqlite` 32-bit-int truncation while keeping `ORDER BY` correct.
- Drops the interim CLI drain in `callable.ts` (PR #3962, closed as superseded by #3967).

## Tests

`deno task cf test packages/patterns/lunch-poll/main.test.tsx` → **18/18**.

## Follow-ups (separate, stacked)

A free-text-name join variant and Lunch-Stats correctness fixes (per-place scoping + yellow tally) live on `gideon/lunch-poll-freetext-join`, which branches off this one — separate PR to keep this scoped to the SQLite migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated lunch-poll visit and vote history to the SQLite builtin for durable storage and added a new “Lunch stats” view. Pattern-only change; live-deployable on current `main`.

- **New Features**
  - Store history in `sqliteDatabase` tables: `visits` and `vote_history`; `logVisit` writes both in one commit.
  - “Recently eaten” now queries SQLite with `LIMIT 8`; queries re-run via a `sqliteRev` counter; counts are exposed.
  - Added `cfLink<User>` columns alongside frozen name snapshots; timestamps stored as zero‑padded text to dodge `@db/sqlite` 32‑bit truncation.
  - Updated tests to cover visit logging, backdating, single-row deletes, clears, and vote-history snapshots.

<sup>Written for commit 15bd8a7c39f955a71a5619bc7bfa6dee41393ffb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/main.test.tsx = 27s
---END COPY-PASTE---