### PR TITLE
feat(profiles): add owner-protected bio field + #profileBio wish target (CT-1648)

### DIFF
--- a/docs/common/conventions/wish.md
+++ b/docs/common/conventions/wish.md
@@ -106,6 +106,7 @@ ordered **default first, then by MRU**:
 wish({ query: "#profile" }) // the default profile (headless); see [UI] below
 wish({ query: "#profileName" }) // default profile's initialNameApplied
 wish({ query: "#profileAvatar" }) // default profile's avatar
+wish({ query: "#profileBio" }) // default profile's bio (free-text description)
 wish({ query: "#profileSpace" }) // default profile's space cell
 ```
 

--- a/docs/specs/shared-profile-space.md
+++ b/docs/specs/shared-profile-space.md
@@ -165,15 +165,23 @@ type ProfileDefaultPattern = {
   [UI]: VNode;
   name: string;
   avatar: string;
+  bio: string;
   elements: ProfileElement[];
   addElement: Stream<AddProfileElementEvent>;
   removeElement: Stream<{ cell: Cell<unknown> }>;
+  setBio: Stream<SetProfileBioEvent>;
   initialNameApplied: string;
 };
 ```
 
 `avatar` starts as a string. The first implementation can use a URL, data URL,
 or emoji-like text. Binary/blob avatar upload is out of scope.
+
+`bio` (CT-1648) is a short, owner-authored free-text description, the canonical
+shared-profile bio — distinct from Home's legacy `learned.summary`. Like `name`
+and `avatar` it is owner-protected (written only through `setBio`), readable
+from the profile result, and exposed as the well-known wish target
+`#profileBio`.
 
 `elements` is the profile-space analog of favorites and mentionables. Each
 entry points at a piece that lives in the profile space. `tag` stores the
@@ -359,6 +367,7 @@ wish({ query: "#profile" })            // homeDefault.profile
 wish({ query: "#profileSpace" })       // the profile space cell, derived from the profile link
 wish({ query: "#profileName" })        // homeDefault.profileName, then profile.initialNameApplied
 wish({ query: "#profileAvatar" })      // homeDefault.profile.avatar
