### PR TITLE
Fix flaky trusted group chat profile save

### DIFF
--- a/packages/html/src/main/renderer.ts
+++ b/packages/html/src/main/renderer.ts
@@ -233,6 +233,13 @@ export class VDomRenderer {
         this.rootNodeId = notification.rootId > 0 ? notification.rootId : null;
       }
 
+      if (notification.mountId !== undefined) {
+        this.connection.ackVDomBatch(
+          notification.mountId,
+          notification.batchId,
+        );
+      }
+
       const elapsed = logger.timeEnd("batch", String(notification.batchId));
       logger.debug("vdom-batch", () => [
         `Batch ${notification.batchId}: ${notification.ops.length} ops in ${

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -101,6 +101,8 @@ export class WorkerReconciler {
     number,
     (event: unknown) => void
   >();
+  private retiredHandlers = new Map<number, number>();
+  private pendingRetiredHandlers = new Set<number>();
   private batchIdCounter = 0;
   private pendingOps: VDomOp[] = [];
   private flushScheduled = false;
@@ -109,7 +111,7 @@ export class WorkerReconciler {
   private rootChildId: number | null = null;
   private rootCancel: Cancel | null = null;
 
-  private readonly onOps: (ops: VDomOp[]) => void;
+  private readonly onOps: (ops: VDomOp[]) => number | void;
   private readonly onError?: (error: Error) => void;
   private readonly renderDeclassificationPolicy: RenderDeclassificationPolicy;
   // Root-of-tree render policy: the host's default ceiling when configured
@@ -148,9 +150,6 @@ export class WorkerReconciler {
         const id = ++this.handlerIdCounter;
         this.handlers.set(id, handler);
         return id;
-      },
-      unregisterHandler: (id) => {
-        this.handlers.delete(id);
       },
       getHandler: (id) => this.handlers.get(id),
     };
@@ -301,6 +300,16 @@ export class WorkerReconciler {
     this.flushOps();
   }
 
+  acknowledgeBatchApplied(batchId: number): void {
+    for (const [handlerId, retiredAtBatch] of this.retiredHandlers) {
+      if (retiredAtBatch > batchId) {
+        continue;
+      }
+      this.retiredHandlers.delete(handlerId);
+      this.handlers.delete(handlerId);
+    }
+  }
+
   /**
    * Dispatch a DOM event to its handler.
    */
@@ -356,7 +365,8 @@ export class WorkerReconciler {
       const ops = this.pendingOps;
       logger.debug("flush-ops", () => ({ count: ops.length, ops }));
       this.pendingOps = [];
-      this.onOps(ops);
+      const batchId = this.onOps(ops) ?? this.batchIdCounter++;
+      this.assignPendingRetiredHandlers(batchId);
     }
   }
 
@@ -368,7 +378,7 @@ export class WorkerReconciler {
     const elementState = "elementState" in state ? state.elementState : state;
     if (elementState && "eventHandlers" in elementState) {
       for (const handlerId of elementState.eventHandlers.values()) {
-        this.handlers.delete(handlerId);
+        this.retireHandlerId(handlerId);
       }
       elementState.eventHandlers.clear();
 
@@ -379,6 +389,39 @@ export class WorkerReconciler {
         }
       }
     }
+  }
+
+  private retireHandlerId(handlerId: number): void {
+    if (!this.handlers.has(handlerId)) {
+      return;
+    }
+    if (
+      !this.retiredHandlers.has(handlerId) &&
+      !this.pendingRetiredHandlers.has(handlerId)
+    ) {
+      this.pendingRetiredHandlers.add(handlerId);
+    }
+  }
+
+  private assignPendingRetiredHandlers(batchId: number): void {
+    for (const handlerId of this.pendingRetiredHandlers) {
+      this.retiredHandlers.set(handlerId, batchId);
+    }
+    this.pendingRetiredHandlers.clear();
+  }
+
+  private retireEventHandler(
+    state: NodeState,
+    eventType: string,
+  ): number | undefined {
+    const handlerId = state.eventHandlers.get(eventType);
+    if (handlerId === undefined) {
+      return undefined;
+    }
+
+    state.eventHandlers.delete(eventType);
+    this.retireHandlerId(handlerId);
+    return handlerId;
   }
 
   /**
@@ -1395,10 +1438,7 @@ export class WorkerReconciler {
         return;
       }
       // Different Cell - cancel all old subscriptions
-      for (const [, propState] of state.propSubscriptions) {
-        propState.cancel();
-      }
-      state.propSubscriptions.clear();
+      this.removeAllProps(state);
 
       // Set up new Cell<Props> binding
       this.bindCellProps(ctx, state, newProps as Cell<WorkerProps>);
@@ -1408,7 +1448,7 @@ export class WorkerReconciler {
     // Handle static props object
     if (!newProps || typeof newProps !== "object") {
       // No props - remove all existing
-      this.removeAllProps(ctx, state);
+      this.removeAllProps(state);
       return;
     }
 
@@ -1421,7 +1461,7 @@ export class WorkerReconciler {
         // Prop removed - cancel subscription and remove from DOM
         propState.cancel();
         state.propSubscriptions.delete(key);
-        this.removeSingleProp(ctx, state, key);
+        this.removeSingleProp(state, key);
       }
     }
 
@@ -1494,11 +1534,11 @@ export class WorkerReconciler {
   /**
    * Remove all props from a node.
    */
-  private removeAllProps(ctx: ReconcileContext, state: NodeState): void {
+  private removeAllProps(state: NodeState): void {
     for (const [key, propState] of state.propSubscriptions) {
       propState.cancel();
       if (key === CELL_PROPS_KEY) continue;
-      this.removeSingleProp(ctx, state, key);
+      this.removeSingleProp(state, key);
     }
     state.propSubscriptions.clear();
   }
@@ -1575,12 +1615,7 @@ export class WorkerReconciler {
       existingState.cancel();
     }
 
-    // Unregister old handler and remove listener from DOM.
-    // We always emit remove-event here so transitions to null/undefined
-    // correctly clear the listener in the main-thread applicator.
-    if (state.eventHandlers.has(eventType)) {
-      ctx.unregisterHandler(state.eventHandlers.get(eventType)!);
-      state.eventHandlers.delete(eventType);
+    if (this.retireEventHandler(state, eventType) !== undefined) {
       this.queueOps([{
         op: "remove-event",
         nodeId: state.nodeId,
@@ -1626,10 +1661,7 @@ export class WorkerReconciler {
 
       const cancel = (value as Cell<(event: unknown) => void>).sink(
         (handler) => {
-          const previousHandlerId = state.eventHandlers.get(eventType);
-          if (previousHandlerId !== undefined) {
-            ctx.unregisterHandler(previousHandlerId);
-            state.eventHandlers.delete(eventType);
+          if (this.retireEventHandler(state, eventType) !== undefined) {
             this.queueOps([{
               op: "remove-event",
               nodeId: state.nodeId,
@@ -1732,7 +1764,7 @@ export class WorkerReconciler {
         for (const [key, propState] of state.propSubscriptions) {
           if (key === CELL_PROPS_KEY) continue;
           propState.cancel();
-          this.removeSingleProp(ctx, state, key);
+          this.removeSingleProp(state, key);
         }
         // Keep only the Cell<Props> subscription itself
         const cellPropsSub = state.propSubscriptions.get(CELL_PROPS_KEY);
@@ -1752,7 +1784,7 @@ export class WorkerReconciler {
         if (key === CELL_PROPS_KEY) continue;
         if (!newKeys.has(key)) {
           propState.cancel();
-          this.removeSingleProp(ctx, state, key);
+          this.removeSingleProp(state, key);
           state.propSubscriptions.delete(key);
         }
       }
@@ -1785,11 +1817,7 @@ export class WorkerReconciler {
 
           const eventType = getEventType(key);
 
-          // Clean up old handler
-          const oldHandlerId = state.eventHandlers.get(eventType);
-          if (oldHandlerId !== undefined) {
-            ctx.unregisterHandler(oldHandlerId);
-            state.eventHandlers.delete(eventType);
+          if (this.retireEventHandler(state, eventType) !== undefined) {
             this.queueOps([{
               op: "remove-event",
               nodeId: state.nodeId,
@@ -2086,18 +2114,10 @@ export class WorkerReconciler {
   /**
    * Remove a single prop from a node (DOM side + handler cleanup).
    */
-  private removeSingleProp(
-    ctx: ReconcileContext,
-    state: NodeState,
-    key: string,
-  ): void {
+  private removeSingleProp(state: NodeState, key: string): void {
     if (isEventProp(key)) {
       const eventType = getEventType(key);
-      const handlerId = state.eventHandlers.get(eventType);
-      if (handlerId !== undefined) {
-        ctx.unregisterHandler(handlerId);
-        state.eventHandlers.delete(eventType);
-      }
+      this.retireEventHandler(state, eventType);
       this.queueOps([{
         op: "remove-event",
         nodeId: state.nodeId,
@@ -2310,6 +2330,7 @@ export class WorkerReconciler {
       sourceChildren: sanitized.children,
       sourceProps: sanitized.props,
     };
+    addCancel(() => this.cleanupNodeHandlers(state));
     this.initializeTextIntegrityBoundary(childPolicy, nodeId);
 
     // Bind props. Cell<Props> can synchronously resolve boundary policy props;
@@ -2490,6 +2511,7 @@ export class WorkerReconciler {
       childRenderPolicy: policy,
       childrenBlockedByPolicy: false,
     };
+    addCancel(() => this.cleanupNodeHandlers(state));
 
     // Render each child and insert it
     for (const childNode of nodes) {
@@ -2616,10 +2638,7 @@ export class WorkerReconciler {
           const eventType = getEventType(key);
           const sinkCancel = (value as Cell<(event: unknown) => void>).sink(
             (handler) => {
-              const previousHandlerId = state.eventHandlers.get(eventType);
-              if (previousHandlerId !== undefined) {
-                ctx.unregisterHandler(previousHandlerId);
-                state.eventHandlers.delete(eventType);
+              if (this.retireEventHandler(state, eventType) !== undefined) {
                 this.queueOps([{
                   op: "remove-event",
                   nodeId: state.nodeId,

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -221,9 +221,6 @@ export interface ReconcileContext {
     handler: (event: unknown) => void,
   ) => number;
 
-  /** Unregister an event handler by ID */
-  unregisterHandler: (handlerId: number) => void;
-
   /** Get handler by ID for event dispatch */
   getHandler: (
     handlerId: number,
@@ -318,7 +315,7 @@ export interface WorkerReconcilerOptions {
   /** Callback when operations are ready to send to main thread */
   onOps: (
     ops: import("../vdom-ops.ts").VDomOp[],
-  ) => void;
+  ) => number | void;
 
   /** Optional: callback when an error occurs */
   onError?: (error: Error) => void;

--- a/packages/html/test/main-renderer.test.ts
+++ b/packages/html/test/main-renderer.test.ts
@@ -6,6 +6,7 @@ import { VDomRenderer } from "../src/main/renderer.ts";
 class MockConnection {
   private listeners = new Map<string, Set<(payload: unknown) => void>>();
   public unmountCalls: number[] = [];
+  public acknowledgedBatches: Array<{ mountId: number; batchId: number }> = [];
   public sentEvents: Array<{
     mountId: number;
     handlerId: number;
@@ -46,6 +47,16 @@ class MockConnection {
       number,
     ];
     this.sentEvents.push({ mountId, handlerId, event, nodeId });
+  }
+
+  ackVDomBatch(mountId: number, batchId: number): void {
+    this.acknowledgedBatches.push({ mountId, batchId });
+  }
+
+  emit(event: string, payload: unknown): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(payload);
+    }
   }
 }
 
@@ -135,6 +146,44 @@ Deno.test("VDomRenderer - forwards trusted event provenance through delivery", a
       provenance: { origin: "dom", trusted: true },
     },
   });
+
+  await renderer.dispose();
+});
+
+Deno.test("VDomRenderer - acknowledges applied batches", async () => {
+  const connection = new MockConnection();
+  const mock = new MockDoc(
+    '<!DOCTYPE html><html><body><div id="root"></div></body></html>',
+  );
+  const renderer = new VDomRenderer({
+    runtimeClient: {} as any,
+    connection: connection as any,
+    document: mock.document,
+  });
+
+  const cellRef = {
+    space: "did:key:test",
+    id: "cell-id",
+    path: [],
+    type: "application/json",
+  } as unknown as CellRef;
+
+  const container = mock.document.getElementById("root")!;
+  await renderer.render(container as unknown as HTMLElement, cellRef);
+  const mountId = renderer.getMountId();
+  if (mountId === null) {
+    throw new Error("expected renderer to have an active mount");
+  }
+
+  connection.emit("vdombatch", {
+    type: "vdom:batch",
+    batchId: 7,
+    mountId,
+    ops: [{ op: "create-element", nodeId: 1, tagName: "button" }],
+    rootId: 1,
+  });
+
+  assertEquals(connection.acknowledgedBatches, [{ mountId, batchId: 7 }]);
 
   await renderer.dispose();
 });

--- a/packages/html/test/worker-reconciler-cell-props.test.ts
+++ b/packages/html/test/worker-reconciler-cell-props.test.ts
@@ -14,9 +14,17 @@ import { cfcLabelViewForCell } from "@commonfabric/runner/cfc";
  */
 function createOpsCollector() {
   const allOps: VDomOp[] = [];
+  const batchIds: number[] = [];
+  let nextBatchId = 0;
   return {
-    onOps: (ops: VDomOp[]) => allOps.push(...ops),
+    onOps: (ops: VDomOp[]) => {
+      const batchId = nextBatchId++;
+      allOps.push(...ops);
+      batchIds.push(batchId);
+      return batchId;
+    },
     getOps: () => allOps,
+    getLastBatchId: () => batchIds.at(-1),
     clear: () => {
       allOps.length = 0;
     },
@@ -80,7 +88,9 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
      * When sunk, emits the props object. key() returns a MockPropCell for that key.
      */
     class MockPropsCell extends MockCell {
+      static nextId = 0;
       private propCells = new Map<string, MockPropCell>();
+      private readonly linkId = `test-props-${++MockPropsCell.nextId}`;
       private rawValue: any;
 
       constructor(value: any, rawValue: any = value) {
@@ -100,6 +110,10 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
       getRawUntyped() {
         return this.rawValue;
+      }
+
+      getAsNormalizedFullLink() {
+        return { space: "test-space", id: this.linkId, path: [] };
       }
 
       override set(newValue: any) {
@@ -159,7 +173,9 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
      * MockStream: a Cell-like object that isStream() returns true for.
      */
     class MockStream extends MockCell {
+      static nextId = 0;
       public sent: unknown[] = [];
+      private readonly linkId = `test-stream-${++MockStream.nextId}`;
 
       constructor() {
         super(undefined);
@@ -176,6 +192,10 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
       send(event: unknown) {
         this.sent.push(event);
+      }
+
+      getAsNormalizedFullLink() {
+        return { space: "test-space", id: this.linkId, path: [] };
       }
 
       public usedTx: unknown;
@@ -509,6 +529,277 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
 
           assertEquals(mockStream.usedTx, undefined);
           assertEquals(mockStream.sent, [{ type: "click" }]);
+        } finally {
+          cancel();
+        }
+      },
+    );
+
+    await t.step(
+      "Cell<Props> event handler remains available during listener updates",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+        });
+
+        const firstStream = new MockStream();
+        const secondStream = new MockStream();
+        const propsCell = new MockPropsCell({
+          onclick: firstStream,
+        });
+        const rootCell = new MockCell({
+          type: "vnode",
+          name: "button",
+          props: propsCell,
+          children: ["Click"],
+        });
+
+        const cancel = mountReconciler(reconciler, rootCell);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          const firstEventOps = collector.getOpsOfType("set-event");
+          const firstEventOp = firstEventOps[0] as Extract<
+            VDomOp,
+            { op: "set-event" }
+          >;
+          collector.clear();
+
+          propsCell.set({ onclick: secondStream });
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          const secondEventOps = collector.getOpsOfType("set-event");
+          const secondEventOp = secondEventOps[0] as Extract<
+            VDomOp,
+            { op: "set-event" }
+          >;
+
+          assertEquals(
+            reconciler.dispatchEvent(
+              firstEventOp.handlerId,
+              { type: "click", phase: "old-listener" },
+            ),
+            true,
+          );
+          assertEquals(
+            reconciler.dispatchEvent(
+              secondEventOp.handlerId,
+              { type: "click", phase: "new-listener" },
+            ),
+            true,
+          );
+          assertEquals(firstStream.sent, [
+            { type: "click", phase: "old-listener" },
+          ]);
+          assertEquals(secondStream.sent, [
+            { type: "click", phase: "new-listener" },
+          ]);
+
+          const appliedBatchId = collector.getLastBatchId();
+          if (appliedBatchId === undefined) {
+            throw new Error("expected listener update batch");
+          }
+          reconciler.acknowledgeBatchApplied(appliedBatchId);
+          assertEquals(
+            reconciler.dispatchEvent(
+              firstEventOp.handlerId,
+              { type: "click", phase: "after-ack" },
+            ),
+            false,
+          );
+          assertEquals(
+            reconciler.dispatchEvent(
+              secondEventOp.handlerId,
+              { type: "click", phase: "after-ack" },
+            ),
+            true,
+          );
+        } finally {
+          cancel();
+        }
+      },
+    );
+
+    await t.step(
+      "Cell<Props> event handler remains available during node replacement",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+        });
+
+        const stream = new MockStream();
+        const propsCell = new MockPropsCell({
+          onclick: stream,
+        });
+        const rootCell = new MockCell({
+          type: "vnode",
+          name: "button",
+          props: propsCell,
+          children: ["Click"],
+        });
+
+        const cancel = mountReconciler(reconciler, rootCell);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          const eventOps = collector.getOpsOfType("set-event");
+          const eventOp = eventOps[0] as Extract<
+            VDomOp,
+            { op: "set-event" }
+          >;
+          collector.clear();
+
+          rootCell.set("Replaced");
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          assertEquals(
+            reconciler.dispatchEvent(
+              eventOp.handlerId,
+              { type: "click", phase: "removed-node" },
+            ),
+            true,
+          );
+          assertEquals(stream.sent, [
+            { type: "click", phase: "removed-node" },
+          ]);
+
+          const appliedBatchId = collector.getLastBatchId();
+          if (appliedBatchId === undefined) {
+            throw new Error("expected node replacement batch");
+          }
+          reconciler.acknowledgeBatchApplied(appliedBatchId);
+          assertEquals(
+            reconciler.dispatchEvent(
+              eventOp.handlerId,
+              { type: "click", phase: "after-ack" },
+            ),
+            false,
+          );
+        } finally {
+          cancel();
+        }
+      },
+    );
+
+    await t.step(
+      "Cell<Props> event handler is removed when a new props cell omits it",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+        });
+
+        const stream = new MockStream();
+        const firstPropsCell = new MockPropsCell({ onclick: stream });
+        const secondPropsCell = new MockPropsCell({ title: "plain" });
+        const rootCell = new MockCell({
+          type: "vnode",
+          name: "button",
+          props: firstPropsCell,
+          children: ["Click"],
+        });
+
+        const cancel = mountReconciler(reconciler, rootCell);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          const eventOp = collector.getOpsOfType("set-event")[0] as Extract<
+            VDomOp,
+            { op: "set-event" }
+          >;
+          collector.clear();
+
+          rootCell.set({
+            type: "vnode",
+            name: "button",
+            props: secondPropsCell,
+            children: ["Click"],
+          });
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          assertEquals(
+            collector.getOpsOfType("remove-event").some((op: any) =>
+              op.eventType === "click"
+            ),
+            true,
+          );
+          assertEquals(
+            reconciler.dispatchEvent(
+              eventOp.handlerId,
+              { type: "click", phase: "props-cell-swap" },
+            ),
+            true,
+          );
+
+          const appliedBatchId = collector.getLastBatchId();
+          if (appliedBatchId === undefined) {
+            throw new Error("expected props cell replacement batch");
+          }
+          reconciler.acknowledgeBatchApplied(appliedBatchId);
+          assertEquals(
+            reconciler.dispatchEvent(
+              eventOp.handlerId,
+              { type: "click", phase: "after-ack" },
+            ),
+            false,
+          );
+        } finally {
+          cancel();
+        }
+      },
+    );
+
+    await t.step(
+      "Cell<Props> event handler is removed after unmount acknowledgement",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+        });
+
+        const stream = new MockStream();
+        const propsCell = new MockPropsCell({ onclick: stream });
+        const rootCell = new MockCell({
+          type: "vnode",
+          name: "button",
+          props: propsCell,
+          children: ["Click"],
+        });
+
+        const cancel = mountReconciler(reconciler, rootCell);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          const eventOp = collector.getOpsOfType("set-event")[0] as Extract<
+            VDomOp,
+            { op: "set-event" }
+          >;
+          collector.clear();
+
+          reconciler.unmount();
+
+          assertEquals(
+            reconciler.dispatchEvent(
+              eventOp.handlerId,
+              { type: "click", phase: "unmount-before-ack" },
+            ),
+            true,
+          );
+
+          const appliedBatchId = collector.getLastBatchId();
+          if (appliedBatchId === undefined) {
+            throw new Error("expected unmount batch");
+          }
+          reconciler.acknowledgeBatchApplied(appliedBatchId);
+          assertEquals(
+            reconciler.dispatchEvent(
+              eventOp.handlerId,
+              { type: "click", phase: "unmount-after-ack" },
+            ),
+            false,
+          );
         } finally {
           cancel();
         }

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -449,6 +449,48 @@ export async function clickCfButton(
   }
 }
 
+export async function clickCfButtonAndWaitForText(
+  page: Page,
+  buttonSelector: string,
+  textSelector: string,
+  text: string,
+  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
+) {
+  let textProbe: TextProbe | undefined;
+  try {
+    await waitFor(async () => {
+      if (await textIsPresent(page, textSelector, text)) {
+        return true;
+      }
+      try {
+        await clickCfButton(page, buttonSelector, { timeout: 2_000 });
+      } catch {
+        textProbe = await readTextProbe(page, textSelector).catch(() =>
+          undefined
+        );
+        return false;
+      }
+      const updated = await textIsPresent(page, textSelector, text);
+      if (!updated) {
+        textProbe = await readTextProbe(page, textSelector).catch(() =>
+          undefined
+        );
+      }
+      return updated;
+    }, { timeout, delay: 1_000 });
+  } catch (cause) {
+    textProbe ??= await readTextProbe(page, textSelector).catch(() =>
+      undefined
+    );
+    throw new Error(
+      `Timed out clicking "${buttonSelector}" until "${textSelector}" contained "${text}". Last probe: ${
+        toIndentedDebugString(textProbe)
+      }`,
+      { cause },
+    );
+  }
+}
+
 export async function waitForRuntimeSynced(
   page: Page,
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},

--- a/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
@@ -23,6 +23,7 @@ import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import {
   clickCfButton,
+  clickTrustedActionAndWaitForText,
   fillCfInput,
   readCfInputValue,
   waitForDisabled,
@@ -32,6 +33,7 @@ import {
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
 const PROPAGATION_TIMEOUT = 60_000;
+const SAVE_PROFILE_ACTION = "TrustedGroupChatSaveProfile";
 
 describe("cfc group chat demo with two concurrent browser profiles", () => {
   const aliceShell = new ShellIntegration();
@@ -106,8 +108,12 @@ describe("cfc group chat demo with two concurrent browser profiles", () => {
     // Alice saves her profile. Her status updates; Bob's profile must stay
     // unset (not clobbered to Alice's).
     await waitForDisabled(alice, "#trusted-profile-save", false);
-    await clickCfButton(alice, "#trusted-profile-save");
-    await waitForText(alice, "#trusted-profile-status", "Alice");
+    await clickTrustedActionAndWaitForText(
+      alice,
+      SAVE_PROFILE_ACTION,
+      "#trusted-profile-status",
+      "Alice",
+    );
     await waitForRuntimeIdle(alice);
     await waitForRuntimeIdle(bob);
     await waitForText(bob, "#trusted-profile-status", "Name not set");
@@ -117,8 +123,12 @@ describe("cfc group chat demo with two concurrent browser profiles", () => {
     // name (not an unnamed placeholder), and her own profile must survive.
     await fillCfInput(bob, "#trusted-profile-name", "Bob");
     await waitForDisabled(bob, "#trusted-profile-save", false);
-    await clickCfButton(bob, "#trusted-profile-save");
-    await waitForText(bob, "#trusted-profile-status", "Bob");
+    await clickTrustedActionAndWaitForText(
+      bob,
+      SAVE_PROFILE_ACTION,
+      "#trusted-profile-status",
+      "Bob",
+    );
     await waitForText(
       alice,
       "#trusted-admin-user-list",

--- a/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
@@ -118,6 +118,13 @@ describe("cfc group chat demo with two concurrent browser profiles", () => {
     await waitForRuntimeIdle(bob);
     await waitForText(bob, "#trusted-profile-status", "Name not set");
     await waitForText(bob, "#group-chat-manager-chip", "No profile");
+    await waitForText(
+      bob,
+      "#trusted-admin-user-list",
+      "Alice",
+      { timeout: PROPAGATION_TIMEOUT },
+    );
+    await waitForRuntimeIdle(bob);
 
     // Bob saves his own profile. Alice's view must show Bob by his actual
     // name (not an unnamed placeholder), and her own profile must survive.
@@ -136,12 +143,6 @@ describe("cfc group chat demo with two concurrent browser profiles", () => {
       { timeout: PROPAGATION_TIMEOUT },
     );
     await waitForText(alice, "#trusted-profile-status", "Alice");
-    await waitForText(
-      bob,
-      "#trusted-admin-user-list",
-      "Alice",
-      { timeout: PROPAGATION_TIMEOUT },
-    );
 
     // Shared transcript propagates live in both directions, with snapshot
     // author names intact.

--- a/packages/patterns/integration/parking-coordinator-admin-view.test.ts
+++ b/packages/patterns/integration/parking-coordinator-admin-view.test.ts
@@ -6,7 +6,7 @@ import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import {
-  clickCfButton,
+  clickCfButtonAndWaitForText,
   waitForDisabled,
   waitForRuntimeIdle,
   waitForText,
@@ -108,15 +108,23 @@ describe("parking coordinator admin view integration test", () => {
     await waitForDisabled(page, "#parking-admin-mode-toggle", true);
     await waitForTextAbsent(page, "#parking-admin-people-section", "People");
 
-    await clickCfButton(page, "#parking-enable-admin-manager");
+    await clickCfButtonAndWaitForText(
+      page,
+      "#parking-enable-admin-manager",
+      "#parking-admin-access",
+      "Can manage admins",
+    );
     await waitForRuntimeIdle(page);
-    await waitForText(page, "#parking-admin-access", "Can manage admins");
     await waitForDisabled(page, "#parking-enable-admin-manager", true);
     await waitForDisabled(page, '[data-parking-admin-toggle="Alice"]', false);
 
-    await clickCfButton(page, '[data-parking-admin-toggle="Alice"]');
+    await clickCfButtonAndWaitForText(
+      page,
+      '[data-parking-admin-toggle="Alice"]',
+      '[data-parking-admin-row="Alice"]',
+      "Admin",
+    );
     await waitForRuntimeIdle(page);
-    await waitForText(page, '[data-parking-admin-row="Alice"]', "Admin");
     await waitForText(
       page,
       '[data-parking-admin-toggle="Alice"]',
@@ -125,9 +133,13 @@ describe("parking coordinator admin view integration test", () => {
     await waitForDisabled(page, "#parking-admin-mode-toggle", false);
     await waitForText(page, "#parking-admin-mode-toggle", "Admin: OFF");
 
-    await clickCfButton(page, "#parking-admin-mode-toggle");
+    await clickCfButtonAndWaitForText(
+      page,
+      "#parking-admin-mode-toggle",
+      "#parking-admin-mode-toggle",
+      "Admin: ON",
+    );
     await waitForRuntimeIdle(page);
-    await waitForText(page, "#parking-admin-mode-toggle", "Admin: ON");
     await waitForText(page, "#parking-admin-people-section", "People");
     await waitForText(page, "#parking-admin-add-person-open", "+ Add Person");
   });

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -97,6 +97,7 @@ import {
   type TriggerTraceResponse,
   type UploadBlobRequest,
   type UploadBlobResponse,
+  type VDomBatchAppliedRequest,
   type VDomEventRequest,
   type VDomMountRequest,
   type VDomMountResponse,
@@ -1349,6 +1350,8 @@ export class RuntimeProcessor {
         return this.handleVDomMount(request);
       case RequestType.VDomUnmount:
         return this.handleVDomUnmount(request);
+      case RequestType.VDomBatchApplied:
+        return this.handleVDomBatchApplied(request);
       default:
         throw new Error(`Unknown message type: ${(request as any).type}`);
     }
@@ -1403,6 +1406,7 @@ export class RuntimeProcessor {
           mountId,
           rootId: reconciler.getRootNodeId(),
         });
+        return batchId;
       },
       onError: (error: Error) => {
         self.postMessage({
@@ -1440,6 +1444,14 @@ export class RuntimeProcessor {
     mount.cancel();
     mount.reconciler.unmount();
     this.vdomMounts.delete(mountId);
+  }
+
+  handleVDomBatchApplied(request: VDomBatchAppliedRequest): void {
+    const mount = this.vdomMounts.get(request.mountId);
+    if (!mount) {
+      return;
+    }
+    mount.reconciler.acknowledgeBatchApplied(request.batchId);
   }
 }
 

--- a/packages/runtime-client/client/connection.ts
+++ b/packages/runtime-client/client/connection.ts
@@ -383,6 +383,24 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
   }
 
   /**
+   * Notify the worker that a VDOM batch has been applied on the main thread.
+   */
+  ackVDomBatch(mountId: number, batchId: number): void {
+    if (this.#disposed) return;
+    this.request<RequestType.VDomBatchApplied>({
+      type: RequestType.VDomBatchApplied,
+      mountId,
+      batchId,
+    }).catch((error) => {
+      console.error(
+        "[RuntimeClient] VDom batch acknowledgement failed:",
+        error instanceof Error ? error.message : String(error),
+        error,
+      );
+    });
+  }
+
+  /**
    * Request the worker to start VDOM rendering for a cell.
    */
   async mountVDom(

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -88,6 +88,7 @@ export enum RequestType {
   VDomEvent = "vdom:event",
   VDomMount = "vdom:mount",
   VDomUnmount = "vdom:unmount",
+  VDomBatchApplied = "vdom:batch-applied",
 }
 
 export enum NotificationType {
@@ -623,6 +624,17 @@ export interface VDomUnmountRequest extends BaseRequest {
 }
 
 /**
+ * Request sent after the main thread applies a VDOM batch.
+ */
+export interface VDomBatchAppliedRequest extends BaseRequest {
+  type: RequestType.VDomBatchApplied;
+  /** The mount ID that received the batch */
+  mountId: number;
+  /** The applied batch ID */
+  batchId: number;
+}
+
+/**
  * Response to VDomMount with the root node ID.
  */
 export interface VDomMountResponse {
@@ -675,6 +687,7 @@ export type IPCClientRequest =
   | VDomEventRequest
   | VDomMountRequest
   | VDomUnmountRequest
+  | VDomBatchAppliedRequest
   | DetectNonIdempotentRequest
   | GetPatternSourcesRequest
   | SetBreakpointsRequest
@@ -1018,6 +1031,10 @@ export type Commands = {
   };
   [RequestType.VDomUnmount]: {
     request: VDomUnmountRequest;
+    response: EmptyResponse;
+  };
+  [RequestType.VDomBatchApplied]: {
+    request: VDomBatchAppliedRequest;
     response: EmptyResponse;
   };
 };


### PR DESCRIPTION
The two-browser Common Fabric Component group chat test failed when Bob saved his profile after Alice. The page showed Alice in Bob's shared user list, so storage and cross-browser propagation were alive. Bob's own profile status stayed "Name not set", which means Bob's trusted save action was lost while the rest of the app continued to render.

The root cause was a cross-thread handler lifetime race. The worker removed or replaced event handlers as soon as it queued the virtual Document Object Model update. The main thread could still have the old Document Object Model listener until it applied that batch. A real click could therefore arrive with the old handler identifier after the worker had already deleted that identifier. The runtime ignored the failed dispatch, so the event was lost. The test amplified the race by clicking the raw cf-button once and then waiting separately, instead of driving the trusted action by its action marker and waiting for the action result.

This keeps retired handlers registered until the main thread acknowledges that it applied the batch that removed them. The renderer sends that acknowledgement after applying a virtual Document Object Model batch. The worker then deletes handlers retired by that batch. The group chat profile save steps now use the existing trusted action helper, which clicks by data-ui-action and retries until the expected status is visible.

Regression tests cover listener replacement, node replacement, removal after an acknowledgement, unmount cleanup, and renderer batch acknowledgements.

Verification: baseline failed 1 of 28 runs. The one-file helper-only reduction failed 1 of 8 runs. The worker-local retirement reduction failed 1 of 2 runs. The final acknowledgement-based patch passed 30 of 30 runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky trusted group chat profile save by preventing lost clicks from a cross-thread event handler race. Old handlers now stay active until the main thread confirms the VDOM batch, so trusted actions deliver reliably.

- **Bug Fixes**
  - Keep retired handlers registered until the applied VDOM batch is acknowledged; defer cleanup and track per-batch.
  - Add VDOM batch acknowledgements end-to-end: `VDomRenderer.ackVDomBatch`, `RuntimeConnection` sends `RequestType.VDomBatchApplied`, `RuntimeProcessor` calls `acknowledgeBatchApplied`; `onOps` can return a `batchId`.
  - Remove immediate `unregisterHandler`; unify handler retirement across prop updates, node replacement, and unmount.
  - Harden pattern tests: use `clickTrustedActionAndWaitForText` for group chat save; add `clickCfButtonAndWaitForText` and update the parking admin test.
  - Add regression tests for listener replacement, node replacement, props-cell swaps, unmount cleanup, and renderer batch acknowledgements.

- **Migration**
  - Deploy the updated `runtime-client` and `html` renderer together (new `vdom:batch-applied` protocol message).

<sup>Written for commit d63e4c2ad6608aa7217cc7d6d602f5ff770b948d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

