### PR TITLE
Unexclude webhook test from cfcheck

### DIFF
--- a/packages/patterns/test/webhook-test.tsx
+++ b/packages/patterns/test/webhook-test.tsx
@@ -2,6 +2,7 @@ import {
   computed,
   Default,
   handler,
+  type JSONValue,
   NAME,
   pattern,
   Stream,
@@ -24,16 +25,16 @@ interface WebhookPatternInput {
 export interface WebhookPatternOutput {
   [NAME]: string;
   [UI]: VNode;
-  webhookInbox: Stream<unknown>;
+  webhookInbox: Stream<JSONValue>;
   webhookConfig: WebhookConfig | null;
-  lastEvent: unknown;
+  lastEvent: JSONValue | null;
 }
 
 // ===== Handler =====
 
 const onWebhookEvent = handler<
-  unknown,
-  { lastEvent: Writable<unknown> }
+  JSONValue,
+  { lastEvent: Writable<JSONValue | null> }
 >((event, { lastEvent }) => {
   lastEvent.set(event);
 });
@@ -42,7 +43,7 @@ const onWebhookEvent = handler<
 
 const WebhookTest = pattern<WebhookPatternInput, WebhookPatternOutput>(
   ({ webhookConfig }) => {
-    const lastEvent = new Writable(null as unknown);
+    const lastEvent = new Writable<JSONValue | null>(null);
     const webhookInbox = onWebhookEvent({ lastEvent });
 
     const inboxDisplay = computed(() => {

--- a/tasks/cfcheck.ts
+++ b/tasks/cfcheck.ts
@@ -57,7 +57,6 @@ const EXCLUDED_PATTERN_FILES = new Set<string>([
   "packages/patterns/google/extractors/usps-informed-delivery.tsx",
   "packages/patterns/mod.ts",
   "packages/patterns/scrabble/scrabble-words.ts",
-  "packages/patterns/test/webhook-test.tsx",
   "packages/patterns/weekly-calendar/weekly-calendar.tsx",
 ]);
 


### PR DESCRIPTION
Remove packages/patterns/test/webhook-test.tsx from EXCLUDED_PATTERN_FILES so cfcheck covers it.

cfcheck rejected the handler because the webhook stream payload was typed as unknown. The schema generator cannot derive a schema for unknown handler input.

Use JSONValue for the webhook inbox and lastEvent cell, with null as the initial lastEvent value. The webhook ingest route reads requests via c.req.json() and returns 400 for invalid JSON, so JSONValue matches the route contract while still allowing arbitrary webhook payloads.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `cfcheck` for the webhook test by unexcluding the file and typing webhook payloads as `JSONValue` so schema generation succeeds and matches the ingest route.

- **Bug Fixes**
  - Removed `packages/patterns/test/webhook-test.tsx` from `EXCLUDED_PATTERN_FILES` in `tasks/cfcheck.ts`.
  - Typed `webhookInbox` as `Stream<JSONValue>` and `lastEvent` as `JSONValue | null`; updated handler generics and initialized `new Writable<JSONValue | null>(null)`.

<sup>Written for commit e5a6868db0d4f891c09f20150868edafeb7f9934. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

