### PR TITLE
fix(patterns): settle before click in clickCfButtonAndWaitForText (CT-1738 #4, stacked on #4174)

### DIFF
--- a/packages/html/src/debug.ts
+++ b/packages/html/src/debug.ts
@@ -141,10 +141,12 @@ function formatTree(node: unknown, indent = 0): string {
 
 /**
  * Walk every active render's DOM subtree, descending through shadow roots, and
- * await `updateComplete` on each Lit element. Returns true if any element was
- * mid-update — pending when scanned, or resolving its `updateComplete` to a
- * re-triggered or thrown update during the drain — which signals the view was
- * not yet settled and the caller should drain again.
+ * await `updateComplete` on each Lit element. Returns `churned` — true if any
+ * element was mid-update (pending when scanned, or resolving its
+ * `updateComplete` to a re-triggered or thrown update during the drain), which
+ * signals the view was not yet settled and the caller should drain again — and
+ * `errors`, the reasons of any updates that threw, so a give-up can name the
+ * actual failure rather than blame re-rendering.
  *
  * This closes the gap between "the worker is reactively idle" and "the DOM is
  * interactive": custom elements such as cf-modal enable pointer events and bind
@@ -156,7 +158,7 @@ function formatTree(node: unknown, indent = 0): string {
  */
 export async function drainViewUpdates(
   roots: Iterable<Element> = activeRenderRoots(),
-): Promise<boolean> {
+): Promise<{ churned: boolean; errors: unknown[] }> {
   const pending: Promise<unknown>[] = [];
   let sawPending = false;
 
@@ -184,13 +186,22 @@ export async function drainViewUpdates(
   // updated(), as cf-modal does when toggling open), and rejects when the
   // update threw. Treat false and rejected as still-churning so the loop drains
   // again instead of exiting a cycle early; allSettled keeps a thrown update
-  // from aborting the check. An element that never stops churning trips
-  // viewSettled's maxPasses warning rather than spinning forever.
+  // from aborting the check. Collect rejection reasons so a give-up after
+  // maxPasses can name the throwing update instead of blaming re-rendering. An
+  // element that never stops churning trips viewSettled's maxPasses warning
+  // rather than spinning forever.
   const results = await Promise.allSettled(pending);
-  const churned = results.some(
-    (r) => r.status === "rejected" || r.value === false,
-  );
-  return sawPending || churned;
+  const errors: unknown[] = [];
+  let churned = sawPending;
+  for (const r of results) {
+    if (r.status === "rejected") {
+      errors.push(r.reason);
+      churned = true;
+    } else if (r.value === false) {
+      churned = true;
+    }
+  }
+  return { churned, errors };
 }
 
 function activeRenderRoots(): Element[] {
@@ -211,7 +222,9 @@ function activeRenderRoots(): Element[] {
  * A view that re-renders on every cycle (an animation that requests Lit updates
  * on a timer) never reports settled. Rather than fail such a view, the loop
  * gives up after maxPasses and warns: by then the view is interactive even
- * though it is still updating.
+ * though it is still updating. If the churn was a thrown update rather than
+ * benign re-rendering, the warning names that error so a real failure is not
+ * misread as animation.
  *
  * `roots` is forwarded to drainViewUpdates to scope the drain (used by tests);
  * it defaults to every active render's container.
@@ -221,16 +234,27 @@ export async function viewSettled(
   options: { maxPasses?: number; roots?: Iterable<Element> } = {},
 ): Promise<void> {
   const maxPasses = options.maxPasses ?? 50;
+  let lastErrors: unknown[] = [];
   for (let pass = 0; pass < maxPasses; pass++) {
     await idle();
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    const pending = await drainViewUpdates(options.roots);
-    if (!pending) return;
+    const { churned, errors } = await drainViewUpdates(options.roots);
+    lastErrors = errors;
+    if (!churned) return;
   }
-  console.warn(
-    `viewSettled: view still reported pending updates after ${maxPasses} ` +
-      `passes; proceeding. A perpetually re-rendering element can cause this.`,
-  );
+  if (lastErrors.length > 0) {
+    console.warn(
+      `viewSettled: gave up after ${maxPasses} passes; a view update threw ` +
+        `during the final drain (folded into churn, not re-thrown). Last of ` +
+        `${lastErrors.length} error(s):`,
+      lastErrors[lastErrors.length - 1],
+    );
+  } else {
+    console.warn(
+      `viewSettled: view still reported pending updates after ${maxPasses} ` +
+        `passes; proceeding. A perpetually re-rendering element can cause this.`,
+    );
+  }
 }
 
 /**

--- a/packages/html/test/view-settled.test.ts
+++ b/packages/html/test/view-settled.test.ts
@@ -46,7 +46,7 @@ function roots(...els: FakeEl[]): Iterable<Element> {
 Deno.test("drainViewUpdates - churn detection", async (t) => {
   await t.step("a settled element is not churning", async () => {
     assertEquals(
-      await drainViewUpdates(roots(lit(Promise.resolve(true)))),
+      (await drainViewUpdates(roots(lit(Promise.resolve(true))))).churned,
       false,
     );
   });
@@ -55,7 +55,8 @@ Deno.test("drainViewUpdates - churn detection", async (t) => {
     "plain elements without updateComplete are ignored",
     async () => {
       assertEquals(
-        await drainViewUpdates(roots(plain({ children: [plain()] }))),
+        (await drainViewUpdates(roots(plain({ children: [plain()] }))))
+          .churned,
         false,
       );
     },
@@ -63,42 +64,52 @@ Deno.test("drainViewUpdates - churn detection", async (t) => {
 
   await t.step("an element pending at scan time is churning", async () => {
     assertEquals(
-      await drainViewUpdates(
+      (await drainViewUpdates(
         roots(lit(Promise.resolve(true), { isUpdatePending: true })),
-      ),
+      )).churned,
       true,
     );
   });
 
   await t.step(
-    "a superseded update (resolves false) is churning",
+    "a superseded update (resolves false) is churning with no error",
     async () => {
-      assertEquals(
-        await drainViewUpdates(roots(lit(Promise.resolve(false)))),
-        true,
+      const { churned, errors } = await drainViewUpdates(
+        roots(lit(Promise.resolve(false))),
       );
+      assertEquals(churned, true);
+      assertEquals(errors, []);
     },
   );
 
   await t.step(
-    "a thrown update (rejects) is churning and does not throw",
+    "a thrown update (rejects) is churning and surfaces the error",
     async () => {
-      const rejected = Promise.reject(new Error("update threw"));
+      const boom = new Error("update threw");
+      const rejected = Promise.reject(boom);
       rejected.catch(() => {});
-      assertEquals(await drainViewUpdates(roots(lit(rejected))), true);
+      const { churned, errors } = await drainViewUpdates(roots(lit(rejected)));
+      assertEquals(churned, true);
+      assertEquals(errors, [boom]);
     },
   );
 
   await t.step("descends into children and shadow roots", async () => {
     const churningInShadow = plain({ shadow: [lit(Promise.resolve(false))] });
-    assertEquals(await drainViewUpdates(roots(churningInShadow)), true);
+    assertEquals(
+      (await drainViewUpdates(roots(churningInShadow))).churned,
+      true,
+    );
 
     const settledNested = plain({ children: [lit(Promise.resolve(true))] });
-    assertEquals(await drainViewUpdates(roots(settledNested)), false);
+    assertEquals(
+      (await drainViewUpdates(roots(settledNested))).churned,
+      false,
+    );
   });
 
   await t.step("no active renders means nothing is churning", async () => {
-    assertEquals(await drainViewUpdates(), false);
+    assertEquals((await drainViewUpdates()).churned, false);
   });
 });
 
@@ -147,6 +158,33 @@ Deno.test("viewSettled - loop", async (t) => {
       }
       assertEquals(passes, 3);
       assertEquals(warn.calls.length, 1);
+    },
+  );
+
+  await t.step(
+    "names the thrown update when it gives up after maxPasses",
+    async () => {
+      const warn = stub(console, "warn", () => {});
+      const boom = new Error("update threw");
+      const rejected = Promise.reject(boom);
+      rejected.catch(() => {});
+      let passes = 0;
+      const idle = () => {
+        passes++;
+        return Promise.resolve();
+      };
+      try {
+        await viewSettled(idle, {
+          roots: roots(lit(rejected)),
+          maxPasses: 2,
+        });
+      } finally {
+        warn.restore();
+      }
+      assertEquals(passes, 2);
+      assertEquals(warn.calls.length, 1);
+      // the actual error is surfaced as a console.warn argument, not lost
+      assertEquals(warn.calls[0].args.includes(boom), true);
     },
   );
 });

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -1,4 +1,4 @@
-import { Page, waitFor } from "@commonfabric/integration";
+import { awaitViewSettled, Page, waitFor } from "@commonfabric/integration";
 import { toIndentedDebugString } from "@commonfabric/data-model/value-debug";
 
 const DEFAULT_CFC_BROWSER_TIMEOUT = 30_000;
@@ -456,28 +456,55 @@ export async function clickCfButtonAndWaitForText(
   text: string,
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
+  // Single timeout budget shared across settle, click, and wait-for-effect.
+  const deadline = Date.now() + timeout;
+  const remaining = () => Math.max(1, deadline - Date.now());
+
   let textProbe: TextProbe | undefined;
+
+  // Fast path: the effect may already be present (idempotent re-entry).
+  if (await textIsPresent(page, textSelector, text)) {
+    return;
+  }
+
+  // Settle the view BEFORE clicking, then click exactly ONCE. awaitViewSettled
+  // resolves only once the worker is idle, the vdom batch has been applied to
+  // the main thread, and Lit updates have drained — i.e. the button's handler
+  // is actually bound. A single settled click is delivered to a live handler,
+  // so we never re-click: re-clicking a freshly-rendered control is racy (it
+  // can double-fire, and against a dismissable overlay the repeat clicks
+  // dismiss it). See docs/development/UI_TESTING.md.
+  try {
+    await waitFor(() => awaitViewSettled(page), {
+      timeout: remaining(),
+      delay: 250,
+    });
+    await clickCfButton(page, buttonSelector, { timeout: remaining() });
+  } catch (cause) {
+    textProbe = await readTextProbe(page, textSelector).catch(() => undefined);
+    throw new Error(
+      `Failed to click "${buttonSelector}" while waiting for "${textSelector}" to contain "${text}". Last probe: ${
+        toIndentedDebugString(textProbe)
+      }`,
+      { cause },
+    );
+  }
+
+  // The click is delivered; settle the view and wait for its effect. The settle
+  // re-runs each poll, so an effect that renders a few cycles after the click —
+  // including an optimistic perUser/perSpace write whose chip trails the
+  // commit — is captured without ever re-clicking.
   try {
     await waitFor(async () => {
+      await awaitViewSettled(page);
       if (await textIsPresent(page, textSelector, text)) {
         return true;
       }
-      try {
-        await clickCfButton(page, buttonSelector, { timeout: 2_000 });
-      } catch {
-        textProbe = await readTextProbe(page, textSelector).catch(() =>
-          undefined
-        );
-        return false;
-      }
-      const updated = await textIsPresent(page, textSelector, text);
-      if (!updated) {
-        textProbe = await readTextProbe(page, textSelector).catch(() =>
-          undefined
-        );
-      }
-      return updated;
-    }, { timeout, delay: 1_000 });
+      textProbe = await readTextProbe(page, textSelector).catch(() =>
+        undefined
+      );
+      return false;
+    }, { timeout: remaining(), delay: 250 });
   } catch (cause) {
     textProbe ??= await readTextProbe(page, textSelector).catch(() =>
       undefined


### PR DESCRIPTION
> ⚠️ **Draft — stacked on #4174.** Builds on @Hixie's `viewSettled` primitive and currently includes that commit (`5b5cd5d6d`). **Do not merge before #4174.** Once #4174 lands I'll rebase onto `main` so this shows only the helper change (`f2b8238fa`).

## What

Reworks `clickCfButtonAndWaitForText` (`packages/patterns/integration/cfc-browser-helpers.ts`) from a re-click-until-it-takes loop into the **settle → click once → settle-wait** shape that #4174's `awaitViewSettled` enables.

## Why — CT-1738 flake #4 (parking)

The `parking-coordinator-admin-view` test intermittently times out 30s waiting for the admin chip to flip to "Can manage admins" after clicking "Enable manager demo" (3 independent CI occurrences, including on #4181's run). Verified root cause (structural + empirical — full writeup on CT-1738):

- It's the view-readiness gap #4174 documents: `rt.idle()` (all the old helper observed) covers worker reactivity but **not** the worker→main vdom apply + Lit `updated()` cycle that binds the button's handler. A click issued before the handler is bound is dropped.
- The credential flip is an **optimistic, local** `perUser` write — `commitOperations` notifies subscribers synchronously *before* any server round-trip (`packages/runner/src/storage/v2.ts:1741-1762`). Confirmed empirically by re-running the parking scenario with `synced()` stripped from the runner's between-step settle (63/63 still pass). So once the click lands, a **single settle** makes the chip flip — no storage convergence needed. (The deeper server-push gap is real but unrelated → CT-1757.)
- The old loop's re-clicking is exactly the anti-pattern #4174's docs warn against.

## Change

- `awaitViewSettled` **before** the click → handler bound → a single click lands.
- Click **once**, never re-click.
- Settle + wait for the effect (the post-click loop re-settles each poll, catching an optimistically-rendered chip that trails the click).
- One shared timeout budget across the three phases.

Isolated to `clickCfButtonAndWaitForText`, whose only caller is the parking test. `clickCfButton` and `waitForRuntimeIdle` are left **unchanged**, so the group-chat and other cfc-browser tests are unaffected.

## Verification

- Typecheck + lint clean.
- Parking integration test passes locally against a real headless browser — the previously-flaky step completes in **10s** with no re-clicking.
- Honest caveat: a single local pass can't prove a flake fixed (the test usually passes locally). Real validation is stress-running this shard in CI once rebased on merged #4174.

Refs CT-1738.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Settle the view before clicking in `clickCfButtonAndWaitForText` to avoid dropped clicks and flaky waits, and improve `viewSettled` diagnostics when updates throw. Uses settle → click once → settle-and-wait; addresses CT-1738.

- **Bug Fixes**
  - Reworked `clickCfButtonAndWaitForText` to call `awaitViewSettled(page)` (from `@commonfabric/integration`) before the click, click exactly once, then re-settle while waiting for the text; uses one shared timeout and a fast path if the text is already present.
  - Updated `drainViewUpdates` to return `{ churned, errors }`, and `viewSettled` to warn with the last thrown update error when giving up after `maxPasses`; tests adjusted accordingly.

<sup>Written for commit 29b2aa1ec234afd67bc043bf2954e6ffce1f97a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

