### PR TITLE
Drop undefined/boolean schema-fn guards now that interning accepts them

### DIFF
--- a/packages/data-model/src/schema-utils.ts
+++ b/packages/data-model/src/schema-utils.ts
@@ -415,7 +415,7 @@ export function internPathSelector(
 ): SchemaPathSelector {
   const { path, schema } = selector;
 
-  const interned = schema === undefined ? undefined : internSchema(schema);
+  const interned = internSchema(schema);
   const topMap: CanonicalSelectorMap = (typeof interned === "object")
     ? canonicalSelectorsByObjectSchema
     : canonicalSelectorsByPrimitiveSchema;

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2900,8 +2900,8 @@ export function internCellLinkSchema(
 export function internCellLinkSchema(
   schema?: JSONSchema,
 ): JSONSchema | undefined {
-  if (schema === undefined) return undefined;
-  // Already canonical (covers boolean schemas): skip the proxy scan.
+  // Already canonical (covers `undefined` and boolean schemas): skip the proxy
+  // scan and return as-is.
   if (isInternedSchema(schema)) return schema;
   if (containsCellResult(schema)) {
     return internSchema(JSON.parse(JSON.stringify(schema)) as JSONSchema);

--- a/packages/runner/src/cfc/schema-refs.ts
+++ b/packages/runner/src/cfc/schema-refs.ts
@@ -230,11 +230,11 @@ export const resolveCfcSchemaRefs = (
     if (cached !== undefined) {
       return cached === RESOLVED_UNDEFINED ? undefined : cached;
     }
-    // Intern record results so the cached instance is canonical and frozen —
-    // downstream identity-keyed caches then hit, and sharing it across
-    // callers is safe.
+    // Intern the result so the cached instance is canonical and frozen —
+    // downstream identity-keyed caches then hit, and sharing it across callers
+    // is safe. Primitive and `undefined` results intern to themselves.
     const raw = resolveCfcSchemaRefsUncached(schemaObj, fullSchema);
-    const result = raw !== undefined && isRecord(raw) ? internSchema(raw) : raw;
+    const result = internSchema(raw);
     byFull.set(fullKey, result === undefined ? RESOLVED_UNDEFINED : result);
     return result;
   }

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -320,9 +320,7 @@ export function resolveLink(
   // constructed schemas; interning here collapses structurally-equal
   // outputs to the same `===` reference across calls, letting
   // identity-based caches downstream hit rather than miss.
-  if (result.schema !== undefined) {
-    result.schema = internSchema(result.schema);
-  }
+  result.schema = internSchema(result.schema);
 
   // Remove overwrite field, i.e. when the last followed link was a write
   // redirect. The idea is that this is a link pointing to the final value, it

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -517,7 +517,9 @@ function resolveSchemaRefsCanonical(
   let cached = _resolvedRefCache.get(schema);
   if (cached === undefined) {
     const resolved = ContextualFlowControl.resolveSchemaRefs(schema);
-    cached = resolved === undefined ? null : internSchema(resolved);
+    // `null` (not `undefined`) is the cache's "resolved to nothing" sentinel,
+    // so it stays distinct from "absent" on `Map.get()`.
+    cached = internSchema(resolved) ?? null;
     _resolvedRefCache.set(schema, cached);
   }
   return cached === null ? undefined : cached;

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -835,9 +835,9 @@ export class CycleTracker<K> {
  * canonical hash string without invoking `hashStringOf()` on
  * already-interned inputs.
  *
- * An `undefined` `extraKey` is normalized to `true` (JSON Schema's
- * "accept everything", which is exactly what `undefined` means at
- * every current call site), so the intern call can always be made.
+ * By contract, an `undefined` `extraKey` is equivalent to `true` (JSON
+ * Schema's "accept everything"): both are normalized to `true`, so they share
+ * one cache entry.
  *
  * This will not work correctly if the key is modified after being
  * added.

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1527,9 +1527,7 @@ export abstract class BaseObjectTraverser {
     selector: SchemaPathSelector,
   ): SchemaPathSelector {
     const schema = selector.schema ?? false;
-    const schemaKey = typeof schema === "boolean"
-      ? String(schema)
-      : hashSchema(schema);
+    const schemaKey = hashSchema(schema);
     const cacheKey = `${selector.path.join("\0")}\0${schemaKey}`;
     const cached = _coverageSelectorCache.get(cacheKey);
     if (cached !== undefined) {

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -154,31 +154,15 @@ function internSet(
 }
 
 /**
- * Memo-key fragment for a schema: `hashSchema()` for objects, small
- * constants for value-like schemas. The memo gates only admit interned or
- * deep-frozen schemas, whose structural hash is computed once and
- * WeakMap-cached by value-hash — so this is an O(1) lookup after first
- * touch, with no separate token bookkeeping. Structural keying also lets
- * distinct-but-equal frozen schemas share memo entries, which identity
- * tokens could not.
- */
-function schemaKeyPart(schema: JSONSchema | undefined): string {
-  if (schema === undefined) return "u";
-  if (typeof schema === "boolean") return schema ? "t" : "f";
-  return hashSchema(schema);
-}
-
-/**
- * True when a schema input can safely feed an identity-keyed memo:
- * value-like (`undefined`/boolean), interned, or deep-frozen. Frozen
+ * True when a schema input can safely feed an identity-keyed memo: interned
+ * (which covers `undefined` and boolean schemas) or deep-frozen. Frozen
  * suffices — the identity cannot go stale through later mutation. The
  * distinction matters on the server: doc values arrive deep-frozen from the
  * wire-decode boundary, so their embedded link schemas are frozen but never
  * interned, and an interned-only gate would bypass every seam memo there.
  */
 function isMemoizableSchemaInput(schema: JSONSchema | undefined): boolean {
-  return schema === undefined || typeof schema === "boolean" ||
-    isInternedSchema(schema) || isDeepFrozen(schema);
+  return isInternedSchema(schema) || isDeepFrozen(schema);
 }
 
 /**
@@ -206,7 +190,7 @@ function pathKey(path: readonly string[]): string {
  * (interning only substitutes the canonical instance of an equal schema).
  *
  * Keyed on content (injective `pathKey()` encodings) plus cached schema
- * hashes (`schemaKeyPart()`), in one module-level capped `Map`: callers
+ * hashes (`hashSchema()`), in one module-level capped `Map`: callers
  * like `traversePointerWithSchema` mint a fresh selector object per call
  * (only its `schema` is identity-stable), so a cache rooted on selector
  * identity would never hit, and every miss would mint yet another distinct
@@ -231,8 +215,8 @@ function narrowAndCombineSelectorForLink(
   const key = isMemoizableSchemaInput(selector.schema) &&
       isMemoizableSchemaInput(linkSchema)
     ? `${pathKey(selector.path)}|${pathKey(docPath)}|${pathKey(targetPath)}|${
-      schemaKeyPart(selector.schema)
-    }|${schemaKeyPart(linkSchema)}`
+      hashSchema(selector.schema)
+    }|${hashSchema(linkSchema)}`
     : undefined;
   if (key !== undefined) {
     const cached = _linkHopSelectorCache.get(key);


### PR DESCRIPTION
Follow-up to the `undefined`-schema interning work (#4148): now that
`internSchema()`, `hashSchema()`, `isInternedSchema()`, and
`internSchemaAsTaggedHashString()` all accept `undefined` (and have always
accepted booleans), this removes the call-site guards that worked around their
former narrower types. All changes are behavior-equivalent; affected suites
pass.

## `undefined`-guard removals

- **`schema-utils.ts`** (`internPathSelector`): `internSchema(schema)` directly
  instead of `schema === undefined ? undefined : internSchema(schema)`.
- **`traverse.ts`** (resolved-ref cache): `internSchema(resolved) ?? null`,
  keeping `null` as the "resolved to nothing" cache sentinel.
- **`link-resolution.ts`**: assign `internSchema(result.schema)`
  unconditionally; the `undefined` case is now a harmless no-op write.
- **`cfc/schema-refs.ts`**: `internSchema(raw)` directly — the only
  non-record, non-`undefined` possibility is a boolean, which interns to
  itself, so the `isRecord` guard around it was unnecessary.
- **`cell.ts`** (`internCellLinkSchema`): drop the leading
  `schema === undefined` early return; `isInternedSchema(undefined)` is now
  `true`, so the existing "already canonical" check returns `undefined` as-is.

## value-case fold-ins (`traverse.ts`)

- Remove `schemaKeyPart()`; the link-hop cache key uses `hashSchema()`
  directly. `undefined`/`true`/`false` hash to distinct stable strings, so the
  key stays injective.
- Simplify `isMemoizableSchemaInput()` to `isInternedSchema(schema) ||
  isDeepFrozen(schema)`; the `=== undefined` / `typeof === "boolean"` clauses
  are subsumed (`isInternedSchema()` is `true` for both).
- `internCoverageSelector` hashes boolean coverage-keys via `hashSchema()`
  instead of `String()`-ing them.

## doc-only

- Reframe `CompoundCycleTracker`'s `extraKey ?? true` as an intentional part of
  the cycle-key contract (`undefined` is equivalent to `true` / "accept
  everything"), not an interning workaround. The normalization is retained
  deliberately — dropping it would split `undefined` and `true` into distinct
  cycle keys.

## Deliberately left alone

- The `""`-sentinel identity-key builders (`server-sync.ts`, `v2-watch.ts`,
  `selector-tracker.ts`) — these strings may cross persistence/wire boundaries.
- The `undefined → false` conflations (`traverse.ts` `internCoverageSelector`'s
  `?? false`, `selector-tracker.ts`) — deliberate "missing ⇒ reject-all"
  semantics, including the boolean-as-sentinel comparisons there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Performance Baseline

This PR doesn't do anything that can reasonably be expected to affect the "Check" CI job, but it seems to be running consistently slow right now (doing something networky by the looks of it). The following accounts for that hopefully-transient slowdown:

NEW_PERF_BASELINE: job: Check = 289s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `undefined`/boolean guards now that `internSchema()`, `hashSchema()`, and related helpers accept them. This simplifies interning and caching code with no behavior changes.

- **Refactors**
  - `packages/data-model/src/schema-utils.ts`: `internPathSelector()` interns `schema` directly.
  - `packages/runner/src/link-resolution.ts`: always assign `result.schema = internSchema(result.schema)`.
  - `packages/runner/src/cfc/schema-refs.ts`: cache stores `internSchema(raw)`; primitives and `undefined` pass through.
  - `packages/runner/src/cell.ts`: `internCellLinkSchema()` drops the `schema === undefined` early return; `isInternedSchema()` now short-circuits for `undefined` and booleans.
  - `packages/runner/src/traverse.ts`:
    - Remove `schemaKeyPart()`; use `hashSchema()` directly in link-hop and coverage selector cache keys.
    - Simplify `isMemoizableSchemaInput()` to `isInternedSchema(schema) || isDeepFrozen(schema)`.
    - Resolved-ref cache: `internSchema(resolved) ?? null` (keeps `null` sentinel).
    - Doc tweak: `extraKey` treats `undefined` as `true` by contract.

<sup>Written for commit 8106da03f29b5db50d808573a0134f899f846a2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

