### PR TITLE
cf-tabs: don't write the bound cell on mount/selection-sync — $value safe inside computeds (CT-1752)

### DIFF
--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
@@ -327,3 +327,103 @@ describe("CFTabs cf-change emission contract (CT-1746)", () => {
     expect(cell.get()).toBe("active");
   });
 });
+
+/**
+ * Pure-on-mount contract (makes cf-tabs safe to instantiate inside a render
+ * `computed()`).
+ *
+ * A component bound with `$value` is only safe to re-create inside a computed
+ * that reads the same cell if it NEVER writes that cell as a side effect of
+ * mount/selection-sync — only on a genuine user gesture. (cf-input already
+ * honors this; it writes only on input/change events, never on bind.) If
+ * cf-tabs writes the cell during `updateTabSelection()` — e.g. defaulting an
+ * empty/unmatched cell to the first tab via `selectFirst()` → `setValue()` —
+ * then each recompute re-mounts it, re-writes the cell, and re-triggers the
+ * computed: a "Too many iterations" CPU-spin (the CT-1677 settle class).
+ *
+ * These tests pin the contract: mount and cell-driven sync produce ZERO cell
+ * writes, while the no-match fallback still selects the first tab VISUALLY.
+ */
+describe("CFTabs pure-on-mount contract (safe inside computed)", () => {
+  // Count writes to the bound cell by wrapping `.set` before binding.
+  function countingCell(initial: string) {
+    const cell = createMockCellHandle<string>(initial);
+    let writes = 0;
+    const origSet = cell.set.bind(cell);
+    (cell as unknown as { set: (v: string) => unknown }).set = (v: string) => {
+      writes++;
+      return origSet(v);
+    };
+    return { cell, writes: () => writes };
+  }
+
+  it("does NOT write the bound cell on mount when the value matches no tab", () => {
+    // Empty cell matches none of the tabs — the no-match path.
+    const { cell, writes } = countingCell("");
+
+    // makeTabs() binds the controller and runs updateTabSelection() — i.e. the
+    // mount/selection-sync that must not write.
+    const h = makeTabs(cell, ["active", "progress", "pending"]);
+
+    expect(writes()).toBe(0); // FAILS pre-fix: selectFirst() writes "active"
+    expect(cell.get()).toBe(""); // cell stays untouched until a real gesture
+    // ...but the first tab is still selected VISUALLY (the fallback survives).
+    expect(h.selectedTab()).toBe("active");
+    expect(h.visiblePanel()).toBe("active");
+  });
+
+  it("a re-mount (recompute) over an unmatched cell stays write-free and idempotent", () => {
+    const { cell, writes } = countingCell("");
+    const h = makeTabs(cell, ["active", "progress", "pending"]);
+
+    // Simulate the computed re-running: re-bind + re-sync several times.
+    const reSync = (h.tabs as unknown as {
+      updateTabSelection: () => void;
+    }).updateTabSelection.bind(h.tabs);
+    reSync();
+    reSync();
+    reSync();
+
+    expect(writes()).toBe(0);
+    expect(cell.get()).toBe("");
+    expect(h.selectedTab()).toBe("active"); // still visually defaulted
+  });
+
+  it("a cell-driven change to an unmatched value does not write back", () => {
+    const { cell, writes } = countingCell("active");
+    const h = makeTabs(cell, ["active", "progress"]);
+    // Programmatic/backend push to a value no tab matches.
+    pushUpdate(cell, "archived");
+
+    expect(writes()).toBe(0); // sync must not echo a write
+    expect(cell.get()).toBe("archived");
+    expect(h.selectedTab()).toBe("active"); // visual fallback to first tab
+  });
+
+  it("still writes the cell on a real user gesture (gesture path is unaffected)", () => {
+    const { cell, writes } = countingCell("");
+    const h = makeTabs(cell, ["active", "progress"]);
+    expect(writes()).toBe(0); // mount wrote nothing
+
+    h.clickTab("progress"); // genuine gesture
+
+    expect(writes()).toBe(1); // exactly one write, from the gesture
+    expect(cell.get()).toBe("progress");
+  });
+
+  it("all tabs disabled: no write and nothing selected (the firstEnabled-undefined branch)", () => {
+    // Exercises the new fallback's `if (firstEnabled)` guard when there is no
+    // enabled tab to fall back to: effectiveValue stays the (unmatched) cell
+    // value, so no tab is selected — and crucially still no cell write.
+    const { cell, writes } = countingCell("");
+    const h = makeTabs(cell, ["active", "progress"]);
+    h.fakeTabs.forEach((t) => (t.disabled = true));
+
+    // Re-sync (as a recompute / prop update would) now that all are disabled.
+    (h.tabs as unknown as { updateTabSelection: () => void })
+      .updateTabSelection();
+
+    expect(writes()).toBe(0);
+    expect(h.selectedTab()).toBe(undefined); // no enabled tab to default to
+  });
+});

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
@@ -227,15 +227,33 @@ export class CFTabs extends BaseElement {
       return;
     }
 
