### PR TITLE
perf(ci): shard cfcheck across parallel jobs

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -43,11 +43,31 @@ jobs:
       - name: 🔎 Type check codebase
         run: deno task check
 
-      - name: 🔎 Check Common Fabric patterns
-        run: deno task cfcheck
-
       - name: 🧭 Check cf-review skill facts
         run: deno task check-skill-facts
+
+  cfcheck:
+    name: "CFC Pattern Check (${{ matrix.shard }}/${{ matrix.total }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+        total: [4]
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🦕 Setup Deno
+        uses: ./.github/actions/deno-setup
+
+      - name: 🔍 Verify lock file & install dependencies
+        run: deno install --frozen=true
+
+      - name: 🔎 Check Common Fabric patterns
+        env:
+          CFCHECK_SHARD: "${{ matrix.shard }}/${{ matrix.total }}"
+        run: deno task cfcheck
 
   test:
     name: "Test"

--- a/tasks/cfcheck.ts
+++ b/tasks/cfcheck.ts
@@ -92,9 +92,37 @@ function formatError(error: unknown): string {
   return String(error);
 }
 
+// Optional sharding for CI fan-out: CFCHECK_SHARD="i/n" (1-based) checks only
+// the files where (index % n) == (i - 1). Pattern compiles are single-threaded
+// CPU work that doesn't parallelize within one process, so the way to use more
+// cores is more PROCESSES — run n shards as n parallel CI jobs (mirrors the
+// existing "Pattern Tests (1/4..4/4)" fan-out). Stale-exclusion validation
+// runs on shard 1 only (it needs the full file list).
+function parseShard(): { index: number; count: number } {
+  const raw = Deno.env.get("CFCHECK_SHARD");
+  if (!raw) return { index: 0, count: 1 };
+  const match = raw.match(/^(\d+)\/(\d+)$/);
+  if (!match) {
+    console.error(`Invalid CFCHECK_SHARD "${raw}"; expected "i/n" (1-based).`);
+    Deno.exit(1);
+  }
+  const index = Number(match[1]) - 1;
+  const count = Number(match[2]);
+  if (count < 1 || index < 0 || index >= count) {
+    console.error(`CFCHECK_SHARD "${raw}" out of range.`);
+    Deno.exit(1);
+  }
+  return { index, count };
+}
+
+const shard = parseShard();
+
 const allFiles = await collectPatternFiles(PATTERNS_DIR);
-const filesToCheck = allFiles.filter((file) =>
+const eligibleFiles = allFiles.filter((file) =>
   !EXCLUDED_PATTERN_FILES.has(file)
+);
+const filesToCheck = eligibleFiles.filter((_file, i) =>
+  i % shard.count === shard.index
 );
 const excludedPresent = allFiles.filter((file) =>
   EXCLUDED_PATTERN_FILES.has(file)
@@ -103,15 +131,19 @@ const staleExclusions = [...EXCLUDED_PATTERN_FILES].filter((file) =>
   !allFiles.includes(file)
 );
 
-if (staleExclusions.length > 0) {
+// Stale exclusions reference the full corpus, so only the first shard checks.
+if (shard.index === 0 && staleExclusions.length > 0) {
   console.error("Stale cfcheck exclusions:");
   for (const file of staleExclusions) console.error(`  ${file}`);
   Deno.exit(1);
 }
 
+const shardLabel = shard.count > 1
+  ? ` [shard ${shard.index + 1}/${shard.count}]`
+  : "";
 console.log(
   `Common Fabric checking ${filesToCheck.length} pattern files` +
-    ` (${excludedPresent.length} excluded).`,
+    ` (${excludedPresent.length} excluded)${shardLabel}.`,
 );
 
 const failures: Array<{ file: string; error: string }> = [];


### PR DESCRIPTION
## Problem

The `deno task cfcheck` step added in #4138 compiles all ~359 pattern files and was wired into the **Check** job. On the 2-vCPU `ubuntu-latest` runner it takes **~200s**, which tripled the Check job (≈80s → ≈280s the moment #4138 landed) and has been tripping the **perf-check** gate on essentially every PR since.

## Why sharding (and not batching / caching)

I measured the alternatives before landing this:

| Approach | full-run | result |
|---|---|---|
| baseline | ~68s local / ~200s CI | — |
| in-process batch = `hardwareConcurrency` | ~78s local | **worse** — these are single-threaded synchronous TS compiles; batching gives no CPU parallelism, only memory pressure |
| reuse compiler + cache parsed lib SourceFiles | ~70s local | **no meaningful win** — per-program bind+typecheck dominates, not lib parsing |
| `ts.createProgram` `oldProgram` reuse | ~76s local | **no win** — each pattern is a distinct root, so TS structural reuse bails |
| **4 parallel processes (this PR)** | **26s local (vs 70s serial)** | **2.7x; on CI ~4x via separate runners** |

The only thing that uses more cores is more **processes**. (A deeper amortization — typechecking all patterns in one shared program, like `batchTypeCheckFixtures` does for the test suite — is a real follow-up I'm prototyping separately; it needs the per-pattern transform decoupled from the typecheck.)

## Change

- `tasks/cfcheck.ts` gains `CFCHECK_SHARD="i/n"` (1-based, modulo split). The stale-exclusion check runs on shard 1 only (it needs the full file list). Unset → checks everything, unchanged.
- `.github/workflows/deno.yml`: cfcheck moves out of the Check job into a **4-way matrix job** (`CFC Pattern Check (i/4)`), mirroring the existing `Runner Tests (i/4)` fan-out. Each shard checks ~90 files on its own runner.

Net: cfcheck wall-clock drops ~4x, it no longer gates the Check status, and the Check job (and the perf-check) return to their ~80s baseline.

## Verification

- 4 shards split 90/90/90/89 = 359, every shard exits 0.
- 4 concurrent shards: 26s wall vs 70s serial locally.
- Default `deno task cfcheck` (no shard env) checks all 359, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sharded `deno task cfcheck` across 4 parallel CI jobs to cut wall time and unblock the main Check. Adds `CFCHECK_SHARD="i/n"` support and moves the check into a matrix job, dropping runtime ~4x and restoring the Check job to its ~80s baseline.

- **New Features**
  - `tasks/cfcheck.ts`: supports `CFCHECK_SHARD="i/n"` modulo split; shard 1 runs stale-exclusion validation; unset checks all files.
  - `.github/workflows/deno.yml`: removes cfcheck from Check and adds a 4-way matrix job (“CFC Pattern Check (i/4)”) so each shard runs on its own runner.

<sup>Written for commit e3c96973d3f566e4df9e073dfb47f4769567f398. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

