### PR TITLE
refactor: remove redundant JSONSchema casts around internSchema

### DIFF
--- a/packages/data-model/src/schema-utils.ts
+++ b/packages/data-model/src/schema-utils.ts
@@ -37,7 +37,7 @@ function getBasicSchema(key: string) {
   } else {
     const result = BASIC_SCHEMAS[key] = internSchema({
       type: key as JSONSchemaTypes,
-    }) as JSONSchemaObj;
+    });
     return result;
   }
 }
@@ -299,7 +299,7 @@ export function emptySchemaObject() {
   if (found) {
     return found;
   } else {
-    const result = BASIC_SCHEMAS[key] = internSchema({}) as JSONSchemaObj;
+    const result = BASIC_SCHEMAS[key] = internSchema({});
     return result;
   }
 }

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -87,8 +87,8 @@ const MAX_SERIALIZE_DEPTH = 100;
  * advertise it as an input parameter.
  */
 function stripInjectedResult(
-  schema: unknown,
-): unknown {
+  schema: JSONSchema,
+): JSONSchema {
   if (!schema || typeof schema !== "object") return schema;
   const obj = schema as Record<string, unknown>;
   if (obj.type !== "object") return schema;
@@ -135,7 +135,7 @@ function normalizeInputSchema(schemaLike: unknown): JSONSchema {
     };
   }
   if (!isObject(inputSchema)) inputSchema = { type: "object" };
-  const stripped = stripInjectedResult(inputSchema) as JSONSchema;
+  const stripped = stripInjectedResult(inputSchema);
   return prepareSchemaForLLM(stripped);
 }
 

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -1230,9 +1230,7 @@ function buildToolCatalog(
       logger.warn("llm", `No input schema found for tool ${entry.name}`);
       continue;
     }
-    const normalizedInputSchema = normalizeInputSchema(
-      inputSchema as JSONSchema | boolean,
-    ) as JSONSchema;
+    const normalizedInputSchema = normalizeInputSchema(inputSchema);
     const description: string = toolValue.description ??
       (normalizedInputSchema as any)?.description ?? "";
     llmTools[entry.name] = {

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -458,7 +458,7 @@ export class ContextualFlowControl {
           if (typeof optSchema !== "boolean" && typeof optSchema !== "object") {
             return optSchema;
           }
-          const subSchema = optSchema as JSONSchema | boolean;
+          const subSchema = optSchema as JSONSchema;
           if (subSchema === false) {
             continue;
           } else if (ContextualFlowControl.isTrueSchema(subSchema)) {
@@ -471,7 +471,7 @@ export class ContextualFlowControl {
             // `Set<JSONSchema>`, and correctly handles non-JSON-compatible
             // `FabricValue`s (e.g. `FabricEpochNsec`, `FabricBytes`,
             // `FabricHash`) that may appear in schema `default` fields.
-            subSchemas.add(internSchema(subSchema as JSONSchema));
+            subSchemas.add(internSchema(subSchema));
           }
         }
         // Only update cursor from subSchemas if the isTrueSchema branch

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1408,7 +1408,7 @@ function unwrapAsCellSchema(schema: JSONSchemaObj): JSONSchemaObj {
   const result = internSchema({
     ...restSchema,
     ...(asCellValues.length > 1 && { asCell: asCellValues.slice(1) }),
-  }) as JSONSchemaObj;
+  });
   if (cacheable) {
     unwrappedAsCellSchemaCache.set(schema, result);
   }

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -331,7 +331,7 @@ function combinatorRestSchema(
   const cached = byKeyword.get(keyword);
   if (cached !== undefined) return cached;
   const { [keyword]: _dropped, ...rest } = schema;
-  const interned = internSchema(rest as JSONSchema) as JSONSchemaObj;
+  const interned = internSchema(rest);
   byKeyword.set(keyword, interned);
   return interned;
 }


### PR DESCRIPTION
Audits and removes unnecessary type casts around `internSchema()` and related schema plumbing. `internSchema<T extends JSONSchema | undefined>(schema: T): T` returns the argument type unchanged, so casting its result is redundant whenever the argument is already the target type — and since every `JSONSchemaObj` property is optional, object literals and rest-spreads are assignable to it directly.

## Commits

- **drop redundant casts on `internSchema()` results** — `traverse.ts` (`internSchema(rest as JSONSchema) as JSONSchemaObj` → `internSchema(rest)`; the result cast only existed because the argument cast widened `T` to the union, forcing a re-narrow) and two `internSchema({...}) as JSONSchemaObj` sites in `schema-utils.ts`.
- **`cfc.ts` subSchema dedup** — `as JSONSchema | boolean` → `as JSONSchema` (`JSONSchema` already includes `boolean`), plus a vestigial `subSchema as JSONSchema` argument cast.
- **`llm-dialog.ts` dead casts** — `normalizeInputSchema(schemaLike: unknown): JSONSchema` takes `unknown` and returns `JSONSchema`, so both casts around the call were no-ops.
- **`stripInjectedResult` typed `JSONSchema → JSONSchema`** — it's a schema-*preserving* transform (returns input unchanged for booleans / non-`type:object` values, or a `result`-stripped shallow clone), so the tighter signature is honest and lets the caller drop its `as JSONSchema`. (Contrast `normalizeInputSchema`, which fabricates a schema from non-schema input and rightly keeps `unknown`.)

All changes are type-only erasure; no runtime behavior changes. `deno check`, `deno lint`, and `deno fmt --check` clean on every touched file.

## Deliberately left out

- `selector-tracker.ts:358` — load-bearing cast on a genuinely-generic `FabricValue` deep-walk; the "I passed a schema → I get a schema" assertion belongs at the call boundary, not as an overload on a value-generic helper.
- `cell.ts:2907` — the `as JSONSchema` there tames the `any` from a `JSON.parse(JSON.stringify(...))` round-trip. That round-trip is the real issue (it flattens non-JSON `FabricValue`s in schema `default`s) and is already tracked by `TODO(danfuzz)` in `cloneSchemaMutable`; it deserves its own correctness PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

This is a typesystem-only PR, so the following accounts for a performance problem not related to this PR (and might be spurious):

NEW_PERF_BASELINE: job: Check = 295s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes redundant JSON Schema casts around `internSchema` and tightens a helper signature to reduce noise and improve type safety. Type-only cleanup with no runtime changes.

- **Refactors**
  - Dropped `as JSONSchemaObj` and other result/argument casts around `internSchema(...)` in `traverse.ts`, `schema-utils.ts`, and `schema.ts`.
  - Simplified `cfc.ts` sub-schema handling by treating `JSONSchema | boolean` as `JSONSchema` and passing directly to `internSchema(...)`.
  - In `llm-dialog.ts`, typed `stripInjectedResult` as `JSONSchema -> JSONSchema` and removed no-op casts around `normalizeInputSchema(...)`.

<sup>Written for commit 2a7cab065c62c19fe97faec11e06e06841697027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

