### PR TITLE
refactor(data-model): retire FabricHash toJSON()/fromJson()

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -106,7 +106,6 @@ export interface FabricHash extends FabricPrimitive {
   readonly length: number;
   readonly hashString: string;
   toString(): string;
-  toJSON(): { "/": string };
 }
 
 export interface FabricHashConstructor {

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -108,23 +108,6 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
   }
 
   /**
-   * Returns the JSON representation: `{ '/': '<tag>:<base64urlHash>' }`.
-   * Preserves the `{"/": string}` shape used by `Reference.View.toJSON()`.
-   */
-  toJSON(): { "/": string } {
-    return { "/": this.#fullStringForm };
-  }
-
-  /**
-   * Parses an instance from its legacy JSON representation
-   * `{ '/': '<tag>:<base64urlHash>' }` (same as what is _produced_ by
-   * `toJSON()`).
-   */
-  static fromJson(source: { "/": string }): FabricHash {
-    return this.fromString(source["/"]);
-  }
-
-  /**
    * Parses an instance from its string representation
    * (`<tag>:<base64urlHash>`).
    */

--- a/packages/data-model/test/fabric-primitives/FabricHash.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricHash.test.ts
@@ -33,16 +33,6 @@ describe("FabricHash", () => {
       });
     });
 
