### PR TITLE
feat(lunch-poll): free-text join + Lunch Stats fixes (yellow tally, per-place scoping)

### DIFF
--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -2,13 +2,14 @@
 
 How to deploy the lunch poll, update it in place without losing data, share it,
 verify it actually worked, and recover it when it breaks. Written for someone
-(human or agent) operating the poll for the first time — read top to bottom once.
+(human or agent) operating the poll for the first time — read top to bottom
+once.
 
 > **Status (2026-06-15): live-deployable.** The visit history + per-visit vote
 > snapshots live in the **SQLite builtin** (`sqliteDatabase`). The old
 > "`db.exec` throws 'invalid database handle' on a deployed piece" bug is
-> **resolved** by runtime PR #3967 (merged to main) — no pattern-side
-> workaround needed. Full root-cause writeup is in `SQLITE-DEPLOY-BUG.md`.
+> **resolved** by runtime PR #3967 (merged to main) — no pattern-side workaround
+> needed. Full root-cause writeup is in `SQLITE-DEPLOY-BUG.md`.
 
 ## Where the data lives (mental model)
 
@@ -17,15 +18,15 @@ addressed by `(space, causal-cell-id)` — not to "the pattern" in the abstract.
 So "share the state" = "everyone points at the same piece"; "copy the state" =
 "move that piece's values into a new piece." There are **two** stores:
 
-1. **`PerSpace` input cells** — shared by everyone in the space:
-   `question`, `city`, `options`, `votes`, `users`, `adminName`, `webSearchUrl`,
+1. **`PerSpace` input cells** — shared by everyone in the space: `question`,
+   `city`, `options`, `votes`, `users`, `adminName`, `webSearchUrl`,
    `sqliteRev`. Plus **`myName`** which is **`PerUser`** (keyed by your DID).
 2. **A pattern-owned SQLite database** (`sqliteDatabase(...)`) holding the
    `visits` and `vote_history` tables — i.e. the "Recently eaten" log and the
    "Lunch stats". This is **not** a `PerSpace` input; it's a cell-derived db
    tied to the piece's result cell. (There is no `history` input cell anymore —
