### PR TITLE
Accept `undefined` as a schema for interning

### DIFF
--- a/packages/data-model/src/SchemaAndHash.ts
+++ b/packages/data-model/src/SchemaAndHash.ts
@@ -11,9 +11,16 @@ import type { FabricHash } from "@/fabric-primitives/FabricHash.ts";
  * To create instances, use `internSchema()` from `schema-hash.ts` —
  * it handles freezing, hashing, and caching. The constructor is public
  * for direct use when both the frozen schema and hash are already in hand.
+ *
+ * This class accepts `undefined` as its "schema" upon construction as a
+ * concession to making the schema intern mechanism work straightforwardly with
+ * `undefined`. However, in nearly every client use having `undefined` be a
+ * possible value for `.schema` is undesirable, so that accessor `throw`s
+ * instead of returning `undefined`. For the few cases where `undefined` is
+ * acceptable, there is `.schemaOrUndefined`.
  */
 export class SchemaAndHash {
-  readonly #schema: JSONSchema;
+  readonly #schema: JSONSchema | undefined;
   readonly #hash: FabricHash;
 
   /**
@@ -22,7 +29,7 @@ export class SchemaAndHash {
    * Prefer `internSchema()` from `schema-hash.ts` for the friendly entry
    * point that handles freezing, hashing, and interning.
    */
-  constructor(schema: JSONSchema, hash: FabricHash) {
+  constructor(schema: JSONSchema | undefined, hash: FabricHash) {
     if (!isDeepFrozen(schema)) {
       throw new Error("SchemaAndHash: schema must be deep-frozen");
     }
@@ -31,8 +38,20 @@ export class SchemaAndHash {
     Object.freeze(this);
   }
 
-  /** The deep-frozen schema. */
+  /** The schema. */
   get schema(): JSONSchema {
+    if (typeof this.#schema === "undefined") {
+      throw new Error("`schema` is `undefined`.");
+    }
+
+    return this.#schema;
+  }
+
+  /**
+   * The schema per se, or `undefined` if this instance was constructed with
+   * `schema === undefined`.
+   */
+  get schemaOrUndefined(): JSONSchema | undefined {
     return this.#schema;
   }
 

--- a/packages/data-model/src/schema-hash.ts
+++ b/packages/data-model/src/schema-hash.ts
@@ -53,7 +53,10 @@ export function hashSchema(schema: JSONSchema | undefined): string {
  *   schemas are primitives and can't be `WeakMap`/`WeakRef` targets).
  */
 const schemaToSah = new WeakMap<JSONSchemaObj, SchemaAndHash>();
-const hashToRef = new Map<string, WeakRef<JSONSchemaObj> | boolean | undefined>();
+const hashToRef = new Map<
+  string,
+  WeakRef<JSONSchemaObj> | boolean | undefined
+>();
 
 /**
  * Prefab instances of `SchemaAndHash` for all possible primitive-value schemas
@@ -80,7 +83,9 @@ hashToRef.set(primInterns.undefined.taggedHashString, undefined);
 /**
  * Helper for `internSchema()`, which always returns a `SchemaAndHash`.
  */
-function internSchemaReturningSchemaAndHash(schema: JSONSchema | undefined): SchemaAndHash {
+function internSchemaReturningSchemaAndHash(
+  schema: JSONSchema | undefined,
+): SchemaAndHash {
   // Return prefab instances for primitives.
   switch (schema) {
     case true: {
@@ -165,24 +170,24 @@ function internSchemaReturningSchemaAndHash(schema: JSONSchema | undefined): Sch
  * shallow-cloned as mutable, for the express purpose of tactical modification
  * and then immediately treated once again as deep-immutable.
  */
-export function internSchema<T extends JSONSchema>(
+export function internSchema<T extends JSONSchema | undefined>(
   schema: T,
   wantSchemaAndHash?: false,
 ): T;
-export function internSchema<T extends JSONSchema>(
+export function internSchema<T extends JSONSchema | undefined>(
   schema: T,
   wantSchemaAndHash: true,
 ): SchemaAndHash;
-export function internSchema<T extends JSONSchema>(
+export function internSchema<T extends JSONSchema | undefined>(
   schema: T,
   wantSchemaAndHash?: boolean,
-): JSONSchema | SchemaAndHash;
-export function internSchema<T extends JSONSchema>(
+): JSONSchema | undefined | SchemaAndHash;
+export function internSchema<T extends JSONSchema | undefined>(
   schema: T,
   wantSchemaAndHash: boolean = false,
-): JSONSchema | SchemaAndHash {
+): JSONSchema | undefined | SchemaAndHash {
   const sahResult = internSchemaReturningSchemaAndHash(schema);
-  return wantSchemaAndHash ? sahResult : sahResult.schema;
+  return wantSchemaAndHash ? sahResult : sahResult.schemaOrUndefined;
 }
 
 /**
@@ -272,6 +277,8 @@ export function isInternedSchema(schema: JSONSchema | undefined): boolean {
  * names the operation and avoids the non-obvious `true` (`wantSchemaAndHash`)
  * argument at call sites.
  */
-export function internSchemaAsTaggedHashString(schema: JSONSchema): string {
+export function internSchemaAsTaggedHashString(
+  schema: JSONSchema | undefined,
+): string {
   return internSchema(schema, true).taggedHashString;
 }

--- a/packages/data-model/src/schema-hash.ts
+++ b/packages/data-model/src/schema-hash.ts
@@ -19,12 +19,13 @@ import { hashOf, hashStringOf } from "./value-hash.ts";
 /**
  * Computes a deterministic hash of a JSONSchema. Structurally-equal schemas
  * always produce the same hash. Returns a string for use as a map key or cache
- * key.
+ * key. This accepts `undefined` as a convenience for contexts where that value
+ * is useful to mean "no relevant schema," or "missing schema," and so on.
  *
  * This function is a pass-through to `hashStringOf()`, just with a narrower
  * argument type.
  */
-export function hashSchema(schema: JSONSchema): string {
+export function hashSchema(schema: JSONSchema | undefined): string {
   return hashStringOf(schema);
 }
 

--- a/packages/data-model/src/schema-hash.ts
+++ b/packages/data-model/src/schema-hash.ts
@@ -171,37 +171,19 @@ export function internSchema<T extends JSONSchema>(
 /**
  * Looks up a previously interned schema by its hash. Accepts a
  * `FabricHash` or a plain string. Returns `undefined` if the schema
- * has not been interned or has been garbage-collected. If found, returns either
- * the `schema` or full `SchemaAndHash` depending on the `wantSchemaAndHash`
- * argument.
+ * has not been interned or has been garbage-collected. If found, returns the
+ * corresponding full `SchemaAndHash`.
  */
 export function findInternedSchema(
   hash: FabricHash | string,
-  wantSchemaAndHash?: false,
-): JSONSchema | undefined;
-export function findInternedSchema(
-  hash: FabricHash | string,
-  wantSchemaAndHash: true,
-): SchemaAndHash | undefined;
-export function findInternedSchema(
-  hash: FabricHash | string,
-  wantSchemaAndHash?: boolean,
-): JSONSchema | SchemaAndHash | undefined;
-export function findInternedSchema(
-  hash: FabricHash | string,
-  wantSchemaAndHash: boolean = false,
-): JSONSchema | SchemaAndHash | undefined {
+): SchemaAndHash | undefined {
   const hashStr = typeof hash === "string" ? hash : hash.toString();
 
   const refOrBoolean = hashToRef.get(hashStr);
 
   switch (typeof refOrBoolean) {
     case "boolean": {
-      if (wantSchemaAndHash) {
-        return refOrBoolean ? booleanInterns.true : booleanInterns.false;
-      } else {
-        return refOrBoolean;
-      }
+      return refOrBoolean ? booleanInterns.true : booleanInterns.false;
     }
 
     case "undefined": {
@@ -222,8 +204,10 @@ export function findInternedSchema(
         return undefined;
       }
 
-      const resultSah = schemaToSah.get(schema)!;
-      return wantSchemaAndHash ? resultSah : resultSah.schema;
+      // The `!` below is valid because we know that `schemaToSah` definitely
+      // has a mapping for `schema`. Otherwise, we wouldn't have found a
+      // `refOrBoolean` to look up.
+      return schemaToSah.get(schema)!;
     }
 
     default: {

--- a/packages/data-model/src/schema-hash.ts
+++ b/packages/data-model/src/schema-hash.ts
@@ -237,7 +237,7 @@ export function findInternedSchema(
 
       // The `!` below is valid because we know that `schemaToSah` definitely
       // has a mapping for `schema`. Otherwise, we wouldn't have found a
-      // `refOrBoolean` to look up.
+      // `refOrPrim` to look up.
       return schemaToSah.get(schema)!;
     }
 

--- a/packages/data-model/src/schema-hash.ts
+++ b/packages/data-model/src/schema-hash.ts
@@ -186,9 +186,9 @@ export function internSchema<T extends JSONSchema>(
 }
 
 /**
- * Looks up a previously interned schema by its hash. Accepts a
- * `FabricHash` or a plain string. Returns `undefined` if the schema
- * has not been interned or has been garbage-collected. If found, returns the
+ * Looks up a previously interned schema by its hash. Accepts a `FabricHash` or
+ * a plain string of the _tagged_ hash. Returns `undefined` if the schema has
+ * not been interned or has been garbage-collected. If found, returns the
  * corresponding full `SchemaAndHash`.
  *
  * This function _will_ find the `SchemaAndHash` corresponding to the "schema"

--- a/packages/data-model/src/schema-hash.ts
+++ b/packages/data-model/src/schema-hash.ts
@@ -53,11 +53,16 @@ export function hashSchema(schema: JSONSchema | undefined): string {
  *   schemas are primitives and can't be `WeakMap`/`WeakRef` targets).
  */
 const schemaToSah = new WeakMap<JSONSchemaObj, SchemaAndHash>();
-const hashToRef = new Map<string, WeakRef<JSONSchemaObj> | boolean>();
+const hashToRef = new Map<string, WeakRef<JSONSchemaObj> | boolean | undefined>();
 
-const booleanInterns = {
-  true: new SchemaAndHash(true, hashOf(true)),
+/**
+ * Prefab instances of `SchemaAndHash` for all possible primitive-value schemas
+ * (including `undefined`).
+ */
+const primInterns = {
   false: new SchemaAndHash(false, hashOf(false)),
+  true: new SchemaAndHash(true, hashOf(true)),
+  undefined: new SchemaAndHash(undefined, hashOf(undefined)),
 };
 
 const schemaFinalizer = new FinalizationRegistry<string>((hashStr) => {
@@ -67,17 +72,28 @@ const schemaFinalizer = new FinalizationRegistry<string>((hashStr) => {
   }
 });
 
-// Seeds `hashToRef` with intern records for `boolean` schemas.
-hashToRef.set(booleanInterns.true.taggedHashString, true);
-hashToRef.set(booleanInterns.false.taggedHashString, false);
+// Seeds `hashToRef` with intern records for the primitive-value schemas.
+hashToRef.set(primInterns.false.taggedHashString, false);
+hashToRef.set(primInterns.true.taggedHashString, true);
+hashToRef.set(primInterns.undefined.taggedHashString, undefined);
 
 /**
  * Helper for `internSchema()`, which always returns a `SchemaAndHash`.
  */
-function internSchemaReturningSchemaAndHash(schema: JSONSchema): SchemaAndHash {
-  // Boolean schemas are primitives — return prefab instances.
-  if (typeof schema === "boolean") {
-    return schema ? booleanInterns.true : booleanInterns.false;
+function internSchemaReturningSchemaAndHash(schema: JSONSchema | undefined): SchemaAndHash {
+  // Return prefab instances for primitives.
+  switch (schema) {
+    case true: {
+      return primInterns.true;
+    }
+
+    case false: {
+      return primInterns.false;
+    }
+
+    case undefined: {
+      return primInterns.undefined;
+    }
   }
 
   // At this point `schema` is a `JSONSchemaObj`.
@@ -91,7 +107,7 @@ function internSchemaReturningSchemaAndHash(schema: JSONSchema): SchemaAndHash {
 
   // Check the hash-keyed reverse map (structurally-equal but different object).
   const hash = hashOf(frozen);
-  const hashStr = hash.toString();
+  const hashStr = hash.taggedHashString;
 
   const maybeRef = hashToRef.get(hashStr);
 
@@ -174,30 +190,39 @@ export function internSchema<T extends JSONSchema>(
  * `FabricHash` or a plain string. Returns `undefined` if the schema
  * has not been interned or has been garbage-collected. If found, returns the
  * corresponding full `SchemaAndHash`.
+ *
+ * This function _will_ find the `SchemaAndHash` corresponding to the "schema"
+ * `undefined`.
  */
 export function findInternedSchema(
   hash: FabricHash | string,
 ): SchemaAndHash | undefined {
-  const hashStr = typeof hash === "string" ? hash : hash.toString();
+  const hashStr = typeof hash === "string" ? hash : hash.taggedHashString;
 
-  const refOrBoolean = hashToRef.get(hashStr);
+  const refOrPrim = hashToRef.get(hashStr);
 
-  switch (typeof refOrBoolean) {
+  switch (typeof refOrPrim) {
     case "boolean": {
-      return refOrBoolean ? booleanInterns.true : booleanInterns.false;
+      return refOrPrim ? primInterns.true : primInterns.false;
     }
 
     case "undefined": {
-      return undefined;
+      // We have to disambiguate "the caller passed the hash of `undefined`"
+      // from "the caller passed in a hash that does not correspond to an
+      // interned schema."
+      const undefinedSah = primInterns.undefined;
+      return (hashStr === undefinedSah.taggedHashString)
+        ? undefinedSah
+        : undefined;
     }
 
     case "object": {
-      if (refOrBoolean === null) {
+      if (refOrPrim === null) {
         // Shouldn't happen!
         throw new Error("Unexpected `null` reference in schema intern table.");
       }
 
-      const schema = refOrBoolean.deref();
+      const schema = refOrPrim.deref();
 
       if (schema === undefined) {
         // The `WeakRef`'s referent got collected. Clean up.
@@ -214,7 +239,7 @@ export function findInternedSchema(
     default: {
       // Shouldn't happen!
       throw new Error(
-        `Unexpected type in schema intern table: ${typeof refOrBoolean}`,
+        `Unexpected type in schema intern table: ${typeof refOrPrim}`,
       );
     }
   }
@@ -225,13 +250,20 @@ export function findInternedSchema(
  * `false` even if there is already a schema in the intern cache that is
  * equivalent to the given one, unless `schema` is in fact the one that is in
  * the cache.
+ *
+ * This returns `true` for the primitive-value schemas and `undefined`.
  */
-export function isInternedSchema(schema: JSONSchema): boolean {
-  if (typeof schema === "boolean") {
-    return true;
-  }
+export function isInternedSchema(schema: JSONSchema | undefined): boolean {
+  switch (typeof schema) {
+    case "boolean":
+    case "undefined": {
+      return true;
+    }
 
-  return schemaToSah.has(schema);
+    default: {
+      return schemaToSah.has(schema);
+    }
+  }
 }
 
 /**

--- a/packages/data-model/src/schema-utils.ts
+++ b/packages/data-model/src/schema-utils.ts
@@ -509,14 +509,6 @@ export const DEFAULT_SELECTOR: SchemaPathSelector = Object.freeze({
  * (and thus deep-frozen) via `internSchema()`. The `|` delimiter is outside
  * the base64url alphabet used by hash strings, so the two halves cannot
  * merge ambiguously.
- *
- * Used at the `traverse.ts` sites that key an intern cache on a merge
- * operation's two input schemas. Interning the inputs stabilizes their
- * identities in `internSchema()`'s `WeakMap`, so subsequent calls with the
- * same object references hit the hash-cache fast path in O(1) rather
- * than re-hashing. See
- * `coordination/docs/2026-04-16-modern-schema-hash-cache-audit.md` §1
- * for the motivating regression.
  */
 export function internSchemaPairAsKey(a: JSONSchema, b: JSONSchema): string {
   return `${internSchemaAsTaggedHashString(a)}|${

--- a/packages/data-model/test/SchemaAndHash.test.ts
+++ b/packages/data-model/test/SchemaAndHash.test.ts
@@ -30,9 +30,23 @@ describe("SchemaAndHash", () => {
       expect(sah.hash).toBe(HASH_A);
     });
 
-    it("accepts a boolean schema (primitives are inherently frozen)", () => {
-      const sah = new SchemaAndHash(true, HASH_A);
-      expect(sah.schema).toBe(true);
+    it("rejects a non-deep-frozen schema", () => {
+      expect(() => new SchemaAndHash({ type: "number" }, HASH_A)).toThrow(
+        /deep-frozen/,
+      );
+    });
+
+    it("accepts both boolean schemas", () => {
+      const sahTrue = new SchemaAndHash(true, HASH_A);
+      expect(sahTrue.schema).toBe(true);
+
+      const sahFalse = new SchemaAndHash(false, HASH_A);
+      expect(sahFalse.schema).toBe(false);
+    });
+
+    it("accepts `schema === undefined`", () => {
+      const sah = new SchemaAndHash(undefined, HASH_A);
+      expect(sah.schemaOrUndefined).toBe(undefined);
     });
 
     it("produces a frozen instance", () => {
@@ -49,6 +63,43 @@ describe("SchemaAndHash", () => {
           (sah as unknown as Record<string, unknown>).schema = false;
         }).toThrow();
       });
+
+      it("is the schema that the instance was constructed with", () => {
+        const schema1 = true;
+        const schema2 = toDeepFrozenSchema({ type: "number", title: "yes!" });
+        const sah1 = new SchemaAndHash(schema1, HASH_A);
+        const sah2 = new SchemaAndHash(schema2, HASH_A);
+        expect(sah1.schema).toBe(schema1);
+        expect(sah2.schema).toBe(schema2);
+      });
+
+      it("throws when `schema === undefined`", () => {
+        const sah = new SchemaAndHash(undefined, HASH_A);
+        expect(() => sah.schema).toThrow(/undefined/);
+      });
+    });
+
+    describe(".schemaOrUndefined", () => {
+      it("is not writable", () => {
+        const sah = new SchemaAndHash(true, HASH_A);
+        expect(() => {
+          (sah as unknown as Record<string, unknown>).schema = false;
+        }).toThrow();
+      });
+
+      it("is the schema that the instance was constructed with", () => {
+        const schema1 = false;
+        const schema2 = toDeepFrozenSchema({ type: "string", title: "yes!" });
+        const sah1 = new SchemaAndHash(schema1, HASH_A);
+        const sah2 = new SchemaAndHash(schema2, HASH_A);
+        expect(sah1.schema).toBe(schema1);
+        expect(sah2.schema).toBe(schema2);
+      });
+
+      it("returns `undefined` when `schema === undefined`", () => {
+        const sah = new SchemaAndHash(undefined, HASH_A);
+        expect(sah.schemaOrUndefined).toBe(undefined);
+      });
     });
 
     describe(".hash", () => {
@@ -57,6 +108,13 @@ describe("SchemaAndHash", () => {
         expect(() => {
           (sah as unknown as Record<string, unknown>).hash = "tampered";
         }).toThrow();
+      });
+
+      it("is the hash that the instance was constructed with", () => {
+        const sah1 = new SchemaAndHash(true, HASH_A);
+        const sah2 = new SchemaAndHash(false, HASH_B);
+        expect(sah1.hash).toBe(HASH_A);
+        expect(sah2.hash).toBe(HASH_B);
       });
     });
 

--- a/packages/data-model/test/SchemaAndHash.test.ts
+++ b/packages/data-model/test/SchemaAndHash.test.ts
@@ -83,7 +83,7 @@ describe("SchemaAndHash", () => {
       it("is not writable", () => {
         const sah = new SchemaAndHash(true, HASH_A);
         expect(() => {
-          (sah as unknown as Record<string, unknown>).schema = false;
+          (sah as unknown as Record<string, unknown>).schemaOrUndefined = false;
         }).toThrow();
       });
 
@@ -92,8 +92,8 @@ describe("SchemaAndHash", () => {
         const schema2 = toDeepFrozenSchema({ type: "string", title: "yes!" });
         const sah1 = new SchemaAndHash(schema1, HASH_A);
         const sah2 = new SchemaAndHash(schema2, HASH_A);
-        expect(sah1.schema).toBe(schema1);
-        expect(sah2.schema).toBe(schema2);
+        expect(sah1.schemaOrUndefined).toBe(schema1);
+        expect(sah2.schemaOrUndefined).toBe(schema2);
       });
 
       it("returns `undefined` when `schema === undefined`", () => {

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -68,13 +68,13 @@ describe("schema-hash", () => {
     });
 
     for (const wantSah of [false, true]) {
-      const callIntern = (schema: JSONSchema, fullResult = false) => {
+      const callIntern = (schema: JSONSchema | undefined, fullResult = false) => {
         const result = internSchema(schema, wantSah);
 
         if (wantSah) {
           assert(result instanceof SchemaAndHash);
           assert(result.hash instanceof FabricHash);
-          return fullResult ? result : result.schema;
+          return fullResult ? result : result.schemaOrUndefined;
         } else {
           return result;
         }
@@ -135,6 +135,11 @@ describe("schema-hash", () => {
         it("handles boolean schema `false`", () => {
           const result = callIntern(false);
           expect(result).toBe(false);
+        });
+
+        it("handles schema `undefined`", () => {
+          const result = callIntern(undefined);
+          expect(result).toBe(undefined);
         });
 
         it("handles empty object schema", () => {
@@ -292,14 +297,19 @@ describe("schema-hash", () => {
       expect(internSchemaAsTaggedHashString(schema)).toBe(sah.taggedHashString);
     });
 
-    it("returns the boolean schema's prefab `.taggedHashString` for `true`", () => {
+    it("returns the prefab `.taggedHashString` for `true`", () => {
       const expected = internSchema(true, true).taggedHashString;
       expect(internSchemaAsTaggedHashString(true)).toBe(expected);
     });
 
-    it("returns the boolean schema's prefab `.taggedHashString` for `false`", () => {
+    it("returns the prefab `.taggedHashString` for `false`", () => {
       const expected = internSchema(false, true).taggedHashString;
       expect(internSchemaAsTaggedHashString(false)).toBe(expected);
+    });
+
+    it("returns the prefab `.taggedHashString` for `undefined`", () => {
+      const expected = internSchema(undefined, true).taggedHashString;
+      expect(internSchemaAsTaggedHashString(undefined)).toBe(expected);
     });
 
     it("produces matching strings for structurally-equal objects", () => {

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -13,7 +13,7 @@ import {
 } from "@/schema-hash.ts";
 import { SchemaAndHash } from "@/SchemaAndHash.ts";
 import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
-import { hashStringOf } from "@/value-hash.ts";
+import { hashStringOf, taggedHashStringOf } from "@/value-hash.ts";
 import { isDeepFrozen } from "@/deep-freeze.ts";
 import { toDeepFrozenSchema } from "@/schema-utils.ts";
 
@@ -208,6 +208,10 @@ describe("schema-hash", () => {
       expect(isInternedSchema(false)).toBe(true);
     });
 
+    it("returns `true` for `undefined`", () => {
+      expect(isInternedSchema(undefined)).toBe(true);
+    });
+
     it("returns `true` for a freshly interned schema", () => {
       const schema = internSchema({ type: "string" });
       expect(isInternedSchema(schema)).toBe(true);
@@ -271,6 +275,13 @@ describe("schema-hash", () => {
       const foundFalse = callFind(sahFalse.hash);
       expect(foundTrue).toBe(sahTrue);
       expect(foundFalse).toBe(sahFalse);
+    });
+
+    it("finds `undefined`", () => {
+      const undefinedHash = taggedHashStringOf(undefined);
+      const found = callFind(undefinedHash);
+      expect(found).not.toBe(undefined);
+      expect(found!.schemaOrUndefined).toBe(undefined);
     });
   });
 

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -237,13 +237,6 @@ describe("schema-hash", () => {
       return result;
     };
 
-    const expectSame = (
-      got: SchemaAndHash | undefined,
-      expectedSah: SchemaAndHash,
-    ) => {
-      expect(got).toBe(expectedSah);
-    };
-
     it("finds a previously interned schema by FabricHash", () => {
       const sah = internSchema(
         { type: "array", items: { type: "string" } },

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -218,75 +218,59 @@ describe("schema-hash dispatch", () => {
   });
 
   describe("findInternedSchema()", () => {
-    it("defaults to `wantSchemaAndHash = false`", () => {
-      const hash = internSchema({}, true).hash;
+    const callFind = (hash: FabricHash | string) => {
       const result = findInternedSchema(hash);
-      expect(result).not.toBe(undefined);
-      expect(result).not.toBeInstanceOf(SchemaAndHash);
+
+      if (result !== undefined) {
+        expect(result).toBeInstanceOf(SchemaAndHash);
+        expect(result.hash).toBeInstanceOf(FabricHash);
+      }
+
+      return result;
+    };
+
+    const expectSame = (
+      got: SchemaAndHash | undefined,
+      expectedSah: SchemaAndHash,
+    ) => {
+      expect(got).toBe(expectedSah);
+    };
+
+    it("finds a previously interned schema by FabricHash", () => {
+      const sah = internSchema(
+        { type: "array", items: { type: "string" } },
+        true,
+      );
+      const found = callFind(sah.hash);
+      expect(found).toBe(sah);
     });
 
-    for (const wantSah of [false, true]) {
-      const callFind = (hash: FabricHash | string) => {
-        const result = findInternedSchema(hash, wantSah);
+    it("finds a previously interned schema by hash string", () => {
+      const sah = internSchema(
+        {
+          type: "object",
+          properties: { z: { type: "boolean" } },
+        },
+        true,
+      );
+      const found = callFind(sah.taggedHashString);
+      expect(found).toBe(sah);
+    });
 
-        if (wantSah && (result !== undefined)) {
-          const resultSah = result as SchemaAndHash;
-          expect(resultSah).toBeInstanceOf(SchemaAndHash);
-          expect(resultSah.hash).toBeInstanceOf(FabricHash);
-        }
+    it("returns `undefined` for unknown hash", () => {
+      const unknown = new FabricHash(new Uint8Array(32), "fid1");
+      const found = callFind(unknown);
+      expect(found).toBe(undefined);
+    });
 
-        return result;
-      };
-
-      const expectSame = (
-        got: JSONSchema | SchemaAndHash | undefined,
-        expectedSah: SchemaAndHash,
-      ) => {
-        if (wantSah) {
-          expect(got).toBe(expectedSah);
-        } else {
-          expect(got).toBe(expectedSah.schema);
-        }
-      };
-
-      describe(`with \`wantSchemaAndHash = ${wantSah}\``, () => {
-        it("finds a previously interned schema by FabricHash", () => {
-          const sah = internSchema(
-            { type: "array", items: { type: "string" } },
-            true,
-          );
-          const found = callFind(sah.hash);
-          expectSame(found, sah);
-        });
-
-        it("finds a previously interned schema by hash string", () => {
-          const sah = internSchema(
-            {
-              type: "object",
-              properties: { z: { type: "boolean" } },
-            },
-            true,
-          );
-          const found = callFind(sah.taggedHashString);
-          expectSame(found, sah);
-        });
-
-        it("returns `undefined` for unknown hash", () => {
-          const unknown = new FabricHash(new Uint8Array(32), "fid1");
-          const found = callFind(unknown);
-          expect(found).toBe(undefined);
-        });
-
-        it("finds interned boolean schemas", () => {
-          const sahTrue = internSchema(true, true);
-          const sahFalse = internSchema(false, true);
-          const foundTrue = callFind(sahTrue.hash);
-          const foundFalse = callFind(sahFalse.hash);
-          expectSame(foundTrue, sahTrue);
-          expectSame(foundFalse, sahFalse);
-        });
-      });
-    }
+    it("finds interned boolean schemas", () => {
+      const sahTrue = internSchema(true, true);
+      const sahFalse = internSchema(false, true);
+      const foundTrue = callFind(sahTrue.hash);
+      const foundFalse = callFind(sahFalse.hash);
+      expect(foundTrue).toBe(sahTrue);
+      expect(foundFalse).toBe(sahFalse);
+    });
   });
 
   describe("internSchemaAsTaggedHashString()", () => {

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -17,14 +17,22 @@ import { hashStringOf } from "@/value-hash.ts";
 import { isDeepFrozen } from "@/deep-freeze.ts";
 import { toDeepFrozenSchema } from "@/schema-utils.ts";
 
-describe("schema-hash dispatch", () => {
+describe("schema-hash", () => {
   describe("hashSchema()", () => {
     it("returns a string", () => {
       const result = hashSchema({ type: "number" });
       expect(typeof result).toBe("string");
     });
 
-    it("agrees with general `hashStringOf()`", () => {
+    it("agrees with `hashStringOf()` on primitives", () => {
+      for (const v of [false, true, undefined]) {
+        const result1 = hashSchema(v);
+        const result2 = hashStringOf(v);
+        expect(result1).toBe(result2);
+      }
+    });
+
+    it("agrees with `hashStringOf()` on plain objects", () => {
       const result1 = hashSchema({ type: "number", title: "Yes!" });
       const result2 = hashStringOf({ type: "number", title: "Yes!" });
       expect(result1).toBe(result2);

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -68,7 +68,10 @@ describe("schema-hash", () => {
     });
 
     for (const wantSah of [false, true]) {
-      const callIntern = (schema: JSONSchema | undefined, fullResult = false) => {
+      const callIntern = (
+        schema: JSONSchema | undefined,
+        fullResult = false,
+      ) => {
         const result = internSchema(schema, wantSah);
 
         if (wantSah) {


### PR DESCRIPTION
Makes `undefined` a first-class "schema" value throughout the schema-intern
machinery, so callers can intern / hash / look it up the same way they already
do for `true`, `false`, and object schemas — useful in contexts where
`undefined` meaningfully stands for "no relevant schema" / "missing schema".

## `SchemaAndHash`

- The class now accepts `undefined` as its constructed "schema" (a concession to
  making the intern mechanism work straightforwardly with `undefined`).
- `.schema` **throws** when the instance holds `undefined`, since nearly every
  client wants a real schema there; the few callers that tolerate `undefined`
  use the new `.schemaOrUndefined` accessor.

## `schema-hash.ts`

- `internSchema()`, `hashSchema()`, `isInternedSchema()`, and
  `internSchemaAsTaggedHashString()` all widen their parameter from `JSONSchema`
  to `JSONSchema | undefined`. These are backward-compatible widenings;
  `internSchema()`'s generic preserves exact return types for existing callers.
- A prefab `SchemaAndHash` for `undefined` joins the `true` / `false` prefabs
  (renamed `booleanInterns` → `primInterns`), seeded into the reverse map.
- `findInternedSchema()` drops its `wantSchemaAndHash` parameter and always
  returns `SchemaAndHash | undefined` (it had no non-test callers using the
  bare-schema form). Its `undefined` case disambiguates "the hash of the
  `undefined` schema" from "a hash that isn't interned at all" — the two
  otherwise look identical through a `Map` whose value can be `undefined`.
- Switches a couple of `hash.toString()` keys to the equivalent
  `hash.taggedHashString` for clarity (both return the same string).

## `schema-utils.ts`

- Drops a stale, internally-focused comment from `internSchemaPairAsKey()`.

## Tests

Adds `undefined`-path coverage across `SchemaAndHash` and the `schema-hash`
entry points — including both arms of the `findInternedSchema()` ambiguity
(finds the `undefined` schema vs. returns `undefined` for an unknown hash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts `undefined` as a first-class schema for interning and hashing to remove ambiguity around “no schema” and make these cases easy to handle.

- **New Features**
  - `SchemaAndHash` now allows `undefined`. `.schema` throws when it holds `undefined`; use `.schemaOrUndefined` when that’s acceptable.
  - `internSchema()`, `hashSchema()`, `isInternedSchema()`, and `internSchemaAsTaggedHashString()` now accept `JSONSchema | undefined`.
  - Added prefab interns for `true`, `false`, and `undefined`; reverse map disambiguates the `undefined` schema from unknown hashes. Uses `taggedHashString` consistently.
  - `findInternedSchema()` always returns a `SchemaAndHash` (no flag) and accepts a `FabricHash` or tagged hash string.

- **Migration**
  - If a schema might be `undefined`, use `.schemaOrUndefined` instead of `.schema`.
  - Update `findInternedSchema()` call sites: remove the `wantSchemaAndHash` argument and read from the returned `SchemaAndHash` (e.g., `.schemaOrUndefined`, `.hash`, `.taggedHashString`). Ensure any hash strings passed are tagged.

<sup>Written for commit 0c8d774e73569eefafbc1b19083f5a4d71f26518. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

