### PR TITLE
refactor(memory): prune nascent SourceLink; type EntityDocument.source as EntityRef

### DIFF
--- a/docs/specs/memory-v2/01-data-model.md
+++ b/docs/specs/memory-v2/01-data-model.md
@@ -48,10 +48,6 @@ Key properties:
 Entity values are stored in an **envelope** with well-known top-level keys:
 
 ```typescript
-interface SourceLink {
-  "/": string; // Short source id; runtime resolves to of:<short-id>
-}
-
 interface SigilLink {
   "/": {
     "link@1": {
@@ -67,20 +63,24 @@ interface InternalManifestEntry {
   link: SigilLink;
 }
 
-type EntityDocumentField = FabricValue | SourceLink | SigilLink | undefined;
-
 interface EntityDocument {
   value?: FabricValue; // The cell's data when present.
-  source?: SourceLink; // {"/":"<short-id>"} -> resolves to of:<short-id> in same space.
+  source?: EntityRef; // Serialized short-link form {"/":"<short-id>"} -> resolves to of:<short-id> in same space.
   pattern?: SigilLink; // Well-known metadata link to a pattern cell.
   argument?: SigilLink; // Well-known metadata link to an argument cell.
   internal?: InternalManifestEntry[]; // Manifest of derived internal cells.
   result?: SigilLink; // Well-known metadata link back to a result cell.
   schema?: FabricValue; // Optional schema metadata.
   slug?: string; // Optional URL/address metadata.
-  [key: string]: EntityDocumentField;
+  [key: string]: FabricValue;
 }
 ```
+
+The implementation no longer defines separate `SourceLink` or
+`EntityDocumentField` types: `source` is an `EntityRef` (whose serialized
+short-link form is `{"/":"<short-id>"}`), and an arbitrary document field is
+just a `FabricValue` (which already subsumes the short-link, sigil-link, and
+`undefined` cases above).
 
 The `value` property holds the cell's actual data. Storing it under a key
 (rather than as the top-level value) lets the envelope carry sibling metadata

--- a/docs/specs/memory-v2/README.md
+++ b/docs/specs/memory-v2/README.md
@@ -205,26 +205,23 @@ interface Commit {
   createdAt: string;
 }
 
-interface SourceLink {
-  "/": string;
-}
-
 interface SigilLink {
   "/": { "link@1": { id?: string; path?: string[]; space?: string } };
 }
 
