### PR TITLE
fix(memory,runner): eliminate distinct-key write over-conflict (conflict-granularity)

### DIFF
--- a/docs/specs/memory-v2/08-conflict-granularity.md
+++ b/docs/specs/memory-v2/08-conflict-granularity.md
@@ -1,0 +1,104 @@
+# Commit-conflict granularity
+
+This note describes how Memory v2 decides whether a committing transaction's
+**reads** conflict with concurrent **writes**, and the three refinements that
+make distinct, non-interacting operations stop colliding.
+
+## The model
+
+A commit carries a read-set (`confirmed` / `pending`) and a set of write
+operations. On commit the server checks, for each read, whether any write with a
+higher `seq` on the same entity invalidates it (`findConflictSeq`). The check is
+two-tier:
+
+- **Tier-1** (`set` / `delete`): path-**blind**. A whole-document set or delete
+  conflicts with *any* read of that entity — the document the reader observed no
+  longer exists in the form it saw.
+- **Tier-2** (`patch`): path-**aware**. A patch conflicts with a read only if a
+  touched path overlaps the read path.
+
+The bug this note addresses: two writers touching **different keys of the same
+container** (e.g. `votes.alice` and `votes.bob`) collided at Tier-2 even though
+neither logically depended on the other, exhausting the retry budget and dropping
+writes under contention. Three independent sources of spurious dependencies
+produced that collision; each is removed at its own seam.
+
+## 1. Recursive reads use leaf-only touched paths
+
+`touchedPathsForPatch` historically injected a patch's **parent** path for
+`add`/`remove`/`move`, so a key add to `["value","map","k"]` also "touched"
+`["value","map"]`. For a **recursive** read that parent path is:
+
+- **redundant** — bidirectional `pathsOverlap` already matches a container reader
+  (`["value","map"]`) against the leaf write (`["value","map","k"]`), because the
+  container read is a *prefix of* the leaf; and
+- **harmful** — the injected parent also prefix-matches every disjoint **sibling**
+  reader (`["value","map","j"]`, a distinct-key writer's own-key/diff and
+  link-resolution reads), whose value did not change.
+
+`patchOverlapsRead` now uses **leaf-only** touched paths (`touchedLeafPathsForPatch`)
+— the same discipline already applied to the scheduler reader-dirty index
+(CT-1623). Same-key writes still conflict (the leaf exactly matches an own-key
+read); whole-container and keyset readers still conflict (their read prefixes the
+leaf). Only the spurious sibling match is dropped. The runner never emits non-tail
+array `add`/`remove` or `move`, so array index shifts (the one shape where
+leaf-only could miss a conflict) never arise from the runner — they manifest as
+per-index `replace` (leaf-exact) plus a container-pathed tail `splice`.
+
+## 2. Shape (nonRecursive) reads conflict only at-or-above the read path
+
+A read can be **shape-only**: the reader observed a container's key-set /
+existence but not the deep values beneath it (QueryResultProxy creation,
+`ownKeys`, `getOwnPropertyDescriptor`, `has`, array `length`). Such reads are now
+tagged `nonRecursive` and carried through to the engine (previously the flag was
+stripped at the client boundary).
+
+For a nonRecursive read, `patchOverlapsNonRecursiveRead` conflicts only with a
+write touching the read path **itself or an ancestor** — `isPrefixPath(touched,
+readPath)`. This keeps the **parent-injecting** `touchedPathsForPatch`, so a key
+`add`/`remove` (which injects the container's path) still conflicts with a keyset
+reader — the shape it observed changed. A disjoint deep-value `replace` strictly
+*below* the read path no longer over-conflicts. The shallow predicate is a strict
+subset of the recursive one, so it can only remove spurious conflicts, never miss
+a genuine one.
+
+## 3. asCell reference-resolution reads are not value dependencies
+
+Materializing an `asCell` argument **resolves a reference**: it follows the arg's
+write-redirect and reads the target container's *shape* to construct the `Cell`.
+That read does not consume a value — the holder depends on the referent only when
+it reads **through** the cell in its body. Such reference-resolution reads are
+tagged `excludeReadFromConflict` at the traversal seam
+(`traverseObjectWithSchema`, gated on `hasAsCell(propSchema)`), and
+`buildReads` drops them from the conflict set when they are `nonRecursive`. They
+remain in the journal for reactivity. A **by-value** argument (`hasAsCell` false)
+is a genuine dependency and is never marked; the gate ensures by-value scalar
+reads — which are also recorded `nonRecursive` — keep their dependency.
+
+## Composition
+
+The three are orthogonal and compose at one matcher:
+
+| read kind | matched by | touched paths |
+|---|---|---|
+| recursive value read | `patchOverlapsRead` | leaf-only |
+| nonRecursive shape read | `patchOverlapsNonRecursiveRead` | parent-injected |
+| asCell reference-resolution read | excluded from conflict | — |
+
+Net effect: disjoint-key writers no longer collide; same-key RMW, whole-container
+reads, keyset readers, and genuine value dependencies all still conflict.
+
+## Related history
+
+This supersedes / composes prior spike PRs:
+
+- **#4199** (exclude a write's own machinery reads): superseded by §1 — fixing the
+  matcher (no read deletion) avoids #4199's cross-space regression and preserves
+  same-key RMW conflicts.
+- **#4200** (honor nonRecursive shape reads): incorporated as §2.
+- **#4210** (reactive computes don't immediately re-queue on conflict): orthogonal
+  (reduces retry-storm cost rather than conflict count); lands independently.
+
+Out of scope (separate lever): whole-document reads by output-derivation computes
+that re-derive and replace a shared result document, and genuine shared-leaf
+read-modify-write (array push) — neither is a granularity artifact.

--- a/docs/specs/memory-v2/08-conflict-granularity.md
+++ b/docs/specs/memory-v2/08-conflict-granularity.md
@@ -40,10 +40,52 @@ produced that collision; each is removed at its own seam.
 — the same discipline already applied to the scheduler reader-dirty index
 (CT-1623). Same-key writes still conflict (the leaf exactly matches an own-key
 read); whole-container and keyset readers still conflict (their read prefixes the
-leaf). Only the spurious sibling match is dropped. The runner never emits non-tail
-array `add`/`remove` or `move`, so array index shifts (the one shape where
-leaf-only could miss a conflict) never arise from the runner — they manifest as
-per-index `replace` (leaf-exact) plus a container-pathed tail `splice`.
+leaf). Only the spurious sibling match is dropped. The one shape where leaf-only could
+miss a conflict — an array **index shift** — never arises from the runner; see
+[Array writes and the leaf-only matcher](#array-writes-and-the-leaf-only-matcher)
+below.
+
+### Array writes and the leaf-only matcher
+
+Leaf-only matching has exactly one blind spot: an `add`/`remove`/`move` whose
+target is an **array index**. Such an op *shifts* sibling elements, but its leaf
+path captures only the touched index — so a recursive reader of a shifted sibling
+(`arr/5` after an insert at `arr/2`) would neither conflict on commit nor
+re-trigger via the (also leaf-only) reader-dirty index. That would be a silent
+stale read.
+
+This is safe because **the runner never emits an indexed-array
+`add`/`remove`/`move`**. `buildArrayPatchCandidates`
+(runner `storage/v2-transaction.ts`) encodes every array change as one of three
+shapes, all of which both the leaf-only commit matcher and the leaf-only
+reader-dirty index handle conservatively:
+
+- **in-place element change** → `replace` at `arr/i` (leaf-exact; no shift);
+- **tail grow / shrink** → a `splice` whose path **is the array** (`arr`), which
+  prefix-matches every index reader below it; and
+- **messy cases** (mid-array presence change, sparse growth) → a whole-array
+  `replace` at `arr` (same conservative coverage).
+
+`move` is never generated at all. So an array index shift always reaches the
+engine as a `splice` or whole-array `replace` on the array path — never as an
+indexed structural op.
+
+Because the safety of leaf-only matching *depends* on this — and it is a
+whole-system property of the producer rather than something the engine enforces —
+it is guarded two ways:
+
+- a runtime assertion, `assertNoIndexedArrayStructuralOps`, runs at the sole
+  patch-generator chokepoint (`buildPatchOperation`) and throws if a future
+  regression ever emits an indexed-array `add`/`remove`/`move`; and
+- a generator test (`packages/runner/test/memory-v2-native-commit.test.ts`,
+  "v2 patch generator never emits indexed-array add/remove/move") drives every
+  array idiom through real cell writes and asserts the emitted ops.
+
+The engine still *accepts* indexed-array structural ops — they remain
+protocol-legal (the nonRecursive matcher handles them via parent injection, and
+stacked-commit tests exercise committed `move`s). The guarantee is narrower and
+lives on the producer side: the **runner** never emits one, which is what keeps
+the recursive leaf-only matcher free of false-negatives in production.
 
 ## 2. Shape (nonRecursive) reads conflict only at-or-above the read path
 

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -553,6 +553,289 @@ Deno.test("memory v2 engine conflicts are scoped by declared scope", async () =>
   }
 });
 
