### PR TITLE
feat(profiles): profile-badge hover/focus tooltip — bio + pinned count (CT-1648)

### DIFF
--- a/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
+++ b/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
@@ -104,9 +104,9 @@ export default pattern<ProfileBadgeStoryInput, ProfileBadgeStoryOutput>(() => {
               alignItems: "flex-start",
             }}
           >
-            <cf-profile-badge $profile={ada} size={size} />
-            <cf-profile-badge $profile={grace} size={size} />
-            <cf-profile-badge $profile={alan} size={size} />
+            <cf-profile-badge $profile={ada} size={size} noNavigate />
+            <cf-profile-badge $profile={grace} size={size} noNavigate />
+            <cf-profile-badge $profile={alan} size={size} noNavigate />
           </div>
         </div>
 

--- a/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
+++ b/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
@@ -118,8 +118,8 @@ export default pattern<ProfileBadgeStoryInput, ProfileBadgeStoryOutput>(() => {
           only renders for a runtime-attested profile (a “represents-principal”
           CFC label), which this story can’t mint, so these badges stay in the
           plain “presented” state. Hover or focus a badge to see its tooltip
-          (CT-1648): Ada has a bio + 3 pinned patterns, Grace has a bio only,
-          and Alan — with neither — shows no tooltip.
+          (CT-1648): Ada has a bio + 3 pinned pieces, Grace has a bio only, and
+          Alan — with neither — shows no tooltip.
         </span>
       </div>
     ),

--- a/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
+++ b/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
@@ -15,11 +15,27 @@ const svgAvatar = (rgb: string, label: string): string =>
 
 // A profile cell, as presented to <cf-profile-badge $profile={...} />. The badge
 // reads the cell's [NAME] (person's name under the multi-profile model) and
-// falls back to `name`, plus `avatar`.
-type ProfileValue = { [NAME]: string; name: string; avatar: string };
+// falls back to `name`, plus `avatar`. `bio` + `elements` (pinned pieces) feed
+// the hover/focus tooltip (CT-1648); items only need a `title` for the count.
+type ProfileValue = {
+  [NAME]: string;
+  name: string;
+  avatar: string;
+  bio?: string;
+  elements?: Array<{ title: string }>;
+};
 
-const makeProfile = (display: string, avatar: string) =>
-  new Writable<ProfileValue>({ [NAME]: display, name: display, avatar });
+const makeProfile = (
+  display: string,
+  avatar: string,
+  extra: { bio?: string; elements?: Array<{ title: string }> } = {},
+) =>
+  new Writable<ProfileValue>({
+    [NAME]: display,
+    name: display,
+    avatar,
+    ...extra,
+  });
 
 const sizeItems = [
   { label: "xs", value: "xs" },
@@ -47,9 +63,20 @@ export interface ProfileBadgeStoryOutput {
 }
 
 export default pattern<ProfileBadgeStoryInput, ProfileBadgeStoryOutput>(() => {
-  // Three profiles exercising each avatar render path: image, emoji, initials.
-  const ada = makeProfile("Ada Lovelace", svgAvatar("rgb(99,102,241)", "AL"));
-  const grace = makeProfile("Grace Hopper", "🦊");
+  // Three profiles exercising each avatar render path: image, emoji, initials —
+  // and each tooltip state (CT-1648): bio + pins, bio only, and none.
+  const ada = makeProfile("Ada Lovelace", svgAvatar("rgb(99,102,241)", "AL"), {
+    bio:
+      "Mathematician & writer; first to see that a computing engine could go beyond pure calculation.",
+    elements: [
+      { title: "Analytical Engine notes" },
+      { title: "Bernoulli generator" },
+      { title: "Note G" },
+    ],
+  });
+  const grace = makeProfile("Grace Hopper", "🦊", {
+    bio: "Rear admiral and compiler pioneer; popularized the term “debugging.”",
+  });
   const alan = makeProfile("Alan Turing", "");
 
   const size = new Writable<"xs" | "sm" | "md" | "lg" | "xl">("md");
@@ -90,7 +117,9 @@ export default pattern<ProfileBadgeStoryInput, ProfileBadgeStoryOutput>(() => {
           (Grace), initials (Alan). The verified seal — a DID-derived aura —
           only renders for a runtime-attested profile (a “represents-principal”
           CFC label), which this story can’t mint, so these badges stay in the
-          plain “presented” state.
+          plain “presented” state. Hover or focus a badge to see its tooltip
+          (CT-1648): Ada has a bio + 3 pinned patterns, Grace has a bio only,
+          and Alan — with neither — shows no tooltip.
         </span>
       </div>
     ),

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -56,8 +56,10 @@ Capability and app demos (root files): `annotation.tsx`,
 `cheeseboard.tsx`, `compiler.tsx`, `deep-research.tsx`, `dice.tsx` (+
 `dice-handlers.ts`), `group-chat-lobby.tsx`, `group-chat-room.tsx`, `image.tsx`,
 `image-analysis.tsx`, `link-preview.tsx`, `map-demo.tsx`, `mobile-app-demo.tsx`,
-`pattern-index.tsx`, `self.tsx`, `self-improving-classifier.tsx`,
-`shopping-list.tsx`, `store-mapper.tsx`, `text-swapper.tsx`.
+`pattern-index.tsx`, `profile-roster-live-demo.tsx` (demo: live multi-user
+profile roster — every participant's cross-space profile badge), `self.tsx`,
+`self-improving-classifier.tsx`, `shopping-list.tsx`, `store-mapper.tsx`,
+`text-swapper.tsx`.
 
 App and integration directories: `activity-log/`, `agent/`, `airtable/`,
 `auth/`, `base/`, `battleship/`, `budget-tracker/`, `calendar/`, `card-piles/`,

--- a/packages/patterns/profile-roster-live-demo.tsx
+++ b/packages/patterns/profile-roster-live-demo.tsx
@@ -30,7 +30,7 @@ import {
  *   - the badge's bio + pinned-count hover tooltip (CT-1648).
  *
  * If cross-space profile reads work across users, viewer A hovering viewer B's
- * badge sees B's bio + pinned-pattern count. If they don't, this demo is exactly
+ * badge sees B's bio + pinned-piece count. If they don't, this demo is exactly
  * the harness that surfaces the gap.
  */
 

--- a/packages/patterns/profile-roster-live-demo.tsx
+++ b/packages/patterns/profile-roster-live-demo.tsx
@@ -1,0 +1,176 @@
+import {
+  type Cell,
+  computed,
+  Default,
+  equals,
+  handler,
+  NAME,
+  pattern,
+  type PerSpace,
+  type PerUser,
+  safeDateNow,
+  Stream,
+  UI,
+  type VNode,
+  wish,
+  Writable,
+} from "commonfabric";
+
+/**
+ * LIVE multi-user profile roster demo (CT-1648/CT-1650 end-to-end check).
+ *
+ * Unlike `shared-profile-roster` (which SNAPSHOTS each participant's name+avatar
+ * at join time and renders others with a plain `<cf-avatar>`), this demo stores
+ * each participant's live `#profile` cell and renders EVERY participant — not
+ * just the current viewer — with the trusted `<cf-profile-badge>` bound to that
+ * cross-space profile cell. That exercises the full stack in a genuine
+ * multi-user setting:
+ *   - per-user profile spaces (CT-1650),
+ *   - cross-space profile READ materialization (CT-1667/1687),
+ *   - the badge's bio + pinned-count hover tooltip (CT-1648).
+ *
+ * If cross-space profile reads work across users, viewer A hovering viewer B's
+ * badge sees B's bio + pinned-pattern count. If they don't, this demo is exactly
+ * the harness that surfaces the gap.
+ */
+
+export type ParticipantProfileCell = Cell<
+  { name?: string; avatar?: string; bio?: string }
+>;
+
+export interface Participant {
+  /** Live link to the contributor's profile cell — stable identity + live data. */
+  profile: ParticipantProfileCell;
+  /** Snapshot name (fallback label if the live cell can't resolve). */
+  name: string;
+  joinedAt: number;
+}
+
+export interface Roster {
+  participants: Participant[] | Default<[]>;
+}
+
+export interface ViewerState {
+  joined?: boolean;
+}
+
+const DEFAULT_ROSTER: Roster = { participants: [] };
+const EMPTY_VIEWER: ViewerState = {};
+
+type RosterCell = Writable<Roster | Default<typeof DEFAULT_ROSTER>>;
+type ViewerCell = Writable<ViewerState | Default<typeof EMPTY_VIEWER>>;
+
+export type JoinEvent = Record<PropertyKey, never>;
+
+const join = handler<JoinEvent, {
+  roster: RosterCell;
+  viewer: ViewerCell;
+  profile: ParticipantProfileCell | undefined;
+  name: string;
+}>((_event, { roster, viewer, profile, name }) => {
+  const trimmed = (name ?? "").trim();
+  if (!trimmed) return;
+  if (!profile) return;
+  const participants = roster.key("participants");
+  const already = participants.get().some((p) => equals(p.profile, profile));
+  if (!already) {
+    participants.push({ profile, name: trimmed, joinedAt: safeDateNow() });
+  }
+  viewer.set({ joined: true });
+});
+
+export interface ProfileRosterLiveInput {
+  roster?: PerSpace<Roster | Default<typeof DEFAULT_ROSTER>>;
+  viewer?: PerUser<ViewerState | Default<typeof EMPTY_VIEWER>>;
+}
+
+export interface ProfileRosterLiveOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  roster: PerSpace<Roster | Default<typeof DEFAULT_ROSTER>>;
+  viewer: PerUser<ViewerState | Default<typeof EMPTY_VIEWER>>;
+  participantCount: number;
+  join: Stream<JoinEvent>;
+}
+
+const headerLabel = {
+  fontSize: "0.75rem",
+  fontWeight: "600",
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  color: "#6b7280",
+};
+
+export default pattern<ProfileRosterLiveInput, ProfileRosterLiveOutput>(
+  ({ roster, viewer }) => {
+    const profileWish = wish<{ name?: string; avatar?: string }>({
+      query: "#profile",
+    });
+    const profileNameWish = wish<string>({ query: "#profileName" });
+
+    const myName = computed(() => profileNameWish.result ?? "");
+    const myProfile = profileWish.result;
+
+    const participants = roster.participants;
+    const participantCount = participants.length;
+    const hasJoined = computed(() => viewer.joined === true);
+    const joinLabel = computed(() =>
+      hasJoined ? "Joined" : "Join as " + (myName || "…")
+    );
+
+    const boundJoin = join({
+      roster,
+      viewer,
+      profile: myProfile,
+      name: myName,
+    });
+
+    return {
+      [NAME]: "Live profile roster",
+      [UI]: (
+        <cf-screen>
+          <cf-vstack gap="3" style={{ padding: "1rem", maxWidth: "440px" }}>
+            <cf-vstack gap="1">
+              <span style={headerLabel}>You</span>
+              {
+                /* `#profile` is a wish RESULT (not the raw profile piece), so a
+                click would route to a non-piece id and fail to load. The self
+                badge is non-navigable (same convention as profile-home's self
+                badge); the participant badges below bind raw profile cells and
+                DO navigate. */
+              }
+              <cf-profile-badge
+                $profile={profileWish.result}
+                size="md"
+                noNavigate
+              />
+            </cf-vstack>
+
+            <cf-hstack justify="between" align="center">
+              <cf-heading level={3}>
+                Participants ({participantCount})
+              </cf-heading>
+              <cf-button onClick={boundJoin} disabled={hasJoined}>
+                {joinLabel}
+              </cf-button>
+            </cf-hstack>
+
+            {
+              /* EVERY participant rendered as a LIVE badge bound to their own
+              cross-space profile cell — hover to see their bio + pinned count. */
+            }
+            <cf-vstack gap="2">
+              {participants.map((p) => (
+                <cf-profile-badge $profile={p.profile} size="md" />
+              ))}
+            </cf-vstack>
+          </cf-vstack>
+        </cf-screen>
+      ),
+      roster,
+      viewer,
+      participantCount,
+      join: boundJoin,
+    };
+  },
+);

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -450,7 +450,7 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
       [NAME]: name.get(),
       name: name.get(),
       avatar: avatar.get(),
-      // Surfaced in the badge hover tooltip (CT-1648); the pinned-pattern count
+      // Surfaced in the badge hover tooltip (CT-1648); the pinned-piece count
       // populates on roster badges bound to the full profile cell.
       bio: bio.get(),
     }));

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -426,11 +426,16 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
       const viewer = viewerProfile.result;
       return viewer !== undefined && equals(self, viewer) === true;
     });
-    // Edit form shows only when the owner has toggled into edit mode; visitors
-    // (and the owner before toggling) see the read-only presentation. Ownership
-    // is re-derived inline rather than referencing `isOwner` so each computed is
-    // self-contained (avoids nested-computed unwrap surprises).
-    const isEditing = computed(() => {
+    // `isEditing` is the raw view-toggle state (the user's intent), kept
+    // independent of ownership so it stays a clean, testable signal. The edit
+    // FORM is gated separately on `showEditForm` below; a visitor never sees the
+    // toggle button, so for them `editing` stays false in practice anyway.
+    const isEditing = computed(() => editing.get() === true);
+    // The edit form is shown only to the owner who has toggled into edit mode;
+    // visitors (and the owner before toggling) see the read-only presentation.
+    // Ownership is re-derived inline rather than referencing `isOwner` so each
+    // computed is self-contained (avoids nested-computed unwrap surprises).
+    const showEditForm = computed(() => {
       const viewer = viewerProfile.result;
       const owner = viewer !== undefined && equals(self, viewer) === true;
       return editing.get() === true && owner;
@@ -514,7 +519,7 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
                 profile cell. The edit form is gated behind the toggle below. */
             }
             {ifElse(
-              isEditing,
+              showEditForm,
               null,
               <cf-vstack gap="4" data-ui-region="profile-presentation">
                 <cf-profile-badge
@@ -587,9 +592,9 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
               </cf-vstack>,
             )}
 
-            {/* The existing edit form, now revealed only in edit mode. */}
+            {/* The existing edit form, revealed only to the owner in edit mode. */}
             {ifElse(
-              isEditing,
+              showEditForm,
               <cf-vstack gap="4" data-ui-region="profile-edit">
                 <cf-vstack gap="2">
                   <label>Name</label>

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -8,8 +8,10 @@ import {
   NAME,
   pattern,
   RepresentsCurrentUser,
+  SELF,
   Stream,
   UI,
+  wish,
   Writable,
   WriteAuthorizedBy,
 } from "commonfabric";
@@ -380,7 +382,7 @@ const applyInitialName = lift<
 });
 
 export default pattern<ProfileHomeInput, ProfileHomeOutput>(
-  ({ initialName }) => {
+  ({ initialName, [SELF]: self }) => {
     const initialProfileName = trimInitialName(initialName);
     const name = new Writable<
       OwnerProtectedProfileWrite<string, typeof setName>
@@ -409,7 +411,30 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
     // Rendered profile view (CT-1748): the cell view shows a read-only
     // presentation by default; the owner flips this to reveal the edit form.
     const editing = new Writable<boolean>(false).for("editing");
-    const isEditing = computed(() => editing.get() === true);
+    // Is the current viewer the profile owner? `wish("#profile")` resolves the
+    // VIEWER's own default profile (from their home); `SELF` is THIS profile's
+    // cell. They are the same cell only when the owner is viewing their own
+    // (default) profile — a visitor's `#profile` is a different per-user profile
+    // cell, so this is never a false positive (a non-owner can never be granted
+    // edit). The edit form + button are gated on this so visitors get a
+    // read-only view; the field writes are independently CFC-owner-protected,
+    // so this is a UX gate, not the security boundary. Known limitation: an
+    // owner viewing one of their OWN non-default profiles reads as a visitor
+    // here (safe false-negative — they just don't get the inline edit form).
+    const viewerProfile = wish<{ name?: string }>({ query: "#profile" });
+    const isOwner = computed(() => {
+      const viewer = viewerProfile.result;
+      return viewer !== undefined && equals(self, viewer) === true;
+    });
+    // Edit form shows only when the owner has toggled into edit mode; visitors
+    // (and the owner before toggling) see the read-only presentation. Ownership
+    // is re-derived inline rather than referencing `isOwner` so each computed is
+    // self-contained (avoids nested-computed unwrap surprises).
+    const isEditing = computed(() => {
+      const viewer = viewerProfile.result;
+      const owner = viewer !== undefined && equals(self, viewer) === true;
+      return editing.get() === true && owner;
+    });
     // Whether a non-empty bio has been authored — drives the presentation-mode
     // bio block (CT-1648).
     const hasBio = computed(() => (bio.get() ?? "").trim().length > 0);
@@ -542,15 +567,23 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
                   ))}
                 </cf-vstack>
 
-                <cf-hstack>
-                  <cf-button
-                    variant="ghost"
-                    size="sm"
-                    onClick={toggleProfileEditing({ editing })}
-                  >
-                    Edit profile
-                  </cf-button>
-                </cf-hstack>
+                {
+                  /* Only the owner gets the edit affordance; a visitor sees a
+                  read-only profile (and CFC would reject their writes anyway). */
+                }
+                {ifElse(
+                  isOwner,
+                  <cf-hstack>
+                    <cf-button
+                      variant="ghost"
+                      size="sm"
+                      onClick={toggleProfileEditing({ editing })}
+                    >
+                      Edit profile
+                    </cf-button>
+                  </cf-hstack>,
+                  null,
+                )}
               </cf-vstack>,
             )}
 

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -425,6 +425,9 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
       [NAME]: name.get(),
       name: name.get(),
       avatar: avatar.get(),
+      // Surfaced in the badge hover tooltip (CT-1648); the pinned-pattern count
+      // populates on roster badges bound to the full profile cell.
+      bio: bio.get(),
     }));
 
     const parsedUserTags = computed(() =>

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
@@ -1,7 +1,11 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { NAME } from "@commonfabric/runtime-client";
-import { CFProfileBadge, profileDisplayFromValue } from "./cf-profile-badge.ts";
+import {
+  CFProfileBadge,
+  profileDisplayFromValue,
+  profileTooltipFromValue,
+} from "./cf-profile-badge.ts";
 import { identitySeal } from "./identity-seal.ts";
 
 const OWNER_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
@@ -498,6 +502,46 @@ describe("CFProfileBadge", () => {
       expect(profileDisplayFromValue({})).toEqual({
         name: undefined,
         avatar: undefined,
+      });
+    });
+  });
+
+  describe("profileTooltipFromValue (CT-1648)", () => {
+    it("extracts a trimmed bio and the pinned-element count", () => {
+      const val = {
+        name: "Ada",
+        bio: "  Mathematician & first programmer.  ",
+        elements: [{ title: "Counter" }, { title: "Notes" }],
+      };
+      expect(profileTooltipFromValue(val)).toEqual({
+        bio: "Mathematician & first programmer.",
+        pinnedCount: 2,
+      });
+    });
+
+    it("treats a blank bio as none and a missing elements list as zero", () => {
+      expect(profileTooltipFromValue({ name: "Ada", bio: "   " })).toEqual({
+        bio: undefined,
+        pinnedCount: 0,
+      });
+    });
+
+    it("returns empty details for a projection without bio/elements", () => {
+      // The self-view projection ({name, avatar}) carries no bio/elements.
+      expect(profileTooltipFromValue({ name: "Ada", avatar: "🦊" })).toEqual({
+        bio: undefined,
+        pinnedCount: 0,
+      });
+    });
+
+    it("returns empty details for non-object input", () => {
+      expect(profileTooltipFromValue(undefined)).toEqual({
+        bio: undefined,
+        pinnedCount: 0,
+      });
+      expect(profileTooltipFromValue("nope")).toEqual({
+        bio: undefined,
+        pinnedCount: 0,
       });
     });
   });

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -36,6 +36,34 @@ export type ProfileBadgeDisplay = {
   avatar: string | undefined;
 };
 