-   if you find older docs/scripts referencing `history`, they predate the
-   SQLite migration.)
+   if you find older docs/scripts referencing `history`, they predate the SQLite
+   migration.)
 
 Both stores survive an in-place `setsrc` (see Option A). Only the `PerSpace`
 cells can be copied to another piece via the CLI (see Option B's caveat).
@@ -119,10 +120,10 @@ deno task cf piece step --piece "$MINE" -s "$SPACE"
 deno task cf piece inspect --piece "$MINE" -s "$SPACE" --summary
 ```
 
-This is a **one-time snapshot copy**, not a live link — the pieces diverge after.
-**The SQLite history does NOT copy this way** — `visits`/`vote_history` live in a
-per-piece, cell-derived SQLite db, not in `PerSpace` inputs, so the loop above
-leaves your copy's "Recently eaten" / "Lunch stats" empty.
+This is a **one-time snapshot copy**, not a live link — the pieces diverge
+after. **The SQLite history does NOT copy this way** — `visits`/`vote_history`
+live in a per-piece, cell-derived SQLite db, not in `PerSpace` inputs, so the
+loop above leaves your copy's "Recently eaten" / "Lunch stats" empty.
 
 ### Migrating the SQLite history to another piece (the current gap)
 
@@ -130,15 +131,15 @@ There is **no in-builtin way to share or repoint a writable history db** between
 pieces today (sqlite-builtin spec §03 "Database sources"):
 
 - **Cell-derived** (what this poll uses) is keyed to the piece's own handle-cell
-  entity id — *"no way to point the database at an arbitrary cell"* (deliberate,
+  entity id — _"no way to point the database at an arbitrary cell"_ (deliberate,
   to avoid ambient authority). Two pieces can't share it, and a fresh piece
   can't adopt an old one's db.
-- The **on-disk injected** source (`cf piece link sqlite:…`) *can* be shared
+- The **on-disk injected** source (`cf piece link sqlite:…`) _can_ be shared
   across pieces (same path → same handle), but is **read-only in v1** — writes
   are rejected, so it's no good for a live, mutated history.
 - The **VM-file** source is stubbed (not implemented).
 
-So moving history to a *different* piece needs an explicit mechanism. Options,
+So moving history to a _different_ piece needs an explicit mechanism. Options,
 none built yet:
 
 1. **App-level export → import (portable).** Add a full-dump query output
@@ -149,28 +150,28 @@ none built yet:
 2. **Local filesystem dump (hack).**
    `sqlite3 A-cell.sqlite ".dump visits vote_history" | sqlite3 B-cell.sqlite`.
    Local only (needs the files), you must map each piece → its
-   `cell-<hash>.sqlite`, and it must run while the piece is **idle** (the file is
-   ATTACHed during transactions). No `cf` surface for this yet.
+   `cell-<hash>.sqlite`, and it must run while the piece is **idle** (the file
+   is ATTACHed during transactions). No `cf` surface for this yet.
 3. **Avoid the need:** keep iterating on the same piece (`setsrc`, Option A — no
    migration), or re-log visits via `logVisit`.
 
-Honest trade-off: the pre-SQLite **array** history *was* copyable as a `PerSpace`
-cell; the SQLite migration made it more durable-per-piece but no longer
-CLI-portable. Whether to invest in a portable/shared-history mechanism is an open
-design question — discuss before building.
+Honest trade-off: the pre-SQLite **array** history _was_ copyable as a
+`PerSpace` cell; the SQLite migration made it more durable-per-piece but no
+longer CLI-portable. Whether to invest in a portable/shared-history mechanism is
+an open design question — discuss before building.
 
 ## Verifying a deploy actually worked
 
 This pattern's reads behave in a way that trips people up over the CLI:
 
-- **Reactive queries only resolve under a *subscribed* runtime (a browser).**
-  `recentVisits`, `placeStats`, `historyCount`, `mostRecentTitle` are
-  `db.query` results that re-run on the `sqliteRev` counter. A `cf piece get`
-  does **not** subscribe, so right after a write these read as
-  `{ pending: true }` / `0` over the CLI — even though the write landed. A
-  freshly `new`-ed piece also isn't registered with the background-charm-service
-  (`monitoring 0 spaces`), so nothing pumps the re-query headlessly. **Open the
-  piece in a browser** and the live subscription resolves them.
+- **Reactive queries only resolve under a _subscribed_ runtime (a browser).**
+  `recentVisits`, `placeStats`, `historyCount`, `mostRecentTitle` are `db.query`
+  results that re-run on the `sqliteRev` counter. A `cf piece get` does **not**
+  subscribe, so right after a write these read as `{ pending: true }` / `0` over
+  the CLI — even though the write landed. A freshly `new`-ed piece also isn't
+  registered with the background-charm-service (`monitoring 0 spaces`), so
+  nothing pumps the re-query headlessly. **Open the piece in a browser** and the
+  live subscription resolves them.
 
 - **To verify a write landed without a browser, read the SQLite file directly.**
   `db.exec` writes (`logVisit`, `clearHistory`, `removeHistoryEntry`) persist
@@ -187,6 +188,7 @@ This pattern's reads behave in a way that trips people up over the CLI:
   (On prod the db lives server-side — confirm via the browser instead.)
 
 **Smoke test after deploy** (host-gated handlers need a join first):
+
 ```bash
 deno task cf piece call --piece "$PIECE" -s "$SPACE" joinAs '{"name":"Host"}'
 deno task cf piece step --piece "$PIECE" -s "$SPACE"
@@ -197,7 +199,8 @@ deno task cf piece step --piece "$PIECE" -s "$SPACE"
 # No "invalid database handle" error => db.exec works (i.e. the runtime has #3967).
 # Then confirm the row via the sqlite recipe above, or in the browser.
 ```
-If `db.exec` *does* throw "invalid database handle" on a deployed piece, the
+
+If `db.exec` _does_ throw "invalid database handle" on a deployed piece, the
 server is running a runtime from **before #3967** — not a pattern bug.
 
 ## Identity & joining
@@ -223,9 +226,9 @@ the `users` directory are `PerSpace`. Consequences that bite:
 3. **Names are unique.** `joinAs` rejects a name already in `users`. If a
    test/seed claimed your name, pick another or clear the stale entry.
 
-4. **Host role is claimable.** Any joined participant can take the host seat with
-   **Become host** (`claimHost`). A squatted/stale host seat doesn't need an
-   operator reset — just join and click Become host. (You can also reset
+4. **Host role is claimable.** Any joined participant can take the host seat
+   with **Become host** (`claimHost`). A squatted/stale host seat doesn't need
+   an operator reset — just join and click Become host. (You can also reset
    `adminName` to `""` directly when no one is joined.)
 
 ## Resetting / re-seeding state (host or operator)
@@ -234,8 +237,9 @@ the `users` directory are `PerSpace`. Consequences that bite:
 everyone sees, and direct `set` races anyone's live browser session.**
 
 - **Votes:** use the in-app `resetVotes` (host) — or call it via CLI.
-- **History (SQLite):** there is no `history` input cell. Use the **`clearHistory`
-  handler** (host-gated) — it clears both `visits` and `vote_history`:
+- **History (SQLite):** there is no `history` input cell. Use the
+  **`clearHistory` handler** (host-gated) — it clears both `visits` and
+  `vote_history`:
   ```bash
   deno task cf piece call --piece "$PIECE" -s "$SPACE" clearHistory '{}'
   deno task cf piece step --piece "$PIECE" -s "$SPACE"
@@ -259,6 +263,7 @@ everyone sees, and direct `set` races anyone's live browser session.**
 deno task cf piece new packages/patterns/lunch-poll/main.tsx -s "$SPACE"
 # → prints a new fid1:… — update the "canonical piece" block above.
 ```
+
 You need `WRITE`/`OWNER` on the space (ACL-gated); a denied write changes
 nothing.
 
@@ -285,11 +290,13 @@ NEW=$(deno task cf piece new packages/patterns/lunch-poll/main.tsx \
 ### Home space won't load (profile setup, `main`-style builds)
 
 Unrelated to the poll itself, but bites colleagues setting up a profile: if a
-home space fails to load with `Handler used as lift, because $stream: true was
-overwritten`, the space's **stored** root pattern is a stale compiled artifact.
-Fix: open the header menu → **Toggle debug mode** (🐛) → click the red
-**Recreate Root Pattern** button in the debugger drawer, then reload. (Console
-fallback: `localStorage.setItem("showDebuggerView","true")` then reload.) The
+home space fails to load with
+`Handler used as lift, because $stream: true was
+overwritten`, the space's
+**stored** root pattern is a stale compiled artifact. Fix: open the header menu
+→ **Toggle debug mode** (🐛) → click the red **Recreate Root Pattern** button in
+the debugger drawer, then reload. (Console fallback:
+`localStorage.setItem("showDebuggerView","true")` then reload.) The
 free-text-join build of this poll sidesteps the profile requirement entirely.
 
 ## Performance notes
@@ -299,7 +306,8 @@ graph/runtime cost (instantiation measures ~linear, ~12ms/option), it's the
 **per-option AI work done host-side on load**: each option triggers an image
 generation, a web search, and a `generateText` homepage-verification call,
 serialized behind a 30s mutex. Results are cached (`option.imageUrl` etc.), so
-warm loads are cheaper; the pain is the first host load of un-cached options. See
-willkelly's perf investigation in
-[labs#4141](https://github.com/commontoolsinc/labs/pull/4141) (keyed-collection /
-runtime-aggregate direction) for the deeper aggregate + write-conflict findings.
+warm loads are cheaper; the pain is the first host load of un-cached options.
+See willkelly's perf investigation in
+[labs#4141](https://github.com/commontoolsinc/labs/pull/4141) (keyed-collection
+/ runtime-aggregate direction) for the deeper aggregate + write-conflict
+findings.

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -1,175 +1,271 @@
-# Deploying & sharing lunch-poll state
+# Deploying, updating & sharing lunch-poll state
 
-> **⚠️ The SQLite migration is NOT live-deployable yet (as of 2026-06-04).** The
-> visit history + vote-history were moved into SQLite (`sqliteDatabase`), and
-> the pattern is correct and green in `cf test`, BUT on a _deployed_ piece
-> `db.exec` throws "invalid database handle" — an open sqlite-builtin bug (see
-> `session_outputs/2026-06-04_lunch-poll-sqlite/`). **Keep the canonical piece
-> on the previous array-based-history build** until that's fixed. The notes
-> below about `history: PerSpace` describe that previous build; the migrated
-> build replaces `history` with SQLite tables and adds a `sqliteRev` PerSpace
-> counter.
+How to deploy the lunch poll, update it in place without losing data, share it,
+verify it actually worked, and recover it when it breaks. Written for someone
+(human or agent) operating the poll for the first time — read top to bottom once.
 
-This pattern's durable data lives in **`PerSpace` cells** (`users`, `options`,
-`votes`, `adminName`, `question`; the previous build also had `history`). That
-state belongs to **one deployed piece instance** in one space — addressed by
-`(space, causal-cell-id)` — not to "the pattern" in the abstract. So "share the
-state" means "everyone points at the same piece," and "copy the state" means
-"move those cell values into a new piece." This doc covers both, plus the
-identity caveat that bites first.
+> **Status (2026-06-15): live-deployable.** The visit history + per-visit vote
+> snapshots live in the **SQLite builtin** (`sqliteDatabase`). The old
+> "`db.exec` throws 'invalid database handle' on a deployed piece" bug is
+> **resolved** by runtime PR #3967 (merged to main) — no pattern-side
+> workaround needed. Full root-cause writeup is in `SQLITE-DEPLOY-BUG.md`.
+
+## Where the data lives (mental model)
+
+A poll's durable state belongs to **one deployed piece instance in one space**,
+addressed by `(space, causal-cell-id)` — not to "the pattern" in the abstract.
+So "share the state" = "everyone points at the same piece"; "copy the state" =
+"move that piece's values into a new piece." There are **two** stores:
+
+1. **`PerSpace` input cells** — shared by everyone in the space:
+   `question`, `city`, `options`, `votes`, `users`, `adminName`, `webSearchUrl`,
+   `sqliteRev`. Plus **`myName`** which is **`PerUser`** (keyed by your DID).
+2. **A pattern-owned SQLite database** (`sqliteDatabase(...)`) holding the
+   `visits` and `vote_history` tables — i.e. the "Recently eaten" log and the
+   "Lunch stats". This is **not** a `PerSpace` input; it's a cell-derived db
+   tied to the piece's result cell. (There is no `history` input cell anymore —
+   if you find older docs/scripts referencing `history`, they predate the
+   SQLite migration.)
+
+Both stores survive an in-place `setsrc` (see Option A). Only the `PerSpace`
+cells can be copied to another piece via the CLI (see Option B's caveat).
 
 ## The canonical piece
 
-There is one shared instance everyone should iterate on. **These values are a
-deployment pointer, not a stable identifier — current as of 2026-06-01.** A
-piece is tied to one space/server and can be reset or wedged; if it 404s,
-`inspect` fails, or it stops responding to clicks, re-establish it (see
-"Re-establishing" / "Recovering a wedged piece" below) and update this block.
-(The prior `lunch-2026-05-26` piece went stale — `inspect` reported "missing
-pattern ID" — and was superseded by the `lunch-2026-05-29` instance below.)
+One shared instance everyone iterates on. **This is a deployment pointer, not a
+stable identifier — current as of 2026-06-15.** A piece is tied to one
+space/server and can be reset, wedged, or lost; if it 404s, `inspect` fails, or
+it stops responding, re-establish it (see "Recovering" below) and update this
+block.
 
 ```
-space:  lunch-2026-05-29
-piece:  fid1:89LeEO1n8boDR1aCFy2zUakZPhyeflsPSg72-H_ZJOE
-url:    https://toolshed.saga-castor.ts.net/lunch-2026-05-29/fid1:89LeEO1n8boDR1aCFy2zUakZPhyeflsPSg72-H_ZJOE
+space:  team-lunch
+piece:  fid1:zJT0lRy-Hd6p_ZsK_h6CZoK3rLcWOmsqwzqnHCAOlAg
+url:    https://toolshed.saga-castor.ts.net/team-lunch/fid1:zJT0lRy-Hd6p_ZsK_h6CZoK3rLcWOmsqwzqnHCAOlAg
 ```
 
-Set these once so you don't repeat flags (substitute your own identity key path
-and the current piece/space):
+(History: the `rapids` space held an earlier poll; `lunch-2026-05-26` /
+`lunch-2026-05-29` were earlier pointers. `team-lunch` is a fresh space made to
+avoid that confusion.)
+
+## Environment setup
 
 ```bash
-export CF_API_URL=https://toolshed.saga-castor.ts.net/
-export CF_IDENTITY=/path/to/your-identity.key   # e.g. ~/.config/commonfabric/identity.key
-PIECE=fid1:89LeEO1n8boDR1aCFy2zUakZPhyeflsPSg72-H_ZJOE   # current as of 2026-06-01
-SPACE=lunch-2026-05-29
+export CF_API_URL=https://toolshed.saga-castor.ts.net/   # prod; or http://localhost:8000 for local dev
+export CF_IDENTITY=./your-identity.key
+PIECE=fid1:zJT0lRy-Hd6p_ZsK_h6CZoK3rLcWOmsqwzqnHCAOlAg    # current as of 2026-06-15
+SPACE=team-lunch
 ```
 
-## Option A — deploy your version onto the shared state (recommended)
+**Identity key:**
 
-To push code changes **and keep the accumulated state**, update the source of
-the existing piece in place. Do **not** run `cf piece new` — that mints a fresh,
-empty instance.
+- **Local dev** — the local toolshed trusts the identity derived from the
+  passphrase `"implicit trust"`. Mint a matching key (use `deno run`, **not**
+  `deno task`, when redirecting — the task wrapper prints ANSI preamble that
+  pollutes the file):
+  ```bash
+  deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
+  chmod 600 cf.key
+  ```
+- **Prod** — deploy with your own identity, or mint a fresh one
+  (`deno run -A packages/cli/mod.ts id new > prod.key`) and share that key with
+  whoever should be able to update the piece. Whoever deployed owns it; the
+  **host** is a separate, in-poll role (first joiner — see Identity below).
+
+## Option A — update the existing piece in place (recommended)
+
+To push code changes **and keep all accumulated state**, update the source of
+the existing piece. Do **not** run `cf piece new` — that mints a fresh, empty
+instance.
 
 ```bash
 deno task cf piece setsrc --piece "$PIECE" -s "$SPACE" \
   packages/patterns/lunch-poll/main.tsx
+deno task cf piece step --piece "$PIECE" -s "$SPACE"
 ```
 
-Why this preserves state: cell ids are derived from the causal generation chain,
-not from contents, and scope is excluded from that computation. Swapping the
-program with `setsrc` keeps the same result cell, so `users`/`votes`/`history`
-survive. **Adding a new `PerSpace` field is safe** — on an existing piece it
-just hydrates to its `Default<>` while the populated fields keep their data.
+**What survives `setsrc` (verified):** both the `PerSpace` cells
+(`users`/`votes`/`options`/…) **and** the SQLite `visits`/`vote_history` tables.
+Cell ids derive from the causal generation chain (not contents, scope excluded),
+so `setsrc` keeps the same result cell, and the SQLite db — being derived from
+that cell — keeps its rows. **Adding a new `PerSpace` field is safe** — on an
+existing piece it hydrates to its `Default<>` while populated fields keep their
+data.
 
-Caveat: this holds as long as an input's identity in the recipe stays stable.
-Adding fields is safe; heavily reordering/renaming pattern inputs can in
-principle shift the causal chain and orphan old data. Don't treat the piece as a
-database you can refactor freely without thinking about it. If state must be
-durable even against re-`new`ing, store it in a separate dedicated data piece
-the poll links to (not yet implemented here).
+**Caveat:** this holds only while each input's identity in the recipe stays
+stable. Adding fields is safe; heavily **reordering or renaming** pattern inputs
+can shift the causal chain and orphan old data. Don't refactor the input
+interface casually against a piece you care about.
 
 ## Option B — copy the state into your own piece
 
-If you want your **own** instance seeded with the current data (e.g. to
-experiment without touching the shared poll):
+To get your **own** instance seeded with the current data (e.g. to experiment
+without touching the shared poll):
 
 ```bash
 # 1. Create your own empty piece (note the new ID it prints).
 MINE=$(deno task cf piece new packages/patterns/lunch-poll/main.tsx \
-  -s "$SPACE" | grep '^fid1:')
+  -s "$SPACE" | grep -oE 'fid1:[A-Za-z0-9_-]+' | head -1)
 
 # 2. Copy each PerSpace field from the canonical piece into yours.
 #    `--input` reads/writes the input cell where these live.
