### PR TITLE
fix(runner): preserve FabricValues through schema interning/cloning (drop JSON round-trips)

### DIFF
--- a/packages/data-model/src/schema-hash.ts
+++ b/packages/data-model/src/schema-hash.ts
@@ -194,7 +194,7 @@ export function internSchema<T extends JSONSchema | undefined>(
 
 /**
  * Like {@link #internSchema}, except that when given a non-deep-frozen `schema`
- * it makes a deep-frozen clone of it first instead ofy freezing it in place.
+ * it makes a deep-frozen clone of it first instead of freezing it in place.
  * This is for the rare cases where it is _not_ safe to do freezing in place.
  * _Do not reach for this function_ unless you are sure that you're in unsafe
  * territory, and strongly recommend commenting the use site with an explanation

--- a/packages/data-model/src/schema-hash.ts
+++ b/packages/data-model/src/schema-hash.ts
@@ -8,6 +8,7 @@ import type { JSONSchema, JSONSchemaObj } from "@commonfabric/api";
 import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
 import { SchemaAndHash } from "./SchemaAndHash.ts";
 import { toDeepFrozenSchema } from "./schema-utils.ts";
+import { cloneIfNecessary } from "./value-clone.ts";
 import { hashOf, hashStringOf } from "./value-hash.ts";
 
 //
@@ -81,7 +82,8 @@ hashToRef.set(primInterns.true.taggedHashString, true);
 hashToRef.set(primInterns.undefined.taggedHashString, undefined);
 
 /**
- * Helper for `internSchema()`, which always returns a `SchemaAndHash`.
+ * Helper for `internSchema()` and friends, which always returns a
+ * `SchemaAndHash`.
  */
 function internSchemaReturningSchemaAndHash(
   schema: JSONSchema | undefined,
@@ -188,6 +190,24 @@ export function internSchema<T extends JSONSchema | undefined>(
 ): JSONSchema | undefined | SchemaAndHash {
   const sahResult = internSchemaReturningSchemaAndHash(schema);
   return wantSchemaAndHash ? sahResult : sahResult.schemaOrUndefined;
+}
+
+/**
+ * Like {@link #internSchema}, except that it makes a deep-frozen clone of the
+ * given `schema` first instead of possibly freezing it in place. This is for
+ * the rare cases where it is _not_ safe to do freezing in place. _Do not reach
+ * for this function_ unless you are sure that you're in unsafe territory, and
+ * strongly recommend commenting the use site with an explanation about why.
+ */
+export function deepFrozenCloneAndInternSchema<
+  T extends JSONSchema | undefined,
+>(
+  schema: T,
+): T {
+  const sahResult = internSchemaReturningSchemaAndHash(
+    cloneIfNecessary(schema),
+  );
+  return sahResult.schemaOrUndefined as T;
 }
 
 /**

--- a/packages/data-model/src/schema-hash.ts
+++ b/packages/data-model/src/schema-hash.ts
@@ -8,7 +8,6 @@ import type { JSONSchema, JSONSchemaObj } from "@commonfabric/api";
 import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
 import { SchemaAndHash } from "./SchemaAndHash.ts";
 import { toDeepFrozenSchema } from "./schema-utils.ts";
-import { cloneIfNecessary } from "./value-clone.ts";
 import { hashOf, hashStringOf } from "./value-hash.ts";
 
 //
@@ -83,10 +82,11 @@ hashToRef.set(primInterns.undefined.taggedHashString, undefined);
 
 /**
  * Helper for `internSchema()` and friends, which always returns a
- * `SchemaAndHash`.
+ * `SchemaAndHash` and takes configurable sharing-or-not.
  */
 function internSchemaReturningSchemaAndHash(
   schema: JSONSchema | undefined,
+  canShare: boolean,
 ): SchemaAndHash {
   // Return prefab instances for primitives.
   switch (schema) {
@@ -110,7 +110,7 @@ function internSchemaReturningSchemaAndHash(
 
   // `toDeepFrozenSchema()` returns the same reference if already deep-frozen or
   // if no sub-properties needed to be cloned to achieve frozenness.
-  const frozen = toDeepFrozenSchema(schema, true) as JSONSchemaObj;
+  const frozen = toDeepFrozenSchema(schema, canShare);
 
   // Check the hash-keyed reverse map (structurally-equal but different object).
   const hash = hashOf(frozen);
@@ -188,25 +188,24 @@ export function internSchema<T extends JSONSchema | undefined>(
   schema: T,
   wantSchemaAndHash: boolean = false,
 ): JSONSchema | undefined | SchemaAndHash {
-  const sahResult = internSchemaReturningSchemaAndHash(schema);
+  const sahResult = internSchemaReturningSchemaAndHash(schema, true);
   return wantSchemaAndHash ? sahResult : sahResult.schemaOrUndefined;
 }
 
 /**
- * Like {@link #internSchema}, except that it makes a deep-frozen clone of the
- * given `schema` first instead of possibly freezing it in place. This is for
- * the rare cases where it is _not_ safe to do freezing in place. _Do not reach
- * for this function_ unless you are sure that you're in unsafe territory, and
- * strongly recommend commenting the use site with an explanation about why.
+ * Like {@link #internSchema}, except that when given a non-deep-frozen `schema`
+ * it makes a deep-frozen clone of it first instead ofy freezing it in place.
+ * This is for the rare cases where it is _not_ safe to do freezing in place.
+ * _Do not reach for this function_ unless you are sure that you're in unsafe
+ * territory, and strongly recommend commenting the use site with an explanation
+ * about why.
  */
 export function deepFrozenCloneAndInternSchema<
   T extends JSONSchema | undefined,
 >(
   schema: T,
 ): T {
-  const sahResult = internSchemaReturningSchemaAndHash(
-    cloneIfNecessary(schema),
-  );
+  const sahResult = internSchemaReturningSchemaAndHash(schema, false);
   return sahResult.schemaOrUndefined as T;
 }
 

--- a/packages/data-model/src/schema-utils.ts
+++ b/packages/data-model/src/schema-utils.ts
@@ -121,14 +121,6 @@ export function toDeepFrozenSchema<T extends JSONSchema | undefined>(
  * @param deep When `true`, nested objects are recursively cloned (deep copy).
  *   Defaults to `false` (shallow copy). Pass `true` when the caller intends to
  *   mutate nested properties.
- *
- * Note: do not use this on proxy-wrapped schemas from the runtime — those
- * sites currently use `JSON.parse(JSON.stringify(...))` instead.
- *
- * TODO(danfuzz): Get those runtime sites off the
- * `JSON.parse(JSON.stringify(...))` round-trip — e.g. by teaching this
- * function to handle proxy-wrapped schemas — so nothing relies on a
- * stringify/parse round-trip to normalize a schema.
  */
 export function cloneSchemaMutable(
   schema: JSONSchema | undefined,

--- a/packages/data-model/src/schema-utils.ts
+++ b/packages/data-model/src/schema-utils.ts
@@ -66,7 +66,8 @@ export function isNontrivialSchema(
 }
 
 /**
- * Returns a deep-frozen copy of (or reference to) a JSONSchema.
+ * Returns a deep-frozen copy of (or reference to) a JSONSchema, returning
+ * primitives as-is.
  *
  * - When `canShare` is `true`, the input `schema` is allowed to be modified,
  *   including freezing it in place and returning it directly. Use this when the
@@ -76,14 +77,14 @@ export function isNontrivialSchema(
  * - When `canShare` is `false`, the `schema` is cloned first if not already
  *   deep-frozen, so that the original is not modified.
  *
- * Boolean schemas (`true` / `false`) are primitives and therefore already
- * immutable — they are returned as-is regardless of `canShare`.
+ * As with other schema functions, this one accepts `undefined` for use when
+ * it's possible for a schema value to be missing or optional.
  *
  * Note: Use `internSchema()` in preference to this function, which can cost a
  * little more to run but which will save both time and memory when the schema
  * in question is reused.
  */
-export function toDeepFrozenSchema<T extends JSONSchema>(
+export function toDeepFrozenSchema<T extends JSONSchema | undefined>(
   schema: T,
   canShare: boolean = false,
 ): T {

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -5,6 +5,7 @@ import { expect } from "@std/expect";
 import type { JSONSchema, JSONSchemaObj } from "@commonfabric/api";
 
 import {
+  deepFrozenCloneAndInternSchema,
   findInternedSchema,
   hashSchema,
   internSchema,
@@ -205,6 +206,38 @@ describe("schema-hash", () => {
         });
       });
     }
+  });
+
+  describe("deepFrozenCloneAndInternSchema()", () => {
+    it("interns a deep-frozen clone without freezing the input in place", () => {
+      const input: JSONSchema = {
+        type: "object",
+        properties: { name: { type: "string" } },
+      };
+      expect(Object.isFrozen(input)).toBe(false); // precondition
+
+      const result = deepFrozenCloneAndInternSchema(input);
+
+      expect(result).not.toBe(input); // a clone, not the same object
+      expect(result).toEqual(input); // structurally equal
+      expect(isInternedSchema(result)).toBe(true);
+      expect(isDeepFrozen(result)).toBe(true);
+      // The whole point of this function: the caller's object is untouched,
+      // unlike `internSchema()`, which would deep-freeze it in place.
+      expect(Object.isFrozen(input)).toBe(false);
+    });
+
+    it("interns by content (equal inputs collapse to one instance)", () => {
+      const a = deepFrozenCloneAndInternSchema({ type: "number", title: "x" });
+      const b = deepFrozenCloneAndInternSchema({ type: "number", title: "x" });
+      expect(a).toBe(b);
+    });
+
+    it("passes `undefined` and boolean schemas through", () => {
+      expect(deepFrozenCloneAndInternSchema(undefined)).toBe(undefined);
+      expect(deepFrozenCloneAndInternSchema(true)).toBe(true);
+      expect(deepFrozenCloneAndInternSchema(false)).toBe(false);
+    });
   });
 
   describe("isInternedSchema()", () => {

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -24,18 +24,17 @@ import {
 import { internSchema, isInternedSchema } from "@/schema-hash.ts";
 
 describe("schema-utils", () => {
-  describe("toDeepFrozenSchema", () => {
-    describe("boolean schemas", () => {
-      it("returns boolean `true` as-is", () => {
-        const result = toDeepFrozenSchema(true, false);
-        expect(result).toBe(true);
+  describe("toDeepFrozenSchema()", () => {
+    for (const prim of [false, true, undefined]) {
+      describe(`on primitive \`${prim}\``, () => {
+        it("returns the value as-is given both values of `canShare`", () => {
+          const result1 = toDeepFrozenSchema(prim, false);
+          const result2 = toDeepFrozenSchema(prim, true);
+          expect(result1).toBe(prim);
+          expect(result2).toBe(prim);
+        });
       });
-
-      it("returns boolean `false` as-is", () => {
-        const result = toDeepFrozenSchema(false, true);
-        expect(result).toBe(false);
-      });
-    });
+    }
 
     describe("`canShare=true`", () => {
       it("freezes input in place", () => {
@@ -315,7 +314,7 @@ describe("schema-utils", () => {
     });
   });
 
-  describe("isNontrivialSchema", () => {
+  describe("isNontrivialSchema()", () => {
     describe("nullish inputs", () => {
       it("returns `false` for `undefined`", () => {
         expect(isNontrivialSchema(undefined)).toBe(false);
@@ -397,7 +396,7 @@ describe("schema-utils", () => {
     });
   });
 
-  describe("cloneSchemaMutable", () => {
+  describe("cloneSchemaMutable()", () => {
     it("returns `{}` for boolean `true`", () => {
       expect(cloneSchemaMutable(true)).toEqual({});
     });
@@ -515,7 +514,7 @@ describe("schema-utils", () => {
     });
   });
 
-  describe("schemaWithProperties", () => {
+  describe("schemaWithProperties()", () => {
     it("returns a new object with overrides applied", () => {
       const schema: JSONSchemaObj = { type: "object", description: "old" };
       const result = schemaWithProperties(schema, {
@@ -693,7 +692,7 @@ describe("schema-utils", () => {
     });
   });
 
-  describe("schemaWithoutProperties", () => {
+  describe("schemaWithoutProperties()", () => {
     it("removes a single named property", () => {
       const schema: JSONSchemaObj = { type: "object", asCell: ["cell"] };
       const result = schemaWithoutProperties(schema, "asCell") as JSONSchemaObj;
@@ -788,7 +787,7 @@ describe("schema-utils", () => {
     });
   });
 
-  describe("schemaForValueType", () => {
+  describe("schemaForValueType()", () => {
     function testType(
       typeName: JSONSchemaTypes,
       example: FabricValue,
@@ -923,7 +922,7 @@ describe("schema-utils", () => {
     });
   });
 
-  describe("internPathSelector", () => {
+  describe("internPathSelector()", () => {
     // Content-unique markers guarantee no prior interning has seen these
     // schemas — avoids the flake shape Dan flagged on PR #3335.
     const uniqueSchema = (): JSONSchemaObj => ({

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -14,7 +14,10 @@ import type {
   JSONSchema,
 } from "commonfabric";
 import type { Schema } from "@commonfabric/api/schema";
-import { isNontrivialSchema } from "@commonfabric/data-model/schema-utils";
+import {
+  isNontrivialSchema,
+  toDeepFrozenSchema,
+} from "@commonfabric/data-model/schema-utils";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import {
   LLMDialogResultSchema,
@@ -757,7 +760,7 @@ type DialogMessageObservationMap = Record<string, unknown[]>;
 type DialogRequestSnapshot = {
   llmParams: LLMRequest;
   toolCatalog: ToolCatalog;
-  userResultSchema: unknown;
+  userResultSchema: JSONSchema | undefined;
   queueName?: string;
   observationMaxConfidentiality?: readonly unknown[];
   systemObservedConfidentiality: readonly unknown[];
@@ -1312,13 +1315,18 @@ function materializeDialogRequestSnapshot(
   >;
   const builtinTools = inputs.key("builtinTools").withTx(tx).get() !== false;
   const toolCatalog = buildToolCatalog(toolsCell, builtinTools);
-  const userResultSchema = inputs.key("resultSchema").withTx(tx).get();
+  // TODO(danfuzz): `resultSchema` is untrusted input, so this `as` is an
+  // unchecked assertion. Replace with a runtime validating guard, e.g.
+  // `asSchemaOrThrow(schema: unknown): schema is JSONSchema`.
+  const userResultSchema = inputs.key("resultSchema").withTx(tx).get() as
+    | JSONSchema
+    | undefined;
   if (userResultSchema) {
     toolCatalog.llmTools[PRESENT_RESULT_TOOL_NAME] = {
       description:
         "Call this tool to present a structured result. This stores the result for the caller.",
       inputSchema: prepareSchemaForLLM(
-        JSON.parse(JSON.stringify(userResultSchema)),
+        toDeepFrozenSchema(userResultSchema),
       ),
     };
   }
@@ -2151,9 +2159,10 @@ function handleSchema(
   resolved: ResolvedToolCall & { type: "schema" },
 ): { type: string; value: any } {
   const schema = getCellSchema(resolved.cellRef) ?? {};
-  // TODO(danfuzz): Replace JSON.parse(JSON.stringify(...)) with
-  // cloneSchemaMutable() here.
-  const value = JSON.parse(JSON.stringify(schema));
+  // Deep-frozen clone: `schema` may be a query-result proxy, so de-proxy and
+  // preserve `FabricValue` leaves rather than mangling them through JSON. The
+  // result is a read-only `"json"` tool payload, so freezing is fine.
+  const value = toDeepFrozenSchema(schema);
   return { type: "json", value };
 }
 
@@ -2930,17 +2939,18 @@ async function startRequest(
     builtinTools,
   );
 
-  // If resultSchema is provided, inject presentResult built-in tool
+  // If resultSchema is provided, inject presentResult built-in tool.
+  // TODO(danfuzz): `resultSchema` is untrusted input, so this `as` is an
+  // unchecked assertion. Replace with a runtime validating guard, e.g.
+  // `asSchemaOrThrow(schema: unknown): schema is JSONSchema`.
   const userResultSchema = capturedRequest?.userResultSchema ??
-    inputs.key("resultSchema").get();
+    (inputs.key("resultSchema").get() as JSONSchema | undefined);
   if (userResultSchema && capturedRequest === undefined) {
     toolCatalog.llmTools[PRESENT_RESULT_TOOL_NAME] = {
       description:
         "Call this tool to present a structured result. This stores the result for the caller.",
-      // TODO(danfuzz): Replace JSON.parse(JSON.stringify(...)) with
-      // cloneSchemaMutable() here.
       inputSchema: prepareSchemaForLLM(
-        JSON.parse(JSON.stringify(userResultSchema)),
+        toDeepFrozenSchema(userResultSchema),
       ),
     };
   }

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -15,7 +15,6 @@ import {
   BuiltInGenerateTextParams,
   BuiltInLLMMessage,
   BuiltInLLMParams,
-  JSONSchema,
 } from "@commonfabric/api";
 import type { Schema } from "@commonfabric/api/schema";
 import { hashOf } from "@commonfabric/data-model/value-hash";

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -19,6 +19,7 @@ import {
 } from "@commonfabric/api";
 import type { Schema } from "@commonfabric/api/schema";
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import { toDeepFrozenSchema } from "@commonfabric/data-model/schema-utils";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { cfcLabelViewForCellFailClosed } from "../cfc/label-view.ts";
 import {
@@ -1166,7 +1167,7 @@ export function generateObject<T extends Record<string, unknown>>(
     // Determine whether to use the tool-calling path or the direct generateObject path
     const hasTools = isObject(tools) && Object.keys(tools).length > 0;
     const validationSchema = schemaSanitizePromptInjection
-      ? JSON.parse(JSON.stringify(schema)) as JSONSchema
+      ? toDeepFrozenSchema(schema)
       : undefined;
     const resultSchemaForObserved = (
       observedConfidentiality: readonly unknown[],
@@ -1225,10 +1226,8 @@ export function generateObject<T extends Record<string, unknown>>(
           [llmToolExecutionHelpers.PRESENT_RESULT_TOOL_NAME]: {
             description:
               "Call this tool with the final structured result matching the required schema. This should be your last action.",
-            // TODO(danfuzz): Replace JSON.parse(JSON.stringify(...)) with
-            // cloneSchemaMutable() here.
             inputSchema: llmToolExecutionHelpers.prepareSchemaForLLM(
-              JSON.parse(JSON.stringify(schema)),
+              toDeepFrozenSchema(schema),
             ),
           },
         },
@@ -1557,10 +1556,8 @@ export function generateObject<T extends Record<string, unknown>>(
       const generateObjectParams: LLMGenerateObjectRequest = {
         messages: requestMessages,
         maxTokens: maxTokens ?? 8192,
-        // TODO(danfuzz): Replace JSON.parse(JSON.stringify(...)) with
-        // cloneSchemaMutable() here.
         schema: llmToolExecutionHelpers.prepareSchemaForLLM(
-          JSON.parse(JSON.stringify(schema)),
+          toDeepFrozenSchema(schema),
         ) as Record<string, unknown>,
         model: model ?? DEFAULT_GENERATE_OBJECT_MODELS,
         metadata: {

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -19,7 +19,11 @@ import {
   type Pattern,
   UI,
 } from "../builder/types.ts";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
+import {
+  deepFrozenCloneAndInternSchema,
+  hashSchema,
+  internSchema,
+} from "@commonfabric/data-model/schema-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { getPatternEnvironment } from "../env.ts";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -1259,21 +1263,27 @@ function createWishCandidatesCell(
   return runtime.getImmutableCell(space, values, undefined, tx);
 }
 
-// asCell-wrapped schemas per serialized content. The stringify itself is one
-// unavoidable walk (through the query-result proxy when the input is one),
-// but parse + intern repeat for the same content on every wish send.
+// asCell-wrapped schemas keyed by content hash. `hashSchema()` is one
+// unavoidable walk (through the query-result proxy when the input is one) and
+// is the cache key: it is `FabricValue`-aware, so schemas that differ only in
+// non-JSON `FabricValue` content (e.g. a `FabricBytes` default) get distinct
+// keys — a `JSON.stringify()` key would collide them. The clone-and-intern
+// repeats for the same content on every wish send, so cache it.
 const schemaAsCellCache = new LRUCache<string, JSONSchema>({ capacity: 256 });
 
 function schemaAsCell(schema: unknown): JSONSchema {
   if (schema && typeof schema === "object") {
-    const json = JSON.stringify(schema);
-    let result = schemaAsCellCache.get(json);
+    const key = hashSchema(schema as JSONSchema);
+    let result = schemaAsCellCache.get(key);
     if (result === undefined) {
-      result = internSchema({
-        ...(JSON.parse(json) as Record<string, unknown>),
+      // `schema` may be a query-result proxy, so deep-frozen-clone rather than
+      // freeze in place; the clone de-proxies and preserves `FabricValue`
+      // leaves that a JSON round-trip would mangle.
+      result = deepFrozenCloneAndInternSchema({
+        ...(schema as Record<string, unknown>),
         asCell: ["cell"],
       });
-      schemaAsCellCache.put(json, result);
+      schemaAsCellCache.put(key, result);
     }
     return result;
   }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2904,7 +2904,7 @@ export function internCellLinkSchema(
   // scan and return as-is.
   if (isInternedSchema(schema)) return schema;
   if (containsCellResult(schema)) {
-    return internSchema(JSON.parse(JSON.stringify(schema)) as JSONSchema);
+    return internSchema(cloneIfNecessary(schema));
   }
   return internSchema(schema);
 }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -14,6 +14,7 @@ import {
 import { codecOf } from "@commonfabric/data-model/codec-common";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import {
+  deepFrozenCloneAndInternSchema,
   internSchema,
   isInternedSchema,
 } from "@commonfabric/data-model/schema-hash";
@@ -2885,13 +2886,13 @@ function containsCellResult(value: unknown): boolean {
  * contract `resolveSchema()` already applies to cell schemas on every
  * read/write-policy path.
  *
- * Exception: schemas read through a query-result proxy (e.g. the wish
- * builtin's `schema` argument) must NOT be frozen in place — `Object.freeze`
- * forwards through the proxy and would freeze the underlying stored value,
- * breaking the proxy's object invariants (and any later `JSON.stringify` of
- * it). Those are round-tripped to a plain value first, the documented
- * convention for proxy-wrapped schemas (see `cloneSchemaMutable`'s note in
- * data-model's schema-utils).
+ * Exception: a schema that (transitively) contains a query-result proxy —
+ * e.g. the wish builtin's `schema` argument — must NOT be frozen in place,
+ * as that would push structural mutation through the proxy onto the live
+ * backing value (and trip the proxy's structural-mutation guard). Such schemas
+ * are interned via `deepFrozenCloneAndInternSchema()`, which deep-freezes a
+ * clone — de-proxying the containers and preserving `FabricValue` leaves —
+ * instead of freezing the argument in place.
  */
 export function internCellLinkSchema(schema: JSONSchema): JSONSchema;
 export function internCellLinkSchema(
@@ -2904,7 +2905,7 @@ export function internCellLinkSchema(
   // scan and return as-is.
   if (isInternedSchema(schema)) return schema;
   if (containsCellResult(schema)) {
-    return internSchema(cloneIfNecessary(schema));
+    return deepFrozenCloneAndInternSchema(schema);
   }
   return internSchema(schema);
 }

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -1,4 +1,5 @@
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
 import { isRecord } from "@commonfabric/utils/types";
 import { getTopFrame } from "./builder/pattern.ts";
 import { isStreamValue } from "./builder/types.ts";
@@ -168,7 +169,13 @@ export function createQueryResultProxy<T>(
     return createCell(runtime, link, tx, false, "stream", cfcLabelView) as T;
   }
 
-  if (!isRecord(value)) return value;
+  // `FabricPrimitive`s (byte sequences, temporal values, hashes, ...) are
+  // immutable leaves that behave like primitives -- there is no reactive
+  // substructure to resolve and they are already frozen. Hand back the value
+  // directly, exactly as for JS primitives above; wrapping one in a live proxy
+  // serves no purpose and would leak that proxy into any consumer that
+  // deep-clones or freezes the surrounding value (e.g. schema interning).
+  if (!isRecord(value) || value instanceof FabricPrimitive) return value;
 
   // Stored objects are deep-frozen during storage normalization
   // (fabricFromNativeValueModern). A frozen proxy target would force every

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -177,6 +177,12 @@ export function createQueryResultProxy<T>(
   // deep-clones or freezes the surrounding value (e.g. schema interning).
   if (!isRecord(value) || value instanceof FabricPrimitive) return value;
 
+  // TODO(danfuzz): This may have to do something special to handle concrete
+  // instances of `FabricInstance` so that they get perceived as such by the
+  // proxy's clients. Unlike `FabricPrimitive`, `FabricInstance`s are not
+  // necessarily frozen and _do_ expose outgoing references (just as plain
+  // objects and arrays do).
+
   // Stored objects are deep-frozen during storage normalization
   // (fabricFromNativeValueModern). A frozen proxy target would force every
   // property access through the invariant guard (ECMAScript 10.5.8: a [[Get]]

--- a/packages/runner/test/query-result-proxy-fabric-primitive.test.ts
+++ b/packages/runner/test/query-result-proxy-fabric-primitive.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { FabricPrimitive } from "@commonfabric/data-model/fabric-value";
+import { Runtime } from "../src/runtime.ts";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { internCellLinkSchema } from "../src/cell.ts";
+import { isCellResultForDereferencing } from "../src/query-result-proxy.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("test proxy fabric primitive");
+const space = signer.did();
+
+// A `FabricPrimitive` (byte sequence, temporal value, hash, ...) is an
+// immutable leaf. The query-result proxy must hand it back raw rather than
+// wrapping it in a live proxy: a wrapped primitive leaks the proxy into any
+// consumer that deep-clones or freezes the surrounding value -- notably schema
+// interning, which deep-freezes its argument and trips the proxy's
+// structural-mutation guard.
+describe("query-result proxy: FabricPrimitive leaves are not proxy-wrapped", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("returns a FabricBytes leaf raw, not as a cell-result proxy", () => {
+    const cell = runtime.getCell(space, "bytesCell", undefined, tx);
+    cell.set({ bytes: new Uint8Array([1, 2, 3, 4]) });
+    const leaf = (cell.getAsQueryResult() as Record<string, unknown>).bytes;
+    expect(isCellResultForDereferencing(leaf)).toBe(false);
+    expect(leaf instanceof FabricPrimitive).toBe(true);
+  });
+
+  it("returns a temporal (Date -> FabricEpochNsec) leaf raw", () => {
+    const cell = runtime.getCell(space, "dateCell", undefined, tx);
+    cell.set({ when: new Date(0) });
+    const leaf = (cell.getAsQueryResult() as Record<string, unknown>).when;
+    expect(isCellResultForDereferencing(leaf)).toBe(false);
+    expect(leaf instanceof FabricPrimitive).toBe(true);
+  });
+});
+
+// End-to-end: a schema whose `default` carries a non-JSON FabricValue, read
+// through a query-result proxy, must intern without throwing AND without losing
+// the value to a JSON shadow.
+describe("internCellLinkSchema preserves FabricValue schema defaults read through a proxy", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("preserves a FabricBytes default (no throw, no JSON-mangling)", () => {
+    const cell = runtime.getCell(space, "schemaBytes", undefined, tx);
+    cell.set({ type: "object", default: { bytes: new Uint8Array([5, 6, 7]) } });
+    const proxySchema = cell.getAsQueryResult();
+    const interned = internCellLinkSchema(proxySchema as never) as {
+      default: { bytes: unknown };
+    };
+    expect(interned.default.bytes instanceof FabricPrimitive).toBe(true);
+  });
+
+  it("preserves a temporal default (no throw, no JSON-mangling)", () => {
+    const cell = runtime.getCell(space, "schemaDate", undefined, tx);
+    cell.set({ type: "object", default: { when: new Date(0) } });
+    const proxySchema = cell.getAsQueryResult();
+    const interned = internCellLinkSchema(proxySchema as never) as {
+      default: { when: unknown };
+    };
+    expect(interned.default.when instanceof FabricPrimitive).toBe(true);
+  });
+});

--- a/packages/schema-generator/src/formatters/native-type-formatter.ts
+++ b/packages/schema-generator/src/formatters/native-type-formatter.ts
@@ -75,6 +75,11 @@ export class NativeTypeFormatter implements TypeFormatter {
   ): JSONSchemaMutable {
     const typeName = NativeTypeFormatter.getTypeName(type);
     const schema = NATIVE_TYPE_SCHEMAS[typeName!];
+    // TODO(danfuzz): `structuredClone()` mangles non-JSON `FabricValue`s —
+    // harmless while `NATIVE_TYPE_SCHEMAS` are plain JSON, but a problem once
+    // schema-generator covers the full `FabricValue` spectrum. See the matching
+    // note on `cloneSchemaDefinition()` re: a FabricValue-aware clone and
+    // whether mutability is even needed.
     return (typeof schema === "boolean" ? schema : structuredClone(schema!));
   }
 

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -352,6 +352,12 @@ export function getPrimarySymbol(type: ts.Type): ts.Symbol | undefined {
 export function cloneSchemaDefinition<T extends JSONSchemaMutable>(
   schema: T,
 ): T {
+  // TODO(danfuzz): `structuredClone()` mangles non-JSON `FabricValue`s —
+  // harmless while generated schemas are plain JSON, but a problem once
+  // schema-generator covers the full `FabricValue` spectrum. It then needs a
+  // FabricValue-aware clone; also revisit whether a freely-mutable result is
+  // required at all (callers just return it), since an immutable base plus
+  // `cloneForMutation()` for scoped edits is a safer pattern.
   return (typeof schema === "boolean" ? schema : structuredClone(schema)) as T;
 }
 


### PR DESCRIPTION
## Problem

Schemas read through a query-result proxy were detached before interning/cloning via `JSON.parse(JSON.stringify(...))` (and, in `wish`, an equivalent split `stringify`/`parse`). That round-trip **silently flattens non-JSON `FabricValue`s** (`FabricBytes`, the temporal primitives, `Hash`, …) that can live in schema `default`/`const` fields — the very values `internSchema` otherwise preserves. The naive alternative (`internSchema(cloneIfNecessary(schema))`) instead **threw**, because the proxy leaked into the clone and tripped the structural-mutation guard.

Root cause: the query-result proxy wrapped `FabricPrimitive` leaves in a live proxy, so a `FabricValue`-aware clone (`cloneIfNecessary`) couldn't de-proxy them — its immutable-leaf arms returned the proxy as-is.

## Fix

**1. Proxy (Cell layer) — `query-result-proxy.ts`**
A `FabricPrimitive` is an immutable leaf that behaves like a primitive (already frozen, no reactive substructure). Hand it back raw, exactly as for JS primitives, rather than wrapping it. This is the layer that may know data-model; `cloneHelper` stays proxy-unaware.

**2. `deepFrozenCloneAndInternSchema()` / `toDeepFrozenSchema(schema, canShare)`**
A dedicated helper for the sites that must *not* freeze their schema argument in place: it deep-frozen-**clones** (de-proxying containers, preserving `FabricValue` leaves) and interns. Built on `toDeepFrozenSchema`'s `canShare` flag (`internSchema` → `true` = freeze in place; the helper → `false` = clone).

**3. Convert the round-trip sites**
- `internCellLinkSchema` (`cell.ts`) → `deepFrozenCloneAndInternSchema` (canonical, reused → intern).
- `wish` `schemaAsCell` → the helper, **and** re-key its LRU cache on `hashSchema()` instead of `JSON.stringify` — the JSON key collided schemas differing only in `FabricValue` content.
- `llm.ts` / `llm-dialog.ts` schema feeders (validation schema, `prepareSchemaForLLM` inputs, `handleSchema`) → `toDeepFrozenSchema(schema)` (consumed per turn, not reused → no interning). `prepareSchemaForLLM` only reads its input, so a frozen schema is safe. Also tightened `DialogRequestSnapshot.userResultSchema` (`unknown` → `JSONSchema | undefined`).

## Tests
- New regression test (`query-result-proxy-fabric-primitive.test.ts`): proxy returns raw `FabricPrimitive` leaves; `internCellLinkSchema` preserves `FabricBytes`/temporal defaults — **verified red on the prior code**.
- New `deepFrozenCloneAndInternSchema` tests (no freeze-in-place, content interning, `undefined`/boolean passthrough).
- Full runner suite green (**628 passed, 0 failed**); data-model schema-hash suite green.

## Deliberately deferred (flagged in-code as `TODO(danfuzz)`)
- An `asSchemaOrThrow(schema: unknown): schema is JSONSchema` runtime guard for the untrusted `resultSchema` reads in `llm-dialog.ts` (the boundary `as` is an unchecked assertion).
- A `FabricValue`-aware clone in `schema-generator` (its `structuredClone(schema)` is harmless only while generated schemas are plain JSON), plus revisiting whether those results need to be freely mutable at all.
- Non-schema payload round-trips (llm messages / metadata / params) — a separate `cloneIfNecessary` concern if `FabricValue`s become reachable there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves non-JSON `FabricValue` defaults in schemas and avoids proxy freeze errors by replacing JSON round-trips with Fabric-aware deep-frozen cloning/interning. Also stops wrapping `FabricPrimitive` leaves in query-result proxies.

- **Bug Fixes**
  - Query-result proxy now returns `FabricPrimitive` leaves raw (no proxy wrap), preventing leaks into clones and freeze-in-place errors. Note: `FabricInstance` handling is not yet implemented.
  - `internCellLinkSchema` uses deep-frozen clone + intern, preserving `FabricBytes`/temporal defaults read via proxy.
  - `wish` caches `schemaAsCell` by `hashSchema()` (no `JSON.stringify` collisions) and builds it via deep-frozen clone + intern.
  - `llm.ts` and `llm-dialog.ts` replace JSON round-trips with `toDeepFrozenSchema()` for validation/tool inputs and `"json"` payloads; `userResultSchema` is now `JSONSchema | undefined`.

- **Refactors**
  - Added `deepFrozenCloneAndInternSchema()` in `@commonfabric/data-model`; `toDeepFrozenSchema()` now accepts `undefined`.
  - Dropped stale `cloneSchemaMutable()` round-trip note; added TODOs in `@commonfabric/schema-generator` about `structuredClone` mangling `FabricValue`s; removed an unused import in `llm.ts`.
  - New tests cover proxy behavior and schema preservation; suites updated and passing.

<sup>Written for commit 169ab3c9d0f871560c102c107be83a22e714e542. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

