### PR TITLE
Clean up group chat profile registration

### DIFF
--- a/packages/patterns/cfc-group-chat-demo/trusted.tsx
+++ b/packages/patterns/cfc-group-chat-demo/trusted.tsx
@@ -384,13 +384,10 @@ export const registerProfile = (
   profile: ProfileCell,
 ): void => {
   const currentProfiles = profilesValue(profiles);
-  const nextProfiles =
-    currentProfiles.some((knownProfile) => equals(knownProfile, profile))
-      ? currentProfiles
-      : [...currentProfiles, profile];
-  profiles.set(
-    nextProfiles.map((profile) => ({ profile })) as SharedProfilesValue,
-  );
+  if (currentProfiles.some((knownProfile) => equals(knownProfile, profile))) {
+    return;
+  }
+  profiles.push({ profile } as SharedProfileEntry);
 };
 
 export const applyTrustedProfileSave = (


### PR DESCRIPTION
Profile registration only needs to add the current user's profile link when it is not already present. The old helper built a replacement list from the current shared profile entries and wrote the whole list back with profiles.set(...). That made the helper touch entries that it did not need to change.

Keep the existing duplicate check, return early when the profile is already registered, and append the one missing entry with profiles.push({ profile }). This keeps the write focused on the current user's registration and leaves existing profile entries untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified group chat profile registration to only append the current user's profile when it’s missing, instead of rewriting the full list. This reduces unnecessary writes and leaves existing entries untouched.

<sup>Written for commit 47708a276838d8dd0bc5b7f318767c8c095e1f91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

