### PR TITLE
[DO NOT LAND - TEST PR] feat(ci): comment on PRs when test coverage regresses

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -667,7 +667,8 @@ jobs:
     permissions:
       contents: read
       actions: read
-      pull-requests: read
+      # write: the coverage gate posts a once-per-PR comment on regressions.
+      pull-requests: write
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4

--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -3,11 +3,13 @@ import * as path from "@std/path";
 import {
   collectCoverageDebtMetricsFromLcov,
   collectSourceFiles,
+  collectUncoveredLinesForFiles,
   countTrackedSourceLines,
   countUncoveredProfileLines,
   metricGroupFor,
   parseLcov,
   shouldTrackSourceFile,
+  trackedSourceLineNumbers,
 } from "./coverage-metrics.ts";
 
 Deno.test("parseLcov accumulates hits per source line", () => {
@@ -38,6 +40,21 @@ Deno.test("countTrackedSourceLines ignores blank and comment-only lines", () => 
       "const inline = 2; // comment",
     ].join("\n")),
     3,
+  );
+});
+
+Deno.test("trackedSourceLineNumbers reports the executable line numbers", () => {
+  assertEquals(
+    trackedSourceLineNumbers([
+      "", // 1
+      "// comment", // 2
+      "const value = 1;", // 3
+      "/* block", // 4
+      "comment */", // 5
+      "export const next = value + 1;", // 6
+      "const inline = 2; // comment", // 7
+    ].join("\n")),
+    [3, 6, 7],
   );
 });
 
