### PR TITLE
chore(ts-transformers): lint rule banning bare node.getText(); migrate risky sites

### DIFF
--- a/packages/ts-transformers/deno.json
+++ b/packages/ts-transformers/deno.json
@@ -21,6 +21,9 @@
       "./test/fixtures/**/*.expected.jsx",
       "./test/fixtures/**/*.expected.ts",
       "./test/fixtures/**/*.expected.tsx"
+    ],
+    "plugins": [
+      "./lint-plugins/no-node-get-text.ts"
     ]
   }
 }

--- a/packages/ts-transformers/lint-plugins/no-node-get-text.ts
+++ b/packages/ts-transformers/lint-plugins/no-node-get-text.ts
@@ -1,0 +1,43 @@
+// Forbids bare `node.getText()` (called with no SourceFile argument) in the
+// transformer source.
+//
+// `ts.Node.getText()` reads the node's source positions, which are absent on
+// synthetic nodes the transformer creates — so it throws at runtime on them.
+// Use `getNodeText()` / `getExpressionText()` from `src/ast/utils.ts`, which
+// print synthetic nodes instead. The `getText(sourceFile)` form is left alone:
+// that is the sanctioned wrapper's own call.
+//
+// Test files are exempt: they assert against source parsed in the test, whose
+// nodes always carry real positions, so `getText()` is safe and idiomatic there.
+export default {
+  name: "cf-ts-transformers",
+  rules: {
+    "no-node-get-text": {
+      create(context) {
+        if (context.filename.includes("/test/")) {
+          return {};
+        }
+        return {
+          CallExpression(node) {
+            const callee = node.callee;
+            if (
+              callee.type === "MemberExpression" &&
+              !callee.computed &&
+              callee.property.type === "Identifier" &&
+              callee.property.name === "getText" &&
+              node.arguments.length === 0
+            ) {
+              context.report({
+                node,
+                message:
+                  "Bare node.getText() throws on synthetic AST nodes. Use " +
+                  "getNodeText()/getExpressionText() from ast/utils.ts, or pass " +
+                  "a SourceFile.",
+              });
+            }
+          },
+        };
+      },
+    },
+  },
+} satisfies Deno.lint.Plugin;

