### PR TITLE
fix(ci): gate pattern & CLI integration jobs on toolshed /_health

### DIFF
--- a/.github/actions/wait-for-toolshed/action.yml
+++ b/.github/actions/wait-for-toolshed/action.yml
@@ -1,0 +1,31 @@
+name: "Wait for Toolshed"
+description: "Poll the toolshed /_health endpoint until it returns 200, so tests never race a not-yet-bound server."
+inputs:
+  url:
+    description: "Base toolshed URL, no trailing slash (the action appends /_health)."
+    default: "http://localhost:8000"
+  timeout:
+    description: "Maximum seconds to wait for the server to become ready."
+    default: "60"
+runs:
+  using: "composite"
+  steps:
+    # Mirrors scripts/start-local-dev.sh `wait_for_http`: poll /_health until 200
+    # so the test step starts against a bound server instead of hard-failing on a
+    # `Connection refused` race (CT-1738).
+    - name: ⏳ Wait for Toolshed to be ready
+      shell: bash
+      run: |
+        url="${{ inputs.url }}/_health"
+        deadline=$(( SECONDS + ${{ inputs.timeout }} ))
+        echo "Waiting for toolshed at $url ..."
+        while (( SECONDS < deadline )); do
+          status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 "$url" 2>/dev/null || true)
+          if [[ "$status" == "200" ]]; then
+            echo "  toolshed is ready."
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "::error::toolshed did not become ready at $url within ${{ inputs.timeout }}s"
+        exit 1

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -344,6 +344,11 @@ jobs:
           echo "${{ github.workspace }}/common-binaries" >> $GITHUB_PATH
           CFTS_AI_GATEWAY_URL="" MEMORY_URL="$TOOLSHED_URL" API_URL="$TOOLSHED_URL" ./common-binaries/toolshed --port="$TOOLSHED_PORT" &
 
+      - name: ⏳ Wait for Toolshed to be ready
+        uses: ./.github/actions/wait-for-toolshed
+        with:
+          url: http://localhost:${{ matrix.toolshed_port }}
+
       - name: 📦 Install CLI integration dependencies
         env:
           INSTALL_FUSE_DEPS: ${{ matrix.install_fuse_deps }}
@@ -436,6 +441,11 @@ jobs:
           CFTS_AI_GATEWAY_URL="" \
           CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
           ./common-binaries/toolshed &
+
+      - name: ⏳ Wait for Toolshed to be ready
+        uses: ./.github/actions/wait-for-toolshed
+        with:
+          url: http://localhost:8000
 
       # For Astral
       # https://github.com/lino-levan/astral/blob/f5ef833b2c5bde3783564a6b925073d5d46bb4b8/README.md#no-usable-sandbox-with-user-namespace-cloning-enabled


### PR DESCRIPTION
## What

Adds a `/_health` readiness gate to the two pattern-test CI jobs that launch the toolshed with a bare background `&` and then run tests with no wait.

- New reusable composite action `.github/actions/wait-for-toolshed` — polls `/_health` until `200` with a bounded 60s deadline, mirroring `scripts/start-local-dev.sh`'s `wait_for_http` and the existing `deno-setup` composite-action convention.
- Gates `pattern-integration-test` and `cli-integration-test` on it, between the toolshed launch and the test step.

## Why

Both jobs do `./common-binaries/toolshed &` then run tests immediately. `startServer()` runs `initializeRuntime()` **synchronously before** `Deno.serve` binds, and the storage WebSocket transport has no connect retry/backoff — so a test whose first request beats the bind gets a hard `Connection refused (os error 111)` that surfaces mid-run and clears on re-run. That's one of the flake signatures catalogued in [CT-1738](https://linear.app/common-tools/issue/CT-1738) (e.g. `Can't load profile-create.tsx ... Connection refused` against `localhost:8000`).

The gate is a true *happens-before* fence: `/_health` returns `200` only after `Deno.serve` binds, so the test step cannot start against an unbound port — it removes the race rather than widening a window.

## Scope

- `package-integration-test` already self-gates via `deno task integration` → `start-local-dev.sh` (`wait_for_http` on `/_health`), so it's left unchanged.
- This addresses only the connection-refused / start-race class (CT-1738 #2). The settle-timeout flakes are a separate root cause: #3 is fixed by #4174's `viewSettled`; #4 (parking) is a follow-up that builds on it.

## Verification

- Both YAML files parse cleanly (`@std/yaml`).
- `/_health` is an unauthenticated `200 {status:"OK"}` (`packages/toolshed/routes/health`).
- Structural argument over a single green run: the gate establishes server-bound-before-first-fetch.

Refs CT-1738.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the pattern and CLI integration CI jobs on the toolshed `/_health` endpoint so tests only start after the server is bound. This removes connection-refused flakes tracked in CT-1738.

- **Bug Fixes**
  - Added reusable action `./.github/actions/wait-for-toolshed` that polls `/_health` until `200` (60s max).
  - Gated `pattern-integration-test` and `cli-integration-test` after launching `toolshed`, preventing the start-up race.
  - Left `package-integration-test` unchanged; it already waits via `start-local-dev.sh`.

<sup>Written for commit f5c2c7e02f67dcf3f862259a83af823508b1132f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

