### PR TITLE
feat(ci): comment on PRs when test coverage regresses

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -667,7 +667,8 @@ jobs:
     permissions:
       contents: read
       actions: read
-      pull-requests: read
+      # write: the coverage gate posts a once-per-PR comment on regressions.
+      pull-requests: write
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4

--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -2,12 +2,14 @@ import { assertEquals } from "@std/assert";
 import * as path from "@std/path";
 import {
   collectCoverageDebtMetricsFromLcov,
+  collectCoverageDebtReportFromLcov,
   collectSourceFiles,
   countTrackedSourceLines,
   countUncoveredProfileLines,
   metricGroupFor,
   parseLcov,
   shouldTrackSourceFile,
+  trackedSourceLineNumbers,
 } from "./coverage-metrics.ts";
 
 Deno.test("parseLcov accumulates hits per source line", () => {
@@ -38,6 +40,21 @@ Deno.test("countTrackedSourceLines ignores blank and comment-only lines", () => 
       "const inline = 2; // comment",
     ].join("\n")),
     3,
+  );
+});
+
+Deno.test("trackedSourceLineNumbers reports the executable line numbers", () => {
+  assertEquals(
+    trackedSourceLineNumbers([
+      "", // 1
+      "// comment", // 2
+      "const value = 1;", // 3
+      "/* block", // 4
+      "comment */", // 5
+      "export const next = value + 1;", // 6
+      "const inline = 2; // comment", // 7
+    ].join("\n")),
+    [3, 6, 7],
   );
 });
 
@@ -117,6 +134,63 @@ Deno.test("collectCoverageDebtMetricsFromLcov computes debt from compact reports
         metric.name === "coverage-debt: packages/example uncovered lines"
       )?.uncoveredLines,
       1,
