### PR TITLE
First-class profile rendering: cf-profile-badge variants + seal + consistent use (CT-1761)

### DIFF
--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -140,7 +140,7 @@ cell means none confirmed — check the component source before assuming.
 | `cf-picker` | Carousel selection over cells with `[UI]` | `$items`, `$selectedIndex` |
 | `cf-piece` | Provides piece context to child components | |
 | `cf-plaid-link` | Plaid banking integration | `$auth` |
-| `cf-profile-badge` | The blessed, trusted way to render a profile identity (avatar + name + the generative verification seal — a DID-derived aura ring + cursor glint, no shield icon); navigable to the profile. Variants `full`/`chip`/`circle`/`hero` (CT-1761). Prefer it over a bare name/avatar anywhere an identity appears. | `$profile`, `variant`, `size`, `noNavigate` |
+| `cf-profile-badge` | The blessed, trusted way to render a profile identity (avatar + name + the generative verification seal — a DID-derived aura ring + cursor glint, no shield icon); navigable to the profile. Variants `full`/`chip`/`circle`/`hero` + `size`/`noNavigate` attrs (CT-1761). Prefer it over a bare name/avatar anywhere an identity appears. | `$profile` |
 | `cf-progress` | Progress bar, determinate or indeterminate | |
 | `cf-prompt-input` | Multiline prompt input with `@`-mentions, attachments, voice | `$mentionable`, `$model` |
 | `cf-question` | Asks a single question and collects the answer | |

--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -140,7 +140,7 @@ cell means none confirmed — check the component source before assuming.
 | `cf-picker` | Carousel selection over cells with `[UI]` | `$items`, `$selectedIndex` |
 | `cf-piece` | Provides piece context to child components | |
 | `cf-plaid-link` | Plaid banking integration | `$auth` |
-| `cf-profile-badge` | The blessed, trusted way to render a profile identity (avatar + name + verification seal); navigable to the profile. Variants `full`/`chip`/`circle` (CT-1761). Prefer it over a bare name/avatar anywhere an identity appears. | `$profile`, `variant`, `size`, `noNavigate` |
+| `cf-profile-badge` | The blessed, trusted way to render a profile identity (avatar + name + the generative verification seal — a DID-derived aura ring + cursor glint, no shield icon); navigable to the profile. Variants `full`/`chip`/`circle`/`hero` (CT-1761). Prefer it over a bare name/avatar anywhere an identity appears. | `$profile`, `variant`, `size`, `noNavigate` |
 | `cf-progress` | Progress bar, determinate or indeterminate | |
 | `cf-prompt-input` | Multiline prompt input with `@`-mentions, attachments, voice | `$mentionable`, `$model` |
 | `cf-question` | Asks a single question and collects the answer | |

--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -140,7 +140,7 @@ cell means none confirmed — check the component source before assuming.
 | `cf-picker` | Carousel selection over cells with `[UI]` | `$items`, `$selectedIndex` |
 | `cf-piece` | Provides piece context to child components | |
 | `cf-plaid-link` | Plaid banking integration | `$auth` |
-| `cf-profile-badge` | Displays name + avatar from a subscribed profile cell | |
+| `cf-profile-badge` | The blessed, trusted way to render a profile identity (avatar + name + verification seal); navigable to the profile. Variants `full`/`chip`/`circle` (CT-1761). Prefer it over a bare name/avatar anywhere an identity appears. | `$profile`, `variant`, `size`, `noNavigate` |
 | `cf-progress` | Progress bar, determinate or indeterminate | |
 | `cf-prompt-input` | Multiline prompt input with `@`-mentions, attachments, voice | `$mentionable`, `$model` |
 | `cf-question` | Asks a single question and collects the answer | |

--- a/docs/common/patterns/multi-user-patterns.md
+++ b/docs/common/patterns/multi-user-patterns.md
@@ -214,16 +214,18 @@ the self-containment fallback (renders with remote profile spaces offline). See
 `packages/patterns/lunch-poll/main.tsx`.
 
 **`<cf-profile-badge>` is the one idiomatic way to render an identity** — avatar +
-name + the runtime-attested verification seal, navigable to the person's profile.
-Prefer it anywhere an identity appears (rosters, message authors, "playing as",
-scoreboards); inline a name into a string only as an explicit fallback. Three
-variants, all carrying the seal/glint (CT-1761):
+name + the runtime-attested generative seal (a DID-derived aura ring + cursor
+glint; there is no shield icon), navigable to the person's profile. Prefer it
+anywhere an identity appears (rosters, message authors, "playing as",
+scoreboards); inline a name into a string only as an explicit fallback. Four
+variants, all carrying the same seal (CT-1761):
 
 | variant | shows | use for |
 | ------- | ----- | ------- |
-| `full` (default) | avatar + name + seal | profile pages, roster rows, "playing as", message authors |
+| `full` (default) | avatar + name pill | roster rows, "playing as" |
 | `chip` | name + compact seal dot (no avatar) | inline names in dense UI, participant strips |
 | `circle` | avatar + seal ring only (name on hover / for AT) | avatar strips, message gutters |
+| `hero` | large avatar over name | profile page header (pair with `noNavigate`) |
 
 Storing a live profile **cell** in shared state is what lets every viewer render
 the badge. Keep that shared state **object-wrapped** (`{ items: [...] }`, like the

--- a/docs/common/patterns/multi-user-patterns.md
+++ b/docs/common/patterns/multi-user-patterns.md
@@ -196,13 +196,19 @@ remember which entry is theirs. For simpler demos where names are immutable and
 unique enough for the domain, a `PerUser<string>` display name plus shared
 records that carry that name can also be acceptable.
 
-Source the display name and avatar from the viewer's **shared profile** rather
-than a free-text field: `wish({ query: "#profile" })` resolves the current
-viewer's profile, and its built-in `[UI]` covers the whole lifecycle (create
-surface when the user has no profile, a picker with inline create when they
-have several). Snapshot the resolved `#profileName` / `#profileAvatar` strings
-into the shared entry on join. See `docs/specs/shared-profile-rosters.md`;
-worked examples: `packages/patterns/profile-group-chat/main.tsx`,
+Source identity from the viewer's **shared profile** rather than a free-text
+field: `wish({ query: "#profile" })` resolves the current viewer's profile, and
+its built-in `[UI]` covers the whole lifecycle (create surface when the user has
+no profile, a picker with inline create when they have several). On join, store
+a **link to that profile cell** in the shared entry and render every participant
+with a live, visitable `<cf-profile-badge $profile={p.profile} />` — cross-space
+reads resolve for any authorized viewer (CT-1667/1687), so the badge stays
+current, carries the verified-identity seal, and links to each contributor's
+profile. Snapshotting the `#profileName` / `#profileAvatar` strings instead is
+the self-containment fallback (renders with remote profile spaces offline). See
+`docs/specs/shared-profile-rosters.md`; canonical live-link demo:
+`packages/patterns/profile-roster-live-demo.tsx`; snapshot examples:
+`packages/patterns/profile-group-chat/main.tsx`,
 `packages/patterns/scrabble/scrabble.tsx`,
 `packages/patterns/battleship/multiplayer/lobby.tsx`,
 `packages/patterns/lunch-poll/main.tsx`.

