### PR TITLE
refactor(runner): drop orphaned ALL_PIECES_ID well-known constant

### DIFF
--- a/packages/runner/src/builtins/well-known.ts
+++ b/packages/runner/src/builtins/well-known.ts
@@ -1,9 +1,0 @@
-/**
- * Well-known entity IDs and patterns used by built-in functions.
- */
-
-/**
- * Well-known entity ID for the all pieces list.
- */
-export const ALL_PIECES_ID =
-  "baedreiahv63wxwgaem4hzjkizl4qncfgvca7pj5cvdon7cukumfon3ioye";

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
+import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
-import { ALL_PIECES_ID } from "../src/builtins/well-known.ts";
 import { NAME, UI } from "../src/builder/types.ts";
 import { parseWishTarget, tagMatchesHashtag } from "../src/builtins/wish.ts";
 import {
@@ -16,6 +16,11 @@ import {
 
 const signer = await Identity.fromPassphrase("wish built-in tests");
 const space = signer.did();
+
+// Stable entity id used to address the test's "all pieces" cell. The value is
+// opaque to these tests, which set up the cell and the space link to it
+// directly; it's a real content-hash id so it stays well-formed.
+const allPiecesId = taggedHashStringOf("all-pieces");
 
 describe("wish built-in", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
@@ -46,7 +51,7 @@ describe("wish built-in", () => {
   it("resolves the well known all pieces cell", async () => {
     const allPiecesCell = runtime.getCellFromEntityId<unknown[]>(
       space,
-      { "/": ALL_PIECES_ID },
+      { "/": allPiecesId },
       [],
       undefined,
       tx,
@@ -100,13 +105,13 @@ describe("wish built-in", () => {
     expect(result.key("firstPieceTitle").get()?.result).toEqual(
       piecesData[0].title,
     );
-    expect(linkData?.id).toEqual(`of:${ALL_PIECES_ID}`);
+    expect(linkData?.id).toEqual(`of:${allPiecesId}`);
   });
 
   it("resolves semantic wishes with # prefixes", async () => {
     const allPiecesCell = runtime.getCellFromEntityId(
       space,
-      { "/": ALL_PIECES_ID },
+      { "/": allPiecesId },
       [],
       undefined,
       tx,
@@ -418,7 +423,7 @@ describe("wish built-in", () => {
     it("resolves allPieces using tag parameter", async () => {
       const allPiecesCell = runtime.getCellFromEntityId<unknown[]>(
         space,
-        { "/": ALL_PIECES_ID },
+        { "/": allPiecesId },
         [],
         undefined,
         tx,
@@ -466,7 +471,7 @@ describe("wish built-in", () => {
     it("resolves nested paths using tag and path parameters", async () => {
       const allPiecesCell = runtime.getCellFromEntityId<unknown[]>(
         space,
-        { "/": ALL_PIECES_ID },
+        { "/": allPiecesId },
         [],
         undefined,
         tx,
@@ -520,7 +525,7 @@ describe("wish built-in", () => {
     it("resolves slashed path embedded in tag query", async () => {
       const allPiecesCell = runtime.getCellFromEntityId<unknown[]>(
         space,
-        { "/": ALL_PIECES_ID },
+        { "/": allPiecesId },
         [],
         undefined,
         tx,

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
+import { hashOf } from "@commonfabric/data-model/value-hash";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { createBuilder } from "../src/builder/factory.ts";
@@ -20,7 +20,8 @@ const space = signer.did();
 // Stable entity id used to address the test's "all pieces" cell. The value is
 // opaque to these tests, which set up the cell and the space link to it
 // directly; it's a real content-hash id so it stays well-formed.
-const allPiecesId = taggedHashStringOf("all-pieces");
+const allPiecesEntityId = hashOf("all-pieces");
+const allPiecesId = allPiecesEntityId.taggedHashString;
 
 describe("wish built-in", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
@@ -51,7 +52,7 @@ describe("wish built-in", () => {
   it("resolves the well known all pieces cell", async () => {
     const allPiecesCell = runtime.getCellFromEntityId<unknown[]>(
       space,
-      { "/": allPiecesId },
+      allPiecesEntityId,
       [],
       undefined,
       tx,
@@ -111,7 +112,7 @@ describe("wish built-in", () => {
   it("resolves semantic wishes with # prefixes", async () => {
     const allPiecesCell = runtime.getCellFromEntityId(
       space,
-      { "/": allPiecesId },
+      allPiecesEntityId,
       [],
       undefined,
       tx,
@@ -423,7 +424,7 @@ describe("wish built-in", () => {
     it("resolves allPieces using tag parameter", async () => {
       const allPiecesCell = runtime.getCellFromEntityId<unknown[]>(
         space,
-        { "/": allPiecesId },
+        allPiecesEntityId,
         [],
         undefined,
         tx,
@@ -471,7 +472,7 @@ describe("wish built-in", () => {
     it("resolves nested paths using tag and path parameters", async () => {
       const allPiecesCell = runtime.getCellFromEntityId<unknown[]>(
         space,
-        { "/": allPiecesId },
+        allPiecesEntityId,
         [],
         undefined,
         tx,
@@ -525,7 +526,7 @@ describe("wish built-in", () => {
     it("resolves slashed path embedded in tag query", async () => {
       const allPiecesCell = runtime.getCellFromEntityId<unknown[]>(
         space,
-        { "/": allPiecesId },
+        allPiecesEntityId,
         [],
         undefined,
         tx,


### PR DESCRIPTION
## What

Removes `ALL_PIECES_ID` from `packages/runner/src/builtins/well-known.ts` (and the now-empty module along with it).

## Why

`ALL_PIECES_ID` was a stale **CIDv1-format** id (`baedrei…`) left over from before the system moved off CIDv1 entity ids — a bug that it was never updated. It turns out to have no production consumers at all: the only reference anywhere was `wish.test.ts`, so the entire `well-known.ts` module existed solely to hold this one dead, wrong-format constant.

## How

- Delete `builtins/well-known.ts`.
- In `wish.test.ts`, mint a local id via `hashOf("all-pieces")` (a real, already-frozen `FabricHash`, matching how entity ids are actually produced) and derive the string form via `.taggedHashString`. The repeated `{ "/": … }` literal is hoisted into a single `allPiecesEntityId` const. The value is opaque to the test, which sets up the all-pieces cell and the space link to it directly.

## Testing

- `deno check packages/runner/test/wish.test.ts` — clean.
- `deno fmt --check` — clean.
- `deno test packages/runner/test/wish.test.ts` — the all-pieces resolution tests pass. One unrelated test (`fetches the profile-create pattern … apiUrl`) fails identically on clean `main` — it's an offline network-fetch test, not affected by this change.

## Note

Two *other* files independently hardcode the same CIDv1 string (not the symbol): a CLI help example in `cli/commands/piece.ts` and a test token in `cli/test/charm.test.ts`. Left out of scope here; can be cleaned up separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

This PR removes a dead file and makes perf-neutral edits to the one unit test that used it.

NEW_PERF_BASELINE: job: Pattern Reload Integration Tests = 96s
NEW_PERF_BASELINE: job: Package Integration Tests (runtime-client) = 104s
NEW_PERF_BASELINE: job: CLI Integration Tests (fuse) = 107s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the stale CIDv1 `ALL_PIECES_ID` and delete the unused `builtins/well-known.ts` module. Tests now derive a real `FabricHash` for the “all pieces” id using `hashOf("all-pieces")`, matching how ids are produced.

- **Refactors**
  - Delete `packages/runner/src/builtins/well-known.ts` and its `ALL_PIECES_ID`.
  - Update `packages/runner/test/wish.test.ts` to mint `allPiecesEntityId` via `hashOf("all-pieces")` and use `.taggedHashString` in assertions.

<sup>Written for commit c796c0734e3eeeda264d19d46a885ac4db0c6c7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