-type EntityDocumentField = FabricValue | SourceLink | SigilLink | undefined;
-
+// `source` is an `EntityRef` (serialized short-link form `{"/":"<short-id>"}`);
+// an arbitrary document field is a `FabricValue`. The former `SourceLink` /
+// `EntityDocumentField` aliases are no longer separate types.
 interface EntityDocument {
   value?: FabricValue;
-  source?: SourceLink;
+  source?: EntityRef;
   pattern?: SigilLink;
   argument?: SigilLink;
   internal?: SigilLink;
   result?: SigilLink;
   schema?: FabricValue;
   slug?: string;
-  [key: string]: EntityDocumentField;
+  [key: string]: FabricValue;
 }
 
 interface WatchSpec {

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -1,5 +1,9 @@
 import { assertEquals, assertExists, assertThrows } from "@std/assert";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import {
+  type EntityRef,
+  entityRefFromString,
+} from "@commonfabric/data-model/cell-rep";
 import { toFileUrl } from "@std/path";
 import { Database } from "@db/sqlite";
 import {
@@ -61,11 +65,9 @@ const decodeStored = <Value extends FabricValue>(
   source: string | null | undefined,
 ): Value => decodeMemoryBoundary<Value>(source ?? "null");
 
-const toSourceLink = (id: string) => ({ "/": id } as const);
-
 const toEntityDocument = (
   value: unknown,
-  source?: { "/": string },
+  source?: EntityRef,
   metadata: Record<string, unknown> = {},
 ): EntityDocument => {
   const document: Record<string, unknown> = {
@@ -557,7 +559,7 @@ Deno.test("memory v2 engine persists set and delete commits as seq revisions", a
   try {
     const document = toEntityDocument(
       { hello: "world" },
-      toSourceLink("origin"),
+      entityRefFromString("origin"),
     );
 
     const setResult = applyCommit(engine, {
@@ -714,14 +716,14 @@ Deno.test("memory v2 engine preserves source-only entity documents", async () =>
         operations: [{
           op: "set",
           id: "of:piece:1",
-          value: toEntityDocument(undefined, toSourceLink("process:1")),
+          value: toEntityDocument(undefined, entityRefFromString("process:1")),
         }],
       },
     });
 
     assertEquals(
       read(engine, { id: "of:piece:1" }),
-      toEntityDocument(undefined, toSourceLink("process:1")),
+      toEntityDocument(undefined, entityRefFromString("process:1")),
     );
   } finally {
     close(engine);
@@ -829,7 +831,7 @@ Deno.test("memory v2 engine replays patch revisions for current and point-in-tim
         profile: { name: "Alice" },
         tags: ["one"],
       },
-      toSourceLink("origin"),
+      entityRefFromString("origin"),
     );
 
     applyCommit(engine, {
@@ -879,7 +881,7 @@ Deno.test("memory v2 engine replays patch revisions for current and point-in-tim
           profile: { name: "Bob", title: "Dr" },
           tags: ["one", "two", "three"],
         },
-        toSourceLink("origin"),
+        entityRefFromString("origin"),
       ),
     );
     assertEquals(read(engine, { id: "entity:patch", seq: 1 }), original);

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from "@std/testing/bdd";
 import { assert, assertEquals, assertThrows } from "@std/assert";
 import {
+  type EntityRef,
+  entityRefFromString,
   resetModernCellRepConfig,
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
@@ -21,11 +23,9 @@ import {
   toValuePath,
 } from "../v2.ts";
 
-const toSourceLink = (id: string) => ({ "/": id } as const);
-
 const toEntityDocument = (
   value: unknown,
-  source?: { "/": string },
+  source?: EntityRef,
   metadata: Record<string, unknown> = {},
 ) => {
   const document: Record<string, unknown> = {
@@ -51,7 +51,7 @@ describe("memory v2 protocol constants", () => {
 
 describe("memory v2 documents", () => {
   it("builds explicit in-memory documents", () => {
-    const source = toSourceLink("abc123");
+    const source = entityRefFromString("abc123");
     assertEquals(
       toEntityDocument({ hello: "world" }, source),
       {

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "@std/testing/bdd";
-import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import {
   resetModernCellRepConfig,
   setModernCellRepConfig,
@@ -10,7 +10,6 @@ import {
   DEFAULT_BRANCH,
   encodeMemoryBoundary,
   getMemoryProtocolFlags,
-  isSourceLink,
   MEMORY_PROTOCOL,
   parseMemoryProtocolFlags,
   resetCommitPreconditionsConfig,
@@ -95,14 +94,6 @@ describe("memory v2 paths", () => {
         schema: false,
       },
     );
-  });
-});
-
-describe("memory v2 source links", () => {
-  it("recognizes short source links", () => {
-    assert(isSourceLink({ "/": "abc123" }));
-    assertFalse(isSourceLink({ "/": { link: "abc123" } }));
-    assertFalse(isSourceLink({}));
   });
 });
 

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1,4 +1,7 @@
-import { getModernCellRepConfig } from "@commonfabric/data-model/cell-rep";
+import {
+  type EntityRef,
+  getModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
 import {
   jsonFromValue,
   valueFromJson,
@@ -34,16 +37,16 @@ export type ValueSchemaPathSelector =
   & Omit<SchemaPathSelector, "path">
   & { path: ValuePath };
 
-export interface SourceLink {
-  "/": string;
-}
-
-export type EntityDocumentField = FabricValue | SourceLink | undefined;
-
+/**
+ * A logical stored document. Today the system only produces and consumes the
+ * `value` field; `source` and any additional metadata fields are reserved for
+ * future use and carried as opaque payload (a document is validated merely as
+ * "an object" — see {@link isEntityDocument}).
+ */
 export interface EntityDocument {
   value?: FabricValue;
-  source?: SourceLink;
-  [key: string]: EntityDocumentField;
+  source?: EntityRef;
+  [key: string]: FabricValue;
 }
 
 export interface Blob {
@@ -693,23 +696,13 @@ export const toDocumentSelector = (
     path: toDocumentPath(["value", ...selector.path]),
   }) as DocumentSchemaPathSelector;
 
-export const isSourceLink = (value: unknown): value is SourceLink => {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    return false;
-  }
-
-  const candidate = value as Record<string, unknown>;
-  return Object.keys(candidate).length === 1 &&
-    typeof candidate["/"] === "string";
-};
-
 export const isEntityDocument = (
   value: unknown,
 ): value is EntityDocument => isObject(value);
 
 export const getEntityDocumentMetadata = (
   document: EntityDocument,
-): Record<string, EntityDocumentField> => {
+): Record<string, FabricValue> => {
   const {
     value: _value,
     ...metadata


### PR DESCRIPTION
## What & why

Follow-up to the EntityDocument/SourceLink spelunking: `SourceLink` and the `EntityDocumentField` alias were **nascent scaffolding**. Ground truth from the audit:

- The only `EntityDocument` field production actually produces or consumes is **`value`** (e.g. ACL reads in `memory/v2/server.ts:713`; `writeDocument` takes `EntityDocument["value"]`). `isEntityDocument` is literally `isObject` — the engine treats a document as an opaque object; `source` and metadata fields ride along as opaque payload.
- **`isSourceLink`** had **zero production callers** (one unit test only).
- **`EntityDocumentField`** = `FabricValue | SourceLink | undefined` was a long-winded alias for `FabricValue` (which already subsumes the `{ "/": string }` object and `undefined`).

## Changes

- `EntityDocument.source` typed as **`EntityRef`** (its serialized short-link form `{"/":"<short-id>"}` is unchanged).
- Removed **`isSourceLink()`** (and its lone unit test) and the **`SourceLink`** type.
- **`EntityDocumentField` → `FabricValue`** (the `[key]` index signature and the — already dead — `getEntityDocumentMetadata` return type).
- Doc comment on `EntityDocument` noting only `value` is currently used.
- **Spec sync** (minimal/faithful): `memory-v2/01-data-model.md` + `README.md` retype `source` as `EntityRef`, fold the `SourceLink`/`EntityDocumentField` aliases into `EntityRef`/`FabricValue`, and **keep the design narrative** (SigilLink, the named-metadata envelope, the short-id source format).

## Notes

- Type-only change — no runtime behavior change.
- `getEntityDocumentMetadata` is also dead (zero callers) but left in place (out of the stated scope); easy to prune in a follow-up if wanted.

## Verification

Workspace `deno task check` clean; memory suite 211 and runner suite 634, 0 failed; `lint` clean. (memory-v2 specs are excluded from `deno fmt`.)

## Performance Baseline

This is basically a type-only PR. So the following accounts for a spurious perf check failure:

NEW_PERF_BASELINE: job: Package Integration Tests (runtime-client) = 96s


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes the nascent `SourceLink` scaffolding and types `EntityDocument.source` as `EntityRef`; tests now mint `EntityRef` via `entityRefFromString`. Type-only change; no runtime behavior changes.

- **Refactors**
  - `EntityDocument.source` → `EntityRef` (serialized short-link `{"/":"<short-id>"}` unchanged).
  - Removed `isSourceLink()` and the `SourceLink` type (and its lone unit test).
  - `EntityDocumentField` → `FabricValue` (index signature, `getEntityDocumentMetadata` return type).
  - Added note on `EntityDocument` that only `value` is currently used.
  - Updated specs: `memory-v2/01-data-model.md` and `README.md` to reflect `EntityRef` and `FabricValue`.
  - Tests: replace hand-built short links with `entityRefFromString`; `toEntityDocument` helpers accept `EntityRef`.

- **Migration**
  - Replace any `SourceLink` references with `EntityRef`.
  - Remove uses of `isSourceLink()`.
  - Use `FabricValue` where `EntityDocumentField` was referenced.

<sup>Written for commit df156540ef1e38a73c44821e9856d64b0d3cd224. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