--- a/docs/common/patterns/multi-user-patterns.md
+++ b/docs/common/patterns/multi-user-patterns.md
@@ -227,11 +227,15 @@ variants, all carrying the seal/glint (CT-1761):
 
 Storing a live profile **cell** in shared state is what lets every viewer render
 the badge. Keep that shared state **object-wrapped** (`{ items: [...] }`, like the
-roster's `Roster`) rather than a bare `Writable<T[]>`: a bare array with a nested
-live cell unwraps to a weak object and breaks CTS handler-state / `.get()`-snapshot
-output typing (group-chat's message array avoids it by outputting the raw
-`PerSpace` cell; scrabble's `players` array, output as a `.get()` snapshot, hits
-it — so its scoreboard still badges only the viewer's own card).
+roster's `Roster` or scrabble's `PlayerRoster`) rather than a bare
+`Writable<T[]>`: a bare array with a nested live cell unwraps to a weak object and
+breaks CTS handler-state / `.get()`-snapshot output typing. Two rules make it
+work (see `scrabble.tsx`): type the **input** value-side — `PerSpace<Roster>`,
+not `PerSpace<Writable<Roster>>` (handlers still take `Writable<Roster>` state, so
+the body uses field access `players.list` while handlers use `.get()`/`.key()`);
+and type the **output** as a profile-less view (`Omit<Player, "profile">`) so the
+flat `.get()` snapshot doesn't try to reconcile the live cell. With both, the
+whole scrabble scoreboard renders `circle` badges for every player.
 
 Do not store user DIDs, session ids, or generated ids only to simulate scoped
 visibility. Let `PerUser<T>` and `PerSession<T>` select the right storage

--- a/docs/common/patterns/multi-user-patterns.md
+++ b/docs/common/patterns/multi-user-patterns.md
@@ -207,11 +207,31 @@ current, carries the verified-identity seal, and links to each contributor's
 profile. Snapshotting the `#profileName` / `#profileAvatar` strings instead is
 the self-containment fallback (renders with remote profile spaces offline). See
 `docs/specs/shared-profile-rosters.md`; canonical live-link demo:
-`packages/patterns/profile-roster-live-demo.tsx`; snapshot examples:
+`packages/patterns/profile-roster-live-demo.tsx`; worked examples:
 `packages/patterns/profile-group-chat/main.tsx`,
 `packages/patterns/scrabble/scrabble.tsx`,
 `packages/patterns/battleship/multiplayer/lobby.tsx`,
 `packages/patterns/lunch-poll/main.tsx`.
+
+**`<cf-profile-badge>` is the one idiomatic way to render an identity** — avatar +
+name + the runtime-attested verification seal, navigable to the person's profile.
+Prefer it anywhere an identity appears (rosters, message authors, "playing as",
+scoreboards); inline a name into a string only as an explicit fallback. Three
+variants, all carrying the seal/glint (CT-1761):
+
+| variant | shows | use for |
+| ------- | ----- | ------- |
+| `full` (default) | avatar + name + seal | profile pages, roster rows, "playing as", message authors |
+| `chip` | name + compact seal dot (no avatar) | inline names in dense UI, participant strips |
+| `circle` | avatar + seal ring only (name on hover / for AT) | avatar strips, message gutters |
+
+Storing a live profile **cell** in shared state is what lets every viewer render
+the badge. Keep that shared state **object-wrapped** (`{ items: [...] }`, like the
+roster's `Roster`) rather than a bare `Writable<T[]>`: a bare array with a nested
+live cell unwraps to a weak object and breaks CTS handler-state / `.get()`-snapshot
+output typing (group-chat's message array avoids it by outputting the raw
+`PerSpace` cell; scrabble's `players` array, output as a `.get()` snapshot, hits
+it — so its scoreboard still badges only the viewer's own card).
 
 Do not store user DIDs, session ids, or generated ids only to simulate scoped
 visibility. Let `PerUser<T>` and `PerSession<T>` select the right storage

--- a/docs/specs/shared-profile-rosters.md
+++ b/docs/specs/shared-profile-rosters.md
@@ -34,10 +34,14 @@ contribute their own entry when they join**:
   and launches the framework picker when there are two or more. Patterns just
   read `wish(...).result`; the multi-profile selection is handled for them.
 - The join handler writes that viewer's contribution into the shared roster —
-  either a **link** to their live profile or a **stable snapshot** of
-  name/avatar (see next section).
-- Every other user renders names and avatars straight from `participants`. No
-  cross-user profile enumeration is ever required.
+  by default a **link** to their live profile cell (rendered with
+  `<cf-profile-badge>`), or a **stable snapshot** of name/avatar for the
+  self-containment case (see next section).
+- Every other user renders each participant from `participants` — a live
+  `<cf-profile-badge $profile={p.profile} />` bound to the contributed profile
+  cell, which resolves cross-space for any authorized viewer (CT-1667/1687) and
+  is **visitable** (clicking it opens that user's live profile). No cross-user
+  profile enumeration is ever required.
 
 This is the same shape used by `packages/patterns/scrabble/scrabble.tsx`
 (a `PerSpace` `players` roster + a join handler that `push`es the current
@@ -48,11 +52,35 @@ name/avatar from the shared profile instead of a free-text field.
 
 ## Why links vs snapshots
 
-A roster entry can store either a **live link** to the contributor's profile or
-a **snapshot** of the values copied at join time. They are different
-trade-offs.
+A roster entry can store a **live link** to the contributor's profile cell (the
+default — rendered with the trusted, visitable `<cf-profile-badge>`) or a
+**snapshot** of the values copied at join time (a self-containment fallback).
+They are different trade-offs.
 
-### Snapshot (recommended default)
+### Live link (recommended)
+
+Store a reference to the contributor's profile cell (the `result` of their
+`#profile` wish) and render it with `<cf-profile-badge $profile={p.profile} />`:
+
+```ts
+participants.push({ profile: myProfile, joinedAt: safeDateNow() });
+// render: <cf-profile-badge $profile={p.profile} />
+```
+
+- **Pros:** Always current — a profile rename or avatar change propagates to
+  every roster that links it, with no refresh path. The runtime materializes
+  cross-space link targets on read (a read that finds the target absent kicks an
+  async load and re-renders on arrival — CT-1667/1687, PR #4019), so the link
+  resolves for any viewer with access to the profile's space. The badge is
+  **visitable** — clicking it opens the contributor's live profile — and carries
+  the runtime-attested verified-identity seal plus the bio / pinned-count
+  tooltip. This is the idiom: wish for `#profile`, key identity with `equals()`,
+  render the real cell.
+- **Cons:** First render shows blanks until the cross-space load lands, and
+  the roster's freshness couples to the remote space's availability — offline
+  or unreachable profile spaces render empty rather than stale.
+
+### Snapshot (self-containment fallback)
 
 Copy the resolved `name` and `avatar` strings into the roster entry when the user
 joins:
@@ -64,46 +92,40 @@ participants.push({ name, avatar, joinedAt: safeDateNow() });
 - **Pros:** Self-contained — every other viewer renders from plain strings
   already in the shared space, no cross-space resolution, no dependency on the
   joiner's profile space being reachable later. Cheap, durable, and trivially
-  serializable. Renders identically for all viewers.
+  serializable. Renders identically and immediately for all viewers. Best when
+  the roster must stay legible with remote profile spaces offline, or when you
+  explicitly do not want a live cross-space dependency.
 - **Cons:** Goes stale. If the user renames themselves or changes their avatar
   after joining, the roster keeps the old values until they re-join / you add a
-  refresh path.
-
-### Live link
-
-Store a reference to the contributor's profile cell (the `result` of their
-`#profile` wish) and let consumers render it reactively (e.g. via
-`cf-cell-link` / `cf-render`):
-
-- **Pros:** Always current — a profile rename propagates to every roster that
-  links it. The runtime materializes cross-space link targets on read (a read
-  that finds the target absent kicks an async load and re-renders on arrival —
-  CT-1667, PR #4019), so the link resolves for any viewer with access to the
-  profile's space.
-- **Cons:** First render shows blanks until the cross-space load lands, and
-  the roster's freshness couples to the remote space's availability — offline
-  or unreachable profile spaces render empty rather than stale.
+  refresh path. Renders a plain `<cf-avatar>` — no verified seal, not visitable.
 
 ### Verdict
 
-**Default to a snapshot.** It matches the "each user contributes their own data"
-model, keeps the shared roster fully self-describing inside the space, and
-renders identically (and immediately) for all viewers regardless of remote
-space availability. Reach for a live link when freshness genuinely matters —
-it resolves cross-space for any authorized viewer — and consider a **hybrid**:
-store the snapshot for immediate, availability-independent rendering *and*
-keep the link alongside it for live freshness or an explicit "refresh from
-profile" action.
+**Default to a live link rendered with `<cf-profile-badge>`.** Cross-space reads
+now resolve for any authorized viewer (CT-1667/1687, verified end-to-end across
+multiple real identities), so the live badge gives current data, a verified
+identity seal, the bio/pinned tooltip, and a visitable link to each
+contributor's profile — for the whole price of storing one cell reference.
+Reach for a **snapshot** when the roster must render with remote profile spaces
+unreachable, or when you deliberately want no live cross-space dependency; a
+**hybrid** (snapshot for immediate, availability-independent text *plus* the
+live link for the badge and freshness) gives both.
 
-## Reference demo
+## Reference demos
 
-A complete, copy-pasteable pattern. It uses the snapshot approach (the
-recommended default) for *rendering* — name/avatar are copied at join time —
+The **canonical live-link reference** is
+[`packages/patterns/profile-roster-live-demo.tsx`](../../packages/patterns/profile-roster-live-demo.tsx):
+every participant renders with a live, visitable `<cf-profile-badge>` bound to
+their real profile cell, identity is keyed with `equals()`, and it was verified
+end-to-end across multiple real identities. Prefer it as the starting point.
+
+The snapshot pattern below is the **self-containment variant** — it renders
+name/avatar from strings copied at join time (no live cross-space dependency)
 and additionally stores each joiner's profile **cell as the stable identity
-key**, deduped with `equals()`. Note this is distinct from the "live link" path
-above: the cell is used for *identity comparison*, not dereferenced for
-cross-space render, so it does not depend on other users' profile spaces being
-reachable. Every API used below is exercised elsewhere in the repo:
+key**, deduped with `equals()`. Here the cell is used only for *identity
+comparison*, not dereferenced for cross-space render, so it never depends on
+other users' profile spaces being reachable. Every API used below is exercised
+elsewhere in the repo:
 
 - `wish<string>({ query: "#profileName" | "#profileAvatar" })` and reading
   `.result` — `packages/patterns/shared-profile-demo/main.tsx`,
@@ -350,22 +372,25 @@ export default pattern<RosterDemoInput, RosterDemoOutput>(
 - **No `.set()` before the pattern takes over.** The roster/viewer cells use
   `Default<>` so they start empty without any imperative seeding.
 
-### Live-link variant (advanced)
+### Live-link variant (the recommended idiom)
 
-If you adopt the live-link approach instead, resolve the whole profile and store
-its cell reference, then render reactively. The current viewer's own result is
-known to render via `cf-cell-link` / `cf-render`:
+The live-link approach — store each joiner's profile **cell** and render it with
+a visitable `<cf-profile-badge>` — is the recommended idiom; see
+[`profile-roster-live-demo.tsx`](../../packages/patterns/profile-roster-live-demo.tsx)
+for the complete pattern. The shape:
 
 ```tsx
 const profileWish = wish({ query: "#profile" }); // result is ProfileHomeOutput-shaped
-// In a handler that has access to the live cell, push { profile: profileWish.result, joinedAt }.
-// Render an entry with: <cf-cell-link $cell={entry.profile} /> or <cf-render $cell={entry.profile} />.
+// In the join handler, push { profile: profileWish.result, joinedAt }.
+// Render each entry with: <cf-profile-badge $profile={entry.profile} />
+//   — live, carries the verified-identity seal + bio/pinned tooltip, visitable.
 ```
 
-Cross-space resolution works for any viewer with access to the profile's
-space (CT-1667, PR #4019); the trade-off is availability — entries render
-blank while the remote space is unreachable. A hybrid (snapshot for immediate
-rendering + link for freshness or an explicit refresh) gives both.
+Cross-space resolution works for any viewer with access to the profile's space
+(CT-1667/1687, PR #4019); the trade-off is availability — entries render blank
+while the remote space is unreachable. A hybrid (snapshot strings for immediate,
+availability-independent text + the link for the badge and freshness) gives
+both.
 
 ## Recommended approach for chat/game patterns
 
@@ -377,39 +402,35 @@ rendering + link for freshness or an explicit refresh) gives both.
    `wish({ query: "#profile" })` (or `#profileName` / `#profileAvatar` for just
    the fields). This returns the user's default profile under PR #3830, with the
    framework picker handling the multi-profile case.
-3. **Store a snapshot** (name + avatar copied at join time) in the roster by
-   default. Use a live link when freshness matters; prefer a hybrid if you
-   want freshness without coupling first render to remote-space availability.
-4. Append idempotently — guard on "already joined" so re-renders and reconnects
+3. **Store a live link** to each joiner's profile cell by default and render it
+   with `<cf-profile-badge $profile={p.profile} />` (live, visitable, verified
+   seal + tooltip). Fall back to a snapshot (name + avatar copied at join time)
+   when the roster must render with remote profile spaces unreachable; a hybrid
+   gives availability-independent text plus the live badge.
+4. Append idempotently — guard on "already joined" (keyed on the profile cell
+   with `equals()`, never the mutable display name) so re-renders and reconnects
    don't duplicate entries (see the `join` handler above).
-5. Render every other participant's name/avatar directly from `participants`.
-   Do not attempt to enumerate other users' profiles — there is no runtime
-   primitive for it, and the contributed roster already has everything you need.
+5. Render every participant directly from `participants`. Do not attempt to
+   enumerate other users' profiles — there is no runtime primitive for it, and
+   the contributed roster already has everything you need.
 
-## Runnable pattern
+## Runnable patterns
 
-A deployable version now lives at
-[`packages/patterns/shared-profile-roster/main.tsx`](../../packages/patterns/shared-profile-roster/main.tsx).
-It follows the snapshot model above and renders with the identity components:
+Two deployable versions:
 
-- Participants render via **`<cf-avatar src={p.avatar} name={p.name} />`** — one
-  component covering the image / glyph / initials cases uniformly (no hand-rolled
-  `<img>` + placeholder `<div>`).
-- The current viewer's own identity renders via the trusted
-  **`<cf-profile-badge $profile={profileWish.result} />`**. (Live profile cells
-  now also resolve cross-space for other authorized viewers — CT-1667.)
-
-Verified deployed (`cf piece new … main.tsx`): renders with 0 console errors;
-participant rows show image/emoji/initials avatars; the viewer badge shows the
-profile (or a graceful "Unknown profile" fallback when the identity has none).
-
-## Follow-ups (not done here)
-
-- The runnable pattern uses a **snapshot** roster. A live-link / hybrid variant
-  (rendering *other* users' entries via `cf-profile-badge` bound to their profile
-  cell) is unblocked now that cross-space link targets materialize on read
-  (CT-1667, PR #4019); it still deserves a multi-user browser pass before being
-  promoted to the recommended path.
+- **Live link (canonical):**
+  [`packages/patterns/profile-roster-live-demo.tsx`](../../packages/patterns/profile-roster-live-demo.tsx)
+  renders *every* participant with a live, visitable
+  **`<cf-profile-badge $profile={p.profile} />`** bound to their real profile
+  cell — current data, verified seal, bio/pinned tooltip, navigable to each
+  contributor's profile. Verified end-to-end across multiple real identities.
+- **Snapshot (self-containment variant):**
+  [`packages/patterns/shared-profile-roster/main.tsx`](../../packages/patterns/shared-profile-roster/main.tsx)
+  renders participants via **`<cf-avatar src={p.avatar} name={p.name} />`** from
+  strings copied at join time, with the current viewer's own identity on a
+  trusted `<cf-profile-badge>`. Verified deployed (`cf piece new … main.tsx`): 0
+  console errors; participant rows show image/emoji/initials avatars; the viewer
+  badge shows the profile (or a graceful "Unknown profile" fallback).
 
 ## References
 
@@ -420,7 +441,11 @@ profile (or a graceful "Unknown profile" fallback when the identity has none).
 - `packages/patterns/system/profile-home.tsx` — `ProfileHomeOutput`
   (`name`, `avatar`, `elements`, `initialNameApplied`) that `#profile` resolves
   to.
+- `packages/patterns/profile-roster-live-demo.tsx` — canonical live-link roster:
+  every participant on a visitable `<cf-profile-badge>` bound to their real cell.
 - `packages/patterns/shared-profile-demo/main.tsx` — minimal `#profile` consumer.
+- `packages/ui/src/v2/components/cf-profile-badge/` — trusted, visitable identity
+  badge (verified seal + bio / pinned-piece tooltip).
 - `packages/patterns/scrabble/scrabble.tsx`,
   `packages/patterns/scoped-user-directory/main.tsx`,
   `packages/patterns/scoped-group-chat/main-plain-inputs.tsx` — `PerSpace`

--- a/docs/specs/shared-profile-space.md
+++ b/docs/specs/shared-profile-space.md
@@ -108,6 +108,11 @@ result schema so each viewer sees their own profile projection.
 Add a well-known field to the home default pattern:
 
 ```ts
+// v1 single-profile shape (historical). Superseded by multi-profile support
+// (PR #3830): the home default pattern now carries
+//   profiles: Cell<ProfileDefaultPattern>[]; defaultProfile; mru
+// and there is no `profileName` mirror field — see HOME_SPACE.md for the
+// current shape. The per-profile space behavior described below still holds.
 type HomeDefaultPattern = {
   favorites: Favorite[];
   profile?: Cell<ProfileDefaultPattern>;
@@ -365,7 +370,7 @@ Add these explicit profile targets:
 ```tsx
 wish({ query: "#profile" })            // homeDefault.profile
 wish({ query: "#profileSpace" })       // the profile space cell, derived from the profile link
-wish({ query: "#profileName" })        // homeDefault.profileName, then profile.initialNameApplied
+wish({ query: "#profileName" })        // default profile's initialNameApplied (no `profileName` mirror field post-#3830)
 wish({ query: "#profileAvatar" })      // homeDefault.profile.avatar
 wish({ query: "#profileBio" })         // homeDefault.profile.bio (CT-1648)
 ```

--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -4256,6 +4256,12 @@ interface CFProfileBadgeAttributes<T> extends CFHTMLAttributes<T> {
   "$profile"?: CellLike<any>;
   "size"?: "xs" | "sm" | "md" | "lg" | "xl" | CellLike<string>;
   /**
+   * Badge shape (CT-1761), all carrying the same verification treatment:
+   * `full` (default) = avatar + name + shield; `chip` = compact name + seal dot
+   * (no avatar); `circle` = avatar + seal ring only (name on hover / for AT).
+   */
+  "variant"?: "full" | "chip" | "circle" | CellLike<string>;
+  /**
    * Suppress click-to-navigate. Set when the badge is bound to a derived view
    * of a profile (e.g. the self-badge on a profile-home page) rather than the
    * profile's own root piece, so a click would route to an invalid URL.

--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -4256,11 +4256,13 @@ interface CFProfileBadgeAttributes<T> extends CFHTMLAttributes<T> {
   "$profile"?: CellLike<any>;
   "size"?: "xs" | "sm" | "md" | "lg" | "xl" | CellLike<string>;
   /**
-   * Badge shape (CT-1761), all carrying the same verification treatment:
-   * `full` (default) = avatar + name + shield; `chip` = compact name + seal dot
-   * (no avatar); `circle` = avatar + seal ring only (name on hover / for AT).
+   * Badge shape (CT-1761), all carrying the same generative seal (aura ring +
+   * cursor glint — there is no shield icon): `full` (default) = avatar + name;
+   * `chip` = compact name + seal dot (no avatar); `circle` = avatar + seal ring
+   * only (name on hover / for AT); `hero` = large avatar-over-name for a profile
+   * page header (pair with `noNavigate`).
    */
-  "variant"?: "full" | "chip" | "circle" | CellLike<string>;
+  "variant"?: "full" | "chip" | "circle" | "hero" | CellLike<string>;
   /**
    * Suppress click-to-navigate. Set when the badge is bound to a derived view
    * of a profile (e.g. the self-badge on a profile-home page) rather than the

--- a/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
+++ b/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
@@ -54,6 +54,22 @@ const sectionLabel = {
   margin: "0 0 8px",
 };
 
+// Fixed-width monospace tag so the three variant rows line up.
+const variantTag = {
+  fontFamily: "monospace",
+  fontSize: "0.75rem",
+  color: "#9ca3af",
+  width: "3.5rem",
+  flex: "0 0 auto",
+};
+
+const variantRow = {
+  display: "flex",
+  gap: "12px",
+  alignItems: "center",
+  flexWrap: "wrap",
+};
+
 // deno-lint-ignore no-empty-interface
 interface ProfileBadgeStoryInput {}
 export interface ProfileBadgeStoryOutput {
@@ -110,6 +126,32 @@ export default pattern<ProfileBadgeStoryInput, ProfileBadgeStoryOutput>(() => {
           </div>
         </div>
 
+        <div>
+          <p style={sectionLabel}>Variants (CT-1761) — full · chip · circle</p>
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "16px" }}
+          >
+            <div style={variantRow}>
+              <span style={variantTag}>full</span>
+              <cf-profile-badge $profile={ada} variant="full" noNavigate />
+              <cf-profile-badge $profile={grace} variant="full" noNavigate />
+              <cf-profile-badge $profile={alan} variant="full" noNavigate />
+            </div>
+            <div style={variantRow}>
+              <span style={variantTag}>chip</span>
+              <cf-profile-badge $profile={ada} variant="chip" noNavigate />
+              <cf-profile-badge $profile={grace} variant="chip" noNavigate />
+              <cf-profile-badge $profile={alan} variant="chip" noNavigate />
+            </div>
+            <div style={variantRow}>
+              <span style={variantTag}>circle</span>
+              <cf-profile-badge $profile={ada} variant="circle" noNavigate />
+              <cf-profile-badge $profile={grace} variant="circle" noNavigate />
+              <cf-profile-badge $profile={alan} variant="circle" noNavigate />
+            </div>
+          </div>
+        </div>
+
         <span
           style={{ fontSize: "0.875rem", color: "#6b7280", maxWidth: "40ch" }}
         >
@@ -119,7 +161,11 @@ export default pattern<ProfileBadgeStoryInput, ProfileBadgeStoryOutput>(() => {
           CFC label), which this story can’t mint, so these badges stay in the
           plain “presented” state. Hover or focus a badge to see its tooltip
           (CT-1648): Ada has a bio + 3 pinned pieces, Grace has a bio only, and
-          Alan — with neither — shows no tooltip.
+          Alan — with neither — shows no tooltip. The variants (CT-1761) all
+          carry the same verification treatment: <code>full</code> is
+          avatar + name + shield; <code>chip</code> is a compact name + seal dot
+          for inline use; <code>circle</code> is avatar + seal ring only (name on
+          hover / for screen readers).
         </span>
       </div>
     ),

--- a/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
+++ b/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
@@ -127,7 +127,9 @@ export default pattern<ProfileBadgeStoryInput, ProfileBadgeStoryOutput>(() => {
         </div>
 
         <div>
-          <p style={sectionLabel}>Variants (CT-1761) — full · chip · circle</p>
+          <p style={sectionLabel}>
+            Variants (CT-1761) — full · chip · circle · hero
+          </p>
           <div
             style={{ display: "flex", flexDirection: "column", gap: "16px" }}
           >
@@ -149,23 +151,29 @@ export default pattern<ProfileBadgeStoryInput, ProfileBadgeStoryOutput>(() => {
               <cf-profile-badge $profile={grace} variant="circle" noNavigate />
               <cf-profile-badge $profile={alan} variant="circle" noNavigate />
             </div>
+            <div style={variantRow}>
+              <span style={variantTag}>hero</span>
+              <cf-profile-badge $profile={ada} variant="hero" noNavigate />
+              <cf-profile-badge $profile={grace} variant="hero" noNavigate />
+            </div>
           </div>
         </div>
 
         <span
           style={{ fontSize: "0.875rem", color: "#6b7280", maxWidth: "40ch" }}
         >
-          The shield is the system seal. Avatar paths shown: image (Ada), emoji
-          (Grace), initials (Alan). The verified seal — a DID-derived aura —
-          only renders for a runtime-attested profile (a “represents-principal”
-          CFC label), which this story can’t mint, so these badges stay in the
-          plain “presented” state. Hover or focus a badge to see its tooltip
-          (CT-1648): Ada has a bio + 3 pinned pieces, Grace has a bio only, and
-          Alan — with neither — shows no tooltip. The variants (CT-1761) all
-          carry the same verification treatment: <code>full</code> is
-          avatar + name + shield; <code>chip</code> is a compact name + seal dot
-          for inline use; <code>circle</code> is avatar + seal ring only (name on
-          hover / for screen readers).
+          Avatar paths shown: image (Ada), emoji (Grace), initials (Alan). The
+          verification signal is the generative seal — a DID-derived aura ring
+          plus a cursor-reactive glint (there is no shield icon). It only renders
+          for a runtime-attested profile (a “represents-principal” CFC label),
+          which this story can’t mint, so these badges stay in the plain
+          “presented” state. Hover or focus a badge to see its tooltip (CT-1648):
+          Ada has a bio + 3 pinned pieces, Grace has a bio only, and Alan — with
+          neither — shows no tooltip. The variants (CT-1761) all carry the same
+          seal: <code>full</code> is an avatar + name pill; <code>chip</code> is a
+          compact name + seal dot for inline use; <code>circle</code> is
+          avatar + seal ring only (name on hover / for screen readers);
+          <code>hero</code> is a large avatar-over-name for a profile page header.
         </span>
       </div>
     ),

--- a/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
+++ b/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
@@ -173,7 +173,7 @@ export default pattern<ProfileBadgeStoryInput, ProfileBadgeStoryOutput>(() => {
           carry the same seal: <code>full</code> is an avatar + name pill;{" "}
           <code>chip</code> is a compact name + seal dot for inline use;{" "}
           <code>circle</code>{" "}
-          is avatar + seal ring only (name on hover / for screen readers);
+          is avatar + seal ring only (name on hover / for screen readers);{" "}
           <code>hero</code>{" "}
           is a large avatar-over-name for a profile page header.
         </span>

--- a/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
+++ b/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
@@ -164,16 +164,18 @@ export default pattern<ProfileBadgeStoryInput, ProfileBadgeStoryOutput>(() => {
         >
           Avatar paths shown: image (Ada), emoji (Grace), initials (Alan). The
           verification signal is the generative seal — a DID-derived aura ring
-          plus a cursor-reactive glint (there is no shield icon). It only renders
-          for a runtime-attested profile (a “represents-principal” CFC label),
-          which this story can’t mint, so these badges stay in the plain
-          “presented” state. Hover or focus a badge to see its tooltip (CT-1648):
-          Ada has a bio + 3 pinned pieces, Grace has a bio only, and Alan — with
-          neither — shows no tooltip. The variants (CT-1761) all carry the same
-          seal: <code>full</code> is an avatar + name pill; <code>chip</code> is a
-          compact name + seal dot for inline use; <code>circle</code> is
-          avatar + seal ring only (name on hover / for screen readers);
-          <code>hero</code> is a large avatar-over-name for a profile page header.
+          plus a cursor-reactive glint (there is no shield icon). It only
+          renders for a runtime-attested profile (a “represents-principal” CFC
+          label), which this story can’t mint, so these badges stay in the plain
+          “presented” state. Hover or focus a badge to see its tooltip
+          (CT-1648): Ada has a bio + 3 pinned pieces, Grace has a bio only, and
+          Alan — with neither — shows no tooltip. The variants (CT-1761) all
+          carry the same seal: <code>full</code> is an avatar + name pill;{" "}
+          <code>chip</code> is a compact name + seal dot for inline use;{" "}
+          <code>circle</code>{" "}
+          is avatar + seal ring only (name on hover / for screen readers);
+          <code>hero</code>{" "}
+          is a large avatar-over-name for a profile page header.
         </span>
       </div>
     ),

--- a/packages/patterns/profile-group-chat/main.tsx
+++ b/packages/patterns/profile-group-chat/main.tsx
@@ -178,11 +178,22 @@ export default pattern<ProfileGroupChatInput, ProfileGroupChatOutput>(
               <span style={headerLabel}>
                 In this room ({participantCount})
               </span>
-              <cf-hstack gap="2" align="center" style={{ flexWrap: "wrap" }}>
+              {
+                /* Plain flex row (not cf-hstack) — cf-hstack's :host clips
+                  overflow:hidden, which cuts the badges' verified glow. */
+              }
+              <div
+                style={{
+                  display: "flex",
+                  gap: "0.5rem",
+                  alignItems: "center",
+                  flexWrap: "wrap",
+                }}
+              >
                 {participants.map((p) => (
                   <cf-profile-badge variant="chip" $profile={p.profile} />
                 ))}
-              </cf-hstack>
+              </div>
             </cf-vstack>
 
             {
@@ -193,7 +204,13 @@ export default pattern<ProfileGroupChatInput, ProfileGroupChatOutput>(
             }
             <cf-vstack gap="3" style={{ minHeight: "160px" }}>
               {messages.map((message) => (
-                <cf-hstack gap="2" align="start">
+                <div
+                  style={{
+                    display: "flex",
+                    gap: "0.5rem",
+                    alignItems: "flex-start",
+                  }}
+                >
                   <cf-profile-badge
                     variant="circle"
                     size="sm"
@@ -209,7 +226,7 @@ export default pattern<ProfileGroupChatInput, ProfileGroupChatOutput>(
                       {message.body}
                     </span>
                   </cf-vstack>
-                </cf-hstack>
+                </div>
               ))}
             </cf-vstack>
 

--- a/packages/patterns/profile-group-chat/main.tsx
+++ b/packages/patterns/profile-group-chat/main.tsx
@@ -2,6 +2,7 @@ import {
   type Cell,
   computed,
   Default,
+  equals,
   handler,
   NAME,
   pattern,
@@ -131,16 +132,19 @@ export default pattern<ProfileGroupChatInput, ProfileGroupChatOutput>(
 
     const messageCount = messages.length;
 
-    // Distinct participants (deduped by author name), derived from the shared
-    // log — the roster, rendered as a strip of `chip` profile badges bound to
-    // each contributor's live profile cell.
+    // Distinct participants, derived from the shared log — the roster, rendered
+    // as a strip of `chip` profile badges bound to each contributor's live
+    // profile cell. Dedupe by profile-CELL identity (`equals`), never the
+    // display name: two distinct people can share a name ("Ben" + "Ben"), and
+    // each is a separate participant — keying on the name would collapse them.
     const participants = computed<{ name: string; profile: ChatProfileCell }[]>(
       () => {
-        const seen = new Set<string>();
         const out: { name: string; profile: ChatProfileCell }[] = [];
         for (const m of messages ?? []) {
-          if (m && m.author && m.authorProfile && !seen.has(m.author)) {
-            seen.add(m.author);
+          if (
+            m && m.authorProfile &&
+            !out.some((p) => equals(p.profile, m.authorProfile))
+          ) {
             out.push({ name: m.author, profile: m.authorProfile });
           }
         }

--- a/packages/patterns/profile-group-chat/main.tsx
+++ b/packages/patterns/profile-group-chat/main.tsx
@@ -25,9 +25,10 @@ import {
  *     `wish({ query: "#profile" })`, and the live profile **cell** is stored on
  *     each message — cross-space reads resolve for any viewer (CT-1667/1687), so
  *     every identity in the UI renders through the trusted, first-class
- *     `<cf-profile-badge>`: messages as `full` badges, the participant strip as
- *     `chip` badges, the viewer's own as `full`. Each badge carries the
- *     verified-identity seal and links to that person's profile.
+ *     `<cf-profile-badge>`: message gutters as `circle` badges (avatar + seal,
+ *     with a plain name label), the participant strip as `chip` badges, the
+ *     viewer's own as `full`. Each badge carries the verified-identity seal and
+ *     links to that person's profile.
  *   - A snapshot of name/avatar rides alongside the cell as a durable fallback
  *     label (used for participant dedup and if the live cell is momentarily
  *     unresolved).
@@ -185,28 +186,30 @@ export default pattern<ProfileGroupChatInput, ProfileGroupChatOutput>(
             </cf-vstack>
 
             {
-              /* Messages — each sender's identity is a first-class `full` badge
-              (avatar + name + seal, navigable to their profile); the body sits
-              indented beneath it. */
+              /* Messages — classic chat layout: the sender's avatar as a
+              `circle` profile badge (verified seal ring, navigable to their
+              profile) in the gutter, with the name as a plain text label above
+              the body. */
             }
             <cf-vstack gap="3" style={{ minHeight: "160px" }}>
               {messages.map((message) => (
-                <cf-vstack gap="1">
+                <cf-hstack gap="2" align="start">
                   <cf-profile-badge
-                    variant="full"
+                    variant="circle"
                     size="sm"
                     $profile={message.authorProfile}
                   />
-                  <span
-                    style={{
-                      fontSize: "0.875rem",
-                      whiteSpace: "pre-wrap",
-                      marginLeft: "1.875rem",
-                    }}
-                  >
-                    {message.body}
-                  </span>
-                </cf-vstack>
+                  <cf-vstack gap="0">
+                    <span style={{ fontSize: "0.8125rem", fontWeight: "600" }}>
+                      {message.author}
+                    </span>
+                    <span
+                      style={{ fontSize: "0.875rem", whiteSpace: "pre-wrap" }}
+                    >
+                      {message.body}
+                    </span>
+                  </cf-vstack>
+                </cf-hstack>
               ))}
             </cf-vstack>
 

--- a/packages/patterns/profile-group-chat/main.tsx
+++ b/packages/patterns/profile-group-chat/main.tsx
@@ -1,4 +1,5 @@
 import {
+  type Cell,
   computed,
   Default,
   handler,
@@ -21,20 +22,29 @@ import {
  * Demonstrates the CT-1649 roster approach in a genuine multiplayer pattern:
  *   - Messages live in a `PerSpace` array (shared by everyone in the space).
  *   - The sender's identity is resolved from THEIR shared profile via
- *     `wish({ query: "#profileName" / "#profileAvatar" })` and snapshotted onto
- *     each message at send time — so every other viewer renders it from plain
- *     strings already in the space (no cross-space profile resolution needed).
- *   - Each message + the participant strip render with `<cf-avatar>`; the
- *     current viewer's own live profile renders with the trusted
- *     `<cf-profile-badge>`.
+ *     `wish({ query: "#profile" })`, and the live profile **cell** is stored on
+ *     each message — cross-space reads resolve for any viewer (CT-1667/1687), so
+ *     every identity in the UI renders through the trusted, first-class
+ *     `<cf-profile-badge>`: messages as `full` badges, the participant strip as
+ *     `chip` badges, the viewer's own as `full`. Each badge carries the
+ *     verified-identity seal and links to that person's profile.
+ *   - A snapshot of name/avatar rides alongside the cell as a durable fallback
+ *     label (used for participant dedup and if the live cell is momentarily
+ *     unresolved).
  *
  * Compare to `packages/patterns/scoped-group-chat/main-plain-inputs.tsx`, which
- * this is modeled on — the only change is sourcing name/avatar from the shared
- * profile rather than a typed-in name. See `docs/specs/shared-profile-rosters.md`.
+ * this is modeled on — the change is sourcing identity from the shared profile
+ * (cell, not just strings) and rendering it through the badge.
+ * See `docs/specs/shared-profile-rosters.md`.
  */
 
+/** Live link to a contributor's profile cell — stable identity + live data. */
+export type ChatProfileCell = Cell<{ name?: string; avatar?: string }>;
+
 export interface ChatMessage {
-  /** Sender's profile name, snapshotted at send time. */
+  /** Sender's live profile cell — rendered first-class via cf-profile-badge. */
+  authorProfile: ChatProfileCell;
+  /** Sender's profile name, snapshotted at send time (durable fallback label). */
   author: string;
   /** Sender's profile avatar (URL or glyph), snapshotted at send time. */
   avatar: string;
@@ -49,19 +59,25 @@ type DraftCell = Writable<string>;
 
 export type SendEvent = Record<PropertyKey, never>;
 
-// Append a message, snapshotting the sender's resolved profile name/avatar.
-// `name`/`avatar` arrive as plain strings (named `computed` values auto-unwrap
-// as handler state); `draft` is a live PerUser cell.
+// Append a message. `profile` is the sender's live profile cell (the identity
+// rendered first-class via cf-profile-badge); it round-trips through `push` as a
+// link. `name`/`avatar` arrive as plain strings (named `computed` values
+// auto-unwrap as handler state) and are snapshotted as a durable fallback label;
+// `draft` is a live PerUser cell.
 const sendMessage = handler<SendEvent, {
   messages: MessagesCell;
   draft: DraftCell;
+  // May be undefined until the viewer's `#profile` wish resolves; guarded below.
+  profile: ChatProfileCell | undefined;
   name: string;
   avatar: string;
-}>((_event, { messages, draft, name, avatar }) => {
+}>((_event, { messages, draft, profile, name, avatar }) => {
   const author = (name ?? "").trim();
   const body = (draft.get() ?? "").trim();
   if (!author || !body) return; // No profile yet, or empty message.
+  if (!profile) return; // No resolved profile cell — no first-class identity.
   messages.push({
+    authorProfile: profile,
     author,
     avatar: (avatar ?? "").trim(),
     body,
@@ -97,36 +113,45 @@ const headerLabel = {
 export default pattern<ProfileGroupChatInput, ProfileGroupChatOutput>(
   ({ messages, draft }) => {
     // Resolve THIS viewer's shared profile (their default profile / picker
-    // result under PR #3830). `#profile` is the live cell for cf-profile-badge;
-    // the field targets give the strings we snapshot onto each message.
-    const profileWish = wish({ query: "#profile" });
+    // result under PR #3830). `#profile` is the live cell — the identity key
+    // stored on each message and rendered via cf-profile-badge; the field
+    // targets give the snapshot strings (fallback label + participant dedup).
+    const profileWish = wish<{ name?: string; avatar?: string }>({
+      query: "#profile",
+    });
     const profileNameWish = wish<string>({ query: "#profileName" });
     const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
 
     const myName = computed(() => profileNameWish.result ?? "");
     const myAvatar = computed(() => profileAvatarWish.result ?? "");
     const hasProfile = computed(() => (profileNameWish.result ?? "") !== "");
+    // The live profile cell — stored on each message and passed to the badge.
+    const myProfile = profileWish.result;
 
     const messageCount = messages.length;
 
-    // Distinct participants (deduped by author), derived from the shared log —
-    // the roster, rendered as a strip of cf-avatars.
-    const participants = computed<{ name: string; avatar: string }[]>(() => {
-      const seen = new Set<string>();
-      const out: { name: string; avatar: string }[] = [];
-      for (const m of messages ?? []) {
-        if (m && m.author && !seen.has(m.author)) {
-          seen.add(m.author);
-          out.push({ name: m.author, avatar: m.avatar ?? "" });
+    // Distinct participants (deduped by author name), derived from the shared
+    // log — the roster, rendered as a strip of `chip` profile badges bound to
+    // each contributor's live profile cell.
+    const participants = computed<{ name: string; profile: ChatProfileCell }[]>(
+      () => {
+        const seen = new Set<string>();
+        const out: { name: string; profile: ChatProfileCell }[] = [];
+        for (const m of messages ?? []) {
+          if (m && m.author && m.authorProfile && !seen.has(m.author)) {
+            seen.add(m.author);
+            out.push({ name: m.author, profile: m.authorProfile });
+          }
         }
-      }
-      return out;
-    });
+        return out;
+      },
+    );
     const participantCount = computed(() => participants.length);
 
     const send = sendMessage({
       messages,
       draft,
+      profile: myProfile,
       name: myName,
       avatar: myAvatar,
     });
@@ -144,41 +169,44 @@ export default pattern<ProfileGroupChatInput, ProfileGroupChatOutput>(
               </cf-vstack>
             </cf-hstack>
 
-            {/* Roster strip — distinct participants by shared profile. */}
+            {
+              /* Roster strip — distinct participants, each a `chip` badge bound
+              to their live profile cell (name + DID-hued seal dot, navigable). */
+            }
             <cf-vstack gap="1">
               <span style={headerLabel}>
                 In this room ({participantCount})
               </span>
               <cf-hstack gap="2" align="center" style={{ flexWrap: "wrap" }}>
                 {participants.map((p) => (
-                  <cf-hstack gap="1" align="center">
-                    <cf-avatar src={p.avatar} name={p.name} size="xs" />
-                    <span style={{ fontSize: "0.8125rem" }}>{p.name}</span>
-                  </cf-hstack>
+                  <cf-profile-badge variant="chip" $profile={p.profile} />
                 ))}
               </cf-hstack>
             </cf-vstack>
 
-            {/* Messages — each shows the sender's snapshotted profile avatar. */}
+            {
+              /* Messages — each sender's identity is a first-class `full` badge
+              (avatar + name + seal, navigable to their profile); the body sits
+              indented beneath it. */
+            }
             <cf-vstack gap="3" style={{ minHeight: "160px" }}>
               {messages.map((message) => (
-                <cf-hstack gap="2" align="start">
-                  <cf-avatar
-                    src={message.avatar}
-                    name={message.author}
+                <cf-vstack gap="1">
+                  <cf-profile-badge
+                    variant="full"
                     size="sm"
+                    $profile={message.authorProfile}
                   />
-                  <cf-vstack gap="0">
-                    <span style={{ fontSize: "0.8125rem", fontWeight: "600" }}>
-                      {message.author}
-                    </span>
-                    <span
-                      style={{ fontSize: "0.875rem", whiteSpace: "pre-wrap" }}
-                    >
-                      {message.body}
-                    </span>
-                  </cf-vstack>
-                </cf-hstack>
+                  <span
+                    style={{
+                      fontSize: "0.875rem",
+                      whiteSpace: "pre-wrap",
+                      marginLeft: "1.875rem",
+                    }}
+                  >
+                    {message.body}
+                  </span>
+                </cf-vstack>
               ))}
             </cf-vstack>
 

--- a/packages/patterns/profile-group-chat/main.tsx
+++ b/packages/patterns/profile-group-chat/main.tsx
@@ -126,9 +126,15 @@ export default pattern<ProfileGroupChatInput, ProfileGroupChatOutput>(
 
     const myName = computed(() => profileNameWish.result ?? "");
     const myAvatar = computed(() => profileAvatarWish.result ?? "");
-    const hasProfile = computed(() => (profileNameWish.result ?? "") !== "");
     // The live profile cell — stored on each message and passed to the badge.
     const myProfile = profileWish.result;
+    // Gate the composer on BOTH the name (for the snapshot/label) AND the live
+    // profile CELL the send handler requires. Keying only on `#profileName`
+    // would enable Send in the window where the name resolves but the `#profile`
+    // cell hasn't, and the handler would then silently drop the message.
+    const hasProfile = computed(() =>
+      (profileNameWish.result ?? "") !== "" && profileWish.result !== undefined
+    );
 
     const messageCount = messages.length;
 

--- a/packages/patterns/profile-roster-live-demo.tsx
+++ b/packages/patterns/profile-roster-live-demo.tsx
@@ -41,7 +41,7 @@ export type ParticipantProfileCell = Cell<
 export interface Participant {
   /** Live link to the contributor's profile cell — stable identity + live data. */
   profile: ParticipantProfileCell;
-  /** Snapshot name (fallback label if the live cell can't resolve). */
+  /** Display name, snapshotted at join time (durable label; survives even if the live cell is momentarily unresolved on first render). */
   name: string;
   joinedAt: number;
 }

--- a/packages/patterns/scrabble/scrabble.tsx
+++ b/packages/patterns/scrabble/scrabble.tsx
@@ -10,9 +10,11 @@
  */
 
 import {
+  type Cell,
   computed,
   Default,
   handler,
+  ifElse,
   NAME,
   nonPrivateRandom,
   pattern,
@@ -39,13 +41,35 @@ export interface PlacedTile {
   col: number;
 }
 
+/** Live link to a player's profile cell — rendered first-class via the badge. */
+export type ScrabbleProfileCell = Cell<{ name?: string; avatar?: string }>;
+
 export interface Player {
   name: string;
   /** Avatar URL or glyph, snapshotted from the joiner's shared profile. */
   avatar?: string;
+  /**
+   * Live profile cell — present for profile-joined players (the scoreboard
+   * renders it via `<cf-profile-badge>`), absent for headless name-only joins
+   * (test seam), which fall back to `<cf-avatar>`.
+   */
+  profile?: ScrabbleProfileCell;
   color: string;
   score: number;
   joinedAt: number;
+}
+
+/** Outward snapshot of a player (no live profile cell — that stays internal). */
+export type PlayerView = Omit<Player, "profile">;
+
+/**
+ * Shared player roster. Object-wrapped (not a bare `Writable<Player[]>`) so each
+ * Player can carry a live `profile` cell: a bare array with a nested cell
+ * unwraps to a weak object and breaks CTS handler-state / output typing — see
+ * the profile-roster pattern + docs/common/patterns/multi-user-patterns.md.
+ */
+export interface PlayerRoster {
+  list: Player[];
 }
 
 export interface GameEvent {
@@ -308,7 +332,10 @@ const EXAMPLE_WORDS = new Set([
 type BoardCell = Writable<PlacedTile[] | Default<[]>>;
 type BagCell = Writable<Letter[] | Default<[]>>;
 type BagIndexCell = Writable<number | Default<0>>;
-type PlayersCell = Writable<Player[] | Default<[]>>;
+const DEFAULT_PLAYER_ROSTER: PlayerRoster = { list: [] };
+type PlayersCell = Writable<
+  PlayerRoster | Default<typeof DEFAULT_PLAYER_ROSTER>
+>;
 type EventsCell = Writable<GameEvent[] | Default<[]>>;
 type RackCell = Writable<Letter[] | Default<[]>>;
 type PlacedCell = Writable<PlacedTile[] | Default<[]>>;
@@ -320,7 +347,7 @@ export interface GameInput {
   board?: PerSpace<BoardCell>;
   bag?: PerSpace<BagCell>;
   bagIndex?: PerSpace<BagIndexCell>;
-  players?: PerSpace<PlayersCell>;
+  players?: PerSpace<PlayerRoster | Default<typeof DEFAULT_PLAYER_ROSTER>>;
   gameEvents?: PerSpace<EventsCell>;
   rack?: PerUser<RackCell>;
   placed?: PerUser<PlacedCell>;
@@ -333,7 +360,7 @@ export interface GameOutput {
   board: readonly PlacedTile[];
   bag: readonly Letter[];
   bagIndex: number;
-  players: readonly Player[];
+  players: readonly PlayerView[];
   gameEvents: readonly GameEvent[];
   rack: readonly Letter[];
   placed: readonly PlacedTile[];
@@ -616,6 +643,7 @@ function returnedLetters(tiles: readonly PlacedTile[]): Letter[] {
 function joinPlayerByName(
   nameInput: string | undefined,
   avatar: string,
+  profile: ScrabbleProfileCell | undefined,
   myName: NameCell,
   rack: RackCell,
   placed: PlacedCell,
@@ -633,7 +661,7 @@ function joinPlayerByName(
   }
 
   const currentName = trimmedName(myName.get());
-  const existingPlayers = players.get();
+  const existingPlayers = players.get().list;
   const existingPlayer = existingPlayers.find((player) => player.name === name);
   if (existingPlayer) {
     if (currentName !== name) {
@@ -669,11 +697,12 @@ function joinPlayerByName(
   const player: Player = {
     name,
     avatar: (avatar ?? "").trim(),
+    ...(profile ? { profile } : {}),
     color: getRandomColor(existingPlayers.length),
     score: 0,
     joinedAt: safeDateNow(),
   };
-  players.set([...existingPlayers, player]);
+  players.key("list").set([...existingPlayers, player]);
   myName.set(name);
   rack.set(drawn);
   placed.set([]);
@@ -690,12 +719,15 @@ function joinPlayerByName(
 }
 
 // Join with the viewer's resolved profile. `name`/`avatar` arrive as plain
-// strings (named `computed` values auto-unwrap as handler state).
+// strings (named `computed` values auto-unwrap as handler state); `profile` is
+// the viewer's live profile cell, stored on the Player so the scoreboard
+// renders their identity first-class.
 const joinGameHandler = handler<
   void,
   {
     name: string;
     avatar: string;
+    profile: ScrabbleProfileCell | undefined;
     myName: NameCell;
     rack: RackCell;
     placed: PlacedCell;
@@ -711,6 +743,7 @@ const joinGameHandler = handler<
   {
     name,
     avatar,
+    profile,
     myName,
     rack,
     placed,
@@ -725,6 +758,7 @@ const joinGameHandler = handler<
   joinPlayerByName(
     name,
     avatar,
+    profile,
     myName,
     rack,
     placed,
@@ -757,6 +791,7 @@ const joinWithNameHandler = handler<
   joinPlayerByName(
     name,
     "",
+    undefined, // headless name-only join (test seam) has no profile cell
     myName,
     rack,
     placed,
@@ -788,7 +823,7 @@ const resetGameHandler = handler<
   board.set([]);
   bag.set(createTileBag());
   bagIndex.set(0);
-  players.set([]);
+  players.key("list").set([]);
   gameEvents.set([]);
   rack.set([]);
   placed.set([]);
@@ -1081,8 +1116,8 @@ const submitTurn = handler<
     bagIndex.set(currentIndex + drawn.length);
   }
 
-  players.set(
-    players.get().map((player) =>
+  players.key("list").set(
+    players.get().list.map((player) =>
       player.name === name
         ? { ...player, score: player.score + turnScore.total }
         : player
@@ -1108,7 +1143,7 @@ const submitTurn = handler<
 // recompute would make the computed results non-idempotent.
 const EMPTY_TILES: PlacedTile[] = [];
 const EMPTY_LETTERS: Letter[] = [];
-const EMPTY_PLAYERS: Player[] = [];
+const EMPTY_PLAYERS: PlayerView[] = [];
 const EMPTY_EVENTS: GameEvent[] = [];
 
 const ScrabbleGame = pattern<GameInput, GameOutput>(
@@ -1151,7 +1186,9 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
     );
 
     const joined = computed(() =>
-      players.get().some((player) => player.name === trimmedName(myName.get()))
+      (players.list ?? []).some((player) =>
+        player.name === trimmedName(myName.get())
+      )
     );
     const rackCount = rack.get().length;
     const bagCount = Math.max(0, bag.get().length - bagIndex.get());
@@ -1161,6 +1198,7 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
     const joinGame = joinGameHandler({
       name: profileName,
       avatar: profileAvatar,
+      profile: profileWish.result,
       myName,
       rack,
       placed,
@@ -1545,7 +1583,7 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
             <strong style={{ textAlign: "center", color: "#d9f99d" }}>
               Players
             </strong>
-            {players.map((player) => (
+            {players.list.map((player) => (
               <div
                 style={{
                   padding: "10px",
@@ -1558,11 +1596,24 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
                 }}
               >
                 <div style={{ display: "flex", justifyContent: "center" }}>
-                  <cf-avatar
-                    src={player.avatar}
-                    name={player.name}
-                    size="sm"
-                  />
+                  {
+                    /* Profile-joined players render first-class via the trusted
+                      `circle` badge (avatar + seal ring, navigable); headless
+                      name-only joins (no profile cell) fall back to cf-avatar. */
+                  }
+                  {ifElse(
+                    computed(() => player.profile !== undefined),
+                    <cf-profile-badge
+                      variant="circle"
+                      size="sm"
+                      $profile={player.profile}
+                    />,
+                    <cf-avatar
+                      src={player.avatar}
+                      name={player.name}
+                      size="sm"
+                    />,
+                  )}
                 </div>
                 <div
                   style={{
@@ -1608,7 +1659,7 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
       board: computed(() => board.get() ?? EMPTY_TILES),
       bag: computed(() => bag.get() ?? EMPTY_LETTERS),
       bagIndex: computed(() => bagIndex.get() ?? 0),
-      players: computed(() => players.get() ?? EMPTY_PLAYERS),
+      players: computed(() => players.list ?? EMPTY_PLAYERS),
       gameEvents: computed(() => gameEvents.get() ?? EMPTY_EVENTS),
       rack: computed(() => rack.get() ?? EMPTY_LETTERS),
       placed: computed(() => placed.get() ?? EMPTY_TILES),

--- a/packages/patterns/scrabble/scrabble.tsx
+++ b/packages/patterns/scrabble/scrabble.tsx
@@ -1143,8 +1143,11 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
     const hasProfile = computed(() =>
       (profileNameWish.result ?? "").trim() !== ""
     );
+    // The button is the JOIN action; the adjacent `#profile` wish UI is the
+    // create/pick surface. Label it as such (a disabled "Join" until the viewer
+    // has a profile) rather than mislabeling the button "Create a profile…".
     const joinLabel = computed(() =>
-      hasProfile ? `Join as ${profileName}` : "Create a profile to join"
+      hasProfile ? `Join as ${profileName}` : "Join"
     );
 
     const joined = computed(() =>
@@ -1237,9 +1240,16 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
               <h2 style={{ margin: 0, fontSize: "24px" }}>{gameName}</h2>
               {joined
                 ? (
-                  <span style={{ color: "#d9f99d", fontSize: "14px" }}>
-                    Playing as <strong>{myName}</strong>
-                  </span>
+                  <cf-hstack gap="2" align="center">
+                    <span style={{ color: "#d9f99d", fontSize: "14px" }}>
+                      Playing as
+                    </span>
+                    {/* The viewer's own identity, first-class (CT-1761). */}
+                    <cf-profile-badge
+                      variant="chip"
+                      $profile={profileWish.result}
+                    />
+                  </cf-hstack>
                 )
                 : (
                   <div

--- a/packages/patterns/scrabble/scrabble.tsx
+++ b/packages/patterns/scrabble/scrabble.tsx
@@ -1659,7 +1659,14 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
       board: computed(() => board.get() ?? EMPTY_TILES),
       bag: computed(() => bag.get() ?? EMPTY_LETTERS),
       bagIndex: computed(() => bagIndex.get() ?? 0),
-      players: computed(() => players.list ?? EMPTY_PLAYERS),
+      // Strip the internal live `profile` cell so the outward snapshot matches
+      // the declared `PlayerView` contract (plain name/score/etc.) — external
+      // readers never receive a cross-space profile link.
+      players: computed(() =>
+        (players.list ?? EMPTY_PLAYERS).map(
+          ({ profile: _profile, ...player }) => player,
+        )
+      ),
       gameEvents: computed(() => gameEvents.get() ?? EMPTY_EVENTS),
       rack: computed(() => rack.get() ?? EMPTY_LETTERS),
       placed: computed(() => placed.get() ?? EMPTY_TILES),

--- a/packages/patterns/shared-profile-roster/main.tsx
+++ b/packages/patterns/shared-profile-roster/main.tsx
@@ -27,9 +27,15 @@ import {
  * Storage model: a **snapshot** (name + avatar copied at join time) is the
  * recommended default — the roster is then fully self-describing inside the
  * shared space and never depends on other users' profile spaces being reachable.
- * Participants render from those snapshot strings via `<cf-avatar>`. The current
- * viewer's OWN live profile is the one case where a live profile cell is
- * reliably resolvable, so it's shown with the trusted `<cf-profile-badge>`.
+ * Participants render from those snapshot strings via `<cf-avatar>`, and the
+ * current viewer's OWN live profile is shown with the trusted
+ * `<cf-profile-badge>`.
+ *
+ * Live cross-space profile reads now resolve for *any* participant (CT-1667/1687
+ * materialize absent cross-space link targets on read), so a roster CAN render
+ * every participant with a live `<cf-profile-badge>` — see
+ * `profile-roster-live-demo.tsx` for that variant. Snapshotting is still the
+ * recommended default here for self-containment and first-render stability.
  */
 
 /**

--- a/packages/patterns/shared-profile-roster/main.tsx
+++ b/packages/patterns/shared-profile-roster/main.tsx
@@ -24,18 +24,19 @@ import {
  * contributes their OWN entry on join, sourced from their shared profile
  * (`wish({ query: "#profile" })`). See `docs/specs/shared-profile-rosters.md`.
  *
- * Storage model: a **snapshot** (name + avatar copied at join time) is the
- * recommended default — the roster is then fully self-describing inside the
- * shared space and never depends on other users' profile spaces being reachable.
- * Participants render from those snapshot strings via `<cf-avatar>`, and the
- * current viewer's OWN live profile is shown with the trusted
+ * This pattern demonstrates the **snapshot** (self-containment) variant: name +
+ * avatar are copied at join time, so the roster is fully self-describing inside
+ * the shared space and never depends on other users' profile spaces being
+ * reachable. Participants render from those snapshot strings via `<cf-avatar>`,
+ * and the current viewer's OWN live profile is shown with the trusted
  * `<cf-profile-badge>`.
  *
- * Live cross-space profile reads now resolve for *any* participant (CT-1667/1687
- * materialize absent cross-space link targets on read), so a roster CAN render
- * every participant with a live `<cf-profile-badge>` — see
- * `profile-roster-live-demo.tsx` for that variant. Snapshotting is still the
- * recommended default here for self-containment and first-render stability.
+ * The recommended default is now the **live-link** variant — every participant
+ * rendered with a live, visitable `<cf-profile-badge $profile={p.profile} />`
+ * bound to their real profile cell (cross-space reads resolve for any authorized
+ * viewer, CT-1667/1687). See `profile-roster-live-demo.tsx`. Prefer snapshotting
+ * (this file) only when the roster must stay legible with remote profile spaces
+ * offline, or when you deliberately want no live cross-space dependency.
  */
 
 /**

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -443,23 +443,6 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
     // Whether a non-empty bio has been authored — drives the presentation-mode
     // bio block (CT-1648).
     const hasBio = computed(() => (bio.get() ?? "").trim().length > 0);
-    // Self-view cell for <cf-profile-badge>: the badge resolves name/avatar from
-    // a bound profile cell. Bound to this DERIVED self-cell (a computed
-    // projection, not the profile's own root piece), so the badge is marked
-    // `no-navigate` — a click would otherwise resolve to this non-piece cell id
-    // and route to an invalid URL. TODO(CT-1748 follow-up): bind the actual
-    // profile result cell so the badge can navigate to the canonical profile
-    // page AND the runtime-attested represents-principal label drives the
-    // verified identity seal.
-    const selfProfile = computed(() => ({
-      [NAME]: name.get(),
-      name: name.get(),
-      avatar: avatar.get(),
-      // Surfaced in the badge hover tooltip (CT-1648); the pinned-piece count
-      // populates on roster badges bound to the full profile cell.
-      bio: bio.get(),
-    }));
-
     const parsedUserTags = computed(() =>
       userTagsText.get().split(",").map((tag) => tag.trim()).filter((tag) =>
         tag.length > 0
@@ -522,9 +505,17 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
               showEditForm,
               null,
               <cf-vstack gap="4" data-ui-region="profile-presentation">
+                {
+                  /* Hero identity (CT-1761): bound to the profile's OWN root
+                    cell (`self`), not a derived projection — so the badge reads
+                    the runtime-attested represents-principal label and draws the
+                    real verified seal. `noNavigate` keeps it non-clickable on
+                    the profile's own page. */
+                }
                 <cf-profile-badge
                   id="profile-badge"
-                  $profile={selfProfile}
+                  variant="hero"
+                  $profile={self}
                   size="xl"
                   noNavigate
                 />

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
@@ -74,6 +74,29 @@ describe("CFProfileBadge", () => {
     expect(el.size).toBe("md");
   });
 
+  describe("variants (CT-1761)", () => {
+    it("defaults to the full variant", () => {
+      const el = new CFProfileBadge();
+      expect(el.variant).toBe("full");
+    });
+
+    it("renders without throwing for every variant in presented + verified states", () => {
+      // The render branches (avatar vs seal-dot, name on/off, shield on/off,
+      // circle aria-label, inline accent styles) must all be reachable without a
+      // DOM. The real visual check is the browser pass; this guards the wiring.
+      for (const variant of ["full", "chip", "circle"] as const) {
+        const el = new CFProfileBadge() as any;
+        el.variant = variant;
+        el._name = "Ada";
+        expect(el.render()).toBeTruthy(); // presented
+
+        el._state = "verified";
+        el._seal = identitySeal(OWNER_DID);
+        expect(el.render()).toBeTruthy(); // verified
+      }
+    });
+  });
+
   describe("async resolve lifecycle", () => {
     it("does not subscribe when the element disconnects during resolve", async () => {
       const slowResolution = deferred<any>();

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
@@ -84,7 +84,7 @@ describe("CFProfileBadge", () => {
       // The render branches (avatar vs seal-dot, name on/off, shield on/off,
       // circle aria-label, inline accent styles) must all be reachable without a
       // DOM. The real visual check is the browser pass; this guards the wiring.
-      for (const variant of ["full", "chip", "circle"] as const) {
+      for (const variant of ["full", "chip", "circle", "hero"] as const) {
         const el = new CFProfileBadge() as any;
         el.variant = variant;
         el._name = "Ada";

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -210,7 +210,14 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         }
       }
 
-      /* CT-1750: navigable badges (bound to a real profile cell) act as links. */
+      /* CT-1750: navigable badges (bound to a real profile cell) act as links.
+        The pointer is set on BOTH the host and the inner badge: the badge fills
+        the host's content box, but a flex/line-box can stretch the host past it,
+        and that uncovered host area would otherwise show the default arrow. */
+      :host([data-navigable]) {
+        cursor: pointer;
+      }
+
       .badge[data-navigable] {
         cursor: pointer;
       }
@@ -228,7 +235,6 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         text-overflow: ellipsis;
         max-width: 16ch;
       }
-
 
       /* The generative aura ring. Transparent until the badge is verified; when
         verified, a separate aura-ring layer carries the per-identity conic
@@ -534,6 +540,9 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
 
   protected override updated(changed: PropertyValues): void {
     super.updated(changed);
+    // Reflect navigability to the host so `:host([data-navigable])` can draw the
+    // pointer cursor over the whole host box (not just the inner `.badge`).
+    this.toggleAttribute("data-navigable", this._navigable);
     // Register for cursor sheen only while actually verified + connected. The
     // shared controller manages reduced-motion (it won't run the loop while the
     // user prefers reduced motion, and tears it down live if they enable it).
@@ -817,7 +826,9 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         data-state="${this._state}"
         ?data-navigable="${this._navigable}"
         ?data-has-tooltip="${hasTooltip}"
-        role="${this._navigable ? "link" : (variant === "circle" ? "img" : nothing)}"
+        role="${this._navigable
+          ? "link"
+          : (variant === "circle" ? "img" : nothing)}"
         aria-label="${variant === "circle" ? displayName : nothing}"
         tabindex="${this._navigable ? "0" : (hasTooltip ? "0" : nothing)}"
         @click="${this._handleClick}"
@@ -828,8 +839,7 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
             ? html`
               <span class="aura-ring" part="aura-ring" style="${ringStyle}"> </span>
             `
-            : null}
-          ${showAvatar
+            : null} ${showAvatar
             ? html`
               <cf-avatar
                 part="avatar"
@@ -841,8 +851,7 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
             `
             : html`
               <span class="seal-dot" part="seal-dot" style="${dotStyle}"></span>
-            `}
-          ${verified
+            `} ${verified
             ? html`
               <span class="aura-glow" part="aura-glow" aria-hidden="true"></span>
               <span class="aura-sheen" part="aura-sheen" aria-hidden="true"></span>
@@ -853,8 +862,7 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
           ? html`
             <span class="name" part="name">${displayName}</span>
           `
-          : null}
-        ${hasTooltip
+          : null} ${hasTooltip
           ? html`
             <span class="tooltip" part="tooltip" role="tooltip">
               <span class="tooltip-name">${this._name ?? "Profile"}</span>

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -386,6 +386,41 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
       .badge[data-state="verified"] .seal {
         color: var(--cf-theme-color-primary, hsl(212, 100%, 47%));
       }
+
+      /* ---- Variants (CT-1761) -------------------------------------------- */
+
+      /* chip: compact name-first pill. No avatar — a small DID-hued "seal dot"
+        carries the identity treatment, so an inline name still reads as a
+        first-class, verifiable identity rather than plain text. */
+      .badge[data-variant="chip"] {
+        gap: 0.375rem;
+        padding: 0.125rem 0.5rem 0.125rem 0.3125rem;
+      }
+
+      .seal-dot {
+        display: block;
+        width: 0.5rem;
+        height: 0.5rem;
+        border-radius: var(--cf-border-radius-full, 9999px);
+        background: var(--cf-theme-color-border, hsl(0, 0%, 80%));
+        box-sizing: border-box;
+      }
+
+      /* The verified dot is filled with the identity accent (supplied inline)
+        and sits inside the shared .aura, so it inherits the same ring + glow +
+        cursor-sheen liveness as the full badge — just at dot scale. */
+      .badge[data-variant="chip"][data-state="verified"] .aura .seal-dot {
+        box-shadow: 0 0 0 1.5px var(--cf-theme-color-surface, hsl(0, 0%, 99%));
+      }
+
+      /* circle: avatar + seal ring only. Drop the pill chrome and the name; the
+        ring IS the seal. Used for dense avatar strips and message gutters. */
+      .badge[data-variant="circle"] {
+        gap: 0;
+        padding: 0;
+        border: none;
+        background: transparent;
+      }
     `,
   ];
 
@@ -395,6 +430,21 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
 
   @property({ type: String, reflect: true })
   accessor size: AvatarSize = "md";
+
+  /**
+   * Badge shape. All variants carry the same verification treatment (the
+   * DID-derived seal/glint); they differ only in how much chrome they draw:
+   *  - `full` (default): avatar + name + verification shield. The canonical
+   *    presentation for profile pages, roster rows, "playing as", etc.
+   *  - `chip`: name + a compact DID-hued seal dot (no avatar). For inline names
+   *    in dense UI where a full pill is too heavy but the identity treatment
+   *    should still read.
+   *  - `circle`: avatar + seal ring only, no name text (the name rides
+   *    `aria-label` + the hover tooltip). For avatar strips and message gutters.
+   * @attr {string} variant - full | chip | circle (default full)
+   */
+  @property({ type: String, reflect: true })
+  accessor variant: "full" | "chip" | "circle" = "full";
 
   @consume({ context: runtimeContext, subscribe: true })
   @property({ attribute: false })
@@ -727,6 +777,10 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
       }; box-shadow: 0 0 0 1px hsl(${hue} 80% 58% / 0.3), 0 0 10px -1px hsl(${hue} 85% 60% / 0.7);`
       : "";
     const sealStyle = verified ? `color: ${this._seal!.accent};` : "";
+    // The chip's seal-dot is filled with the same DID-derived accent when
+    // verified (supplied inline, like the shield), so an inline name still
+    // carries the identity's color even without an avatar.
+    const dotStyle = verified ? `background: ${this._seal!.accent};` : "";
     const sealTitle = verified
       ? "Identity verified by the system"
       : "System-rendered identity";
@@ -734,23 +788,36 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
     // this identity's palette.
     const auraStyle = verified ? `--seal-hue: ${hue};` : "";
 
+    // CT-1761: variant shape. `full` is the canonical avatar+name+shield pill;
+    // `chip` drops the avatar for a compact name + seal dot; `circle` drops the
+    // name + shield for an avatar + seal ring (name rides aria-label/tooltip).
+    const variant = this.variant;
+    const showAvatar = variant !== "chip";
+    const showName = variant !== "circle";
+    const showShield = variant === "full";
+    const displayName = this._name ?? "Unknown profile";
+
     // CT-1648: hover/focus tooltip surfacing the profile's configured details
-    // (bio + pinned-piece count). Only rendered when there's something extra
-    // to show beyond the name already on the badge.
+    // (bio + pinned-piece count). Always shown for `circle` (whose name is
+    // otherwise invisible); otherwise only when there's something beyond the
+    // already-visible name.
     const pinnedLabel = this._pinnedCount === 1
       ? "1 pinned piece"
       : `${this._pinnedCount} pinned pieces`;
-    const hasTooltip = this._bio !== undefined || this._pinnedCount > 0;
+    const hasTooltip = this._bio !== undefined || this._pinnedCount > 0 ||
+      variant === "circle";
 
     return html`
       <span
         class="badge"
         part="root"
         data-cf-profile-badge
+        data-variant="${variant}"
         data-state="${this._state}"
         ?data-navigable="${this._navigable}"
         ?data-has-tooltip="${hasTooltip}"
-        role="${this._navigable ? "link" : nothing}"
+        role="${this._navigable ? "link" : (variant === "circle" ? "img" : nothing)}"
+        aria-label="${variant === "circle" ? displayName : nothing}"
         tabindex="${this._navigable ? "0" : (hasTooltip ? "0" : nothing)}"
         @click="${this._handleClick}"
         @keydown="${this._handleKeydown}"
@@ -761,13 +828,19 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
               <span class="aura-ring" part="aura-ring" style="${ringStyle}"> </span>
             `
             : null}
-          <cf-avatar
-            part="avatar"
-            exportparts="avatar"
-            .src="${this._avatar}"
-            .name="${this._name}"
-            size="${this.size}"
-          ></cf-avatar>
+          ${showAvatar
+            ? html`
+              <cf-avatar
+                part="avatar"
+                exportparts="avatar"
+                .src="${this._avatar}"
+                .name="${this._name}"
+                size="${this.size}"
+              ></cf-avatar>
+            `
+            : html`
+              <span class="seal-dot" part="seal-dot" style="${dotStyle}"></span>
+            `}
           ${verified
             ? html`
               <span class="aura-glow" part="aura-glow" aria-hidden="true"></span>
@@ -775,32 +848,38 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
             `
             : null}
         </span>
-        <span class="name" part="name">
-          ${this._name ?? "Unknown profile"}
-        </span>
-        <span
-          class="seal"
-          part="seal"
-          aria-hidden="true"
-          title="${sealTitle}"
-          style="${sealStyle}"
-        >
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-            ${verified
-              ? html`
-                <path d="M9 12l2 2 4-4" />
-              `
-              : null}
-          </svg>
-        </span>
+        ${showName
+          ? html`
+            <span class="name" part="name">${displayName}</span>
+          `
+          : null}
+        ${showShield
+          ? html`
+            <span
+              class="seal"
+              part="seal"
+              aria-hidden="true"
+              title="${sealTitle}"
+              style="${sealStyle}"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+                ${verified
+                  ? html`
+                    <path d="M9 12l2 2 4-4" />
+                  `
+                  : null}
+              </svg>
+            </span>
+          `
+          : null}
         ${hasTooltip
           ? html`
             <span class="tooltip" part="tooltip" role="tooltip">

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -229,19 +229,6 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         max-width: 16ch;
       }
 
-      .seal {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        color: var(--cf-theme-color-muted-foreground, hsl(0, 0%, 55%));
-        flex: 0 0 auto;
-      }
-
-      .seal svg {
-        width: 0.875rem;
-        height: 0.875rem;
-        display: block;
-      }
 
       /* The generative aura ring. Transparent until the badge is verified; when
         verified, a separate aura-ring layer carries the per-identity conic
@@ -381,12 +368,6 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         }
       }
 
-      /* When verified the seal mark is tinted with the identity's accent color
-        (also DID-derived), supplied inline. */
-      .badge[data-state="verified"] .seal {
-        color: var(--cf-theme-color-primary, hsl(212, 100%, 47%));
-      }
-
       /* ---- Variants (CT-1761) -------------------------------------------- */
 
       /* chip: compact name-first pill. No avatar — a small DID-hued "seal dot"
@@ -421,6 +402,26 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         border: none;
         background: transparent;
       }
+
+      /* hero: large, centered avatar-over-name. For a profile page header — the
+        seal aura is the focal point, so drop the pill chrome and stack the name
+        beneath the avatar at display scale. */
+      .badge[data-variant="hero"] {
+        flex-direction: column;
+        gap: 0.625rem;
+        padding: 0;
+        border: none;
+        background: transparent;
+        align-items: center;
+        text-align: center;
+      }
+
+      .badge[data-variant="hero"] .name {
+        font-size: var(--cf-font-size-xl, 1.5rem);
+        font-weight: var(--cf-font-weight-bold, 700);
+        max-width: min(28ch, 100%);
+        white-space: normal;
+      }
     `,
   ];
 
@@ -432,19 +433,22 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
   accessor size: AvatarSize = "md";
 
   /**
-   * Badge shape. All variants carry the same verification treatment (the
-   * DID-derived seal/glint); they differ only in how much chrome they draw:
-   *  - `full` (default): avatar + name + verification shield. The canonical
-   *    presentation for profile pages, roster rows, "playing as", etc.
+   * Badge shape. The verification treatment is ALWAYS the generative seal — the
+   * DID-derived aura ring + the cursor-reactive glint (a pattern can mimic the
+   * chrome but cannot earn the seal for a DID it doesn't control). Variants
+   * differ only in how much chrome they draw around it:
+   *  - `full` (default): avatar + name pill. Roster rows, "playing as", etc.
    *  - `chip`: name + a compact DID-hued seal dot (no avatar). For inline names
    *    in dense UI where a full pill is too heavy but the identity treatment
    *    should still read.
    *  - `circle`: avatar + seal ring only, no name text (the name rides
    *    `aria-label` + the hover tooltip). For avatar strips and message gutters.
-   * @attr {string} variant - full | chip | circle (default full)
+   *  - `hero`: large, centered avatar-over-name presentation. For a profile
+   *    page header, where the seal IS the point. Pair with `noNavigate`.
+   * @attr {string} variant - full | chip | circle | hero (default full)
    */
   @property({ type: String, reflect: true })
-  accessor variant: "full" | "chip" | "circle" = "full";
+  accessor variant: "full" | "chip" | "circle" | "hero" = "full";
 
   @consume({ context: runtimeContext, subscribe: true })
   @property({ attribute: false })
@@ -776,25 +780,22 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         this._seal!.ringGradient
       }; box-shadow: 0 0 0 1px hsl(${hue} 80% 58% / 0.3), 0 0 10px -1px hsl(${hue} 85% 60% / 0.7);`
       : "";
-    const sealStyle = verified ? `color: ${this._seal!.accent};` : "";
     // The chip's seal-dot is filled with the same DID-derived accent when
-    // verified (supplied inline, like the shield), so an inline name still
-    // carries the identity's color even without an avatar.
+    // verified (supplied inline), so an inline name still carries the identity's
+    // color even without an avatar.
     const dotStyle = verified ? `background: ${this._seal!.accent};` : "";
-    const sealTitle = verified
-      ? "Identity verified by the system"
-      : "System-rendered identity";
     // Per-identity hue, supplied inline so the hover shimmer is tinted to match
     // this identity's palette.
     const auraStyle = verified ? `--seal-hue: ${hue};` : "";
 
-    // CT-1761: variant shape. `full` is the canonical avatar+name+shield pill;
-    // `chip` drops the avatar for a compact name + seal dot; `circle` drops the
-    // name + shield for an avatar + seal ring (name rides aria-label/tooltip).
+    // CT-1761: variant shape. The verification signal is ALWAYS the generative
+    // seal (aura ring + cursor glint) — there is no separate shield icon. `full`
+    // is an avatar+name pill; `chip` drops the avatar for a compact name + seal
+    // dot; `circle` drops the name for an avatar + seal ring (name rides
+    // aria-label/tooltip); `hero` is a large avatar-over-name presentation.
     const variant = this.variant;
     const showAvatar = variant !== "chip";
     const showName = variant !== "circle";
-    const showShield = variant === "full";
     const displayName = this._name ?? "Unknown profile";
 
     // CT-1648: hover/focus tooltip surfacing the profile's configured details
@@ -851,33 +852,6 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         ${showName
           ? html`
             <span class="name" part="name">${displayName}</span>
-          `
-          : null}
-        ${showShield
-          ? html`
-            <span
-              class="seal"
-              part="seal"
-              aria-hidden="true"
-              title="${sealTitle}"
-              style="${sealStyle}"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
-                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-                ${verified
-                  ? html`
-                    <path d="M9 12l2 2 4-4" />
-                  `
-                  : null}
-              </svg>
-            </span>
           `
           : null}
         ${hasTooltip


### PR DESCRIPTION
## Summary

Makes `cf-profile-badge` the one idiomatic, consistent way to render any identity, and wires it through the multi-user examples — driven by playtest feedback that identities were rendered inconsistently (plain `cf-avatar` / free-text names) and the profile page never showed the verification seal.

Stacked on a **CT-1645 docs coherence pass** (the shared-profile epic is done): the first two commits sweep stale profile-space spec details and reframe the canonical roster idiom to the **live, visitable `cf-profile-badge`** (snapshot demoted to a self-containment fallback). The rest is **[CT-1761](https://linear.app/common-tools/issue/CT-1761)**.

## cf-profile-badge

- **Variants** `full` / `chip` / `circle` / `hero` (one `variant` prop). All carry the same verification signal — the generative seal (DID-derived aura ring + cursor-reactive glint).
- **Removed the shield icon** — it conveyed nothing; the seal is the actual signal.
- **`hero`** variant: large avatar-over-name for a profile page header.
- **Pointer cursor** now covers the whole clickable badge (`:host` was `auto`, so flex/line-box overhang showed the default arrow).

## Patterns

- **profile-home**: the presentation bound a `computed` projection (which can never carry the represents-principal label → no seal). Now binds the profile's own root cell (`self`) + `hero` variant → the real **verified seal renders on the profile page**. (Browser-confirmed after a `cf piece set-home` — profile-home is bundled into the home, so the change needs a home redeploy + a fresh profile to show; noted below.)
- **profile-group-chat**: stores each sender's live profile cell on messages; renders message gutters as `circle` badges + a plain name label, the "in this room" strip as `chip` badges. Deduped by profile-**cell** identity (`equals`), not the display-name string, so two distinct "Ben"s both appear. Badge rows use plain flex divs (not `cf-hstack`, whose `overflow:hidden` clipped the verified glow).
- **scrabble**: the whole Players scoreboard renders `circle` badges (needed object-wrapping the `players` roster so each Player can carry a live profile cell — value-typed `PerSpace` input + profile-less output view; see multi-user-patterns.md). Fixed the "Create a profile to join" button mislabel → "Join" / "Join as X". "Playing as" renders a `chip`.

## Docs

COMPONENTS.md + multi-user-patterns.md + shared-profile-rosters.md: badge is the one idiomatic identity renderer (variant cheat-sheet, seal-not-shield), object-wrap rule for shared state holding live cells, live-link roster as the canonical default. Catalog story shows all four variants.

## Deploy note

`profile-home.tsx` is bundled into the home space (`home.tsx` → `profile-create.tsx` → `profile-home.tsx`), so the hero+seal change lands via `cf piece set-home` and only newly-created profiles pick it up — not a blocker, just a rollout step.

## Verification

- cf-profile-badge unit tests pass (variants + render smoke across `full`/`chip`/`circle`/`hero`).
- scrabble pattern tests 12/12; group-chat/scrabble/profile-home/story type-check + lint clean.
- Browser-verified end-to-end in a fresh space: variants, no-shield, hero+seal on a fresh profile, chat circle+label (glow intact), scrabble scoreboard badges + label, pointer cursor — all 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `cf-profile-badge` the single, trusted identity renderer with `full`/`chip`/`circle`/`hero` variants and a generative verification seal, then applies it across chat, Scrabble, and the profile page. Adds follow-ups for CT-1761: gate chat send on the resolved profile cell and align Scrabble’s `players` output with its declared view.

- **New Features**
  - `cf-profile-badge`: adds `variant` (`full`/`chip`/`circle`/`hero`), removes the shield icon in favor of the generative seal (aura ring + cursor glint), improves ARIA (`circle` uses `aria-label`/`role="img"`), and shows a pointer over the entire navigable host.
  - Profile page: binds the badge to the profile’s own `self` cell and uses the `hero` variant with `noNavigate` so the verified seal appears on the header.
  - Group chat: stores each sender’s live profile cell on messages and renders identities via `cf-profile-badge` (`circle` in gutters with a name label, `chip` in the “in this room” strip).
  - Scrabble: object-wraps the `players` roster so each `Player` can carry an optional profile cell; the scoreboard renders `circle` badges for profile-joined players (falls back to `cf-avatar` when no profile) and “Playing as” uses a `chip` badge.
  - Docs: make `cf-profile-badge` the canonical identity renderer and flip rosters to live, visitable badges as the default (snapshot as the offline fallback); catalog story shows all variants; JSX typing includes `variant`.

- **Bug Fixes**
  - Chat: Send is disabled until the `#profile` cell resolves (prevents dropped messages); participant list dedupes by profile cell (`equals`), not display name; badge glow no longer clips (plain flex rows).
  - Scrabble: strips the live `profile` cell from the `players` output to match the `PlayerView` contract; fixes the join button label to “Join” / “Join as X”.
  - UI: pointer cursor now covers the entire navigable badge host.
  - Docs: COMPONENTS props column lists only `$profile` (moved `variant`/`size`/`noNavigate` details into the description).

<sup>Written for commit 0b081dcb1a439ae27ecb2484688e71ce6544020c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

