### PR TITLE
fix(runner): detect links that target their own subpath

### DIFF
--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -91,7 +91,7 @@ const canFollowLinkHop = (
  *
  * It returns a `ResolvedFullLink` that points to a document that no longer has
  * any links between the top and the value at `link.path`. When a cycle is
- * detected, a warning is logged and a static link to `undefined` returned.
+ * detected, an error is logged and thrown.
  *
  * `lastNode` controls whether to follow links on the last path segment. By
  * default all links are followed, but if `lastNode` is `LastNode.WriteRedirect`
@@ -107,13 +107,16 @@ const canFollowLinkHop = (
  * - A/foo → A/foo
  * - A → B → C → A
  *
- * But there are cycles that can lead to growing paths, e.g.
- * - A → A/foo
+ * A link whose target passes back through the link's own position in the same
+ * document (e.g. A → A/foo) makes the path grow on every hop, so the pair
+ * never repeats; that shape is detected separately on the first hop.
+ *
+ * Growing-path cycles that span documents, e.g.
  * - A → B, B → A/foo
  *
- * These are difficult to detect, since there are many legitimate cases for the
- * same link to be followed several times, so instead we just have an upper
- * bound of 1000 iterations, and log a warning.
+ * are difficult to detect, since there are many legitimate cases for the
+ * same link to be followed several times, so they are bounded by an upper
+ * limit of `MAX_PATH_RESOLUTION_LENGTH` iterations, which throws.
  *
  * @param tx - The storage transaction to read from.
  * @param link - The link to read.
@@ -281,6 +284,24 @@ export function resolveLink(
         ]);
         link = undefinedDataLink(link);
         break;
+      }
+      // A link whose target passes back through the link's own position can
+      // never resolve: the value at that position is the link itself, so
+      // every hop re-follows it with a longer path and the (document, path)
+      // cycle key never repeats. Detect this on the first hop.
+      const hopSource = nextHop.source;
+      const hopTarget = nextHop.link;
+      if (
+        hopTarget.space === hopSource.space &&
+        hopTarget.id === hopSource.id &&
+        hopTarget.scope === hopSource.scope &&
+        hopTarget.path.length > hopSource.path.length &&
+        hopSource.path.every((part, i) => hopTarget.path[i] === part)
+      ) {
+        const detail = `link at [${hopSource.path.join("/")}] targets its ` +
+          `own subpath [${hopTarget.path.join("/")}]`;
+        logger.error("link-res-error", `Link cycle detected: ${detail}`);
+        throw new Error(`Link cycle detected at ${key}: ${detail}`);
       }
       recordDereferenceHop(tx, nextHop);
       const nextLink = nextHop.link;

