### PR TITLE
Refactor how tags work to remove `as any` in home.tsx

### DIFF
--- a/docs/common/conventions/wish.md
+++ b/docs/common/conventions/wish.md
@@ -139,13 +139,20 @@ any space. You can wish for the favorites list directly (see
 `system/favorites-manager.tsx` for a full example):
 
 ```tsx
-type Favorite = { cell: { [NAME]?: string }; tag: string };
+type Favorite = { cell: { [NAME]?: string }; tags: string[] };
 const wishResult = wish<Array<Favorite>>({ query: "#favorites" });
 ```
 
-The `tag` field contains the serialized `resultSchema` of the piece pointed to
-by `cell`. It is populated automatically when a favorite is added and is used
-for tag-based searching in the wish system.
+The `tags` field holds the discovery tags of the piece pointed to by `cell` —
+the hashtags from its schema's doc comment, lowercased and without the leading
+`#`. The favorites client derives them from the piece's schema when the
+favorite is added (the schema is not reachable from inside the home pattern's
+handler), and the wish system matches against them.
+
+Favorites created before the `tags` field instead carry a `tag` field holding
+the piece's serialized result schema; the wish system still reads it,
+extracting hashtags from the serialized text. The `tag` field is deprecated;
+do not write it.
 
 ### When to Use Each Scope
 

--- a/packages/api/cfc.test.ts
+++ b/packages/api/cfc.test.ts
@@ -1,0 +1,81 @@
+import { assertEquals } from "@std/assert";
+import { CFC_ATOM_TYPE, CFC_RUNTIME_SUBJECT, cfcAtom } from "./cfc.ts";
+
+Deno.test("cfcAtom.resource builds a resource atom (default and explicit subject/scope)", () => {
+  assertEquals(cfcAtom.resource("MyClass"), {
+    type: CFC_ATOM_TYPE.Resource,
+    class: "MyClass",
+    subject: CFC_RUNTIME_SUBJECT,
+  });
+
+  const scope = cfcAtom.builtin("scope-source");
+  assertEquals(cfcAtom.resource("MyClass", "did:web:example", scope), {
+    type: CFC_ATOM_TYPE.Resource,
+    class: "MyClass",
+    subject: "did:web:example",
+    scope,
+  });
+});
+
+Deno.test("cfcAtom.caveat builds a caveat atom (with and without `by`)", () => {
+  const source = cfcAtom.builtin("source");
+
+  assertEquals(cfcAtom.caveat("derived-from", source), {
+    type: CFC_ATOM_TYPE.Caveat,
+    kind: "derived-from",
+    source,
+  });
+
+  const by = cfcAtom.injectionSafe();
+  assertEquals(cfcAtom.caveat("derived-from", source, by), {
+    type: CFC_ATOM_TYPE.Caveat,
+    kind: "derived-from",
+    source,
+    by,
+  });
+});
+
+Deno.test("cfcAtom.builtin builds a builtin atom", () => {
+  assertEquals(cfcAtom.builtin("navigateTo"), {
+    type: CFC_ATOM_TYPE.Builtin,
+    name: "navigateTo",
+  });
+});
+
+Deno.test("cfcAtom.injectionSafe builds an injection-safe atom", () => {
+  assertEquals(cfcAtom.injectionSafe(), {
+    type: CFC_ATOM_TYPE.InjectionSafe,
+  });
+});
+
+Deno.test("cfcAtom.userSurfaceInput builds a user-surface-input atom", () => {
+  assertEquals(cfcAtom.userSurfaceInput("did:key:user", "chat", "digest123"), {
+    type: CFC_ATOM_TYPE.UserSurfaceInput,
+    user: "did:key:user",
+    surface: "chat",
+    valueDigest: "digest123",
+  });
+});
+
+Deno.test("cfcAtom.promptSlotBound builds a prompt-slot-bound atom", () => {
+  const source = cfcAtom.userSurfaceInput("did:key:user", "chat", "digest123");
+  assertEquals(
+    cfcAtom.promptSlotBound(
+      source,
+      "instruction",
+      "kernel",
+      "did:web:example",
+      "chat",
+      "digest123",
+    ),
+    {
+      type: CFC_ATOM_TYPE.PromptSlotBound,
+      source,
+      role: "instruction",
+      kernelName: "kernel",
+      subject: "did:web:example",
+      surface: "chat",
+      valueDigest: "digest123",
+    },
+  );
+});

--- a/packages/api/deno.json
+++ b/packages/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@commonfabric/api",
   "tasks": {
-    "test": "echo 'No tests to run.'"
+    "test": "deno test --allow-read"
   },
   "exports": {
     ".": "./index.ts",

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1514,6 +1514,9 @@ export type JSONSchemaObj = {
   readonly [ID]?: unknown;
   readonly [ID_FIELD]?: unknown;
   readonly scope?: SchemaScope;
+  // Discovery hashtags from the doc comment (lowercased, without the leading
+  // `#`). Populated by the schema generator; mirrors the description text.
+  readonly tags?: readonly string[];
   // makes it so that your handler gets a Cell object for that property. So you can call .set()/.update()/.push()/etc on it.
   readonly asCell?: readonly AsCellType[];
   // temporarily used to assign labels like "confidential"

--- a/packages/data-model/deno.json
+++ b/packages/data-model/deno.json
@@ -38,6 +38,7 @@
     "./codec-json": "./src/codec-json/index.ts",
     "./native-type-tags": "./src/native-type-tags.ts",
     "./schema-hash": "./src/schema-hash.ts",
+    "./schema-tags": "./src/schema-tags.ts",
     "./schema-utils": "./src/schema-utils.ts",
     "./SchemaAndHash": "./src/SchemaAndHash.ts",
     "./value-debug": "./src/value-debug.ts",

--- a/packages/data-model/src/schema-tags.ts
+++ b/packages/data-model/src/schema-tags.ts
@@ -1,0 +1,22 @@
+/**
+ * Discovery-tag extraction for schema doc text.
+ *
+ * This module is a dependency-free leaf so that the schema generator (which
+ * type-checks its import graph under stricter compiler options) can share
+ * the hashtag definition with runtime consumers.
+ */
+
+const HASHTAG_PATTERN = /#([a-z0-9-]+)/gi;
+
+/**
+ * Extract hashtag tokens from free text. Returns the tokens lowercased,
+ * without the leading `#`, deduplicated, in order of first appearance.
+ */
+export function extractHashtags(text: string): string[] {
+  const tags: string[] = [];
+  for (const match of text.matchAll(HASHTAG_PATTERN)) {
+    const tag = match[1]!.toLowerCase();
+    if (!tags.includes(tag)) tags.push(tag);
+  }
+  return tags;
+}

--- a/packages/data-model/src/schema-tags.ts
+++ b/packages/data-model/src/schema-tags.ts
@@ -54,12 +54,6 @@ const RECORD_VALUED_KEYWORDS = new Set<string>([
  * Reads the structured `tags` fields emitted by the schema generator,
  * aggregated across the schema tree (root and nested schemas), lowercased
  * and deduplicated.
- *
- * Schemas generated before structured tags carry hashtags only in
- * description text. When no structured `tags` field is present anywhere in
- * the tree, falls back to extracting hashtags from the serialized schema.
- * TODO(remove-legacy-tags): drop the serialized-text fallback once stored
- * schemas predating structured tags have been regenerated.
  */
 export function tagsFromSchema(
   schema: JSONSchema | undefined | null,
@@ -99,11 +93,5 @@ export function tagsFromSchema(
   };
 
   visit(schema);
-  if (tags.length > 0) return tags;
-
-  // Legacy fallback: hashtags embedded in description text of schemas that
-  // predate the structured `tags` field.
-  // TODO(remove-legacy-tags): remove once stored schemas have been
-  // regenerated with structured tags.
-  return extractHashtags(JSON.stringify(schema));
+  return tags;
 }

--- a/packages/data-model/src/schema-tags.ts
+++ b/packages/data-model/src/schema-tags.ts
@@ -1,10 +1,13 @@
 /**
- * Discovery-tag extraction for schema doc text.
+ * Discovery-tag utilities for JSONSchema values.
  *
- * This module is a dependency-free leaf so that the schema generator (which
- * type-checks its import graph under stricter compiler options) can share
- * the hashtag definition with runtime consumers.
+ * This module is a dependency-free leaf (only the `JSONSchema` type) so that
+ * the schema generator — which type-checks its import graph under stricter
+ * compiler options — and client-side consumers can share the tag definition
+ * with the runtime.
  */
+
+import type { JSONSchema } from "@commonfabric/api";
 
 const HASHTAG_PATTERN = /#([a-z0-9-]+)/gi;
 
@@ -19,4 +22,88 @@ export function extractHashtags(text: string): string[] {
     if (!tags.includes(tag)) tags.push(tag);
   }
   return tags;
+}
+
+/**
+ * Schema keywords whose values are themselves schemas (or collections of
+ * schemas). Used to walk the schema tree without descending into data
+ * positions such as `default` or `examples`.
+ */
+const SCHEMA_CHILD_KEYWORDS = [
+  "properties",
+  "additionalProperties",
+  "items",
+  "anyOf",
+  "allOf",
+  "oneOf",
+  "not",
+  "contentSchema",
+  "$defs",
+  "definitions",
+] as const;
+
+const RECORD_VALUED_KEYWORDS = new Set<string>([
+  "properties",
+  "$defs",
+  "definitions",
+]);
+
+/**
+ * Collect the discovery tags of a schema.
+ *
+ * Reads the structured `tags` fields emitted by the schema generator,
+ * aggregated across the schema tree (root and nested schemas), lowercased
+ * and deduplicated.
+ *
+ * Schemas generated before structured tags carry hashtags only in
+ * description text. When no structured `tags` field is present anywhere in
+ * the tree, falls back to extracting hashtags from the serialized schema.
+ * TODO(remove-legacy-tags): drop the serialized-text fallback once stored
+ * schemas predating structured tags have been regenerated.
+ */
+export function tagsFromSchema(
+  schema: JSONSchema | undefined | null,
+): string[] {
+  if (schema === null || typeof schema !== "object") return [];
+
+  const tags: string[] = [];
+  const visited = new Set<object>();
+
+  const visit = (node: unknown): void => {
+    if (node === null || typeof node !== "object" || Array.isArray(node)) {
+      return;
+    }
+    if (visited.has(node)) return;
+    visited.add(node);
+
+    const record = node as Record<string, unknown>;
+    if (Array.isArray(record.tags)) {
+      for (const tag of record.tags) {
+        if (typeof tag !== "string") continue;
+        const lowered = tag.toLowerCase();
+        if (!tags.includes(lowered)) tags.push(lowered);
+      }
+    }
+
+    for (const keyword of SCHEMA_CHILD_KEYWORDS) {
+      const child = record[keyword];
+      if (child === null || typeof child !== "object") continue;
+      if (Array.isArray(child)) {
+        for (const entry of child) visit(entry);
+      } else if (RECORD_VALUED_KEYWORDS.has(keyword)) {
+        for (const value of Object.values(child)) visit(value);
+      } else {
+        visit(child);
+      }
+    }
+  };
+
+  visit(schema);
+  if (tags.length > 0) return tags;
+
+  // Legacy fallback: hashtags embedded in description text of schemas that
+  // predate the structured `tags` field.
+  // TODO(remove-legacy-tags): remove once stored schemas have been
+  // regenerated with structured tags.
+  return extractHashtags(JSON.stringify(schema));
 }

--- a/packages/data-model/test/schema-tags.test.ts
+++ b/packages/data-model/test/schema-tags.test.ts
@@ -1,7 +1,8 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { extractHashtags } from "@/schema-tags.ts";
+import type { JSONSchema } from "@commonfabric/api";
+import { extractHashtags, tagsFromSchema } from "@/schema-tags.ts";
 
 describe("extractHashtags", () => {
   it("extracts tags lowercased without the leading #", () => {
@@ -21,5 +22,70 @@ describe("extractHashtags", () => {
 
   it("returns empty for text without hashtags", () => {
     expect(extractHashtags("no tags here")).toEqual([]);
+  });
+});
+
+describe("tagsFromSchema", () => {
+  it("reads structured tags from the root", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      description: "A #note",
+      tags: ["note"],
+    };
+    expect(tagsFromSchema(schema)).toEqual(["note"]);
+  });
+
+  it("aggregates structured tags across nested schemas", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      tags: ["note"],
+      properties: {
+        annotations: {
+          type: "array",
+          tags: ["annotation"],
+          items: { type: "string" },
+        },
+      },
+    };
+    expect(tagsFromSchema(schema)).toEqual(["note", "annotation"]);
+  });
+
+  it("does not read tags from data positions like default", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      tags: ["note"],
+      properties: {
+        config: {
+          type: "object",
+          default: { tags: ["not-a-schema-tag"] },
+        },
+      },
+    };
+    expect(tagsFromSchema(schema)).toEqual(["note"]);
+  });
+
+  it("falls back to hashtags in description text for legacy schemas", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      description: "An #annotation pointing at an existing cell.",
+      properties: {
+        content: { type: "string", description: "See #backlink." },
+      },
+    };
+    expect(tagsFromSchema(schema)).toEqual(["annotation", "backlink"]);
+  });
+
+  it("prefers structured tags over description text when both exist", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      description: "A #stale-tag in prose",
+      tags: ["fresh-tag"],
+    };
+    expect(tagsFromSchema(schema)).toEqual(["fresh-tag"]);
+  });
+
+  it("returns empty for boolean and missing schemas", () => {
+    expect(tagsFromSchema(true)).toEqual([]);
+    expect(tagsFromSchema(undefined)).toEqual([]);
   });
 });

