### PR TITLE
Make lunch poll host takeover explicit

### DIFF
--- a/packages/patterns/lunch-poll/participant-identity-card.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.tsx
@@ -139,7 +139,6 @@ export default pattern<
 >(
   ({ users, myName, adminName }) => {
     const joinName = Writable.perSession.of<string>("");
-    const claimHostRevealed = Writable.perSession.of<boolean>(false);
     const profileNameWish = wish<string>({ query: "#profileName" });
     const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
 
@@ -170,7 +169,6 @@ export default pattern<
       const viewer = trimmedName(myName.get());
       return viewer !== "" && viewer !== trimmedName(adminName.get());
     });
-    const isClaimHostRevealed = computed(() => claimHostRevealed.get());
 
     return {
       [NAME]: "Participant identity",
@@ -227,65 +225,33 @@ export default pattern<
           )}
 
           {canClaimHost
-            ? (isClaimHostRevealed
-              ? (
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "8px",
-                    flexWrap: "wrap",
-                    padding: "8px 12px",
-                    marginBottom: "16px",
-                    backgroundColor: "#eef2ff",
-                    border: "1px solid #c7d2fe",
-                    borderRadius: "8px",
-                    fontSize: "13px",
-                    color: "#3730a3",
-                  }}
+            ? (
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  flexWrap: "wrap",
+                  padding: "8px 12px",
+                  marginBottom: "16px",
+                  backgroundColor: "#eef2ff",
+                  border: "1px solid #c7d2fe",
+                  borderRadius: "8px",
+                  fontSize: "13px",
+                  color: "#3730a3",
+                }}
+              >
+                <span>{joinHint}</span>
+                <cf-button
+                  size="sm"
+                  variant="secondary"
+                  aria-label="Become host"
+                  onClick={() => boundClaimHost.send({})}
                 >
-                  <span>{joinHint}</span>
-                  <cf-button
-                    size="sm"
-                    variant="secondary"
-                    onClick={() => {
-                      boundClaimHost.send({});
-                      claimHostRevealed.set(false);
-                    }}
-                  >
-                    Become host
-                  </cf-button>
-                  <cf-button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => claimHostRevealed.set(false)}
-                  >
-                    Cancel
-                  </cf-button>
-                </div>
-              )
-              : (
-                <div style={{ marginBottom: "16px" }}>
-                  <button
-                    type="button"
-                    aria-label="Hosting info — click to take over as host"
-                    title="Click to take over as host"
-                    style={{
-                      background: "none",
-                      border: "none",
-                      padding: 0,
-                      fontSize: "13px",
-                      color: "#6b7280",
-                      cursor: "pointer",
-                      textDecoration: "underline dotted",
-                      textUnderlineOffset: "3px",
-                    }}
-                    onClick={() => claimHostRevealed.set(true)}
-                  >
-                    {joinHint}
-                  </button>
-                </div>
-              ))
+                  Become host
+                </cf-button>
+              </div>
+            )
             : null}
         </div>
       ),


### PR DESCRIPTION
## Why

The lunch poll host takeover affordance was hidden behind a dotted-underlined status label and, under load, the intermediate reveal state could take a long time to appear. The host transfer action should be obvious and direct before deploying the pattern to Toolshed.

## What Changed

- Replaced the hidden host label reveal flow with a visible Become host button for joined non-host participants.
- Removed the per-session reveal cell and confirm/cancel state.
- Kept the existing claimHost stream contract by sending the empty payload.

## Test plan

- deno task cf check packages/patterns/lunch-poll/participant-identity-card.tsx
- deno task cf check packages/patterns/lunch-poll/main.tsx
- deno task cf test packages/patterns/lunch-poll/participant-identity-card.test.tsx
- deno task cf test packages/patterns/lunch-poll/main.test.tsx
- deno task cf test packages/patterns/lunch-poll/poll-option-card.test.tsx
- deno task cf test packages/patterns/lunch-poll/multi-user.test.tsx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the hidden host takeover flow with a visible “Become host” button for joined non-host participants, making host transfer obvious and faster under load. Keeps the existing `claimHost` stream contract by sending an empty payload.

- **New Features**
  - Added a visible “Become host” button with an aria-label for accessibility.
  - Removed the reveal and confirm/cancel states to reduce clicks and latency.
  - Continued to send `{}` to `claimHost` to preserve the current behavior.

<sup>Written for commit 57646c6af999bcf44f51d87f31eb90e13c95e3db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

