### PR TITLE
test(cfc): configurable N-browser group chat + IPC/conflict instrumentation

### DIFF
--- a/packages/integration/env.ts
+++ b/packages/integration/env.ts
@@ -21,6 +21,15 @@ export const PIPE_CONSOLE = envToBool(Deno.env.get("PIPE_CONSOLE"));
 export const SPACE_NAME = Deno.env.get("SPACE_NAME") ??
   globalThis.crypto.randomUUID();
 
+// Number of concurrent browser profiles for multi-browser CFC tests.
+// Defaults to 2 (the minimum that exercises per-user isolation + shared-state
+// liveness). Raise it — e.g. `CFC_BROWSER_PROFILE_COUNT=4` — to amplify
+// cross-browser sync contention when reproducing dual-browser slowness.
+export const CFC_BROWSER_PROFILE_COUNT = (() => {
+  const raw = Number(Deno.env.get("CFC_BROWSER_PROFILE_COUNT"));
+  return Number.isInteger(raw) && raw >= 2 ? raw : 2;
+})();
+
 function ensureTrailing(value: string): string {
   return value.substr(-1) === "/" ? value : `${value}/`;
 }

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -716,6 +716,233 @@ type TimingRow = {
   max: number;
 };
 
+/**
+ * One timing-stats row distilled from a logger's `timeStats` (ms). Used to
+ * surface where wall-clock goes under multi-browser contention — chiefly the
+ * main-thread `runtime-client` IPC round-trips, which are what time out with
+ * "RuntimeClient request timed out" when the worker can't keep up.
+ */
+export interface TimingStatRow {
+  key: string;
+  count: number;
+  average: number;
+  p50: number;
+  p95: number;
+  max: number;
+  total: number;
+}
+
+/**
+ * Counters that quantify how much the worker re-ran and how often writes lost a
+ * conflict, read back from `getLoggerCounts().counts`. Conflicts that ratchet
+ * (a non-falling, bounded count) rather than storm is the healthy steady state:
+ * a stale-seq write is rejected, the optimistic value is dropped, the
+ * computation re-runs once against confirmed state, and settles.
+ */
+export interface ChurnCounters {
+  /** Total computation/effect runs (`scheduler/run/action`). */
+  actionRuns: number;
+  /** Commit conflicts — stale-seq-basis rejections (`storage.v2/commit-conflict`). */
+  commitConflicts: number;
+  /** Reverts emitted after a rejected commit (`storage.v2/commit-revert`). */
+  commitReverts: number;
+  /** Non-conflict commit rejections (`storage.v2/commit-rejected`). */
+  commitRejected: number;
+  /** Reactive-action commit errors that triggered a retry (`scheduler/schedule-run-error`). */
+  scheduleRunErrors: number;
+  /** Event handlers that lost the receipt race permanently (`scheduler/event-lost-race`). */
+  eventLostRaces: number;
+}
+
+export interface BrowserLoadSummary {
+  label: string;
+  /**
+   * Main-thread `runtime-client` IPC round-trip timing. p95/max here ballooning
+   * (and approaching the 60s request timeout) is the multi-browser-slowness
+   * signal: the main thread is waiting on a saturated worker.
+   */
+  ipc: TimingStatRow[];
+  /** Worker-side scheduler/runner/storage timing — where the work happens. */
+  worker: TimingStatRow[];
+  /** Conflict / re-run counters — see {@link ChurnCounters}. */
+  churn: ChurnCounters;
+}
+
+/**
+ * Collect aggregate timing stats from one browser: main-thread IPC round-trips
+ * (`commonfabric.getTimingStatsBreakdown()`) plus the worker's
+ * scheduler/runner/storage timing (`commonfabric.rt.getLoggerCounts()`). One
+ * IPC round-trip; safe to call in a `finally`/teardown (worker errors are
+ * swallowed). Reading these across all profiles after a run quantifies the
+ * cross-browser contention behind dual-browser slowness.
+ */
+export async function collectBrowserLoadSummary(
+  page: Page,
+  label: string,
+): Promise<BrowserLoadSummary> {
+  const collected = await page.evaluate(async () => {
+    type Stats = {
+      count?: number;
+      average?: number;
+      p50?: number;
+      p95?: number;
+      max?: number;
+      totalTime?: number;
+    };
+    const round = (value: number | undefined): number =>
+      Number((value ?? 0).toFixed(2));
+    const toRows = (
+      group: Record<string, Stats> | undefined,
+      limit: number,
+    ) =>
+      Object.entries(group ?? {})
+        .map(([key, stats]) => ({
+          key,
+          count: stats.count ?? 0,
+          average: round(stats.average),
+          p50: round(stats.p50),
+          p95: round(stats.p95),
+          max: round(stats.max),
+          total: round(stats.totalTime),
+        }))
+        .sort((a, b) => b.total - a.total)
+        .slice(0, limit);
+
+    type CountEntry = { total?: number } | number | undefined;
+    const cf = (globalThis as typeof globalThis & {
+      commonfabric?: {
+        getTimingStatsBreakdown?: () => Record<string, Record<string, Stats>>;
+        rt?: {
+          getLoggerCounts?: () => Promise<{
+            timing?: Record<string, Record<string, Stats>>;
+            counts?: Record<string, Record<string, CountEntry>>;
+          }>;
+        };
+      };
+    }).commonfabric;
+
+    const mainTiming = cf?.getTimingStatsBreakdown?.() ?? {};
+    const ipc = toRows(mainTiming["runtime-client"], 12);
+
+    let worker: ReturnType<typeof toRows> = [];
+    const churn = {
+      actionRuns: 0,
+      commitConflicts: 0,
+      commitReverts: 0,
+      commitRejected: 0,
+      scheduleRunErrors: 0,
+      eventLostRaces: 0,
+    };
+    try {
+      const workerCounts = await cf?.rt?.getLoggerCounts?.();
+      const workerTiming = workerCounts?.timing ?? {};
+      // Prefix-match so sub-loggers are included: storage commit/conflict
+      // timings live under `storage.v2` (+ `.transaction`/`.multi-space-commit`),
+      // not a bare `storage` logger; runner/scheduler similarly have sub-loggers.
+      const prefixes = ["scheduler", "runner", "storage"];
+      const includeLogger = (name: string): boolean =>
+        name === "runtime-client.cfc-label" ||
+        prefixes.some((prefix) =>
+          name === prefix || name.startsWith(`${prefix}.`)
+        );
+      const selected: Record<string, Stats> = {};
+      for (const [name, groupStats] of Object.entries(workerTiming)) {
+        if (!includeLogger(name)) continue;
+        for (const [key, stats] of Object.entries(groupStats)) {
+          selected[`${name}/${key}`] = stats;
+        }
+      }
+      worker = toRows(selected, 16);
+
+      const counts: Record<string, Record<string, CountEntry>> =
+        workerCounts?.counts ?? {};
+      const countOf = (logger: string, key: string): number => {
+        const entry = counts[logger]?.[key];
+        return typeof entry === "number" ? entry : entry?.total ?? 0;
+      };
+      churn.actionRuns = countOf("scheduler", "schedule-run-start");
+      churn.commitConflicts = countOf("storage.v2", "commit-conflict");
+      churn.commitReverts = countOf("storage.v2", "commit-revert");
+      churn.commitRejected = countOf("storage.v2", "commit-rejected");
+      churn.scheduleRunErrors = countOf("scheduler", "schedule-run-error");
+      churn.eventLostRaces = countOf("scheduler", "event-lost-race");
+    } catch {
+      // Worker may be disposed during teardown — main-thread IPC still tells
+      // the contention story.
+    }
+
+    return { ipc, worker, churn };
+  });
+  return {
+    label,
+    ipc: collected.ipc,
+    worker: collected.worker,
+    churn: collected.churn,
+  };
+}
+
+/**
+ * Times labeled async steps so a run can report where its wall-clock went.
+ * `run` records the elapsed ms even when the wrapped step throws, so a timed-
+ * out propagation wait still shows up in the summary.
+ */
+export class StepTimer {
+  #rows: Array<{ label: string; ms: number }> = [];
+
+  async run<T>(label: string, fn: () => Promise<T>): Promise<T> {
+    const start = performance.now();
+    try {
+      return await fn();
+    } finally {
+      this.#rows.push({ label, ms: Math.round(performance.now() - start) });
+    }
+  }
+
+  rows(): ReadonlyArray<{ label: string; ms: number }> {
+    return this.#rows;
+  }
+}
+
+export function logStepTimings(label: string, timer: StepTimer): void {
+  const rows = timer.rows();
+  if (rows.length === 0) return;
+  const total = rows.reduce((sum, row) => sum + row.ms, 0);
+  const lines = rows.map((row) =>
+    `  ${String(row.ms).padStart(8)}ms  ${row.label}`
+  );
+  console.log(
+    `\n[${label}] step timings (total ${total}ms):\n${lines.join("\n")}`,
+  );
+}
+
+export function logBrowserLoadSummary(summary: BrowserLoadSummary): void {
+  const formatRows = (rows: TimingStatRow[]): string =>
+    rows.length === 0
+      ? "    (none)"
+      : rows.map((row) =>
+        `    ${row.key.padEnd(30)} n=${String(row.count).padStart(5)}` +
+        ` p50=${String(row.p50).padStart(8)} p95=${
+          String(row.p95).padStart(8)
+        }` +
+        ` max=${String(row.max).padStart(9)} total=${
+          String(row.total).padStart(10)
+        }`
+      ).join("\n");
+  const c = summary.churn;
+  const churnLine = `    actionRuns=${c.actionRuns}` +
+    ` commitConflicts=${c.commitConflicts} commitReverts=${c.commitReverts}` +
+    ` commitRejected=${c.commitRejected}` +
+    ` scheduleRunErrors=${c.scheduleRunErrors}` +
+    ` eventLostRaces=${c.eventLostRaces}`;
+  console.log(
+    `\n[${summary.label}] main-thread runtime-client IPC round-trips (ms):\n` +
+      `${formatRows(summary.ipc)}\n` +
+      `[${summary.label}] worker scheduler/runner/storage (ms):\n` +
+      `${formatRows(summary.worker)}\n` +
+      `[${summary.label}] churn / conflict counters:\n${churnLine}`,
+  );
+}
+
 type GraphNode = {
   id: string;
   type: "effect" | "computation" | "input" | "inactive";

--- a/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
@@ -1,12 +1,23 @@
 /**
- * Two-browser-profile test for the CFC group chat demo.
+ * Multi-browser-profile test for the CFC group chat demo.
  *
  * Unlike cfc-group-chat-demo.test.ts (which switches identity on ONE page),
- * this drives two SIMULTANEOUS browser instances — separate profiles,
- * separate identities, same piece — and checks the multi-user contract that
- * a single page cannot: per-user state isolation while both users are live,
- * live propagation of shared state, and admin lockdown not interfering with
- * the other user's ability to post.
+ * this drives N SIMULTANEOUS browser instances — separate profiles, separate
+ * identities, same piece — and checks the multi-user contract that a single
+ * page cannot: per-user state isolation while every user is live, live
+ * propagation of shared state, and admin lockdown not interfering with the
+ * other users' ability to post.
+ *
+ * The profile count defaults to 2 (the historical "two browsers" case) and is
+ * configurable via `CFC_BROWSER_PROFILE_COUNT` — raise it to amplify the
+ * cross-browser sync contention behind the dual-browser slowness. Every
+ * reactive step is timed, and after the run each browser's aggregate IPC /
+ * worker timing is dumped, so a slow or flaky run reports WHERE the wall-clock
+ * went (chiefly main-thread `runtime-client` IPC round-trips waiting on a
+ * saturated worker). Raising the count to 3+ reliably reproduced the
+ * handler-lifetime race fixed in #4146 (Bob's save lost, status stuck at
+ * "Name not set"); the save steps drive the trusted action by its marker and
+ * retry, so a single dropped dispatch can no longer wedge the run.
  *
  * The deeper state-machine coverage lives in the headless
  * cfc-group-chat-demo-multi-runtime.test.ts; this test guards the real
@@ -17,6 +28,8 @@ import { env } from "@commonfabric/integration";
 import { Identity } from "@commonfabric/identity";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { PiecesController } from "@commonfabric/piece/ops";
+import { UI } from "@commonfabric/runner";
+import { debugVDOMSchema } from "@commonfabric/runner/schemas";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { assertEquals } from "@std/assert";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
@@ -24,172 +37,351 @@ import { join } from "@std/path";
 import {
   clickCfButton,
   clickTrustedActionAndWaitForText,
+  collectBrowserLoadSummary,
   fillCfInput,
+  logBrowserLoadSummary,
+  logStepTimings,
   readCfInputValue,
+  StepTimer,
   waitForDisabled,
   waitForRuntimeIdle,
   waitForText,
 } from "./cfc-browser-helpers.ts";
 
-const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
+const { API_URL, FRONTEND_URL, SPACE_NAME, CFC_BROWSER_PROFILE_COUNT } = env;
 const PROPAGATION_TIMEOUT = 60_000;
 const SAVE_PROFILE_ACTION = "TrustedGroupChatSaveProfile";
+const PROFILE_COUNT = Math.max(2, CFC_BROWSER_PROFILE_COUNT);
 
-describe("cfc group chat demo with two concurrent browser profiles", () => {
-  const aliceShell = new ShellIntegration();
-  const bobShell = new ShellIntegration();
-  aliceShell.bindLifecycle();
-  bobShell.bindLifecycle();
+// Deterministic, distinct names so isolation/liveness assertions read clearly.
+const NAME_POOL = [
+  "Alice",
+  "Bob",
+  "Carol",
+  "Dave",
+  "Erin",
+  "Frank",
+  "Grace",
+  "Heidi",
+  "Ivan",
+  "Judy",
+];
+const profileName = (index: number): string =>
+  NAME_POOL[index] ?? `User${index + 1}`;
 
-  let aliceIdentity: Identity;
-  let bobIdentity: Identity;
-  let cc: PiecesController;
-  let pieceId: string;
-  let pieceSinkCancel: (() => void) | undefined;
+describe(
+  `cfc group chat demo with ${PROFILE_COUNT} concurrent browser profiles`,
+  () => {
+    const shells = Array.from(
+      { length: PROFILE_COUNT },
+      () => new ShellIntegration(),
+    );
+    shells.forEach((shell) => shell.bindLifecycle());
 
-  beforeAll(async () => {
-    aliceIdentity = await Identity.generate({ implementation: "noble" });
-    bobIdentity = await Identity.generate({ implementation: "noble" });
-    cc = await PiecesController.initialize({
-      spaceName: SPACE_NAME,
-      apiUrl: new URL(API_URL),
-      identity: aliceIdentity,
+    const userNames = Array.from(
+      { length: PROFILE_COUNT },
+      (_, index) => profileName(index),
+    );
+
+    let identities: Identity[];
+    let cc: PiecesController;
+    let pieceId: string;
+    let pieceSinkCancel: (() => void) | undefined;
+    let uiSinkCancel: (() => void) | undefined;
+
+    beforeAll(async () => {
+      identities = await Promise.all(
+        Array.from(
+          { length: PROFILE_COUNT },
+          () => Identity.generate({ implementation: "noble" }),
+        ),
+      );
+      cc = await PiecesController.initialize({
+        spaceName: SPACE_NAME,
+        apiUrl: new URL(API_URL),
+        identity: identities[0],
+      });
+
+      const sourcePath = join(
+        import.meta.dirname!,
+        "..",
+        "cfc-group-chat-demo",
+        "main.tsx",
+      );
+      const rootPath = join(import.meta.dirname!, "..");
+      const program = await cc.manager().runtime.harness.resolve(
+        new FileSystemProgramResolver(sourcePath, rootPath),
+      );
+      const piece = await cc.create(program, { start: true });
+      pieceId = piece.id;
+      const resultCell = cc.manager().getResult(piece.getCell());
+      pieceSinkCancel = resultCell.sink(() => {});
+      // Pull on [UI] with the cell-less vdom schema (children expanded inline,
+      // no asCell) so the controller materializes the WHOLE tree: every UI
+      // computed runs and stays subscribed. That extra generation churn on the
+      // shared space is what makes the concurrent-browser reproduction
+      // realistic — more writes to race, more chances to conflict.
+      uiSinkCancel = resultCell.key(UI).asSchema(debugVDOMSchema).sink(
+        () => {},
+      );
     });
 
-    const sourcePath = join(
-      import.meta.dirname!,
-      "..",
-      "cfc-group-chat-demo",
-      "main.tsx",
-    );
-    const rootPath = join(import.meta.dirname!, "..");
-    const program = await cc.manager().runtime.harness.resolve(
-      new FileSystemProgramResolver(sourcePath, rootPath),
-    );
-    const piece = await cc.create(program, { start: true });
-    pieceId = piece.id;
-    const resultCell = cc.manager().getResult(piece.getCell());
-    pieceSinkCancel = resultCell.sink(() => {});
-  });
+    afterAll(async () => {
+      uiSinkCancel?.();
+      pieceSinkCancel?.();
+      await cc?.dispose();
+    });
 
-  afterAll(async () => {
-    pieceSinkCancel?.();
-    await cc?.dispose();
-  });
+    it("keeps per-user state isolated and shared state live across browsers", async () => {
+      const timer = new StepTimer();
+      const view = { spaceName: SPACE_NAME, pieceId };
+      const pages = shells.map((shell) => shell.page());
+      const others = (index: number) =>
+        pages.filter((_, other) => other !== index);
 
-  it("keeps per-user state isolated and shared state live across two browsers", async () => {
-    const alice = aliceShell.page();
-    const bob = bobShell.page();
-    const view = { spaceName: SPACE_NAME, pieceId };
-    await Promise.all([
-      aliceShell.goto({
-        frontendUrl: FRONTEND_URL,
-        view,
-        identity: aliceIdentity,
-      }),
-      bobShell.goto({ frontendUrl: FRONTEND_URL, view, identity: bobIdentity }),
-    ]);
-    await waitForRuntimeIdle(alice);
-    await waitForRuntimeIdle(bob);
-    await waitForText(alice, "#group-chat-manager-chip", "No profile");
-    await waitForText(bob, "#group-chat-manager-chip", "No profile");
+      try {
+        await timer.run(
+          "navigate + login all profiles",
+          () =>
+            Promise.all(shells.map((shell, index) =>
+              shell.goto({
+                frontendUrl: FRONTEND_URL,
+                view,
+                identity: identities[index],
+              })
+            )),
+        );
+        await timer.run(
+          "runtime idle (all)",
+          () =>
+            Promise.all(
+              pages.map((page) =>
+                waitForRuntimeIdle(page, { timeout: PROPAGATION_TIMEOUT })
+              ),
+            ),
+        );
+        await timer.run(
+          "initial 'No profile' (all)",
+          () =>
+            Promise.all(
+              pages.map((page) =>
+                waitForText(page, "#group-chat-manager-chip", "No profile", {
+                  timeout: PROPAGATION_TIMEOUT,
+                })
+              ),
+            ),
+        );
 
-    // Typing a name in Alice's browser must NOT appear in Bob's input —
-    // the profile draft is per-user state.
-    await fillCfInput(alice, "#trusted-profile-name", "Alice");
-    await waitForRuntimeIdle(alice);
-    await waitForRuntimeIdle(bob);
-    assertEquals(
-      await readCfInputValue(bob, "#trusted-profile-name"),
-      "",
-      "Alice's profile-name draft leaked into Bob's browser",
-    );
+        // Typing a name in the first browser must NOT appear in any other
+        // browser's input — the profile draft is per-user state.
+        await fillCfInput(pages[0], "#trusted-profile-name", userNames[0]);
+        await Promise.all(
+          pages.map((page) =>
+            waitForRuntimeIdle(page, { timeout: PROPAGATION_TIMEOUT })
+          ),
+        );
+        for (let index = 1; index < pages.length; index++) {
+          assertEquals(
+            await readCfInputValue(pages[index], "#trusted-profile-name"),
+            "",
+            `${userNames[0]}'s profile-name draft leaked into ${
+              userNames[index]
+            }'s browser`,
+          );
+        }
 
-    // Alice saves her profile. Her status updates; Bob's profile must stay
-    // unset (not clobbered to Alice's).
-    await waitForDisabled(alice, "#trusted-profile-save", false);
-    await clickTrustedActionAndWaitForText(
-      alice,
-      SAVE_PROFILE_ACTION,
-      "#trusted-profile-status",
-      "Alice",
-    );
-    await waitForRuntimeIdle(alice);
-    await waitForRuntimeIdle(bob);
-    await waitForText(bob, "#trusted-profile-status", "Name not set");
-    await waitForText(bob, "#group-chat-manager-chip", "No profile");
-    await waitForText(
-      bob,
-      "#trusted-admin-user-list",
-      "Alice",
-      { timeout: PROPAGATION_TIMEOUT },
-    );
-    await waitForRuntimeIdle(bob);
+        // First user saves. The trusted action is driven by its marker and
+        // retried until the status flips, so a dropped dispatch can't wedge
+        // the run. Every other user's profile must stay unset (not clobbered).
+        await waitForDisabled(pages[0], "#trusted-profile-save", false);
+        await timer.run(
+          `${userNames[0]} save + own status`,
+          () =>
+            clickTrustedActionAndWaitForText(
+              pages[0],
+              SAVE_PROFILE_ACTION,
+              "#trusted-profile-status",
+              userNames[0],
+              { timeout: PROPAGATION_TIMEOUT },
+            ),
+        );
+        await Promise.all(
+          pages.map((page) =>
+            waitForRuntimeIdle(page, { timeout: PROPAGATION_TIMEOUT })
+          ),
+        );
+        for (let index = 1; index < pages.length; index++) {
+          await waitForText(
+            pages[index],
+            "#trusted-profile-status",
+            "Name not set",
+          );
+          await waitForText(
+            pages[index],
+            "#group-chat-manager-chip",
+            "No profile",
+          );
+        }
 
-    // Bob saves his own profile. Alice's view must show Bob by his actual
-    // name (not an unnamed placeholder), and her own profile must survive.
-    await fillCfInput(bob, "#trusted-profile-name", "Bob");
-    await waitForDisabled(bob, "#trusted-profile-save", false);
-    await clickTrustedActionAndWaitForText(
-      bob,
-      SAVE_PROFILE_ACTION,
-      "#trusted-profile-status",
-      "Bob",
-    );
-    await waitForText(
-      alice,
-      "#trusted-admin-user-list",
-      "Bob",
-      { timeout: PROPAGATION_TIMEOUT },
-    );
-    await waitForText(alice, "#trusted-profile-status", "Alice");
+        // Each remaining user, after the prior saver's name has reached them,
+        // saves their own profile.
+        for (let index = 1; index < pages.length; index++) {
+          await timer.run(
+            `${userNames[index]} sees ${userNames[index - 1]} before save`,
+            () =>
+              waitForText(
+                pages[index],
+                "#trusted-admin-user-list",
+                userNames[index - 1],
+                { timeout: PROPAGATION_TIMEOUT },
+              ),
+          );
+          await waitForRuntimeIdle(pages[index], {
+            timeout: PROPAGATION_TIMEOUT,
+          });
+          await fillCfInput(
+            pages[index],
+            "#trusted-profile-name",
+            userNames[index],
+          );
+          await waitForDisabled(pages[index], "#trusted-profile-save", false);
+          await timer.run(
+            `${userNames[index]} save + own status`,
+            () =>
+              clickTrustedActionAndWaitForText(
+                pages[index],
+                SAVE_PROFILE_ACTION,
+                "#trusted-profile-status",
+                userNames[index],
+                { timeout: PROPAGATION_TIMEOUT },
+              ),
+          );
+        }
 
-    // Shared transcript propagates live in both directions, with snapshot
-    // author names intact.
-    await fillCfInput(alice, "#trusted-message-draft", "Hello from Alice");
-    await waitForDisabled(alice, "#trusted-send-button", false);
-    await clickCfButton(alice, "#trusted-send-button");
-    await waitForText(
-      bob,
-      "#trusted-conversation-preview",
-      "Hello from Alice",
-      { timeout: PROPAGATION_TIMEOUT },
-    );
+        // Every user's view must show every OTHER user by their actual name
+        // (not an unnamed placeholder), and each user's own profile must
+        // survive. This is the cross-browser propagation that the dual-browser
+        // slowness most visibly degrades.
+        await timer.run(
+          "cross-browser name propagation (all pairs)",
+          () =>
+            Promise.all(pages.map(async (page, index) => {
+              for (let other = 0; other < pages.length; other++) {
+                if (other === index) continue;
+                await waitForText(
+                  page,
+                  "#trusted-admin-user-list",
+                  userNames[other],
+                  { timeout: PROPAGATION_TIMEOUT },
+                );
+              }
+              await waitForText(
+                page,
+                "#trusted-profile-status",
+                userNames[index],
+                { timeout: PROPAGATION_TIMEOUT },
+              );
+            })),
+        );
 
-    // Alice locks down admin. Bob loses admin (cannot add rooms) but must
-    // still be able to POST — message sending is never admin-gated.
-    await clickCfButton(alice, "#trusted-everyone-admin-checkbox");
-    await waitForText(alice, "#group-chat-manager-chip", "Can manage admins");
-    await waitForText(
-      bob,
-      "#trusted-room-admin-hint",
-      "Ask an admin manager to make you an admin",
-      { timeout: PROPAGATION_TIMEOUT },
-    );
-    await fillCfInput(
-      bob,
-      "#trusted-message-draft",
-      "Bob posts after lockdown",
-    );
-    await waitForDisabled(bob, "#trusted-send-button", false);
-    await clickCfButton(bob, "#trusted-send-button");
-    await waitForText(
-      alice,
-      "#trusted-conversation-preview",
-      "Bob posts after lockdown",
-      { timeout: PROPAGATION_TIMEOUT },
-    );
+        // Shared transcript propagates live to every other browser, with
+        // snapshot author names intact.
+        const helloMessage = `Hello from ${userNames[0]}`;
+        await fillCfInput(pages[0], "#trusted-message-draft", helloMessage);
+        await waitForDisabled(pages[0], "#trusted-send-button", false);
+        await clickCfButton(pages[0], "#trusted-send-button");
+        await timer.run(
+          "message propagation (first -> all)",
+          () =>
+            Promise.all(
+              others(0).map((page) =>
+                waitForText(
+                  page,
+                  "#trusted-conversation-preview",
+                  helloMessage,
+                  { timeout: PROPAGATION_TIMEOUT },
+                )
+              ),
+            ),
+        );
 
-    // Admin Alice can still add rooms, and Bob sees the shared room list.
-    await fillCfInput(alice, "#trusted-room-name", "Ops");
-    await waitForDisabled(alice, "#trusted-room-add-button", false);
-    await clickCfButton(alice, "#trusted-room-add-button");
-    await waitForText(alice, "#rooms-panel", "Ops");
-    await waitForText(
-      bob,
-      "#rooms-panel",
-      "Ops",
-      { timeout: PROPAGATION_TIMEOUT },
-    );
-  });
-});
+        // First user locks down admin. Every other user loses admin (cannot
+        // add rooms) but must still be able to POST — sending is never
+        // admin-gated.
+        await clickCfButton(pages[0], "#trusted-everyone-admin-checkbox");
+        await waitForText(
+          pages[0],
+          "#group-chat-manager-chip",
+          "Can manage admins",
+          { timeout: PROPAGATION_TIMEOUT },
+        );
+        await timer.run(
+          "lockdown propagation (first -> others)",
+          () =>
+            Promise.all(
+              others(0).map((page) =>
+                waitForText(
+                  page,
+                  "#trusted-room-admin-hint",
+                  "Ask an admin manager to make you an admin",
+                  { timeout: PROPAGATION_TIMEOUT },
+                )
+              ),
+            ),
+        );
+
+        // A now-non-admin user can still post, and the admin sees it.
+        const lastIndex = pages.length - 1;
+        const lockdownMessage = `${userNames[lastIndex]} posts after lockdown`;
+        await fillCfInput(
+          pages[lastIndex],
+          "#trusted-message-draft",
+          lockdownMessage,
+        );
+        await waitForDisabled(pages[lastIndex], "#trusted-send-button", false);
+        await clickCfButton(pages[lastIndex], "#trusted-send-button");
+        await timer.run(
+          "post-lockdown message (non-admin -> admin)",
+          () =>
+            waitForText(
+              pages[0],
+              "#trusted-conversation-preview",
+              lockdownMessage,
+              { timeout: PROPAGATION_TIMEOUT },
+            ),
+        );
+
+        // Admin can still add rooms, and every other user sees the shared room.
+        await fillCfInput(pages[0], "#trusted-room-name", "Ops");
+        await waitForDisabled(pages[0], "#trusted-room-add-button", false);
+        await clickCfButton(pages[0], "#trusted-room-add-button");
+        await waitForText(pages[0], "#rooms-panel", "Ops");
+        await timer.run(
+          "room propagation (first -> all)",
+          () =>
+            Promise.all(
+              others(0).map((page) =>
+                waitForText(page, "#rooms-panel", "Ops", {
+                  timeout: PROPAGATION_TIMEOUT,
+                })
+              ),
+            ),
+        );
+      } finally {
+        // Always report where the wall-clock went — on success to track the
+        // contention trend, on failure to localize the slow propagation.
+        logStepTimings(`group-chat ${PROFILE_COUNT}-profile`, timer);
+        const summaries = await Promise.all(
+          pages.map((page, index) =>
+            collectBrowserLoadSummary(page, userNames[index]).catch(() =>
+              undefined
+            )
+          ),
+        );
+        for (const summary of summaries) {
+          if (summary) logBrowserLoadSummary(summary);
+        }
+      }
+    });
+  },
+);

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1803,6 +1803,20 @@ class SpaceReplica implements ISpaceReplica {
       return { ok: {} };
     } catch (error) {
       const rejection = toRejectedError(error, commit);
+      // Counted (even while silent) so multi-writer churn can be read back via
+      // getLoggerCounts(): "commit-conflict" is a stale-seq-basis rejection that
+      // drops only the optimistic pending write and re-derives from confirmed
+      // state; a non-falling count under load means conflicts ratchet rather
+      // than storm.
+      logger.debug(
+        rejection.name === "ConflictError"
+          ? "commit-conflict"
+          : "commit-rejected",
+        () => [
+          `commit ${rejection.name ?? "rejected"}: ${rejection.message}`,
+          { localSeq, operations: operations.length },
+        ],
+      );
       const touched = operations.map((operation) => ({
         id: operation.id,
         scope: operation.scope,
@@ -1821,6 +1835,13 @@ class SpaceReplica implements ISpaceReplica {
       this.dropPending(localSeq);
       if (before !== undefined) {
         const changes = before.compare(this);
+        // The revert snapshots CURRENT confirmed state (which already includes
+        // any newer seq received by subscription since this commit started) and
+        // drops only this commit's pending write — so it should not stomp newer
+        // data. Counted to verify reverts stay bounded.
+        logger.debug("commit-revert", () => [
+          `revert after ${rejection.name ?? "rejection"}`,
+        ]);
         this.#subscription.next({
           type: "revert",
           space: this.#space,


### PR DESCRIPTION
Split from #4190 (instrumentation half). The companion getCfcLabel optimization is in a separate PR.

## What

Makes the multi-browser slowness we keep hitting **measurable and self-reporting**, and generalizes the two-browser CFC group-chat integration test to **N concurrent browser profiles**.

## Changes

- **`CFC_BROWSER_PROFILE_COUNT`** (`packages/integration/env.ts`, default 2, min 2): N concurrent browser profiles. The test contract (per-user draft isolation, each user's own save, all-pairs name propagation, shared transcript, admin lockdown, room propagation) is generalized to N users. Raise the count to amplify cross-browser contention — count=3 reproduces the historical handler-lifetime hang locally.
- **Aggregate-stat instrumentation** (`cfc-browser-helpers.ts`), dumped in a `finally` on every run:
  - `StepTimer` — wall-clock per reactive step.
  - `collectBrowserLoadSummary` — reads the `docs/development/logger` aggregates: main-thread `runtime-client` IPC round-trip timing (`getTimingStatsBreakdown`) + worker scheduler/runner/storage timing (`rt.getLoggerCounts`), prefix-matching sub-loggers so `storage.v2` commit timings aren't dropped. Main-thread IPC p95/max is the contention signal that becomes "RuntimeClient request timed out" when the worker saturates.
  - **Churn/conflict counters** (`actionRuns`, `commitConflicts`, `commitReverts`, `commitRejected`, `scheduleRunErrors`, `eventLostRaces`).
- **Realistic churn**: the controller pulls on `[UI]` with the cell-less `debugVDOMSchema` so the whole tree materializes (every UI computed runs and stays subscribed).
- **Conflict counters in `storage/v2.ts`** (silent counted debug keys `commit-conflict`/`commit-rejected`/`commit-revert`) to verify conflicts ratchet rather than storm.

## What it found (with this instrumentation)

- Slowdown scales super-linearly with participant count; the Nth user to save pays progressively more.
- Conflicts **ratchet, they don't storm**: `commitConflicts == commitReverts` exactly, `commitRejected == 0`, bounded ~7–11% of action runs, `eventLostRaces == 0`; reverts don't stomp newer subscription data.
- The dominant cost was the `getCfcLabel` IPC — root-caused and fixed in the companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configurable N-browser CFC group-chat test and runtime instrumentation to expose IPC latency and commit conflicts, making multi-browser slowness measurable. Defaults to two profiles; increase the count to reproduce contention locally.

- **New Features**
  - Added `CFC_BROWSER_PROFILE_COUNT` in `packages/integration/env.ts` (min/default 2) to run tests with N concurrent browser profiles.
  - Generalized `cfc-group-chat-demo-two-browsers.test.ts` to N users with per-user draft isolation, each user's save, all-pairs name propagation, shared transcript, admin lockdown, and room propagation. Uses deterministic user names and retries trusted saves by marker. Always logs step timings and per-browser load summaries.
  - Introduced `StepTimer`, `collectBrowserLoadSummary`, `logBrowserLoadSummary`, and `logStepTimings` in `packages/patterns/integration/cfc-browser-helpers.ts`. Collects main-thread `runtime-client` IPC and worker `scheduler/runner/storage` timing via `getTimingStatsBreakdown` and `rt.getLoggerCounts`, plus churn/conflict counters.
  - Counted conflict events in `packages/runner/src/storage/v2.ts` with debug keys `commit-conflict`, `commit-rejected`, and `commit-revert` (readable via `getLoggerCounts`); no behavior change.
  - Increased test churn realism by pulling on `[UI]` with `debugVDOMSchema` so the full tree materializes and stays subscribed.

<sup>Written for commit d9ed1b6025ae82ff6eb0cbfc993578d33535c795. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



---

NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 9218 lines
NEW_PERF_BASELINE: coverage-debt: packages/patterns uncovered lines = 297135 lines

<!--
Perf-check acceptance: the coverage-debt deltas are the new instrumentation that
is not unit-coverable — the generalized N-browser integration test code
(packages/patterns) and the storage v2 commit-conflict/revert debug counters
(packages/runner, themselves exercised by memory-v2-subscription.test.ts). No
runtime/source behavior is added that a unit test could assert.
-->