+/** Extra profile details surfaced in the badge hover/focus tooltip (CT-1648). */
+export type ProfileBadgeTooltip = {
+  bio: string | undefined;
+  pinnedCount: number;
+};
+
+/**
+ * Extracts the tooltip details (bio + pinned-pattern count) from a subscribed
+ * profile-cell value. `bio` is the owner-authored free-text description;
+ * `pinnedCount` is the number of profile `elements` (pinned pieces / cards).
+ * Both are best-effort: a badge bound to a derived projection (e.g. the
+ * self-view `{name, avatar}` cell) simply yields no bio and a zero count. Pure,
+ * so it is unit-testable without a runtime.
+ */
+export const profileTooltipFromValue = (val: unknown): ProfileBadgeTooltip => {
+  if (!val || typeof val !== "object") {
+    return { bio: undefined, pinnedCount: 0 };
+  }
+  const record = val as Record<PropertyKey, unknown>;
+  const rawBio = record["bio"];
+  const bio = typeof rawBio === "string" && rawBio.trim().length > 0
+    ? rawBio.trim()
+    : undefined;
+  const elements = record["elements"];
+  const pinnedCount = Array.isArray(elements) ? elements.length : 0;
+  return { bio, pinnedCount };
+};
+
 /**
  * Extracts the display name + avatar from a subscribed profile-cell value.
  * Prefers the profile's own editable `name` field, falling back to the cell's
@@ -99,6 +127,7 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
       }
 
       .badge {
+        position: relative;
         box-sizing: border-box;
         display: inline-flex;
         align-items: center;
@@ -110,6 +139,77 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         background: var(--cf-theme-color-surface, hsl(0, 0%, 99%));
         color: var(--cf-theme-color-text, hsl(0, 0%, 9%));
         line-height: 1;
+      }
+
+      /* CT-1648: hover/focus tooltip surfacing the profile's configured bio +
+        pinned-pattern count. Hidden until the badge is hovered or focused
+        (keyboard focus drives it on touch/AT). pointer-events:none so it never
+        intercepts the badge's own click/navigation. */
+      .tooltip {
+        position: absolute;
+        top: calc(100% + 0.4rem);
+        left: 0;
+        z-index: 30;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        box-sizing: border-box;
+        width: max-content;
+        max-width: 18rem;
+        padding: 0.5rem 0.625rem;
+        border-radius: var(--cf-border-radius-md, 0.5rem);
+        border: 1px solid var(--cf-theme-color-border, hsl(0, 0%, 89%));
+        background: var(--cf-theme-color-surface, hsl(0, 0%, 99%));
+        color: var(--cf-theme-color-text, hsl(0, 0%, 9%));
+        box-shadow: 0 6px 20px -6px rgba(0, 0, 0, 0.28);
+        opacity: 0;
+        visibility: hidden;
+        transform: translateY(-2px);
+        transition:
+          opacity 120ms ease-out,
+          transform 120ms ease-out,
+          visibility 120ms;
+        pointer-events: none;
+        text-align: left;
+        white-space: normal;
+      }
+
+      .badge:hover .tooltip,
+      .badge:focus-visible .tooltip,
+      .badge:focus-within .tooltip {
+        opacity: 1;
+        visibility: visible;
+        transform: translateY(0);
+      }
+
+      .tooltip-name {
+        font-size: var(--cf-font-size-sm, 0.8125rem);
+        font-weight: var(--cf-font-weight-semibold, 600);
+      }
+
+      .tooltip-bio {
+        font-size: var(--cf-font-size-xs, 0.75rem);
+        line-height: 1.35;
+        color: var(--cf-theme-color-text-secondary, hsl(0, 0%, 40%));
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+      }
+
+      .tooltip-meta {
+        font-size: var(--cf-font-size-xs, 0.75rem);
+        color: var(--cf-theme-color-muted-foreground, hsl(0, 0%, 45%));
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .tooltip {
+          transition: none;
+          transform: none;
+        }
+        .badge:hover .tooltip,
+        .badge:focus-visible .tooltip,
+        .badge:focus-within .tooltip {
+          transform: none;
+        }
       }
 
       /* CT-1750: navigable badges (bound to a real profile cell) act as links. */
