### PR TITLE
Fix sandbox tokenizer dropping regexAllowed across whitespace

### DIFF
--- a/packages/runner/src/sandbox/compiled-js-parser.ts
+++ b/packages/runner/src/sandbox/compiled-js-parser.ts
@@ -1153,6 +1153,16 @@ function advanceScanner(
 
   const charCode = source.charCodeAt(cursor);
 
+  // Trivia is transparent to regex-vs-division classification: the previous
+  // significant token decides whether the next `/` opens a regex literal, so
+  // skipping it leaves `regexAllowed` unchanged. Leading whitespace consumes any
+  // following comments through skipTrivia, mirroring how a leading comment (in
+  // the `/` branch below) already consumes following whitespace — a run of mixed
+  // whitespace and comments is skipped the same way regardless of its order.
+  if (isWhitespaceCode(charCode)) {
+    return skipTrivia(source, cursor, end);
+  }
+
   if (charCode === 39 || charCode === 34) {
     state.regexAllowed = false;
     return scanStringLiteral(source, cursor, charCode, end);

--- a/packages/runner/test/esm-module-body-verifier.test.ts
+++ b/packages/runner/test/esm-module-body-verifier.test.ts
@@ -134,4 +134,44 @@ describe("verifyCompiledModuleBody", () => {
     }, "/main.ts");
     expect(() => verifyCompiledModuleBody(body, "/main.ts")).toThrow();
   });
+
+  it("accepts a module with several regex literals", () => {
+    // The scanner classifies each `/` as a regex start or a division operator
+    // based on the previous token. Whitespace between a regex-prefix keyword
+    // (e.g. `return`) and the regex must stay transparent to that decision —
+    // otherwise the opening `/` is read as division and a later `/` (after a
+    // `+` quantifier or `]` class close that re-allows a regex) is mistaken for
+    // a regex start, running the closing-`/` scan off the end of the module.
+    const body = compiledBody({
+      "/regexes.ts": `export function anchored(s: string): boolean {\n` +
+        `  return /^#[\\p{L}\\p{M}\\p{Nd}_]+/u.test(s);\n` +
+        `}\n` +
+        `export function global(s: string): string[] {\n` +
+        `  return s.match(/#[\\p{L}\\p{M}\\p{Nd}_]+/gu) ?? [];\n` +
+        `}\n` +
+        `export function charClass(s: string): boolean {\n` +
+        `  return /[a-z0-9]+/u.test(s);\n` +
+        `}\n` +
+        `export function escapedSlash(s: string): boolean {\n` +
+        `  return /a\\/b/u.test(s);\n` +
+        `}\n`,
+    }, "/regexes.ts");
+    expect(() => verifyCompiledModuleBody(body, "/regexes.ts")).not.toThrow();
+  });
+
+  it("still classifies real division after the whitespace fix", () => {
+    // The companion regression: making whitespace transparent must not turn a
+    // genuine division operator into a regex. A module that only divides should
+    // verify (the `/` is an operator, never a literal).
+    const body = compiledBody({
+      "/division.ts":
+        `export function ratio(x: number, y: number): number {\n` +
+        `  return x / y / 2;\n` +
+        `}\n` +
+        `export function half(x: number): number {\n` +
+        `  return (x + 1) / 2;\n` +
+        `}\n`,
+    }, "/division.ts");
+    expect(() => verifyCompiledModuleBody(body, "/division.ts")).not.toThrow();
+  });
 });


### PR DESCRIPTION
The compiled-bundle tokenizer in compiled-js-parser.ts misclassified regular-expression literals in any module whose source contained a regex with a quantifier or character class before its closing slash. The module verifier reported "Unterminated regular expression" and rejected the module, so `deno task cf check` failed on otherwise-valid code.

The scanner decides whether a `/` opens a regex literal or is a division operator from a `regexAllowed` flag that tracks the previous significant token. The scanning loop calls advanceScanner on every character, including whitespace, and whitespace fell through to the switch's default branch, which clears regexAllowed. A space between a regex-prefix keyword and the regex therefore reset the flag that the keyword had just set.

For `return /^#[ab]+/u.test(s)` the failure unfolds as:

  1. `return` sets regexAllowed = true.
  2. The following space hits the default branch and clears it.
  3. The opening `/` is read as division (looksLikeRegexStart only recognizes punctuation prefixes, not keywords, so it does not rescue it).
  4. The regex body is walked as ordinary tokens; the `+` quantifier sets regexAllowed = true again, so the regex's closing `/` is taken for a regex opener and the scan for its closing `/` runs off the end of the module.

A plain literal such as `/x/u` hits the same misclassification but, with nothing re-enabling regexAllowed before its closing slash, silently tokenizes as two divisions instead of throwing. The crash needs a quantifier, `*`, or class-close before the closing slash, which a second regex literal reliably introduces -- hence the original "two regex literals" framing.

The fix makes trivia transparent in advanceScanner: a whitespace character is skipped through skipTrivia without touching regexAllowed, so the previous significant token continues to govern the next `/`. Routing whitespace through skipTrivia (rather than advancing one character) also keeps trivia handling order-independent: a leading whitespace run consumes any following comments in the same step, mirroring how the comment branch already consumes following whitespace. Because the change is in advanceScanner itself, it covers every call site (statement splitting, comma lists, template expressions, and the AMD bundle path).

Add two tests through the full compile-then-verify pipeline: one module with anchored, global, unicode-flag, character-class, and escaped-slash regex literals (fails before the fix), and a division-only module that guards against misreading a genuine `/` operator as a regex.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sandbox tokenizer misclassifying regex literals after whitespace (e.g., after `return`), which caused "Unterminated regular expression" verifier errors and `deno task cf check` failures.

- **Bug Fixes**
  - In `advanceScanner`, treat whitespace as trivia and skip via `skipTrivia` without changing `regexAllowed`, preserving regex-vs-division decisions across spaces/comments and making trivia skipping order-independent.
  - Applies across all scan paths (statement splitting, lists, template expressions, AMD). Adds end-to-end tests: a module with several regex forms and a division-only module.

<sup>Written for commit 0bd84c2f7b837179382477ce0f0a35738438af39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

