### PR TITLE
ci: shard all.test.ts across pattern-integration shards and rebalance

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -43,6 +43,9 @@ jobs:
       - name: 🔎 Type check codebase
         run: deno task check
 
+      - name: 🧪 Run tasks/ unit tests
+        run: deno test --allow-read --allow-write --allow-env --allow-run tasks/
+
       - name: 🧭 Check cf-review skill facts
         run: deno task check-skill-facts
 
@@ -523,6 +526,7 @@ jobs:
           mkdir -p ../../test-results
           HEADLESS=1 \
           API_URL=http://localhost:8000/ \
+          PATTERN_INTEGRATION_SHARD="${{ matrix.shard }}/${{ matrix.total }}" \
           DENO_COVERAGE_DIR=../../coverage/raw/pattern-integration-${{ matrix.shard }} \
           deno test --v8-flags=--max-old-space-size=4096 --trace-leaks -A \
             --junit-path=../../test-results/patterns-${{ matrix.shard }}.xml \

--- a/packages/patterns/integration/all.test.ts
+++ b/packages/patterns/integration/all.test.ts
@@ -8,16 +8,43 @@ import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 
 const { API_URL } = env;
 
+// Optional sharding for CI fan-out: PATTERN_INTEGRATION_SHARD="i/n" (1-based)
+// runs only the patterns where (sorted index % n) == (i - 1), so the pattern
+// compiles spread across the n parallel "Pattern Integration Tests (i/n)" jobs
+// instead of all landing in one. Mirrors the CFCHECK_SHARD fan-out in
+// tasks/cfcheck.ts. Unset (local dev) runs every pattern.
+function parsePatternShard(): { index: number; count: number } {
+  const raw = Deno.env.get("PATTERN_INTEGRATION_SHARD");
+  if (!raw) return { index: 0, count: 1 };
+  const match = raw.match(/^(\d+)\/(\d+)$/);
+  if (!match) {
+    throw new Error(
+      `Invalid PATTERN_INTEGRATION_SHARD "${raw}"; expected "i/n" (1-based).`,
+    );
+  }
+  const index = Number(match[1]) - 1;
+  const count = Number(match[2]);
+  if (count < 1 || index < 0 || index >= count) {
+    throw new Error(`PATTERN_INTEGRATION_SHARD "${raw}" out of range.`);
+  }
+  return { index, count };
+}
+
 describe("Compile all patterns", () => {
   const skippedPatterns = [
     "system/link-tool.tsx", // Utility handlers, not a standalone pattern
   ];
 
-  // Add a test for each pattern, but skip ones that have issues
-  for (const file of Deno.readDirSync(join(import.meta.dirname!, ".."))) {
-    const { name } = file;
-    if (!name.endsWith(".tsx")) continue;
-    if (skippedPatterns.includes(name)) continue;
+  const shard = parsePatternShard();
+  const patterns = [...Deno.readDirSync(join(import.meta.dirname!, ".."))]
+    .filter((file) => file.name.endsWith(".tsx"))
+    .map((file) => file.name)
+    .filter((name) => !skippedPatterns.includes(name))
+    .sort();
+
+  // Add a test for each pattern in this shard's slice.
+  for (const [i, name] of patterns.entries()) {
+    if (i % shard.count !== shard.index) continue;
 
     it(`Executes: ${name}`, async () => {
       // Heap monitoring for bisection experiments (CT-1148)

--- a/tasks/select-generated-pattern-files.test.ts
+++ b/tasks/select-generated-pattern-files.test.ts
@@ -1,8 +1,11 @@
 import { assertEquals } from "@std/assert";
 import {
+  listGeneratedPatternTests,
   parseShard,
   selectGeneratedPatternFiles,
 } from "./select-generated-pattern-files.ts";
+
+const TOTAL_SHARDS = 4;
 
 Deno.test("parseShard parses shard notation", () => {
   assertEquals(parseShard("2/4"), { index: 2, total: 4 });
@@ -38,4 +41,50 @@ Deno.test("selectGeneratedPatternFiles round-robins sorted names", () => {
     "bravo.test.ts",
     "delta.test.ts",
   ]);
+});
+
+Deno.test("every real generated pattern file is covered exactly once across shards", async () => {
+  // Read the actual generated-patterns directory so a file that silently falls
+  // out of every shard fails here — CI itself would run green, because a
+  // dropped file is simply never executed.
+  const files = await listGeneratedPatternTests();
+
+  // Guard against the test passing vacuously if the listing breaks.
+  assertEquals(
+    files.length > 0,
+    true,
+    "expected generated pattern files to exist",
+  );
+
+  const shardOf = new Map<string, number[]>();
+  for (let index = 1; index <= TOTAL_SHARDS; index++) {
+    for (
+      const name of selectGeneratedPatternFiles(files, {
+        index,
+        total: TOTAL_SHARDS,
+      })
+    ) {
+      const shards = shardOf.get(name) ?? [];
+      shards.push(index);
+      shardOf.set(name, shards);
+    }
+  }
+
+  for (const name of files) {
+    const shards = shardOf.get(name) ?? [];
+    assertEquals(
+      shards.length,
+      1,
+      `${name} should run in exactly one shard, got ${JSON.stringify(shards)}`,
+    );
+  }
+
+  // No phantom files: everything selected corresponds to a real file.
+  for (const name of shardOf.keys()) {
+    assertEquals(
+      files.includes(name),
+      true,
+      `selected ${name} is not a real generated pattern file`,
+    );
+  }
 });

--- a/tasks/select-generated-pattern-files.ts
+++ b/tasks/select-generated-pattern-files.ts
@@ -1,24 +1,7 @@
 #!/usr/bin/env -S deno run --allow-read
 
-type Shard = {
-  index: number;
-  total: number;
-};
-
-export function parseShard(raw: string): Shard {
-  const match = raw.match(/^([1-9][0-9]*)\/([1-9][0-9]*)$/);
-  if (!match) {
-    throw new Error(`Expected shard argument like 1/4, got: ${raw}`);
-  }
-
-  const index = Number(match[1]);
-  const total = Number(match[2]);
-  if (index > total) {
-    throw new Error(`Shard index ${index} exceeds total shard count ${total}`);
-  }
-
-  return { index, total };
-}
+import { parseShard, type Shard } from "./shard-utils.ts";
+export { parseShard };
 
 export function selectGeneratedPatternFiles(
   names: string[],
@@ -29,7 +12,7 @@ export function selectGeneratedPatternFiles(
     .filter((_, index) => index % shard.total === shard.index - 1);
 }
 
-async function listGeneratedPatternTests(): Promise<string[]> {
+export async function listGeneratedPatternTests(): Promise<string[]> {
   const integrationDir = new URL(
     "../packages/generated-patterns/integration/patterns/",
     import.meta.url,

--- a/tasks/select-pattern-integration-files.test.ts
+++ b/tasks/select-pattern-integration-files.test.ts
@@ -1,6 +1,13 @@
 import { assertEquals } from "@std/assert";
-import { shardForPatternIntegrationFile } from "./select-pattern-integration-files.ts";
-import { parseShard, stableShardForName } from "./shard-utils.ts";
+import {
+  assignPatternIntegrationShards,
+  listPatternIntegrationTests,
+  selectPatternIntegrationFiles,
+} from "./select-pattern-integration-files.ts";
+import { parseShard } from "./shard-utils.ts";
+
+const TOTAL_SHARDS = 4;
+const ALL_PATTERNS_FILE = "all.test.ts";
 
 Deno.test("parseShard parses shard notation", () => {
   assertEquals(parseShard("2/4"), { index: 2, total: 4 });
@@ -18,28 +25,145 @@ Deno.test("parseShard rejects invalid shard notation", () => {
   }
 });
 
-Deno.test("pattern integration four-way shard keeps slow files balanced", () => {
-  // The heaviest end-to-end tests are spread one per shard so no shard
-  // dominates: group-chat (shard 2), parking-coordinator (shard 3), and
-  // spec-gallery (shard 4); `all` runs alone on shard 1.
-  assertEquals(shardForPatternIntegrationFile("all.test.ts", 4), 1);
+Deno.test("pattern integration four-way shard keeps the heaviest tests apart", () => {
+  const heavy = [
+    "parking-coordinator-admin-view.test.ts",
+    "cfc-group-chat-demo-two-browsers.test.ts",
+    "cfc-spec-gallery.test.ts",
+    "cfc-group-chat-demo.test.ts",
+  ];
+  const assignment = assignPatternIntegrationShards(heavy, TOTAL_SHARDS);
+  const shardOf = (file: string) => assignment.get(file);
+
+  // The two group-chat browser tests are the heaviest end-to-end tests on CI
+  // (~41s for two-browsers, ~29s for the single-browser one). They must not
+  // share a shard, or that shard carries ~70s of group-chat work alone.
   assertEquals(
-    shardForPatternIntegrationFile("cfc-group-chat-demo.test.ts", 4),
-    2,
+    shardOf("cfc-group-chat-demo-two-browsers.test.ts") !==
+      shardOf("cfc-group-chat-demo.test.ts"),
+    true,
+    "the two group-chat browser tests must be on different shards",
   );
+
+  // The three heaviest single files land on distinct shards.
+  const top = [
+    "parking-coordinator-admin-view.test.ts",
+    "cfc-group-chat-demo-two-browsers.test.ts",
+    "cfc-spec-gallery.test.ts",
+  ].map(shardOf);
   assertEquals(
-    shardForPatternIntegrationFile("parking-coordinator-admin-view.test.ts", 4),
+    new Set(top).size,
     3,
-  );
-  assertEquals(
-    shardForPatternIntegrationFile("cfc-spec-gallery.test.ts", 4),
-    4,
+    "the three heaviest tests should be on distinct shards",
   );
 });
 
-Deno.test("unknown pattern integration files are assigned deterministically", () => {
+Deno.test("all.test.ts runs in every shard", () => {
+  const files = [
+    "all.test.ts",
+    "counter.test.ts",
+    "default-app.test.ts",
+    "parking-coordinator-admin-view.test.ts",
+  ];
+  for (let index = 1; index <= 4; index++) {
+    const selected = selectPatternIntegrationFiles(files, { index, total: 4 });
+    assertEquals(
+      selected.includes("./integration/all.test.ts"),
+      true,
+      `shard ${index} should include all.test.ts`,
+    );
+  }
+});
+
+Deno.test("every non-all file is assigned to exactly one shard", () => {
+  const files = [
+    "all.test.ts",
+    "parking-coordinator-admin-view.test.ts",
+    "cfc-spec-gallery.test.ts",
+    "default-app.test.ts",
+    "cfc-group-chat-demo.test.ts",
+    "counter.test.ts",
+    "new-unmapped-file.test.ts",
+  ];
+  const counts = new Map<string, number>();
+  for (let index = 1; index <= 4; index++) {
+    const selected = selectPatternIntegrationFiles(files, { index, total: 4 });
+    for (const path of selected) {
+      if (path === "./integration/all.test.ts") continue;
+      counts.set(path, (counts.get(path) ?? 0) + 1);
+    }
+  }
+  for (const file of files) {
+    if (file === "all.test.ts") continue;
+    assertEquals(
+      counts.get(`./integration/${file}`),
+      1,
+      `${file} should appear on exactly one shard`,
+    );
+  }
+});
+
+Deno.test("every real integration file is covered exactly once across shards", async () => {
+  // Read the actual integration directory so a file that silently falls out of
+  // every shard fails here — CI itself would run green, because a dropped file
+  // is simply never executed.
+  const files = await listPatternIntegrationTests();
+
+  // Guard against the test passing vacuously if the listing breaks.
   assertEquals(
-    shardForPatternIntegrationFile("new-test-file.test.ts", 4),
-    stableShardForName("new-test-file.test.ts", 4),
+    files.includes(ALL_PATTERNS_FILE),
+    true,
+    `expected ${ALL_PATTERNS_FILE} in the integration directory`,
   );
+
+  const shardOf = new Map<string, number[]>();
+  for (let index = 1; index <= TOTAL_SHARDS; index++) {
+    const selected = selectPatternIntegrationFiles(files, {
+      index,
+      total: TOTAL_SHARDS,
+    });
+    for (const path of selected) {
+      const name = path.replace("./integration/", "");
+      const shards = shardOf.get(name) ?? [];
+      shards.push(index);
+      shardOf.set(name, shards);
+    }
+  }
+
+  for (const name of files) {
+    const shards = shardOf.get(name) ?? [];
+    if (name === ALL_PATTERNS_FILE) {
+      assertEquals(
+        shards,
+        [1, 2, 3, 4],
+        `${name} should run in every shard`,
+      );
+    } else {
+      assertEquals(
+        shards.length,
+        1,
+        `${name} should run in exactly one shard, got ${
+          JSON.stringify(shards)
+        }`,
+      );
+    }
+  }
+
+  // No phantom files: everything selected corresponds to a real file.
+  for (const name of shardOf.keys()) {
+    assertEquals(
+      files.includes(name),
+      true,
+      `selected ${name} is not a real integration file`,
+    );
+  }
+});
+
+Deno.test("unlisted pattern integration files round-robin over the unlisted set", () => {
+  // Files not in the table are distributed round-robin, so two unlisted files
+  // land on consecutive shards rather than colliding.
+  const files = ["all.test.ts", "new-a.test.ts", "new-b.test.ts"];
+  const assignment = assignPatternIntegrationShards(files, TOTAL_SHARDS);
+  assertEquals(assignment.get("new-a.test.ts"), 1);
+  assertEquals(assignment.get("new-b.test.ts"), 2);
 });

--- a/tasks/select-pattern-integration-files.ts
+++ b/tasks/select-pattern-integration-files.ts
@@ -1,43 +1,95 @@
 #!/usr/bin/env -S deno run --allow-read
 
-import { parseShard, shardForFile, stableShardForName } from "./shard-utils.ts";
-export { parseShard, stableShardForName };
+import { parseShard } from "./shard-utils.ts";
+export { parseShard };
+
+// `all.test.ts` compiles and instantiates every authored pattern, so its cost
+// grows with the pattern catalog. It runs in EVERY shard and splits its own
+// pattern list by PATTERN_INTEGRATION_SHARD (see
+// packages/patterns/integration/all.test.ts), spreading the compile work across
+// shards instead of pinning it to one. It is therefore excluded from the
+// per-file shard assignment below.
+const ALL_PATTERNS_FILE = "all.test.ts";
 
 // Explicit assignments balance the four browser-integration shards by
-// wall-time. The heaviest end-to-end tests (~45-52s each) are spread one per
-// shard so no single shard dominates. `all.test.ts` is the heaviest single
-// file and gets its own shard. Approx test wall-times (excluding ~35s
-// server/browser startup per shard) keep shards within ~100-115s of each other.
+// wall-time, using observed CI per-file timings. The heaviest end-to-end tests
+// are parking-coordinator (~43s), cfc-group-chat-demo-two-browsers (~41s),
+// cfc-spec-gallery (~33s), cfc-group-chat-demo (~29s), and default-app (~26s);
+// they are spread so no shard carries two of them. The two group-chat browser
+// tests in particular go on different shards (they alone sum to ~70s). Each
+// shard also runs its slice of `all.test.ts` (see above). These weights span
+// ~100x, so a count-based split (hash or plain round-robin) cannot balance them;
+// the table is what keeps the shards even. Files not listed here fall back to
+// round-robin over the unlisted files.
 const FOUR_SHARD_ASSIGNMENTS: Record<string, number> = {
-  "all.test.ts": 1, // ~heavy, runs alone
+  // shard 1
+  "parking-coordinator-admin-view.test.ts": 1,
+  "cfc-authorized-save.test.ts": 1,
+  "nested-counter.test.ts": 1,
+  "chat-note.test.ts": 1,
+  "fetch-data.test.ts": 1,
 
-  "cfc-group-chat-demo.test.ts": 2, // ~52s
-  "default-app.test.ts": 2, // ~47s
-  "chat-note.test.ts": 2, // tiny
-  "fetch-data.test.ts": 2, // tiny
-  "instantiate-pattern.test.ts": 2, // ~1s
+  // shard 2
+  "cfc-group-chat-demo-two-browsers.test.ts": 2,
+  "cfc-staged-publish.test.ts": 2,
+  "cfc-group-chat-demo-multi-runtime.test.ts": 2,
+  "cfc-authorship-chat.test.ts": 2,
 
-  "cfc-authorized-save.test.ts": 3, // ~25s
-  "cfc-staged-publish.test.ts": 3, // ~24s
-  "cfc-render-policy-demo.test.ts": 3, // ~17s
-  "llm.test.ts": 3, // tiny
-  "parking-coordinator-admin-view.test.ts": 3, // ~42s
+  // shard 3
+  "cfc-spec-gallery.test.ts": 3,
+  "shared-profile.test.ts": 3,
+  "cfc-render-policy-demo.test.ts": 3,
+  "counter.test.ts": 3,
 
-  "nested-counter.test.ts": 4, // ~21s
-  "counter.test.ts": 4, // ~21s
-  "cfc-authorship-chat.test.ts": 4, // ~22s
-  "chatbot.test.ts": 4, // tiny
-  "cfc-spec-gallery.test.ts": 4, // ~45s
+  // shard 4
+  "cfc-group-chat-demo.test.ts": 4,
+  "default-app.test.ts": 4,
+  "home-profile.test.ts": 4,
+  "instantiate-pattern.test.ts": 4,
+  "llm.test.ts": 4,
+  "chatbot.test.ts": 4,
 };
 
-export function shardForPatternIntegrationFile(
-  name: string,
+// Assign each end-to-end file (everything except `all.test.ts`) to a shard:
+// the explicit table when running the canonical four-way split, else round-robin
+// over the unlisted files so a newly added file still lands somewhere even.
+export function assignPatternIntegrationShards(
+  files: string[],
   total: number,
-): number {
-  return shardForFile(name, total, FOUR_SHARD_ASSIGNMENTS);
+): Map<string, number> {
+  const assignment = new Map<string, number>();
+  let roundRobin = 0;
+  for (
+    const name of files.filter((name) => name !== ALL_PATTERNS_FILE).sort()
+  ) {
+    const pinned = total === 4 ? FOUR_SHARD_ASSIGNMENTS[name] : undefined;
+    assignment.set(name, pinned ?? (roundRobin++ % total) + 1);
+  }
+  return assignment;
 }
 
-async function listPatternIntegrationTests(): Promise<string[]> {
+// Select the files for one shard. `all.test.ts` is included in every shard (it
+// shards its own pattern list internally); the remaining files are assigned to
+// exactly one shard each.
+export function selectPatternIntegrationFiles(
+  files: string[],
+  shard: { index: number; total: number },
+): string[] {
+  const selected: string[] = [];
+  for (
+    const [name, assigned] of assignPatternIntegrationShards(files, shard.total)
+  ) {
+    if (assigned === shard.index) selected.push(`./integration/${name}`);
+  }
+
+  if (files.includes(ALL_PATTERNS_FILE)) {
+    selected.unshift(`./integration/${ALL_PATTERNS_FILE}`);
+  }
+
+  return selected;
+}
+
+export async function listPatternIntegrationTests(): Promise<string[]> {
   const integrationDir = new URL(
     "../packages/patterns/integration/",
     import.meta.url,
@@ -57,11 +109,7 @@ async function listPatternIntegrationTests(): Promise<string[]> {
 if (import.meta.main) {
   const shard = parseShard(Deno.args[0] ?? "");
   const files = await listPatternIntegrationTests();
-  const selected = files
-    .filter((name) =>
-      shardForPatternIntegrationFile(name, shard.total) === shard.index
-    )
-    .map((name) => `./integration/${name}`);
+  const selected = selectPatternIntegrationFiles(files, shard);
 
   if (selected.length === 0) {
     throw new Error(

--- a/tasks/select-runner-test-files.test.ts
+++ b/tasks/select-runner-test-files.test.ts
@@ -1,9 +1,11 @@
 import { assertEquals } from "@std/assert";
 import {
+  listRunnerTests,
   selectRunnerTestFiles,
-  shardForRunnerTestFile,
 } from "./select-runner-test-files.ts";
-import { parseShard, stableShardForName } from "./shard-utils.ts";
+import { parseShard } from "./shard-utils.ts";
+
+const TOTAL_SHARDS = 4;
 
 Deno.test("parseShard parses shard notation", () => {
   assertEquals(parseShard("2/4"), { index: 2, total: 4 });
@@ -21,50 +23,56 @@ Deno.test("parseShard rejects invalid shard notation", () => {
   }
 });
 
-Deno.test("runner test four-way shard keeps slow files balanced", () => {
-  // The heaviest files are spread one per shard so no shard dominates.
-  assertEquals(shardForRunnerTestFile("engine.test.ts", 4), 1);
-  assertEquals(shardForRunnerTestFile("piece-helpers.test.ts", 4), 2);
-  assertEquals(shardForRunnerTestFile("json-utils.test.ts", 4), 3);
-  assertEquals(shardForRunnerTestFile("reactive-dependencies.test.ts", 4), 4);
+Deno.test("runner test round-robin keeps shard counts even", () => {
+  const files = Array.from({ length: 30 }, (_, i) => ({
+    name: `t${String(i).padStart(2, "0")}.test.ts`,
+  }));
+  const counts = [1, 2, 3, 4].map((index) =>
+    selectRunnerTestFiles(files, { index, total: TOTAL_SHARDS }).length
+  );
+  assertEquals(
+    Math.max(...counts) - Math.min(...counts) <= 1,
+    true,
+    `${counts}`,
+  );
 });
 
-Deno.test("runner test sharding is stable when files are added or removed", () => {
-  const baseFiles = [
-    { name: "engine.test.ts" },
-    { name: "piece-helpers.test.ts" },
-    { name: "json-utils.test.ts" },
-    { name: "small-a.test.ts" },
-    { name: "small-b.test.ts" },
-  ];
+Deno.test("every real runner test file is covered exactly once across shards", async () => {
+  // Read the actual runner test directory so a file that silently falls out of
+  // every shard fails here — CI itself would run green, because a dropped file
+  // is simply never executed.
+  const files = await listRunnerTests();
+  const names = files.map((file) => file.name);
 
-  const before = [1, 2, 3, 4].map((index) =>
-    selectRunnerTestFiles(baseFiles, { index, total: 4 })
-  );
+  // Guard against the test passing vacuously if the listing breaks.
+  assertEquals(names.length > 0, true, "expected runner test files to exist");
 
-  // Adding a new file should not move any existing file between shards.
-  const withNewFile = [
-    ...baseFiles,
-    { name: "new-feature.test.ts" },
-  ];
-  const after = [1, 2, 3, 4].map((index) =>
-    selectRunnerTestFiles(withNewFile, { index, total: 4 })
-  );
+  const shardOf = new Map<string, number[]>();
+  for (let index = 1; index <= TOTAL_SHARDS; index++) {
+    for (
+      const name of selectRunnerTestFiles(files, { index, total: TOTAL_SHARDS })
+    ) {
+      const shards = shardOf.get(name) ?? [];
+      shards.push(index);
+      shardOf.set(name, shards);
+    }
+  }
 
-  for (const file of baseFiles) {
-    const shardBefore = before.findIndex((s) => s.includes(file.name));
-    const shardAfter = after.findIndex((s) => s.includes(file.name));
+  for (const name of names) {
+    const shards = shardOf.get(name) ?? [];
     assertEquals(
-      shardBefore,
-      shardAfter,
-      `${file.name} moved from shard ${shardBefore + 1} to ${shardAfter + 1}`,
+      shards.length,
+      1,
+      `${name} should run in exactly one shard, got ${JSON.stringify(shards)}`,
     );
   }
-});
 
-Deno.test("unknown runner test files are assigned deterministically", () => {
-  assertEquals(
-    shardForRunnerTestFile("new-test-file.test.ts", 4),
-    stableShardForName("new-test-file.test.ts", 4),
-  );
+  // No phantom files: everything selected corresponds to a real file.
+  for (const name of shardOf.keys()) {
+    assertEquals(
+      names.includes(name),
+      true,
+      `selected ${name} is not a real runner test file`,
+    );
+  }
 });

--- a/tasks/select-runner-test-files.ts
+++ b/tasks/select-runner-test-files.ts
@@ -1,49 +1,24 @@
 #!/usr/bin/env -S deno run --allow-read
 
-import { parseShard, shardForFile, stableShardForName } from "./shard-utils.ts";
-export { parseShard, stableShardForName };
+import { parseShard } from "./shard-utils.ts";
+export { parseShard };
 
-// Explicit assignments balance the four runner-test shards by wall-time.
-// The heaviest files are spread across shards so no single shard dominates.
-// Files not listed here fall through to a stable hash of their filename.
-const FOUR_SHARD_ASSIGNMENTS: Record<string, number> = {
-  "engine.test.ts": 1, // ~700k weight, heaviest — runs with hash-assigned small files
-
-  "piece-helpers.test.ts": 2, // ~320k
-  "memory-v2-watch-refresh-race.test.ts": 2, // ~95k
-  "pattern-scope.test.ts": 2, // ~75k
-
-  "json-utils.test.ts": 3, // ~210k
-  "runner.test.ts": 3, // ~100k
-  "wish.test.ts": 3, // ~95k
-  "navigate-handler.test.ts": 3, // ~80k
-
-  "reactive-dependencies.test.ts": 4, // ~180k
-  "pattern-manager.test.ts": 4, // ~145k
-  "data-updating.test.ts": 4, // ~80k
-  "scheduler-ordering.test.ts": 4, // ~80k
-};
-
-export function shardForRunnerTestFile(
-  name: string,
-  total: number,
-): number {
-  return shardForFile(name, total, FOUR_SHARD_ASSIGNMENTS);
-}
-
+// Runner test files are split across shards by round-robin over the sorted file
+// list. There is no per-file weighting: a byte-size table used to live here, but
+// file size does not track run time, so it balanced no better than plain
+// round-robin. A time-weighted split would do better and can be added if the
+// imbalance starts to matter on the critical path.
 export function selectRunnerTestFiles(
   files: { name: string }[],
   shard: { index: number; total: number },
 ): string[] {
   return files
-    .filter((file) =>
-      shardForRunnerTestFile(file.name, shard.total) === shard.index
-    )
     .map((file) => file.name)
-    .sort();
+    .sort()
+    .filter((_, i) => i % shard.total === shard.index - 1);
 }
 
-async function listRunnerTests(): Promise<{ name: string }[]> {
+export async function listRunnerTests(): Promise<{ name: string }[]> {
   const testDir = new URL("../packages/runner/test/", import.meta.url);
   const files: { name: string }[] = [];
 

--- a/tasks/shard-utils.ts
+++ b/tasks/shard-utils.ts
@@ -17,23 +17,3 @@ export function parseShard(raw: string): Shard {
 
   return { index, total };
 }
-
-export function stableShardForName(name: string, total: number): number {
-  let hash = 2166136261;
-  for (const char of name) {
-    hash ^= char.charCodeAt(0);
-    hash = Math.imul(hash, 16777619);
-  }
-  return (hash >>> 0) % total + 1;
-}
-
-export function shardForFile(
-  name: string,
-  total: number,
-  fourShardAssignments: Record<string, number>,
-): number {
-  if (total === 4 && fourShardAssignments[name]) {
-    return fourShardAssignments[name];
-  }
-  return stableShardForName(name, total);
-}


### PR DESCRIPTION
ci: shard all.test.ts across pattern-integration shards and simplify selection
"Pattern Integration Tests (1/4)" ran ~289s across recent main runs — over
the 3-minute required-job budget — and gated CI wall-time, because shard 1
ran all.test.ts alone. all.test.ts compiles and instantiates every authored
pattern (~59, sequentially), so its cost grows with the catalog; it was the
bulk of that shard's test step.

Make all.test.ts shard-aware: it reads PATTERN_INTEGRATION_SHARD="i/n" (the
same fan-out CFCHECK_SHARD uses for pattern checks) and runs only its slice
of patterns. The selector includes all.test.ts in every shard and the job
passes the shard down to deno test, so the compile work spreads across all
four shards instead of pinning one.

Assign the end-to-end test files by observed CI per-file timings, keeping
the two group-chat browser tests on different shards. They are the heaviest
end-to-end tests on CI — cfc-group-chat-demo-two-browsers ~41s (it drives
two browsers) and cfc-group-chat-demo ~29s — so putting both on one shard
(as a first, local-timing-based attempt did) overloads it. The heaviest
files (parking-coordinator ~43s, two-browsers ~41s, cfc-spec-gallery ~33s,
cfc-group-chat-demo ~29s, default-app ~26s) are now spread so no shard
carries two; the four shards' end-to-end load sits within ~5%.

Add coverage tests for all three sharded selectors (pattern-integration,
runner, generated-patterns): each reads its real test directory and asserts
every file lands in exactly one shard, with no phantom files. Without them a
file that silently fell out of every shard would never run and CI would
still pass green. The tasks/ tests were only type-checked, never executed
(tasks/ is not a workspace member and check.sh only runs `deno check`), so
run them in the Check job to enforce these.

Then simplify shard selection down to the parts that earn their keep.
Measured each scheme against real per-file timings (runner: local seconds,
which track CI; pattern: observed CI seconds), per-shard totals and max/min:

  Runner (301 files):
    pure hash            15.5 / 15.6 / 32.2 / 13.6   max/min 2.37
    pure round-robin     25.2 / 12.4 / 17.0 / 22.4   max/min 2.02
    current table+hash   20.2 / 15.6 / 27.7 / 13.4   max/min 2.07
    ideal (by time)      19.2 / 19.2 / 19.2 / 19.2   max/min 1.00

  Pattern e2e (19 files, 0.4s-43s each):
    pure hash            22.9 / 171.1 / 65.9 / 17.8  max/min 9.61
    pure round-robin     53.2 / 71.2 / 68.6 / 84.7   max/min 1.59
    current table        67.8 / 70.8 / 70.7 / 68.4   max/min 1.04

Conclusions:

- The hash fallback (FNV over the filename) is worse than round-robin on
  balance in both cases, badly so for pattern (it dumped 171s of ~277 onto
  one shard) — a small file count hashes lumpily. Its only edge is
  insertion-stability (adding a file moves no others), but that barely
  matters once the heavy files are pinned by a table, since reshuffling a
  tail of small uniform files doesn't move a shard's total enough to trip a
  +15% baseline. So replace it with round-robin everywhere.

- The runner table balanced no better than plain round-robin (2.07 vs 2.02)
  and actually worse than it. It is byte-size based, and file size does not
  track run time (it listed piece-helpers as heavy at "320k", but that test
  runs fast). It carries no weight, so delete it: runner now round-robins
  over the sorted file list, like generated patterns already do.

- The pattern table is essential and stays. Its files span ~100x in weight,
  which no count-based split can balance (hash 9.61x, round-robin 1.59x);
  the time-weighted table holds it at 1.04x. Unlisted files fall back to
  round-robin over the unlisted set.

Net: shard-utils keeps only parseShard; the FNV hash and the table/hash
combinator are gone; generated patterns reuses the shared parseShard instead
of its duplicate. Pattern shard assignment is unchanged for current files
(the table is complete). Runner assignment changes to round-robin.

Because the per-shard perf metrics stay in force, this rebalance shifts
individual shard baselines by design (every shard now carries an all.test.ts
slice, and runner re-sorts), so it needs NEW_PERF_BASELINE overrides in the
PR description from the perf-check log's copy-paste block.

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: job: Pattern Integration Tests (4/4) = 164s
NEW_PERF_BASELINE: job: Runner Tests (1/4) = 244s
NEW_PERF_BASELINE: job: Runner Tests (4/4) = 191s
NEW_PERF_BASELINE: job: Pattern Integration Tests (2/4) = 166s
---END COPY-PASTE---

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shard `all.test.ts` across the 4 pattern-integration shards and rebalance file assignments to cut the slowest shard from ~289s to ~165s and reduce CI wall time. Simplify sharding: remove hash-based fallbacks, use round-robin for unlisted files and runner tests, and add coverage guards.

- **New Features**
  - `all.test.ts` is shard-aware via `PATTERN_INTEGRATION_SHARD` ("i/n"): it runs in every shard and executes only its slice of patterns.
  - New tests read real test directories to ensure every file is scheduled exactly once (and `all.test.ts` in all shards) for pattern integration, runner, and generated patterns; `tasks/` unit tests now run in the Check workflow.

- **Refactors**
  - Keep the 4-way table to separate the heaviest e2e tests; unlisted files now round-robin across shards (no hashing).
  - Runner tests now use pure round-robin (removed the per-file table); `shard-utils.ts` keeps only `parseShard`; exported `listPatternIntegrationTests()`, `listRunnerTests()`, and `listGeneratedPatternTests()` for reuse; CI passes `PATTERN_INTEGRATION_SHARD` to `deno test`.

<sup>Written for commit a671742e92154911b629badb7c2ecd8ff789c35a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