@@ -322,6 +422,13 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
   @state()
   private accessor _avatar: string | undefined = undefined;
 
+  // CT-1648: extra details surfaced in the hover/focus tooltip.
+  @state()
+  private accessor _bio: string | undefined = undefined;
+
+  @state()
+  private accessor _pinnedCount = 0;
+
   @state()
   private accessor _state: ProfileBadgeState = "presented";
 
@@ -486,15 +593,32 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
 
       // Subscribe with a minimal schema so the runtime only resolves the fields
       // we render, rather than walking the whole profile output graph (mirrors
-      // cf-cell-link's $NAME-only subscription).
+      // cf-cell-link's $NAME-only subscription). `bio` + `elements` feed the
+      // hover tooltip (CT-1648); `elements` items request only `title` (a
+      // same-space string) so we never deep-resolve the cross-space `cell` links
+      // just to count them.
       const named = resolved.asSchema<
-        { [NAME]?: string; name?: string; avatar?: string }
+        {
+          [NAME]?: string;
+          name?: string;
+          avatar?: string;
+          bio?: string;
+          elements?: Array<{ title?: string }>;
+        }
       >({
         type: "object",
         properties: {
           [NAME]: { type: "string" },
           name: { type: "string" },
           avatar: { type: "string" },
+          bio: { type: "string" },
+          elements: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: { title: { type: "string" } },
+            },
+          },
         },
       });
       this._unsubscribe = named.subscribe((val) => this._applyValue(val));
