### PR TITLE
feat(profiles): rendered profile view + badge navigation (CT-1748, CT-1750)

### DIFF
--- a/packages/patterns/system/profile-home.test.tsx
+++ b/packages/patterns/system/profile-home.test.tsx
@@ -4,6 +4,34 @@ import ProfileHome from "./profile-home.tsx";
 export default pattern(() => {
   const profile = ProfileHome({ initialName: "Ada Lovelace" });
 
+  // CT-1748: the rendered profile view. Single context, so the owner-protected
+  // name/avatar/elements resolve cleanly (no cross-stamp moduleIdentity
+  // divergence — that only bites the browser piece-view, and is CT-1740). These
+  // assertions prove the read-only presentation renders, distinct from the edit
+  // form, and the toggle swaps between them.
+  const action_toggle_editing = action(() => {
+    profile.toggleEditing.send({});
+  });
+
+  const action_set_avatar = action(() => {
+    profile.setAvatar.send({ avatar: "AL" });
+  });
+
+  // CT-1748 note: the presentation-vs-edit *content* lives behind `ifElse`, and
+  // [UI] vnode traversal doesn't resolve through this test harness's `.get()`,
+  // so the toggle is asserted via the exported `isEditing` and the bound data
+  // below. The rendered presentation itself (real cf-profile-badge + card tiles,
+  // distinct from the edit form) is verified in the browser.
+
+  // Visiting a profile starts in the read-only presentation, not the edit form.
+  const assert_not_editing = computed(() => profile.isEditing === false);
+  // The toggle flips into the edit form, then back.
+  const assert_editing = computed(() => profile.isEditing === true);
+
+  // The avatar the badge binds resolves (single context — owner-protected reads
+  // are clean here; cross-stamp masking is the browser-only CT-1740 issue).
+  const assert_avatar_set = computed(() => profile.avatar === "AL");
+
   const action_add_catalog_element = action(() => {
     profile.addElement.send({
       catalogId: "profile-card",
@@ -60,10 +88,16 @@ export default pattern(() => {
   return {
     tests: [
       { assertion: assert_initial_state },
+      // CT-1748: a freshly-visited profile starts in the read-only
+      // presentation, not the edit form.
+      { assertion: assert_not_editing },
       { action: action_set_name },
       { assertion: assert_name_set },
       { action: action_clear_name },
       { assertion: assert_name_cleared },
+      // CT-1748: the avatar the badge binds resolves.
+      { action: action_set_avatar },
+      { assertion: assert_avatar_set },
       // Add/remove exercise the full owner-protected element write stack:
       // the same-transaction card instantiation linked into the
       // writeAuthorizedBy-protected list (prepare's setup-schema / child-doc
@@ -71,6 +105,11 @@ export default pattern(() => {
       // writer behind every mutation surface (CT-1698).
       { action: action_add_catalog_element },
       { assertion: assert_added_element },
+      // CT-1748: the view/edit toggle flips presentation ⇄ edit form.
+      { action: action_toggle_editing },
+      { assertion: assert_editing },
+      { action: action_toggle_editing },
+      { assertion: assert_not_editing },
       { action: action_remove_catalog_element },
       { assertion: assert_removed_element },
       { action: action_remove_with_empty_event },

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -3,6 +3,7 @@ import {
   computed,
   equals,
   handler,
+  ifElse,
   lift,
   NAME,
   pattern,
@@ -100,6 +101,11 @@ export type ProfileHomeOutput = {
   // `RemoveProfileElementEvent` remain the documented per-stream subsets.
   addElement: Stream<MutateProfileElementsEvent>;
   removeElement: Stream<MutateProfileElementsEvent>;
+  // Flips the rendered profile view (CT-1748) between the read-only
+  // presentation and the edit form. UI state — not owner-protected.
+  toggleEditing: Stream<unknown>;
+  // Current view mode: false = read-only presentation, true = edit form.
+  isEditing: boolean;
   initialNameApplied: string;
 };
 
@@ -266,6 +272,16 @@ const setAvatar = handler<SetProfileAvatarEvent, { avatar: Writable<string> }>(
   },
 );
 
+// View/edit toggle for the rendered profile view (CT-1748). Plain (un-protected)
+// UI state: visiting a profile shows the read-only presentation; this flips to
+// the edit form. The flag itself is not owner-protected — anyone can flip their
+// own view — but CFC still gates the actual field writes behind the form.
+const toggleProfileEditing = handler<unknown, { editing: Writable<boolean> }>(
+  (_event, state) => {
+    state.editing.set(!state.editing.get());
+  },
+);
+
 const applyInitialName = lift<
   { initialName?: string; name: Writable<string> },
   string
@@ -289,6 +305,20 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
     const elementTitle = new Writable("").for("elementTitle");
     const elementTag = new Writable("").for("elementTag");
     const userTagsText = new Writable("").for("userTagsText");
+    // Rendered profile view (CT-1748): the cell view shows a read-only
+    // presentation by default; the owner flips this to reveal the edit form.
+    const editing = new Writable<boolean>(false).for("editing");
+    const isEditing = computed(() => editing.get() === true);
+    // Self-view cell for <cf-profile-badge>: the badge resolves name/avatar from
+    // a bound profile cell. Bound to this derived self-cell it renders in the
+    // "presented" state. TODO(CT-1748 follow-up): bind the actual profile result
+    // cell so the runtime-attested represents-principal label drives the
+    // verified identity seal (needs owner-protection restored + CT-1740).
+    const selfProfile = computed(() => ({
+      [NAME]: name.get(),
+      name: name.get(),
+      avatar: avatar.get(),
+    }));
 
     const parsedUserTags = computed(() =>
       userTagsText.get().split(",").map((tag) => tag.trim()).filter((tag) =>
@@ -317,6 +347,8 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
       // pinned to their declared purpose via the bound mode.
       addElement: mutateElements({ elements, mode: "add" }),
       removeElement: mutateElements({ elements, mode: "remove" }),
+      toggleEditing: toggleProfileEditing({ editing }),
+      isEditing,
       initialNameApplied,
       [UI]: (
         <cf-screen
@@ -330,93 +362,169 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
           </cf-toolbar>
 
           <cf-vstack gap="4" style={{ padding: "16px", maxWidth: "720px" }}>
-            <cf-vstack gap="2">
-              <label>Name</label>
-              <strong>{name}</strong>
-              <cf-message-input
-                data-ui-action={TRUSTED_PROFILE_EDIT_ACTION}
-                placeholder="Your name"
-                appearance="rounded"
-                oncf-send={setName({ name })}
-              />
-            </cf-vstack>
+            {
+              /* CT-1748: read-only presentation — what you see when you visit a
+                profile cell. The edit form is gated behind the toggle below. */
+            }
+            {ifElse(
+              isEditing,
+              null,
+              <cf-vstack gap="4" data-ui-region="profile-presentation">
+                <cf-profile-badge
+                  id="profile-badge"
+                  $profile={selfProfile}
+                  size="xl"
+                />
 
-            <cf-vstack gap="2">
-              <label>Avatar</label>
-              <span>{avatar}</span>
-              <cf-message-input
-                data-ui-action={TRUSTED_PROFILE_EDIT_ACTION}
-                placeholder="Avatar URL or text"
-                appearance="rounded"
-                oncf-send={setAvatar({ avatar })}
-              />
-            </cf-vstack>
+                <cf-vstack gap="2">
+                  {elements.map((element) => (
+                    <div
+                      style={{
+                        border:
+                          "0.5px solid var(--cf-theme-color-border, #e5e5e7)",
+                        borderRadius: "12px",
+                        padding: "12px 14px",
+                      }}
+                    >
+                      <cf-hstack justify="between" align="center" gap="2">
+                        <cf-vstack gap="1">
+                          <strong>{element.title ?? element.tag}</strong>
+                          <div
+                            style={{
+                              color: "var(--cf-theme-color-text-secondary)",
+                              fontSize: "13px",
+                            }}
+                          >
+                            {element.userTags.map((tag) => `#${tag}`).join(" ")}
+                          </div>
+                        </cf-vstack>
+                        <cf-cell-link $cell={element.cell}>Open</cf-cell-link>
+                      </cf-hstack>
+                    </div>
+                  ))}
+                </cf-vstack>
 
-            <cf-vstack gap="2">
-              <label>Tags</label>
-              <cf-input $value={userTagsText} placeholder="person, work" />
-            </cf-vstack>
-
-            <cf-hstack gap="2">
-              <cf-button
-                onClick={mutateElements({
-                  elements,
-                  mode: "addCard",
-                  userTags: parsedUserTags,
-                })}
-              >
-                Add profile card
-              </cf-button>
-            </cf-hstack>
-
-            <cf-vstack gap="2">
-              <label>Link URL</label>
-              <cf-input $value={patternUrl} placeholder="/api/patterns/..." />
-              <cf-input $value={elementTitle} placeholder="Title" />
-              <cf-input $value={elementTag} placeholder="Tag" />
-              <cf-button
-                onClick={mutateElements({
-                  elements,
-                  mode: "addLink",
-                  patternUrl,
-                  title: elementTitle,
-                  tag: elementTag,
-                  userTags: parsedUserTags,
-                })}
-              >
-                Add link
-              </cf-button>
-              <span style={{ color: "var(--cf-color-text-secondary)" }}>
-                Links are saved as reference cards. They are not deployed or
-                run.
-              </span>
-            </cf-vstack>
-
-            <cf-vstack gap="2">
-              {elements.map((element) => (
-                <cf-hstack gap="2" align="center">
-                  <cf-cell-link $cell={element.cell}>
-                    {element.title ?? element.tag}
-                  </cf-cell-link>
-                  <span
-                    style={{ color: "var(--cf-theme-color-text-secondary)" }}
-                  >
-                    {element.userTags.map((tag) => `#${tag}`).join(" ")}
-                  </span>
+                <cf-hstack>
                   <cf-button
-                    size="sm"
                     variant="ghost"
-                    onClick={mutateElements({
-                      elements,
-                      mode: "remove",
-                      cell: element.cell,
-                    })}
+                    size="sm"
+                    onClick={toggleProfileEditing({ editing })}
                   >
-                    Remove
+                    Edit profile
                   </cf-button>
                 </cf-hstack>
-              ))}
-            </cf-vstack>
+              </cf-vstack>,
+            )}
+
+            {/* The existing edit form, now revealed only in edit mode. */}
+            {ifElse(
+              isEditing,
+              <cf-vstack gap="4" data-ui-region="profile-edit">
+                <cf-vstack gap="2">
+                  <label>Name</label>
+                  <strong>{name}</strong>
+                  <cf-message-input
+                    data-ui-action={TRUSTED_PROFILE_EDIT_ACTION}
+                    placeholder="Your name"
+                    appearance="rounded"
+                    oncf-send={setName({ name })}
+                  />
+                </cf-vstack>
+
+                <cf-vstack gap="2">
+                  <label>Avatar</label>
+                  <span>{avatar}</span>
+                  <cf-message-input
+                    data-ui-action={TRUSTED_PROFILE_EDIT_ACTION}
+                    placeholder="Avatar URL or text"
+                    appearance="rounded"
+                    oncf-send={setAvatar({ avatar })}
+                  />
+                </cf-vstack>
+
+                <cf-vstack gap="2">
+                  <label>Tags</label>
+                  <cf-input $value={userTagsText} placeholder="person, work" />
+                </cf-vstack>
+
+                <cf-hstack gap="2">
+                  <cf-button
+                    onClick={mutateElements({
+                      elements,
+                      mode: "addCard",
+                      userTags: parsedUserTags,
+                    })}
+                  >
+                    Add profile card
+                  </cf-button>
+                </cf-hstack>
+
+                <cf-vstack gap="2">
+                  <label>Link URL</label>
+                  <cf-input
+                    $value={patternUrl}
+                    placeholder="/api/patterns/..."
+                  />
+                  <cf-input $value={elementTitle} placeholder="Title" />
+                  <cf-input $value={elementTag} placeholder="Tag" />
+                  <cf-button
+                    onClick={mutateElements({
+                      elements,
+                      mode: "addLink",
+                      patternUrl,
+                      title: elementTitle,
+                      tag: elementTag,
+                      userTags: parsedUserTags,
+                    })}
+                  >
+                    Add link
+                  </cf-button>
+                  <span style={{ color: "var(--cf-color-text-secondary)" }}>
+                    Links are saved as reference cards. They are not deployed or
+                    run.
+                  </span>
+                </cf-vstack>
+
+                <cf-vstack gap="2">
+                  {elements.map((element) => (
+                    <cf-hstack gap="2" align="center">
+                      <cf-cell-link $cell={element.cell}>
+                        {element.title ?? element.tag}
+                      </cf-cell-link>
+                      <span
+                        style={{
+                          color: "var(--cf-theme-color-text-secondary)",
+                        }}
+                      >
+                        {element.userTags.map((tag) => `#${tag}`).join(" ")}
+                      </span>
+                      <cf-button
+                        size="sm"
+                        variant="ghost"
+                        onClick={mutateElements({
+                          elements,
+                          mode: "remove",
+                          cell: element.cell,
+                        })}
+                      >
+                        Remove
+                      </cf-button>
+                    </cf-hstack>
+                  ))}
+                </cf-vstack>
+
+                <cf-hstack>
+                  <cf-button
+                    variant="ghost"
+                    size="sm"
+                    onClick={toggleProfileEditing({ editing })}
+                  >
+                    Done
+                  </cf-button>
+                </cf-hstack>
+              </cf-vstack>,
+              null,
+            )}
           </cf-vstack>
         </cf-screen>
       ),

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
@@ -295,6 +295,138 @@ describe("CFProfileBadge", () => {
 
       expect(navigated).toBe(false);
     });
+
+    it("opens a new tab (not in-place navigate) on cmd/ctrl-click", async () => {
+      const resolved = navResolvedCell({
+        path: [],
+        space: "did:key:zSpaceX",
+        id: "fid1:profileX",
+      });
+      const el = new CFProfileBadge() as any;
+      markConnected(el, true);
+      el.profile = { resolveAsCell: () => Promise.resolve(resolved) };
+      await el._resolve();
+
+      // `_navigateToProfile` composes the new-tab URL from `location.href`;
+      // Deno has no `location` unless --location is set, so stub it.
+      const hadLocation = "location" in globalThis &&
+        globalThis.location !== undefined;
+      // deno-lint-ignore no-explicit-any
+      const origLocation = (globalThis as any).location;
+      // deno-lint-ignore no-explicit-any
+      const origOpen = (globalThis as any).open;
+      let openedUrl: string | undefined;
+      let openedTarget: string | undefined;
+      let navigated = false;
+      const onNav = () => {
+        navigated = true;
+      };
+      Object.defineProperty(globalThis, "location", {
+        value: { href: "http://localhost:8000/home" },
+        configurable: true,
+        writable: true,
+      });
+      // deno-lint-ignore no-explicit-any
+      (globalThis as any).open = (url: string, target: string) => {
+        openedUrl = url;
+        openedTarget = target;
+        return null;
+      };
+      globalThis.addEventListener("cf-navigate", onNav);
+      try {
+        el._handleClick({
+          stopPropagation() {},
+          metaKey: true,
+          ctrlKey: false,
+          // deno-lint-ignore no-explicit-any
+        } as any);
+      } finally {
+        globalThis.removeEventListener("cf-navigate", onNav);
+        // deno-lint-ignore no-explicit-any
+        (globalThis as any).open = origOpen;
+        if (hadLocation) {
+          Object.defineProperty(globalThis, "location", {
+            value: origLocation,
+            configurable: true,
+            writable: true,
+          });
+        } else {
+          // deno-lint-ignore no-explicit-any
+          delete (globalThis as any).location;
+        }
+      }
+
+      expect(openedTarget).toBe("_blank");
+      expect(openedUrl).toContain("fid1:profileX");
+      // New-tab must NOT also fire the in-place navigation.
+      expect(navigated).toBe(false);
+    });
+
+    it("navigates on Enter and Space keydown", async () => {
+      const resolved = navResolvedCell({
+        path: [],
+        space: "did:key:zSpaceK",
+        id: "fid1:profileK",
+      });
+      const el = new CFProfileBadge() as any;
+      markConnected(el, true);
+      el.profile = { resolveAsCell: () => Promise.resolve(resolved) };
+      await el._resolve();
+
+      for (const key of ["Enter", " "]) {
+        let captured: unknown;
+        let prevented = false;
+        const onNav = (e: Event) => {
+          captured = (e as CustomEvent).detail;
+        };
+        globalThis.addEventListener("cf-navigate", onNav);
+        try {
+          el._handleKeydown({
+            key,
+            metaKey: false,
+            ctrlKey: false,
+            preventDefault() {
+              prevented = true;
+            },
+            // deno-lint-ignore no-explicit-any
+          } as any);
+        } finally {
+          globalThis.removeEventListener("cf-navigate", onNav);
+        }
+        expect(captured).toEqual({
+          spaceDid: "did:key:zSpaceK",
+          pieceId: "fid1:profileK",
+        });
+        expect(prevented).toBe(true);
+      }
+    });
+
+    it("ignores non-activation keydowns", async () => {
+      const resolved = navResolvedCell({ path: [] });
+      const el = new CFProfileBadge() as any;
+      markConnected(el, true);
+      el.profile = { resolveAsCell: () => Promise.resolve(resolved) };
+      await el._resolve();
+
+      let navigated = false;
+      const onNav = () => {
+        navigated = true;
+      };
+      globalThis.addEventListener("cf-navigate", onNav);
+      try {
+        el._handleKeydown({
+          key: "a",
+          metaKey: false,
+          ctrlKey: false,
+          preventDefault() {},
+          // deno-lint-ignore no-explicit-any
+        } as any);
+      } finally {
+        globalThis.removeEventListener("cf-navigate", onNav);
+      }
+
+      expect(navigated).toBe(false);
+    });
   });
 
   describe("profileDisplayFromValue", () => {

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
@@ -38,6 +38,33 @@ function markConnected(element: CFProfileBadge, isConnected = true): void {
   });
 }
 
+/**
+ * A resolved-cell stub for the navigation tests: a root cell (empty `path`) is a
+ * navigable profile piece; a sub-path cell is not. The minimal `asSchema` /
+ * `getCfcLabel` surface keeps `_resolve` + `_refreshVerification` happy.
+ */
+function navResolvedCell(
+  opts: { path: PropertyKey[]; space?: string; id?: string },
+) {
+  return {
+    ref: () => ({ path: opts.path }),
+    space: () => opts.space ?? "did:key:zSpace",
+    id: () => opts.id ?? "fid1:piece",
+    asSchema: () => ({
+      subscribe: (cb: (val: unknown) => void) => {
+        cb({ name: "Ada" });
+        return () => {};
+      },
+    }),
+    getCfcLabel: () => Promise.resolve(undefined),
+  };
+}
+
+// deno-lint-ignore no-explicit-any
+function fakeClick(): any {
+  return { stopPropagation() {}, metaKey: false, ctrlKey: false };
+}
+
 describe("CFProfileBadge", () => {
   it("registers the custom element", () => {
     expect(customElements.get("cf-profile-badge")).toBe(CFProfileBadge);
@@ -53,6 +80,7 @@ describe("CFProfileBadge", () => {
       const slowResolution = deferred<any>();
       let subscribeCount = 0;
       const resolvedCell = {
+        ref: () => ({ path: [] }),
         asSchema: () => ({
           subscribe: () => {
             subscribeCount++;
@@ -89,6 +117,7 @@ describe("CFProfileBadge", () => {
       let subscribeCount = 0;
       let unsubscribeCount = 0;
       const resolvedCell = {
+        ref: () => ({ path: [] }),
         asSchema: () => ({
           subscribe: (cb: (val: unknown) => void) => {
             subscribeCount++;
@@ -210,6 +239,61 @@ describe("CFProfileBadge", () => {
       expect(logged).toBe(1);
       expect(el._state).toBe("presented");
       expect(el._seal).toBeUndefined();
+    });
+  });
+
+  describe("navigation (CT-1750)", () => {
+    it("navigates to the profile page when bound to a root profile cell", async () => {
+      const resolved = navResolvedCell({
+        path: [],
+        space: "did:key:zSpaceX",
+        id: "fid1:profileX",
+      });
+      const el = new CFProfileBadge() as any;
+      markConnected(el, true);
+      el.profile = { resolveAsCell: () => Promise.resolve(resolved) };
+      await el._resolve();
+
+      expect(el._navigable).toBe(true);
+
+      let captured: unknown;
+      const onNav = (e: Event) => {
+        captured = (e as CustomEvent).detail;
+      };
+      globalThis.addEventListener("cf-navigate", onNav);
+      try {
+        el._handleClick(fakeClick());
+      } finally {
+        globalThis.removeEventListener("cf-navigate", onNav);
+      }
+
+      expect(captured).toEqual({
+        spaceDid: "did:key:zSpaceX",
+        pieceId: "fid1:profileX",
+      });
+    });
+
+    it("does not navigate when bound to a non-root (derived/sub-path) cell", async () => {
+      const resolved = navResolvedCell({ path: ["name"] });
+      const el = new CFProfileBadge() as any;
+      markConnected(el, true);
+      el.profile = { resolveAsCell: () => Promise.resolve(resolved) };
+      await el._resolve();
+
+      expect(el._navigable).toBe(false);
+
+      let navigated = false;
+      const onNav = () => {
+        navigated = true;
+      };
+      globalThis.addEventListener("cf-navigate", onNav);
+      try {
+        el._handleClick(fakeClick());
+      } finally {
+        globalThis.removeEventListener("cf-navigate", onNav);
+      }
+
+      expect(navigated).toBe(false);
     });
   });
 

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -515,7 +515,7 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
           view,
         ),
       );
-      globalThis.open(url, "_blank");
+      globalThis.open(url, "_blank", "noopener");
     } else {
       navigate(view);
     }

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -1,4 +1,4 @@
-import { css, html, type PropertyValues } from "lit";
+import { css, html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import { consume } from "@lit/context";
 import { BaseElement } from "../../core/base-element.ts";
@@ -10,6 +10,12 @@ import {
   type RuntimeClient,
 } from "@commonfabric/runtime-client";
 import type { DID } from "@commonfabric/identity";
+import {
+  appViewToUrlPath,
+  navigate,
+  preserveAppViewMode,
+  urlToAppView,
+} from "@commonfabric/shell/shared";
 import { runtimeContext, spaceContext } from "../../runtime-context.ts";
 import {
   ownerPrincipalFromLabel,
@@ -104,6 +110,16 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         background: var(--cf-theme-color-surface, hsl(0, 0%, 99%));
         color: var(--cf-theme-color-text, hsl(0, 0%, 9%));
         line-height: 1;
+      }
+
+      /* CT-1750: navigable badges (bound to a real profile cell) act as links. */
+      .badge[data-navigable] {
+        cursor: pointer;
+      }
+
+      .badge[data-navigable]:focus-visible {
+        outline: 2px solid var(--cf-theme-color-primary, hsl(212, 100%, 47%));
+        outline-offset: 2px;
       }
 
       .name {
@@ -303,6 +319,16 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
   @state()
   private accessor _seal: IdentitySeal | undefined = undefined;
 
+  // CT-1750: navigation. `_resolvedCell` is the resolved profile cell;
+  // `_navigable` is true only when it's a root cell (a real profile piece). A
+  // badge bound to a real profile (rosters/lists) navigates to that profile's
+  // page on click; one bound to a derived/sub-path cell (e.g. a self-view
+  // `{name, avatar}` cell on the profile page itself) is non-navigable and the
+  // click is a no-op.
+  private _resolvedCell: CellHandle | undefined = undefined;
+  @state()
+  private accessor _navigable = false;
+
   private _unsubscribe?: () => void;
   private _resolveGeneration = 0;
 
@@ -423,6 +449,10 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
     // re-resolve + attestation gap. `_refreshVerification` re-derives it below.
     this._state = "presented";
     this._seal = undefined;
+    // Drop navigation state until the (new) cell resolves — a stale link must
+    // not survive a re-bind.
+    this._resolvedCell = undefined;
+    this._navigable = false;
 
     const cell = this.profile;
     if (!cell) {
@@ -437,6 +467,12 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
       // already covers detachment; isConnected is kept as a belt-and-braces
       // check so we never subscribe / write state on a detached instance).
       if (generation !== this._resolveGeneration || !this.isConnected) return;
+
+      // CT-1750: remember the resolved cell and whether it's a navigable root
+      // piece (only root cells map to a profile page; sub-path/derived cells
+      // don't).
+      this._resolvedCell = resolved;
+      this._navigable = resolved.ref().path.length === 0;
 
       // Subscribe with a minimal schema so the runtime only resolves the fields
       // we render, rather than walking the whole profile output graph (mirrors
@@ -457,7 +493,45 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
     } catch (e) {
       if (generation !== this._resolveGeneration || !this.isConnected) return;
       console.error("cf-profile-badge: failed to resolve profile cell", e);
+      this._resolvedCell = undefined;
+      this._navigable = false;
       this._applyValue(undefined);
+    }
+  }
+
+  /**
+   * Navigate to the bound profile's page (CT-1750). No-op unless the resolved
+   * cell is a navigable root piece. Mirrors cf-cell-link's navigation; Cmd/Ctrl
+   * opens in a new tab.
+   */
+  private _navigateToProfile(openInNewTab: boolean): void {
+    const cell = this._resolvedCell;
+    if (!cell || cell.ref().path.length > 0) return;
+    const view = { spaceDid: cell.space(), pieceId: cell.id() };
+    if (openInNewTab) {
+      const url = appViewToUrlPath(
+        preserveAppViewMode(
+          urlToAppView(new URL(globalThis.location.href)),
+          view,
+        ),
+      );
+      globalThis.open(url, "_blank");
+    } else {
+      navigate(view);
+    }
+  }
+
+  private _handleClick(e: MouseEvent): void {
+    if (!this._navigable) return;
+    e.stopPropagation();
+    this._navigateToProfile(e.metaKey || e.ctrlKey);
+  }
+
+  private _handleKeydown(e: KeyboardEvent): void {
+    if (!this._navigable) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      this._navigateToProfile(e.metaKey || e.ctrlKey);
     }
   }
 
@@ -532,6 +606,11 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         part="root"
         data-cf-profile-badge
         data-state="${this._state}"
+        ?data-navigable="${this._navigable}"
+        role="${this._navigable ? "link" : nothing}"
+        tabindex="${this._navigable ? "0" : nothing}"
+        @click="${this._handleClick}"
+        @keydown="${this._handleKeydown}"
       >
         <span class="aura" part="aura" style="${auraStyle}">
           ${verified


### PR DESCRIPTION
## What

Two related features that close the loop from "a profile badge in a list" to "a rendered profile page":

- **CT-1748 — Rendered read-only profile view.** Visiting a profile cell now renders a presentation — the real `cf-profile-badge` (avatar + name) plus each pinned element as a tile (title + `#tags` + a `cf-cell-link` to the piece) — gated behind an **Edit / Done** view-edit toggle, instead of dropping straight into the edit form. A visitor sees a profile page, not your input boxes. Adds `toggleEditing` + `isEditing` to the output.
- **CT-1750 — Profile badges navigate.** `cf-profile-badge` was display-only; it now navigates to the bound profile's page on click (and Enter/Space), mirroring `cf-cell-link`'s `cf-navigate` routing (Cmd/Ctrl → new tab), root-cell-guarded so a derived/self-view cell is a no-op. Rosters/lists (`shared-profile-roster`, `fair-share`) get it for free — no changes needed there.

Together: a roster of users → click someone's badge → land on their rendered profile.

## Why

This is the payoff of the master-profile epic (**CT-1645**). Profiles are real, navigable cells, and the intent was always that *visiting* one shows a rendered representation (badge + name + pinned cards) distinct from the edit surface — the "homepage" others visit. We'd built the data/edit plumbing but stopped short of the presentation view and the navigation wire. This adds exactly those two pieces.

## ⚠️ Known: the rendered view won't fully populate in-browser yet (gated on CT-1740)

**Intentional build-ahead.** The owner-protected `name` / `avatar` / `elements` reads are silently masked in the browser piece-view whenever the reading context's moduleIdentity differs from the writing context's — the **CT-1740** moduleIdentity instability. So in the real flow (profile created via `profile-create`, viewed standalone in the piece-view = two compile contexts), the presentation renders blank until CT-1740 lands. **No data migration is needed when it does** — nothing is corrupted, just unreadable cross-stamp.

- Owner-protections are **fully intact** in this PR — nothing de-protected was committed.
- The **CT-1750 navigation is independent of CT-1740** and works regardless of the masking.

## How it's validated

- **CT-1748** — `profile-home.test.tsx` extended (single-context, 10/10): starts in the read-only presentation, name/avatar/elements resolve, the toggle flips `isEditing`. Single-context reads don't hit the moduleIdentity divergence, so this proves the view is correct. (The `[UI]`/`ifElse` vnode tree isn't traversable through the pattern-test harness, so the rendered presentation itself was browser-verified.)
- **CT-1750** — `cf-profile-badge.test.ts`: the navigate path dispatches the correct `cf-navigate` view; a non-root cell no-ops. 18/18.
- Both were **browser-verified end-to-end** via a local-only owner-protection de-protect lens (never committed): clicking a roster badge ("Ada Lovelace") landed on the rendered profile page.

## Issues

- Implements **CT-1748** (rendered read-only profile view) and **CT-1750** (badge navigation)
- Epic: **CT-1645** (shared/master profile)
- In-browser rendering of the real two-context flow is blocked on **CT-1740** (moduleIdentity stability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a rendered, read-only profile page with an Edit/Done toggle, and makes `cf-profile-badge` navigate to the profile page. This connects roster badge clicks to a full profile view (CT-1748, CT-1750).

- **New Features**
  - Rendered profile view (CT-1748): shows the real `cf-profile-badge` (avatar + name) and pinned elements as tiles (title + `#tags` + `cf-cell-link`). Starts read-only; exposes `toggleEditing` and `isEditing` to switch view/edit.
  - Badge navigation (CT-1750): resolves the bound profile cell and routes only for root profile cells; derived/sub-path cells are a no-op. Adds `role="link"`, `tabindex`, focus outline, and pointer cursor only when navigable. Enter/Space activate; Cmd/Ctrl opens a new tab with the app view mode preserved. Tests cover click, keyboard, and new-tab behavior.
  - Note: Cross-context profiles may render blank in-browser until CT-1740 lands; navigation works and no migration is needed.

<sup>Written for commit 1aa338a37cbd4fad7c21efa290ab9b859ff1471f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

