### PR TITLE
cf-tabs: don't flash the first tab while $value is unresolved (mount flicker)

### DIFF
--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
@@ -416,6 +416,23 @@ describe("CFTabs pure-on-mount contract (safe inside computed)", () => {
     expect(writes()).toBe(0); // pure read throughout — no cell write
   });
 
+  it("clears the selection when the bound value is explicitly set to empty", () => {
+    // Empty is not only the mount transient — a consumer can clear the bound
+    // cell ("" / unset) to mean "no tab active". The early-return form held the
+    // prior selection (stale tab + panel stuck visible); selection-sync must
+    // instead drop it. (Still write-free — clearing is a pure read.)
+    const { cell, writes } = countingCell("progress");
+    const h = makeTabs(cell, ["active", "progress", "pending"]);
+    expect(h.selectedTab()).toBe("progress"); // initially selected
+    expect(h.visiblePanel()).toBe("progress");
+
+    pushUpdate(cell, ""); // explicit clear
+
+    expect(h.selectedTab()).toBe(undefined); // selection dropped, not stale
+    expect(h.visiblePanel()).toBe(undefined);
+    expect(writes()).toBe(0);
+  });
+
   it("a cell-driven change to an unmatched value does not write back", () => {
     const { cell, writes } = countingCell("active");
     const h = makeTabs(cell, ["active", "progress"]);

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
@@ -106,7 +106,10 @@ class FakeTab {
 
 class FakeTabPanel {
   value: string;
-  hidden = false;
+  // Mirror the real CFTabPanel constructor default (hidden = true). cf-tab-panel
+  // starts hidden and is revealed only when updateTabSelection() matches it; a
+  // `false` default would make panels look visible before any sync runs.
+  hidden = true;
   attributes = new Map<string, string>();
   constructor(value: string) {
     this.value = value;
@@ -342,7 +345,10 @@ describe("CFTabs cf-change emission contract (CT-1746)", () => {
  * computed: a "Too many iterations" CPU-spin (the CT-1677 settle class).
  *
  * These tests pin the contract: mount and cell-driven sync produce ZERO cell
- * writes, while the no-match fallback still selects the first tab VISUALLY.
+ * writes. The no-match fallback selects the first tab VISUALLY only for a
+ * NON-empty stale value; an empty / unresolved value (the durable-$value
+ * mount transient) holds the current selection rather than flashing the first
+ * tab — see the mount-flicker regression test below.
  */
 describe("CFTabs pure-on-mount contract (safe inside computed)", () => {
   // Count writes to the bound cell by wrapping `.set` before binding.
@@ -357,8 +363,8 @@ describe("CFTabs pure-on-mount contract (safe inside computed)", () => {
     return { cell, writes: () => writes };
   }
 
-  it("does NOT write the bound cell on mount when the value matches no tab", () => {
-    // Empty cell matches none of the tabs — the no-match path.
+  it("does NOT write the bound cell on mount when the value is empty / unresolved", () => {
+    // Empty cell — the durable-$value mount transient (value not delivered yet).
     const { cell, writes } = countingCell("");
 
     // makeTabs() binds the controller and runs updateTabSelection() — i.e. the
@@ -367,12 +373,14 @@ describe("CFTabs pure-on-mount contract (safe inside computed)", () => {
 
     expect(writes()).toBe(0); // FAILS pre-fix: selectFirst() writes "active"
     expect(cell.get()).toBe(""); // cell stays untouched until a real gesture
-    // ...but the first tab is still selected VISUALLY (the fallback survives).
-    expect(h.selectedTab()).toBe("active");
-    expect(h.visiblePanel()).toBe("active");
+    // ...and NO tab is flashed: an empty/unresolved value holds the selection
+    // rather than snapping to the first tab (which would flicker once the cell
+    // resolves to a non-first value).
+    expect(h.selectedTab()).toBe(undefined);
+    expect(h.visiblePanel()).toBe(undefined);
   });
 
-  it("a re-mount (recompute) over an unmatched cell stays write-free and idempotent", () => {
+  it("a re-mount (recompute) over an empty cell stays write-free and idempotent", () => {
     const { cell, writes } = countingCell("");
     const h = makeTabs(cell, ["active", "progress", "pending"]);
 
@@ -386,7 +394,26 @@ describe("CFTabs pure-on-mount contract (safe inside computed)", () => {
 
     expect(writes()).toBe(0);
     expect(cell.get()).toBe("");
-    expect(h.selectedTab()).toBe("active"); // still visually defaulted
+    expect(h.selectedTab()).toBe(undefined); // held — no first-tab flash
+  });
+
+  it("does not flash the first tab while the bound value is unresolved, then selects the resolved value (mount-flicker regression)", () => {
+    // Reproduces the durable-$value mount race that produces "flickers between
+    // two tabs": the synchronous mount sync sees an empty (not-yet-delivered)
+    // value, then the cell resolves to a NON-first tab. The selection must go
+    // straight to the resolved tab — never transiently snapping to the first.
+    const { cell, writes } = countingCell(""); // unresolved at mount
+    const h = makeTabs(cell, ["active", "progress", "pending", "feed"]);
+
+    // While unresolved: nothing is flashed (NOT the first tab "active").
+    expect(h.selectedTab()).toBe(undefined);
+    expect(h.visiblePanel()).toBe(undefined);
+
+    // Cell resolves to a non-first tab — selection jumps straight to it.
+    pushUpdate(cell, "pending");
+    expect(h.selectedTab()).toBe("pending");
+    expect(h.visiblePanel()).toBe("pending");
+    expect(writes()).toBe(0); // pure read throughout — no cell write
   });
 
   it("a cell-driven change to an unmatched value does not write back", () => {

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
@@ -227,37 +227,36 @@ export class CFTabs extends BaseElement {
       return;
     }
 
-    // An empty / unresolved value means the bound cell has not delivered its
-    // value YET — the common case being a durable `$value` cell whose stored
-    // value (e.g. "delta") hasn't been synced when the synchronous mount syncs
-    // (firstUpdated + slotchange) run. getValue() coerces that to "". Do NOT
-    // treat this as a no-match and snap to the first tab: the cell controller's
-    // subscription will fire updateTabSelection again with the real value a
-    // beat later, so falling back here makes the selection show the FIRST tab
-    // and then jump to the real one — the "flickers between two tabs" on every
-    // (re)mount. Hold the current selection until a concrete value arrives.
-    // (An intentionally-empty binding shows no selection until set; consumers
-    // that want a default must initialize the cell, e.g. `Writable.of("a")`.)
-    if (currentValue === undefined || currentValue === "") {
-      return;
-    }
-
-    // Decide which tab to show. If a NON-empty bound value matches no tab (a
-    // stale / invalid selection), fall back to the first enabled tab — but
-    // VISUALLY ONLY. We must NOT write the cell from here.
+    // Decide which value the selection should reflect.
     //
-    // cf-tabs is bound through `$value` and may be instantiated inside a render
-    // `computed()` that reads the same cell. Writing the cell during
-    // mount/selection-sync would re-trigger that computed, which re-mounts
-    // cf-tabs, which writes again — a non-settling "Too many iterations" spin
-    // (the CT-1677 settle class). So selection-sync stays a pure read: the cell
-    // is committed only on a genuine user gesture (handleTabClick /
-    // handleKeydown via emitUserChange). This mirrors cf-input, which writes
-    // only on input events and never on bind. A consumer that needs the cell to
-    // carry the default should initialize it (e.g. `Writable.of("active")`).
+    // An empty / undefined value means the bound cell either hasn't delivered
+    // its value yet (the durable `$value` mount transient — getValue() coerces
+    // the not-yet-synced value to "") OR was explicitly cleared. In NEITHER
+    // case do we snap to the first tab: doing so makes the selection briefly
+    // show the FIRST tab and then jump to the real value once the cell resolves
+    // — the "flickers between two tabs" on every (re)mount. We leave
+    // effectiveValue empty, so the apply loop below matches no tab and thus
+    // deselects every tab / hides every panel. On a fresh mount nothing was
+    // selected, so that is a no-op and the real value re-syncs a beat later via
+    // the controller's onChange; on an explicit clear it correctly drops the
+    // (now stale) prior selection rather than leaving it stuck.
+    //
+    // A NON-empty value that matches no tab is a genuinely stale/invalid
+    // selection: fall back to the first enabled tab — but VISUALLY ONLY. We
+    // must NOT write the cell from here. cf-tabs is bound through `$value` and
+    // may be instantiated inside a render `computed()` that reads the same
+    // cell; writing the cell during mount/selection-sync would re-trigger that
+    // computed, re-mount cf-tabs, and write again — a non-settling "Too many
+    // iterations" spin (the CT-1677 settle class). So selection-sync stays a
+    // pure read: the cell is committed only on a genuine user gesture
+    // (handleTabClick / handleKeydown via emitUserChange). This mirrors
+    // cf-input, which writes only on input events and never on bind. A consumer
+    // that needs the cell to carry a default should initialize it (e.g.
+    // `Writable.of("active")`).
+    const isEmpty = currentValue === undefined || currentValue === "";
     const tabValues = Array.from(tabs, (tab) => (tab as CFTab).value);
     let effectiveValue = currentValue;
-    if (!tabValues.includes(currentValue) && tabs.length > 0) {
+    if (!isEmpty && !tabValues.includes(currentValue) && tabs.length > 0) {
       const firstEnabled = Array.from(tabs).find(
         (tab) => !(tab as CFTab).disabled,
       ) as CFTab | undefined;

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
@@ -227,9 +227,24 @@ export class CFTabs extends BaseElement {
       return;
     }
 
-    // Decide which tab to show. If the bound value matches no tab (an empty or
-    // stale initial value), fall back to the first enabled tab — but VISUALLY
-    // ONLY. We must NOT write the cell from here.
+    // An empty / unresolved value means the bound cell has not delivered its
+    // value YET — the common case being a durable `$value` cell whose stored
+    // value (e.g. "delta") hasn't been synced when the synchronous mount syncs
+    // (firstUpdated + slotchange) run. getValue() coerces that to "". Do NOT
+    // treat this as a no-match and snap to the first tab: the cell controller's
+    // subscription will fire updateTabSelection again with the real value a
+    // beat later, so falling back here makes the selection show the FIRST tab
+    // and then jump to the real one — the "flickers between two tabs" on every
+    // (re)mount. Hold the current selection until a concrete value arrives.
+    // (An intentionally-empty binding shows no selection until set; consumers
+    // that want a default must initialize the cell, e.g. `Writable.of("a")`.)
+    if (currentValue === undefined || currentValue === "") {
+      return;
+    }
+
+    // Decide which tab to show. If a NON-empty bound value matches no tab (a
+    // stale / invalid selection), fall back to the first enabled tab — but
+    // VISUALLY ONLY. We must NOT write the cell from here.
     //
     // cf-tabs is bound through `$value` and may be instantiated inside a render
     // `computed()` that reads the same cell. Writing the cell during


### PR DESCRIPTION
## Problem

`cf-tabs` "flickers between two tabs after a few interactions" — a long-standing, repeatedly-chased bug. This is a **render-path race**, distinct from the cell-write feedback loops already fixed by [#4134](https://github.com/commontoolsinc/labs/pull/4134) (CT-1746, gesture-only `cf-change`) and [#4151](https://github.com/commontoolsinc/labs/pull/4151) (CT-1752, pure-on-mount). Those killed the *"Too many iterations"* scheduler loop; this flicker never writes the cell, so it was invisible to those fixes and their tests.

## Root cause (reproduced live)

On every (re)mount, the synchronous selection-syncs (`firstUpdated` + the two `slotchange` listeners + Lit's `updated()`) read the bound `$value` cell **before** the cell controller's subscription delivers its value. For a durable cell (`.for("activeTab")`) that read is `""` (`StringCellController` coerces the not-yet-delivered value to empty).

The old no-match fallback treated `""` as a stale value and **snapped to the first tab**; a beat later the real value (e.g. `delta`) arrived and selection jumped to it — a visible **first-tab → real-tab** flip on each mount. Once you've selected a non-first tab, the durable cell persists it, so every remount flickers between the first tab and your tab. (That's also why it only shows "after a few interactions" — on the default first tab the fallback agrees.)

Captured live with an instrumented `updateTabSelection` (durable value = `delta`):

| call | value read | tab selected |
|---|---|---|
| 1–2 | `delta` | — (no tabs yet) |
| 3–6 | `""` | **`alpha`** ← fallback to first tab |
| 7 | `delta` | `delta` |

## Fix

In `updateTabSelection`, treat an empty/undefined `currentValue` as *"unresolved"* and **hold the current selection** (return early) rather than falling back to the first tab. The first-tab fallback now applies only to a **non-empty** value that matches no tab (a genuinely stale selection). Selection-sync still never writes the cell.

After the fix (same instrumentation, re-mount with `delta`): the empty syncs are suppressed (`selectedAfter: []`) and only the resolved `delta` is applied — `alpha` never flashes.

## Tests

- Pure-on-mount tests now assert empty → *nothing selected* (was first-tab).
- New **mount-flicker regression test**: unresolved value → no flash, then resolves straight to a non-first tab.
- `FakeTabPanel`'s default `hidden` corrected to `true` to mirror the real `CFTabPanel` constructor (the old `false` made suppressed panels look visible in the harness).

`deno test` 13/13 steps green; `deno fmt` + `deno lint` clean.

## Known residual / optional follow-up

There's still a brief *"no tab selected"* window before the durable value resolves — sub-2ms in light panels (won't paint), but possibly a one-frame flash in heavyweight panels (e.g. `home.tsx`). The clean follow-up is to coalesce the ~6 redundant per-mount sync paths into a single microtask apply using the latest value. Left out here to keep the change minimal and synchronous (it would require reworking the synchronous test harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `cf-tabs` from flashing the first tab on mount by treating empty/undefined `$value` as unresolved and showing no selection until it resolves; an explicit `""` now clears the selection. The first-tab fallback only runs for non-empty stale values, removing the first-tab → real-tab flicker.

- **Bug Fixes**
  - In `updateTabSelection`, skip the first-tab fallback for `""`/`undefined`; let the apply loop run with an empty value to deselect. Fallback only for non-empty no-match, and never write to the cell.
  - Add a mount-flicker regression test and a clear-on-empty test; update pure-on-mount assertions to expect “nothing selected” while unresolved.
  - Set `FakeTabPanel.hidden` default to `true` to match `CFTabPanel`.

<sup>Written for commit 893f83de3ca1edd4879d68875758750c993f46fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

