### PR TITLE
fix(profiles): derive profile space from per-user cause, not display name (CT-1650)

### DIFF
--- a/docs/common/conventions/HOME_SPACE.md
+++ b/docs/common/conventions/HOME_SPACE.md
@@ -75,8 +75,10 @@ most-recently-used (MRU) ordering:
 - `homeSpaceCell.defaultPattern.mru` — recency-ordered links; drives ordering
   after the default.
 
-Each profile lives in its own space, created with `PatternFactory.inSpace(name)`
-running `/api/patterns/system/profile-home.tsx`; the link is appended to
+Each profile lives in its own space, created with the anonymous
+`PatternFactory.inSpace()` (CT-1650 — a *named* `inSpace(name)` would derive the
+space DID from the display name alone and collide same-named profiles across
+users) running `/api/patterns/system/profile-home.tsx`; the link is appended to
 `profiles`. The home Profile tab renders the **profile picker**
 (`profile-picker.tsx`): it lists profiles, lets the user create more inline, pick
 the default, and stamp MRU. There is no `profileName` mirror field anymore.

--- a/docs/specs/shared-profile-space.md
+++ b/docs/specs/shared-profile-space.md
@@ -128,17 +128,24 @@ home-field convention is `homeSpaceCell.defaultPattern.profile`.
 
 ### Profile Space Identity
 
-Profile creation uses `PatternFactory.inSpace(...)`:
+Profile creation uses the **anonymous** `PatternFactory.inSpace()` (CT-1650):
 
 ```ts
-const profile = ProfileHome.inSpace(spaceName)({ initialName: name });
+const profile = ProfileHome.inSpace()({ initialName: name });
 ```
 
-When `spaceName` is a non-DID string, the runner resolves it during async
-post-run through the existing named-space derivation path. When the argument is
-omitted, the runner generates a fresh DID. The home default pattern's `profile`
-link is the durable source of truth after creation. Runtime-only `.inSpace`
-annotations are also rewritten to the resolved DID during post-run.
+The argument MUST be omitted. A *named* `inSpace(spaceName)` derives the space
+DID from `Identity.fromPassphrase("common user").derive(spaceName)` (the
+`createSession` spaceName path) — the name ALONE, ignoring the authenticated
+user — so two users picking the same profile name, or one user creating two
+same-named profiles, collide into a single shared space. The anonymous case
+instead derives a fresh DID from the creating handler's frame cause (per-user
+home-space input links + the durable per-event id), so the space is unique per
+user AND per creation event, stable across the cross-space-commit retry. The
+display name is therefore independent of the space identity (it flows only to
+`initialName` and stays editable). The home default pattern's `profile` link is
+the durable source of truth after creation, and runtime-only `.inSpace`
+annotations are rewritten to the resolved DID during post-run.
 
 ### Profile Default Pattern Output
 
@@ -212,8 +219,9 @@ If `profile` is missing:
 - render an input field for the user's profile name
 - submitting it stores the requested name, which drives a profile-creation
   action/lift
-- that action starts `system/profile-home.tsx` with `.inSpace(name)`, passes the
-  submitted name as the initial profile name, and writes the resulting profile
+- that action starts `system/profile-home.tsx` with the anonymous `.inSpace()`
+  (see Profile Space Identity above), passes the submitted name as the initial
+  profile name, and writes the resulting profile
   default-pattern link to `homeDefaultPattern.profile`
 
 If `profile` is present:

--- a/packages/patterns/system/profile-create.tsx
+++ b/packages/patterns/system/profile-create.tsx
@@ -56,6 +56,18 @@ export type CreateProfileEvent = {
 // the `.inSpace(...)` call opts the transaction into a multi-space commit (see
 // builder/pattern.ts `optIntoInSpaceMultiSpaceCommit` → runner
 // `enableCrossSpaceChildCommit`).
+//
+// CT-1650: the profile space is created via ANONYMOUS `inSpace()` — never
+// `inSpace(name)`. A named target derives its DID from
+// `fromPassphrase("common user").derive(name)` (createSession spaceName path),
+// i.e. the display NAME alone, so two different users picking the same profile
+// name — or one user creating two same-named profiles — collide into a single
+// shared space. The anonymous case instead derives the DID from this handler's
+// frame cause, which carries the creating user's per-home-space input links plus
+// the durable per-event id (runner.ts `createPatternFrame` cause): unique per
+// user AND per creation event, stable across the cross-space-commit retry. The
+// display name flows ONLY to `initialName` (editable later, independent of the
+// space identity). Existing profiles keep their already-baked concrete DID link.
 export const submitProfileCreation = handler<
   CreateProfileEvent,
   {
@@ -67,7 +79,7 @@ export const submitProfileCreation = handler<
     draftName?.get() ?? "").trim();
   if (name) {
     profiles.push(
-      ProfileHome.inSpace(name)({
+      ProfileHome.inSpace()({
         initialName: name,
       }) as ProfileHomeOutput,
     );

--- a/packages/runner/test/profile-space-identity-collision.test.ts
+++ b/packages/runner/test/profile-space-identity-collision.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { fromFileUrl } from "@std/path";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// CT-1650: two DIFFERENT users who create a profile with the SAME display name
+// must end up in DISTINCT profile spaces. Before the fix, profile-create seeded
+// via `ProfileHome.inSpace(name)`, and `createSession({ spaceName })` derived the
+// space DID from `fromPassphrase("common user").derive(name)` — the display name
+// ALONE, ignoring the authenticated user — so equal names collided into one
+// space. The fix routes profile creation through an anonymous `inSpace()` whose
+// DID derives from the creating handler's cause (which carries the per-user home
+// space links + the per-event id), making it per-user AND per-profile unique
+// while the display name flows only to `initialName`.
+
+const userA = await Identity.fromPassphrase("ct1650-user-a");
+const userB = await Identity.fromPassphrase("ct1650-user-b");
+
+const sysDir = fromFileUrl(new URL("../../patterns/system/", import.meta.url));
+const read = (n: string) => Deno.readTextFileSync(sysDir + n);
+
+// A tiny host that owns the home `profiles` list and embeds the REAL
+// profile-create pattern (mirrors profile-create-real-card-add.test.ts).
+const WRAPPER_SRC = [
+  "import ProfileCreate from './profile-create.tsx';",
+  "import { pattern, Writable } from 'commonfabric';",
+  "import type { ProfileHomeOutput } from './profile-home.tsx';",
+  "",
+  "export default pattern(() => {",
+  "  const profiles = new Writable<ProfileHomeOutput[]>([]).for('profiles');",
+  "  const created = ProfileCreate({ profiles });",
+  "  return { profiles, createProfile: created.createProfile };",
+  "});",
+].join("\n");
+
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [
+    { name: "/main.tsx", contents: WRAPPER_SRC },
+    { name: "/profile-create.tsx", contents: read("profile-create.tsx") },
+    { name: "/profile-home.tsx", contents: read("profile-home.tsx") },
+  ],
+};
+
+const RESULT_CAUSE = "ct1650 profile space identity";
+const PROFILE_NAME = "Ada Lovelace";
+
+const profileLinkListSchema = {
+  type: "array",
+  items: { type: "unknown", asCell: ["cell"] },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+// Run profile-create as `signer`, fire createProfile with `name`, return the
+// space DID of the freshly-created profile (its own inSpace space).
+async function createProfileSpace(
+  signer: Identity,
+  name: string,
+): Promise<string> {
+  const space = signer.did();
+  const manager = EmulatedStorageManager.emulate({ as: signer });
+  const rt = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: manager,
+  });
+  try {
+    const tx1 = rt.edit();
+    const parent = await rt.patternManager.compilePattern(PROGRAM, {
+      space,
+      tx: tx1,
+    });
+    const resultCell = rt.getCell<Record<string, unknown>>(
+      space,
+      RESULT_CAUSE,
+      undefined,
+      tx1,
+    );
+    // deno-lint-ignore no-explicit-any
+    const r = rt.run(tx1, parent as any, {}, resultCell);
+    rt.prepareTxForCommit(tx1);
+    const commit1 = await tx1.commit();
+    expect(commit1.error).toBeUndefined();
+    await r.pull();
+
+    const tx2 = rt.edit();
+    r.withTx(tx2).key("createProfile").send({ name });
+    const commit2 = await tx2.commit();
+    expect(commit2.error).toBeUndefined();
+    await r.pull();
+    await rt.idle();
+    await r.pull();
+
+    const profiles = r.key("profiles").asSchema(profileLinkListSchema)
+      // deno-lint-ignore no-explicit-any
+      .get() as any[];
+    expect(profiles.length).toBe(1);
+    const link = profiles[0].getAsNormalizedFullLink();
+    // Sanity: the profile lives in its OWN space, not the home space.
+    expect(link.space).not.toBe(space);
+    return link.space as string;
+  } finally {
+    await rt.dispose();
+    await manager.close();
+  }
+}
+
+describe("CT-1650 profile space identity (per-user, name-independent)", () => {
+  let spaceA: string;
+  let spaceB: string;
+  let spaceA2: string;
+
+  beforeEach(async () => {
+    spaceA = await createProfileSpace(userA, PROFILE_NAME);
+    spaceB = await createProfileSpace(userB, PROFILE_NAME);
+    // Same user, a SECOND profile with the same name — must not collide either.
+    spaceA2 = await createProfileSpace(userA, PROFILE_NAME);
+  });
+
+  it("two users with the same profile name get distinct spaces", () => {
+    expect(spaceA).not.toBe(spaceB);
+  });
+
+  it("one user's two same-named profiles get distinct spaces", () => {
+    expect(spaceA).not.toBe(spaceA2);
+  });
+
+  it("derived spaces are real DID spaces", () => {
+    expect(spaceA.startsWith("did:key:")).toBe(true);
+    expect(spaceB.startsWith("did:key:")).toBe(true);
+  });
+});


### PR DESCRIPTION
## CT-1650 — profile space identity derivation collides across users

### The bug
`profile-create.tsx` seeded each profile via `ProfileHome.inSpace(name)`. The **named** `inSpace` path derives the space DID from `Identity.fromPassphrase("common user").derive(name)` (the `createSession` spaceName branch, `packages/identity/src/session.ts:24-34`) — the **display name alone**, ignoring the authenticated user. So:

- two different users who pick the same profile name, **or**
- one user who creates two same-named profiles

…collide into a single shared profile space.

Observed live and reproduced in test: two "Ada Lovelace" profiles under different identities both resolve to `did:key:z6Mki2GJXAviRRHwhBNHzBoeG6SPxAXbhM8EAPJ2znNZnBKP`.

### The fix
Route profile creation through the **anonymous** `ProfileHome.inSpace()`. Its DID derives from the creating handler's frame cause (`runner.ts` `createPatternFrame`: `{ ...inputs, $event }`), which carries the per-user home-space input links **plus** the durable per-event id — unique per user **and** per creation event, and stable across the cross-space-commit retry. The display name now flows **only** to `initialName` (editable, independent of the space identity).

`createSession`/`resolveSpaceName` are **unchanged globally**, so any intentional shared-by-name spaces keep their semantics. (Grep confirms no production `inSpace("name")` caller relies on shared-by-name today — only profile-create did.)

### Migration
`profiles[]` stores **concrete** cross-space DID links, so existing profiles keep resolving to their already-baked space; only **new** profiles get unique spaces. New-profiles-only migration, acceptable pre-launch. (Users who already collided pre-fix remain merged in the old shared space — pre-existing damage the fix can't un-merge.)

### Acceptance criteria
- [x] Profile space DID not derived solely from the display name
- [x] Two users with the same name → distinct spaces
- [x] Display name editable independently of the space identity (flows only to `initialName`)
- [x] Existing profile links keep working (concrete DID; documented new-profiles-only migration)
- [x] Integration test covering two users + same name

### Tests
`packages/runner/test/profile-space-identity-collision.test.ts` runs the **real** profile-create + profile-home under two different signers and asserts:
- two users, same name → distinct spaces (red baseline reproduced the exact live DID `z6Mki2GJ…`);
- one user's two same-named profiles → distinct;
- both are real `did:key:` spaces.

Existing `profile-create-real-card-add`, `profile-home-pin-piece`, `inspace-child-owner-{write,seed}`, `profile-owner-cfc`, `inspace-child-reload` all still pass.

Docs updated for coherence: the spec's **"Profile Space Identity"** section and `HOME_SPACE.md` described the now-fixed `inSpace(name)` derivation — both now point at the anonymous `inSpace()` with the rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1650 by creating profile spaces with anonymous `inSpace()` instead of name-based `inSpace(name)`, removing same-name collisions across users and profiles. Existing profiles keep working; new profiles get unique DIDs independent of display name.

- **Bug Fixes**
  - Route profile creation through `ProfileHome.inSpace()` (no arg) so the space DID derives from the per-user frame cause, not the display name.
  - Display name now only sets `initialName`; space identity is fully decoupled from the name.
  - Added `profile-space-identity-collision.test.ts` and updated docs (`HOME_SPACE.md`, spec) to reflect the new behavior.

- **Migration**
  - No action needed; existing profiles keep their concrete DID links.
  - Only new profiles get unique spaces; intentional named-space behavior elsewhere remains unchanged.

<sup>Written for commit be83e64a364ac9d77329c7fb8d12b008d4a7fbd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