+wish({ query: "#profileBio" })         // homeDefault.profile.bio (CT-1648)
 ```
 
 The optional `[UI]` for `wish({ query: "#profile" })` is persona-aware:

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -94,14 +94,27 @@ export type SetProfileAvatarEvent = {
   target?: { value?: string };
 };
 
+export type SetProfileBioEvent = {
+  bio?: string;
+  detail?: { message?: string };
+  key?: string;
+  target?: { value?: string };
+};
+
 export type ProfileHomeOutput = {
   [NAME]: string;
   [UI]: unknown;
   name: OwnerProtectedProfileWrite<string, typeof setName>;
   avatar: OwnerProtectedProfileWrite<string, typeof setAvatar>;
+  // A short, human-authored free-text description of the profile owner
+  // (CT-1648). Owner-protected like name/avatar; the canonical shared-profile
+  // bio (distinct from Home's legacy `learned.summary`). Readable from the
+  // profile result and via `wish({ query: "#profileBio" })`.
+  bio: OwnerProtectedProfileWrite<string, typeof setBio>;
   elements: OwnerProtectedProfileWrite<ProfileElement[], typeof mutateElements>;
   setName: Stream<SetProfileNameEvent>;
   setAvatar: Stream<SetProfileAvatarEvent>;
+  setBio: Stream<SetProfileBioEvent>;
   // Both element streams accept the full mutation event (the union shape of
   // the one authorized writer); `AddProfileElementEvent` /
   // `RemoveProfileElementEvent` remain the documented per-stream subsets.
@@ -329,6 +342,26 @@ const setAvatar = handler<SetProfileAvatarEvent, { avatar: Writable<string> }>(
   },
 );
 
+// THE authorized writer for the owner-protected `bio` field (CT-1648). Bio is
+// multi-line free text, so — unlike setName — it is NOT Enter-gated and is
+// driven by a Save button reading the bound (unprotected) draft cell: a direct
+// `$value` two-way binding onto the protected `bio` cell would bypass this
+// handler and be rejected by CFC. Falls back through event fields so a future
+// "set bio" event path (or a test) can pass the value directly.
+const setBio = handler<
+  SetProfileBioEvent,
+  { bio: Writable<string>; draft?: Writable<string> }
+>(
+  (event, state) => {
+    const bio = (event.bio ?? event.detail?.message ??
+      event.target?.value ?? state.draft?.get() ?? "").trim();
+    state.bio.set(bio);
+    // Clear the draft after a successful save (mirrors the form handlers
+    // elsewhere in this file).
+    state.draft?.set("");
+  },
+);
+
 // View/edit toggle for the rendered profile view (CT-1748). Plain (un-protected)
 // UI state: visiting a profile shows the read-only presentation; this flips to
 // the edit form. The flag itself is not owner-protected — anyone can flip their
@@ -355,6 +388,12 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
     const avatar = new Writable<
       OwnerProtectedProfileWrite<string, typeof setAvatar>
     >("").for("avatar");
+    const bio = new Writable<
+      OwnerProtectedProfileWrite<string, typeof setBio>
+    >("").for("bio");
+    // Unprotected draft backing the bio textarea; saved into the protected
+    // `bio` cell through `setBio` (CT-1648).
+    const bioDraft = new Writable("").for("bioDraft");
     const elements = new Writable<
       OwnerProtectedProfileWrite<ProfileElement[], typeof mutateElements>
     >([]).for("elements");
@@ -371,6 +410,9 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
     // presentation by default; the owner flips this to reveal the edit form.
     const editing = new Writable<boolean>(false).for("editing");
     const isEditing = computed(() => editing.get() === true);
+    // Whether a non-empty bio has been authored — drives the presentation-mode
+    // bio block (CT-1648).
+    const hasBio = computed(() => (bio.get() ?? "").trim().length > 0);
     // Self-view cell for <cf-profile-badge>: the badge resolves name/avatar from
     // a bound profile cell. Bound to this DERIVED self-cell (a computed
     // projection, not the profile's own root piece), so the badge is marked
@@ -405,9 +447,11 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
       [NAME]: displayName,
       name,
       avatar,
+      bio,
       elements,
       setName: setName({ name }),
       setAvatar: setAvatar({ avatar }),
+      setBio: setBio({ bio, draft: bioDraft }),
       // Both exported streams are instances of the one authorized writer,
       // pinned to their declared purpose via the bound mode.
       addElement: mutateElements({ elements, mode: "add" }),
@@ -451,6 +495,21 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
                   size="xl"
                   noNavigate
                 />
+
+                {ifElse(
+                  hasBio,
+                  <p
+                    data-ui-region="profile-bio"
+                    style={{
+                      margin: 0,
+                      whiteSpace: "pre-wrap",
+                      color: "var(--cf-theme-color-text-secondary)",
+                    }}
+                  >
+                    {bio}
+                  </p>,
+                  null,
+                )}
 
                 <cf-vstack gap="2">
                   {elements.map((element) => (
@@ -516,6 +575,20 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
                     appearance="rounded"
                     oncf-send={setAvatar({ avatar })}
                   />
+                </cf-vstack>
+
+                <cf-vstack gap="2">
+                  <label>Bio</label>
+                  <span style={{ whiteSpace: "pre-wrap" }}>{bio}</span>
+                  <cf-textarea
+                    data-ui-action={TRUSTED_PROFILE_EDIT_ACTION}
+                    $value={bioDraft}
+                    placeholder="A short bio…"
+                    style="width: 100%;"
+                  />
+                  <cf-button onClick={setBio({ bio, draft: bioDraft })}>
+                    Save bio
+                  </cf-button>
                 </cf-vstack>
 
                 <cf-vstack gap="2">

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -177,6 +177,7 @@ function getResolutionKind(parsed: ParsedWishTarget): string {
     case "#profile":
     case "#profileName":
     case "#profileAvatar":
+    case "#profileBio":
     case "#profileSpace":
       return "home-target";
     default:
@@ -849,6 +850,15 @@ function resolveHomeSpaceTarget(
       return [{
         cell: getDefaultProfileCell(ctx),
         pathPrefix: ["avatar"],
+      }];
+    }
+
+    case "#profileBio": {
+      // The owner-authored free-text bio of the default profile (CT-1648).
+      // Tracks edits made via the profile's setBio handler.
+      return [{
+        cell: getDefaultProfileCell(ctx),
+        pathPrefix: ["bio"],
       }];
     }
 

--- a/packages/runner/test/profile-home-bio.test.ts
+++ b/packages/runner/test/profile-home-bio.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { fromFileUrl } from "@std/path";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// CT-1648: profiles carry an owner-authored free-text `bio`. It starts empty,
+// is written ONLY through the authorized `setBio` handler (owner-protected like
+// name/avatar), and is readable from the profile result. This drives the real
+// shipped `profile-home.tsx` and exercises create -> edit -> read.
+const signer = await Identity.fromPassphrase("profile-home-bio");
+const space = signer.did();
+
+const sysDir = fromFileUrl(new URL("../../patterns/system/", import.meta.url));
+const PROGRAM: RuntimeProgram = {
+  main: "/profile-home.tsx",
+  files: [
+    {
+      name: "/profile-home.tsx",
+      contents: Deno.readTextFileSync(sysDir + "profile-home.tsx"),
+    },
+  ],
+};
+
+const RESULT_CAUSE = "profile-home bio";
+
+describe("profile-home bio (owner-protected free-text field)", () => {
+  let manager: EmulatedStorageManager;
+
+  beforeEach(() => {
+    manager = EmulatedStorageManager.emulate({ as: signer });
+  });
+  afterEach(async () => {
+    await manager?.close();
+  });
+
+  it("starts empty, then accepts create + edit through setBio", async () => {
+    const rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: manager,
+    });
+    try {
+      const tx = rt.edit();
+      const pattern = await rt.patternManager.compilePattern(PROGRAM, {
+        space,
+        tx,
+      });
+      const resultCell = rt.getCell<Record<string, unknown>>(
+        space,
+        RESULT_CAUSE,
+        undefined,
+        tx,
+      );
+      // deno-lint-ignore no-explicit-any
+      const result = rt.run(
+        tx,
+        pattern as any,
+        { initialName: "Ada" },
+        resultCell,
+      );
+      rt.prepareTxForCommit(tx);
+      const commit = await tx.commit();
+      expect(commit.error).toBeUndefined();
+      await result.pull();
+
+      // Fresh profile: bio is empty.
+      expect(result.key("bio").get() ?? "").toBe("");
+
+      // Create a bio via the authorized setBio stream (the "pin from event"
+      // path; the edit form binds the same handler to the bio draft cell).
+      const tx2 = rt.edit();
+      result.withTx(tx2).key("setBio").send({
+        bio: "Mathematician & first programmer.",
+      });
+      const commit2 = await tx2.commit();
+      expect(commit2.error).toBeUndefined();
+      await result.pull();
+      await rt.idle();
+      await result.pull();
+      expect(result.key("bio").get()).toBe("Mathematician & first programmer.");
+
+      // Editing replaces the value (and trims surrounding whitespace).
+      const tx3 = rt.edit();
+      result.withTx(tx3).key("setBio").send({
+        bio: "  Countess of Lovelace.  ",
+      });
+      const commit3 = await tx3.commit();
+      expect(commit3.error).toBeUndefined();
+      await result.pull();
+      await rt.idle();
+      await result.pull();
+      expect(result.key("bio").get()).toBe("Countess of Lovelace.");
+    } finally {
+      await rt.dispose();
+    }
+  });
+});

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -2267,6 +2267,7 @@ describe("wish built-in", () => {
         name: "Ada Lovelace",
         initialNameApplied: "Ada Lovelace",
         avatar: "ada.png",
+        bio: "Mathematician & first programmer.",
         elements: [],
       });
       profileSpaceCell.key("defaultPattern").set(profileDefaultCell);
@@ -2294,6 +2295,7 @@ describe("wish built-in", () => {
           profile: wish({ query: "#profile" }),
           profileName: wish({ query: "#profileName" }),
           profileAvatar: wish({ query: "#profileAvatar" }),
+          profileBio: wish({ query: "#profileBio" }),
           profileSpace: wish({ query: "#profileSpace" }),
         };
       });
@@ -2313,6 +2315,9 @@ describe("wish built-in", () => {
       expect(result.key("profile").get()?.result?.name).toBe("Ada Lovelace");
       expect(result.key("profileName").get()?.result).toBe("Ada Lovelace");
       expect(result.key("profileAvatar").get()?.result).toBe("ada.png");
+      expect(result.key("profileBio").get()?.result).toBe(
+        "Mathematician & first programmer.",
+      );
       expect(result.key("profileSpace").get()?.result?.defaultPattern?.name)
         .toBe("Ada Lovelace");
     });


### PR DESCRIPTION
## CT-1648 — add a bio field to shared profiles

Profiles had `name`, `avatar`, and `elements` but no first-class human-authored description. This adds a `bio` free-text field to `system/profile-home.tsx` — the canonical shared-profile bio, distinct from Home's legacy `learned.summary`.

### What changed
- **`bio` field (owner-protected).** Same protection model as `name`/`avatar` (`OwnerProtectedProfileWrite<string, typeof setBio>`), written only through the authorized `setBio` handler.
- **Edit UI.** Because a direct `$value` two-way binding onto the protected `bio` cell would bypass `setBio` and be rejected by CFC, the edit form binds a multi-line `cf-textarea` to an unprotected **draft** cell and saves it through `setBio` via a **Save bio** button (bio is not Enter-gated, unlike name). Presentation mode renders the bio under the badge when non-empty (`white-space: pre-wrap`).
- **`#profileBio` wish target.** Mirrors `#profileAvatar` (default profile cell, path `["bio"]`) so consumers can read the bio without knowing the profile space DID. `#profile` consumers can also read `.bio` from the profile result directly.