--- a/packages/ts-transformers/src/ast/event-handlers.ts
+++ b/packages/ts-transformers/src/ast/event-handlers.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { getNodeText } from "./utils.ts";
 
 export function isSafeEventHandlerCall(node: ts.CallExpression): boolean {
   const expression = node.expression;
@@ -57,7 +58,7 @@ export function isEventHandlerJsxAttribute(
     return false;
   }
 
-  const attrName = jsxAttribute.name.getText();
+  const attrName = getNodeText(jsxAttribute.name);
 
   // Fast path: conventional "on*" naming
   if (attrName.startsWith("on")) {

--- a/packages/ts-transformers/src/ast/mod.ts
+++ b/packages/ts-transformers/src/ast/mod.ts
@@ -64,6 +64,7 @@ export {
   getExpressionText,
   getMemberSymbol,
   getMethodCallTarget,
+  getNodeText,
   getTypeAtLocationWithFallback,
   getVariableInitializer,
   isFunctionParameter,

--- a/packages/ts-transformers/src/ast/utils.ts
+++ b/packages/ts-transformers/src/ast/utils.ts
@@ -1,44 +1,53 @@
 import * as ts from "typescript";
 import { getEnclosingFunctionLikeDeclaration } from "./function-predicates.ts";
 
-const expressionTextCache = new WeakMap<ts.Expression, string>();
-const syntheticExpressionPrinter = ts.createPrinter();
-const syntheticExpressionSourceFile = ts.createSourceFile(
+const nodeTextCache = new WeakMap<ts.Node, string>();
+const syntheticNodePrinter = ts.createPrinter();
+const syntheticNodeSourceFile = ts.createSourceFile(
   "",
   "",
   ts.ScriptTarget.Latest,
 );
 
 /**
- * Safely get text from an expression, handling both regular and synthetic nodes.
- * Synthetic nodes (created by transformers) don't have valid source positions,
- * so we use a printer instead of getText().
+ * Safely get the source text of any node, handling both regular and synthetic
+ * nodes. Synthetic nodes (created by transformers) have no valid source
+ * positions, so `node.getText()` throws on them; this prints them instead.
+ * Prefer this (or {@link getExpressionText}) over `getText()` in the
+ * transformer — a lint rule enforces it.
  */
-export function getExpressionText(expr: ts.Expression): string {
-  const cached = expressionTextCache.get(expr);
+export function getNodeText(node: ts.Node): string {
+  const cached = nodeTextCache.get(node);
   if (cached !== undefined) {
     return cached;
   }
 
   let text: string;
-  const sourceFile = expr.getSourceFile();
+  const sourceFile = node.getSourceFile();
   // Check both: no source file OR synthetic node (pos=-1)
-  if (!sourceFile || expr.pos === -1) {
+  if (!sourceFile || node.pos === -1) {
     // Synthetic node - use printer
     try {
-      text = syntheticExpressionPrinter.printNode(
+      text = syntheticNodePrinter.printNode(
         ts.EmitHint.Unspecified,
-        expr,
-        syntheticExpressionSourceFile,
+        node,
+        syntheticNodeSourceFile,
       );
     } catch {
-      text = `<error printing ${ts.SyntaxKind[expr.kind]}>`;
+      text = `<error printing ${ts.SyntaxKind[node.kind]}>`;
     }
   } else {
-    text = expr.getText(sourceFile);
+    // The sanctioned getText() call: guarded by the synthetic check above, and
+    // passes the source file (the form the no-node-get-text lint rule allows).
+    text = node.getText(sourceFile);
   }
-  expressionTextCache.set(expr, text);
+  nodeTextCache.set(node, text);
   return text;
+}
+
+/** Safe source text for an expression. See {@link getNodeText}. */
+export function getExpressionText(expr: ts.Expression): string {
+  return getNodeText(expr);
 }
 
 /**
@@ -342,7 +351,7 @@ function isBuilderOwnedFunctionLike(func: ts.FunctionLikeDeclaration): boolean {
     return false;
   }
 
-  const funcName = callExpr.parent.expression.getText();
+  const funcName = getNodeText(callExpr.parent.expression);
   return funcName.includes("pattern") ||
     funcName.includes("handler") ||
     funcName.includes("lift");

--- a/packages/ts-transformers/src/transformers/opaque-get-validation.ts
+++ b/packages/ts-transformers/src/transformers/opaque-get-validation.ts
@@ -12,6 +12,7 @@ import ts from "typescript";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import { getCellKind } from "@commonfabric/schema-generator/cell-brand";
 import { detectCallKind, isReactiveOriginCall } from "../ast/call-kind.ts";
+import { getNodeText } from "../ast/mod.ts";
 
 export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
@@ -74,7 +75,7 @@ export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
 
     if (isReactive) {
       // Get the receiver text for the error message
-      const receiverText = receiverExpr.getText();
+      const receiverText = getNodeText(receiverExpr);
       const callText = `${receiverText}.get()`;
 
       context.reportDiagnostic({

--- a/packages/ts-transformers/src/transformers/pattern-context-validation.ts
+++ b/packages/ts-transformers/src/transformers/pattern-context-validation.ts
@@ -41,6 +41,7 @@ import {
   classifyArrayMethodCallSite,
   detectCallKind,
   detectDirectBuilderCall,
+  getNodeText,
   isInRestrictedReactiveContext,
   isInsideRestrictedContext,
   isInsideSafeCallbackWrapper,
@@ -254,7 +255,7 @@ export class PatternContextValidationTransformer
 
     const problemAccess = this.findProblematicAccess(node);
     const accessText = problemAccess
-      ? `'${problemAccess.getText()}'`
+      ? `'${getNodeText(problemAccess)}'`
       : "property access";
 
     context.reportDiagnostic({
@@ -386,7 +387,8 @@ export class PatternContextValidationTransformer
       context.reportDiagnostic({
         severity: "error",
         type: "compute-context:local-reactive-use",
-        message: `Reactive value '${culprit.getText()}' is created in this ` +
+        message:
+          `Reactive value '${getNodeText(culprit)}' is created in this ` +
           `computed()/lift() callback and cannot be used as a plain value ` +
           `here. Move this use into a nested computed(() => ...) or ` +
           `module-scope lift() callback.`,

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -6,6 +6,7 @@ import {
 } from "../core/mod.ts";
 import { createSchemaTransformerV2 } from "@commonfabric/schema-generator";
 import {
+  getNodeText,
   getTypeFromTypeNodeWithFallback,
   visitEachChildWithJsx,
 } from "../ast/mod.ts";
@@ -59,12 +60,7 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
         }
 
         if (logger) {
-          let typeText = "unknown";
-          try {
-            typeText = schemaTypeArg.getText();
-          } catch {
-            // synthetic nodes may not support getText(); ignore
-          }
+          const typeText = getNodeText(schemaTypeArg);
           logger(`[SchemaTransformer] Found toSchema<${typeText}>() call`);
         }
 
@@ -520,7 +516,7 @@ function isToSchemaNode(node: ts.Node): node is ToSchemaNode {
   // Raw property access expression `__cfHelpers.toSchema<T>()`
   if (
     ts.isPropertyAccessExpression(expression) &&
-    expression.expression.getText() === CF_HELPERS_IDENTIFIER &&
+    getNodeText(expression.expression) === CF_HELPERS_IDENTIFIER &&
     expression.name.text === "toSchema"
   ) {
     return true;

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -13,6 +13,7 @@ import {
   detectNewExpressionKind,
   ensureTypeNodeRegistered,
   getLiftAppliedInnerCall,
+  getNodeText,
   getTypeAtLocationWithFallback,
   getTypeFromTypeNodeWithFallback,
   getVariableInitializer,
@@ -851,7 +852,7 @@ function isScopeBrandProperty(prop: ts.Symbol): boolean {
     const name = "name" in declaration
       ? (declaration as { name?: ts.Node }).name
       : undefined;
-    return !!name && name.getText().includes("SCOPE_BRAND");
+    return !!name && getNodeText(name).includes("SCOPE_BRAND");
   });
 }
 

--- a/packages/ts-transformers/src/transformers/write-authorized-by-validation.ts
+++ b/packages/ts-transformers/src/transformers/write-authorized-by-validation.ts
@@ -1,5 +1,6 @@
 import ts from "typescript";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
+import { getNodeText } from "../ast/mod.ts";
 
 export class WriteAuthorizedByValidationTransformer
   extends HelpersOnlyTransformer {
@@ -236,8 +237,9 @@ function declarationKey(
   declaration: ts.Declaration,
   reference: ts.TypeReferenceNode,
 ): string {
-  const args = reference.typeArguments?.map((arg) => arg.getText()).join(",") ??
-    "";
+  const args =
+    reference.typeArguments?.map((arg) => getNodeText(arg)).join(",") ??
+      "";
   return `${declaration.getSourceFile().fileName}:${declaration.pos}:${args}`;
 }
 


### PR DESCRIPTION
ts.Node.getText() reads source positions that synthetic nodes (created by the transformer) lack, so it throws on them at runtime. Add a deno lint plugin rule (cf-ts-transformers/no-node-get-text) that flags the bare `node.getText()` form in the transformer source, pointing authors at getNodeText()/ getExpressionText(). The `getText(sourceFile)` form and test files (which assert against real parsed source) are exempt.

Generalize getExpressionText into getNodeText(node: ts.Node) — the same safe-print-on-synthetic logic, now usable for any node (type args, names, ...); getExpressionText delegates to it. Migrate the nine bare getText() call sites in src to getNodeText: schema-injection, schema-generator (×2, dropping a now- redundant try/catch), pattern-context-validation (×2), write-authorized-by- validation, opaque-get-validation, event-handlers, and ast/utils.

deno lint, deno fmt --check, deno task check, and the test suite (292 passed) all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Deno lint rule that forbids bare `node.getText()` in transformers and replaces risky sites with a safe `getNodeText()` helper to prevent crashes on synthetic nodes. Also generalizes `getExpressionText()` to reuse the same safe logic.

- **New Features**
  - Lint rule `cf-ts-transformers/no-node-get-text` flags `node.getText()` without a `SourceFile`, suggesting `getNodeText()`/`getExpressionText()`.
  - `getText(sourceFile)` is allowed; test files are exempt. Configured in `deno.json`.

- **Refactors**
  - Added `getNodeText(node: ts.Node)`; `getExpressionText()` now delegates to it.
  - Replaced nine bare `getText()` calls across transformers; removed a redundant try/catch in schema-generator.
  - Exported and used `getNodeText` in updated modules.
  - Lint, format, type checks, and all 292 tests pass.

<sup>Written for commit 1b3a8a93586faf52988fd62a2aa1399da6d15c5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: job: Check = 271s
---END COPY-PASTE---
