### PR TITLE
Framework-provided sandbox ids for the bash tool

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2114,6 +2114,35 @@ export interface PatternToolResult<E = Record<PropertyKey, never>> {
   useResultSchemaForObservation?: boolean;
 }
 
+// Marker branding a tool-input field as framework-provided: the runtime fills
+// it (e.g. the bash tool's `sandboxId`), and `patternTool` rejects any attempt
+// to pre-fill it through extraParams. Compile-time only; at runtime a
+// `FrameworkProvided<T>` value is just a `T`. The brand is a symbol-keyed
+// property, so schema generation emits the inner type's schema unchanged.
+//
+// Shaped as `(T & brand) | T` (like Default<>): the bare `| T` arm keeps the
+// type nameable in emitted declarations, while the branded arm is what
+// FrameworkProvidedKeys<> detects.
+export declare const FRAMEWORK_PROVIDED_MARKER: unique symbol;
+type FrameworkProvidedMarker = { readonly [FRAMEWORK_PROVIDED_MARKER]: true };
+export type FrameworkProvided<T> = (T & FrameworkProvidedMarker) | T;
+
+// Distributes over the union members of V (naked param) so it sees the brand in
+// the `(T & brand) | T` shape: `true` for the branded arm, `false` for the bare
+// one, hence `boolean` for the whole union. `any` is excluded — `any extends X`
+// is `boolean`, which would otherwise flag every loosely-typed field.
+type _HasFrameworkBrand<V> = IsAny<V> extends true ? false
+  : V extends FrameworkProvidedMarker ? true
+  : false;
+
+// The keys of T whose value is `FrameworkProvided<...>` — the fields an author
+// must not pre-fill. `NonNullable` lets it see the brand through an optional
+// `field?: FrameworkProvided<...>`.
+type FrameworkProvidedKeys<T> = {
+  [K in keyof T]-?: true extends _HasFrameworkBrand<NonNullable<T[K]>> ? K
+    : never;
+}[keyof T];
+
 export type PatternToolFunction = <
   T,
   E extends object = Record<PropertyKey, never>,
@@ -2123,8 +2152,12 @@ export type PatternToolFunction = <
   // its closure) is no longer supported — wrap it yourself:
   // `patternTool(pattern(fn), extraParams?)`.
   pattern: PatternFactory<T, any>,
-  // Validate that E (after stripping cells) is a subset of T
-  extraParams?: StripCell<E> extends Partial<T> ? FactoryInput<E> : never,
+  // Reject pre-filling a framework-provided field (e.g. the bash tool's
+  // `sandboxId`); otherwise validate that E (after stripping cells) is a subset
+  // of T.
+  extraParams?: [keyof E & FrameworkProvidedKeys<T>] extends [never]
+    ? (StripCell<E> extends Partial<T> ? FactoryInput<E> : never)
+    : never,
 ) => PatternToolResult<E>;
 
 // Public (schema-light) surface, matching PatternFunction's index.ts shape: the

--- a/packages/api/test/framework-provided.test.ts
+++ b/packages/api/test/framework-provided.test.ts
@@ -1,0 +1,33 @@
+import { assert, assertEquals } from "@std/assert";
+// Runtime import: the `commonfabric` entrypoint (packages/api/index.ts) is
+// almost entirely type declarations. Importing a runtime value forces the
+// module to actually load, so its public surface is exercised under coverage.
+import { CFC_CANONICAL_ALIAS_NAMES } from "commonfabric";
+import type { FrameworkProvided, PatternToolResult } from "commonfabric";
+
+Deno.test("FrameworkProvided is a compile-time brand, transparent at runtime", () => {
+  // A `FrameworkProvided<T>` value carries no runtime brand — it is just a `T`,
+  // so a tool body (e.g. the bash tool reading `sandboxId`) can use it as the
+  // bare value. The annotation below compiles only if the brand stays
+  // assignable to its base type.
+  const id = "sandbox-abc";
+  const branded = id as unknown as FrameworkProvided<string>;
+  const asString: string = branded;
+  assertEquals(asString, id);
+  assertEquals(typeof branded, "string");
+});
+
+Deno.test("commonfabric exposes its runtime surface", () => {
+  // Smoke-check the public entrypoint's one runtime export.
+  assert(Array.isArray(CFC_CANONICAL_ALIAS_NAMES));
+  assert(CFC_CANONICAL_ALIAS_NAMES.length > 0);
+});
+
+Deno.test("PatternToolResult carries pattern + extraParams", () => {
+  // The shape patternTool() returns; referenced as a type so the public export
+  // is part of the checked surface.
+  const result: Pick<PatternToolResult<{ a: number }>, "extraParams"> = {
+    extraParams: { a: 1 },
+  };
+  assertEquals(result.extraParams.a, 1);
+});