@@ -118,6 +135,53 @@ Deno.test("collectCoverageDebtMetricsFromLcov computes debt from compact reports
       )?.uncoveredLines,
       1,
     );
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
+});
+
+Deno.test("collectUncoveredLinesForFiles resolves lines only for requested files", async () => {
+  const rootDir = await Deno.makeTempDir({ prefix: "coverage-lines-test-" });
+  try {
+    const coveredPath = path.join(rootDir, "packages/example/src/covered.ts");
+    const untestedPath = path.join(rootDir, "packages/example/src/untested.ts");
+    const otherPath = path.join(rootDir, "packages/example/src/other.ts");
+    await Deno.mkdir(path.dirname(coveredPath), { recursive: true });
+    await Deno.writeTextFile(
+      coveredPath,
+      [
+        "export const covered = 1;",
+        "export const uncovered = 2;",
+      ].join("\n"),
+    );
+    // Never appears in the LCOV report, so every tracked line is uncovered.
+    await Deno.writeTextFile(untestedPath, "export const neverRun = 3;\n");
+    // Not requested, so it should not be read or returned.
+    await Deno.writeTextFile(otherPath, "export const ignored = 4;\n");
+
+    const uncovered = await collectUncoveredLinesForFiles({
+      rootDir,
+      lcov: [
+        `SF:${coveredPath}`,
+        "DA:1,1",
+        "DA:2,0",
+        "end_of_record",
+      ].join("\n"),
+      files: [
+        "packages/example/src/covered.ts",
+        "packages/example/src/untested.ts",
+        // A test file is not tracked source, so it is skipped.
+        "packages/example/src/covered.test.ts",
+      ],
+    });
+
+    // Covered file: only the zero-hit line.
+    assertEquals(uncovered.get("packages/example/src/covered.ts"), [2]);
+    // Absent from the report: every tracked line is uncovered.
+    assertEquals(uncovered.get("packages/example/src/untested.ts"), [1]);
+    // Untracked and unrequested files are absent.
+    assertEquals(uncovered.has("packages/example/src/covered.test.ts"), false);
+    assertEquals(uncovered.has("packages/example/src/other.ts"), false);
   } finally {
     await Deno.remove(rootDir, { recursive: true });
   }

--- a/tasks/coverage-metrics.ts
+++ b/tasks/coverage-metrics.ts
@@ -65,7 +65,7 @@ interface LcovFileCoverage {
 export async function collectCoverageDebtMetrics(
   options: CoverageDebtMetricsOptions,
 ): Promise<CoverageDebtMetric[]> {
-  const lcov = await denoCoverageLcov(options.coverageProfileDir);
+  const lcov = await lcovFromCoverageProfile(options.coverageProfileDir);
   return await collectCoverageDebtMetricsFromLcov({
     rootDir: options.rootDir,
     lcov,
@@ -84,6 +84,8 @@ export async function collectCoverageDebtMetricsFromLcov(
 
   for (const source of sourceFiles) {
     const coverage = lcovCoverage.get(source.absolutePath);
+    // A file the tests never loaded has no coverage record; every tracked
+    // line counts as uncovered, matching how the debt metric scores it.
     const uncovered = coverage
       ? countUncoveredProfileLines(coverage)
       : source.trackedLineCount;
@@ -110,6 +112,50 @@ export async function collectCoverageDebtMetricsFromLcov(
   }
 
   return metrics;
+}
+
+/**
+ * Return the uncovered source line numbers for specific files, keyed by their
+ * repository-relative POSIX path. Only the requested files are inspected, so a
+ * caller that needs per-line detail for a handful of files (e.g. a PR's changed
+ * files) does not pay to materialize line arrays for the whole workspace.
+ */
+export async function collectUncoveredLinesForFiles(
+  options: CoverageDebtMetricsFromLcovOptions & { files: Iterable<string> },
+): Promise<Map<string, number[]>> {
+  const lcovCoverage = parseLcov(options.lcov);
+  const result = new Map<string, number[]>();
+
+  for (const requested of options.files) {
+    const relativePath = toPosix(requested);
+    if (result.has(relativePath) || !shouldTrackSourceFile(relativePath)) {
+      continue;
+    }
+
+    const absolutePath = path.normalize(
+      path.join(options.rootDir, relativePath),
+    );
+    const coverage = lcovCoverage.get(absolutePath);
+
+    let uncoveredLines: number[];
+    if (coverage) {
+      uncoveredLines = uncoveredProfileLineNumbers(coverage);
+    } else {
+      // No coverage record: the file was never loaded by any test, so every
+      // tracked line is uncovered.
+      let content: string;
+      try {
+        content = await Deno.readTextFile(absolutePath);
+      } catch {
+        continue;
+      }
+      uncoveredLines = trackedSourceLineNumbers(content);
+    }
+
+    if (uncoveredLines.length > 0) result.set(relativePath, uncoveredLines);
+  }
+
+  return result;
 }
 
 export async function collectSourceFiles(
@@ -165,11 +211,16 @@ export function metricGroupFor(relativePath: string): string {
 }
 
 export function countTrackedSourceLines(content: string): number {
-  let count = 0;
+  return trackedSourceLineNumbers(content).length;
+}
+
+export function trackedSourceLineNumbers(content: string): number[] {
+  const lineNumbers: number[] = [];
   let inBlockComment = false;
 
-  for (const line of content.split(/\r?\n/)) {
-    let text = line.trim();
+  const lines = content.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index++) {
+    let text = lines[index].trim();
     if (text.length === 0) continue;
 
     while (text.length > 0) {
@@ -200,12 +251,12 @@ export function countTrackedSourceLines(content: string): number {
         continue;
       }
 
-      count++;
+      lineNumbers.push(index + 1);
       break;
     }
   }
 
-  return count;
+  return lineNumbers;
 }
 
 export function parseLcov(lcov: string): Map<string, LcovFileCoverage> {
@@ -244,14 +295,21 @@ export function parseLcov(lcov: string): Map<string, LcovFileCoverage> {
 }
 
 export function countUncoveredProfileLines(coverage: LcovFileCoverage): number {
-  let uncovered = 0;
-  for (const hits of coverage.lineHits.values()) {
-    if (hits === 0) uncovered++;
-  }
-  return uncovered;
+  return uncoveredProfileLineNumbers(coverage).length;
 }
 
-async function denoCoverageLcov(coverageProfileDir: string): Promise<string> {
+function uncoveredProfileLineNumbers(coverage: LcovFileCoverage): number[] {
+  const lineNumbers: number[] = [];
+  for (const [lineNumber, hits] of coverage.lineHits) {
+    if (hits === 0) lineNumbers.push(lineNumber);
+  }
+  return lineNumbers.sort((a, b) => a - b);
+}
+
+/** Run `deno coverage --lcov` over a profile directory and return the report. */
+export async function lcovFromCoverageProfile(
+  coverageProfileDir: string,
+): Promise<string> {
   const tmpDir = await Deno.makeTempDir({ prefix: "coverage-lcov-" });
   const outputPath = path.join(tmpDir, "coverage.lcov");
   try {

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -21,11 +21,16 @@ import {
   applyBaselineOverrides,
   type Artifact,
   type BaselineOverrides,
+  buildCoverageDebtSuggestionComment,
   computeBaseline,
   computeCiWallTimeRevisitSignals,
   COVERAGE_BASELINE_RESET_MARKER,
+  COVERAGE_SUGGESTION_MARKER,
+  coverageGroupForChangedFile,
   coverageGroupsForChangedFiles,
   coverageMetricGroupName,
+  type CoverageSuggestionFileLines,
+  type CoverageSuggestionGroup,
   downloadAndExtractArtifact,
   downloadAndParseJUnit,
   downloadAndParsePerfMetrics,
@@ -34,12 +39,14 @@ import {
   extractTestFileMetrics,
   fetchArtifactsForRun,
   fetchCurrentPRBody,
+  fetchIssueComments,
   fetchJobsForRun,
   fetchPRFiles,
   fetchPRForCommit,
   formatMetricValue,
   formatOverrideSuggestion,
   githubGet,
+  githubPost,
   isCoverageDebtMetric,
   mapConcurrent,
   type MetricTimeline,
@@ -47,11 +54,13 @@ import {
   MIN_REGRESSION_PCT,
   MIN_SAMPLES,
   newestArtifactsByName,
+  parseAddedLinesFromPatch,
   parseBaselineOverrides,
   PERF_METRICS_ARTIFACT_NAME,
   PERF_METRICS_BACKFILL_ARTIFACT_NAME,
   PERF_METRICS_BACKFILL_FILE,
   PERF_METRICS_FILE,
+  type PRFile,
   type PRInfo,
   readAndParseEvent,
   REPO,
@@ -68,9 +77,10 @@ import {
 } from "./perf-lib.ts";
 import * as path from "@std/path";
 import {
-  collectCoverageDebtMetrics,
   collectCoverageDebtMetricsFromLcov,
+  collectUncoveredLinesForFiles,
   COVERAGE_PROFILE_ARTIFACT_PREFIX,
+  lcovFromCoverageProfile,
 } from "./coverage-metrics.ts";
 
 /** How many recent main-branch runs to use for baseline. */
@@ -372,7 +382,7 @@ function printMetricTable(rows: Row[], includeStatus = false): void {
 async function extractCoverageDebtSamples(
   run: WorkflowRun,
   artifacts: Artifact[],
-): Promise<Map<string, TimingSample>> {
+): Promise<{ samples: Map<string, TimingSample>; lcov: string }> {
   const metrics = new Map<string, TimingSample>();
   const coverageArtifacts = newestArtifactsByName(artifacts.filter(
     (artifact) =>
@@ -394,6 +404,7 @@ async function extractCoverageDebtSamples(
 
   const profileDir = await Deno.makeTempDir({ prefix: "coverage-profiles-" });
   const lcovDir = await Deno.makeTempDir({ prefix: "coverage-lcov-" });
+  let lcov = "";
   try {
     let profileFileCount = 0;
     let lcovFileCount = 0;
@@ -413,21 +424,16 @@ async function extractCoverageDebtSamples(
       );
     }
 
-    const coverageMetrics = lcovFileCount > 0
-      ? await collectCoverageDebtMetricsFromLcov({
-        rootDir: Deno.cwd(),
-        lcov: await readCombinedLcov(lcovDir),
-      })
-      : await collectCoverageDebtMetrics({
-        rootDir: Deno.cwd(),
-        coverageProfileDir: profileDir,
-      });
+    lcov = lcovFileCount > 0
+      ? await readCombinedLcov(lcovDir)
+      : await lcovFromCoverageProfile(profileDir);
 
+    const coverageMetrics = await collectCoverageDebtMetricsFromLcov({
+      rootDir: Deno.cwd(),
+      lcov,
+    });
     for (const metric of coverageMetrics) {
-      metrics.set(
-        metric.name,
-        sampleForRun(run, metric.uncoveredLines),
-      );
+      metrics.set(metric.name, sampleForRun(run, metric.uncoveredLines));
     }
 
     console.log(
@@ -446,7 +452,86 @@ async function extractCoverageDebtSamples(
     } catch { /* ignore cleanup errors */ }
   }
 
-  return metrics;
+  return { samples: metrics, lcov };
+}
+
+/**
+ * Post a once-per-PR comment that tells the author (and an LLM) how to cover the
+ * new code that tripped the coverage gate. Skips silently if a previous run
+ * already posted one, and never throws — posting is best-effort so it cannot
+ * mask the regression failure itself.
+ */
+async function postCoverageDebtSuggestion(
+  prNumber: number,
+  coverageFailures: Row[],
+  prFiles: PRFile[],
+  lcov: string,
+): Promise<void> {
+  const groups = coverageFailures
+    .map((failure) => ({
+      group: coverageMetricGroupName(failure.metric),
+      target: Math.round(failure.median ?? 0),
+      current: Math.round(failure.current),
+    }))
+    .filter((group): group is CoverageSuggestionGroup => group.group !== null);
+
+  if (groups.length === 0) return;
+
+  const failingGroups = new Set(groups.map((group) => group.group));
+
+  // Resolve uncovered line numbers only for changed files in the regressed
+  // groups, so we never materialize per-line data for the whole workspace.
+  const changedInFailingGroups = prFiles
+    .map((prFile) => prFile.filename.replaceAll("\\", "/"))
+    .filter((relativePath) => {
+      const group = coverageGroupForChangedFile(relativePath);
+      return group !== null && failingGroups.has(group);
+    });
+  const uncoveredByPath = await collectUncoveredLinesForFiles({
+    rootDir: Deno.cwd(),
+    lcov,
+    files: changedInFailingGroups,
+  });
+
+  // Count, per changed file, the lines this PR added that coverage marks
+  // uncovered.
+  const files: CoverageSuggestionFileLines[] = [];
+  for (const prFile of prFiles) {
+    const relativePath = prFile.filename.replaceAll("\\", "/");
+    const group = coverageGroupForChangedFile(relativePath);
+    if (!group || !failingGroups.has(group)) continue;
+
+    const uncoveredLines = uncoveredByPath.get(relativePath);
+    if (!uncoveredLines || !prFile.patch) continue;
+
+    const addedLines = parseAddedLinesFromPatch(prFile.patch);
+    const uncoveredCount = uncoveredLines.filter((line) =>
+      addedLines.has(line)
+    ).length;
+    if (uncoveredCount > 0) files.push({ relativePath, group, uncoveredCount });
+  }
+
+  try {
+    const existing = await fetchIssueComments(prNumber);
+    if (
+      existing.some((comment) =>
+        comment.body.includes(COVERAGE_SUGGESTION_MARKER)
+      )
+    ) {
+      console.log(
+        `Coverage suggestion comment already present on PR #${prNumber}; not posting again.`,
+      );
+      return;
+    }
+
+    const body = buildCoverageDebtSuggestionComment({ groups, files });
+    await githubPost(`/repos/${REPO}/issues/${prNumber}/comments`, { body });
+    console.log(`Posted coverage suggestion comment to PR #${prNumber}.`);
+  } catch (error) {
+    console.warn(
+      `  Warning: could not post coverage suggestion comment to PR #${prNumber}: ${error}`,
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -524,10 +609,11 @@ async function main() {
   // another API request on the current workflow run.
   const currentRunInfo = currentWorkflowRunFromEvent(event, runIdNum);
   let changedCoverageGroups: Set<string> | undefined;
+  let prFiles: PRFile[] = [];
 
   if (prNumber) {
     try {
-      const prFiles = await fetchPRFiles(parseInt(prNumber));
+      prFiles = await fetchPRFiles(parseInt(prNumber));
       changedCoverageGroups = coverageGroupsForChangedFiles(
         prFiles.map((file) => file.filename),
       );
@@ -595,19 +681,21 @@ async function main() {
 
   // Extract coverage debt metrics from coverage profile artifacts.
   let coverageDataError: unknown;
+  let coverageLcov = "";
   try {
     if (currentArtifactsError) {
       throw new Error(
         `Could not fetch current run artifacts: ${currentArtifactsError}`,
       );
     }
-    const coverageMetrics = await extractCoverageDebtSamples(
+    const coverage = await extractCoverageDebtSamples(
       currentRunInfo,
       currentArtifacts,
     );
-    for (const [name, sample] of coverageMetrics) {
+    for (const [name, sample] of coverage.samples) {
       currentMetrics.set(name, sample);
     }
+    coverageLcov = coverage.lcov;
   } catch (e) {
     coverageDataError = e;
     console.error(
@@ -1222,6 +1310,17 @@ async function main() {
       console.log(`NEW_PERF_BASELINE: ${f.metric} = ${suggested}`);
     }
     console.log("---END COPY-PASTE---");
+  }
+
+  // A coverage regression on a real PR earns a once-per-PR comment pointing the
+  // author at the uncovered files and how to cover them.
+  if (coverageFailures.length > 0 && prNumber) {
+    await postCoverageDebtSuggestion(
+      parseInt(prNumber),
+      coverageFailures,
+      prFiles,
+      coverageLcov,
+    );
   }
 
   Deno.exit(1);

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -1,10 +1,18 @@
-import { assertAlmostEquals, assertEquals, assertThrows } from "@std/assert";
+import {
+  assertAlmostEquals,
+  assertEquals,
+  assertFalse,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
 import {
   applyBaselineOverrides,
   type Artifact,
+  buildCoverageDebtSuggestionComment,
   computeBaseline,
   computeCiWallTimeRevisitSignals,
   COVERAGE_BASELINE_RESET_MARKER,
+  COVERAGE_SUGGESTION_MARKER,
   coverageGroupsForChangedFiles,
   coverageMetricGroupName,
   downloadAndExtractArtifact,
@@ -18,6 +26,7 @@ import {
   githubGet,
   type Job,
   newestArtifactsByName,
+  parseAddedLinesFromPatch,
   parseBaselineOverrides,
   parsePerfMetricsBackfillFile,
   parsePerfMetricsFile,
@@ -760,6 +769,92 @@ Deno.test("coverage debt gating follows changed source groups", () => {
       undefined,
     ),
     true,
+  );
+});
+
+Deno.test("parseAddedLinesFromPatch maps added lines to their new line numbers", () => {
+  const patch = [
+    "@@ -1,3 +1,5 @@",
+    " const a = 1;",
+    "-const b = 2;",
+    "+const b = 20;",
+    "+const c = 3;",
+    " const d = 4;",
+    "+const e = 5;",
+    "\\ No newline at end of file",
+  ].join("\n");
+
+  const added = parseAddedLinesFromPatch(patch);
+
+  assertEquals([...added.entries()], [
+    [2, "const b = 20;"],
+    [3, "const c = 3;"],
+    [5, "const e = 5;"],
+  ]);
+});
+
+Deno.test("parseAddedLinesFromPatch tracks line numbers across multiple hunks", () => {
+  const patch = [
+    "@@ -10,2 +10,3 @@",
+    " keep;",
+    "+added at 11;",
+    " keep;",
+    "@@ -40,1 +41,2 @@",
+    " keep;",
+    "+added at 42;",
+  ].join("\n");
+
+  const added = parseAddedLinesFromPatch(patch);
+
+  assertEquals(added.get(11), "added at 11;");
+  assertEquals(added.get(42), "added at 42;");
+  assertEquals(added.size, 2);
+});
+
+Deno.test("buildCoverageDebtSuggestionComment lists files (not lines), command, and targets", () => {
+  const comment = buildCoverageDebtSuggestionComment({
+    groups: [
+      { group: "packages/runner", target: 12, current: 15 },
+    ],
+    files: [
+      {
+        relativePath: "packages/runner/src/cell.ts",
+        group: "packages/runner",
+        uncoveredCount: 2,
+      },
+    ],
+  });
+
+  // Posted-once marker so a later run can detect it.
+  assertStringIncludes(comment, COVERAGE_SUGGESTION_MARKER);
+  // The regressed group with its target and current value.
+  assertStringIncludes(comment, "`packages/runner`");
+  assertStringIncludes(comment, "| 12 | 15 | +3 |");
+  // The affected file with its uncovered-line count, but no per-line code dump.
+  assertStringIncludes(comment, "`packages/runner/src/cell.ts` — 2 lines");
+  // The prompt block still carries the command and the metric target.
+  assertStringIncludes(comment, "tasks/coverage-metrics.ts");
+  assertStringIncludes(
+    comment,
+    "coverage-debt: packages/runner uncovered lines  <=  12",
+  );
+  // The comment ends at the prompt block — no verify/footer sections.
+  assertFalse(comment.includes("### Verify locally"));
+});
+
+Deno.test("buildCoverageDebtSuggestionComment handles a regression with no pinned lines", () => {
+  const comment = buildCoverageDebtSuggestionComment({
+    groups: [
+      { group: "tasks", target: 0, current: 4 },
+    ],
+    files: [],
+  });
+
+  assertStringIncludes(comment, COVERAGE_SUGGESTION_MARKER);
+  assertStringIncludes(comment, "Could not tie the regression");
+  assertStringIncludes(
+    comment,
+    "coverage-debt: tasks uncovered lines  <=  0",
   );
 });
 

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -20,6 +20,25 @@ export const PERF_METRICS_BACKFILL_FILE = "perf-metrics-backfill.json";
 export const COVERAGE_METRIC_PREFIX = "coverage-debt:";
 export const COVERAGE_BASELINE_RESET_MARKER = "NEW_COVERAGE_BASELINE";
 
+/**
+ * Hidden marker placed at the top of the coverage-debt suggestion comment so
+ * the gate posts it at most once per PR.
+ */
+export const COVERAGE_SUGGESTION_MARKER = "<!-- coverage-debt-suggestion -->";
+
+/**
+ * Command an author (or an LLM) runs locally to reproduce the coverage gate.
+ * Collects coverage from the unit-test suites and prints the per-group
+ * uncovered-line counts as JSON. The integration suites are omitted, so the
+ * local counts are conservative: meeting the target locally also clears CI.
+ */
+export const COVERAGE_LOCAL_CHECK_COMMAND = [
+  "rm -rf coverage/raw/local",
+  'DENO_COVERAGE_DIR="$(pwd)/coverage/raw/local" deno task test',
+  "deno run --allow-read --allow-write --allow-run tasks/coverage-metrics.ts \\",
+  '  --profile-dir="$(pwd)/coverage/raw/local" --root="$(pwd)"',
+].join("\n");
+
 /** Minimum number of historical samples before we compute a baseline. */
 export const MIN_SAMPLES = 5;
 
@@ -182,6 +201,13 @@ export interface PRInfo {
 
 export interface PRFile {
   filename: string;
+  /** Unified diff for this file. Absent for binary or oversized changes. */
+  patch?: string;
+}
+
+export interface IssueComment {
+  id: number;
+  body: string;
 }
 
 export interface CurrentPRBody {
@@ -1416,6 +1442,218 @@ export function shouldGateCoverageDebtMetric(
   return changedCoverageGroups.has(group);
 }
 
+/**
+ * Parse a unified diff (the per-file `patch` from the GitHub PR files API) and
+ * return the lines this PR adds, keyed by their line number in the new file
+ * and mapped to the added source text (without the leading `+`).
+ */
+export function parseAddedLinesFromPatch(patch: string): Map<number, string> {
+  const added = new Map<number, string>();
+  let newLineNumber = 0;
+
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("@@")) {
+      const match = /@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+      if (match) newLineNumber = parseInt(match[1], 10);
+      continue;
+    }
+
+    if (line.startsWith("+")) {
+      if (line.startsWith("+++")) continue;
+      added.set(newLineNumber, line.slice(1));
+      newLineNumber++;
+      continue;
+    }
+
+    if (line.startsWith("-")) {
+      // Deletion: present only in the old file, so the new-file cursor holds.
+      continue;
+    }
+
+    // "\ No newline at end of file" markers and the trailing empty element
+    // from splitting do not advance the new-file cursor.
+    if (line.startsWith("\\") || line === "") continue;
+
+    // Context line: present in both files.
+    newLineNumber++;
+  }
+
+  return added;
+}
+
+/** A changed source group whose uncovered-line count regressed. */
+export interface CoverageSuggestionGroup {
+  group: string;
+  /** Uncovered-line count from latest `main`; the PR must not exceed it. */
+  target: number;
+  /** Uncovered-line count this PR produced. */
+  current: number;
+}
+
+/** Count of lines a PR added that no test executes, for one file. */
+export interface CoverageSuggestionFileLines {
+  relativePath: string;
+  group: string;
+  uncoveredCount: number;
+}
+
+export interface CoverageDebtSuggestionInput {
+  groups: CoverageSuggestionGroup[];
+  files: CoverageSuggestionFileLines[];
+}
+
+const MAX_SUGGESTION_FILES = 50;
+
+/**
+ * Cap the file listing so a large PR does not produce an enormous comment.
+ * Returns the files trimmed to the budget and how many were dropped.
+ */
+function limitSuggestionFiles(
+  files: CoverageSuggestionFileLines[],
+): { files: CoverageSuggestionFileLines[]; omitted: number } {
+  if (files.length <= MAX_SUGGESTION_FILES) {
+    return { files, omitted: 0 };
+  }
+  return {
+    files: files.slice(0, MAX_SUGGESTION_FILES),
+    omitted: files.length - MAX_SUGGESTION_FILES,
+  };
+}
+
+function uncoveredLineCount(count: number): string {
+  return `${count} ${count === 1 ? "line" : "lines"}`;
+}
+
+function formatTargetList(groups: CoverageSuggestionGroup[]): string[] {
+  return groups.map((group) =>
+    `  ${COVERAGE_METRIC_PREFIX} ${group.group} uncovered lines  <=  ${group.target}   (this PR: ${group.current})`
+  );
+}
+
+/**
+ * Build the plain-text prompt an author can paste into an AI coding agent. It
+ * is self-contained: the files holding the new uncovered code, the command to
+ * reproduce the gate, and the target thresholds it must reach.
+ */
+function buildCoverageSuggestionPrompt(
+  input: CoverageDebtSuggestionInput,
+  limitedFiles: CoverageSuggestionFileLines[],
+  omitted: number,
+): string[] {
+  const lines: string[] = [
+    "Test coverage for this branch regressed: it adds source lines that no",
+    "test executes, and the CI coverage gate is failing. Add or extend tests so",
+    "the new code in the files below is executed. Write real tests that exercise",
+    "the code paths; do not delete assertions, mark lines ignored, or weaken the",
+    "gate.",
+    "",
+  ];
+
+  if (limitedFiles.length > 0) {
+    lines.push("Files with new uncovered lines (count in parentheses):");
+    lines.push("");
+    for (const file of limitedFiles) {
+      lines.push(`  ${file.relativePath} (${file.uncoveredCount})`);
+    }
+    if (omitted > 0) {
+      lines.push(`  ...and ${omitted} more file(s).`);
+    }
+    lines.push("");
+  } else {
+    lines.push(
+      "The uncovered lines could not be tied to specific files from the diff.",
+      "Run the command below to measure each group.",
+      "",
+    );
+  }
+
+  lines.push("After adding tests, verify from the repository root:");
+  lines.push("");
+  for (const command of COVERAGE_LOCAL_CHECK_COMMAND.split("\n")) {
+    lines.push(`  ${command}`);
+  }
+  lines.push("");
+  lines.push(
+    "That prints one JSON object of coverage-debt metrics. The gate passes when",
+    "each of these metrics is at or below its target:",
+    "",
+  );
+  lines.push(...formatTargetList(input.groups));
+  lines.push("");
+  lines.push(
+    "The local run omits the integration suites, so its counts are conservative:",
+    "if every metric meets its target locally, CI will pass too.",
+  );
+
+  return lines;
+}
+
+/**
+ * Build the Markdown body of the once-per-PR coverage-regression comment. Leads
+ * with the hidden marker so a later run can detect that it was already posted.
+ */
+export function buildCoverageDebtSuggestionComment(
+  input: CoverageDebtSuggestionInput,
+): string {
+  const { files, omitted } = limitSuggestionFiles(input.files);
+  const out: string[] = [COVERAGE_SUGGESTION_MARKER];
+
+  out.push("## 🧪 Test coverage regressed");
+  out.push("");
+  out.push(
+    "This PR adds source lines that no test exercises, so the coverage gate in " +
+      "the **Performance Check** job is failing. The gate ratchets each changed " +
+      "source group against its uncovered-line count on `main`: the group must " +
+      "not end up with more uncovered lines than that baseline.",
+  );
+  out.push("");
+
+  out.push("| Source group | Baseline (target) | This PR | Over by |");
+  out.push("| --- | ---: | ---: | ---: |");
+  for (const group of input.groups) {
+    out.push(
+      `| \`${group.group}\` | ${group.target} | ${group.current} | +${
+        group.current - group.target
+      } |`,
+    );
+  }
+  out.push("");
+
+  out.push("### Files with new uncovered lines");
+  out.push("");
+  if (files.length > 0) {
+    for (const file of files) {
+      out.push(
+        `- \`${file.relativePath}\` — ${
+          uncoveredLineCount(file.uncoveredCount)
+        }`,
+      );
+    }
+    if (omitted > 0) {
+      out.push(`- _…and ${omitted} more file(s)._`);
+    }
+  } else {
+    out.push(
+      "Could not tie the regression to specific files from the diff (the " +
+        "uncovered code may be in modified rather than newly-added lines). " +
+        "Use the command below to measure each group.",
+    );
+  }
+  out.push("");
+
+  out.push("### Prompt for an AI coding agent");
+  out.push("");
+  out.push(
+    "Copy the block below into an AI coding agent to add the missing tests:",
+  );
+  out.push("");
+  out.push("````text");
+  out.push(...buildCoverageSuggestionPrompt(input, files, omitted));
+  out.push("````");
+
+  return out.join("\n");
+}
+
 /** Escape a string for use inside a Markdown table cell. */
 export function escapeTableCell(s: string): string {
   return s.replace(/\|/g, "\\|").replace(/\n/g, " ");
@@ -1509,6 +1747,26 @@ export async function fetchPRFiles(prNumber: number): Promise<PRFile[]> {
   }
 
   return files;
+}
+
+/** Fetch every issue comment on a PR (PR conversation comments). */
+export async function fetchIssueComments(
+  issueNumber: number,
+): Promise<IssueComment[]> {
+  const comments: IssueComment[] = [];
+  const perPage = 100;
+
+  for (let page = 1;; page++) {
+    const data = await githubGet<{ id: number; body: string | null }[]>(
+      `/repos/${REPO}/issues/${issueNumber}/comments?per_page=${perPage}&page=${page}`,
+    );
+    for (const comment of data) {
+      comments.push({ id: comment.id, body: comment.body ?? "" });
+    }
+    if (data.length < perPage) break;
+  }
+
+  return comments;
 }
 
 export function pullRequestBodyFromEvent(


### PR DESCRIPTION
When the coverage-debt gate in the Performance Check job finds a changed source group with more uncovered lines than its main baseline, post a once-per-PR comment that helps cover the new code.

The comment lists the changed files that gained uncovered lines (with a count each) and a self-contained prompt to hand an AI coding agent, including the command and per-group line targets to reproduce the gate locally. A hidden marker keeps later runs from posting duplicates, and posting is best-effort so it never masks the regression failure.

coverage-metrics.ts computes the debt metrics as plain counts and resolves per-file uncovered line numbers only on demand (collectUncoveredLinesForFiles), so the metrics-only path never materializes line arrays for the whole workspace. perf-lib.ts gains the diff parser and comment builder; the perf-check job gets pull-requests: write.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Posts a once-per-PR comment when the `coverage-debt` gate regresses, listing changed files with new uncovered lines and a prompt with the local command and per-group targets to reproduce the gate. This helps authors add the missing tests quickly.

- **New Features**
  - CI posts a single coverage-regression comment per PR using a hidden marker.
  - Comment shows regressed groups (target vs current) and changed files with uncovered line counts.
  - Includes a copy-paste prompt with the local command and metric targets.
  - Best-effort posting; never masks the failing gate.
  - Workflow permission updated to `pull-requests: write`.

- **Refactors**
  - Added `collectUncoveredLinesForFiles` to resolve uncovered lines only for requested files.
  - Exported `lcovFromCoverageProfile` for reuse.
  - Added `parseAddedLinesFromPatch` to map added lines to new-file line numbers.
  - Added `buildCoverageDebtSuggestionComment` and `fetchIssueComments`; wired into `perf-check`.

<sup>Written for commit 5e2d4f8fd10a143488d7da32043410d9428b79da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