--- a/packages/runner/test/link-resolution.bench.ts
+++ b/packages/runner/test/link-resolution.bench.ts
@@ -233,12 +233,12 @@ Deno.bench("resolveLink with infinitely growing path (A->A/foo)", () => {
   // Create a link from A to A/foo using setRaw to bypass cycle detection on write
   cellA.setRaw(cellA.key("foo").getAsLink());
 
-  // resolveLink throws when it hits the iteration limit for growing path cycles
+  // resolveLink detects the self-subpath cycle on the first hop and throws
   let threw = false;
   try {
     resolveLink(runtime, tx, cellA.getAsNormalizedFullLink());
   } catch (e) {
-    if (e instanceof Error && e.message.includes("iteration limit")) {
+    if (e instanceof Error && e.message.includes("Link cycle detected")) {
       threw = true;
     } else {
       throw e;
@@ -246,7 +246,7 @@ Deno.bench("resolveLink with infinitely growing path (A->A/foo)", () => {
   }
 
   if (!threw) {
-    throw new Error("Expected resolveLink to throw iteration limit error");
+    throw new Error("Expected resolveLink to throw a cycle error");
   }
 
   tx.commit();

--- a/packages/runner/test/link-resolution.test.ts
+++ b/packages/runner/test/link-resolution.test.ts
@@ -1155,8 +1155,9 @@ describe("link-resolution", () => {
       expect(() => cellB.get()).toThrow();
     });
 
-    it("detects cycle when resolving link to its own subpath", async () => {
-      // Test case: A -> A/foo creates an infinite growing path
+    it("detects cycle when resolving link to its own subpath", () => {
+      // Test case: A -> A/foo creates an infinite growing path. The
+      // self-subpath shape is detected on the first hop.
       const cellA = runtime.getCell<any>(
         space,
         "self-subpath-cycle",
@@ -1167,32 +1168,100 @@ describe("link-resolution", () => {
       // Create a link from A to A/foo
       cellA.setRaw(cellA.key("foo").getAsLink());
 
-      // Race the resolution against a 1 second timeout to ensure it doesn't hang
-      let timeoutId: ReturnType<typeof setTimeout> | undefined;
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(
-          () => reject(new Error("Resolution timed out after 1 second")),
-          1000,
-        );
-      });
+      expect(() => resolveLink(runtime, tx, cellA.getAsNormalizedFullLink()))
+        .toThrow("Link cycle detected");
+    });
 
-      const resolutionPromise = new Promise<any>((resolve) => {
-        // When we resolve this link, it should detect the growing path cycle
-        // and return the empty document with a data: URI
-        resolve(resolveLink(runtime, tx, cellA.getAsNormalizedFullLink()));
-      });
+    it("detects cycle for a self-subpath link below the document root", () => {
+      // Test case: A/a -> A/a/b
+      const cellA = runtime.getCell<any>(
+        space,
+        "nested-self-subpath-cycle",
+        undefined,
+        tx,
+      );
 
-      try {
-        await expect(Promise.race([resolutionPromise, timeoutPromise])).rejects
-          .toThrow(
-            "Link resolution iteration limit reached",
-          );
-      } finally {
-        // Clean up the timeout if it was set
-        if (timeoutId !== undefined) {
-          clearTimeout(timeoutId);
-        }
-      }
+      cellA.setRaw({ a: cellA.key("a").key("b").getAsLink() });
+
+      expect(() =>
+        resolveLink(runtime, tx, cellA.key("a").getAsNormalizedFullLink())
+      )
+        .toThrow("Link cycle detected");
+    });
+
+    it("reads of a self-subpath link fail deterministically", () => {
+      // The Cell Inspector wedge shape: every read fails immediately with a
+      // cycle error rather than burning the resolution iteration budget.
+      const cellA = runtime.getCell<any>(
+        space,
+        "wedge-read-cycle",
+        undefined,
+        tx,
+      );
+
+      cellA.setRaw(cellA.key("x").getAsLink());
+
+      expect(() => cellA.get()).toThrow("Link cycle detected");
+    });
+
+    it("follows same-document links to sibling paths", () => {
+      // A link within a document targeting a non-overlapping path resolves.
+      const cellA = runtime.getCell<any>(
+        space,
+        "same-doc-sibling-link",
+        undefined,
+        tx,
+      );
+
+      cellA.setRaw({ x: cellA.key("y").getAsLink(), y: 5 });
+
+      expect(cellA.key("x").get()).toBe(5);
+    });
+
+    it("resolves same-document links to an ancestor path", () => {
+      // A link at a deeper path targeting its own ancestor is not the
+      // self-subpath shape (the target does not pass through the link's
+      // position); resolution terminates at the ancestor.
+      const cellA = runtime.getCell<any>(
+        space,
+        "same-doc-ancestor-link",
+        undefined,
+        tx,
+      );
+
+      cellA.setRaw({ a: { b: cellA.key("a").getAsLink() } });
+
+      const resolved = resolveLink(
+        runtime,
+        tx,
+        cellA.key("a").key("b").getAsNormalizedFullLink(),
+      );
+      expect(resolved.id).toBe(cellA.getAsNormalizedFullLink().id);
+      expect(resolved.path).toEqual(["a"]);
+    });
+
+    it("bounds cross-document growing-path cycles by the iteration limit", () => {
+      // Test case: A -> B, B -> A/foo. The path grows through two documents,
+      // so the first-hop self-subpath check does not apply; the iteration
+      // limit still backstops it.
+      const cellA = runtime.getCell<any>(
+        space,
+        "cross-doc-growing-A",
+        undefined,
+        tx,
+      );
+      const cellB = runtime.getCell<any>(
+        space,
+        "cross-doc-growing-B",
+        undefined,
+        tx,
+      );
+
+      cellA.setRaw(cellB.getAsLink());
+      cellB.setRaw(cellA.key("foo").getAsLink());
+
+      expect(() => resolveLink(runtime, tx, cellA.getAsNormalizedFullLink()))
+        .toThrow("Link resolution iteration limit reached");
     });
 
     it("detects cycles in nested paths", () => {


### PR DESCRIPTION
Link resolution detects cycles by remembering each (space, document, scope, path) tuple it visits and throwing when one repeats. A link whose target passes back through the link's own position in the same document escapes that check: the value at that position is the link itself, so every hop re-follows the same link with a path one segment longer. The tuple never repeats, so resolution kept going until it hit the iteration cap and threw a generic "iteration limit reached" — after ~100 hops and ~200 storage reads — on every read of such a cell.

Detect this shape on the first hop instead. When a followed link's target is in the same document and scope as the position the link was found at, and that position's path is a strict prefix of the target path, the link can never resolve, so throw a "Link cycle detected" error immediately. This reports the problem deterministically in one or two reads rather than burning the resolution budget.

The check runs after the scope-follow guard, so a self-referential link that is also scope-blocked still resolves to undefined as before. Sibling links (A/x -> A/y) and ancestor links (A/a/b -> A/a), whose target paths are not a strict extension of the link's position, are unaffected. Growing-path cycles that span multiple documents still can't be recognized up front and remain bounded by the iteration cap.

Also corrects the resolveLink docstring, which described an older behavior (log a warning and return undefined, with a 1000-iteration bound) that no longer matches the code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect and fail fast when a link targets its own subpath (e.g. A -> A/foo), throwing a clear "Link cycle detected" on the first hop instead of hitting the iteration limit. This makes failures deterministic and reduces storage reads.

- **Bug Fixes**
  - Add a first-hop check in resolveLink: if same space/id/scope and the source path is a strict prefix of the target, log and throw with source/target path details.
  - Preserve scope guard: scope-blocked self-references still resolve to undefined; same-document sibling/ancestor links still resolve; cross-document growing-path cycles remain bounded by `MAX_PATH_RESOLUTION_LENGTH`.
  - Update docstring, tests, and bench to expect the new error and cover nested self-subpath, deterministic read failures, sibling/ancestor success, and cross-document cycles.

<sup>Written for commit ecb1872833bb199dc8dd5f97c54290a9d0e91e77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

