### PR TITLE
fix(runner): don't record a write's own machinery reads as conflict dependencies

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -70,6 +70,7 @@ import {
 } from "./query-result-proxy.ts";
 import { diffAndUpdate } from "./data-updating.ts";
 import { type LastNode, resolveLink } from "./link-resolution.ts";
+import { excludeReadFromConflict } from "./storage/reactivity-log.ts";
 import {
   type Action,
   ignoreReadForScheduling,
@@ -1151,6 +1152,25 @@ export class CellImpl<T extends FabricValue>
      * the post-commit outbox for external side effects that must happen only
      * after success.
      */
+    onCommit?: (tx: IExtendedStorageTransaction) => void,
+  ): Cell<T> {
+    // Run the write under an ambient "exclude from conflict" read meta so the
+    // write machinery's reads (link resolution of the target + the diff read of
+    // the slot being written) are not recorded as conflict dependencies — a
+    // blind write logically depends on nothing. Genuine handler reads happen
+    // during argument evaluation, before set() runs, so they are not wrapped and
+    // still take a dependency (read-modify-write still conflicts).
+    if (this.tx) {
+      return this.tx.runWithAmbientReadMeta(
+        excludeReadFromConflict,
+        () => this.#setInner(newValue, onCommit),
+      );
+    }
+    return this.#setInner(newValue, onCommit);
+  }
+
+  #setInner(
+    newValue: AnyCellWrapping<T> | T,
     onCommit?: (tx: IExtendedStorageTransaction) => void,
   ): Cell<T> {
     const resolvedToValueLink = resolveLink(

--- a/packages/runner/src/storage/reactivity-log.ts
+++ b/packages/runner/src/storage/reactivity-log.ts
@@ -63,6 +63,29 @@ export function isReadMarkedAsAttemptedWrite(meta?: Metadata): boolean {
   return meta?.[markReadAsAttemptedWriteMarker] === true;
 }
 
+// Marks reads performed by WRITE MACHINERY
+// (link resolution of the write target + the diff read of the slot being
+// written). These are NOT genuine read-dependencies of the writer — a blind
+// write is a pure producer that depends on nothing — so they must NOT be
+// recorded as conflict dependencies (else two writes to DIFFERENT keys of one
+// document collide via the writer's incidental container/target reads and the
+// peer add-patch's parent-injection). They stay in the journal for reactivity;
+// only the commit-time conflict set (buildReads) excludes them. Genuine handler
+// reads happen OUTSIDE the write op (argument evaluation precedes set()), so
+// they are not tagged and still take a dependency (read-modify-write still
+// conflicts). Orthogonal to attemptedWrite (CFC) and schedulerDependency.
+const excludeReadFromConflictMarker: unique symbol = Symbol(
+  "excludeReadFromConflictMarker",
+);
+
+export const excludeReadFromConflict: Metadata = {
+  [excludeReadFromConflictMarker]: true,
+};
+
+export function isReadExcludedFromConflict(meta?: Metadata): boolean {
+  return meta?.[excludeReadFromConflictMarker] === true;
+}
+
 export function isMutableTransactionReadAllowed(meta?: Metadata): boolean {
   return meta?.[allowMutableTransactionReadMarker] === true;
 }

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -77,6 +77,7 @@ import type {
 import { SelectorTracker } from "./selector-tracker.ts";
 import * as SubscriptionManager from "./subscription.ts";
 import { getDirectTransactionReadActivities } from "./transaction-inspection.ts";
+import { isReadExcludedFromConflict } from "./reactivity-log.ts";
 import { toTransactionDocumentValue } from "./v2-document.ts";
 import { hasValueAtPath, readValueAtPath } from "./v2-path.ts";
 import {
@@ -1886,6 +1887,17 @@ class SpaceReplica implements ISpaceReplica {
         continue;
       }
 
+      // Reads performed by write machinery (link resolution of the target + the
+      // diff read of the slot being written) are tagged excludeReadFromConflict
+      // via the ambient meta set in Cell.set. They are NOT genuine
+      // read-dependencies — a blind write depends on nothing — so excluding them
+      // lets two writes to DIFFERENT keys of one document merge instead of
+      // colliding. They remain in the journal for reactivity; genuine handler
+      // reads (evaluated before set()) are unmarked and still recorded.
+      if (isReadExcludedFromConflict(read.meta)) {
+        continue;
+      }
+
       const scope = normalizeCellScope(read.scope);
       const record = this.#docs.get(docKey(read.id as URI, scope));
       const pendingLocalSeq = record?.pending
@@ -1911,14 +1923,13 @@ class SpaceReplica implements ISpaceReplica {
         });
       }
     }
-    return {
-      confirmed: compactCommitReads(this.#space, confirmed).map((
-        { nonRecursive: _skip, ...read },
-      ) => read),
-      pending: compactCommitReads(this.#space, pending).map((
-        { nonRecursive: _skip, ...read },
-      ) => read),
-    };
+    const confirmedCompacted = compactCommitReads(this.#space, confirmed).map((
+      { nonRecursive: _skip, ...read },
+    ) => read);
+    const pendingCompacted = compactCommitReads(this.#space, pending).map((
+      { nonRecursive: _skip, ...read },
+    ) => read);
+    return { confirmed: confirmedCompacted, pending: pendingCompacted };
   }
 
   private applySessionSync(

--- a/packages/runner/test/cell-write-conflict-granularity.test.ts
+++ b/packages/runner/test/cell-write-conflict-granularity.test.ts
@@ -1,0 +1,235 @@
+// Conflict-detection granularity for cell writes, verified against a real
+// loopback MemoryV2Server.
+//
+// A blind cell write (`cell.key(k).set(v)` with no prior read of the slot) is a
+// PURE PRODUCER: its write-machinery reads — link resolution of the target plus
+// the diff read of the slot being written — are not recorded as conflict
+// dependencies. So two writes to DIFFERENT keys of one document merge instead of
+// colliding. A GENUINE read (a `.get()` evaluated before the set) still takes a
+// dependency, so read-modify-write of the same key still conflicts, and tier-1
+// whole-doc set/delete still conflicts any genuine reader.
+//
+// Harness: two real Runtimes, each with its own per-space replicas, loopback-
+// connected to ONE shared in-process MemoryV2Server. Convergence is forced with
+// explicit pull()/sync()/synced() — never a bare get() on an un-pulled local
+// projection.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { MemorySpace } from "../src/storage/interface.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("write-conflict-granularity");
+const space = signer.did();
+
+// Two StorageManagers sharing ONE real server, each with its own replicas.
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager.sharedServer = server;
+    return manager;
+  }
+
+  private sharedServer!: MemoryV2Server.Server;
+
+  // Shared server: serve it without ever initializing the base class's private
+  // `#server`, whose `close()` would close the shared server once per manager.
+  protected override server(): MemoryV2Server.Server {
+    return this.sharedServer;
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+  });
+
+// The native commit operations the runtime will SEND for `space`, after
+// prepareTxForCommit. Used to pin the lowering contract (keyed sub-path writes
+// lower to `op:patch`).
+function captureCommitOps(
+  tx: IExtendedStorageTransaction,
+  sp: MemorySpace,
+): Array<{ op: string }> {
+  const inner =
+    (tx as unknown as { tx: { getNativeCommit?: (s: MemorySpace) => unknown } })
+      .tx;
+  const native = inner.getNativeCommit?.(sp) as
+    | { operations?: Array<Record<string, unknown>> }
+    | undefined;
+  return (native?.operations ?? []).map((o) => ({ op: String(o.op) }));
+}
+
+describe("write-conflict granularity: blind writes are pure producers", () => {
+  let server: MemoryV2Server.Server;
+  let storageA: SharedServerStorageManager;
+  let storageB: SharedServerStorageManager;
+  let rtA: Runtime;
+  let rtB: Runtime;
+
+  beforeEach(() => {
+    server = newSharedServer();
+    storageA = SharedServerStorageManager.connectTo(server, { as: signer });
+    storageB = SharedServerStorageManager.connectTo(server, { as: signer });
+    rtA = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storageA,
+    });
+    rtB = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storageB,
+    });
+  });
+
+  afterEach(async () => {
+    await rtB.dispose();
+    await rtA.dispose();
+    await storageB.close();
+    await storageA.close();
+    await server.close();
+  });
+
+  // Seed a shared open-schema Record from rtA and sync it to the server.
+  async function seedRecord(cause: string, value: Record<string, unknown>) {
+    const rec = rtA.getCell<Record<string, unknown>>(space, cause, undefined);
+    const tx = rtA.edit();
+    rec.withTx(tx).set(value);
+    rtA.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await storageA.synced();
+    return rec;
+  }
+
+  // Authoritative server state, read via a FRESH runtime/replica (no prior
+  // local projection to be stale).
+  async function serverTruth(cause: string): Promise<unknown> {
+    const storageC = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    const rtC = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storageC,
+    });
+    try {
+      const recC = rtC.getCell<Record<string, unknown>>(
+        space,
+        cause,
+        undefined,
+      );
+      await recC.sync();
+      await recC.pull();
+      return recC.get();
+    } finally {
+      await rtC.dispose();
+      await storageC.close();
+    }
+  }
+
+  it("two blind adds of DIFFERENT keys merge (no spurious conflict)", async () => {
+    const CAUSE = "blind-add-merge";
+    const recA = await seedRecord(CAUSE, { a: 1, b: 2 });
+
+    // Peer rtB blind-adds key `p`, commits first.
+    const recB = rtB.getCell<Record<string, unknown>>(space, CAUSE, undefined);
+    await recB.sync();
+    await recB.pull();
+    const peerTx = rtB.edit();
+    recB.withTx(peerTx).key("p").set(10);
+    rtB.prepareTxForCommit(peerTx);
+    const peerOps = captureCommitOps(peerTx, space);
+    expect((await peerTx.commit()).error).toBeUndefined();
+    await storageB.synced();
+
+    // rtA blind-adds a DIFFERENT key `q` against a baseline that has NOT seen p.
+    const tx = rtA.edit();
+    recA.withTx(tx).key("q").set(20);
+    rtA.prepareTxForCommit(tx);
+    const ops = captureCommitOps(tx, space);
+    const res = await tx.commit();
+    await storageA.synced();
+
+    // Lowering contract: a keyed sub-path write is a `patch`, not a whole-doc set.
+    expect(peerOps.every((o) => o.op === "patch")).toBe(true);
+    expect(ops.every((o) => o.op === "patch")).toBe(true);
+    // The win: the disjoint blind add is NOT spuriously rejected.
+    expect(res.error).toBeUndefined();
+    // Both writes are present in authoritative server state.
+    expect(await serverTruth(CAUSE)).toEqual({ a: 1, b: 2, p: 10, q: 20 });
+  });
+
+  it("read-modify-write of the SAME key still conflicts (no lost update)", async () => {
+    const CAUSE = "rmw-same-key";
+    const recA = await seedRecord(CAUSE, { a: 1, b: 2 });
+
+    const recB = rtB.getCell<Record<string, unknown>>(space, CAUSE, undefined);
+    await recB.sync();
+    await recB.pull();
+    const peerTx = rtB.edit();
+    recB.withTx(peerTx).key("a").set(100);
+    rtB.prepareTxForCommit(peerTx);
+    expect((await peerTx.commit()).error).toBeUndefined();
+    await storageB.synced();
+
+    // rtA does a GENUINE read of `a` (via .get(), before the set), then writes
+    // `a` based on it — a read-modify-write. The genuine read is a real
+    // dependency, so the concurrent change to `a` must reject it.
+    const tx = rtA.edit();
+    const v = recA.withTx(tx).get() as { a: number };
+    recA.withTx(tx).key("a").set(v.a + 1);
+    rtA.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeDefined();
+  });
+
+  it("tier-1 whole-doc delete still conflicts a genuine reader", async () => {
+    const CAUSE = "tier1-delete";
+    const recA = await seedRecord(CAUSE, { a: 1, b: 2 });
+
+    // Peer rtB deletes the whole doc at the root (a tier-1, path-blind op).
+    const recB = rtB.getCell<Record<string, unknown>>(space, CAUSE, undefined);
+    await recB.sync();
+    await recB.pull();
+    const peerTx = rtB.edit();
+    const upLink = recB.getAsNormalizedFullLink();
+    (peerTx as unknown as {
+      writeOrThrow: (a: unknown, v: unknown, o?: { delete?: boolean }) => void;
+    }).writeOrThrow(
+      {
+        space: upLink.space,
+        id: upLink.id,
+        scope: upLink.scope,
+        type: "application/json" as const,
+        path: [] as string[],
+      },
+      undefined,
+      { delete: true },
+    );
+    rtB.prepareTxForCommit(peerTx);
+    await peerTx.commit();
+    await storageB.synced();
+
+    // rtA does a genuine read (enumerates the doc) then writes — the tier-1
+    // delete is path-blind and must reject any genuine confirmed read.
+    const tx = rtA.edit();
+    const v = recA.withTx(tx).get() as Record<string, unknown>;
+    void Object.keys(v).length;
+    recA.withTx(tx).key("slot").set(1);
+    rtA.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Why (the correctness case)
A cell write records reads to build its patch: it resolves the write target's link and reads the current value of the slot it is about to write (to diff). Those were recorded as the writer's **conflict dependencies** — so a writer was treated as *depending on the very thing it blindly overwrites*. That false dependency makes two writes to **different keys of one document collide** (writer A's incidental container read overlaps writer B's add-patch parent path), even though `a` and `b` never logically interacted.

## What
- `Cell.set` runs its body under `runWithAmbientReadMeta(excludeReadFromConflict)` (a new read-meta marker), so its machinery reads (link resolution of the target + the diff read) carry the marker.
- `buildReads` drops marked reads from the **commit-time conflict set**; they remain in the journal for reactivity/CFC. A blind write becomes a **pure producer**.

## Semantic to be aware of
Two **blind** writes to the **same** key become last-writer-wins instead of conflict-and-retry — the correct semantics of a blind write (neither read the prior value). **Genuine** reads (a `.get()` evaluated before the set) still take a dependency, so read-modify-write still conflicts. (Direction approved by seefeld/wilk.)

## Verified
- `test/cell-write-conflict-granularity.test.ts` (real `MemoryV2Server`): disjoint blind adds **merge**; same-key RMW and tier-1 whole-doc delete **still conflict**.
- Targeted suites green with the change active: patterns-handlers / patterns-lift, scheduler-observations / static-writes, runner.

## Status
Active (no longer flag-gated). Remaining before merge: full CI green (running) + review.

## Perf note (honest)
Fixes the **direct-write** over-conflict. Does **not** move the lunch-poll / write-contention probe — that is dominated by pervasive coarse reads of the shared pattern doc by the reactive machinery + subscriptions (#4190), a separate workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)