-    // Track if any tab matches the current value
-    let hasMatch = false;
+    // Decide which tab to show. If the bound value matches no tab (an empty or
+    // stale initial value), fall back to the first enabled tab — but VISUALLY
+    // ONLY. We must NOT write the cell from here.
+    //
+    // cf-tabs is bound through `$value` and may be instantiated inside a render
+    // `computed()` that reads the same cell. Writing the cell during
+    // mount/selection-sync would re-trigger that computed, which re-mounts
+    // cf-tabs, which writes again — a non-settling "Too many iterations" spin
+    // (the CT-1677 settle class). So selection-sync stays a pure read: the cell
+    // is committed only on a genuine user gesture (handleTabClick /
+    // handleKeydown via emitUserChange). This mirrors cf-input, which writes
+    // only on input events and never on bind. A consumer that needs the cell to
+    // carry the default should initialize it (e.g. `Writable.of("active")`).
+    const tabValues = Array.from(tabs, (tab) => (tab as CFTab).value);
+    let effectiveValue = currentValue;
+    if (!tabValues.includes(currentValue) && tabs.length > 0) {
+      const firstEnabled = Array.from(tabs).find(
+        (tab) => !(tab as CFTab).disabled,
+      ) as CFTab | undefined;
+      if (firstEnabled) effectiveValue = firstEnabled.value;
+    }
 
     // Update tabs - use property access instead of getAttribute
     // because JSX sets properties, not attributes
     tabs.forEach((tab) => {
       const tabValue = (tab as CFTab).value;
-      if (tabValue === currentValue) {
-        hasMatch = true;
+      if (tabValue === effectiveValue) {
         tab.setAttribute("aria-selected", "true");
         tab.setAttribute("data-selected", "true");
         (tab as CFTab).selected = true;
@@ -250,7 +268,7 @@ export class CFTabs extends BaseElement {
     // because JSX sets properties, not attributes
     panels.forEach((panel) => {
       const panelValue = (panel as CFTabPanel).value;
-      if (panelValue === currentValue) {
+      if (panelValue === effectiveValue) {
         panel.removeAttribute("hidden");
         panel.setAttribute("data-selected", "true");
         (panel as CFTabPanel).hidden = false;
@@ -260,11 +278,6 @@ export class CFTabs extends BaseElement {
         (panel as CFTabPanel).hidden = true;
       }
     });
-
-    // If no tab matched the current value, default to first enabled tab
-    if (!hasMatch && tabs.length > 0) {
-      this.selectFirst();
-    }
   }
 
   private handleSlotChange = () => {


### PR DESCRIPTION
## Problem

`cf-tabs.updateTabSelection()` calls `selectFirst()` → `setValue()` — a **write to the bound cell** — whenever the cell's value matches no tab (an empty or stale initial value). That makes `cf-tabs` unsafe to instantiate inside a render `computed()` that reads the same cell: each recompute re-mounts the component, the mount writes the cell, and the write re-triggers the computed → a non-settling **"Too many iterations"** spin (the CT-1677 settle class).

A `$value`-bound component is only safe to re-create inside such a computed if it writes the cell **only on a genuine user gesture**, never as a side effect of mount/sync. `cf-input` already honors this (writes on input events, never on `bind`); `cf-tabs` did not.

Sibling to CT-1746 (the `cf-change` echo). Together they remove **both** non-gesture write paths, making `cf-tabs $value` safe inside render computeds.

## Fix

`updateTabSelection()`'s no-match fallback now selects the first enabled tab **visually only** (via a local `effectiveValue`) and never writes the cell. The cell is still committed on user gestures (`handleTabClick` / `handleKeydown` → `emitUserChange`), so `$value`-only switching is unchanged. The public `selectFirst()`/`selectLast()` API is untouched (no internal callers remain). A consumer that wants the cell to carry the default should initialize it (all current consumers already do, e.g. `Writable.of(\"active\")`).

## Verification

**Unit** (`cf-tabs.test.ts`): new *pure-on-mount contract* group — reproduced red first (`writes()===1` on mount), green after the fix. Asserts mount + cell-driven sync produce **zero** cell writes, the visual first-tab fallback still works, and a user gesture still writes exactly once. Existing CT-1746 emission tests and sibling suites (`cell-controller`, `cf-input`, `cf-tab-list`, `cf-select`) all green; lint + typecheck clean.

**Live** (isolated labs toolshed on a patched build): deployed a probe with `<cf-tabs $value={cell}>` **inside** the `[UI]` computed with an **empty** initial value — the exact pre-fix loop trigger. Results:
- Mount: **0** "Too many iterations"; first tab shown visually.
- `commonfabric.detectNonIdempotent()`: **0** non-idempotent, **0** cycles, **0%** scheduler busy.
- Real clicks (Tab B → Tab C): switch correctly, **0** "Too many iterations" each; cell commits to the clicked value on gesture.
- Post-interaction: still 0 / 0 / 0%.

## Follow-up (loom, separate)

Once adopted in loom's vendor pin: retire the `projects.tsx` static-JSX carve-out and flip `tests/test_mobile_settle_shapes.py` (it currently *asserts* `cf-tabs` stays out of computeds).

Linear: CT-1752

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `cf-tabs` pure on mount by removing bound-cell writes during selection sync. Prevents "Too many iterations" and makes `$value` safe inside render `computed()`. Addresses Linear CT-1752.

- **Bug Fixes**
  - Use a local `effectiveValue` in `updateTabSelection()` to fall back visually to the first enabled tab when no match; if no tabs are enabled, select none.
  - Keep selection sync read-only: no write-backs on mount, re-sync, or when the cell changes to an unmatched value; write only on real user gestures.
  - Add pure-on-mount contract tests asserting zero writes on mount/re-sync and exactly one write on a gesture.

<sup>Written for commit 2cdde01193bea3b8101d8d90c531c2f241290bcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

