### PR TITLE
Add coverage debt metrics to perf gate (mark II)

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -99,7 +99,21 @@ jobs:
       - name: 🧪 Run parallel workspace tests
         run: deno task test
         env:
+          DENO_COVERAGE_DIR: coverage/raw/workspace
           TEST_DISABLED_PACKAGES: runner
+
+      - name: 🧾 Write coverage report
+        if: always()
+        run: deno run --allow-read --allow-write --allow-run tasks/write-coverage-lcov.ts coverage/raw/workspace coverage/lcov/workspace.lcov
+
+      - name: 📤 Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-profile-workspace
+          path: coverage/lcov/workspace.lcov
+          retention-days: 90
+          if-no-files-found: ignore
 
   runner-test:
     name: "Runner Tests (${{ matrix.shard }}/${{ matrix.total }})"
@@ -124,6 +138,8 @@ jobs:
 
       - name: 🧪 Run runner tests
         working-directory: packages/runner
+        env:
+          DENO_COVERAGE_DIR: ../../coverage/raw/runner-${{ matrix.shard }}
         run: |
           TEST_FILES=$(deno run --allow-read ../../tasks/select-runner-test-files.ts ${{ matrix.shard }}/${{ matrix.total }})
           if [ -z "$TEST_FILES" ]; then
@@ -139,6 +155,19 @@ jobs:
             --allow-write=/tmp,/var/folders \
             --allow-run=git \
             $TEST_FILES
+
+      - name: 🧾 Write coverage report
+        if: always()
+        run: deno run --allow-read --allow-write --allow-run tasks/write-coverage-lcov.ts coverage/raw/runner-${{ matrix.shard }} coverage/lcov/runner-${{ matrix.shard }}.lcov
+
+      - name: 📤 Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-profile-runner-${{ matrix.shard }}
+          path: coverage/lcov/runner-${{ matrix.shard }}.lcov
+          retention-days: 90
+          if-no-files-found: ignore
 
   build-binaries:
     name: "Build Binaries"
@@ -192,6 +221,8 @@ jobs:
 
       - name: 🧪 Run generated patterns integration tests
         working-directory: packages/generated-patterns
+        env:
+          DENO_COVERAGE_DIR: ../../coverage/raw/generated-patterns-${{ matrix.shard }}
         run: |
           TEST_FILES=$(deno run --allow-read ../../tasks/select-generated-pattern-files.ts ${{ matrix.shard }}/${{ matrix.total }})
           if [ -z "$TEST_FILES" ]; then
@@ -204,6 +235,19 @@ jobs:
           LOG_LEVEL=warn deno test --trace-leaks -A --parallel \
             --junit-path=../../test-results/generated-patterns-${{ matrix.shard }}.xml \
             $TEST_FILES
+
+      - name: 🧾 Write coverage report
+        if: always()
+        run: deno run --allow-read --allow-write --allow-run tasks/write-coverage-lcov.ts coverage/raw/generated-patterns-${{ matrix.shard }} coverage/lcov/generated-patterns-${{ matrix.shard }}.lcov
+
+      - name: 📤 Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-profile-generated-patterns-${{ matrix.shard }}
+          path: coverage/lcov/generated-patterns-${{ matrix.shard }}.lcov
+          retention-days: 90
+          if-no-files-found: ignore
 
       - name: 📤 Upload test timing data
         if: always()
@@ -268,6 +312,7 @@ jobs:
       - name: 🧪 Run ${{ matrix.step_name }}
         working-directory: ${{ matrix.package_dir }}
         env:
+          DENO_COVERAGE_DIR: ../../coverage/raw/package-${{ matrix.suite_name }}
           HEADLESS_ENABLED: ${{ matrix.headless }}
           JUNIT_NAME: ${{ matrix.junit_name }}
           TOOLSHED_PORT: 8000
@@ -279,6 +324,19 @@ jobs:
           API_URL="http://localhost:${TOOLSHED_PORT}/" \
           INTEGRATION_TEST_FLAGS="--junit-path=../../test-results/${JUNIT_NAME}.xml" \
           deno task integration
+
+      - name: 🧾 Write coverage report
+        if: always()
+        run: deno run --allow-read --allow-write --allow-run tasks/write-coverage-lcov.ts coverage/raw/package-${{ matrix.suite_name }} coverage/lcov/package-${{ matrix.suite_name }}.lcov
+
+      - name: 📤 Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-profile-package-${{ matrix.suite_name }}
+          path: coverage/lcov/package-${{ matrix.suite_name }}.lcov
+          retention-days: 90
+          if-no-files-found: ignore
 
       - name: 📤 Upload test timing data
         if: always()
@@ -451,9 +509,23 @@ jobs:
           mkdir -p ../../test-results
           HEADLESS=1 \
           API_URL=http://localhost:8000/ \
+          DENO_COVERAGE_DIR=../../coverage/raw/pattern-integration-${{ matrix.shard }} \
           deno test --v8-flags=--max-old-space-size=4096 --trace-leaks -A \
             --junit-path=../../test-results/patterns-${{ matrix.shard }}.xml \
             "${TEST_FILES[@]}"
+
+      - name: 🧾 Write coverage report
+        if: always()
+        run: deno run --allow-read --allow-write --allow-run tasks/write-coverage-lcov.ts coverage/raw/pattern-integration-${{ matrix.shard }} coverage/lcov/pattern-integration-${{ matrix.shard }}.lcov
+
+      - name: 📤 Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-profile-pattern-integration-${{ matrix.shard }}
+          path: coverage/lcov/pattern-integration-${{ matrix.shard }}.lcov
+          retention-days: 90
+          if-no-files-found: ignore
 
       - name: 📤 Upload test timing data
         if: always()
@@ -486,7 +558,21 @@ jobs:
           HEADLESS=1 \
           EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=true \
           CF_EXPECT_PERSISTENT_SCHEDULER_STATE=1 \
+          DENO_COVERAGE_DIR=coverage/raw/pattern-reload \
           deno task integration --junit-dir=test-results patterns-reload
+
+      - name: 🧾 Write coverage report
+        if: always()
+        run: deno run --allow-read --allow-write --allow-run tasks/write-coverage-lcov.ts coverage/raw/pattern-reload coverage/lcov/pattern-reload.lcov
+
+      - name: 📤 Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-profile-pattern-reload
+          path: coverage/lcov/pattern-reload.lcov
+          retention-days: 90
+          if-no-files-found: ignore
 
       - name: 📤 Upload test timing data
         if: always()
@@ -525,7 +611,20 @@ jobs:
         run: |
           chmod +x ./common-binaries/cf
           mkdir -p test-results
-          CF_BINARY=./common-binaries/cf deno task integration --junit-dir=test-results pattern-tests ${{ matrix.chunk }}/${{ matrix.total }}
+          DENO_COVERAGE_DIR=coverage/raw/pattern-unit-${{ matrix.chunk }} CF_BINARY=./common-binaries/cf deno task integration --junit-dir=test-results pattern-tests ${{ matrix.chunk }}/${{ matrix.total }}
+
+      - name: 🧾 Write coverage report
+        if: always()
+        run: deno run --allow-read --allow-write --allow-run tasks/write-coverage-lcov.ts coverage/raw/pattern-unit-${{ matrix.chunk }} coverage/lcov/pattern-unit-${{ matrix.chunk }}.lcov
+
+      - name: 📤 Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-profile-pattern-unit-${{ matrix.chunk }}
+          path: coverage/lcov/pattern-unit-${{ matrix.chunk }}.lcov
+          retention-days: 90
+          if-no-files-found: ignore
 
       - name: 📤 Upload test timing data
         if: always()

--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -50,3 +50,31 @@ failure by itself.
 
 Good CI optimization PRs should reduce critical-path wall time without making
 the workflow harder to reason about.
+
+## Coverage Debt Baselines
+
+Performance Check also tracks coverage debt as uncovered source lines. Coverage
+debt uses a strict latest-main ratchet: any increase fails unless the PR
+explicitly accepts it.
+
+Use the narrow per-metric form when a PR intentionally increases one coverage
+debt metric:
+
+```text
+NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 123 lines
+```
+
+Use the broad reset marker only to bootstrap coverage data for the first time,
+or when the upstream coverage baseline is known to be bogus and should be
+re-seeded for one cycle:
+
+```text
+NEW_COVERAGE_BASELINE
+```
+
+When that PR merges, the main run's coverage metrics become the new ratchet
+baseline for later PRs. During that one reset cycle, Performance Check seeds
+from the available coverage report artifacts, but any artifact that is present
+must still download and extract. Jobs with no reportable covered files upload
+an empty LCOV report so missing artifacts still mean the report upload itself
+failed.