--- a/packages/data-model/test/schema-tags.test.ts
+++ b/packages/data-model/test/schema-tags.test.ts
@@ -64,28 +64,72 @@ describe("tagsFromSchema", () => {
     expect(tagsFromSchema(schema)).toEqual(["note"]);
   });
 
-  it("falls back to hashtags in description text for legacy schemas", () => {
-    const schema: JSONSchema = {
-      type: "object",
-      description: "An #annotation pointing at an existing cell.",
-      properties: {
-        content: { type: "string", description: "See #backlink." },
-      },
-    };
-    expect(tagsFromSchema(schema)).toEqual(["annotation", "backlink"]);
-  });
-
-  it("prefers structured tags over description text when both exist", () => {
+  it("reads only structured tags, ignoring hashtags in description text", () => {
     const schema: JSONSchema = {
       type: "object",
       description: "A #stale-tag in prose",
       tags: ["fresh-tag"],
+      properties: {
+        content: { type: "string", description: "See #backlink." },
+      },
     };
     expect(tagsFromSchema(schema)).toEqual(["fresh-tag"]);
+  });
+
+  it("returns empty when a schema has hashtags only in its description", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      description: "An #annotation with no structured tags.",
+    };
+    expect(tagsFromSchema(schema)).toEqual([]);
   });
 
   it("returns empty for boolean and missing schemas", () => {
     expect(tagsFromSchema(true)).toEqual([]);
     expect(tagsFromSchema(undefined)).toEqual([]);
+  });
+
+  it("collects tags from anyOf/allOf/oneOf branches", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      anyOf: [{ type: "object", tags: ["from-anyof"] }],
+      allOf: [{ type: "object", tags: ["from-allof"] }],
+      oneOf: [{ type: "object", tags: ["from-oneof"] }],
+    };
+    expect(tagsFromSchema(schema)).toEqual([
+      "from-anyof",
+      "from-allof",
+      "from-oneof",
+    ]);
+  });
+
+  it("skips boolean schemas sitting in a schema-collection keyword", () => {
+    const schema: JSONSchema = {
+      type: "object",
+      // A boolean schema as an anyOf branch is a non-object node; the walk
+      // must skip it without error and still collect the sibling's tags.
+      anyOf: [true, { type: "object", tags: ["real"] }],
+    };
+    expect(tagsFromSchema(schema)).toEqual(["real"]);
+  });
+
+  it("skips non-string entries in a tags array", () => {
+    const schema = {
+      type: "object",
+      tags: ["good", 42, "also-good"],
+    } as unknown as JSONSchema;
+    expect(tagsFromSchema(schema)).toEqual(["good", "also-good"]);
+  });
+
+  it("visits a shared schema node only once", () => {
+    const shared: JSONSchema = { type: "object", tags: ["shared"] };
+    const schema: JSONSchema = {
+      type: "object",
+      anyOf: [shared],
+      allOf: [shared],
+    };
+    // The visited set prevents the shared node from being walked twice; the
+    // tag is collected once regardless.
+    expect(tagsFromSchema(schema)).toEqual(["shared"]);
   });
 });

--- a/packages/data-model/test/schema-tags.test.ts
+++ b/packages/data-model/test/schema-tags.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { extractHashtags } from "@/schema-tags.ts";
+
+describe("extractHashtags", () => {
+  it("extracts tags lowercased without the leading #", () => {
+    expect(extractHashtags("A #Note about #quick-capture")).toEqual([
+      "note",
+      "quick-capture",
+    ]);
+  });
+
+  it("deduplicates while preserving first-appearance order", () => {
+    expect(extractHashtags("#b then #a then #B again")).toEqual(["b", "a"]);
+  });
+
+  it("stops tokens at characters outside [a-z0-9-]", () => {
+    expect(extractHashtags("#todo_list")).toEqual(["todo"]);
+  });
+
+  it("returns empty for text without hashtags", () => {
+    expect(extractHashtags("no tags here")).toEqual([]);
+  });
+});