+Deno.test("memory v2 engine: leaf-only commit conflict — disjoint-key writers merge, same-key/container readers still conflict", async () => {
+  const { engine, path } = await createEngine();
+  const sessionId = "session:alice";
+  const principal = "did:key:alice";
+  const id = "entity:map";
+  const scope = "space" as const;
+
+  try {
+    // seq 1: establish a map with keys a, b.
+    applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id,
+          scope,
+          value: toEntityDocument({ a: "1", b: "2" }),
+        }],
+      },
+    });
+
+    // seq 2: a concurrent writer ADDS a new key `c`. An add/remove patch is the
+    // case where `touchedPathsForPatch` used to inject the parent ["value"].
+    applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id,
+          scope,
+          patches: [{ op: "add", path: "/value/c", value: "3" }],
+        }],
+      },
+    });
+
+    // DISTINCT-KEY: a writer whose conflict read is only the SIBLING key `a`
+    // (as a keyed `.set()`'s own-key/diff read is) must NOT conflict with the
+    // seq-2 add of `c`. Leaf-only: ["value","c"] does not overlap ["value","a"].
+    // Pre-fix (parent-injected ["value"]) this collided — the write-contention bug.
+    const merged = applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 3,
+        reads: {
+          confirmed: [{
+            id,
+            scope,
+            path: toDocumentPath(["value", "a"]),
+            seq: 1,
+          }],
+          pending: [],
+        },
+        operations: [{
+          op: "patch",
+          id,
+          scope,
+          patches: [{ op: "add", path: "/value/d", value: "4" }],
+        }],
+      },
+    });
+    assertEquals(merged.seq, 3);
+
+    // SAME-KEY: a writer that read `c` (the key the seq-2 add created) MUST still
+    // conflict — genuine read-modify-write is preserved (leaf exactly matches).
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId,
+          principal,
+          commit: {
+            localSeq: 4,
+            reads: {
+              confirmed: [{
+                id,
+                scope,
+                path: toDocumentPath(["value", "c"]),
+                seq: 1,
+              }],
+              pending: [],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:sink",
+              scope,
+              value: toEntityDocument("x"),
+            }],
+          },
+        }),
+      Error,
+      "stale confirmed read",
+    );
+
+    // CONTAINER READER: a writer that read the whole container ["value"] MUST
+    // still conflict with a key add (the container's value changed) — caught via
+    // the bidirectional overlap (the container read is a prefix of the leaf add).
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId,
+          principal,
+          commit: {
+            localSeq: 5,
+            reads: {
+              confirmed: [{
+                id,
+                scope,
+                path: toDocumentPath(["value"]),
+                seq: 1,
+              }],
+              pending: [],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:sink2",
+              scope,
+              value: toEntityDocument("y"),
+            }],
+          },
+        }),
+      Error,
+      "stale confirmed read",
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 engine: nonRecursive shape read conflicts with key add but not a disjoint deep-value write", async () => {
+  const { engine, path } = await createEngine();
+  const sessionId = "session:alice";
+  const principal = "did:key:alice";
+  const id = "entity:shape";
+  const scope = "space" as const;
+
+  try {
+    // seq 1: container with a value at key x.
+    applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id,
+          scope,
+          value: toEntityDocument({ x: "1" }),
+        }],
+      },
+    });
+    // seq 2: a key ADD (changes the container's key-set).
+    applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id,
+          scope,
+          patches: [{ op: "add", path: "/value/y", value: "3" }],
+        }],
+      },
+    });
+    // seq 3: a disjoint DEEP-VALUE replace strictly below the container.
+    applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 3,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id,
+          scope,
+          patches: [{ op: "replace", path: "/value/x", value: "2" }],
+        }],
+      },
+    });
+
+    // A: a SHAPE (nonRecursive) reader of the container observed at seq 2 must
+    // NOT conflict with the seq-3 deep-value replace — it never depended on x's
+    // value, only the container's shape.
+    const ok = applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 4,
+        reads: {
+          confirmed: [{
+            id,
+            scope,
+            path: toDocumentPath(["value"]),
+            seq: 2,
+            nonRecursive: true,
+          }],
+          pending: [],
+        },
+        operations: [{
+          op: "set",
+          id: "entity:sinkA",
+          scope,
+          value: toEntityDocument("ok"),
+        }],
+      },
+    });
+    assertEquals(ok.seq, 4);
+
+    // B: a RECURSIVE reader of the same container observed at seq 2 MUST conflict
+    // with the seq-3 deep-value replace (its read covered x).
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId,
+          principal,
+          commit: {
+            localSeq: 5,
+            reads: {
+              confirmed: [{
+                id,
+                scope,
+                path: toDocumentPath(["value"]),
+                seq: 2,
+              }],
+              pending: [],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:sinkB",
+              scope,
+              value: toEntityDocument("x"),
+            }],
+          },
+        }),
+      Error,
+      "stale confirmed read",
+    );
+
+    // C: a SHAPE reader observed at seq 1 MUST still conflict with the seq-2 key
+    // ADD — adding a key changes the key-set the shape read observed.
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId,
+          principal,
+          commit: {
+            localSeq: 6,
+            reads: {
+              confirmed: [{
+                id,
+                scope,
+                path: toDocumentPath(["value"]),
+                seq: 1,
+                nonRecursive: true,
+              }],
+              pending: [],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:sinkC",
+              scope,
+              value: toEntityDocument("y"),
+            }],
+          },
+        }),
+      Error,
+      "stale confirmed read",
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
 Deno.test("memory v2 engine persists set and delete commits as seq revisions", async () => {
   const { engine, path } = await createEngine();
 

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -972,6 +972,225 @@ Deno.test("memory v2 engine: nonRecursive shape read conflicts with array move a
   }
 });
 
+Deno.test("memory v2 engine: leaf-only matcher does NOT conflict on a synthetic indexed-array add (intentional; runner never emits one)", async () => {
+  // DIVERGENCE MARKER. The recursive commit matcher is leaf-only, so an indexed
+  // array `add` (which the engine accepts but the runner never produces) touches
+  // ONLY the added index — it does not conflict a reader of a sibling index.
+  // This is intentional: it keeps commit-conflict aligned with the leaf-only
+  // scheduler reader-dirty index (the invariant #4210 relies on). Production
+  // safety comes from the diff generator never emitting an indexed-array add (see
+  // packages/runner/test/memory-v2-native-commit.test.ts and the
+  // `assertNoIndexedArrayStructuralOps` guard in storage/v2-transaction.ts), NOT
+  // from the matcher conflicting it. Ben's #4307 deliberately diverges here (its
+  // "keeps array add conflicts conservative" test asserts the opposite); that
+  // extra conservatism is what makes #4307 incompatible with #4210, because the
+  // reader-dirty index would not re-trigger the conflicted reader.
+  const { engine, path } = await createEngine();
+  const sessionId = "session:alice";
+  const principal = "did:key:alice";
+  const id = "entity:array-leaf-only";
+
+  try {
+    // seq 1: array seed.
+    applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id,
+          value: toEntityDocument({ poll: { answers: ["bob"] } }),
+        }],
+      },
+    });
+
+    // seq 2: a (synthetic) indexed-array add inserting at index 1.
+    applyCommit(engine, {
+      sessionId: "session:other",
+      principal: "did:key:other",
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id,
+          patches: [{
+            op: "add",
+            path: "/value/poll/answers/1",
+            value: "alice",
+          }],
+        }],
+      },
+    });
+
+    // A reader of the sibling index `answers/0` observed at seq 1 is NOT rejected
+    // by the leaf-only matcher: the seq-2 add touched only `answers/1`. (Here
+    // `answers/0` is in fact unchanged by an insert at index 1, so allowing it is
+    // also semantically correct; the general point is that leaf-only conflicts no
+    // sibling-index reader on an indexed add — hence the runner must never emit
+    // one.)
+    applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 2,
+        reads: {
+          confirmed: [{
+            id,
+            path: toDocumentPath(["value", "poll", "answers", "0"]),
+            seq: 1,
+          }],
+          pending: [],
+        },
+        operations: [{
+          op: "set",
+          id: "entity:derived",
+          value: toEntityDocument({ firstAnswer: "bob" }),
+        }],
+      },
+    });
+    assertEquals(read(engine, { id: "entity:derived" }), {
+      value: { firstAnswer: "bob" },
+    });
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 engine: leaf-only matcher conflicts conservatively with array splice and whole-array replace (the shapes the runner DOES emit)", async () => {
+  // The runner encodes every array length change as a `splice` on the array path
+  // or a whole-array `replace` (never an indexed add/remove). Both carry the
+  // ARRAY's own path, which the leaf-only matcher treats as touching every index
+  // below it — so a recursive reader of any sibling index conflicts. This pins
+  // that leaf-only stays conservative (no false-negative) for the array ops that
+  // actually occur in production, which is what makes #4220 safe given the
+  // divergence-marker test above.
+  const { engine, path } = await createEngine();
+  const sessionId = "session:alice";
+  const principal = "did:key:alice";
+  const id = "entity:array-conservative";
+
+  try {
+    // seq 1: array seed.
+    applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id,
+          value: toEntityDocument({ arr: ["a", "b", "c"] }),
+        }],
+      },
+    });
+
+    // seq 2: a SPLICE on the array path (how the runner encodes a length change).
+    applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id,
+          patches: [{
+            op: "splice",
+            path: "/value/arr",
+            index: 0,
+            remove: 1,
+            add: ["z"],
+          }],
+        }],
+      },
+    });
+
+    // A recursive reader of the sibling index `arr/0` observed at seq 1 MUST
+    // conflict with the seq-2 splice (the splice's array path prefix-matches the
+    // index read) — leaf-only stays conservative for shifts encoded as splice.
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId,
+          principal,
+          commit: {
+            localSeq: 3,
+            reads: {
+              confirmed: [{
+                id,
+                path: toDocumentPath(["value", "arr", "0"]),
+                seq: 1,
+              }],
+              pending: [],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:sinkSplice",
+              value: toEntityDocument("s"),
+            }],
+          },
+        }),
+      Error,
+      "stale confirmed read",
+    );
+
+    // seq 3: a whole-array REPLACE (the runner's fallback for messy shifts).
+    applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 4,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id,
+          patches: [{
+            op: "replace",
+            path: "/value/arr",
+            value: ["p", "q"],
+          }],
+        }],
+      },
+    });
+
+    // A recursive reader of `arr/1` observed at seq 2 MUST conflict with the
+    // seq-3 whole-array replace (replace's array path prefix-matches the read).
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId,
+          principal,
+          commit: {
+            localSeq: 5,
+            reads: {
+              confirmed: [{
+                id,
+                path: toDocumentPath(["value", "arr", "1"]),
+                seq: 2,
+              }],
+              pending: [],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:sinkReplace",
+              value: toEntityDocument("r"),
+            }],
+          },
+        }),
+      Error,
+      "stale confirmed read",
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
 Deno.test("memory v2 engine persists set and delete commits as seq revisions", async () => {
   const { engine, path } = await createEngine();
 

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -836,6 +836,142 @@ Deno.test("memory v2 engine: nonRecursive shape read conflicts with key add but 
   }
 });
 
