### PR TITLE
fix(ts-transformers): register cast-wrapped non-exported builder consts in __cfReg (CT-1743)

### DIFF
--- a/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
+++ b/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
@@ -414,12 +414,6 @@ function collectTopLevelBuilderArtifactNames(
   }
 }
 
-/**
- * The set of LOCAL binding names that are exported from the module by any form:
- * `export const foo`, `export { foo }` / `export { foo as bar }` (the local name
- * `foo`), and `export default foo`. Used to keep exported builder artifacts out
- * of `__cfReg` (they are addressable through the module namespace instead).
- */
 /** Strip parentheses and `as` / `satisfies` / type-assertion wrappers to reach
  * the underlying builder/identifier expression. Used both for `export default x`
  * recognition and for top-level `const foo = handler(...) as XFactory`
@@ -437,6 +431,12 @@ function unwrapTypeWrappers(expr: ts.Expression): ts.Expression {
   return current;
 }
 
+/**
+ * The set of LOCAL binding names that are exported from the module by any form:
+ * `export const foo`, `export { foo }` / `export { foo as bar }` (the local name
+ * `foo`), and `export default foo`. Used to keep exported builder artifacts out
+ * of `__cfReg` (they are addressable through the module namespace instead).
+ */
 function collectExportedLocalNames(sourceFile: ts.SourceFile): Set<string> {
   const names = new Set<string>();
   for (const statement of sourceFile.statements) {

--- a/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
+++ b/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
@@ -398,7 +398,15 @@ function collectTopLevelBuilderArtifactNames(
   for (const decl of statement.declarationList.declarations) {
     if (!ts.isIdentifier(decl.name)) continue;
     if (exportedLocalNames.has(decl.name.text)) continue;
-    const init = decl.initializer;
+    // Unwrap `as` / `satisfies` / parenthesized / type-assertion wrappers before
+    // the call check: a cast-typed builder const (`const x = handler(...) as
+    // XFactory`) has an AsExpression initializer, not a CallExpression. Without
+    // this it is silently excluded from `__cfReg`, so a non-exported handler/lift
+    // gets no content-addressed provenance and falls to the SES-source fallback at
+    // resolve time — `navigateTo`/SubPattern imports then read undefined (CT-1743).
+    const init = decl.initializer
+      ? unwrapTypeWrappers(decl.initializer)
+      : undefined;
     if (!init || !ts.isCallExpression(init)) continue;
     if (detectCallKind(init, context.checker)?.kind === "builder") {
       out.push(decl.name.text);
@@ -412,9 +420,13 @@ function collectTopLevelBuilderArtifactNames(
  * `foo`), and `export default foo`. Used to keep exported builder artifacts out
  * of `__cfReg` (they are addressable through the module namespace instead).
  */
-/** Strip parentheses and `as` / `satisfies` wrappers to reach the underlying
- * `export default` expression (so a wrapped identifier is still recognized). */
-function unwrapDefaultExportExpression(expr: ts.Expression): ts.Expression {
+/** Strip parentheses and `as` / `satisfies` / type-assertion wrappers to reach
+ * the underlying builder/identifier expression. Used both for `export default x`
+ * recognition and for top-level `const foo = handler(...) as XFactory`
+ * registration — without unwrapping, a cast-wrapped builder const is excluded
+ * from `__cfReg`, loses content-addressed provenance, and falls to the SES
+ * fallback at resolve time (CT-1743). */
+function unwrapTypeWrappers(expr: ts.Expression): ts.Expression {
   let current = expr;
   while (
     ts.isParenthesizedExpression(current) || ts.isAsExpression(current) ||
@@ -448,7 +460,7 @@ function collectExportedLocalNames(sourceFile: ts.SourceFile): Set<string> {
       // `export default foo` — unwrap parens / `as` / `satisfies` so a wrapped
       // identifier (`export default (foo)`, `export default foo satisfies T`) is
       // still recognized as exporting the local `foo`.
-      const expr = unwrapDefaultExportExpression(statement.expression);
+      const expr = unwrapTypeWrappers(statement.expression);
       if (ts.isIdentifier(expr)) names.add(expr.text);
     }
   }

--- a/packages/ts-transformers/test/transform.test.ts
+++ b/packages/ts-transformers/test/transform.test.ts
@@ -53,6 +53,47 @@ export function make() {
     assert(!main.includes('.for("already", true)'));
   });
 
+  it("registers cast-wrapped non-exported builder consts in __cfReg (CT-1743)", async () => {
+    // A non-exported top-level handler written as `const x = handler(...) as T`
+    // must still be __cfReg-registered. Without unwrapping the `as` cast its
+    // AsExpression initializer fails the CallExpression check, so it is excluded
+    // from __cfReg, gets no content-addressed provenance, and at resolve time
+    // falls to the SES source fallback that strips its builder imports — the
+    // CT-1743 `navigateTo`-of-undefined crash. The no-cast sibling is the
+    // positive control (it has always registered).
+    const source = `
+import { handler } from "commonfabric";
+
+type OpenFactory = (args: { id: string }) => unknown;
+
+const openWithCast = handler<
+  { id: string },
+  { count: number }
+>((_event, { count }) => {
+  void count;
+}) as OpenFactory;
+
+const openNoCast = handler<
+  { id: string },
+  { count: number }
+>((_event, { count }) => {
+  void count;
+});
+`;
+
+    const output = await transformFiles({
+      "/main.ts": source,
+    }, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const main = output["/main.ts"]!;
+
+    const reg = main.match(/__cfReg\(\{([\s\S]*?)\}\)/);
+    assert(reg, "expected a __cfReg registration call in the output");
+    assertStringIncludes(reg[1], "openNoCast"); // positive control
+    assertStringIncludes(reg[1], "openWithCast"); // CT-1743 regression guard
+  });
+
   it("adds stable property causes to pattern-owned lowered derives", async () => {
     const source = `
 import { pattern } from "commonfabric";


### PR DESCRIPTION
## Summary

Fixes [CT-1743](https://linear.app/common-tools/issue/CT-1743) — `navigateTo(SubPattern({...}))` throwing `Cannot read properties of undefined (reading 'navigateTo')` for module-scope handlers (breaks Mobile Loom entity navigation under identity E4/E5).

**Root cause (one line in the transformer).** `collectTopLevelBuilderArtifactNames` in [`builder-call-hoisting.ts`](packages/ts-transformers/src/transformers/builder-call-hoisting.ts) decides which non-exported top-level builder consts get added to the module's `__cfReg({...})` registration — the feed that gives each a content-addressed `{identity, symbol}` and thus **verified provenance** at load. It tested `ts.isCallExpression(init)` **directly on the initializer**, so a cast-typed builder const written as `const open = handler(...) as OpenFactory` (an `AsExpression` initializer — the sanctioned idiom for a typed module-scope handler) failed the check and was **silently dropped from `__cfReg`**.

Without provenance the handler has no `$implRef` and no verified live implementation, so `Runner.resolveJavaScriptFunction` falls through to the stringified-source **SES fallback**, which recompiles the body *without builder imports* — `navigateTo` / cross-module SubPattern references then read `undefined`.

This is why the symptom was shape-specific:
- **exported** handlers escaped it — addressable via the export namespace, not `__cfReg`;
- `action(...)` / `lift(...)` escaped it — they hoist to synthetic `__cfHandler_N` / `__cfLift_N` symbols that are registered directly;
- only **non-exported `handler(...) as XFactory`** consts fell through.

## Fix

Unwrap `as` / `satisfies` / parenthesized / type-assertion wrappers before the call check, reusing the wrapper-stripping the `export default` path already does (generalized `unwrapDefaultExportExpression` → `unwrapTypeWrappers`).

With the fix, the unmodified cf-loom-mobile bundle (casts intact) now registers all six previously-missing handlers in `__cfReg`.

## Tests

- New regression test in [`test/transform.test.ts`](packages/ts-transformers/test/transform.test.ts) — asserts a cast-wrapped non-exported handler appears in `__cfReg`; **fails without the fix** (verified via stash), the no-cast sibling is the positive control.
- Full `ts-transformers` suite green (292 passed).

## Notes

- No runtime change — the fix is entirely in the transformer's `__cfReg` collection. The existing provenance machinery (`recordModuleProvenance`, arm-1/arm-2 resolution) then handles these handlers exactly like the already-working exported / `action` ones.
- Workaround for already-deployed patterns (no rebuild): drop the `as XFactory` cast, or `export` the handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1743 by registering non-exported handlers written as `const x = handler(...) as T` in `__cfReg`, restoring provenance and preventing `navigateTo` undefined errors for module-scope handlers.

- **Bug Fixes**
  - Unwrap `as`/`satisfies`/parenthesized/type-assertion wrappers before call detection in `collectTopLevelBuilderArtifactNames`.
  - Generalized `unwrapDefaultExportExpression` to `unwrapTypeWrappers` and used it for both default-export recognition and `__cfReg` collection.
  - Added a regression test to ensure cast-wrapped non-exported handlers are included in `__cfReg`.

- **Refactors**
  - Moved the `collectExportedLocalNames` JSDoc to the correct function (no behavior change).

<sup>Written for commit a5d37292c47b2298bad89d73a3415829a9b91ee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