+    );
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
+});
+
+Deno.test("collectCoverageDebtReportFromLcov lists uncovered line numbers per file", async () => {
+  const rootDir = await Deno.makeTempDir({ prefix: "coverage-report-test-" });
+  try {
+    const coveredPath = path.join(rootDir, "packages/example/src/covered.ts");
+    const untestedPath = path.join(rootDir, "packages/example/src/untested.ts");
+    await Deno.mkdir(path.dirname(coveredPath), { recursive: true });
+    await Deno.writeTextFile(
+      coveredPath,
+      [
+        "export const covered = 1;",
+        "export const uncovered = 2;",
+      ].join("\n"),
+    );
+    // This file never appears in the LCOV report, so every tracked line counts
+    // as uncovered.
+    await Deno.writeTextFile(
+      untestedPath,
+      "export const neverRun = 3;\n",
+    );
+
+    const report = await collectCoverageDebtReportFromLcov({
+      rootDir,
+      lcov: [
+        `SF:${coveredPath}`,
+        "DA:1,1",
+        "DA:2,0",
+        "end_of_record",
+      ].join("\n"),
+    });
+
+    assertEquals(
+      report.metrics.find((metric) =>
+        metric.name === "coverage-debt: packages/example uncovered lines"
+      )?.uncoveredLines,
+      2,
+    );
+    assertEquals(
+      report.files.map((file) => ({
+        relativePath: file.relativePath,
+        uncoveredLines: file.uncoveredLines,
+      })),
+      [
+        {
+          relativePath: "packages/example/src/covered.ts",
+          uncoveredLines: [2],
+        },
+        {
+          relativePath: "packages/example/src/untested.ts",
+          uncoveredLines: [1],
+        },
+      ],
     );
   } finally {
     await Deno.remove(rootDir, { recursive: true });

--- a/tasks/coverage-metrics.ts
+++ b/tasks/coverage-metrics.ts
@@ -51,11 +51,25 @@ export interface CoverageDebtMetric {
   uncoveredLines: number;
 }
 
+/** Per-file list of source line numbers that no test executed. */
+export interface FileUncoveredLines {
+  relativePath: string;
+  metricGroup: string;
+  /** Source line numbers with zero hits, sorted ascending. */
+  uncoveredLines: number[];
+}
+
+/** Aggregate debt metrics plus the per-file breakdown of uncovered lines. */
+export interface CoverageDebtReport {
+  metrics: CoverageDebtMetric[];
+  files: FileUncoveredLines[];
+}
+
 interface SourceFile {
   absolutePath: string;
   relativePath: string;
   metricGroup: string;
-  trackedLineCount: number;
+  trackedLines: number[];
 }
 
 interface LcovFileCoverage {
@@ -65,34 +79,57 @@ interface LcovFileCoverage {
 export async function collectCoverageDebtMetrics(
   options: CoverageDebtMetricsOptions,
 ): Promise<CoverageDebtMetric[]> {
-  const lcov = await denoCoverageLcov(options.coverageProfileDir);
-  return await collectCoverageDebtMetricsFromLcov({
-    rootDir: options.rootDir,
-    lcov,
-  });
+  return (await collectCoverageDebtReport(options)).metrics;
 }
 
 export async function collectCoverageDebtMetricsFromLcov(
   options: CoverageDebtMetricsFromLcovOptions,
 ): Promise<CoverageDebtMetric[]> {
+  return (await collectCoverageDebtReportFromLcov(options)).metrics;
+}
+
+export async function collectCoverageDebtReport(
+  options: CoverageDebtMetricsOptions,
+): Promise<CoverageDebtReport> {
+  const lcov = await denoCoverageLcov(options.coverageProfileDir);
+  return await collectCoverageDebtReportFromLcov({
+    rootDir: options.rootDir,
+    lcov,
+  });
+}
+
+export async function collectCoverageDebtReportFromLcov(
+  options: CoverageDebtMetricsFromLcovOptions,
+): Promise<CoverageDebtReport> {
   const sourceFiles = await collectSourceFiles(options.rootDir);
   const lcovCoverage = parseLcov(options.lcov);
 
   let workspaceUncovered = 0;
   const groupUncovered = new Map<string, number>();
   const groupNames = new Set(sourceFiles.map((source) => source.metricGroup));
+  const files: FileUncoveredLines[] = [];
 
   for (const source of sourceFiles) {
     const coverage = lcovCoverage.get(source.absolutePath);
-    const uncovered = coverage
-      ? countUncoveredProfileLines(coverage)
-      : source.trackedLineCount;
+    // A file the tests never loaded has no coverage record; every tracked
+    // line counts as uncovered, matching how the debt metric scores it.
+    const uncoveredLines = coverage
+      ? uncoveredProfileLineNumbers(coverage)
+      : source.trackedLines;
 
-    workspaceUncovered += uncovered;
+    workspaceUncovered += uncoveredLines.length;
     groupUncovered.set(
       source.metricGroup,
-      (groupUncovered.get(source.metricGroup) ?? 0) + uncovered,
+      (groupUncovered.get(source.metricGroup) ?? 0) + uncoveredLines.length,
     );
+
+    if (uncoveredLines.length > 0) {
+      files.push({
+        relativePath: source.relativePath,
+        metricGroup: source.metricGroup,
+        uncoveredLines,
+      });
+    }
   }
 
   const metrics: CoverageDebtMetric[] = [
@@ -109,7 +146,7 @@ export async function collectCoverageDebtMetricsFromLcov(
     });
   }
 
-  return metrics;
+  return { metrics, files };
 }
 
 export async function collectSourceFiles(
@@ -129,7 +166,7 @@ export async function collectSourceFiles(
         absolutePath: path.normalize(file),
         relativePath,
         metricGroup: metricGroupFor(relativePath),
-        trackedLineCount: countTrackedSourceLines(content),
+        trackedLines: trackedSourceLineNumbers(content),
       });
     }
   }
@@ -165,11 +202,16 @@ export function metricGroupFor(relativePath: string): string {
 }
 
 export function countTrackedSourceLines(content: string): number {
-  let count = 0;
+  return trackedSourceLineNumbers(content).length;
+}
+
+export function trackedSourceLineNumbers(content: string): number[] {
+  const lineNumbers: number[] = [];
   let inBlockComment = false;
 
-  for (const line of content.split(/\r?\n/)) {
-    let text = line.trim();
+  const lines = content.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index++) {
+    let text = lines[index].trim();
     if (text.length === 0) continue;
 
     while (text.length > 0) {
@@ -200,12 +242,12 @@ export function countTrackedSourceLines(content: string): number {
         continue;
       }
 
-      count++;
+      lineNumbers.push(index + 1);
       break;
     }
   }
 
-  return count;
+  return lineNumbers;
 }
 
 export function parseLcov(lcov: string): Map<string, LcovFileCoverage> {
@@ -244,11 +286,15 @@ export function parseLcov(lcov: string): Map<string, LcovFileCoverage> {
 }
 
 export function countUncoveredProfileLines(coverage: LcovFileCoverage): number {
-  let uncovered = 0;
-  for (const hits of coverage.lineHits.values()) {
-    if (hits === 0) uncovered++;
+  return uncoveredProfileLineNumbers(coverage).length;
+}
+
+function uncoveredProfileLineNumbers(coverage: LcovFileCoverage): number[] {
+  const lineNumbers: number[] = [];
+  for (const [lineNumber, hits] of coverage.lineHits) {
+    if (hits === 0) lineNumbers.push(lineNumber);
   }
-  return uncovered;
+  return lineNumbers.sort((a, b) => a - b);
 }
 
 async function denoCoverageLcov(coverageProfileDir: string): Promise<string> {

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -21,11 +21,16 @@ import {
   applyBaselineOverrides,
   type Artifact,
   type BaselineOverrides,
+  buildCoverageDebtSuggestionComment,
   computeBaseline,
   computeCiWallTimeRevisitSignals,
   COVERAGE_BASELINE_RESET_MARKER,
+  COVERAGE_SUGGESTION_MARKER,
+  coverageGroupForChangedFile,
   coverageGroupsForChangedFiles,
   coverageMetricGroupName,
+  type CoverageSuggestionFileLines,
+  type CoverageSuggestionGroup,
   downloadAndExtractArtifact,
   downloadAndParseJUnit,
   downloadAndParsePerfMetrics,
@@ -34,12 +39,14 @@ import {
   extractTestFileMetrics,
   fetchArtifactsForRun,
   fetchCurrentPRBody,
+  fetchIssueComments,
   fetchJobsForRun,
   fetchPRFiles,
   fetchPRForCommit,
   formatMetricValue,
   formatOverrideSuggestion,
   githubGet,
+  githubPost,
   isCoverageDebtMetric,
   mapConcurrent,
   type MetricTimeline,
@@ -47,11 +54,13 @@ import {
   MIN_REGRESSION_PCT,
   MIN_SAMPLES,
   newestArtifactsByName,
+  parseAddedLinesFromPatch,
   parseBaselineOverrides,
   PERF_METRICS_ARTIFACT_NAME,
   PERF_METRICS_BACKFILL_ARTIFACT_NAME,
   PERF_METRICS_BACKFILL_FILE,
   PERF_METRICS_FILE,
+  type PRFile,
   type PRInfo,
   readAndParseEvent,
   REPO,
@@ -68,9 +77,10 @@ import {
 } from "./perf-lib.ts";
 import * as path from "@std/path";
 import {
-  collectCoverageDebtMetrics,
-  collectCoverageDebtMetricsFromLcov,
+  collectCoverageDebtReport,
+  collectCoverageDebtReportFromLcov,
   COVERAGE_PROFILE_ARTIFACT_PREFIX,
+  type FileUncoveredLines,
 } from "./coverage-metrics.ts";
 
 /** How many recent main-branch runs to use for baseline. */
@@ -372,7 +382,9 @@ function printMetricTable(rows: Row[], includeStatus = false): void {
 async function extractCoverageDebtSamples(
   run: WorkflowRun,
   artifacts: Artifact[],
-): Promise<Map<string, TimingSample>> {
+): Promise<
+  { samples: Map<string, TimingSample>; uncovered: FileUncoveredLines[] }
+> {
   const metrics = new Map<string, TimingSample>();
   const coverageArtifacts = newestArtifactsByName(artifacts.filter(
     (artifact) =>
@@ -394,6 +406,7 @@ async function extractCoverageDebtSamples(
 
   const profileDir = await Deno.makeTempDir({ prefix: "coverage-profiles-" });
   const lcovDir = await Deno.makeTempDir({ prefix: "coverage-lcov-" });
+  let uncovered: FileUncoveredLines[] = [];
   try {
     let profileFileCount = 0;
     let lcovFileCount = 0;
@@ -413,25 +426,26 @@ async function extractCoverageDebtSamples(
       );
     }
 
-    const coverageMetrics = lcovFileCount > 0
-      ? await collectCoverageDebtMetricsFromLcov({
+    const report = lcovFileCount > 0
+      ? await collectCoverageDebtReportFromLcov({
         rootDir: Deno.cwd(),
         lcov: await readCombinedLcov(lcovDir),
       })
-      : await collectCoverageDebtMetrics({
+      : await collectCoverageDebtReport({
         rootDir: Deno.cwd(),
         coverageProfileDir: profileDir,
       });
 
-    for (const metric of coverageMetrics) {
+    for (const metric of report.metrics) {
       metrics.set(
         metric.name,
         sampleForRun(run, metric.uncoveredLines),
       );
     }
+    uncovered = report.files;
 
     console.log(
-      `Extracted ${coverageMetrics.length} coverage debt metrics from ${
+      `Extracted ${report.metrics.length} coverage debt metrics from ${
         lcovFileCount > 0
           ? `${lcovFileCount} LCOV report files`
           : `${profileFileCount} coverage profile files`
@@ -446,7 +460,76 @@ async function extractCoverageDebtSamples(
     } catch { /* ignore cleanup errors */ }
   }
 
-  return metrics;
+  return { samples: metrics, uncovered };
+}
+
+/**
+ * Post a once-per-PR comment that tells the author (and an LLM) how to cover the
+ * new code that tripped the coverage gate. Skips silently if a previous run
+ * already posted one, and never throws — posting is best-effort so it cannot
+ * mask the regression failure itself.
+ */
+async function postCoverageDebtSuggestion(
+  prNumber: number,
+  coverageFailures: Row[],
+  prFiles: PRFile[],
+  uncoveredFiles: FileUncoveredLines[],
+  runUrl: string,
+): Promise<void> {
+  const groups = coverageFailures
+    .map((failure) => ({
+      group: coverageMetricGroupName(failure.metric),
+      target: Math.round(failure.median ?? 0),
+      current: Math.round(failure.current),
+    }))
+    .filter((group): group is CoverageSuggestionGroup => group.group !== null);
+
+  if (groups.length === 0) return;
+
+  const failingGroups = new Set(groups.map((group) => group.group));
+  const uncoveredByPath = new Map(
+    uncoveredFiles.map((file) => [file.relativePath, file]),
+  );
+
+  // Intersect the lines this PR added with the lines coverage marks uncovered,
+  // restricted to the source groups that actually regressed.
+  const files: CoverageSuggestionFileLines[] = [];
+  for (const prFile of prFiles) {
+    const relativePath = prFile.filename.replaceAll("\\", "/");
+    const group = coverageGroupForChangedFile(relativePath);
+    if (!group || !failingGroups.has(group)) continue;
+
+    const uncovered = uncoveredByPath.get(relativePath);
+    if (!uncovered || !prFile.patch) continue;
+
+    const addedLines = parseAddedLinesFromPatch(prFile.patch);
+    const lines = uncovered.uncoveredLines
+      .filter((line) => addedLines.has(line))
+      .map((line) => ({ line, text: addedLines.get(line)! }));
+    if (lines.length > 0) files.push({ relativePath, group, lines });
+  }
+
+  try {
+    const existing = await fetchIssueComments(prNumber);
+    if (
+      existing.some((comment) =>
+        comment.body.includes(COVERAGE_SUGGESTION_MARKER)
+      )
+    ) {
+      console.log(
+        `Coverage suggestion comment already present on PR #${prNumber}; not posting again.`,
+      );
+      return;
+    }
+
+    const body = buildCoverageDebtSuggestionComment({ groups, files, runUrl });
+    await githubPost(`/repos/${REPO}/issues/${prNumber}/comments`, { body });
+    console.log(`Posted coverage suggestion comment to PR #${prNumber}.`);
+  } catch (error) {
+    console.warn(
+      `  Warning: could not post coverage suggestion comment to PR #${prNumber}: ${error}`,
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -524,10 +607,11 @@ async function main() {
   // another API request on the current workflow run.
   const currentRunInfo = currentWorkflowRunFromEvent(event, runIdNum);
   let changedCoverageGroups: Set<string> | undefined;
+  let prFiles: PRFile[] = [];
 
   if (prNumber) {
     try {
-      const prFiles = await fetchPRFiles(parseInt(prNumber));
+      prFiles = await fetchPRFiles(parseInt(prNumber));
       changedCoverageGroups = coverageGroupsForChangedFiles(
         prFiles.map((file) => file.filename),
       );
@@ -595,19 +679,21 @@ async function main() {
 
   // Extract coverage debt metrics from coverage profile artifacts.
   let coverageDataError: unknown;
+  let coverageUncoveredFiles: FileUncoveredLines[] = [];
   try {
     if (currentArtifactsError) {
       throw new Error(
         `Could not fetch current run artifacts: ${currentArtifactsError}`,
       );
     }
-    const coverageMetrics = await extractCoverageDebtSamples(
+    const coverage = await extractCoverageDebtSamples(
       currentRunInfo,
       currentArtifacts,
     );
-    for (const [name, sample] of coverageMetrics) {
+    for (const [name, sample] of coverage.samples) {
       currentMetrics.set(name, sample);
     }
+    coverageUncoveredFiles = coverage.uncovered;
   } catch (e) {
     coverageDataError = e;
     console.error(
@@ -1222,6 +1308,18 @@ async function main() {
       console.log(`NEW_PERF_BASELINE: ${f.metric} = ${suggested}`);
     }
     console.log("---END COPY-PASTE---");
+  }
+
+  // A coverage regression on a real PR earns a once-per-PR comment pointing the
+  // author at the uncovered lines and how to cover them.
+  if (coverageFailures.length > 0 && prNumber) {
+    await postCoverageDebtSuggestion(
+      parseInt(prNumber),
+      coverageFailures,
+      prFiles,
+      coverageUncoveredFiles,
+      currentRunInfo.html_url,
+    );
   }
 
   Deno.exit(1);

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -1,10 +1,17 @@
-import { assertAlmostEquals, assertEquals, assertThrows } from "@std/assert";
+import {
+  assertAlmostEquals,
+  assertEquals,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
 import {
   applyBaselineOverrides,
   type Artifact,
+  buildCoverageDebtSuggestionComment,
   computeBaseline,
   computeCiWallTimeRevisitSignals,
   COVERAGE_BASELINE_RESET_MARKER,
+  COVERAGE_SUGGESTION_MARKER,
   coverageGroupsForChangedFiles,
   coverageMetricGroupName,
   downloadAndExtractArtifact,
@@ -18,6 +25,7 @@ import {
   githubGet,
   type Job,
   newestArtifactsByName,
+  parseAddedLinesFromPatch,
   parseBaselineOverrides,
   parsePerfMetricsBackfillFile,
   parsePerfMetricsFile,
@@ -760,6 +768,97 @@ Deno.test("coverage debt gating follows changed source groups", () => {
       undefined,
     ),
     true,
+  );
+});
+
+Deno.test("parseAddedLinesFromPatch maps added lines to their new line numbers", () => {
+  const patch = [
+    "@@ -1,3 +1,5 @@",
+    " const a = 1;",
+    "-const b = 2;",
+    "+const b = 20;",
+    "+const c = 3;",
+    " const d = 4;",
+    "+const e = 5;",
+    "\\ No newline at end of file",
+  ].join("\n");
+
+  const added = parseAddedLinesFromPatch(patch);
+
+  assertEquals([...added.entries()], [
+    [2, "const b = 20;"],
+    [3, "const c = 3;"],
+    [5, "const e = 5;"],
+  ]);
+});
+
+Deno.test("parseAddedLinesFromPatch tracks line numbers across multiple hunks", () => {
+  const patch = [
+    "@@ -10,2 +10,3 @@",
+    " keep;",
+    "+added at 11;",
+    " keep;",
+    "@@ -40,1 +41,2 @@",
+    " keep;",
+    "+added at 42;",
+  ].join("\n");
+
+  const added = parseAddedLinesFromPatch(patch);
+
+  assertEquals(added.get(11), "added at 11;");
+  assertEquals(added.get(42), "added at 42;");
+  assertEquals(added.size, 2);
+});
+
+Deno.test("buildCoverageDebtSuggestionComment includes marker, lines, command, and targets", () => {
+  const comment = buildCoverageDebtSuggestionComment({
+    groups: [
+      { group: "packages/runner", target: 12, current: 15 },
+    ],
+    files: [
+      {
+        relativePath: "packages/runner/src/cell.ts",
+        group: "packages/runner",
+        lines: [
+          { line: 42, text: "  return uncoveredHelper();" },
+          { line: 43, text: "}" },
+        ],
+      },
+    ],
+    runUrl: "https://example.test/run/99",
+  });
+
+  // Posted-once marker so a later run can detect it.
+  assertStringIncludes(comment, COVERAGE_SUGGESTION_MARKER);
+  // The regressed group with its target and current value.
+  assertStringIncludes(comment, "`packages/runner`");
+  assertStringIncludes(comment, "| 12 | 15 | +3 |");
+  // The specific uncovered new line.
+  assertStringIncludes(comment, "42  ");
+  assertStringIncludes(comment, "return uncoveredHelper();");
+  // The local command and the metric target the LLM checks against.
+  assertStringIncludes(comment, "tasks/coverage-metrics.ts");
+  assertStringIncludes(
+    comment,
+    "coverage-debt: packages/runner uncovered lines  <=  12",
+  );
+  // The escape hatch for intentional debt.
+  assertStringIncludes(comment, COVERAGE_BASELINE_RESET_MARKER);
+});
+
+Deno.test("buildCoverageDebtSuggestionComment handles a regression with no pinned lines", () => {
+  const comment = buildCoverageDebtSuggestionComment({
+    groups: [
+      { group: "tasks", target: 0, current: 4 },
+    ],
+    files: [],
+  });
+
+  assertStringIncludes(comment, COVERAGE_SUGGESTION_MARKER);
+  assertStringIncludes(comment, "Could not tie the regression");
+  assertStringIncludes(
+    comment,
+    "coverage-debt: tasks uncovered lines  <=  0",
   );
 });
 

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -20,6 +20,25 @@ export const PERF_METRICS_BACKFILL_FILE = "perf-metrics-backfill.json";
 export const COVERAGE_METRIC_PREFIX = "coverage-debt:";
 export const COVERAGE_BASELINE_RESET_MARKER = "NEW_COVERAGE_BASELINE";
 
+/**
+ * Hidden marker placed at the top of the coverage-debt suggestion comment so
+ * the gate posts it at most once per PR.
+ */
+export const COVERAGE_SUGGESTION_MARKER = "<!-- coverage-debt-suggestion -->";
+
+/**
+ * Command an author (or an LLM) runs locally to reproduce the coverage gate.
+ * Collects coverage from the unit-test suites and prints the per-group
+ * uncovered-line counts as JSON. The integration suites are omitted, so the
+ * local counts are conservative: meeting the target locally also clears CI.
+ */
+export const COVERAGE_LOCAL_CHECK_COMMAND = [
+  "rm -rf coverage/raw/local",
+  'DENO_COVERAGE_DIR="$(pwd)/coverage/raw/local" deno task test',
+  "deno run --allow-read --allow-write --allow-run tasks/coverage-metrics.ts \\",
+  '  --profile-dir="$(pwd)/coverage/raw/local" --root="$(pwd)"',
+].join("\n");
+
 /** Minimum number of historical samples before we compute a baseline. */
 export const MIN_SAMPLES = 5;
 
@@ -182,6 +201,13 @@ export interface PRInfo {
 
 export interface PRFile {
   filename: string;
+  /** Unified diff for this file. Absent for binary or oversized changes. */
+  patch?: string;
+}
+
+export interface IssueComment {
+  id: number;
+  body: string;
 }
 
 export interface CurrentPRBody {
@@ -1416,6 +1442,261 @@ export function shouldGateCoverageDebtMetric(
   return changedCoverageGroups.has(group);
 }
 
+/**
+ * Parse a unified diff (the per-file `patch` from the GitHub PR files API) and
+ * return the lines this PR adds, keyed by their line number in the new file
+ * and mapped to the added source text (without the leading `+`).
+ */
+export function parseAddedLinesFromPatch(patch: string): Map<number, string> {
+  const added = new Map<number, string>();
+  let newLineNumber = 0;
+
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("@@")) {
+      const match = /@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+      if (match) newLineNumber = parseInt(match[1], 10);
+      continue;
+    }
+
+    if (line.startsWith("+")) {
+      if (line.startsWith("+++")) continue;
+      added.set(newLineNumber, line.slice(1));
+      newLineNumber++;
+      continue;
+    }
+
+    if (line.startsWith("-")) {
+      // Deletion: present only in the old file, so the new-file cursor holds.
+      continue;
+    }
+
+    // "\ No newline at end of file" markers and the trailing empty element
+    // from splitting do not advance the new-file cursor.
+    if (line.startsWith("\\") || line === "") continue;
+
+    // Context line: present in both files.
+    newLineNumber++;
+  }
+
+  return added;
+}
+
+/** A changed source group whose uncovered-line count regressed. */
+export interface CoverageSuggestionGroup {
+  group: string;
+  /** Uncovered-line count from latest `main`; the PR must not exceed it. */
+  target: number;
+  /** Uncovered-line count this PR produced. */
+  current: number;
+}
+
+/** Lines a PR added that no test executes, for one file. */
+export interface CoverageSuggestionFileLines {
+  relativePath: string;
+  group: string;
+  lines: { line: number; text: string }[];
+}
+
+export interface CoverageDebtSuggestionInput {
+  groups: CoverageSuggestionGroup[];
+  files: CoverageSuggestionFileLines[];
+  /** URL of the workflow run that detected the regression. */
+  runUrl?: string;
+}
+
+const MAX_SUGGESTION_LINES_PER_FILE = 40;
+const MAX_SUGGESTION_LINES_TOTAL = 200;
+
+/**
+ * Cap the uncovered-line listing so a large PR does not produce an enormous
+ * comment. Returns the files trimmed to the budget and whether anything was
+ * dropped.
+ */
+function limitSuggestionFiles(
+  files: CoverageSuggestionFileLines[],
+): { files: CoverageSuggestionFileLines[]; truncated: boolean } {
+  const limited: CoverageSuggestionFileLines[] = [];
+  let remaining = MAX_SUGGESTION_LINES_TOTAL;
+  let truncated = false;
+
+  for (const file of files) {
+    if (remaining <= 0) {
+      truncated = true;
+      break;
+    }
+    const perFile = file.lines.slice(0, MAX_SUGGESTION_LINES_PER_FILE);
+    const lines = perFile.slice(0, remaining);
+    if (lines.length < file.lines.length) truncated = true;
+    remaining -= lines.length;
+    limited.push({ ...file, lines });
+  }
+
+  return { files: limited, truncated };
+}
+
+function formatTargetList(groups: CoverageSuggestionGroup[]): string[] {
+  return groups.map((group) =>
+    `  ${COVERAGE_METRIC_PREFIX} ${group.group} uncovered lines  <=  ${group.target}   (this PR: ${group.current})`
+  );
+}
+
+/**
+ * Build the plain-text prompt an author can paste into an AI coding agent. It
+ * is self-contained: the specific uncovered lines, the command to reproduce the
+ * gate, and the target thresholds it must reach.
+ */
+function buildCoverageSuggestionPrompt(
+  input: CoverageDebtSuggestionInput,
+  limitedFiles: CoverageSuggestionFileLines[],
+  truncated: boolean,
+): string[] {
+  const lines: string[] = [
+    "Test coverage for this branch regressed: it adds source lines that no",
+    "test executes, and the CI coverage gate is failing. Add or extend tests so",
+    "the uncovered lines below are executed. Write real tests that exercise the",
+    "code paths; do not delete assertions, mark lines ignored, or weaken the gate.",
+    "",
+  ];
+
+  if (limitedFiles.length > 0) {
+    lines.push(
+      "Uncovered lines added in this change (file, then `line: code`):",
+    );
+    lines.push("");
+    for (const file of limitedFiles) {
+      lines.push(file.relativePath);
+      for (const entry of file.lines) {
+        lines.push(`  ${entry.line}: ${entry.text}`);
+      }
+      lines.push("");
+    }
+    if (truncated) {
+      lines.push(
+        "(Listing truncated. Run the command below to see every uncovered line.)",
+      );
+      lines.push("");
+    }
+  } else {
+    lines.push(
+      "The uncovered lines could not be tied to specific added lines from the",
+      "diff. Run the command below to find which lines are uncovered.",
+      "",
+    );
+  }
+
+  lines.push("After adding tests, verify from the repository root:");
+  lines.push("");
+  for (const command of COVERAGE_LOCAL_CHECK_COMMAND.split("\n")) {
+    lines.push(`  ${command}`);
+  }
+  lines.push("");
+  lines.push(
+    "That prints one JSON object of coverage-debt metrics. The gate passes when",
+    "each of these metrics is at or below its target:",
+    "",
+  );
+  lines.push(...formatTargetList(input.groups));
+  lines.push("");
+  lines.push(
+    "The local run omits the integration suites, so its counts are conservative:",
+    "if every metric meets its target locally, CI will pass too.",
+  );
+
+  return lines;
+}
+
+/**
+ * Build the Markdown body of the once-per-PR coverage-regression comment. Leads
+ * with the hidden marker so a later run can detect that it was already posted.
+ */
+export function buildCoverageDebtSuggestionComment(
+  input: CoverageDebtSuggestionInput,
+): string {
+  const { files, truncated } = limitSuggestionFiles(input.files);
+  const out: string[] = [COVERAGE_SUGGESTION_MARKER];
+
+  out.push("## 🧪 Test coverage regressed");
+  out.push("");
+  out.push(
+    "This PR adds source lines that no test exercises, so the coverage gate in " +
+      "the **Performance Check** job is failing. The gate ratchets each changed " +
+      "source group against its uncovered-line count on `main`: the group must " +
+      "not end up with more uncovered lines than that baseline.",
+  );
+  out.push("");
+
+  out.push("| Source group | Baseline (target) | This PR | Over by |");
+  out.push("| --- | ---: | ---: | ---: |");
+  for (const group of input.groups) {
+    out.push(
+      `| \`${group.group}\` | ${group.target} | ${group.current} | +${
+        group.current - group.target
+      } |`,
+    );
+  }
+  out.push("");
+
+  out.push("### Uncovered lines added in this PR");
+  out.push("");
+  if (files.length > 0) {
+    for (const file of files) {
+      const body = file.lines
+        .map((entry) => `${String(entry.line).padStart(6)}  ${entry.text}`)
+        .join("\n");
+      out.push(`\`${file.relativePath}\``);
+      out.push("```");
+      out.push(body);
+      out.push("```");
+    }
+    if (truncated) {
+      out.push(
+        "_Showing the first uncovered lines only; the command below lists them all._",
+      );
+    }
+  } else {
+    out.push(
+      "Could not tie the regression to specific added lines from the diff " +
+        "(the uncovered code may be in modified rather than newly-added lines). " +
+        "Use the command below to locate the uncovered lines.",
+    );
+  }
+  out.push("");
+
+  out.push("### Prompt for an AI coding agent");
+  out.push("");
+  out.push(
+    "Copy the block below into an AI coding agent to add the missing tests:",
+  );
+  out.push("");
+  out.push("````text");
+  out.push(...buildCoverageSuggestionPrompt(input, files, truncated));
+  out.push("````");
+  out.push("");
+
+  out.push("### Verify locally");
+  out.push("");
+  out.push("```bash");
+  out.push(COVERAGE_LOCAL_CHECK_COMMAND);
+  out.push("```");
+  out.push("");
+  out.push("The gate passes when each metric is at or below its target:");
+  out.push("");
+  out.push("```");
+  out.push(...formatTargetList(input.groups));
+  out.push("```");
+  out.push("");
+
+  out.push("---");
+  const runRef = input.runUrl ? ` ([run](${input.runUrl}))` : "";
+  out.push(
+    `*Posted once per PR by the coverage gate in \`tasks/perf-check.ts\`${runRef}. ` +
+      "To intentionally accept the new debt instead, add `" +
+      COVERAGE_BASELINE_RESET_MARKER + "` to the PR description.*",
+  );
+
+  return out.join("\n");
+}
+
 /** Escape a string for use inside a Markdown table cell. */
 export function escapeTableCell(s: string): string {
   return s.replace(/\|/g, "\\|").replace(/\n/g, " ");
@@ -1509,6 +1790,26 @@ export async function fetchPRFiles(prNumber: number): Promise<PRFile[]> {
   }
 
   return files;
+}
+
+/** Fetch every issue comment on a PR (PR conversation comments). */
+export async function fetchIssueComments(
+  issueNumber: number,
+): Promise<IssueComment[]> {
+  const comments: IssueComment[] = [];
+  const perPage = 100;
+
+  for (let page = 1;; page++) {
+    const data = await githubGet<{ id: number; body: string | null }[]>(
+      `/repos/${REPO}/issues/${issueNumber}/comments?per_page=${perPage}&page=${page}`,
+    );
+    for (const comment of data) {
+      comments.push({ id: comment.id, body: comment.body ?? "" });
+    }
+    if (data.length < perPage) break;
+  }
+
+  return comments;
 }
 
 export function pullRequestBodyFromEvent(


### PR DESCRIPTION
When the coverage-debt gate in the Performance Check job finds a changed source group with more uncovered lines than its main baseline, post a once-per-PR comment that helps cover the new code.

The comment lists the specific lines the PR added that no test executes, a self-contained prompt to hand an AI coding agent, and the command plus per-group line targets to reproduce the gate locally. A hidden marker on the comment keeps later runs from posting duplicates, and posting is best-effort so it never masks the regression failure.

coverage-metrics.ts now reports per-file uncovered line numbers alongside the aggregate metrics; perf-lib.ts gains the diff parser, comment builder, and issue-comment fetch; the perf-check job gets pull-requests: write.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Posts a once-per-PR comment when the coverage-debt gate detects a regression, pointing to the exact uncovered lines and how to reproduce locally. Extends coverage tooling to report per-file uncovered line numbers and updates CI permissions to allow commenting.

- New Features
  - Comments on coverage regressions with:
    - The specific uncovered lines this PR added (per file, from diff).
    - A local command and per-group targets to reproduce the gate.
    - A hidden marker to prevent duplicates; posting is best-effort.
  - `tasks/coverage-metrics.ts`: adds per-file uncovered line numbers alongside aggregate metrics.
  - `tasks/perf-lib.ts`: adds diff parser, comment builder, and issue-comment fetch; integrated in `tasks/perf-check.ts`.
  - `.github/workflows/deno.yml`: sets `pull-requests: write` so the job can comment.

<sup>Written for commit 2df785a107c36a83ec9d300ed0001fecd3fee0a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

