### PR TITLE
perf(runtime-client): getCfcLabel is a pure store read; reactive callers own liveness

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -142,6 +142,14 @@ const logger = getLogger("cell", { level: "warn" });
 
 type SinkOptions = {
   changeGroup?: ChangeGroup;
+  /**
+   * Read the cell's display CFC label as part of the sink's tracked read set
+   * and pass it to the callback as a second argument. Reading it on the sink's
+   * transaction makes the cfc-metadata path a reactive dependency, so a
+   * label-only write (value unchanged) re-fires the sink — the basis for
+   * reactive label delivery over a subscription. Off by default.
+   */
+  includeCfcLabel?: boolean;
 };
 
 export type RawCellReadOptions = IReadOptions & {
@@ -295,7 +303,10 @@ declare module "@commonfabric/api" {
     asSchemaFromLinks<T = unknown>(): Cell<T>;
     withTx(tx?: IExtendedStorageTransaction): Cell<T>;
     sink(
-      callback: (value: Readonly<T>) => Cancel | undefined | void,
+      callback: (
+        value: Readonly<T>,
+        cfcLabel?: CfcLabelView | undefined,
+      ) => Cancel | undefined | void,
       options?: SinkOptions,
     ): Cancel;
     sinkMeta(
@@ -1599,7 +1610,10 @@ export class CellImpl<T extends FabricValue>
   }
 
   sink(
-    callback: (value: Readonly<T>) => Cancel | undefined | void,
+    callback: (
+      value: Readonly<T>,
+      cfcLabel?: CfcLabelView | undefined,
+    ) => Cancel | undefined | void,
     options: SinkOptions = {},
   ): Cancel {
     // Check if this is a stream
@@ -2244,7 +2258,10 @@ function asCellImpl(cell: unknown): CellImpl<FabricValue> | undefined {
 }
 
 function subscribeToReferencedDocs<T>(
-  callback: (value: T) => Cancel | undefined | void,
+  callback: (
+    value: T,
+    cfcLabel?: CfcLabelView | undefined,
+  ) => Cancel | undefined | void,
   runtime: Runtime,
   ref: CellViewRef,
   options: SinkOptions = {},
@@ -2268,7 +2285,15 @@ function subscribeToReferencedDocs<T>(
       if (needsTraversal && newValue !== undefined && newValue !== null) {
         deepTraverse(newValue);
       }
-      sink.cleanup = callback(newValue);
+      // Read the label on the SINK's transaction (`tx`), not the child `extraTx`,
+      // so the cfc-metadata read joins this sink's reactive dependency set: a
+      // later label-only write re-fires the sink. `cfcLabelViewForCell` is a
+      // pure store read (no sync); `internalVerifierRead` keeps it reactive but
+      // out of CFC taint. Raw here — the worker redacts before it leaves.
+      const cfcLabel = options.includeCfcLabel
+        ? cfcLabelViewForCell(createCell(runtime, link, tx))
+        : undefined;
+      sink.cleanup = callback(newValue, cfcLabel);
 
       // no async await here, but that also means no retry. TODO(seefeld): Should
       // we add a retry? So far all sinks are read-only, so they get re-triggered

--- a/packages/runner/test/cfc-label-sync-strategy.bench.ts
+++ b/packages/runner/test/cfc-label-sync-strategy.bench.ts
@@ -1,0 +1,151 @@
+/**
+ * Documents why the `getCfcLabel` per-call sync (runtime-processor's former
+ * `syncMetaLinkedDocs`) was removed — and guards against reintroducing it.
+ *
+ * `getCfcLabel` is a DISPLAY-label read on the render hot path. It used to
+ * re-sync the cell's whole root meta-graph on every call with a SERIAL
+ * `await sync()` per node. Split timing put that at ~99.97% of the IPC, bimodal
+ * p50 0.1ms / p95 >1s under multi-writer churn: when a node's watch is
+ * mid-refresh the `sync()` blocks on a server round-trip, and serial awaits make
+ * the cost the SUM of those round-trips along the whole graph. End-to-end the
+ * `getCfcLabel` IPC p95 ran 0.5–4.2s at 4 concurrent browser profiles.
+ *
+ * The resolution: `getCfcLabel` does NOT sync at all — it is a pure, non-blocking
+ * read of the current store. Its only callers are reactive UI components that
+ * subscribe to the cell and re-read the label on change, so a not-yet-loaded doc
+ * yields an empty label that self-heals when the subscription delivers it. The
+ * caller owns liveness. End-to-end the `getCfcLabel` IPC p95 dropped to <1ms.
+ *
+ * A storage emulator can't reproduce the real cost — it has no network latency
+ * and a single replica holds its own writes, so nothing is ever "cold" or
+ * mid-refresh. This instead models the cost STRUCTURE: each genuine sync is one
+ * awaited round-trip (`ROUND_TRIP_MS`); an already-present doc is a Set lookup.
+ * The strategies then show their true asymptotics, ending at the pure read:
+ *   - serial-await     [old] — SUM of round-trips (one per node).
+ *   - parallel-batch          — ~one round-trip (all coalesced).
+ *   - skip-when-present       — zero round-trips when warm; one batch when cold.
+ *   - pure-read        [new] — no sync at all (caller owns liveness).
+ */
+
+import { sleep } from "@commonfabric/utils/sleep";
+
+// Fan-out of a deeply-nested piece's root meta-graph (root + sub-pattern
+// surfaces + their argument/pattern docs).
+const NODE_COUNT = 32;
+// Representative in-flight watch-refresh round-trip under multi-writer churn.
+// Real measurements showed ~0.4–1.4s; 2ms keeps the bench fast while preserving
+// the serial-sum vs parallel-max vs skip-zero structure.
+const ROUND_TRIP_MS = 2;
+
+type Replica = Set<number>;
+
+// One genuine sync = one awaited round-trip; an already-present node is free.
+const syncNode = async (replica: Replica, node: number): Promise<void> => {
+  if (!replica.has(node)) {
+    await sleep(ROUND_TRIP_MS);
+    replica.add(node);
+  }
+};
+
+const warmReplica = (): Replica =>
+  new Set(Array.from({ length: NODE_COUNT }, (_, index) => index));
+const coldReplica = (): Replica => new Set();
+
+// --- "ensure the whole meta-graph is available" strategies ------------------
+
+const ensureSerial = async (replica: Replica) => {
+  for (let node = 0; node < NODE_COUNT; node++) {
+    // Old syncMetaLinkedDocs: unconditional, serial await per node.
+    await sleep(ROUND_TRIP_MS);
+    replica.add(node);
+  }
+};
+
+const ensureParallel = async (replica: Replica) => {
+  await Promise.all(
+    Array.from({ length: NODE_COUNT }, async (_, node) => {
+      await sleep(ROUND_TRIP_MS);
+      replica.add(node);
+    }),
+  );
+};
+
+const ensureSkipWhenPresent = async (replica: Replica) => {
+  const cold: number[] = [];
+  for (let node = 0; node < NODE_COUNT; node++) {
+    if (!replica.has(node)) cold.push(node);
+  }
+  if (cold.length > 0) {
+    await Promise.all(cold.map((node) => syncNode(replica, node)));
+  }
+};
+
+// The shipped behavior: getCfcLabel never syncs — the reactive caller owns
+// liveness, so the read does no graph work at all.
+const ensurePureRead = (_replica: Replica): void => {};
+
+Deno.bench(
+  "syncMetaLinkedDocs (warm) - serial await per node [old]",
+  { group: "cfc-label-sync-warm", baseline: true },
+  async (b) => {
+    const replica = warmReplica();
+    b.start();
+    await ensureSerial(replica);
+    b.end();
+  },
+);
+
+Deno.bench(
+  "syncMetaLinkedDocs (warm) - parallel batch",
+  { group: "cfc-label-sync-warm" },
+  async (b) => {
+    const replica = warmReplica();
+    b.start();
+    await ensureParallel(replica);
+    b.end();
+  },
+);
+
+Deno.bench(
+  "syncMetaLinkedDocs (warm) - skip when present",
+  { group: "cfc-label-sync-warm" },
+  async (b) => {
+    const replica = warmReplica();
+    b.start();
+    await ensureSkipWhenPresent(replica);
+    b.end();
+  },
+);
+
+Deno.bench(
+  "getCfcLabel (warm) - pure read, no sync [new]",
+  { group: "cfc-label-sync-warm" },
+  async (b) => {
+    const replica = warmReplica();
+    b.start();
+    await ensurePureRead(replica);
+    b.end();
+  },
+);
+
+Deno.bench(
+  "syncMetaLinkedDocs (cold) - serial await per node [old]",
+  { group: "cfc-label-sync-cold", baseline: true },
+  async (b) => {
+    const replica = coldReplica();
+    b.start();
+    await ensureSerial(replica);
+    b.end();
+  },
+);
+
+Deno.bench(
+  "syncMetaLinkedDocs (cold) - skip when present [new]",
+  { group: "cfc-label-sync-cold" },
+  async (b) => {
+    const replica = coldReplica();
+    b.start();
+    await ensureSkipWhenPresent(replica);
+    b.end();
+  },
+);

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -1304,4 +1304,72 @@ describe("CFC label view helpers", () => {
 
     expect(cfcLabelViewForCell(resultCell)).toBeUndefined();
   });
+
+  it("re-fires an includeCfcLabel sink on a label-only write (value unchanged)", async () => {
+    const signer = await Identity.fromPassphrase(
+      "cfc label view sink reactivity",
+    );
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+    try {
+      const cell = runtime.getCell<{ body: string }>(
+        signer.did(),
+        "cfc-label-sink-reactivity",
+      );
+      const id = parseLink(cell.getAsLink()).id!;
+      const writeDoc = (integrityAtom: string) => {
+        const tx = runtime.edit();
+        tx.writeOrThrow({
+          space: signer.did(),
+          id,
+          type: "application/json",
+          path: [],
+        }, {
+          // SAME value both times — only the label changes.
+          value: { body: "unchanging" },
+          cfc: {
+            version: 1,
+            schemaHash: "sink-reactivity",
+            labelMap: {
+              version: 1,
+              entries: [{ path: [], label: { integrity: [integrityAtom] } }],
+            },
+          },
+        });
+        return tx.commit();
+      };
+
+      await writeDoc("authored-by-alice");
+      await runtime.idle();
+
+      const fires: Array<
+        { value: { body: string } | undefined; label: unknown }
+      > = [];
+      const cancel = cell.sink((value, cfcLabel) => {
+        fires.push({ value, label: cfcLabel });
+      }, { includeCfcLabel: true });
+
+      // The label-only write: value identical, integrity atom changed.
+      await writeDoc("authored-by-bob");
+      await runtime.idle();
+      cancel();
+
+      // Fired on subscribe AND again on the label-only write.
+      expect(fires.length).toBeGreaterThanOrEqual(2);
+      // The value never changed across fires — this was purely a label change.
+      for (const fire of fires) {
+        expect(fire.value).toEqual({ body: "unchanging" });
+      }
+      // The first delivered label carried alice, the last carries bob.
+      expect(JSON.stringify(fires[0].label)).toContain("authored-by-alice");
+      expect(JSON.stringify(fires.at(-1)!.label)).toContain("authored-by-bob");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
 });

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -852,7 +852,7 @@ describe("RuntimeProcessor home pattern IPC", () => {
 });
 
 describe("RuntimeProcessor CFC label IPC", () => {
-  it("returns a label view for a cell ref", async () => {
+  it("returns a label view for a cell ref", () => {
     const ref: CellRef = {
       id: "of:cfc-label-cell" as CellRef["id"],
       space: "did:key:test" as CellRef["space"],
@@ -882,17 +882,16 @@ describe("RuntimeProcessor CFC label IPC", () => {
           },
           getAsNormalizedFullLink: () => ref,
           getMetaRaw: () => undefined,
-          sync: () => Promise.resolve(),
         }),
       },
     } as unknown as RuntimeProcessor;
 
-    await expect(
+    expect(
       RuntimeProcessor.prototype.handleCellGetCfcLabel.call(processor, {
         type: RequestType.CellGetCfcLabel,
         cell: ref,
       }),
-    ).resolves.toEqual({
+    ).toEqual({
       cfcLabel: {
         version: 1,
         entries: [{
@@ -1022,7 +1021,7 @@ describe("RuntimeProcessor CFC label IPC", () => {
     });
   });
 
-  it("does not look up CFC labels from a result meta cell", async () => {
+  it("does not look up CFC labels from a result meta cell", () => {
     const resultRef: CellRef = {
       id: "of:cfc-label-result" as CellRef["id"],
       space: "did:key:test" as CellRef["space"],
@@ -1084,97 +1083,65 @@ describe("RuntimeProcessor CFC label IPC", () => {
     };
     const processor = { runtime } as unknown as RuntimeProcessor;
 
-    await expect(Promise.resolve(
+    expect(
       RuntimeProcessor.prototype.handleCellGetCfcLabel.call(processor, {
         type: RequestType.CellGetCfcLabel,
         cell: resultRef,
       }),
-    )).resolves.toEqual({
+    ).toEqual({
       cfcLabel: undefined,
     });
-    expect(resultSynced).toBe(true);
+    // getCfcLabel is a pure read: it never syncs (the reactive caller owns
+    // liveness), and it reads only the cell's OWN stored label — it does not
+    // follow the "result" meta link to pull CFC from a source/meta cell.
+    expect(resultSynced).toBe(false);
     expect(sourceSynced).toBe(false);
   });
 
-  it("syncs pattern and argument metadata links before reading labels", async () => {
-    const resultRef: CellRef = {
-      id: "of:cfc-label-sync-result" as CellRef["id"],
+  it("reads the cell's own stored label without syncing (caller owns liveness)", () => {
+    const ref: CellRef = {
+      id: "of:cfc-label-pure-read" as CellRef["id"],
       space: "did:key:test" as CellRef["space"],
       scope: "space",
       path: [],
     };
-    const patternRef: CellRef = {
-      id: "of:cfc-label-sync-pattern" as CellRef["id"],
-      space: "did:key:test" as CellRef["space"],
-      scope: "space",
-      path: [],
-    };
-    const argumentRef: CellRef = {
-      id: "of:cfc-label-sync-argument" as CellRef["id"],
-      space: "did:key:test" as CellRef["space"],
-      scope: "space",
-      path: [],
-    };
-    const syncLog: string[] = [];
-    const cells = new Map<string, unknown>();
-    const runtime = {
-      getCellFromLink: (link: CellRef) => cells.get(link.id),
-      readTx: () => {
-        return {
+    let synced = false;
+    const cell = {
+      runtime: {
+        readTx: () => ({
           readOrThrow: () => ({
-            version: 1,
-            schemaHash: "test-schema",
-            labelMap: {
+            value: "labelled data",
+            cfc: {
               version: 1,
-              entries: [{
-                path: [],
-                label: { confidentiality: ["result-label"] },
-              }],
+              schemaHash: "test-schema",
+              labelMap: {
+                version: 1,
+                entries: [{
+                  path: [],
+                  label: { confidentiality: ["result-label"] },
+                }],
+              },
             },
           }),
-        };
+        }),
+      },
+      getAsNormalizedFullLink: () => ref,
+      getMetaRaw: () => undefined,
+      sync: () => {
+        synced = true;
+        return Promise.resolve();
       },
     };
-    const makeCell = (
-      name: string,
-      ref: CellRef,
-      links: Partial<Record<"pattern" | "argument", CellRef>> = {},
-    ) => {
-      let synced = false;
-      return {
-        ...ref,
-        sourceURI: `${ref.space}/${ref.scope}/${ref.id}`,
-        runtime,
-        getAsNormalizedFullLink: () => ref,
-        getMetaRaw: (metaField: "pattern" | "argument") => {
-          return synced && links[metaField] !== undefined
-            ? cellRefToSigilLink(links[metaField]!)
-            : undefined;
-        },
-        sync: () => {
-          synced = true;
-          syncLog.push(name);
-          return Promise.resolve();
-        },
-      };
-    };
-    cells.set(
-      resultRef.id,
-      makeCell("result", resultRef, {
-        pattern: patternRef,
-        argument: argumentRef,
-      }),
-    );
-    cells.set(patternRef.id, makeCell("pattern", patternRef));
-    cells.set(argumentRef.id, makeCell("argument", argumentRef));
-    const processor = { runtime } as unknown as RuntimeProcessor;
+    const processor = {
+      runtime: { getCellFromLink: () => cell },
+    } as unknown as RuntimeProcessor;
 
-    await expect(
+    expect(
       RuntimeProcessor.prototype.handleCellGetCfcLabel.call(processor, {
         type: RequestType.CellGetCfcLabel,
-        cell: resultRef,
+        cell: ref,
       }),
-    ).resolves.toEqual({
+    ).toEqual({
       cfcLabel: {
         version: 1,
         entries: [{
@@ -1183,81 +1150,10 @@ describe("RuntimeProcessor CFC label IPC", () => {
         }],
       },
     });
-
-    expect(syncLog).toEqual([
-      "result",
-      "pattern",
-      "argument",
-      "result",
-    ]);
-  });
-
-  it("does not loop when metadata links form a cycle", async () => {
-    const resultRef: CellRef = {
-      id: "of:cfc-label-cycle-result" as CellRef["id"],
-      space: "did:key:test" as CellRef["space"],
-      scope: "space",
-      path: [],
-    };
-    const patternRef: CellRef = {
-      id: "of:cfc-label-cycle-pattern" as CellRef["id"],
-      space: "did:key:test" as CellRef["space"],
-      scope: "space",
-      path: [],
-    };
-    const syncLog: string[] = [];
-    const cells = new Map<string, unknown>();
-    const runtime = {
-      getCellFromLink: (link: CellRef) => cells.get(link.id),
-      readTx: () => ({
-        readOrThrow: () => undefined,
-      }),
-    };
-    const makeCell = (
-      name: string,
-      ref: CellRef,
-      links: Partial<Record<"pattern" | "argument", CellRef>> = {},
-    ) => {
-      let synced = false;
-      return {
-        ...ref,
-        sourceURI: `${ref.space}/${ref.scope}/${ref.id}`,
-        runtime,
-        getAsNormalizedFullLink: () => ref,
-        getMetaRaw: (metaField: "pattern" | "argument") => {
-          return synced && links[metaField] !== undefined
-            ? cellRefToSigilLink(links[metaField]!)
-            : undefined;
-        },
-        sync: () => {
-          synced = true;
-          syncLog.push(name);
-          return Promise.resolve();
-        },
-      };
-    };
-    cells.set(
-      resultRef.id,
-      makeCell("result", resultRef, {
-        pattern: patternRef,
-      }),
-    );
-    cells.set(
-      patternRef.id,
-      makeCell("pattern", patternRef, {
-        argument: resultRef,
-      }),
-    );
-    const processor = { runtime } as unknown as RuntimeProcessor;
-
-    await expect(
-      RuntimeProcessor.prototype.handleCellGetCfcLabel.call(processor, {
-        type: RequestType.CellGetCfcLabel,
-        cell: resultRef,
-      }),
-    ).resolves.toEqual({ cfcLabel: undefined });
-
-    expect(syncLog).toEqual(["result", "pattern", "result"]);
+    // No sync: the label is read from the current store. A not-yet-loaded doc
+    // would yield an empty label that self-heals when the reactive caller's
+    // subscription delivers it.
+    expect(synced).toBe(false);
   });
 
   it("ignores schema-bearing anyOf refs when reading nested stored labels", async () => {

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -5,6 +5,7 @@ import { JsonEncodingContext } from "@commonfabric/data-model/codec-json";
 import { PieceManager } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
 import {
+  getLogger,
   getLoggerCountsBreakdown,
   getLoggerFlagsBreakdown,
   getTimingStatsBreakdown,
@@ -131,6 +132,13 @@ import type { JSONValue, RuntimeOptions } from "@commonfabric/runner";
 
 const MAX_SERIALIZATION_DEPTH = 5;
 const blobUploadEncoding = new JsonEncodingContext();
+
+// Split-timing for the CFC label IPC path. Counts/timing are readable via
+// getLoggerCounts(); enabled silently so the hot path pays only the timestamp.
+const cfcLabelLogger = getLogger("runtime-client.cfc-label", {
+  enabled: true,
+  level: "error",
+});
 
 function resolveBlobUrl(url: string, apiUrl: URL, space: DID): string {
   const spaceBaseUrl = new URL(`/${space}/`, apiUrl);
@@ -746,31 +754,33 @@ export class RuntimeProcessor {
     };
   }
 
-  async handleCellGetCfcLabel(
+  handleCellGetCfcLabel(
     request: CellGetCfcLabelRequest,
-  ): Promise<CfcLabelViewResponse> {
+  ): CfcLabelViewResponse {
     // Label reads must use the runtime's stored cell identity. The request
     // schema is client-supplied view context, not trusted label provenance.
     const { schema: _schema, ...cellRef } = request.cell;
     const cell = getCell(this.runtime, cellRef);
-    const rootCell = this.runtime.getCellFromLink({
-      ...cell.getAsNormalizedFullLink(),
-      path: [],
-    });
-    await syncMetaLinkedDocs(rootCell);
-    await cell.sync();
-    // `getCfcLabel()` is the pattern-facing INTROSPECTION surface: the response
-    // is returned to the caller, not round-tripped back into a cell. Redact
-    // `Caveat.source` identities here so a pattern can't learn which principal
-    // introduced a caveat (audit item 28b, inv-12). Observation labeling, the
-    // dereference-trace enforcement path, and the carried-label view all read
-    // the label through other seams and keep `source`.
+    // Pure, non-blocking read of the CURRENT local store — no sync. getCfcLabel
+    // is the display-label seam, and its only callers are reactive UI components
+    // (cf-cfc-label, cf-cfc-authorship, cf-profile-badge) that subscribe to the
+    // cell and re-read the label whenever it changes. They own liveness: a
+    // not-yet-loaded doc is also not rendered, so an empty label is the correct
+    // deferred answer and self-heals when the subscription delivers the doc
+    // (which carries its `cfc` metadata). The earlier per-call source-chain sync
+    // re-loaded already-present docs and, under multi-writer churn, blocked on
+    // in-flight watch refreshes — ~99.97% of this IPC's cost, p95 >1s at 4
+    // browsers. The enforcement path reads labels through other seams; here we
+    // only redact `Caveat.source` for display (audit item 28b, inv-12).
+    const totalStart = performance.now();
     const cfcLabel = cfcLabelViewForCell(cell);
-    return {
+    const response = {
       cfcLabel: cfcLabel === undefined
         ? undefined
         : redactCaveatSourcesForDisplay(cfcLabel),
     };
+    cfcLabelLogger.time(totalStart, "total");
+    return response;
   }
 
   handleGetCell(request: GetCellRequest): CellResponse {
@@ -1445,32 +1455,5 @@ export class RuntimeProcessor {
       return;
     }
     mount.reconciler.acknowledgeBatchApplied(request.batchId);
-  }
-}
-
-/**
- * Sync a root cell and each direct metadata-linked cell reachable from it.
- *
- * `internal` is raw manifest metadata, not a direct metadata link. Callers that
- * need a transactional root cell can create it first and pass it.
- */
-async function syncMetaLinkedDocs(
-  cell: Cell<any>,
-  cycleCheck: Set<string> = new Set<string>(),
-) {
-  const pendingCells = [cell];
-  cycleCheck.add(cell.sourceURI);
-  while (pendingCells.length > 0) {
-    const currentCell = pendingCells.shift()!;
-    await currentCell.sync();
-    for (const meta of ["pattern", "argument"] as const) {
-      const link = getMetaLink(currentCell, meta);
-      if (link === undefined) continue;
-      const linkedCell = currentCell.runtime.getCellFromLink(link, undefined);
-      if (linkedCell === undefined) continue;
-      if (cycleCheck.has(linkedCell.sourceURI)) continue;
-      cycleCheck.add(linkedCell.sourceURI);
-      pendingCells.push(linkedCell);
-    }
   }
 }

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -42,6 +42,7 @@ import {
   BooleanResponse,
   type CellGetCfcLabelRequest,
   type CellGetRequest,
+  type CellGetResponse,
   type CellResolveAsCellRequest,
   CellResponse,
   type CellSendRequest,
@@ -65,7 +66,6 @@ import {
   GraphSnapshotResponse,
   type InitializationData,
   IPCClientRequest,
-  JSONValueResponse,
   type LoggerCountsResponse,
   type LoggerMetadata,
   type LogLevel,
@@ -635,7 +635,7 @@ export class RuntimeProcessor {
 
   handleCellGet(
     request: CellGetRequest,
-  ): JSONValueResponse {
+  ): CellGetResponse {
     let cell = getCell(this.runtime, request.cell);
     if (request.meta !== undefined) {
       const rootCell = getCell(this.runtime, { ...request.cell, path: [] });
@@ -665,7 +665,18 @@ export class RuntimeProcessor {
       doNotConvertCellResults: true,
       includeCfcLabelView: true,
     });
-    return { value: converted };
+    if (!request.includeCfcLabel) {
+      return { value: converted };
+    }
+    // Same display-label read as handleCellGetCfcLabel: pure store read, then
+    // redact Caveat.source for display (audit 28b). One round-trip for both.
+    const cfcLabel = cfcLabelViewForCell(cell);
+    return {
+      value: converted,
+      cfcLabel: cfcLabel === undefined
+        ? undefined
+        : redactCaveatSourcesForDisplay(cfcLabel),
+    };
   }
 
   handleCellSet(request: CellSetRequest): void {
@@ -698,7 +709,7 @@ export class RuntimeProcessor {
 
     const cell = getCell(this.runtime, request.cell);
 
-    const cancel = cell.sink((value) => {
+    const cancel = cell.sink((value, cfcLabel) => {
       // Log empty-schema subscriptions that produce CellResult proxies.
       // These are the call sites that need real schemas added.
       const hasSchema = hasExplicitSubscriptionSchema(request.cell.schema);
@@ -718,6 +729,13 @@ export class RuntimeProcessor {
         doNotConvertCellResults: true,
         includeCfcLabelView: true,
       });
+      // The sink read the raw label on its tracked tx (so cfc writes re-fire
+      // it); redact Caveat.source here before it crosses to the main thread.
+      const redactedLabel = request.includeCfcLabel
+        ? (cfcLabel === undefined
+          ? undefined
+          : redactCaveatSourcesForDisplay(cfcLabel))
+        : undefined;
 
       // `.sink` fires synchronously on invocation. Trigger the notification
       // in a microtask so that the subscription response returns
@@ -727,9 +745,10 @@ export class RuntimeProcessor {
           type: NotificationType.CellUpdate,
           cell: request.cell,
           value: converted,
+          ...(request.includeCfcLabel ? { cfcLabel: redactedLabel } : {}),
         })
       );
-    });
+    }, { includeCfcLabel: request.includeCfcLabel === true });
 
     this.subscriptions.set(key, cancel);
     return { value: true };

--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -243,3 +243,80 @@ describe("CellHandle CFC label IPC", () => {
     }]);
   });
 });
+
+describe("CellHandle reactive CFC label delivery", () => {
+  const makeRuntime = () =>
+    ({
+      [$conn]: () => ({
+        request: () => Promise.resolve({ value: undefined }),
+        subscribe: () => Promise.resolve(),
+        unsubscribe: () => Promise.resolve(),
+      }),
+    }) as unknown as RuntimeClient;
+  const ref: CellRef = {
+    id: "of:reactive-label-cell" as CellRef["id"],
+    space: "did:key:test" as CellRef["space"],
+    scope: "space",
+    path: [],
+  };
+  const labelA = {
+    version: 1 as const,
+    entries: [{ path: [], label: { integrity: ["authored-by-alice"] } }],
+  };
+  const labelB = {
+    version: 1 as const,
+    entries: [{ path: [], label: { integrity: ["authored-by-bob"] } }],
+  };
+
+  it("delivers the label and re-fires a label-aware subscriber on a label-only change", () => {
+    const cell = new CellHandle<string>(makeRuntime(), ref);
+    const calls: Array<[string | undefined, unknown]> = [];
+    cell.subscribe((value, cfcLabel) => {
+      calls.push([value, cfcLabel]);
+    }, { includeCfcLabel: true });
+
+    // Immediate call on subscribe with the current (empty) state.
+    expect(calls).toEqual([[undefined, undefined]]);
+
+    cell[$onCellUpdate]("v1", { cfcLabel: labelA });
+    expect(calls.at(-1)).toEqual(["v1", labelA]);
+    expect(cell.cfcLabel).toEqual(labelA);
+
+    // Same VALUE, different LABEL → still fires (the reactivity that value
+    // subscriptions miss).
+    cell[$onCellUpdate]("v1", { cfcLabel: labelB });
+    expect(calls.at(-1)).toEqual(["v1", labelB]);
+    expect(cell.cfcLabel).toEqual(labelB);
+
+    // Same value AND same label → deduped, no extra call.
+    const before = calls.length;
+    cell[$onCellUpdate]("v1", { cfcLabel: labelB });
+    expect(calls.length).toBe(before);
+  });
+
+  it("does not fire a non-label subscriber on a label-only change", () => {
+    const cell = new CellHandle<string>(makeRuntime(), ref);
+    const calls: Array<string | undefined> = [];
+    cell.subscribe((value) => {
+      calls.push(value);
+    }); // no includeCfcLabel
+
+    expect(cell.wantsCfcLabel).toBe(false);
+    cell[$onCellUpdate]("v1", { cfcLabel: labelA });
+    const afterValue = calls.length; // fired once for the value change
+    // Label-only change must be invisible to a value-only subscriber.
+    cell[$onCellUpdate]("v1", { cfcLabel: labelB });
+    expect(calls.length).toBe(afterValue);
+  });
+
+  it("a value-only notification leaves the cached label untouched", () => {
+    const cell = new CellHandle<string>(makeRuntime(), ref);
+    cell.subscribe(() => {}, { includeCfcLabel: true });
+    cell[$onCellUpdate]("v1", { cfcLabel: labelA });
+    expect(cell.cfcLabel).toEqual(labelA);
+    // No `labelUpdate` arg = value-only update; label stays.
+    cell[$onCellUpdate]("v2");
+    expect(cell.get()).toBe("v2");
+    expect(cell.cfcLabel).toEqual(labelA);
+  });
+});

--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -319,4 +319,33 @@ describe("CellHandle reactive CFC label delivery", () => {
     expect(cell.get()).toBe("v2");
     expect(cell.cfcLabel).toEqual(labelA);
   });
+
+  it("re-establishes the backend subscription when a label-aware subscriber is added later", async () => {
+    const events: string[] = [];
+    const runtime = {
+      [$conn]: () => ({
+        request: () => Promise.resolve({ value: undefined }),
+        subscribe: () => {
+          events.push("subscribe");
+          return Promise.resolve();
+        },
+        unsubscribe: () => {
+          events.push("unsubscribe");
+          return Promise.resolve();
+        },
+      }),
+    } as unknown as RuntimeClient;
+    const cell = new CellHandle<string>(runtime, ref);
+
+    cell.subscribe(() => {}); // value-only first
+    expect(cell.wantsCfcLabel).toBe(false);
+    expect(events).toEqual(["subscribe"]);
+
+    // A label-aware subscription on the SAME handle re-opens the backend sub so
+    // it carries labels (the old one was label-less and would be deduped away).
+    cell.subscribe(() => {}, { includeCfcLabel: true });
+    expect(cell.wantsCfcLabel).toBe(true);
+    await Promise.resolve(); // let the unsubscribe().finally(subscribe) settle
+    expect(events).toEqual(["subscribe", "unsubscribe", "subscribe"]);
+  });
 });

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -42,7 +42,14 @@ export class CellHandle<T = unknown> {
   #conn: InitializedRuntimeConnection;
   #ref: CellRef;
   #value: T | undefined;
-  #callbacks = new Map<number, (value: Readonly<T>) => void>();
+  #cfcLabel: CfcLabelView | undefined;
+  // Whether any subscriber asked for the CFC label. Sticky: once a label-aware
+  // subscription exists on this handle, label changes also fire its callbacks.
+  #wantsCfcLabel = false;
+  #callbacks = new Map<
+    number,
+    (value: Readonly<T>, cfcLabel: CfcLabelView | undefined) => void
+  >();
   #nextCallbackId = 0;
   #schemaWarned = false;
 
@@ -109,7 +116,8 @@ export class CellHandle<T = unknown> {
 
     for (const callback of this.#callbacks.values()) {
       try {
-        callback(value as Readonly<T>);
+        // Optimistic local set doesn't change the label; carry the current one.
+        callback(value as Readonly<T>, this.#cfcLabel);
       } catch (error) {
         console.error("[CellHandle] Callback error:", error);
       }
@@ -176,14 +184,34 @@ export class CellHandle<T = unknown> {
    * and whenever the value changes.
    * The callback's return value (if a Cancel function) is called before the next update.
    */
+  /** The cell's current display CFC label, for label-aware subscribers. */
+  get cfcLabel(): CfcLabelView | undefined {
+    return this.#cfcLabel;
+  }
+
+  /** Whether this handle subscribed asking for reactive CFC-label delivery. */
+  get wantsCfcLabel(): boolean {
+    return this.#wantsCfcLabel;
+  }
+
   subscribe(
-    callback: (value: T | undefined) => Cancel | undefined | void,
+    callback: (
+      value: T | undefined,
+      cfcLabel?: CfcLabelView | undefined,
+    ) => Cancel | undefined | void,
+    options: { includeCfcLabel?: boolean } = {},
   ): Cancel {
     this.#requireSchema("subscribe");
+    if (options.includeCfcLabel) {
+      this.#wantsCfcLabel = true;
+    }
     const callbackId = this.#nextCallbackId++;
     let cleanup: Cancel | undefined | void;
 
-    const wrappedCallback = (value: T | undefined) => {
+    const wrappedCallback = (
+      value: T | undefined,
+      cfcLabel: CfcLabelView | undefined,
+    ) => {
       if (typeof cleanup === "function") {
         try {
           cleanup();
@@ -193,7 +221,7 @@ export class CellHandle<T = unknown> {
       }
       cleanup = undefined;
       try {
-        cleanup = callback(value);
+        cleanup = callback(value, cfcLabel);
       } catch (error) {
         console.error("[CellHandle] Callback error:", error);
       }
@@ -204,7 +232,7 @@ export class CellHandle<T = unknown> {
 
     // Always call callback immediately with current value
     // This matches Cell behavior - callback is always called, even if value is undefined
-    wrappedCallback(this.#value);
+    wrappedCallback(this.#value, this.#cfcLabel);
 
     return () => {
       if (typeof cleanup === "function") {
@@ -317,19 +345,29 @@ export class CellHandle<T = unknown> {
 
   // Called when cell has been updated from the backend with
   // a raw value that may contain CellRefs.
-  [$onCellUpdate](value: unknown): void {
+  [$onCellUpdate](
+    value: unknown,
+    labelUpdate?: { cfcLabel: CfcLabelView | undefined },
+  ): void {
     const applied = applyValue(
       value,
       this.#value,
       this as CellHandle<unknown>,
     ) as T;
-    if (valuesEqual(applied, this.#value)) {
+    const valueChanged = !valuesEqual(applied, this.#value);
+    // A label-only change (value identical) still fires label-aware subscribers.
+    // `labelUpdate` is present only on notifications that carried a label, so a
+    // value-only notification never spuriously churns the label.
+    const labelChanged = labelUpdate !== undefined && this.#wantsCfcLabel &&
+      !cfcLabelViewsEqual(labelUpdate.cfcLabel, this.#cfcLabel);
+    if (!valueChanged && !labelChanged) {
       return;
     }
 
-    this.#value = applied;
+    if (valueChanged) this.#value = applied;
+    if (labelUpdate !== undefined) this.#cfcLabel = labelUpdate.cfcLabel;
     for (const callback of this.#callbacks.values()) {
-      callback(this.#value);
+      callback(this.#value as Readonly<T>, this.#cfcLabel);
     }
   }
 

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -202,6 +202,14 @@ export class CellHandle<T = unknown> {
     options: { includeCfcLabel?: boolean } = {},
   ): Cancel {
     this.#requireSchema("subscribe");
+    // If a label-aware subscription is added AFTER a value-only one already
+    // opened the backend subscription, that backend sub carries no label and
+    // the connection would dedup this one away. Re-establish it so it delivers
+    // labels (the worker recreates its sink with includeCfcLabel). This works
+    // when this handle is the sole subscriber of its ref; a value-only handle
+    // sharing the exact same ref would keep the backend sub label-less.
+    const upgradeToCfcLabel = options.includeCfcLabel === true &&
+      !this.#wantsCfcLabel && this.#callbacks.size > 0;
     if (options.includeCfcLabel) {
       this.#wantsCfcLabel = true;
     }
@@ -228,7 +236,14 @@ export class CellHandle<T = unknown> {
     };
 
     this.#callbacks.set(callbackId, wrappedCallback);
-    this.#conn.subscribe(this);
+    if (upgradeToCfcLabel) {
+      // Tear down the label-less backend sub, then re-open it label-aware.
+      void this.#conn.unsubscribe(this).finally(() => {
+        this.#conn.subscribe(this);
+      });
+    } else {
+      this.#conn.subscribe(this);
+    }
 
     // Always call callback immediately with current value
     // This matches Cell behavior - callback is always called, even if value is undefined

--- a/packages/runtime-client/client/connection.ts
+++ b/packages/runtime-client/client/connection.ts
@@ -159,13 +159,15 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
       if (!instances.has(cell)) {
         this.#recordSubscriptionDiagnostic(key, "localSubscribes");
         instances.add(cell);
-        // Copy the cached value from an existing subscriber to the new one
-        // This ensures late subscribers get the initial value
+        // Copy the cached value (and label) from an existing subscriber to the
+        // new one so late subscribers get the initial value.
         const existingInstance = instances.values().next().value;
         if (existingInstance) {
           const cachedValue = existingInstance.get();
           if (cachedValue !== undefined) {
-            cell[$onCellUpdate](cachedValue);
+            cell[$onCellUpdate](cachedValue, {
+              cfcLabel: existingInstance.cfcLabel,
+            });
           }
         }
       }
@@ -178,6 +180,10 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
     const _ = await this.request<RequestType.CellSubscribe>({
       type: RequestType.CellSubscribe,
       cell: cell.ref(),
+      // First subscriber to a ref key decides label delivery for that backend
+      // subscription (the worker dedups by ref key too). Label-displaying
+      // callers create dedicated handles, so they are that first subscriber.
+      ...(cell.wantsCfcLabel ? { includeCfcLabel: true } : {}),
     }).catch((error) => {
       if (!isRuntimeDisposedError(error)) {
         console.error("[RuntimeClient] Subscription failed:", error);
@@ -347,10 +353,17 @@ export class RuntimeConnection extends EventEmitter<RuntimeConnectionEvents> {
       return;
     }
 
+    // Field presence (not value) signals a label-aware notification, so a
+    // label of `undefined` is still delivered and a value-only update never
+    // touches the cached label.
+    const labelUpdate = "cfcLabel" in message
+      ? { cfcLabel: message.cfcLabel }
+      : undefined;
+
     const subscribed = this.#subscribed.get(cellRefToKey(cellRef));
     if (subscribed && subscribed.size > 0) {
       for (const instance of subscribed) {
-        instance[$onCellUpdate](value);
+        instance[$onCellUpdate](value, labelUpdate);
       }
     }
   }

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -185,6 +185,10 @@ export interface CellGetRequest extends BaseRequest {
   type: RequestType.CellGet;
   cell: CellRef;
   meta?: MetaField;
+  // Opt in to having the cell's display CFC label returned alongside the value,
+  // so a caller that needs both pays one round-trip instead of a separate
+  // CellGetCfcLabel request.
+  includeCfcLabel?: boolean;
 }
 
 export interface CellSetRequest extends BaseRequest {
@@ -202,6 +206,11 @@ export interface CellSendRequest extends BaseRequest {
 export interface CellSubscribeRequest extends BaseRequest {
   type: RequestType.CellSubscribe;
   cell: CellRef;
+  // Opt in to reactive CFC-label delivery: each CellUpdate then carries the
+  // cell's current display label, and the worker reads that label as a tracked
+  // dependency of the sink, so a label-only write (value unchanged) re-fires
+  // the subscription. Off by default — only label-displaying callers pay it.
+  includeCfcLabel?: boolean;
 }
 
 export interface CellUnsubscribeRequest extends BaseRequest {
@@ -705,6 +714,12 @@ export interface JSONValueResponse {
   value: JSONValue | undefined;
 }
 
+export interface CellGetResponse extends JSONValueResponse {
+  // Present only when the request set `includeCfcLabel`. `undefined` is a valid
+  // value (the cell carries no label); the field is omitted when not requested.
+  cfcLabel?: CfcLabelView | undefined;
+}
+
 export interface CellResponse {
   cell: CellRef;
 }
@@ -736,6 +751,10 @@ export interface CellUpdateNotification {
   type: NotificationType.CellUpdate;
   cell: CellRef;
   value: JSONValue;
+  // Present only for subscriptions that opted in via `includeCfcLabel`. Carries
+  // the cell's current display label so the client re-renders on label changes
+  // without a separate getCfcLabel round-trip.
+  cfcLabel?: CfcLabelView | undefined;
 }
 
 export interface ConsoleNotification {
@@ -812,6 +831,7 @@ export type RemoteResponse =
   | NullResponse
   | BooleanResponse
   | JSONValueResponse
+  | CellGetResponse
   | CellResponse
   | CfcLabelViewResponse
   | GraphSnapshotResponse
@@ -928,7 +948,7 @@ export type Commands = {
   // Cell requests
   [RequestType.CellGet]: {
     request: CellGetRequest;
-    response: JSONValueResponse;
+    response: CellGetResponse;
   };
   [RequestType.CellSet]: {
     request: CellSetRequest;

--- a/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.test.ts
+++ b/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.test.ts
@@ -122,6 +122,48 @@ describe("CFCFCAuthorship", () => {
     expect(element.authorshipState).toBe("verified");
   });
 
+  it("retries the resolved cell label until its cold doc loads", async () => {
+    // getCfcLabel is a pure, non-blocking store read, so a resolved cell whose
+    // doc hasn't loaded yet returns nothing. This component does not subscribe
+    // to the internally-resolved cell, so it must poll until the label lands —
+    // otherwise a cold linked/bound-prop author stays unverified forever.
+    const cfcLabel = {
+      version: 1 as const,
+      entries: [{
+        path: [],
+        label: { integrity: [{ kind: "authored-by", subject: "alice" }] },
+      }],
+    };
+    let labelAvailable = false;
+    const element = new CFCFCAuthorship();
+    Object.defineProperty(element, "isConnected", {
+      value: true,
+      configurable: true,
+    });
+
+    try {
+      element.author = "alice";
+      element.value = {
+        getCfcLabel: () => Promise.resolve(undefined),
+        resolveAsCell: () =>
+          Promise.resolve({
+            getCfcLabel: () =>
+              Promise.resolve(labelAvailable ? cfcLabel : undefined),
+          }),
+      };
+
+      await element.refreshLabel();
+      expect(element.authorshipState).not.toBe("verified");
+
+      labelAvailable = true;
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(element.authorshipState).toBe("verified");
+    } finally {
+      element.disconnectedCallback();
+    }
+  });
+
   it("uses resolved root authorship when the direct label only has nested entries", async () => {
     const directLabel = {
       version: 1 as const,

--- a/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.ts
+++ b/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.ts
@@ -14,7 +14,10 @@ type CfcLabelResolvableValue = {
 };
 
 type CfcLabelSubscribableValue = {
-  subscribe(callback: (value: unknown) => void): () => void;
+  subscribe(
+    callback: (value: unknown, cfcLabel?: CfcLabelView | undefined) => void,
+    options?: { includeCfcLabel?: boolean },
+  ): () => void;
 };
 
 type CfcReadableClaimValue = {
@@ -673,9 +676,13 @@ export class CFCFCAuthorship extends BaseElement {
       return false;
     }
 
+    // includeCfcLabel makes the worker read this cell's label (and its
+    // one-hop link target's) on the sink's tracked tx, so a label-only change
+    // re-fires this subscription and refreshLabel re-reads the new label — the
+    // resolved-cell label is now reactive, not just polled.
     this._unsubscribeValue = value.subscribe(() => {
       void this.refreshLabel();
-    });
+    }, { includeCfcLabel: true });
     return true;
   }
 
@@ -707,7 +714,7 @@ export class CFCFCAuthorship extends BaseElement {
       const previous = this._authorClaim;
       this._authorClaim = claim;
       this.requestUpdate("author", previous);
-    });
+    }, { includeCfcLabel: true });
     return true;
   }
 

--- a/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.ts
+++ b/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.ts
@@ -24,6 +24,11 @@ type CfcReadableClaimValue = {
 };
 
 const DEFAULT_AUTHORSHIP_KIND = "authored-by";
+// Poll cadence for re-reading a label whose resolved cell wasn't loaded yet.
+// Mirrors cf-cfc-label's retry-on-undefined; bounded so a resolved cell that
+// genuinely never carries a label stops retrying.
+const LABEL_RETRY_INTERVAL_MS = 100;
+const MAX_LABEL_RETRY_COUNT = 100;
 const AUTHOR_FIELDS = [
   "subject",
   "author",
@@ -166,10 +171,23 @@ const readClaimValue = async (
   return undefined;
 };
 
+interface LabelViewResult {
+  readonly view: CfcLabelView | undefined;
+  /**
+   * True when the fallback `resolveAsCell()` path read a resolved cell's label
+   * and got nothing back. `getCfcLabel` is a pure, non-blocking store read, so
+   * an empty result means the resolved cell's doc is not loaded yet. This
+   * component subscribes to `value`/`author`, NOT to that internally-resolved
+   * cell, so its load would not re-trigger this read — the caller retries until
+   * it lands (same liveness contract cf-cfc-label gets from its undefined-retry).
+   */
+  readonly pendingResolution: boolean;
+}
+
 const readLabelView = async (
   value: unknown,
   requiredRootIntegrityKind?: string,
-): Promise<CfcLabelView | undefined> => {
+): Promise<LabelViewResult> => {
   let direct: CfcLabelView | undefined;
   if (hasLabelQuery(value)) {
     direct = await value.getCfcLabel();
@@ -179,18 +197,20 @@ const readLabelView = async (
     direct !== undefined && requiredRootIntegrityKind !== undefined &&
     labelHasRootIntegrityKind(direct, requiredRootIntegrityKind)
   ) {
-    return direct;
+    return { view: direct, pendingResolution: false };
   }
 
   let resolvedLabel: CfcLabelView | undefined;
+  let pendingResolution = false;
   if (hasLabelResolution(value)) {
     const resolved = await value.resolveAsCell();
     if (hasLabelQuery(resolved)) {
       resolvedLabel = await resolved.getCfcLabel();
+      pendingResolution = resolvedLabel === undefined;
     }
   }
 
-  return mergeLabelViews(direct, resolvedLabel);
+  return { view: mergeLabelViews(direct, resolvedLabel), pendingResolution };
 };
 
 const primitiveToString = (value: unknown): string | undefined => {
@@ -544,6 +564,10 @@ export class CFCFCAuthorship extends BaseElement {
   private _observedAuthor: unknown = undefined;
   private _unsubscribeValue: (() => void) | undefined;
   private _unsubscribeAuthor: (() => void) | undefined;
+  private _labelRetryTimeout: ReturnType<typeof setTimeout> | undefined;
+  private _labelRetryCount = 0;
+  private _valueResolutionPending = false;
+  private _authorResolutionPending = false;
 
   constructor() {
     super();
@@ -611,6 +635,7 @@ export class CFCFCAuthorship extends BaseElement {
   override disconnectedCallback() {
     this.clearValueSubscription();
     this.clearAuthorSubscription();
+    this.clearLabelRetry();
     super.disconnectedCallback();
   }
 
@@ -641,6 +666,8 @@ export class CFCFCAuthorship extends BaseElement {
 
     this.clearValueSubscription();
     this._observedValue = value;
+    // New value → fresh retry budget for its (possibly cold) resolved label.
+    this._labelRetryCount = 0;
 
     if (!hasLabelSubscription(value)) {
       return false;
@@ -665,6 +692,8 @@ export class CFCFCAuthorship extends BaseElement {
 
     this.clearAuthorSubscription();
     this._observedAuthor = author;
+    // New author → fresh retry budget for its (possibly cold) resolved label.
+    this._labelRetryCount = 0;
 
     if (!hasLabelSubscription(author)) {
       return false;
@@ -690,14 +719,16 @@ export class CFCFCAuthorship extends BaseElement {
 
   async refreshLabel(): Promise<void> {
     const requestId = ++this._labelRequestId;
-    const cfcLabel = await readLabelView(
+    const { view, pendingResolution } = await readLabelView(
       this.value,
       this.kind ?? DEFAULT_AUTHORSHIP_KIND,
     );
     if (requestId === this._labelRequestId) {
       const previous = this.cfcLabel;
-      this.cfcLabel = cfcLabel;
+      this.cfcLabel = view;
       this.requestUpdate("cfcLabel", previous);
+      this._valueResolutionPending = pendingResolution;
+      this.reconcileLabelRetry();
     }
   }
 
@@ -712,16 +743,20 @@ export class CFCFCAuthorship extends BaseElement {
       const previous = this._authorClaim;
       this._authorClaim = undefined;
       this.requestUpdate("author", previous);
+      this._authorResolutionPending = false;
+      this.reconcileLabelRetry();
       return;
     }
 
     let authorClaim: unknown;
+    let pendingResolution = false;
     try {
       const valueClaim = canReadAuthor
         ? await readClaimValue(author)
         : undefined;
-      const profileLabel = await readLabelView(author, "represents-principal");
-      const profileSubject = representsPrincipalSubjectForLabel(profileLabel);
+      const profile = await readLabelView(author, "represents-principal");
+      pendingResolution = profile.pendingResolution;
+      const profileSubject = representsPrincipalSubjectForLabel(profile.view);
       authorClaim = principalAuthorClaim(
         profileSubject,
         authorDisplayName(valueClaim) ?? primitiveToString(this.authorName),
@@ -734,6 +769,46 @@ export class CFCFCAuthorship extends BaseElement {
       const previous = this._authorClaim;
       this._authorClaim = authorClaim;
       this.requestUpdate("author", previous);
+      this._authorResolutionPending = pendingResolution;
+      this.reconcileLabelRetry();
+    }
+  }
+
+  // Re-read the label(s) while a resolved cell's doc is still loading. The
+  // resolved cell is queried one-shot inside `readLabelView` and is not
+  // subscribed to, so without this poll a cold linked/bound-prop author would
+  // stay unverified until an unrelated `value`/`author` change happened to
+  // re-run the read. Bounded by MAX_LABEL_RETRY_COUNT.
+  private reconcileLabelRetry(): void {
+    if (this._valueResolutionPending || this._authorResolutionPending) {
+      this.scheduleLabelRetry();
+    } else {
+      this.clearLabelRetry();
+      this._labelRetryCount = 0;
+    }
+  }
+
+  private scheduleLabelRetry(): void {
+    if (
+      !this.isConnected ||
+      this._labelRetryTimeout !== undefined ||
+      this._labelRetryCount >= MAX_LABEL_RETRY_COUNT
+    ) {
+      return;
+    }
+    this._labelRetryTimeout = setTimeout(() => {
+      this._labelRetryTimeout = undefined;
+      if (!this.isConnected) return;
+      this._labelRetryCount += 1;
+      void this.refreshLabel();
+      void this.refreshAuthorClaim();
+    }, LABEL_RETRY_INTERVAL_MS);
+  }
+
+  private clearLabelRetry(): void {
+    if (this._labelRetryTimeout !== undefined) {
+      clearTimeout(this._labelRetryTimeout);
+      this._labelRetryTimeout = undefined;
     }
   }
 

--- a/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.test.ts
+++ b/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.test.ts
@@ -73,7 +73,7 @@ describe("CFCFCLabel", () => {
     expect(element.cfcLabel).toEqual(cfcLabel);
   });
 
-  it("refreshes the label when a bound cell emits an update", async () => {
+  it("delivers the initial label from a subscribable bound value", async () => {
     const cfcLabel = {
       version: 1 as const,
       entries: [{
@@ -81,51 +81,48 @@ describe("CFCFCLabel", () => {
         label: { confidentiality: ["prompt-influence"] },
       }],
     };
-    let labelCalls = 0;
-    let emitUpdate: (() => void) | undefined;
     const element = new CFCFCLabel();
-
     element.value = {
-      getCfcLabel: () =>
-        Promise.resolve(labelCalls++ < 2 ? undefined : cfcLabel),
-      subscribe: (callback: () => void) => {
-        emitUpdate = () => callback();
-        callback();
+      subscribe: (
+        callback: (value: unknown, label?: unknown) => void,
+      ) => {
+        callback(undefined, cfcLabel);
         return () => {};
       },
     };
     await Promise.resolve();
 
-    expect(element.cfcLabel).toBeUndefined();
-    if (!emitUpdate) {
-      throw new Error("expected cf-cfc-label to subscribe to the bound cell");
-    }
-    emitUpdate();
-    await Promise.resolve();
-
     expect(element.cfcLabel).toEqual(cfcLabel);
   });
 
-  it("loads the initial label for a subscribable bound value", async () => {
-    const cfcLabel = {
+  it("reacts to a later label change delivered over the subscription", async () => {
+    const labelA = {
       version: 1 as const,
-      entries: [{
-        path: [],
-        label: { confidentiality: ["prompt-influence"] },
-      }],
+      entries: [{ path: [], label: { integrity: ["authored-by-alice"] } }],
     };
+    const labelB = {
+      version: 1 as const,
+      entries: [{ path: [], label: { integrity: ["authored-by-bob"] } }],
+    };
+    let emit: ((label: unknown) => void) | undefined;
     const element = new CFCFCLabel();
-
     element.value = {
-      getCfcLabel: () => Promise.resolve(cfcLabel),
-      subscribe: () => () => {},
+      subscribe: (callback: (value: unknown, label?: unknown) => void) => {
+        emit = (label) => callback(undefined, label);
+        callback(undefined, labelA);
+        return () => {};
+      },
     };
     await Promise.resolve();
+    expect(element.cfcLabel).toEqual(labelA);
 
-    expect(element.cfcLabel).toEqual(cfcLabel);
+    // A label-only change (same value) arrives over the same subscription.
+    emit!(labelB);
+    await Promise.resolve();
+    expect(element.cfcLabel).toEqual(labelB);
   });
 
-  it("retries when label metadata arrives after the first value query", async () => {
+  it("uses subscription delivery, not getCfcLabel, for subscribable values", async () => {
     const cfcLabel = {
       version: 1 as const,
       entries: [{
@@ -133,114 +130,29 @@ describe("CFCFCLabel", () => {
         label: { confidentiality: ["prompt-influence"] },
       }],
     };
-    let labelAvailable = false;
-    const element = new CFCFCLabel();
-    Object.defineProperty(element, "isConnected", {
-      value: true,
-      configurable: true,
-    });
-
-    try {
-      element.value = {
-        getCfcLabel: () =>
-          Promise.resolve(labelAvailable ? cfcLabel : undefined),
-        subscribe: () => () => {},
-      };
-      await Promise.resolve();
-      expect(element.cfcLabel).toBeUndefined();
-
-      labelAvailable = true;
-      await new Promise((resolve) => setTimeout(resolve, 150));
-
-      expect(element.cfcLabel).toEqual(cfcLabel);
-    } finally {
-      element.disconnectedCallback();
-    }
-  });
-
-  it("replaces stale pending retries after a newer refresh", async () => {
-    const cfcLabel = {
-      version: 1 as const,
-      entries: [{
-        path: [],
-        label: { confidentiality: ["prompt-influence"] },
-      }],
-    };
-    let labelAvailable = false;
-    const element = new CFCFCLabel();
-    Object.defineProperty(element, "isConnected", {
-      value: true,
-      configurable: true,
-    });
-
-    try {
-      element.value = {
-        getCfcLabel: () =>
-          Promise.resolve(labelAvailable ? cfcLabel : undefined),
-        subscribe: () => () => {},
-      };
-      await Promise.resolve();
-      expect(element.cfcLabel).toBeUndefined();
-
-      await element.refreshLabel();
-      labelAvailable = true;
-      await new Promise((resolve) => setTimeout(resolve, 150));
-
-      expect(element.cfcLabel).toEqual(cfcLabel);
-    } finally {
-      element.disconnectedCallback();
-    }
-  });
-
-  it("does not duplicate label refreshes for the same bound value", async () => {
-    const cfcLabel = {
-      version: 1 as const,
-      entries: [{
-        path: [],
-        label: { confidentiality: ["prompt-influence"] },
-      }],
-    };
-    let labelCalls = 0;
-    const requestedProperties: (PropertyKey | undefined)[] = [];
+    let getCfcLabelCalls = 0;
+    let requestedIncludeCfcLabel: boolean | undefined;
     const element = new CFCFCLabel();
     element.value = {
       getCfcLabel: () => {
-        labelCalls += 1;
+        getCfcLabelCalls += 1;
         return Promise.resolve(cfcLabel);
       },
-      subscribe: () => () => {},
+      subscribe: (
+        callback: (value: unknown, label?: unknown) => void,
+        options?: { includeCfcLabel?: boolean },
+      ) => {
+        requestedIncludeCfcLabel = options?.includeCfcLabel;
+        callback(undefined, cfcLabel);
+        return () => {};
+      },
     };
-    const lifecycle = element as unknown as {
-      firstUpdated(changedProperties: Map<PropertyKey, unknown>): void;
-      updated(changedProperties: Map<PropertyKey, unknown>): void;
-    };
-    const updateHost = element as unknown as {
-      requestUpdate(
-        name?: PropertyKey,
-        oldValue?: unknown,
-        options?: unknown,
-      ): void;
-    };
-    const requestUpdate = updateHost.requestUpdate.bind(updateHost);
-
-    lifecycle.firstUpdated(new Map());
-    await Promise.resolve();
-    updateHost.requestUpdate = ((
-      name?: PropertyKey,
-      oldValue?: unknown,
-      options?: unknown,
-    ) => {
-      requestedProperties.push(name);
-      requestUpdate(name, oldValue, options);
-    }) as typeof updateHost.requestUpdate;
-    lifecycle.updated(
-      new Map<PropertyKey, unknown>([["value", element.value]]),
-    );
     await Promise.resolve();
 
-    expect(labelCalls).toBe(1);
+    expect(requestedIncludeCfcLabel).toBe(true);
     expect(element.cfcLabel).toEqual(cfcLabel);
-    expect(requestedProperties).toContain("cfcLabel");
+    // The label rides the subscription; no separate getCfcLabel round-trip.
+    expect(getCfcLabelCalls).toBe(0);
   });
 });
 

--- a/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
+++ b/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
@@ -14,16 +14,16 @@ type CfcLabelQueryableValue = {
 };
 
 type CfcLabelSubscribableValue = {
-  subscribe(callback: (value: unknown) => void): () => void;
+  subscribe(
+    callback: (value: unknown, cfcLabel?: CfcLabelView | undefined) => void,
+    options?: { includeCfcLabel?: boolean },
+  ): () => void;
 };
 
 const LABEL_KEYS = [
   "confidentiality",
   "integrity",
 ] as const satisfies readonly LabelKey[];
-
-const LABEL_RETRY_INTERVAL_MS = 100;
-const MAX_LABEL_RETRY_COUNT = 100;
 
 const hasLabelQuery = (value: unknown): value is CfcLabelQueryableValue =>
   typeof value === "object" && value !== null &&
@@ -208,8 +208,6 @@ export class CFCFCLabel extends BaseElement {
   private _value: unknown = undefined;
   private _observedValue: unknown = undefined;
   private _unsubscribeValue: (() => void) | undefined;
-  private _labelRetryTimeout: ReturnType<typeof setTimeout> | undefined;
-  private _labelRetryCount = 0;
 
   constructor() {
     super();
@@ -235,7 +233,6 @@ export class CFCFCLabel extends BaseElement {
   }
 
   override disconnectedCallback() {
-    this.clearLabelRetry();
     this.clearValueSubscription();
     super.disconnectedCallback();
   }
@@ -270,17 +267,18 @@ export class CFCFCLabel extends BaseElement {
     }
 
     this.clearValueSubscription();
-    this.clearLabelRetry();
-    this._labelRetryCount = 0;
     this._observedValue = value;
 
     if (!hasLabelSubscription(value)) {
       return false;
     }
 
-    this._unsubscribeValue = value.subscribe(() => {
-      void this.refreshLabel();
-    });
+    // Reactive label delivery: the label rides each subscription update and the
+    // worker reads it on the sink's tracked tx, so a label-only change re-fires
+    // here too — no poll, no separate getCfcLabel round-trip.
+    this._unsubscribeValue = value.subscribe((_value, cfcLabel) => {
+      this.applyLabel(cfcLabel);
+    }, { includeCfcLabel: true });
     return true;
   }
 
@@ -290,57 +288,23 @@ export class CFCFCLabel extends BaseElement {
     this._observedValue = undefined;
   }
 
-  private clearLabelRetry(): void {
-    if (this._labelRetryTimeout === undefined) {
-      return;
-    }
-    clearTimeout(this._labelRetryTimeout);
-    this._labelRetryTimeout = undefined;
+  private applyLabel(cfcLabel: CfcLabelView | undefined): void {
+    const previous = this.cfcLabel;
+    this.cfcLabel = cfcLabel;
+    this.requestUpdate("cfcLabel", previous);
   }
 
-  private scheduleLabelRetry(requestId: number): void {
-    if (
-      !this.isConnected ||
-      this._labelRetryCount >= MAX_LABEL_RETRY_COUNT
-    ) {
-      return;
-    }
-
-    this.clearLabelRetry();
-    this._labelRetryTimeout = setTimeout(() => {
-      this._labelRetryTimeout = undefined;
-      if (
-        requestId === this._labelRequestId &&
-        this.cfcLabel === undefined &&
-        hasLabelQuery(this.value)
-      ) {
-        this._labelRetryCount += 1;
-        void this.refreshLabel();
-      }
-    }, LABEL_RETRY_INTERVAL_MS);
-  }
-
+  // Fallback for a value that exposes getCfcLabel but not subscribe (no live
+  // channel). Subscribable values get their label reactively via observeValue.
   async refreshLabel(): Promise<void> {
     const requestId = ++this._labelRequestId;
-    if (!hasLabelQuery(this.value)) {
-      this.clearLabelRetry();
-      const previous = this.cfcLabel;
-      this.cfcLabel = undefined;
-      this.requestUpdate("cfcLabel", previous);
+    if (hasLabelSubscription(this.value) || !hasLabelQuery(this.value)) {
+      if (!hasLabelSubscription(this.value)) this.applyLabel(undefined);
       return;
     }
-
     const cfcLabel = await this.value.getCfcLabel();
     if (requestId === this._labelRequestId) {
-      const previous = this.cfcLabel;
-      this.cfcLabel = cfcLabel;
-      this.requestUpdate("cfcLabel", previous);
-      if (cfcLabel === undefined) {
-        this.scheduleLabelRetry(requestId);
-      } else {
-        this.clearLabelRetry();
-        this._labelRetryCount = 0;
-      }
+      this.applyLabel(cfcLabel);
     }
   }
 

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
@@ -6,11 +6,6 @@ import { identitySeal } from "./identity-seal.ts";
 
 const OWNER_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
 
-/** A resolved-cell stub that answers `getCfcLabel()` with the given label. */
-function labelCell(label: unknown) {
-  return { getCfcLabel: () => Promise.resolve(label) };
-}
-
 function representsPrincipalLabel(subject: string) {
   return {
     version: 1,
@@ -152,12 +147,13 @@ describe("CFProfileBadge", () => {
   });
 
   describe("verification seal", () => {
-    it("enters the verified state and derives the seal from the owner DID", async () => {
+    it("enters the verified state and derives the seal from the owner DID", () => {
       const el = new CFProfileBadge() as any;
       markConnected(el, true);
 
-      await el._refreshVerification(
-        labelCell(representsPrincipalLabel(OWNER_DID)),
+      el._deriveVerification(
+        representsPrincipalLabel(OWNER_DID),
+        el._resolveGeneration,
       );
 
       expect(el._state).toBe("verified");
@@ -166,55 +162,47 @@ describe("CFProfileBadge", () => {
       expect(el._seal?.hue).toBe(identitySeal(OWNER_DID).hue);
     });
 
-    it("re-derives verification when the value subscription fires (cold profile self-heals)", async () => {
+    it("re-derives verification when the label arrives over the subscription (cold self-heals)", async () => {
       const el = new CFProfileBadge() as any;
       markConnected(el, true);
 
-      // `getCfcLabel` is a pure store read: cold first (no label), then the
-      // attestation appears once the doc loads.
-      let labelReady = false;
-      let subscriptionCallback: ((val: unknown) => void) | undefined;
+      // The subscription delivers (value, cfcLabel). Cold first: value but no
+      // label; then the label appears once the profile doc loads — over the
+      // SAME subscription, no separate getCfcLabel read.
+      let deliver: ((val: unknown, label?: unknown) => void) | undefined;
       const resolved = {
         ref: () => ({ path: [] }),
         space: () => "did:key:zSpace",
         id: () => "fid1:piece",
         asSchema: () => ({
-          subscribe: (cb: (val: unknown) => void) => {
-            subscriptionCallback = cb;
+          subscribe: (cb: (val: unknown, label?: unknown) => void) => {
+            deliver = cb;
             return () => {};
           },
         }),
-        getCfcLabel: () =>
-          Promise.resolve(
-            labelReady ? representsPrincipalLabel(OWNER_DID) : undefined,
-          ),
       };
       el.profile = { resolveAsCell: () => Promise.resolve(resolved) };
 
       await el._resolve();
-      // Let the initial (cold) verification read settle: no label yet.
-      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      deliver?.({ name: "Ada" }, undefined);
       expect(el._state).toBe("presented");
       expect(el._seal).toBeUndefined();
 
-      // The doc loads: the label is now present and the value subscription
-      // fires, re-deriving verification.
-      labelReady = true;
-      subscriptionCallback?.({ name: "Ada" });
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
+      // The label-only change (doc loaded) re-fires the subscription.
+      deliver?.({ name: "Ada" }, representsPrincipalLabel(OWNER_DID));
       expect(el._state).toBe("verified");
       expect(el._seal?.did).toBe(OWNER_DID);
     });
 
-    it("stays presented (no seal) when the label has no represents-principal atom", async () => {
+    it("stays presented (no seal) when the label has no represents-principal atom", () => {
       const el = new CFProfileBadge() as any;
       markConnected(el, true);
 
-      await el._refreshVerification(labelCell({
+      el._deriveVerification({
         version: 1,
         entries: [{ path: [], label: { integrity: ["profile-link"] } }],
-      }));
+      }, el._resolveGeneration);
 
       expect(el._state).toBe("presented");
       expect(el._seal).toBeUndefined();
@@ -237,47 +225,21 @@ describe("CFProfileBadge", () => {
       expect(el._seal).toBeUndefined();
     });
 
-    it("discards a label read superseded mid-flight (no stale seal write)", async () => {
+    it("ignores a label delivered after a re-bind (stale generation)", () => {
       const el = new CFProfileBadge() as any;
       markConnected(el, true);
 
-      // A label read whose timing we control.
-      const gate = deferred<unknown>();
-      const verify = el._refreshVerification({
-        getCfcLabel: () => gate.promise,
-      });
-
-      // Simulate a re-bind / disconnect superseding this read: both `_resolve`
-      // and `disconnectedCallback` bump `_resolveGeneration`.
+      const staleGeneration = el._resolveGeneration;
+      // A re-bind / disconnect bumps the generation.
       el._resolveGeneration++;
 
-      // The read now resolves with a valid attestation — but it is stale.
-      gate.resolve(representsPrincipalLabel(OWNER_DID));
-      await verify;
+      // A subscription callback from the prior binding fires late with a valid
+      // attestation — it must NOT flip the badge to verified.
+      el._deriveVerification(
+        representsPrincipalLabel(OWNER_DID),
+        staleGeneration,
+      );
 
-      // The superseded read must NOT have flipped the badge to verified.
-      expect(el._state).toBe("presented");
-      expect(el._seal).toBeUndefined();
-    });
-
-    it("logs and stays presented when the label read fails", async () => {
-      const el = new CFProfileBadge() as any;
-      markConnected(el, true);
-
-      const originalError = console.error;
-      let logged = 0;
-      console.error = () => {
-        logged++;
-      };
-      try {
-        await el._refreshVerification({
-          getCfcLabel: () => Promise.reject(new Error("ipc boom")),
-        });
-      } finally {
-        console.error = originalError;
-      }
-
-      expect(logged).toBe(1);
       expect(el._state).toBe("presented");
       expect(el._seal).toBeUndefined();
     });

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
@@ -166,6 +166,47 @@ describe("CFProfileBadge", () => {
       expect(el._seal?.hue).toBe(identitySeal(OWNER_DID).hue);
     });
 
+    it("re-derives verification when the value subscription fires (cold profile self-heals)", async () => {
+      const el = new CFProfileBadge() as any;
+      markConnected(el, true);
+
+      // `getCfcLabel` is a pure store read: cold first (no label), then the
+      // attestation appears once the doc loads.
+      let labelReady = false;
+      let subscriptionCallback: ((val: unknown) => void) | undefined;
+      const resolved = {
+        ref: () => ({ path: [] }),
+        space: () => "did:key:zSpace",
+        id: () => "fid1:piece",
+        asSchema: () => ({
+          subscribe: (cb: (val: unknown) => void) => {
+            subscriptionCallback = cb;
+            return () => {};
+          },
+        }),
+        getCfcLabel: () =>
+          Promise.resolve(
+            labelReady ? representsPrincipalLabel(OWNER_DID) : undefined,
+          ),
+      };
+      el.profile = { resolveAsCell: () => Promise.resolve(resolved) };
+
+      await el._resolve();
+      // Let the initial (cold) verification read settle: no label yet.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(el._state).toBe("presented");
+      expect(el._seal).toBeUndefined();
+
+      // The doc loads: the label is now present and the value subscription
+      // fires, re-deriving verification.
+      labelReady = true;
+      subscriptionCallback?.({ name: "Ada" });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(el._state).toBe("verified");
+      expect(el._seal?.did).toBe(OWNER_DID);
+    });
+
     it("stays presented (no seal) when the label has no represents-principal atom", async () => {
       const el = new CFProfileBadge() as any;
       markConnected(el, true);

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -341,6 +341,9 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
 
   private _unsubscribe?: () => void;
   private _resolveGeneration = 0;
+  // Bumped on each verification read so a slower earlier read can't overwrite a
+  // newer one's state when verification re-runs reactively (below).
+  private _verifyRequestId = 0;
 
   // Liveness: whether this seal is currently registered with the shared cursor
   // controller, and the last sheen alpha written (so far-from-cursor frames can
@@ -497,7 +500,17 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
           avatar: { type: "string" },
         },
       });
-      this._unsubscribe = named.subscribe((val) => this._applyValue(val));
+      // Re-derive verification on every value update, not just once: the
+      // runtime-attested label (`getCfcLabel`) is read as a pure, non-blocking
+      // store read, so a not-yet-loaded profile doc first returns no label and
+      // leaves the badge "presented". When the subscription delivers the doc
+      // (the same load that populates name/avatar), the label is present and the
+      // badge re-derives to "verified". The request-id guard in
+      // `_refreshVerification` drops a slower earlier read.
+      this._unsubscribe = named.subscribe((val) => {
+        this._applyValue(val);
+        void this._refreshVerification(resolved);
+      });
 
       void this._refreshVerification(resolved);
     } catch (e) {
@@ -569,9 +582,13 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
    */
   private async _refreshVerification(cell: CellHandle): Promise<void> {
     const generation = this._resolveGeneration;
+    const requestId = ++this._verifyRequestId;
+    const superseded = () =>
+      generation !== this._resolveGeneration ||
+      requestId !== this._verifyRequestId || !this.isConnected;
     try {
       const view = await readCfcLabelView(cell);
-      if (generation !== this._resolveGeneration || !this.isConnected) return;
+      if (superseded()) return;
       const owner = ownerPrincipalFromLabel(view);
       if (owner) {
         this._seal = identitySeal(owner);
@@ -581,7 +598,7 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         this._state = "presented";
       }
     } catch (e) {
-      if (generation !== this._resolveGeneration || !this.isConnected) return;
+      if (superseded()) return;
       // Surface the IPC/label-read failure (mirrors `_resolve`'s catch) rather
       // than silently collapsing every failure to the unverified state.
       console.error(

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -6,6 +6,7 @@ import "../cf-avatar/cf-avatar.ts";
 import type { AvatarSize } from "../cf-avatar/cf-avatar.ts";
 import {
   type CellHandle,
+  type CfcLabelView,
   NAME,
   type RuntimeClient,
 } from "@commonfabric/runtime-client";
@@ -17,10 +18,7 @@ import {
   urlToAppView,
 } from "@commonfabric/shell/shared";
 import { runtimeContext, spaceContext } from "../../runtime-context.ts";
-import {
-  ownerPrincipalFromLabel,
-  readCfcLabelView,
-} from "../../core/cfc-label.ts";
+import { ownerPrincipalFromLabel } from "../../core/cfc-label.ts";
 import { type IdentitySeal, identitySeal } from "./identity-seal.ts";
 import {
   registerSeal,
@@ -341,9 +339,6 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
 
   private _unsubscribe?: () => void;
   private _resolveGeneration = 0;
-  // Bumped on each verification read so a slower earlier read can't overwrite a
-  // newer one's state when verification re-runs reactively (below).
-  private _verifyRequestId = 0;
 
   // Liveness: whether this seal is currently registered with the shared cursor
   // controller, and the last sheen alpha written (so far-from-cursor frames can
@@ -500,19 +495,16 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
           avatar: { type: "string" },
         },
       });
-      // Re-derive verification on every value update, not just once: the
-      // runtime-attested label (`getCfcLabel`) is read as a pure, non-blocking
-      // store read, so a not-yet-loaded profile doc first returns no label and
-      // leaves the badge "presented". When the subscription delivers the doc
-      // (the same load that populates name/avatar), the label is present and the
-      // badge re-derives to "verified". The request-id guard in
-      // `_refreshVerification` drops a slower earlier read.
-      this._unsubscribe = named.subscribe((val) => {
+      // The runtime-attested label rides each subscription update
+      // (`includeCfcLabel`), read on the sink's tracked tx — so verification
+      // re-derives whenever the profile's label changes (re-labeling, or the
+      // doc first loading), not just on name/avatar edits, with no separate
+      // getCfcLabel round-trip. The `generation` guard drops a callback that
+      // fires after a re-bind/detach.
+      this._unsubscribe = named.subscribe((val, cfcLabel) => {
         this._applyValue(val);
-        void this._refreshVerification(resolved);
-      });
-
-      void this._refreshVerification(resolved);
+        this._deriveVerification(cfcLabel, generation);
+      }, { includeCfcLabel: true });
     } catch (e) {
       if (generation !== this._resolveGeneration || !this.isConnected) return;
       console.error("cf-profile-badge: failed to resolve profile cell", e);
@@ -574,37 +566,24 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
    * attestation → the badge stays in the plain "presented" state (a pattern can
    * mimic the chrome but cannot mint the label that unlocks the seal).
    *
-   * LIFECYCLE: this awaits a label read, so after the await it MUST re-check
-   * `generation === this._resolveGeneration && this.isConnected` before writing
-   * `_state`/`_seal` — `disconnectedCallback` bumps the generation, so a badge
-   * detached (or re-bound) mid-read won't leak a state write onto a stale /
-   * detached instance (same hazard guarded in `_resolve`).
+   * `generation` is captured by the subscription callback in `_resolve`; a
+   * callback that fires after a re-bind/detach (which bumps the generation)
+   * bails before writing `_state`/`_seal`, so it can't leak onto a stale or
+   * detached instance.
    */
-  private async _refreshVerification(cell: CellHandle): Promise<void> {
-    const generation = this._resolveGeneration;
-    const requestId = ++this._verifyRequestId;
-    const superseded = () =>
-      generation !== this._resolveGeneration ||
-      requestId !== this._verifyRequestId || !this.isConnected;
-    try {
-      const view = await readCfcLabelView(cell);
-      if (superseded()) return;
-      const owner = ownerPrincipalFromLabel(view);
-      if (owner) {
-        this._seal = identitySeal(owner);
-        this._state = "verified";
-      } else {
-        this._seal = undefined;
-        this._state = "presented";
-      }
-    } catch (e) {
-      if (superseded()) return;
-      // Surface the IPC/label-read failure (mirrors `_resolve`'s catch) rather
-      // than silently collapsing every failure to the unverified state.
-      console.error(
-        "cf-profile-badge: failed to read CFC label for verification",
-        e,
-      );
+  private _deriveVerification(
+    cfcLabel: CfcLabelView | undefined,
+    generation: number,
+  ): void {
+    if (generation !== this._resolveGeneration || !this.isConnected) return;
+    // The label is the runtime-attested, display-redacted view delivered over
+    // the subscription; redaction strips Caveat.source but keeps the
+    // `represents-principal` integrity atom that unlocks the seal.
+    const owner = ownerPrincipalFromLabel(cfcLabel);
+    if (owner) {
+      this._seal = identitySeal(owner);
+      this._state = "verified";
+    } else {
       this._seal = undefined;
       this._state = "presented";
     }


### PR DESCRIPTION
Split from #4190 (the improvement half). The instrumentation that found this is in #4202.

## Problem

`getCfcLabel` is the display-label IPC — it should be ~instant. Split-timing it showed the entire cost is `syncMetaLinkedDocs`: it re-synced the cell's **whole root pattern/argument meta-graph** on every call with a **serial `await sync()` per node**.

```
runtime-client.cfc-label/total              n=36 p50=0.1ms  p95=1374ms
runtime-client.cfc-label/syncMetaLinkedDocs n=36 p50=0     p95=1374ms   <- 99.97%
```

Bimodal: **p50 0.1ms** (graph already covered by settled watches → `pull` no-ops) vs **p95 >1s** (a node's watch is mid-refresh → `pull` awaits a server round-trip). Under multi-writer churn the shared space's watches refresh constantly, so display-label latency coupled to *other* browsers' writes. End-to-end the `getCfcLabel` IPC p95 ran **0.5–4.2s** at 4 concurrent browser profiles.

## Fix

`getCfcLabel` is the **display** seam (the enforcement path reads labels through other seams), and its only callers are reactive UI components — `cf-cfc-label`, `cf-cfc-authorship`, `cf-profile-badge` — that subscribe to the cell and re-read the label whenever it changes. So make it a **pure, non-blocking read of the current store**: a not-yet-loaded doc is also not rendered, so an empty label is the correct *deferred* answer and self-heals when the subscription delivers the doc (which carries its `cfc` metadata). The caller owns liveness.

`getCfcLabel` IPC p95 → **<1ms**. The meta-graph sync, the source-chain sync test, and the cycle test are removed.

### `cf-profile-badge` made reactive

`cf-profile-badge` was the one caller whose verification read was **one-shot per `_resolve`** (not re-fired on the value subscription), so it relied on `getCfcLabel` self-syncing for a cold profile. Its verification is now reactive — `_refreshVerification` re-runs from the value-subscription callback, guarded by a `_verifyRequestId` so a slower earlier read can't stomp a newer one. A cold badge now reaches the verified state when the profile doc arrives.

### Bench

`cfc-label-sync-strategy.bench.ts` documents the cost structure that motivated the removal (serial-sum vs parallel-max vs skip-zero vs pure-read) and guards against reintroducing a per-call sync.

## Verification

`runtime-processor` + `cf-profile-badge` + `cfc-label-view` unit suites green. (End-to-end, all three `cfc-group-chat-demo` integration tests pass on the combined branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `getCfcLabel` a pure, non-blocking store read and add opt‑in reactive CFC‑label delivery over `CellSubscribe`/`CellGet`, so label-only changes re-render instantly; display-label IPC p95 is now <1ms. Label reads keep display redaction (`Caveat.source` is stripped).

- **New Features**
  - Added `includeCfcLabel` to `CellSubscribe` and `CellGet`; responses/notifications include the redacted label.
  - `cell.sink({ includeCfcLabel })` reads the label on the sink’s transaction, making label writes re-fire reactive subscribers.
  - `CellHandle` tracks `cfcLabel`, dedups updates, and fires label-aware callbacks on value or label changes; late subscribers inherit cached label. Also upgrades the backend subscription if a label-aware subscriber is added later, so labels flow.
  - `cf-cfc-label` uses subscription delivery (`{ includeCfcLabel: true }`) and drops polling; `getCfcLabel` remains a fallback for non-subscribable values.
  - `cf-profile-badge` derives verification from the subscription-delivered label (generation-guarded), so cold profiles self-heal when the doc loads.
  - `cf-cfc-authorship` subscribes with `{ includeCfcLabel: true }` and keeps a bounded retry when a resolved cell’s label is initially missing.

- **Refactors**
  - `getCfcLabel` now returns the current stored label without syncing or traversing metadata; removed `syncMetaLinkedDocs`.
  - Added timing for `runtime-client.cfc-label`; handler is now synchronous.
  - Kept display redaction; only `Caveat.source` is stripped for UI.
  - `packages/runner/test/cfc-label-sync-strategy.bench.ts` documents the pure-read strategy and guards against reintroducing per-call sync.
  - Updated tests for reactive label delivery and pure reads; removed sync/cycle tests.

<sup>Written for commit 6f010d24b9ee380347f8d35beaca593a232c84a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



---

NEW_PERF_BASELINE: job: Package Integration Tests (runtime-client) = 113s
NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 9218 lines
NEW_PERF_BASELINE: coverage-debt: packages/ui uncovered lines = 38828 lines

<!-- END perf-check acceptances
Acceptance rationale: the small coverage-debt deltas are uncovered branches in
the new opt-in label-delivery path (cell.ts includeCfcLabel read; component
fallback branches) — the core mechanism is covered by cfc-label-view
"re-fires an includeCfcLabel sink on a label-only write", the cell-handle
reactive-label tests, and the three component suites. The runtime-client
integration-job time is shared-runner noise. -->