--- a/packages/home-schemas/favorites.ts
+++ b/packages/home-schemas/favorites.ts
@@ -11,6 +11,13 @@ export const favoriteEntrySchema = {
   properties: {
     // we use type unknown to validate, but avoid including children
     cell: { type: "unknown", asCell: ["cell"] },
+    // Discovery tags snapshotted from the piece's schema when favorited
+    // (lowercased, without the leading `#`). Matched by wish() tag search.
+    tags: { type: "array", items: { type: "string" }, default: [] },
+    // Serialized schema of the piece, snapshotted when favorited. Replaced
+    // by `tags`; still read so favorites created before `tags` keep matching.
+    // TODO(remove-legacy-tags): drop this field once stored favorites have
+    // been rewritten with `tags`.
     tag: { type: "string", default: "" },
     userTags: { type: "array", items: { type: "string" }, default: [] },
     spaceName: { type: "string" },

--- a/packages/home-schemas/favorites.ts
+++ b/packages/home-schemas/favorites.ts
@@ -14,11 +14,6 @@ export const favoriteEntrySchema = {
     // Discovery tags snapshotted from the piece's schema when favorited
     // (lowercased, without the leading `#`). Matched by wish() tag search.
     tags: { type: "array", items: { type: "string" }, default: [] },
-    // Serialized schema of the piece, snapshotted when favorited. Replaced
-    // by `tags`; still read so favorites created before `tags` keep matching.
-    // TODO(remove-legacy-tags): drop this field once stored favorites have
-    // been rewritten with `tags`.
-    tag: { type: "string", default: "" },
     userTags: { type: "array", items: { type: "string" }, default: [] },
     spaceName: { type: "string" },
   },

--- a/packages/patterns/system/home-ben.tsx
+++ b/packages/patterns/system/home-ben.tsx
@@ -15,7 +15,11 @@ import Journal from "./journal.tsx";
 // Types from favorites-manager.tsx and journal.tsx
 type Favorite = {
   cell: { [NAME]?: string };
-  tag: string;
+  // Discovery tags snapshotted from the piece's schema when favorited.
+  tags: string[];
+  // Serialized schema of the piece; replaced by `tags`.
+  // TODO(remove-legacy-tags): drop once stored favorites carry `tags`.
+  tag?: string;
   userTags: string[];
   spaceName?: string;
 };
@@ -90,7 +94,8 @@ function captureSnapshot(
 }
 
 /**
- * Extract hashtags from schema tag string for searchability
+ * Extract hashtags from a legacy serialized-schema tag string.
+ * TODO(remove-legacy-tags): drop once stored favorites carry `tags`.
  */
 function extractTags(schemaTag: string): string[] {
   const tags: string[] = [];
@@ -103,31 +108,25 @@ function extractTags(schemaTag: string): string[] {
 
 // Handler to add a favorite
 const addFavorite = handler<
-  { piece: Writable<{ [NAME]?: string }>; tag?: string; spaceName?: string },
+  { piece: Writable<{ [NAME]?: string }>; tags?: string[]; spaceName?: string },
   { favorites: Writable<Favorite[]>; journal: Writable<JournalEntry[]> }
->(({ piece, tag, spaceName }, { favorites, journal }) => {
+>(({ piece, tags, spaceName }, { favorites, journal }) => {
   const current = favorites.get();
   if (!current.some((f) => f && equals(f.cell, piece))) {
-    // HACK(seefeld): Access internal API to get schema.
-    // Once we sandbox, we need proper reflection
-    //
-    // This first resolves all links, then clears the schema, so it's forced to
-    // read the schema defined in the pattern, then reconstructs that schema.
-    let schema = (piece as any)?.resolveAsCell()?.asSchema(undefined)
-      .asSchemaFromLinks?.()?.schema;
-    if (typeof schema !== "object") schema = ""; // schema can be true or false
-
-    const schemaTag = tag || JSON.stringify(schema) || "";
+    // Discovery tags are derived by the client and passed in; the handler
+    // just stores them.
+    const finalTags = tags ?? [];
+    const hashTags = finalTags.map((t) => `#${t}`);
 
     favorites.push({
       cell: piece,
-      tag: schemaTag,
+      tags: finalTags,
       userTags: [],
       spaceName,
     });
 
     // Add journal entry for the favorite action
-    const snapshot = captureSnapshot(piece, schemaTag);
+    const snapshot = captureSnapshot(piece, hashTags.join(" "));
     journal.push({
       timestamp: safeDateNow(),
       eventType: "piece:favorited",
@@ -135,7 +134,7 @@ const addFavorite = handler<
       snapshot,
       narrative: "",
       narrativePending: true,
-      tags: extractTags(schemaTag),
+      tags: hashTags,
       space: spaceName || "",
     });
   }
@@ -148,10 +147,17 @@ const removeFavorite = handler<
 >(({ piece }, { favorites, journal }) => {
   const favorite = favorites.get().find((f) => f && equals(f.cell, piece));
   if (favorite) {
+    // TODO(remove-legacy-tags): favorites created before `tags` carry only
+    // the serialized-schema `tag`; extract hashtags from it until stored
+    // favorites have been rewritten.
+    const hashTags = favorite.tags?.length
+      ? favorite.tags.map((t) => `#${t}`)
+      : extractTags(favorite.tag || "");
+
     // Capture snapshot before removing
     const snapshot = captureSnapshot(
       piece as Writable<{ [NAME]?: string }>,
-      favorite.tag,
+      hashTags.join(" "),
     );
 
     favorites.remove(favorite);
@@ -164,7 +170,7 @@ const removeFavorite = handler<
       snapshot,
       narrative: "",
       narrativePending: true,
-      tags: extractTags(favorite.tag || ""),
+      tags: hashTags,
       space: favorite.spaceName || "",
     });
   }

--- a/packages/patterns/system/home-ben.tsx
+++ b/packages/patterns/system/home-ben.tsx
@@ -17,9 +17,6 @@ type Favorite = {
   cell: { [NAME]?: string };
   // Discovery tags snapshotted from the piece's schema when favorited.
   tags: string[];
-  // Serialized schema of the piece; replaced by `tags`.
-  // TODO(remove-legacy-tags): drop once stored favorites carry `tags`.
-  tag?: string;
   userTags: string[];
   spaceName?: string;
 };
@@ -93,19 +90,6 @@ function captureSnapshot(
   return { name, schemaTag: schemaTag || "", valueExcerpt };
 }
 
-/**
- * Extract hashtags from a legacy serialized-schema tag string.
- * TODO(remove-legacy-tags): drop once stored favorites carry `tags`.
- */
-function extractTags(schemaTag: string): string[] {
-  const tags: string[] = [];
-  const hashtagMatches = schemaTag.match(/#([a-z0-9-]+)/gi);
-  if (hashtagMatches) {
-    tags.push(...hashtagMatches.map((t) => t.toLowerCase()));
-  }
-  return tags;
-}
-
 // Handler to add a favorite
 const addFavorite = handler<
   { piece: Writable<{ [NAME]?: string }>; tags?: string[]; spaceName?: string },
@@ -147,12 +131,7 @@ const removeFavorite = handler<
 >(({ piece }, { favorites, journal }) => {
   const favorite = favorites.get().find((f) => f && equals(f.cell, piece));
   if (favorite) {
-    // TODO(remove-legacy-tags): favorites created before `tags` carry only
-    // the serialized-schema `tag`; extract hashtags from it until stored
-    // favorites have been rewritten.
-    const hashTags = favorite.tags?.length
-      ? favorite.tags.map((t) => `#${t}`)
-      : extractTags(favorite.tag || "");
+    const hashTags = (favorite.tags ?? []).map((t) => `#${t}`);
 
     // Capture snapshot before removing
     const snapshot = captureSnapshot(

--- a/packages/patterns/system/home.tsx
+++ b/packages/patterns/system/home.tsx
@@ -23,7 +23,11 @@ import type { ProfileHomeOutput } from "./profile-home.tsx";
 // Types from favorites-manager.tsx
 type Favorite = {
   cell: { [NAME]?: string };
-  tag: string;
+  // Discovery tags snapshotted from the piece's schema when favorited.
+  tags: string[];
+  // Serialized schema of the piece; replaced by `tags`.
+  // TODO(remove-legacy-tags): drop once stored favorites carry `tags`.
+  tag?: string;
   userTags: string[];
   spaceName?: string;
 };
@@ -59,22 +63,16 @@ export type HomeOutput = {
 
 // Handler to add a favorite
 const addFavorite = handler<
-  { piece: Writable<{ [NAME]?: string }>; tag?: string; spaceName?: string },
+  { piece: Writable<{ [NAME]?: string }>; tags?: string[]; spaceName?: string },
   { favorites: Writable<Favorite[]> }
->(({ piece, tag, spaceName }, { favorites }) => {
+>(({ piece, tags, spaceName }, { favorites }) => {
   const current = favorites.get();
   if (!current.some((f) => f && equals(f.cell, piece))) {
-    // HACK(seefeld): Access internal API to get schema.
-    // Once we sandbox, we need proper reflection
-    let schema = (piece as any)?.resolveAsCell()?.asSchema(undefined)
-      .asSchemaFromLinks?.()?.schema;
-    if (typeof schema !== "object") schema = "";
-
-    const schemaTag = tag || JSON.stringify(schema) || "";
-
+    // Discovery tags are derived by the client (which can see the piece's
+    // schema) and passed in; the handler just stores them.
     favorites.push({
       cell: piece,
-      tag: schemaTag,
+      tags: tags ?? [],
       userTags: [],
       spaceName,
     });

--- a/packages/patterns/system/home.tsx
+++ b/packages/patterns/system/home.tsx
@@ -25,9 +25,6 @@ type Favorite = {
   cell: { [NAME]?: string };
   // Discovery tags snapshotted from the piece's schema when favorited.
   tags: string[];
-  // Serialized schema of the piece; replaced by `tags`.
-  // TODO(remove-legacy-tags): drop once stored favorites carry `tags`.
-  tag?: string;
   userTags: string[];
   spaceName?: string;
 };

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -7,6 +7,7 @@ import {
 } from "@commonfabric/api";
 import { h } from "@commonfabric/html";
 import { favoriteListSchema } from "@commonfabric/home-schemas";
+import { extractHashtags } from "@commonfabric/data-model/schema-tags";
 import { HttpProgramResolver } from "@commonfabric/js-compiler";
 import { type Cell } from "../cell.ts";
 import { type Action, type ReactivityLog } from "../scheduler.ts";
@@ -459,8 +460,14 @@ function searchFavoritesForHashtag(
         for (const t of userTags) {
           if (t.toLowerCase() === searchTermWithoutHash) return true;
         }
-        // Search schema tag for hashtags
-        return tagMatchesHashtag(entry.tag, searchTermWithoutHash);
+        // Match the discovery tags snapshotted when favorited.
+        // TODO(remove-legacy-tags): favorites created before `tags` carry
+        // only the serialized-schema `tag`; extract hashtags from it until
+        // stored favorites have been rewritten.
+        const entryTags = entry.tags?.length
+          ? entry.tags
+          : extractHashtags(entry.tag ?? "");
+        return entryTags.includes(searchTermWithoutHash);
       }),
   );
 
@@ -748,19 +755,14 @@ function resolveHomeSpaceTarget(
           if (t.toLowerCase().includes(searchTerm)) return true;
         }
 
-        let tag = entry.tag;
-        if (!tag) {
-          try {
-            const { schema } = entry.cell.asSchemaFromLinks()
-              .getAsNormalizedFullLink();
-            if (schema !== undefined) {
-              tag = JSON.stringify(schema);
-            }
-          } catch {
-            // Schema not available yet
-          }
-        }
-        return tag?.toLowerCase().includes(searchTerm);
+        // Match the discovery tags snapshotted when favorited.
+        // TODO(remove-legacy-tags): favorites created before `tags` carry
+        // only the serialized-schema `tag`; extract hashtags from it until
+        // stored favorites have been rewritten.
+        const entryTags = entry.tags?.length
+          ? entry.tags
+          : extractHashtags(entry.tag ?? "");
+        return entryTags.some((t) => t.includes(searchTerm));
       });
 
       if (!match) {

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -7,7 +7,6 @@ import {
 } from "@commonfabric/api";
 import { h } from "@commonfabric/html";
 import { favoriteListSchema } from "@commonfabric/home-schemas";
-import { extractHashtags } from "@commonfabric/data-model/schema-tags";
 import { HttpProgramResolver } from "@commonfabric/js-compiler";
 import { type Cell } from "../cell.ts";
 import { type Action, type ReactivityLog } from "../scheduler.ts";
@@ -461,13 +460,7 @@ function searchFavoritesForHashtag(
           if (t.toLowerCase() === searchTermWithoutHash) return true;
         }
         // Match the discovery tags snapshotted when favorited.
-        // TODO(remove-legacy-tags): favorites created before `tags` carry
-        // only the serialized-schema `tag`; extract hashtags from it until
-        // stored favorites have been rewritten.
-        const entryTags = entry.tags?.length
-          ? entry.tags
-          : extractHashtags(entry.tag ?? "");
-        return entryTags.includes(searchTermWithoutHash);
+        return (entry.tags ?? []).includes(searchTermWithoutHash);
       }),
   );
 
@@ -756,13 +749,7 @@ function resolveHomeSpaceTarget(
         }
 
         // Match the discovery tags snapshotted when favorited.
-        // TODO(remove-legacy-tags): favorites created before `tags` carry
-        // only the serialized-schema `tag`; extract hashtags from it until
-        // stored favorites have been rewritten.
-        const entryTags = entry.tags?.length
-          ? entry.tags
-          : extractHashtags(entry.tag ?? "");
-        return entryTags.some((t) => t.includes(searchTerm));
+        return (entry.tags ?? []).some((t) => t.includes(searchTerm));
       });
 
       if (!match) {

--- a/packages/runner/test/home-add-favorite.test.ts
+++ b/packages/runner/test/home-add-favorite.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("home add-favorite tests");
+const space = signer.did();
+
+type FavoriteEntry = { tags?: string[]; tag?: string; userTags?: string[] };
+
+// Compiles and runs the real home pattern, then drives its addFavorite handler
+// the way the runtime client does after deriving tags: it sends the tags as
+// data, and the handler just stores them.
+describe("home addFavorite handler", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("stores the discovery tags it is given", async () => {
+    const patternsRoot = join(import.meta.dirname!, "..", "..", "patterns");
+    const program = await runtime.harness.resolve(
+      new FileSystemProgramResolver(
+        join(patternsRoot, "system", "home.tsx"),
+        patternsRoot,
+      ),
+    );
+    const homePattern = await runtime.patternManager.compilePattern(program, {
+      space,
+    });
+
+    const resultCell = runtime.getCell(space, "home-instance");
+    const home = await runtime.runSynced(resultCell, homePattern, {});
+    await home.pull();
+    await runtime.idle();
+
+    const target = runtime.getCell(space, "favorited-piece", undefined, tx);
+    target.set({ content: "x" });
+    await tx.commit();
+    tx = runtime.edit();
+
+    // deno-lint-ignore no-explicit-any
+    (home.key("addFavorite") as any).send({
+      piece: target.getAsLink(),
+      tags: ["alpha", "beta"],
+      spaceName: "test-space",
+    });
+
+    let favorites: FavoriteEntry[] = [];
+    for (let i = 0; i < 50; i++) {
+      await runtime.idle();
+      favorites =
+        (home.key("favorites").get() as FavoriteEntry[] | undefined) ?? [];
+      if (favorites.length > 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+
+    expect(favorites.length).toBe(1);
+    expect(favorites[0].tags).toEqual(["alpha", "beta"]);
+    expect(favorites[0].userTags).toEqual([]);
+  });
+});

--- a/packages/runner/test/pattern-scope.test.ts
+++ b/packages/runner/test/pattern-scope.test.ts
@@ -2691,7 +2691,7 @@ Deno.test("wish home-space output is at least user scoped", async () => {
     );
     favoriteItem.set({ name: "Favorite" });
     defaultPatternCell.key("favorites").set([
-      { cell: favoriteItem, tag: "#favorite" },
+      { cell: favoriteItem, tags: ["favorite"] },
     ]);
     homeSpaceCell.key("defaultPattern").set(defaultPatternCell);
 
@@ -2720,7 +2720,7 @@ Deno.test("wish home-space output is at least user scoped", async () => {
     assertEquals(favoritesLink?.scope, "user");
     assertEquals(
       result.key("favorites").key("result").get() as unknown,
-      [{ cell: favoriteItem.get(), tag: "#favorite" }],
+      [{ cell: favoriteItem.get(), tags: ["favorite"] }],
     );
   } finally {
     await runtime.dispose();

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -907,7 +907,7 @@ describe("wish built-in", () => {
         tx,
       );
       favoriteItem.set({ type: "favorite" });
-      favoritesCell.set([{ cell: favoriteItem, tag: "#test-tag" }]);
+      favoritesCell.set([{ cell: favoriteItem, tags: ["test-tag"] }]);
       (homeSpaceCell as any).key("defaultPattern").set(homeDefaultPatternCell);
 
       await tx.commit();
@@ -1001,7 +1001,7 @@ describe("wish built-in", () => {
         tx,
       );
       favoriteItem.set({ type: "favorite" });
-      favoritesCell.set([{ cell: favoriteItem, tag: "#test-tag" }]);
+      favoritesCell.set([{ cell: favoriteItem, tags: ["test-tag"] }]);
       (homeSpaceCell as any).key("defaultPattern").set(homeDefaultPatternCell);
 
       await tx.commit();
@@ -1120,53 +1120,6 @@ describe("wish built-in", () => {
       expect(data?.type).toBe("favorite");
     });
 
-    it("falls back to the legacy tag when tags is empty", async () => {
-      const homeSpaceCell = runtime.getHomeSpaceCell(tx);
-      const homeDefaultPatternCell = runtime.getCell(
-        userIdentity.did(),
-        "default-pattern-legacy",
-        undefined,
-        tx,
-      );
-      const favoritesCell = homeDefaultPatternCell.key("favorites");
-      const favoriteItem = runtime.getCell(
-        userIdentity.did(),
-        "favorite-item-legacy",
-        undefined,
-        tx,
-      );
-      favoriteItem.set({ type: "favorite" });
-      // An empty tags array must not mask the legacy serialized-schema tag.
-      favoritesCell.set([
-        { cell: favoriteItem, tags: [], tag: "#legacy-fallback" },
-      ]);
-      (homeSpaceCell as any).key("defaultPattern").set(homeDefaultPatternCell);
-
-      await tx.commit();
-      await runtime.idle();
-      tx = runtime.edit();
-
-      const wishPattern = pattern(() => {
-        return { result: wish({ query: "#legacy-fallback", scope: ["~"] }) };
-      });
-      const resultCell = runtime.getCell<{ result?: { result?: unknown } }>(
-        patternSpace.did(),
-        "legacy-fallback-result",
-        undefined,
-        tx,
-      );
-      const result = runtime.run(tx, wishPattern, {}, resultCell);
-      await tx.commit();
-      tx = runtime.edit();
-      await result.pull();
-
-      const data = (() => {
-        const r = result.key("result").get()?.result;
-        return (r as any)?.get?.() ?? r;
-      })();
-      expect(data?.type).toBe("favorite");
-    });
-
     it('searches both favorites and mentionables with scope: ["~", "."]', async () => {
       // Setup: Add favorites to home space
       const homeSpaceCell = runtime.getHomeSpaceCell(tx);
@@ -1184,7 +1137,7 @@ describe("wish built-in", () => {
         tx,
       );
       favoriteItem.set({ type: "favorite" });
-      favoritesCell.set([{ cell: favoriteItem, tag: "#fav-tag" }]);
+      favoritesCell.set([{ cell: favoriteItem, tags: ["fav-tag"] }]);
       (homeSpaceCell as any).key("defaultPattern").set(homeDefaultPatternCell);
 
       await tx.commit();
@@ -1298,7 +1251,7 @@ describe("wish built-in", () => {
         tx,
       );
       favoriteItem.set({ type: "favorite" });
-      favoritesCell.set([{ cell: favoriteItem, tag: "#test-tag" }]);
+      favoritesCell.set([{ cell: favoriteItem, tags: ["test-tag"] }]);
       (homeSpaceCell as any).key("defaultPattern").set(homeDefaultPatternCell);
 
       await tx.commit();
@@ -1449,7 +1402,7 @@ describe("wish built-in", () => {
         tx,
       );
       favoriteItem.set({ type: "favorite" });
-      favoritesCell.set([{ cell: favoriteItem, tag: "#test-tag" }]);
+      favoritesCell.set([{ cell: favoriteItem, tags: ["test-tag"] }]);
       (homeSpaceCell as any).key("defaultPattern").set(homeDefaultPatternCell);
 
       await tx.commit();
@@ -1791,7 +1744,7 @@ describe("wish built-in", () => {
           tx,
         );
         favoriteItem.set({ type: "from-favorites" });
-        favoritesCell.set([{ cell: favoriteItem, tag: "#combo-tag" }]);
+        favoritesCell.set([{ cell: favoriteItem, tags: ["combo-tag"] }]);
         (homeSpaceCell as any).key("defaultPattern").set(
           homeDefaultPatternCell,
         );
@@ -2099,7 +2052,10 @@ describe("wish built-in", () => {
         tx,
       );
       const favoritesCell = homeDefaultPatternCell.key("favorites");
-      favoritesCell.set([{ cell: sharedPiece.withTx(tx), tag: "#shared-tag" }]);
+      favoritesCell.set([{
+        cell: sharedPiece.withTx(tx),
+        tags: ["shared-tag"],
+      }]);
       (homeSpaceCell as any).key("defaultPattern").set(homeDefaultPatternCell);
 
       await tx.commit();
@@ -3052,7 +3008,7 @@ describe("wish built-in", () => {
       });
 
       favoritesCell.set([
-        { cell: authItem, tag: "#googleAuth" },
+        { cell: authItem, tags: ["googleauth"] },
       ]);
       (homeSpaceCell as any).key("defaultPattern").set(defaultPatternCell);
 
@@ -3116,8 +3072,8 @@ describe("wish built-in", () => {
       favoriteItem2.set({ name: "Different item" });
 
       favoritesCell.set([
-        { cell: favoriteItem1, tag: "#myTag #awesome" },
-        { cell: favoriteItem2, tag: "no hashtag here" },
+        { cell: favoriteItem1, tags: ["mytag", "awesome"] },
+        { cell: favoriteItem2, tags: [] },
       ]);
       (homeSpaceCell as any).key("defaultPattern").set(defaultPatternCell);
 
@@ -3178,7 +3134,7 @@ describe("wish built-in", () => {
       );
       const favoritesCell = defaultPatternCell.key("favorites");
       favoritesCell.set([
-        { cell: pieceCell, tag: "#counterPiece test piece" },
+        { cell: pieceCell, tags: ["counterpiece"] },
       ]);
       (homeSpaceCell as any).key("defaultPattern").set(defaultPatternCell);
 

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -1076,6 +1076,97 @@ describe("wish built-in", () => {
       expect(data.type).toBe("favorite");
     });
 
+    it("matches favorites by structured tags", async () => {
+      const homeSpaceCell = runtime.getHomeSpaceCell(tx);
+      const homeDefaultPatternCell = runtime.getCell(
+        userIdentity.did(),
+        "default-pattern-structured",
+        undefined,
+        tx,
+      );
+      const favoritesCell = homeDefaultPatternCell.key("favorites");
+      const favoriteItem = runtime.getCell(
+        userIdentity.did(),
+        "favorite-item-structured",
+        undefined,
+        tx,
+      );
+      favoriteItem.set({ type: "favorite" });
+      favoritesCell.set([{ cell: favoriteItem, tags: ["structured-tag"] }]);
+      (homeSpaceCell as any).key("defaultPattern").set(homeDefaultPatternCell);
+
+      await tx.commit();
+      await runtime.idle();
+      tx = runtime.edit();
+
+      const wishPattern = pattern(() => {
+        return { result: wish({ query: "#structured-tag", scope: ["~"] }) };
+      });
+      const resultCell = runtime.getCell<{ result?: { result?: unknown } }>(
+        patternSpace.did(),
+        "structured-tags-result",
+        undefined,
+        tx,
+      );
+      const result = runtime.run(tx, wishPattern, {}, resultCell);
+      await tx.commit();
+      tx = runtime.edit();
+      await result.pull();
+
+      const data = (() => {
+        const r = result.key("result").get()?.result;
+        return (r as any)?.get?.() ?? r;
+      })();
+      expect(data?.type).toBe("favorite");
+    });
+
+    it("falls back to the legacy tag when tags is empty", async () => {
+      const homeSpaceCell = runtime.getHomeSpaceCell(tx);
+      const homeDefaultPatternCell = runtime.getCell(
+        userIdentity.did(),
+        "default-pattern-legacy",
+        undefined,
+        tx,
+      );
+      const favoritesCell = homeDefaultPatternCell.key("favorites");
+      const favoriteItem = runtime.getCell(
+        userIdentity.did(),
+        "favorite-item-legacy",
+        undefined,
+        tx,
+      );
+      favoriteItem.set({ type: "favorite" });
+      // An empty tags array must not mask the legacy serialized-schema tag.
+      favoritesCell.set([
+        { cell: favoriteItem, tags: [], tag: "#legacy-fallback" },
+      ]);
+      (homeSpaceCell as any).key("defaultPattern").set(homeDefaultPatternCell);
+
+      await tx.commit();
+      await runtime.idle();
+      tx = runtime.edit();
+
+      const wishPattern = pattern(() => {
+        return { result: wish({ query: "#legacy-fallback", scope: ["~"] }) };
+      });
+      const resultCell = runtime.getCell<{ result?: { result?: unknown } }>(
+        patternSpace.did(),
+        "legacy-fallback-result",
+        undefined,
+        tx,
+      );
+      const result = runtime.run(tx, wishPattern, {}, resultCell);
+      await tx.commit();
+      tx = runtime.edit();
+      await result.pull();
+
+      const data = (() => {
+        const r = result.key("result").get()?.result;
+        return (r as any)?.get?.() ?? r;
+      })();
+      expect(data?.type).toBe("favorite");
+    });
+
     it('searches both favorites and mentionables with scope: ["~", "."]', async () => {
       // Setup: Add favorites to home space
       const homeSpaceCell = runtime.getHomeSpaceCell(tx);

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -1120,6 +1120,49 @@ describe("wish built-in", () => {
       expect(data?.type).toBe("favorite");
     });
 
+    it("matches favorites by user tags", async () => {
+      const homeSpaceCell = runtime.getHomeSpaceCell(tx);
+      const homeDefaultPatternCell = runtime.getCell(
+        userIdentity.did(),
+        "default-pattern-usertags",
+        undefined,
+        tx,
+      );
+      const favoritesCell = homeDefaultPatternCell.key("favorites");
+      const favoriteItem = runtime.getCell(
+        userIdentity.did(),
+        "favorite-item-usertags",
+        undefined,
+        tx,
+      );
+      favoriteItem.set({ type: "favorite" });
+      // No schema-derived tags; only a user-applied tag should match.
+      favoritesCell.set([{ cell: favoriteItem, tags: [], userTags: ["mine"] }]);
+      (homeSpaceCell as any).key("defaultPattern").set(homeDefaultPatternCell);
+
+      await tx.commit();
+      await runtime.idle();
+      tx = runtime.edit();
+
+      const wishPattern = pattern(() => {
+        return { result: wish({ query: "#mine", scope: ["~"] }) };
+      });
+      const resultCell = runtime.getCell<{ result?: { result?: unknown } }>(
+        patternSpace.did(),
+        "favorites-usertags-result",
+        undefined,
+        tx,
+      );
+      const result = runtime.run(tx, wishPattern, {}, resultCell);
+      await tx.commit();
+      tx = runtime.edit();
+      await result.pull();
+
+      const r = result.key("result").get()?.result;
+      const data = (r as any)?.get?.() ?? r;
+      expect(data?.type).toBe("favorite");
+    });
+
     it('searches both favorites and mentionables with scope: ["~", "."]', async () => {
       // Setup: Add favorites to home space
       const homeSpaceCell = runtime.getHomeSpaceCell(tx);
@@ -2298,6 +2341,153 @@ describe("wish built-in", () => {
       expect(favorites).toBeDefined();
       expect(Array.isArray(favorites)).toBe(true);
       expect((favorites as any[])[0].tag).toEqual("test favorite");
+    });
+
+    // Helper: stand up the home space with a single favorite carrying the given
+    // discovery/user tags, then resolve `#favorites/<term>` against it.
+    async function resolveFavoritesTerm(
+      label: string,
+      entry: { tags?: string[]; userTags?: string[] },
+      term: string,
+    ) {
+      const homeSpaceCell = runtime.getHomeSpaceCell(tx);
+      const defaultPatternCell = runtime.getCell(
+        userIdentity.did(),
+        `default-pattern-${label}`,
+        undefined,
+        tx,
+      );
+      const favoritesCell = defaultPatternCell.key("favorites");
+      const favoriteItem = runtime.getCell(
+        userIdentity.did(),
+        `favorite-item-${label}`,
+        undefined,
+        tx,
+      );
+      favoriteItem.set({ name: "My Favorite", value: 42 });
+      favoritesCell.set([
+        {
+          cell: favoriteItem,
+          tags: entry.tags ?? [],
+          userTags: entry.userTags ?? [],
+        },
+      ]);
+      (homeSpaceCell as any).key("defaultPattern").set(defaultPatternCell);
+
+      await tx.commit();
+      await runtime.idle();
+      tx = runtime.edit();
+
+      const wishPattern = pattern(() => {
+        return { result: wish({ query: `#favorites/${term}` }) };
+      });
+      const resultCell = runtime.getCell<{
+        result?: { result?: unknown; error?: string };
+      }>(
+        patternSpace.did(),
+        `favorites-term-${label}-result`,
+        undefined,
+        tx,
+      );
+      const result = runtime.run(tx, wishPattern, {}, resultCell);
+      await tx.commit();
+      tx = runtime.edit();
+      await result.pull();
+      return result.key("result").get();
+    }
+
+    // A `#favorites/<term>` query finds a favorite whose discovery tag or user
+    // tag matches `term`. These tests assert the match decision (no "No favorite
+    // found" error when one matches; the error when none do) — that is the code
+    // path the favorite matchers own.
+    it("matches a #favorites/<term> query by a structured discovery tag", async () => {
+      const resolved = await resolveFavoritesTerm(
+        "tag",
+        { tags: ["weather"] },
+        "weather",
+      );
+      expect(resolved?.error).toBeUndefined();
+    });
+
+    it("matches a #favorites/<term> query by a user tag substring", async () => {
+      const resolved = await resolveFavoritesTerm(
+        "usertag",
+        { userTags: ["mynotebook"] },
+        "note",
+      );
+      expect(resolved?.error).toBeUndefined();
+    });
+
+    it("reports an error for #favorites/<term> when nothing matches", async () => {
+      const resolved = await resolveFavoritesTerm(
+        "nomatch",
+        { tags: ["weather"], userTags: ["mine"] },
+        "missing",
+      );
+      expect(resolved?.result).toBeUndefined();
+      expect(resolved?.error).toMatch(/No favorite found matching/);
+    });
+
+    // Other well-known home-space targets resolve to fixed paths under the home
+    // default pattern.
+    async function resolveHomeTarget(
+      label: string,
+      key: string,
+      value: unknown,
+      query: string,
+    ) {
+      const homeSpaceCell = runtime.getHomeSpaceCell(tx);
+      const defaultPatternCell = runtime.getCell(
+        userIdentity.did(),
+        `default-pattern-${label}`,
+        undefined,
+        tx,
+      );
+      defaultPatternCell.key(key).set(value);
+      (homeSpaceCell as any).key("defaultPattern").set(defaultPatternCell);
+
+      await tx.commit();
+      await runtime.idle();
+      tx = runtime.edit();
+
+      const wishPattern = pattern(() => {
+        return { result: wish({ query }) };
+      });
+      const resultCell = runtime.getCell<{ result?: { result?: unknown } }>(
+        patternSpace.did(),
+        `home-target-${label}-result`,
+        undefined,
+        tx,
+      );
+      const result = runtime.run(tx, wishPattern, {}, resultCell);
+      await tx.commit();
+      tx = runtime.edit();
+      await result.pull();
+      return result.key("result").get();
+    }
+
+    it("resolves #journal to the home journal list", async () => {
+      const resolved = await resolveHomeTarget(
+        "journal",
+        "journal",
+        [{ narrative: "first entry" }],
+        "#journal",
+      );
+      expect(resolved?.error).toBeUndefined();
+      const journal = resolved?.result;
+      expect(Array.isArray(journal)).toBe(true);
+      expect((journal as any[])[0].narrative).toBe("first entry");
+    });
+
+    it("resolves #learned to the home learned object", async () => {
+      const resolved = await resolveHomeTarget(
+        "learned",
+        "learned",
+        { summary: "a learned summary" },
+        "#learned",
+      );
+      expect(resolved?.error).toBeUndefined();
+      expect((resolved?.result as any)?.summary).toBe("a learned summary");
     });
 
     it("resolves well-known profile targets from the home default profile link", async () => {

--- a/packages/runtime-client/favorites-manager.test.ts
+++ b/packages/runtime-client/favorites-manager.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { JSONSchema } from "@commonfabric/api";
+import type { DID } from "@commonfabric/identity";
+import { FavoritesManager } from "./favorites-manager.ts";
+import type { RuntimeClient } from "./runtime-client.ts";
+
+const space = "did:key:test-space" as DID;
+
+// A handler stub that records what addFavorite sends.
+class SendRecorder {
+  sent: Array<Record<string, unknown>> = [];
+  send(payload: Record<string, unknown>) {
+    this.sent.push(payload);
+  }
+}
+
+// A RuntimeClient stub exposing only what FavoritesManager.addFavorite touches:
+// the home-pattern handle path (ensureHomePatternRunning → asSchema → key →
+// handler) and getPage (whose resolved ref carries the piece's schema).
+function stubRuntime(
+  schema: JSONSchema | undefined,
+  recorder: SendRecorder,
+): { rt: RuntimeClient; getPageCalls: number } {
+  let getPageCalls = 0;
+  const homeHandle: Record<string, unknown> = {
+    asSchema: () => homeHandle,
+    sync: () => Promise.resolve(),
+    key: () => recorder,
+  };
+  const rt = {
+    ensureHomePatternRunning: () => Promise.resolve(homeHandle),
+    getPage: () => {
+      getPageCalls++;
+      return Promise.resolve({
+        cell: () => ({ ref: () => ({ schema }) }),
+      });
+    },
+  } as unknown as RuntimeClient;
+  return {
+    rt,
+    get getPageCalls() {
+      return getPageCalls;
+    },
+  };
+}
+
+describe("FavoritesManager.addFavorite tag derivation", () => {
+  it("derives structured tags from the piece schema", async () => {
+    const recorder = new SendRecorder();
+    const { rt } = stubRuntime({
+      type: "object",
+      description: "A #note",
+      tags: ["search", "discovery"],
+    }, recorder);
+
+    await new FavoritesManager(rt).addFavorite(space, "piece-1");
+
+    expect(recorder.sent.length).toBe(1);
+    expect(recorder.sent[0].tags).toEqual(["search", "discovery"]);
+    expect(recorder.sent[0].piece).toMatchObject({ id: "of:piece-1", space });
+  });
+
+  it("falls back to description hashtags for legacy schemas", async () => {
+    const recorder = new SendRecorder();
+    const { rt } = stubRuntime({
+      type: "object",
+      description: "An #annotation piece.",
+    }, recorder);
+
+    await new FavoritesManager(rt).addFavorite(space, "piece-2");
+
+    expect(recorder.sent[0].tags).toEqual(["annotation"]);
+  });
+
+  it("prefers an explicit tag over the schema and skips the schema read", async () => {
+    const recorder = new SendRecorder();
+    const stub = stubRuntime(
+      { type: "object", tags: ["schema-tag"] },
+      recorder,
+    );
+
+    await new FavoritesManager(stub.rt).addFavorite(
+      space,
+      "piece-3",
+      "#Custom-Tag",
+    );
+
+    expect(recorder.sent[0].tags).toEqual(["custom-tag"]);
+    // An explicit tag short-circuits derivation; getPage is never called.
+    expect(stub.getPageCalls).toBe(0);
+  });
+
+  it("stores no tags when the piece has no readable schema", async () => {
+    const recorder = new SendRecorder();
+    const { rt } = stubRuntime(undefined, recorder);
+
+    await new FavoritesManager(rt).addFavorite(space, "piece-4");
+
+    expect(recorder.sent[0].tags).toEqual([]);
+  });
+});

--- a/packages/runtime-client/favorites-manager.test.ts
+++ b/packages/runtime-client/favorites-manager.test.ts
@@ -4,99 +4,201 @@ import type { JSONSchema } from "@commonfabric/api";
 import type { DID } from "@commonfabric/identity";
 import { FavoritesManager } from "./favorites-manager.ts";
 import type { RuntimeClient } from "./runtime-client.ts";
+import { RuntimeDisposedError } from "./shared/disposed-error.ts";
 
 const space = "did:key:test-space" as DID;
 
-// A handler stub that records what addFavorite sends.
-class SendRecorder {
-  sent: Array<Record<string, unknown>> = [];
-  send(payload: Record<string, unknown>) {
-    this.sent.push(payload);
-  }
+interface StubOptions {
+  schema?: JSONSchema; // schema carried on the resolved piece ref
+  getPageThrows?: boolean; // make getPage reject (derivation error path)
+  favorites?: unknown; // value returned by the favorites cell
+  ensureThrows?: boolean; // make ensureHomePatternRunning reject
+  ensureDisposed?: boolean; // reject with a RuntimeDisposedError
 }
 
-// A RuntimeClient stub exposing only what FavoritesManager.addFavorite touches:
-// the home-pattern handle path (ensureHomePatternRunning → asSchema → key →
-// handler) and getPage (whose resolved ref carries the piece's schema).
-function stubRuntime(
-  schema: JSONSchema | undefined,
-  recorder: SendRecorder,
-): { rt: RuntimeClient; getPageCalls: number } {
+// A single flexible RuntimeClient stub covering everything FavoritesManager
+// touches: the home-pattern handle chain (ensureHomePatternRunning → asSchema →
+// key → handler / favorites cell) and getPage (whose resolved ref carries the
+// piece schema).
+function makeStub(opts: StubOptions = {}) {
+  const sent: Array<Record<string, unknown>> = [];
+  let subscribeCb: ((v: unknown) => void) | undefined;
+  let unsubscribed = false;
   let getPageCalls = 0;
+
+  const handler = { send: (p: Record<string, unknown>) => sent.push(p) };
+  const favoritesCell: Record<string, unknown> = {
+    asSchema: () => favoritesCell,
+    sync: () => Promise.resolve(),
+    get: () => opts.favorites,
+    subscribe: (cb: (v: unknown) => void) => {
+      subscribeCb = cb;
+      return () => {
+        unsubscribed = true;
+      };
+    },
+  };
   const homeHandle: Record<string, unknown> = {
     asSchema: () => homeHandle,
     sync: () => Promise.resolve(),
-    key: () => recorder,
+    key: (k: string) => (k === "favorites" ? favoritesCell : handler),
   };
   const rt = {
-    ensureHomePatternRunning: () => Promise.resolve(homeHandle),
+    ensureHomePatternRunning: () =>
+      opts.ensureDisposed
+        ? Promise.reject(new RuntimeDisposedError("disposed"))
+        : opts.ensureThrows
+        ? Promise.reject(new Error("ensure failed"))
+        : Promise.resolve(homeHandle),
     getPage: () => {
       getPageCalls++;
-      return Promise.resolve({
-        cell: () => ({ ref: () => ({ schema }) }),
-      });
+      return opts.getPageThrows
+        ? Promise.reject(new Error("getPage failed"))
+        : Promise.resolve({
+          cell: () => ({ ref: () => ({ schema: opts.schema }) }),
+        });
     },
   } as unknown as RuntimeClient;
+
   return {
     rt,
-    get getPageCalls() {
-      return getPageCalls;
-    },
+    sent,
+    invokeSubscribe: (v: unknown) => subscribeCb?.(v),
+    hasSubscriber: () => subscribeCb !== undefined,
+    wasUnsubscribed: () => unsubscribed,
+    getPageCalls: () => getPageCalls,
   };
 }
 
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 describe("FavoritesManager.addFavorite tag derivation", () => {
   it("derives structured tags from the piece schema", async () => {
-    const recorder = new SendRecorder();
-    const { rt } = stubRuntime({
-      type: "object",
-      description: "A #note",
-      tags: ["search", "discovery"],
-    }, recorder);
-
-    await new FavoritesManager(rt).addFavorite(space, "piece-1");
-
-    expect(recorder.sent.length).toBe(1);
-    expect(recorder.sent[0].tags).toEqual(["search", "discovery"]);
-    expect(recorder.sent[0].piece).toMatchObject({ id: "of:piece-1", space });
+    const stub = makeStub({
+      schema: {
+        type: "object",
+        description: "A #note",
+        tags: ["search", "go"],
+      },
+    });
+    await new FavoritesManager(stub.rt).addFavorite(space, "piece-1");
+    expect(stub.sent[0].tags).toEqual(["search", "go"]);
+    expect(stub.sent[0].piece).toMatchObject({ id: "of:piece-1", space });
   });
 
-  it("falls back to description hashtags for legacy schemas", async () => {
-    const recorder = new SendRecorder();
-    const { rt } = stubRuntime({
-      type: "object",
-      description: "An #annotation piece.",
-    }, recorder);
-
-    await new FavoritesManager(rt).addFavorite(space, "piece-2");
-
-    expect(recorder.sent[0].tags).toEqual(["annotation"]);
-  });
-
-  it("prefers an explicit tag over the schema and skips the schema read", async () => {
-    const recorder = new SendRecorder();
-    const stub = stubRuntime(
-      { type: "object", tags: ["schema-tag"] },
-      recorder,
-    );
-
-    await new FavoritesManager(stub.rt).addFavorite(
-      space,
-      "piece-3",
-      "#Custom-Tag",
-    );
-
-    expect(recorder.sent[0].tags).toEqual(["custom-tag"]);
-    // An explicit tag short-circuits derivation; getPage is never called.
-    expect(stub.getPageCalls).toBe(0);
+  it("prefers an explicit tag and skips the schema read", async () => {
+    const stub = makeStub({ schema: { type: "object", tags: ["schema-tag"] } });
+    await new FavoritesManager(stub.rt).addFavorite(space, "p", "#Custom-Tag");
+    expect(stub.sent[0].tags).toEqual(["custom-tag"]);
+    expect(stub.getPageCalls()).toBe(0);
   });
 
   it("stores no tags when the piece has no readable schema", async () => {
-    const recorder = new SendRecorder();
-    const { rt } = stubRuntime(undefined, recorder);
+    const stub = makeStub({ schema: undefined });
+    await new FavoritesManager(stub.rt).addFavorite(space, "p");
+    expect(stub.sent[0].tags).toEqual([]);
+  });
 
-    await new FavoritesManager(rt).addFavorite(space, "piece-4");
+  it("stores no tags when the schema read fails", async () => {
+    const stub = makeStub({ getPageThrows: true });
+    await new FavoritesManager(stub.rt).addFavorite(space, "p");
+    expect(stub.sent[0].tags).toEqual([]);
+  });
+});
 
-    expect(recorder.sent[0].tags).toEqual([]);
+describe("FavoritesManager other operations", () => {
+  it("removeFavorite sends the piece reference", async () => {
+    const stub = makeStub();
+    await new FavoritesManager(stub.rt).removeFavorite(space, "piece-x");
+    expect(stub.sent[0]).toMatchObject({
+      piece: { id: "of:piece-x", space },
+    });
+  });
+
+  it("getFavorites returns the favorites list", async () => {
+    const entries = [{ cell: {}, tags: ["a"], userTags: [] }];
+    const stub = makeStub({ favorites: entries });
+    const result = await new FavoritesManager(stub.rt).getFavorites();
+    expect(result).toEqual(entries);
+  });
+
+  it("getFavorites returns [] when the cell is empty", async () => {
+    const stub = makeStub({ favorites: undefined });
+    expect(await new FavoritesManager(stub.rt).getFavorites()).toEqual([]);
+  });
+
+  it("subscribeFavorites delivers values and stops on unsubscribe", async () => {
+    const stub = makeStub();
+    const seen: unknown[] = [];
+    const cancel = new FavoritesManager(stub.rt).subscribeFavorites((f) =>
+      seen.push(f)
+    );
+    await tick();
+    expect(stub.hasSubscriber()).toBe(true);
+
+    stub.invokeSubscribe([{ cell: {}, tags: ["x"], userTags: [] }]);
+    expect(seen).toEqual([[{ cell: {}, tags: ["x"], userTags: [] }]]);
+
+    // A null delivery is normalized to an empty array.
+    stub.invokeSubscribe(undefined);
+    expect(seen[1]).toEqual([]);
+
+    cancel();
+    expect(stub.wasUnsubscribed()).toBe(true);
+    // After cleanup, further deliveries are dropped.
+    stub.invokeSubscribe([{ cell: {}, tags: ["y"], userTags: [] }]);
+    expect(seen.length).toBe(2);
+  });
+
+  it("subscribeFavorites reports setup errors to onError", async () => {
+    const stub = makeStub({ ensureThrows: true });
+    const seen: unknown[] = [];
+    let reported: Error | undefined;
+    new FavoritesManager(stub.rt).subscribeFavorites(
+      (f) => seen.push(f),
+      (err) => {
+        reported = err;
+      },
+    );
+    await tick();
+    await tick();
+    expect(reported?.message).toBe("ensure failed");
+    // The callback is still invoked once with an empty list on failure.
+    expect(seen).toEqual([[]]);
+  });
+
+  it("subscribeFavorites treats a runtime-disposed error as cancellation", async () => {
+    const stub = makeStub({ ensureDisposed: true });
+    const seen: unknown[] = [];
+    let reported: Error | undefined;
+    new FavoritesManager(stub.rt).subscribeFavorites(
+      (f) => seen.push(f),
+      (err) => {
+        reported = err;
+      },
+    );
+    await tick();
+    await tick();
+    // A disposed runtime is an expected teardown race, not an error: neither
+    // onError nor the empty-list callback fires.
+    expect(reported).toBeUndefined();
+    expect(seen).toEqual([]);
+  });
+
+  it("subscribeFavorites logs setup errors when no onError is given", async () => {
+    const stub = makeStub({ ensureThrows: true });
+    const original = console.error;
+    let logged = false;
+    console.error = () => {
+      logged = true;
+    };
+    try {
+      new FavoritesManager(stub.rt).subscribeFavorites(() => {});
+      await tick();
+      await tick();
+    } finally {
+      console.error = original;
+    }
+    expect(logged).toBe(true);
   });
 });

--- a/packages/runtime-client/favorites-manager.ts
+++ b/packages/runtime-client/favorites-manager.ts
@@ -15,6 +15,7 @@ import {
   Home,
   homeSchema,
 } from "@commonfabric/home-schemas";
+import { tagsFromSchema } from "@commonfabric/data-model/schema-tags";
 import { isRuntimeDisposedError } from "./shared/disposed-error.ts";
 
 type HandlerName = "addFavorite" | "removeFavorite";
@@ -29,9 +30,16 @@ export class FavoritesManager {
 
   /**
    * Add a piece to favorites (stored in the home space).
+   *
+   * Discovery tags are derived here, on the client, from the piece's result
+   * schema — which the backend surfaces on the piece's resolved cell ref.
+   * Deriving before the handler avoids the handler's event typing shadowing
+   * the piece's authored schema. An explicit `tag` overrides the derived
+   * tags.
+   *
    * @param space - The space the piece lives in (part of its address)
    * @param pieceId - The entity ID of the piece to add
-   * @param tag - Optional tag/category for the favorite
+   * @param tag - Optional explicit discovery tag (overrides schema tags)
    * @param spaceName - Optional human-readable name of the space
    */
   async addFavorite(
@@ -42,7 +50,35 @@ export class FavoritesManager {
   ): Promise<void> {
     const handler = await this.#getHandler("addFavorite");
     const pieceCellRef = this.#createPieceRef(space, pieceId);
-    await handler.send({ piece: pieceCellRef, tag: tag || "", spaceName });
+    const tags = await this.#deriveTags(space, pieceId, tag);
+    await handler.send({ piece: pieceCellRef, tags, spaceName });
+  }
+
+  /**
+   * Derive the discovery tags for a piece. An explicit tag wins; otherwise
+   * read the piece's result schema (carried on its resolved cell ref) and
+   * extract its tags. Returns `[]` when no schema is available — a tagless
+   * favorite that later code can heal.
+   */
+  async #deriveTags(
+    space: DID,
+    pieceId: string,
+    explicitTag?: string,
+  ): Promise<string[]> {
+    if (explicitTag) return [explicitTag.toLowerCase().replace(/^#/, "")];
+    try {
+      // `getPage` resolves the piece's cell ref, which the backend serializes
+      // with its result schema (`getAsLink({ includeSchema: true })`). It does
+      // not start the piece (runIt defaults to false), so a piece that is not
+      // already running may resolve without a schema and yield no tags — a
+      // tagless favorite that later code can heal.
+      const page = await this.#rt.getPage(pieceId, space);
+      const schema = page?.cell().ref().schema;
+      return schema ? tagsFromSchema(schema) : [];
+    } catch {
+      // A missing or unreadable piece schema yields no tags, not a failure.
+      return [];
+    }
   }
 
   /**

--- a/packages/schema-generator/src/doc-utils.ts
+++ b/packages/schema-generator/src/doc-utils.ts
@@ -1,4 +1,19 @@
 import ts from "typescript";
+import { extractHashtags } from "@commonfabric/data-model/schema-tags";
+
+/**
+ * Mirror the hashtags found in a schema's description text into a structured
+ * `tags` field. Sets `tags` only when the text contains hashtags, leaving the
+ * field absent otherwise (the same omit-empty convention used for
+ * `description`, `required`, and `$comment`).
+ */
+export function attachDocTags(
+  schema: Record<string, unknown>,
+  text: string,
+): void {
+  const tags = extractHashtags(text);
+  if (tags.length > 0) schema.tags = tags;
+}
 
 /**
  * Extract plain-text JSDoc from a symbol. Filters out tag lines starting with

--- a/packages/schema-generator/src/formatters/intersection-formatter.ts
+++ b/packages/schema-generator/src/formatters/intersection-formatter.ts
@@ -8,7 +8,7 @@ import type { SchemaGenerator } from "../schema-generator.ts";
 import { cloneSchemaDefinition, getNativeTypeSchema } from "../type-utils.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isRecord } from "@commonfabric/utils/types";
-import { extractDocFromType } from "../doc-utils.ts";
+import { attachDocTags, extractDocFromType } from "../doc-utils.ts";
 import { isCellType } from "../typescript/cell-brand.ts";
 
 const logger = getLogger("schema-generator.intersection");
@@ -283,6 +283,9 @@ export class IntersectionFormatter implements TypeFormatter {
       (schema as Record<string, unknown>).description = uniqueDocTexts.join(
         "\n\n",
       );
+    }
+    if (typeof schema.description === "string") {
+      attachDocTags(schema as Record<string, unknown>, schema.description);
     }
 
     const commentParts: string[] = [];

--- a/packages/schema-generator/src/formatters/object-formatter.ts
+++ b/packages/schema-generator/src/formatters/object-formatter.ts
@@ -20,7 +20,11 @@ import {
   isOptionalSymbol,
 } from "../typescript/property-optionality.ts";
 import type { SchemaGenerator } from "../schema-generator.ts";
-import { extractDocFromSymbolAndDecls, getDeclDocs } from "../doc-utils.ts";
+import {
+  attachDocTags,
+  extractDocFromSymbolAndDecls,
+  getDeclDocs,
+} from "../doc-utils.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isRecord } from "@commonfabric/utils/types";
 
@@ -320,6 +324,7 @@ export class ObjectFormatter implements TypeFormatter {
       if (text && isRecord(generated)) {
         const conflicts = all.filter((s) => s && s !== text);
         (generated as Record<string, unknown>).description = text;
+        attachDocTags(generated as Record<string, unknown>, text);
         if (conflicts.length > 0) {
           const comment = typeof generated.$comment === "string"
             ? (generated.$comment as string)
@@ -375,6 +380,7 @@ export class ObjectFormatter implements TypeFormatter {
       }
       if (foundDocs.length > 0 && isRecord(apSchema)) {
         (apSchema as Record<string, unknown>).description = foundDocs[0]!;
+        attachDocTags(apSchema as Record<string, unknown>, foundDocs[0]!);
         if (foundDocs.length > 1) {
           const comment = typeof apSchema.$comment === "string"
             ? (apSchema.$comment as string)

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -26,7 +26,7 @@ import {
   safeGetNodeText,
   safeGetTypeOfSymbolAtLocation,
 } from "./type-utils.ts";
-import { extractDocFromType } from "./doc-utils.ts";
+import { attachDocTags, extractDocFromType } from "./doc-utils.ts";
 
 /**
  * Main schema generator that uses a chain of formatters
@@ -671,6 +671,9 @@ export class SchemaGenerator implements ISchemaGenerator {
     const docInfo = extractDocFromType(type, context.typeChecker);
     if (docInfo.firstDoc && isRecord(schema) && !("description" in schema)) {
       (schema as Record<string, unknown>).description = docInfo.firstDoc;
+    }
+    if (isRecord(schema) && typeof schema.description === "string") {
+      attachDocTags(schema as Record<string, unknown>, schema.description);
     }
     return schema;
   }

--- a/packages/schema-generator/test/fixtures/schema/descriptions-hashtag-tags.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-hashtag-tags.expected.json
@@ -1,0 +1,28 @@
+{
+  "description": "A #note the user took, discoverable via #quick-capture.",
+  "properties": {
+    "annotations": {
+      "description": "Linked #annotation entries.",
+      "items": {
+        "type": "string"
+      },
+      "tags": [
+        "annotation"
+      ],
+      "type": "array"
+    },
+    "content": {
+      "description": "The note body.",
+      "type": "string"
+    }
+  },
+  "required": [
+    "annotations",
+    "content"
+  ],
+  "tags": [
+    "note",
+    "quick-capture"
+  ],
+  "type": "object"
+}

--- a/packages/schema-generator/test/fixtures/schema/descriptions-hashtag-tags.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-hashtag-tags.input.ts
@@ -1,0 +1,7 @@
+/** A #note the user took, discoverable via #quick-capture. */
+interface SchemaRoot {
+  /** The note body. */
+  content: string;
+  /** Linked #annotation entries. */
+  annotations: string[];
+}

--- a/packages/schema-generator/test/fixtures/schema/descriptions-index-signature-tags.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-index-signature-tags.expected.json
@@ -1,0 +1,11 @@
+{
+  "additionalProperties": {
+    "description": "Maps ids to #catalog entries.",
+    "tags": [
+      "catalog"
+    ],
+    "type": "string"
+  },
+  "properties": {},
+  "type": "object"
+}

--- a/packages/schema-generator/test/fixtures/schema/descriptions-index-signature-tags.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-index-signature-tags.input.ts
@@ -1,0 +1,4 @@
+interface SchemaRoot {
+  /** Maps ids to #catalog entries. */
+  [id: string]: string;
+}

--- a/packages/schema-generator/test/fixtures/schema/descriptions-intersection-hashtag-tags.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-intersection-hashtag-tags.expected.json
@@ -1,0 +1,24 @@
+{
+  "$comment": "Docs inherited from intersection constituents. Sources: RecipeBase, Schedulable.",
+  "description": "A #recipe with ingredients.\n\nSchedulable on the #meal-plan.",
+  "properties": {
+    "ingredients": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "plannedFor": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "ingredients",
+    "plannedFor"
+  ],
+  "tags": [
+    "recipe",
+    "meal-plan"
+  ],
+  "type": "object"
+}

--- a/packages/schema-generator/test/fixtures/schema/descriptions-intersection-hashtag-tags.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-intersection-hashtag-tags.input.ts
@@ -1,0 +1,11 @@
+/** A #recipe with ingredients. */
+type RecipeBase = {
+  ingredients: string[];
+};
+
+/** Schedulable on the #meal-plan. */
+type Schedulable = {
+  plannedFor: string;
+};
+
+type SchemaRoot = RecipeBase & Schedulable;


### PR DESCRIPTION
Change how tags work to enable the clean removal of the `as any` in the home.tsx pattern.

This is stacked as 3 separate commits for easier review. See the individual commit messages for details.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored discovery tags end-to-end: the schema generator emits structured `tags` from doc-comment hashtags, the runtime client derives and sends them when favoriting, home handlers store them, and `wish()` matches favorites by these tags only. Removes the legacy serialized-schema `tag` and the schema introspection hack in home handlers.

- **New Features**
  - `schema-generator` attaches `tags: string[]` from doc-comment hashtags at root, object properties, index signatures, and intersections; `JSONSchemaObj.tags` added in `@commonfabric/api`.
  - New `@commonfabric/data-model/schema-tags` with `extractHashtags` and `tagsFromSchema` used by the generator and runtime client.
  - `FavoritesManager` derives tags from a piece’s schema via `getPage` and sends them to `addFavorite`; home handlers accept `{ tags?: string[] }` and just store them.
  - `wish()` hashtag search matches favorites by stored `tags`.

- **Migration**
  - Favorites that only have the old `tag` field no longer match hashtag searches.
  - Re-favorite items or backfill `tags` from their schemas to restore discoverability.

<sup>Written for commit f6c3a22682957edebc329559dfe36edec973ee56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