-for field in question users options votes history adminName; do
+for field in question city users options votes adminName webSearchUrl; do
   deno task cf piece get --piece "$PIECE" -s "$SPACE" "$field" --input -q \
     | deno task cf piece set --piece "$MINE" -s "$SPACE" "$field" --input -q
 done
 
-# 3. Recompute so derived values (counts, ranking, nudges) refresh.
+# 3. Recompute so derived values (counts, ranking) refresh.
 deno task cf piece step --piece "$MINE" -s "$SPACE"
 deno task cf piece inspect --piece "$MINE" -s "$SPACE" --summary
 ```
 
-This is a **one-time snapshot copy**, not a live link — the two pieces diverge
-after this. There is no automatic carry-over of `PerSpace` data between pieces.
+This is a **one-time snapshot copy**, not a live link — the pieces diverge after.
+**The SQLite history does NOT copy this way** — `visits`/`vote_history` are not
+`PerSpace` inputs, so the loop above leaves your copy's "Recently eaten" / "Lunch
+stats" empty. If you need the history too, either keep iterating on the same
+piece (Option A), or re-log the visits via the `logVisit` handler.
 
-## Identity: why a fresh viewer "isn't recognized"
+## Verifying a deploy actually worked
 
-`myName` is **`PerUser`** — keyed by the authenticated **DID**, not the space.
-`adminName` (first joiner) and the `users` directory are `PerSpace`. Two
-consequences trip everyone up:
+This pattern's reads behave in a way that trips people up over the CLI:
 
-1. **CLI and browser are different identities unless you make them the same.**
-   If you join/seed from the `cf` CLI (one DID) and then open the piece in a
-   browser (a different passphrase/passkey DID), the browser's `myName` is empty
-   — it shows you the join card and won't treat you as host. To act as the same
-   person in both, import your CLI key into the browser (`Import CLI Key`); see
-   [`docs/development/SHARED_IDENTITY.md`](../../../docs/development/SHARED_IDENTITY.md).
-   Verify with `cf id did "$CF_IDENTITY"` and the browser's `shell.identity`
-   log.
+- **Reactive queries only resolve under a *subscribed* runtime (a browser).**
+  `recentVisits`, `placeStats`, `historyCount`, `mostRecentTitle` are
+  `db.query` results that re-run on the `sqliteRev` counter. A `cf piece get`
+  does **not** subscribe, so right after a write these read as
+  `{ pending: true }` / `0` over the CLI — even though the write landed. A
+  freshly `new`-ed piece also isn't registered with the background-charm-service
+  (`monitoring 0 spaces`), so nothing pumps the re-query headlessly. **Open the
+  piece in a browser** and the live subscription resolves them.
 
-2. **Names are unique (name-as-identity).** `joinAs` rejects a name already in
-   `users`. So if a test/seed already claimed your preferred name, you can't
-   re-join under it from another identity — pick a different name, or clear the
-   stale entry.
+- **To verify a write landed without a browser, read the SQLite file directly.**
+  `db.exec` writes (`logVisit`, `clearHistory`, `removeHistoryEntry`) persist
+  regardless of the query/subscription issue. On **local dev** the per-piece db
+  is under the toolshed cache; find it by table, and **use `sqlite3`, not `grep`
+  (the files are binary)**:
+  ```bash
+  DBDIR=packages/toolshed/cache/memory/engine-v3/engine-v3
+  for db in "$DBDIR"/*.sqlite; do
+    sqlite3 "$db" "SELECT title, logged_by FROM visits;" 2>/dev/null \
+      && echo "  ^ $db"
+  done
+  ```
+  (On prod the db lives server-side — confirm via the browser instead.)
 
-3. **Host role is claimable.** The host seat (`adminName`) goes to the _first_
-   joiner, but any joined participant can take it over with the **Become host**
-   button (`claimHost` sets `adminName` to themselves). So a stuck/squatted host
-   seat no longer requires an operator reset — just join and click Become host.
-   (You can still reset `adminName` to `""` directly if no one is joined.)
-
-### Resetting / re-seeding state (host or operator)
-
-There is no "reset everything" handler (`resetVotes` only clears votes). To wipe
-or seed the shared cells directly, write the input cells. **This mutates shared
-state — coordinate before running against the canonical piece.**
-
+**Smoke test after deploy** (host-gated handlers need a join first):
 ```bash
-echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" users     --input -q
-echo '""' | deno task cf piece set --piece "$PIECE" -s "$SPACE" adminName --input -q
-echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" options   --input -q
-echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" votes     --input -q
-echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" history   --input -q
+deno task cf piece call --piece "$PIECE" -s "$SPACE" joinAs '{"name":"Host"}'
 deno task cf piece step --piece "$PIECE" -s "$SPACE"
+deno task cf piece call --piece "$PIECE" -s "$SPACE" addOption '{"title":"Test Cafe"}'
+deno task cf piece step --piece "$PIECE" -s "$SPACE"
+deno task cf piece call --piece "$PIECE" -s "$SPACE" logVisit '{"title":"Test Cafe"}'
+deno task cf piece step --piece "$PIECE" -s "$SPACE"
+# No "invalid database handle" error => db.exec works (i.e. the runtime has #3967).
+# Then confirm the row via the sqlite recipe above, or in the browser.
 ```
+If `db.exec` *does* throw "invalid database handle" on a deployed piece, the
+server is running a runtime from **before #3967** — not a pattern bug.
 
-After this, the first person to join in the browser becomes host as their own
-browser identity.
+## Identity & joining
 
-## Re-establishing the canonical piece (if it's lost)
+`myName` is `PerUser` (keyed by your authenticated DID); `adminName` (host) and
+the `users` directory are `PerSpace`. Consequences that bite:
+
+1. **This build joins by free-text name.** Type a name in the join field and
+   click Join — no profile needed; the **first person to join becomes host**.
+   (On `main`, joining instead goes through the shared-profile `wish` flow,
+   which requires a profile in your home space. This `freetext-join` variant
+   removes that gate. The `joinAs` handler still honors an explicit `name`, so
+   CLI/headless joins work either way.)
+
+2. **CLI and browser are different identities unless you make them the same.**
+   If you join/seed from the `cf` CLI (one DID) then open the piece in a browser
+   (a different DID), the browser's `myName` is empty and it won't treat you as
+   host. To act as the same person in both, import your CLI key in the browser
+   via **Import CLI Key**; see
+   [`docs/development/SHARED_IDENTITY.md`](../../../docs/development/SHARED_IDENTITY.md).
+   Verify with `cf id did "$CF_IDENTITY"`.
+
+3. **Names are unique.** `joinAs` rejects a name already in `users`. If a
+   test/seed claimed your name, pick another or clear the stale entry.
+
+4. **Host role is claimable.** Any joined participant can take the host seat with
+   **Become host** (`claimHost`). A squatted/stale host seat doesn't need an
+   operator reset — just join and click Become host. (You can also reset
+   `adminName` to `""` directly when no one is joined.)
+
+## Resetting / re-seeding state (host or operator)
+
+**Coordinate before running this against the shared piece — it mutates state
+everyone sees, and direct `set` races anyone's live browser session.**
+
+- **Votes:** use the in-app `resetVotes` (host) — or call it via CLI.
+- **History (SQLite):** there is no `history` input cell. Use the **`clearHistory`
+  handler** (host-gated) — it clears both `visits` and `vote_history`:
+  ```bash
+  deno task cf piece call --piece "$PIECE" -s "$SPACE" clearHistory '{}'
+  deno task cf piece step --piece "$PIECE" -s "$SPACE"
+  ```
+- **PerSpace cells:** write the input cells directly (note: **no `history`**):
+  ```bash
+  echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" users     --input -q
+  echo '""' | deno task cf piece set --piece "$PIECE" -s "$SPACE" adminName --input -q
+  echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" options   --input -q
+  echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" votes     --input -q
+  deno task cf piece step --piece "$PIECE" -s "$SPACE"
+  ```
+  After this, the first person to join in the browser becomes host as their own
+  browser identity.
+
+## Recovering the piece
+
+### Re-establishing (if it's lost / 404s)
 
 ```bash
 deno task cf piece new packages/patterns/lunch-poll/main.tsx -s "$SPACE"
-# → prints a new fid1:… — update PIECE above and the "canonical piece" section.
+# → prints a new fid1:… — update the "canonical piece" block above.
 ```
+You need `WRITE`/`OWNER` on the space (ACL-gated); a denied write changes
+nothing.
 
-You need `WRITE`/`OWNER` on the space (ACL-gated). A denied write is rejected by
-the kernel and changes nothing.
+### Recovering a wedged piece
 
-## Recovering a wedged piece
-
-A piece can get into a bad **process** state — e.g. a write that wedges the
-scheduler mid-settle. Symptom: the UI renders but **clicks do nothing**, with no
-console errors (a settle loop instead flickers / logs warnings). Observed once
-when a "reset votes" click wedged the running instance.
-
-`setsrc` does **not** fix this: it swaps the program but reuses the same process
-cell, so the bad reactive state persists. The cure is a fresh process:
+A piece can get into a bad **process** state — UI renders but **clicks do
+nothing**, no console errors (a settle loop flickers / logs warnings). Observed
+once when a "reset votes" click wedged the running instance. `setsrc` does
+**not** fix this (it reuses the same process cell); the cure is a fresh process:
 
 ```bash
-# 1. Confirm it's instance-specific: deploy the same code to a NEW piece and
-#    open it. If the fresh piece works, the old one's process is wedged.
+# 1. Confirm it's instance-specific: deploy the same code to a NEW piece. If the
+#    fresh piece works, the old one's process is wedged.
 NEW=$(deno task cf piece new packages/patterns/lunch-poll/main.tsx \
-  -s "$SPACE" | grep '^fid1:')
+  -s "$SPACE" | grep -oE 'fid1:[A-Za-z0-9_-]+' | head -1)
 
-# 2. The data usually survives in the old piece's cells — copy it across with
-#    the Option B loop (get --input | set --input) into the fresh piece.
-#    Tip: don't copy users/adminName — leave them empty so the first joiner
-#    becomes host; or copy them and use "Become host" to reclaim the role.
+# 2. Copy the PerSpace state across with the Option B loop. (SQLite history will
+#    NOT carry — see Option B's caveat.) Tip: leave users/adminName empty so the
+#    first joiner becomes host, or copy them and use Become host.
 
 # 3. Make the fresh piece canonical: update the "canonical piece" block above.
 ```
 
-Avoid writing to the cells of a piece someone is actively using in the browser —
-direct `set` races their live session.
+### Home space won't load (profile setup, `main`-style builds)
+
+Unrelated to the poll itself, but bites colleagues setting up a profile: if a
+home space fails to load with `Handler used as lift, because $stream: true was
+overwritten`, the space's **stored** root pattern is a stale compiled artifact.
+Fix: open the header menu → **Toggle debug mode** (🐛) → click the red
+**Recreate Root Pattern** button in the debugger drawer, then reload. (Console
+fallback: `localStorage.setItem("showDebuggerView","true")` then reload.) The
+free-text-join build of this poll sidesteps the profile requirement entirely.
+
+## Performance notes
+
+Cold loads of a poll with many options can take **minutes** — this is **not**
+graph/runtime cost (instantiation measures ~linear, ~12ms/option), it's the
+**per-option AI work done host-side on load**: each option triggers an image
+generation, a web search, and a `generateText` homepage-verification call,
+serialized behind a 30s mutex. Results are cached (`option.imageUrl` etc.), so
+warm loads are cheaper; the pain is the first host load of un-cached options. See
+willkelly's perf investigation in
+[labs#4141](https://github.com/commontoolsinc/labs/pull/4141) (keyed-collection /
+runtime-aggregate direction) for the deeper aggregate + write-conflict findings.

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -120,10 +120,44 @@ deno task cf piece inspect --piece "$MINE" -s "$SPACE" --summary
 ```
 
 This is a **one-time snapshot copy**, not a live link — the pieces diverge after.
-**The SQLite history does NOT copy this way** — `visits`/`vote_history` are not
-`PerSpace` inputs, so the loop above leaves your copy's "Recently eaten" / "Lunch
-stats" empty. If you need the history too, either keep iterating on the same
-piece (Option A), or re-log the visits via the `logVisit` handler.
+**The SQLite history does NOT copy this way** — `visits`/`vote_history` live in a
+per-piece, cell-derived SQLite db, not in `PerSpace` inputs, so the loop above
+leaves your copy's "Recently eaten" / "Lunch stats" empty.
+
+### Migrating the SQLite history to another piece (the current gap)
+
+There is **no in-builtin way to share or repoint a writable history db** between
+pieces today (sqlite-builtin spec §03 "Database sources"):
+
+- **Cell-derived** (what this poll uses) is keyed to the piece's own handle-cell
+  entity id — *"no way to point the database at an arbitrary cell"* (deliberate,
+  to avoid ambient authority). Two pieces can't share it, and a fresh piece
+  can't adopt an old one's db.
+- The **on-disk injected** source (`cf piece link sqlite:…`) *can* be shared
+  across pieces (same path → same handle), but is **read-only in v1** — writes
+  are rejected, so it's no good for a live, mutated history.
+- The **VM-file** source is stubbed (not implemented).
+
+So moving history to a *different* piece needs an explicit mechanism. Options,
+none built yet:
+
+1. **App-level export → import (portable).** Add a full-dump query output
+   (`SELECT * FROM visits` / `vote_history`) plus an `importHistory(rows)`
+   handler that `db.exec`-inserts them, then script export-from-A → import-to-B.
+   Caveat: reading the export over the CLI hits the subscriber gotcha above —
+   resolve it in a browser, or (locally) read the `cell-*.sqlite` file directly.
+2. **Local filesystem dump (hack).**
+   `sqlite3 A-cell.sqlite ".dump visits vote_history" | sqlite3 B-cell.sqlite`.
+   Local only (needs the files), you must map each piece → its
+   `cell-<hash>.sqlite`, and it must run while the piece is **idle** (the file is
+   ATTACHed during transactions). No `cf` surface for this yet.
+3. **Avoid the need:** keep iterating on the same piece (`setsrc`, Option A — no
+   migration), or re-log visits via `logVisit`.
+
+Honest trade-off: the pre-SQLite **array** history *was* copyable as a `PerSpace`
+cell; the SQLite migration made it more durable-per-piece but no longer
+CLI-portable. Whether to invest in a portable/shared-history mechanism is an open
+design question — discuss before building.
 
 ## Verifying a deploy actually worked
 

--- a/packages/patterns/lunch-poll/LUNCH-COORDINATOR-TODO.md
+++ b/packages/patterns/lunch-poll/LUNCH-COORDINATOR-TODO.md
@@ -52,15 +52,15 @@ nobody suggests the same place three days running.
     2. _(worked around, test-runner only)_ `reactOn: db` left the `recentVisits`
        query stale after writes in the emulated test runner; reacting on a
        `PerSpace<number>` `sqliteRev` counter the handlers bump is reliable.
-    3. **⚠️ OPEN, blocks live deploy:** on a _deployed_ piece, `db.exec` in the
-       mutating handlers throws "invalid database handle" — the `SqliteDb`
-       handle isn't materialized on the deployed handler-input path (works fine
-       in the emulated `cf test` runner). Reliably reproduced; root cause not
-       yet isolated (it is NOT the cfLink column, NOT any single query — likely
-       an emergent interaction in this scoped pattern). **Filed for the
-       sqlite-builtin owner; the live canonical piece stays on the previous
-       array-based history until this is fixed.** The migration here is complete
-       and green in tests, ready to deploy once the bug is resolved.
+    3. _(resolved by runtime PR #3967)_ On a _deployed_ piece, `db.exec` in the
+       mutating handlers threw "invalid database handle" — the `SqliteDb` handle
+       wasn't materialized on the deployed handler-input path (worked fine in
+       the emulated `cf test` runner). Root cause was a **client-side dispatch
+       race**: `cf piece call` dispatched the handler before its asCell input
+       docs had synced into the local replica, so the synchronous handle read
+       saw an empty doc. Fixed in the runtime by #3967 (merged) and verified
+       end-to-end on a deployed prod piece — `db.exec` writes land and the
+       migration is fully live. Full writeup in `SQLITE-DEPLOY-BUG.md`.
 
 ### 1b. Durable vote-history snapshot ✅ (shipped)
 

--- a/packages/patterns/lunch-poll/lunch-stats.test.tsx
+++ b/packages/patterns/lunch-poll/lunch-stats.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Regression test for the "Lunch stats" (`placeStats`) aggregate.
+ *
+ * Two properties that previously broke:
+ *  1. Per-place scoping. Each `logVisit` snapshots EVERY option's votes against
+ *     that one visit, so the tallies must count only the votes cast FOR the
+ *     visited place (`vh.option_title = v.title`). Before the fix the join was
+ *     on `visit_id` alone and summed the whole board.
+ *  2. Yellow tally. The query only summed green/red; yellow votes were dropped.
+ *
+ * Scenario (single identity, host): vote 🟡 on Thai and 🔴 on Chipotle, then log
+ * a visit to Thai. Thai's snapshot therefore contains a yellow-for-Thai and a
+ * red-for-Chipotle. Correct stats for Thai: 1 visit, 0 green, 1 yellow, 0 red.
+ *   - old per-place bug would show reds = 1 (counting the Chipotle veto)
+ *   - pre-yellow query had no `yellows` field at all (=> undefined !== 1)
+ */
+
+import { action, computed, pattern } from "commonfabric";
+import CozyPoll from "./main.tsx";
+
+export default pattern(() => {
+  const poll = CozyPoll({});
+
+  const join = action(() => {
+    poll.joinAs.send({ name: "Alex" });
+  });
+  // Thai is options[0], Chipotle is options[1] (insertion order).
+  const add_thai = action(() => {
+    poll.addOption.send({ title: "Thai" });
+  });
+  const add_chipotle = action(() => {
+    poll.addOption.send({ title: "Chipotle" });
+  });
+  const vote_yellow_thai = action(() => {
+    const thai = poll.options[0];
+    if (thai) poll.castVote.send({ optionId: thai.id, voteType: "yellow" });
+  });
+  const vote_red_chipotle = action(() => {
+    const chipotle = poll.options[1];
+    if (chipotle) {
+      poll.castVote.send({ optionId: chipotle.id, voteType: "red" });
+    }
+  });
+  const log_thai = action(() => {
+    poll.logVisit.send({ title: "Thai" });
+  });
+
+  // Only Thai was visited, so placeStats has exactly its row.
+  const assert_thai_stats_scoped_and_yellow = computed(() => {
+    const s = (poll.placeStats ?? [])[0];
+    return !!s &&
+      s.title === "Thai" &&
+      s.visits === 1 &&
+      s.greens === 0 &&
+      s.yellows === 1 &&
+      s.reds === 0;
+  });
+
+  return {
+    tests: [
+      { action: join },
+      { action: add_thai },
+      { action: add_chipotle },
+      { action: vote_yellow_thai },
+      { action: vote_red_chipotle },
+      { action: log_thai },
+      { assertion: assert_thai_stats_scoped_and_yellow },
+    ],
+  };
+});

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -200,6 +200,19 @@ export interface VoteHistoryRow {
 }
 
 /**
+ * A "Lunch stats" row — the `placeStats` aggregate. Per visited place: how many
+ * times we went, and the green/yellow/red tallies of the votes cast FOR that
+ * place (across all its visits' snapshots).
+ */
+export interface PlaceStat {
+  title: string;
+  visits: number;
+  greens: number;
+  yellows: number;
+  reds: number;
+}
+
+/**
  * Log a visit — by existing option id, or a free-typed place title.
  * `wentAt` backdates the entry (ms epoch); omitted → the host's date draft,
  * which itself defaults to today.
@@ -882,6 +895,9 @@ export interface CozyPollOutput {
   mostRecentTitle: string;
   // Count of rows in the vote_history snapshot table.
   voteHistoryCount: number;
+  // The "Lunch stats" aggregate (per-place visit + green/yellow/red tallies of
+  // votes cast for that place). Exposed so tests/consumers can read it.
+  placeStats: readonly PlaceStat[];
   isJoined: boolean;
   isAdmin: boolean;
   homePageLookupUrls: readonly string[];
@@ -1094,12 +1110,11 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     // every option's votes, so without that filter the tallies would sum the
     // whole board, not the place we went to. Read-only (no handlers), so it's
     // free of the lift hazard above.
-    const placeStats = db.query<
-      { title: string; visits: number; greens: number; reds: number }
-    >(
+    const placeStats = db.query<PlaceStat>(
       `SELECT v.title AS title,
               count(DISTINCT v.id) AS visits,
               sum(CASE WHEN vh.vote_color = 'green' THEN 1 ELSE 0 END) AS greens,
+              sum(CASE WHEN vh.vote_color = 'yellow' THEN 1 ELSE 0 END) AS yellows,
               sum(CASE WHEN vh.vote_color = 'red' THEN 1 ELSE 0 END) AS reds
        FROM visits v
        LEFT JOIN vote_history vh
@@ -2336,6 +2351,9 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                             <span style={{ color: "#2f8a64" }}>
                               🟢 {stat.greens}
                             </span>
+                            <span style={{ color: "#b27722" }}>
+                              🟡 {stat.yellows}
+                            </span>
                             <span style={{ color: "#a33b35" }}>
                               🔴 {stat.reds}
                             </span>
@@ -2493,6 +2511,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       recentVisits,
       mostRecentTitle,
       voteHistoryCount,
+      placeStats: placeStatsRows,
       isJoined,
       isAdmin,
       homePageLookupUrls,

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -1089,8 +1089,11 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       recentVisits.result?.[0]?.title ?? ""
     );
     // 📊 Lunch stats: per-place visit count + green/red tallies across the
-    // whole durable record, joining visits to their vote snapshots. Read-only
-    // (no handlers), so it's free of the lift hazard above.
+    // whole durable record. The join is restricted to vote snapshots cast FOR
+    // the visited place (`vh.option_title = v.title`) — each visit snapshots
+    // every option's votes, so without that filter the tallies would sum the
+    // whole board, not the place we went to. Read-only (no handlers), so it's
+    // free of the lift hazard above.
     const placeStats = db.query<
       { title: string; visits: number; greens: number; reds: number }
     >(
@@ -1099,7 +1102,8 @@ export default pattern<CozyPollInput, CozyPollOutput>(
               sum(CASE WHEN vh.vote_color = 'green' THEN 1 ELSE 0 END) AS greens,
               sum(CASE WHEN vh.vote_color = 'red' THEN 1 ELSE 0 END) AS reds
        FROM visits v
-       LEFT JOIN vote_history vh ON vh.visit_id = v.id
+       LEFT JOIN vote_history vh
+              ON vh.visit_id = v.id AND vh.option_title = v.title
        GROUP BY v.title
        ORDER BY visits DESC, greens DESC
        LIMIT 5`,

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -434,28 +434,38 @@ const joinAs = handler<JoinEvent, {
   users: UsersCell;
   myName: NameCell;
   adminName: NameCell;
+  joinName: NameCell;
   profileName: string;
   profileAvatar: string;
-}>(({ name }, { users, myName, adminName, profileName, profileAvatar }) => {
-  const override = trimmedName(name);
-  const trimmed = override || trimmedName(profileName);
-  if (!trimmed) return;
-  const current = trimmedName(myName.get());
-  if (current) return;
-  const existing = users.get();
-  if (existing.some((u) => u.name === trimmed)) return;
-  const user: User = {
-    name: trimmed,
-    avatar: override ? "" : (profileAvatar ?? "").trim(),
-    color: colorForIndex(existing.length),
-    joinedAt: safeDateNow(),
-  };
-  users.push(user);
-  myName.set(trimmed);
-  if (trimmedName(adminName.get()) === "") {
-    adminName.set(trimmed);
-  }
-});
+}>(
+  (
+    { name },
+    { users, myName, adminName, joinName, profileName, profileAvatar },
+  ) => {
+    // Name priority: an explicit event `name` (tests/headless) wins, then the
+    // free-text join field, then the viewer's shared profile name as a graceful
+    // fallback for anyone who already made a profile and didn't type anything.
+    const override = trimmedName(name) || trimmedName(joinName.get());
+    const trimmed = override || trimmedName(profileName);
+    if (!trimmed) return;
+    const current = trimmedName(myName.get());
+    if (current) return;
+    const existing = users.get();
+    if (existing.some((u) => u.name === trimmed)) return;
+    const user: User = {
+      name: trimmed,
+      avatar: override ? "" : (profileAvatar ?? "").trim(),
+      color: colorForIndex(existing.length),
+      joinedAt: safeDateNow(),
+    };
+    users.push(user);
+    myName.set(trimmed);
+    if (trimmedName(adminName.get()) === "") {
+      adminName.set(trimmed);
+    }
+    joinName.set("");
+  },
+);
 
 // Open host takeover: any joined participant can claim the host role, which
 // transfers it away from the current host (isAdmin is derived from this). This
@@ -948,6 +958,9 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     // not exposed as pattern inputs. Uses the scoped-constructor idiom
     // introduced by parking-coordinator (PR #3610).
     const optionDraft = Writable.perSession.of<string>("");
+    // Free-text join name draft (this variant joins by typing a name instead of
+    // going through the shared-profile wish flow).
+    const joinName = Writable.perSession.of<string>("");
     // Host's draft for the poll's city (scopes the menu web search).
     const cityDraft = Writable.perSession.of<string>("");
     // Which option's homepage link is being edited (null = none), plus the
@@ -969,29 +982,21 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     // Shared marker that retriggers the host's reactive homepage lookup nodes.
     // Missing homepage links are also looked up on first host load.
     const homePageRefresh = Writable.perSpace.of<number>(0);
-    // Resolve THIS viewer's shared profile. The `#profile` wish's built-in UI
-    // covers the whole lifecycle: a create surface when the viewer has no
-    // profile, a link when they have one, and a picker (with inline create)
-    // when they have several. The field targets give the snapshot strings.
-    const profileWish = wish<{ name?: string; avatar?: string }>({
-      query: "#profile",
-    });
+    // This variant joins via a free-text name field (below), so the profile
+    // wish is no longer the join gate. We still resolve the viewer's shared
+    // profile name/avatar as a graceful fallback: anyone who already created a
+    // profile can join with one click (no typing) and keep their avatar.
     const profileNameWish = wish<string>({ query: "#profileName" });
     const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
 
     const profileName = computed(() => profileNameWish.result ?? "");
     const profileAvatar = computed(() => profileAvatarWish.result ?? "");
-    const hasProfile = computed(() =>
-      (profileNameWish.result ?? "").trim() !== ""
-    );
-    const joinLabel = computed(() =>
-      hasProfile ? `Join as ${profileName}` : "Create a profile to join"
-    );
 
     const boundJoin = joinAs({
       users,
       myName,
       adminName,
+      joinName,
       profileName,
       profileAvatar,
     });
@@ -1320,21 +1325,23 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                     <div
                       style={{
                         display: "flex",
-                        flexDirection: "column",
                         gap: "8px",
+                        alignItems: "center",
                       }}
                     >
                       {
-                        /* Built-in profile UI: create a profile when there is
-                          none, pick between existing profiles otherwise. */
+                        /* Free-text join: type a name and join. No profile
+                          required — anyone with a shared profile can still join
+                          by leaving this blank (joinAs falls back to it). */
                       }