--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -1,0 +1,98 @@
+import { assertEquals } from "@std/assert";
+import * as path from "@std/path";
+import {
+  collectCoverageDebtMetricsFromLcov,
+  countTrackedSourceLines,
+  countUncoveredProfileLines,
+  metricGroupFor,
+  parseLcov,
+  shouldTrackSourceFile,
+} from "./coverage-metrics.ts";
+
+Deno.test("parseLcov accumulates hits per source line", () => {
+  const coverage = parseLcov([
+    "SF:/repo/packages/example/src/mod.ts",
+    "DA:1,1",
+    "DA:2,0",
+    "DA:2,3",
+    "DA:3,0",
+    "end_of_record",
+  ].join("\n"));
+
+  const file = coverage.get("/repo/packages/example/src/mod.ts");
+  assertEquals(file?.lineHits.get(1), 1);
+  assertEquals(file?.lineHits.get(2), 3);
+  assertEquals(countUncoveredProfileLines(file!), 1);
+});
+
+Deno.test("countTrackedSourceLines ignores blank and comment-only lines", () => {
+  assertEquals(
+    countTrackedSourceLines([
+      "",
+      "// comment",
+      "const value = 1;",
+      "/* block",
+      "comment */",
+      "export const next = value + 1;",
+      "const inline = 2; // comment",
+    ].join("\n")),
+    3,
+  );
+});
+
+Deno.test("source inventory helpers group tracked files by package", () => {
+  assertEquals(shouldTrackSourceFile("packages/runner/src/cell.ts"), true);
+  assertEquals(
+    shouldTrackSourceFile("packages/runner/test/cell.test.ts"),
+    false,
+  );
+  assertEquals(
+    shouldTrackSourceFile("packages/vendor-astral/src/page.ts"),
+    false,
+  );
+  assertEquals(
+    metricGroupFor("packages/runner/src/cell.ts"),
+    "packages/runner",
+  );
+  assertEquals(metricGroupFor("tasks/perf-check.ts"), "tasks");
+});
+
+Deno.test("collectCoverageDebtMetricsFromLcov computes debt from compact reports", async () => {
+  const rootDir = await Deno.makeTempDir({ prefix: "coverage-lcov-test-" });
+  try {
+    const sourcePath = path.join(rootDir, "packages/example/src/mod.ts");
+    await Deno.mkdir(path.dirname(sourcePath), { recursive: true });
+    await Deno.writeTextFile(
+      sourcePath,
+      [
+        "export const covered = 1;",
+        "export const uncovered = 2;",
+      ].join("\n"),
+    );
+
+    const metrics = await collectCoverageDebtMetricsFromLcov({
+      rootDir,
+      lcov: [
+        `SF:${sourcePath}`,
+        "DA:1,1",
+        "DA:2,0",
+        "end_of_record",
+      ].join("\n"),
+    });
+
+    assertEquals(
+      metrics.find((metric) =>
+        metric.name === "coverage-debt: workspace uncovered lines"
+      )?.uncoveredLines,
+      1,
+    );
+    assertEquals(
+      metrics.find((metric) =>
+        metric.name === "coverage-debt: packages/example uncovered lines"
+      )?.uncoveredLines,
+      1,
+    );
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
+});

--- a/tasks/coverage-metrics.ts
+++ b/tasks/coverage-metrics.ts
@@ -1,0 +1,325 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run
+import * as path from "@std/path";
+
+export const COVERAGE_PROFILE_ARTIFACT_PREFIX = "coverage-profile-";
+export const COVERAGE_METRIC_PREFIX = "coverage-debt:";
+
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx"]);
+const SOURCE_ROOTS = ["packages", "tasks", "scripts"];
+const EXCLUDED_PATH_PARTS = new Set([
+  ".cache",
+  "build",
+  "coverage",
+  "dist",
+  "fixtures",
+  "integration",
+  "node_modules",
+  "test",
+  "tests",
+  "vendor-astral",
+]);
+
+const EXCLUDED_RELATIVE_PREFIXES = [
+  "packages/generated-patterns/integration/",
+  "packages/patterns/factory-outputs/",
+  "packages/patterns-saves-backup/",
+  "packages/static/assets/",
+];
+
+const EXCLUDED_FILE_SUFFIXES = [
+  ".bench.ts",
+  ".bench.tsx",
+  ".d.ts",
+  ".spec.ts",
+  ".spec.tsx",
+  ".test.ts",
+  ".test.tsx",
+];
+
+export interface CoverageDebtMetricsOptions {
+  rootDir: string;
+  coverageProfileDir: string;
+}
+
+export interface CoverageDebtMetricsFromLcovOptions {
+  rootDir: string;
+  lcov: string;
+}
+
+export interface CoverageDebtMetric {
+  name: string;
+  uncoveredLines: number;
+}
+
+interface SourceFile {
+  absolutePath: string;
+  relativePath: string;
+  metricGroup: string;
+  trackedLineCount: number;
+}
+
+interface LcovFileCoverage {
+  lineHits: Map<number, number>;
+}
+
+export async function collectCoverageDebtMetrics(
+  options: CoverageDebtMetricsOptions,
+): Promise<CoverageDebtMetric[]> {
+  const lcov = await denoCoverageLcov(options.coverageProfileDir);
+  return await collectCoverageDebtMetricsFromLcov({
+    rootDir: options.rootDir,
+    lcov,
+  });
+}
+
+export async function collectCoverageDebtMetricsFromLcov(
+  options: CoverageDebtMetricsFromLcovOptions,
+): Promise<CoverageDebtMetric[]> {
+  const sourceFiles = await collectSourceFiles(options.rootDir);
+  const lcovCoverage = parseLcov(options.lcov);
+
+  let workspaceUncovered = 0;
+  const groupUncovered = new Map<string, number>();
+  const groupNames = new Set(sourceFiles.map((source) => source.metricGroup));
+
+  for (const source of sourceFiles) {
+    const coverage = lcovCoverage.get(source.absolutePath);
+    const uncovered = coverage
+      ? countUncoveredProfileLines(coverage)
+      : source.trackedLineCount;
+
+    workspaceUncovered += uncovered;
+    groupUncovered.set(
+      source.metricGroup,
+      (groupUncovered.get(source.metricGroup) ?? 0) + uncovered,
+    );
+  }
+
+  const metrics: CoverageDebtMetric[] = [
+    {
+      name: `${COVERAGE_METRIC_PREFIX} workspace uncovered lines`,
+      uncoveredLines: workspaceUncovered,
+    },
+  ];
+
+  for (const group of [...groupNames].sort()) {
+    metrics.push({
+      name: `${COVERAGE_METRIC_PREFIX} ${group} uncovered lines`,
+      uncoveredLines: groupUncovered.get(group) ?? 0,
+    });
+  }
+
+  return metrics;
+}
+
+export async function collectSourceFiles(
+  rootDir: string,
+): Promise<SourceFile[]> {
+  const files: SourceFile[] = [];
+  for (const sourceRoot of SOURCE_ROOTS) {
+    const fullRoot = path.join(rootDir, sourceRoot);
+    if (!await existsDirectory(fullRoot)) continue;
+
+    for await (const file of walkFiles(fullRoot)) {
+      const relativePath = toPosix(path.relative(rootDir, file));
+      if (!shouldTrackSourceFile(relativePath)) continue;
+
+      const content = await Deno.readTextFile(file);
+      files.push({
+        absolutePath: path.normalize(file),
+        relativePath,
+        metricGroup: metricGroupFor(relativePath),
+        trackedLineCount: countTrackedSourceLines(content),
+      });
+    }
+  }
+  return files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+}
+
+export function shouldTrackSourceFile(relativePath: string): boolean {
+  const normalized = toPosix(relativePath);
+  const extension = path.extname(normalized);
+  if (!SOURCE_EXTENSIONS.has(extension)) return false;
+
+  if (EXCLUDED_FILE_SUFFIXES.some((suffix) => normalized.endsWith(suffix))) {
+    return false;
+  }
+
+  if (
+    EXCLUDED_RELATIVE_PREFIXES.some((prefix) => normalized.startsWith(prefix))
+  ) {
+    return false;
+  }
+
+  const parts = normalized.split("/");
+  return !parts.some((part) => EXCLUDED_PATH_PARTS.has(part));
+}
+
+export function metricGroupFor(relativePath: string): string {
+  const normalized = toPosix(relativePath);
+  const parts = normalized.split("/");
+  if (parts[0] === "packages" && parts[1]) {
+    return `packages/${parts[1]}`;
+  }
+  return parts[0] ?? "workspace";
+}
+
+export function countTrackedSourceLines(content: string): number {
+  let count = 0;
+  let inBlockComment = false;
+
+  for (const line of content.split(/\r?\n/)) {
+    let text = line.trim();
+    if (text.length === 0) continue;
+
+    while (text.length > 0) {
+      if (inBlockComment) {
+        const end = text.indexOf("*/");
+        if (end < 0) {
+          text = "";
+          break;
+        }
+        text = text.slice(end + 2).trim();
+        inBlockComment = false;
+        continue;
+      }
+
+      if (text.startsWith("//")) {
+        text = "";
+        break;
+      }
+
+      if (text.startsWith("/*")) {
+        const end = text.indexOf("*/", 2);
+        if (end < 0) {
+          text = "";
+          inBlockComment = true;
+          break;
+        }
+        text = text.slice(end + 2).trim();
+        continue;
+      }
+
+      count++;
+      break;
+    }
+  }
+
+  return count;
+}
+
+export function parseLcov(lcov: string): Map<string, LcovFileCoverage> {
+  const files = new Map<string, LcovFileCoverage>();
+  let currentPath: string | undefined;
+
+  for (const line of lcov.split(/\r?\n/)) {
+    if (line.startsWith("SF:")) {
+      currentPath = path.normalize(line.slice(3));
+      if (!files.has(currentPath)) {
+        files.set(currentPath, { lineHits: new Map() });
+      }
+      continue;
+    }
+
+    if (line.startsWith("DA:") && currentPath) {
+      const [lineNumberRaw, hitsRaw] = line.slice(3).split(",");
+      const lineNumber = Number(lineNumberRaw);
+      const hits = Number(hitsRaw);
+      if (Number.isFinite(lineNumber) && Number.isFinite(hits)) {
+        const file = files.get(currentPath)!;
+        file.lineHits.set(
+          lineNumber,
+          (file.lineHits.get(lineNumber) ?? 0) + hits,
+        );
+      }
+      continue;
+    }
+
+    if (line === "end_of_record") {
+      currentPath = undefined;
+    }
+  }
+
+  return files;
+}
+
+export function countUncoveredProfileLines(coverage: LcovFileCoverage): number {
+  let uncovered = 0;
+  for (const hits of coverage.lineHits.values()) {
+    if (hits === 0) uncovered++;
+  }
+  return uncovered;
+}
+
+async function denoCoverageLcov(coverageProfileDir: string): Promise<string> {
+  const tmpDir = await Deno.makeTempDir({ prefix: "coverage-lcov-" });
+  const outputPath = path.join(tmpDir, "coverage.lcov");
+  try {
+    const result = await new Deno.Command(Deno.execPath(), {
+      args: [
+        "coverage",
+        "--lcov",
+        `--output=${outputPath}`,
+        coverageProfileDir,
+      ],
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+
+    if (!result.success) {
+      const stderr = new TextDecoder().decode(result.stderr);
+      throw new Error(`deno coverage failed: ${stderr.trim()}`);
+    }
+
+    return await Deno.readTextFile(outputPath);
+  } finally {
+    try {
+      await Deno.remove(tmpDir, { recursive: true });
+    } catch { /* ignore cleanup errors */ }
+  }
+}
+
+async function existsDirectory(dir: string): Promise<boolean> {
+  try {
+    return (await Deno.stat(dir)).isDirectory;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return false;
+    throw error;
+  }
+}
+
+function toPosix(filePath: string): string {
+  return filePath.split(path.SEPARATOR).join("/");
+}
+
+async function* walkFiles(dir: string): AsyncGenerator<string> {
+  for await (const entry of Deno.readDir(dir)) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory) {
+      yield* walkFiles(full);
+    } else {
+      yield full;
+    }
+  }
+}
+
+if (import.meta.main) {
+  const args = new Map<string, string>();
+  for (const arg of Deno.args) {
+    const match = /^--([^=]+)=(.*)$/.exec(arg);
+    if (match) args.set(match[1], match[2]);
+  }
+
+  const rootDir = args.get("root") ?? Deno.cwd();
+  const coverageProfileDir = args.get("profile-dir");
+  if (!coverageProfileDir) {
+    console.error("--profile-dir is required.");
+    Deno.exit(1);
+  }
+
+  const metrics = await collectCoverageDebtMetrics({
+    rootDir,
+    coverageProfileDir,
+  });
+  console.log(JSON.stringify({ metrics }, null, 2));
+}

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -23,6 +23,8 @@ import {
   type BaselineOverrides,
   computeBaseline,
   computeCiWallTimeRevisitSignals,
+  COVERAGE_BASELINE_RESET_MARKER,
+  downloadAndExtractArtifact,
   downloadAndParseJUnit,
   downloadAndParsePerfMetrics,
   downloadAndParsePerfMetricsBackfill,
@@ -35,6 +37,7 @@ import {
   formatMetricValue,
   formatOverrideSuggestion,
   githubGet,
+  isCoverageDebtMetric,
   mapConcurrent,
   type MetricTimeline,
   MIN_ABSOLUTE_DELTA,
@@ -53,11 +56,18 @@ import {
   timingArtifactLabel,
   type TimingSample,
   TOKEN,
+  walkFiles,
   WORKFLOW_FILE,
   type WorkflowRun,
   writePerfMetricsBackfillFile,
   writePerfMetricsFile,
 } from "./perf-lib.ts";
+import * as path from "@std/path";
+import {
+  collectCoverageDebtMetrics,
+  collectCoverageDebtMetricsFromLcov,
+  COVERAGE_PROFILE_ARTIFACT_PREFIX,
+} from "./coverage-metrics.ts";
 
 /** How many recent main-branch runs to use for baseline. */
 const BASELINE_RUNS = 20;
@@ -131,6 +141,185 @@ const EXCLUDED_METRIC_PATTERNS = [
   /^step: pattern unit tests$/,
 ];
 
+const EXPECTED_COVERAGE_ARTIFACT_NAMES = [
+  "coverage-profile-workspace",
+  ...[1, 2, 3, 4].map((shard) => `coverage-profile-runner-${shard}`),
+  ...[1, 2, 3, 4].map((shard) =>
+    `coverage-profile-generated-patterns-${shard}`
+  ),
+  "coverage-profile-package-runner",
+  "coverage-profile-package-runtime-client",
+  "coverage-profile-package-shell",
+  ...[1, 2, 3, 4].map((shard) =>
+    `coverage-profile-pattern-integration-${shard}`
+  ),
+  "coverage-profile-pattern-reload",
+  ...[1, 2, 3, 4, 5].map((chunk) => `coverage-profile-pattern-unit-${chunk}`),
+];
+
+function sampleForRun(run: WorkflowRun, value: number): TimingSample {
+  return {
+    runId: run.id,
+    runUrl: run.html_url,
+    sha: run.head_sha,
+    createdAt: run.created_at,
+    durationSeconds: value,
+  };
+}
+
+async function copyCoverageArtifactFiles(
+  artifact: Artifact,
+  profileDir: string,
+  lcovDir: string,
+): Promise<{ profileFiles: number; lcovFiles: number }> {
+  const extractedDir = await downloadAndExtractArtifact(
+    artifact.id,
+    "coverage-profile-",
+  );
+  if (!extractedDir) {
+    throw new Error(
+      `Failed to download or extract coverage profile artifact ${artifact.name} (${artifact.id}).`,
+    );
+  }
+
+  let profileFiles = 0;
+  let lcovFiles = 0;
+  try {
+    for await (const file of walkFiles(extractedDir)) {
+      const isProfile = file.endsWith(".json");
+      const isLcov = file.endsWith(".lcov");
+      if (!isProfile && !isLcov) continue;
+      const count = isLcov ? lcovFiles : profileFiles;
+      const destDir = isLcov ? lcovDir : profileDir;
+      const dest = path.join(
+        destDir,
+        `${artifact.id}-${count}-${path.basename(file)}`,
+      );
+      await Deno.copyFile(file, dest);
+      if (isLcov) lcovFiles++;
+      else profileFiles++;
+    }
+
+    if (profileFiles === 0 && lcovFiles === 0) {
+      throw new Error(
+        `Coverage profile artifact ${artifact.name} (${artifact.id}) contained no profile or LCOV files.`,
+      );
+    }
+  } finally {
+    try {
+      await Deno.remove(extractedDir, { recursive: true });
+    } catch { /* ignore cleanup errors */ }
+  }
+
+  return { profileFiles, lcovFiles };
+}
+
+async function readCombinedLcov(lcovDir: string): Promise<string> {
+  const chunks: string[] = [];
+  for await (const file of walkFiles(lcovDir)) {
+    if (!file.endsWith(".lcov")) continue;
+    chunks.push(await Deno.readTextFile(file));
+  }
+  return chunks.join("\n");
+}
+
+interface ExtractCoverageDebtSamplesOptions {
+  /**
+   * Used only for explicit coverage baseline bootstraps/resets. Present
+   * artifacts must still be valid, but the expected matrix may change while
+   * seeding the first usable coverage artifact set.
+   */
+  allowMissingExpectedArtifacts?: boolean;
+}
+
+async function extractCoverageDebtSamples(
+  run: WorkflowRun,
+  artifacts: Artifact[],
+  options: ExtractCoverageDebtSamplesOptions = {},
+): Promise<Map<string, TimingSample>> {
+  const metrics = new Map<string, TimingSample>();
+  const coverageArtifacts = newestArtifactsByName(artifacts.filter(
+    (artifact) =>
+      artifact.name.startsWith(COVERAGE_PROFILE_ARTIFACT_PREFIX) &&
+      !artifact.expired,
+  ));
+  const coverageArtifactNames = new Set(
+    coverageArtifacts.map((artifact) => artifact.name),
+  );
+  const missingArtifacts = EXPECTED_COVERAGE_ARTIFACT_NAMES.filter((name) =>
+    !coverageArtifactNames.has(name)
+  );
+
+  if (missingArtifacts.length > 0) {
+    if (!options.allowMissingExpectedArtifacts) {
+      throw new Error(
+        `Missing coverage profile artifact(s): ${missingArtifacts.join(", ")}`,
+      );
+    }
+    console.warn(
+      `  Warning: coverage baseline reset active; continuing with available coverage profile artifacts despite missing expected artifact(s): ${
+        missingArtifacts.join(", ")
+      }`,
+    );
+  }
+
+  const profileDir = await Deno.makeTempDir({ prefix: "coverage-profiles-" });
+  const lcovDir = await Deno.makeTempDir({ prefix: "coverage-lcov-" });
+  try {
+    let profileFileCount = 0;
+    let lcovFileCount = 0;
+    for (const artifact of coverageArtifacts) {
+      const copied = await copyCoverageArtifactFiles(
+        artifact,
+        profileDir,
+        lcovDir,
+      );
+      profileFileCount += copied.profileFiles;
+      lcovFileCount += copied.lcovFiles;
+    }
+
+    if (profileFileCount === 0 && lcovFileCount === 0) {
+      throw new Error(
+        "Coverage profile artifacts contained no profile or LCOV files.",
+      );
+    }
+
+    const coverageMetrics = lcovFileCount > 0
+      ? await collectCoverageDebtMetricsFromLcov({
+        rootDir: Deno.cwd(),
+        lcov: await readCombinedLcov(lcovDir),
+      })
+      : await collectCoverageDebtMetrics({
+        rootDir: Deno.cwd(),
+        coverageProfileDir: profileDir,
+      });
+
+    for (const metric of coverageMetrics) {
+      metrics.set(
+        metric.name,
+        sampleForRun(run, metric.uncoveredLines),
+      );
+    }
+
+    console.log(
+      `Extracted ${coverageMetrics.length} coverage debt metrics from ${
+        lcovFileCount > 0
+          ? `${lcovFileCount} LCOV report files`
+          : `${profileFileCount} coverage profile files`
+      }.`,
+    );
+  } finally {
+    try {
+      await Deno.remove(profileDir, { recursive: true });
+    } catch { /* ignore cleanup errors */ }
+    try {
+      await Deno.remove(lcovDir, { recursive: true });
+    } catch { /* ignore cleanup errors */ }
+  }
+
+  return metrics;
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -169,14 +358,26 @@ async function main() {
         `  Warning: could not fetch live PR body and no pull_request event body was available: ${prBody.errorMessage}`,
       );
     }
-    prOverrides = parseBaselineOverrides(prBody.body);
+    try {
+      prOverrides = parseBaselineOverrides(prBody.body);
+    } catch (error) {
+      console.error(
+        `Invalid performance baseline override in PR description: ${error}`,
+      );
+      Deno.exit(1);
+    }
   } else {
-    prOverrides = { metrics: new Map() };
+    prOverrides = { metrics: new Map(), coverageBaselineReset: false };
   }
 
   if (prOverrides.metrics.size > 0) {
     console.log(
       `PR description contains ${prOverrides.metrics.size} NEW_PERF_BASELINE override(s).`,
+    );
+  }
+  if (prOverrides.coverageBaselineReset) {
+    console.log(
+      `PR description contains ${COVERAGE_BASELINE_RESET_MARKER}; coverage debt ratchet failures will be treated as an intentional baseline reset.`,
     );
   }
 
@@ -193,17 +394,48 @@ async function main() {
   // The event payload has the metadata needed for samples, so avoid spending
   // another API request on the current workflow run.
   const currentRunInfo = currentWorkflowRunFromEvent(event, runIdNum);
+  let currentRunCoverageBaselineReset = prOverrides.coverageBaselineReset;
+
+  if (!prNumber && currentRunInfo.head_sha) {
+    const pr = await fetchPRForCommit(currentRunInfo.head_sha);
+    if (pr?.body) {
+      try {
+        const overrides = parseBaselineOverrides(pr.body);
+        currentRunCoverageBaselineReset = overrides.coverageBaselineReset;
+        if (currentRunCoverageBaselineReset) {
+          console.log(
+            `Current main run was introduced by PR #${pr.number} with ${COVERAGE_BASELINE_RESET_MARKER}; missing expected coverage artifacts may be re-seeded from the available profile set.`,
+          );
+        }
+      } catch (error) {
+        console.warn(
+          `  Warning: ignoring invalid baseline override in current run PR #${pr.number}: ${error}`,
+        );
+      }
+    }
+  }
 
   // Extract job/step metrics
   for (const [name, sample] of extractMetrics(currentRunInfo, currentJobs)) {
     currentMetrics.set(name, sample);
   }
 
+  let currentArtifacts: Artifact[] = [];
+  let currentArtifactsError: unknown;
+
+  // Fetch artifacts once; coverage extraction depends on this, while timing
+  // artifact parsing below is best-effort.
+  try {
+    currentArtifacts = await fetchArtifactsForRun(runIdNum);
+  } catch (e) {
+    currentArtifactsError = e;
+    console.warn(`  Warning: could not fetch artifacts for current run: ${e}`);
+  }
+
   // Extract per-test metrics from JUnit artifacts
   try {
-    const artifacts = await fetchArtifactsForRun(runIdNum);
     // Newest per name: a re-run of a flagged test job must refresh its metric.
-    const timingArtifacts = newestArtifactsByName(artifacts.filter(
+    const timingArtifacts = newestArtifactsByName(currentArtifacts.filter(
       (a) => a.name.startsWith("test-timing-") && !a.expired,
     ));
     for (const artifact of timingArtifacts) {
@@ -218,13 +450,47 @@ async function main() {
       }
     }
   } catch (e) {
-    console.warn(`  Warning: could not fetch artifacts for current run: ${e}`);
+    console.warn(
+      `  Warning: could not extract timing metrics from current run artifacts: ${e}`,
+    );
+  }
+
+  // Extract coverage debt metrics from coverage profile artifacts.
+  let coverageDataError: unknown;
+  try {
+    if (currentArtifactsError) {
+      throw new Error(
+        `Could not fetch current run artifacts: ${currentArtifactsError}`,
+      );
+    }
+    const coverageMetrics = await extractCoverageDebtSamples(
+      currentRunInfo,
+      currentArtifacts,
+      {
+        allowMissingExpectedArtifacts: currentRunCoverageBaselineReset,
+      },
+    );
+    for (const [name, sample] of coverageMetrics) {
+      currentMetrics.set(name, sample);
+    }
+  } catch (e) {
+    coverageDataError = e;
+    console.error(
+      `  Error: could not extract coverage debt metrics for current run: ${e}`,
+    );
   }
 
   await writePerfMetricsFile(PERF_METRICS_FILE, currentMetrics);
   console.log(
     `Wrote ${PERF_METRICS_FILE} with ${currentMetrics.size} metrics.`,
   );
+
+  if (coverageDataError && !informationalOnly) {
+    console.error(
+      "Failing because coverage debt data is required for pull request checks.",
+    );
+    Deno.exit(1);
+  }
 
   if (currentMetrics.size === 0) {
     console.log("No metrics extracted from current run. Nothing to check.");
@@ -373,8 +639,18 @@ async function main() {
 
         if (pr) {
           prInfoBySha.set(run.head_sha, pr);
-          const overrides = parseBaselineOverrides(pr.body ?? "");
-          if (overrides.metrics.size > 0) {
+          let overrides: BaselineOverrides;
+          try {
+            overrides = parseBaselineOverrides(pr.body ?? "");
+          } catch (error) {
+            console.warn(
+              `  Warning: ignoring invalid baseline override in merged PR #${pr.number}: ${error}`,
+            );
+            return;
+          }
+          if (
+            overrides.metrics.size > 0 || overrides.coverageBaselineReset
+          ) {
             overridesBySha.set(run.head_sha, overrides);
           }
         }
@@ -457,6 +733,10 @@ async function main() {
     timeline.samples.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
   }
 
+  const coverageBaselineAvailable = [...timelines.keys()].some(
+    isCoverageDebtMetric,
+  );
+
   // Apply baseline overrides from merged PRs
   if (overridesBySha.size > 0) {
     console.log(
@@ -491,6 +771,69 @@ async function main() {
     const current = currentSample.durationSeconds;
     const timeline = timelines.get(metric);
     const n = timeline?.samples.length ?? 0;
+    const isCoverageMetric = isCoverageDebtMetric(metric);
+
+    if (isCoverageMetric) {
+      const latestBaseline = timeline?.samples.at(-1)?.durationSeconds;
+      const override = prOverrides.metrics.get(metric);
+      const coverageReset = prOverrides.coverageBaselineReset;
+
+      if (latestBaseline === undefined) {
+        if (
+          coverageReset || (override !== undefined && current <= override)
+        ) {
+          rows.push({ metric, status: "ovrd", current, n });
+        } else if (current > 0) {
+          const row: Row = {
+            metric,
+            status: "OVER",
+            current,
+            median: 0,
+            variance: 0,
+            stddev: 0,
+            threshold: 0,
+            n,
+            pctIncrease: 100,
+          };
+          rows.push(row);
+          failures.push(row);
+        } else {
+          rows.push({ metric, status: "n/a", current, n });
+        }
+        continue;
+      }
+
+      const pctIncrease = latestBaseline === 0
+        ? current > 0 ? 100 : 0
+        : ((current - latestBaseline) / latestBaseline) * 100;
+      const stats = {
+        median: latestBaseline,
+        variance: 0,
+        stddev: 0,
+        threshold: latestBaseline,
+        pctIncrease,
+      };
+
+      if (coverageReset) {
+        rows.push({ metric, status: "ovrd", current, n, ...stats });
+        continue;
+      }
+
+      if (override !== undefined && current <= override) {
+        rows.push({ metric, status: "ovrd", current, n, ...stats });
+        continue;
+      }
+
+      if (current > latestBaseline) {
+        const row: Row = { metric, status: "OVER", current, n, ...stats };
+        rows.push(row);
+        failures.push(row);
+      } else {
+        rows.push({ metric, status: "OK", current, n, ...stats });
+      }
+      continue;
+    }
+
     const baseline = timeline && n >= MIN_SAMPLES
       ? computeBaseline(
         timeline.samples.map((s) => s.durationSeconds),
@@ -576,10 +919,13 @@ async function main() {
       }% (whichever is higher); non-bench metrics also require at least +${MIN_ABSOLUTE_DELTA}s.`,
   );
   console.log(
+    "Coverage debt metrics use a strict latest-main ratchet: any increase fails.",
+  );
+  console.log(
     "Status key: OVER = over threshold (fails); CLOSE = ≥50% of margin consumed;",
   );
   console.log(
-    "  OK = <50% consumed; ovrd = saved by a PR override; excl = metric excluded from the check;",
+    "  OK = <50% consumed; ovrd = saved by a PR override/reset; excl = metric excluded from the check;",
   );
   console.log(
     `  n/a = fewer than ${MIN_SAMPLES} baseline samples.`,
@@ -603,11 +949,20 @@ async function main() {
         return "Subtests";
       case "bench":
         return "Benchmarks";
+      case "coverage-debt":
+        return "Coverage Debt";
       default:
         return prefix;
     }
   };
-  const KIND_ORDER = ["Jobs", "Steps", "Test files", "Subtests", "Benchmarks"];
+  const KIND_ORDER = [
+    "Jobs",
+    "Steps",
+    "Test files",
+    "Subtests",
+    "Benchmarks",
+    "Coverage Debt",
+  ];
   // Sort order within each kind: most at-risk of failing the check first.
   // `ovrd` sits below `OK` because an override-protected metric is at strictly
   // lower risk of tripping the check than an unguarded OK metric — the author
@@ -738,15 +1093,47 @@ async function main() {
     Deno.exit(0);
   }
 
+  const coverageFailures = failures.filter((f) =>
+    isCoverageDebtMetric(f.metric)
+  );
+  const perMetricFailures = failures.filter((f) =>
+    !isCoverageDebtMetric(f.metric)
+  );
+
+  if (coverageFailures.length > 0) {
+    const verb = coverageBaselineAvailable ? "reset" : "bootstrap";
+    console.log(
+      `\nTo ${verb} the coverage ratchet for one cycle, add the coverage reset marker to your PR description.`,
+    );
+    console.log(
+      "Coverage debt can still be accepted one metric at a time with NEW_PERF_BASELINE when that is the narrower change.",
+    );
+  }
+
   console.log(
     "\nTo accept these regressions, add the following to your PR description:\n",
   );
   console.log("---BEGIN COPY-PASTE---");
-  for (const f of failures) {
+  if (coverageFailures.length > 0) {
+    console.log(COVERAGE_BASELINE_RESET_MARKER);
+  }
+  for (const f of perMetricFailures) {
     const suggested = formatOverrideSuggestion(f.metric, f.current);
     console.log(`NEW_PERF_BASELINE: ${f.metric} = ${suggested}`);
   }
   console.log("---END COPY-PASTE---");
+
+  if (coverageFailures.length > 0) {
+    console.log(
+      "\nIndividual coverage override alternatives:",
+    );
+    console.log("---BEGIN COPY-PASTE---");
+    for (const f of coverageFailures) {
+      const suggested = formatOverrideSuggestion(f.metric, f.current);
+      console.log(`NEW_PERF_BASELINE: ${f.metric} = ${suggested}`);
+    }
+    console.log("---END COPY-PASTE---");
+  }
 
   Deno.exit(1);
 }

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -1,20 +1,27 @@
-import { assertAlmostEquals, assertEquals } from "@std/assert";
+import { assertAlmostEquals, assertEquals, assertThrows } from "@std/assert";
 import {
+  applyBaselineOverrides,
   type Artifact,
   computeBaseline,
   computeCiWallTimeRevisitSignals,
+  COVERAGE_BASELINE_RESET_MARKER,
+  downloadAndExtractArtifact,
   extractMetrics,
   fetchCurrentPRBody,
   fetchPRBody,
+  formatMetricValue,
+  formatOverrideSuggestion,
   githubGet,
   type Job,
   newestArtifactsByName,
+  parseBaselineOverrides,
   parsePerfMetricsBackfillFile,
   parsePerfMetricsFile,
   serializePerfMetrics,
   serializePerfMetricsBackfill,
   type Step,
   timingArtifactLabel,
+  type TimingSample,
   type WorkflowRun,
 } from "./perf-lib.ts";
 
@@ -610,6 +617,104 @@ Deno.test("computeBaseline uses the 3 sigma threshold when it exceeds 15 percent
   assertEquals(baseline?.threshold, 160);
 });
 
+Deno.test("coverage debt metrics format and parse line units", () => {
+  const metric = "coverage-debt: workspace uncovered lines";
+  assertEquals(formatMetricValue(metric, 12), "12 lines");
+  assertEquals(formatMetricValue(metric, 1), "1 line");
+  assertEquals(formatOverrideSuggestion(metric, 12.2), "13 lines");
+
+  const overrides = parseBaselineOverrides(
+    "NEW_PERF_BASELINE: coverage-debt: workspace uncovered lines = 7 lines",
+  );
+  assertEquals(overrides.metrics.get(metric), 7);
+  assertEquals(overrides.coverageBaselineReset, false);
+});
+
+Deno.test("baseline override parser rejects line units for non-coverage metrics", () => {
+  assertThrows(
+    () =>
+      parseBaselineOverrides(
+        "NEW_PERF_BASELINE: job: Check = 7 lines",
+      ),
+    Error,
+    "line units are only valid for coverage-debt metrics",
+  );
+});
+
+Deno.test("baseline override parser rejects time units for coverage metrics", () => {
+  assertThrows(
+    () =>
+      parseBaselineOverrides(
+        "NEW_PERF_BASELINE: coverage-debt: workspace uncovered lines = 7s",
+      ),
+    Error,
+    "coverage-debt metrics must use line units",
+  );
+});
+
+Deno.test("coverage baseline reset marker parses from PR body", () => {
+  const overrides = parseBaselineOverrides(
+    `Reset coverage debt for one cycle\n${COVERAGE_BASELINE_RESET_MARKER}\n`,
+  );
+
+  assertEquals(overrides.coverageBaselineReset, true);
+  assertEquals(overrides.metrics.size, 0);
+});
+
+Deno.test("coverage baseline reset truncates coverage timelines only", () => {
+  const coverageMetric = "coverage-debt: workspace uncovered lines";
+  const jobMetric = "job: Check";
+  const sample = (
+    sha: string,
+    day: number,
+    durationSeconds: number,
+  ): TimingSample => ({
+    runId: day,
+    runUrl: `https://example.test/run/${day}`,
+    sha,
+    createdAt: `2026-01-0${day}T00:00:00Z`,
+    durationSeconds,
+  });
+  const oldCoverage = sample("old", 1, 9);
+  const resetCoverage = sample("reset", 2, 12);
+  const newCoverage = sample("new", 3, 10);
+  const oldJob = sample("old", 1, 20);
+  const resetJob = sample("reset", 2, 21);
+  const newJob = sample("new", 3, 22);
+  const timelines = new Map([
+    [
+      coverageMetric,
+      {
+        name: coverageMetric,
+        samples: [oldCoverage, resetCoverage, newCoverage],
+      },
+    ],
+    [
+      jobMetric,
+      { name: jobMetric, samples: [oldJob, resetJob, newJob] },
+    ],
+  ]);
+
+  applyBaselineOverrides(
+    timelines,
+    new Map([
+      [
+        "reset",
+        { metrics: new Map(), coverageBaselineReset: true },
+      ],
+    ]),
+  );
+
+  assertEquals(
+    timelines.get(coverageMetric)?.samples.map((s) => s.sha),
+    ["reset", "new"],
+  );
+  assertEquals(
+    timelines.get(jobMetric)?.samples.map((s) => s.sha),
+    ["old", "reset", "new"],
+  );
+});
+
 Deno.test("fetchPRBody reads the live pull request body from the GitHub API", async () => {
   const originalFetch = globalThis.fetch;
   let requestedUrl: string | undefined;
@@ -732,6 +837,49 @@ Deno.test("githubGet does not retry non-transient GitHub responses", async () =>
     assertEquals(calls, 1);
   } finally {
     globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("downloadAndExtractArtifact retries transient artifact downloads", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  let calls = 0;
+  try {
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.join(" "));
+    };
+    globalThis.fetch = ((_input, _init) => {
+      calls++;
+      if (calls < 4) {
+        return Promise.resolve(
+          new Response("temporary artifact backend error", {
+            status: 503,
+            headers: { "retry-after": "0" },
+          }),
+        );
+      }
+      return Promise.resolve(new Response("gone", { status: 410 }));
+    }) as typeof fetch;
+
+    assertEquals(await downloadAndExtractArtifact(123, "artifact-test-"), null);
+    assertEquals(calls, 4);
+    assertEquals(
+      warnings.some((warning) =>
+        warning.includes("GitHub artifact download 410")
+      ),
+      true,
+    );
+    assertEquals(
+      warnings.some((warning) =>
+        warning.includes("attempt 1: GitHub artifact download 503") &&
+        warning.includes("attempt 4: GitHub artifact download 410")
+      ),
+      true,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
   }
 });
 

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -17,6 +17,8 @@ export const PERF_METRICS_ARTIFACT_NAME = "perf-metrics";
 export const PERF_METRICS_FILE = "perf-metrics.json";
 export const PERF_METRICS_BACKFILL_ARTIFACT_NAME = "perf-metrics-backfill";
 export const PERF_METRICS_BACKFILL_FILE = "perf-metrics-backfill.json";
+export const COVERAGE_METRIC_PREFIX = "coverage-debt:";
+export const COVERAGE_BASELINE_RESET_MARKER = "NEW_COVERAGE_BASELINE";
 
 /** Minimum number of historical samples before we compute a baseline. */
 export const MIN_SAMPLES = 5;
@@ -180,8 +182,10 @@ export interface CurrentPRBody {
 }
 
 export interface BaselineOverrides {
-  /** Metric name -> value in the metric's native unit (seconds or nanoseconds). */
+  /** Metric name -> value in the metric's native unit. */
   metrics: Map<string, number>;
+  /** Reset all coverage-debt metrics at the commit carrying this marker. */
+  coverageBaselineReset: boolean;
 }
 
 export type CiWallTimeRevisitSignalKind =
@@ -211,6 +215,11 @@ const GITHUB_GET_MAX_ATTEMPTS = 4;
 const GITHUB_GET_RETRY_BASE_DELAY_MS = 250;
 const GITHUB_GET_RETRY_MAX_DELAY_MS = 5_000;
 const RETRYABLE_GITHUB_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+const RETRYABLE_ARTIFACT_DOWNLOAD_STATUSES = new Set([
+  ...RETRYABLE_GITHUB_STATUSES,
+  403,
+  404,
+]);
 
 function retryAfterDelayMs(value: string | null): number | undefined {
   if (value == null) return undefined;
@@ -239,6 +248,15 @@ function githubRetryDelayMs(resp: Response, attempt: number): number {
 function sleep(ms: number): Promise<void> {
   if (ms <= 0) return Promise.resolve();
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function responseBodySnippet(resp: Response): Promise<string> {
+  try {
+    const body = await resp.text();
+    return body.length > 1_000 ? `${body.slice(0, 1_000)}...` : body;
+  } catch (error) {
+    return `Could not read response body: ${error}`;
+  }
 }
 
 export async function githubGet<T>(path: string): Promise<T> {
@@ -379,27 +397,9 @@ export function newestArtifactsByName(artifacts: Artifact[]): Artifact[] {
 export async function downloadAndParseJUnit(
   artifactId: number,
 ): Promise<JUnitTestSuite[]> {
-  const resp = await fetch(
-    `https://api.github.com/repos/${REPO}/actions/artifacts/${artifactId}/zip`,
-    { headers: apiHeaders() },
-  );
-  if (!resp.ok) return [];
-
-  const tmpDir = await Deno.makeTempDir({ prefix: "perf-junit-" });
-  const zipPath = `${tmpDir}/artifact.zip`;
-
+  const tmpDir = await downloadAndExtractArtifact(artifactId, "perf-junit-");
+  if (!tmpDir) return [];
   try {
-    const data = new Uint8Array(await resp.arrayBuffer());
-    await Deno.writeFile(zipPath, data);
-
-    const unzip = new Deno.Command("unzip", {
-      args: ["-o", zipPath, "-d", tmpDir],
-      stdout: "null",
-      stderr: "null",
-    });
-    const result = await unzip.output();
-    if (!result.success) return [];
-
     const suites: JUnitTestSuite[] = [];
     for await (const entry of walkFiles(tmpDir)) {
       if (entry.endsWith(".xml")) {
@@ -528,30 +528,107 @@ export async function writePerfMetricsBackfillFile(
   );
 }
 
+export async function downloadAndExtractArtifact(
+  artifactId: number,
+  tmpPrefix: string,
+): Promise<string | null> {
+  const artifactPath = `/repos/${REPO}/actions/artifacts/${artifactId}/zip`;
+  const url = `https://api.github.com${artifactPath}`;
+  let lastError = "unknown error";
+  const attemptErrors: string[] = [];
+
+  for (let attempt = 1; attempt <= GITHUB_GET_MAX_ATTEMPTS; attempt++) {
+    let resp: Response;
+    try {
+      resp = await fetch(url, { headers: apiHeaders() });
+    } catch (error) {
+      lastError = `fetch failed: ${error}`;
+      attemptErrors.push(`attempt ${attempt}: ${lastError}`);
+      if (attempt < GITHUB_GET_MAX_ATTEMPTS) {
+        await sleep(
+          Math.min(
+            GITHUB_GET_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+            GITHUB_GET_RETRY_MAX_DELAY_MS,
+          ),
+        );
+        continue;
+      }
+      break;
+    }
+
+    if (!resp.ok) {
+      const body = await responseBodySnippet(resp);
+      lastError =
+        `GitHub artifact download ${resp.status} ${resp.statusText}: ${body}`;
+      attemptErrors.push(`attempt ${attempt}: ${lastError}`);
+      if (
+        attempt < GITHUB_GET_MAX_ATTEMPTS &&
+        RETRYABLE_ARTIFACT_DOWNLOAD_STATUSES.has(resp.status)
+      ) {
+        await sleep(githubRetryDelayMs(resp, attempt));
+        continue;
+      }
+      break;
+    }
+
+    const tmpDir = await Deno.makeTempDir({ prefix: tmpPrefix });
+    const zipPath = `${tmpDir}/artifact.zip`;
+
+    try {
+      const data = new Uint8Array(await resp.arrayBuffer());
+      await Deno.writeFile(zipPath, data);
+
+      const unzip = new Deno.Command("unzip", {
+        args: ["-o", zipPath, "-d", tmpDir],
+        stdout: "null",
+        stderr: "piped",
+      });
+      const result = await unzip.output();
+      if (result.success) {
+        return tmpDir;
+      }
+
+      const stderr = new TextDecoder().decode(result.stderr).trim();
+      lastError = `unzip failed with exit code ${result.code}${
+        stderr ? `: ${stderr}` : ""
+      }`;
+    } catch (error) {
+      lastError = `${error}`;
+    }
+    attemptErrors.push(`attempt ${attempt}: ${lastError}`);
+
+    try {
+      await Deno.remove(tmpDir, { recursive: true });
+    } catch { /* ignore cleanup errors */ }
+
+    if (attempt < GITHUB_GET_MAX_ATTEMPTS) {
+      await sleep(
+        Math.min(
+          GITHUB_GET_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+          GITHUB_GET_RETRY_MAX_DELAY_MS,
+        ),
+      );
+    }
+  }
+
+  console.warn(
+    `  Warning: could not download/extract artifact ${artifactId} (${artifactPath}) after ${GITHUB_GET_MAX_ATTEMPTS} attempt(s): ${lastError}`,
+  );
+  console.warn(
+    `  Artifact download attempts: ${attemptErrors.join(" | ")}`,
+  );
+  return null;
+}
+
 export async function downloadAndParsePerfMetrics(
   artifactId: number,
 ): Promise<Map<string, TimingSample> | null> {
-  const resp = await fetch(
-    `https://api.github.com/repos/${REPO}/actions/artifacts/${artifactId}/zip`,
-    { headers: apiHeaders() },
+  const tmpDir = await downloadAndExtractArtifact(
+    artifactId,
+    "perf-metrics-",
   );
-  if (!resp.ok) return null;
-
-  const tmpDir = await Deno.makeTempDir({ prefix: "perf-metrics-" });
-  const zipPath = `${tmpDir}/artifact.zip`;
-
+  if (!tmpDir) return null;
   try {
-    const data = new Uint8Array(await resp.arrayBuffer());
-    await Deno.writeFile(zipPath, data);
-
-    const unzip = new Deno.Command("unzip", {
-      args: ["-o", zipPath, "-d", tmpDir],
-      stdout: "null",
-      stderr: "null",
-    });
-    const result = await unzip.output();
-    if (!result.success) return null;
-
     const jsonPath = `${tmpDir}/${PERF_METRICS_FILE}`;
     const content = await Deno.readTextFile(jsonPath);
     return parsePerfMetricsFile(content);
@@ -567,27 +644,12 @@ export async function downloadAndParsePerfMetrics(
 export async function downloadAndParsePerfMetricsBackfill(
   artifactId: number,
 ): Promise<Map<number, Map<string, TimingSample>> | null> {
-  const resp = await fetch(
-    `https://api.github.com/repos/${REPO}/actions/artifacts/${artifactId}/zip`,
-    { headers: apiHeaders() },
+  const tmpDir = await downloadAndExtractArtifact(
+    artifactId,
+    "perf-metrics-backfill-",
   );
-  if (!resp.ok) return null;
-
-  const tmpDir = await Deno.makeTempDir({ prefix: "perf-metrics-backfill-" });
-  const zipPath = `${tmpDir}/artifact.zip`;
-
+  if (!tmpDir) return null;
   try {
-    const data = new Uint8Array(await resp.arrayBuffer());
-    await Deno.writeFile(zipPath, data);
-
-    const unzip = new Deno.Command("unzip", {
-      args: ["-o", zipPath, "-d", tmpDir],
-      stdout: "null",
-      stderr: "null",
-    });
-    const result = await unzip.output();
-    if (!result.success) return null;
-
     const jsonPath = `${tmpDir}/${PERF_METRICS_BACKFILL_FILE}`;
     const content = await Deno.readTextFile(jsonPath);
     return parsePerfMetricsBackfillFile(content);
@@ -1274,6 +1336,10 @@ export function computeBaseline(
 // Formatting
 // ---------------------------------------------------------------------------
 
+export function isCoverageDebtMetric(name: string): boolean {
+  return name.startsWith(COVERAGE_METRIC_PREFIX);
+}
+
 /** Escape a string for use inside a Markdown table cell. */
 export function escapeTableCell(s: string): string {
   return s.replace(/\|/g, "\\|").replace(/\n/g, " ");
@@ -1294,6 +1360,10 @@ export function formatNanos(ns: number): string {
 }
 
 export function formatMetricValue(name: string, value: number): string {
+  if (isCoverageDebtMetric(name)) {
+    const rounded = Math.round(value);
+    return `${rounded} ${rounded === 1 ? "line" : "lines"}`;
+  }
   return name.startsWith("bench:") ? formatNanos(value) : formatDuration(value);
 }
 
@@ -1386,23 +1456,50 @@ export async function fetchCurrentPRBody(
  * Format (visible markdown, one per line):
  *   NEW_PERF_BASELINE: job: Package Integration Tests = 300s
  *   NEW_PERF_BASELINE: bench: foo > bar = 500us
+ *   NEW_COVERAGE_BASELINE
  *
- * Values require a unit suffix: s, ms, us/µs, ns.
- * The value is stored in the metric's native unit (seconds for
- * job/step/test, nanoseconds for bench).
+ * Values require a unit suffix: s, ms, us/µs, ns, line, or lines.
+ * The value is stored in the metric's native unit.
+ * Coverage-debt metrics must use line units; non-coverage metrics must use
+ * time units.
+ * `NEW_COVERAGE_BASELINE` is a whole-coverage ratchet reset marker; it has no
+ * value and lets the PR's/main run's coverage metrics become the next baseline.
  */
 export function parseBaselineOverrides(body: string): BaselineOverrides {
-  const result: BaselineOverrides = { metrics: new Map() };
+  const result: BaselineOverrides = {
+    metrics: new Map(),
+    coverageBaselineReset: new RegExp(
+      `^\\s*${COVERAGE_BASELINE_RESET_MARKER}(?::\\s*.*)?\\s*$`,
+      "m",
+    ).test(body),
+  };
 
   const re =
-    /NEW_PERF_BASELINE:\s*(.+?)\s*=\s*(\d+(?:\.\d+)?)\s*(ns|µs|us|ms|s)/g;
+    /NEW_PERF_BASELINE:\s*(.+?)\s*=\s*(\d+(?:\.\d+)?)\s*(ns|µs|us|ms|s|lines?)/g;
   let match;
   while ((match = re.exec(body)) !== null) {
     const metric = match[1].trim();
     let value = parseFloat(match[2]);
     const unit = match[3];
+    const isLineUnit = unit === "line" || unit === "lines";
+    const isCoverageMetric = isCoverageDebtMetric(metric);
 
-    // Convert to seconds first
+    if (isLineUnit && !isCoverageMetric) {
+      throw new Error(
+        `Invalid NEW_PERF_BASELINE override for "${metric}": line units are only valid for coverage-debt metrics.`,
+      );
+    }
+    if (!isLineUnit && isCoverageMetric) {
+      throw new Error(
+        `Invalid NEW_PERF_BASELINE override for "${metric}": coverage-debt metrics must use line units.`,
+      );
+    }
+
+    if (isLineUnit) {
+      result.metrics.set(metric, value);
+      continue;
+    }
+
     switch (unit) {
       case "ns":
         value /= 1e9;
@@ -1418,7 +1515,6 @@ export function parseBaselineOverrides(body: string): BaselineOverrides {
         break;
     }
 
-    // For bench metrics, convert seconds to nanoseconds (native unit)
     if (metric.startsWith("bench:")) {
       value *= 1e9;
     }
@@ -1437,6 +1533,10 @@ export function formatOverrideSuggestion(
   metric: string,
   value: number,
 ): string {
+  if (isCoverageDebtMetric(metric)) {
+    const rounded = Math.ceil(value);
+    return `${rounded} ${rounded === 1 ? "line" : "lines"}`;
+  }
   if (metric.startsWith("bench:")) {
     // value is in nanoseconds
     if (value < 1_000) return `${value.toFixed(0)}ns`;
@@ -1471,9 +1571,10 @@ export function addSample(
  * latest override point.
  *
  * `overridesBySha` maps commit SHA -> BaselineOverrides parsed from the
- * merged PR for that commit.  When a commit has a per-metric override, we
- * discard all samples for the affected metrics that precede that commit
- * (keeping the override commit's sample and everything after).
+ * merged PR for that commit.  When a commit has a per-metric override, or a
+ * whole-coverage reset for coverage-debt metrics, we discard all samples for
+ * the affected metrics that precede that commit (keeping the override commit's
+ * sample and everything after).
  */
 export function applyBaselineOverrides(
   timelines: Map<string, MetricTimeline>,
@@ -1488,7 +1589,11 @@ export function applyBaselineOverrides(
       const overrides = overridesBySha.get(sha);
       if (!overrides) continue;
 
-      if (overrides.metrics.has(metricName)) {
+      if (
+        overrides.metrics.has(metricName) ||
+        (overrides.coverageBaselineReset &&
+          isCoverageDebtMetric(metricName))
+      ) {
         latestOverrideIdx = i;
       }
     }

--- a/tasks/perf-regression.ts
+++ b/tasks/perf-regression.ts
@@ -417,13 +417,24 @@ async function main() {
     if (pr) {
       prInfoBySha.set(run.head_sha, pr);
       if (pr.body) {
-        const overrides = parseBaselineOverrides(pr.body);
-        if (overrides.metrics.size > 0) {
+        let overrides: BaselineOverrides;
+        try {
+          overrides = parseBaselineOverrides(pr.body);
+        } catch (error) {
+          console.warn(
+            `  Warning: ignoring invalid baseline override in PR #${pr.number}: ${error}`,
+          );
+          return;
+        }
+        if (overrides.metrics.size > 0 || overrides.coverageBaselineReset) {
           overridesBySha.set(run.head_sha, overrides);
+          const reset = overrides.coverageBaselineReset
+            ? ", coverage reset"
+            : "";
           console.log(
             `  Found baseline override in PR #${pr.number} (${
               run.head_sha.slice(0, 8)
-            }) [${overrides.metrics.size} metric(s)]`,
+            }) [${overrides.metrics.size} metric(s)${reset}]`,
           );
         }
       }

--- a/tasks/test.ts
+++ b/tasks/test.ts
@@ -36,6 +36,7 @@ export async function testPackage(
   memberPath: string,
   packageName: string,
   packagePath: string,
+  coverageRoot: string | undefined,
 ): Promise<{
   memberPath: string;
   packageName: string;
@@ -46,10 +47,18 @@ export async function testPackage(
   const startedAt = Date.now();
   let result: Deno.CommandOutput;
   try {
+    const env: Record<string, string> = { ENV: "test" };
+    if (coverageRoot) {
+      env.DENO_COVERAGE_DIR = path.join(
+        coverageRoot,
+        packageName.replaceAll("/", "__"),
+      );
+    }
+
     result = await new Deno.Command(Deno.execPath(), {
       args: ["task", "test"],
       cwd: packagePath,
-      env: { ENV: "test" },
+      env,
       stdout: "piped",
       stderr: "piped",
     }).output();
@@ -82,6 +91,7 @@ export async function runTests(disabledPackages: string[]): Promise<boolean> {
   const suiteStartedAt = Date.now();
   const manifest = JSON.parse(await Deno.readTextFile("./deno.json"));
   const members: string[] = manifest.workspace;
+  const coverageRoot = Deno.env.get("DENO_COVERAGE_DIR");
 
   const tests = [];
   for (const memberPath of members) {
@@ -92,7 +102,7 @@ export async function runTests(disabledPackages: string[]): Promise<boolean> {
     }
     console.log(`Testing ${packageName}...`);
     const packagePath = path.resolve(workspaceCwd, memberPath);
-    tests.push(testPackage(memberPath, packageName, packagePath));
+    tests.push(testPackage(memberPath, packageName, packagePath, coverageRoot));
   }
 
   const results = await Promise.all(tests);

--- a/tasks/write-coverage-lcov.ts
+++ b/tasks/write-coverage-lcov.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-run
+import * as path from "@std/path";
+
+async function collectCoverageProfileFiles(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  try {
+    for await (const entry of Deno.readDir(dir)) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory) {
+        files.push(...await collectCoverageProfileFiles(fullPath));
+      } else if (entry.name.endsWith(".json")) {
+        files.push(fullPath);
+      }
+    }
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return [];
+    throw error;
+  }
+
+  return files;
+}
+
+async function removeEmptyCoverageProfiles(files: string[]): Promise<number> {
+  let removed = 0;
+  for (const file of files) {
+    const info = await Deno.stat(file);
+    if (info.size > 0) continue;
+    await Deno.remove(file);
+    removed++;
+  }
+  return removed;
+}
+
+async function writeEmptyLcov(
+  outputPath: string,
+  reason: string,
+): Promise<void> {
+  await Deno.mkdir(path.dirname(outputPath), { recursive: true });
+  await Deno.writeTextFile(outputPath, "");
+  console.warn(`${reason}; wrote empty LCOV report to ${outputPath}.`);
+}
+
+async function main(): Promise<void> {
+  const [profileDir, outputPath] = Deno.args;
+  if (!profileDir || !outputPath) {
+    console.error(
+      "Usage: deno run --allow-read --allow-write --allow-run tasks/write-coverage-lcov.ts <profile-dir> <output.lcov>",
+    );
+    Deno.exit(2);
+  }
+
+  const profileFiles = await collectCoverageProfileFiles(profileDir);
+  if (profileFiles.length === 0) {
+    await writeEmptyLcov(
+      outputPath,
+      `No coverage profile files found in ${profileDir}`,
+    );
+    return;
+  }
+
+  const removedEmptyProfiles = await removeEmptyCoverageProfiles(profileFiles);
+  if (removedEmptyProfiles > 0) {
+    console.warn(
+      `Removed ${removedEmptyProfiles} empty coverage profile file(s) from ${profileDir}.`,
+    );
+  }
+
+  const remainingProfileFiles = await collectCoverageProfileFiles(profileDir);
+  if (remainingProfileFiles.length === 0) {
+    await writeEmptyLcov(
+      outputPath,
+      `No non-empty coverage profile files remain in ${profileDir}`,
+    );
+    return;
+  }
+
+  await Deno.mkdir(path.dirname(outputPath), { recursive: true });
+  const result = await new Deno.Command(Deno.execPath(), {
+    args: ["coverage", "--lcov", `--output=${outputPath}`, profileDir],
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+
+  if (!result.success) {
+    const stderr = new TextDecoder().decode(result.stderr);
+    if (stderr.includes("No covered files included in the report")) {
+      await writeEmptyLcov(
+        outputPath,
+        `No reportable covered files found in ${profileDir}`,
+      );
+      return;
+    }
+    throw new Error(`deno coverage failed: ${stderr.trim()}`);
+  }
+
+  console.log(`Wrote LCOV coverage report to ${outputPath}`);
+}
+
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
Now with more empty .lcov files so we can distinguish upload failures from shards with no coverage tracking at all.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds coverage debt (uncovered lines) to the Performance Check. CI now emits LCOV from all test shards and the gate enforces a strict ratchet against main, with per-metric overrides and a one-cycle reset marker.

- **New Features**
  - Tracks coverage debt as uncovered lines for the workspace and per-package groups.
  - Enforces a strict latest-main ratchet; any increase fails unless accepted.
  - Supports per-metric overrides using line units, e.g. `NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 123 lines`.
  - Supports a one-cycle reset with `NEW_COVERAGE_BASELINE` to bootstrap or reseed baselines.
  - CI sets `DENO_COVERAGE_DIR`, converts profiles to LCOV via `tasks/write-coverage-lcov.ts`, and uploads `coverage-profile-*` artifacts for all shards/suites (workspace, runner shards, generated-patterns shards, package suites, pattern integration shards, pattern reload, pattern unit chunks).
  - Uploads empty `.lcov` files when no reportable files exist to distinguish upload failures from no-coverage cases.
  - Gate reads LCOV first (if present) or raw profiles, with resilient artifact download and unzip behavior.

- **Migration**
  - If your PR intentionally increases uncovered lines, add a per-metric override with line units:
    - `NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = N lines`
  - To seed or reset all coverage baselines for one cycle, add:
    - `NEW_COVERAGE_BASELINE`

<sup>Written for commit be65093590fd8e9e6a43d26910856ed05185d104. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


NEW_COVERAGE_BASELINE

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: job: Check = 289s
NEW_PERF_BASELINE: job: CLI Integration Tests (fuse) = 98s
NEW_PERF_BASELINE: job: CLI Integration Tests (core-piece-values) = 81s
NEW_PERF_BASELINE: job: Generated Patterns Integration Tests (1/4) = 105s
NEW_PERF_BASELINE: job: Generated Patterns Integration Tests (2/4) = 94s
NEW_PERF_BASELINE: job: Generated Patterns Integration Tests (2/4) = 107s
NEW_PERF_BASELINE: job: Generated Patterns Integration Tests (3/4) = 186s
NEW_PERF_BASELINE: job: Generated Patterns Integration Tests (4/4) = 101s
NEW_PERF_BASELINE: job: Generated Patterns Integration Tests = 107s
NEW_PERF_BASELINE: job: Package Integration Tests (runtime-client) = 117s
NEW_PERF_BASELINE: job: Pattern Integration Tests (1/4) = 305s
NEW_PERF_BASELINE: job: Pattern Integration Tests = 305s
NEW_PERF_BASELINE: job: Pattern Reload Integration Tests = 72s
NEW_PERF_BASELINE: job: Runner Tests (1/4) = 180s
NEW_PERF_BASELINE: job: Runner Tests (2/4) = 143s
NEW_PERF_BASELINE: job: Runner Tests (3/4) = 211s
NEW_PERF_BASELINE: job: Runner Tests (4/4) = 164s
NEW_PERF_BASELINE: job: Runner Tests = 211s
NEW_PERF_BASELINE: job: Test = 217s
NEW_PERF_BASELINE: step: generated patterns integration = 84s
NEW_PERF_BASELINE: step: pattern reload integration = 58s
NEW_PERF_BASELINE: step: patterns integration = 265s
NEW_PERF_BASELINE: step: runner integration = 73s
NEW_PERF_BASELINE: step: runner tests = 187s
NEW_PERF_BASELINE: step: runtime-client integration = 59s
NEW_PERF_BASELINE: step: workspace tests = 158s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/main.test.tsx = 29s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/multi-user.test.tsx = 56s
NEW_PERF_BASELINE: test: pattern-unit-4/pattern-unit-tests = 277s
---END COPY-PASTE---