### PR TITLE
refactor(schema-generator): name the opaque-brand formatter helpers for what they detect

### DIFF
--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -353,7 +353,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       "ComparableCell",
     ];
     for (const kind of wrapperKinds) {
-      const unwrappedType = this.recursivelyUnwrapOpaqueRef(
+      const unwrappedType = this.recursivelyUnwrapOpaqueCell(
         type,
         kind,
         context.typeChecker,
@@ -757,11 +757,13 @@ export class CommonFabricFormatter implements TypeFormatter {
   }
 
   /**
-   * Recursively unwrap OpaqueRef layers to find a wrapper type (Cell/Stream/OpaqueRef).
-   * This handles cases like FactoryInput<OpaqueRef<Stream<T>>> where the type is wrapped in
-   * multiple layers of OpaqueRef due to the FactoryInput type's recursive definition.
+   * Recursively unwrap opaque-branded (OpaqueCell) layers to find a wrapper
+   * type (Cell/Stream/etc.). This handles cases like
+   * FactoryInput<OpaqueCell<Stream<T>>> where the target is wrapped in multiple
+   * opaque-branded layers due to the recursive definition of the FactoryInput
+   * type.
    */
-  private recursivelyUnwrapOpaqueRef(
+  private recursivelyUnwrapOpaqueCell(
     type: ts.Type,
     targetWrapperKind: WrapperKind,
     checker: ts.TypeChecker,
@@ -787,7 +789,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       const unionType = type as ts.UnionType;
       for (const member of unionType.types) {
         // Try to unwrap this member
-        const result = this.recursivelyUnwrapOpaqueRef(
+        const result = this.recursivelyUnwrapOpaqueCell(
           member,
           targetWrapperKind,
           checker,
@@ -797,11 +799,11 @@ export class CommonFabricFormatter implements TypeFormatter {
       }
     }
 
-    // If this is an OpaqueRef type, extract its type argument and recurse
-    if (this.isOpaqueRefType(type, checker)) {
-      const innerType = this.extractOpaqueRefTypeArgument(type, checker);
+    // If this is an opaque-branded cell, extract its type argument and recurse
+    if (this.isOpaqueCellType(type, checker)) {
+      const innerType = this.extractOpaqueCellTypeArgument(type, checker);
       if (innerType) {
-        return this.recursivelyUnwrapOpaqueRef(
+        return this.recursivelyUnwrapOpaqueCell(
           innerType,
           targetWrapperKind,
           checker,
@@ -823,14 +825,18 @@ export class CommonFabricFormatter implements TypeFormatter {
       : undefined;
   }
 
-  private isOpaqueRefType(type: ts.Type, checker: ts.TypeChecker): boolean {
+  // Detects the "opaque" cell brand, carried by OpaqueCell<T>. Named for the
+  // brand it matches, not the `Reactive`/`OpaqueRef` annotation spelling: those
+  // are an identity alias for T (no runtime wrapper, no brand), so they cannot
+  // be detected structurally here — only OpaqueCell can.
+  private isOpaqueCellType(type: ts.Type, checker: ts.TypeChecker): boolean {
     return isCellBrand(type, checker, "opaque");
   }
 
   /**
-   * Extract the type argument T from OpaqueRef<T> or OpaqueCell<T>
+   * Extract the type argument T from an opaque-branded cell (OpaqueCell<T>).
    */
-  private extractOpaqueRefTypeArgument(
+  private extractOpaqueCellTypeArgument(
     type: ts.Type,
     checker: ts.TypeChecker,
   ): ts.Type | undefined {


### PR DESCRIPTION
## Summary

Follow-up cleanup to the `OpaqueRef` → `Reactive` rename. The common-fabric formatter's opaque-brand detection helpers were still spelled `OpaqueRef`, but they detect the **`"opaque"` cell brand**, which is carried by `OpaqueCell<T>` — not by `OpaqueRef`/`Reactive`. After the rename, `Reactive<T>` (and its deprecated alias `OpaqueRef<T>`) is an identity alias for `T`: no runtime wrapper, no brand, so it cannot be detected structurally at all. The old names pointed at a type these helpers can't actually see.

Pure rename + comment accuracy, **no behavior change**:
- `isOpaqueRefType` → `isOpaqueCellType`
- `extractOpaqueRefTypeArgument` → `extractOpaqueCellTypeArgument`
- `recursivelyUnwrapOpaqueRef` → `recursivelyUnwrapOpaqueCell`
- local vars in the union detector renamed to match (`opaqueCellMember`, etc.)

All three helpers are `private`/file-local.

## Deliberately left untouched

- The `"OpaqueRef"` `CellWrapperKind` and its spelling-path mapping: `Reactive`/`OpaqueRef` *spellings* still normalize to it (`wrapper-names.ts`), so it's reachable via the syntactic path even though the brand path (`getCellWrapperInfo`) never yields it. Retiring it (the `// may be obsolete` note in `cell-brand.ts`) is a separate task that belongs with the eventual removal of the `OpaqueRef` spelling.
- The union-shape comments inside `getOpaqueUnionInfo` (e.g. "`T | OpaqueRef<T>`"): that method is being renamed to `getFactoryInputUnionInfo` in #4140, and its comments are stale for a different reason (the broadened `FactoryInput` union) that's better addressed there.

## Coordination with #4140

This touches `common-fabric-formatter.ts`, which #4140 also edits (it renames the sibling `isOpaqueUnion`/`getOpaqueUnionInfo` → `isFactoryInputUnion`/`getFactoryInputUnionInfo`). The two PRs rename **different** methods, but my call-site updates land inside `getOpaqueUnionInfo`, so whichever merges second needs a small mechanical rebase. No semantic overlap. Happy to sequence either way.

## Validation

- `deno fmt` / `deno lint` / `deno check` on the touched file.
- `cd packages/schema-generator && deno task test` → 26 passed (240 steps), 0 failed (unchanged from main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed opaque-brand detection helpers in `schema-generator` to match what they detect: the "opaque" brand on `OpaqueCell<T>`, not `Reactive`/`OpaqueRef`. No behavior change.

- **Refactors**
  - `isOpaqueRefType` → `isOpaqueCellType`
  - `extractOpaqueRefTypeArgument` → `extractOpaqueCellTypeArgument`
  - `recursivelyUnwrapOpaqueRef` → `recursivelyUnwrapOpaqueCell`
  - Renamed related local vars and updated comments (helpers remain `private`).

<sup>Written for commit 980951272a51224e44f8e714913b8a061106b4ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

