### PR TITLE
fix(runner): refuse structural mutation of live query-result proxies

### DIFF
--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -516,6 +516,32 @@ export function createQueryResultProxy<T>(
       }
       return prop in value;
     },
+    // A query-result proxy is a live, transaction-backed view: reads resolve
+    // through the get trap on every access. Structural mutations (freeze, seal,
+    // defineProperty, delete) cannot be honored without either corrupting the
+    // backing store (when the proxy fronts the live value) or defeating live
+    // resolution (a non-configurable target property forces [[Get]] to return
+    // the target's own value, bypassing the trap). So we refuse them outright;
+    // callers that need an immutable/structurally-edited form must snapshot the
+    // proxy to a plain value first.
+    preventExtensions: () => {
+      throw new Error(
+        "Cannot freeze or seal a live cell-result proxy; snapshot it to a " +
+          "plain value first.",
+      );
+    },
+    defineProperty: () => {
+      throw new Error(
+        "Cannot define properties on a live cell-result proxy; assign through " +
+          "a transaction, or snapshot to a plain value first.",
+      );
+    },
+    deleteProperty: () => {
+      throw new Error(
+        "Cannot delete properties on a live cell-result proxy; mutate through " +
+          "a transaction, or snapshot to a plain value first.",
+      );
+    },
   }) as T;
 
   // Cache the proxy in the appropriate cache before returning

--- a/packages/runner/test/query-result-proxy-mutation-guard.test.ts
+++ b/packages/runner/test/query-result-proxy-mutation-guard.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("test proxy mutation guard");
+const space = signer.did();
+
+// A query-result proxy is a live, transaction-backed view. Structural
+// mutations (freeze/seal/defineProperty/delete) cannot be honored without
+// either corrupting the backing store or defeating live read-resolution, so
+// the proxy refuses them outright -- callers must snapshot to a plain value
+// first. These tests lock in that refusal.
+describe("query-result proxy structural-mutation guard", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  function makeProxy(): Record<string, unknown> {
+    const cell = runtime.getCell(space, "guarded", undefined, tx);
+    cell.set({ a: 1, b: { c: 2 } });
+    return cell.getAsQueryResult() as Record<string, unknown>;
+  }
+
+  it("refuses Object.freeze", () => {
+    const proxy = makeProxy();
+    expect(() => Object.freeze(proxy)).toThrow("live cell-result proxy");
+  });
+
+  it("refuses Object.seal", () => {
+    const proxy = makeProxy();
+    expect(() => Object.seal(proxy)).toThrow("live cell-result proxy");
+  });
+
+  it("refuses Object.preventExtensions", () => {
+    const proxy = makeProxy();
+    expect(() => Object.preventExtensions(proxy)).toThrow(
+      "live cell-result proxy",
+    );
+  });
+
+  it("refuses Object.defineProperty", () => {
+    const proxy = makeProxy();
+    expect(() =>
+      Object.defineProperty(proxy, "added", { value: 1, enumerable: true })
+    ).toThrow("live cell-result proxy");
+  });
+
+  it("refuses delete", () => {
+    const proxy = makeProxy();
+    expect(() => {
+      delete proxy.a;
+    }).toThrow("live cell-result proxy");
+  });
+
+  it("still allows a snapshotted plain copy to be frozen", () => {
+    const proxy = makeProxy();
+    // The documented escape hatch: round-trip to a detached plain value, which
+    // is freely freezable.
+    const snapshot = JSON.parse(JSON.stringify(proxy));
+    expect(() => Object.freeze(snapshot)).not.toThrow();
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(snapshot).toEqual({ a: 1, b: { c: 2 } });
+  });
+});


### PR DESCRIPTION
## Problem

A query-result proxy (`createQueryResultProxy`, `packages/runner/src/query-result-proxy.ts`) is a live, transaction-backed view: reads resolve through its `get` trap on every access. The handler defined only `get`, `set`, `ownKeys`, `getOwnPropertyDescriptor`, and `has` — **no** `preventExtensions`, `defineProperty`, or `deleteProperty`. So structural mutations forwarded to the proxy *target* via default `Reflect.*`:

- **Unfrozen backing value** (`proxyTarget = value`): the target *is* the live stored object, so `Object.freeze` / `Object.seal` / `Object.defineProperty` / `delete proxy.x` **silently mutated stored state**.
- **Frozen backing value** (stub target): `Object.freeze` prevent-extensions'd the empty stub, then threw a confusing invariant error on the first per-key `defineProperty`.

## Why not "just make freeze work"

A live resolving proxy is fundamentally incompatible with being frozen:

- A `preventExtensions` trap may only return `true` if the target is *actually* non-extensible — you can't swallow the freeze and lie that it succeeded.
- A non-configurable/non-writable target property forces `[[Get]]` to return the target's own value (ECMAScript 10.5.8), **bypassing the get trap's live link resolution**.

So "reads resolve live" and "reports itself frozen" are mutually exclusive. The coherent behavior is to refuse structural mutation, not fake it.

## Change

Add `preventExtensions`, `defineProperty`, and `deleteProperty` traps that throw a clear message directing callers to snapshot the proxy to a plain value first. **Reactive writes are unaffected** — `proxy.x = y` still routes through the `set` trap and a transaction; only structural mutation is blocked.

This formalizes an invariant the codebase already hand-maintains: every site that needs an immutable or structurally-edited form already snapshots/clones first —

- `internCellLinkSchema` (`cell.ts`) — `JSON.parse(JSON.stringify(...))` when `containsCellResult`.
- `annotateWithBackToCellSymbols` (`schema.ts:869`) — `shallowMutableClone` when `isCellResultForDereferencing`, before `defineProperty`+`freeze`.
- the `wish` builtin's `schemaAsCell` — JSON round-trip before `internSchema`.

So the guard can only catch *new* mistakes; it turns the previously silent backing-store corruption into a loud, actionable error.

## Verification

- Static trace of `runner/src` + `data-model/src`: no site applies a structural mutation to an un-snapshotted proxy.
- New focused regression test (`query-result-proxy-mutation-guard.test.ts`): freeze / seal / preventExtensions / defineProperty / delete each throw; a JSON-snapshotted plain copy still freezes fine.
- Full runner suite green: **626 passed, 0 failed**.

## Not in scope

This does **not** address the `JSON.parse(JSON.stringify(...))` round-trip in `internCellLinkSchema` — that round-trip flattens non-JSON `FabricValue`s in schema `default`s and wants a Fabric-aware clone, tracked separately by `TODO(danfuzz)` in `cloneSchemaMutable`. This PR only stops structural mutation from leaking to the backing store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

The following accounts for slowness not related to this PR:

NEW_PERF_BASELINE: job: Check = 273s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refuse structural mutation on live query-result proxies to prevent silent backing-store changes and confusing freeze/seal errors. Reactive writes via `set` still work.

- **Bug Fixes**
  - Added `preventExtensions`, `defineProperty`, and `deleteProperty` traps in `createQueryResultProxy` (in `packages/runner/src/query-result-proxy.ts`) that throw with a clear “snapshot to a plain value first” message.
  - Added `packages/runner/test/query-result-proxy-mutation-guard.test.ts` to verify `freeze`, `seal`, `preventExtensions`, `defineProperty`, and `delete` all throw, while a JSON-snapshotted copy can be frozen.

<sup>Written for commit d0932b274824d3b5680e4e8873fe80622b547c1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

