### PR TITLE
fix(integration): add viewSettled readiness primitive and fix flaky d…

### DIFF
--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -184,6 +184,68 @@ describe("shadow DOM component test", () => {
 });
 ```
 
+## Waiting Until the UI Is Interactive
+
+Finding an element is one problem; knowing *when* it is ready to be clicked or
+typed into is a separate one. The reactive scheduler runs in a worker while the
+DOM lives on the main thread, so after a state change there are three stages
+before a control is interactive:
+
+1. the worker settles reactively — `rt.idle()` covers this;
+2. the resulting vdom batch crosses to the main thread and is applied — this is
+   where the click listener is attached;
+3. the Lit elements finish their update cycle — `cf-modal`, for example, only
+   binds handlers and removes `pointer-events: none` in its `updated()`
+   callback, one cycle after its `open` property is set.
+
+Only stage 1 is visible through the runtime idle signal, so an element can exist
+in the DOM, be found by a selector, and still drop a click because its handler
+is not bound yet.
+
+**Use `awaitViewSettled(page)`** from `@commonfabric/integration` before issuing
+the first click or keystroke after navigation or any state change. It resolves
+once all three stages are done, so a single click then lands on a bound handler:
+
+```typescript
+import { awaitViewSettled, waitFor } from "@commonfabric/integration";
+
+// Before interacting: wait until the view is mounted and interactive.
+await waitFor(() => awaitViewSettled(page));
+const button = await page.waitForSelector("cf-button[role='button']");
+await button.click(); // delivered to a bound handler
+
+// After interacting: settle, then wait for the click's specific effect.
+await waitFor(async () => {
+  await awaitViewSettled(page);
+  return (await page.$("cf-modal[open]", { strategy: "pierce" })) !== null;
+});
+```
+
+### Do not reach for these instead
+
+Each of the following is what `awaitViewSettled` replaces. They are either racy
+(they do not cover all three stages) or wasteful (a CDP round trip every poll):
+
+- **`await sleep(ms)`, `page.waitForTimeout(ms)`, or any fixed delay** — guesses
+  at timing; too short flakes, too long wastes wall-clock.
+- **`await rt.idle()` or `awaitRuntimeIdle(page)` alone, then interact** — covers
+  stage 1 only. The element may be in the DOM with no handler bound, or be a
+  `cf-modal` whose `pointer-events` are still off.
+- **`await waitFor(() => findButtonWithText(page, "X"))` then click** — presence
+  is not interactivity, and every poll is a CDP `evaluate` round trip (the
+  default 50 ms interval also quantizes timing measurements; see
+  `packages/integration/utils.ts`).
+- **`await waitFor(() => clickButtonWithText(page, "X"))`, re-clicking until it
+  "takes"** — fires the stimulus speculatively. It can double-fire (creating
+  duplicate state) and, against a `dismissable` overlay such as `cf-modal`,
+  repeated clicks behind the open modal dismiss it and leave the test stuck.
+- **`page.waitForSelector(...)` in a retry loop to "wait it out"** — Astral's
+  `waitForSelector` is itself a tight CDP poll, and a present element is not a
+  ready one.
+
+The shape is always: settle the view, click once, then wait for the effect —
+never poll-and-pray, and never re-click.
+
 ## Best Practices
 
 1. **Use roles first**: `button`, `textbox`, `checkbox`, etc.

--- a/packages/html/src/debug.ts
+++ b/packages/html/src/debug.ts
@@ -140,6 +140,100 @@ function formatTree(node: unknown, indent = 0): string {
 }
 
 /**
+ * Walk every active render's DOM subtree, descending through shadow roots, and
+ * await `updateComplete` on each Lit element. Returns true if any element was
+ * mid-update — pending when scanned, or resolving its `updateComplete` to a
+ * re-triggered or thrown update during the drain — which signals the view was
+ * not yet settled and the caller should drain again.
+ *
+ * This closes the gap between "the worker is reactively idle" and "the DOM is
+ * interactive": custom elements such as cf-modal enable pointer events and bind
+ * handlers in their Lit `updated()` callback, one update cycle after the
+ * property that drives them is set.
+ *
+ * `roots` defaults to every active render's container; pass explicit roots to
+ * scope the drain (used by tests).
+ */
+export async function drainViewUpdates(
+  roots: Iterable<Element> = activeRenderRoots(),
+): Promise<boolean> {
+  const pending: Promise<unknown>[] = [];
+  let sawPending = false;
+
+  const visit = (node: Element) => {
+    const el = node as Element & {
+      updateComplete?: Promise<unknown>;
+      isUpdatePending?: boolean;
+    };
+    if (el.updateComplete && typeof el.updateComplete.then === "function") {
+      if (el.isUpdatePending) sawPending = true;
+      pending.push(el.updateComplete);
+    }
+    for (const child of node.children) visit(child);
+    if (node.shadowRoot) {
+      for (const child of node.shadowRoot.children) visit(child);
+    }
+  };
+
+  for (const root of roots) {
+    visit(root);
+  }
+
+  // updateComplete resolves true once the element settles, false when the
+  // element re-triggered its own update during the cycle (a property set in
+  // updated(), as cf-modal does when toggling open), and rejects when the
+  // update threw. Treat false and rejected as still-churning so the loop drains
+  // again instead of exiting a cycle early; allSettled keeps a thrown update
+  // from aborting the check. An element that never stops churning trips
+  // viewSettled's maxPasses warning rather than spinning forever.
+  const results = await Promise.allSettled(pending);
+  const churned = results.some(
+    (r) => r.status === "rejected" || r.value === false,
+  );
+  return sawPending || churned;
+}
+
+function activeRenderRoots(): Element[] {
+  return Array.from(getActiveRenders().values(), ({ parent }) => parent);
+}
+
+/**
+ * Resolve once the worker is reactively idle AND the rendered view has caught
+ * up to that state: vdom batches applied to the DOM and Lit elements finished
+ * updating, so event handlers are bound and modal/overlay interactivity is on.
+ *
+ * Each pass waits for worker idle, yields a macrotask so any in-flight
+ * worker-to-main vdom batch messages are delivered and applied, then drains
+ * pending Lit updates. When a full pass finds nothing pending the view is
+ * settled. The loop converges because draining cannot, on a quiet runtime,
+ * produce new work indefinitely.
+ *
+ * A view that re-renders on every cycle (an animation that requests Lit updates
+ * on a timer) never reports settled. Rather than fail such a view, the loop
+ * gives up after maxPasses and warns: by then the view is interactive even
+ * though it is still updating.
+ *
+ * `roots` is forwarded to drainViewUpdates to scope the drain (used by tests);
+ * it defaults to every active render's container.
+ */
+export async function viewSettled(
+  idle: () => Promise<void>,
+  options: { maxPasses?: number; roots?: Iterable<Element> } = {},
+): Promise<void> {
+  const maxPasses = options.maxPasses ?? 50;
+  for (let pass = 0; pass < maxPasses; pass++) {
+    await idle();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    const pending = await drainViewUpdates(options.roots);
+    if (!pending) return;
+  }
+  console.warn(
+    `viewSettled: view still reported pending updates after ${maxPasses} ` +
+      `passes; proceeding. A perpetually re-rendering element can cause this.`,
+  );
+}
+
+/**
  * Create the debug helpers object to register on globalThis.commonfabric.vdom.
  */
 export function createVDomDebugHelpers() {

--- a/packages/html/test/view-settled.test.ts
+++ b/packages/html/test/view-settled.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the view-readiness helpers (drainViewUpdates / viewSettled).
+ *
+ * The helpers read elements structurally (children, shadowRoot, updateComplete,
+ * isUpdatePending), so the tests drive them with plain fakes rather than a real
+ * DOM. updateComplete mirrors Lit's contract: it resolves true once settled,
+ * false when the element re-triggered its own update (supersession), and rejects
+ * when the update threw.
+ */
+
+import { assertEquals } from "@std/assert";
+import { stub } from "@std/testing/mock";
+import { drainViewUpdates, viewSettled } from "../src/debug.ts";
+
+interface FakeEl {
+  children: FakeEl[];
+  shadowRoot: { children: FakeEl[] } | null;
+  updateComplete?: Promise<boolean>;
+  isUpdatePending?: boolean;
+}
+
+function lit(
+  updateComplete: Promise<boolean>,
+  opts: { isUpdatePending?: boolean; children?: FakeEl[]; shadow?: FakeEl[] } =
+    {},
+): FakeEl {
+  return {
+    children: opts.children ?? [],
+    shadowRoot: opts.shadow ? { children: opts.shadow } : null,
+    updateComplete,
+    isUpdatePending: opts.isUpdatePending ?? false,
+  };
+}
+
+function plain(opts: { children?: FakeEl[]; shadow?: FakeEl[] } = {}): FakeEl {
+  return {
+    children: opts.children ?? [],
+    shadowRoot: opts.shadow ? { children: opts.shadow } : null,
+  };
+}
+
+function roots(...els: FakeEl[]): Iterable<Element> {
+  return els as unknown as Iterable<Element>;
+}
+
+Deno.test("drainViewUpdates - churn detection", async (t) => {
+  await t.step("a settled element is not churning", async () => {
+    assertEquals(
+      await drainViewUpdates(roots(lit(Promise.resolve(true)))),
+      false,
+    );
+  });
+
+  await t.step(
+    "plain elements without updateComplete are ignored",
+    async () => {
+      assertEquals(
+        await drainViewUpdates(roots(plain({ children: [plain()] }))),
+        false,
+      );
+    },
+  );
+
+  await t.step("an element pending at scan time is churning", async () => {
+    assertEquals(
+      await drainViewUpdates(
+        roots(lit(Promise.resolve(true), { isUpdatePending: true })),
+      ),
+      true,
+    );
+  });
+
+  await t.step(
+    "a superseded update (resolves false) is churning",
+    async () => {
+      assertEquals(
+        await drainViewUpdates(roots(lit(Promise.resolve(false)))),
+        true,
+      );
+    },
+  );
+
+  await t.step(
+    "a thrown update (rejects) is churning and does not throw",
+    async () => {
+      const rejected = Promise.reject(new Error("update threw"));
+      rejected.catch(() => {});
+      assertEquals(await drainViewUpdates(roots(lit(rejected))), true);
+    },
+  );
+
+  await t.step("descends into children and shadow roots", async () => {
+    const churningInShadow = plain({ shadow: [lit(Promise.resolve(false))] });
+    assertEquals(await drainViewUpdates(roots(churningInShadow)), true);
+
+    const settledNested = plain({ children: [lit(Promise.resolve(true))] });
+    assertEquals(await drainViewUpdates(roots(settledNested)), false);
+  });
+
+  await t.step("no active renders means nothing is churning", async () => {
+    assertEquals(await drainViewUpdates(), false);
+  });
+});
+
+Deno.test("viewSettled - loop", async (t) => {
+  await t.step(
+    "polls idle each pass until the view settles",
+    async () => {
+      const e = lit(Promise.resolve(false));
+      let passes = 0;
+      const idle = () => {
+        passes++;
+        if (passes >= 2) e.updateComplete = Promise.resolve(true);
+        return Promise.resolve();
+      };
+      await viewSettled(idle, { roots: roots(e) });
+      assertEquals(passes, 2);
+    },
+  );
+
+  await t.step("settles in one pass when nothing is pending", async () => {
+    let passes = 0;
+    const idle = () => {
+      passes++;
+      return Promise.resolve();
+    };
+    await viewSettled(idle, { roots: roots(lit(Promise.resolve(true))) });
+    assertEquals(passes, 1);
+  });
+
+  await t.step(
+    "warns and gives up after maxPasses when the view never settles",
+    async () => {
+      const warn = stub(console, "warn", () => {});
+      let passes = 0;
+      const idle = () => {
+        passes++;
+        return Promise.resolve();
+      };
+      try {
+        await viewSettled(idle, {
+          roots: roots(lit(Promise.resolve(false))),
+          maxPasses: 3,
+        });
+      } finally {
+        warn.restore();
+      }
+      assertEquals(passes, 3);
+      assertEquals(warn.calls.length, 1);
+    },
+  );
+});

--- a/packages/integration/utils.ts
+++ b/packages/integration/utils.ts
@@ -1,4 +1,5 @@
 import { sleep } from "@commonfabric/utils/sleep";
+import type { Page } from "./page.ts";
 
 // Default poll interval between predicate calls. Polls are cheap (a CDP
 // evaluate round-trip), and a coarse interval quantizes every wall-clock
@@ -41,4 +42,32 @@ export const waitFor = async (
   throw new Error(
     `Timeout: waitFor predicate could not complete after ${timeout}ms.`,
   );
+};
+
+/**
+ * Wait until the shell's rendered UI has caught up to runtime state and is
+ * interactive. The reactive scheduler runs in a worker while the DOM lives on
+ * the main thread, so there are three stages between a state change and a
+ * clickable control: the worker settles reactively, the resulting vdom batch
+ * crosses to the main thread and is applied, and the Lit elements finish their
+ * update cycle (which is when cf-modal binds handlers and drops
+ * `pointer-events:none`). This resolves once all three have happened.
+ *
+ * Returns true once settled, or false when the shell has not yet exposed
+ * `commonfabric.viewSettled` (for example the runtime is still starting), so a
+ * caller can keep polling with `waitFor`.
+ *
+ * Call this before issuing a click or keystroke after navigation or any state
+ * change, so the stimulus lands on a bound handler instead of a freshly
+ * rendered element whose handler is not wired up yet.
+ */
+export const awaitViewSettled = async (page: Page): Promise<boolean> => {
+  return await page.evaluate(async () => {
+    const settled = (globalThis as {
+      commonfabric?: { viewSettled?: () => Promise<void> };
+    }).commonfabric?.viewSettled;
+    if (!settled) return false;
+    await settled();
+    return true;
+  });
 };

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -1,4 +1,5 @@
 import {
+  awaitViewSettled,
   CdpWorkerProfiler,
   env,
   Page,
@@ -696,10 +697,19 @@ describe("default-app flow test", () => {
         throw error;
       }
 
+      // Wait until the notebook toolbar is mounted and interactive before
+      // clicking. viewSettled resolves once the worker is idle and the
+      // rendered view has caught up (vdom applied, Lit updates drained), so the
+      // New Note button's handler is bound and a single click is not dropped.
+      await waitFor(async () => await awaitViewSettled(page));
+      assert(
+        await clickButtonWithTitle(page, "New Note"),
+        "Expected New Note click to succeed",
+      );
+      // The click is delivered; wait until its effect — the open modal with its
+      // "Create Another" button — has rendered and become interactive.
       await waitFor(async () => {
-        return !!(await clickButtonWithTitle(page, "New Note"));
-      });
-      await waitFor(async () => {
+        await awaitViewSettled(page);
         return !!(await findButtonWithText(page, "Create Another"));
       });
       await waitFor(async () => await resetEventInvocationTrace(page));

--- a/packages/shell/src/globals.ts
+++ b/packages/shell/src/globals.ts
@@ -4,6 +4,7 @@ declare global {
   var app: App;
   var commonfabric: {
     rt?: RuntimeClient;
+    viewSettled?: () => Promise<void>;
     detectNonIdempotent?: (durationMs?: number) => Promise<unknown>;
     watchWrites?: (
       options?:

--- a/packages/shell/src/globals.ts
+++ b/packages/shell/src/globals.ts
@@ -4,7 +4,6 @@ declare global {
   var app: App;
   var commonfabric: {
     rt?: RuntimeClient;
-    viewSettled?: () => Promise<void>;
     detectNonIdempotent?: (durationMs?: number) => Promise<unknown>;
     watchWrites?: (
       options?:

--- a/packages/shell/src/lib/debug-utils.ts
+++ b/packages/shell/src/lib/debug-utils.ts
@@ -21,6 +21,23 @@ import type {
 import type { DID } from "@commonfabric/identity";
 import { isRecord } from "@commonfabric/utils/types";
 import type { MetaField } from "@commonfabric/api";
+import { viewSettled } from "@commonfabric/html/debug";
+
+/**
+ * Build the `commonfabric.viewSettled` helper for a runtime. The returned
+ * function resolves once the rendered view is interactive — the worker is idle
+ * and the resulting vdom and Lit updates have drained. getRt is read on each
+ * call so the helper tracks runtime replacement; with no runtime the idle step
+ * is skipped.
+ */
+export function createViewSettled(
+  getRt: () => RuntimeClient | undefined,
+): () => Promise<void> {
+  return () =>
+    viewSettled(async () => {
+      await getRt()?.idle();
+    });
+}
 
 interface DebugCellOptions {
   /** Space DID — defaults to current shell space */

--- a/packages/shell/src/lib/debug-utils.ts
+++ b/packages/shell/src/lib/debug-utils.ts
@@ -21,7 +21,7 @@ import type {
 import type { DID } from "@commonfabric/identity";
 import { isRecord } from "@commonfabric/utils/types";
 import type { MetaField } from "@commonfabric/api";
-import { viewSettled } from "@commonfabric/html/debug";
+import { createVDomDebugHelpers, viewSettled } from "@commonfabric/html/debug";
 
 /**
  * Build the `commonfabric.viewSettled` helper for a runtime. The returned
@@ -37,6 +37,64 @@ export function createViewSettled(
     viewSettled(async () => {
       await getRt()?.idle();
     });
+}
+
+/** The commonfabric console globals exposed for the active runtime. */
+export type CommonfabricDebugState =
+  & Partial<ReturnType<typeof createDebugUtils>>
+  & {
+    rt?: RuntimeClient;
+    viewSettled?: () => Promise<void>;
+    vdom?: ReturnType<typeof createVDomDebugHelpers>;
+    detectNonIdempotent?: (durationMs?: number) => Promise<unknown>;
+  };
+
+type CommonfabricGlobal = { commonfabric?: CommonfabricDebugState };
+
+/**
+ * Install the per-runtime commonfabric console globals — rt, viewSettled, vdom,
+ * detectNonIdempotent, and the cell debug utilities — for the active runtime.
+ */
+export function exposeCommonfabricGlobals(
+  global: CommonfabricGlobal,
+  runtime: RuntimeClient,
+  getRuntime: () => RuntimeClient | undefined,
+  getSpace: () => DID | undefined,
+): void {
+  global.commonfabric ??= {};
+  const cf = global.commonfabric;
+  cf.rt = runtime;
+  cf.viewSettled = createViewSettled(getRuntime);
+  cf.vdom = createVDomDebugHelpers();
+  cf.detectNonIdempotent = async (durationMs = 5000) => {
+    const result = await runtime.detectNonIdempotent(durationMs);
+    console.table(
+      result.nonIdempotent.map((r) => ({
+        action: r.actionId,
+        differingWrites: r.differingWriteKeys.join(", "),
+      })),
+    );
+    console.log("Cycles:", result.cycles);
+    return result;
+  };
+  const debugUtils = createDebugUtils(getSpace, getRuntime);
+  cf.readCell = debugUtils.readCell;
+  cf.readArgumentCell = debugUtils.readArgumentCell;
+  cf.subscribeToCell = debugUtils.subscribeToCell;
+  cf.watchWrites = debugUtils.watchWrites;
+  cf.getWriteStackTrace = debugUtils.getWriteStackTrace;
+  cf.explainTriggerTrace = debugUtils.explainTriggerTrace;
+}
+
+/**
+ * Clear the per-runtime commonfabric console globals (rt and viewSettled) when
+ * the runtime is torn down, so they cannot run against a disposed runtime.
+ */
+export function clearRuntimeDebugGlobals(global: CommonfabricGlobal): void {
+  if (global.commonfabric) {
+    global.commonfabric.rt = undefined;
+    global.commonfabric.viewSettled = undefined;
+  }
 }
 
 interface DebugCellOptions {

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -17,8 +17,11 @@ import { type RuntimeClient } from "@commonfabric/runtime-client";
 import { type DID } from "@commonfabric/identity";
 import { resolveSpaceDid, RuntimeInternals } from "@commonfabric/lib-shell";
 import { shouldRecreateRuntime } from "../lib/runtime-lifecycle.ts";
-import { createVDomDebugHelpers } from "@commonfabric/html/debug";
-import { createDebugUtils, createViewSettled } from "../lib/debug-utils.ts";
+import {
+  clearRuntimeDebugGlobals,
+  type CommonfabricDebugState,
+  exposeCommonfabricGlobals,
+} from "../lib/debug-utils.ts";
 import { runtimeContext, spaceContext } from "@commonfabric/ui";
 import { provide } from "@lit/context";
 import {
@@ -26,13 +29,6 @@ import {
   type ThemePreference,
 } from "../lib/theme-preference.ts";
 import { EXPERIMENTAL } from "../lib/env.ts";
-
-type CommonfabricDebugState = Partial<ReturnType<typeof createDebugUtils>> & {
-  rt?: RuntimeClient;
-  viewSettled?: () => Promise<void>;
-  vdom?: ReturnType<typeof createVDomDebugHelpers>;
-  detectNonIdempotent?: (durationMs?: number) => Promise<unknown>;
-};
 
 function getCommonfabricGlobal(): typeof globalThis & {
   commonfabric?: CommonfabricDebugState;
@@ -103,11 +99,7 @@ export class XRootView extends BaseView {
           // Clear the runtime and space when no app state
           this.runtime = undefined;
           this.space = undefined;
-          const global = getCommonfabricGlobal();
-          if (global.commonfabric) {
-            global.commonfabric.rt = undefined;
-            global.commonfabric.viewSettled = undefined;
-          }
+          clearRuntimeDebugGlobals(getCommonfabricGlobal());
           return undefined;
         }
 
@@ -125,11 +117,7 @@ export class XRootView extends BaseView {
           rt.dispose().catch(console.error);
           this.runtime = undefined;
           this.space = undefined;
-          const global = getCommonfabricGlobal();
-          if (global.commonfabric) {
-            global.commonfabric.rt = undefined;
-            global.commonfabric.viewSettled = undefined;
-          }
+          clearRuntimeDebugGlobals(getCommonfabricGlobal());
           return;
         }
 
@@ -137,39 +125,14 @@ export class XRootView extends BaseView {
         // from app.view in updated() independent of the runtime's life.
         this.runtime = rt.runtime();
 
-        // Expose RuntimeClient for console debugging
-        // (e.g. commonfabric.rt.setLoggerLevel("debug"))
-        const global = getCommonfabricGlobal();
-        global.commonfabric ??= {};
-        global.commonfabric.rt = this.runtime;
-        global.commonfabric.viewSettled = createViewSettled(() => this.runtime);
-        global.commonfabric.vdom = createVDomDebugHelpers();
-        global.commonfabric.detectNonIdempotent = async (
-          durationMs = 5000,
-        ) => {
-          const result = await rt.runtime().detectNonIdempotent(durationMs);
-          console.table(
-            result.nonIdempotent.map((r: any) => ({
-              action: r.actionId,
-              differingWrites: r.differingWriteKeys.join(", "),
-            })),
-          );
-          console.log("Cycles:", result.cycles);
-          return result;
-        };
-
-        // Debug utilities for inspecting cell values from the console
-        const debugUtils = createDebugUtils(
-          () => this.space as DID,
+        // Expose the runtime and cell debug utilities for console use
+        // (e.g. commonfabric.rt.setLoggerLevel("debug")).
+        exposeCommonfabricGlobals(
+          getCommonfabricGlobal(),
+          this.runtime,
           () => this.runtime,
+          () => this.space as DID,
         );
-        global.commonfabric.readCell = debugUtils.readCell;
-        global.commonfabric.readArgumentCell = debugUtils.readArgumentCell;
-        global.commonfabric.subscribeToCell = debugUtils.subscribeToCell;
-        global.commonfabric.watchWrites = debugUtils.watchWrites;
-        global.commonfabric.getWriteStackTrace = debugUtils.getWriteStackTrace;
-        global.commonfabric.explainTriggerTrace =
-          debugUtils.explainTriggerTrace;
 
         return rt;
       },

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -18,7 +18,7 @@ import { type DID } from "@commonfabric/identity";
 import { resolveSpaceDid, RuntimeInternals } from "@commonfabric/lib-shell";
 import { shouldRecreateRuntime } from "../lib/runtime-lifecycle.ts";
 import { createVDomDebugHelpers } from "@commonfabric/html/debug";
-import { createDebugUtils } from "../lib/debug-utils.ts";
+import { createDebugUtils, createViewSettled } from "../lib/debug-utils.ts";
 import { runtimeContext, spaceContext } from "@commonfabric/ui";
 import { provide } from "@lit/context";
 import {
@@ -29,6 +29,7 @@ import { EXPERIMENTAL } from "../lib/env.ts";
 
 type CommonfabricDebugState = Partial<ReturnType<typeof createDebugUtils>> & {
   rt?: RuntimeClient;
+  viewSettled?: () => Promise<void>;
   vdom?: ReturnType<typeof createVDomDebugHelpers>;
   detectNonIdempotent?: (durationMs?: number) => Promise<unknown>;
 };
@@ -105,6 +106,7 @@ export class XRootView extends BaseView {
           const global = getCommonfabricGlobal();
           if (global.commonfabric) {
             global.commonfabric.rt = undefined;
+            global.commonfabric.viewSettled = undefined;
           }
           return undefined;
         }
@@ -126,6 +128,7 @@ export class XRootView extends BaseView {
           const global = getCommonfabricGlobal();
           if (global.commonfabric) {
             global.commonfabric.rt = undefined;
+            global.commonfabric.viewSettled = undefined;
           }
           return;
         }
@@ -139,6 +142,7 @@ export class XRootView extends BaseView {
         const global = getCommonfabricGlobal();
         global.commonfabric ??= {};
         global.commonfabric.rt = this.runtime;
+        global.commonfabric.viewSettled = createViewSettled(() => this.runtime);
         global.commonfabric.vdom = createVDomDebugHelpers();
         global.commonfabric.detectNonIdempotent = async (
           durationMs = 5000,

--- a/packages/shell/test/debug-utils.test.ts
+++ b/packages/shell/test/debug-utils.test.ts
@@ -1,10 +1,14 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
+  createViewSettled,
   summarizeDebugValue,
   summarizeTriggerTraceEntries,
 } from "../src/lib/debug-utils.ts";
-import type { TriggerTraceEntry } from "@commonfabric/runtime-client";
+import type {
+  RuntimeClient,
+  TriggerTraceEntry,
+} from "@commonfabric/runtime-client";
 
 describe("debug utils", () => {
   it("summarizeDebugValue classifies common metadata/result shapes", () => {
@@ -144,5 +148,44 @@ describe("debug utils", () => {
     expect(rootOnly.traceEntries).toBe(2);
     expect(rootOnly.nestedEntries).toBe(0);
     expect(rootOnly.topChanges).toHaveLength(1);
+  });
+});
+
+describe("createViewSettled", () => {
+  const asRuntime = (rt: { idle: () => Promise<void> } | undefined) =>
+    rt as unknown as RuntimeClient | undefined;
+
+  it("idles the runtime, then settles the view", async () => {
+    let idleCalls = 0;
+    const rt = {
+      idle: () => {
+        idleCalls += 1;
+        return Promise.resolve();
+      },
+    };
+    await createViewSettled(() => asRuntime(rt))();
+    expect(idleCalls).toBeGreaterThan(0);
+  });
+
+  it("resolves without throwing when there is no runtime", async () => {
+    await createViewSettled(() => undefined)();
+  });
+
+  it("reads the runtime on each call so it tracks replacement", async () => {
+    const holder: { rt?: { idle: () => Promise<void> } } = {};
+    let idleCalls = 0;
+    const settled = createViewSettled(() => asRuntime(holder.rt));
+
+    await settled();
+    expect(idleCalls).toBe(0);
+
+    holder.rt = {
+      idle: () => {
+        idleCalls += 1;
+        return Promise.resolve();
+      },
+    };
+    await settled();
+    expect(idleCalls).toBeGreaterThan(0);
   });
 });

--- a/packages/shell/test/debug-utils.test.ts
+++ b/packages/shell/test/debug-utils.test.ts
@@ -1,7 +1,11 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { stub } from "@std/testing/mock";
 import {
+  clearRuntimeDebugGlobals,
+  type CommonfabricDebugState,
   createViewSettled,
+  exposeCommonfabricGlobals,
   summarizeDebugValue,
   summarizeTriggerTraceEntries,
 } from "../src/lib/debug-utils.ts";
@@ -187,5 +191,62 @@ describe("createViewSettled", () => {
     };
     await settled();
     expect(idleCalls).toBeGreaterThan(0);
+  });
+});
+
+describe("runtime debug globals", () => {
+  type Globals = { commonfabric?: CommonfabricDebugState };
+
+  it("exposeCommonfabricGlobals installs the console globals", async () => {
+    let idleCalls = 0;
+    const detectResult = { nonIdempotent: [], cycles: 0 };
+    const runtime = {
+      idle: () => {
+        idleCalls += 1;
+        return Promise.resolve();
+      },
+      detectNonIdempotent: () => Promise.resolve(detectResult),
+    } as unknown as RuntimeClient;
+    const global: Globals = {};
+
+    exposeCommonfabricGlobals(global, runtime, () => runtime, () => undefined);
+
+    const cf = global.commonfabric!;
+    expect(cf.rt).toBe(runtime);
+    expect(typeof cf.viewSettled).toBe("function");
+    expect(typeof cf.vdom).toBe("object");
+    expect(typeof cf.detectNonIdempotent).toBe("function");
+    expect(typeof cf.readCell).toBe("function");
+    expect(typeof cf.watchWrites).toBe("function");
+
+    await cf.viewSettled!();
+    expect(idleCalls).toBeGreaterThan(0);
+
+    const table = stub(console, "table", () => {});
+    const log = stub(console, "log", () => {});
+    try {
+      expect(await cf.detectNonIdempotent!()).toBe(detectResult);
+    } finally {
+      table.restore();
+      log.restore();
+    }
+  });
+
+  it("clearRuntimeDebugGlobals clears rt and viewSettled", () => {
+    const global: Globals = {
+      commonfabric: {
+        rt: {} as RuntimeClient,
+        viewSettled: () => Promise.resolve(),
+      },
+    };
+    clearRuntimeDebugGlobals(global);
+    expect(global.commonfabric!.rt).toBeUndefined();
+    expect(global.commonfabric!.viewSettled).toBeUndefined();
+  });
+
+  it("clearRuntimeDebugGlobals is a no-op without a commonfabric global", () => {
+    const global: Globals = {};
+    clearRuntimeDebugGlobals(global);
+    expect(global.commonfabric).toBeUndefined();
   });
 });


### PR DESCRIPTION
…efault-app test

The notebook step of default-app.test.ts ("should persist and reload every rapidly created notebook note") was flaky on CI: it timed out after 60s waiting for the New Note modal's "Create Another" button to appear.

Root cause is a readiness gap. The reactive scheduler runs in a worker while the DOM lives on the main thread, so after a state change there are three stages before a control is interactive:

  1. the worker settles reactively (this is all rt.idle() observes);
  2. the resulting vdom batch crosses to the main thread and is applied, which is where the click listener is attached;
  3. the Lit elements finish their update cycle -- cf-modal only binds handlers and drops pointer-events:none in its updated() callback, one cycle after its open property is set.

Only stage 1 is visible through the runtime idle signal. The test clicked the New Note button once, before its onClick was wired up, so the click was dropped, the modal never opened, and the wait timed out. Re-clicking until it "took" made matters worse: the modal is dismissable, so repeated clicks behind it dismissed and reopened it in a flicker that corrupted the rest of the flow.

Add a main-thread readiness primitive that closes all three stages:

  - packages/html/src/debug.ts: viewSettled() loops idle -> yield a macrotask so in-flight vdom batches are applied -> drainViewUpdates() awaits Lit updateComplete across every active render subtree (including shadow roots) -> repeat to a fixpoint. drainViewUpdates uses Promise.allSettled because Lit rejects updateComplete when an element's update is superseded mid-churn; a rejection means the element kept changing, which the re-drain captures, so it must not abort the check. On non-convergence (a perpetually re-rendering element) viewSettled warns and proceeds rather than failing an interactive view.
  - packages/shell/src/views/RootView.ts: expose it as commonfabric.viewSettled alongside commonfabric.rt, and clear it on runtime teardown so it cannot run against a torn-down runtime. The running app never calls it; it is a test-support global, so the change is additive with no app behavior change.
  - packages/integration/utils.ts: awaitViewSettled(page) wraps the global for tests, returning false until the runtime exposes it so callers can poll with waitFor.

The test now settles the view before clicking New Note (so the single click lands on a bound handler), then waits for the modal's effect. The rapid-create loop is unchanged, preserving the concurrent-create stress it guards.

docs/development/UI_TESTING.md documents the primitive and enumerates the inferior waits it replaces (fixed sleeps, rt.idle()-then-interact, poll-for- element-then-click, re-click-until-it-takes, waitForSelector retry loops).

Verified: default-app passes across fresh and warm/accumulating-state servers (the condition that reproduced the flake); html (32) and shell (12) unit suites green; shared-profile integration green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a UI readiness primitive so tests only interact once the view is interactive, fixing the flaky default‑app notebook flow. Exposes it as `commonfabric.viewSettled` and adds `awaitViewSettled(page)` in `@commonfabric/integration` for polling.

- **New Features**
  - `@commonfabric/html/debug`: add `viewSettled()` and `drainViewUpdates()` (idle → macrotask yield → await Lit `updateComplete` across DOM and shadow roots; warn after max passes). Unit tests added.
  - Shell: expose as `commonfabric.viewSettled` via `createViewSettled()`; installed by `exposeCommonfabricGlobals()` and cleared by `clearRuntimeDebugGlobals()`; reads the runtime on each call and resolves even with no runtime. Unit tests cover the creator and console‑globals wiring.
  - `@commonfabric/integration`: add `awaitViewSettled(page)` that returns `false` until available for `waitFor` polling. Docs add “Waiting Until the UI Is Interactive” with usage and anti‑patterns to avoid.

- **Bug Fixes**
  - Default‑app notebook test settles the view before clicking “New Note,” then settles again and waits for the modal’s effect, removing dropped clicks and modal flicker.

<sup>Written for commit 0e7b0f55884238bab23069f1b849006cdb77f776. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: subtest: pattern-unit-5/pattern-unit-tests > packages/patterns/shopping-list.test.tsx = 28s
---END COPY-PASTE---
