### PR TITLE
feat(data-model): flag-dispatch the serialized entity-id ref form

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2673,11 +2673,14 @@ export declare function UiPromptSlot(props: UiPromptSlotProps): JSXElement;
 export declare function UiDisclosure(props: UiDisclosureProps): JSXElement;
 
 /**
- * Get the entity ID from a cell or value.
- * Returns { "/": "id-string" } format if the value has an entity ID, undefined otherwise.
- * Useful for extracting IDs from newly created charms for linking.
+ * Get the entity ID from a cell or value, or undefined if it has none. The
+ * concrete reference form is dispatched on the "modern cell representation"
+ * flag: a `{ "/": "id-string" }` object with the flag off, a `FabricHash` with
+ * it on. Useful for extracting IDs from newly created charms for linking.
  */
-export type GetEntityIdFunction = (value: any) => { "/": string } | undefined;
+export type GetEntityIdFunction = (
+  value: any,
+) => { "/": string } | FabricHash | undefined;
 export declare const getEntityId: GetEntityIdFunction;
 
 export declare const schema: SchemaFunction;

--- a/packages/cli/lib/sqlite-source.ts
+++ b/packages/cli/lib/sqlite-source.ts
@@ -51,7 +51,7 @@ export function deriveDiskHandleId(space: string, absPath: string): string {
     scheme: "sqlite",
   });
   // The canonical id string is the tagged-hash form, matching
-  // `handle.entityId["/"]` — the form the runtime uses for a db handle's
-  // `value.id`.
+  // `entityRefToString(handle.entityId)` — the form the runtime uses for a db
+  // handle's `value.id`.
   return ref.taggedHashString;
 }

--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -1,6 +1,11 @@
 /**
- * Stub for the nascent "modern cell representation" classes.
+ * The nascent "modern cell representation". This module owns the experiment
+ * flag and the flag-dispatched production and recognition of the serialized
+ * entity-id reference form.
  */
+
+import { isRecord } from "@commonfabric/utils/types";
+import { FabricHash } from "@/fabric-primitives/index.ts";
 
 //
 // Configuration flags