+Deno.test("memory v2 engine: nonRecursive shape read conflicts with array move and splice patches", async () => {
+  // A non-recursive (keyset / shape) read is matched against a patch via the
+  // parent-injecting `touchedPathsForPatch` (patchOverlapsNonRecursiveRead). The
+  // add/remove arms are covered above; this pins the `move` and `splice` arms —
+  // reordering or splicing an array changes the shape a keyset reader observed,
+  // so it must conflict (the patch's parent path is injected and prefix-matches
+  // the read).
+  const { engine, path } = await createEngine();
+  const sessionId = "session:alice";
+  const principal = "did:key:alice";
+  const id = "entity:array-shape";
+  const scope = "space" as const;
+
+  try {
+    // seq 1: a container holding an array.
+    applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id,
+          scope,
+          value: toEntityDocument({ arr: ["a", "b", "c"] }),
+        }],
+      },
+    });
+
+    // seq 2: a MOVE within the array (reorders elements).
+    applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id,
+          scope,
+          patches: [{ op: "move", from: "/value/arr/0", path: "/value/arr/2" }],
+        }],
+      },
+    });
+
+    // A shape reader of the array observed at seq 1 MUST conflict with the seq-2
+    // move (covers `touchedPathsForPatch`'s `move` arm via the injected parent).
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId,
+          principal,
+          commit: {
+            localSeq: 3,
+            reads: {
+              confirmed: [{
+                id,
+                scope,
+                path: toDocumentPath(["value", "arr"]),
+                seq: 1,
+                nonRecursive: true,
+              }],
+              pending: [],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:sinkMove",
+              scope,
+              value: toEntityDocument("m"),
+            }],
+          },
+        }),
+      Error,
+      "stale confirmed read",
+    );
+
+    // seq 3: a SPLICE on the array (removes an element, adds another).
+    applyCommit(engine, {
+      sessionId,
+      principal,
+      commit: {
+        localSeq: 4,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id,
+          scope,
+          patches: [{
+            op: "splice",
+            path: "/value/arr",
+            index: 0,
+            remove: 1,
+            add: ["z"],
+          }],
+        }],
+      },
+    });
+
+    // A shape reader observed at seq 2 (after the move, before the splice) MUST
+    // conflict with the seq-3 splice (covers `touchedPathsForPatch`'s `splice`
+    // arm: the spliced array path prefix-matches the keyset read).
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId,
+          principal,
+          commit: {
+            localSeq: 5,
+            reads: {
+              confirmed: [{
+                id,
+                scope,
+                path: toDocumentPath(["value", "arr"]),
+                seq: 2,
+                nonRecursive: true,
+              }],
+              pending: [],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:sinkSplice",
+              scope,
+              value: toEntityDocument("s"),
+            }],
+          },
+        }),
+      Error,
+      "stale confirmed read",
+    );
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
 Deno.test("memory v2 engine persists set and delete commits as seq revisions", async () => {
   const { engine, path } = await createEngine();
 

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -114,6 +114,16 @@ export interface ConfirmedRead {
   branch?: BranchName;
   path: ReadPath;
   seq: number;
+  /**
+   * When true, this is a SHALLOW (shape-only) read — the reader observed the
+   * container at `path` (its key set / existence) but did NOT depend on the deep
+   * values of its descendants. The engine then conflicts only with writes
+   * AT-OR-ABOVE `path` (including key add/remove, whose patch injects the parent
+   * path), not with disjoint deep-value writes strictly below `path`. Strict
+   * subset of the recursive overlap ⇒ never a false-negative. Absent/false ⇒
+   * recursive read (the historical behavior).
+   */
+  nonRecursive?: boolean;
 }
 
 export interface PendingRead {
@@ -121,6 +131,8 @@ export interface PendingRead {
   scope?: CellScope;
   path: ReadPath;
   localSeq: number;
+  /** See {@link ConfirmedRead.nonRecursive}. */
+  nonRecursive?: boolean;
 }
 
 export interface SchedulerObservationCommit {

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -2,7 +2,12 @@ import { Database } from "@db/sqlite";
 import type { FabricValue } from "@commonfabric/api";
 import { runWrite } from "./sqlite/exec.ts";
 import { applyPatch } from "./patch.ts";
-import { parentPath, parsePointer, pathsOverlap } from "./path.ts";
+import {
+  isPrefixPath,
+  parentPath,
+  parsePointer,
+  pathsOverlap,
+} from "./path.ts";
 import {
   type BranchName,
   type CellScope,
@@ -3506,6 +3511,7 @@ const validateConfirmedReads = (
       scopeKey,
       read.seq,
       read.path,
+      read.nonRecursive ?? false,
     );
     if (conflictSeq !== null) {
       throw new ConflictError(
@@ -3551,6 +3557,7 @@ const resolvePendingReads = (
       resolveScopeKey(read.scope, { principal, sessionId }),
       resolution.seq,
       read.path,
+      read.nonRecursive ?? false,
     );
     if (conflictSeq !== null) {
       throw new ConflictError(
@@ -3569,6 +3576,12 @@ const findConflictSeq = (
   scopeKey: string,
   afterSeq: number,
   readPath: readonly string[],
+  // When true, treat `readPath` as a SHALLOW (shape-only) dependency — conflict
+  // only with writes at-or-above it (patchOverlapsNonRecursiveRead). Tier-1
+  // (set/delete) stays path-blind even for a shallow read: a whole-doc
+  // replace/delete changes the container the shape read observed, so it must
+  // still conflict. Only Tier-2 (patch) granularity is refined.
+  nonRecursive: boolean = false,
 ): number | null => {
   const setOrDeleteConflict = engine.statements.selectSetDeleteConflict.get({
     branch,
@@ -3591,12 +3604,11 @@ const findConflictSeq = (
       data: string | null;
     }>
   ) {
-    if (
-      patchOverlapsRead(
-        decodeStoredPatchList(conflict.data),
-        readPath,
-      )
-    ) {
+    const patches = decodeStoredPatchList(conflict.data);
+    const overlaps = nonRecursive
+      ? patchOverlapsNonRecursiveRead(patches, readPath)
+      : patchOverlapsRead(patches, readPath);
+    if (overlaps) {
       return conflict.seq;
     }
   }
@@ -3635,6 +3647,7 @@ const schedulerObservationReadDropReason = (
       scopeKey,
       read.seq,
       read.path,
+      read.nonRecursive ?? false,
     );
     if (conflictSeq !== null) {
       return "stale-confirmed-read";
@@ -3666,6 +3679,7 @@ const schedulerObservationReadDropReason = (
       resolveScopeKey(read.scope, { principal, sessionId }),
       resolution.seq,
       read.path,
+      read.nonRecursive ?? false,
     );
     if (conflictSeq !== null) {
       return "stale-pending-read";
@@ -3866,12 +3880,43 @@ const applySchedulerObservationBatchCommit = (
   };
 };
 
+// The COMMIT conflict matcher uses LEAF-ONLY touched paths (no add/remove/move
+// parent-path injection) — the same discipline `touchedLeafPathsForPatch`
+// applies to the scheduler reader-dirty index (CT-1623), here extended to the
+// commit-conflict path. For a recursive read the injected parent is REDUNDANT
+// (bidirectional `pathsOverlap` already matches a container reader against the
+// leaf write, since the container read is a prefix of the leaf) and HARMFUL (the
+// parent prefix-matches every disjoint SIBLING reader — e.g. a distinct-key
+// writer's own-key/diff and link-resolution reads — manufacturing the
+// write-contention over-conflict). Same-key writes still conflict (the leaf
+// exactly matches an own-key read) and whole-container readers still conflict
+// (their read prefixes the leaf). Keyset/shape readers are matched separately by
+// the nonRecursive path, which keeps the parent injection.
 const patchOverlapsRead = (
   patches: readonly PatchOp[],
   readPath: readonly string[],
 ): boolean => {
   return patches.some((patch) =>
-    touchedPathsForPatch(patch).some((path) => pathsOverlap(path, readPath))
+    touchedLeafPathsForPatch(patch).some((path) => pathsOverlap(path, readPath))
+  );
+};
+
+// Overlap test for a SHALLOW (nonRecursive / shape-only) read. A shape read at
+// `readPath` observed the container's key-set / existence but not its descendants'
+// deep values, so it conflicts only with a write touching `readPath` itself or an
+// ANCESTOR of it — `isPrefixPath(touched, readPath)`. Here we DO use the
+// parent-injecting `touchedPathsForPatch`: a key add/remove injects the patch's
+// parent path, which equals `readPath` for a direct child mutation, so a keyset
+// reader still conflicts with key add/remove (the shape it observed changed). A
+// disjoint deep-value `replace` strictly BELOW `readPath` touches no ancestor, so
+// it no longer over-conflicts. Strict subset of `patchOverlapsRead` ⇒ never a
+// false-negative. (Recursive reads use the leaf-only `patchOverlapsRead` above.)
+const patchOverlapsNonRecursiveRead = (
+  patches: readonly PatchOp[],
+  readPath: readonly string[],
+): boolean => {
+  return patches.some((patch) =>
+    touchedPathsForPatch(patch).some((path) => isPrefixPath(path, readPath))
   );
 };
 
@@ -3894,27 +3939,28 @@ const touchedPathsForPatch = (patch: PatchOp): string[][] => {
   }
 };
 
-// Scheduler reader-dirty propagation uses the EXACT changed leaf paths, not the
-// ancestor/parent paths that `touchedPathsForPatch` adds for add/remove/move.
+// The EXACT changed leaf paths of a patch — without the ancestor/parent paths
+// that `touchedPathsForPatch` adds for add/remove/move. Used by BOTH the
+// scheduler reader-dirty index (`schedulerWriteAddressesForRevisions`) and the
+// commit-conflict matcher (`patchOverlapsRead`).
 //
 // `touchedPathsForPatch` emits a patch's parent path so that whole-container
-// reads are invalidated when a key is added/removed. For the scheduler reader
-// index that parent path is both REDUNDANT and HARMFUL:
-//   - Redundant: `schedulerPathsOverlap` matches a reader of the container
-//     (e.g. read `["value"]`, deep or shallow) against the LEAF write
-//     (e.g. `["value","plusOne"]`) via its bidirectional / length+1 rules, so
-//     shape/whole-object readers are already dirtied by the leaf alone.
+// reads are invalidated when a key is added/removed. For structural-overlap
+// matching that parent path is both REDUNDANT and HARMFUL:
+//   - Redundant: bidirectional prefix overlap already matches a reader of the
+//     container (e.g. read `["value"]`) against the LEAF write
+//     (e.g. `["value","plusOne"]`) — the container read is a prefix of the leaf —
+//     so shape/whole-object readers are caught by the leaf alone.
 //   - Harmful: the parent write (e.g. `["value"]`) ALSO prefix-matches every
-//     SIBLING reader (`["value","doubled"]`, ...), whose value did not change.
-//     Unlike the in-memory `determineTriggeredActions` (which deep-equals each
-//     read path), the server-side match is purely structural, so those siblings
-//     are marked dirty in `scheduler_action_state` even though they are
-//     unchanged. On reload they rehydrate-as-dirty and re-run — the dominant
-//     residual reload re-run for patterns whose computeds write sibling fields
-//     of a shared result cell (CT-1623).
-// Emitting only the leaf paths keeps every correct match and drops the spurious
-// sibling dirtying.
-const schedulerTouchedLeafPathsForPatch = (patch: PatchOp): string[][] => {
+//     disjoint SIBLING reader (`["value","doubled"]`, ...), whose value did not
+//     change. The structural match has no way to tell the sibling is unchanged,
+//     so it over-fires: spurious reload re-runs for the scheduler index
+//     (CT-1623), and spurious commit conflicts for distinct-key writers (the
+//     write-contention drops). Emitting only the leaf paths keeps every correct
+//     match and drops the spurious sibling match. Keyset/shape (nonRecursive)
+//     readers, which DO need to see key add/remove, are matched by a separate
+//     path that retains `touchedPathsForPatch`'s parent injection.
+const touchedLeafPathsForPatch = (patch: PatchOp): string[][] => {
   switch (patch.op) {
     case "replace":
     case "splice":
@@ -3934,7 +3980,7 @@ const schedulerWriteAddressesForRevisions = (
   const writes = new Map<string, SchedulerObservationAddress>();
   for (const revision of revisions) {
     const paths = revision.op === "patch" && revision.patches
-      ? revision.patches.flatMap(schedulerTouchedLeafPathsForPatch)
+      ? revision.patches.flatMap(touchedLeafPathsForPatch)
       : [[]];
     for (const path of paths) {
       const write = normalizeSchedulerAddress({

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -194,7 +194,18 @@ export function createQueryResultProxy<T>(
   // directly, exactly as for JS primitives above; wrapping one in a live proxy
   // serves no purpose and would leak that proxy into any consumer that
   // deep-clones or freezes the surrounding value (e.g. schema interning).
-  if (!isRecord(value) || value instanceof FabricPrimitive) return value;
+  if (!isRecord(value) || value instanceof FabricPrimitive) {
+    // The SHAPE_READ above tracks only the container's shape, but a
+    // FabricPrimitive is an atomic VALUE the consumer materializes here (handed
+    // back directly, like a JS primitive), not a container whose shape it
+    // inspects. Register a recursive value read so an in-place change to the
+    // primitive (e.g. a FabricBytes updated to different bytes) re-triggers
+    // consumers — a nonRecursive read is compared shape-only and would miss it.
+    if (value instanceof FabricPrimitive) {
+      readTx.readValueOrThrow(link);
+    }
+    return value;
+  }
 
   // TODO(danfuzz): This may have to do something special to handle concrete
   // instances of `FabricInstance` so that they get perceived as such by the

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -172,6 +172,14 @@ export function createQueryResultProxy<T>(
   ]);
   const value = readTx.readValueOrThrow(link, SHAPE_READ) as any;
 
+  // The SHAPE_READ above only tracks the container's shape, but the stream
+  // check depends on a specific field's VALUE. Register an explicit read of
+  // `$stream` when present, so a value flipping into/out of a stream marker
+  // re-triggers consumers. [review: ubik2]
+  if (isRecord(value) && "$stream" in value) {
+    readTx.readValueOrThrow({ ...link, path: [...link.path, "$stream"] });
+  }
+
   // If the value is a stream marker ({ $stream: true }), return a Cell with
   // stream kind so that .send() is available. This handles the case where a
   // pattern's Output type wasn't explicitly specified, causing the capture
@@ -491,7 +499,9 @@ export function createQueryResultProxy<T>(
     getOwnPropertyDescriptor: (target, prop) => {
       if (Array.isArray(target) && prop === "length") {
         const readTx = runtime.readTx(tx);
-        const current = readTx.readValueOrThrow(link, SHAPE_READ);
+        // Read the array fully (not SHAPE_READ) so the length descriptor tracks
+        // element add/remove, matching the `length` get trap above. [review: ubik2]
+        const current = readTx.readValueOrThrow(link);
         return {
           configurable: false,
           enumerable: false,

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -9,7 +9,10 @@ import { resolveLink } from "./link-resolution.ts";
 import { type NormalizedFullLink } from "./link-utils.ts";
 import { type Cell, createCell, recursivelyAddIDIfNeeded } from "./cell.ts";
 import { type Runtime } from "./runtime.ts";
-import { type IExtendedStorageTransaction } from "./storage/interface.ts";
+import {
+  type IExtendedStorageTransaction,
+  type IReadOptions,
+} from "./storage/interface.ts";
 import { toURI } from "./uri-utils.ts";
 import {
   type CfcLabelView,
@@ -21,6 +24,14 @@ import {
 
 // Maximum recursion depth to prevent infinite loops
 const MAX_RECURSION_DEPTH = 100;
+
+// Container/shape reads (proxy creation, ownKeys, getOwnPropertyDescriptor, has,
+// array length) are recorded as nonRecursive so the engine applies shallow
+// (shape-only) conflict granularity to them — matching how the scheduler
+// reader-dirty index already treats nonRecursive reads. Value materialization
+// (leaf scalars via child-proxy creation, array methods that consume elements)
+// stays recursive.
+const SHAPE_READ: IReadOptions = { nonRecursive: true };
 
 // Cache of target objects to their proxies, scoped by ReactivityLog
 type ProxyCache = {
@@ -159,7 +170,7 @@ export function createQueryResultProxy<T>(
       readTx.getCfcState().dereferenceTraces.slice(traceStart),
     ),
   ]);
-  const value = readTx.readValueOrThrow(link) as any;
+  const value = readTx.readValueOrThrow(link, SHAPE_READ) as any;
 
   // If the value is a stream marker ({ $stream: true }), return a Cell with
   // stream kind so that .send() is available. This handles the case where a
@@ -471,7 +482,7 @@ export function createQueryResultProxy<T>(
     },
     ownKeys: () => {
       const readTx = runtime.readTx(tx);
-      const current = readTx.readValueOrThrow(link);
+      const current = readTx.readValueOrThrow(link, SHAPE_READ);
       if (isRecord(current) || Array.isArray(current)) {
         return Reflect.ownKeys(current);
       }
@@ -480,7 +491,7 @@ export function createQueryResultProxy<T>(
     getOwnPropertyDescriptor: (target, prop) => {
       if (Array.isArray(target) && prop === "length") {
         const readTx = runtime.readTx(tx);
-        const current = readTx.readValueOrThrow(link);
+        const current = readTx.readValueOrThrow(link, SHAPE_READ);
         return {
           configurable: false,
           enumerable: false,
@@ -500,7 +511,7 @@ export function createQueryResultProxy<T>(
         return Object.getOwnPropertyDescriptor(value, prop);
       }
       const readTx = runtime.readTx(tx);
-      const current = readTx.readValueOrThrow(link) as typeof value;
+      const current = readTx.readValueOrThrow(link, SHAPE_READ) as typeof value;
       if ((isRecord(current) || Array.isArray(current)) && prop in current) {
         return {
           configurable: true,
@@ -523,7 +534,7 @@ export function createQueryResultProxy<T>(
         return prop in value;
       }
       const readTx = runtime.readTx(tx);
-      const current = readTx.readValueOrThrow(link);
+      const current = readTx.readValueOrThrow(link, SHAPE_READ);
       if (isRecord(current) || Array.isArray(current)) {
         return prop in current;
       }

--- a/packages/runner/src/reactive-dependencies.ts
+++ b/packages/runner/src/reactive-dependencies.ts
@@ -270,6 +270,19 @@ function commonPrefixLength(
  * - Objects: changed iff the key set changed (not the values).
  * - Arrays: changed iff the key set changed (not the values).
  * - Primitives: changed iff the value changed.
+ *
+ * NOTE: FabricSpecialObjects (FabricBytes / other FabricPrimitives) are NOT
+ * meaningfully handled here. They hold state in private fields with zero
+ * enumerable own-props, so the object branch below compares them by their
+ * (empty) key set and calls any two "unchanged" — detecting neither an in-place
+ * value change nor a class/type change. They are kept off this path upstream:
+ * query-result-proxy materializes a FabricPrimitive as an atomic value (a
+ * recursive read), so its change-detection runs through `valueEqual`, not here.
+ * And the intended behavior here is genuinely ambiguous: for an opaque, keyless
+ * leaf, should a "shallow" read react to a class/type change (its shape) or to
+ * any value change (it being atomic)? We don't decide — if a FabricSpecialObject
+ * ever reaches here via a nonRecursive read, treat it as an unhandled gap, not
+ * defined behavior.
  */
 function shallowEqual(
   before: FabricValue,

--- a/packages/runner/src/storage/reactivity-log.ts
+++ b/packages/runner/src/storage/reactivity-log.ts
@@ -95,6 +95,30 @@ export function isSchedulerDependencyRead(meta?: Metadata): boolean {
   return meta?.[schedulerDependencyReadMarker] === true;
 }
 
+const excludeReadFromConflictMarker: unique symbol = Symbol(
+  "excludeReadFromConflictMarker",
+);
+
+/**
+ * Marks reads that resolve a REFERENCE rather than consume a value, so they must
+ * NOT be recorded as commit-time conflict dependencies. Building an asCell
+ * argument follows its write-redirect link (followPointer reads the target's
+ * shape), but the handler depends on the referent's VALUE only if it reads
+ * THROUGH the cell in its body — those reads are recorded separately and stay
+ * unmarked. The marked materialization reads remain in the journal for
+ * reactivity; only buildReads (the conflict set) excludes them. This is the same
+ * mechanism #4199 applied to Cell.set's link resolution, here applied to the
+ * argument-materialization seam where the probe's over-conflict actually lives.
+ * Orthogonal to schedulerDependencyRead and attemptedWrite.
+ */
+export const excludeReadFromConflict: Metadata = {
+  [excludeReadFromConflictMarker]: true,
+};
+
+export function isReadExcludedFromConflict(meta?: Metadata): boolean {
+  return meta?.[excludeReadFromConflictMarker] === true;
+}
+
 export function reactivityLogFromActivities(
   activities: Iterable<Activity>,
 ): TransactionReactivityLog {

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -9,7 +9,11 @@ import type {
   PatchOp,
   SqliteOperation,
 } from "@commonfabric/memory/v2";
-import { encodePointer, pathsOverlap } from "../../../memory/v2/path.ts";
+import {
+  encodePointer,
+  parsePointer,
+  pathsOverlap,
+} from "../../../memory/v2/path.ts";
 import { PathKeyMap } from "@commonfabric/utils/path-key-map";
 import type { FabricValue } from "@commonfabric/api";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -605,6 +609,59 @@ const buildArrayPatchCandidates = (
   }
 
   return candidates;
+};
+
+// A concrete RFC 6901 array-index segment: a non-negative integer with no
+// leading zeros. Mirrors `isArraySegment` in memory/v2/patch.ts. The `-` append
+// marker is intentionally NOT an index — appending never shifts existing
+// elements, so a leaf-only matcher handles it conservatively via the array path.
+const ARRAY_INDEX_SEGMENT = /^(0|[1-9]\d*)$/;
+
+const terminalSegmentIsArrayIndex = (pointer: string): boolean => {
+  const segments = parsePointer(pointer);
+  const last = segments[segments.length - 1];
+  return last !== undefined && ARRAY_INDEX_SEGMENT.test(last);
+};
+
+// Generator invariant guard (see docs/specs/memory-v2/08-conflict-granularity.md
+// §"Array writes and the leaf-only matcher"). The commit-conflict matcher and
+// the scheduler reader-dirty index are both LEAF-ONLY, which is sound only if
+// array element insert/remove/reorder reaches the engine as a `splice` on the
+// array path or a whole-array `replace` — never as an `add`/`remove`/`move` at an
+// array INDEX. Such an op SHIFTS sibling elements, but its leaf path captures
+// only the touched index, so a leaf-only matcher would neither conflict (commit)
+// nor re-trigger (reader-dirty) a reader of a shifted sibling — a silent stale
+// read. `buildArrayPatchCandidates` only ever emits per-index `replace`,
+// array-path `splice`, or whole-array `replace`, so this assertion can never fire
+// for real input; it converts a future regression in the array diff path into a
+// loud failure instead of silent data loss. (A numeric *object* key is flagged
+// too — the generator never emits a structural op on one either.)
+const assertNoIndexedArrayStructuralOps = (
+  patches: readonly PatchOp[],
+): void => {
+  for (const patch of patches) {
+    let offending: string | null = null;
+    if (patch.op === "add" || patch.op === "remove") {
+      if (terminalSegmentIsArrayIndex(patch.path)) offending = patch.path;
+    } else if (patch.op === "move") {
+      if (
+        terminalSegmentIsArrayIndex(patch.path) ||
+        terminalSegmentIsArrayIndex(patch.from)
+      ) {
+        offending = `${patch.from} -> ${patch.path}`;
+      }
+    }
+    if (offending !== null) {
+      throw new Error(
+        `v2 patch generator invariant violation: emitted an indexed-array ` +
+          `${patch.op} (${offending}). Array element insert/remove/reorder must ` +
+          `be a splice on the array path or a whole-array replace; an indexed ` +
+          `add/remove/move shifts siblings that the leaf-only conflict and ` +
+          `reader-dirty matchers cannot track (see ` +
+          `docs/specs/memory-v2/08-conflict-granularity.md).`,
+      );
+    }
+  }
 };
 
 const isPrefixPath = (
@@ -2230,6 +2287,8 @@ export class V2StorageTransaction implements IStorageTransaction {
       ...nonOverlappingCoverCandidates.map((candidate) => candidate.patch),
       ...retainedNonCoverCandidates.map((candidate) => candidate.patch),
     ];
+
+    assertNoIndexedArrayStructuralOps(patches);
 
     return { op: "patch", id, type, scope, patches, value: doc.current.value };
   }

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -636,7 +636,11 @@ const terminalSegmentIsArrayIndex = (pointer: string): boolean => {
 // for real input; it converts a future regression in the array diff path into a
 // loud failure instead of silent data loss. (A numeric *object* key is flagged
 // too — the generator never emits a structural op on one either.)
-const assertNoIndexedArrayStructuralOps = (
+//
+// Exported for direct unit testing: the throw and `move` paths are unreachable
+// through the generator (which is the invariant), so they can only be exercised
+// by calling this with hand-built patches.
+export const assertNoIndexedArrayStructuralOps = (
   patches: readonly PatchOp[],
 ): void => {
   for (const patch of patches) {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -77,6 +77,7 @@ import type {
 import { SelectorTracker } from "./selector-tracker.ts";
 import * as SubscriptionManager from "./subscription.ts";
 import { getDirectTransactionReadActivities } from "./transaction-inspection.ts";
+import { isReadExcludedFromConflict } from "./reactivity-log.ts";
 import { toTransactionDocumentValue } from "./v2-document.ts";
 import { hasValueAtPath, readValueAtPath } from "./v2-path.ts";
 import {
@@ -2104,6 +2105,16 @@ class SpaceReplica implements ISpaceReplica {
         continue;
       }
 
+      // Reference-resolution reads (e.g. asCell argument materialization following
+      // a write-redirect to construct the Cell) are tagged excludeReadFromConflict.
+      // Scoped to NONRECURSIVE (shape/topology) reads: those resolve a reference,
+      // not consume a value, so they must not enter the conflict set (they stay in
+      // the journal for reactivity). A RECURSIVE read in the same scope is a real
+      // value dependency (a by-value arg) and is kept. Inert unless reads are marked.
+      if (isReadExcludedFromConflict(read.meta) && read.nonRecursive === true) {
+        continue;
+      }
+
       const scope = normalizeCellScope(read.scope);
       const record = this.#docs.get(docKey(read.id as URI, scope));
       const pendingLocalSeq = record?.pending
@@ -2129,13 +2140,13 @@ class SpaceReplica implements ISpaceReplica {
         });
       }
     }
+    // Keep the nonRecursive flag on the reads sent to the engine (it was
+    // historically stripped here). The engine applies shallow (shape-only)
+    // conflict granularity to nonRecursive reads (patchOverlapsNonRecursiveRead),
+    // matching how the scheduler reader-dirty index already treats them.
     return {
-      confirmed: compactCommitReads(this.#space, confirmed).map((
-        { nonRecursive: _skip, ...read },
-      ) => read),
-      pending: compactCommitReads(this.#space, pending).map((
-        { nonRecursive: _skip, ...read },
-      ) => read),
+      confirmed: compactCommitReads(this.#space, confirmed),
+      pending: compactCommitReads(this.#space, pending),
     };
   }
 

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -62,7 +62,10 @@ import type {
   WriterError,
 } from "./storage/interface.ts";
 import { createReadOnlyTransactionError } from "./storage/interface.ts";
-import { ignoreReadForScheduling } from "./storage/reactivity-log.ts";
+import {
+  excludeReadFromConflict,
+  ignoreReadForScheduling,
+} from "./storage/reactivity-log.ts";
 import { resolve } from "./storage/transaction/attestation.ts";
 import {
   type IMemorySpaceValueAddress,
@@ -3648,8 +3651,22 @@ export class SchemaObjectTraverser<V extends FabricValue>
         filteredObj[propKey] = val;
       } else {
         const propDoc = { address: propAddress, value: propValue };
-        this.tx.read(propDoc.address, READ_NON_RECURSIVE_FOR_SCHEDULING);
-        const { ok: val, error } = this.traverseWithSchema(propDoc, propSchema);
+        // When the property is asCell (and reaches here as a sigil link rather
+        // than the inline-value branch above), the descent + pointer resolution
+        // only RESOLVE THE REFERENCE to construct the Cell — they read the link
+        // target's shape, not a value the holder consumes. Those reads must not
+        // become commit-time conflict dependencies (a holder of a reference must
+        // not collide with disjoint writers under the referent's container). They
+        // stay in the journal for reactivity; the holder takes a real dependency
+        // only when it reads THROUGH the Cell in its body. A by-value property
+        // (`hasAsCell` false) is a genuine dependency and is left unmarked.
+        const descend = () => {
+          this.tx.read(propDoc.address, READ_NON_RECURSIVE_FOR_SCHEDULING);
+          return this.traverseWithSchema(propDoc, propSchema);
+        };
+        const { ok: val, error } = SchemaObjectTraverser.hasAsCell(propSchema)
+          ? this.tx.runWithAmbientReadMeta(excludeReadFromConflict, descend)
+          : descend();
         if (error === undefined) {
           filteredObj[propKey] = val;
         }

--- a/packages/runner/test/ascell-link-read-through-conflict.test.ts
+++ b/packages/runner/test/ascell-link-read-through-conflict.test.ts
@@ -1,0 +1,119 @@
+// Verification for review feedback (ubik2/robin) on #4220's Half A
+// (excludeReadFromConflict): excluding the asCell *reference-resolution* read
+// from the commit-conflict set must NOT exclude a value read *through* the link.
+// A holder that reads a linked value and branches on it still depends on that
+// value — a concurrent change to it must invalidate the holder's commit.
+//
+// Scenario (robin's example):
+//   cellB = { isAdmin: true }
+//   cellA = { isAdmin -> link to cellB.isAdmin }   (read via an asCell schema)
+//   holder reads cellA.isAdmin THROUGH the link (consuming `true`) and writes.
+//   A concurrent writer sets cellB.isAdmin = false.
+//   => the holder's commit must conflict.
+
+import { assert } from "@std/assert";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase(
+  "ascell-link-read-through-conflict",
+);
+const space = signer.did();
+
+const asCellSchema = {
+  type: "object",
+  properties: { isAdmin: { asCell: ["cell"] } },
+  required: ["isAdmin"],
+} as const satisfies JSONSchema;
+
+describe("asCell link: value read-through stays a commit-conflict dependency", () => {
+  let storage: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storage = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: storage,
+    });
+    tx = runtime.edit();
+  });
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storage?.close();
+  });
+
+  // Seed cellB = { isAdmin: true } and cellA = { isAdmin: <link to cellB.isAdmin> }.
+  const seed = async () => {
+    const cellB = runtime.getCell<{ isAdmin: boolean }>(
+      space,
+      "cellB",
+      undefined,
+      tx,
+    );
+    cellB.set({ isAdmin: true });
+    const cellA = runtime.getCell(space, "cellA", true, tx);
+    cellA.setRaw({ isAdmin: cellB.key("isAdmin").getAsLink() });
+    await tx.commit();
+    tx = runtime.edit();
+    return { cellA, cellB };
+  };
+
+  it("the read-through lands in the commit-conflict set", async () => {
+    const { cellA, cellB } = await seed();
+
+    const holder = cellA.withTx(tx).asSchema(asCellSchema).get() as unknown as {
+      isAdmin: { get: () => boolean };
+    };
+    expect(holder.isAdmin.get()).toBe(true);
+
+    const replica = storage.open(space).replica as unknown as {
+      buildReads(source: unknown, localSeq: number): {
+        confirmed: Array<{ id: string; path: string[] }>;
+      };
+    };
+    const confirmed = replica.buildReads(tx.tx, 1).confirmed;
+    const cellBId = cellB.getAsNormalizedFullLink().id;
+    assert(
+      confirmed.some((r) => r.id === cellBId && r.path.includes("isAdmin")),
+      "cellB.isAdmin (the linked value) must be a commit-conflict dependency; " +
+        `confirmed = ${
+          confirmed.map((r) => r.id.slice(-6) + "/" + r.path.join("."))
+        }`,
+    );
+  });
+
+  it("a concurrent change to the linked value conflicts the holder's commit", async () => {
+    const { cellA, cellB } = await seed();
+    const cellC = runtime.getCell<string>(space, "cellC", undefined, tx);
+
+    // Holder: read isAdmin through the link, branch, write — keep tx open.
+    const holder = cellA.withTx(tx).asSchema(asCellSchema).get() as unknown as {
+      isAdmin: { get: () => boolean };
+    };
+    const isAdmin = holder.isAdmin.get();
+    expect(isAdmin).toBe(true);
+    if (isAdmin) cellC.withTx(tx).set("allowed because isAdmin was true");
+
+    // Concurrent writer flips the linked value.
+    const writerTx = runtime.edit();
+    cellB.withTx(writerTx).key("isAdmin").set(false);
+    expect((await writerTx.commit()).ok).toBeDefined();
+
+    // The holder's late commit must be rejected — it read a value that changed.
+    const committed = await tx.commit();
+    assert(
+      committed.error !== undefined,
+      "holder's commit must conflict (it read cellB.isAdmin, which changed); " +
+        `got ok=${JSON.stringify(committed.ok)}`,
+    );
+    tx = runtime.edit();
+  });
+});

--- a/packages/runner/test/memory-v2-native-commit.test.ts
+++ b/packages/runner/test/memory-v2-native-commit.test.ts
@@ -1,4 +1,10 @@
-import { assert, assertEquals, assertExists, assertRejects } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertThrows,
+} from "@std/assert";
 import { fromFileUrl } from "@std/path/from-file-url";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { Identity } from "@commonfabric/identity";
@@ -12,6 +18,7 @@ import type {
 } from "../src/storage/interface.ts";
 import type { PatchOp } from "@commonfabric/memory/v2";
 import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import { assertNoIndexedArrayStructuralOps } from "../src/storage/v2-transaction.ts";
 
 const signer = await Identity.fromPassphrase("memory-v2-native-commit");
 const space = signer.did();
@@ -1242,5 +1249,40 @@ Deno.test("v2 patch generator never emits indexed-array add/remove/move (leaf-on
     assert(seen.has("replace"), `expected a replace op; saw ${[...seen]}`);
   } finally {
     await storage.close();
+  }
+});
+
+Deno.test("assertNoIndexedArrayStructuralOps rejects indexed-array structural ops and allows the rest", () => {
+  // The guard's throw and `move` paths are unreachable through the diff generator
+  // (that's the invariant the previous test pins), so they're exercised directly
+  // here with hand-built patches.
+  const rejected: PatchOp[][] = [
+    [{ op: "add", path: "/value/arr/1", value: "x" }],
+    [{ op: "remove", path: "/value/arr/2" }],
+    [{ op: "add", path: "/value/arr/0", value: "x" }],
+    [{ op: "remove", path: "/value/arr/10" }],
+    // move: numeric on `path`, and numeric on `from` (covers both operands).
+    [{ op: "move", from: "/value/arr/0", path: "/value/arr/2" }],
+    [{ op: "move", from: "/value/arr/0", path: "/value/obj/k" }],
+  ];
+  for (const patches of rejected) {
+    assertThrows(
+      () => assertNoIndexedArrayStructuralOps(patches),
+      Error,
+      "indexed-array",
+    );
+  }
+
+  const allowed: PatchOp[][] = [
+    [{ op: "add", path: "/value/obj/key", value: "x" }], // object key, not index
+    [{ op: "remove", path: "/value/obj/key" }],
+    [{ op: "add", path: "/value/arr/-", value: "x" }], // append marker, not index
+    [{ op: "replace", path: "/value/arr/0", value: "x" }], // in-place, no shift
+    [{ op: "splice", path: "/value/arr", index: 0, remove: 1, add: ["z"] }],
+    [{ op: "move", from: "/value/a", path: "/value/b" }], // object-key move
+    [],
+  ];
+  for (const patches of allowed) {
+    assertNoIndexedArrayStructuralOps(patches); // must not throw
   }
 });

--- a/packages/runner/test/memory-v2-native-commit.test.ts
+++ b/packages/runner/test/memory-v2-native-commit.test.ts
@@ -10,6 +10,8 @@ import type {
   StorageTransactionRejected,
   Unit,
 } from "../src/storage/interface.ts";
+import type { PatchOp } from "@commonfabric/memory/v2";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
 
 const signer = await Identity.fromPassphrase("memory-v2-native-commit");
 const space = signer.did();
@@ -1101,6 +1103,143 @@ Deno.test("memory v2 transactions keep materialized-parent writes as fine-graine
         ],
       }],
     }]);
+  } finally {
+    await storage.close();
+  }
+});
+
+Deno.test("v2 patch generator never emits indexed-array add/remove/move (leaf-only matcher invariant)", async () => {
+  // The commit-conflict matcher (memory/v2/engine.ts patchOverlapsRead) and the
+  // scheduler reader-dirty index (schedulerTouchedLeafPathsForPatch) are both
+  // LEAF-ONLY. That is sound only if array element insert/remove/reorder reaches
+  // the engine as a `splice` on the array path or a whole-array `replace` — never
+  // as an indexed `add`/`remove`/`move`, which shift sibling indices that the
+  // leaf-only matchers cannot track (a reader of a shifted sibling would neither
+  // conflict on commit nor re-trigger via reader-dirty). This test pins that the
+  // diff generator upholds that invariant for every array idiom a pattern can
+  // express through cell writes. The runtime guard
+  // `assertNoIndexedArrayStructuralOps` (v2-transaction.ts) would also throw on a
+  // regression; this test inspects the emitted ops independently so a regression
+  // surfaces as a clear diff, not only via the guard.
+  const { storage, drafts } = captureNativeDrafts();
+  const id = "of:memory-v2-array-shape-invariant";
+
+  const isIndexSegment = (segment: string | undefined): boolean =>
+    segment !== undefined && /^(0|[1-9]\d*)$/.test(segment);
+  const terminalIsIndex = (pointer: string): boolean =>
+    isIndexSegment(pointer.split("/").at(-1));
+  const offendingOps = (patches: readonly PatchOp[]): PatchOp[] =>
+    patches.filter((patch) =>
+      ((patch.op === "add" || patch.op === "remove") &&
+        terminalIsIndex(patch.path)) ||
+      (patch.op === "move" &&
+        (terminalIsIndex(patch.path) || terminalIsIndex(patch.from)))
+    );
+  const patchesInDrafts = (): PatchOp[] =>
+    drafts.flatMap((draft) =>
+      draft.operations.flatMap((operation) =>
+        operation.op === "patch" ? operation.patches : []
+      )
+    );
+
+  const writeItems = async (value: FabricValue): Promise<void> => {
+    const tx = storage.edit();
+    assert(tx.write({ space, id, type, path: ["value", "items"] }, value).ok);
+    assert((await tx.commit()).ok);
+  };
+
+  // Set `base`, then diff to `next` (exactly how cell.set / cell.push /
+  // cell.remove reconstruct and write the whole array). Returns the op kinds the
+  // generator emitted, after asserting none was an indexed-array structural op.
+  const safeDiff = async (
+    label: string,
+    base: FabricValue[],
+    next: FabricValue[],
+  ): Promise<string[]> => {
+    await writeItems(base);
+    drafts.length = 0;
+    await writeItems(next);
+    const patches = patchesInDrafts();
+    assertEquals(
+      offendingOps(patches),
+      [],
+      `idiom "${label}" emitted an indexed-array structural op: ${
+        JSON.stringify(patches)
+      }`,
+    );
+    return patches.map((patch) => patch.op);
+  };
+
+  try {
+    // Seed with a sentinel distinct from every `base` below so each safeDiff's
+    // base-write is a real change (no no-op commit on the first iteration).
+    const seed = storage.edit();
+    assert(
+      seed.write({ space, id, type, path: [] }, {
+        value: { items: ["seed"] },
+      }).ok,
+    );
+    assert((await seed.commit()).ok);
+
+    const seen = new Set<string>();
+    const record = (ops: string[]) => ops.forEach((op) => seen.add(op));
+
+    const scalars = ["a", "b", "c"];
+    record(await safeDiff("tail append (push)", scalars, ["a", "b", "c", "d"]));
+    record(await safeDiff("tail shrink (pop)", scalars, ["a", "b"]));
+    record(await safeDiff("head insert (unshift)", scalars, ["x", ...scalars]));
+    record(await safeDiff("head remove (shift)", scalars, ["b", "c"]));
+    record(await safeDiff("middle insert", scalars, ["a", "x", "b", "c"]));
+    record(await safeDiff("middle remove", scalars, ["a", "c"]));
+    record(await safeDiff("reorder", scalars, ["c", "b", "a"]));
+    record(await safeDiff("in-place element edit", scalars, ["a", "B", "c"]));
+    record(await safeDiff("clear", scalars, []));
+    record(
+      await safeDiff("grow then differ", scalars, ["p", "q", "r", "s", "t"]),
+    );
+
+    // Arrays of objects (the lunch-poll vote-row shape).
+    const objs = [{ k: "a" }, { k: "b" }, { k: "c" }];
+    record(
+      await safeDiff("objects push", [{ k: "a" }], [{ k: "a" }, { k: "b" }]),
+    );
+    record(
+      await safeDiff("objects reorder", objs, [{ k: "c" }, { k: "b" }, {
+        k: "a",
+      }]),
+    );
+    record(
+      await safeDiff("objects middle remove", objs, [{ k: "a" }, { k: "c" }]),
+    );
+
+    // Index-targeted writes (the other producer entry point): in-place edit and
+    // a grow-at-length write. Both must stay `replace` / `splice`.
+    await writeItems(["a", "b"]);
+    drafts.length = 0;
+    const inPlace = storage.edit();
+    assert(
+      inPlace.write({ space, id, type, path: ["value", "items", "0"] }, "Z").ok,
+    );
+    assert((await inPlace.commit()).ok);
+    const inPlacePatches = patchesInDrafts();
+    assertEquals(offendingOps(inPlacePatches), []);
+    record(inPlacePatches.map((patch) => patch.op));
+
+    drafts.length = 0;
+    const growAtIndex = storage.edit();
+    assert(
+      growAtIndex.write({ space, id, type, path: ["value", "items", "2"] }, "c")
+        .ok,
+    );
+    assert((await growAtIndex.commit()).ok);
+    const growPatches = patchesInDrafts();
+    assertEquals(offendingOps(growPatches), []);
+    record(growPatches.map((patch) => patch.op));
+
+    // Sanity: the idioms above actually exercised the array diff path and
+    // produced the safe shapes, so the no-indexed-op assertions aren't vacuous.
+    assert(seen.has("splice"), `expected a splice op; saw ${[...seen]}`);
+    assert(seen.has("replace"), `expected a replace op; saw ${[...seen]}`);
   } finally {
     await storage.close();
   }

--- a/packages/runner/test/memory-v2-read-compaction.test.ts
+++ b/packages/runner/test/memory-v2-read-compaction.test.ts
@@ -3,6 +3,7 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import { excludeReadFromConflict } from "../src/storage/reactivity-log.ts";
+import { txToReactivityLog } from "../src/scheduler.ts";
 
 const DOCUMENT_ADDRESS = {
   id: "bench:read-compaction" as const,
@@ -214,6 +215,65 @@ Deno.test("memory v2 excludeReadFromConflict drops ONLY marked nonRecursive (ref
   assert(
     paths.includes("value.scalar"),
     `unmarked nonRecursive by-value read must be kept; got ${paths}`,
+  );
+
+  await runtime.dispose();
+  await storage.close();
+});
+
+Deno.test("memory v2 excludeReadFromConflict reads STAY in the reactivity log (a repointed link still re-triggers the holder)", async () => {
+  // excludeReadFromConflict removes a read from the COMMIT-CONFLICT set only; it
+  // must NOT remove it from the reactivity log. The asCell reference-resolution
+  // read (the link read) therefore remains a reactive dependency, so if the link
+  // is repointed the holder is reader-dirtied and re-runs — it just no longer
+  // collides with disjoint writers under the referent. This pins the reactivity
+  // half (the conflict half is covered by the test above).
+  const { signer, storage, runtime } = await createRuntime(
+    "memory-v2-read-compaction-exclude-reactivity",
+  );
+  const space = signer.did();
+
+  const seed = runtime.edit();
+  seed.writeValueOrThrow(
+    { ...DOCUMENT_ADDRESS, space },
+    { refShape: { a: 1, b: 2 } },
+  );
+  assertEquals((await seed.commit()).ok, {});
+
+  const tx = runtime.edit();
+  // The link read: a marked, nonRecursive reference-resolution shape read.
+  tx.readValueOrThrow(
+    { ...DOCUMENT_ADDRESS, space, path: ["refShape"] },
+    { meta: excludeReadFromConflict, nonRecursive: true },
+  );
+
+  const replica = storage.open(space).replica as unknown as {
+    buildReads(source: unknown, localSeq: number): {
+      confirmed: Array<{ path: string[]; seq: number }>;
+      pending: Array<{ path: string[]; localSeq: number }>;
+    };
+  };
+
+  // Conflict set DROPS the link read (no spurious collision with disjoint writers).
+  const conflictPaths = replica.buildReads(tx.tx, 1).confirmed.map((read) =>
+    read.path.join(".")
+  );
+  assert(
+    !conflictPaths.some((p) => p.endsWith("refShape")),
+    `reference read must be excluded from the conflict set; got ${conflictPaths}`,
+  );
+
+  // Reactivity log KEEPS the link read (as a shallow/nonRecursive read) — this is
+  // what makes a repointed link re-trigger the holder.
+  const log = txToReactivityLog(tx);
+  const reactivePaths = [...log.reads, ...log.shallowReads].map((address) =>
+    address.path.join(".")
+  );
+  assert(
+    reactivePaths.some((p) => p.endsWith("refShape")),
+    `reference read must stay a reactive dependency; got reads=${
+      log.reads.map((a) => a.path.join("."))
+    } shallowReads=${log.shallowReads.map((a) => a.path.join("."))}`,
   );
 
   await runtime.dispose();

--- a/packages/runner/test/memory-v2-read-compaction.test.ts
+++ b/packages/runner/test/memory-v2-read-compaction.test.ts
@@ -1,7 +1,8 @@
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
+import { excludeReadFromConflict } from "../src/storage/reactivity-log.ts";
 
 const DOCUMENT_ADDRESS = {
   id: "bench:read-compaction" as const,
@@ -156,6 +157,63 @@ Deno.test("memory v2 excludes inline data URI reads from tracked commit dependen
   assertEquals(
     reads.confirmed.map((read) => ({ id: read.id, path: read.path })),
     [{ id: DOCUMENT_ADDRESS.id, path: ["value", "live"] }],
+  );
+
+  await runtime.dispose();
+  await storage.close();
+});
+
+Deno.test("memory v2 excludeReadFromConflict drops ONLY marked nonRecursive (reference) reads — by-value reads are kept", async () => {
+  const { signer, storage, runtime } = await createRuntime(
+    "memory-v2-read-compaction-exclude-conflict",
+  );
+  const space = signer.did();
+
+  const seed = runtime.edit();
+  seed.writeValueOrThrow(
+    { ...DOCUMENT_ADDRESS, space },
+    { refShape: { a: 1, b: 2 }, scalar: 5, other: 7 },
+  );
+  assertEquals((await seed.commit()).ok, {});
+
+  const tx = runtime.edit();
+  // (1) marked + nonRecursive: an asCell reference-resolution shape read -> EXCLUDED.
+  tx.readValueOrThrow(
+    { ...DOCUMENT_ADDRESS, space, path: ["refShape"] },
+    { meta: excludeReadFromConflict, nonRecursive: true },
+  );
+  // (2) marked + RECURSIVE: the nonRecursive guard keeps it (defense for value reads).
+  tx.readValueOrThrow(
+    { ...DOCUMENT_ADDRESS, space, path: ["other"] },
+    { meta: excludeReadFromConflict },
+  );
+  // (3) UNMARKED + nonRecursive: a by-value scalar argument read -> KEPT.
+  //     This is the closed hole: the over-broad scoping used to drop this.
+  tx.readValueOrThrow(
+    { ...DOCUMENT_ADDRESS, space, path: ["scalar"] },
+    { nonRecursive: true },
+  );
+
+  const replica = storage.open(space).replica as unknown as {
+    buildReads(source: unknown, localSeq: number): {
+      confirmed: Array<{ path: string[]; seq: number }>;
+      pending: Array<{ path: string[]; localSeq: number }>;
+    };
+  };
+  const reads = replica.buildReads(tx.tx, 1);
+  const paths = reads.confirmed.map((read) => read.path.join("."));
+
+  assert(
+    !paths.includes("value.refShape"),
+    `marked nonRecursive reference read should be excluded; got ${paths}`,
+  );
+  assert(
+    paths.includes("value.other"),
+    `marked RECURSIVE read must be kept (value dependency); got ${paths}`,
+  );
+  assert(
+    paths.includes("value.scalar"),
+    `unmarked nonRecursive by-value read must be kept; got ${paths}`,
   );
 
   await runtime.dispose();

--- a/packages/runner/test/query-result-proxy-shape-reactivity.test.ts
+++ b/packages/runner/test/query-result-proxy-shape-reactivity.test.ts
@@ -1,0 +1,92 @@
+// Verification for review feedback on #4220's query-result-proxy SHAPE_READ
+// change. Several container reads in the proxy were made `nonRecursive` so the
+// engine applies shape-only conflict granularity. The concern: that this drops
+// the reactive dependency on what those reads observe, at two spots —
+//   - `query-result-proxy.ts:179` — the `$stream` marker check at proxy creation
+//     reads `value.$stream` off the SHAPE_READ result.
+//   - `query-result-proxy.ts:217` — the array proxy stub is sized from
+//     `value.length` off the SHAPE_READ result.
+//
+// Neither drops reactivity:
+//   - The SHAPE_READ records a *nonRecursive* read of the container, and a
+//     nonRecursive read is re-triggered by a write to a DIRECT child (the
+//     scheduler's length+1 overlap rule). `$stream` and array elements are
+//     direct children, so adding/removing/flipping them re-runs the consumer.
+//   - The `length` *stub* at :217 is just a placeholder; live `length` access
+//     goes through the proxy's get trap, which reads recursively and is tracked.
+//
+// These tests assert the reads are actually in the reactivity log.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { txToReactivityLog } from "../src/scheduler.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("qrp-shape-reactivity");
+const space = signer.did();
+
+describe("query-result-proxy nonRecursive shape reads stay reactive", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+    tx = runtime.edit();
+  });
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("reading an array proxy's length registers a tracked read (so growth/shrink re-triggers)", () => {
+    const c = runtime.getCell<{ array: number[] }>(
+      space,
+      "qrp-length",
+      undefined,
+      tx,
+    );
+    c.set({ array: [1, 2, 3] });
+
+    const proxy = c.getAsQueryResult() as { array: number[] };
+    expect(proxy.array.length).toBe(3);
+
+    // The length get trap reads the array live, so the access is a registered
+    // dependency — a later element add/remove (which changes length) re-triggers.
+    const log = txToReactivityLog(tx);
+    const reads = [...log.reads, ...log.shallowReads].map((a) =>
+      a.path.join(".")
+    );
+    expect(reads.some((p) => p.endsWith("array"))).toBe(true);
+  });
+
+  it("materializing a proxy registers the nonRecursive container read the $stream check uses", () => {
+    const c = runtime.getCell<{ inner: { value: number } }>(
+      space,
+      "qrp-stream",
+      undefined,
+      tx,
+    );
+    c.set({ inner: { value: 1 } });
+
+    // createQueryResultProxy SHAPE_READs each container it materializes (this is
+    // the read isStreamValue inspects). It lands in the log as a nonRecursive
+    // (shallow) read, so adding/removing/flipping a `$stream` direct child
+    // re-triggers and re-decides stream-vs-proxy.
+    const proxy = c.getAsQueryResult() as { inner: { value: number } };
+    expect(proxy.inner.value).toBe(1);
+
+    const shallow = txToReactivityLog(tx).shallowReads.map((a) =>
+      a.path.join(".")
+    );
+    // The top-level container (where a `$stream` marker would live) is recorded
+    // as a nonRecursive read.
+    expect(shallow).toContain("value");
+    expect(shallow.some((p) => p.endsWith("inner"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

Under everyday concurrent load, Common Fabric **drops writes**. Two users writing *different keys of one shared document* — e.g. `votes.alice` and `votes.bob` in lunch-poll — collide on every commit attempt, retry until the budget (5) is exhausted, and the loser's write is dropped. In the write-contention probe this is ~**40% of writes at 10 concurrent writers**. This is the write-loss behind #4178.

These drops are **loud, not silent**: each one logs `Event handler transaction failed after exhausting all retries` — we measured one log line per dropped write (`missing ≈ exhaustions`, ~1:1). What makes them pernicious is twofold: the commit is **fire-and-forget**, so the failure is logged but never surfaced back to the originating handler; and drops **cascade** — a dropped write silently voids downstream actions whose precondition it was (those guard-no-op and log nothing). So the system is shouting about lost writes in the logs while the app quietly carries on with missing data. (An earlier suspicion of a *second, genuinely-silent* drop mechanism was investigated and refuted — the quiet part is the cascade, not a second drop.)

The root cause is **over-conflict**: the commit-time conflict check treats reads as *coarser dependencies than they actually are*, so logically-independent operations get flagged as conflicting and serialize through the retry budget. Two writers to disjoint keys should never interact; today they do.

The fix is a single principle —

> **Only genuine value-dependencies belong in commit-conflict detection.**

— applied at the three seams where a spurious dependency was being recorded or matched. None of these is OT/CRDT for genuine read-modify-write; each just stops the engine from inventing a dependency that isn't there.

## The concepts

A commit carries a read-set; on commit, each read is checked against concurrent writes on the same entity, and conflicts if a later write *touches a path that overlaps the read*. Three independent sources of spurious dependency made disjoint operations collide:

### 1. Recursive reads over-matched via parent-injected write paths
A key `add`/`remove` injected its **parent** container path into the write's "touched" set. For a *recursive* read that parent path is both **redundant** (a container reader's path is already a prefix of the leaf write, so it's caught either way) and **harmful** (the parent also prefix-matches every *disjoint sibling* reader, whose value never changed). Recursive reads now match via **leaf-only** touched paths — the exact discipline already shipped for the scheduler reader-dirty index (CT-1623), here extended to the commit-conflict path.

### 2. Shape (key-set) reads were treated as deep reads
Some reads only observe a container's **shape** — its key-set or existence — not the deep values beneath it (proxy creation, `ownKeys`, `getOwnPropertyDescriptor`, `has`, `length`). These are now marked `nonRecursive` and carried to the engine, which matches them shallowly: a key-set reader still conflicts with a key add/remove (the shape it observed changed), but a disjoint deep-value write *below* it no longer over-conflicts.

### 3. Resolving an asCell reference was recorded as a value dependency
Materializing an `asCell` argument **resolves a reference**: it follows the arg's write-redirect and reads the target container's shape to construct the `Cell`. That read doesn't consume a value — the holder depends on the referent only when it reads *through* the cell in its body — yet it was entering the writer's conflict set, so two writers merely *holding a reference* to the same container collided on its shape. These reference-resolution reads are now excluded from the conflict set at the traversal seam (gated on `hasAsCell`). **This was the dominant conflict source, and none of the prior spike PRs touched it** — which is why none of them moved the needle on their own.

### How they compose

| read kind | matched by | touched paths |
|---|---|---|
| recursive value read | `patchOverlapsRead` | leaf-only |
| nonRecursive shape read | `patchOverlapsNonRecursiveRead` | parent-injected |
| asCell reference-resolution read | excluded from conflict | — |

Design note: `docs/specs/memory-v2/08-conflict-granularity.md`.

## Relation to the existing spike PRs (safe to close, leaving available for context)

- **#4199** (don't record a write's own machinery reads) — **superseded by (1)**: fixing the *matcher* instead of deleting reads avoids #4199's cross-space `home-profile` regression *and* preserves same-key RMW conflicts (#4199 turned those into last-writer-wins).
- **#4200** (honor nonRecursive shape reads) — **incorporated as (2)**.
- **#4210** (reactive computes don't re-queue on conflict) — **orthogonal** (reduces retry-storm *cost*, not conflict *count*); lands independently.

## What still conflicts (no false-negatives)

Every refinement is a strict *subset* of the old overlap, so it can only remove spurious conflicts, never miss a genuine one: same-key read-modify-write, whole-container reads, and key-set readers vs key add/remove all still conflict; tier-1 whole-doc set/delete stays path-blind; and a **by-value** argument (`hasAsCell` false) is never excluded, so by-value scalar reads — also recorded `nonRecursive` — keep their dependency.

## Not in scope (separate, broader lever)

A mixed-workload residual remains from **whole-document reads** by output-derivation computes that re-derive and replace a shared result doc, plus genuine shared-leaf read-modify-write (array `push`) — neither is a granularity artifact (the latter wants client-side recovery / rebase, cf. #4196).

## Measurements & validation

- **Write-contention probe** (N runtimes writing unique markers, cold-read of canonical storage): distinct-key drop rate **20/50 → 0** at 10 concurrent writers; retry-exhaustion log lines → 0.
- **New regression tests**, each meaningful (fails when its mechanism is reverted):
  - `v2-engine-test`: leaf-only (disjoint-key writers merge; same-key / container readers still conflict) + nonRecursive (shape read vs key-add conflicts, vs disjoint deep-value does not; recursive read of the same container still conflicts).
  - `memory-v2-read-compaction`: `buildReads` excludes a marked nonRecursive reference read, keeps a marked-recursive read and an unmarked nonRecursive by-value read.
- **Suites green on the main base:** full memory v2 suite (213 passed), runner conflict/proxy/handler/lift suites, cross-space + inSpace-child (confirms no #4199-style regression), integration multi-runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)