### PR TITLE
Evidence: shared-state writes silently dropped under concurrency

### DIFF
--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -202,14 +202,24 @@ export class MultiRuntimeHarness {
   readonly sessions: MultiRuntimeSession[];
   readonly pieceId: string;
   #server?: StandaloneMemoryServer;
+  /** Resolved space + api url so late ("cold") sessions can join the same
+   *  storage after the original sessions were created. */
+  readonly spaceName: string;
+  readonly apiUrl: string;
+  /** Cold sessions added post-hoc via {@link addColdSession}; disposed too. */
+  readonly coldSessions: MultiRuntimeSession[] = [];
 
   private constructor(
     sessions: MultiRuntimeSession[],
     pieceId: string,
+    spaceName: string,
+    apiUrl: string,
     server?: StandaloneMemoryServer,
   ) {
     this.sessions = sessions;
     this.pieceId = pieceId;
+    this.spaceName = spaceName;
+    this.apiUrl = apiUrl;
     this.#server = server;
   }
 
@@ -272,7 +282,7 @@ export class MultiRuntimeHarness {
         await session.client().call("openPiece", { pieceId });
       }
 
-      return new MultiRuntimeHarness(sessions, pieceId, server);
+      return new MultiRuntimeHarness(sessions, pieceId, spaceName, apiUrl, server);
     } catch (error) {
       bootstrap?.terminate();
       for (const session of sessions) {
@@ -281,6 +291,41 @@ export class MultiRuntimeHarness {
       await server?.close().catch(() => {});
       throw error;
     }
+  }
+
+  /**
+   * Spawn a fresh runtime that opens the piece for the FIRST time, *after* the
+   * original sessions have already done their work, and return it. Unlike the
+   * pre-opened sessions, a cold session has never subscribed to the result
+   * graph, so its first reads (and its first `sqliteQuery` issuance) materialize
+   * directly from committed storage — bypassing any `reactOn` re-trigger / cross-
+   * runtime invalidation that a long-lived session depends on. This is the only
+   * way to observe canonical server truth (e.g. the real SQLite row count)
+   * independent of a runtime's reactive-read freshness.
+   *
+   * A distinct `identity` defaults to a fresh passphrase-derived one; pass an
+   * existing session's `identity` to cold-open as that same user.
+   */
+  async addColdSession(
+    label: string,
+    identity?: Identity,
+  ): Promise<MultiRuntimeSession> {
+    const id = identity ??
+      await Identity.fromPassphrase(
+        `multi-runtime-harness cold ${label}`,
+        { implementation: "noble" },
+      );
+    const client = new WorkerClient(label);
+    await client.call("init", {
+      rawIdentity: id.serialize(),
+      spaceName: this.spaceName,
+      apiUrl: this.apiUrl,
+      diagnostics: false,
+    });
+    await client.call("openPiece", { pieceId: this.pieceId });
+    const session = new MultiRuntimeSession(label, id, client);
+    this.coldSessions.push(session);
+    return session;
   }
 
   session(label: string): MultiRuntimeSession {
@@ -326,7 +371,7 @@ export class MultiRuntimeHarness {
   }
 
   async dispose(): Promise<void> {
-    for (const session of this.sessions) {
+    for (const session of [...this.sessions, ...this.coldSessions]) {
       await session.disposeSession().catch((error) => {
         console.warn(`Failed to dispose session "${session.label}":`, error);
       });

--- a/packages/patterns/lunch-poll/DROPPED-WRITES-EVIDENCE.md
+++ b/packages/patterns/lunch-poll/DROPPED-WRITES-EVIDENCE.md
@@ -4,9 +4,12 @@
 some writes are **silently lost in canonical storage** — no error to the app, and
 the loss can be **invisible and displaced** from its cause (a dropped *identity*
 write silently voids every later action that depended on it). It is a **general
-runtime behavior, not SQLite-specific**, and **keying does not avoid it** (the
-conflict unit is the whole document, not the field). There is **one** mechanism;
-two earlier "second mechanism" hypotheses were investigated and **refuted**.
+runtime behavior, not SQLite-specific**. The engine is **not** fundamentally
+document-granular (disjoint `patch` writes with fine reads merge); the drops come
+from pattern-handler write shapes that **over-conflict** — coarse, document-wide
+reads plus a path-blind `set`/`delete` path — so **keying *as authored today* does
+not avoid it** (§2). There is **one** mechanism; two earlier "second mechanism"
+hypotheses were investigated and **refuted**.
 
 This is reproducible and grounded in the runtime code. It is **for discussion** —
 we have a root cause but **no chosen fix**.
@@ -39,25 +42,39 @@ Both `cold == live` (no reactive-read lag) and stable across reps.
 
 ## 2. Root cause (code-grounded)
 
-**The write-conflict / serialization unit is the entity-DOCUMENT** — the tuple
-`(branch, id, scope_key)` — decided server-side, **not** per-field and **not**
-per-space. The governing predicate has no field/path/space column:
+**The conflict check is two-tier**, and the distinction is the crux. (Both tiers
+are pinned against a real `MemoryV2Server` in #4196's
+`packages/runner/test/cell-write-conflict-granularity.test.ts`.)
 
-```sql
--- packages/memory/v2/engine.ts:529  SELECT_SET_DELETE_CONFLICT
-WHERE branch=:branch AND id=:id AND scope_key=:scope_key AND seq > :after_seq
-  AND op IN ('set','delete')
-```
+- **tier-1 — `set`/`delete`: path-BLIND.** The predicate carries no field/path
+  column, so any whole-doc `set`/`delete` conflicts with everything on the
+  `(branch, id, scope_key)` document:
+  ```sql
+  -- packages/memory/v2/engine.ts:529  SELECT_SET_DELETE_CONFLICT
+  WHERE branch=:branch AND id=:id AND scope_key=:scope_key AND seq > :after_seq
+    AND op IN ('set','delete')
+  ```
+- **tier-2 — `patch`: path-overlap-gated.** Disjoint `patch` writes with *fine*
+  reads **merge cleanly** — the engine is **NOT** fundamentally document-granular.
+  (#4196 ARM 1: two disjoint sibling bumps both land; server merges to
+  `{nameDraft:"Alice", otherSibling:1}`, neither rejected.)
 
-From that one fact, everything follows and matches every measurement:
+So conflict granularity is decided by the **writer's recorded read-set (plus op
+type)** — not by the engine being doc-locked. The drops we measure come from
+**pattern-handler write shapes that over-conflict:**
 
-- **Coarse *within* a document → keying does not help.** A plain `Record`'s keys
-  live inline in one document; `.key(id)` only extends the link *path* while
-  keeping the same entity `id` (`cell.ts:1492-1521`), and a primitive value is
-  never split into its own entity doc (`data-updating.ts:838-902`). So
-  `map.key(a).set()` and `map.key(b).set()` — **distinct keys** — collide exactly
-  like a shared `list.push()`. Measured: distinct-key 20 vs shared-list 19 of 50
-  missing at 10 users.
+- **Handler writes record COARSE reads → tier-2 overlaps everything.** A handler
+  `.get()` (or resolving `.key(id)`) records a **root `[]` read**, a prefix of
+  every concurrent patch path, so tier-2's overlap check always fires and even
+  **distinct-key** writes collide. (`.key(id)` shares the parent entity `id` and
+  only extends the path — `cell.ts:1492-1521`; primitives stay inline,
+  `data-updating.ts:838-902`.) Measured: distinct-key 20 vs shared-list 19 of 50
+  missing at 10 users. **So keying *as authored today* doesn't help — not because
+  the engine can't discriminate fields, but because these handlers record
+  document-wide reads** (+ the tier-1 blindness above). With fine reads (as a
+  `$value`-bound write records), the same disjoint writes would merge (#4196).
+  *(Exact read-path our handlers record vs `$value` writes is being pinned in the
+  granularity prototype.)*
 - **Bounded *across* documents.** Two distinct cells get distinct `id`s and never
   co-select in the conflict SQL (`scope_key` for `"space"` is the constant
   `DEFAULT_SCOPE_KEY`, `engine.ts:46-53`). Measured: a writer group on cell `list`
@@ -115,17 +132,19 @@ and **both refuted**:
   minimal repro is identically clean (`missing == exhaustions`). The contention
   pattern is not the trigger.
 
-So there is **one** mechanism (per-document conflict → retry exhaustion → silent
-drop), which manifests directly *and* via the cascade. (The earlier
-`main-sqlite-rev.tsx` lost-update line in `PERF-SESSION` is superseded by this.)
+So there is **one** mechanism (over-conflict → retry exhaustion → silent drop),
+which manifests directly *and* via the cascade. (The earlier `main-sqlite-rev.tsx`
+lost-update line in `PERF-SESSION` is superseded by this.)
 
 ---
 
 ## 5. Severity
 
 - **Silent to the app** — `send()` resolves; no exception, no Result error.
-- **Keying does not save you** — the intuitive "give each user their own slot" fix
-  still collides (whole-document conflict unit).
+- **Keying *as authored today* does not save you** — distinct-key writes still
+  collide because the handler records coarse, document-wide reads (not because the
+  engine is doc-locked; with fine reads they'd merge — #4196). "Give each user
+  their own slot" only pays off once the recorded read-set is finer.
 - **Cascading + displaced** — a dropped identity/setup write silently voids
   dependent actions far from the fault.
 - **Threshold scales with contention** — plain cells drop by ~10 concurrent writers
@@ -147,15 +166,28 @@ rather than silently losing the write. Our findings split the space in two:
    (`events.ts:609-616, 661`) — at minimum an observable error the app can
    retry/queue/show. This is the headline ask and covers the cascade (where the
    symptom is otherwise invisible).
-2. **Don't conflict where writes are independent.** For commutative / distinct-key
-   writes (append, per-user slots), finer-grained **per-path** conflict detection
-   (extend the conflict predicate + the read precondition with the write path)
-   would let them commit concurrently — directly removing the coarse-within-doc
-   collisions. Alternatives: split hot collections so each key is its own entity
-   doc; or a CRDT/server-merge for commutative ops.
+2. **Don't conflict where writes are independent.** The engine's tier-2 `patch`
+   path **already** merges disjoint writes when reads are fine (#4196's real-server
+   test proves it) — so the lever is making handler writes record **finer reads**
+   (stop the root `[]` read so the existing path-overlap check discriminates), plus
+   making the tier-1 `set`/`delete` path path-aware. The non-negotiable invariant:
+   never under-record a read the handler actually depended on (that would turn
+   over-conflict into a *silent lost update* — strictly worse). Alternatives: split
+   hot collections so each key is its own entity doc; or CRDT/server-merge for
+   commutative ops. *(Granularity options + a prototype plan are being worked
+   separately.)*
 3. **Mitigations (rate, not structure):** larger retry budget + jittered backoff —
    cheaper, reduces the drop *rate* under bursts, but a hot doc with N > budget
    concurrent writers still drops.
+
+**Related work.** [#4196](https://github.com/commontoolsinc/labs/pull/4196)
+(per-key commit queue + bounded rebase, runtime-client) is the **client-side
+recovery** half: it serializes one client's same-key writes and *re-lands* a
+rejected write instead of clobbering. It deliberately does **not** change engine
+granularity ("that hardening stays with #4178") and ships the
+`cell-write-conflict-granularity.test.ts` real-server harness this doc's two-tier
+model is pinned against. #4196 = recover at the client; #4178 = stop
+over-conflicting at the engine.
 
 ---
 

--- a/packages/patterns/lunch-poll/DROPPED-WRITES-EVIDENCE.md
+++ b/packages/patterns/lunch-poll/DROPPED-WRITES-EVIDENCE.md
@@ -1,94 +1,195 @@
-# Evidence: shared-state writes are silently dropped under concurrency
+# Shared-state writes are silently dropped under concurrency — root cause + evidence
 
-**Claim.** When multiple runtimes (users) write the same shared state concurrently,
-some writes are **silently lost** — and the loss is in **canonical storage**, not a
-stale UI. This is a **general runtime behavior, not SQLite-specific**: a plain
-keyed *cell* variant drops writes too, just at higher concurrency than SQLite.
+**TL;DR.** When multiple runtimes (users) write the same document/cell concurrently,
+some writes are **silently lost in canonical storage** — no error to the app, and
+the loss can be **invisible and displaced** from its cause (a dropped *identity*
+write silently voids every later action that depended on it). It is a **general
+runtime behavior, not SQLite-specific**, and **keying does not avoid it** (the
+conflict unit is the whole document, not the field). There is **one** mechanism;
+two earlier "second mechanism" hypotheses were investigated and **refuted**.
 
-How we know it's storage and not a read glitch: the probe opens a **fresh runtime
-that never subscribed** to the result graph (`MultiRuntimeHarness.addColdSession`).
-Its first read materializes directly from committed storage, bypassing every
-`reactOn`/dedup/cross-runtime propagation hop — so the **cold-auditor count is
-canonical server truth**. Where cold == live but both are below the attempted
-count, the writes are genuinely gone.
+This is reproducible and grounded in the runtime code. It is **for discussion** —
+we have a root cause but **no chosen fix**.
 
-## Reproduce
+---
+
+## 1. The demonstration (cold-reader = canonical storage truth)
+
+The probe opens a **fresh runtime that never subscribed** to the result graph
+(`MultiRuntimeHarness.addColdSession`). Its first read materializes directly from
+committed storage, bypassing every reactive/propagation hop — so the cold-auditor
+count is **canonical server truth**, not a stale UI. Where cold == live but both
+are below the attempted count, the writes are genuinely gone.
+
+| storage | concurrency | landed (cold storage) |
+| ------- | ----------- | --------------------- |
+| plain keyed CELL (`main-indexed.tsx`) | 10 users | **18 / 30** |
+| SQLite (`main-sqlite.tsx`) | 5 users | **1 / 15** |
+
+```
+# main-indexed.tsx, 3 options × 10 users (30 attempted):
+  cold-auditor voteCount=18 votes.len=18   ->  WRITES DROPPED — 18/30 in storage
+# main-sqlite.tsx, 3 options × 5 users (15 attempted):
+  cold-auditor voteCount=1  votes.len=1    ->  WRITES DROPPED — 1/15 in storage
+```
+
+Both `cold == live` (no reactive-read lag) and stable across reps.
+
+---
+
+## 2. Root cause (code-grounded)
+
+**The write-conflict / serialization unit is the entity-DOCUMENT** — the tuple
+`(branch, id, scope_key)` — decided server-side, **not** per-field and **not**
+per-space. The governing predicate has no field/path/space column:
+
+```sql
+-- packages/memory/v2/engine.ts:529  SELECT_SET_DELETE_CONFLICT
+WHERE branch=:branch AND id=:id AND scope_key=:scope_key AND seq > :after_seq
+  AND op IN ('set','delete')
+```
+
+From that one fact, everything follows and matches every measurement:
+
+- **Coarse *within* a document → keying does not help.** A plain `Record`'s keys
+  live inline in one document; `.key(id)` only extends the link *path* while
+  keeping the same entity `id` (`cell.ts:1492-1521`), and a primitive value is
+  never split into its own entity doc (`data-updating.ts:838-902`). So
+  `map.key(a).set()` and `map.key(b).set()` — **distinct keys** — collide exactly
+  like a shared `list.push()`. Measured: distinct-key 20 vs shared-list 19 of 50
+  missing at 10 users.
+- **Bounded *across* documents.** Two distinct cells get distinct `id`s and never
+  co-select in the conflict SQL (`scope_key` for `"space"` is the constant
+  `DEFAULT_SCOPE_KEY`, `engine.ts:46-53`). Measured: a writer group on cell `list`
+  drops the same whether a disjoint group hammers a *different* cell (42%) or that
+  cell is idle (40%) — vs 69% when all writers share one cell.
+- **Per-document, not per-user.** Because the space scope_key is constant, writer
+  identity does not partition the unit — every user's write to one cell lands in
+  one conflict group, so concurrency on that cell is what drives drops.
+- **Retry budget = 5, then silent.** A conflicting handler commit is non-permanent
+  and retries up to `DEFAULT_RETRIES_FOR_EVENTS = 5`
+  (`scheduler/constants.ts:5`). The commit is **fire-and-forget — not awaited**
+  (`events.ts:609-616`), so `send()` resolves and the run "succeeds" regardless. On
+  exhaustion the runtime logs one `schedule-error` line (`events.ts:661`) but
+  **nothing propagates to the app/caller**.
+
+Re-run confirms the accounting in the simple case: every dropped write is exactly
+one logged exhaustion (`missing == exhaustions`, e.g. 45 = 45 across modes).
+
+---
+
+## 3. The blast radius: drops **cascade** (the dangerous part)
+
+A dropped write is not always the user-visible symptom — it can be an **identity
+or setup write** whose loss silently invalidates everything downstream.
+
+Concretely in the lunch poll: `joinAs` writes the *contended* `usersByName` /
+`userOrder` docs **and** sets the user's `myName` (`PerUser`) **in the same
+transaction** (`main-indexed.tsx:156-177`). Under concurrent joins, some join
+transactions exhaust retries and drop — taking the `myName.set()` with them. That
+user now has an empty `myName`, so `castVote`'s first line
+`if (!me || !optionId) return` (`main-indexed.tsx:246`) makes **every vote they
+cast silently no-op** — no write, no error, no exhaustion line.
+
+Measured directly: at 3×10, instrumenting the guard showed **9 `castVote`s firing
+with `me=""`**. So the symptom ("my votes don't count") appears nowhere near the
+actual fault (a dropped *join* one phase earlier). The failure is both **invisible**
+(no error at either point) and **displaced** (logged, if at all, against a
+different action). This is why "the client should know" matters more than it first
+sounds.
+
+---
+
+## 4. What it is NOT (two refuted hypotheses)
+
+The lunch-poll case showed `missing(12) > exhaustions(6)`, which *looked* like a
+**second, silent** drop mechanism. It is not — it is the cascade above (the extra
+missing votes were never *attempted* as writes; their root drop was logged at the
+*join* phase). Two structural hypotheses were tested in a minimal SQLite-free repro
+and **both refuted**:
+
+- **"Silent lost-update on the shared-subrecord write shape"** — a minimal handler
+  mirroring `castVote` exactly (`tally.get()` then `tally.key(b).key(leaf).set()`)
+  shows `missing == exhaustions`, **no silent loss**.
+- **"The multi-bucket structure causes it"** — at 1, 2, and 3 shared buckets the
+  minimal repro is identically clean (`missing == exhaustions`). The contention
+  pattern is not the trigger.
+
+So there is **one** mechanism (per-document conflict → retry exhaustion → silent
+drop), which manifests directly *and* via the cascade. (The earlier
+`main-sqlite-rev.tsx` lost-update line in `PERF-SESSION` is superseded by this.)
+
+---
+
+## 5. Severity
+
+- **Silent to the app** — `send()` resolves; no exception, no Result error.
+- **Keying does not save you** — the intuitive "give each user their own slot" fix
+  still collides (whole-document conflict unit).
+- **Cascading + displaced** — a dropped identity/setup write silently voids
+  dependent actions far from the fault.
+- **Threshold scales with contention** — plain cells drop by ~10 concurrent writers
+  to one doc; SQLite by ~5 (it adds a shared `handle.rev` RMW + a wider commit
+  window); the `sqliteRev` variant by ~2–3. So SQLite-per-row is **worse**, not
+  better — it reintroduces and multiplies the shared funnel.
+
+---
+
+## 6. Fix surface (directions, not a chosen fix)
+
+Per team discussion (Robin): for a *genuine* read-modify-write of the same value (a
+shared counter, a toggle) there is **no perfect resolution** — that fundamentally
+needs optimistic concurrency, and the priority is that the **client is told**
+rather than silently losing the write. Our findings split the space in two:
+
+1. **Surface exhaustion to the caller (always).** Propagate a write failure after
+   the retry budget to the app instead of fire-and-forget + log-only
+   (`events.ts:609-616, 661`) — at minimum an observable error the app can
+   retry/queue/show. This is the headline ask and covers the cascade (where the
+   symptom is otherwise invisible).
+2. **Don't conflict where writes are independent.** For commutative / distinct-key
+   writes (append, per-user slots), finer-grained **per-path** conflict detection
+   (extend the conflict predicate + the read precondition with the write path)
+   would let them commit concurrently — directly removing the coarse-within-doc
+   collisions. Alternatives: split hot collections so each key is its own entity
+   doc; or a CRDT/server-merge for commutative ops.
+3. **Mitigations (rate, not structure):** larger retry budget + jittered backoff —
+   cheaper, reduces the drop *rate* under bursts, but a hot doc with N > budget
+   concurrent writers still drops.
+
+---
+
+## 7. Reproduce
 
 ```bash
-cd labs-perf   # (this worktree)
+cd labs-perf
 
-# SQLite vote storage, 3 options × 5 concurrent users (15 votes attempted):
-deno run -A packages/patterns/lunch-poll/probe-sqlite-landing.ts \
-  --program=main-sqlite.tsx --case=3x5 --rounds=3
+# Lunch-poll: the cascade case (cell storage, 10 users) and SQLite (5 users):
+deno run -A packages/patterns/lunch-poll/probe-sqlite-landing.ts --program=main-indexed.tsx --case=3x10 --rounds=3
+deno run -A packages/patterns/lunch-poll/probe-sqlite-landing.ts --program=main-sqlite.tsx  --case=3x5  --rounds=3
 
-# Plain keyed CELL storage, 3 options × 10 concurrent users (30 attempted):
-deno run -A packages/patterns/lunch-poll/probe-sqlite-landing.ts \
-  --program=main-indexed.tsx --case=3x10 --rounds=3
+# Minimal, SQLite-free, no lunch-poll: plain cell drops + names which writes vanish.
+# Compare missing vs the "exhausting all retries" stderr count (they match -> one mechanism).
+deno run -A packages/patterns/write-contention/probe.ts --users=10 --rounds=5 --mode=map 2>/tmp/wc.err
+grep -c "exhausting all retries" /tmp/wc.err
+
+# Conflict unit is the document, not the space (disjoint cells don't contend):
+deno run -A packages/patterns/write-contention/probe-space.ts --groupA=10 --groupB=10 --rounds=5
 ```
 
-`--case=Nx U` = N options × U users; attempted distinct votes = `N_options × U`
-(each user votes each option once over the rounds, deduped by `(voter,option)`).
+`--case=N×U` = N options × U users; attempted distinct votes = `N × U`.
 
-## Captured output (clean `main` base, this machine)
+Full methodology (re-validation, the concurrency sweep, the structural grounding)
+is in [`PERF-SESSION-2026-06-15.md`](./PERF-SESSION-2026-06-15.md).
 
-### 1. SQLite storage — 5 concurrent users — **1 of 15 landed**
+---
 
-```
-# probe-sqlite-landing program=main-sqlite.tsx case=3x5 rounds=3 (expect 15 votes if all land)
-## cold auditor (fresh runtime, first sqliteQuery = server truth):
-  cold-auditor voteCount=1 votes.len=1
-## live sessions (re-read after cold open + settle):
-  user-1..user-5   voteCount=1
-## verdict:
-  WRITES DROPPED — cold reader sees only 1/15 in canonical storage.
-```
+## 8. Open / not yet done
 
-`14` `Event handler transaction failed after exhausting all retries` lines in
-stderr. Conservation: **1 landed + 14 exhausted = 15 attempted.**
-
-### 2. Plain keyed CELL storage — 10 concurrent users — **18 of 30 landed**
-
-```
-# probe-sqlite-landing program=main-indexed.tsx case=3x10 rounds=3 (expect 30 votes if all land)
-## cold auditor (fresh runtime, first sqliteQuery = server truth):
-  cold-auditor voteCount=18 votes.len=18
-## live sessions (re-read after cold open + settle):
-  user-1..user-10  voteCount=18
-## verdict:
-  WRITES DROPPED — cold reader sees only 18/30 in canonical storage.
-```
-
-**12 votes lost, but only `6` `exhausting all retries` lines** — i.e. **~half the
-dropped writes produce no log line at all.**
-
-## Mechanism (summary)
-
-Concurrent writes to shared state serialize on a shared revision via
-optimistic concurrency. Each write retries up to a fixed budget
-(`DEFAULT_RETRIES_FOR_EVENTS = 5`, `packages/runner/src/scheduler/constants.ts`).
-Past that, the write is **abandoned** — yet `send()` still resolves and the run
-completes "successfully," so nothing surfaces the loss
-(`packages/runner/src/scheduler/events.ts` takes a log-only branch on exhaustion;
-the event commit is fire-and-forget).
-
-The **drop threshold roughly halves with each added/wider contention point**:
-plain cell variants tolerate ~10 concurrent writers before dropping; SQLite
-(`db.exec` read-modify-writes one shared `handle.rev` per write, plus a wider
-commit window) drops by ~5; a variant with a second shared counter
-(`main-sqlite-rev.tsx`) by ~2–3.
-
-Full methodology, the concurrency sweep, the rev-funnel-vs-write-window
-disambiguation, and the still-open per-row instrumentation are in
-[`PERF-SESSION-2026-06-15.md`](./PERF-SESSION-2026-06-15.md) (see "Re-validated on
-rebased main" and "Phase 3").
-
-## Open question for discussion
-
-Should a write that exhausts its retry budget **hard-fail / surface an error**
-rather than silently dropping (and emit a log line *every* time)? And on the perf
-side, keying fixes graph cost but inherits this contention 1:1 — a real fix likely
-needs per-row writes that don't funnel through a shared revision.
-
-> Distinct from this issue: the SQL-backed **reactive-read** lag (low live counts
-> at low concurrency where storage is actually full) is a separate read-side
-> propagation gap; it is *not* the cause of the losses above.
+- **No chosen or implemented fix** — section 6 is candidate directions.
+- **Headless only.** Reproduced on the real runtime stack run headless (cold == live,
+  no reactive lag); a live toolshed/browser deployment repro would make it airtight
+  against "but production differs."
+- *Separate, not this issue:* the SQL-backed **reactive-read** lag (low live counts
+  at low concurrency where storage is actually full) is a read-side propagation gap,
+  not the cause of the losses here.

--- a/packages/patterns/lunch-poll/DROPPED-WRITES-EVIDENCE.md
+++ b/packages/patterns/lunch-poll/DROPPED-WRITES-EVIDENCE.md
@@ -1,0 +1,94 @@
+# Evidence: shared-state writes are silently dropped under concurrency
+
+**Claim.** When multiple runtimes (users) write the same shared state concurrently,
+some writes are **silently lost** — and the loss is in **canonical storage**, not a
+stale UI. This is a **general runtime behavior, not SQLite-specific**: a plain
+keyed *cell* variant drops writes too, just at higher concurrency than SQLite.
+
+How we know it's storage and not a read glitch: the probe opens a **fresh runtime
+that never subscribed** to the result graph (`MultiRuntimeHarness.addColdSession`).
+Its first read materializes directly from committed storage, bypassing every
+`reactOn`/dedup/cross-runtime propagation hop — so the **cold-auditor count is
+canonical server truth**. Where cold == live but both are below the attempted
+count, the writes are genuinely gone.
+
+## Reproduce
+
+```bash
+cd labs-perf   # (this worktree)
+
+# SQLite vote storage, 3 options × 5 concurrent users (15 votes attempted):
+deno run -A packages/patterns/lunch-poll/probe-sqlite-landing.ts \
+  --program=main-sqlite.tsx --case=3x5 --rounds=3
+
+# Plain keyed CELL storage, 3 options × 10 concurrent users (30 attempted):
+deno run -A packages/patterns/lunch-poll/probe-sqlite-landing.ts \
+  --program=main-indexed.tsx --case=3x10 --rounds=3
+```
+
+`--case=Nx U` = N options × U users; attempted distinct votes = `N_options × U`
+(each user votes each option once over the rounds, deduped by `(voter,option)`).
+
+## Captured output (clean `main` base, this machine)
+
+### 1. SQLite storage — 5 concurrent users — **1 of 15 landed**
+
+```
+# probe-sqlite-landing program=main-sqlite.tsx case=3x5 rounds=3 (expect 15 votes if all land)
+## cold auditor (fresh runtime, first sqliteQuery = server truth):
+  cold-auditor voteCount=1 votes.len=1
+## live sessions (re-read after cold open + settle):
+  user-1..user-5   voteCount=1
+## verdict:
+  WRITES DROPPED — cold reader sees only 1/15 in canonical storage.
+```
+
+`14` `Event handler transaction failed after exhausting all retries` lines in
+stderr. Conservation: **1 landed + 14 exhausted = 15 attempted.**
+
+### 2. Plain keyed CELL storage — 10 concurrent users — **18 of 30 landed**
+
+```
+# probe-sqlite-landing program=main-indexed.tsx case=3x10 rounds=3 (expect 30 votes if all land)
+## cold auditor (fresh runtime, first sqliteQuery = server truth):
+  cold-auditor voteCount=18 votes.len=18
+## live sessions (re-read after cold open + settle):
+  user-1..user-10  voteCount=18
+## verdict:
+  WRITES DROPPED — cold reader sees only 18/30 in canonical storage.
+```
+
+**12 votes lost, but only `6` `exhausting all retries` lines** — i.e. **~half the
+dropped writes produce no log line at all.**
+
+## Mechanism (summary)
+
+Concurrent writes to shared state serialize on a shared revision via
+optimistic concurrency. Each write retries up to a fixed budget
+(`DEFAULT_RETRIES_FOR_EVENTS = 5`, `packages/runner/src/scheduler/constants.ts`).
+Past that, the write is **abandoned** — yet `send()` still resolves and the run
+completes "successfully," so nothing surfaces the loss
+(`packages/runner/src/scheduler/events.ts` takes a log-only branch on exhaustion;
+the event commit is fire-and-forget).
+
+The **drop threshold roughly halves with each added/wider contention point**:
+plain cell variants tolerate ~10 concurrent writers before dropping; SQLite
+(`db.exec` read-modify-writes one shared `handle.rev` per write, plus a wider
+commit window) drops by ~5; a variant with a second shared counter
+(`main-sqlite-rev.tsx`) by ~2–3.
+
+Full methodology, the concurrency sweep, the rev-funnel-vs-write-window
+disambiguation, and the still-open per-row instrumentation are in
+[`PERF-SESSION-2026-06-15.md`](./PERF-SESSION-2026-06-15.md) (see "Re-validated on
+rebased main" and "Phase 3").
+
+## Open question for discussion
+
+Should a write that exhausts its retry budget **hard-fail / surface an error**
+rather than silently dropping (and emit a log line *every* time)? And on the perf
+side, keying fixes graph cost but inherits this contention 1:1 — a real fix likely
+needs per-row writes that don't funnel through a shared revision.
+
+> Distinct from this issue: the SQL-backed **reactive-read** lag (low live counts
+> at low concurrency where storage is actually full) is a separate read-side
+> propagation gap; it is *not* the cause of the losses above.

--- a/packages/patterns/lunch-poll/PERF-SESSION-2026-06-15.md
+++ b/packages/patterns/lunch-poll/PERF-SESSION-2026-06-15.md
@@ -214,13 +214,18 @@ exit-code blindness. Data-integrity hazard for any array-variant sweep.
 Structural grounding (multi-agent code read + adversarial verify) + direct
 instrumentation. Full team-facing writeup: **`DROPPED-WRITES-EVIDENCE.md`**.
 
-- **Conflict unit = the entity-DOCUMENT** `(branch, id, scope_key)`, server-side.
-  The governing predicate `SELECT_SET_DELETE_CONFLICT` (`memory/v2/engine.ts:529`)
-  has NO field/path/space column. So: distinct keys in one Record collide (keying
-  doesn't help — `cell.ts:1492-1521`, `data-updating.ts:838-902`); disjoint cells
-  don't (distinct ids; `scope` "space" → constant `DEFAULT_SCOPE_KEY`,
-  `engine.ts:46-53`). Retry budget 5 (`scheduler/constants.ts:5`); commit is
-  fire-and-forget (`events.ts:609-616`) so the drop is **silent to the caller**.
+- **Conflict is TWO-tier** (REFINED 2026-06-16 by #4196's real-server test): tier-1
+  `set`/`delete` is **path-blind** (`SELECT_SET_DELETE_CONFLICT`, `engine.ts:529`,
+  no field column); tier-2 `patch` is **path-overlap-gated** and disjoint patches
+  with FINE reads **merge** — the engine is NOT fundamentally doc-granular. Our
+  handler writes over-conflict because they record COARSE root reads (via
+  `.get()`/`.key()` resolution, `cell.ts:1492-1521`) that overlap every patch — so
+  distinct keys collide *here*, but "keying doesn't help" is a property of the
+  write shape, not the engine. Disjoint cells don't conflict (distinct ids; `scope`
+  "space" → constant `DEFAULT_SCOPE_KEY`, `engine.ts:46-53`). Retry budget 5
+  (`scheduler/constants.ts:5`); commit fire-and-forget (`events.ts:609-616`) →
+  **silent to the caller**. (Full refinement + #4196 cross-link in
+  `DROPPED-WRITES-EVIDENCE.md`.)
 - **The "unlogged residual" (12 missing > 6 exhaustions) is RESOLVED — it is a
   CASCADE of the same bug, NOT a second mechanism.** `joinAs` writes the contended
   `usersByName`/`userOrder` docs AND `myName` (`PerUser`) in one tx

--- a/packages/patterns/lunch-poll/PERF-SESSION-2026-06-15.md
+++ b/packages/patterns/lunch-poll/PERF-SESSION-2026-06-15.md
@@ -209,6 +209,35 @@ Deterministically crashes the `array` 3×2 join phase; spreads to more workers u
 load (user-2 then user-9 at 3×10). Exit code stays 0 (`results[].ok=false`) — harness
 exit-code blindness. Data-integrity hazard for any array-variant sweep.
 
+### Root cause grounded + residual RESOLVED — 2026-06-16
+
+Structural grounding (multi-agent code read + adversarial verify) + direct
+instrumentation. Full team-facing writeup: **`DROPPED-WRITES-EVIDENCE.md`**.
+
+- **Conflict unit = the entity-DOCUMENT** `(branch, id, scope_key)`, server-side.
+  The governing predicate `SELECT_SET_DELETE_CONFLICT` (`memory/v2/engine.ts:529`)
+  has NO field/path/space column. So: distinct keys in one Record collide (keying
+  doesn't help — `cell.ts:1492-1521`, `data-updating.ts:838-902`); disjoint cells
+  don't (distinct ids; `scope` "space" → constant `DEFAULT_SCOPE_KEY`,
+  `engine.ts:46-53`). Retry budget 5 (`scheduler/constants.ts:5`); commit is
+  fire-and-forget (`events.ts:609-616`) so the drop is **silent to the caller**.
+- **The "unlogged residual" (12 missing > 6 exhaustions) is RESOLVED — it is a
+  CASCADE of the same bug, NOT a second mechanism.** `joinAs` writes the contended
+  `usersByName`/`userOrder` docs AND `myName` (`PerUser`) in one tx
+  (`main-indexed.tsx:156-177`); a dropped join takes `myName.set()` with it →
+  empty `myName` → `castVote`'s guard `if (!me) return` (`:246`) silently no-ops
+  that user's votes. Instrumented: **9 `castVote`s fired with `me=""`** at 3×10.
+  So the "extra" missing votes were never *attempted* as writes; their root drop
+  was logged at the *join* phase, not the vote phase.
+- **Two hypotheses REFUTED** by a minimal SQLite-free repro
+  (`write-contention/repro.tsx`): the shared-subrecord write *shape* (minimal
+  `tally.get()` + `key().set()` → `missing == exhaustions`, no silent loss) and the
+  multi-bucket *structure* (buckets 1/2/3 all clean). This supersedes the
+  line-90 `sqlite-rev` lost-update guess.
+- **`events.ts:663` counter instrumentation is no longer needed** — the cascade
+  (not a hidden silent path) explains the residual; the per-row exhaustion mapping
+  is moot.
+
 ### Cross-cutting insight (bridges this session's earlier work)
 
 The vote-read failure is the **same SQLite-query cross-runtime reactivity gap**

--- a/packages/patterns/lunch-poll/PERF-SESSION-2026-06-15.md
+++ b/packages/patterns/lunch-poll/PERF-SESSION-2026-06-15.md
@@ -1,0 +1,273 @@
+# Lunch-poll perf investigation — session handoff (2026-06-15)
+
+Continuation of willkelly's #4141 ("Keyed collections POC + lunch poll perf
+diagnostics"). This doc records where the investigation stands so a fresh session
+can resume without re-deriving anything.
+
+## Where this lives
+
+- **Worktree:** `cf-feat-1/labs-perf`, branch `perf-investigation` (created off
+  `origin/poc/keyed-collections` = wilk's #4141). Isolated from the lunch-poll
+  feature checkout in `cf-feat-1/labs` (on `gideon/lunch-poll-freetext-join`,
+  PR #4145).
+- **Harness:** `packages/patterns/lunch-poll/diagnose.ts` (wilk's). Run headless:
+  ```bash
+  cd cf-feat-1/labs-perf
+  deno run -A packages/patterns/lunch-poll/diagnose.ts \
+    --program=<file>.tsx --cases=1x2,3x5,10x5 --rounds=3 --skip-refresh
+  ```
+  `--cases=n×u` = options × users; `m = users × rounds`. `--skip-refresh` omits
+  the per-option homepage/image AI enrichment phase. Reports per-phase graph
+  node/edge counts + `topReadSites`; emits `ConflictError` retries during the
+  concurrent-vote-round phases. Full wilk findings: `keyed-collections/PERF.md`.
+
+## The three cost centers (lunch poll's "minutes to load")
+
+| # | Cost center | Scales with | Status |
+| - | ----------- | ----------- | ------ |
+| A | array-vote-aggregate reactive-graph growth (~1 node+edge per vote) | votes × options | **confirmed**, fixable |
+| B | per-option AI enrichment on load (image gen + web search + generateText, behind a 30s mutex) | option count (cold) | confirmed; **separable**, not yet addressed |
+| C | concurrent-write `ConflictError` retries (read-modify-write of the shared `votes` cell) | users voting at once | **confirmed**; keyed/indexed does NOT fix it |
+
+NOTE: our merged #4144 moved *history* to SQLite but **votes are still an
+array**, so A and C are fully live on current `main`.
+
+## Results so far (3×5 case, `--skip-refresh`, this machine)
+
+| variant | graph (host-adds) | retries | wall | final votes |
+| ------- | ----------------- | ------: | ---: | ----------: |
+| `main.tsx` (array) | 397n / 1004e | 36 | 57.5s | 15 ✓ |
+| `main-indexed.tsx` (keyed cell, wilk's) | 68n / 139e | 36 | 14.2s | 15 ✓ |
+| `main-sqlite.tsx` (`reactOn: db`, NEW) | **52n / 81e** | 7 | 12.4s | 1 ✗ |
+| `main-sqlite-rev.tsx` (`reactOn: sqliteRev`, NEW) | 53n | 7 | 11.8s | 0 ✗ |
+
+1×2 for reference: array 214n/463e/3-retries; indexed 54n/105e/3; sqlite 52n/81e/3.
+
+### Solid conclusions
+
+- **A confirmed + ranked.** Array graph grows with votes (397n at 3×5); indexed
+  is ~flat (68n); **SQLite is flattest (52n, identical at 1×2 and 3×5)**. Both
+  alternatives crush the array baseline on graph size and wall time.
+- **C confirmed.** Array and keyed-indexed show **identical 36 retries** at 3×5
+  (3 at 1×2) — both read-modify-write a shared `votes` cell. The keyed/indexed
+  approach fixes graph scaling (A) but **not** write contention (C). Retries grow
+  super-linearly with concurrency (2→5 users ⇒ 3→36 retries).
+
+### The open confound — RESOLVED 2026-06-15 (writes DROPPED, not unsurfaced)
+
+The SQLite variants showed only **7 retries** but also **failed to surface votes**
+(final 0–1 vs 15 at 3×5). Confound: "per-row inserts dodge contention" vs "writes
+don't land / don't surface." **Resolved by a cold-reader probe**
+(`probe-sqlite-landing.ts` + `MultiRuntimeHarness.addColdSession`): after the
+3×5 vote rounds, open the piece in a FRESH runtime that never subscribed — its
+first `sqliteQuery` has an empty `requestHash`, so it reads **canonical server
+SQLite truth**, bypassing every `reactOn`/dedup/cross-runtime hop.
+
+**Verdict: WRITES DROPPED.** Cold auditor sees **1/15** in storage. Stderr
+confirms the mechanism: **14 of 15 `castVote` transactions** (`main-sqlite.tsx:260:3`)
+emit `Event handler transaction failed after exhausting all retries` — they blow
+`editWithRetry`'s ~5–6 budget contending on the **shared handle `rev`** that
+`db.exec` read-modify-writes ([cell.ts:1133-1142]). 15 attempted − 14 dropped =
+1 landed, matching the cold count exactly. (76 raw retry WARNs + 14 hard
+exhaustions.)
+
+**This INVERTS the tentative read.** SQLite does NOT dodge contention — the
+`rev`-as-mutex serializes ALL writes through one cell (same contention as a shared
+array cell) but with a **hard retry ceiling that silently drops writes** instead
+of converging. Array/indexed RMW a shared cell too, but their retries converge so
+all 15 land (final 15 ✓, ~36 visible retries); SQLite drops 14 (final 1 ✗). So
+SQLite-as-written is **strictly worse under concurrency**, not better.
+
+The diagnose "7 retries" is therefore **not** low contention — it under-counts,
+because its retry metric only registers retries on transactions that *eventually
+commit*; the 14 that exhausted-and-dropped never appear. Do not use diagnose's
+SQLite retry number as a contention measure.
+
+Note the 1/15 is **lost writes, NOT the reactive-propagation gap** — if writes had
+landed, the cold reader would have read 15. The propagation gap (below) is real
+and separate, but it is not what causes 1/15 here.
+
+Adding a bumped `sqliteRev` counter (`main-sqlite-rev.tsx`) did not fix surfacing
+(still 0) — now expected: a second shared RMW cell (`sqliteRev`) ADDS a contention
+point, so it can only worsen the drop rate, never raise *successful*-retry counts.
+
+### Re-validated on rebased main — 2026-06-16 (3×5, `--skip-refresh`, this machine)
+
+Re-ran all four variants (3 reps each) + the cold-reader probe (3 reps) + a 1×2
+control on the rebased `main` (latest runtime + wilk's POC), via a multi-agent
+workflow with adversarial verification. **The 2026-06-15 conclusion HOLDS in full,
+and the mechanism is now `structural+measured` (code path AND numbers agree), not
+model-only.**
+
+| variant | maxNodes / maxEdges | retry WARNs | exhaustions | final votes |
+| ------- | ------------------- | ----------: | ----------: | ----------: |
+| `main.tsx` (array) | 431n / ~1190e | 72 | **0** | 15 ✓ (reps 1–2) |
+| `main-indexed.tsx` | 68n / 140e | 72 | **0** | 15 ✓ (3/3) |
+| `main-sqlite.tsx` | 54n / 84e | 82–83 | **14** | **1 ✗** (3/3) |
+| `main-sqlite-rev.tsx` | 55n / 86e | 83 | **14** | **1 ✗** (3/3) |
+
+- **Drop is real, not a propagation gap.** Cold auditor reads `voteCount=1`, all 5
+  live sessions `=1` (3/3 reps). Cross-checked by an adversary with a *distinct-SQL*
+  count query (`SELECT COUNT(*) … WHERE 1=1`) whose different `requestHash` is
+  dedup-proof — still returned 1, so it round-tripped to the on-disk file. The db is
+  **space-scoped** (`sqlite-builtins.ts`: `scope = outputBinding?.scope ?? "space"`;
+  `main-sqlite.tsx` declares no scope), so the fresh-identity cold reader hits the
+  same identity-independent file. Not a partition/dedup artifact.
+- **Conservation closes exactly:** 1 survivor + 14 `exhausting all retries` = 15
+  attempts. The 3×5 vote rotation is a Latin square → **15 distinct `(voter,option)`
+  keys**, so `INSERT OR REPLACE` collapses nothing — denominator 15 is correct.
+- **1×2 control LANDS all (2/2 `WRITES LANDED`)** → the drop is **concurrency-induced**,
+  not constant.
+- **Silent-drop path nailed structurally:** `send()` commits only the (uncontended)
+  event *enqueue* and resolves; the actual `castVote` handler tx runs later
+  *fire-and-forget* in the scheduler; on retry exhaustion the un-awaited commit takes
+  the **log-only** branch (`events.ts:663`) and abandons the tx — so cases finish
+  with `ok:true` and full JSON while 14 rows silently never land. Ceiling is
+  `DEFAULT_RETRIES_FOR_EVENTS=5` (`scheduler/constants.ts:5`), **identical** for all
+  three variants, so the divergence is contention crossing a fixed ceiling, not a
+  budget difference. At 3×5 SQLite (wider commit window) crosses it while the cell
+  variants stay under. **[Superseded by Phase 3 below:** the early guess that
+  `indexed`'s `.key(optionId).key(me)` sub-paths reduce contention is **wrong** —
+  `indexed` contends byte-identically to `array`; keying fixes cost-center A
+  (graph), not C (contention).**]**
+
+**Correction to the line-90 note above.** `main-sqlite-rev.tsx` does **not** remove
+the `rev` mutex — `db.exec` *unconditionally* RMWs `handle.rev` (`cell.ts:1133-1142`),
+and `main-sqlite-rev.tsx:272` adds a *second* `sqliteRev` RMW on top. It measures
+**1/15, identical to plain sqlite** — but that is **floor saturation** (only one
+writer can win the serialized race, so ≤1 can ever survive at 3×5), *not* evidence
+that the extra counter "worsens" drops, nor (as the workflow first inferred) that a
+"wider write window" is independently load-bearing. **What is established:** all
+writes funnel through one shared `handle.rev` under a fixed 5-retry ceiling
+(`i` + `iii`). **What is NOT yet separated:** the relative contribution of the
+`rev` funnel vs. the SQLite commit's own conflict window — both variants sit at the
+1-survivor floor, so 3×5 can't distinguish them. A cleaner separation needs a
+lower-concurrency sweep (e.g. 3×2, 3×3) or a per-option-handle variant.
+
+**Caveats / byproducts (do not affect the conclusion):**
+- `main.tsx` rep 3 hit a **flaky `CloneForMutationError`** (`non-mutable-leaf`,
+  `valueKind:null`) in the user-3 worker's pull-settle loop
+  (`scheduler/pull-execution.ts`) — `results[0].ok=false` yet **process exit 0**
+  (harness exit-code blindness: failure detection requires parsing JSON, not the exit
+  code). Array baseline therefore rests on n=2 valid reps (both 15/15). Separate
+  flaky-worker issue, not a votes signal.
+- `retry WARN` counts roughly doubled vs the old base (array/indexed 36→72, sqlite
+  7→83); ordering preserved and `exhaustion`/`finalVotes` stable. Reinforces: the
+  diagnose retry number is not a usable contention measure.
+- The silent-drop link is `structural+measured`-by-inference (conservation), **not**
+  yet by a fired counter at `events.ts:663` mapped to specific missing rows — that
+  instrumentation is the definitive close (see agenda).
+
+### Phase 3 — cost-center C characterized (2026-06-16)
+
+Concurrency sweep, options=3, rounds=3, `--skip-refresh`, each (variant,concurrency)
+in its OWN invocation (clean per-case stderr), strictly serial. Attempted distinct
+votes = 3 × users. Cell-variant drops were **cold-verified** (not trusted from the
+reactive read, which Phase 3 proved unreliable — see below).
+
+**C-curve (array ≡ indexed on every contention signal):**
+
+| users | attempted | retryWarns | finalVotes | exhaustions | indexed n / array n |
+| ----: | --------: | ---------: | ---------: | ----------: | ------------------: |
+| 2 | 6 | 6 | 6/6 | 0 | 68 / n/a\* |
+| 3 | 9 | 20 | 9/9 | 0 | 68 / 423 |
+| 5 | 15 | 72 | 15/15 | 0 | 68 / 431 |
+| 10 | 30 | 186 | **18/30** | **6** | 68 / 436 |
+
+\* array 3×2 had NO valid rep — flaky `CloneForMutationError` in the join phase (see byproduct).
+
+- **C is super-linear but decelerating** (retryWarns 6→20→72→186; overall power-law
+  exponent ~2.1). The deceleration at 5→10u and the vote loss share ONE cause: the
+  fixed `DEFAULT_RETRIES_FOR_EVENTS=5` ceiling — past it, events stop retrying and
+  drop instead of re-contending.
+- **Keying fixes A, NOT C.** `indexed` (flat 68-node graph) contends *byte-identically*
+  to `array` (same retryWarns/exhaustions/drops). So fixing the graph blowup un-blocks
+  the keyed path only to ~5 users; at 10u it hits C and silently drops 40%.
+- **Silent drops are a GENERAL runtime behavior, not SQLite-specific.** Cold-verified:
+  `indexed` at 3×10 reads **18/30 in canonical storage** (cold == live == 18) — 12
+  real lost writes on a plain cell variant. So any high-contention shared write hits
+  this; SQLite just crosses the threshold sooner.
+- **Drop threshold ≈ halves with each added/wider contention point:** cells drop at
+  ~10u; plain `sqlite` (handle.rev funnel + wider commit window) by ~5u (cold 6/6 @2u,
+  9/9 @3u, 1 @5u); `sqlite-rev` (a *second* shared RMW, line 272) by ~2–3u (cold 3/6,
+  4/9). **Both levers matter** — funnel *count* (sqlite-rev < sqlite) AND commit-window
+  *width* (sqlite < an equivalent cell). (The workflow first over-credited the funnel
+  count alone; the sqlite-vs-cell threshold gap shows the window matters too. Low-conc
+  cold counts are N=1 with high variance — treat magnitudes as estimates, direction as
+  solid.)
+- **The drop is even quieter than "exhaustion."** At indexed 3×10, 12 votes drop but
+  only **6** `exhausting all retries` lines — ~half the lost writes log *nothing*.
+  Mechanism for the unlogged residual unidentified (open).
+
+**Still model-only (project-distrusted):** the per-row exhaustion → specific missing
+`(voter,option)` mapping, and the unlogged-residual mechanism. The events.ts:663
+counter instrumentation remains the definitive close.
+
+**Byproduct bug (separate from perf, real):** `CloneForMutationError`
+(`cannot mutate null`) in `storage/v2.ts applyPendingVersion` → `value-clone.ts`.
+Deterministically crashes the `array` 3×2 join phase; spreads to more workers under
+load (user-2 then user-9 at 3×10). Exit code stays 0 (`results[].ok=false`) — harness
+exit-code blindness. Data-integrity hazard for any array-variant sweep.
+
+### Cross-cutting insight (bridges this session's earlier work)
+
+The vote-read failure is the **same SQLite-query cross-runtime reactivity gap**
+seen earlier this session: `recentVisits` only resolved under a subscribed
+browser runtime, never headless CLI (`reactOn: db` staleness + no cross-runtime
+propagation). Array/indexed *cells* propagate correctly (votes=15); SQLite query
+reads do not. **So raw SQLite pushdown is NOT a drop-in for live multi-user
+reactive reads** — it needs the finer invalidation + cross-runtime propagation
+that wilk flagged as runtime work. SQLite wins on graph (and *maybe* contention),
+but loses on reactive read propagation as it stands.
+
+## Remaining agenda (resume here)
+
+1. ~~**Resolve the Phase-2 confound.**~~ **DONE 2026-06-15** — see "open confound
+   — RESOLVED" above. Cold-reader probe (`probe-sqlite-landing.ts`,
+   `addColdSession`) proves **writes dropped** (1/15 in storage; 14 castVote
+   txns exhaust retries on the shared handle `rev`). SQLite-as-written is worse
+   under concurrency, not better; the diagnose "7 retries" under-counts.
+   **Re-validated 2026-06-16 on rebased main** (see "Re-validated on rebased main"
+   above): holds in full, mechanism upgraded to `structural+measured`. `sqlite-rev`
+   drops the same 1/15 as plain sqlite — **floor saturation**, so it does not
+   separate the `rev`-funnel from the SQLite write window.
+   _Definitive close (only model-only residual left):_ instrument a counter at the
+   `events.ts:663` exhaustion log and assert it fires ~14× per 3×5 sqlite run AND
+   maps each exhaustion to a specific missing `(voter,option)` row — converts the
+   silent-drop link from inference/conservation to a fired-counter proof.
+2. **Phase 3 — characterize C.** Retry counts vs user concurrency (e.g.
+   `--cases=3x2,3x5,3x10`) for array/indexed; confirm the super-linear curve and
+   whether it's the next wall after A is fixed.
+3. **Phase 4 — B is separable.** Defer/lazy the per-option image/search/LLM off
+   the load path (independent of A/C). Note: even `--skip-refresh` leaves the
+   per-option enrichment *computeds* in the graph (hot `topReadSites` clustered
+   on `homePageSearch`/`displayHomePageUrl`), so structural deferral matters, not
+   just skipping the fetch.
+
+## Files created this session (in this worktree, branch `perf-investigation`)
+
+- `main-sqlite.tsx` — diagnostic variant: `main-indexed.tsx` with ONLY the vote
+  storage swapped to a SQLite table (per-row `INSERT OR REPLACE`, `reactOn: db`,
+  no shared votes cell). Isolates the vote-write mechanism.
+- `main-sqlite-rev.tsx` — same, but `reactOn: sqliteRev` (a counter bumped in
+  `castVote`) to test reliable reads + whether the counter reintroduces
+  contention.
+- `probe-sqlite-landing.ts` — step-1 cold-reader probe. Drives join → options →
+  concurrent vote rounds, then cold-opens a fresh runtime to read canonical
+  server SQLite truth (writes-landed vs writes-dropped). Run:
+  `deno run -A packages/patterns/lunch-poll/probe-sqlite-landing.ts --program=main-sqlite.tsx --case=3x5 --rounds=3`
+- `../integration/multi-runtime-harness.ts` — **modified** (reusable): added
+  `spaceName`/`apiUrl` fields + `addColdSession(label, identity?)` to spawn a
+  post-hoc runtime that opens the piece fresh. Disposed with the harness.
+- `PERF-SESSION-2026-06-15.md` — this doc.
+
+## Lunch-poll feature work status (separate from perf)
+
+- #4144 (SQLite history migration) — **merged** to main.
+- #4145 (`gideon/lunch-poll-freetext-join`: free-text join + Lunch Stats
+  per-place + yellow tally + docs) — **open**, rebased onto main, mergeable,
+  cubic's 3 review comments all addressed. CI running after the `deno fmt` fix.
+- `cf-feat-1/labs/packages/patterns/lunch-poll/perf.test.tsx` — untracked scratch
+  perf probe (single-user graph-scaling); keep as a guard or delete.
+- Live prod piece: `toolshed.saga-castor.ts.net/team-lunch/fid1:zJT0…` (free-text
+  join + stats fixes deployed via `setsrc`). Deploy key at `labs/prod.key`.

--- a/packages/patterns/lunch-poll/diagnose.ts
+++ b/packages/patterns/lunch-poll/diagnose.ts
@@ -1,0 +1,716 @@
+import {
+  MultiRuntimeHarness,
+  type MultiRuntimeSession,
+  type RuntimeDiagnosticsSnapshot,
+} from "../integration/multi-runtime-harness.ts";
+
+interface PollOutputSummary {
+  users: readonly { name?: string }[];
+  options: readonly { id?: string; title?: string }[];
+  votes: readonly {
+    voterName?: string;
+    optionId?: string;
+    voteType?: string;
+  }[];
+  history: readonly unknown[];
+  adminName: string;
+  myName: string;
+  userCount: number;
+  optionCount: number;
+  voteCount: number;
+  historyCount: number;
+  isJoined: boolean;
+  isAdmin: boolean;
+  homePageLookupUrls: readonly string[];
+}
+
+interface TraceAddressSummary {
+  space?: string;
+  entityId?: string;
+  path?: readonly string[];
+}
+
+interface ActionRunTraceSummary {
+  actionId: string;
+  actionType: string;
+  durationMs: number;
+  declaredWrites: readonly TraceAddressSummary[];
+  actualWrites: readonly TraceAddressSummary[];
+}
+
+interface DiagnosticsSummary {
+  label: string;
+  graph: {
+    nodes: number;
+    edges: number;
+    byType: Record<string, number>;
+    dirty: number;
+    pending: number;
+    demanded: number;
+    liveEffects: number;
+    pullDemandRoots: number;
+    topReadNodes: readonly { id: string; type: string; readCount: number }[];
+  };
+  settle: {
+    totalHistoryEntries: number;
+    recent: readonly {
+      iterations: number;
+      totalDurationMs: number;
+      initialSeedCount: number;
+      maxWorkSetSize: number;
+      maxOrderSize: number;
+      actionsRun: number;
+      settledEarly: boolean;
+    }[];
+  };
+  actions: {
+    totalTraceEntries: number;
+    newTraceEntries: number;
+    slowestNew: readonly ActionRunTraceSummary[];
+    newWritesByPath: Record<string, number>;
+  };
+}
+
+interface MatrixConfig {
+  program: string;
+  optionCounts: readonly number[];
+  userCounts: readonly number[];
+  voteRounds: number;
+  includeHomepageRefresh: boolean;
+}
+
+interface CaseConfig {
+  optionCount: number;
+  userCount: number;
+  voteRounds: number;
+  includeHomepageRefresh: boolean;
+}
+
+interface CompactSessionSample {
+  label: string;
+  poll: {
+    myName: string;
+    isAdmin: boolean;
+    users: number;
+    options: number;
+    votes: number;
+    activeLookupUrls: number;
+  };
+  graph: {
+    nodes: number;
+    edges: number;
+    computations: number;
+    inputs: number;
+    dirty: number;
+    pending: number;
+    demanded: number;
+  };
+  settle: {
+    totalHistoryEntries: number;
+    maxRecentSettleMs: number;
+    maxRecentWorkSet: number;
+    recentActionsRun: number;
+  };
+  actions: {
+    totalTraceEntries: number;
+    newTraceEntries: number;
+    slowestNew: {
+      site: string;
+      durationMs: number;
+      actualWrites: number;
+    } | null;
+  };
+  topReadSites: readonly { site: string; readCount: number; type: string }[];
+}
+
+interface PhaseSample {
+  phase: string;
+  elapsedMs: number;
+  aggregate: {
+    maxNodes: number;
+    maxEdges: number;
+    maxDirty: number;
+    maxPending: number;
+    maxDemanded: number;
+    maxRecentSettleMs: number;
+    maxRecentWorkSet: number;
+    totalRecentActionsRun: number;
+    totalNewTraceEntries: number;
+    topReadSites: readonly { site: string; readCount: number; type: string }[];
+  };
+  sessions: readonly CompactSessionSample[];
+}
+
+interface CaseResult {
+  case: {
+    users: number;
+    options: number;
+    voteRounds: number;
+    includeHomepageRefresh: boolean;
+  };
+  phases: PhaseSample[];
+}
+
+const traceCursors = new Map<string, number>();
+const TEST_WEB_SEARCH_URL =
+  "data:application/json,%7B%22results%22%3A%5B%5D%7D";
+const VOTE_COLORS = ["green", "yellow", "red"] as const;
+let matrixProgram = "main.tsx";
+const ROOT_PATH = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const asString = (value: unknown): string =>
+  typeof value === "string" ? value : "";
+
+const asNumber = (value: unknown): number =>
+  typeof value === "number" && Number.isFinite(value) ? value : 0;
+
+const asBoolean = (value: unknown): boolean => value === true;
+
+const asRecordArray = (value: unknown): readonly Record<string, unknown>[] =>
+  Array.isArray(value) ? value.filter(isRecord) : [];
+
+const asStringArray = (value: unknown): readonly string[] =>
+  Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+
+function pollSummary(value: unknown): PollOutputSummary {
+  if (!isRecord(value)) {
+    throw new Error(
+      `poll output is not an object: ${JSON.stringify(value)}`,
+    );
+  }
+  return {
+    users: asRecordArray(value.users),
+    options: asRecordArray(value.options),
+    votes: asRecordArray(value.votes),
+    history: Array.isArray(value.history) ? value.history : [],
+    adminName: asString(value.adminName),
+    myName: asString(value.myName),
+    userCount: asNumber(value.userCount),
+    optionCount: asNumber(value.optionCount),
+    voteCount: asNumber(value.voteCount),
+    historyCount: asNumber(value.historyCount),
+    isJoined: asBoolean(value.isJoined),
+    isAdmin: asBoolean(value.isAdmin),
+    homePageLookupUrls: asStringArray(value.homePageLookupUrls),
+  };
+}
+
+function pathKey(address: TraceAddressSummary): string {
+  return `${address.space ?? "?"}/${address.entityId ?? "?"}/$$trel/${
+    (address.path ?? []).join(".")
+  }`;
+}
+
+function traceAddressSummary(value: unknown): TraceAddressSummary {
+  if (!isRecord(value)) return {};
+  return {
+    space: asString(value.space),
+    entityId: asString(value.entityId),
+    path: asStringArray(value.path),
+  };
+}
+
+function traceEntrySummary(value: unknown): ActionRunTraceSummary {
+  if (!isRecord(value)) {
+    return {
+      actionId: "",
+      actionType: "",
+      durationMs: 0,
+      declaredWrites: [],
+      actualWrites: [],
+    };
+  }
+  return {
+    actionId: asString(value.actionId),
+    actionType: asString(value.actionType),
+    durationMs: asNumber(value.durationMs),
+    declaredWrites: Array.isArray(value.declaredWrites)
+      ? value.declaredWrites.map(traceAddressSummary)
+      : [],
+    actualWrites: Array.isArray(value.actualWrites)
+      ? value.actualWrites.map(traceAddressSummary)
+      : [],
+  };
+}
+
+function summarizeSettleEntry(value: unknown) {
+  const stats = isRecord(value) && isRecord(value.stats) ? value.stats : {};
+  const iterations = Array.isArray(stats.iterations) ? stats.iterations : [];
+  let maxWorkSetSize = 0;
+  let maxOrderSize = 0;
+  let actionsRun = 0;
+  for (const iteration of iterations) {
+    if (!isRecord(iteration)) continue;
+    maxWorkSetSize = Math.max(maxWorkSetSize, asNumber(iteration.workSetSize));
+    maxOrderSize = Math.max(maxOrderSize, asNumber(iteration.orderSize));
+    actionsRun += asNumber(iteration.actionsRun);
+  }
+  return {
+    iterations: iterations.length,
+    totalDurationMs: asNumber(stats.totalDurationMs),
+    initialSeedCount: asNumber(stats.initialSeedCount),
+    maxWorkSetSize,
+    maxOrderSize,
+    actionsRun,
+    settledEarly: asBoolean(stats.settledEarly),
+  };
+}
+
+function diagnosticsSummary(
+  label: string,
+  diagnostics: RuntimeDiagnosticsSnapshot,
+): DiagnosticsSummary {
+  const byType: Record<string, number> = {};
+  let dirty = 0;
+  let pending = 0;
+  let demanded = 0;
+  let liveEffects = 0;
+  let pullDemandRoots = 0;
+  const topReadNodes = diagnostics.graph.nodes
+    .map((node) => ({
+      id: node.id,
+      type: node.type,
+      readCount: (node.reads?.length ?? 0) + (node.shallowReads?.length ?? 0),
+    }))
+    .filter((node) => node.readCount > 0)
+    .sort((a, b) => b.readCount - a.readCount)
+    .slice(0, 8);
+
+  for (const node of diagnostics.graph.nodes) {
+    byType[node.type] = (byType[node.type] ?? 0) + 1;
+    if (node.isDirty) dirty++;
+    if (node.isPending) pending++;
+    if (node.isDemanded) demanded++;
+    if (node.isLiveEffect) liveEffects++;
+    if (node.isPullDemandRoot) pullDemandRoots++;
+  }
+
+  const previousTraceLength = traceCursors.get(label) ?? 0;
+  traceCursors.set(label, diagnostics.actionRunTrace.length);
+  const newTrace = diagnostics.actionRunTrace.slice(previousTraceLength)
+    .map(traceEntrySummary);
+  const newWritesByPath: Record<string, number> = {};
+  for (const entry of newTrace) {
+    for (const write of entry.actualWrites) {
+      const key = pathKey(write);
+      newWritesByPath[key] = (newWritesByPath[key] ?? 0) + 1;
+    }
+  }
+
+  return {
+    label,
+    graph: {
+      nodes: diagnostics.graph.nodes.length,
+      edges: diagnostics.graph.edges.length,
+      byType,
+      dirty,
+      pending,
+      demanded,
+      liveEffects,
+      pullDemandRoots,
+      topReadNodes,
+    },
+    settle: {
+      totalHistoryEntries: diagnostics.settleStatsHistory.length,
+      recent: diagnostics.settleStatsHistory.slice(-5).map(
+        summarizeSettleEntry,
+      ),
+    },
+    actions: {
+      totalTraceEntries: diagnostics.actionRunTrace.length,
+      newTraceEntries: newTrace.length,
+      slowestNew: [...newTrace].sort((a, b) => b.durationMs - a.durationMs)
+        .slice(0, 8),
+      newWritesByPath,
+    },
+  };
+}
+
+const maxOf = (values: readonly number[]): number =>
+  values.length === 0 ? 0 : Math.max(...values);
+
+function compactActionSite(actionId: string): string {
+  const marker = `lunch-poll/${matrixProgram}:`;
+  const markerIndex = actionId.indexOf(marker);
+  if (markerIndex >= 0) {
+    const rest = actionId.slice(markerIndex + marker.length);
+    const [line = "?", column = "?"] = rest.split(":");
+    return `${matrixProgram}:${line}:${column}`;
+  }
+  if (actionId.startsWith("raw:")) {
+    return actionId.split(":").slice(0, 3).join(":");
+  }
+  if (actionId.startsWith("pull:")) return "pull:result";
+  if (actionId.startsWith("sink:")) return "sink:result";
+  return actionId.slice(0, 80);
+}
+
+function compactTopReadSites(
+  diagnostics: DiagnosticsSummary,
+): readonly { site: string; readCount: number; type: string }[] {
+  const bySite = new Map<
+    string,
+    { site: string; readCount: number; type: string }
+  >();
+  for (const node of diagnostics.graph.topReadNodes) {
+    const site = compactActionSite(node.id);
+    const previous = bySite.get(site);
+    bySite.set(site, {
+      site,
+      readCount: (previous?.readCount ?? 0) + node.readCount,
+      type: previous?.type ?? node.type,
+    });
+  }
+  return [...bySite.values()]
+    .sort((a, b) => b.readCount - a.readCount)
+    .slice(0, 6);
+}
+
+function compactSessionSample(
+  label: string,
+  poll: PollOutputSummary,
+  diagnostics: DiagnosticsSummary,
+): CompactSessionSample {
+  const recent = diagnostics.settle.recent;
+  const slowest = diagnostics.actions.slowestNew[0];
+  return {
+    label,
+    poll: {
+      myName: poll.myName,
+      isAdmin: poll.isAdmin,
+      users: poll.userCount,
+      options: poll.optionCount,
+      votes: poll.voteCount,
+      activeLookupUrls: poll.homePageLookupUrls.filter((url) => url !== "")
+        .length,
+    },
+    graph: {
+      nodes: diagnostics.graph.nodes,
+      edges: diagnostics.graph.edges,
+      computations: diagnostics.graph.byType.computation ?? 0,
+      inputs: diagnostics.graph.byType.input ?? 0,
+      dirty: diagnostics.graph.dirty,
+      pending: diagnostics.graph.pending,
+      demanded: diagnostics.graph.demanded,
+    },
+    settle: {
+      totalHistoryEntries: diagnostics.settle.totalHistoryEntries,
+      maxRecentSettleMs: maxOf(recent.map((entry) => entry.totalDurationMs)),
+      maxRecentWorkSet: maxOf(recent.map((entry) => entry.maxWorkSetSize)),
+      recentActionsRun: recent.reduce(
+        (sum, entry) => sum + entry.actionsRun,
+        0,
+      ),
+    },
+    actions: {
+      totalTraceEntries: diagnostics.actions.totalTraceEntries,
+      newTraceEntries: diagnostics.actions.newTraceEntries,
+      slowestNew: slowest
+        ? {
+          site: compactActionSite(slowest.actionId),
+          durationMs: slowest.durationMs,
+          actualWrites: slowest.actualWrites.length,
+        }
+        : null,
+    },
+    topReadSites: compactTopReadSites(diagnostics),
+  };
+}
+
+function aggregateSessions(
+  sessions: readonly CompactSessionSample[],
+): PhaseSample["aggregate"] {
+  const topBySite = new Map<
+    string,
+    { site: string; readCount: number; type: string }
+  >();
+  for (const session of sessions) {
+    for (const site of session.topReadSites) {
+      const previous = topBySite.get(site.site);
+      if (!previous || site.readCount > previous.readCount) {
+        topBySite.set(site.site, site);
+      }
+    }
+  }
+  return {
+    maxNodes: maxOf(sessions.map((session) => session.graph.nodes)),
+    maxEdges: maxOf(sessions.map((session) => session.graph.edges)),
+    maxDirty: maxOf(sessions.map((session) => session.graph.dirty)),
+    maxPending: maxOf(sessions.map((session) => session.graph.pending)),
+    maxDemanded: maxOf(sessions.map((session) => session.graph.demanded)),
+    maxRecentSettleMs: maxOf(
+      sessions.map((session) => session.settle.maxRecentSettleMs),
+    ),
+    maxRecentWorkSet: maxOf(
+      sessions.map((session) => session.settle.maxRecentWorkSet),
+    ),
+    totalRecentActionsRun: sessions.reduce(
+      (sum, session) => sum + session.settle.recentActionsRun,
+      0,
+    ),
+    totalNewTraceEntries: sessions.reduce(
+      (sum, session) => sum + session.actions.newTraceEntries,
+      0,
+    ),
+    topReadSites: [...topBySite.values()]
+      .sort((a, b) => b.readCount - a.readCount)
+      .slice(0, 8),
+  };
+}
+
+async function samplePhase(
+  phase: string,
+  harness: MultiRuntimeHarness,
+  runActions: () => Promise<void>,
+): Promise<PhaseSample> {
+  const startedAt = performance.now();
+  await runActions();
+  await harness.settle(3);
+  const sessions = await Promise.all(harness.sessions.map(async (session) => {
+    const poll = pollSummary(await session.read());
+    const diagnostics = diagnosticsSummary(
+      session.label,
+      await session.diagnostics(),
+    );
+    return compactSessionSample(session.label, poll, diagnostics);
+  }));
+  const sample = {
+    phase,
+    elapsedMs: performance.now() - startedAt,
+    aggregate: aggregateSessions(sessions),
+    sessions,
+  } satisfies PhaseSample;
+  console.error(
+    `[lunch-poll diagnose] ${phase}: maxNodes=${sample.aggregate.maxNodes} ` +
+      `maxEdges=${sample.aggregate.maxEdges} maxSettleMs=${
+        sample.aggregate.maxRecentSettleMs.toFixed(1)
+      } totalNewTrace=${sample.aggregate.totalNewTraceEntries}`,
+  );
+  return sample;
+}
+
+async function optionIds(session: MultiRuntimeSession): Promise<string[]> {
+  const poll = pollSummary(await session.read());
+  return poll.options.map((option) => option.id).filter((id): id is string =>
+    typeof id === "string" && id !== ""
+  );
+}
+
+async function createHarness(config: CaseConfig): Promise<MultiRuntimeHarness> {
+  const harness = await MultiRuntimeHarness.create({
+    programPath: new URL(`./${matrixProgram}`, import.meta.url).pathname,
+    rootPath: ROOT_PATH,
+    diagnostics: true,
+    input: {
+      webSearchUrl: TEST_WEB_SEARCH_URL,
+    },
+    sessions: Array.from(
+      { length: config.userCount },
+      (_entry, index) => `user-${index + 1}`,
+    ),
+    spaceName:
+      `lunch-poll-diagnostics-${config.userCount}u-${config.optionCount}o-${crypto.randomUUID()}`,
+  });
+  return harness;
+}
+
+async function runCase(config: CaseConfig): Promise<CaseResult> {
+  traceCursors.clear();
+  const harness = await createHarness(config);
+  const phases: PhaseSample[] = [];
+  const labels = Array.from(
+    { length: config.userCount },
+    (_entry, index) => `user-${index + 1}`,
+  );
+  const sessions = labels.map((label) => harness.session(label));
+  const host = sessions[0];
+
+  try {
+    phases.push(await samplePhase("baseline-open", harness, async () => {}));
+
+    phases.push(
+      await samplePhase("all-users-join", harness, async () => {
+        await host.send("joinAs", { name: "User 1" });
+        await Promise.all(
+          sessions.slice(1).map((session, index) =>
+            session.send("joinAs", { name: `User ${index + 2}` })
+          ),
+        );
+      }),
+    );
+
+    phases.push(
+      await samplePhase("host-adds-options", harness, async () => {
+        for (let index = 0; index < config.optionCount; index++) {
+          await host.send("addOption", { title: `Restaurant ${index + 1}` });
+        }
+      }),
+    );
+
+    for (let round = 0; round < config.voteRounds; round++) {
+      phases.push(
+        await samplePhase(
+          `concurrent-vote-round-${round + 1}`,
+          harness,
+          async () => {
+            const ids = await optionIds(host);
+            if (ids.length === 0) return;
+            await Promise.all(
+              sessions.map((session, index) =>
+                session.send("castVote", {
+                  optionId: ids[(round + index) % ids.length],
+                  voteType: VOTE_COLORS[(round + index) % VOTE_COLORS.length],
+                })
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    if (config.includeHomepageRefresh) {
+      phases.push(
+        await samplePhase(
+          "host-refreshes-homepage-lookups",
+          harness,
+          async () => {
+            await host.send("enrichHomePages", {});
+          },
+        ),
+      );
+    }
+
+    return {
+      case: {
+        users: config.userCount,
+        options: config.optionCount,
+        voteRounds: config.voteRounds,
+        includeHomepageRefresh: config.includeHomepageRefresh,
+      },
+      phases,
+    };
+  } finally {
+    await harness.dispose();
+  }
+}
+
+function numberArg(name: string, fallback: number): number {
+  const prefix = `--${name}=`;
+  const arg = Deno.args.find((entry) => entry.startsWith(prefix));
+  if (!arg) return fallback;
+  const parsed = Number(arg.slice(prefix.length));
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function numberListArg(name: string, fallback: readonly number[]): number[] {
+  const prefix = `--${name}=`;
+  const arg = Deno.args.find((entry) => entry.startsWith(prefix));
+  if (!arg) return [...fallback];
+  const parsed = arg.slice(prefix.length).split(",")
+    .map((entry) => Number(entry.trim()))
+    .filter((entry) => Number.isInteger(entry) && entry >= 0);
+  return parsed.length > 0 ? parsed : [...fallback];
+}
+
+function stringArg(name: string, fallback: string): string {
+  const prefix = `--${name}=`;
+  const arg = Deno.args.find((entry) => entry.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : fallback;
+}
+
+function explicitCasesArg(
+  config: MatrixConfig,
+): CaseConfig[] | undefined {
+  const prefix = "--cases=";
+  const arg = Deno.args.find((entry) => entry.startsWith(prefix));
+  if (!arg) return undefined;
+  const cases = arg.slice(prefix.length).split(",").flatMap((entry) => {
+    const match = entry.trim().match(/^(\d+)x(\d+)$/);
+    if (!match) return [];
+    const optionCount = Number(match[1]);
+    const userCount = Number(match[2]);
+    return [{
+      optionCount,
+      userCount,
+      voteRounds: config.voteRounds,
+      includeHomepageRefresh: config.includeHomepageRefresh,
+    }];
+  });
+  return cases.length > 0 ? cases : undefined;
+}
+
+function matrixConfigFromArgs(): MatrixConfig {
+  const quick = Deno.args.includes("--quick");
+  return {
+    program: stringArg("program", "main.tsx"),
+    optionCounts: numberListArg("options", quick ? [1, 3] : [1, 3, 10]),
+    userCounts: numberListArg("users", quick ? [2] : [2, 5]),
+    voteRounds: numberArg("rounds", quick ? 1 : 3),
+    includeHomepageRefresh: !Deno.args.includes("--skip-refresh"),
+  };
+}
+
+function casesFromConfig(config: MatrixConfig): CaseConfig[] {
+  const explicit = explicitCasesArg(config);
+  if (explicit) return explicit;
+  const cases: CaseConfig[] = [];
+  for (const optionCount of config.optionCounts) {
+    for (const userCount of config.userCounts) {
+      cases.push({
+        optionCount,
+        userCount,
+        voteRounds: config.voteRounds,
+        includeHomepageRefresh: config.includeHomepageRefresh,
+      });
+    }
+  }
+  return cases;
+}
+
+async function run(): Promise<void> {
+  const config = matrixConfigFromArgs();
+  matrixProgram = config.program;
+  const cases = casesFromConfig(config);
+  const startedAt = performance.now();
+  const results: ({ ok: true; result: CaseResult } | {
+    ok: false;
+    case: CaseConfig;
+    error: string;
+  })[] = [];
+
+  for (const caseConfig of cases) {
+    console.error(
+      `[lunch-poll diagnose] case ${caseConfig.optionCount} options x ` +
+        `${caseConfig.userCount} users, rounds=${caseConfig.voteRounds}`,
+    );
+    try {
+      results.push({ ok: true, result: await runCase(caseConfig) });
+    } catch (error) {
+      results.push({
+        ok: false,
+        case: caseConfig,
+        error: error instanceof Error
+          ? `${error.message}\n${error.stack ?? ""}`
+          : String(error),
+      });
+    }
+  }
+
+  console.log(JSON.stringify(
+    {
+      kind: "lunch-poll-scaling-diagnostics",
+      config,
+      elapsedMs: performance.now() - startedAt,
+      results,
+    },
+    null,
+    2,
+  ));
+}
+
+if (import.meta.main) await run();

--- a/packages/patterns/lunch-poll/main-indexed.tsx
+++ b/packages/patterns/lunch-poll/main-indexed.tsx
@@ -1,0 +1,561 @@
+/// <cts-enable />
+/**
+ * Indexed Lunch Poll - diagnostic variant.
+ *
+ * This file intentionally keeps a smaller UI than `main.tsx` while preserving
+ * the core poll contract used by the headless diagnostics. Its purpose is to
+ * compare authoring complexity and graph shape when the pattern author stores
+ * collaboration state in keyed structures instead of flat shared arrays.
+ */
+
+import {
+  computed,
+  Default,
+  handler,
+  NAME,
+  nonPrivateRandom,
+  pattern,
+  type PerSpace,
+  type PerUser,
+  safeDateNow,
+  Stream,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+const WEB_SEARCH_URL = "/api/agent-tools/web-search";
+
+export interface User {
+  name: string;
+  avatar?: string;
+  color: string;
+  joinedAt: number;
+}
+
+export interface Option {
+  id: string;
+  title: string;
+  addedByName: string;
+  homePageUrl?: string;
+  homePageUrlOverride?: string;
+  imageUrl?: string;
+}
+
+export type VoteColor = "green" | "yellow" | "red";
+
+export interface Vote {
+  voterName: string;
+  optionId: string;
+  voteType: VoteColor;
+}
+
+export interface JoinEvent {
+  name?: string;
+}
+
+export type ClaimHostEvent = Record<PropertyKey, never>;
+
+export interface AddOptionEvent {
+  title?: string;
+}
+
+export interface RemoveOptionEvent {
+  optionId: string;
+}
+
+export interface CastVoteEvent {
+  optionId: string;
+  voteType: VoteColor;
+}
+
+export type ResetVotesEvent = Record<PropertyKey, never>;
+export type ClearVoteEvent = Record<PropertyKey, never>;
+export type EnrichHomePagesEvent = Record<PropertyKey, never>;
+
+export interface SetCityEvent {
+  city?: string;
+}
+
+export interface SetOptionUrlEvent {
+  optionId: string;
+  url?: string;
+}
+
+export interface HistoryEntry {
+  id: string;
+  title: string;
+  loggedByName: string;
+  wentAt: number;
+}
+
+export interface LogVisitEvent {
+  optionId?: string;
+  title?: string;
+  wentAt?: number;
+}
+
+export interface RemoveHistoryEntryEvent {
+  id: string;
+}
+
+export type ClearHistoryEvent = Record<PropertyKey, never>;
+
+type OptionsById = Record<string, Option>;
+type UsersByName = Record<string, User>;
+type VotesByOption = Record<string, Record<string, VoteColor>>;
+
+const EMPTY_OPTIONS_BY_ID: OptionsById = {};
+const EMPTY_USERS_BY_NAME: UsersByName = {};
+const EMPTY_VOTES_BY_OPTION: VotesByOption = {};
+
+type OptionsByIdCell = Writable<
+  OptionsById | Default<typeof EMPTY_OPTIONS_BY_ID>
+>;
+type OptionOrderCell = Writable<string[] | Default<[]>>;
+type UsersByNameCell = Writable<
+  UsersByName | Default<typeof EMPTY_USERS_BY_NAME>
+>;
+type UserOrderCell = Writable<string[] | Default<[]>>;
+type VotesByOptionCell = Writable<
+  VotesByOption | Default<typeof EMPTY_VOTES_BY_OPTION>
+>;
+type NameCell = Writable<string | Default<"">>;
+type CityCell = Writable<string | Default<"Berkeley, CA">>;
+type RefreshCell = Writable<number | Default<0>>;
+
+const PLAYER_COLORS = [
+  "#2f8a64",
+  "#c2573a",
+  "#3b4a6b",
+  "#a33b35",
+  "#b27722",
+  "#7c3aed",
+];
+
+const EMPTY_OPTIONS: Option[] = [];
+const EMPTY_VOTES: Vote[] = [];
+const EMPTY_USERS: User[] = [];
+const EMPTY_HISTORY: HistoryEntry[] = [];
+
+const trimmedName = (n: string | undefined) => (n ?? "").trim();
+
+const colorForIndex = (index: number): string =>
+  PLAYER_COLORS[index % PLAYER_COLORS.length] ?? PLAYER_COLORS[0];
+
+const newOptionId = (): string =>
+  `o_${Math.floor(safeDateNow()).toString(36)}_${
+    Math.floor(nonPrivateRandom() * 1_000_000).toString(36)
+  }`;
+
+const isOption = (value: Option | undefined): value is Option =>
+  value !== undefined;
+
+const isUser = (value: User | undefined): value is User => value !== undefined;
+
+const joinAs = handler<JoinEvent, {
+  usersByName: UsersByNameCell;
+  userOrder: UserOrderCell;
+  myName: NameCell;
+  adminName: NameCell;
+}>(({ name }, { usersByName, userOrder, myName, adminName }) => {
+  const trimmed = trimmedName(name);
+  if (!trimmed) return;
+  if (trimmedName(myName.get())) return;
+  const users = usersByName.get() ?? {};
+  if (users[trimmed]) return;
+  const order = userOrder.get() ?? [];
+  usersByName.key(trimmed).set({
+    name: trimmed,
+    avatar: "",
+    color: colorForIndex(order.length),
+    joinedAt: safeDateNow(),
+  });
+  userOrder.push(trimmed);
+  myName.set(trimmed);
+  if (!trimmedName(adminName.get())) adminName.set(trimmed);
+});
+
+const claimHost = handler<ClaimHostEvent, {
+  myName: NameCell;
+  adminName: NameCell;
+}>((_, { myName, adminName }) => {
+  const me = trimmedName(myName.get());
+  if (!me || trimmedName(adminName.get()) === me) return;
+  adminName.set(me);
+});
+
+const addOption = handler<AddOptionEvent, {
+  optionsById: OptionsByIdCell;
+  optionOrder: OptionOrderCell;
+  myName: NameCell;
+  adminName: NameCell;
+}>(({ title }, { optionsById, optionOrder, myName, adminName }) => {
+  const me = trimmedName(myName.get());
+  if (!me || me !== trimmedName(adminName.get())) return;
+  const trimmed = trimmedName(title);
+  if (!trimmed) return;
+  const id = newOptionId();
+  optionsById.key(id).set({
+    id,
+    title: trimmed,
+    addedByName: me,
+    homePageUrl: "",
+    homePageUrlOverride: "",
+    imageUrl: "",
+  });
+  optionOrder.push(id);
+});
+
+const removeOption = handler<RemoveOptionEvent, {
+  optionsById: OptionsByIdCell;
+  optionOrder: OptionOrderCell;
+  votesByOption: VotesByOptionCell;
+  myName: NameCell;
+  adminName: NameCell;
+}>(
+  (
+    { optionId },
+    { optionsById, optionOrder, votesByOption, myName, adminName },
+  ) => {
+    const me = trimmedName(myName.get());
+    if (!me || me !== trimmedName(adminName.get())) return;
+    const currentOptions = optionsById.get() ?? {};
+    if (!currentOptions[optionId]) return;
+
+    const nextOptions: OptionsById = {};
+    for (const [id, option] of Object.entries(currentOptions)) {
+      if (id !== optionId) nextOptions[id] = option;
+    }
+    optionsById.set(nextOptions);
+    optionOrder.set((optionOrder.get() ?? []).filter((id) => id !== optionId));
+
+    const nextVotes: VotesByOption = {};
+    for (const [id, bucket] of Object.entries(votesByOption.get() ?? {})) {
+      if (id !== optionId) nextVotes[id] = bucket;
+    }
+    votesByOption.set(nextVotes);
+  },
+);
+
+const castVote = handler<CastVoteEvent, {
+  votesByOption: VotesByOptionCell;
+  myName: NameCell;
+}>(({ optionId, voteType }, { votesByOption, myName }) => {
+  const me = trimmedName(myName.get());
+  if (!me || !optionId) return;
+  const bucket = votesByOption.get()?.[optionId] ?? {};
+  if (bucket[me] === voteType) {
+    const nextBucket: Record<string, VoteColor> = {};
+    for (const [name, color] of Object.entries(bucket)) {
+      if (name !== me) nextBucket[name] = color;
+    }
+    votesByOption.key(optionId).set(nextBucket);
+    return;
+  }
+  votesByOption.key(optionId).key(me).set(voteType);
+});
+
+const clearMyVote = handler<ClearVoteEvent, {
+  votesByOption: VotesByOptionCell;
+  myName: NameCell;
+}>((_, { votesByOption, myName }) => {
+  const me = trimmedName(myName.get());
+  if (!me) return;
+  const nextVotes: VotesByOption = {};
+  for (const [optionId, bucket] of Object.entries(votesByOption.get() ?? {})) {
+    const nextBucket: Record<string, VoteColor> = {};
+    for (const [name, color] of Object.entries(bucket)) {
+      if (name !== me) nextBucket[name] = color;
+    }
+    nextVotes[optionId] = nextBucket;
+  }
+  votesByOption.set(nextVotes);
+});
+
+const resetVotes = handler<ResetVotesEvent, {
+  votesByOption: VotesByOptionCell;
+  myName: NameCell;
+  adminName: NameCell;
+}>((_, { votesByOption, myName, adminName }) => {
+  const me = trimmedName(myName.get());
+  if (!me || me !== trimmedName(adminName.get())) return;
+  votesByOption.set({});
+});
+
+const setCity = handler<SetCityEvent, {
+  city: CityCell;
+  myName: NameCell;
+  adminName: NameCell;
+}>(({ city: nextCity }, { city, myName, adminName }) => {
+  const me = trimmedName(myName.get());
+  if (!me || me !== trimmedName(adminName.get())) return;
+  const next = trimmedName(nextCity);
+  if (next) city.set(next);
+});
+
+const enrichHomePages = handler<EnrichHomePagesEvent, {
+  myName: NameCell;
+  adminName: NameCell;
+  homePageRefresh: RefreshCell;
+}>((_, { myName, adminName, homePageRefresh }) => {
+  const me = trimmedName(myName.get());
+  if (!me || me !== trimmedName(adminName.get())) return;
+  homePageRefresh.set(Number(homePageRefresh.get() ?? 0) + 1);
+});
+
+const noopOptionUrl = handler<
+  SetOptionUrlEvent,
+  { homePageRefresh: RefreshCell }
+>(
+  () => {},
+);
+const noopLogVisit = handler<LogVisitEvent, { homePageRefresh: RefreshCell }>(
+  () => {},
+);
+const noopRemoveHistory = handler<
+  RemoveHistoryEntryEvent,
+  { homePageRefresh: RefreshCell }
+>(() => {});
+const noopClearHistory = handler<
+  ClearHistoryEvent,
+  { homePageRefresh: RefreshCell }
+>(
+  () => {},
+);
+
+interface OptionTally {
+  option: Option;
+  green: number;
+  yellow: number;
+  red: number;
+  voters: Array<{ name: string; voteType: VoteColor; color: string }>;
+}
+
+function buildVotesSnapshot(votesByOption: VotesByOption): Vote[] {
+  const votes: Vote[] = [];
+  for (const [optionId, bucket] of Object.entries(votesByOption)) {
+    for (const [voterName, voteType] of Object.entries(bucket)) {
+      votes.push({ voterName, optionId, voteType });
+    }
+  }
+  return votes;
+}
+
+function buildTallies(
+  options: readonly Option[],
+  votesByOption: VotesByOption,
+  usersByName: UsersByName,
+): OptionTally[] {
+  const tallies = options.map((option): OptionTally => {
+    const bucket = votesByOption[option.id] ?? {};
+    let green = 0;
+    let yellow = 0;
+    let red = 0;
+    const voters: Array<{ name: string; voteType: VoteColor; color: string }> =
+      [];
+    for (const [name, voteType] of Object.entries(bucket)) {
+      if (voteType === "green") green++;
+      if (voteType === "yellow") yellow++;
+      if (voteType === "red") red++;
+      voters.push({
+        name,
+        voteType,
+        color: usersByName[name]?.color ?? "#888",
+      });
+    }
+    return { option, green, yellow, red, voters };
+  });
+  return tallies.sort((a, b) => {
+    if (a.red !== b.red) return a.red - b.red;
+    return b.green - a.green;
+  });
+}
+
+function buildRankByOptionId(
+  tallies: readonly OptionTally[],
+): Record<string, number> {
+  const ranks: Record<string, number> = {};
+  for (let index = 0; index < tallies.length; index++) {
+    ranks[tallies[index]!.option.id] = index + 1;
+  }
+  return ranks;
+}
+
+export interface IndexedCozyPollInput {
+  question?: PerSpace<string | Default<"Where should we eat?">>;
+  city?: PerSpace<string | Default<"Berkeley, CA">>;
+  optionsById?: PerSpace<OptionsById | Default<typeof EMPTY_OPTIONS_BY_ID>>;
+  optionOrder?: PerSpace<string[] | Default<[]>>;
+  votesByOption?: PerSpace<
+    VotesByOption | Default<typeof EMPTY_VOTES_BY_OPTION>
+  >;
+  usersByName?: PerSpace<UsersByName | Default<typeof EMPTY_USERS_BY_NAME>>;
+  userOrder?: PerSpace<string[] | Default<[]>>;
+  adminName?: PerSpace<string | Default<"">>;
+  myName?: PerUser<string | Default<"">>;
+  webSearchUrl?: PerSpace<string | Default<typeof WEB_SEARCH_URL>>;
+}
+
+export interface IndexedCozyPollOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  question: string;
+  city: string;
+  options: readonly Option[];
+  votes: readonly Vote[];
+  users: readonly User[];
+  history: readonly HistoryEntry[];
+  adminName: string;
+  myName: string;
+  userCount: number;
+  optionCount: number;
+  voteCount: number;
+  historyCount: number;
+  isJoined: boolean;
+  isAdmin: boolean;
+  homePageLookupUrls: readonly string[];
+  joinAs: Stream<JoinEvent>;
+  claimHost: Stream<ClaimHostEvent>;
+  addOption: Stream<AddOptionEvent>;
+  removeOption: Stream<RemoveOptionEvent>;
+  castVote: Stream<CastVoteEvent>;
+  clearMyVote: Stream<ClearVoteEvent>;
+  resetVotes: Stream<ResetVotesEvent>;
+  logVisit: Stream<LogVisitEvent>;
+  removeHistoryEntry: Stream<RemoveHistoryEntryEvent>;
+  clearHistory: Stream<ClearHistoryEvent>;
+  setCity: Stream<SetCityEvent>;
+  enrichHomePages: Stream<EnrichHomePagesEvent>;
+  setOptionUrl: Stream<SetOptionUrlEvent>;
+}
+
+export default pattern<IndexedCozyPollInput, IndexedCozyPollOutput>(
+  ({
+    question,
+    city,
+    optionsById,
+    optionOrder,
+    votesByOption,
+    usersByName,
+    userOrder,
+    adminName,
+    myName,
+    webSearchUrl,
+  }) => {
+    const homePageRefresh = Writable.perSpace.of<number | Default<0>>(0);
+
+    const optionList = computed(() =>
+      (optionOrder ?? [])
+        .map((id) => optionsById?.[id])
+        .filter(isOption)
+    );
+    const userList = computed(() =>
+      (userOrder ?? [])
+        .map((name) => usersByName?.[name])
+        .filter(isUser)
+    );
+    const votesSnapshot = computed(() =>
+      buildVotesSnapshot(votesByOption ?? {})
+    );
+    const tallies = computed(() =>
+      buildTallies(optionList, votesByOption ?? {}, usersByName ?? {})
+    );
+    const rankByOptionId = computed(() => buildRankByOptionId(tallies));
+
+    const me = trimmedName(myName);
+    const admin = trimmedName(adminName);
+    const isJoined = me !== "";
+    const isAdmin = me !== "" && me === admin;
+    const searchEndpoint = trimmedName(webSearchUrl) || WEB_SEARCH_URL;
+    const homePageLookupUrls = computed(() =>
+      optionList.map(() => isAdmin ? searchEndpoint : "")
+    );
+
+    const boundJoin = joinAs({ usersByName, userOrder, myName, adminName });
+    const boundClaimHost = claimHost({ myName, adminName });
+    const boundAddOption = addOption({
+      optionsById,
+      optionOrder,
+      myName,
+      adminName,
+    });
+    const boundRemoveOption = removeOption({
+      optionsById,
+      optionOrder,
+      votesByOption,
+      myName,
+      adminName,
+    });
+    const boundCastVote = castVote({ votesByOption, myName });
+    const boundClearMyVote = clearMyVote({ votesByOption, myName });
+    const boundResetVotes = resetVotes({ votesByOption, myName, adminName });
+    const boundSetCity = setCity({ city, myName, adminName });
+    const boundEnrichHomePages = enrichHomePages({
+      myName,
+      adminName,
+      homePageRefresh,
+    });
+
+    return {
+      [NAME]: "Indexed lunch poll diagnostic",
+      [UI]: (
+        <div>
+          <h2>{question}</h2>
+          <p>
+            Host: {admin || "none"} · Me: {me || "not joined"} · City: {city}
+          </p>
+          <p>
+            {userList.length} users · {optionList.length} options ·{" "}
+            {votesSnapshot.length} votes
+          </p>
+          <div>
+            {optionList.map((option) => {
+              const tally = tallies.find((entry) =>
+                entry.option.id === option.id
+              );
+              const rank = rankByOptionId[option.id] ?? 0;
+              return (
+                <div>
+                  <strong>#{rank} {option.title}</strong>
+                  <span>
+                    Green {tally?.green ?? 0} · Yellow {tally?.yellow ?? 0}{" "}
+                    · Red {tally?.red ?? 0}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ),
+      question,
+      city,
+      options: computed(() => optionList ?? EMPTY_OPTIONS),
+      votes: computed(() => votesSnapshot ?? EMPTY_VOTES),
+      users: computed(() => userList ?? EMPTY_USERS),
+      history: computed(() => EMPTY_HISTORY),
+      adminName: computed(() => trimmedName(adminName)),
+      myName: computed(() => trimmedName(myName)),
+      userCount: userList.length,
+      optionCount: optionList.length,
+      voteCount: votesSnapshot.length,
+      historyCount: 0,
+      isJoined,
+      isAdmin,
+      homePageLookupUrls,
+      joinAs: boundJoin,
+      claimHost: boundClaimHost,
+      addOption: boundAddOption,
+      removeOption: boundRemoveOption,
+      castVote: boundCastVote,
+      clearMyVote: boundClearMyVote,
+      resetVotes: boundResetVotes,
+      logVisit: noopLogVisit({ homePageRefresh }),
+      removeHistoryEntry: noopRemoveHistory({ homePageRefresh }),
+      clearHistory: noopClearHistory({ homePageRefresh }),
+      setCity: boundSetCity,
+      enrichHomePages: boundEnrichHomePages,
+      setOptionUrl: noopOptionUrl({ homePageRefresh }),
+    };
+  },
+);

--- a/packages/patterns/lunch-poll/main-sqlite-rev.tsx
+++ b/packages/patterns/lunch-poll/main-sqlite-rev.tsx
@@ -1,0 +1,505 @@
+/// <cts-enable />
+/**
+ * SQLite Lunch Poll - diagnostic variant.
+ *
+ * Same harness contract as `main-indexed.tsx`, but the *vote* state is stored in
+ * a SQLite table (one row per (voter, option) via `db.exec` INSERT OR REPLACE)
+ * instead of a shared `votesByOption` cell. Options/users stay as indexed cells
+ * — so this isolates ONE variable: the vote-write mechanism.
+ *
+ * Hypothesis under test (from the Phase-1 diagnostics): the array AND indexed
+ * variants both read-modify-write a shared `votes` cell, so they show identical
+ * concurrent ConflictError retries. Per-row SQLite inserts touch distinct rows
+ * with no shared mutable cell and `reactOn: db` (no rev-counter), so concurrent
+ * voters should contend less. `voteCount`/votes are surfaced via single query
+ * nodes, so the reactive graph should also stay flat in vote count.
+ */
+
+import {
+  cfSqlite,
+  computed,
+  Default,
+  handler,
+  NAME,
+  nonPrivateRandom,
+  pattern,
+  type PerSpace,
+  type PerUser,
+  safeDateNow,
+  type SqliteDb,
+  sqliteDatabase,
+  Stream,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+const WEB_SEARCH_URL = "/api/agent-tools/web-search";
+
+export interface User {
+  name: string;
+  avatar?: string;
+  color: string;
+  joinedAt: number;
+}
+
+export interface Option {
+  id: string;
+  title: string;
+  addedByName: string;
+  homePageUrl?: string;
+  homePageUrlOverride?: string;
+  imageUrl?: string;
+}
+
+export type VoteColor = "green" | "yellow" | "red";
+
+export interface Vote {
+  voterName: string;
+  optionId: string;
+  voteType: VoteColor;
+}
+
+export interface JoinEvent {
+  name?: string;
+}
+
+export type ClaimHostEvent = Record<PropertyKey, never>;
+
+export interface AddOptionEvent {
+  title?: string;
+}
+
+export interface RemoveOptionEvent {
+  optionId: string;
+}
+
+export interface CastVoteEvent {
+  optionId: string;
+  voteType: VoteColor;
+}
+
+export type ResetVotesEvent = Record<PropertyKey, never>;
+export type ClearVoteEvent = Record<PropertyKey, never>;
+export type EnrichHomePagesEvent = Record<PropertyKey, never>;
+
+export interface SetCityEvent {
+  city?: string;
+}
+
+export interface SetOptionUrlEvent {
+  optionId: string;
+  url?: string;
+}
+
+export interface HistoryEntry {
+  id: string;
+  title: string;
+  loggedByName: string;
+  wentAt: number;
+}
+
+export interface LogVisitEvent {
+  optionId?: string;
+  title?: string;
+  wentAt?: number;
+}
+
+export interface RemoveHistoryEntryEvent {
+  id: string;
+}
+
+export type ClearHistoryEvent = Record<PropertyKey, never>;
+
+interface VoteRow {
+  voterName: string;
+  optionId: string;
+  voteType: VoteColor;
+}
+
+interface CountRow {
+  n: number;
+}
+
+type OptionsById = Record<string, Option>;
+type UsersByName = Record<string, User>;
+
+const EMPTY_OPTIONS_BY_ID: OptionsById = {};
+const EMPTY_USERS_BY_NAME: UsersByName = {};
+
+type OptionsByIdCell = Writable<
+  OptionsById | Default<typeof EMPTY_OPTIONS_BY_ID>
+>;
+type OptionOrderCell = Writable<string[] | Default<[]>>;
+type UsersByNameCell = Writable<
+  UsersByName | Default<typeof EMPTY_USERS_BY_NAME>
+>;
+type UserOrderCell = Writable<string[] | Default<[]>>;
+type NameCell = Writable<string | Default<"">>;
+type CityCell = Writable<string | Default<"Berkeley, CA">>;
+type RefreshCell = Writable<number | Default<0>>;
+type RevCell = Writable<number | Default<0>>;
+
+const PLAYER_COLORS = [
+  "#2f8a64",
+  "#c2573a",
+  "#3b4a6b",
+  "#a33b35",
+  "#b27722",
+  "#7c3aed",
+];
+
+const EMPTY_OPTIONS: Option[] = [];
+const EMPTY_VOTES: Vote[] = [];
+const EMPTY_USERS: User[] = [];
+const EMPTY_HISTORY: HistoryEntry[] = [];
+
+const trimmedName = (n: string | undefined) => (n ?? "").trim();
+
+const colorForIndex = (index: number): string =>
+  PLAYER_COLORS[index % PLAYER_COLORS.length] ?? PLAYER_COLORS[0];
+
+const newOptionId = (): string =>
+  `o_${Math.floor(safeDateNow()).toString(36)}_${
+    Math.floor(nonPrivateRandom() * 1_000_000).toString(36)
+  }`;
+
+const voteKey = (voter: string, optionId: string): string =>
+  `${voter}::${optionId}`;
+
+const isOption = (value: Option | undefined): value is Option =>
+  value !== undefined;
+
+const isUser = (value: User | undefined): value is User => value !== undefined;
+
+const joinAs = handler<JoinEvent, {
+  usersByName: UsersByNameCell;
+  userOrder: UserOrderCell;
+  myName: NameCell;
+  adminName: NameCell;
+}>(({ name }, { usersByName, userOrder, myName, adminName }) => {
+  const trimmed = trimmedName(name);
+  if (!trimmed) return;
+  if (trimmedName(myName.get())) return;
+  const users = usersByName.get() ?? {};
+  if (users[trimmed]) return;
+  const order = userOrder.get() ?? [];
+  usersByName.key(trimmed).set({
+    name: trimmed,
+    avatar: "",
+    color: colorForIndex(order.length),
+    joinedAt: safeDateNow(),
+  });
+  userOrder.push(trimmed);
+  myName.set(trimmed);
+  if (!trimmedName(adminName.get())) adminName.set(trimmed);
+});
+
+const claimHost = handler<ClaimHostEvent, {
+  myName: NameCell;
+  adminName: NameCell;
+}>((_, { myName, adminName }) => {
+  const me = trimmedName(myName.get());
+  if (!me || trimmedName(adminName.get()) === me) return;
+  adminName.set(me);
+});
+
+const addOption = handler<AddOptionEvent, {
+  optionsById: OptionsByIdCell;
+  optionOrder: OptionOrderCell;
+  myName: NameCell;
+  adminName: NameCell;
+}>(({ title }, { optionsById, optionOrder, myName, adminName }) => {
+  const me = trimmedName(myName.get());
+  if (!me || me !== trimmedName(adminName.get())) return;
+  const trimmed = trimmedName(title);
+  if (!trimmed) return;
+  const id = newOptionId();
+  optionsById.key(id).set({
+    id,
+    title: trimmed,
+    addedByName: me,
+    homePageUrl: "",
+    homePageUrlOverride: "",
+    imageUrl: "",
+  });
+  optionOrder.push(id);
+});
+
+const removeOption = handler<RemoveOptionEvent, {
+  optionsById: OptionsByIdCell;
+  optionOrder: OptionOrderCell;
+  db: SqliteDb;
+  myName: NameCell;
+  adminName: NameCell;
+}>(
+  (
+    { optionId },
+    { optionsById, optionOrder, db, myName, adminName },
+  ) => {
+    const me = trimmedName(myName.get());
+    if (!me || me !== trimmedName(adminName.get())) return;
+    const currentOptions = optionsById.get() ?? {};
+    if (!currentOptions[optionId]) return;
+
+    const nextOptions: OptionsById = {};
+    for (const [id, option] of Object.entries(currentOptions)) {
+      if (id !== optionId) nextOptions[id] = option;
+    }
+    optionsById.set(nextOptions);
+    optionOrder.set((optionOrder.get() ?? []).filter((id) => id !== optionId));
+    db.exec("DELETE FROM votes WHERE option_id = ?", [optionId]);
+  },
+);
+
+// Vote write: a single per-(voter,option) row, INSERT OR REPLACE. No shared
+// votes cell, no rev-counter — the queries below `reactOn: db`.
+const castVote = handler<CastVoteEvent, {
+  db: SqliteDb;
+  myName: NameCell;
+  rev: RevCell;
+}>(({ optionId, voteType }, { db, myName, rev }) => {
+  const me = trimmedName(myName.get());
+  if (!me || !optionId) return;
+  db.exec(
+    "INSERT OR REPLACE INTO votes (id, voter, option_id, vote_type) " +
+      "VALUES (?, ?, ?, ?)",
+    [voteKey(me, optionId), me, optionId, voteType],
+  );
+  // Bump the shared rev counter so the queries (reactOn: sqliteRev) re-run.
+  // NOTE: this is the read-modify-write of a shared cell we expect to
+  // reintroduce concurrent-write contention.
+  rev.set((rev.get() ?? 0) + 1);
+});
+
+const clearMyVote = handler<ClearVoteEvent, {
+  db: SqliteDb;
+  myName: NameCell;
+}>((_, { db, myName }) => {
+  const me = trimmedName(myName.get());
+  if (!me) return;
+  db.exec("DELETE FROM votes WHERE voter = ?", [me]);
+});
+
+const resetVotes = handler<ResetVotesEvent, {
+  db: SqliteDb;
+  myName: NameCell;
+  adminName: NameCell;
+}>((_, { db, myName, adminName }) => {
+  const me = trimmedName(myName.get());
+  if (!me || me !== trimmedName(adminName.get())) return;
+  db.exec("DELETE FROM votes");
+});
+
+const setCity = handler<SetCityEvent, {
+  city: CityCell;
+  myName: NameCell;
+  adminName: NameCell;
+}>(({ city: nextCity }, { city, myName, adminName }) => {
+  const me = trimmedName(myName.get());
+  if (!me || me !== trimmedName(adminName.get())) return;
+  const next = trimmedName(nextCity);
+  if (next) city.set(next);
+});
+
+const enrichHomePages = handler<EnrichHomePagesEvent, {
+  myName: NameCell;
+  adminName: NameCell;
+  homePageRefresh: RefreshCell;
+}>((_, { myName, adminName, homePageRefresh }) => {
+  const me = trimmedName(myName.get());
+  if (!me || me !== trimmedName(adminName.get())) return;
+  homePageRefresh.set(Number(homePageRefresh.get() ?? 0) + 1);
+});
+
+const noopOptionUrl = handler<
+  SetOptionUrlEvent,
+  { homePageRefresh: RefreshCell }
+>(() => {});
+const noopLogVisit = handler<LogVisitEvent, { homePageRefresh: RefreshCell }>(
+  () => {},
+);
+const noopRemoveHistory = handler<
+  RemoveHistoryEntryEvent,
+  { homePageRefresh: RefreshCell }
+>(() => {});
+const noopClearHistory = handler<
+  ClearHistoryEvent,
+  { homePageRefresh: RefreshCell }
+>(() => {});
+
+export interface SqliteCozyPollInput {
+  question?: PerSpace<string | Default<"Where should we eat?">>;
+  city?: PerSpace<string | Default<"Berkeley, CA">>;
+  optionsById?: PerSpace<OptionsById | Default<typeof EMPTY_OPTIONS_BY_ID>>;
+  optionOrder?: PerSpace<string[] | Default<[]>>;
+  usersByName?: PerSpace<UsersByName | Default<typeof EMPTY_USERS_BY_NAME>>;
+  userOrder?: PerSpace<string[] | Default<[]>>;
+  adminName?: PerSpace<string | Default<"">>;
+  myName?: PerUser<string | Default<"">>;
+  webSearchUrl?: PerSpace<string | Default<typeof WEB_SEARCH_URL>>;
+}
+
+export interface SqliteCozyPollOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  question: string;
+  city: string;
+  options: readonly Option[];
+  votes: readonly Vote[];
+  users: readonly User[];
+  history: readonly HistoryEntry[];
+  adminName: string;
+  myName: string;
+  userCount: number;
+  optionCount: number;
+  voteCount: number;
+  historyCount: number;
+  isJoined: boolean;
+  isAdmin: boolean;
+  homePageLookupUrls: readonly string[];
+  joinAs: Stream<JoinEvent>;
+  claimHost: Stream<ClaimHostEvent>;
+  addOption: Stream<AddOptionEvent>;
+  removeOption: Stream<RemoveOptionEvent>;
+  castVote: Stream<CastVoteEvent>;
+  clearMyVote: Stream<ClearVoteEvent>;
+  resetVotes: Stream<ResetVotesEvent>;
+  logVisit: Stream<LogVisitEvent>;
+  removeHistoryEntry: Stream<RemoveHistoryEntryEvent>;
+  clearHistory: Stream<ClearHistoryEvent>;
+  setCity: Stream<SetCityEvent>;
+  enrichHomePages: Stream<EnrichHomePagesEvent>;
+  setOptionUrl: Stream<SetOptionUrlEvent>;
+}
+
+export default pattern<SqliteCozyPollInput, SqliteCozyPollOutput>(
+  ({
+    question,
+    city,
+    optionsById,
+    optionOrder,
+    usersByName,
+    userOrder,
+    adminName,
+    myName,
+    webSearchUrl,
+  }) => {
+    const { table } = cfSqlite;
+    const db = sqliteDatabase({
+      tables: {
+        votes: table({
+          id: "text primary key",
+          voter: "text",
+          option_id: "text",
+          vote_type: "text",
+        }),
+      },
+    });
+
+    const homePageRefresh = Writable.perSpace.of<number | Default<0>>(0);
+    const sqliteRev = Writable.perSpace.of<number | Default<0>>(0);
+
+    const optionList = computed(() =>
+      (optionOrder ?? [])
+        .map((id) => optionsById?.[id])
+        .filter(isOption)
+    );
+    const userList = computed(() =>
+      (userOrder ?? [])
+        .map((name) => usersByName?.[name])
+        .filter(isUser)
+    );
+
+    // Votes + count come from single query nodes (flat in vote count).
+    const votesQuery = db.query<VoteRow>(
+      "SELECT voter AS voterName, option_id AS optionId, " +
+        "vote_type AS voteType FROM votes",
+      { reactOn: sqliteRev },
+    );
+    const voteCountQuery = db.query<CountRow>(
+      "SELECT COUNT(*) AS n FROM votes",
+      { reactOn: sqliteRev },
+    );
+    const votesSnapshot = computed<Vote[]>(() => votesQuery.result ?? []);
+    const voteCount = computed(() => voteCountQuery.result?.[0]?.n ?? 0);
+
+    const me = trimmedName(myName);
+    const admin = trimmedName(adminName);
+    const isJoined = me !== "";
+    const isAdmin = me !== "" && me === admin;
+    const searchEndpoint = trimmedName(webSearchUrl) || WEB_SEARCH_URL;
+    const homePageLookupUrls = computed(() =>
+      optionList.map(() => isAdmin ? searchEndpoint : "")
+    );
+
+    const boundJoin = joinAs({ usersByName, userOrder, myName, adminName });
+    const boundClaimHost = claimHost({ myName, adminName });
+    const boundAddOption = addOption({
+      optionsById,
+      optionOrder,
+      myName,
+      adminName,
+    });
+    const boundRemoveOption = removeOption({
+      optionsById,
+      optionOrder,
+      db,
+      myName,
+      adminName,
+    });
+    const boundCastVote = castVote({ db, myName, rev: sqliteRev });
+    const boundClearMyVote = clearMyVote({ db, myName });
+    const boundResetVotes = resetVotes({ db, myName, adminName });
+    const boundSetCity = setCity({ city, myName, adminName });
+    const boundEnrichHomePages = enrichHomePages({
+      myName,
+      adminName,
+      homePageRefresh,
+    });
+
+    return {
+      [NAME]: "SQLite lunch poll diagnostic",
+      [UI]: (
+        <div>
+          <h2>{question}</h2>
+          <p>
+            Host: {admin || "none"} · Me: {me || "not joined"} · City: {city}
+          </p>
+          <p>
+            {userList.length} users · {optionList.length} options ·{" "}
+            {voteCount} votes
+          </p>
+        </div>
+      ),
+      question,
+      city,
+      options: computed(() => optionList ?? EMPTY_OPTIONS),
+      votes: computed(() => votesSnapshot ?? EMPTY_VOTES),
+      users: computed(() => userList ?? EMPTY_USERS),
+      history: computed(() => EMPTY_HISTORY),
+      adminName: computed(() => trimmedName(adminName)),
+      myName: computed(() => trimmedName(myName)),
+      userCount: userList.length,
+      optionCount: optionList.length,
+      voteCount,
+      historyCount: 0,
+      isJoined,
+      isAdmin,
+      homePageLookupUrls,
+      joinAs: boundJoin,
+      claimHost: boundClaimHost,
+      addOption: boundAddOption,
+      removeOption: boundRemoveOption,
+      castVote: boundCastVote,
+      clearMyVote: boundClearMyVote,
+      resetVotes: boundResetVotes,
+      logVisit: noopLogVisit({ homePageRefresh }),
+      removeHistoryEntry: noopRemoveHistory({ homePageRefresh }),
+      clearHistory: noopClearHistory({ homePageRefresh }),
+      setCity: boundSetCity,
+      enrichHomePages: boundEnrichHomePages,
+      setOptionUrl: noopOptionUrl({ homePageRefresh }),
+    };
+  },
+);

--- a/packages/patterns/lunch-poll/main-sqlite.tsx
+++ b/packages/patterns/lunch-poll/main-sqlite.tsx
@@ -1,0 +1,498 @@
+/// <cts-enable />
+/**
+ * SQLite Lunch Poll - diagnostic variant.
+ *
+ * Same harness contract as `main-indexed.tsx`, but the *vote* state is stored in
+ * a SQLite table (one row per (voter, option) via `db.exec` INSERT OR REPLACE)
+ * instead of a shared `votesByOption` cell. Options/users stay as indexed cells
+ * — so this isolates ONE variable: the vote-write mechanism.
+ *
+ * Hypothesis under test (from the Phase-1 diagnostics): the array AND indexed
+ * variants both read-modify-write a shared `votes` cell, so they show identical
+ * concurrent ConflictError retries. Per-row SQLite inserts touch distinct rows
+ * with no shared mutable cell and `reactOn: db` (no rev-counter), so concurrent
+ * voters should contend less. `voteCount`/votes are surfaced via single query
+ * nodes, so the reactive graph should also stay flat in vote count.
+ */
+
+import {
+  cfSqlite,
+  computed,
+  Default,
+  handler,
+  NAME,
+  nonPrivateRandom,
+  pattern,
+  type PerSpace,
+  type PerUser,
+  safeDateNow,
+  type SqliteDb,
+  sqliteDatabase,
+  Stream,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+const WEB_SEARCH_URL = "/api/agent-tools/web-search";
+
+export interface User {
+  name: string;
+  avatar?: string;
+  color: string;
+  joinedAt: number;
+}
+
+export interface Option {
+  id: string;
+  title: string;
+  addedByName: string;
+  homePageUrl?: string;
+  homePageUrlOverride?: string;
+  imageUrl?: string;
+}
+
+export type VoteColor = "green" | "yellow" | "red";
+
+export interface Vote {
+  voterName: string;
+  optionId: string;
+  voteType: VoteColor;
+}
+
+export interface JoinEvent {
+  name?: string;
+}
+
+export type ClaimHostEvent = Record<PropertyKey, never>;
+
+export interface AddOptionEvent {
+  title?: string;
+}
+
+export interface RemoveOptionEvent {
+  optionId: string;
+}
+
+export interface CastVoteEvent {
+  optionId: string;
+  voteType: VoteColor;
+}
+
+export type ResetVotesEvent = Record<PropertyKey, never>;
+export type ClearVoteEvent = Record<PropertyKey, never>;
+export type EnrichHomePagesEvent = Record<PropertyKey, never>;
+
+export interface SetCityEvent {
+  city?: string;
+}
+
+export interface SetOptionUrlEvent {
+  optionId: string;
+  url?: string;
+}
+
+export interface HistoryEntry {
+  id: string;
+  title: string;
+  loggedByName: string;
+  wentAt: number;
+}
+
+export interface LogVisitEvent {
+  optionId?: string;
+  title?: string;
+  wentAt?: number;
+}
+
+export interface RemoveHistoryEntryEvent {
+  id: string;
+}
+
+export type ClearHistoryEvent = Record<PropertyKey, never>;
+
+interface VoteRow {
+  voterName: string;
+  optionId: string;
+  voteType: VoteColor;
+}
+
+interface CountRow {
+  n: number;
+}
+
+type OptionsById = Record<string, Option>;
+type UsersByName = Record<string, User>;
+
+const EMPTY_OPTIONS_BY_ID: OptionsById = {};
+const EMPTY_USERS_BY_NAME: UsersByName = {};
+
+type OptionsByIdCell = Writable<
+  OptionsById | Default<typeof EMPTY_OPTIONS_BY_ID>
+>;
+type OptionOrderCell = Writable<string[] | Default<[]>>;
+type UsersByNameCell = Writable<
+  UsersByName | Default<typeof EMPTY_USERS_BY_NAME>
+>;
+type UserOrderCell = Writable<string[] | Default<[]>>;
+type NameCell = Writable<string | Default<"">>;
+type CityCell = Writable<string | Default<"Berkeley, CA">>;
+type RefreshCell = Writable<number | Default<0>>;
+
+const PLAYER_COLORS = [
+  "#2f8a64",
+  "#c2573a",
+  "#3b4a6b",
+  "#a33b35",
+  "#b27722",
+  "#7c3aed",
+];
+
+const EMPTY_OPTIONS: Option[] = [];
+const EMPTY_VOTES: Vote[] = [];
+const EMPTY_USERS: User[] = [];
+const EMPTY_HISTORY: HistoryEntry[] = [];
+
+const trimmedName = (n: string | undefined) => (n ?? "").trim();
+
+const colorForIndex = (index: number): string =>
+  PLAYER_COLORS[index % PLAYER_COLORS.length] ?? PLAYER_COLORS[0];
+
+const newOptionId = (): string =>
+  `o_${Math.floor(safeDateNow()).toString(36)}_${
+    Math.floor(nonPrivateRandom() * 1_000_000).toString(36)
+  }`;
+
+const voteKey = (voter: string, optionId: string): string =>
+  `${voter}::${optionId}`;
+
+const isOption = (value: Option | undefined): value is Option =>
+  value !== undefined;
+
+const isUser = (value: User | undefined): value is User => value !== undefined;
+
+const joinAs = handler<JoinEvent, {
+  usersByName: UsersByNameCell;
+  userOrder: UserOrderCell;
+  myName: NameCell;
+  adminName: NameCell;
+}>(({ name }, { usersByName, userOrder, myName, adminName }) => {
+  const trimmed = trimmedName(name);
+  if (!trimmed) return;
+  if (trimmedName(myName.get())) return;
+  const users = usersByName.get() ?? {};
+  if (users[trimmed]) return;
+  const order = userOrder.get() ?? [];
+  usersByName.key(trimmed).set({
+    name: trimmed,
+    avatar: "",
+    color: colorForIndex(order.length),
+    joinedAt: safeDateNow(),
+  });
+  userOrder.push(trimmed);
+  myName.set(trimmed);
+  if (!trimmedName(adminName.get())) adminName.set(trimmed);
+});
+
+const claimHost = handler<ClaimHostEvent, {
+  myName: NameCell;
+  adminName: NameCell;
+}>((_, { myName, adminName }) => {
+  const me = trimmedName(myName.get());
+  if (!me || trimmedName(adminName.get()) === me) return;
+  adminName.set(me);
+});
+
+const addOption = handler<AddOptionEvent, {
+  optionsById: OptionsByIdCell;
+  optionOrder: OptionOrderCell;
+  myName: NameCell;
+  adminName: NameCell;
+}>(({ title }, { optionsById, optionOrder, myName, adminName }) => {
+  const me = trimmedName(myName.get());
+  if (!me || me !== trimmedName(adminName.get())) return;
+  const trimmed = trimmedName(title);
+  if (!trimmed) return;
+  const id = newOptionId();
+  optionsById.key(id).set({
+    id,
+    title: trimmed,
+    addedByName: me,
+    homePageUrl: "",
+    homePageUrlOverride: "",
+    imageUrl: "",
+  });
+  optionOrder.push(id);
+});
+
+const removeOption = handler<RemoveOptionEvent, {
+  optionsById: OptionsByIdCell;
+  optionOrder: OptionOrderCell;
+  db: SqliteDb;
+  myName: NameCell;
+  adminName: NameCell;
+}>(
+  (
+    { optionId },
+    { optionsById, optionOrder, db, myName, adminName },
+  ) => {
+    const me = trimmedName(myName.get());
+    if (!me || me !== trimmedName(adminName.get())) return;
+    const currentOptions = optionsById.get() ?? {};
+    if (!currentOptions[optionId]) return;
+
+    const nextOptions: OptionsById = {};
+    for (const [id, option] of Object.entries(currentOptions)) {
+      if (id !== optionId) nextOptions[id] = option;
+    }
+    optionsById.set(nextOptions);
+    optionOrder.set((optionOrder.get() ?? []).filter((id) => id !== optionId));
+    db.exec("DELETE FROM votes WHERE option_id = ?", [optionId]);
+  },
+);
+
+// Vote write: a single per-(voter,option) row, INSERT OR REPLACE. No shared
+// votes cell, no rev-counter — the queries below `reactOn: db`.
+const castVote = handler<CastVoteEvent, {
+  db: SqliteDb;
+  myName: NameCell;
+}>(({ optionId, voteType }, { db, myName }) => {
+  const me = trimmedName(myName.get());
+  if (!me || !optionId) return;
+  db.exec(
+    "INSERT OR REPLACE INTO votes (id, voter, option_id, vote_type) " +
+      "VALUES (?, ?, ?, ?)",
+    [voteKey(me, optionId), me, optionId, voteType],
+  );
+});
+
+const clearMyVote = handler<ClearVoteEvent, {
+  db: SqliteDb;
+  myName: NameCell;
+}>((_, { db, myName }) => {
+  const me = trimmedName(myName.get());
+  if (!me) return;
+  db.exec("DELETE FROM votes WHERE voter = ?", [me]);
+});
+
+const resetVotes = handler<ResetVotesEvent, {
+  db: SqliteDb;
+  myName: NameCell;
+  adminName: NameCell;
+}>((_, { db, myName, adminName }) => {
+  const me = trimmedName(myName.get());
+  if (!me || me !== trimmedName(adminName.get())) return;
+  db.exec("DELETE FROM votes");
+});
+
+const setCity = handler<SetCityEvent, {
+  city: CityCell;
+  myName: NameCell;
+  adminName: NameCell;
+}>(({ city: nextCity }, { city, myName, adminName }) => {
+  const me = trimmedName(myName.get());
+  if (!me || me !== trimmedName(adminName.get())) return;
+  const next = trimmedName(nextCity);
+  if (next) city.set(next);
+});
+
+const enrichHomePages = handler<EnrichHomePagesEvent, {
+  myName: NameCell;
+  adminName: NameCell;
+  homePageRefresh: RefreshCell;
+}>((_, { myName, adminName, homePageRefresh }) => {
+  const me = trimmedName(myName.get());
+  if (!me || me !== trimmedName(adminName.get())) return;
+  homePageRefresh.set(Number(homePageRefresh.get() ?? 0) + 1);
+});
+
+const noopOptionUrl = handler<
+  SetOptionUrlEvent,
+  { homePageRefresh: RefreshCell }
+>(() => {});
+const noopLogVisit = handler<LogVisitEvent, { homePageRefresh: RefreshCell }>(
+  () => {},
+);
+const noopRemoveHistory = handler<
+  RemoveHistoryEntryEvent,
+  { homePageRefresh: RefreshCell }
+>(() => {});
+const noopClearHistory = handler<
+  ClearHistoryEvent,
+  { homePageRefresh: RefreshCell }
+>(() => {});
+
+export interface SqliteCozyPollInput {
+  question?: PerSpace<string | Default<"Where should we eat?">>;
+  city?: PerSpace<string | Default<"Berkeley, CA">>;
+  optionsById?: PerSpace<OptionsById | Default<typeof EMPTY_OPTIONS_BY_ID>>;
+  optionOrder?: PerSpace<string[] | Default<[]>>;
+  usersByName?: PerSpace<UsersByName | Default<typeof EMPTY_USERS_BY_NAME>>;
+  userOrder?: PerSpace<string[] | Default<[]>>;
+  adminName?: PerSpace<string | Default<"">>;
+  myName?: PerUser<string | Default<"">>;
+  webSearchUrl?: PerSpace<string | Default<typeof WEB_SEARCH_URL>>;
+}
+
+export interface SqliteCozyPollOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  question: string;
+  city: string;
+  options: readonly Option[];
+  votes: readonly Vote[];
+  users: readonly User[];
+  history: readonly HistoryEntry[];
+  adminName: string;
+  myName: string;
+  userCount: number;
+  optionCount: number;
+  voteCount: number;
+  historyCount: number;
+  isJoined: boolean;
+  isAdmin: boolean;
+  homePageLookupUrls: readonly string[];
+  joinAs: Stream<JoinEvent>;
+  claimHost: Stream<ClaimHostEvent>;
+  addOption: Stream<AddOptionEvent>;
+  removeOption: Stream<RemoveOptionEvent>;
+  castVote: Stream<CastVoteEvent>;
+  clearMyVote: Stream<ClearVoteEvent>;
+  resetVotes: Stream<ResetVotesEvent>;
+  logVisit: Stream<LogVisitEvent>;
+  removeHistoryEntry: Stream<RemoveHistoryEntryEvent>;
+  clearHistory: Stream<ClearHistoryEvent>;
+  setCity: Stream<SetCityEvent>;
+  enrichHomePages: Stream<EnrichHomePagesEvent>;
+  setOptionUrl: Stream<SetOptionUrlEvent>;
+}
+
+export default pattern<SqliteCozyPollInput, SqliteCozyPollOutput>(
+  ({
+    question,
+    city,
+    optionsById,
+    optionOrder,
+    usersByName,
+    userOrder,
+    adminName,
+    myName,
+    webSearchUrl,
+  }) => {
+    const { table } = cfSqlite;
+    const db = sqliteDatabase({
+      tables: {
+        votes: table({
+          id: "text primary key",
+          voter: "text",
+          option_id: "text",
+          vote_type: "text",
+        }),
+      },
+    });
+
+    const homePageRefresh = Writable.perSpace.of<number | Default<0>>(0);
+
+    const optionList = computed(() =>
+      (optionOrder ?? [])
+        .map((id) => optionsById?.[id])
+        .filter(isOption)
+    );
+    const userList = computed(() =>
+      (userOrder ?? [])
+        .map((name) => usersByName?.[name])
+        .filter(isUser)
+    );
+
+    // Votes + count come from single query nodes (flat in vote count).
+    const votesQuery = db.query<VoteRow>(
+      "SELECT voter AS voterName, option_id AS optionId, " +
+        "vote_type AS voteType FROM votes",
+      { reactOn: db },
+    );
+    const voteCountQuery = db.query<CountRow>(
+      "SELECT COUNT(*) AS n FROM votes",
+      { reactOn: db },
+    );
+    const votesSnapshot = computed<Vote[]>(() => votesQuery.result ?? []);
+    const voteCount = computed(() => voteCountQuery.result?.[0]?.n ?? 0);
+
+    const me = trimmedName(myName);
+    const admin = trimmedName(adminName);
+    const isJoined = me !== "";
+    const isAdmin = me !== "" && me === admin;
+    const searchEndpoint = trimmedName(webSearchUrl) || WEB_SEARCH_URL;
+    const homePageLookupUrls = computed(() =>
+      optionList.map(() => isAdmin ? searchEndpoint : "")
+    );
+
+    const boundJoin = joinAs({ usersByName, userOrder, myName, adminName });
+    const boundClaimHost = claimHost({ myName, adminName });
+    const boundAddOption = addOption({
+      optionsById,
+      optionOrder,
+      myName,
+      adminName,
+    });
+    const boundRemoveOption = removeOption({
+      optionsById,
+      optionOrder,
+      db,
+      myName,
+      adminName,
+    });
+    const boundCastVote = castVote({ db, myName });
+    const boundClearMyVote = clearMyVote({ db, myName });
+    const boundResetVotes = resetVotes({ db, myName, adminName });
+    const boundSetCity = setCity({ city, myName, adminName });
+    const boundEnrichHomePages = enrichHomePages({
+      myName,
+      adminName,
+      homePageRefresh,
+    });
+
+    return {
+      [NAME]: "SQLite lunch poll diagnostic",
+      [UI]: (
+        <div>
+          <h2>{question}</h2>
+          <p>
+            Host: {admin || "none"} · Me: {me || "not joined"} · City: {city}
+          </p>
+          <p>
+            {userList.length} users · {optionList.length} options ·{" "}
+            {voteCount} votes
+          </p>
+        </div>
+      ),
+      question,
+      city,
+      options: computed(() => optionList ?? EMPTY_OPTIONS),
+      votes: computed(() => votesSnapshot ?? EMPTY_VOTES),
+      users: computed(() => userList ?? EMPTY_USERS),
+      history: computed(() => EMPTY_HISTORY),
+      adminName: computed(() => trimmedName(adminName)),
+      myName: computed(() => trimmedName(myName)),
+      userCount: userList.length,
+      optionCount: optionList.length,
+      voteCount,
+      historyCount: 0,
+      isJoined,
+      isAdmin,
+      homePageLookupUrls,
+      joinAs: boundJoin,
+      claimHost: boundClaimHost,
+      addOption: boundAddOption,
+      removeOption: boundRemoveOption,
+      castVote: boundCastVote,
+      clearMyVote: boundClearMyVote,
+      resetVotes: boundResetVotes,
+      logVisit: noopLogVisit({ homePageRefresh }),
+      removeHistoryEntry: noopRemoveHistory({ homePageRefresh }),
+      clearHistory: noopClearHistory({ homePageRefresh }),
+      setCity: boundSetCity,
+      enrichHomePages: boundEnrichHomePages,
+      setOptionUrl: noopOptionUrl({ homePageRefresh }),
+    };
+  },
+);

--- a/packages/patterns/lunch-poll/probe-sqlite-landing.ts
+++ b/packages/patterns/lunch-poll/probe-sqlite-landing.ts
@@ -1,0 +1,176 @@
+/**
+ * Step-1 probe: resolve the SQLite "writes landed vs writes dropped" confound.
+ *
+ * The diagnose harness reads votes through each live runtime's reactive
+ * `sqliteQuery` (`reactOn: db`). That read is downstream of the exact cross-
+ * runtime invalidation gap under investigation, so a low surfaced-vote count
+ * cannot distinguish:
+ *   (a) writes landed in server SQLite but never re-surfaced (pure reactivity), vs
+ *   (b) writes were dropped (retry exhaustion on the shared handle `rev` mutex).
+ *
+ * This probe drives the same join → add-options → concurrent-vote-rounds load,
+ * then opens a FRESH ("cold") runtime that has never subscribed to the result
+ * graph. Its first `sqliteQuery` issuance has an empty `requestHash`, so it
+ * materializes directly from committed storage — canonical server truth,
+ * independent of any `reactOn` re-trigger. The cold count decides (a) vs (b).
+ *
+ * Run:
+ *   deno run -A packages/patterns/lunch-poll/probe-sqlite-landing.ts \
+ *     --program=main-sqlite.tsx --case=3x5 --rounds=3
+ */
+
+import { MultiRuntimeHarness } from "../integration/multi-runtime-harness.ts";
+
+const TEST_WEB_SEARCH_URL =
+  "data:application/json,%7B%22results%22%3A%5B%5D%7D";
+const VOTE_COLORS = ["green", "yellow", "red"] as const;
+const ROOT_PATH = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+
+function stringArg(name: string, fallback: string): string {
+  const prefix = `--${name}=`;
+  const arg = Deno.args.find((entry) => entry.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : fallback;
+}
+
+function numberArg(name: string, fallback: number): number {
+  const prefix = `--${name}=`;
+  const arg = Deno.args.find((entry) => entry.startsWith(prefix));
+  if (!arg) return fallback;
+  const parsed = Number(arg.slice(prefix.length));
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const asNumber = (value: unknown): number =>
+  typeof value === "number" && Number.isFinite(value) ? value : 0;
+
+interface VoteView {
+  voteCount: number;
+  votesLen: number;
+  myName: string;
+}
+
+function voteView(value: unknown): VoteView {
+  if (!isRecord(value)) return { voteCount: 0, votesLen: 0, myName: "?" };
+  return {
+    voteCount: asNumber(value.voteCount),
+    votesLen: Array.isArray(value.votes) ? value.votes.length : 0,
+    myName: typeof value.myName === "string" ? value.myName : "?",
+  };
+}
+
+async function main(): Promise<void> {
+  const program = stringArg("program", "main-sqlite.tsx");
+  const rounds = numberArg("rounds", 3);
+  const caseArg = stringArg("case", "3x5");
+  const match = caseArg.match(/^(\d+)x(\d+)$/);
+  if (!match) throw new Error(`--case must be NxM (options x users); got ${caseArg}`);
+  const optionCount = Number(match[1]);
+  const userCount = Number(match[2]);
+
+  console.log(
+    `# probe-sqlite-landing program=${program} case=${optionCount}x${userCount} ` +
+      `rounds=${rounds} (expect ${optionCount * userCount} votes if all land)`,
+  );
+
+  const labels = Array.from(
+    { length: userCount },
+    (_e, i) => `user-${i + 1}`,
+  );
+
+  const harness = await MultiRuntimeHarness.create({
+    programPath: new URL(`./${program}`, import.meta.url).pathname,
+    rootPath: ROOT_PATH,
+    diagnostics: false,
+    input: { webSearchUrl: TEST_WEB_SEARCH_URL },
+    sessions: labels,
+    spaceName: `probe-sqlite-landing-${userCount}u-${optionCount}o-${crypto.randomUUID()}`,
+  });
+
+  try {
+    const sessions = labels.map((label) => harness.session(label));
+    const host = sessions[0];
+
+    // Join.
+    await host.send("joinAs", { name: "User 1" });
+    await Promise.all(
+      sessions.slice(1).map((s, i) => s.send("joinAs", { name: `User ${i + 2}` })),
+    );
+    await harness.settle(3);
+
+    // Host adds options.
+    for (let i = 0; i < optionCount; i++) {
+      await host.send("addOption", { title: `Restaurant ${i + 1}` });
+    }
+    await harness.settle(3);
+
+    const hostPoll = await host.read();
+    const optionIds =
+      (isRecord(hostPoll) && Array.isArray(hostPoll.options))
+        ? hostPoll.options
+          .map((o) => (isRecord(o) ? o.id : undefined))
+          .filter((id): id is string => typeof id === "string" && id !== "")
+        : [];
+    console.log(`# options created: ${optionIds.length}`);
+
+    // Concurrent vote rounds — same rotation as diagnose.ts.
+    for (let round = 0; round < rounds; round++) {
+      await Promise.all(
+        sessions.map((s, index) =>
+          s.send("castVote", {
+            optionId: optionIds[(round + index) % optionIds.length],
+            voteType: VOTE_COLORS[(round + index) % VOTE_COLORS.length],
+          })
+        ),
+      );
+      await harness.settle(3);
+    }
+
+    // What each LIVE (long-subscribed) runtime currently surfaces.
+    console.log("\n## live sessions (reactive read, post-votes):");
+    for (const s of sessions) {
+      const v = voteView(await s.read());
+      console.log(
+        `  ${s.label.padEnd(8)} myName=${v.myName.padEnd(8)} ` +
+          `voteCount=${v.voteCount} votes.len=${v.votesLen}`,
+      );
+    }
+
+    // THE DECISIVE READ: a cold runtime opening the piece for the first time.
+    const cold = await harness.addColdSession("cold-auditor");
+    const coldV = voteView(await cold.read());
+    console.log("\n## cold auditor (fresh runtime, first sqliteQuery = server truth):");
+    console.log(
+      `  cold-auditor voteCount=${coldV.voteCount} votes.len=${coldV.votesLen}`,
+    );
+
+    // Re-read live sessions AFTER the cold open + a settle, in case the cold
+    // open's fresh write-back or extra sync nudges their reactive reads.
+    await harness.settle(3);
+    console.log("\n## live sessions (re-read after cold open + settle):");
+    for (const s of sessions) {
+      const v = voteView(await s.read());
+      console.log(`  ${s.label.padEnd(8)} voteCount=${v.voteCount} votes.len=${v.votesLen}`);
+    }
+
+    const expected = optionCount * userCount;
+    console.log("\n## verdict:");
+    if (coldV.voteCount >= expected) {
+      console.log(
+        `  WRITES LANDED — cold reader sees ${coldV.voteCount}/${expected}. ` +
+          `Low live counts are a pure reactive-propagation gap, not lost writes.`,
+      );
+    } else {
+      console.log(
+        `  WRITES DROPPED — cold reader sees only ${coldV.voteCount}/${expected} ` +
+          `in canonical storage. The low retry count is a lost-write artifact.`,
+      );
+    }
+  } finally {
+    await harness.dispose();
+  }
+}
+
+if (import.meta.main) await main();

--- a/packages/patterns/write-contention/probe-space.ts
+++ b/packages/patterns/write-contention/probe-space.ts
@@ -1,0 +1,133 @@
+/**
+ * Space-level granularity probe — SQLite-free.
+ *
+ * Tests whether the write-conflict/serialization unit is the DOCUMENT or
+ * something broader (the space). Two DISJOINT writer groups push UNIQUE markers
+ * to two DISJOINT cells that are never co-written:
+ *   - group A (size --groupA) pushes -> `list`
+ *   - group B (size --groupB) pushes -> `listB`
+ *
+ * Run three configs and compare group A's drop rate:
+ *   baseline   --groupA=10 --groupB=0   (listB idle)
+ *   split      --groupA=10 --groupB=10  (listB busy, but DIFFERENT cell/writers)
+ *   saturated  --groupA=20 --groupB=0   (all 20 on the SAME cell)
+ *
+ *   split ≈ saturated >> baseline  => SPACE-level conflict (disjoint cells collide)
+ *   split ≈ baseline  << saturated => per-DOCUMENT conflict (no cross-cell effect)
+ *
+ *   deno run -A packages/patterns/write-contention/probe-space.ts \
+ *     --groupA=10 --groupB=10 --rounds=5 2>/tmp/wcs.err
+ */
+
+import { MultiRuntimeHarness } from "../integration/multi-runtime-harness.ts";
+
+const ROOT_PATH = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+
+function numberArg(name: string, fallback: number): number {
+  const prefix = `--${name}=`;
+  const arg = Deno.args.find((entry) => entry.startsWith(prefix));
+  if (!arg) return fallback;
+  const parsed = Number(arg.slice(prefix.length));
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const asStringArray = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === "string")
+    : [];
+
+async function readCell(
+  read: () => Promise<unknown>,
+  key: string,
+): Promise<string[]> {
+  const out = await read();
+  return isRecord(out) ? asStringArray(out[key]) : [];
+}
+
+function report(
+  groupName: string,
+  cellName: string,
+  attempted: string[],
+  cold: string[],
+  live: string[],
+): void {
+  const coldSet = new Set(cold);
+  const landed = attempted.filter((m) => coldSet.has(m));
+  const missing = attempted.length - landed.length;
+  const pct = attempted.length > 0
+    ? ((missing / attempted.length) * 100).toFixed(0)
+    : "0";
+  console.log(
+    `  ${groupName} -> ${cellName}: attempted=${attempted.length} ` +
+      `landed(cold)=${landed.length} MISSING=${missing} (${pct}%)  ` +
+      `[cold=${coldSet.size} live=${new Set(live).size}]`,
+  );
+}
+
+async function main(): Promise<void> {
+  const groupA = numberArg("groupA", 10);
+  const groupB = numberArg("groupB", 0);
+  const rounds = numberArg("rounds", 5);
+
+  console.log(
+    `# space-probe  groupA=${groupA}->list  groupB=${groupB}->listB  ` +
+      `rounds=${rounds}  (attempted: A=${groupA * rounds}, B=${groupB * rounds})`,
+  );
+
+  const aLabels = Array.from({ length: groupA }, (_e, i) => `a${i + 1}`);
+  const bLabels = Array.from({ length: groupB }, (_e, i) => `b${i + 1}`);
+  const harness = await MultiRuntimeHarness.create({
+    programPath: new URL("./repro.tsx", import.meta.url).pathname,
+    rootPath: ROOT_PATH,
+    diagnostics: false,
+    sessions: [...aLabels, ...bLabels],
+    spaceName: `wc-space-${groupA}a-${groupB}b-${crypto.randomUUID()}`,
+  });
+
+  const attemptedA: string[] = [];
+  const attemptedB: string[] = [];
+
+  try {
+    const aSessions = aLabels.map((l) => harness.session(l));
+    const bSessions = bLabels.map((l) => harness.session(l));
+    await harness.settle(2);
+
+    for (let round = 0; round < rounds; round++) {
+      await Promise.all([
+        ...aSessions.map((s) => {
+          const marker = `${s.label}#${round}`;
+          attemptedA.push(marker);
+          return s.send("append", { marker });
+        }),
+        ...bSessions.map((s) => {
+          const marker = `${s.label}#${round}`;
+          attemptedB.push(marker);
+          return s.send("appendB", { marker });
+        }),
+      ]);
+      await harness.settle(3);
+    }
+
+    const reader = (aSessions[0] ?? bSessions[0]);
+    const cold = await harness.addColdSession("cold-auditor");
+    const coldList = await readCell(() => cold.read(), "list");
+    const coldListB = await readCell(() => cold.read(), "listB");
+    await harness.settle(3);
+    const liveList = await readCell(() => reader.read(), "list");
+    const liveListB = await readCell(() => reader.read(), "listB");
+
+    console.log("\n## storage truth (cold reader):");
+    if (groupA > 0) report("groupA", "list ", attemptedA, coldList, liveList);
+    if (groupB > 0) report("groupB", "listB", attemptedB, coldListB, liveListB);
+    console.log(
+      "\n   compare groupA->list MISSING across baseline / split / saturated runs.",
+    );
+  } finally {
+    await harness.dispose();
+  }
+}
+
+if (import.meta.main) await main();

--- a/packages/patterns/write-contention/probe.ts
+++ b/packages/patterns/write-contention/probe.ts
@@ -1,0 +1,177 @@
+/**
+ * Write-contention probe — SQLite-free.
+ *
+ * Drives N concurrent runtimes, each writing UNIQUE markers to a shared cell via
+ * two paths (shared-list push vs distinct-key set), then opens a fresh COLD
+ * runtime to read canonical storage truth. Reports, per path:
+ *   - attempted vs landed (and the IDENTITY of every missing write), and
+ *   - cold vs live (to separate real lost writes from any reactive-read lag).
+ *
+ * Pair with stderr to count retry exhaustions and answer the two crux questions:
+ *   1. one mechanism or two? -> compare `missing` (cold storage) against the
+ *      `exhausting all retries` stderr line count. missing > exhaustions implies
+ *      a SECOND, silent path (a lost-update that never logs).
+ *   2. coarse or fine conflict? -> does the distinct-KEY path drop as badly as
+ *      the shared-LIST path? If yes, conflict detection is coarse-grained
+ *      (independent writes still collide).
+ *
+ * Run (capture stderr to grep exhaustions):
+ *   deno run -A packages/patterns/write-contention/probe.ts \
+ *     --users=10 --rounds=5 --mode=both 2>/tmp/wc.err
+ *   grep -c "exhausting all retries" /tmp/wc.err
+ */
+
+import { MultiRuntimeHarness } from "../integration/multi-runtime-harness.ts";
+
+const ROOT_PATH = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+
+function stringArg(name: string, fallback: string): string {
+  const prefix = `--${name}=`;
+  const arg = Deno.args.find((entry) => entry.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : fallback;
+}
+
+function numberArg(name: string, fallback: number): number {
+  const prefix = `--${name}=`;
+  const arg = Deno.args.find((entry) => entry.startsWith(prefix));
+  if (!arg) return fallback;
+  const parsed = Number(arg.slice(prefix.length));
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((v): v is string => typeof v === "string")
+    : [];
+}
+
+/** Read (list, mapKeys) from a runtime's piece output. */
+async function readView(
+  read: () => Promise<unknown>,
+): Promise<{ list: string[]; mapKeys: string[] }> {
+  const out = await read();
+  if (!isRecord(out)) return { list: [], mapKeys: [] };
+  return {
+    list: asStringArray(out.list),
+    mapKeys: asStringArray(out.mapKeys),
+  };
+}
+
+/** Accounting for one write path against the attempted marker set. */
+function account(
+  pathName: string,
+  attempted: string[],
+  landedColdRaw: string[],
+  landedLiveRaw: string[],
+): void {
+  const attemptedSet = new Set(attempted);
+  const cold = new Set(landedColdRaw);
+  const live = new Set(landedLiveRaw);
+  // landed-in-storage = cold reads that are genuine attempted markers
+  const coldLanded = [...cold].filter((m) => attemptedSet.has(m));
+  const missing = attempted.filter((m) => !cold.has(m));
+  const dupes = landedColdRaw.length - new Set(landedColdRaw).size;
+
+  console.log(`\n## ${pathName}`);
+  console.log(
+    `  attempted=${attempted.length}  landed(cold storage)=${coldLanded.length}` +
+      `  MISSING=${missing.length}` +
+      (dupes > 0 ? `  (note: ${dupes} duplicate entries in storage)` : ""),
+  );
+  console.log(
+    `  cold=${cold.size} vs live=${live.size}` +
+      (cold.size === live.size
+        ? "  (cold==live: no reactive-read lag)"
+        : "  (cold!=live: some reactive-read lag present)"),
+  );
+  if (missing.length > 0) {
+    const sample = missing.slice(0, 8).join(", ");
+    console.log(
+      `  sample missing: ${sample}${missing.length > 8 ? ", …" : ""}`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const users = numberArg("users", 10);
+  const rounds = numberArg("rounds", 5);
+  const mode = stringArg("mode", "both"); // both | list | map
+  const doList = mode === "both" || mode === "list";
+  const doMap = mode === "both" || mode === "map";
+
+  console.log(
+    `# write-contention probe  users=${users} rounds=${rounds} mode=${mode}  ` +
+      `(attempted per active path = ${users * rounds})`,
+  );
+
+  const labels = Array.from({ length: users }, (_e, i) => `w${i + 1}`);
+  const harness = await MultiRuntimeHarness.create({
+    programPath: new URL("./repro.tsx", import.meta.url).pathname,
+    rootPath: ROOT_PATH,
+    diagnostics: false,
+    sessions: labels,
+    spaceName: `write-contention-${users}u-${crypto.randomUUID()}`,
+  });
+
+  const attempted: string[] = [];
+
+  try {
+    const sessions = labels.map((label) => harness.session(label));
+    await harness.settle(2);
+
+    // Concurrent write rounds: every runtime fires its writes for the round
+    // simultaneously (max contention), using a UNIQUE marker per (runtime,round).
+    for (let round = 0; round < rounds; round++) {
+      await Promise.all(
+        sessions.map((s) => {
+          const marker = `${s.label}#${round}`;
+          attempted.push(marker);
+          const writes: Promise<void>[] = [];
+          if (doList) writes.push(s.send("append", { marker }));
+          if (doMap) writes.push(s.send("setKey", { id: marker, marker }));
+          return Promise.all(writes).then(() => undefined);
+        }),
+      );
+      await harness.settle(3);
+    }
+    // attempted currently has one entry per (runtime,round) but doMap/doList
+    // share the same marker, so the attempted SET is exactly users*rounds.
+    const attemptedUnique = [...new Set(attempted)];
+
+    // Live reading (one long-subscribed runtime), then the decisive cold read.
+    const live = await readView(() => sessions[0].read());
+    const cold = await harness.addColdSession("cold-auditor");
+    const coldView = await readView(() => cold.read());
+    await harness.settle(3);
+    const liveAfter = await readView(() => sessions[0].read());
+
+    console.log(
+      `\n# attempted unique markers: ${attemptedUnique.length}` +
+        ` (expected ${users * rounds})`,
+    );
+
+    if (doList) {
+      account("LIST (shared-leaf push)", attemptedUnique, coldView.list, liveAfter.list);
+    }
+    if (doMap) {
+      account("MAP (distinct-key set)", attemptedUnique, coldView.mapKeys, liveAfter.mapKeys);
+    }
+
+    console.log(
+      "\n## next: grep stderr for `exhausting all retries`; compare to MISSING above.",
+    );
+    console.log(
+      "   missing > exhaustions  => a SECOND, silent (unlogged) drop path.",
+    );
+    console.log(
+      "   map MISSING ~= list MISSING  => coarse-grained conflict (independent writes collide).",
+    );
+  } finally {
+    await harness.dispose();
+  }
+}
+
+if (import.meta.main) await main();

--- a/packages/patterns/write-contention/probe.ts
+++ b/packages/patterns/write-contention/probe.ts
@@ -48,15 +48,16 @@ function asStringArray(value: unknown): string[] {
     : [];
 }
 
-/** Read (list, mapKeys) from a runtime's piece output. */
+/** Read (list, mapKeys, tallyLeaves) from a runtime's piece output. */
 async function readView(
   read: () => Promise<unknown>,
-): Promise<{ list: string[]; mapKeys: string[] }> {
+): Promise<{ list: string[]; mapKeys: string[]; tally: string[] }> {
   const out = await read();
-  if (!isRecord(out)) return { list: [], mapKeys: [] };
+  if (!isRecord(out)) return { list: [], mapKeys: [], tally: [] };
   return {
     list: asStringArray(out.list),
     mapKeys: asStringArray(out.mapKeys),
+    tally: asStringArray(out.tallyLeaves),
   };
 }
 
@@ -98,9 +99,11 @@ function account(
 async function main(): Promise<void> {
   const users = numberArg("users", 10);
   const rounds = numberArg("rounds", 5);
-  const mode = stringArg("mode", "both"); // both | list | map
+  const mode = stringArg("mode", "both"); // both | list | map | nested
+  const buckets = numberArg("buckets", 3); // nested-mode: # of shared sub-buckets
   const doList = mode === "both" || mode === "list";
   const doMap = mode === "both" || mode === "map";
+  const doNested = mode === "nested";
 
   console.log(
     `# write-contention probe  users=${users} rounds=${rounds} mode=${mode}  ` +
@@ -126,12 +129,20 @@ async function main(): Promise<void> {
     // simultaneously (max contention), using a UNIQUE marker per (runtime,round).
     for (let round = 0; round < rounds; round++) {
       await Promise.all(
-        sessions.map((s) => {
+        sessions.map((s, index) => {
           const marker = `${s.label}#${round}`;
           attempted.push(marker);
           const writes: Promise<void>[] = [];
           if (doList) writes.push(s.send("append", { marker }));
           if (doMap) writes.push(s.send("setKey", { id: marker, marker }));
+          if (doNested) {
+            // Same rotation as the lunch-poll diagnose: spreads writers across
+            // `buckets` shared sub-buckets (~users/buckets writers share each).
+            const bucket = String((round + index) % buckets);
+            writes.push(
+              s.send("nestedSet", { bucket, leafKey: marker, marker }),
+            );
+          }
           return Promise.all(writes).then(() => undefined);
         }),
       );
@@ -158,6 +169,14 @@ async function main(): Promise<void> {
     }
     if (doMap) {
       account("MAP (distinct-key set)", attemptedUnique, coldView.mapKeys, liveAfter.mapKeys);
+    }
+    if (doNested) {
+      account(
+        "NESTED (shared-subrecord RMW)",
+        attemptedUnique,
+        coldView.tally,
+        liveAfter.tally,
+      );
     }
 
     console.log(

--- a/packages/patterns/write-contention/repro.tsx
+++ b/packages/patterns/write-contention/repro.tsx
@@ -67,8 +67,20 @@ const setKey = handler<SetKeyEvent, { map: MapCell }>(
   },
 );
 
+// SECOND INDEPENDENT shared-list cell, disjoint from `list`. For the space-level
+// granularity test: if writers pushing ONLY `listB` raise the drop rate of a
+// disjoint writer group pushing ONLY `list`, the serialization unit is broader
+// than the document (independent cells in one space collide).
+const appendB = handler<AppendEvent, { listB: ListCell }>(
+  ({ marker }, { listB }) => {
+    if (!marker) return;
+    listB.push(marker);
+  },
+);
+
 export interface ContentionInput {
   list?: PerSpace<MarkerList | Default<typeof EMPTY_LIST>>;
+  listB?: PerSpace<MarkerList | Default<typeof EMPTY_LIST>>;
   map?: PerSpace<MarkerMap | Default<typeof EMPTY_MAP>>;
 }
 
@@ -76,31 +88,41 @@ export interface ContentionOutput {
   [NAME]: string;
   [UI]: VNode;
   list: readonly string[];
+  listB: readonly string[];
   mapKeys: readonly string[];
   listCount: number;
+  listBCount: number;
   mapCount: number;
   append: Stream<AppendEvent>;
+  appendB: Stream<AppendEvent>;
   setKey: Stream<SetKeyEvent>;
 }
 
-export default pattern<ContentionInput, ContentionOutput>(({ list, map }) => {
-  const listSnapshot = computed(() => list ?? EMPTY_LIST);
-  const mapKeys = computed(() => Object.keys(map ?? EMPTY_MAP));
-  const listCount = computed(() => (list ?? EMPTY_LIST).length);
-  const mapCount = computed(() => Object.keys(map ?? EMPTY_MAP).length);
+export default pattern<ContentionInput, ContentionOutput>(
+  ({ list, listB, map }) => {
+    const listSnapshot = computed(() => list ?? EMPTY_LIST);
+    const listBSnapshot = computed(() => listB ?? EMPTY_LIST);
+    const mapKeys = computed(() => Object.keys(map ?? EMPTY_MAP));
+    const listCount = computed(() => (list ?? EMPTY_LIST).length);
+    const listBCount = computed(() => (listB ?? EMPTY_LIST).length);
+    const mapCount = computed(() => Object.keys(map ?? EMPTY_MAP).length);
 
-  return {
-    [NAME]: "write-contention repro",
-    [UI]: (
-      <div>
-        list={listCount} · map={mapCount}
-      </div>
-    ),
-    list: listSnapshot,
-    mapKeys,
-    listCount,
-    mapCount,
-    append: append({ list }),
-    setKey: setKey({ map }),
-  };
-});
+    return {
+      [NAME]: "write-contention repro",
+      [UI]: (
+        <div>
+          list={listCount} · listB={listBCount} · map={mapCount}
+        </div>
+      ),
+      list: listSnapshot,
+      listB: listBSnapshot,
+      mapKeys,
+      listCount,
+      listBCount,
+      mapCount,
+      append: append({ list }),
+      appendB: appendB({ listB }),
+      setKey: setKey({ map }),
+    };
+  },
+);

--- a/packages/patterns/write-contention/repro.tsx
+++ b/packages/patterns/write-contention/repro.tsx
@@ -78,10 +78,37 @@ const appendB = handler<AppendEvent, { listB: ListCell }>(
   },
 );
 
+// Nested Record (bucket -> {leafKey: marker}) for the shared-SUBRECORD
+// read-modify-write shape that the lunch-poll castVote uses (a full .get() of
+// the parent doc, then a deep keyed .set() into a SHARED bucket). All writers
+// share one bucket "B" but write DISTINCT leaves — the candidate silent
+// lost-update path (a write commits, then a peer's commit clobbers it without a
+// CAS conflict and without a logged exhaustion).
+type Tally = Record<string, Record<string, string>>;
+const EMPTY_TALLY: Tally = {};
+type TallyCell = Writable<Tally | Default<typeof EMPTY_TALLY>>;
+
+export interface NestedSetEvent {
+  bucket?: string;
+  leafKey?: string;
+  marker?: string;
+}
+
+const nestedSet = handler<NestedSetEvent, { tally: TallyCell }>(
+  ({ bucket, leafKey, marker }, { tally }) => {
+    if (!bucket || !leafKey || !marker) return;
+    // Full-document read of the parent, exactly like castVote's
+    // `votesByOption.get()?.[optionId]` — captures a whole-doc since-snapshot.
+    const _snapshot = tally.get();
+    tally.key(bucket).key(leafKey).set(marker);
+  },
+);
+
 export interface ContentionInput {
   list?: PerSpace<MarkerList | Default<typeof EMPTY_LIST>>;
   listB?: PerSpace<MarkerList | Default<typeof EMPTY_LIST>>;
   map?: PerSpace<MarkerMap | Default<typeof EMPTY_MAP>>;
+  tally?: PerSpace<Tally | Default<typeof EMPTY_TALLY>>;
 }
 
 export interface ContentionOutput {
@@ -90,39 +117,53 @@ export interface ContentionOutput {
   list: readonly string[];
   listB: readonly string[];
   mapKeys: readonly string[];
+  tallyLeaves: readonly string[];
   listCount: number;
   listBCount: number;
   mapCount: number;
+  tallyCount: number;
   append: Stream<AppendEvent>;
   appendB: Stream<AppendEvent>;
   setKey: Stream<SetKeyEvent>;
+  nestedSet: Stream<NestedSetEvent>;
 }
 
 export default pattern<ContentionInput, ContentionOutput>(
-  ({ list, listB, map }) => {
+  ({ list, listB, map, tally }) => {
     const listSnapshot = computed(() => list ?? EMPTY_LIST);
     const listBSnapshot = computed(() => listB ?? EMPTY_LIST);
     const mapKeys = computed(() => Object.keys(map ?? EMPTY_MAP));
+    const tallyLeaves = computed(() =>
+      Object.values(tally ?? EMPTY_TALLY).flatMap((b) => Object.keys(b ?? {}))
+    );
     const listCount = computed(() => (list ?? EMPTY_LIST).length);
     const listBCount = computed(() => (listB ?? EMPTY_LIST).length);
     const mapCount = computed(() => Object.keys(map ?? EMPTY_MAP).length);
+    const tallyCount = computed(() =>
+      Object.values(tally ?? EMPTY_TALLY)
+        .flatMap((b) => Object.keys(b ?? {})).length
+    );
 
     return {
       [NAME]: "write-contention repro",
       [UI]: (
         <div>
-          list={listCount} · listB={listBCount} · map={mapCount}
+          list={listCount} · listB={listBCount} · map={mapCount} ·
+          tally={tallyCount}
         </div>
       ),
       list: listSnapshot,
       listB: listBSnapshot,
       mapKeys,
+      tallyLeaves,
       listCount,
       listBCount,
       mapCount,
+      tallyCount,
       append: append({ list }),
       appendB: appendB({ listB }),
       setKey: setKey({ map }),
+      nestedSet: nestedSet({ tally }),
     };
   },
 );

--- a/packages/patterns/write-contention/repro.tsx
+++ b/packages/patterns/write-contention/repro.tsx
@@ -1,0 +1,106 @@
+/// <cts-enable />
+/**
+ * Minimal write-contention repro — NO SQLite.
+ *
+ * The lunch-poll work showed concurrent shared-state writes are silently dropped
+ * under contention, and that it is NOT SQLite-specific (a keyed cell variant
+ * dropped 18/30 at 10 users). This pattern strips away ALL lunch-poll baggage to
+ * study the GENERAL mechanism on plain `PerSpace` cells.
+ *
+ * Two write paths, so a multi-runtime driver can A/B them under identical
+ * concurrency:
+ *   - `append(marker)`        -> list.push(marker)          SHARED-LEAF read-modify-write
+ *                                                            (models the array `votes.push`)
+ *   - `setKey({id, marker})`  -> map.key(id).set(marker)    DISTINCT-KEY write
+ *                                                            (models keyed/indexed `.key().set()`)
+ *
+ * Each runtime writes UNIQUE markers, so a cold reader of canonical storage can
+ * name exactly WHICH writes landed vs vanished — and whether distinct-key writes
+ * drop as badly as shared-list writes (the coarse- vs fine-grained-conflict
+ * question raised by Phase 3, where keyed `indexed` contended identically to the
+ * shared-list `array`).
+ */
+
+import {
+  computed,
+  Default,
+  handler,
+  NAME,
+  pattern,
+  type PerSpace,
+  Stream,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+type MarkerList = string[];
+type MarkerMap = Record<string, string>;
+
+const EMPTY_LIST: MarkerList = [];
+const EMPTY_MAP: MarkerMap = {};
+
+type ListCell = Writable<MarkerList | Default<typeof EMPTY_LIST>>;
+type MapCell = Writable<MarkerMap | Default<typeof EMPTY_MAP>>;
+
+export interface AppendEvent {
+  marker?: string;
+}
+export interface SetKeyEvent {
+  id?: string;
+  marker?: string;
+}
+
+// SHARED-LEAF read-modify-write: every runtime pushes onto ONE list cell.
+const append = handler<AppendEvent, { list: ListCell }>(
+  ({ marker }, { list }) => {
+    if (!marker) return;
+    list.push(marker);
+  },
+);
+
+// DISTINCT-KEY write: every runtime writes its OWN key in a shared map.
+const setKey = handler<SetKeyEvent, { map: MapCell }>(
+  ({ id, marker }, { map }) => {
+    if (!id || !marker) return;
+    map.key(id).set(marker);
+  },
+);
+
+export interface ContentionInput {
+  list?: PerSpace<MarkerList | Default<typeof EMPTY_LIST>>;
+  map?: PerSpace<MarkerMap | Default<typeof EMPTY_MAP>>;
+}
+
+export interface ContentionOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  list: readonly string[];
+  mapKeys: readonly string[];
+  listCount: number;
+  mapCount: number;
+  append: Stream<AppendEvent>;
+  setKey: Stream<SetKeyEvent>;
+}
+
+export default pattern<ContentionInput, ContentionOutput>(({ list, map }) => {
+  const listSnapshot = computed(() => list ?? EMPTY_LIST);
+  const mapKeys = computed(() => Object.keys(map ?? EMPTY_MAP));
+  const listCount = computed(() => (list ?? EMPTY_LIST).length);
+  const mapCount = computed(() => Object.keys(map ?? EMPTY_MAP).length);
+
+  return {
+    [NAME]: "write-contention repro",
+    [UI]: (
+      <div>
+        list={listCount} · map={mapCount}
+      </div>
+    ),
+    list: listSnapshot,
+    mapKeys,
+    listCount,
+    mapCount,
+    append: append({ list }),
+    setKey: setKey({ map }),
+  };
+});


### PR DESCRIPTION
**For discussion, not for merge** — a diagnostic harness + a grounded root cause, not a fix.

## TL;DR
Under concurrent multi-user writes to the same document/cell, writes are **silently lost in canonical storage** — no error to the app. It is **general, not SQLite-specific**, **keying does not avoid it** (the conflict unit is the whole document, not the field), and the failure can be **invisible and displaced**: a dropped *identity/setup* write silently voids every later action that depended on it.

Full code-grounded writeup: [`packages/patterns/lunch-poll/DROPPED-WRITES-EVIDENCE.md`](https://github.com/commontoolsinc/labs/blob/perf/shared-state-write-drops/packages/patterns/lunch-poll/DROPPED-WRITES-EVIDENCE.md).

## Evidence (cold-reader = canonical storage truth)
A fresh runtime that never subscribed reads committed storage directly, so its count is server truth (not a stale UI):

| storage | concurrency | landed (cold storage) |
| ------- | ----------- | --------------------- |
| plain keyed CELL (`main-indexed.tsx`) | 10 users | **18 / 30** |
| SQLite (`main-sqlite.tsx`) | 5 users | **1 / 15** |

## Root cause (grounded)
- **Conflict unit = the entity-DOCUMENT** `(branch, id, scope_key)`. The conflict predicate `SELECT_SET_DELETE_CONFLICT` (`memory/v2/engine.ts:529`) has **no field/path/space column** → distinct keys in one `Record` collide (keying doesn't help: `cell.ts:1492-1521`); disjoint cells don't (distinct ids; space scope_key is constant).
- Retry budget `DEFAULT_RETRIES_FOR_EVENTS = 5` (`scheduler/constants.ts:5`); the commit is **fire-and-forget** (`events.ts:609-616`) → silent to the caller, only a scheduler-level log on exhaustion (`events.ts:661`).

## The cascade (the dangerous part)
`joinAs` writes the contended `usersByName`/`userOrder` docs **and** `myName` (`PerUser`) in one tx (`main-indexed.tsx:156-177`). A dropped join takes `myName.set()` with it → empty `myName` → `castVote`'s `if (!me) return` guard makes that user's votes **silently no-op**. Measured: **9 `castVote`s fired with `me=""`** at 3×10. So the symptom ("my votes don't count") is nowhere near the fault (a dropped join, one phase earlier).

## What it is NOT
The lunch-poll `missing(12) > exhaustions(6)` *looked* like a second, silent mechanism — it's the cascade above. Two structural hypotheses (a shared-subrecord write-shape lost-update; the multi-bucket structure) were reproduced in a minimal SQLite-free repro and **refuted** (both `missing == exhaustions`). There is **one** mechanism.

## Status
- Root cause ✅ (grounded + measured + re-run).
- **No fix.** Fix surface in the doc §6: (1) surface exhaustion to the caller instead of fire-and-forget (the headline ask; covers the cascade); (2) finer per-path conflict detection so independent writes don't collide; (3) split hot docs / CRDT for commutative ops; (4) bigger retry budget + backoff (rate, not structure). Per team discussion, genuine same-value RMW has no perfect resolution — the priority is that the client is told.

## Reproduce
```bash
deno run -A packages/patterns/lunch-poll/probe-sqlite-landing.ts --program=main-indexed.tsx --case=3x10 --rounds=3
deno run -A packages/patterns/lunch-poll/probe-sqlite-landing.ts --program=main-sqlite.tsx  --case=3x5  --rounds=3
# minimal, SQLite-free; missing == 'exhausting all retries' count -> one mechanism:
deno run -A packages/patterns/write-contention/probe.ts --users=10 --rounds=5 --mode=map 2>/tmp/wc.err; grep -c "exhausting all retries" /tmp/wc.err
# conflict unit is the document, not the space (disjoint cells don't contend):
deno run -A packages/patterns/write-contention/probe-space.ts --groupA=10 --groupB=10 --rounds=5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)