### PR TITLE
perf(cfcheck): type-check + verify all patterns in one batched program

### DIFF
--- a/packages/cli/lib/dev.ts
+++ b/packages/cli/lib/dev.ts
@@ -19,7 +19,7 @@ import { experimentalOptionsFromEnv } from "./utils.ts";
 const FABRIC_IMPORTS_REQUIRE_SPACE_MESSAGE =
   "fabric imports require a space context (options.fabricImports)";
 
-async function createRuntime() {
+export async function createRuntime() {
   const { StorageManager } = await import(
     "@commonfabric/runner/storage/cache.deno"
   );

--- a/packages/js-compiler/typescript/compiler.ts
+++ b/packages/js-compiler/typescript/compiler.ts
@@ -468,7 +468,17 @@ export class TypeScriptCompiler {
     const sourceByStem = new Map<string, string>();
     for (const name of sourceNames) {
       if (name.endsWith(".d.ts")) continue;
-      sourceByStem.set(name.replace(/\.[^./]+$/, ""), name);
+      const stem = name.replace(/\.[^./]+$/, "");
+      const existing = sourceByStem.get(stem);
+      if (existing !== undefined) {
+        // Two sources emit to the same `<stem>.js` (e.g. `/a.ts` and `/a.tsx`).
+        // The output→source mapping would be ambiguous; fail loudly rather than
+        // silently drop one (parity with compileToModules).
+        throw new Error(
+          `Ambiguous emit target: '${existing}' and '${name}' both compile to '${stem}.js'`,
+        );
+      }
+      sourceByStem.set(stem, name);
     }
     const writes = host.getWrites();
     const modules = new Map<string, { js: string; sourceMap?: SourceMap }>();

--- a/packages/js-compiler/typescript/compiler.ts
+++ b/packages/js-compiler/typescript/compiler.ts
@@ -388,6 +388,101 @@ export class TypeScriptCompiler {
     }
     return result;
   }
+
+  /**
+   * Like {@link compileToModules}, but COLLECTS type/declaration/transformer
+   * diagnostics per file instead of throwing on the first one. Returns the
+   * emitted bodies plus every error-severity diagnostic, each attributed to its
+   * source file. For batch callers (cfcheck over the whole pattern corpus) that
+   * must report all failing patterns by name, not abort on the first.
+   */
+  compileToModulesCollecting(
+    program: Program,
+    inputOptions: TypeScriptCompilerOptions = {},
+  ): {
+    modules: Map<string, { js: string; sourceMap?: SourceMap }>;
+    diagnostics: { file: string; message: string }[];
+  } {
+    const runtimeModules = inputOptions.runtimeModules ?? [];
+    validateSource(program);
+    const sourceNames = program.files.map(({ name }) => name);
+    const tsOptions = getCompilerOptions();
+    tsOptions.skipLibCheck = true;
+
+    const host = new TypeScriptHost(
+      program,
+      this.typeLibs,
+      runtimeModules,
+      inputOptions.specifierAliases,
+    );
+    const tsProgram = ts.createProgram(sourceNames, tsOptions, host);
+
+    const authored = new Set(
+      program.files.filter((f) => !f.name.endsWith(".d.ts")).map((f) => f.name),
+    );
+    const diagnostics: { file: string; message: string }[] = [];
+    const pushTs = (d: ts.Diagnostic) => {
+      const message = ts.flattenDiagnosticMessageText(d.messageText, "\n");
+      if (d.file) {
+        const { line } = d.file.getLineAndCharacterOfPosition(d.start ?? 0);
+        diagnostics.push({
+          file: d.file.fileName,
+          message: `${line + 1}: ${message}`,
+        });
+      } else {
+        diagnostics.push({ file: "", message });
+      }
+    };
+
+    // Type + declaration diagnostics for authored files only (skipLibCheck
+    // already excludes the declaration libs).
+    for (const sourceFile of tsProgram.getSourceFiles()) {
+      if (!authored.has(sourceFile.fileName)) continue;
+      for (const d of tsProgram.getSemanticDiagnostics(sourceFile)) pushTs(d);
+      for (const d of tsProgram.getSyntacticDiagnostics(sourceFile)) pushTs(d);
+    }
+
+    // Transform + emit, collecting (not throwing) transformer diagnostics.
+    const { beforeTransformers, getDiagnostics } = createTransformers(
+      tsProgram,
+      inputOptions,
+    );
+    const { diagnostics: emitDiagnostics } = tsProgram.emit(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { before: beforeTransformers },
+    );
+    for (const d of emitDiagnostics) pushTs(d);
+    if (getDiagnostics) {
+      for (const d of getDiagnostics()) {
+        if (d.severity !== "error") continue;
+        diagnostics.push({
+          file: d.fileName,
+          message: `${d.line}: ${d.message}`,
+        });
+      }
+    }
+
+    const sourceByStem = new Map<string, string>();
+    for (const name of sourceNames) {
+      if (name.endsWith(".d.ts")) continue;
+      sourceByStem.set(name.replace(/\.[^./]+$/, ""), name);
+    }
+    const writes = host.getWrites();
+    const modules = new Map<string, { js: string; sourceMap?: SourceMap }>();
+    for (const [outName, contents] of Object.entries(writes)) {
+      if (!outName.endsWith(".js")) continue;
+      const sourceName = sourceByStem.get(outName.replace(/\.js$/, ""));
+      if (sourceName === undefined) continue;
+      modules.set(sourceName, {
+        js: contents,
+        sourceMap: parseSourceMap(writes[`${outName}.map`]),
+      });
+    }
+    return { modules, diagnostics };
+  }
 }
 
 function validateSource(artifact: Program) {

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -520,6 +520,12 @@ export class Engine extends EventTarget implements Harness {
     fileCount: number;
     diagnostics: readonly { file?: string; message: string }[];
   }> {
+    // Nothing to check (e.g. an empty CI shard, or every program failed to
+    // resolve upstream) — there is no entry to compile, so return cleanly.
+    if (programs.length === 0) {
+      return { patternCount: 0, fileCount: 0, diagnostics: [] };
+    }
+
     const runTransform = options.transform ?? true;
     const unioned = new Map<string, Source>();
     const mains: string[] = [];

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -498,6 +498,94 @@ export class Engine extends EventTarget implements Harness {
   }
 
   /**
+   * PROTOTYPE (cfcheck #2): type-check + SES-verify many authored programs in a
+   * SINGLE TypeScript program.
+   *
+   * Each program is resolved with the runtime `.d.ts` type environment injected
+   * exactly as {@link compileToRecordGraph} does (pretransform → resolve), then
+   * every resolved file is unioned and compiled as roots of one `ts.Program`.
+   * The expensive lib/API parse+bind+typecheck is therefore paid ONCE for the
+   * whole batch instead of once per program — the amortization the per-pattern
+   * cfcheck path (≈330 separate programs) throws away.
+   *
+   * Returns the batch's transformer/type diagnostics rather than throwing, so a
+   * caller can attribute failures. NOT wired into anything yet; measures the
+   * ceiling and surfaces cross-program hazards (e.g. duplicate `declare global`).
+   */
+  async typeCheckBatch(
+    programs: RuntimeProgram[],
+    options: { transform?: boolean } = {},
+  ): Promise<{
+    patternCount: number;
+    fileCount: number;
+    diagnostics: readonly { file?: string; message: string }[];
+  }> {
+    const runTransform = options.transform ?? true;
+    const unioned = new Map<string, Source>();
+    const mains: string[] = [];
+    for (const program of programs) {
+      const id = computeId(program);
+      const mapped = pretransformProgramForModules(program, id);
+      const resolver = new EngineProgramResolver(
+        mapped,
+        this.ctRuntime.staticCache,
+      );
+      const resolved = await this.resolve(resolver);
+      for (const file of uniqueSourcesByName(resolved.files)) {
+        if (!unioned.has(file.name)) unioned.set(file.name, file);
+      }
+      mains.push(mapped.main);
+    }
+
+    const merged: RuntimeProgram = {
+      main: mains[0]!,
+      files: [...unioned.values()],
+    };
+
+    const { compiler } = await this.getCompilerInternals();
+    const { modules, diagnostics: compileDiagnostics } = compiler
+      .compileToModulesCollecting(merged, {
+        runtimeModules: Engine.runtimeModuleNames(),
+        beforeTransformers: runTransform
+          ? (program) => {
+            const pipeline = new CommonFabricTransformerPipeline();
+            return {
+              factories: pipeline.toFactories(program),
+              getDiagnostics: () => pipeline.getDiagnostics(),
+            };
+          }
+          : undefined,
+      });
+    const diagnostics: { file?: string; message: string }[] = [
+      ...compileDiagnostics,
+    ];
+
+    // SES-verify each emitted body. compileToRecordGraph runs this per module
+    // (verifyCompiledModuleBody); compileToModules does not, so the batch must
+    // run it explicitly or it would silently lose cfcheck's SES coverage. Body
+    // verification is per-body AST work (no type-checking), so it stays cheap.
+    if (runTransform) {
+      for (const [name, body] of modules) {
+        if (name.endsWith(".d.ts")) continue;
+        try {
+          verifyCompiledModuleBody(body.js, name);
+        } catch (error) {
+          diagnostics.push({
+            file: name,
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+
+    return {
+      patternCount: programs.length,
+      fileCount: unioned.size,
+      diagnostics,
+    };
+  }
+
+  /**
    * Cold-recovery path: recompile cacheable modules from the AUTHORED source
    * already stored in the content-addressed **source set** (`pattern:<identity>`
    * cells), loaded by identity — i.e. recreate the pattern from its stored

--- a/tasks/cfcheck.ts
+++ b/tasks/cfcheck.ts
@@ -1,7 +1,7 @@
-import { process } from "../packages/cli/lib/dev.ts";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { createRuntime } from "../packages/cli/lib/dev.ts";
 
 const PATTERNS_DIR = "packages/patterns";
-const CHECK_BATCH_SIZE = 8;
 
 const NON_PATTERN_PREFIXES = [
   "packages/patterns/integration/",
@@ -147,26 +147,36 @@ console.log(
 );
 
 const failures: Array<{ file: string; error: string }> = [];
+const cwd = Deno.cwd();
 
-for (let i = 0; i < filesToCheck.length; i += CHECK_BATCH_SIZE) {
-  const batch = filesToCheck.slice(i, i + CHECK_BATCH_SIZE);
-  await Promise.all(
-    batch.map(async (file) => {
-      try {
-        await process({
-          main: `${Deno.cwd()}/${file}`,
-          rootPath: Deno.cwd(),
-          check: true,
-          run: false,
-        });
-      } catch (error) {
-        failures.push({
-          file,
-          error: formatError(error),
-        });
-      }
-    }),
-  );
+// Resolve every pattern's authored module graph (the pattern + its local
+// imports). A resolve failure — e.g. a malformed import — is a per-file
+// failure, reported like any other.
+const runtime = await createRuntime();
+const programs = [];
+for (const file of filesToCheck) {
+  try {
+    programs.push(
+      await runtime.harness.resolve(
+        new FileSystemProgramResolver(`${cwd}/${file}`, cwd),
+      ),
+    );
+  } catch (error) {
+    failures.push({ file, error: formatError(error) });
+  }
+}
+
+// Type-check + transform + SES-verify ALL patterns in ONE TypeScript program.
+// The lib/API parse+bind is paid once for the whole shard instead of once per
+// pattern (the per-program bind, not the type-check itself, was cfcheck's
+// dominant cost — measured). Diagnostics come back attributed per file.
+const result = await runtime.harness.typeCheckBatch(programs);
+for (const diagnostic of result.diagnostics) {
+  // Strip the engine's internal `/fid1:<hash>` path prefix back to a repo path.
+  const file = (diagnostic.file ?? "")
+    .replace(/^\/fid1:[^/]+\//, "")
+    .replace(`${cwd}/`, "") || "(batch)";
+  failures.push({ file, error: diagnostic.message });
 }
 
 if (failures.length > 0) {


### PR DESCRIPTION
**Stacked on #4168** (sharding). Review the top commit. Productionizes the batched-typecheck approach we validated by prototype.

## Why

cfcheck compiled each of ~359 patterns as its **own** TypeScript program. The dominant cost isn't the type-check — it's the per-program lib/API parse+bind, paid once per pattern. Measured on the full corpus (my machine):

| | time |
|---|---|
| per-pattern, with type-check | 68.9s |
| per-pattern, `noCheck:true` (no type-check) | **69.8s** — *same* |
| **batched, one program** | **34s** (typecheck+transform+SES) |

`noCheck` saving nothing is the tell: the repeated bind dominates, and only one shared program fixes it.

## What

- **engine `typeCheckBatch(programs)`**: resolves each authored program with the runtime `.d.ts` environment injected (same path `compileToRecordGraph` uses), unions every file, compiles them as roots of ONE program. Runs the SES body verifier (`verifyCompiledModuleBody`) per emitted module — `compileToModules` doesn't run it (unlike `compileToRecordGraph`), so the batch must, or it would silently drop cfcheck's Secure-ECMAScript coverage.
- **js-compiler `compileToModulesCollecting`**: mirrors `compileToModules` but **collects** type/syntactic/transformer diagnostics per file instead of throwing on the first — so cfcheck names every failing pattern, not just the first.
- **cfcheck**: resolve all (sharded) files → one `typeCheckBatch`. Composes with #4168: each shard batches its ~90 files into one program.

## Coverage parity — the investigation

While prototyping, the batch appeared to "miss" a failure the per-pattern path caught (`cfc/api-cfc.ts`, an SES "Top-level value not allowed"). Run to ground: **`api-cfc.ts` is a symlink** (`→ ../../api/cfc.ts`), and cfcheck's `if (!entry.isFile) continue;` guard deliberately skips symlinks — so cfcheck never checks it; my prototype's walk just over-collected it. No real gap. I then added the SES body verifier to the batch so SES violations *are* caught regardless.

## Verification

- 359-file real set → **0 errors** (parity with current cfcheck green); no cross-pattern global-declaration clashes.
- Negative controls: a type error and an SES violation are both **caught and attributed to the right file** with line numbers, reporting *all* failures (not fail-fast).
- js-compiler tests green; harness/engine/compile runner tests 28/28; full repo `deno task check` green.
- ~70s → ~36s serial; ~17s across 4 concurrent shards locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch type-checks all `cfcheck` patterns in one TypeScript program and verifies SES per module, removing repeated lib/API binding and cutting run time (~70s → ~36s serial; ~17s with sharding). Keeps parity and reports all failures with per-file attribution.

- **New Features**
  - Added `Engine.typeCheckBatch(programs)` to compile all patterns in one program and run SES body verification per emitted module.
  - Added `TypeScriptCompiler.compileToModulesCollecting` to collect type/syntax/transformer diagnostics per file.
  - Updated `cfcheck` to resolve all patterns via `FileSystemProgramResolver` and run a single batch per shard; exported `createRuntime` from `packages/cli/lib/dev.ts` for reuse.

- **Bug Fixes**
  - `typeCheckBatch` returns cleanly for empty input (avoids undefined main crash).
  - `compileToModulesCollecting` guards ambiguous emit targets (e.g., `a.ts` + `a.tsx`), failing loudly instead of overwriting.

<sup>Written for commit a3c9967ee36ef0d68be2f9de264253e9ad760c73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/main.test.tsx = 26s
---END COPY-PASTE---