-                      <div>{profileWish[UI]}</div>
-                      <cf-button
-                        onClick={boundJoin}
-                        disabled={computed(() => !hasProfile)}
-                      >
-                        {joinLabel}
-                      </cf-button>
+                      <cf-input
+                        $value={joinName}
+                        placeholder="Your name…"
+                        aria-label="Your name"
+                        timing-strategy="immediate"
+                        style="flex:1"
+                      />
+                      <cf-button onClick={boundJoin}>Join</cf-button>
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
**Stacked on #4144** (`gideon/lunch-poll-sqlite-migration`). Review/merge that first; this branch only adds the diff below on top.

## Summary

Two independent improvements to the lunch poll, plus a docs refresh:

### 1. Free-text name join (drop the `#profile` gate for this variant)
Replaces the shared-profile `wish` join flow (#3968) with a plain "your name" field + Join button — a teammate can join without first creating a profile in their home space. The profile name/avatar are kept as a **graceful fallback** (anyone who already has a profile can one-click Join with the field blank and keep their avatar). `joinAs` reads the name from `event > joinName draft > profile name`.

This is a deliberate reversal of #3968's direction *for this pattern*, kept on its own branch so it can be discussed separately from the SQLite migration. Lowest-friction option for a self-serve team lunch poll.

### 2. Lunch Stats correctness (the `placeStats` aggregate)
- **Per-place scoping fix.** Each `logVisit` snapshots *every* option's votes against one visit, so the old join (on `visit_id` only) summed the whole board — a place with 6 green votes showed `🟢35 🔴5`. Restricted to votes cast for the visited place (`AND vh.option_title = v.title`). Verified against SQLite directly.
- **Yellow tally.** The query only summed green/red; yellow snapshots were stored but never aggregated or shown. Added a `yellows` sum and a 🟡 in the card.
- **Exposed `placeStats` as a pattern output** (mirrors `recentVisits`) so the aggregate is testable, and added `lunch-stats.test.tsx` locking in both fixes (`1× 🟢0 🟡1 🔴0`).

### 3. Docs
Rewrote `DEPLOY-AND-SHARE.md` as a current, first-time-operator runbook (live-deployable status, SQLite data model, what `setsrc` preserves, the subscriber/CLI-`pending` gotcha + how to verify writes via the per-piece sqlite file, free-text join, reset/recover, perf notes), and documented the **cross-piece SQLite-history migration gap** (cell-derived db is per-piece/un-pointable; injected source is read-only; options + trade-offs) for team discussion.

## Tests
`cf test` — main **18/18**, lunch-stats **1/1**; `cf check` clean.

## Note
The per-place fix + yellow tally are already live on the `team-lunch` prod piece (deployed via `setsrc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds free‑text joining (type your name; no profile needed) and fixes Lunch Stats so tallies are correct per place with a yellow count. Also exposes `placeStats` and refreshes the deploy/runbook to reflect live deployability and the SQLite copy caveat.

- **New Features**
  - Join via a simple name field; blank falls back to your profile name/avatar; the field clears after joining.
  - Expose `placeStats` and show a 🟡 count in the UI (green, yellow, red). Docs updated: live-deployable status, verify writes, use `clearHistory` for SQLite, and note that SQLite history does not copy between pieces.

- **Bug Fixes**
  - Scope Lunch Stats to votes for the visited place (`AND vh.option_title = v.title`) and include yellow votes.
  - Add `lunch-stats.test.tsx` to lock in per‑place scoping and yellow counts.

<sup>Written for commit 394859243a9da99da1ce741e91853565ac7064d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/main.test.tsx = 31s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/multi-user.test.tsx = 57s
NEW_PERF_BASELINE: test: pattern-unit-4/pattern-unit-tests = 284s
NEW_PERF_BASELINE: step: pattern reload integration = 59s
---END COPY-PASTE---