@@ -548,8 +672,11 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
 
   private _applyValue(val: unknown): void {
     const { name, avatar } = profileDisplayFromValue(val);
+    const { bio, pinnedCount } = profileTooltipFromValue(val);
     this._name = name;
     this._avatar = avatar;
+    this._bio = bio;
+    this._pinnedCount = pinnedCount;
     this.requestUpdate();
   }
 
@@ -611,6 +738,14 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
     // this identity's palette.
     const auraStyle = verified ? `--seal-hue: ${hue};` : "";
 
+    // CT-1648: hover/focus tooltip surfacing the profile's configured details
+    // (bio + pinned-pattern count). Only rendered when there's something extra
+    // to show beyond the name already on the badge.
+    const pinnedLabel = this._pinnedCount === 1
+      ? "1 pinned pattern"
+      : `${this._pinnedCount} pinned patterns`;
+    const hasTooltip = this._bio !== undefined || this._pinnedCount > 0;
+
     return html`
       <span
         class="badge"
@@ -618,8 +753,9 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         data-cf-profile-badge
         data-state="${this._state}"
         ?data-navigable="${this._navigable}"
+        ?data-has-tooltip="${hasTooltip}"
         role="${this._navigable ? "link" : nothing}"
-        tabindex="${this._navigable ? "0" : nothing}"
+        tabindex="${this._navigable ? "0" : (hasTooltip ? "0" : nothing)}"
         @click="${this._handleClick}"
         @keydown="${this._handleKeydown}"
       >
@@ -669,6 +805,24 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
               : null}
           </svg>
         </span>
+        ${hasTooltip
+          ? html`
+            <span class="tooltip" part="tooltip" role="tooltip">
+              <span class="tooltip-name">${this._name ?? "Profile"}</span>
+              ${this._bio !== undefined
+                ? html`
+                  <span class="tooltip-bio">${this._bio}</span>
+                `
+                : null} ${this._pinnedCount > 0
+                ? html`
+                  <span class="tooltip-meta">
+                    <span aria-hidden="true">📌</span> ${pinnedLabel}
+                  </span>
+                `
+                : null}
+            </span>
+          `
+          : null}
       </span>
     `;
   }

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -742,8 +742,8 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
     // (bio + pinned-pattern count). Only rendered when there's something extra
     // to show beyond the name already on the badge.
     const pinnedLabel = this._pinnedCount === 1
