### PR TITLE
fix(runtime-client): serialize direct cell writes via a per-key commit queue

### DIFF
--- a/packages/runner/test/cell-write-conflict-granularity.test.ts
+++ b/packages/runner/test/cell-write-conflict-granularity.test.ts
@@ -1,0 +1,808 @@
+// Cell-write conflict granularity, and the runtime-client commit queue's
+// recovery, verified against a real loopback MemoryV2Server.
+//
+// A $value cell-write to a LINKED field records a PURELY STRUCTURAL read-set
+// (link-source value read + sigil probe + cfc-label read) at DEEP, DISJOINT
+// paths on the shared upstream doc. The server's conflict detection is OP-TYPE
+// granular, not doc-seq granular:
+//   - a concurrent sibling-value bump commits as a `patch` (tier-2,
+//     path-overlap-gated) and does NOT conflict — disjoint paths merge cleanly;
+//   - a whole-doc `set`/`delete` is tier-1 (path-blind) and DOES reject the
+//     linked write on its structural reads ("stale confirmed read").
+// ARMs 1–4 instrument the peer op-type via `getNativeCommit` and separate these
+// cases. The R1–R4 arms then prove the per-key commit queue (RuntimeProcessor
+// handleCellSet) serializes same-key writes (own-write race) and recovers via
+// bounded rebase from a tier-1 delete and a create-race.
+//
+// Harness recipe from cross-space-value-read.test.ts: two real Runtimes, each
+// with its OWN per-space replicas, loopback-connected to ONE shared in-process
+// MemoryV2Server. Convergence is forced with explicit pull()/sync()/synced() —
+// never a bare get() on an un-pulled local projection.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type {
+  IExtendedStorageTransaction,
+  MemorySpace,
+} from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("ipc-structural-conflict-spike");
+const space = signer.did();
+
+// Two StorageManagers sharing ONE real server, each with its own replicas.
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager.sharedServer = server;
+    return manager;
+  }
+
+  private sharedServer!: MemoryV2Server.Server;
+
+  // Shared server: serve it without ever initializing the base class's
+  // private `#server`, whose `close()` would close the shared server once per
+  // manager.
+  protected override server(): MemoryV2Server.Server {
+    return this.sharedServer;
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+  });
+
+// Read the native commit operations the runtime will SEND for `space`, after
+// prepareTxForCommit but before commit(). This is the load-bearing instrument:
+// it pins which buildPatchOperation branch the write actually took.
+function captureCommitOps(
+  tx: IExtendedStorageTransaction,
+  sp: MemorySpace,
+): Array<{ op: string; id?: string; path?: readonly unknown[] }> {
+  // ExtendedStorageTransaction exposes the inner IStorageTransaction at `.tx`,
+  // which carries getNativeCommit(space).
+  const inner =
+    (tx as unknown as { tx: { getNativeCommit?: (s: MemorySpace) => unknown } })
+      .tx;
+  const native = inner.getNativeCommit?.(sp) as
+    | { operations?: Array<Record<string, unknown>> }
+    | undefined;
+  return (native?.operations ?? []).map((o) => ({
+    op: String(o.op),
+    id: o.id as string | undefined,
+    // patch ops carry a `patches` array; set/delete do not
+    path: (o as { patches?: unknown[] }).patches as
+      | readonly unknown[]
+      | undefined,
+  }));
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Faithful in-test replica of the runtime-client per-key COMMIT QUEUE
+// (RuntimeProcessor.handleCellSet / commitLatestForKey on the spike branch),
+// driving REAL Runtime commits. Importing RuntimeProcessor here would invert the
+// pace-layer stack (runner is layer-1; runtime-client is layer-5/6), so we
+// reproduce the queue's exact mechanics — serialized chain, bounded rebase,
+// seq-skip on supersession — over the real runtime/storage to prove the
+// SERVER-SIDE behavior the queue depends on. `commit` is a caller-supplied
+// closure that performs one real `tx.commit()` of `value` and returns its
+// result; `events` records what the queue observed, for assertions.
+const CELL_SET_COMMIT_RETRIES = 5;
+
+type QueueEvent =
+  | { kind: "commit"; seq: number; value: string }
+  | { kind: "landed"; value: string }
+  | { kind: "rebase"; retriesLeft: number; value: string }
+  | { kind: "supersede"; from: number; to: number }
+  | { kind: "exhausted"; value: string }
+  | { kind: "threw"; value: string };
+
+function makeCommitQueue(
+  commit: (value: string) => Promise<{ error?: unknown }>,
+) {
+  const latest = new Map<
+    string,
+    { seq: number; value: string; retriesLeft: number }
+  >();
+  const chains = new Map<string, Promise<void>>();
+  const events: QueueEvent[] = [];
+
+  async function commitLatestForKey(key: string): Promise<void> {
+    for (;;) {
+      const cur0 = latest.get(key);
+      if (!cur0) return;
+      const attemptSeq = cur0.seq;
+      const applied = cur0.value;
+      events.push({ kind: "commit", seq: attemptSeq, value: applied });
+      let result: { error?: unknown };
+      try {
+        result = await commit(applied);
+      } catch {
+        events.push({ kind: "threw", value: applied });
+        return;
+      }
+      if (!result.error) {
+        events.push({ kind: "landed", value: applied });
+        return;
+      }
+      const current = latest.get(key);
+      if (!current) return;
+      if (current.seq !== attemptSeq) {
+        events.push({ kind: "supersede", from: attemptSeq, to: current.seq });
+        continue;
+      }
+      if (current.retriesLeft <= 0) {
+        events.push({ kind: "exhausted", value: applied });
+        return;
+      }
+      current.retriesLeft--;
+      events.push({
+        kind: "rebase",
+        retriesLeft: current.retriesLeft,
+        value: current.value,
+      });
+    }
+  }
+
+  function enqueue(key: string, value: string): void {
+    const prev = latest.get(key);
+    const enqueuedSeq = (prev?.seq ?? 0) + 1;
+    latest.set(key, {
+      seq: enqueuedSeq,
+      value,
+      retriesLeft: CELL_SET_COMMIT_RETRIES,
+    });
+    const prevTail = chains.get(key) ?? Promise.resolve();
+    const tail = prevTail.then(() => commitLatestForKey(key));
+    chains.set(key, tail);
+    tail.finally(() => {
+      if (chains.get(key) === tail) {
+        chains.delete(key);
+        const c = latest.get(key);
+        if (c && c.seq === enqueuedSeq) latest.delete(key);
+      }
+    });
+  }
+
+  // Drain: every enqueued key's chain tail has settled.
+  async function drain(): Promise<void> {
+    // chains may be repopulated during await; loop until empty.
+    for (let i = 0; i < 50 && chains.size > 0; i++) {
+      await Promise.all([...chains.values()]);
+    }
+  }
+
+  return { enqueue, drain, events, chains, latest };
+}
+
+describe("finding-1: $value linked write vs concurrent sibling bump", () => {
+  let server: MemoryV2Server.Server;
+  let storageA: SharedServerStorageManager;
+  let storageB: SharedServerStorageManager;
+  let rtA: Runtime;
+  let rtB: Runtime;
+
+  beforeEach(() => {
+    server = newSharedServer();
+    storageA = SharedServerStorageManager.connectTo(server, { as: signer });
+    storageB = SharedServerStorageManager.connectTo(server, { as: signer });
+    rtA = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storageA,
+    });
+    rtB = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storageB,
+    });
+  });
+
+  afterEach(async () => {
+    await rtB.dispose();
+    await rtA.dispose();
+    await storageB.close();
+    await storageA.close();
+    await server.close();
+  });
+
+  // SHARED UPSTREAM DOC: { nameDraft: "", otherSibling: 0 } (value path).
+  // DOWNSTREAM DOC holds a write-redirect link at `name` -> upstream nameDraft.
+  // A write through downstream.name resolves the redirect into the upstream
+  // doc, triggering link-resolution's structural reads + cfc-label read.
+  const UPSTREAM_CAUSE = "shared-upstream-doc";
+  const DOWNSTREAM_CAUSE = "downstream-linking-doc";
+
+  async function seedUpstream(
+    rt: Runtime,
+    storage: SharedServerStorageManager,
+  ) {
+    const upstream = rt.getCell<{ nameDraft: string; otherSibling: number }>(
+      space,
+      UPSTREAM_CAUSE,
+      undefined,
+    );
+    const tx = rt.edit();
+    upstream.withTx(tx).set({ nameDraft: "", otherSibling: 0 });
+    rt.prepareTxForCommit(tx);
+    const res = await tx.commit();
+    expect(
+      res.error,
+      `seed upstream commit error: ${JSON.stringify(res.error)}`,
+    )
+      .toBeUndefined();
+    await storage.synced();
+    return upstream;
+  }
+
+  // Build the downstream doc whose `name` field is a write-redirect link into
+  // upstream ["nameDraft"]. This is the $value binding the demo uses.
+  async function seedDownstreamLink(
+    rt: Runtime,
+    storage: SharedServerStorageManager,
+    upstream: ReturnType<Runtime["getCell"]>,
+  ) {
+    const downstream = rt.getCell<{ name: unknown }>(
+      space,
+      DOWNSTREAM_CAUSE,
+      undefined,
+    );
+    const tx = rt.edit();
+    // Write-redirect link at downstream.name -> upstream.nameDraft.
+    const redirect = upstream.key("nameDraft").getAsWriteRedirectLink();
+    downstream.withTx(tx).set({ name: redirect });
+    rt.prepareTxForCommit(tx);
+    const res = await tx.commit();
+    expect(
+      res.error,
+      `seed downstream commit error: ${JSON.stringify(res.error)}`,
+    )
+      .toBeUndefined();
+    await storage.synced();
+    return downstream;
+  }
+
+  // Perform the actual $value linked write: write a string through the
+  // downstream `name` field, which resolves the write-redirect into the
+  // upstream doc. Returns { result, ops }.
+  async function writeLinkedValue(
+    rt: Runtime,
+    downstream: ReturnType<Runtime["getCell"]>,
+    value: string,
+  ) {
+    const tx = rt.edit();
+    downstream.withTx(tx).key("name").set(value);
+    rt.prepareTxForCommit(tx);
+    const ops = captureCommitOps(tx, space);
+    const result = await tx.commit();
+    return { result, ops };
+  }
+
+  it("DIAGNOSTIC: linked write read-set + op-type (no concurrency)", async () => {
+    const upstream = await seedUpstream(rtA, storageA);
+    const downstream = await seedDownstreamLink(rtA, storageA, upstream);
+
+    const { result } = await writeLinkedValue(
+      rtA,
+      downstream,
+      "Alice",
+    );
+    // Confirm the upstream value actually moved through the redirect.
+    await storageA.synced();
+    expect(result.error).toBeUndefined();
+  });
+
+  it("ARM 1 (control): sibling PATCH bump does NOT reject the linked write", async () => {
+    const upstreamA = await seedUpstream(rtA, storageA);
+    const downstreamA = await seedDownstreamLink(rtA, storageA, upstreamA);
+
+    // rtB opens the SAME upstream doc and pulls to converge.
+    const upstreamB = rtB.getCell<{ nameDraft: string; otherSibling: number }>(
+      space,
+      UPSTREAM_CAUSE,
+      undefined,
+    );
+    await upstreamB.sync();
+    await upstreamB.pull();
+
+    // PEER (rtB) bumps a DISJOINT SIBLING via in-place set -> expect leaf patch.
+    const peerTx = rtB.edit();
+    upstreamB.withTx(peerTx).key("otherSibling").set(1);
+    rtB.prepareTxForCommit(peerTx);
+    const peerOps = captureCommitOps(peerTx, space);
+    const peerRes = await peerTx.commit();
+    await storageB.synced();
+    expect(peerRes.error).toBeUndefined();
+
+    // rtA writes the linked $value (resolves redirect into upstream nameDraft).
+    // NOTE: rtA's local replica has NOT yet seen the peer bump. The conflict
+    // (if any) is detected server-side at commit on the read-set's seq baseline.
+    const { result } = await writeLinkedValue(
+      rtA,
+      downstreamA,
+      "Alice",
+    );
+
+    // Assertion: per synthesis, a sibling PATCH must NOT reject.
+    expect(peerOps.every((o) => o.op === "patch")).toBe(true);
+    expect(result.error).toBeUndefined();
+
+    // CONVERGENCE PROBE: pull BOTH runtimes and read the upstream doc.
+    // The SERVER merged both patches (neither commit was rejected); the
+    // question is whether each local replica reflects the merge. A fresh
+    // third reader observes the server's authoritative merged state.
+    await storageA.synced();
+    await storageB.synced();
+    await upstreamA.sync();
+    await upstreamA.pull();
+    await upstreamB.sync();
+    await upstreamB.pull();
+    await rtA.idle();
+    await rtB.idle();
+
+    // Authoritative server truth via a FRESH runtime/replica (no prior local
+    // state to be stale). This is what actually landed in the shared server.
+    const storageC = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const rtC = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storageC,
+    });
+    try {
+      const upstreamC = rtC.getCell<
+        { nameDraft: string; otherSibling: number }
+      >(
+        space,
+        UPSTREAM_CAUSE,
+        undefined,
+      );
+      await upstreamC.sync();
+      await upstreamC.pull();
+      const serverTruth = upstreamC.get();
+      // Both writes merged server-side: the sibling patch and the linked write
+      // coexist (tier-2 path-granular: disjoint patches do not conflict).
+      expect(serverTruth).toEqual({ nameDraft: "Alice", otherSibling: 1 });
+    } finally {
+      await rtC.dispose();
+      await storageC.close();
+    }
+  });
+
+  it("ARM 2 (root SET via Cell.set): does it emit `set` or a leaf `patch`?", async () => {
+    const upstreamA = await seedUpstream(rtA, storageA);
+    const downstreamA = await seedDownstreamLink(rtA, storageA, upstreamA);
+
+    const upstreamB = rtB.getCell<{ nameDraft: string; otherSibling: number }>(
+      space,
+      UPSTREAM_CAUSE,
+      undefined,
+    );
+    await upstreamB.sync();
+    await upstreamB.pull();
+
+    // The design predicted: replace the WHOLE upstream value (root .set) forces
+    // the tier-1 `set` fallback. EMPIRICAL TEST of that prediction.
+    const peerTx = rtB.edit();
+    upstreamB.withTx(peerTx).set({ nameDraft: "", otherSibling: 1 });
+    rtB.prepareTxForCommit(peerTx);
+    const peerOps = captureCommitOps(peerTx, space);
+    const peerRes = await peerTx.commit();
+    await storageB.synced();
+    expect(peerRes.error).toBeUndefined();
+
+    const { result } = await writeLinkedValue(rtA, downstreamA, "Alice");
+    // FINDING: Cell.set diffs to the changed leaf, so a root .set of an
+    // EXISTING doc emits a leaf `patch`, NOT a `set`. The design's premise
+    // ("root write -> set fallback") is FALSE for Cell.set on an existing doc.
+    expect(peerOps.every((o) => o.op === "patch")).toBe(true);
+    // ...and therefore the linked write is NOT rejected (tier-2 path-granular).
+    expect(result.error).toBeUndefined();
+  });
+
+  it("ARM 3 (doc DELETE via setRaw(undefined)): tier-1 `delete` path-blind conflict", async () => {
+    const upstreamA = await seedUpstream(rtA, storageA);
+    const downstreamA = await seedDownstreamLink(rtA, storageA, upstreamA);
+
+    const upstreamB = rtB.getCell<{ nameDraft: string; otherSibling: number }>(
+      space,
+      UPSTREAM_CAUSE,
+      undefined,
+    );
+    await upstreamB.sync();
+    await upstreamB.pull();
+
+    // PEER deletes the whole upstream DOC at the doc ROOT (path []), NOT the
+    // value subtree. Writing undefined with {delete:true} at the doc address
+    // makes doc.current.value === undefined -> getNativeCommit emits a tier-1
+    // `delete` op. (setRaw(undefined) writes the value subtree -> a `patch`
+    // `replace /value` instead, which is a different and buggy path.)
+    const peerTx = rtB.edit();
+    const upLink = upstreamB.getAsNormalizedFullLink();
+    const docRootAddress = {
+      space: upLink.space,
+      id: upLink.id,
+      scope: upLink.scope,
+      type: "application/json" as const,
+      path: [] as string[],
+    };
+    // writeOrThrow at the doc-root address with {delete:true}.
+    (peerTx as unknown as {
+      writeOrThrow: (
+        a: typeof docRootAddress,
+        v: unknown,
+        o?: { delete?: boolean },
+      ) => void;
+    }).writeOrThrow(docRootAddress, undefined, { delete: true });
+    rtB.prepareTxForCommit(peerTx);
+    const peerOps = captureCommitOps(peerTx, space);
+    await peerTx.commit();
+    await storageB.synced();
+
+    const { result } = await writeLinkedValue(rtA, downstreamA, "Alice");
+    // FINDING: a tier-1 `delete` is path-blind. The linked write's structural
+    // reads (cfc + link-source on the upstream doc) take a dependency on the
+    // upstream doc revision, so the delete collateral-rejects the linked write
+    // "even though nothing it logically depends on changed."
+    expect(peerOps.some((o) => o.op === "delete")).toBe(true);
+    expect(result.error).toBeDefined();
+  });
+
+  it("ARM 4 (doc CREATE race): concurrent creators emit `set`; tier-1 conflict", async () => {
+    // Both runtimes CREATE the same upstream doc concurrently (no prior seed).
+    // A doc create has initial.value === undefined -> buildPatchOperation null
+    // -> `set` op. The loser's read-set (the doc-absent precondition / read)
+    // collides with the winner's `set` via tier-1.
+    const upstreamA = rtA.getCell<{ nameDraft: string; otherSibling: number }>(
+      space,
+      "doc-create-race-upstream",
+      undefined,
+    );
+    const txA = rtA.edit();
+    upstreamA.withTx(txA).set({ nameDraft: "", otherSibling: 0 });
+    rtA.prepareTxForCommit(txA);
+    const opsA = captureCommitOps(txA, space);
+
+    // B creates the same doc with different content, having never seen A.
+    const upstreamB = rtB.getCell<{ nameDraft: string; otherSibling: number }>(
+      space,
+      "doc-create-race-upstream",
+      undefined,
+    );
+    const txB = rtB.edit();
+    upstreamB.withTx(txB).set({ nameDraft: "x", otherSibling: 9 });
+    rtB.prepareTxForCommit(txB);
+
+    await txA.commit();
+    await txB.commit();
+    // Doc create emits `set`. One creator wins; the other's create is rejected.
+    expect(opsA.every((o) => o.op === "set")).toBe(true);
+  });
+});
+
+// SHAPE-C: the per-key commit QUEUE (runtime-client) exercised against the REAL
+// conflict mechanism. Reuses the two-runtime harness above via a fresh server
+// per test. Each test drives the queue replica (makeCommitQueue) over rtA and
+// records what the queue observed, then asserts the SERVER truth.
+describe("shape-C commit queue over real runtime", () => {
+  let server: MemoryV2Server.Server;
+  let storageA: SharedServerStorageManager;
+  let storageB: SharedServerStorageManager;
+  let rtA: Runtime;
+  let rtB: Runtime;
+
+  const UPSTREAM_CAUSE = "shared-upstream-doc";
+  const DOWNSTREAM_CAUSE = "downstream-linking-doc";
+
+  beforeEach(() => {
+    server = newSharedServer();
+    storageA = SharedServerStorageManager.connectTo(server, { as: signer });
+    storageB = SharedServerStorageManager.connectTo(server, { as: signer });
+    rtA = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storageA,
+    });
+    rtB = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storageB,
+    });
+  });
+
+  afterEach(async () => {
+    await rtB.dispose();
+    await rtA.dispose();
+    await storageB.close();
+    await storageA.close();
+    await server.close();
+  });
+
+  async function seedUpstream(
+    rt: Runtime,
+    storage: SharedServerStorageManager,
+  ) {
+    const upstream = rt.getCell<{ nameDraft: string; otherSibling: number }>(
+      space,
+      UPSTREAM_CAUSE,
+      undefined,
+    );
+    const tx = rt.edit();
+    upstream.withTx(tx).set({ nameDraft: "", otherSibling: 0 });
+    rt.prepareTxForCommit(tx);
+    const res = await tx.commit();
+    expect(res.error).toBeUndefined();
+    await storage.synced();
+    return upstream;
+  }
+
+  async function seedDownstreamLink(
+    rt: Runtime,
+    storage: SharedServerStorageManager,
+    upstream: ReturnType<Runtime["getCell"]>,
+  ) {
+    const downstream = rt.getCell<{ name: unknown }>(
+      space,
+      DOWNSTREAM_CAUSE,
+      undefined,
+    );
+    const tx = rt.edit();
+    const redirect = upstream.key("nameDraft").getAsWriteRedirectLink();
+    downstream.withTx(tx).set({ name: redirect });
+    rt.prepareTxForCommit(tx);
+    const res = await tx.commit();
+    expect(res.error).toBeUndefined();
+    await storage.synced();
+    return downstream;
+  }
+
+  // The queue's per-attempt commit: one real linked-$value write of `value`
+  // through downstream.name -> upstream.nameDraft. Tracks concurrency: how many
+  // tx.commit() calls were in flight simultaneously (the serialization probe).
+  function makeLinkedCommit(
+    downstream: ReturnType<Runtime["getCell"]>,
+  ) {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let commitCount = 0;
+    const commit = async (value: string) => {
+      commitCount++;
+      const tx = rtA.edit();
+      downstream.withTx(tx).key("name").set(value);
+      rtA.prepareTxForCommit(tx);
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      try {
+        return await tx.commit();
+      } finally {
+        inFlight--;
+      }
+    };
+    return {
+      commit,
+      stats: () => ({ commitCount, maxInFlight }),
+    };
+  }
+
+  async function serverTruth(): Promise<unknown> {
+    const storageC = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const rtC = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storageC,
+    });
+    try {
+      const upstreamC = rtC.getCell<
+        { nameDraft: string; otherSibling: number }
+      >(
+        space,
+        UPSTREAM_CAUSE,
+        undefined,
+      );
+      await upstreamC.sync();
+      await upstreamC.pull();
+      return upstreamC.get();
+    } finally {
+      await rtC.dispose();
+      await storageC.close();
+    }
+  }
+
+  it("R1: two same-key writes through the queue serialize, no rollback-erasure", async () => {
+    const upstreamA = await seedUpstream(rtA, storageA);
+    const downstreamA = await seedDownstreamLink(rtA, storageA, upstreamA);
+
+    const { commit, stats } = makeLinkedCommit(downstreamA);
+    const q = makeCommitQueue(commit);
+    // The actual flake shape: ONE client emits two sets to the SAME linked path
+    // back-to-back ("B" then "Bob").
+    q.enqueue("name", "B");
+    q.enqueue("name", "Bob");
+    await q.drain();
+    await storageA.synced();
+
+    const { maxInFlight } = stats();
+    // SERIALIZATION: at most one tx.commit() was ever in flight. This is the
+    // property that PREVENTS the own-write race (concurrent same-path commits,
+    // one confirming while the other rejects-and-rolls-back).
+    expect(maxInFlight).toBe(1);
+
+    // No rollback-erasure: a FRESH reader observes the final value "Bob",
+    // never a dead-end where a confirmed "Bob" was reverted by a late reject.
+    const truth = serverTruth();
+    expect(await truth).toEqual({ nameDraft: "Bob", otherSibling: 0 });
+  });
+
+  it("R2: ARM3 tier-1 delete — does the queue rebase and recover?", async () => {
+    const upstreamA = await seedUpstream(rtA, storageA);
+    const downstreamA = await seedDownstreamLink(rtA, storageA, upstreamA);
+
+    // Peer rtB deletes the whole upstream DOC at root (tier-1, path-blind).
+    const upstreamB = rtB.getCell<{ nameDraft: string; otherSibling: number }>(
+      space,
+      UPSTREAM_CAUSE,
+      undefined,
+    );
+    await upstreamB.sync();
+    await upstreamB.pull();
+    const peerTx = rtB.edit();
+    const upLink = upstreamB.getAsNormalizedFullLink();
+    (peerTx as unknown as {
+      writeOrThrow: (
+        a: unknown,
+        v: unknown,
+        o?: { delete?: boolean },
+      ) => void;
+    }).writeOrThrow(
+      {
+        space: upLink.space,
+        id: upLink.id,
+        scope: upLink.scope,
+        type: "application/json" as const,
+        path: [] as string[],
+      },
+      undefined,
+      { delete: true },
+    );
+    rtB.prepareTxForCommit(peerTx);
+    const peerRes = await peerTx.commit();
+    await storageB.synced();
+    expect(peerRes.error).toBeUndefined();
+
+    // Now drive the linked write "Alice" through the queue. The first commit
+    // collateral-rejects (tier-1 delete is path-blind); the queue rebases.
+    const { commit, stats } = makeLinkedCommit(downstreamA);
+    const q = makeCommitQueue(commit);
+    q.enqueue("name", "Alice");
+    await q.drain();
+    await storageA.synced();
+
+    const { commitCount } = stats();
+    const rebases = q.events.filter((e) => e.kind === "rebase").length;
+    const landed = q.events.some((e) => e.kind === "landed");
+    const exhausted = q.events.some((e) => e.kind === "exhausted");
+
+    // VERDICT GATES (honest, per JC-4): the rebase MUST fire (the value is not
+    // silently dropped), attempts are BOUNDED (<= 1 + budget), and the queue
+    // reaches a terminal state (landed OR exhausted) — never an infinite loop.
+    expect(rebases).toBeGreaterThanOrEqual(1);
+    expect(commitCount).toBeLessThanOrEqual(1 + CELL_SET_COMMIT_RETRIES);
+    expect(landed || exhausted).toBe(true);
+  });
+
+  it("R3: ARM4 create-race — does the queue handle it or leave a gap?", async () => {
+    const cause = "doc-create-race-queue";
+    // Winner: rtB creates the doc first and syncs.
+    const upstreamB = rtB.getCell<{ nameDraft: string; otherSibling: number }>(
+      space,
+      cause,
+      undefined,
+    );
+    const txB = rtB.edit();
+    upstreamB.withTx(txB).set({ nameDraft: "winner", otherSibling: 9 });
+    rtB.prepareTxForCommit(txB);
+    const resB = await txB.commit();
+    expect(resB.error).toBeUndefined();
+    await storageB.synced();
+
+    // Loser: rtA tries to CREATE the same doc through the queue. rtA's replica
+    // has not seen B's create, so the first commit hits the create-race
+    // (StorageTransactionInconsistent / tier-1). The queue rebases.
+    const upstreamA = rtA.getCell<{ nameDraft: string; otherSibling: number }>(
+      space,
+      cause,
+      undefined,
+    );
+    let commitCount = 0;
+    const commit = async (value: string) => {
+      commitCount++;
+      const tx = rtA.edit();
+      upstreamA.withTx(tx).set({ nameDraft: value, otherSibling: 0 });
+      rtA.prepareTxForCommit(tx);
+      // A rebase must re-read the doc so the retry layers a patch onto the
+      // winner's now-existing doc rather than re-attempting a create.
+      return await tx.commit();
+    };
+    const q = makeCommitQueue(commit);
+    q.enqueue(cause, "loser");
+    // Between attempts, converge rtA's replica so a rebase sees the winner doc.
+    const drainWithSync = async () => {
+      for (let i = 0; i < 50 && q.chains.size > 0; i++) {
+        await Promise.all([...q.chains.values()]);
+        await storageA.synced();
+        await upstreamA.sync();
+        await upstreamA.pull();
+      }
+    };
+    await drainWithSync();
+    await storageA.synced();
+
+    const landed = q.events.some((e) => e.kind === "landed");
+    const exhausted = q.events.some((e) => e.kind === "exhausted");
+    const threw = q.events.some((e) => e.kind === "threw");
+
+    // VERDICT GATES (honest, per JC-5): attempts are BOUNDED — no infinite
+    // create-loop — and the queue reaches a terminal state. Whether the loser's
+    // value LANDS (rebased patch onto the winner) or the create-race throws a
+    // non-rebaseable StorageTransactionInconsistent (caught -> "threw",
+    // terminal) is the observed behavior the test RECORDS, not a recovery
+    // guarantee.
+    expect(commitCount).toBeLessThanOrEqual(1 + CELL_SET_COMMIT_RETRIES);
+    expect(landed || exhausted || threw).toBe(true);
+  });
+
+  it("R4: dispose mid-flight stops further commits", async () => {
+    const upstreamA = await seedUpstream(rtA, storageA);
+    const downstreamA = await seedDownstreamLink(rtA, storageA, upstreamA);
+
+    // A commit closure that blocks on a gate we control, so we can "dispose"
+    // (flip a disposed flag + clear the queue) WHILE a commit is unresolved.
+    let disposed = false;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    let commitCount = 0;
+    const commit = async (value: string) => {
+      commitCount++;
+      await gate; // hold the first commit open
+      if (disposed) {
+        // Mirror the real loop bailing on isDisposed() at the await boundary:
+        // a disposed queue issues no further commit. We model that by returning
+        // a benign landed result and letting the chain settle.
+        return { error: undefined };
+      }
+      const tx = rtA.edit();
+      downstreamA.withTx(tx).key("name").set(value);
+      rtA.prepareTxForCommit(tx);
+      return await tx.commit();
+    };
+    const q = makeCommitQueue(commit);
+    q.enqueue("name", "Alice");
+    // Let the first commit reach the gate.
+    await Promise.resolve();
+    await Promise.resolve();
+    const before = commitCount;
+    expect(before).toBe(1);
+    // "Dispose": stop scheduling, clear queue state (mirrors dispose()).
+    disposed = true;
+    q.chains.clear();
+    q.latest.clear();
+    release();
+    await sleep(5);
+    // No NEW commit was scheduled after disposal.
+    expect(commitCount).toBe(before);
+  });
+});

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1566,8 +1566,23 @@ describe("RuntimeProcessor CFC commit preparation", () => {
         expect(value).toBe("new value");
       },
     };
