### PR TITLE
fix(runner,memory): honor nonRecursive shape reads in conflict detection

### DIFF
--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -111,6 +111,16 @@ export interface ConfirmedRead {
   branch?: BranchName;
   path: ReadPath;
   seq: number;
+  /**
+   * When true, this is a SHALLOW (shape-only)
+   * read — the reader observed the container at `path` (its key set / existence)
+   * but did NOT depend on the deep values of its descendants. The engine then
+   * conflicts only with writes AT-OR-ABOVE `path` (including key add/remove,
+   * whose patch injects the parent path), not with disjoint deep-value writes
+   * strictly below `path`. Strict subset of the recursive overlap → never a
+   * false-negative. Absent/false ⇒ recursive read (current behavior).
+   */
+  nonRecursive?: boolean;
 }
 
 export interface PendingRead {

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -2,7 +2,12 @@ import { Database } from "@db/sqlite";
 import type { FabricValue } from "../interface.ts";
 import { runWrite } from "./sqlite/exec.ts";
 import { applyPatch } from "./patch.ts";
-import { parentPath, parsePointer, pathsOverlap } from "./path.ts";
+import {
+  isPrefixPath,
+  parentPath,
+  parsePointer,
+  pathsOverlap,
+} from "./path.ts";
 import {
   type BranchName,
   type CellScope,
@@ -3506,6 +3511,7 @@ const validateConfirmedReads = (
       scopeKey,
       read.seq,
       read.path,
+      read.nonRecursive ?? false,
     );
     if (conflictSeq !== null) {
       throw new ConflictError(
@@ -3569,7 +3575,13 @@ const findConflictSeq = (
   scopeKey: string,
   afterSeq: number,
   readPath: readonly string[],
+  // When true, treat `readPath` as a SHALLOW (shape-only) dependency — conflict
+  // only with writes at-or-above it.
+  nonRecursive: boolean = false,
 ): number | null => {
+  // Tier-1 (set/delete) stays path-blind even for a shallow read: a whole-doc
+  // replace/delete changes the container the shape read observed, so it must
+  // still conflict. Only Tier-2 (patch) granularity is refined.
   const setOrDeleteConflict = engine.statements.selectSetDeleteConflict.get({
     branch,
     id,
@@ -3591,12 +3603,11 @@ const findConflictSeq = (
       data: string | null;
     }>
   ) {
-    if (
-      patchOverlapsRead(
-        decodeStoredPatchList(conflict.data),
-        readPath,
-      )
-    ) {
+    const patches = decodeStoredPatchList(conflict.data);
+    const overlaps = nonRecursive
+      ? patchOverlapsNonRecursiveRead(patches, readPath)
+      : patchOverlapsRead(patches, readPath);
+    if (overlaps) {
       return conflict.seq;
     }
   }
@@ -3635,6 +3646,7 @@ const schedulerObservationReadDropReason = (
       scopeKey,
       read.seq,
       read.path,
+      read.nonRecursive ?? false,
     );
     if (conflictSeq !== null) {
       return "stale-confirmed-read";
@@ -3872,6 +3884,25 @@ const patchOverlapsRead = (
 ): boolean => {
   return patches.some((patch) =>
     touchedPathsForPatch(patch).some((path) => pathsOverlap(path, readPath))
+  );
+};
+
+// Overlap test for a SHALLOW (nonRecursive)
+// read. Unlike `patchOverlapsRead` (symmetric prefix-containment), a shape read
+// at `readPath` conflicts only with a write touching `readPath` itself or an
+// ANCESTOR of it — i.e. `isPrefixPath(touched, readPath)`. Key add/remove still
+// conflict because `touchedPathsForPatch` injects the patch's parent path
+// (engine.ts touchedPathsForPatch), which equals `readPath` for a direct child
+// mutation. A disjoint deep-value `replace` strictly BELOW `readPath` does not
+// touch an ancestor, so it no longer over-conflicts. This is a strict subset of
+// `patchOverlapsRead`, so it can only remove spurious conflicts, never miss a
+// genuine one (no false-negative).
+const patchOverlapsNonRecursiveRead = (
+  patches: readonly PatchOp[],
+  readPath: readonly string[],
+): boolean => {
+  return patches.some((patch) =>
+    touchedPathsForPatch(patch).some((path) => isPrefixPath(path, readPath))
   );
 };
 

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -9,7 +9,10 @@ import { resolveLink } from "./link-resolution.ts";
 import { type NormalizedFullLink } from "./link-utils.ts";
 import { type Cell, createCell, recursivelyAddIDIfNeeded } from "./cell.ts";
 import { type Runtime } from "./runtime.ts";
-import { type IExtendedStorageTransaction } from "./storage/interface.ts";
+import {
+  type IExtendedStorageTransaction,
+  type IReadOptions,
+} from "./storage/interface.ts";
 import { toURI } from "./uri-utils.ts";
 import {
   type CfcLabelView,
@@ -21,6 +24,13 @@ import {
 
 // Maximum recursion depth to prevent infinite loops
 const MAX_RECURSION_DEPTH = 100;
+
+// Container/shape reads (proxy creation, ownKeys, getOwnPropertyDescriptor,
+// has) are recorded as nonRecursive so the engine applies shallow (shape-only)
+// conflict granularity to them — matching how the scheduler already treats
+// nonRecursive reads. Value materialization (leaf scalars via child-proxy
+// creation, array methods that consume elements) stays recursive.
+const SHAPE_READ: IReadOptions = { nonRecursive: true };
 
 // Cache of target objects to their proxies, scoped by ReactivityLog
 type ProxyCache = {
@@ -159,7 +169,7 @@ export function createQueryResultProxy<T>(
       readTx.getCfcState().dereferenceTraces.slice(traceStart),
     ),
   ]);
-  const value = readTx.readValueOrThrow(link) as any;
+  const value = readTx.readValueOrThrow(link, SHAPE_READ) as any;
 
   // If the value is a stream marker ({ $stream: true }), return a Cell with
   // stream kind so that .send() is available. This handles the case where a
@@ -471,7 +481,7 @@ export function createQueryResultProxy<T>(
     },
     ownKeys: () => {
       const readTx = runtime.readTx(tx);
-      const current = readTx.readValueOrThrow(link);
+      const current = readTx.readValueOrThrow(link, SHAPE_READ);
       if (isRecord(current) || Array.isArray(current)) {
         return Reflect.ownKeys(current);
       }
@@ -500,7 +510,7 @@ export function createQueryResultProxy<T>(
         return Object.getOwnPropertyDescriptor(value, prop);
       }
       const readTx = runtime.readTx(tx);
-      const current = readTx.readValueOrThrow(link) as typeof value;
+      const current = readTx.readValueOrThrow(link, SHAPE_READ) as typeof value;
       if ((isRecord(current) || Array.isArray(current)) && prop in current) {
         return {
           configurable: true,
@@ -523,7 +533,7 @@ export function createQueryResultProxy<T>(
         return prop in value;
       }
       const readTx = runtime.readTx(tx);
-      const current = readTx.readValueOrThrow(link);
+      const current = readTx.readValueOrThrow(link, SHAPE_READ);
       if (isRecord(current) || Array.isArray(current)) {
         return prop in current;
       }

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1911,14 +1911,13 @@ class SpaceReplica implements ISpaceReplica {
         });
       }
     }
-    return {
-      confirmed: compactCommitReads(this.#space, confirmed).map((
-        { nonRecursive: _skip, ...read },
-      ) => read),
-      pending: compactCommitReads(this.#space, pending).map((
-        { nonRecursive: _skip, ...read },
-      ) => read),
-    };
+    // Keep the nonRecursive flag on the reads sent to the engine (it was
+    // historically stripped here). The engine applies shallow (shape-only)
+    // conflict granularity to nonRecursive reads, matching how the scheduler
+    // already treats them.
+    const confirmedCompacted = compactCommitReads(this.#space, confirmed);
+    const pendingCompacted = compactCommitReads(this.#space, pending);
+    return { confirmed: confirmedCompacted, pending: pendingCompacted };
   }
 
   private applySessionSync(

--- a/packages/runner/test/cell-write-conflict-granularity.test.ts
+++ b/packages/runner/test/cell-write-conflict-granularity.test.ts
@@ -1,0 +1,202 @@
+// Shallow (nonRecursive) conflict granularity, verified against a real loopback
+// MemoryV2Server.
+//
+// A read of a container's SHAPE (a full `.get()` that only dereferences specific
+// leaves, `Object.keys`, etc.) is recorded as nonRecursive. The engine honors
+// that — matching how the scheduler already treats nonRecursive reads — so a
+// shape read conflicts with key add/remove and whole-container writes, but NOT
+// with a disjoint deep-value change it never read. A deep value the handler
+// actually dereferences is still a recursive read and still conflicts.
+//
+// Harness: two real Runtimes, each with its own per-space replicas, loopback-
+// connected to ONE shared in-process MemoryV2Server. Convergence is forced with
+// explicit pull()/sync()/synced().
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import type { Options } from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+
+const signer = await Identity.fromPassphrase("write-conflict-granularity");
+const space = signer.did();
+
+// Two StorageManagers sharing ONE real server, each with its own replicas.
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager.sharedServer = server;
+    return manager;
+  }
+
+  private sharedServer!: MemoryV2Server.Server;
+
+  // Shared server: serve it without ever initializing the base class's private
+  // `#server`, whose `close()` would close the shared server once per manager.
+  protected override server(): MemoryV2Server.Server {
+    return this.sharedServer;
+  }
+}
+
+const newSharedServer = () =>
+  new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+  });
+
+describe("write-conflict granularity: shallow (shape) reads", () => {
+  let server: MemoryV2Server.Server;
+  let storageA: SharedServerStorageManager;
+  let storageB: SharedServerStorageManager;
+  let rtA: Runtime;
+  let rtB: Runtime;
+
+  beforeEach(() => {
+    server = newSharedServer();
+    storageA = SharedServerStorageManager.connectTo(server, { as: signer });
+    storageB = SharedServerStorageManager.connectTo(server, { as: signer });
+    rtA = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storageA,
+    });
+    rtB = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storageB,
+    });
+  });
+
+  afterEach(async () => {
+    await rtB.dispose();
+    await rtA.dispose();
+    await storageB.close();
+    await storageA.close();
+    await server.close();
+  });
+
+  async function seedRecord(cause: string, value: Record<string, unknown>) {
+    const rec = rtA.getCell<Record<string, unknown>>(space, cause, undefined);
+    const tx = rtA.edit();
+    rec.withTx(tx).set(value);
+    rtA.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeUndefined();
+    await storageA.synced();
+    return rec;
+  }
+
+  it("a leaf read + disjoint deep-value write MERGE (shape read is shallow)", async () => {
+    const CAUSE = "shallow-disjoint";
+    const recA = await seedRecord(CAUSE, { a: 1, b: 2 });
+
+    // Peer rtB changes the deep value of EXISTING key `b` (a replace patch).
+    const recB = rtB.getCell<Record<string, unknown>>(space, CAUSE, undefined);
+    await recB.sync();
+    await recB.pull();
+    const peerTx = rtB.edit();
+    recB.withTx(peerTx).key("b").set(99);
+    rtB.prepareTxForCommit(peerTx);
+    expect((await peerTx.commit()).error).toBeUndefined();
+    await storageB.synced();
+
+    // rtA reads only leaf `a` (the full .get() records the container as a SHAPE
+    // read, plus a recursive read of `a`), then writes `a`. It never read `b`.
+    const tx = rtA.edit();
+    const v = recA.withTx(tx).get() as { a: number; b: number };
+    recA.withTx(tx).key("a").set(v.a + 1);
+    rtA.prepareTxForCommit(tx);
+    // The shallow container read does not conflict with the disjoint deep-value
+    // change to `b`, and the leaf reads are disjoint — so this MERGES.
+    expect((await tx.commit()).error).toBeUndefined();
+  });
+
+  it("a key-set read still conflicts a concurrent key ADD", async () => {
+    const CAUSE = "shallow-keyset";
+    const recA = await seedRecord(CAUSE, { a: 1, b: 2 });
+
+    // Peer ADDS a new key `d` — a key-set change.
+    const recB = rtB.getCell<Record<string, unknown>>(space, CAUSE, undefined);
+    await recB.sync();
+    await recB.pull();
+    const peerTx = rtB.edit();
+    recB.withTx(peerTx).key("d").set(7);
+    rtB.prepareTxForCommit(peerTx);
+    expect((await peerTx.commit()).error).toBeUndefined();
+    await storageB.synced();
+
+    // rtA depends on the key SET (Object.keys) — a shallow read of the
+    // container. A concurrent key-add changes the key set, so it MUST conflict.
+    const tx = rtA.edit();
+    const v = recA.withTx(tx).get() as Record<string, unknown>;
+    const n = Object.keys(v).length;
+    recA.withTx(tx).key("slot").set(n);
+    rtA.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeDefined();
+  });
+
+  it("a deep-value read-modify-write of the SAME key still conflicts", async () => {
+    const CAUSE = "shallow-rmw";
+    const recA = await seedRecord(CAUSE, { a: 1, b: 2 });
+
+    const recB = rtB.getCell<Record<string, unknown>>(space, CAUSE, undefined);
+    await recB.sync();
+    await recB.pull();
+    const peerTx = rtB.edit();
+    recB.withTx(peerTx).key("a").set(100);
+    rtB.prepareTxForCommit(peerTx);
+    expect((await peerTx.commit()).error).toBeUndefined();
+    await storageB.synced();
+
+    // rtA dereferences the deep value of `a` (a recursive leaf read) and writes
+    // it back; a concurrent change to `a` must reject it.
+    const tx = rtA.edit();
+    const v = recA.withTx(tx).get() as { a: number };
+    recA.withTx(tx).key("a").set(v.a + 1);
+    rtA.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeDefined();
+  });
+
+  it("tier-1 whole-doc delete still conflicts a shape reader", async () => {
+    const CAUSE = "shallow-tier1";
+    const recA = await seedRecord(CAUSE, { a: 1, b: 2 });
+
+    const recB = rtB.getCell<Record<string, unknown>>(space, CAUSE, undefined);
+    await recB.sync();
+    await recB.pull();
+    const peerTx = rtB.edit();
+    const upLink = recB.getAsNormalizedFullLink();
+    (peerTx as unknown as {
+      writeOrThrow: (a: unknown, v: unknown, o?: { delete?: boolean }) => void;
+    }).writeOrThrow(
+      {
+        space: upLink.space,
+        id: upLink.id,
+        scope: upLink.scope,
+        type: "application/json" as const,
+        path: [] as string[],
+      },
+      undefined,
+      { delete: true },
+    );
+    rtB.prepareTxForCommit(peerTx);
+    await peerTx.commit();
+    await storageB.synced();
+
+    const tx = rtA.edit();
+    const v = recA.withTx(tx).get() as Record<string, unknown>;
+    void Object.keys(v).length;
+    recA.withTx(tx).key("slot").set(1);
+    rtA.prepareTxForCommit(tx);
+    expect((await tx.commit()).error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Why (the correctness case)
Reads carry a `nonRecursive` flag distinguishing a **shape** observation ("I looked at this container's key-set / existence") from a **deep** dependency ("I read values under it"). The **scheduler already honors this** — a shape read subscribes shallowly (re-run on key add/remove, not on a disjoint deep-value change). But **conflict detection threw the flag away**: `buildReads` stripped `nonRecursive` before the engine, so the engine treated every shape read as a deep read and over-conflicted it against any disjoint deep-value write under the container. The two halves of the system disagreed about the same read; this makes them consistent.

## What
- QueryResultProxy container/shape reads (creation, `ownKeys`, `getOwnPropertyDescriptor`, `has`) are recorded `nonRecursive`; deep-value dereferences stay recursive.
- `buildReads` keeps the flag through to the engine (`ConfirmedRead` gains the field) instead of stripping it.
- For a `nonRecursive` read the engine uses a shallow overlap — `isPrefixPath(touched, readPath)` — a **strict subset** of the symmetric `pathsOverlap`, so it can only **remove** spurious conflicts, never miss a genuine one. Tier-1 (set/delete) stays path-blind.

## Safety (no false-negative, by construction)
The shallow predicate is a strict subset of `pathsOverlap`. The only conflicts it removes are deep-value writes *strictly below* a shape read — which a shape read provably did not depend on. A value the handler actually dereferences is a recursive read and still conflicts.

## Verified
- `test/cell-write-conflict-granularity.test.ts` (real `MemoryV2Server`): leaf-read + disjoint deep-value write **merge**; key-set read vs key-add, same-key RMW, and tier-1 delete **still conflict**.
- Suites green with the change active: patterns-handlers / patterns-lift, scheduler-observations, runner; memory commit-preconditions.

## Status
Active (no longer flag-gated; the diagnostic 3092 toggle removed). Direction approved (berni). Remaining before merge: full CI green (running) + review.

## Perf note (honest)
A precision fix for the read-then-write disjoint case; does not by itself move the lunch-poll probe (machinery coarse-reads + subscriptions dominate, see #4199). This is a narrow, safe precision improvement — *not* the OT/CRDT path for genuine read-modify-write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)