### PR TITLE
fix(runner): recover result schema from result doc meta in llm-dialog getCellSchema

### DIFF
--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -35,6 +35,7 @@ import { type Action, ignoreReadForScheduling } from "../scheduler.ts";
 import { Runtime } from "../runtime.ts";
 import { spaceCellSchema } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import { getResultCellWithSourceSchema } from "../piece-helpers.ts";
 import { schemaToTypeString } from "../schema-format.ts";
 import { formatTransactionSummary } from "../storage/transaction-summary.ts";
 import {
@@ -242,25 +243,17 @@ function prepareSchemaForLLM(schema: JSONSchema): JSONSchema {
 function getCellSchema(
   cell: Cell<unknown>,
 ): JSONSchema | undefined {
-  // TODO(@ubik2): Previously, we checked the cell for an internal link,
-  // and if we found it, we attached the pattern's schema. I think that
-  // should all be handled properly by the new sigil links that include
-  // the schema, but leaving this until I verify.
-
-  // Extract schema from cell, including from resultSchema of associated pattern
+  // Extract schema from cell, following links that carry an embedded schema
   const { schema } = cell.asSchemaFromLinks().getAsNormalizedFullLink();
 
   if (isNontrivialSchema(schema)) {
     return schema;
   }
 
-  // Try harder: resolve all links, clear the schema, then look up the schema
-  // from the source pattern's resultSchema. This handles cells accessed via
+  // Resolve all links, clear the schema, then look up the schema embedded
+  // in the links along the resolved chain. This handles cells accessed via
   // arrays (e.g., mentionables, recents) where the intermediate cell doesn't
-  // carry a schema but the underlying piece cell's pattern does.
-  // Uses the same trick as addFavorite in home.tsx: clearing the schema with
-  // asSchema(undefined) forces asSchemaFromLinks to look it up fresh from the
-  // source pattern.
+  // carry a schema but a link in the chain does.
   try {
     const resolvedSchema = cell.resolveAsCell().asSchema(undefined)
       .asSchemaFromLinks()?.getAsNormalizedFullLink()?.schema;
@@ -269,6 +262,30 @@ function getCellSchema(
     }
   } catch (e) {
     logger.debug("llm", "getCellSchema fallback failed:", e);
+  }
+
+  // Read the resultSchema stored in a result document's meta "schema" field
+  // (written by updateResultSchemaMeta when a piece runs), projected along
+  // the cell's path. Checked on the cell's own document first (covers paths
+  // into a result document whose links carry no schema), then on the fully
+  // resolved target (covers reference chains that end at a result document).
+  try {
+    const own = getResultCellWithSourceSchema(cell.asSchema(undefined));
+    if (isNontrivialSchema(own.schema)) {
+      return own.schema;
+    }
+  } catch (e) {
+    logger.debug("llm", "getCellSchema meta-schema lookup failed:", e);
+  }
+  try {
+    const resolved = getResultCellWithSourceSchema(
+      cell.resolveAsCell().asSchema(undefined),
+    );
+    if (isNontrivialSchema(resolved.schema)) {
+      return resolved.schema;
+    }
+  } catch (e) {
+    logger.debug("llm", "getCellSchema meta-schema fallback failed:", e);
   }
 
   // Fall back to minimal schema based on current value
@@ -2018,6 +2035,7 @@ function createToolResultMessages(
 }
 
 export const llmDialogTestHelpers = {
+  getCellSchema,
   parseLLMFriendlyLink,
   traverseAndSerialize,
   serializeForLLMObservation,

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1564,12 +1564,10 @@ export class CellImpl<T extends FabricValue>
   }
 
   /**
-   * Follow all links, even beyond write redirects to get final schema.
+   * Follow all links, even beyond write redirects, and adopt the schema
+   * embedded in the resolved link chain, projected along the remaining path.
    *
-   * If there is none look for resultSchema of associated pattern.
-   *
-   * Otherwise the link stays the same, i.e. it does not advance to resolved
-   * link.
+   * The link stays the same, i.e. it does not advance to the resolved link.
    *
    * Note: That means that the schema might change if the link behind it change.
    * The reads are logged though, so should trigger reactive flows.

--- a/packages/runner/test/llm-dialog-cell-schema.test.ts
+++ b/packages/runner/test/llm-dialog-cell-schema.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { type Pattern } from "../src/builder/types.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { trustExecutable } from "./support/trusted-builder.ts";
+import { llmDialogTestHelpers } from "../src/builtins/llm-dialog.ts";
+
+const { getCellSchema } = llmDialogTestHelpers;
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+describe("getCellSchema", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  const resultSchema = {
+    type: "object",
+    description: "A #doubler piece.",
+    properties: {
+      doubled: { type: "number", description: "the doubled #value" },
+    },
+  } as const satisfies JSONSchema;
+  const pattern: Pattern = {
+    argumentSchema: {
+      type: "object",
+      properties: { value: { type: "number" } },
+    },
+    resultSchema,
+    result: { doubled: { $alias: { partialCause: "doubled", path: [] } } },
+    nodes: [
+      {
+        module: {
+          type: "javascript",
+          implementation: (v: number) => v * 2,
+        },
+        inputs: { $alias: { cell: "argument", path: ["value"] } },
+        outputs: { $alias: { partialCause: "doubled", path: [] } },
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  async function runPiece() {
+    const resultCell = runtime.getCell(space, "get-cell-schema-piece");
+    const result = await runtime.runSynced(
+      resultCell,
+      trustExecutable(runtime, pattern),
+      { value: 21 },
+    );
+    await result.pull();
+    await runtime.idle();
+    await tx.commit();
+    tx = runtime.edit();
+    return result;
+  }
+
+  it("recovers resultSchema from result doc meta for a schemaless cell", async () => {
+    const result = await runPiece();
+
+    const bare = (result as any).asSchema(undefined);
+    const schema = getCellSchema(bare) as any;
+
+    expect(schema?.description).toBe("A #doubler piece.");
+    expect(schema?.properties?.doubled?.type).toBe("number");
+  });
+
+  it("recovers field schema from meta projection for a schemaless child cell", async () => {
+    const result = await runPiece();
+
+    const bareField = (result as any).asSchema(undefined).key("doubled");
+    const schema = getCellSchema(bareField) as any;
+
+    expect(schema?.type).toBe("number");
+    expect(schema?.description).toBe("the doubled #value");
+  });
+
+  it("returns the link-embedded schema for a reference written under one", async () => {
+    const result = await runPiece();
+
+    const holderSchema = {
+      type: "object",
+      properties: { ref: { asCell: ["cell"] } },
+    } as const satisfies JSONSchema;
+    const minimalView = (result as any).asSchema({
+      type: "object",
+      properties: { name: { type: "string" } },
+    });
+    const holder = runtime.getCell(
+      space,
+      "get-cell-schema-holder",
+      holderSchema as any,
+      tx,
+    );
+    (holder as any).key("ref").set(minimalView);
+    await tx.commit();
+    tx = runtime.edit();
+
+    const bareRef = runtime
+      .getCell(space, "get-cell-schema-holder", undefined, tx)
+      .key("ref");
+    const schema = getCellSchema(bareRef as any) as any;
+
+    expect(schema?.properties?.name?.type).toBe("string");
+  });
+
+  it("recovers resultSchema from meta of a resolved reference target", async () => {
+    const result = await runPiece();
+
+    const holderSchema = {
+      type: "object",
+      properties: { ref: { asCell: ["cell"] } },
+    } as const satisfies JSONSchema;
+    const holder = runtime.getCell(
+      space,
+      "get-cell-schema-resolved-holder",
+      holderSchema as any,
+      tx,
+    );
+    // Store a schema-cleared reference so the link embeds no schema: the
+    // schema can then only be recovered by resolving the reference to the
+    // result document and reading its meta "schema".
+    (holder as any).key("ref").set((result as any).asSchema(undefined));
+    await tx.commit();
+    tx = runtime.edit();
+
+    const bareRef = runtime
+      .getCell(space, "get-cell-schema-resolved-holder", undefined, tx)
+      .key("ref");
+    // The reference carries no schema in the link or the holder document,
+    // so recovery must follow the reference to the result document's meta.
+    const linkSchema = (bareRef as any).asSchemaFromLinks()
+      .getAsNormalizedFullLink().schema;
+    expect(linkSchema).toBeUndefined();
+    const schema = getCellSchema(bareRef as any) as any;
+
+    expect(schema?.description).toBe("A #doubler piece.");
+    expect(schema?.properties?.doubled?.type).toBe("number");
+  });
+
+  it("falls back to a value-derived schema when no schema is recorded", async () => {
+    const plain = runtime.getCell<{ alpha: number; beta: string }>(
+      space,
+      "get-cell-schema-plain",
+      undefined,
+      tx,
+    );
+    plain.set({ alpha: 1, beta: "two" });
+    await tx.commit();
+    tx = runtime.edit();
+
+    const bare = runtime.getCell(space, "get-cell-schema-plain", undefined, tx);
+    const schema = getCellSchema(bare as any) as any;
+
+    // No pattern schema and no meta "schema": getCellSchema derives a minimal
+    // object schema listing the present keys.
+    expect(schema?.type).toBe("object");
+    expect(Object.keys(schema?.properties ?? {}).sort()).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+});


### PR DESCRIPTION
getCellSchema in the llm-dialog builtin resolves a cell's schema so the read/schema tools can describe a piece to the model. It previously drew on two sources: the schema reachable by following links from the cell's own view, and the schema looked up after resolving all links and clearing any view-imposed schema. Both depend on a schema being embedded in a link sigil somewhere along the resolution chain. A cell that references a piece's result document through a chain that carries no embedded schema recovered nothing from either source and fell through to a minimal schema derived from the current value, losing the pattern's declared property types and descriptions.

The pattern's resultSchema is available the whole time: when a piece runs, applySetupState stores it in the result document's meta "schema" field via updateResultSchemaMeta. Only the piece manager read it back, through getResultCellWithSourceSchema. getCellSchema now consults that meta field before deriving a schema from the value.

The meta lookup is done in two steps, because the resultSchema can be reached two ways. First it reads the meta "schema" of the cell's own document, projected along the cell's path; this covers a path into a result document — for example result.doubled, where the field redirect carries no embedded schema, and where resolving links first would advance past the result document to the derived cell's own document, which has no meta "schema". Then, only if that yields nothing, it reads the meta "schema" of the fully resolved target; this covers reference chains that end at a result document. Both steps reuse getResultCellWithSourceSchema for the projection.

This replaces a TODO that asked whether schema-bearing sigil links had made an older pattern-schema lookup unnecessary. Verified against a piece run through runtime.runSynced: links written by pattern binding do carry schemas for some shapes, but bare references to a result document, and paths into one under the derived-cell manifest, do not, and the meta "schema" read covers those cases.

Also corrects the asSchemaFromLinks doc comment in cell.ts, which claimed the method falls back to the resultSchema of the associated pattern. No such fallback exists in link resolution; the method adopts the schema embedded in the resolved link chain, projected along the remaining path.

Adds tests covering the recovery paths, run against a real piece via runtime.runSynced: a schemaless cell on a result document recovers the resultSchema from meta (asserting the description text, which distinguishes meta recovery from the value-derived fallback); a schemaless child cell recovers its field schema by projecting the meta resultSchema along the path; and a reference written under a minimal schema returns that link-embedded schema. getCellSchema is exposed through the existing llmDialogTestHelpers object for these tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes schema resolution in the LLM dialog by falling back to a result document’s meta "schema" when link chains have no embedded schemas. Restores pattern-defined types and descriptions for result and child cells, including across reference chains.

- **Bug Fixes**
  - `getCellSchema` resolution order: link-embedded schema; resolved-chain schema; result doc meta "schema" via `getResultCellWithSourceSchema` (own doc, then resolved target); else minimal from current value.
  - Exposes `getCellSchema` via `llmDialogTestHelpers` and adds tests covering meta recovery (own doc and resolved target), field-path projection, link-embedded schema, and minimal fallback.
  - Clarifies `asSchemaFromLinks` docs: adopts schema from the resolved link chain only; no fallback to a pattern’s result schema.

<sup>Written for commit cd3d2bff30902a3d3f235051ce54830ed63ef5f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