@@ -26,4 +31,66 @@ export function getModernCellRepConfig(): boolean {
 /** Restores the modern cell representation flag to its default. */
 export function resetModernCellRepConfig(): void {
   modernCellRepEnabled = false;
+}
+
+//
+// Entity-id reference form
+//
+
+/**
+ * The serialized/extracted form of an entity-id reference, as produced by
+ * `Cell.entityId` and `getEntityId` and consumed wherever such a reference is
+ * read back. Its concrete shape is flag-dispatched: with the modern cell
+ * representation _off_ it is a plain `{ "/": "<tag>:<hash>" }` object; with it
+ * _on_ it is a straight {@link FabricHash}.
+ *
+ * This is distinct from the branded `EntityId` (an addressing `FabricHash`):
+ * in modern mode the two coincide, but in legacy mode the serialized reference
+ * is the plain object.
+ *
+ * Recognition ({@link isEntityRef}, {@link entityRefToString}) is strict — it
+ * accepts only the form for the _currently active_ regime, never both. This is
+ * deliberate: a stored hash carries no record of which input form produced it,
+ * so legacy-hash and modern-hash data are a clean break, never intermixed
+ * within one regime.
+ */
+export type EntityRef = FabricHash | { "/": string };
+
+/**
+ * Produces an {@link EntityRef} from a tagged hash string (e.g. `"fid1:…"`).
+ */
+export function entityRefFromString(taggedHash: string): EntityRef {
+  return modernCellRepEnabled
+    ? FabricHash.fromString(taggedHash)
+    : { "/": taggedHash };
+}
+
+/** Produces an {@link EntityRef} from a {@link FabricHash}. */
+export function entityRefFrom(hash: FabricHash): EntityRef {
+  return modernCellRepEnabled ? hash : { "/": hash.taggedHashString };
+}
+
+/**
+ * Recognizes an {@link EntityRef} for the currently active regime: a
+ * {@link FabricHash} in modern mode, a `{ "/": string }` object in legacy mode.
+ */
+export function isEntityRef(value: unknown): value is EntityRef {
+  return modernCellRepEnabled
+    ? value instanceof FabricHash
+    : isRecord(value) && typeof value["/"] === "string";
+}
+
+/**
+ * Extracts the tagged hash string from an {@link EntityRef}. Throws if the
+ * value is not a reference for the currently active regime.
+ */
+export function entityRefToString(value: EntityRef): string {
+  if (modernCellRepEnabled) {
+    if (value instanceof FabricHash) return value.taggedHashString;
+  } else if (isRecord(value) && typeof value["/"] === "string") {
+    return value["/"];
+  }
+  throw new Error(
+    "Not an entity-id reference for the active cell-rep regime.",
+  );
 }

--- a/packages/data-model/test/cell-rep.test.ts
+++ b/packages/data-model/test/cell-rep.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
+import {
+  type EntityRef,
+  entityRefFrom,
+  entityRefFromString,
+  entityRefToString,
+  isEntityRef,
+  resetModernCellRepConfig,
+  setModernCellRepConfig,
+} from "@/cell-rep.ts";
+
+/** A fixed 32-byte hash for deterministic tests. */
+const SAMPLE_HASH = new Uint8Array(32);
+for (let i = 0; i < 32; i++) SAMPLE_HASH[i] = i;
+
+const HASH = new FabricHash(SAMPLE_HASH, "fid1");
+const TAGGED = HASH.taggedHashString; // "fid1:…"
+
+describe("cell-rep entity-id reference", () => {
+  afterEach(() => {
+    resetModernCellRepConfig();
+  });
+
+  describe("with the flag OFF (legacy plain-object form)", () => {
+    it('produces a `{ "/": string }` object from a string', () => {
+      const ref = entityRefFromString(TAGGED);
+      expect(ref).toEqual({ "/": TAGGED });
+      expect(ref).not.toBeInstanceOf(FabricHash);
+    });
+
+    it('produces a `{ "/": string }` object from a FabricHash', () => {
+      expect(entityRefFrom(HASH)).toEqual({ "/": TAGGED });
+    });
+
+    it("recognizes the plain-object form, not a FabricHash", () => {
+      expect(isEntityRef({ "/": TAGGED })).toBe(true);
+      expect(isEntityRef(HASH)).toBe(false);
+      expect(isEntityRef(undefined)).toBe(false);
+      expect(isEntityRef("plain string")).toBe(false);
+    });
+
+    it("extracts the tagged hash string from the plain-object form", () => {
+      expect(entityRefToString({ "/": TAGGED })).toBe(TAGGED);
+    });
+
+    it("throws extracting from a FabricHash (wrong regime)", () => {
+      expect(() => entityRefToString(HASH as EntityRef)).toThrow();
+    });
+  });
+
+  describe("with the flag ON (modern FabricHash form)", () => {
+    it("produces a FabricHash from a string", () => {
+      setModernCellRepConfig(true);
+      const ref = entityRefFromString(TAGGED);
+      expect(ref).toBeInstanceOf(FabricHash);
+      expect((ref as FabricHash).taggedHashString).toBe(TAGGED);
+    });
+
+    it("returns the FabricHash unchanged from a FabricHash", () => {
+      setModernCellRepConfig(true);
+      expect(entityRefFrom(HASH)).toBe(HASH);
+    });
+
+    it("recognizes a FabricHash, not the plain-object form", () => {
+      setModernCellRepConfig(true);
+      expect(isEntityRef(HASH)).toBe(true);
+      expect(isEntityRef({ "/": TAGGED })).toBe(false);
+    });
+
+    it("extracts the tagged hash string from a FabricHash", () => {
+      setModernCellRepConfig(true);
+      expect(entityRefToString(HASH)).toBe(TAGGED);
+    });
+
+    it("throws extracting from the plain-object form (wrong regime)", () => {
+      setModernCellRepConfig(true);
+      expect(() => entityRefToString({ "/": TAGGED } as EntityRef)).toThrow();
+    });
+  });
+
+  it("round-trips a string through both forms in each regime", () => {
+    for (const enabled of [false, true]) {
+      setModernCellRepConfig(enabled);
+      expect(entityRefToString(entityRefFromString(TAGGED))).toBe(TAGGED);
+      expect(entityRefToString(entityRefFrom(HASH))).toBe(TAGGED);
+      resetModernCellRepConfig();
+    }
+  });
+});

--- a/packages/data-model/test/codec-json/json-encoding.test.ts
+++ b/packages/data-model/test/codec-json/json-encoding.test.ts
@@ -138,8 +138,10 @@ describe("json-encoding", () => {
     });
 
     it('`{ "/": "string" }` round-trips via `/object` escaping', () => {
-      const entityId = { "/": "bafyabc123" } as FabricValue;
-      expect(roundTrip(entityId)).toEqual(entityId);
+      // An arbitrary string-valued `/` key — not an entity ref; exercises the
+      // escaping for the `/` key per se.
+      const slashKeyed = { "/": "an arbitrary string" } as FabricValue;
+      expect(roundTrip(slashKeyed)).toEqual(slashKeyed);
     });
 
     it("`$stream` marker passes through unchanged", () => {
@@ -158,10 +160,16 @@ describe("json-encoding", () => {
 
     it('`$alias` marker with nested `{ "/": value }` round-trips', () => {
       const value = {
-        $alias: { path: ["value", "name"], cell: { "/": "bafyabc" } },
+        $alias: {
+          path: ["value", "name"],
+          cell: { "/": "an arbitrary string" },
+        },
       } as FabricValue;
       expect(roundTrip(value)).toEqual({
-        $alias: { path: ["value", "name"], cell: { "/": "bafyabc" } },
+        $alias: {
+          path: ["value", "name"],
+          cell: { "/": "an arbitrary string" },
+        },
       });
     });
 
@@ -169,7 +177,7 @@ describe("json-encoding", () => {
       const value = {
         count: 42n,
         ref: { "/": { "link@1": { id: "of:bafyabc", path: [] } } },
-        items: [1, { "/": "bafyxyz" }, undefined],
+        items: [1, { "/": "another arbitrary string" }, undefined],
       } as FabricValue;
       const decoded = roundTrip(value) as Record<string, unknown>;
       expect(decoded.count).toBe(42n);
@@ -177,7 +185,9 @@ describe("json-encoding", () => {
         { "/": { "link@1": { id: "of:bafyabc", path: [] } } },
       );
       expect((decoded.items as unknown[])[0]).toBe(1);
-      expect((decoded.items as unknown[])[1]).toEqual({ "/": "bafyxyz" });
+      expect((decoded.items as unknown[])[1]).toEqual({
+        "/": "another arbitrary string",
+      });
       expect((decoded.items as unknown[])[2]).toBe(undefined);
     });
 

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -1,4 +1,5 @@
 import { createSession, DID, Identity, Session } from "@commonfabric/identity";
+import { entityRefFromString } from "@commonfabric/data-model/cell-rep";
 import { slugIdForSpace } from "@commonfabric/runner/slugs";
 import { NameSchema } from "@commonfabric/runner/schemas";
 import {
@@ -288,9 +289,10 @@ export class RuntimeInternals extends EventTarget {
 
   async getSlugCell(space: DID, slug: string): Promise<CellHandle<unknown>> {
     this.#check();
-    return await this.#client.getCell(space, {
-      "/": slugIdForSpace(space, slug),
-    });
+    return await this.#client.getCell(
+      space,
+      entityRefFromString(slugIdForSpace(space, slug)),
+    );
   }
 
   async getSlug(space: DID, id: string): Promise<string | undefined> {

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -20,6 +20,11 @@ import {
 } from "@commonfabric/runner";
 import type { CellScope } from "@commonfabric/api";
 import { cfcAtom } from "@commonfabric/api/cfc";
+import {
+  type EntityRef,
+  entityRefToString,
+  isEntityRef,
+} from "@commonfabric/data-model/cell-rep";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { type Session } from "@commonfabric/identity";
 import { isRecord } from "@commonfabric/utils/types";
@@ -374,10 +379,10 @@ export class PieceManager {
       }
 
       // Helper function to add a matching piece to the result
-      const addMatchingPiece = (docId: { "/": string }) => {
-        if (!docId || !docId["/"]) return;
+      const addMatchingPiece = (docId: EntityRef) => {
+        if (!isEntityRef(docId)) return;
 
-        const entityIdStr = docId["/"];
+        const entityIdStr = entityRefToString(docId);
 
         // Skip if we've already processed this entity
         if (seenEntityIds.has(entityIdStr)) return;
@@ -386,7 +391,7 @@ export class PieceManager {
         // Find matching piece by entity ID
         const matchingPiece = allPieces.find((c) => {
           const cId = getEntityId(c);
-          return cId && docId["/"] === cId["/"];
+          return isEntityRef(cId) && entityRefToString(cId) === entityIdStr;
         });
 
         if (matchingPiece) {
@@ -514,11 +519,9 @@ export class PieceManager {
     // Helper function to add a matching piece to the result
     const addReadingPiece = (otherPiece: Cell<unknown>) => {
       const otherPieceId = getEntityId(otherPiece);
-      if (!otherPieceId || !otherPieceId["/"]) return;
+      if (!isEntityRef(otherPieceId)) return;
 
-      const entityIdStr = typeof otherPieceId["/"] === "string"
-        ? otherPieceId["/"]
-        : JSON.stringify(otherPieceId["/"]);
+      const entityIdStr = entityRefToString(otherPieceId);
 
       // Skip if we've already processed this entity
       if (seenEntityIds.has(entityIdStr)) return;
@@ -1027,11 +1030,9 @@ function followCellToResult(
 
   try {
     const docId = cell.entityId;
-    if (!docId || !docId["/"]) return undefined;
+    if (!isEntityRef(docId)) return undefined;
 
-    const docIdStr = typeof docId["/"] === "string"
-      ? docId["/"]
-      : JSON.stringify(docId["/"]);
+    const docIdStr = entityRefToString(docId);
 
     // Prevent cycles
     if (visited.has(docIdStr)) return undefined;

--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createSession, Identity } from "@commonfabric/identity";
 import { NAME, Pattern, Runtime } from "@commonfabric/runner";
+import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { PieceManager } from "../src/manager.ts";
 import { PieceController } from "../src/ops/piece-controller.ts";
@@ -192,7 +193,7 @@ describe("piece pull materialization", () => {
 
     await manager.runWithPattern(
       trustPattern(runtime, tenfoldPattern()),
-      piece.entityId!["/"] as string,
+      entityRefToString(piece.entityId),
       { input: 5 },
       { start: true },
     );
@@ -267,7 +268,7 @@ describe("piece pull materialization", () => {
 
     await manager.runWithPattern(
       trustPattern(runtime, tenfoldPattern()),
-      piece.entityId!["/"] as string,
+      entityRefToString(piece.entityId),
       { input: 5 },
       { start: true },
     );
@@ -293,7 +294,7 @@ describe("piece pull materialization", () => {
 
     await manager.runWithPattern(
       trustPattern(runtime, namedPattern("tenfold", 10)),
-      piece.entityId!["/"] as string,
+      entityRefToString(piece.entityId),
       { input: 5 },
       { start: true },
     );

--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -37,6 +37,10 @@ import { computeInputHashFromValue } from "./fetch-utils.ts";
 import { parseCfLinkToSigil } from "./sqlite/cf-link.ts";
 import { type IFCLabel, mergeLabel } from "../cfc/label-view-core.ts";
 import { cloneIfNecessary } from "@commonfabric/data-model/value-clone";
+import {
+  entityRefToString,
+  isEntityRef,
+} from "@commonfabric/data-model/cell-rep";
 import { columnDeclaresIfc } from "@commonfabric/memory/v2";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 
@@ -475,7 +479,9 @@ export function sqliteDatabase(
       const options = inputsCell.withTx(tx).get() as
         | { tables?: Record<string, unknown> }
         | undefined;
-      const id = handle.entityId?.["/"] ?? JSON.stringify(handle.getAsLink());
+      const id = (isEntityRef(handle.entityId)
+        ? entityRefToString(handle.entityId)
+        : undefined) ?? JSON.stringify(handle.getAsLink());
       // The db's owner: the principal creating this handle (CFC Phase 3 —
       // resolves the row rule's dbOwner(); a FIXED property of the db, not
       // the acting reader). "creator" would be wrong for linked dbs; the

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -12,6 +12,10 @@ import {
   shallowFabricFromNativeValue,
 } from "@commonfabric/data-model/fabric-value";
 import { codecOf } from "@commonfabric/data-model/codec-common";
+import {
+  type EntityRef,
+  entityRefFromString,
+} from "@commonfabric/data-model/cell-rep";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import {
   deepFrozenCloneAndInternSchema,
@@ -379,7 +383,7 @@ declare module "@commonfabric/api" {
     value: T;
     cellLink: SigilLink;
     space: MemorySpace;
-    entityId: { "/": string };
+    entityId: EntityRef;
     sourceURI: URI;
     path: readonly PropertyKey[];
     copyTrap: boolean;
@@ -2211,8 +2215,8 @@ export class CellImpl<T extends FabricValue>
     return createSigilLinkFromParsedLink(this.link);
   }
 
-  get entityId(): { "/": string } {
-    return { "/": fromURI(this.link.id) };
+  get entityId(): EntityRef {
+    return entityRefFromString(fromURI(this.link.id));
   }
 
   get sourceURI(): URI {

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -1,5 +1,10 @@
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
+import {
+  type EntityRef,
+  entityRefFrom,
+  entityRefFromString,
+} from "@commonfabric/data-model/cell-rep";
 import { isRecord } from "@commonfabric/utils/types";
 import { isOpaqueRef } from "./builder/types.ts";
 import {
@@ -128,20 +133,22 @@ export function createRef(
 /**
  * Helper to consistently get an entity ID from various object types
  */
-export function getEntityId(value: any): { "/": string } | undefined {
+export function getEntityId(value: any): EntityRef | undefined {
   if (typeof value === "string") {
     // Handle URI format with "of:" prefix
     if (value.startsWith("of:")) value = fromURI(value);
-    return value.startsWith("{") ? JSON.parse(value) : { "/": value };
+    return value.startsWith("{")
+      ? entityRefFromString(JSON.parse(value)["/"])
+      : entityRefFromString(value);
   }
 
   const link = parseLink(value);
 
   if (!link || !link.id) return undefined;
 
-  const entityId = { "/": fromURI(link.id) };
+  const baseRef = entityRefFromString(fromURI(link.id));
 
   if (link.path && link.path.length > 0) {
-    return { "/": createRef({ path: link.path }, entityId).taggedHashString };
-  } else return entityId;
+    return entityRefFrom(createRef({ path: link.path }, baseRef));
+  } else return baseRef;
 }

--- a/packages/runner/src/piece-helpers.ts
+++ b/packages/runner/src/piece-helpers.ts
@@ -1,3 +1,7 @@
+import {
+  entityRefToString,
+  isEntityRef,
+} from "@commonfabric/data-model/cell-rep";
 import { type Cell, isCell } from "./cell.ts";
 import type { MemorySpace } from "./storage/interface.ts";
 import type { JSONSchema, Pattern } from "./builder/types.ts";
@@ -64,9 +68,7 @@ export function resolveCellPath<T>(
 
 export function cellEntityIdString(cell: Cell<unknown>): string | undefined {
   const id = cell.entityId;
-  if (!id) return undefined;
-  const idValue = id["/"];
-  return typeof idValue === "string" ? idValue : undefined;
+  return isEntityRef(id) ? entityRefToString(id) : undefined;
 }
 
 export function getResultCellWithSourceSchema<T = unknown>(

--- a/packages/runner/test/cell-rep-wedge.test.ts
+++ b/packages/runner/test/cell-rep-wedge.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
+import {
+  type EntityRef,
+  entityRefToString,
+  resetModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
+import { Runtime } from "../src/runtime.ts";
+import { createRef } from "../src/create-ref.ts";
+
+const signer = await Identity.fromPassphrase("cell-rep wedge");
+const space = signer.did();
+
+/**
+ * Exercises the modern-cell-rep flag end to end at the `Cell.entityId` →
+ * `createRef`/`hashOf` boundary that the `map`/`filter`/`flatMap` builtins use
+ * to derive result-cell addresses. The serialized entity-id reference's shape
+ * is itself a hash input, so flipping the flag re-points those derived
+ * addresses — the storage-affecting change the flag gates.
+ */
+describe("modern-cell-rep wedge", () => {
+  afterEach(() => {
+    resetModernCellRepConfig();
+  });
+
+  /** Builds a runtime in the requested regime and reads a fixed cell's id. */
+  async function withCellEntityId<T>(
+    modernCellRep: boolean,
+    fn: (entityId: EntityRef) => T,
+  ): Promise<T> {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { modernCellRep },
+    });
+    const tx = runtime.edit();
+    try {
+      const cell = runtime.getCell<{ value: number }>(
+        space,
+        "wedge-fixed-id",
+        undefined,
+        tx,
+      );
+      return fn(cell.entityId);
+    } finally {
+      await tx.commit();
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  }
+
+  it('flag OFF: entityId is a plain `{ "/": string }` object', async () => {
+    await withCellEntityId(false, (entityId) => {
+      expect(entityId).not.toBeInstanceOf(FabricHash);
+      expect(typeof (entityId as { "/": string })["/"]).toBe("string");
+    });
+  });
+
+  it("flag ON: entityId is a straight FabricHash", async () => {
+    await withCellEntityId(true, (entityId) => {
+      expect(entityId).toBeInstanceOf(FabricHash);
+    });
+  });
+
+  it("names the same cell in both regimes (same tagged hash)", async () => {
+    const legacyTagged = await withCellEntityId(false, entityRefToString);
+    const modernTagged = await withCellEntityId(true, entityRefToString);
+    expect(modernTagged).toBe(legacyTagged);
+  });
+
+  it("re-points derived addresses when the flag flips", async () => {
+    const cause = "fixed-cause";
+    const legacyDerived = await withCellEntityId(
+      false,
+      (entityId) => createRef({ map: entityId }, cause).taggedHashString,
+    );
+    const modernDerived = await withCellEntityId(
+      true,
+      (entityId) => createRef({ map: entityId }, cause).taggedHashString,
+    );
+    // Same underlying cell, same cause — only the reference form differs, and
+    // that difference must propagate into the derived address.
+    expect(modernDerived).not.toBe(legacyDerived);
+  });
+});

--- a/packages/runner/test/data-uri-inlining.test.ts
+++ b/packages/runner/test/data-uri-inlining.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
@@ -482,7 +483,7 @@ describe("data URI inlining", () => {
       const linkToOtherDoc = {
         "/": {
           [LINK_V1_TAG]: {
-            id: linkedCell.entityId["/"],
+            id: entityRefToString(linkedCell.entityId),
             path: [],
             schema: {
               type: "object",
@@ -646,7 +647,7 @@ describe("data URI inlining", () => {
       const linkWithSchema = {
         "/": {
           [LINK_V1_TAG]: {
-            id: docCell.entityId["/"],
+            id: entityRefToString(docCell.entityId),
             path: [],
             schema: {
               type: "object",

--- a/packages/runner/test/doc-map.test.ts
+++ b/packages/runner/test/doc-map.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createRef, entityIdFrom, getEntityId } from "../src/create-ref.ts";
+import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { Runtime } from "../src/runtime.ts";
@@ -106,7 +107,7 @@ describe("cell-map", () => {
       // Use Cell API to retrieve by entity ID
       const retrievedCell = runtime.getCellFromEntityId<{ value: number }>(
         space,
-        entityIdFrom(c.entityId!["/"]),
+        entityIdFrom(entityRefToString(c.entityId)),
       );
 
       // Verify we got the same cell
@@ -132,7 +133,9 @@ describe("cell-map", () => {
       const json = JSON.parse(JSON.stringify(c));
       expect(json["/"]).toBeDefined();
       expect(json["/"][LINK_V1_TAG]).toBeDefined();
-      expect(json["/"][LINK_V1_TAG].id).toContain(c.entityId!["/"].toString());
+      expect(json["/"][LINK_V1_TAG].id).toContain(
+        entityRefToString(c.entityId),
+      );
       expect(json["/"][LINK_V1_TAG].path).toEqual([]);
       expect(json["/"][LINK_V1_TAG].space).toEqual(space);
     });

--- a/packages/runner/test/navigate-handler.test.ts
+++ b/packages/runner/test/navigate-handler.test.ts
@@ -1,4 +1,5 @@
 import { assert, assertEquals } from "@std/assert";
+import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
@@ -16,7 +17,7 @@ async function runNavigateHandlerTest(conditional: boolean): Promise<void> {
     apiUrl: new URL(import.meta.url),
     storageManager,
     navigateCallback: (target) => {
-      navigations.push(target.entityId?.["/"] ?? "");
+      navigations.push(entityRefToString(target.entityId));
     },
   });
 
@@ -110,7 +111,7 @@ Deno.test("navigateTo is idempotent for one result cell", async () => {
     apiUrl: new URL(import.meta.url),
     storageManager,
     navigateCallback: (target) => {
-      navigations.push(target.entityId?.["/"] ?? "");
+      navigations.push(entityRefToString(target.entityId));
     },
   });
 
@@ -186,7 +187,7 @@ Deno.test("navigateTo is idempotent for one result cell", async () => {
     await runtime.idle();
 
     assertEquals(navigations.length, 1);
-    assertEquals(navigations[0], targetOne.entityId?.["/"]);
+    assertEquals(navigations[0], entityRefToString(targetOne.entityId));
   } finally {
     await runtime.dispose();
     await storageManager.close();
@@ -202,7 +203,7 @@ Deno.test(
       apiUrl: new URL(import.meta.url),
       storageManager,
       navigateCallback: (target) => {
-        navigations.push(target.entityId?.["/"] ?? "");
+        navigations.push(entityRefToString(target.entityId));
       },
     });
 
@@ -262,7 +263,7 @@ Deno.test(
       await runtime.idle();
 
       assertEquals(navigations.length, 1);
-      assertEquals(navigations[0], target.entityId?.["/"]);
+      assertEquals(navigations[0], entityRefToString(target.entityId));
     } finally {
       await runtime.dispose();
       await storageManager.close();

--- a/packages/runner/test/query.test.ts
+++ b/packages/runner/test/query.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import { JSONObject, type JSONSchema } from "../src/index.ts";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import {
@@ -78,14 +79,14 @@ describe("Query", () => {
       tx,
     );
     testCell1.set(docValue1);
-    const entityId1 = JSON.parse(JSON.stringify(testCell1.entityId!));
+    const entityId1 = entityRefToString(testCell1.entityId);
     const assert1: Revision<State> = {
       the: "application/json",
-      of: `of:${entityId1["/"]}`,
+      of: `of:${entityId1}`,
       is: { value: testCell1.get() },
       cause: hashOf({
         the: "application/json",
-        of: `of:${entityId1["/"]}`,
+        of: `of:${entityId1}`,
       }),
       since: 1,
     };
@@ -93,7 +94,7 @@ describe("Query", () => {
       name: {
         "/": {
           [LINK_V1_TAG]: {
-            id: `of:${entityId1["/"]}`,
+            id: `of:${entityId1}`,
             path: ["employees", "0", "fullName"],
           },
         },
@@ -108,14 +109,14 @@ describe("Query", () => {
       tx,
     );
     testCell2.setRaw(docValue2);
-    const entityId2 = testCell2.entityId!;
+    const entityId2 = entityRefToString(testCell2.entityId);
     const assert2: Revision<State> = {
       the: "application/json",
-      of: `of:${entityId2["/"]}`,
+      of: `of:${entityId2}`,
       is: { value: docValue2 },
       cause: hashOf({
         the: "application/json",
-        of: `of:${entityId2["/"]}`,
+        of: `of:${entityId2}`,
       }),
       since: 2,
     };
@@ -155,10 +156,10 @@ describe("Query", () => {
       value: (assert2.is as JSONObject).value,
     });
     const selectorSet1 = schemaTracker.get(
-      `did:null:null/space/of:${entityId1["/"]}`,
+      `did:null:null/space/of:${entityId1}`,
     );
     const selectorSet2 = schemaTracker.get(
-      `did:null:null/space/of:${entityId2["/"]}`,
+      `did:null:null/space/of:${entityId2}`,
     );
     expect(selectorSet1?.size).toBe(1);
     expect(selectorSet2?.size).toBe(1);
@@ -181,14 +182,14 @@ describe("Query", () => {
       tx,
     );
     testCell1.set({ employees: [{ name: { first: "Bob" } }] });
-    const entityId1 = JSON.parse(JSON.stringify(testCell1.entityId!));
+    const entityId1 = entityRefToString(testCell1.entityId);
     const assert1: Revision<State> = {
       the: "application/json",
-      of: `of:${entityId1["/"]}`,
+      of: `of:${entityId1}`,
       is: { value: testCell1.get() },
       cause: hashOf({
         the: "application/json",
-        of: `of:${entityId1["/"]}`,
+        of: `of:${entityId1}`,
       }),
       since: 1,
     };
@@ -204,21 +205,21 @@ describe("Query", () => {
       name: {
         "/": {
           [LINK_V1_TAG]: {
-            id: `of:${entityId1["/"]}`,
+            id: `of:${entityId1}`,
             path: ["employees", "0", "name"],
           },
         },
       },
     };
     testCell2.setRaw(docValue2);
-    const entityId2 = testCell2.entityId!;
+    const entityId2 = entityRefToString(testCell2.entityId);
     const assert2: Revision<State> = {
       the: "application/json",
-      of: `of:${entityId2["/"]}`,
+      of: `of:${entityId2}`,
       is: { value: docValue2 },
       cause: hashOf({
         the: "application/json",
-        of: `of:${entityId2["/"]}`,
+        of: `of:${entityId2}`,
       }),
       since: 2,
     };
@@ -251,10 +252,10 @@ describe("Query", () => {
       value: (assert2.is as JSONObject).value,
     });
     const selectorSet1 = schemaTracker.get(
-      `did:null:null/space/of:${entityId1["/"]}`,
+      `did:null:null/space/of:${entityId1}`,
     );
     const selectorSet2 = schemaTracker.get(
-      `did:null:null/space/of:${entityId2["/"]}`,
+      `did:null:null/space/of:${entityId2}`,
     );
     expect(selectorSet1?.size).toBe(1);
     expect(selectorSet2?.size).toBe(1);
@@ -300,16 +301,16 @@ describe("Query", () => {
         },
       },
     });
-    const entityId1 = JSON.parse(JSON.stringify(testCell1.entityId!));
+    const entityId1 = entityRefToString(testCell1.entityId);
     const assert1 = {
       the: "application/json" as MIME,
-      of: `of:${entityId1["/"]}` as URI,
+      of: `of:${entityId1}` as URI,
       is: {
         value: {
           name: {
             "/": {
               [LINK_V1_TAG]: {
-                id: `of:${entityId1["/"]}`,
+                id: `of:${entityId1}`,
                 path: ["name"],
               },
             },
@@ -318,7 +319,7 @@ describe("Query", () => {
       },
       cause: hashOf({
         the: "application/json",
-        of: `of:${entityId1["/"]}`,
+        of: `of:${entityId1}`,
       }),
       since: 1,
     };
@@ -345,7 +346,7 @@ describe("Query", () => {
       value: assert1.is.value,
     });
     const selectorSet1 = schemaTracker.get(
-      `did:null:null/space/of:${entityId1["/"]}`,
+      `did:null:null/space/of:${entityId1}`,
     );
     expect(selectorSet1?.size).toBe(2);
     expect(selectorSet1).toContainEqual({ path: ["value"], schema });
@@ -500,14 +501,14 @@ describe("Query", () => {
       tx,
     );
     testCell1.set(docValue1);
-    const entityId1 = JSON.parse(JSON.stringify(testCell1.entityId!));
+    const entityId1 = entityRefToString(testCell1.entityId);
     const assert1: Revision<State> = {
       the: "application/json",
-      of: `of:${entityId1["/"]}`,
+      of: `of:${entityId1}`,
       is: { value: testCell1.get() },
       cause: hashOf({
         the: "application/json",
-        of: `of:${entityId1["/"]}`,
+        of: `of:${entityId1}`,
       }),
       since: 1,
     };
@@ -517,7 +518,7 @@ describe("Query", () => {
         address: {
           "/": {
             [LINK_V1_TAG]: {
-              id: `of:${entityId1["/"]}`,
+              id: `of:${entityId1}`,
               path: ["home"],
             },
           },
@@ -538,14 +539,14 @@ describe("Query", () => {
       schema,
     };
 
-    const entityId2 = testCell2.entityId!;
+    const entityId2 = entityRefToString(testCell2.entityId);
     const assert2: Revision<State> = {
       the: "application/json",
-      of: `of:${entityId2["/"]}`,
+      of: `of:${entityId2}`,
       is: { value: testCell2.getRaw() },
       cause: hashOf({
         the: "application/json",
-        of: `of:${entityId2["/"]}`,
+        of: `of:${entityId2}`,
       }),
       since: 2,
     };
@@ -575,10 +576,10 @@ describe("Query", () => {
       value: (assert2.is as JSONObject).value,
     });
     const selectorSet1 = schemaTracker.get(
-      `did:null:null/space/of:${entityId1["/"]}`,
+      `did:null:null/space/of:${entityId1}`,
     );
     const selectorSet2 = schemaTracker.get(
-      `did:null:null/space/of:${entityId2["/"]}`,
+      `did:null:null/space/of:${entityId2}`,
     );
     expect(selectorSet1?.size).toBe(1);
     expect(selectorSet2?.size).toBe(1);

--- a/packages/runner/test/scheduler-event-receipts.test.ts
+++ b/packages/runner/test/scheduler-event-receipts.test.ts
@@ -9,6 +9,7 @@ import {
   Runtime,
   space,
 } from "./scheduler-test-utils.ts";
+import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import type {
   Cell,
   IExtendedStorageTransaction,
@@ -554,7 +555,7 @@ Deno.test("navigateTo handler results navigate once and deduplicate redelivery",
     storageManager,
     experimental: { commitPreconditions: true },
     navigateCallback: (target) => {
-      navigations.push(target.entityId?.["/"] ?? "");
+      navigations.push(entityRefToString(target.entityId));
     },
   });
   let tx = runtime.edit();

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -11,6 +11,7 @@ import type {
   WriteStackTraceEntry,
   WriteStackTraceMatcher,
 } from "@commonfabric/runner/shared";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import type { CfcLabelView } from "@commonfabric/runner/cfc/label-view-core";
 import type { DID, KeyPairRaw } from "@commonfabric/identity";
 import { type Program } from "@commonfabric/js-compiler/interface";
@@ -223,7 +224,7 @@ export interface CellGetCfcLabelRequest extends BaseRequest {
 export interface GetCellRequest extends BaseRequest {
   type: RequestType.GetCell;
   space: DID;
-  cause: JSONValue;
+  cause: FabricValue;
   schema?: JSONSchema;
 }
 

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -38,6 +38,7 @@ import {
   type UploadBlobResponse,
 } from "./protocol/mod.ts";
 import { NameSchema } from "@commonfabric/runner/schemas";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 import { RuntimeTransport } from "./client/transport.ts";
 import { EventEmitter } from "./client/emitter.ts";
 import {
@@ -127,7 +128,7 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
   // could be built using this
   async getCell<T>(
     space: DID,
-    cause: JSONValue,
+    cause: FabricValue,
     schema?: JSONSchema,
   ): Promise<CellHandle<T>> {
     const response = await this.#conn.request<RequestType.GetCell>({


### PR DESCRIPTION
## What & why

We're migrating off the legacy hashing object forms. The last major piece changes **how object references are hashed**, which changes stored cell addresses — so it must be gated. The `data-model` "modern cell representation" flag (`cell-rep.ts`) existed but **guarded nothing**. This makes it guard its first real thing: the **production and recognition of the serialized entity-id reference form**.

Today there are two roles for an entity id:
- **Addressing form** — a branded `FabricHash` (`EntityId`), returned by `createRef`.
- **Serialized/extracted form** — a plain `{ "/": string }` object, returned by `Cell.entityId` / `getEntityId`.

The serialized form's *shape* is itself a hash input (`Cell.entityId` → `getCell({ map: parentCell.entityId })` → `createRef`/`hashOf` in `builtins/{map,filter,flatmap}.ts`), so a plain `{ "/": … }` hashes differently than a bare `FabricHash`. Collapsing the serialized role onto the addressing form (flag **on**) re-points derived cell addresses — the gated storage change.

**This PR does not flip the flag.** It builds the wedge: route all production and recognition of the serialized ref form through flag-dispatched functions so **flag off is byte-identical to today** and **flag on uses straight `FabricHash`es**.

### Clean-break semantics

Because a stored hash carries no record of which input form produced it, the flag is a **whole-regime mode switch**: recognition is strict (flag-gated), not permissive. In modern mode the recognizers accept only `FabricHash`; in legacy mode only `{ "/": string }`. A deployment runs entirely in one regime — legacy-hash and modern-hash data never intermix.

## Commits

- **`feat(data-model)`** — New dispatch API in `cell-rep.ts`: `type EntityRef = FabricHash | { "/": string }` plus `entityRefFromString`/`entityRefFrom` (production) and `isEntityRef`/`entityRefToString` (strict recognition/extraction). Routed the core entity-id sites: producers `Cell.entityId` and `getEntityId`; consumers `cellEntityIdString` and `sqlite-builtins`. Widened `@commonfabric/api` `GetEntityIdFunction` to include `FabricHash`, rerouting `piece/manager.ts` and affected tests' `["/"]` extractions through `entityRefToString`.
- **`refactor(runtime-client)`** — Widened the IPC `GetCell` `cause` from `JSONValue` to `FabricValue` (it's hashed on the worker and round-trips through the Fabric JSON codec, so `JSONValue` was too narrow). No-op widening.
- **`fix(lib-shell)`** — `getSlugCell` now mints its entity-ref via `entityRefFromString(...)` instead of a hand-built `{ "/": slugId }`, closing the last in-process bypass.
- **`test(codec-json)`** — De-ref-ified the `/`-escaping fixtures (CID-looking strings → arbitrary; `entityId` → `slashKeyed`) so they read as "a `/` key per se", not entity refs.

## Verification

- New `data-model/test/cell-rep.test.ts` (all four functions × both regimes, incl. wrong-regime throws) and `runner/test/cell-rep-wedge.test.ts` (flag on → `entityId instanceof FabricHash`; **same cell names identically in both regimes but its derived `map` address differs** — the wedge proven).
- Full suites green: data-model 38, runner 634, memory 212, piece 10, lib-shell 5; 0 failed. Workspace `deno task check` + `fmt --check` + `lint` clean. Flag off is byte-identical to before.

## Deferred to follow-on(s)

The remaining `{ "/": string }` constructions are the **cell-link `cell`-field / memory `SourceLink` role**, not entity-id production: memory-layer recognizers (`fact.ts` `"/" in cause`, `v2.isSourceLink`, `consumer.ts`) and test fixtures (`piece/charm-references.test.ts`, memory/runner cell-link fixtures). Also flagged: any consumer that `JSON.stringify`s an entity id (a modern `FabricHash` has no `toJSON()` since #4209 — storage goes through the Fabric `[CODEC]`, so this is a footgun check, not a known break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Coverage Baseline

This PR adds a very small number of uncovered lines.

NEW_COVERAGE_BASELINE



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a flag-dispatched entity-id reference form and routes all production/recognition through it. Flag off keeps `{ "/": string }`; flag on uses `FabricHash`. The flag is not flipped.

- **New Features**
  - Introduces `EntityRef` (`FabricHash | { "/": string }`) and helpers: `entityRefFromString`, `entityRefFrom`, `isEntityRef`, `entityRefToString`.
  - Strict regime recognition: legacy accepts only `{ "/": string }`, modern only `FabricHash`.
  - `Cell.entityId` and `getEntityId` now return `EntityRef`.
  - Verified with new unit and wedge tests: base cell id stays the same across regimes; derived `map` address changes when the flag flips.

- **Refactors**
  - Widens `@commonfabric/api` `GetEntityIdFunction` to return `FabricHash | { "/": string } | undefined`.
  - Widens `runtime-client` `GetCell` `cause` to `FabricValue` and updates protocol types.
  - Routes consumers via `entityRefToString`/`isEntityRef` (`sqlite-builtins`, `piece/manager`, `piece-helpers`, tests).
  - Fixes `lib-shell` `getSlugCell` to use `entityRefFromString` instead of hand-built `{ "/": id }`.
  - Updates JSON codec tests to use arbitrary `/`-key values (no entity-ref semantics).
  - Behavior with the flag off remains byte-identical.

<sup>Written for commit 98ba0040368fad407db6333d93da5f4c2663ab5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

