### PR TITLE
feat(profiles): working profiles end-to-end — card-add CFC fixes + followable piece cards (CT-1740, CT-1755)

### DIFF
--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -4255,6 +4255,14 @@ interface CFProfileBadgeAttributes<T> extends CFHTMLAttributes<T> {
   /** A cell containing a profile (ProfileHomeOutput): renders avatar + name. */
   "$profile"?: CellLike<any>;
   "size"?: "xs" | "sm" | "md" | "lg" | "xl" | CellLike<string>;
+  /**
+   * Suppress click-to-navigate. Set when the badge is bound to a derived view
+   * of a profile (e.g. the self-badge on a profile-home page) rather than the
+   * profile's own root piece, so a click would route to an invalid URL.
+   * (Camel-cased to match the element property — the renderer assigns JSX props
+   * as properties, so a lower-cased name would miss the reactive property.)
+   */
+  "noNavigate"?: boolean;
 }
 
 interface CFChipAttributes<T> extends CFHTMLAttributes<T> {

--- a/packages/js-compiler/mod.ts
+++ b/packages/js-compiler/mod.ts
@@ -30,6 +30,7 @@ export {
 } from "./program.ts";
 export {
   composeBundleSourceMap,
+  identitySourceMap,
   isSourceMap,
   type MappedPosition,
   parseSourceMap,

--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -89,6 +89,36 @@ export function composeBundleSourceMap(
 }
 
 /**
+ * Build an IDENTITY source map for a compiled body whose authored source map
+ * was not retained — every generated line maps to the same line/column of
+ * `source`. Used by the warm/cached module-record load path, where the
+ * content-addressed cache stores compiled bodies but not their per-module
+ * source maps: without a registered frame the ESM loader resolves `fn.src` to
+ * the raw bundle coordinate (`<evalId>.js:..`), which the harness cannot
+ * canonicalize, and CFC verified-source identity fails closed. An identity map
+ * makes `mapPosition(<name>, line, col)` resolve to `<name>:line:col`, which
+ * the engine then rewrites to the canonical `cf:module/<id>/<path>` form via
+ * its per-module name → canonical table (parity with the source-compile path,
+ * which carries a real authored map).
+ *
+ * Line/column coordinates are preserved verbatim (the compiled body IS the
+ * eval'd text under this load), so no positional information is invented — the
+ * map only re-labels the bundle coordinate with the per-module source name.
+ */
+export function identitySourceMap(body: string, source: string): SourceMap {
+  const generator = new SourceMapGenerator({ file: source });
+  const lineCount = (body.match(/\n/g)?.length ?? 0) + 1;
+  for (let line = 1; line <= lineCount; line++) {
+    generator.addMapping({
+      generated: { line, column: 0 },
+      original: { line, column: 0 },
+      source,
+    });
+  }
+  return JSON.parse(generator.toString()) as SourceMap;
+}
+
+/**
  * Maximum number of source maps to cache in memory.
  * When exceeded, oldest (least recently used) entries are evicted.
  *

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -43,7 +43,7 @@ export type ProfileElement = {
   tag: string;
   userTags: readonly string[];
   title?: string;
-  source?: "catalog" | "url";
+  source?: "catalog" | "url" | "piece";
 };
 
 export type AddProfileElementEvent = {
@@ -72,6 +72,12 @@ export type MutateProfileElementsEvent = {
   tag?: string;
   userTags?: readonly string[];
   cell?: any;
+  // "addPiece" inputs: a link to an EXISTING deployed piece (CT-1755). The
+  // card becomes a followable reference to the live piece rather than a local
+  // title-only placeholder. `pieceSpace` is the target space DID; `pieceId` is
+  // the piece id (with or without the `of:` prefix).
+  pieceSpace?: string;
+  pieceId?: string;
 };
 
 export type SetProfileNameEvent = {
@@ -101,6 +107,8 @@ export type ProfileHomeOutput = {
   // `RemoveProfileElementEvent` remain the documented per-stream subsets.
   addElement: Stream<MutateProfileElementsEvent>;
   removeElement: Stream<MutateProfileElementsEvent>;
+  // Pin an existing deployed piece as a followable card (CT-1755).
+  addPiece: Stream<MutateProfileElementsEvent>;
   // Flips the rendered profile view (CT-1748) between the read-only
   // presentation and the edit form. UI state — not owner-protected.
   toggleEditing: Stream<unknown>;
@@ -144,6 +152,17 @@ const UrlPatternReference = pattern<
   }),
 );
 
+// Build a link to an EXISTING deployed piece in (possibly) another space
+// (CT-1755). This is the canonical serialized cross-space link shape
+// (`createSigilLinkFromParsedLink`'s output): a `link@1` sigil carrying the
+// target piece id (URI form, `of:` prefix) and space DID. Stored as a
+// `ProfileElement.cell`, it resolves to the live piece and renders as a
+// followable `<cf-cell-link>` exactly like a `profiles[]` roster entry.
+const pieceReferenceLink = (space: string, pieceId: string): unknown => {
+  const id = pieceId.startsWith("of:") ? pieceId : `of:${pieceId}`;
+  return { "/": { "link@1": { id, space, path: [] } } };
+};
+
 const appendElement = (
   element: ProfileElement,
   elements: Writable<ProfileElement[]>,
@@ -175,7 +194,7 @@ const mutateElements = handler<
     //               without a URL.
     //   "remove"  — the exported remove stream / per-row button: removes
     //               `event.cell ?? state.cell`; no-op without one.
-    mode: "add" | "addCard" | "addLink" | "remove";
+    mode: "add" | "addCard" | "addLink" | "addPiece" | "remove";
     // Per-row remove binding ("remove" mode).
     cell?: any;
     // Link form binding ("addLink" mode).
@@ -183,6 +202,9 @@ const mutateElements = handler<
     title?: Writable<string>;
     tag?: Writable<string>;
     userTags?: string[];
+    // Pin-a-piece form binding ("addPiece" mode, CT-1755).
+    pieceSpace?: Writable<string>;
+    pieceId?: Writable<string>;
   }
 >((event, state) => {
   const userTags = event.userTags ?? state.userTags ?? [];
@@ -212,6 +234,41 @@ const mutateElements = handler<
       state.patternUrl?.set("");
       state.title?.set("");
       state.tag?.set("");
+      return;
+    }
+    case "addPiece": {
+      // Prefer event fields (e.g. a "pin from the piece" flow that passes the
+      // target directly); fall back to the bound form cells (the edit-mode
+      // "Pin a piece" inputs).
+      let space = (event.pieceSpace ?? state.pieceSpace?.get() ?? "").trim();
+      let rawId = (event.pieceId ?? state.pieceId?.get() ?? "").trim();
+      // Convenience: a full piece URL/path pasted into the space field is split
+      // into space + id (the last two path segments). Only a DID-spaced URL
+      // resolves cross-space — a space *name* can't be resolved to a DID from
+      // pattern code, so paste the `did:key:…` form for another space.
+      if (rawId.length === 0 && space.includes("/")) {
+        const segments = space.replace(/^https?:\/\/[^/]+/, "").split("/")
+          .filter((segment) => segment.length > 0);
+        if (segments.length >= 2) {
+          space = segments[segments.length - 2];
+          rawId = segments[segments.length - 1];
+        }
+      }
+      if (space.length === 0 || rawId.length === 0) return;
+      const title = (event.title ?? state.title?.get() ?? "").trim() || rawId;
+      // Tag by the piece id so the same piece can't be pinned twice (dedup in
+      // appendElement is by `cell`; a stable tag keeps the row label sane).
+      const tag = rawId;
+      appendElement({
+        cell: pieceReferenceLink(space, rawId),
+        source: "piece",
+        title,
+        tag,
+        userTags,
+      }, state.elements);
+      state.pieceSpace?.set("");
+      state.pieceId?.set("");
+      state.title?.set("");
       return;
     }
     case "addCard": {
@@ -305,15 +362,23 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
     const elementTitle = new Writable("").for("elementTitle");
     const elementTag = new Writable("").for("elementTag");
     const userTagsText = new Writable("").for("userTagsText");
+    // "Pin a piece" form (CT-1755): a link to an existing deployed piece by
+    // its space DID + piece id.
+    const pieceSpaceForm = new Writable("").for("pieceSpaceForm");
+    const pieceIdForm = new Writable("").for("pieceIdForm");
+    const pieceTitleForm = new Writable("").for("pieceTitleForm");
     // Rendered profile view (CT-1748): the cell view shows a read-only
     // presentation by default; the owner flips this to reveal the edit form.
     const editing = new Writable<boolean>(false).for("editing");
     const isEditing = computed(() => editing.get() === true);
     // Self-view cell for <cf-profile-badge>: the badge resolves name/avatar from
-    // a bound profile cell. Bound to this derived self-cell it renders in the
-    // "presented" state. TODO(CT-1748 follow-up): bind the actual profile result
-    // cell so the runtime-attested represents-principal label drives the
-    // verified identity seal (needs owner-protection restored + CT-1740).
+    // a bound profile cell. Bound to this DERIVED self-cell (a computed
+    // projection, not the profile's own root piece), so the badge is marked
+    // `no-navigate` — a click would otherwise resolve to this non-piece cell id
+    // and route to an invalid URL. TODO(CT-1748 follow-up): bind the actual
+    // profile result cell so the badge can navigate to the canonical profile
+    // page AND the runtime-attested represents-principal label drives the
+    // verified identity seal.
     const selfProfile = computed(() => ({
       [NAME]: name.get(),
       name: name.get(),
@@ -347,6 +412,16 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
       // pinned to their declared purpose via the bound mode.
       addElement: mutateElements({ elements, mode: "add" }),
       removeElement: mutateElements({ elements, mode: "remove" }),
+      // Pin an existing deployed piece as a followable card (CT-1755). Reads
+      // the bound form cells; an event may also pass { pieceSpace, pieceId,
+      // title } directly (e.g. a future "pin from the piece" flow).
+      addPiece: mutateElements({
+        elements,
+        mode: "addPiece",
+        pieceSpace: pieceSpaceForm,
+        pieceId: pieceIdForm,
+        title: pieceTitleForm,
+      }),
       toggleEditing: toggleProfileEditing({ editing }),
       isEditing,
       initialNameApplied,
@@ -374,6 +449,7 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
                   id="profile-badge"
                   $profile={selfProfile}
                   size="xl"
+                  noNavigate
                 />
 
                 <cf-vstack gap="2">
@@ -482,6 +558,38 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
                   <span style={{ color: "var(--cf-color-text-secondary)" }}>
                     Links are saved as reference cards. They are not deployed or
                     run.
+                  </span>
+                </cf-vstack>
+
+                <cf-vstack gap="2">
+                  <label>Pin a piece</label>
+                  <cf-input
+                    $value={pieceSpaceForm}
+                    placeholder="Space DID (or paste a /space/piece URL)"
+                  />
+                  <cf-input
+                    $value={pieceIdForm}
+                    placeholder="Piece id (fid1:…)"
+                  />
+                  <cf-input
+                    $value={pieceTitleForm}
+                    placeholder="Card title (optional)"
+                  />
+                  <cf-button
+                    onClick={mutateElements({
+                      elements,
+                      mode: "addPiece",
+                      pieceSpace: pieceSpaceForm,
+                      pieceId: pieceIdForm,
+                      title: pieceTitleForm,
+                      userTags: parsedUserTags,
+                    })}
+                  >
+                    Pin piece
+                  </cf-button>
+                  <span style={{ color: "var(--cf-color-text-secondary)" }}>
+                    Pins a link to an existing deployed piece. Click the card to
+                    open the live piece.
                   </span>
                 </cf-vstack>
 

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -944,15 +944,32 @@ const rebindWriteAuthorizedByClaims = (
   if (!moduleIdentity) {
     return schema;
   }
+  // Only the function NAMED by a binding may stamp that binding's provenance
+  // moduleIdentity. The writer's own binding (sourceFile + bindingPath) must
+  // match the claim's binding (file + path); otherwise a foreign writer that
+  // merely *initializes* the protected field — e.g. profile-create's
+  // `submitProfileCreation` seeding a freshly `inSpace`'d ProfileHome whose
+  // `elements` bind to profile-home's `mutateElements` — would stamp ITS module
+  // identity onto someone else's binding. That stamp can never match the live
+  // bound writer at verification time (CT-1740: seed stamped profile-create's
+  // id, the card-add write stamped profile-home's → "writeAuthorizedBy must
+  // remain stable"). Leaving the foreign-seeded claim unstamped lets the
+  // genuine bound writer stamp it (one-stamped/one-unstamped reconciles).
+  const writerFile = normalizeIdentitySource(identity.sourceFile);
+  const writerPath = identity.bindingPath;
   return rebindWriteAuthorizedByClaimsInner(
     schema,
-    { moduleIdentity },
+    { moduleIdentity, writerFile, writerPath },
   ) as JSONSchema;
 };
 
 const rebindWriteAuthorizedByClaimsInner = (
   value: unknown,
-  ids: { moduleIdentity?: string },
+  ids: {
+    moduleIdentity?: string;
+    writerFile?: string;
+    writerPath?: readonly string[];
+  },
 ): unknown => {
   if (Array.isArray(value)) {
     let changed = false;
@@ -983,10 +1000,28 @@ const rebindWriteAuthorizedByClaimsInner = (
     // stamp is NOT unstamped: it is recognized as stamped — and unservable —
     // so it fails closed at verification instead of being silently re-bound
     // to whichever verified writer touches it next.
+    const bindingFile = isRecord(claim.__ctWriterIdentityOf) &&
+        typeof claim.__ctWriterIdentityOf.file === "string"
+      ? normalizeIdentitySource(claim.__ctWriterIdentityOf.file)
+      : undefined;
+    const bindingPath = isRecord(claim.__ctWriterIdentityOf) &&
+        Array.isArray(claim.__ctWriterIdentityOf.path)
+      ? claim.__ctWriterIdentityOf.path as readonly string[]
+      : undefined;
+    // The writer must BE the function named by the binding (see the binding
+    // match rationale in rebindWriteAuthorizedByClaims). When we can identify
+    // both bindings, require they match; a mismatch means a foreign writer is
+    // initializing the field, so we leave the claim unstamped.
+    const writerOwnsBinding = ids.writerFile !== undefined &&
+      ids.writerPath !== undefined && bindingFile !== undefined &&
+      bindingPath !== undefined &&
+      ids.writerFile === bindingFile &&
+      arraysEqual(ids.writerPath, bindingPath);
     if (
       isRecord(claim.__ctWriterIdentityOf) &&
       claim.__ctWriterIdentityOf.bundleId === undefined &&
-      claim.__ctWriterIdentityOf.moduleIdentity === undefined
+      claim.__ctWriterIdentityOf.moduleIdentity === undefined &&
+      writerOwnsBinding
     ) {
       const nextIfc = { ...value.ifc };
       nextIfc.writeAuthorizedBy = {

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -48,6 +48,7 @@ import {
 } from "../sandbox/module-record-compiler.ts";
 import {
   composeBundleSourceMap,
+  identitySourceMap,
   type SourceMap,
 } from "@commonfabric/js-compiler";
 import {
@@ -829,12 +830,29 @@ export class Engine extends EventTarget implements Harness {
       for (const [name, specifier] of graph.specifierByPath) {
         sourceNameBySpecifier.set(specifier, name);
       }
+      // On the warm/cached record load (`buildRecordsFromCompiled`) no authored
+      // per-module map is retained, so fall back to an IDENTITY map keyed on the
+      // module's per-module source `name`. Without a registered bundle map the
+      // ESM loader leaves `fn.src` as the raw `${evalId}.js:line:col` bundle
+      // coordinate, which the engine's name → canonical table cannot resolve, so
+      // identity downgrades to `unsupported` and CFC verified-source identity
+      // fails closed (the inSpace-child owner-protected write regression,
+      // CT-1754). The identity map preserves coordinates verbatim and only
+      // re-labels the bundle frame with the canonical source name, so the
+      // EXISTING verified-binding check passes for legitimately compiled modules
+      // without weakening it.
       const bundleSourceMap = composeBundleSourceMap(
-        [...graph.compiledBodies].map(([specifier, body]) => ({
-          body,
-          map: graph.moduleSourceMaps.get(specifier),
-          source: sourceNameBySpecifier.get(specifier),
-        })),
+        [...graph.compiledBodies].map(([specifier, body]) => {
+          const source = sourceNameBySpecifier.get(specifier);
+          return {
+            body,
+            map: graph.moduleSourceMaps.get(specifier) ??
+              (source !== undefined
+                ? identitySourceMap(body, source)
+                : undefined),
+            source,
+          };
+        }),
         `${evalId}.js`,
       );
       if (bundleSourceMap) {
@@ -848,9 +866,22 @@ export class Engine extends EventTarget implements Harness {
       // under Deno's tamed SES stacks). The frame is keyed on the per-module
       // sourceURL with eval-relative line numbers, so register the per-module
       // map shifted by the factory-wrapper line (`(function (...) {\n` = +1).
+      //
+      // When no authored map exists for a module (the warm/cached record load \u2014
+      // `buildRecordsFromCompiled` populates `moduleSourceMaps` only for cached
+      // bodies that retained one), fall back to an IDENTITY map keyed on the
+      // module's per-module source `name`. Without this the eval frame stays a
+      // raw `${evalId}.js:line:col` bundle coordinate that the engine's
+      // per-module name \u2192 canonical table cannot canonicalize, so `fn.src`
+      // never reaches `cf:module/<id>/<path>` and CFC verified-source identity
+      // downgrades to `unsupported` \u2014 the inSpace-child owner-protected write
+      // regression (CT-1754). The identity map preserves coordinates verbatim;
+      // it only re-labels the bundle frame with the module's canonical source
+      // name, so the EXISTING verified-binding check passes for legitimately
+      // compiled modules without weakening it.
       for (const [name, specifier] of graph.specifierByPath) {
-        const map = graph.moduleSourceMaps.get(specifier);
-        if (!map) continue;
+        const map = graph.moduleSourceMaps.get(specifier) ??
+          identitySourceMap(graph.compiledBodies.get(specifier) ?? "", name);
         const sourceUrl = name.replace(/[\r\n\u2028\u2029]/g, "_");
         const moduleMap = composeBundleSourceMap(
           [{ body: "", map, source: name }],

--- a/packages/runner/test/inspace-child-owner-write.test.ts
+++ b/packages/runner/test/inspace-child-owner-write.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// SCOPE (CT-1754): this guards the verified-binding regression only — an
+// inSpace child's owner-protected list, written by a NON-exported mode-bound
+// handler from a fresh session, was rejected because the warm/cached re-load
+// left `fn.src` non-canonical so the writer identity downgraded to
+// `unsupported`. Both sessions here share ONE compiled PROGRAM, so they share
+// one `moduleIdentity` and this does NOT reproduce the separate two-compile-
+// context moduleIdentity *merge-conflict* ("writeAuthorizedBy must remain
+// stable") that still blocks card-add in the real profile-create → piece-view
+// flow (CT-1740). That divergence needs a faithful two-context harness.
+const signer = await Identity.fromPassphrase("inspace-child-owner-write");
+const spaceA = signer.did(); // "home" — runs the parent, creates the child
+const spaceB = (await Identity.fromPassphrase("owner write child B")).did();
+
+// Two-manager shape (same as inspace-child-owner-seed.test.ts): each session
+// has its OWN per-space replicas, loopback-connected to one shared in-process
+// memory server — the real browser/CLI session split. A single emulate
+// manager's shared replicas would mask the warm/cached re-load on the reader
+// (where this CFC verified-binding regression lives).
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager.sharedServer = server;
+    return manager;
+  }
+
+  private sharedServer!: MemoryV2Server.Server;
+
+  protected override server(): MemoryV2Server.Server {
+    return this.sharedServer;
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+  });
+
+// The profile-create flow in miniature, exercising the OWNER-PROTECTED WRITE
+// path (CT-1754). The child pattern owns an `elements` list that is written
+// ONLY by `mutate` — a NON-exported, mode-bound handler (mirrors
+// profile-home.tsx's `mutateElements`: a single handler instance per mode,
+// never exported). The list is exposed for mutation only through the exported
+// `add` stream (`mutate({ items, mode: "add" })`).
+//
+// Standalone (single-context) the write commits fine. The real flow creates
+// the child via `child.inSpace(spaceB)(...)` from the parent, and a FRESH
+// session loads the child from its own space via the warm/cached module path —
+// where `graph.moduleSourceMaps` is empty, so the per-module `//# sourceURL`
+// source frame never registered and `fn.src` resolved to the raw
+// `${evalId}.js:line:col` bundle coordinate instead of the canonical
+// `cf:module/<id>/main.tsx:..` form. That made the function's canonical-source
+// check disagree with its recorded provenance identity, downgrading the writer
+// identity to `unsupported`, and CFC rejected the commit with
+// "writeAuthorizedBy requires a trusted verified binding identity at /".
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        "import {",
+        "  Cfc,",
+        "  handler,",
+        "  pattern,",
+        "  RepresentsCurrentUser,",
+        "  Stream,",
+        "  Writable,",
+        "  WriteAuthorizedBy,",
+        "} from 'commonfabric';",
+        "",
+        "type CurrentPrincipal = { readonly __ctCurrentPrincipal: true };",
+        "",
+        "type OwnerProtected<T, Binding> = RepresentsCurrentUser<",
+        "  Cfc<",
+        "    WriteAuthorizedBy<T, Binding>,",
+        "    { ownerPrincipal: CurrentPrincipal }",
+        "  >",
+        ">;",
+        "",
+        "type MutateEvent = { item?: string };",
+        "",
+        "// THE single authorized writer for the owner-protected `items` list:",
+        "// non-exported, mode-bound (mirrors profile-home.tsx's mutateElements).",
+        "const mutate = handler<",
+        "  MutateEvent,",
+        "  { items: Writable<string[]>; mode: 'add' | 'remove' }",
+        ">((event, state) => {",
+        "  if (state.mode === 'add') {",
+        "    if (event.item === undefined) return;",
+        "    state.items.push(event.item);",
+        "    return;",
+        "  }",
+        "  if (event.item === undefined) return;",
+        "  state.items.set(state.items.get().filter((i) => i !== event.item));",
+        "});",
+        "",
+        "interface ChildOutput {",
+        "  items: OwnerProtected<string[], typeof mutate>;",
+        "  add: Stream<MutateEvent>;",
+        "  remove: Stream<MutateEvent>;",
+        "}",
+        "",
+        "export const child = pattern<{ seed?: string }, ChildOutput>(",
+        "  ({ seed }) => {",
+        "    const items = new Writable<OwnerProtected<string[], typeof mutate>>(",
+        "      seed ? [seed] : [],",
+        "    ).for('items');",
+        "    return {",
+        "      items,",
+        "      add: mutate({ items, mode: 'add' }),",
+        "      remove: mutate({ items, mode: 'remove' }),",
+        "    };",
+        "  },",
+        ");",
+        "",
+        "const create = handler<",
+        "  { seed?: string },",
+        "  { children: Writable<ChildOutput[]> }",
+        ">((event, { children }) => {",
+        `  children.push(child.inSpace("${spaceB}")({`,
+        "    seed: event.seed,",
+        "  }) as ChildOutput);",
+        "});",
+        "",
+        "export default pattern(() => {",
+        "  const children = new Writable<ChildOutput[]>([]).for('children');",
+        "  return { children, create: create({ children }) };",
+        "});",
+      ].join("\n"),
+    },
+  ],
+};
+
+const RESULT_CAUSE = "inspace child owner write parent";
+
+const childLinkListSchema = {
+  type: "array",
+  items: { type: "unknown", asCell: ["cell"] },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+const itemListSchema = {
+  type: "array",
+  items: { type: "string" },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+describe("inSpace child owner-protected write (profile elements)", () => {
+  let server: MemoryV2Server.Server;
+  let managerA: SharedServerStorageManager;
+  let managerB: SharedServerStorageManager;
+
+  beforeEach(() => {
+    server = newSharedServer();
+    managerA = SharedServerStorageManager.connectTo(server, { as: signer });
+    managerB = SharedServerStorageManager.connectTo(server, { as: signer });
+  });
+
+  afterEach(async () => {
+    await managerA?.close();
+    await managerB?.close();
+    await server?.close();
+  });
+
+  it("a fresh session adds an item to the owner-protected list", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: managerA,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: managerB,
+    });
+    try {
+      // Session 1: run the parent in space A; the handler creates the child in
+      // space B with the owner-protected `items` list (profile creation).
+      const tx1 = rt1.edit();
+      const parent = await rt1.patternManager.compilePattern(PROGRAM, {
+        space: spaceA,
+        tx: tx1,
+      });
+      const resultCell1 = rt1.getCell<Record<string, unknown>>(
+        spaceA,
+        RESULT_CAUSE,
+        undefined,
+        tx1,
+      );
+      // deno-lint-ignore no-explicit-any
+      const r1 = rt1.run(tx1, parent as any, {}, resultCell1);
+      // A manual test tx must prepare (the runtime's own commit paths do) or a
+      // CFC-relevant tx is rejected wholesale at commit.
+      rt1.prepareTxForCommit(tx1);
+      const commit1 = await tx1.commit();
+      expect(commit1.error).toBeUndefined();
+      await r1.pull();
+
+      // Fresh tx for the create event: the ifc-carrying schema makes send()
+      // read CFC metadata through the cell's tx, and tx1 is already done.
+      const tx2 = rt1.edit();
+      r1.withTx(tx2).key("create").send({ seed: "first" });
+      const commit2 = await tx2.commit();
+      expect(commit2.error).toBeUndefined();
+      await r1.pull();
+      await rt1.idle();
+
+      await r1.pull();
+      const links = r1.key("children").asSchema(childLinkListSchema)
+        // deno-lint-ignore no-explicit-any
+        .get() as any[];
+      expect(links.length).toBe(1);
+      const childLink = links[0].getAsNormalizedFullLink();
+      expect(childLink.space).toBe(spaceB);
+
+      await rt1.patternManager.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+      await rt1.idle();
+      await rt1.storageManager.synced();
+
+      // Session 2 (own replicas, warm/cached child load): load the child from
+      // its own space and start it (the shell's piece view always starts).
+      const childCell = rt2.getCellFromLink(childLink);
+      await childCell.sync();
+      const started = await rt2.start(childCell);
+      expect(started).toBe(true);
+      await rt2.idle();
+
+      // Send the owner-protected WRITE (the regression site). Before the fix the
+      // commit was rejected with "writeAuthorizedBy requires a trusted verified
+      // binding identity at /" because the warm-load writer identity downgraded
+      // to `unsupported`.
+      const writeTx = rt2.edit();
+      childCell.withTx(writeTx).key("add").send({ item: "second" });
+      const writeCommit = await writeTx.commit();
+      expect(writeCommit.error).toBeUndefined();
+      await childCell.pull();
+      await rt2.idle();
+      await childCell.pull();
+
+      const itemsCell = childCell.key("items").asSchema(itemListSchema);
+      await itemsCell.sync();
+      await itemsCell.pull();
+      const items = itemsCell.get() as string[];
+      expect([...items].sort()).toEqual(["first", "second"]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});

--- a/packages/runner/test/profile-create-real-card-add.test.ts
+++ b/packages/runner/test/profile-create-real-card-add.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { fromFileUrl } from "@std/path";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// GOLD-STANDARD end-to-end repro of the profile card-add flow using the REAL
+// shipped patterns (profile-create.tsx + profile-home.tsx) — no synthetic
+// child. Session A runs profile-create and fires `createProfile`, which seeds a
+// ProfileHome in its OWN inSpace space (the real cross-space create). A FRESH
+// session B then loads that ProfileHome standalone and fires the exported
+// `addElement` stream — the card-add write onto the owner-protected `elements`
+// list (the single non-exported `mutateElements` writer).
+//
+// This is the definitive test of CT-1740: post-#4158 (moduleIdentity over
+// authored source) the seed-time and write-time writeAuthorizedBy stamps must
+// agree across the two compile contexts, so the commit must NOT be rejected
+// with "writeAuthorizedBy must remain stable at /". Pre-#4158 data (seeded with
+// the injected-form stamp) is a migration boundary, not exercised here.
+const signer = await Identity.fromPassphrase("profile-create-real-card-add");
+const spaceA = signer.did();
+
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager.sharedServer = server;
+    return manager;
+  }
+  private sharedServer!: MemoryV2Server.Server;
+  protected override server(): MemoryV2Server.Server {
+    return this.sharedServer;
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+  });
+
+const sysDir = fromFileUrl(
+  new URL("../../patterns/system/", import.meta.url),
+);
+const read = (n: string) => Deno.readTextFileSync(sysDir + n);
+
+// A tiny wrapper that owns the home `profiles` list and embeds the REAL
+// profile-create pattern, exposing its `createProfile` stream. The seed push
+// targets this plain list; the owner-protected surface under test lives in the
+// ProfileHome child that `submitProfileCreation` creates via inSpace.
+const WRAPPER_SRC = [
+  "import ProfileCreate from './profile-create.tsx';",
+  "import { pattern, Writable } from 'commonfabric';",
+  "import type { ProfileHomeOutput } from './profile-home.tsx';",
+  "",
+  "export default pattern(() => {",
+  "  const profiles = new Writable<ProfileHomeOutput[]>([]).for('profiles');",
+  "  const created = ProfileCreate({ profiles });",
+  "  return { profiles, createProfile: created.createProfile };",
+  "});",
+].join("\n");
+
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [
+    { name: "/main.tsx", contents: WRAPPER_SRC },
+    { name: "/profile-create.tsx", contents: read("profile-create.tsx") },
+    { name: "/profile-home.tsx", contents: read("profile-home.tsx") },
+  ],
+};
+
+const RESULT_CAUSE = "profile-create real card add";
+
+const profileLinkListSchema = {
+  type: "array",
+  items: { type: "unknown", asCell: ["cell"] },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+const elementsListSchema = {
+  type: "array",
+  items: { type: "unknown", asCell: ["cell"] },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+describe("profile-create real card-add (REAL patterns, cross-space)", () => {
+  let server: MemoryV2Server.Server;
+  let managerA: SharedServerStorageManager;
+  let managerB: SharedServerStorageManager;
+
+  beforeEach(() => {
+    server = newSharedServer();
+    managerA = SharedServerStorageManager.connectTo(server, { as: signer });
+    managerB = SharedServerStorageManager.connectTo(server, { as: signer });
+  });
+  afterEach(async () => {
+    await managerA?.close();
+    await managerB?.close();
+    await server?.close();
+  });
+
+  it("a fresh session adds a card to a freshly-created profile", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: managerA,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: managerB,
+    });
+    try {
+      // Session A: run profile-create's host and create a profile.
+      const tx1 = rt1.edit();
+      const parent = await rt1.patternManager.compilePattern(PROGRAM, {
+        space: spaceA,
+        tx: tx1,
+      });
+      const resultCell1 = rt1.getCell<Record<string, unknown>>(
+        spaceA,
+        RESULT_CAUSE,
+        undefined,
+        tx1,
+      );
+      // deno-lint-ignore no-explicit-any
+      const r1 = rt1.run(tx1, parent as any, {}, resultCell1);
+      rt1.prepareTxForCommit(tx1);
+      const commit1 = await tx1.commit();
+      expect(commit1.error).toBeUndefined();
+      await r1.pull();
+
+      const tx2 = rt1.edit();
+      r1.withTx(tx2).key("createProfile").send({ name: "AdaTest" });
+      const commit2 = await tx2.commit();
+      expect(commit2.error).toBeUndefined();
+      await r1.pull();
+      await rt1.idle();
+      await r1.pull();
+
+      const profiles = r1.key("profiles").asSchema(profileLinkListSchema)
+        // deno-lint-ignore no-explicit-any
+        .get() as any[];
+      expect(profiles.length).toBe(1);
+      const profileLink = profiles[0].getAsNormalizedFullLink();
+      // The profile lives in its OWN space (inSpace), not the home space.
+      expect(profileLink.space).not.toBe(spaceA);
+
+      await rt1.patternManager.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+      await rt1.idle();
+      await rt1.storageManager.synced();
+
+      // Session B (own replicas, warm/cached STANDALONE ProfileHome load).
+      const profileCell = rt2.getCellFromLink(profileLink);
+      await profileCell.sync();
+      const started = await rt2.start(profileCell);
+      expect(started).toBe(true);
+      await rt2.idle();
+
+      // THE card-add write: the exported addElement stream (an instance of the
+      // non-exported mutateElements writer, mode "add"). Catalog card (no url).
+      const writeTx = rt2.edit();
+      profileCell.withTx(writeTx).key("addElement").send({
+        title: "My Card",
+      });
+      const writeCommit = await writeTx.commit();
+      // The regression site. Pre-fix: "writeAuthorizedBy must remain stable".
+      expect(writeCommit.error).toBeUndefined();
+      await profileCell.pull();
+      await rt2.idle();
+      await profileCell.pull();
+
+      const elementsCell = profileCell.key("elements").asSchema(
+        elementsListSchema,
+      );
+      await elementsCell.sync();
+      await elementsCell.pull();
+      // deno-lint-ignore no-explicit-any
+      const elements = elementsCell.get() as any[];
+      expect(elements.length).toBe(1);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});

--- a/packages/runner/test/profile-home-pin-piece.test.ts
+++ b/packages/runner/test/profile-home-pin-piece.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { fromFileUrl } from "@std/path";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// CT-1755: a profile card can pin an EXISTING deployed piece. `mutateElements`'s
+// `addPiece` mode stores a real cross-space link to the target piece as the
+// element's `cell` (the canonical `link@1` sigil), so the card renders as a
+// followable `<cf-cell-link>` to the live piece rather than a local title-only
+// placeholder. This guards that the stored element resolves to the pinned
+// piece's space + id.
+const signer = await Identity.fromPassphrase("profile-home-pin-piece");
+const space = signer.did();
+
+const TARGET_SPACE =
+  "did:key:z6MkkKEmheMPDZUr4YEkZrW6niR7Bn5FWAuQic5fUUzcGkfq";
+const TARGET_PIECE = "fid1:cMVC_ZTgWedhTzHW8jWbz70xANFfmLmpL-dNU1842Ps";
+
+const sysDir = fromFileUrl(new URL("../../patterns/system/", import.meta.url));
+const PROGRAM: RuntimeProgram = {
+  main: "/profile-home.tsx",
+  files: [
+    {
+      name: "/profile-home.tsx",
+      contents: Deno.readTextFileSync(sysDir + "profile-home.tsx"),
+    },
+  ],
+};
+
+const RESULT_CAUSE = "profile-home pin piece";
+
+const elementsSchema = {
+  type: "array",
+  items: {
+    type: "object",
+    properties: {
+      title: { type: "string" },
+      tag: { type: "string" },
+      source: { type: "string" },
+      cell: { type: "unknown", asCell: ["cell"] },
+    },
+  },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+describe("profile-home addPiece (followable piece card)", () => {
+  let manager: EmulatedStorageManager;
+
+  beforeEach(() => {
+    manager = EmulatedStorageManager.emulate({ as: signer });
+  });
+  afterEach(async () => {
+    await manager?.close();
+  });
+
+  it("pins an existing piece as a cross-space link element", async () => {
+    const rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: manager,
+    });
+    try {
+      const tx = rt.edit();
+      const pattern = await rt.patternManager.compilePattern(PROGRAM, {
+        space,
+        tx,
+      });
+      const resultCell = rt.getCell<Record<string, unknown>>(
+        space,
+        RESULT_CAUSE,
+        undefined,
+        tx,
+      );
+      // deno-lint-ignore no-explicit-any
+      const result = rt.run(tx, pattern as any, { initialName: "Ada" }, resultCell);
+      rt.prepareTxForCommit(tx);
+      const commit = await tx.commit();
+      expect(commit.error).toBeUndefined();
+      await result.pull();
+
+      // Fire the exported `addPiece` stream with the target directly (the
+      // "pin from the piece" event path; the edit-form path binds the same
+      // handler to form cells).
+      const tx2 = rt.edit();
+      result.withTx(tx2).key("addPiece").send({
+        pieceSpace: TARGET_SPACE,
+        pieceId: TARGET_PIECE,
+        title: "Demo Counter",
+      });
+      const commit2 = await tx2.commit();
+      expect(commit2.error).toBeUndefined();
+      await result.pull();
+      await rt.idle();
+      await result.pull();
+
+      const elementsCell = result.key("elements").asSchema(elementsSchema);
+      await elementsCell.sync();
+      await elementsCell.pull();
+      // deno-lint-ignore no-explicit-any
+      const elements = elementsCell.get() as any[];
+      expect(elements.length).toBe(1);
+      expect(elements[0].source).toBe("piece");
+      expect(elements[0].title).toBe("Demo Counter");
+
+      // The element's `cell` is a real link to the pinned piece's space + id.
+      const link = elements[0].cell.getAsNormalizedFullLink();
+      expect(link.space).toBe(TARGET_SPACE);
+      expect(link.id).toBe(`of:${TARGET_PIECE}`);
+    } finally {
+      await rt.dispose();
+    }
+  });
+});

--- a/packages/runner/test/profile-home-pin-piece.test.ts
+++ b/packages/runner/test/profile-home-pin-piece.test.ts
@@ -16,8 +16,7 @@ import type { RuntimeProgram } from "../src/harness/types.ts";
 const signer = await Identity.fromPassphrase("profile-home-pin-piece");
 const space = signer.did();
 
-const TARGET_SPACE =
-  "did:key:z6MkkKEmheMPDZUr4YEkZrW6niR7Bn5FWAuQic5fUUzcGkfq";
+const TARGET_SPACE = "did:key:z6MkkKEmheMPDZUr4YEkZrW6niR7Bn5FWAuQic5fUUzcGkfq";
 const TARGET_PIECE = "fid1:cMVC_ZTgWedhTzHW8jWbz70xANFfmLmpL-dNU1842Ps";
 
 const sysDir = fromFileUrl(new URL("../../patterns/system/", import.meta.url));
@@ -75,7 +74,12 @@ describe("profile-home addPiece (followable piece card)", () => {
         tx,
       );
       // deno-lint-ignore no-explicit-any
-      const result = rt.run(tx, pattern as any, { initialName: "Ada" }, resultCell);
+      const result = rt.run(
+        tx,
+        pattern as any,
+        { initialName: "Ada" },
+        resultCell,
+      );
       rt.prepareTxForCommit(tx);
       const commit = await tx.commit();
       expect(commit.error).toBeUndefined();

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
@@ -362,6 +362,40 @@ describe("CFProfileBadge", () => {
       expect(navigated).toBe(false);
     });
 
+    it("stays non-navigable when noNavigate is set, even on a root cell", async () => {
+      // The profile-home self-badge is bound to a `computed()` projection that
+      // happens to resolve as a root cell (path []) but is NOT a real piece, so
+      // navigating would route to a non-piece cell id. `noNavigate` suppresses
+      // it (a root cell would otherwise be navigable — see the first test).
+      const resolved = navResolvedCell({
+        path: [],
+        space: "did:key:zSpaceN",
+        id: "fid1:profileN",
+      });
+      const el = new CFProfileBadge() as any;
+      markConnected(el, true);
+      el.noNavigate = true;
+      el.profile = { resolveAsCell: () => Promise.resolve(resolved) };
+      await el._resolve();
+
+      expect(el._navigable).toBe(false);
+
+      let navigated = false;
+      const onNav = () => {
+        navigated = true;
+      };
+      globalThis.addEventListener("cf-navigate", onNav);
+      try {
+        // Even a direct call is guarded (belt-and-braces with `_navigable`).
+        el._navigateToProfile(false);
+        el._handleClick(fakeClick());
+      } finally {
+        globalThis.removeEventListener("cf-navigate", onNav);
+      }
+
+      expect(navigated).toBe(false);
+    });
+
     it("navigates on Enter and Space keydown", async () => {
       const resolved = navResolvedCell({
         path: [],

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -306,6 +306,16 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
   @property({ attribute: false })
   accessor space: DID | undefined = undefined;
 
+  /**
+   * Suppress click-to-navigate. Set this when the badge is bound to a derived
+   * view of the profile rather than the profile's own root piece — e.g. the
+   * self-badge on a profile-home page, whose bound cell is a `computed()`
+   * projection (not a navigable piece), so a click would otherwise resolve to a
+   * non-piece cell id and route to an invalid URL.
+   */
+  @property({ type: Boolean, reflect: true, attribute: "nonavigate" })
+  accessor noNavigate = false;
+
   @state()
   private accessor _name: string | undefined = undefined;
 
@@ -472,7 +482,7 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
       // piece (only root cells map to a profile page; sub-path/derived cells
       // don't).
       this._resolvedCell = resolved;
-      this._navigable = resolved.ref().path.length === 0;
+      this._navigable = !this.noNavigate && resolved.ref().path.length === 0;
 
       // Subscribe with a minimal schema so the runtime only resolves the fields
       // we render, rather than walking the whole profile output graph (mirrors
@@ -505,6 +515,7 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
    * opens in a new tab.
    */
   private _navigateToProfile(openInNewTab: boolean): void {
+    if (this.noNavigate) return;
     const cell = this._resolvedCell;
     if (!cell || cell.ref().path.length > 0) return;
     const view = { spaceDid: cell.space(), pieceId: cell.id() };


### PR DESCRIPTION
## Profiles, working end to end

Delivers a working Common Fabric profile: create a profile, add cards, **pin a real deployed piece and click through to the live running piece**, and visit the rendered profile page — with owner-protection (CFC) intact. Four commits across two layers (runtime CFC fix → user-facing feature); kept together so the branch is one working thing rather than several partial PRs.

Builds on #4158 (moduleIdentity over authored source), which fixed the profile *read*/render path but not the *write*.

### 1. `54a2547` — warm-load `fn.src` canonicalization (CT-1754)
The warm/cached record load kept no per-module source map, so a re-loaded handler's `fn.src` stayed the raw `<evalId>.js` bundle coordinate; the verified-binding check couldn't canonicalize it and downgraded the writer to `unsupported`, rejecting owner-protected writes by the non-exported `mutateElements` with *"writeAuthorizedBy requires a trusted verified binding identity"*. Fix: `identitySourceMap()` (`js-compiler/source-map.ts`) + a warm-path fallback at the two source-map registration sites in `engine.ts` — re-labels the bundle frame so the **existing** check passes (not weakened).

### 2. `8ead4e9` — stamp `writeAuthorizedBy` from the binding, not a foreign seeder (CT-1740)
With (1) fixed, card-add then hit *"writeAuthorizedBy **must remain stable**"*. Instrumentation captured the two diverging stamps on a freshly-created profile: the **seed** stamped `profile-create`'s moduleIdentity (`fbbISemF…`) while the card-add **write** stamped `profile-home`'s (`zwdMteV4…`). A claim's provenance was stamped with the *authoring writer's* module — correct only when the writer *is* the bound function. `profile-create`'s `submitProfileCreation` seeds an `inSpace` ProfileHome whose `elements` bind to `profile-home`'s `mutateElements`, so it stamped the wrong module. (Not a hash skew — #4158 made moduleIdentity bundle-invariant; this is wrong-module **attribution**.) Fix: in `rebindWriteAuthorizedByClaims`, only the function **named by the binding** (matching `sourceFile`+`bindingPath`) may stamp it; a foreign initializer leaves it unstamped and the genuine writer stamps it later (reconciles). **Fail-closed** — unstamped claims still fail verification; reconcile requires matching bindings. Adversarial gate + `profile-owner-cfc` security cases stay green.

### 3. `60e0007` — followable piece cards + self-badge nav fix (CT-1755)
Cards were title-only placeholders (`ProfileCatalogCard`/`UrlPatternReference` render a title; URLs were plain text) — nothing pointed at a real piece. Now `mutateElements` has an `addPiece` mode that stores a real cross-space link (`{ "/": { "link@1": { id, space, path } } }`, the same shape `inSpace`/`profiles[]` use) to an **existing deployed piece**; the card renders as a `<cf-cell-link>` showing the live piece name and opens the running piece on click. New edit-mode **"Pin a piece"** form (space DID + piece id, or paste a `/<did>/<id>` URL); an exported `addPiece` stream also takes `{ pieceSpace, pieceId, title }` for a future "pin from the piece" flow. Also: `cf-profile-badge` gains a `noNavigate` prop (+ click guard) — the self-badge is bound to a `computed()` projection (not a real piece), so a click routed to an invalid URL; rosters bind a real profile link and still navigate.

### 4. `da777d9` — tests
`profile-home-pin-piece.test.ts` (the `addPiece` element resolves to the pinned piece's space + id) and a `noNavigate` case in `cf-profile-badge.test.ts`.

## Validation
- **Browser, end to end:** create a profile → render with owner-protection → add a card via the UI → **deploy a counter, pin it by space DID + id, click the card → the live interactive counter** → self-badge no longer navigates.
- **In-process / CI:** gold-standard real-pattern card-add test (red→green), `addPiece` link test, badge `noNavigate` test; full CFC + identity suite (incl. the 42-step adversarial gate and `profile-owner-cfc`) green; `deno check`/`lint` clean.

## Notes
- **Migration boundary:** profiles seeded *before* #4158 carry the legacy injected-form stamp and still conflict on card-add until recreated (accepted, pre-launch). New profiles work.
- **Pinning cross-space** needs the `did:key:…` form (a pattern can't resolve a space *name* → DID; only the shell can). The future "pin from the piece" flow sidesteps this. Inline embed (vs link-out) is a deliberate follow-up.
- The **Performance Check** failure is a documented false positive: the CT-1754 *compiler* change invalidates the pattern compile cache, so this branch runs `cfcheck` cold (~3.5m) vs main's warm ~1m21s; same-machine cold timing is identical with/without the change (main 1m53s ≈ branch 1m57s). Not rebaselined — it self-heals once the cache warms post-merge.

Part of the profiles epic **CT-1645**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
