### PR TITLE
fix(patterns): stabilize notebook regression waits

### DIFF
--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -718,13 +718,13 @@ describe("default-app flow test", () => {
 
       try {
         await waitFor(async () => {
-          await waitForRuntimeIdle(page);
           const state = await collectNotebookSourceState(page);
           return state.argumentNotesLength === noteCreates &&
             state.noteCount === noteCreates &&
             state.showNewNotePrompt === false &&
             state.usedCreateAnotherNote === false;
         });
+        await waitFor(async () => await waitForRuntimeSynced(page));
       } catch (_) {
         // Keep the final assertions below so failures include diagnostics.
       }
@@ -1539,6 +1539,15 @@ async function waitForRuntimeIdle(page: Page): Promise<boolean> {
   });
 }
 
+async function waitForRuntimeSynced(page: Page): Promise<boolean> {
+  return await page.evaluate(async () => {
+    const rt = globalThis.commonfabric?.rt;
+    if (!rt?.allSynced) return false;
+    await rt.allSynced();
+    return true;
+  });
+}
+
 async function disposeBrowserRuntime(page: Page): Promise<void> {
   await page.evaluate(async () => {
     try {
@@ -1595,14 +1604,12 @@ async function collectNotebookSourceState(page: Page): Promise<{
 }> {
   return await page.evaluate(async () => {
     const api = globalThis.commonfabric as {
-      rt?: { idle?: () => Promise<void> };
       readCell?: (options: {
         id: string;
         path?: string[];
         meta?: "argument" | "internal";
       }) => Promise<unknown>;
     } | undefined;
-    await api?.rt?.idle?.();
 
     const appState = globalThis.app?.serialize?.();
     const view = appState?.view;


### PR DESCRIPTION
Poll the notebook source state directly after rapid note creation. Wait for runtime storage sync after the expected source state is visible.

Keep the current tip's setup idle wait and avoid the removed scheduler pull-mode helper.

Verified with deno fmt --check packages/patterns/integration/default-app.test.ts and deno task integration --port-offset=10 patterns default-app.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes notebook integration waits by polling source state right after rapid note creation, then waiting for runtime storage to sync. This reduces test flakes in `packages/patterns/integration/default-app.test.ts`.

- **Bug Fixes**
  - Stop relying on `rt.idle()` before reading source state.
  - Add `waitForRuntimeSynced` (uses `rt.allSynced()`) and wait after the expected state appears.
  - Keep setup `waitForRuntimeIdle` usage; avoid the removed scheduler pull-mode helper.

<sup>Written for commit f1bb0831f7394bc3a16d6967458aeb34d73d0e25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