### Acceptance criteria
- [x] Profile output includes a `bio` field
- [x] Profile UI allows editing it (cf-textarea draft + Save, owner-protected via `setBio`)
- [x] `#profile` consumers can read the value from the profile result (`.bio`)
- [x] Well-known wish target added: **`#profileBio`** (consistent with the existing `#profileName`/`#profileAvatar`/`#profileSpace`)
- [x] Tests cover create/edit/read + wish resolution

### Tests
- `packages/runner/test/profile-home-bio.test.ts` — runs the real `profile-home.tsx`: bio starts empty → `setBio` creates → edit replaces (and trims surrounding whitespace).
- `packages/runner/test/wish.test.ts` — `#profileBio` added to the well-known-profile-targets resolution test (resolves to the seeded bio).

Docs updated: `wish.md` (target list) and `shared-profile-space.md` (output contract + wish targets). `cf check` passes on profile-home/profile-create; lint clean; full `wish.test.ts` + profile suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an owner-protected `bio` field to shared profiles and exposes a `#profileBio` wish target, per CT-1648. The bio is editable via a draft textarea and shown under the profile badge when present.

- **New Features**
  - `bio` field: owner-protected like name/avatar; written only via `setBio` (trims whitespace).
  - Edit UI: `cf-textarea` bound to a draft; Save button persists via `setBio` (not Enter-gated).
  - Presentation: bio renders under the badge when non-empty (`pre-wrap`).
  - Wish: `#profileBio` resolves to the default profile `["bio"]`; `.bio` also available on `#profile` results.

<sup>Written for commit 15f9ec0fac338389785483716769d59e3f5133f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

