### PR TITLE
test(cfc): configurable N-browser group chat + IPC/conflict instrumentation

### DIFF
--- a/packages/integration/env.ts
+++ b/packages/integration/env.ts
@@ -21,6 +21,15 @@ export const PIPE_CONSOLE = envToBool(Deno.env.get("PIPE_CONSOLE"));
 export const SPACE_NAME = Deno.env.get("SPACE_NAME") ??
   globalThis.crypto.randomUUID();
 
+// Number of concurrent browser profiles for multi-browser CFC tests.
+// Defaults to 2 (the minimum that exercises per-user isolation + shared-state
+// liveness). Raise it — e.g. `CFC_BROWSER_PROFILE_COUNT=4` — to amplify
+// cross-browser sync contention when reproducing dual-browser slowness.
+export const CFC_BROWSER_PROFILE_COUNT = (() => {
+  const raw = Number(Deno.env.get("CFC_BROWSER_PROFILE_COUNT"));
+  return Number.isInteger(raw) && raw >= 2 ? raw : 2;
+})();
+
 function ensureTrailing(value: string): string {
   return value.substr(-1) === "/" ? value : `${value}/`;
 }

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -836,17 +836,18 @@ export async function collectBrowserLoadSummary(
     try {
       const workerCounts = await cf?.rt?.getLoggerCounts?.();
       const workerTiming = workerCounts?.timing ?? {};
+      // Prefix-match so sub-loggers are included: storage commit/conflict
+      // timings live under `storage.v2` (+ `.transaction`/`.multi-space-commit`),
+      // not a bare `storage` logger; runner/scheduler similarly have sub-loggers.
+      const prefixes = ["scheduler", "runner", "storage"];
+      const includeLogger = (name: string): boolean =>
+        name === "runtime-client.cfc-label" ||
+        prefixes.some((prefix) =>
+          name === prefix || name.startsWith(`${prefix}.`)
+        );
       const selected: Record<string, Stats> = {};
-      for (
-        const name of [
-          "scheduler",
-          "runner",
-          "storage",
-          "runtime-client.cfc-label",
-        ]
-      ) {
-        const groupStats = workerTiming[name];
-        if (!groupStats) continue;
+      for (const [name, groupStats] of Object.entries(workerTiming)) {
+        if (!includeLogger(name)) continue;
         for (const [key, stats] of Object.entries(groupStats)) {
           selected[`${name}/${key}`] = stats;
         }

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -837,14 +837,21 @@ export async function collectBrowserLoadSummary(
       const workerCounts = await cf?.rt?.getLoggerCounts?.();
       const workerTiming = workerCounts?.timing ?? {};
       const selected: Record<string, Stats> = {};
-      for (const name of ["scheduler", "runner", "storage"]) {
+      for (
+        const name of [
+          "scheduler",
+          "runner",
+          "storage",
+          "runtime-client.cfc-label",
+        ]
+      ) {
         const groupStats = workerTiming[name];
         if (!groupStats) continue;
         for (const [key, stats] of Object.entries(groupStats)) {
           selected[`${name}/${key}`] = stats;
         }
       }
-      worker = toRows(selected, 12);
+      worker = toRows(selected, 16);
 
       const counts: Record<string, Record<string, CountEntry>> =
         workerCounts?.counts ?? {};

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -716,6 +716,225 @@ type TimingRow = {
   max: number;
 };
 
+/**
+ * One timing-stats row distilled from a logger's `timeStats` (ms). Used to
+ * surface where wall-clock goes under multi-browser contention — chiefly the
+ * main-thread `runtime-client` IPC round-trips, which are what time out with
+ * "RuntimeClient request timed out" when the worker can't keep up.
+ */
+export interface TimingStatRow {
+  key: string;
+  count: number;
+  average: number;
+  p50: number;
+  p95: number;
+  max: number;
+  total: number;
+}
+
+/**
+ * Counters that quantify how much the worker re-ran and how often writes lost a
+ * conflict, read back from `getLoggerCounts().counts`. Conflicts that ratchet
+ * (a non-falling, bounded count) rather than storm is the healthy steady state:
+ * a stale-seq write is rejected, the optimistic value is dropped, the
+ * computation re-runs once against confirmed state, and settles.
+ */
+export interface ChurnCounters {
+  /** Total computation/effect runs (`scheduler/run/action`). */
+  actionRuns: number;
+  /** Commit conflicts — stale-seq-basis rejections (`storage.v2/commit-conflict`). */
+  commitConflicts: number;
+  /** Reverts emitted after a rejected commit (`storage.v2/commit-revert`). */
+  commitReverts: number;
+  /** Non-conflict commit rejections (`storage.v2/commit-rejected`). */
+  commitRejected: number;
+  /** Reactive-action commit errors that triggered a retry (`scheduler/schedule-run-error`). */
+  scheduleRunErrors: number;
+  /** Event handlers that lost the receipt race permanently (`scheduler/event-lost-race`). */
+  eventLostRaces: number;
+}
+
+export interface BrowserLoadSummary {
+  label: string;
+  /**
+   * Main-thread `runtime-client` IPC round-trip timing. p95/max here ballooning
+   * (and approaching the 60s request timeout) is the multi-browser-slowness
+   * signal: the main thread is waiting on a saturated worker.
+   */
+  ipc: TimingStatRow[];
+  /** Worker-side scheduler/runner/storage timing — where the work happens. */
+  worker: TimingStatRow[];
+  /** Conflict / re-run counters — see {@link ChurnCounters}. */
+  churn: ChurnCounters;
+}
+
+/**
+ * Collect aggregate timing stats from one browser: main-thread IPC round-trips
+ * (`commonfabric.getTimingStatsBreakdown()`) plus the worker's
+ * scheduler/runner/storage timing (`commonfabric.rt.getLoggerCounts()`). One
+ * IPC round-trip; safe to call in a `finally`/teardown (worker errors are
+ * swallowed). Reading these across all profiles after a run quantifies the
+ * cross-browser contention behind dual-browser slowness.
+ */
+export async function collectBrowserLoadSummary(
+  page: Page,
+  label: string,
+): Promise<BrowserLoadSummary> {
+  const collected = await page.evaluate(async () => {
+    type Stats = {
+      count?: number;
+      average?: number;
+      p50?: number;
+      p95?: number;
+      max?: number;
+      totalTime?: number;
+    };
+    const round = (value: number | undefined): number =>
+      Number((value ?? 0).toFixed(2));
+    const toRows = (
+      group: Record<string, Stats> | undefined,
+      limit: number,
+    ) =>
+      Object.entries(group ?? {})
+        .map(([key, stats]) => ({
+          key,
+          count: stats.count ?? 0,
+          average: round(stats.average),
+          p50: round(stats.p50),
+          p95: round(stats.p95),
+          max: round(stats.max),
+          total: round(stats.totalTime),
+        }))
+        .sort((a, b) => b.total - a.total)
+        .slice(0, limit);
+
+    type CountEntry = { total?: number } | number | undefined;
+    const cf = (globalThis as typeof globalThis & {
+      commonfabric?: {
+        getTimingStatsBreakdown?: () => Record<string, Record<string, Stats>>;
+        rt?: {
+          getLoggerCounts?: () => Promise<{
+            timing?: Record<string, Record<string, Stats>>;
+            counts?: Record<string, Record<string, CountEntry>>;
+          }>;
+        };
+      };
+    }).commonfabric;
+
+    const mainTiming = cf?.getTimingStatsBreakdown?.() ?? {};
+    const ipc = toRows(mainTiming["runtime-client"], 12);
+
+    let worker: ReturnType<typeof toRows> = [];
+    const churn = {
+      actionRuns: 0,
+      commitConflicts: 0,
+      commitReverts: 0,
+      commitRejected: 0,
+      scheduleRunErrors: 0,
+      eventLostRaces: 0,
+    };
+    try {
+      const workerCounts = await cf?.rt?.getLoggerCounts?.();
+      const workerTiming = workerCounts?.timing ?? {};
+      const selected: Record<string, Stats> = {};
+      for (const name of ["scheduler", "runner", "storage"]) {
+        const groupStats = workerTiming[name];
+        if (!groupStats) continue;
+        for (const [key, stats] of Object.entries(groupStats)) {
+          selected[`${name}/${key}`] = stats;
+        }
+      }
+      worker = toRows(selected, 12);
+
+      const counts: Record<string, Record<string, CountEntry>> =
+        workerCounts?.counts ?? {};
+      const countOf = (logger: string, key: string): number => {
+        const entry = counts[logger]?.[key];
+        return typeof entry === "number" ? entry : entry?.total ?? 0;
+      };
+      churn.actionRuns = countOf("scheduler", "schedule-run-start");
+      churn.commitConflicts = countOf("storage.v2", "commit-conflict");
+      churn.commitReverts = countOf("storage.v2", "commit-revert");
+      churn.commitRejected = countOf("storage.v2", "commit-rejected");
+      churn.scheduleRunErrors = countOf("scheduler", "schedule-run-error");
+      churn.eventLostRaces = countOf("scheduler", "event-lost-race");
+    } catch {
+      // Worker may be disposed during teardown — main-thread IPC still tells
+      // the contention story.
+    }
+
+    return { ipc, worker, churn };
+  });
+  return {
+    label,
+    ipc: collected.ipc,
+    worker: collected.worker,
+    churn: collected.churn,
+  };
+}
+
+/**
+ * Times labeled async steps so a run can report where its wall-clock went.
+ * `run` records the elapsed ms even when the wrapped step throws, so a timed-
+ * out propagation wait still shows up in the summary.
+ */
+export class StepTimer {
+  #rows: Array<{ label: string; ms: number }> = [];
+
+  async run<T>(label: string, fn: () => Promise<T>): Promise<T> {
+    const start = performance.now();
+    try {
+      return await fn();
+    } finally {
+      this.#rows.push({ label, ms: Math.round(performance.now() - start) });
+    }
+  }
+
+  rows(): ReadonlyArray<{ label: string; ms: number }> {
+    return this.#rows;
+  }
+}
+
+export function logStepTimings(label: string, timer: StepTimer): void {
+  const rows = timer.rows();
+  if (rows.length === 0) return;
+  const total = rows.reduce((sum, row) => sum + row.ms, 0);
+  const lines = rows.map((row) =>
+    `  ${String(row.ms).padStart(8)}ms  ${row.label}`
+  );
+  console.log(
+    `\n[${label}] step timings (total ${total}ms):\n${lines.join("\n")}`,
+  );
+}
+
+export function logBrowserLoadSummary(summary: BrowserLoadSummary): void {
+  const formatRows = (rows: TimingStatRow[]): string =>
+    rows.length === 0
+      ? "    (none)"
+      : rows.map((row) =>
+        `    ${row.key.padEnd(30)} n=${String(row.count).padStart(5)}` +
+        ` p50=${String(row.p50).padStart(8)} p95=${
+          String(row.p95).padStart(8)
+        }` +
+        ` max=${String(row.max).padStart(9)} total=${
+          String(row.total).padStart(10)
+        }`
+      ).join("\n");
+  const c = summary.churn;
+  const churnLine = `    actionRuns=${c.actionRuns}` +
+    ` commitConflicts=${c.commitConflicts} commitReverts=${c.commitReverts}` +
+    ` commitRejected=${c.commitRejected}` +
+    ` scheduleRunErrors=${c.scheduleRunErrors}` +
+    ` eventLostRaces=${c.eventLostRaces}`;
+  console.log(
+    `\n[${summary.label}] main-thread runtime-client IPC round-trips (ms):\n` +
+      `${formatRows(summary.ipc)}\n` +
+      `[${summary.label}] worker scheduler/runner/storage (ms):\n` +
+      `${formatRows(summary.worker)}\n` +
+      `[${summary.label}] churn / conflict counters:\n${churnLine}`,
+  );
+}
+
 type GraphNode = {
   id: string;
   type: "effect" | "computation" | "input" | "inactive";

--- a/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
@@ -1,12 +1,23 @@
 /**
- * Two-browser-profile test for the CFC group chat demo.
+ * Multi-browser-profile test for the CFC group chat demo.
  *
  * Unlike cfc-group-chat-demo.test.ts (which switches identity on ONE page),
- * this drives two SIMULTANEOUS browser instances — separate profiles,
- * separate identities, same piece — and checks the multi-user contract that
- * a single page cannot: per-user state isolation while both users are live,
- * live propagation of shared state, and admin lockdown not interfering with
- * the other user's ability to post.
+ * this drives N SIMULTANEOUS browser instances — separate profiles, separate
+ * identities, same piece — and checks the multi-user contract that a single
+ * page cannot: per-user state isolation while every user is live, live
+ * propagation of shared state, and admin lockdown not interfering with the
+ * other users' ability to post.
+ *
+ * The profile count defaults to 2 (the historical "two browsers" case) and is
+ * configurable via `CFC_BROWSER_PROFILE_COUNT` — raise it to amplify the
+ * cross-browser sync contention behind the dual-browser slowness. Every
+ * reactive step is timed, and after the run each browser's aggregate IPC /
+ * worker timing is dumped, so a slow or flaky run reports WHERE the wall-clock
+ * went (chiefly main-thread `runtime-client` IPC round-trips waiting on a
+ * saturated worker). Raising the count to 3+ reliably reproduced the
+ * handler-lifetime race fixed in #4146 (Bob's save lost, status stuck at
+ * "Name not set"); the save steps drive the trusted action by its marker and
+ * retry, so a single dropped dispatch can no longer wedge the run.
  *
  * The deeper state-machine coverage lives in the headless
  * cfc-group-chat-demo-multi-runtime.test.ts; this test guards the real
@@ -17,6 +28,8 @@ import { env } from "@commonfabric/integration";
 import { Identity } from "@commonfabric/identity";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { PiecesController } from "@commonfabric/piece/ops";
+import { UI } from "@commonfabric/runner";
+import { debugVDOMSchema } from "@commonfabric/runner/schemas";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { assertEquals } from "@std/assert";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
@@ -24,172 +37,351 @@ import { join } from "@std/path";
 import {
   clickCfButton,
   clickTrustedActionAndWaitForText,
+  collectBrowserLoadSummary,
   fillCfInput,
+  logBrowserLoadSummary,
+  logStepTimings,
   readCfInputValue,
+  StepTimer,
   waitForDisabled,
   waitForRuntimeIdle,
   waitForText,
 } from "./cfc-browser-helpers.ts";
 
-const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
+const { API_URL, FRONTEND_URL, SPACE_NAME, CFC_BROWSER_PROFILE_COUNT } = env;
 const PROPAGATION_TIMEOUT = 60_000;
 const SAVE_PROFILE_ACTION = "TrustedGroupChatSaveProfile";
+const PROFILE_COUNT = Math.max(2, CFC_BROWSER_PROFILE_COUNT);
 
-describe("cfc group chat demo with two concurrent browser profiles", () => {
-  const aliceShell = new ShellIntegration();
-  const bobShell = new ShellIntegration();
-  aliceShell.bindLifecycle();
-  bobShell.bindLifecycle();
+// Deterministic, distinct names so isolation/liveness assertions read clearly.
+const NAME_POOL = [
+  "Alice",
+  "Bob",
+  "Carol",
+  "Dave",
+  "Erin",
+  "Frank",
+  "Grace",
+  "Heidi",
+  "Ivan",
+  "Judy",
+];
+const profileName = (index: number): string =>
+  NAME_POOL[index] ?? `User${index + 1}`;
 
-  let aliceIdentity: Identity;
-  let bobIdentity: Identity;
-  let cc: PiecesController;
-  let pieceId: string;
-  let pieceSinkCancel: (() => void) | undefined;
+describe(
+  `cfc group chat demo with ${PROFILE_COUNT} concurrent browser profiles`,
+  () => {
+    const shells = Array.from(
+      { length: PROFILE_COUNT },
+      () => new ShellIntegration(),
+    );
+    shells.forEach((shell) => shell.bindLifecycle());
 
-  beforeAll(async () => {
-    aliceIdentity = await Identity.generate({ implementation: "noble" });
-    bobIdentity = await Identity.generate({ implementation: "noble" });
-    cc = await PiecesController.initialize({
-      spaceName: SPACE_NAME,
-      apiUrl: new URL(API_URL),
-      identity: aliceIdentity,
+    const userNames = Array.from(
+      { length: PROFILE_COUNT },
+      (_, index) => profileName(index),
+    );
+
+    let identities: Identity[];
+    let cc: PiecesController;
+    let pieceId: string;
+    let pieceSinkCancel: (() => void) | undefined;
+    let uiSinkCancel: (() => void) | undefined;
+
+    beforeAll(async () => {
+      identities = await Promise.all(
+        Array.from(
+          { length: PROFILE_COUNT },
+          () => Identity.generate({ implementation: "noble" }),
+        ),
+      );
+      cc = await PiecesController.initialize({
+        spaceName: SPACE_NAME,
+        apiUrl: new URL(API_URL),
+        identity: identities[0],
+      });
+
+      const sourcePath = join(
+        import.meta.dirname!,
+        "..",
+        "cfc-group-chat-demo",
+        "main.tsx",
+      );
+      const rootPath = join(import.meta.dirname!, "..");
+      const program = await cc.manager().runtime.harness.resolve(
+        new FileSystemProgramResolver(sourcePath, rootPath),
+      );
+      const piece = await cc.create(program, { start: true });
+      pieceId = piece.id;
+      const resultCell = cc.manager().getResult(piece.getCell());
+      pieceSinkCancel = resultCell.sink(() => {});
+      // Pull on [UI] with the cell-less vdom schema (children expanded inline,
+      // no asCell) so the controller materializes the WHOLE tree: every UI
+      // computed runs and stays subscribed. That extra generation churn on the
+      // shared space is what makes the concurrent-browser reproduction
+      // realistic — more writes to race, more chances to conflict.
+      uiSinkCancel = resultCell.key(UI).asSchema(debugVDOMSchema).sink(
+        () => {},
+      );
     });
 
-    const sourcePath = join(
-      import.meta.dirname!,
-      "..",
-      "cfc-group-chat-demo",
-      "main.tsx",
-    );
-    const rootPath = join(import.meta.dirname!, "..");
-    const program = await cc.manager().runtime.harness.resolve(
-      new FileSystemProgramResolver(sourcePath, rootPath),
-    );
-    const piece = await cc.create(program, { start: true });
-    pieceId = piece.id;
-    const resultCell = cc.manager().getResult(piece.getCell());
-    pieceSinkCancel = resultCell.sink(() => {});
-  });
+    afterAll(async () => {
+      uiSinkCancel?.();
+      pieceSinkCancel?.();
+      await cc?.dispose();
+    });
 
-  afterAll(async () => {
-    pieceSinkCancel?.();
-    await cc?.dispose();
-  });
+    it("keeps per-user state isolated and shared state live across browsers", async () => {
+      const timer = new StepTimer();
+      const view = { spaceName: SPACE_NAME, pieceId };
+      const pages = shells.map((shell) => shell.page());
+      const others = (index: number) =>
+        pages.filter((_, other) => other !== index);
 
-  it("keeps per-user state isolated and shared state live across two browsers", async () => {
-    const alice = aliceShell.page();
-    const bob = bobShell.page();
-    const view = { spaceName: SPACE_NAME, pieceId };
-    await Promise.all([
-      aliceShell.goto({
-        frontendUrl: FRONTEND_URL,
-        view,
-        identity: aliceIdentity,
-      }),
-      bobShell.goto({ frontendUrl: FRONTEND_URL, view, identity: bobIdentity }),
-    ]);
-    await waitForRuntimeIdle(alice);
-    await waitForRuntimeIdle(bob);
-    await waitForText(alice, "#group-chat-manager-chip", "No profile");
-    await waitForText(bob, "#group-chat-manager-chip", "No profile");
+      try {
+        await timer.run(
+          "navigate + login all profiles",
+          () =>
+            Promise.all(shells.map((shell, index) =>
+              shell.goto({
+                frontendUrl: FRONTEND_URL,
+                view,
+                identity: identities[index],
+              })
+            )),
+        );
+        await timer.run(
+          "runtime idle (all)",
+          () =>
+            Promise.all(
+              pages.map((page) =>
+                waitForRuntimeIdle(page, { timeout: PROPAGATION_TIMEOUT })
+              ),
+            ),
+        );
+        await timer.run(
+          "initial 'No profile' (all)",
+          () =>
+            Promise.all(
+              pages.map((page) =>
+                waitForText(page, "#group-chat-manager-chip", "No profile", {
+                  timeout: PROPAGATION_TIMEOUT,
+                })
+              ),
+            ),
+        );
 
-    // Typing a name in Alice's browser must NOT appear in Bob's input —
-    // the profile draft is per-user state.
-    await fillCfInput(alice, "#trusted-profile-name", "Alice");
-    await waitForRuntimeIdle(alice);
-    await waitForRuntimeIdle(bob);
-    assertEquals(
-      await readCfInputValue(bob, "#trusted-profile-name"),
-      "",
-      "Alice's profile-name draft leaked into Bob's browser",
-    );
+        // Typing a name in the first browser must NOT appear in any other
+        // browser's input — the profile draft is per-user state.
+        await fillCfInput(pages[0], "#trusted-profile-name", userNames[0]);
+        await Promise.all(
+          pages.map((page) =>
+            waitForRuntimeIdle(page, { timeout: PROPAGATION_TIMEOUT })
+          ),
+        );
+        for (let index = 1; index < pages.length; index++) {
+          assertEquals(
+            await readCfInputValue(pages[index], "#trusted-profile-name"),
+            "",
+            `${userNames[0]}'s profile-name draft leaked into ${
+              userNames[index]
+            }'s browser`,
+          );
+        }
 
-    // Alice saves her profile. Her status updates; Bob's profile must stay
-    // unset (not clobbered to Alice's).
-    await waitForDisabled(alice, "#trusted-profile-save", false);
-    await clickTrustedActionAndWaitForText(
-      alice,
-      SAVE_PROFILE_ACTION,
-      "#trusted-profile-status",
-      "Alice",
-    );
-    await waitForRuntimeIdle(alice);
-    await waitForRuntimeIdle(bob);
-    await waitForText(bob, "#trusted-profile-status", "Name not set");
-    await waitForText(bob, "#group-chat-manager-chip", "No profile");
-    await waitForText(
-      bob,
-      "#trusted-admin-user-list",
-      "Alice",
-      { timeout: PROPAGATION_TIMEOUT },
-    );
-    await waitForRuntimeIdle(bob);
+        // First user saves. The trusted action is driven by its marker and
+        // retried until the status flips, so a dropped dispatch can't wedge
+        // the run. Every other user's profile must stay unset (not clobbered).
+        await waitForDisabled(pages[0], "#trusted-profile-save", false);
+        await timer.run(
+          `${userNames[0]} save + own status`,
+          () =>
+            clickTrustedActionAndWaitForText(
+              pages[0],
+              SAVE_PROFILE_ACTION,
+              "#trusted-profile-status",
+              userNames[0],
+              { timeout: PROPAGATION_TIMEOUT },
+            ),
+        );
+        await Promise.all(
+          pages.map((page) =>
+            waitForRuntimeIdle(page, { timeout: PROPAGATION_TIMEOUT })
+          ),
+        );
+        for (let index = 1; index < pages.length; index++) {
+          await waitForText(
+            pages[index],
+            "#trusted-profile-status",
+            "Name not set",
+          );
+          await waitForText(
+            pages[index],
+            "#group-chat-manager-chip",
+            "No profile",
+          );
+        }
 
-    // Bob saves his own profile. Alice's view must show Bob by his actual
-    // name (not an unnamed placeholder), and her own profile must survive.
-    await fillCfInput(bob, "#trusted-profile-name", "Bob");
-    await waitForDisabled(bob, "#trusted-profile-save", false);
-    await clickTrustedActionAndWaitForText(
-      bob,
-      SAVE_PROFILE_ACTION,
-      "#trusted-profile-status",
-      "Bob",
-    );
-    await waitForText(
-      alice,
-      "#trusted-admin-user-list",
-      "Bob",
-      { timeout: PROPAGATION_TIMEOUT },
-    );
-    await waitForText(alice, "#trusted-profile-status", "Alice");
+        // Each remaining user, after the prior saver's name has reached them,
+        // saves their own profile.
+        for (let index = 1; index < pages.length; index++) {
+          await timer.run(
+            `${userNames[index]} sees ${userNames[index - 1]} before save`,
+            () =>
+              waitForText(
+                pages[index],
+                "#trusted-admin-user-list",
+                userNames[index - 1],
+                { timeout: PROPAGATION_TIMEOUT },
+              ),
+          );
+          await waitForRuntimeIdle(pages[index], {
+            timeout: PROPAGATION_TIMEOUT,
+          });
+          await fillCfInput(
+            pages[index],
+            "#trusted-profile-name",
+            userNames[index],
+          );
+          await waitForDisabled(pages[index], "#trusted-profile-save", false);
+          await timer.run(
+            `${userNames[index]} save + own status`,
+            () =>
+              clickTrustedActionAndWaitForText(
+                pages[index],
+                SAVE_PROFILE_ACTION,
+                "#trusted-profile-status",
+                userNames[index],
+                { timeout: PROPAGATION_TIMEOUT },
+              ),
+          );
+        }
 
-    // Shared transcript propagates live in both directions, with snapshot
-    // author names intact.
-    await fillCfInput(alice, "#trusted-message-draft", "Hello from Alice");
-    await waitForDisabled(alice, "#trusted-send-button", false);
-    await clickCfButton(alice, "#trusted-send-button");
-    await waitForText(
-      bob,
-      "#trusted-conversation-preview",
-      "Hello from Alice",
-      { timeout: PROPAGATION_TIMEOUT },
-    );
+        // Every user's view must show every OTHER user by their actual name
+        // (not an unnamed placeholder), and each user's own profile must
+        // survive. This is the cross-browser propagation that the dual-browser
+        // slowness most visibly degrades.
+        await timer.run(
+          "cross-browser name propagation (all pairs)",
+          () =>
+            Promise.all(pages.map(async (page, index) => {
+              for (let other = 0; other < pages.length; other++) {
+                if (other === index) continue;
+                await waitForText(
+                  page,
+                  "#trusted-admin-user-list",
+                  userNames[other],
+                  { timeout: PROPAGATION_TIMEOUT },
+                );
+              }
+              await waitForText(
+                page,
+                "#trusted-profile-status",
+                userNames[index],
+                { timeout: PROPAGATION_TIMEOUT },
+              );
+            })),
+        );
 
-    // Alice locks down admin. Bob loses admin (cannot add rooms) but must
-    // still be able to POST — message sending is never admin-gated.
-    await clickCfButton(alice, "#trusted-everyone-admin-checkbox");
-    await waitForText(alice, "#group-chat-manager-chip", "Can manage admins");
-    await waitForText(
-      bob,
-      "#trusted-room-admin-hint",
-      "Ask an admin manager to make you an admin",
-      { timeout: PROPAGATION_TIMEOUT },
-    );
-    await fillCfInput(
-      bob,
-      "#trusted-message-draft",
-      "Bob posts after lockdown",
-    );
-    await waitForDisabled(bob, "#trusted-send-button", false);
-    await clickCfButton(bob, "#trusted-send-button");
-    await waitForText(
-      alice,
-      "#trusted-conversation-preview",
-      "Bob posts after lockdown",
-      { timeout: PROPAGATION_TIMEOUT },
-    );
+        // Shared transcript propagates live to every other browser, with
+        // snapshot author names intact.
+        const helloMessage = `Hello from ${userNames[0]}`;
+        await fillCfInput(pages[0], "#trusted-message-draft", helloMessage);
+        await waitForDisabled(pages[0], "#trusted-send-button", false);
+        await clickCfButton(pages[0], "#trusted-send-button");
+        await timer.run(
+          "message propagation (first -> all)",
+          () =>
+            Promise.all(
+              others(0).map((page) =>
+                waitForText(
+                  page,
+                  "#trusted-conversation-preview",
+                  helloMessage,
+                  { timeout: PROPAGATION_TIMEOUT },
+                )
+              ),
+            ),
+        );
 
-    // Admin Alice can still add rooms, and Bob sees the shared room list.
-    await fillCfInput(alice, "#trusted-room-name", "Ops");
-    await waitForDisabled(alice, "#trusted-room-add-button", false);
-    await clickCfButton(alice, "#trusted-room-add-button");
-    await waitForText(alice, "#rooms-panel", "Ops");
-    await waitForText(
-      bob,
-      "#rooms-panel",
-      "Ops",
-      { timeout: PROPAGATION_TIMEOUT },
-    );
-  });
-});
+        // First user locks down admin. Every other user loses admin (cannot
+        // add rooms) but must still be able to POST — sending is never
+        // admin-gated.
+        await clickCfButton(pages[0], "#trusted-everyone-admin-checkbox");
+        await waitForText(
+          pages[0],
+          "#group-chat-manager-chip",
+          "Can manage admins",
+          { timeout: PROPAGATION_TIMEOUT },
+        );
+        await timer.run(
+          "lockdown propagation (first -> others)",
+          () =>
+            Promise.all(
+              others(0).map((page) =>
+                waitForText(
+                  page,
+                  "#trusted-room-admin-hint",
+                  "Ask an admin manager to make you an admin",
+                  { timeout: PROPAGATION_TIMEOUT },
+                )
+              ),
+            ),
+        );
+
+        // A now-non-admin user can still post, and the admin sees it.
+        const lastIndex = pages.length - 1;
+        const lockdownMessage = `${userNames[lastIndex]} posts after lockdown`;
+        await fillCfInput(
+          pages[lastIndex],
+          "#trusted-message-draft",
+          lockdownMessage,
+        );
+        await waitForDisabled(pages[lastIndex], "#trusted-send-button", false);
+        await clickCfButton(pages[lastIndex], "#trusted-send-button");
+        await timer.run(
+          "post-lockdown message (non-admin -> admin)",
+          () =>
+            waitForText(
+              pages[0],
+              "#trusted-conversation-preview",
+              lockdownMessage,
+              { timeout: PROPAGATION_TIMEOUT },
+            ),
+        );
+
+        // Admin can still add rooms, and every other user sees the shared room.
+        await fillCfInput(pages[0], "#trusted-room-name", "Ops");
+        await waitForDisabled(pages[0], "#trusted-room-add-button", false);
+        await clickCfButton(pages[0], "#trusted-room-add-button");
+        await waitForText(pages[0], "#rooms-panel", "Ops");
+        await timer.run(
+          "room propagation (first -> all)",
+          () =>
+            Promise.all(
+              others(0).map((page) =>
+                waitForText(page, "#rooms-panel", "Ops", {
+                  timeout: PROPAGATION_TIMEOUT,
+                })
+              ),
+            ),
+        );
+      } finally {
+        // Always report where the wall-clock went — on success to track the
+        // contention trend, on failure to localize the slow propagation.
+        logStepTimings(`group-chat ${PROFILE_COUNT}-profile`, timer);
+        const summaries = await Promise.all(
+          pages.map((page, index) =>
+            collectBrowserLoadSummary(page, userNames[index]).catch(() =>
+              undefined
+            )
+          ),
+        );
+        for (const summary of summaries) {
+          if (summary) logBrowserLoadSummary(summary);
+        }
+      }
+    });
+  },
+);

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1803,6 +1803,20 @@ class SpaceReplica implements ISpaceReplica {
       return { ok: {} };
     } catch (error) {
       const rejection = toRejectedError(error, commit);
+      // Counted (even while silent) so multi-writer churn can be read back via
+      // getLoggerCounts(): "commit-conflict" is a stale-seq-basis rejection that
+      // drops only the optimistic pending write and re-derives from confirmed
+      // state; a non-falling count under load means conflicts ratchet rather
+      // than storm.
+      logger.debug(
+        rejection.name === "ConflictError"
+          ? "commit-conflict"
+          : "commit-rejected",
+        () => [
+          `commit ${rejection.name ?? "rejected"}: ${rejection.message}`,
+          { localSeq, operations: operations.length },
+        ],
+      );
       const touched = operations.map((operation) => ({
         id: operation.id,
         scope: operation.scope,
@@ -1821,6 +1835,13 @@ class SpaceReplica implements ISpaceReplica {
       this.dropPending(localSeq);
       if (before !== undefined) {
         const changes = before.compare(this);
+        // The revert snapshots CURRENT confirmed state (which already includes
+        // any newer seq received by subscription since this commit started) and
+        // drops only this commit's pending write — so it should not stomp newer
+        // data. Counted to verify reverts stay bounded.
+        logger.debug("commit-revert", () => [
+          `revert after ${rejection.name ?? "rejection"}`,
+        ]);
         this.#subscription.next({
           type: "revert",
           space: this.#space,

--- a/packages/runner/test/cfc-label-sync-strategy.bench.ts
+++ b/packages/runner/test/cfc-label-sync-strategy.bench.ts
@@ -1,5 +1,6 @@
 /**
- * Guards the `getCfcLabel` sync strategy (runtime-processor `syncMetaLinkedDocs`).
+ * Documents why the `getCfcLabel` per-call sync (runtime-processor's former
+ * `syncMetaLinkedDocs`) was removed — and guards against reintroducing it.
  *
  * `getCfcLabel` is a DISPLAY-label read on the render hot path. It used to
  * re-sync the cell's whole root meta-graph on every call with a SERIAL
@@ -9,20 +10,21 @@
  * the cost the SUM of those round-trips along the whole graph. End-to-end the
  * `getCfcLabel` IPC p95 ran 0.5–4.2s at 4 concurrent browser profiles.
  *
- * The fix: skip docs already in the local replica (the renderer is already
- * subscribed to the cells it renders, so they are present — read the current
- * display state without awaiting a refresh), and sync any genuinely cold docs in
- * one parallel batch. End-to-end that dropped the `getCfcLabel` IPC p95 to
- * ~5–11ms.
+ * The resolution: `getCfcLabel` does NOT sync at all — it is a pure, non-blocking
+ * read of the current store. Its only callers are reactive UI components that
+ * subscribe to the cell and re-read the label on change, so a not-yet-loaded doc
+ * yields an empty label that self-heals when the subscription delivers it. The
+ * caller owns liveness. End-to-end the `getCfcLabel` IPC p95 dropped to <1ms.
  *
- * A storage emulator can't reproduce this — it has no network latency and a
- * single replica holds its own writes, so nothing is ever "cold" or mid-refresh.
- * This instead models the cost STRUCTURE the change addresses: each genuine sync
- * is one awaited round-trip (`ROUND_TRIP_MS`); an already-present doc is a Set
- * lookup. The three strategies then show their true asymptotics:
+ * A storage emulator can't reproduce the real cost — it has no network latency
+ * and a single replica holds its own writes, so nothing is ever "cold" or
+ * mid-refresh. This instead models the cost STRUCTURE: each genuine sync is one
+ * awaited round-trip (`ROUND_TRIP_MS`); an already-present doc is a Set lookup.
+ * The strategies then show their true asymptotics, ending at the pure read:
  *   - serial-await     [old] — SUM of round-trips (one per node).
  *   - parallel-batch          — ~one round-trip (all coalesced).
- *   - skip-when-present [new] — zero round-trips when warm; one batch when cold.
+ *   - skip-when-present       — zero round-trips when warm; one batch when cold.
+ *   - pure-read        [new] — no sync at all (caller owns liveness).
  */
 
 import { sleep } from "@commonfabric/utils/sleep";
@@ -78,6 +80,10 @@ const ensureSkipWhenPresent = async (replica: Replica) => {
   }
 };
 
+// The shipped behavior: getCfcLabel never syncs — the reactive caller owns
+// liveness, so the read does no graph work at all.
+const ensurePureRead = (_replica: Replica): void => {};
+
 Deno.bench(
   "syncMetaLinkedDocs (warm) - serial await per node [old]",
   { group: "cfc-label-sync-warm", baseline: true },
@@ -101,12 +107,23 @@ Deno.bench(
 );
 
 Deno.bench(
-  "syncMetaLinkedDocs (warm) - skip when present [new]",
+  "syncMetaLinkedDocs (warm) - skip when present",
   { group: "cfc-label-sync-warm" },
   async (b) => {
     const replica = warmReplica();
     b.start();
     await ensureSkipWhenPresent(replica);
+    b.end();
+  },
+);
+
+Deno.bench(
+  "getCfcLabel (warm) - pure read, no sync [new]",
+  { group: "cfc-label-sync-warm" },
+  async (b) => {
+    const replica = warmReplica();
+    b.start();
+    await ensurePureRead(replica);
     b.end();
   },
 );

--- a/packages/runner/test/cfc-label-sync-strategy.bench.ts
+++ b/packages/runner/test/cfc-label-sync-strategy.bench.ts
@@ -1,0 +1,134 @@
+/**
+ * Guards the `getCfcLabel` sync strategy (runtime-processor `syncMetaLinkedDocs`).
+ *
+ * `getCfcLabel` is a DISPLAY-label read on the render hot path. It used to
+ * re-sync the cell's whole root meta-graph on every call with a SERIAL
+ * `await sync()` per node. Split timing put that at ~99.97% of the IPC, bimodal
+ * p50 0.1ms / p95 >1s under multi-writer churn: when a node's watch is
+ * mid-refresh the `sync()` blocks on a server round-trip, and serial awaits make
+ * the cost the SUM of those round-trips along the whole graph. End-to-end the
+ * `getCfcLabel` IPC p95 ran 0.5–4.2s at 4 concurrent browser profiles.
+ *
+ * The fix: skip docs already in the local replica (the renderer is already
+ * subscribed to the cells it renders, so they are present — read the current
+ * display state without awaiting a refresh), and sync any genuinely cold docs in
+ * one parallel batch. End-to-end that dropped the `getCfcLabel` IPC p95 to
+ * ~5–11ms.
+ *
+ * A storage emulator can't reproduce this — it has no network latency and a
+ * single replica holds its own writes, so nothing is ever "cold" or mid-refresh.
+ * This instead models the cost STRUCTURE the change addresses: each genuine sync
+ * is one awaited round-trip (`ROUND_TRIP_MS`); an already-present doc is a Set
+ * lookup. The three strategies then show their true asymptotics:
+ *   - serial-await     [old] — SUM of round-trips (one per node).
+ *   - parallel-batch          — ~one round-trip (all coalesced).
+ *   - skip-when-present [new] — zero round-trips when warm; one batch when cold.
+ */
+
+import { sleep } from "@commonfabric/utils/sleep";
+
+// Fan-out of a deeply-nested piece's root meta-graph (root + sub-pattern
+// surfaces + their argument/pattern docs).
+const NODE_COUNT = 32;
+// Representative in-flight watch-refresh round-trip under multi-writer churn.
+// Real measurements showed ~0.4–1.4s; 2ms keeps the bench fast while preserving
+// the serial-sum vs parallel-max vs skip-zero structure.
+const ROUND_TRIP_MS = 2;
+
+type Replica = Set<number>;
+
+// One genuine sync = one awaited round-trip; an already-present node is free.
+const syncNode = async (replica: Replica, node: number): Promise<void> => {
+  if (!replica.has(node)) {
+    await sleep(ROUND_TRIP_MS);
+    replica.add(node);
+  }
+};
+
+const warmReplica = (): Replica =>
+  new Set(Array.from({ length: NODE_COUNT }, (_, index) => index));
+const coldReplica = (): Replica => new Set();
+
+// --- "ensure the whole meta-graph is available" strategies ------------------
+
+const ensureSerial = async (replica: Replica) => {
+  for (let node = 0; node < NODE_COUNT; node++) {
+    // Old syncMetaLinkedDocs: unconditional, serial await per node.
+    await sleep(ROUND_TRIP_MS);
+    replica.add(node);
+  }
+};
+
+const ensureParallel = async (replica: Replica) => {
+  await Promise.all(
+    Array.from({ length: NODE_COUNT }, async (_, node) => {
+      await sleep(ROUND_TRIP_MS);
+      replica.add(node);
+    }),
+  );
+};
+
+const ensureSkipWhenPresent = async (replica: Replica) => {
+  const cold: number[] = [];
+  for (let node = 0; node < NODE_COUNT; node++) {
+    if (!replica.has(node)) cold.push(node);
+  }
+  if (cold.length > 0) {
+    await Promise.all(cold.map((node) => syncNode(replica, node)));
+  }
+};
+
+Deno.bench(
+  "syncMetaLinkedDocs (warm) - serial await per node [old]",
+  { group: "cfc-label-sync-warm", baseline: true },
+  async (b) => {
+    const replica = warmReplica();
+    b.start();
+    await ensureSerial(replica);
+    b.end();
+  },
+);
+
+Deno.bench(
+  "syncMetaLinkedDocs (warm) - parallel batch",
+  { group: "cfc-label-sync-warm" },
+  async (b) => {
+    const replica = warmReplica();
+    b.start();
+    await ensureParallel(replica);
+    b.end();
+  },
+);
+
+Deno.bench(
+  "syncMetaLinkedDocs (warm) - skip when present [new]",
+  { group: "cfc-label-sync-warm" },
+  async (b) => {
+    const replica = warmReplica();
+    b.start();
+    await ensureSkipWhenPresent(replica);
+    b.end();
+  },
+);
+
+Deno.bench(
+  "syncMetaLinkedDocs (cold) - serial await per node [old]",
+  { group: "cfc-label-sync-cold", baseline: true },
+  async (b) => {
+    const replica = coldReplica();
+    b.start();
+    await ensureSerial(replica);
+    b.end();
+  },
+);
+
+Deno.bench(
+  "syncMetaLinkedDocs (cold) - skip when present [new]",
+  { group: "cfc-label-sync-cold" },
+  async (b) => {
+    const replica = coldReplica();
+    b.start();
+    await ensureSkipWhenPresent(replica);
+    b.end();
+  },
+);

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -852,7 +852,7 @@ describe("RuntimeProcessor home pattern IPC", () => {
 });
 
 describe("RuntimeProcessor CFC label IPC", () => {
-  it("returns a label view for a cell ref", async () => {
+  it("returns a label view for a cell ref", () => {
     const ref: CellRef = {
       id: "of:cfc-label-cell" as CellRef["id"],
       space: "did:key:test" as CellRef["space"],
@@ -882,17 +882,16 @@ describe("RuntimeProcessor CFC label IPC", () => {
           },
           getAsNormalizedFullLink: () => ref,
           getMetaRaw: () => undefined,
-          sync: () => Promise.resolve(),
         }),
       },
     } as unknown as RuntimeProcessor;
 
-    await expect(
+    expect(
       RuntimeProcessor.prototype.handleCellGetCfcLabel.call(processor, {
         type: RequestType.CellGetCfcLabel,
         cell: ref,
       }),
-    ).resolves.toEqual({
+    ).toEqual({
       cfcLabel: {
         version: 1,
         entries: [{
@@ -1084,97 +1083,65 @@ describe("RuntimeProcessor CFC label IPC", () => {
     };
     const processor = { runtime } as unknown as RuntimeProcessor;
 
-    await expect(Promise.resolve(
+    expect(
       RuntimeProcessor.prototype.handleCellGetCfcLabel.call(processor, {
         type: RequestType.CellGetCfcLabel,
         cell: resultRef,
       }),
-    )).resolves.toEqual({
+    ).toEqual({
       cfcLabel: undefined,
     });
-    expect(resultSynced).toBe(true);
+    // getCfcLabel is a pure read: it never syncs (the reactive caller owns
+    // liveness), and it reads only the cell's OWN stored label — it does not
+    // follow the "result" meta link to pull CFC from a source/meta cell.
+    expect(resultSynced).toBe(false);
     expect(sourceSynced).toBe(false);
   });
 
-  it("syncs pattern and argument metadata links before reading labels", async () => {
-    const resultRef: CellRef = {
-      id: "of:cfc-label-sync-result" as CellRef["id"],
+  it("reads the cell's own stored label without syncing (caller owns liveness)", () => {
+    const ref: CellRef = {
+      id: "of:cfc-label-pure-read" as CellRef["id"],
       space: "did:key:test" as CellRef["space"],
       scope: "space",
       path: [],
     };
-    const patternRef: CellRef = {
-      id: "of:cfc-label-sync-pattern" as CellRef["id"],
-      space: "did:key:test" as CellRef["space"],
-      scope: "space",
-      path: [],
-    };
-    const argumentRef: CellRef = {
-      id: "of:cfc-label-sync-argument" as CellRef["id"],
-      space: "did:key:test" as CellRef["space"],
-      scope: "space",
-      path: [],
-    };
-    const syncLog: string[] = [];
-    const cells = new Map<string, unknown>();
-    const runtime = {
-      getCellFromLink: (link: CellRef) => cells.get(link.id),
-      readTx: () => {
-        return {
+    let synced = false;
+    const cell = {
+      runtime: {
+        readTx: () => ({
           readOrThrow: () => ({
-            version: 1,
-            schemaHash: "test-schema",
-            labelMap: {
+            value: "labelled data",
+            cfc: {
               version: 1,
-              entries: [{
-                path: [],
-                label: { confidentiality: ["result-label"] },
-              }],
+              schemaHash: "test-schema",
+              labelMap: {
+                version: 1,
+                entries: [{
+                  path: [],
+                  label: { confidentiality: ["result-label"] },
+                }],
+              },
             },
           }),
-        };
+        }),
+      },
+      getAsNormalizedFullLink: () => ref,
+      getMetaRaw: () => undefined,
+      sync: () => {
+        synced = true;
+        return Promise.resolve();
       },
     };
-    const makeCell = (
-      name: string,
-      ref: CellRef,
-      links: Partial<Record<"pattern" | "argument", CellRef>> = {},
-    ) => {
-      let synced = false;
-      return {
-        ...ref,
-        sourceURI: `${ref.space}/${ref.scope}/${ref.id}`,
-        runtime,
-        getAsNormalizedFullLink: () => ref,
-        getMetaRaw: (metaField: "pattern" | "argument") => {
-          return synced && links[metaField] !== undefined
-            ? cellRefToSigilLink(links[metaField]!)
-            : undefined;
-        },
-        sync: () => {
-          synced = true;
-          syncLog.push(name);
-          return Promise.resolve();
-        },
-      };
-    };
-    cells.set(
-      resultRef.id,
-      makeCell("result", resultRef, {
-        pattern: patternRef,
-        argument: argumentRef,
-      }),
-    );
-    cells.set(patternRef.id, makeCell("pattern", patternRef));
-    cells.set(argumentRef.id, makeCell("argument", argumentRef));
-    const processor = { runtime } as unknown as RuntimeProcessor;
+    const processor = {
+      runtime: { getCellFromLink: () => cell },
+    } as unknown as RuntimeProcessor;
 
-    await expect(
+    expect(
       RuntimeProcessor.prototype.handleCellGetCfcLabel.call(processor, {
         type: RequestType.CellGetCfcLabel,
-        cell: resultRef,
+        cell: ref,
       }),
-    ).resolves.toEqual({
+    ).toEqual({
       cfcLabel: {
         version: 1,
         entries: [{
@@ -1183,81 +1150,10 @@ describe("RuntimeProcessor CFC label IPC", () => {
         }],
       },
     });
-
-    expect(syncLog).toEqual([
-      "result",
-      "pattern",
-      "argument",
-      "result",
-    ]);
-  });
-
-  it("does not loop when metadata links form a cycle", async () => {
-    const resultRef: CellRef = {
-      id: "of:cfc-label-cycle-result" as CellRef["id"],
-      space: "did:key:test" as CellRef["space"],
-      scope: "space",
-      path: [],
-    };
-    const patternRef: CellRef = {
-      id: "of:cfc-label-cycle-pattern" as CellRef["id"],
-      space: "did:key:test" as CellRef["space"],
-      scope: "space",
-      path: [],
-    };
-    const syncLog: string[] = [];
-    const cells = new Map<string, unknown>();
-    const runtime = {
-      getCellFromLink: (link: CellRef) => cells.get(link.id),
-      readTx: () => ({
-        readOrThrow: () => undefined,
-      }),
-    };
-    const makeCell = (
-      name: string,
-      ref: CellRef,
-      links: Partial<Record<"pattern" | "argument", CellRef>> = {},
-    ) => {
-      let synced = false;
-      return {
-        ...ref,
-        sourceURI: `${ref.space}/${ref.scope}/${ref.id}`,
-        runtime,
-        getAsNormalizedFullLink: () => ref,
-        getMetaRaw: (metaField: "pattern" | "argument") => {
-          return synced && links[metaField] !== undefined
-            ? cellRefToSigilLink(links[metaField]!)
-            : undefined;
-        },
-        sync: () => {
-          synced = true;
-          syncLog.push(name);
-          return Promise.resolve();
-        },
-      };
-    };
-    cells.set(
-      resultRef.id,
-      makeCell("result", resultRef, {
-        pattern: patternRef,
-      }),
-    );
-    cells.set(
-      patternRef.id,
-      makeCell("pattern", patternRef, {
-        argument: resultRef,
-      }),
-    );
-    const processor = { runtime } as unknown as RuntimeProcessor;
-
-    await expect(
-      RuntimeProcessor.prototype.handleCellGetCfcLabel.call(processor, {
-        type: RequestType.CellGetCfcLabel,
-        cell: resultRef,
-      }),
-    ).resolves.toEqual({ cfcLabel: undefined });
-
-    expect(syncLog).toEqual(["result", "pattern", "result"]);
+    // No sync: the label is read from the current store. A not-yet-loaded doc
+    // would yield an empty label that self-heals when the reactive caller's
+    // subscription delivers it.
+    expect(synced).toBe(false);
   });
 
   it("ignores schema-bearing anyOf refs when reading nested stored labels", async () => {

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1021,7 +1021,7 @@ describe("RuntimeProcessor CFC label IPC", () => {
     });
   });
 
-  it("does not look up CFC labels from a result meta cell", async () => {
+  it("does not look up CFC labels from a result meta cell", () => {
     const resultRef: CellRef = {
       id: "of:cfc-label-result" as CellRef["id"],
       space: "did:key:test" as CellRef["space"],

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -754,42 +754,31 @@ export class RuntimeProcessor {
     };
   }
 
-  async handleCellGetCfcLabel(
+  handleCellGetCfcLabel(
     request: CellGetCfcLabelRequest,
-  ): Promise<CfcLabelViewResponse> {
+  ): CfcLabelViewResponse {
     // Label reads must use the runtime's stored cell identity. The request
     // schema is client-supplied view context, not trusted label provenance.
     const { schema: _schema, ...cellRef } = request.cell;
     const cell = getCell(this.runtime, cellRef);
-    const rootCell = this.runtime.getCellFromLink({
-      ...cell.getAsNormalizedFullLink(),
-      path: [],
-    });
+    // Pure, non-blocking read of the CURRENT local store — no sync. getCfcLabel
+    // is the display-label seam, and its only callers are reactive UI components
+    // (cf-cfc-label, cf-cfc-authorship, cf-profile-badge) that subscribe to the
+    // cell and re-read the label whenever it changes. They own liveness: a
+    // not-yet-loaded doc is also not rendered, so an empty label is the correct
+    // deferred answer and self-heals when the subscription delivers the doc
+    // (which carries its `cfc` metadata). The earlier per-call source-chain sync
+    // re-loaded already-present docs and, under multi-writer churn, blocked on
+    // in-flight watch refreshes — ~99.97% of this IPC's cost, p95 >1s at 4
+    // browsers. The enforcement path reads labels through other seams; here we
+    // only redact `Caveat.source` for display (audit item 28b, inv-12).
     const totalStart = performance.now();
-    const syncMetaStart = performance.now();
-    await syncMetaLinkedDocs(rootCell);
-    cfcLabelLogger.time(syncMetaStart, "syncMetaLinkedDocs");
-    const cellSyncStart = performance.now();
-    // Same rationale as syncMetaLinkedDocs: only cold-load the target cell, so a
-    // warm display-label read never blocks on an in-flight watch refresh.
-    if (!isDocLocallyAvailable(cell)) {
-      await cell.sync();
-    }
-    cfcLabelLogger.time(cellSyncStart, "cellSync");
-    // `getCfcLabel()` is the pattern-facing INTROSPECTION surface: the response
-    // is returned to the caller, not round-tripped back into a cell. Redact
-    // `Caveat.source` identities here so a pattern can't learn which principal
-    // introduced a caveat (audit item 28b, inv-12). Observation labeling, the
-    // dereference-trace enforcement path, and the carried-label view all read
-    // the label through other seams and keep `source`.
-    const computeStart = performance.now();
     const cfcLabel = cfcLabelViewForCell(cell);
     const response = {
       cfcLabel: cfcLabel === undefined
         ? undefined
         : redactCaveatSourcesForDisplay(cfcLabel),
     };
-    cfcLabelLogger.time(computeStart, "computeAndRedact");
     cfcLabelLogger.time(totalStart, "total");
     return response;
   }
@@ -1473,68 +1462,5 @@ export class RuntimeProcessor {
       return;
     }
     mount.reconciler.acknowledgeBatchApplied(request.batchId);
-  }
-}
-
-/** True when a cell's doc is already loaded in the local store. */
-function isDocLocallyAvailable(cell: Cell<any>): boolean {
-  try {
-    const { space, id, scope } = cell.getAsNormalizedFullLink();
-    if (!space || typeof id !== "string") return false;
-    return cell.runtime.storageManager.open(space).replica.getDocument(
-      id as URI,
-      scope,
-    ) !== undefined;
-  } catch {
-    // If we cannot determine availability, fall back to syncing.
-    return false;
-  }
-}
-
-/**
- * Sync a root cell and each direct metadata-linked cell reachable from it.
- *
- * `internal` is raw manifest metadata, not a direct metadata link. Callers that
- * need a transactional root cell can create it first and pass it.
- *
- * Only docs NOT already present in the local store are synced. The hot caller —
- * the renderer reading display labels for cells it is actively rendering — has
- * already subscribed to these docs, so they are present and we read the current
- * (possibly mid-refresh) state WITHOUT awaiting an in-flight watch refresh. That
- * await was the entire cost of `getCfcLabel` under multi-writer churn: split
- * timing put `syncMetaLinkedDocs` at ~99.97% of the IPC, bimodal p50 0.1ms /
- * p95 >1s, where the slow tail is one `sync()` blocking on the root doc's
- * in-flight refresh — latency that scales with how hard OTHER browsers churn the
- * shared space. `getCfcLabel` is the DISPLAY label seam (the enforcement path
- * reads the label through other seams); it is eventually consistent via the live
- * subscription, so a one-revision-stale read self-heals on the next render.
- * Genuinely cold docs are still loaded (in parallel per BFS level, so a cold
- * level costs one round-trip, not one per node). Same BFS discovery order and
- * cycle detection as before.
- */
-async function syncMetaLinkedDocs(
-  cell: Cell<any>,
-  cycleCheck: Set<string> = new Set<string>(),
-) {
-  let frontier = [cell];
-  cycleCheck.add(cell.sourceURI);
-  while (frontier.length > 0) {
-    const cold = frontier.filter((current) => !isDocLocallyAvailable(current));
-    if (cold.length > 0) {
-      await Promise.all(cold.map((current) => current.sync()));
-    }
-    const next: Cell<any>[] = [];
-    for (const currentCell of frontier) {
-      for (const meta of ["pattern", "argument"] as const) {
-        const link = getMetaLink(currentCell, meta);
-        if (link === undefined) continue;
-        const linkedCell = currentCell.runtime.getCellFromLink(link, undefined);
-        if (linkedCell === undefined) continue;
-        if (cycleCheck.has(linkedCell.sourceURI)) continue;
-        cycleCheck.add(linkedCell.sourceURI);
-        next.push(linkedCell);
-      }
-    }
-    frontier = next;
   }
 }

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -5,6 +5,7 @@ import { JsonEncodingContext } from "@commonfabric/data-model/codec-json";
 import { PieceManager } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
 import {
+  getLogger,
   getLoggerCountsBreakdown,
   getLoggerFlagsBreakdown,
   getTimingStatsBreakdown,
@@ -131,6 +132,13 @@ import type { JSONValue, RuntimeOptions, URI } from "@commonfabric/runner";
 
 const MAX_SERIALIZATION_DEPTH = 5;
 const blobUploadEncoding = new JsonEncodingContext();
+
+// Split-timing for the CFC label IPC path. Counts/timing are readable via
+// getLoggerCounts(); enabled silently so the hot path pays only the timestamp.
+const cfcLabelLogger = getLogger("runtime-client.cfc-label", {
+  enabled: true,
+  level: "error",
+});
 
 function resolveBlobUrl(url: string, apiUrl: URL, space: DID): string {
   const spaceBaseUrl = new URL(`/${space}/`, apiUrl);
@@ -757,20 +765,33 @@ export class RuntimeProcessor {
       ...cell.getAsNormalizedFullLink(),
       path: [],
     });
+    const totalStart = performance.now();
+    const syncMetaStart = performance.now();
     await syncMetaLinkedDocs(rootCell);
-    await cell.sync();
+    cfcLabelLogger.time(syncMetaStart, "syncMetaLinkedDocs");
+    const cellSyncStart = performance.now();
+    // Same rationale as syncMetaLinkedDocs: only cold-load the target cell, so a
+    // warm display-label read never blocks on an in-flight watch refresh.
+    if (!isDocLocallyAvailable(cell)) {
+      await cell.sync();
+    }
+    cfcLabelLogger.time(cellSyncStart, "cellSync");
     // `getCfcLabel()` is the pattern-facing INTROSPECTION surface: the response
     // is returned to the caller, not round-tripped back into a cell. Redact
     // `Caveat.source` identities here so a pattern can't learn which principal
     // introduced a caveat (audit item 28b, inv-12). Observation labeling, the
     // dereference-trace enforcement path, and the carried-label view all read
     // the label through other seams and keep `source`.
+    const computeStart = performance.now();
     const cfcLabel = cfcLabelViewForCell(cell);
-    return {
+    const response = {
       cfcLabel: cfcLabel === undefined
         ? undefined
         : redactCaveatSourcesForDisplay(cfcLabel),
     };
+    cfcLabelLogger.time(computeStart, "computeAndRedact");
+    cfcLabelLogger.time(totalStart, "total");
+    return response;
   }
 
   handleGetCell(request: GetCellRequest): CellResponse {
@@ -1455,29 +1476,65 @@ export class RuntimeProcessor {
   }
 }
 
+/** True when a cell's doc is already loaded in the local store. */
+function isDocLocallyAvailable(cell: Cell<any>): boolean {
+  try {
+    const { space, id, scope } = cell.getAsNormalizedFullLink();
+    if (!space || typeof id !== "string") return false;
+    return cell.runtime.storageManager.open(space).replica.getDocument(
+      id as URI,
+      scope,
+    ) !== undefined;
+  } catch {
+    // If we cannot determine availability, fall back to syncing.
+    return false;
+  }
+}
+
 /**
  * Sync a root cell and each direct metadata-linked cell reachable from it.
  *
  * `internal` is raw manifest metadata, not a direct metadata link. Callers that
  * need a transactional root cell can create it first and pass it.
+ *
+ * Only docs NOT already present in the local store are synced. The hot caller —
+ * the renderer reading display labels for cells it is actively rendering — has
+ * already subscribed to these docs, so they are present and we read the current
+ * (possibly mid-refresh) state WITHOUT awaiting an in-flight watch refresh. That
+ * await was the entire cost of `getCfcLabel` under multi-writer churn: split
+ * timing put `syncMetaLinkedDocs` at ~99.97% of the IPC, bimodal p50 0.1ms /
+ * p95 >1s, where the slow tail is one `sync()` blocking on the root doc's
+ * in-flight refresh — latency that scales with how hard OTHER browsers churn the
+ * shared space. `getCfcLabel` is the DISPLAY label seam (the enforcement path
+ * reads the label through other seams); it is eventually consistent via the live
+ * subscription, so a one-revision-stale read self-heals on the next render.
+ * Genuinely cold docs are still loaded (in parallel per BFS level, so a cold
+ * level costs one round-trip, not one per node). Same BFS discovery order and
+ * cycle detection as before.
  */
 async function syncMetaLinkedDocs(
   cell: Cell<any>,
   cycleCheck: Set<string> = new Set<string>(),
 ) {
-  const pendingCells = [cell];
+  let frontier = [cell];
   cycleCheck.add(cell.sourceURI);
-  while (pendingCells.length > 0) {
-    const currentCell = pendingCells.shift()!;
-    await currentCell.sync();
-    for (const meta of ["pattern", "argument"] as const) {
-      const link = getMetaLink(currentCell, meta);
-      if (link === undefined) continue;
-      const linkedCell = currentCell.runtime.getCellFromLink(link, undefined);
-      if (linkedCell === undefined) continue;
-      if (cycleCheck.has(linkedCell.sourceURI)) continue;
-      cycleCheck.add(linkedCell.sourceURI);
-      pendingCells.push(linkedCell);
+  while (frontier.length > 0) {
+    const cold = frontier.filter((current) => !isDocLocallyAvailable(current));
+    if (cold.length > 0) {
+      await Promise.all(cold.map((current) => current.sync()));
     }
+    const next: Cell<any>[] = [];
+    for (const currentCell of frontier) {
+      for (const meta of ["pattern", "argument"] as const) {
+        const link = getMetaLink(currentCell, meta);
+        if (link === undefined) continue;
+        const linkedCell = currentCell.runtime.getCellFromLink(link, undefined);
+        if (linkedCell === undefined) continue;
+        if (cycleCheck.has(linkedCell.sourceURI)) continue;
+        cycleCheck.add(linkedCell.sourceURI);
+        next.push(linkedCell);
+      }
+    }
+    frontier = next;
   }
 }

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
@@ -166,6 +166,47 @@ describe("CFProfileBadge", () => {
       expect(el._seal?.hue).toBe(identitySeal(OWNER_DID).hue);
     });
 
+    it("re-derives verification when the value subscription fires (cold profile self-heals)", async () => {
+      const el = new CFProfileBadge() as any;
+      markConnected(el, true);
+
+      // `getCfcLabel` is a pure store read: cold first (no label), then the
+      // attestation appears once the doc loads.
+      let labelReady = false;
+      let subscriptionCallback: ((val: unknown) => void) | undefined;
+      const resolved = {
+        ref: () => ({ path: [] }),
+        space: () => "did:key:zSpace",
+        id: () => "fid1:piece",
+        asSchema: () => ({
+          subscribe: (cb: (val: unknown) => void) => {
+            subscriptionCallback = cb;
+            return () => {};
+          },
+        }),
+        getCfcLabel: () =>
+          Promise.resolve(
+            labelReady ? representsPrincipalLabel(OWNER_DID) : undefined,
+          ),
+      };
+      el.profile = { resolveAsCell: () => Promise.resolve(resolved) };
+
+      await el._resolve();
+      // Let the initial (cold) verification read settle: no label yet.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(el._state).toBe("presented");
+      expect(el._seal).toBeUndefined();
+
+      // The doc loads: the label is now present and the value subscription
+      // fires, re-deriving verification.
+      labelReady = true;
+      subscriptionCallback?.({ name: "Ada" });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(el._state).toBe("verified");
+      expect(el._seal?.did).toBe(OWNER_DID);
+    });
+
     it("stays presented (no seal) when the label has no represents-principal atom", async () => {
       const el = new CFProfileBadge() as any;
       markConnected(el, true);

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -331,6 +331,9 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
 
   private _unsubscribe?: () => void;
   private _resolveGeneration = 0;
+  // Bumped on each verification read so a slower earlier read can't overwrite a
+  // newer one's state when verification re-runs reactively (below).
+  private _verifyRequestId = 0;
 
   // Liveness: whether this seal is currently registered with the shared cursor
   // controller, and the last sheen alpha written (so far-from-cursor frames can
@@ -487,7 +490,17 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
           avatar: { type: "string" },
         },
       });
-      this._unsubscribe = named.subscribe((val) => this._applyValue(val));
+      // Re-derive verification on every value update, not just once: the
+      // runtime-attested label (`getCfcLabel`) is read as a pure, non-blocking
+      // store read, so a not-yet-loaded profile doc first returns no label and
+      // leaves the badge "presented". When the subscription delivers the doc
+      // (the same load that populates name/avatar), the label is present and the
+      // badge re-derives to "verified". The request-id guard in
+      // `_refreshVerification` drops a slower earlier read.
+      this._unsubscribe = named.subscribe((val) => {
+        this._applyValue(val);
+        void this._refreshVerification(resolved);
+      });
 
       void this._refreshVerification(resolved);
     } catch (e) {
@@ -558,9 +571,13 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
    */
   private async _refreshVerification(cell: CellHandle): Promise<void> {
     const generation = this._resolveGeneration;
+    const requestId = ++this._verifyRequestId;
+    const superseded = () =>
+      generation !== this._resolveGeneration ||
+      requestId !== this._verifyRequestId || !this.isConnected;
     try {
       const view = await readCfcLabelView(cell);
-      if (generation !== this._resolveGeneration || !this.isConnected) return;
+      if (superseded()) return;
       const owner = ownerPrincipalFromLabel(view);
       if (owner) {
         this._seal = identitySeal(owner);
@@ -570,7 +587,7 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         this._state = "presented";
       }
     } catch (e) {
-      if (generation !== this._resolveGeneration || !this.isConnected) return;
+      if (superseded()) return;
       // Surface the IPC/label-read failure (mirrors `_resolve`'s catch) rather
       // than silently collapsing every failure to the unverified state.
       console.error(


### PR DESCRIPTION
## What

Generalizes the two-browser CFC group-chat integration test to **N concurrent browser profiles** (`CFC_BROWSER_PROFILE_COUNT`, default 2) and adds aggregate-stat instrumentation so the multi-browser slowness we keep hitting becomes measurable and self-reporting.

This sits on top of #4146 (the handler-lifetime race fix). Raising the profile count to 3+ locally reproduced exactly that race before the fix (Bob's save lost, `#trusted-profile-status` stuck at "Name not set", 60s+ hang); green after. The save steps drive the trusted action by its `data-ui-action` marker and retry, matching #4146.

## Changes

- **`CFC_BROWSER_PROFILE_COUNT`** (`packages/integration/env.ts`, default 2, min 2): N concurrent browser profiles. The test contract (per-user draft isolation, each user's own save, all-pairs name propagation, shared transcript, admin lockdown, room propagation) is generalized to N users.
- **Aggregate-stat instrumentation** (`cfc-browser-helpers.ts`), dumped in a `finally` on every run (success or failure):
  - `StepTimer` — wall-clock per reactive step.
  - `collectBrowserLoadSummary` — reads the `docs/development/logger` aggregates: main-thread `runtime-client` IPC round-trip timing (`getTimingStatsBreakdown`) + worker scheduler/runner/storage timing (`rt.getLoggerCounts`). Main-thread IPC p95/max is the contention signal that becomes "RuntimeClient request timed out" when the worker saturates.
  - **Churn/conflict counters** (`actionRuns`, `commitConflicts`, `commitReverts`, `commitRejected`, `scheduleRunErrors`, `eventLostRaces`).
- **Realistic churn**: the controller pulls on `[UI]` with the cell-less `debugVDOMSchema` so the whole tree materializes (every UI computed runs and stays subscribed).
- **Conflict counters in `storage/v2.ts`** (silent counted debug keys `commit-conflict`/`commit-rejected`/`commit-revert`) to verify conflicts ratchet rather than storm.

## Findings

Detailed measurements (scaling slowdown, conflict-handling verification, and a `getCfcLabel` hotspot) posted as comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the CFC group chat test to N concurrent browser profiles with per-profile IPC/worker/churn logging so cross-browser contention is measurable in CI. Also makes `getCfcLabel` a pure, non-blocking store read and updates UI to re-verify on value changes, cutting label IPC latency and stabilizing multi-browser runs.

- **New Features**
  - Run N browser profiles in parallel (default 2) to stress sync while checking per-user isolation and shared-state propagation.
  - Always log step timings and per-browser load: main-thread `runtime-client` IPC p95/max, worker scheduler/runner/`storage.v2`, and churn/conflict counters.
  - Count `storage v2` commit outcomes via debug keys (`commit-conflict`, `commit-rejected`, `commit-revert`) to verify bounded conflict ratcheting.
  - Drive `TrustedGroupChatSaveProfile` by `data-ui-action` with retry; pull on `[UI]` with `debugVDOMSchema` to materialize the full tree and add realistic generation churn.

- **Performance**
  - `getCfcLabel`: now a synchronous, pure store read (no per-call sync); removed meta-graph sync; added `runtime-client.cfc-label` timing; `cf-profile-badge` re-derives verification on value updates; bench includes pure-read endpoint.
  - Result: label IPC now tens of ms (was 0.5–4.2s at 4 profiles); handler work is sub-ms, remaining time is transport.
  - Fix: prefix-match worker timing to include `storage.v2` in load summaries; updated CFC-label test to be synchronous.

<sup>Written for commit a8e64e5e9827455b7889d7869fe9d9b4bc3af401. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



---

NEW_PERF_BASELINE: step: Type check = 74s
NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 9223 lines
NEW_PERF_BASELINE: coverage-debt: packages/ui uncovered lines = 38826 lines

<!--
Perf-check acceptances:
- "Type check = 74s" is shared-runner wall-time noise (baseline ~53–59s); this
  change removes code from the type-check path, it does not add to it.
- The coverage-debt deltas are the new non-executed bench
  (cfc-label-sync-strategy.bench.ts, run via `deno bench`, not `deno test`) plus
  a few cf-profile-badge reactive branches. The new runtime instrumentation
  (storage v2 commit-conflict/revert counters) IS unit-covered by
  memory-v2-subscription.test.ts ("emits a revert notification when a v2 commit
  conflicts").
-->