+    let sent = false;
+    cellWithTx.send = (value: unknown) => {
+      expect(value).toBe("new value");
+      sent = true;
+    };
     return {
       processor: {
+        isDisposed: () => false,
+        cellSetLatest: new Map<
+          string,
+          { seq: number; value: unknown; retriesLeft: number }
+        >(),
+        cellSetChains: new Map<string, Promise<void>>(),
+        commitLatestForKey: (RuntimeProcessor.prototype as unknown as {
+          commitLatestForKey: (...a: unknown[]) => Promise<void>;
+        }).commitLatestForKey,
+        pendingCellWrites: new Set<Promise<unknown>>(),
         runtime: {
           edit: () => tx,
           prepareTxForCommit: (candidate: unknown) => {
@@ -1585,27 +1600,35 @@ describe("RuntimeProcessor CFC commit preparation", () => {
           },
         },
       } as unknown as RuntimeProcessor,
+      wasSent: () => sent,
     };
+  };
+
+  const flushTicks = async (n = 10) => {
+    for (let i = 0; i < n; i++) await Promise.resolve();
   };
 
   it("prepares cell set transactions before committing", async () => {
     const { processor } = createProcessor();
 
-    await RuntimeProcessor.prototype.handleCellSet.call(processor, {
+    RuntimeProcessor.prototype.handleCellSet.call(processor, {
       type: RequestType.CellSet,
       cell: ref,
       value: "new value",
     });
+    await flushTicks();
   });
 
   it("prepares cell send transactions before committing", async () => {
-    const { processor } = createProcessor();
+    const { processor, wasSent } = createProcessor();
 
-    await RuntimeProcessor.prototype.handleCellSend.call(processor, {
+    RuntimeProcessor.prototype.handleCellSend.call(processor, {
       type: RequestType.CellSend,
       cell: ref,
       event: "new value",
     });
+    expect(wasSent()).toBe(true);
+    await flushTicks();
   });
 });
 
@@ -1971,5 +1994,267 @@ describe("RuntimeProcessor vdom mount render policy", () => {
   it("keeps mounts unbounded when no ceiling is configured", async () => {
     const policy = await mountAndGetRootPolicy(undefined);
     expect(policy.maxConfidentiality).toBeUndefined();
+  });
+});
+
+describe("RuntimeProcessor cell set IPC", () => {
+  const cellRef: CellRef = {
+    id: "of:cell-set-retry" as CellRef["id"],
+    space: "did:key:test-space" as CellRef["space"],
+    scope: "space",
+    path: ["nameDraft"],
+  };
+
+  type Deferred = {
+    resolve: (r: { error?: { message: string } }) => void;
+    promise: Promise<{ error?: { message: string } }>;
+  };
+
+  function makeProcessor(opts?: { editThrowsFirstN?: number }) {
+    const setValues: unknown[] = [];
+    const commits: Deferred[] = [];
+    let editCalls = 0;
+    const processor = {
+      isDisposed: () => false,
+      cellSetLatest: new Map<
+        string,
+        { seq: number; value: unknown; retriesLeft: number }
+      >(),
+      // The per-key commit queue: handleCellSet links same-key writes onto this
+      // chain so their tx.commit() calls serialize (see the U3/supersede tests).
+      cellSetChains: new Map<string, Promise<void>>(),
+      // The chain links call this.commitLatestForKey; bind the real (private)
+      // prototype method so the mock exercises the production loop, not a stub.
+      commitLatestForKey: (RuntimeProcessor.prototype as unknown as {
+        commitLatestForKey: (...a: unknown[]) => Promise<void>;
+      }).commitLatestForKey,
+      runtime: {
+        edit: () => {
+          // Inject a SYNCHRONOUS throw on the first N tx setups (simulates a
+          // CFC-label violation / write-guard / malformed ref). commitLatestForKey
+          // must catch this and resolve the link, not reject + wedge the chain.
+          if (++editCalls <= (opts?.editThrowsFirstN ?? 0)) {
+            throw new Error("synthetic tx-setup throw");
+          }
+          return {
+            commit: () => {
+              let resolve!: Deferred["resolve"];
+              const promise = new Promise<{ error?: { message: string } }>(
+                (res) => {
+                  resolve = res;
+                },
+              );
+              commits.push({ resolve, promise });
+              return promise;
+            },
+          };
+        },
+        getCellFromLink: () => ({
+          withTx: () => ({
+            set: (value: unknown) => {
+              setValues.push(value);
+            },
+          }),
+        }),
+        prepareTxForCommit: () => {},
+      },
+    } as unknown as RuntimeProcessor;
+    const set = (value: string) =>
+      RuntimeProcessor.prototype.handleCellSet.call(processor, {
+        type: RequestType.CellSet,
+        cell: cellRef,
+        value,
+      });
+    return { processor, setValues, commits, set };
+  }
+
+  const flushAsync = async () => {
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+  };
+  const REJECTED = { error: { message: "stale confirmed read: of:test" } };
+
+  it("reapplies the latest value until a rejected commit lands", async () => {
+    // U1 (preserved): a single key's commit, rejected twice, rebases each time
+    // on a fresh tx and lands on the third. Under the per-key commit queue the
+    // first link runs on a microtask (the chain's .then), so flush ONCE before
+    // touching commits[0] — that is the only change from the pre-queue test;
+    // the observable commit/set sequence is identical.
+    const { setValues, commits, set } = makeProcessor();
+    set("Bob");
+    await flushAsync();
+    commits[0].resolve(REJECTED);
+    await flushAsync();
+    commits[1].resolve(REJECTED);
+    await flushAsync();
+    commits[2].resolve({});
+    await flushAsync();
+    // Initial apply + two reapplies, each on a fresh tx.
+    expect(setValues).toEqual(["Bob", "Bob", "Bob"]);
+    expect(commits.length).toBe(3);
+  });
+
+  it("gives up after exhausting the bounded per-cell budget", async () => {
+    // U2 (preserved): the rebase loop is bounded to CELL_SET_COMMIT_RETRIES.
+    // Same one-microtask-later first link as U1, so flush before the loop reads
+    // commits.length.
+    const { setValues, commits, set } = makeProcessor();
+    set("Bob");
+    await flushAsync();
+    for (let i = 0; i < 10 && i < commits.length; i++) {
+      commits[i].resolve(REJECTED);
+      await flushAsync();
+    }
+    // 1 initial + CELL_SET_COMMIT_RETRIES reapplies.
+    expect(setValues.length).toBe(6);
+  });
+
+  it("serializes same-key writes: the 2nd commit is not issued until the 1st resolves", async () => {
+    // U3 (NEW — the prevention property the after-the-fact reapply could not
+    // provide). Two same-key sets are enqueued back-to-back. The queue links
+    // them, so only ONE tx.commit() is in flight: the 2nd link cannot issue its
+    // commit until the 1st link's commit resolves. This structurally forbids the
+    // own-write race (two same-path patches overlapping, the 2nd confirming, the
+    // 1st rejecting and rolling back past the confirmed value).
+    const { processor, setValues, commits, set } = makeProcessor();
+    set("B");
+    set("Bob");
+    await flushAsync();
+    // THE PREVENTION PROPERTY: two same-key sets were enqueued, yet only ONE
+    // tx.commit() is in flight. The 2nd link cannot issue its commit until the
+    // 1st resolves — so the own-write race (two concurrent same-path commits,
+    // one confirming while the other rejects-and-rolls-back) can never form.
+    expect(commits.length).toBe(1);
+    // Read-at-commit supersession: the in-flight link reads the LATEST value
+    // ("Bob"), so the superseded "B" is never committed.
+    expect(setValues).toEqual(["Bob"]);
+
+    // Resolve the first commit successfully. ONLY NOW does the 2nd link run —
+    // proving the serialization barrier. It re-commits the latest ("Bob", an
+    // idempotent re-write) on its own fresh tx; still at most one in flight.
+    commits[0].resolve({});
+    await flushAsync();
+    expect(commits.length).toBe(2);
+    expect(setValues).toEqual(["Bob", "Bob"]);
+    // Drain the 2nd link; the per-key maps clean up to bounded (empty) state.
+    commits[1].resolve({});
+    await flushAsync();
+    const chains =
+      (processor as unknown as { cellSetChains: Map<string, unknown> })
+        .cellSetChains;
+    const latest =
+      (processor as unknown as { cellSetLatest: Map<string, unknown> })
+        .cellSetLatest;
+    expect(chains.size).toBe(0);
+    expect(latest.size).toBe(0);
+  });
+
+  it("rebases to the LATEST value on a rejection, never a stale one", async () => {
+    // U4 (re-pinned). The pre-queue test exercised TWO concurrent commits
+    // (commits[1] resolving before commits[0]) to prove a late rollback of an
+    // older write could not erase a newer confirmed one. Under serialization
+    // that interleaving is structurally impossible to FORM (proven by U3), so
+    // we re-pin to the residual rebase-correctness invariant the queue still
+    // owns: when a commit is rejected, the rebase re-applies the LATEST value,
+    // never the rejected-stale one. A SINGLE set keeps exactly one chain link so
+    // the rebase loop is observed without a trailing idempotent re-commit.
+    const { setValues, commits, set } = makeProcessor();
+    set("B");
+    set("Bob"); // supersedes "B" before the first link even commits
+    await flushAsync();
+    expect(setValues).toEqual(["Bob"]); // first commit already carries latest
+    expect(commits.length).toBe(1);
+    commits[0].resolve(REJECTED); // the (latest-valued) commit is rejected
+    await flushAsync();
+    // The rebase re-applies the LATEST value ("Bob"), never the superseded "B".
+    expect(setValues).toEqual(["Bob", "Bob"]);
+    // "B" was never committed at all — supersession dropped it before any tx.
+    expect(setValues.includes("B")).toBe(false);
+    // Land the rebase, then drain the trailing (2nd enqueued) link's idempotent
+    // re-commit so the test leaves no pending microtasks.
+    commits[1].resolve({});
+    await flushAsync();
+    commits[commits.length - 1].resolve({});
+    await flushAsync();
+    // Every committed value was the latest; no stale "B" ever reached a tx.
+    expect(setValues.every((v) => v === "Bob")).toBe(true);
+  });
+
+  it("a newer set supersedes a pending write without spending retry budget", async () => {
+    // U5 (re-pinned). The pre-queue test asserted a fixed interleaving
+    // (["old","old","new","new"]) that was an artifact of two racing chains.
+    // Under the serialized queue the invariant — not a fixed array — is the
+    // contract: the final landed value is the LATEST input, no value older than
+    // the latest is ever written after it, and a supersession does NOT consume
+    // the rebase budget (seq-skip).
+    const { processor, setValues, commits, set } = makeProcessor();
+    set("old");
+    await flushAsync();
+    expect(setValues).toEqual(["old"]);
+    // A newer set arrives while "old"'s commit is in flight (commits[0]). It
+    // bumps seq and refreshes budget; the in-flight link reads it on rejection.
+    set("new");
+    commits[0].resolve(REJECTED); // the "old" commit fails
+    await flushAsync();
+    // The rejection was for a SUPERSEDED seq, so the loop rebased to "new"
+    // WITHOUT decrementing budget. Land it.
+    const newIdx = setValues.lastIndexOf("new");
+    expect(newIdx).toBeGreaterThanOrEqual(0);
+    // Invariant: no "old" written after the first "new".
+    expect(setValues.slice(newIdx).includes("old")).toBe(false);
+    // Discriminator for the seq-skip optimization itself: the in-flight "new"
+    // entry must still hold FULL budget — the superseded rejection consumed
+    // none. (If the seq-skip were broken and decremented on supersession, this
+    // would read CELL_SET_COMMIT_RETRIES - 1.)
+    // deno-lint-ignore no-explicit-any
+    const entry = [...(processor as any).cellSetLatest.values()][0];
+    expect(entry?.retriesLeft).toBe(5); // CELL_SET_COMMIT_RETRIES, undecremented
+    commits[commits.length - 1].resolve({});
+    await flushAsync();
+    expect(setValues.at(-1)).toBe("new");
+  });
+
+  it("stops issuing commits after dispose mid-flight", async () => {
+    // Dispose while a commit is unresolved: no further tx.commit() is issued
+    // (the loop short-circuits on isDisposed() at each boundary, and dispose
+    // clears the queue maps). The in-flight commit is left to settle under the
+    // existing storageManager.synced() await in the real dispose(); here we just
+    // resolve it as rejected and confirm no rebase follows.
+    const { processor, setValues, commits, set } = makeProcessor();
+    set("Bob");
+    await flushAsync();
+    expect(commits.length).toBe(1);
+    // Simulate disposal: flip the flag and clear the queue, mirroring dispose().
+    (processor as unknown as { isDisposed: () => boolean }).isDisposed = () =>
+      true;
+    (processor as unknown as { cellSetChains: Map<string, unknown> })
+      .cellSetChains.clear();
+    (processor as unknown as { cellSetLatest: Map<string, unknown> })
+      .cellSetLatest.clear();
+    const before = commits.length;
+    commits[0].resolve(REJECTED); // would normally trigger a rebase
+    await flushAsync();
+    // No new commit was issued after disposal.
+    expect(commits.length).toBe(before);
+    expect(setValues).toEqual(["Bob"]);
+  });
+
+  it("a synchronous tx-setup throw resolves the link and frees the key (no wedge, no unhandled rejection)", async () => {
+    // Regression for the widened try in commitLatestForKey: a SYNCHRONOUS throw
+    // from edit()/set()/prepareTxForCommit() (a CFC-label violation, write-guard
+    // or malformed ref — exactly the op-types this queue serializes) must be
+    // caught so the link RESOLVES, not rejects. Without the widened try, the
+    // chain's `.then` carries an unhandled rejection (deno fails the test) AND
+    // the next same-key write wedges (its commit is never issued).
+    const { setValues, commits, set } = makeProcessor({ editThrowsFirstN: 1 });
+    set("a"); // first link: edit() throws synchronously, before any commit
+    await flushAsync();
+    expect(commits.length).toBe(0); // nothing committed; link resolved cleanly
+    // The key is freed: a subsequent same-key write still commits and lands.
+    set("b");
+    await flushAsync();
+    expect(commits.length).toBe(1); // chain NOT wedged — "b" issued its commit
+    commits[0].resolve({});
+    await flushAsync();
+    expect(setValues.at(-1)).toBe("b");
   });
 });

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -2148,6 +2148,32 @@ describe("RuntimeProcessor cell set IPC", () => {
     expect(latest.size).toBe(0);
   });
 
+  it("serializes same-identity writes even when schema/cfcLabelView differ", async () => {
+    // Regression (cubic P2 on #4196): the queue keys on storage IDENTITY
+    // (space:id:path), NOT the full cellRefToKey. Two writes to the SAME cell
+    // whose refs carry DIFFERENT schema must still serialize onto ONE chain —
+    // otherwise same-path writes could commit out of order again (the very race
+    // this queue prevents). With the old schema-inclusive key these split into
+    // two parallel chains and BOTH commits issue at once (commits.length === 2).
+    const { processor, commits } = makeProcessor();
+    const setWithSchema = (value: string, schema: unknown) =>
+      RuntimeProcessor.prototype.handleCellSet.call(processor, {
+        type: RequestType.CellSet,
+        cell: { ...cellRef, schema } as CellRef,
+        value,
+      });
+    setWithSchema("B", { type: "string" });
+    setWithSchema("Bob", { type: "string", title: "name" }); // same id/path, diff schema
+    await flushAsync();
+    // Identity-keyed queue => ONE chain => at most one commit in flight.
+    expect(commits.length).toBe(1);
+    commits[0].resolve({});
+    await flushAsync();
+    expect(commits.length).toBe(2); // 2nd link runs only after the 1st resolves
+    commits[1].resolve({});
+    await flushAsync();
+  });
+
   it("rebases to the LATEST value on a rejection, never a stale one", async () => {
     // U4 (re-pinned). The pre-queue test exercised TWO concurrent commits
     // (commits[1] resolving before commits[0]) to prove a late rollback of an

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -130,6 +130,9 @@ import type { VDomOp } from "../protocol/types.ts";
 import type { JSONValue, RuntimeOptions } from "@commonfabric/runner";
 
 const MAX_SERIALIZATION_DEPTH = 5;
+// Mirrors the scheduler's DEFAULT_RETRIES_FOR_EVENTS: direct UI cell writes
+// get the same bounded rebase-and-retry on commit rejection as handler events.
+const CELL_SET_COMMIT_RETRIES = 5;
 const blobUploadEncoding = new JsonEncodingContext();
 
 function resolveBlobUrl(url: string, apiUrl: URL, space: DID): string {
@@ -295,6 +298,27 @@ export class RuntimeProcessor {
   private _isDisposed = false;
   private disposingPromise: Promise<void> | undefined;
   private subscriptions = new Map<string, Cancel>();
+  // Latest direct write per cell key. A newer set supersedes the value an
+  // already-queued/in-flight commit will write (value is read at commit time,
+  // not capture time). `seq` is a monotonic supersession token: a rebase that
+  // finds seq advanced knows a newer value arrived and rebases to THAT without
+  // spending retry budget on the stale one. Budget refreshes on each user write
+  // (raw UI input is legitimately last-write-wins — Ubik).
+  private cellSetLatest = new Map<
+    string,
+    { seq: number; value: unknown; retriesLeft: number }
+  >();
+  // Per-key COMMIT QUEUE. Value = the tail of an in-flight promise chain for
+  // this key. Same-key writes link onto the tail so their tx.commit() calls
+  // SERIALIZE: the (N+1)th commit is not issued until the Nth commit's
+  // confirmation resolves. This PREVENTS the own-write race (two same-path
+  // patches overlapping, the 2nd confirming, the 1st rejecting and rolling
+  // back past the confirmed value) that the after-the-fact reapply only
+  // repaired. Absent key = no chain in flight. Cross-key writes never serialize
+  // against each other (only same-doc same-path writes race). Subsumes the
+  // dropped read-your-writes barrier: link N+1 rebases off the latest value
+  // only after link N has settled.
+  private cellSetChains = new Map<string, Promise<void>>();
   private telemetry: RuntimeTelemetry;
   #telemetryEnabled = false;
 
@@ -551,6 +575,13 @@ export class RuntimeProcessor {
     this.disposingPromise = (async () => {
       this.telemetry.removeEventListener("telemetry", this.#onTelemetry);
       try {
+        // Quiesce the commit queue: stop scheduling rebases. In-flight
+        // tx.commit() promises are awaited below via storageManager.synced();
+        // commitLatestForKey also bails on isDisposed() at each loop boundary,
+        // so no NEW rebase is issued after disposal.
+        this.cellSetChains.clear();
+        this.cellSetLatest.clear();
+
         this.#siteTableCancel?.();
         this.#siteTableCancel = undefined;
         for (const cancel of this.subscriptions.values()) {
@@ -661,14 +692,131 @@ export class RuntimeProcessor {
   }
 
   handleCellSet(request: CellSetRequest): void {
-    const tx = this.runtime.edit();
-    const cell = getCell(this.runtime, request.cell);
+    const key = cellRefToKey(request.cell);
     const value = mapCellRefsToSigilLinks(request.value);
-    cell.withTx(tx).set(value);
-    this.runtime.prepareTxForCommit(tx);
-    // Local visibility is established by commit(); the promise tracks remote
-    // confirmation/rollback and must not block cell IPC.
-    tx.commit();
+    // `value` is freshly minted by mapCellRefsToSigilLinks (new objects per
+    // request, never aliased) and is only READ across rebases, so no defensive
+    // clone is needed here. If a future change aliases it, clone with
+    // cloneIfNecessary from @commonfabric/data-model/value-clone — NEVER
+    // JSON.parse(JSON.stringify) or structuredClone.
+
+    // Supersede: the queued/in-flight link for this key reads THIS value at
+    // commit time. Bump seq (supersession token) and refresh the rebase budget
+    // (raw UI input is legitimately last-write-wins — Ubik).
+    const prev = this.cellSetLatest.get(key);
+    const enqueuedSeq = (prev?.seq ?? 0) + 1;
+    this.cellSetLatest.set(key, {
+      seq: enqueuedSeq,
+      value,
+      retriesLeft: CELL_SET_COMMIT_RETRIES,
+    });
+
+    // Append a link to this key's serialized chain. The link commits the LATEST
+    // value, rebasing on genuine rejection within budget. The NEXT same-key
+    // write's link does not run until THIS link's promise resolves — that is
+    // the serialization guarantee. (.then with no rejection handler is safe:
+    // commitLatestForKey never rejects — every path returns — so prevTail never
+    // carries a rejection forward.)
+    const prevTail = this.cellSetChains.get(key) ?? Promise.resolve();
+    const tail = prevTail.then(() => this.commitLatestForKey(key, request));
+    this.cellSetChains.set(key, tail);
+
+    // Self-cleanup when this link is the last one standing. Guard on BOTH the
+    // tail identity (a newer link hasn't replaced us) AND seq (no newer write
+    // arrived during our final await). Otherwise a set that landed during the
+    // final await would be stranded with its chain entry dropped.
+    tail.finally(() => {
+      if (this.cellSetChains.get(key) === tail) {
+        this.cellSetChains.delete(key);
+        const cur = this.cellSetLatest.get(key);
+        if (cur && cur.seq === enqueuedSeq) this.cellSetLatest.delete(key);
+      }
+    });
+  }
+
+  // One serialized chain step for a key: commit the latest value once, rebasing
+  // on a genuine rejection within budget, skipping wasted budget when a newer
+  // value superseded mid-flight. Resolves (never rejects) when this step has
+  // fully settled — landed, given up, disposed, or threw. That resolution is
+  // what gates the next chain link.
+  //
+  // We observed (two-browser repro) the local optimistic value end up staler
+  // than the latest confirmed write after an out-of-order rejection: input
+  // emits two sets; the second confirms; the first is rejected afterwards and
+  // its rollback reverts the local doc past the confirmed value. The commit
+  // queue PREVENTS that race by serialization (the 2nd commit is not issued
+  // until the 1st resolves); the bounded rebase below additionally repairs any
+  // residual staleness on a genuine rejection (idempotent when local state
+  // already matches). We have not pinned the optimistic-mirror staleness to the
+  // runtime/storage layer — instrumentation of the runtime rollback there shows
+  // it preserving confirmed writes — so the mechanism is most likely the
+  // client's optimistic mirror, which serialization closes.
+  private async commitLatestForKey(
+    key: string,
+    request: CellSetRequest,
+  ): Promise<void> {
+    for (;;) {
+      if (this.isDisposed()) return;
+      const latest = this.cellSetLatest.get(key);
+      if (!latest) return; // superseded-away / cleaned up; nothing to write.
+
+      const attemptSeq = latest.seq;
+      const applied = latest.value;
+
+      // Local visibility is established synchronously by commit(); the promise
+      // tracks remote confirmation/rollback. AWAIT is the serialization point:
+      // the next chain link cannot issue its tx.commit() until this resolves.
+      // The try spans the WHOLE tx setup, not just the await: a synchronous
+      // throw from edit()/set()/prepareTxForCommit() (a CFC-label violation,
+      // write-guard, or malformed ref — exactly the op-types this queue
+      // serializes) must not reject this link, or the chain's `.then` carries
+      // an unhandled rejection and the next same-key write wedges. Any throw is
+      // terminal (not a rebaseable conflict verdict): log and return, which
+      // resolves this link and frees the next. This is what makes
+      // commitLatestForKey's "never rejects" invariant actually hold.
+      let result: { error?: unknown };
+      try {
+        const tx = this.runtime.edit();
+        const cell = getCell(this.runtime, request.cell);
+        cell.withTx(tx).set(applied);
+        this.runtime.prepareTxForCommit(tx);
+        result = await tx.commit();
+      } catch (error) {
+        console.error(
+          "[RuntimeProcessor] cell set commit rejected",
+          error,
+        );
+        return;
+      }
+
+      if (!result.error) return; // landed.
+
+      // Genuine commit rejection. Re-read latest: a newer write may have arrived
+      // (and refreshed the budget) while we were in flight.
+      const current = this.cellSetLatest.get(key);
+      if (!current) return; // disposed / cleaned up mid-flight.
+      if (this.isDisposed()) return;
+      if (current.seq !== attemptSeq) {
+        // Superseded: rebase to the newer value WITHOUT spending budget on the
+        // now-moot stale one.
+        continue;
+      }
+      if (current.retriesLeft <= 0) {
+        console.error(
+          "[RuntimeProcessor] cell set commit failed after exhausting " +
+            "all retries",
+          result.error,
+        );
+        return;
+      }
+      current.retriesLeft--;
+      console.warn(
+        "[RuntimeProcessor] cell set commit failed; reapplying latest " +
+          `value (${current.retriesLeft} retries left)`,
+        result.error,
+      );
+      // loop -> rebase on a fresh tx with the (possibly newer) latest value.
+    }
   }
 
   handleCellSend(request: CellSendRequest): void {
@@ -677,8 +825,25 @@ export class RuntimeProcessor {
     cell.withTx(tx).send(mapCellRefsToSigilLinks(request.event));
     this.runtime.prepareTxForCommit(tx);
     // Local visibility is established by commit(); the promise tracks remote
-    // confirmation/rollback and must not block cell IPC.
-    tx.commit();
+    // confirmation/rollback and must not block cell IPC. The event itself is
+    // queued through the scheduler (which has its own bounded retry on commit
+    // rejection), so a failed commit here is not retried — re-sending would
+    // double-fire the event — but it must not fail silently either.
+    tx.commit().then((result) => {
+      if (result.error) {
+        console.error(
+          "[RuntimeProcessor] cell send commit failed",
+          result.error,
+        );
+      }
+    }).catch((error) => {
+      // A rejected commit promise (transport/storage throw) must not become an
+      // unhandled rejection — mirror handleCellSet's confirmation.catch.
+      console.error(
+        "[RuntimeProcessor] cell send commit rejected",
+        error,
+      );
+    });
   }
 
   handleCellSubscribe(request: CellSubscribeRequest): BooleanResponse {

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -117,7 +117,7 @@ import {
   getCell,
   mapCellRefsToSigilLinks,
 } from "./utils.ts";
-import { cellRefToKey } from "../shared/utils.ts";
+import { cellRefToIdentityKey, cellRefToKey } from "../shared/utils.ts";
 import { RemoteResponse } from "@commonfabric/runtime-client";
 import {
   normalizeRenderConfidentialityCeiling,
@@ -692,7 +692,11 @@ export class RuntimeProcessor {
   }
 
   handleCellSet(request: CellSetRequest): void {
-    const key = cellRefToKey(request.cell);
+    // Key the commit queue on storage IDENTITY (space:id:path), NOT the full
+    // cellRefToKey: schema/cfcLabelView differences between two writes to the
+    // SAME location must not split them onto separate chains, or same-path
+    // writes could commit out of order again (the race this queue prevents).
+    const key = cellRefToIdentityKey(request.cell);
     const value = mapCellRefsToSigilLinks(request.value);
     // `value` is freshly minted by mapCellRefsToSigilLinks (new objects per
     // request, never aliased) and is only READ across rebases, so no defensive

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -833,6 +833,8 @@ export class RuntimeProcessor {
     // queued through the scheduler (which has its own bounded retry on commit
     // rejection), so a failed commit here is not retried — re-sending would
     // double-fire the event — but it must not fail silently either.
+    // commit() captures errors in its Result (it does not reject) — match the
+    // codebase convention (`tx.commit().then(({ error }) => …)`), no .catch.
     tx.commit().then((result) => {
       if (result.error) {
         console.error(
@@ -840,13 +842,6 @@ export class RuntimeProcessor {
           result.error,
         );
       }
-    }).catch((error) => {
-      // A rejected commit promise (transport/storage throw) must not become an
-      // unhandled rejection — mirror handleCellSet's confirmation.catch.
-      console.error(
-        "[RuntimeProcessor] cell send commit rejected",
-        error,
-      );
     });
   }
 

--- a/packages/runtime-client/shared/utils.ts
+++ b/packages/runtime-client/shared/utils.ts
@@ -2,26 +2,35 @@ import { cloneCfcLabelView } from "@commonfabric/runner/cfc/label-view-core";
 import { CellRef } from "../protocol/mod.ts";
 
 /**
- * Storage-identity key for a cell ref: space + entity id + path, WITHOUT the
- * schema/cfcLabelView interpretation metadata. Two refs with this same key
- * target the same storage location. Use this to serialize writes to a cell
- * (the commit queue): schema/label differences between two writes to the same
- * location must NOT split them onto separate chains, or same-path writes could
- * commit out of order again.
+ * Storage-identity key for a cell ref: space + scope + entity id + path, with
+ * NO schema/cfcLabelView interpretation metadata. Two refs with this same key
+ * target the same storage location and must serialize together (the commit
+ * queue): schema/label differences between two writes to the same location must
+ * NOT split them onto separate chains, or same-path writes could commit out of
+ * order again.
+ *
+ * JSON-encoded so segments can't collide — a ":" or "." inside a space/id/path
+ * segment would make a delimiter-joined string ambiguous (two different cells →
+ * one key → cross-cell serialize/supersede, dropping a write). `scope` IS
+ * included: different-scope refs are effectively different cells. (cf.
+ * cfc/prepare.ts `targetKey`, per @ubik2.)
  */
 export function cellRefToIdentityKey(cell: CellRef): string {
   const id = cell.id.startsWith("of:") ? cell.id.substring(3) : cell.id;
-  return `${cell.space}:${id}:${cell.path.join(".")}`;
+  return JSON.stringify([cell.space, cell.scope ?? null, id, cell.path]);
 }
 
 /**
- * Full subscription key: storage identity PLUS schema/cfcLabelView, since a
- * subscription with a different schema/label is a distinct query.
+ * Subscription key: storage location PLUS schema/cfcLabelView, since a
+ * subscription with a different schema/label is a distinct query. Kept in its
+ * established form (distinct from the commit-queue identity key above); its
+ * own delimiter hardening is a separate, pre-existing concern.
  */
 export function cellRefToKey(cell: CellRef): string {
+  const id = cell.id.startsWith("of:") ? cell.id.substring(3) : cell.id;
   const schema = cell.schema ? `:${JSON.stringify(cell.schema)}` : "";
   const cfcLabelView = cell.cfcLabelView
     ? `:${JSON.stringify(cloneCfcLabelView(cell.cfcLabelView))}`
     : "";
-  return `${cellRefToIdentityKey(cell)}${schema}${cfcLabelView}`;
+  return `${cell.space}:${id}:${cell.path.join(".")}${schema}${cfcLabelView}`;
 }

--- a/packages/runtime-client/shared/utils.ts
+++ b/packages/runtime-client/shared/utils.ts
@@ -1,11 +1,27 @@
 import { cloneCfcLabelView } from "@commonfabric/runner/cfc/label-view-core";
 import { CellRef } from "../protocol/mod.ts";
 
-export function cellRefToKey(cell: CellRef): string {
+/**
+ * Storage-identity key for a cell ref: space + entity id + path, WITHOUT the
+ * schema/cfcLabelView interpretation metadata. Two refs with this same key
+ * target the same storage location. Use this to serialize writes to a cell
+ * (the commit queue): schema/label differences between two writes to the same
+ * location must NOT split them onto separate chains, or same-path writes could
+ * commit out of order again.
+ */
+export function cellRefToIdentityKey(cell: CellRef): string {
   const id = cell.id.startsWith("of:") ? cell.id.substring(3) : cell.id;
+  return `${cell.space}:${id}:${cell.path.join(".")}`;
+}
+
+/**
+ * Full subscription key: storage identity PLUS schema/cfcLabelView, since a
+ * subscription with a different schema/label is a distinct query.
+ */
+export function cellRefToKey(cell: CellRef): string {
   const schema = cell.schema ? `:${JSON.stringify(cell.schema)}` : "";
   const cfcLabelView = cell.cfcLabelView
     ? `:${JSON.stringify(cloneCfcLabelView(cell.cfcLabelView))}`
     : "";
-  return `${cell.space}:${id}:${cell.path.join(".")}${schema}${cfcLabelView}`;
+  return `${cellRefToIdentityKey(cell)}${schema}${cfcLabelView}`;
 }

--- a/packages/runtime-client/shared/utils.ts
+++ b/packages/runtime-client/shared/utils.ts
@@ -22,9 +22,10 @@ export function cellRefToIdentityKey(cell: CellRef): string {
 
 /**
  * Subscription key: storage location PLUS schema/cfcLabelView, since a
- * subscription with a different schema/label is a distinct query. Kept in its
- * established form (distinct from the commit-queue identity key above); its
- * own delimiter hardening is a separate, pre-existing concern.
+ * subscription with a different schema/label is a distinct query. Includes
+ * `scope` (different-scope cells are distinct, and collapsing them could
+ * suppress a subscription or unsubscribe the wrong scope). Kept in its
+ * established delimiter form (its `:`/`.` hardening is a separate concern).
  */
 export function cellRefToKey(cell: CellRef): string {
   const id = cell.id.startsWith("of:") ? cell.id.substring(3) : cell.id;
@@ -32,5 +33,7 @@ export function cellRefToKey(cell: CellRef): string {
   const cfcLabelView = cell.cfcLabelView
     ? `:${JSON.stringify(cloneCfcLabelView(cell.cfcLabelView))}`
     : "";
-  return `${cell.space}:${id}:${cell.path.join(".")}${schema}${cfcLabelView}`;
+  return `${cell.space}:${cell.scope ?? ""}:${id}:${
+    cell.path.join(".")
+  }${schema}${cfcLabelView}`;
 }


### PR DESCRIPTION
## Summary

Replaces fire-and-forget direct cell-write commits with a **per-key, promise-chained commit queue** in `RuntimeProcessor.handleCellSet`, fixing the `cfc-group-chat-demo` two-browser flake's cell-write half ("Bob's profile stays 'Name not set'").

**Supersedes #4126** (reapply-latest) — this is the principled form of the same fix: ordering + bounded rebase, runtime-client-only, no scheduler hook.

## The bug

A `$value` input write (e.g. `nameDraft`) committed fire-and-forget. An input fires two same-key writes (input + change); they raced — the second confirmed, the first was rejected on a **same-path** conflict, and its rollback reverted the local doc **past the confirmed value**. The local optimistic mirror ended up staler than the server with no resync, and a subsequent save read the rolled-back empty draft → "Name not set".

## The fix

`handleCellSet` becomes enqueue-only: it bumps a per-key `seq`/budget and appends a link to that key's serialized chain.

- **Serialization:** link N+1 cannot issue its `tx.commit()` until link N resolves (`await tx.commit()` inside the chain is the serialization point). The out-of-order rollback window can no longer form. Read-your-writes falls out of this — the dropped #4126 `clientWriteBarrier`/scheduler hook is genuinely **obviated**, not renamed.
- **Bounded rebase:** on a genuine commit rejection, the link reapplies the latest value on a fresh tx within budget (`CELL_SET_COMMIT_RETRIES`). A `seq` supersession token lets a rebase skip wasted budget when a newer write arrived mid-flight.
- Runtime-client-only; `handleCellSend` is unaffected (events are queued through the scheduler, which owns delivery retries).

## Mechanism — op-type granular, not doc-seq granular

`cell-write-conflict-granularity.test.ts` pins the real storage behavior against a loopback `MemoryV2Server`. A `$value` write to a linked field records a **purely structural** read-set (link-source value read + sigil probe + `["cfc"]` label read) at **deep, disjoint** paths. The server's conflict check is two-tier:

- **tier-2** (`patch`): path-overlap-gated → a concurrent **sibling-value bump merges cleanly** (it commits as a patch);
- **tier-1** (`set`/`delete`): **path-blind** → only a whole-doc `set`/`delete` rejects the linked write, on its structural reads.

So finding-1's original "doc-seq granular ⇒ any sibling bump rejects" framing was wrong; the real flake is the intra-client **same-path own-write race**, which serialization fixes. The queue additionally **recovers via rebase** from the tier-1 cases (delete, create-race).

## Verification

| | result |
|---|---|
| Unit (`runtime-processor.test.ts`) | 13 pass — serialization (2nd commit not issued until 1st resolves), supersede-without-spending-budget, dispose mid-flight, out-of-order repair, bounded budget |
| Real-commit arms (`cell-write-conflict-granularity.test.ts`) | R1 serialize (`maxInFlight=1`), R2 tier-1 delete → rebase → lands, R3 create-race → rebase → lands, R4 dispose stops commits |
| Two-browser demo | **0/76 profile-flake** (baseline ~5%) |
| fmt / lint / check | clean |

## Relationship to other work

- **Supersedes #4126** — close it; its ablation history (the read-your-writes barrier was neither necessary nor sufficient) is preserved here.
- **#4146** (merged) fixed the *handler-delivery* half of the same flake (a lost trusted click) — independent of this cell-write path.
- **Related: #4178** — the tier-1 **document-granular** conflict (a whole-doc `set`/`delete` collateral-damaging disjoint reads) is the storage-layer coarseness tracked there. This PR **recovers** from it at the client (rebase) but does not change engine granularity; that hardening stays with #4178. Do not touch the engine here — the tier-2 patch path is well-pinned and correct.

cc @seefeldb — this is the IPC-layer seq + promise-chaining you flagged; the model and the granularity findings are in the test. cc @ubik2 — reapply-latest's last-write-wins concern still holds for raw UI input (which is the correct semantics; abort-sensitive ops go through `handleCellSend`/events, untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serializes direct $value cell writes in `runtime-client` with a per-key commit queue keyed on storage identity (`[space,scope,id,path]`) so same-cell writes (even with different schema/label) still serialize. Fixes out‑of‑order rollbacks that reverted confirmed values and removes the two‑browser profile flake (“Name not set”); also hardens subscription keys by including `scope` to avoid cross-scope collisions.

- **Bug Fixes**
  - Per-key, promise-chained queue in `RuntimeProcessor.handleCellSet`, keyed via `cellRefToIdentityKey` (JSON `[space,scope,id,path]`) so schema/cfcLabelView differences don’t split chains.
  - Bounded rebase on real conflicts (`CELL_SET_COMMIT_RETRIES`); a `seq` token lets newer writes supersede without spending budget on stale attempts.
  - Subscription keys now include `scope` in `cellRefToKey` to prevent cross‑scope key collisions that could suppress or mis-route subscriptions.
  - Safe shutdown and logging: `dispose` clears queues; `handleCellSend` uses `tx.commit().then(...)` to log failures (commit doesn’t reject).
  - Tests cover op-type conflict granularity, same-identity/different-schema serialization, create/delete rebase recovery, sync tx-setup throw handling, and mid-flight dispose; two‑browser demo no longer flakes.

<sup>Written for commit d8e3cc3e7f536386868cd11894a5f07e212029e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

