### PR TITLE
Check CFC atom helpers

### DIFF
--- a/packages/api/cfc-atoms.ts
+++ b/packages/api/cfc-atoms.ts
@@ -13,7 +13,6 @@ export type {
   CfcUserSurfaceInputAtom,
 } from "./cfc.ts";
 export {
-  CFC_ATOM_BASE,
   CFC_ATOM_TYPE,
   CFC_COMPILED_BY_ATOM,
   CFC_COMPILED_BY_ATOM_PREFIX,

--- a/packages/api/cfc.ts
+++ b/packages/api/cfc.ts
@@ -24,25 +24,23 @@ export interface CfcAtomObject extends Readonly<Record<string, CfcJsonValue>> {}
 
 export type CfcAtom = CfcJsonValue;
 
-export const CFC_ATOM_BASE = "https://commonfabric.org/cfc/atom/" as const;
-
 export const CFC_ATOM_TYPE = {
-  Builtin: `${CFC_ATOM_BASE}Builtin`,
-  Caveat: `${CFC_ATOM_BASE}Caveat`,
-  InjectionSafe: `${CFC_ATOM_BASE}InjectionSafe`,
-  LinkReference: `${CFC_ATOM_BASE}LinkReference`,
-  Origin: `${CFC_ATOM_BASE}Origin`,
+  Builtin: "https://commonfabric.org/cfc/atom/Builtin",
+  Caveat: "https://commonfabric.org/cfc/atom/Caveat",
+  InjectionSafe: "https://commonfabric.org/cfc/atom/InjectionSafe",
+  LinkReference: "https://commonfabric.org/cfc/atom/LinkReference",
+  Origin: "https://commonfabric.org/cfc/atom/Origin",
   // Hereditary certification (spec §15.1.1 / §3.1.6.1): survives combination
   // via the class-aware meet — present on an output only when present on
   // every input.
-  PolicyCertified: `${CFC_ATOM_BASE}PolicyCertified`,
-  PromptSlotBound: `${CFC_ATOM_BASE}PromptSlotBound`,
-  PromptSlotInfluence: `${CFC_ATOM_BASE}PromptSlotInfluence`,
-  Resource: `${CFC_ATOM_BASE}Resource`,
+  PolicyCertified: "https://commonfabric.org/cfc/atom/PolicyCertified",
+  PromptSlotBound: "https://commonfabric.org/cfc/atom/PromptSlotBound",
+  PromptSlotInfluence: "https://commonfabric.org/cfc/atom/PromptSlotInfluence",
+  Resource: "https://commonfabric.org/cfc/atom/Resource",
   // Runtime-minted derivation provenance (spec §8.9.3): which implementation
   // produced this value. Evidence — not authorable in schemas.
-  TransformedBy: `${CFC_ATOM_BASE}TransformedBy`,
-  UserSurfaceInput: `${CFC_ATOM_BASE}UserSurfaceInput`,
+  TransformedBy: "https://commonfabric.org/cfc/atom/TransformedBy",
+  UserSurfaceInput: "https://commonfabric.org/cfc/atom/UserSurfaceInput",
 } as const;
 
 export const CFC_RUNTIME_SUBJECT = "did:web:commonfabric.org#runtime";
@@ -66,8 +64,7 @@ export const CFC_COMPILED_BY_ATOM_PREFIX = "cf-compiled-by:" as const;
  * real attestation data; until then minting is gated to builtin-authored
  * writes (see prefix doc above).
  */
-export const CFC_COMPILED_BY_ATOM =
-  `${CFC_COMPILED_BY_ATOM_PREFIX}cf-compiler` as const;
+export const CFC_COMPILED_BY_ATOM = "cf-compiled-by:cf-compiler" as const;
 
 export const CFC_CONCEPT_KIND = {
   PromptInfluence: "https://commonfabric.org/cfc/concepts/prompt-influence",

--- a/packages/patterns/cfc/INDEX.md
+++ b/packages/patterns/cfc/INDEX.md
@@ -38,7 +38,6 @@ trusted UI action.
 
 From `api-cfc.ts`:
 
-- `CFC_ATOM_BASE`
 - `CFC_ATOM_TYPE`
 - `CFC_CONCEPT_KIND`
 - `CFC_FUSE_ATOM_CLASS`

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -24,7 +24,6 @@ import {
   resolveCfcSchemaRefsOrThrow,
 } from "./cfc/schema-refs.ts";
 export {
-  CFC_ATOM_BASE,
   CFC_ATOM_TYPE,
   CFC_CONCEPT_KIND,
   CFC_FUSE_ATOM_CLASS,

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -135,7 +135,6 @@ export {
 export { createNodeFactory } from "./builder/module.ts";
 export { opaqueRef as cell } from "./builder/opaque-ref.ts";
 export {
-  CFC_ATOM_BASE,
   CFC_ATOM_TYPE,
   CFC_CONCEPT_KIND,
   CFC_FUSE_ATOM_CLASS,

--- a/packages/static/assets/types/cfc.ts
+++ b/packages/static/assets/types/cfc.ts
@@ -21,8 +21,6 @@ export interface CfcAtomObject extends Readonly<Record<string, CfcJsonValue>> {}
 
 export type CfcAtom = CfcJsonValue;
 
-export declare const CFC_ATOM_BASE: "https://commonfabric.org/cfc/atom/";
-
 export declare const CFC_ATOM_TYPE: {
   readonly Builtin: "https://commonfabric.org/cfc/atom/Builtin";
   readonly Caveat: "https://commonfabric.org/cfc/atom/Caveat";

--- a/tasks/cfcheck.ts
+++ b/tasks/cfcheck.ts
@@ -16,7 +16,6 @@ const EXCLUDED_PATTERN_FILES = new Set<string>([
   "packages/patterns/base/person.tsx",
   "packages/patterns/battleship/multiplayer/repro-minimal.tsx",
   "packages/patterns/cfc-agent-prompt-injection-demo/main.tsx",
-  "packages/patterns/cfc/prompt-injection/atoms.ts",
   "packages/patterns/cfc/prompt-injection/mod.ts",
   "packages/patterns/cfc/prompt-injection/schemas.ts",
   "packages/patterns/cfc/prompt-injection/tools.ts",


### PR DESCRIPTION
The cfchecks task includes the shared prompt-injection atom helper file.

The CFC atom API exposes canonical atom type values as literal top-level data that can be verified in Secure ECMAScript mode.

Shared prompt-injection atom helpers import the common atom vocabulary through the api-cfc.ts symlink, and the obsolete CFC_ATOM_BASE export is no longer part of the public or generated type surfaces.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose canonical CFC atom type URLs as literals for SES verification, and include the shared prompt‑injection atom helpers in `cfcheck`.

- **Refactors**
  - Use literal URLs for `CFC_ATOM_TYPE`; set `CFC_COMPILED_BY_ATOM` to `cf-compiled-by:cf-compiler`.
  - Remove `CFC_ATOM_BASE` from API, runner re‑exports, docs, and generated types; prompt‑injection helpers import via the `api-cfc.ts` symlink.

- **Bug Fixes**
  - `cfcheck` now checks `packages/patterns/cfc/prompt-injection/atoms.ts` by removing it from the exclusion list.

<sup>Written for commit ec767545424b3c7b14b345065ee7fadfd572a135. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