-      ? "1 pinned pattern"
-      : `${this._pinnedCount} pinned patterns`;
+      ? "1 pinned piece"
+      : `${this._pinnedCount} pinned pieces`;
     const hasTooltip = this._bio !== undefined || this._pinnedCount > 0;
 
     return html`

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -43,7 +43,7 @@ export type ProfileBadgeTooltip = {
 };
 
 /**
- * Extracts the tooltip details (bio + pinned-pattern count) from a subscribed
+ * Extracts the tooltip details (bio + pinned-piece count) from a subscribed
  * profile-cell value. `bio` is the owner-authored free-text description;
  * `pinnedCount` is the number of profile `elements` (pinned pieces / cards).
  * Both are best-effort: a badge bound to a derived projection (e.g. the
@@ -142,7 +142,7 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
       }
 
       /* CT-1648: hover/focus tooltip surfacing the profile's configured bio +
-        pinned-pattern count. Hidden until the badge is hovered or focused
+        pinned-piece count. Hidden until the badge is hovered or focused
         (keyboard focus drives it on touch/AT). pointer-events:none so it never
         intercepts the badge's own click/navigation. */
       .tooltip {
@@ -739,7 +739,7 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
     const auraStyle = verified ? `--seal-hue: ${hue};` : "";
 
     // CT-1648: hover/focus tooltip surfacing the profile's configured details
-    // (bio + pinned-pattern count). Only rendered when there's something extra
+    // (bio + pinned-piece count). Only rendered when there's something extra
     // to show beyond the name already on the badge.
     const pinnedLabel = this._pinnedCount === 1
       ? "1 pinned piece"


### PR DESCRIPTION
## Badge tooltip — surface a profile's configured details on hover

The cherry on top of the CT-1648 bio work: `cf-profile-badge` now shows a tooltip on hover (desktop) / focus (keyboard + assistive tech) that surfaces the profile's **bio** and **how many patterns they've pinned** — exposing the bio/elements data right where you meet someone (e.g. their badge on a shared pattern), so the whole profile system feeds in and out and works together.

### What changed
- **Badge data:** the profile subscription now also reads `bio` and `elements`. The `elements` items request only `title` (a same-space string), so counting the pins never deep-resolves the cross-space `cell` links. New pure helper `profileTooltipFromValue` (→ `{ bio, pinnedCount }`) with unit tests.
- **Tooltip UI:** rendered only when there's something extra to show (a bio or ≥1 pin). Shown on `:hover` / `:focus-visible` / `:focus-within`; `pointer-events: none` so it never intercepts the badge's own click/navigation; respects `prefers-reduced-motion`.
- **Self-badge:** `profile-home`'s `selfProfile` projection now carries `bio`, so the owner's own self-badge tooltip shows it too. (The pinned count populates on roster badges that bind the full profile cell; the lightweight self-projection deliberately doesn't carry the cross-space `elements`.)
- **Story:** the `cf-profile-badge` catalog story now gives its example profiles bios + pins to demo all three states — bio+pins (Ada), bio-only (Grace), none (Alan).

### Verification
- Browser-verified via the catalog story: hovering Ada's badge shows **name + bio + "📌 3 pinned patterns"**; Grace shows bio only; Alan shows no tooltip.
- `cf-profile-badge` unit tests (incl. new `profileTooltipFromValue` cases), `cf check`, and lint all green.

### Mobile note
On touch, tapping a navigable badge navigates to the full profile page (which already shows everything), so the hover tooltip is a desktop/keyboard affordance; the mobile path degrades to the full profile view rather than a hover popover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hover/focus tooltip to `cf-profile-badge` that shows the profile bio and pinned piece count (CT-1648). Also adds a live multi-user roster demo and gates profile editing to the owner; keeps `isEditing` a raw toggle while gating the form via ownership.

- New Features
  - Tooltip on `:hover`/`:focus-visible`/`:focus-within`; renders only with a bio or ≥1 pin; `pointer-events: none`; honors `prefers-reduced-motion`; non-navigable badges become focusable when a tooltip is present.
  - Badge subscription now reads `bio` and `elements` (items request `title` only); new pure helper `profileTooltipFromValue` returns `{ bio, pinnedCount }` with tests; `profile-home` self projection includes `bio`.
  - Added `profile-roster-live-demo`: renders every participant with a live `cf-profile-badge` bound to their cross-space profile cell (self badge `noNavigate`); registered in `packages/patterns/index.md`.

- Bug Fixes
  - `profile-home` shows the edit affordance only to the owner by comparing `wish("#profile")` to `SELF`; visitors see a read-only view. `isEditing` remains a raw toggle; a separate `showEditForm = editing && isOwner` gates the edit form.
  - Catalog story badges are marked `noNavigate`; tooltip copy uses “pinned piece(s)”.

<sup>Written for commit 866daf25361b7dded700d77aacaabed6ab600a70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

