### PR TITLE
Fix lunch poll composed UI rendering

### DIFF
--- a/packages/patterns/lunch-poll/participant-identity-card.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.tsx
@@ -219,7 +219,7 @@ export default pattern<
                   timing-strategy="immediate"
                   style="flex:1"
                 />
-                <cf-button onClick={boundJoin}>Join</cf-button>
+                <cf-button onClick={() => boundJoin.send({})}>Join</cf-button>
               </div>
             </div>
           )}

--- a/packages/patterns/lunch-poll/poll-option-card.test.tsx
+++ b/packages/patterns/lunch-poll/poll-option-card.test.tsx
@@ -93,6 +93,15 @@ const STORED_OPTION: Option = {
   imageUrl: "data:image/png;base64,stored",
 };
 
+const EMPTY_IMAGE_OPTION: Option = {
+  id: "opt-no-image",
+  title: "No Image Cafe",
+  addedByName: "Blair",
+  homePageUrl: "",
+  homePageUrlOverride: "",
+  imageUrl: "",
+};
+
 const votes: Vote[] = [
   {
     optionId: "opt-sushi",
@@ -123,6 +132,26 @@ export default pattern(() => {
     me: "Alex",
     isJoined: true,
     isAdmin: true,
+    votes,
+    cityLabel: "Berkeley, CA",
+    searchEndpoint: "",
+    homePageRefresh,
+    linkEditTarget,
+    linkDraft,
+    removeConfirmTarget,
+    castVote,
+    removeOption,
+    logVisit,
+    setOptionUrl,
+    setOptionHomePageUrl,
+    setOptionImage,
+  });
+  const noImageViewerCard = PollOptionCard({
+    option: EMPTY_IMAGE_OPTION,
+    rank: 2,
+    me: "Alex",
+    isJoined: true,
+    isAdmin: false,
     votes,
     cityLabel: "Berkeley, CA",
     searchEndpoint: "",
@@ -193,9 +222,11 @@ export default pattern(() => {
       STORED_OPTION.imageUrl,
     ) !== undefined
   );
-
   const assert_host_did_not_rewrite_stored_art = computed(() =>
     lastImageUrl.get() === ""
+  );
+  const assert_missing_art_is_not_marked_stored = computed(() =>
+    propValue(noImageViewerCard[UI], "data-art-sync") !== "stored"
   );
 
   return {
@@ -206,6 +237,7 @@ export default pattern(() => {
       { assertion: assert_host_controls_render },
       { assertion: assert_stored_art_renders },
       { assertion: assert_host_did_not_rewrite_stored_art },
+      { assertion: assert_missing_art_is_not_marked_stored },
     ],
     card,
   };

--- a/packages/patterns/lunch-poll/poll-option-card.tsx
+++ b/packages/patterns/lunch-poll/poll-option-card.tsx
@@ -269,26 +269,20 @@ export default pattern<PollOptionCardInput, PollOptionCardOutput>(
 
     // Host persists the generated image returned by the image route as a data
     // URL. Other viewers render the stored value without running image-gen.
-    const storedArtSyncState = computed(() =>
-      safeImageUrl(option.imageUrl) ? "stored" : ""
-    );
-    const generatedArtSyncState = computed(() => {
-      const url = safeImageUrl(generatedArt.result);
-      if (url) {
+    const artSyncState = computed(() => {
+      if (safeImageUrl(option.imageUrl)) return "stored";
+      if (!isAdmin) return "";
+      const generatedUrl = safeImageUrl(generatedArt.result ?? "");
+      if (generatedUrl) {
         setOptionImage.send({
           optionId: oid,
-          imageUrl: url,
+          imageUrl: generatedUrl,
         });
         return "stored";
       }
       if (generatedArt.pending) return "pending";
       return generatedArt.error ? "error" : "requested";
     });
-    const artSyncState = storedArtSyncState
-      ? "stored"
-      : isAdmin
-      ? generatedArtSyncState
-      : "";
 
     const homePageSearch = fetchData<WebSearchResponse>({
       url: computed(() =>


### PR DESCRIPTION
## Why

The lunch poll sub-pattern refactor exposed browser/runtime differences on existing deployed state: option images and recent-history rows could disappear even though the underlying data was present. While debugging a join/profile issue, we also found an action-invalid-input flag from option-card art sync and tightened the participant join button so it sends an explicit empty event instead of relying on raw click-event coercion.

This PR keeps the composed sub-pattern structure but moves fragile data-heavy rendering back to the option-card boundary, makes recent-history rendering depend on actual rows, and cleans up the reactive art-sync/join event paths.

## What Changed

- Render stored option images directly from `PollOptionCard` so existing data-URI images survive mapped composition.
- Show the Recently eaten card only when recent visit rows are present.
- Change participant Join to `boundJoin.send({})` so the handler reads the draft name from its bound state.
- Collapse option-card art sync into one explicit `computed()` instead of branching on a computed ref.
- Add focused tests for option-card image rendering/sync state and recent-history row rendering.
- Record the mapped child UI composition lesson in lunch-poll best practices.

## Test plan

- `deno task cf check packages/patterns/lunch-poll/generated-art.tsx`
- `deno task cf check packages/patterns/lunch-poll/participant-identity-card.tsx`
- `deno task cf check packages/patterns/lunch-poll/poll-option-card.tsx`
- `deno task cf check packages/patterns/lunch-poll/main.tsx`
- `deno task cf test packages/patterns/lunch-poll/generated-art.test.tsx`
- `deno task cf test packages/patterns/lunch-poll/participant-identity-card.test.tsx`
- `deno task cf test packages/patterns/lunch-poll/poll-option-card.test.tsx`
- `deno task cf test packages/patterns/lunch-poll/main.test.tsx`
- `deno task cf test packages/patterns/lunch-poll/lunch-stats.test.tsx`
- `deno task cf test packages/patterns/lunch-poll/multi-user.test.tsx` (outside sandbox)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes disappearing option images and the recent-history card by rendering stored images in `PollOptionCard` and gating history on actual rows. Also cleans up join and art-sync logic and adds tests to prevent regressions.

- **Bug Fixes**
  - Render stored option images directly in `PollOptionCard`; generate art only when no image exists. Added a test to ensure missing images aren’t marked “stored”.
  - Show the Recently eaten card only when recent visit rows are present.
  - Use `boundJoin.send({})` for Join to avoid click-event coercion.

- **Refactors**
  - Unified art sync into one computed that persists generated data URIs for admins and reports stored/pending/error/requested; non-admin viewers only render stored images.

<sup>Written for commit da7733a1cf7cabb48f982efc59cd2f4c158725e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