-    describe("toJSON()", () => {
-      it("produces `{ '/': 'fid1:<base64>' }`", () => {
-        const cid = new FabricHash(SAMPLE_HASH, "fid1");
-        const json = cid.toJSON();
-        expect(typeof json["/"]).toBe("string");
-        expect(json["/"].startsWith("fid1:")).toBe(true);
-        expect(json["/"]).toBe(cid.toString());
-      });
-    });
-
     describe(".bytes", () => {
       it("returns a defensive copy", () => {
         const cid = new FabricHash(SAMPLE_HASH, "fid1");
@@ -108,18 +98,6 @@ describe("FabricHash", () => {
   });
 
   describe("static members", () => {
-    describe("fromJson()", () => {
-      it("works on the result of the instance method `toJSON()`", () => {
-        const original = new FabricHash(SAMPLE_HASH, "fid1");
-        const json = original.toJSON();
-        const reconstructed = FabricHash.fromJson(json);
-
-        expect(reconstructed).toBeInstanceOf(FabricHash);
-        expect(reconstructed.toString()).toBe(original.toString());
-        expect(reconstructed.bytes).toEqual(original.bytes);
-      });
-    });
-
     describe("fromString()", () => {
       it("works on the result of the instance method `toString()`", () => {
         // Use a non-fid1 tag to verify the parser doesn't hardcode it.

--- a/packages/memory/entity.ts
+++ b/packages/memory/entity.ts
@@ -14,7 +14,7 @@ export type ToString<T> = string & { toString(): ToString<T> };
 export const entity = <T extends null | NonNullable<unknown>>(
   description: NonNullable<unknown> | null,
 ): Entity<T> => {
-  return { "@": hashOf(description).toJSON()["/"] };
+  return { "@": hashOf(description).taggedHashString };
 };
 
 export const toString = <T extends null | NonNullable<unknown>>(
@@ -31,7 +31,7 @@ export const fromString = <T extends null | NonNullable<unknown>>(
       }`,
     );
   } else {
-    return { "@": FabricHash.fromJson({ "/": source.slice(1) }).toJSON()["/"] };
+    return { "@": FabricHash.fromString(source.slice(1)).taggedHashString };
   }
 };
 

--- a/packages/memory/fact.ts
+++ b/packages/memory/fact.ts
@@ -171,7 +171,7 @@ export function normalizeFact<
     : arg.cause == null
     ? unclaimedRef({ the: arg.the, of: arg.of })
     : "/" in arg.cause
-    ? FabricHash.fromJson(arg.cause as unknown as { "/": string })
+    ? FabricHash.fromString((arg.cause as unknown as { "/": string })["/"])
     : hashOf({
       the: arg.cause.the,
       of: arg.cause.of,

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -142,6 +142,6 @@ export function getEntityId(value: any): { "/": string } | undefined {
   const entityId = { "/": fromURI(link.id) };
 
   if (link.path && link.path.length > 0) {
-    return createRef({ path: link.path }, entityId).toJSON!();
+    return { "/": createRef({ path: link.path }, entityId).taggedHashString };
   } else return entityId;
 }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -136,7 +136,7 @@ function schedulerRawActionName(
     name: rawTargetName,
     inputs: inputCells.map(schedulerActionLinkIdentity),
     outputs: outputCells.map(schedulerActionLinkIdentity),
-  }).toJSON()["/"].slice(0, 12);
+  }).hashString.slice(0, 12);
   return `raw:${rawTargetName}:${identity}`;
 }
 
@@ -154,7 +154,7 @@ function schedulerJavaScriptActionName(
     ),
     reads: reads.map(schedulerActionLinkIdentity),
     writes: writes.map(schedulerActionLinkIdentity),
-  }).toJSON()["/"].slice(0, 12);
+  }).hashString.slice(0, 12);
   return `action:${actionName}:${identity}`;
 }
 

--- a/packages/runner/src/slugs.ts
+++ b/packages/runner/src/slugs.ts
@@ -39,9 +39,5 @@ export function slugCause(space: MemorySpace, slug: string): SlugCause {
 }
 
 export function slugIdForSpace(space: MemorySpace, slug: string): string {
-  const id = hashOf({ causal: slugCause(space, slug) }).toJSON?.()["/"];
-  if (typeof id !== "string") {
-    throw new Error("Could not derive slug id.");
-  }
-  return id;
+  return hashOf({ causal: slugCause(space, slug) }).taggedHashString;
 }

--- a/packages/runner/test/create-ref-fail-closed.test.ts
+++ b/packages/runner/test/create-ref-fail-closed.test.ts
@@ -23,12 +23,12 @@ describe("createRef fail-closed", () => {
   it("derives a stable id from concrete inputs (unchanged)", () => {
     const a = createRef({ x: 1, y: "z" }, "cause");
     const b = createRef({ x: 1, y: "z" }, "cause");
-    expect(a.toJSON!()).toEqual(b.toJSON!());
+    expect(a.taggedHashString).toEqual(b.taggedHashString);
   });
 
   it("still mints a fresh id when no cause is given (documented behavior)", () => {
     const a = createRef({ x: 1 });
     const b = createRef({ x: 1 });
-    expect(a.toJSON!()).not.toEqual(b.toJSON!());
+    expect(a.taggedHashString).not.toEqual(b.taggedHashString);
   });
 });

--- a/packages/runner/test/doc-map.test.ts
+++ b/packages/runner/test/doc-map.test.ts
@@ -15,7 +15,7 @@ describe("hashOf", () => {
   it("should create a reference that is equal to another reference with the same source", () => {
     const ref = hashOf({ hello: "world" });
     const ref2 = hashOf({ hello: "world" });
-    expect(ref.toJSON!()).toEqual(ref2.toJSON!());
+    expect(ref.taggedHashString).toEqual(ref2.taggedHashString);
   });
 });
 
@@ -47,7 +47,7 @@ describe("cell-map", () => {
       const cause = "custom-cause";
       const ref = createRef(source, cause);
       const ref2 = createRef(source);
-      expect(ref.toJSON!()).not.toEqual(ref2.toJSON!());
+      expect(ref.taggedHashString).not.toEqual(ref2.taggedHashString);
     });
   });
 

--- a/packages/runner/test/storage-source-topology-refresh.bench.ts
+++ b/packages/runner/test/storage-source-topology-refresh.bench.ts
@@ -13,7 +13,8 @@ const BASE_URIS = [
 ] as const;
 const PATTERN_ID = "bench-pattern:source-topology";
 const PATTERN_URI = `of:${
-  hashOf({ causal: { patternId: PATTERN_ID, type: "pattern" } }).toJSON()["/"]
+  hashOf({ causal: { patternId: PATTERN_ID, type: "pattern" } })
+    .taggedHashString
 }` as const;
 
 type TestProvider = ReturnType<typeof StorageManager.emulate> extends {


### PR DESCRIPTION
## What

Retires the last two legacy bits of `FabricHash` — `toJSON()` and `static fromJson()` — completing the cleanup that started this thread (the `"/"` getter went in #4204).

## How

Migrate every caller to the modern string API, then delete the methods (and the `toJSON()` declaration on the `@commonfabric/api` `FabricHash` interface):
- `memory/entity.ts`, `memory/fact.ts`, `runner.ts`, and `getEntityId` (`create-ref.ts`): `.toJSON()["/"]` → `.taggedHashString`; `FabricHash.fromJson({ "/": s })` → `FabricHash.fromString(s)`.
- `slugIdForSpace`: `.toJSON?.()["/"]` → `.taggedHashString` (drops a now-dead `typeof … !== "string"` guard).
- tests/bench that compared `.toJSON!()` results now compare `.taggedHashString`.

`toJSON`/`fromJson` were only ever the `{ "/": string }`-serialization shim; `FabricHash`'s wire form is its codec (`{ tag, hash }`), untouched here. Storage is unaffected (same reasoning as #4204; no codec/value-hash/storage/wire file changed, and `toJSON` was never on the conversion path — `FabricHash` dispatches to `NATIVE_TAGS.Hash`, not `HasToJSON`).

## Drive-by fix

The scheduler action-name identity suffix sliced the **tagged** hash string — `hashOf(...).taggedHashString.slice(0, 12)` — spending 5 of its 12 chars on the constant `fid1:` prefix, leaving only ~7 base64url chars (~42 bits) of real entropy in a disambiguation suffix. Switched to the untagged `.hashString.slice(0, 12)` for a full 12 entropy chars (~72 bits). It's a debug/telemetry label (`setRunnableName` sets `.name`/`.src`, not a persisted or collision-critical key), so the value change is safe.

## Testing

`deno task check` + `deno fmt --check` clean. Suites pass: data-model 37/0, memory 212/0, runner 633/0, piece 10/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

This PR mostly removes code and shouldn't affect build time. It _does_ add net three uncovered lines of code, which we accept here.

NEW_COVERAGE_BASELINE
NEW_PERF_BASELINE: job: Build Binaries = 66s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the legacy `FabricHash` JSON helpers by removing `toJSON()` and `fromJson()` and moving all callers to the string API. Also fixes scheduler action-name identity to use the full-entropy untagged hash.

- **Refactors**
  - Replace `.toJSON()["/"]` with `.taggedHashString` and `FabricHash.fromJson({ "/": s })` with `FabricHash.fromString(s)`.
  - Remove `toJSON()` from the `FabricHash` class and its interface in `@commonfabric/api`.
  - Simplify `slugIdForSpace` and related tests to use `.taggedHashString`.
  - No storage or wire-format changes.

- **Bug Fixes**
  - Scheduler action-name identity now slices `.hashString.slice(0, 12)` instead of the tagged string to use all 12 chars for entropy. Debug label only; behavior unchanged otherwise.

<sup>Written for commit 3e37f12d45aec3f5b5d4221e2002d541da3385b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