--- a/packages/patterns/system/common-fabric.tsx
+++ b/packages/patterns/system/common-fabric.tsx
@@ -5,6 +5,7 @@ import {
   fetchJson,
   fetchProgram,
   fetchText,
+  type FrameworkProvided,
   handler,
   ifElse,
   NAME,
@@ -285,7 +286,7 @@ type BashRequest = {
   /** Additional environment variables as key-value pairs. */
   environment?: Record<string, string>;
   /** Sandbox identifier. Automatically provided — do not set. */
-  sandboxId: string;
+  sandboxId: FrameworkProvided<string>;
 };
 
 type BashResult = {

--- a/packages/patterns/system/omnibox-fab.tsx
+++ b/packages/patterns/system/omnibox-fab.tsx
@@ -4,7 +4,6 @@ import {
   handler,
   NAME,
   navigateTo,
-  nonPrivateRandom,
   pattern,
   patternTool,
   Stream,
@@ -120,9 +119,6 @@ export default pattern<OmniboxFABInput>(
     const { entries: summaryEntries } = wish<{
       entries: SummaryIndexEntry[];
     }>({ query: "#summaryIndex" }).result!;
-    const sandboxId = new Writable(
-      `omnibot-${nonPrivateRandom().toString(36).slice(2, 10)}`,
-    );
 
     const profile = wish<string>({ query: "#learnedSummary" });
 
@@ -186,7 +182,7 @@ Be matter-of-fact. Prefer action to explanation.`;
       listMentionable: patternTool(listMentionable, { mentionable }),
       listRecent: patternTool(listRecent, { recentPieces }),
       updateProfile: patternTool(updateProfile),
-      bash: patternTool(bash, { sandboxId }),
+      bash: patternTool(bash),
       searchSpace: patternTool(summarySearchPattern, {
         entries: summaryEntries,
       }),

--- a/packages/patterns/system/suggestion.tsx
+++ b/packages/patterns/system/suggestion.tsx
@@ -7,7 +7,6 @@ import {
   ifElse,
   llmDialog,
   NAME,
-  nonPrivateRandom,
   pattern,
   patternTool,
   type Stream,
@@ -150,10 +149,6 @@ export default pattern<
     return profileText ? `\n\n--- User Context ---\n${profileText}\n---` : "";
   });
 
-  const sandboxId = new Writable(
-    `suggestion-${nonPrivateRandom().toString(36).slice(2, 10)}`,
-  );
-
   const systemPrompt = computed(() => {
     const profileCtx = profileContext;
     const indexText = patternIndex
@@ -194,7 +189,7 @@ Use the user context above to personalize your suggestions when relevant.`;
     messages,
     tools: {
       fetchAndRunPattern: patternTool(fetchAndRunPattern),
-      bash: patternTool(bash, { sandboxId }),
+      bash: patternTool(bash),
       searchSpace: patternTool(summarySearchPattern, {
         entries: summaryEntries,
       }),

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -46,6 +46,11 @@ import {
 import { resolveLinkScope } from "../scope.ts";
 import { type CellScope, ID, NAME, type Pattern } from "../builder/types.ts";
 import { resolveStoredPatternAsync } from "./op-pattern-ref.ts";
+import { getEntityId } from "../create-ref.ts";
+import {
+  entityRefToString,
+  isEntityRef,
+} from "@commonfabric/data-model/cell-rep";
 import { type Action, ignoreReadForScheduling } from "../scheduler.ts";
 import { Runtime } from "../runtime.ts";
 import { spaceCellSchema } from "../runtime.ts";
@@ -163,6 +168,32 @@ function normalizeInputSchema(schemaLike: unknown): JSONSchema {
   if (!isObject(inputSchema)) inputSchema = { type: "object" };
   const stripped = stripInjectedResult(inputSchema);
   return prepareSchemaForLLM(stripped);
+}
+
+// Tool-input fields the framework fills in (see applyAutoProvidedSandboxId).
+// They are removed from the model-facing schema so the model is never asked for
+// a value it cannot set — the runtime owns them.
+const FRAMEWORK_PROVIDED_TOOL_FIELDS: readonly string[] = ["sandboxId"];
+
+// Remove framework-provided fields from a tool's model-facing input schema. The
+// pattern's own argumentSchema (which the runtime reads to decide what to fill)
+// is untouched; only what the model sees changes.
+function stripFrameworkProvidedFields(schema: JSONSchema): JSONSchema {
+  if (!schema || typeof schema !== "object") return schema;
+  const obj = schema as Record<string, unknown>;
+  const props = obj.properties as Record<string, unknown> | undefined;
+  if (!props || typeof props !== "object") return schema;
+  const present = FRAMEWORK_PROVIDED_TOOL_FIELDS.filter((f) => f in props);
+  if (present.length === 0) return schema;
+  const nextProps = { ...props };
+  for (const f of present) delete nextProps[f];
+  const next: Record<string, unknown> = { ...obj, properties: nextProps };
+  if (Array.isArray(obj.required)) {
+    next.required = (obj.required as unknown[]).filter(
+      (k) => !present.includes(k as string),
+    );
+  }
+  return next as JSONSchema;
 }
 
 /**
@@ -1312,7 +1343,7 @@ function buildToolCatalog(
       (normalizedInputSchema as any)?.description ?? "";
     llmTools[entry.name] = {
       description,
-      inputSchema: normalizedInputSchema,
+      inputSchema: stripFrameworkProvidedFields(normalizedInputSchema),
     };
     dynamicToolCells.set(entry.name, entry.cell);
   }
@@ -2315,6 +2346,8 @@ export const llmToolExecutionHelpers = {
   serializeForLLMObservation,
   toolAllowsObservedConfidentiality,
   effectiveObservationCeiling,
+  stripFrameworkProvidedFields,
+  applyAutoProvidedSandboxId,
 };
 
 /**
@@ -2528,6 +2561,58 @@ function handleUpdateArgument(
 }
 
 /**
+ * Auto-provides the `sandboxId` input for tools that declare it (the bash tool
+ * and anything sharing its contract). The framework OWNS this field: a pattern
+ * that declares `sandboxId` never chooses its value, and neither does the model.
+ *
+ * The value is the content-addressed entity id of the tool's own definition
+ * cell. That id is unique to this pattern instance, constant for the life of the
+ * instance, and the same for every call the instance makes — so repeated bash
+ * calls reuse one persistent server-side sandbox, while two instances (or two
+ * users) never land on the same one. The id comes from the instance's identity
+ * rather than the clock or randomness.
+ *
+ * The server names sandboxes by this id (`/v1/sandboxes/<id>`), so any
+ * caller-chosen value is a cross-instance leak vector: two patterns that pin the
+ * same id would share a sandbox, and a pattern could name another instance's (or
+ * another user's). A pattern that pre-fills `sandboxId` through patternTool's
+ * extraParams is rejected outright — a chosen value can never take effect, so
+ * silently dropping it would hide an authoring mistake; this throws instead. A
+ * model-supplied value (untrusted, not an authoring mistake) is overwritten. If
+ * the pattern declares `sandboxId` but no stable id can be derived, this also
+ * throws rather than fall through to an empty, shared name.
+ */
+function applyAutoProvidedSandboxId(
+  args: Record<string, unknown>,
+  pattern: Readonly<Pattern> | undefined,
+  extraParams: Record<string, unknown>,
+  identityCell: Cell<any> | undefined,
+): void {
+  const properties = (pattern?.argumentSchema as
+    | { properties?: Record<string, unknown> }
+    | undefined)?.properties;
+  if (!properties || !("sandboxId" in properties)) return;
+  if (extraParams.sandboxId !== undefined) {
+    throw new Error(
+      "sandboxId is framework-provided for tools that declare it; " +
+        "remove it from patternTool's extraParams",
+    );
+  }
+  const ref = identityCell ? getEntityId(identityCell) : undefined;
+  const entityId = ref && isEntityRef(ref) ? entityRefToString(ref) : undefined;
+  if (typeof entityId !== "string" || entityId.length === 0) {
+    throw new Error(
+      "Cannot auto-provide sandboxId: tool instance has no stable entity id",
+    );
+  }
+  // The entity id carries a URI scheme separator (e.g. "fid1:<hash>"). The id
+  // names a server-side resource at `/v1/sandboxes/<id>`, so map the only unsafe
+  // character (the scheme colon) to a hyphen. The hash body is base64url and is
+  // preserved exactly, so distinct entity ids stay distinct.
+  args.sandboxId = entityId.replace(/[^A-Za-z0-9_-]/g, "-");
+}
+
+/**
  * Handles the invoke tool call (both pattern and handler execution).
  */
 async function handleInvoke(
@@ -2546,6 +2631,9 @@ async function handleInvoke(
   let extraParams: Record<string, unknown> = {};
   let handler: any;
   let useResultSchemaForObservation = false;
+  // The cell the tool was resolved from. Its content-addressed entity id is the
+  // running instance's identity, used to auto-provide a per-instance sandbox id.
+  let identityCell: Cell<any> | undefined;
 
   if (resolved.type === "external") {
     pattern = resolved.toolDef.key("pattern").getRaw() as unknown as
@@ -2556,10 +2644,14 @@ async function handleInvoke(
     useResultSchemaForObservation = Boolean(
       resolved.toolDef.key("useResultSchemaForObservation").get(),
     );
+    identityCell = resolved.toolDef;
   } else if (resolved.type === "invoke") {
     pattern = resolved.pattern;
     extraParams = resolved.extraParams ?? {};
     handler = resolved.handler;
+    // No identity cell for invoke-by-path: a tool that declares `sandboxId` and
+    // is invoked this way fails closed in applyAutoProvidedSandboxId rather than
+    // run with an unprovided id.
   }
 
   // A pattern read raw from a cell is the boundary serialization (refs-only
@@ -2572,6 +2664,19 @@ async function handleInvoke(
     | undefined;
 
   const input = traverseAndCellify(runtime, space, toolCall.input) as object;
+
+  // The model input is the lowest-priority layer; extraParams (author pre-fills)
+  // override it, and the framework-owned sandbox id overrides both.
+  const invocationArgs = {
+    ...input as Record<string, unknown>,
+    ...extraParams,
+  };
+  applyAutoProvidedSandboxId(
+    invocationArgs,
+    pattern,
+    extraParams,
+    identityCell,
+  );
 
   const { resolve, promise } = Promise.withResolvers<any>();
 
@@ -2588,7 +2693,7 @@ async function handleInvoke(
     );
 
     if (pattern) {
-      runtime.run(tx, pattern, { ...input, ...extraParams }, result);
+      runtime.run(tx, pattern, invocationArgs, result);
     } else if (handler) {
       handler.withTx(tx).send({
         ...input,

--- a/packages/runner/test/sandbox-id-auto-provision.test.ts
+++ b/packages/runner/test/sandbox-id-auto-provision.test.ts
@@ -1,0 +1,653 @@
+/**
+ * Verifies the framework auto-provides a stable, per-instance `sandboxId` to
+ * tools that declare it (the bash tool's contract), instead of patterns minting
+ * one from entropy.
+ *
+ * The contract under test: the framework provides the id *whenever the tool
+ * declares a `sandboxId` input and the author does not*. So three cases:
+ *   A. declares `sandboxId`, author does not pre-fill  -> framework provides it,
+ *      and the id is non-empty, resource-safe, identical across an instance's
+ *      calls (one persistent sandbox), distinct between instances (no
+ *      cross-instance/user sharing), and overrides any model-supplied value
+ *      (the model cannot target another instance's sandbox).
+ *   B. declares `sandboxId`, author pre-fills via extraParams -> framework
+ *      defers to the author's value.
+ *   C. does not declare `sandboxId` -> framework injects nothing.
+ *
+ * Observation: handleInvoke creates each tool's result cell with the tool-call
+ * id as its cause (`runtime.getCell(space, toolCall.id, ...)`). The echo tool
+ * returns the `sandboxId` it received, so re-deriving that cell by tool-call id
+ * reads exactly what the bash tool would have sent to the sandbox service.
+ *
+ * The `sandboxId`-declaring schema here is the bash tool's exact argumentSchema
+ * (five fields, `sandboxId` required alongside `command`); the real bash
+ * pattern's runtime argumentSchema declares `sandboxId` the same way, so it
+ * falls under case A when wired as `patternTool(bash)`.
+ */
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import {
+  addMockResponse,
+  clearMockResponses,
+  enableMockMode,
+  loadConversationFixture,
+  resetMockMode,
+} from "@commonfabric/llm/client";
+import type { BuiltInLLMMessage, BuiltInLLMTool } from "@commonfabric/api";
+import type { JSONSchema } from "../src/builder/types.ts";
+import { createBuilder } from "../src/builder/factory.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { llmToolExecutionHelpers } from "../src/builtins/llm-dialog.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+// Mirrors the real bash tool's argumentSchema (packages/patterns/system/
+// common-fabric.tsx): five fields with `sandboxId` required alongside
+// `command`. Using bash's exact shape exercises the same gate input the bash
+// tool presents at invoke time.
+const BASH_LIKE_ARG_SCHEMA: JSONSchema = {
+  type: "object",
+  properties: {
+    command: { type: "string" },
+    workingDirectory: { type: "string" },
+    timeout: { type: "number" },
+    environment: {
+      type: "object",
+      properties: {},
+      additionalProperties: { type: "string" },
+    },
+    // Same field name and "Automatically provided — do not set" contract.
+    sandboxId: { type: "string" },
+  },
+  required: ["command", "sandboxId"],
+};
+
+// A tool that does NOT declare `sandboxId`; reads any extra input loosely.
+const NO_SANDBOX_ARG_SCHEMA: JSONSchema = {
+  type: "object",
+  properties: { command: { type: "string" } },
+  required: ["command"],
+  additionalProperties: true,
+};
+
+// `command` always settles the result; `received` is the sandboxId the tool
+// got, which is absent when the framework injects nothing (case C).
+const ECHO_RESULT_SCHEMA: JSONSchema = {
+  type: "object",
+  properties: {
+    received: { type: "string" },
+    command: { type: "string" },
+  },
+  required: ["command"],
+};
+
+const PRESENT_SCHEMA: JSONSchema = {
+  type: "object",
+  properties: { ok: { type: "boolean" } },
+  required: ["ok"],
+};
+
+describe("auto-provided sandboxId", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+  let pattern: ReturnType<typeof createBuilder>["commonfabric"]["pattern"];
+  let patternTool: ReturnType<
+    typeof createBuilder
+  >["commonfabric"]["patternTool"];
+  let generateObject: ReturnType<
+    typeof createBuilder
+  >["commonfabric"]["generateObject"];
+
+  beforeEach(() => {
+    enableMockMode();
+    clearMockResponses();
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+    const { commonfabric } = createTrustedBuilder(runtime);
+    ({ pattern, patternTool, generateObject } = commonfabric);
+  });
+
+  afterEach(async () => {
+    resetMockMode();
+    await tx.commit();
+    await runtime.idle();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  // Run one agent-loop instance that calls the echo tool once per entry in
+  // `calls`, then finishes. Returns the `sandboxId` the tool received on each
+  // call (read back from each tool result cell by its tool-call id).
+  async function runInstance(opts: {
+    tag: string;
+    calls: Array<{ callId: string; modelInput: Record<string, unknown> }>;
+    argSchema: JSONSchema;
+    extraParams?: Record<string, unknown>;
+  }): Promise<unknown[]> {
+    const { tag, calls, argSchema, extraParams } = opts;
+    clearMockResponses();
+    loadConversationFixture({
+      description: tag,
+      responses: [
+        ...calls.map((call, i) => ({
+          type: "sendRequest" as const,
+          response: {
+            role: "assistant" as const,
+            content: [{
+              type: "tool-call" as const,
+              toolCallId: call.callId,
+              toolName: "echoSandbox",
+              input: call.modelInput,
+            }],
+            id: `${tag}-s${i}`,
+          },
+        })),
+        {
+          type: "sendRequest" as const,
+          response: {
+            role: "assistant" as const,
+            content: [{
+              type: "tool-call" as const,
+              toolCallId: `${tag}-present`,
+              toolName: "presentResult",
+              input: { ok: true },
+            }],
+            id: `${tag}-present-resp`,
+          },
+        },
+      ],
+    });
+
+    const echoSandbox = pattern(
+      ({ command, sandboxId }: { command: string; sandboxId: string }) => ({
+        received: sandboxId,
+        command,
+      }),
+      argSchema,
+      ECHO_RESULT_SCHEMA,
+    );
+
+    const toolDef = extraParams
+      ? patternTool(echoSandbox, extraParams as never)
+      : patternTool(echoSandbox);
+
+    const testPattern = pattern<Record<string, never>>(() =>
+      generateObject({
+        prompt: `auto-sandbox-${tag}`,
+        schema: PRESENT_SCHEMA,
+        tools: { echoSandbox: toolDef as unknown as BuiltInLLMTool },
+      })
+    );
+
+    const runTx = runtime.edit();
+    const resultCell = runtime.getCell(
+      space,
+      `auto-sandbox-instance-${tag}`,
+      testPattern.resultSchema,
+      runTx,
+    );
+    const result = runtime.run(runTx, testPattern, {}, resultCell);
+    runTx.commit();
+
+    await waitForPendingToBecomeFalse(result);
+    await runtime.idle();
+
+    expect(result.key("pending").get()).toBe(false);
+    expect(result.key("error").get()).toBeUndefined();
+
+    return calls.map((call) =>
+      runtime.getCell(space, call.callId, ECHO_RESULT_SCHEMA)
+        .key("received").get()
+    );
+  }
+
+  it(
+    "A: two patterns each call bash twice -> shared within a pattern, distinct across patterns",
+    async () => {
+      // The model supplies the SAME sandboxId on every call — an attempt to make
+      // the four calls share one sandbox. It must be discarded.
+      const modelPin = "shared-by-model";
+      // Pattern 1 calls the tool twice.
+      const [p1a, p1b] = await runInstance({
+        tag: "p1",
+        argSchema: BASH_LIKE_ARG_SCHEMA,
+        calls: [
+          {
+            callId: "p1-1",
+            modelInput: { command: "echo a", sandboxId: modelPin },
+          },
+          {
+            callId: "p1-2",
+            modelInput: { command: "echo b", sandboxId: modelPin },
+          },
+        ],
+      });
+      // Pattern 2 calls the tool twice.
+      const [p2a, p2b] = await runInstance({
+        tag: "p2",
+        argSchema: BASH_LIKE_ARG_SCHEMA,
+        calls: [
+          {
+            callId: "p2-1",
+            modelInput: { command: "echo c", sandboxId: modelPin },
+          },
+          {
+            callId: "p2-2",
+            modelInput: { command: "echo d", sandboxId: modelPin },
+          },
+        ],
+      });
+
+      console.log("pattern 1 sandboxId (both calls):", p1a, "/", p1b);
+      console.log("pattern 2 sandboxId (both calls):", p2a, "/", p2b);
+
+      // All four ids are non-empty, resource-safe, and not the model value.
+      for (const v of [p1a, p1b, p2a, p2b]) {
+        expect(typeof v).toBe("string");
+        expect((v as string).length).toBeGreaterThan(0);
+        expect(v as string).toMatch(/^[A-Za-z0-9_-]+$/);
+        expect(v).not.toBe(modelPin);
+      }
+      // Within each pattern, the two bash calls share one sandbox.
+      expect(p1a).toBe(p1b);
+      expect(p2a).toBe(p2b);
+      // Across the two patterns, the sandboxes are distinct.
+      expect(p1a).not.toBe(p2a);
+    },
+  );
+
+  it(
+    "B: a pattern that pins sandboxId via extraParams is flagged as an error",
+    async () => {
+      // If a pattern could pin `sandboxId`, two patterns pinning the same value
+      // would share one server-side sandbox — a cross-instance/user leak. Rather
+      // than silently drop the pin, the framework rejects it so the authoring
+      // mistake surfaces.
+      let toolOutput: { type?: string; value?: unknown } | undefined;
+      addMockResponse(
+        (req) =>
+          req.messages.some((m) =>
+            typeof m.content === "string" && m.content.includes("pin-via-extra")
+          ),
+        {
+          role: "assistant",
+          content: [{
+            type: "tool-call",
+            toolCallId: "pin-1",
+            toolName: "echoSandbox",
+            input: { command: "ls" },
+          }],
+          id: "pin-s0",
+        },
+      );
+      addMockResponse(
+        (req) => {
+          const toolMsg = req.messages.find((m) => m.role === "tool") as
+            | BuiltInLLMMessage
+            | undefined;
+          const content = Array.isArray(toolMsg?.content)
+            ? toolMsg!.content[0] as {
+              output?: { type?: string; value?: unknown };
+            }
+            : undefined;
+          if (content?.output) toolOutput = content.output;
+          return toolOutput !== undefined;
+        },
+        {
+          role: "assistant",
+          content: [{
+            type: "tool-call",
+            toolCallId: "pin-present",
+            toolName: "presentResult",
+            input: { ok: true },
+          }],
+          id: "pin-s1",
+        },
+      );
+
+      const echoSandbox = pattern(
+        ({ command, sandboxId }: { command: string; sandboxId: string }) => ({
+          received: sandboxId,
+          command,
+        }),
+        BASH_LIKE_ARG_SCHEMA,
+        ECHO_RESULT_SCHEMA,
+      );
+      const testPattern = pattern<Record<string, never>>(() =>
+        generateObject({
+          prompt: "pin-via-extra",
+          schema: PRESENT_SCHEMA,
+          tools: {
+            echoSandbox: patternTool(
+              echoSandbox,
+              { sandboxId: "pinned-by-pattern" } as never,
+            ) as unknown as BuiltInLLMTool,
+          },
+        })
+      );
+
+      const runTx = runtime.edit();
+      const resultCell = runtime.getCell(
+        space,
+        "pin-via-extra-instance",
+        testPattern.resultSchema,
+        runTx,
+      );
+      const result = runtime.run(runTx, testPattern, {}, resultCell);
+      runTx.commit();
+      await waitForPendingToBecomeFalse(result);
+      await runtime.idle();
+
+      // The bash call surfaced an error, not a silently-overridden result.
+      expect(toolOutput?.type).toBe("error-text");
+      expect(String(toolOutput?.value)).toContain("framework-provided");
+    },
+  );
+
+  it(
+    "C: does not declare sandboxId -> framework injects nothing",
+    async () => {
+      const [received] = await runInstance({
+        tag: "nodecl",
+        argSchema: NO_SANDBOX_ARG_SCHEMA,
+        calls: [
+          // Model sends no sandboxId; the framework must not fabricate one.
+          { callId: "nodecl-1", modelInput: { command: "ls" } },
+        ],
+      });
+      expect(received).toBeUndefined();
+    },
+  );
+
+  it(
+    "D: one pattern with two separate bash tools -> the two tools get distinct sandboxes",
+    async () => {
+      // Two distinct `patternTool(bash)` nodes (toolA, toolB) in a single
+      // instance. The id is keyed to the tool-definition cell, so each node is
+      // its own sandbox even within one pattern.
+      clearMockResponses();
+      loadConversationFixture({
+        description: "two-tools",
+        responses: [
+          {
+            type: "sendRequest",
+            response: {
+              role: "assistant",
+              content: [{
+                type: "tool-call",
+                toolCallId: "d-A",
+                toolName: "toolA",
+                input: { command: "echo a" },
+              }],
+              id: "d-s0",
+            },
+          },
+          {
+            type: "sendRequest",
+            response: {
+              role: "assistant",
+              content: [{
+                type: "tool-call",
+                toolCallId: "d-B",
+                toolName: "toolB",
+                input: { command: "echo b" },
+              }],
+              id: "d-s1",
+            },
+          },
+          {
+            type: "sendRequest",
+            response: {
+              role: "assistant",
+              content: [{
+                type: "tool-call",
+                toolCallId: "d-present",
+                toolName: "presentResult",
+                input: { ok: true },
+              }],
+              id: "d-s2",
+            },
+          },
+        ],
+      });
+
+      const echoSandbox = pattern(
+        ({ command, sandboxId }: { command: string; sandboxId: string }) => ({
+          received: sandboxId,
+          command,
+        }),
+        BASH_LIKE_ARG_SCHEMA,
+        ECHO_RESULT_SCHEMA,
+      );
+
+      const testPattern = pattern<Record<string, never>>(() =>
+        generateObject({
+          prompt: "two-bash-tools",
+          schema: PRESENT_SCHEMA,
+          tools: {
+            toolA: patternTool(echoSandbox) as unknown as BuiltInLLMTool,
+            toolB: patternTool(echoSandbox) as unknown as BuiltInLLMTool,
+          },
+        })
+      );
+
+      const runTx = runtime.edit();
+      const resultCell = runtime.getCell(
+        space,
+        "two-bash-tools-instance",
+        testPattern.resultSchema,
+        runTx,
+      );
+      const result = runtime.run(runTx, testPattern, {}, resultCell);
+      runTx.commit();
+
+      await waitForPendingToBecomeFalse(result);
+      await runtime.idle();
+      expect(result.key("error").get()).toBeUndefined();
+
+      const recvA = runtime.getCell(space, "d-A", ECHO_RESULT_SCHEMA)
+        .key("received").get() as unknown;
+      const recvB = runtime.getCell(space, "d-B", ECHO_RESULT_SCHEMA)
+        .key("received").get() as unknown;
+      console.log("toolA sandboxId:", recvA);
+      console.log("toolB sandboxId:", recvB);
+
+      for (const v of [recvA, recvB]) {
+        expect(typeof v).toBe("string");
+        expect((v as string).length).toBeGreaterThan(0);
+      }
+      // Two distinct bash tool nodes -> two distinct sandboxes.
+      expect(recvA).not.toBe(recvB);
+    },
+  );
+
+  it(
+    "E: the framework-provided field is stripped from the model-facing schema",
+    async () => {
+      // The model should never be asked for `sandboxId` — it can't set it.
+      let toolJson: string | undefined;
+      addMockResponse(
+        (req) => {
+          const tools = (req as { tools?: Record<string, unknown> }).tools;
+          if (tools && tools.echoSandbox) {
+            toolJson = JSON.stringify(tools.echoSandbox);
+          }
+          return toolJson !== undefined;
+        },
+        {
+          role: "assistant",
+          content: [{
+            type: "tool-call",
+            toolCallId: "e-present",
+            toolName: "presentResult",
+            input: { ok: true },
+          }],
+          id: "e-s0",
+        },
+      );
+
+      const echoSandbox = pattern(
+        ({ command, sandboxId }: { command: string; sandboxId: string }) => ({
+          received: sandboxId,
+          command,
+        }),
+        BASH_LIKE_ARG_SCHEMA,
+        ECHO_RESULT_SCHEMA,
+      );
+      const testPattern = pattern<Record<string, never>>(() =>
+        generateObject({
+          prompt: "strip-model-schema",
+          schema: PRESENT_SCHEMA,
+          tools: {
+            echoSandbox: patternTool(echoSandbox) as unknown as BuiltInLLMTool,
+          },
+        })
+      );
+
+      const runTx = runtime.edit();
+      const resultCell = runtime.getCell(
+        space,
+        "strip-model-schema-instance",
+        testPattern.resultSchema,
+        runTx,
+      );
+      const result = runtime.run(runTx, testPattern, {}, resultCell);
+      runTx.commit();
+      await waitForPendingToBecomeFalse(result);
+      await runtime.idle();
+
+      console.log("model-facing echoSandbox schema:", toolJson);
+      expect(toolJson).toBeDefined();
+      // The model sees `command` but not the framework-provided `sandboxId`.
+      expect(toolJson!).toContain("command");
+      expect(toolJson!).not.toContain("sandboxId");
+    },
+  );
+});
+
+function waitForPendingToBecomeFalse(result: ReturnType<Runtime["getCell"]>) {
+  const liveResult = result.withTx();
+  const timeoutMs = 2000;
+  return new Promise<void>((resolve, reject) => {
+    const start = Date.now();
+    const tick = async () => {
+      await liveResult.sync();
+      const pending = liveResult.key("pending").get() as unknown;
+      if (pending === false) {
+        resolve();
+        return;
+      }
+      if (Date.now() - start > timeoutMs) {
+        reject(new Error("Timeout waiting for pending to become false"));
+        return;
+      }
+      setTimeout(tick, 10);
+    };
+    tick().catch(reject);
+  });
+}
+
+// Direct unit tests for the framework-provided-field helpers, covering the
+// defensive branches the dialog-driven cases above don't reach: malformed
+// schemas and the fail-closed path when no stable instance id can be derived.
+describe("framework-provided field helpers", () => {
+  const { stripFrameworkProvidedFields, applyAutoProvidedSandboxId } =
+    llmToolExecutionHelpers;
+
+  // A pattern stub whose argumentSchema declares `sandboxId` (only the schema is
+  // read by applyAutoProvidedSandboxId).
+  const declaresSandboxId = {
+    argumentSchema: {
+      type: "object",
+      properties: { command: {}, sandboxId: {} },
+    },
+  } as never;
+
+  it("stripFrameworkProvidedFields: leaves a non-object schema unchanged", () => {
+    const schema = true as unknown as JSONSchema;
+    expect(stripFrameworkProvidedFields(schema)).toBe(schema);
+  });
+
+  it("stripFrameworkProvidedFields: leaves a schema with no properties unchanged", () => {
+    const schema = { type: "object" } as JSONSchema;
+    expect(stripFrameworkProvidedFields(schema)).toBe(schema);
+  });
+
+  it("stripFrameworkProvidedFields: removes sandboxId from properties and required, without mutating the input", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        command: { type: "string" },
+        sandboxId: { type: "string" },
+      },
+      required: ["command", "sandboxId"],
+    } as JSONSchema;
+    const out = stripFrameworkProvidedFields(schema) as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(Object.keys(out.properties)).toEqual(["command"]);
+    expect(out.required).toEqual(["command"]);
+    // Input schema is not mutated.
+    expect(
+      (schema as { properties: Record<string, unknown> }).properties.sandboxId,
+    ).toBeDefined();
+  });
+
+  it("stripFrameworkProvidedFields: leaves a schema without framework fields unchanged", () => {
+    const schema = {
+      type: "object",
+      properties: { command: { type: "string" } },
+      required: ["command"],
+    } as JSONSchema;
+    expect(stripFrameworkProvidedFields(schema)).toBe(schema);
+  });
+
+  it("applyAutoProvidedSandboxId: no-op when the pattern does not declare sandboxId", () => {
+    const args: Record<string, unknown> = { command: "ls" };
+    applyAutoProvidedSandboxId(
+      args,
+      {
+        argumentSchema: { type: "object", properties: { command: {} } },
+      } as never,
+      {},
+      undefined,
+    );
+    expect(args).toEqual({ command: "ls" });
+  });
+
+  it("applyAutoProvidedSandboxId: rejects an author-pinned sandboxId via extraParams", () => {
+    expect(() =>
+      applyAutoProvidedSandboxId(
+        { command: "ls" },
+        declaresSandboxId,
+        { sandboxId: "author-pinned" },
+        undefined,
+      )
+    ).toThrow("framework-provided");
+  });
+
+  it("applyAutoProvidedSandboxId: fails closed when no stable entity id can be derived", () => {
+    // No identity cell -> no entity id. The function must throw rather than fall
+    // through to an empty, shared sandbox name.
+    expect(() =>
+      applyAutoProvidedSandboxId(
+        { command: "ls" },
+        declaresSandboxId,
+        {},
+        undefined,
+      )
+    ).toThrow("no stable entity id");
+  });
+});


### PR DESCRIPTION
The bash tool's input declares `sandboxId` as "Automatically provided — do not set", but the framework never provided it; two patterns minted it from `nonPrivateRandom()` at pattern-body time. The server names sandboxes by this id (`/v1/sandboxes/<id>`), so the same id means the same server-side sandbox (shared filesystem and process state). The id must therefore be unique per pattern instance, stable for that instance's life, and never caller-chosen.

The framework now fills `sandboxId` for any tool that declares it, using the content-addressed entity id of the tool's own definition cell. That id is unique to the pattern instance, constant across the instance's calls (so repeated bash calls reuse one persistent sandbox), and distinct between instances (so two instances — or two users — never share one). It is derived from the instance's identity, not the clock or randomness. The id is keyed to the tool node, so two bash calls of one tool share a sandbox while two separate bash tools, or two instances, get distinct ones. The scheme colon in the entity id is mapped to a hyphen for the server's resource path; the hash body is preserved, so distinct ids stay distinct.

The field is framework-owned — no pattern or model may set it, since a chosen id could reach another instance's sandbox. This is enforced in layers:
  - compile time: a `FrameworkProvided<T>` brand on the field makes `patternTool(bash, { sandboxId })` fail to type-check;
  - model-facing: framework-provided fields are stripped from the schema sent to the model, so it is never asked for a value it cannot set;
  - runtime: a pattern that pins it through extraParams is rejected with a clear error rather than silently ignored, and a model-supplied value is overwritten.

Remove the hand-rolled `nonPrivateRandom()` sandbox id (and the now-unused import) from suggestion.tsx and omnibox-fab.tsx; they now just `patternTool(bash)`. Add a runner test covering the per-instance/per-node sharing scenarios, the three enforcement layers, and the model-schema strip.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-provides a framework-owned `sandboxId` for bash-like tools, derived from the tool node’s entity id. It is stable per instance, shared within a tool, distinct across tools/instances, and never caller-chosen.

- **New Features**
  - Auto-fills `sandboxId` when a tool declares it, using the tool cell’s entity id; non-safe chars are mapped to `-` for server paths.
  - Framework-owned: compile-time `FrameworkProvided<T>` in `@commonfabric/api` (and extraParams typing in `patternTool`) blocks pre-fills; model-facing schemas omit `sandboxId`; runtime overwrites model-sent values, throws on author-pinned values, and errors if no stable entity id is available; keyed to the tool node so repeated calls share one sandbox while separate tools/instances get distinct ones.
  - Tests cover per-instance/per-node sharing (including two-tool distinction), model-schema stripping, prefill rejection, the no-declaration case, and defensive branches; includes an API test exercising the `FrameworkProvided` export.

- **Migration**
  - Stop passing `sandboxId` to `patternTool(bash)`; removed `nonPrivateRandom()`-based ids in `suggestion` and `omnibox-fab`.
  - If you define custom tools with a `sandboxId`, type it as `FrameworkProvided<string>` and do not set it.

<sup>Written for commit db104b150a9ede51657198cb3625e59337ab3eab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

