### PR TITLE
Shell static router tests

### DIFF
--- a/packages/toolshed/routes/shell/shell-static.ts
+++ b/packages/toolshed/routes/shell/shell-static.ts
@@ -1,0 +1,137 @@
+import * as path from "@std/path";
+import { createRouter } from "@/lib/create-app.ts";
+import { getMimeType } from "@/lib/mime-type.ts";
+import {
+  compareETags,
+  createCacheHeaders,
+  generateETag,
+} from "@commonfabric/static/etag";
+
+/**
+ * Inputs the static router reads files and computes ETags with. Injectable so
+ * the serving logic can be exercised against an in-memory or fixture file set.
+ */
+export interface ShellStaticDeps {
+  readFile: (filePath: string) => Promise<Uint8Array>;
+  generateETag: (content: Uint8Array) => Promise<string>;
+}
+
+const defaultDeps: ShellStaticDeps = {
+  readFile: Deno.readFile,
+  generateETag,
+};
+
+/**
+ * Encapsulates static file response with ETag-based caching support.
+ * Handles both 200 (full content) and 304 (not modified) responses.
+ */
+export class StaticResponse {
+  mimeType: string;
+  buffer: Uint8Array;
+  etag: string;
+
+  constructor(
+    buffer: Uint8Array,
+    mimeType: string,
+    etag: string,
+  ) {
+    this.buffer = buffer;
+    this.mimeType = mimeType;
+    this.etag = etag;
+  }
+
+  static async fromFile(filePath: string, deps: ShellStaticDeps = defaultDeps) {
+    const buffer = await deps.readFile(filePath);
+    const mimeType = getMimeType(filePath);
+    const etag = await deps.generateETag(buffer);
+    return new StaticResponse(buffer, mimeType, etag);
+  }
+
+  response(ifNoneMatch?: string | null) {
+    // Check if client has matching ETag
+    if (ifNoneMatch && compareETags(this.etag, ifNoneMatch)) {
+      return new Response(null, {
+        status: 304,
+        headers: {
+          "ETag": this.etag,
+        },
+      });
+    }
+
+    // Simple caching strategy:
+    // Use no-cache + ETag for all files
+    // This means: always validate with server, but use cache if 304
+    const cacheHeaders = createCacheHeaders(this.etag);
+
+    const response = new Response(this.buffer as BufferSource, {
+      status: 200,
+      headers: {
+        "Content-Type": this.mimeType,
+        ...cacheHeaders,
+      },
+    });
+    return response;
+  }
+}
+
+/**
+ * Build a router that serves the compiled shell frontend out of `staticRoot`.
+ *
+ * Responses carry ETag-based caching: a 200 with the file bytes and cache
+ * headers, or a 304 when the client's `If-None-Match` matches. Requests that
+ * do not resolve to a file fall back to `index.html` for client-side routing.
+ * Paths resolving outside `staticRoot` are rejected by the traversal guard and
+ * fall through to the same `index.html` fallback.
+ */
+export function createShellStaticRouter(
+  staticRoot: string,
+  deps: ShellStaticDeps = defaultDeps,
+) {
+  const router = createRouter();
+  const cache = new Map<string, StaticResponse>();
+
+  router.get("/*", async (c) => {
+    let reqPath = c.req.path.slice(1); // Remove leading slash
+
+    // Default to index.html for root path
+    if (!reqPath) {
+      reqPath = "index.html";
+    }
+
+    // Get If-None-Match header for ETag validation
+    const ifNoneMatch = c.req.header("If-None-Match");
+
+    const cached = cache.get(reqPath);
+    if (cached) {
+      return cached.response(ifNoneMatch);
+    }
+
+    try {
+      const filePath = path.join(staticRoot, reqPath);
+      // Reject anything that resolves outside the static root. A relative path
+      // that climbs out of the root starts with "..", and an unrelated
+      // absolute path has no relative route into the root; a plain prefix
+      // check would also accept sibling directories like
+      // `${staticRoot}-dev/...`.
+      const relative = path.relative(staticRoot, filePath);
+      if (relative.startsWith("..") || path.isAbsolute(relative)) {
+        throw new Error("Outside of static root range");
+      }
+      const res = await StaticResponse.fromFile(filePath, deps);
+      cache.set(reqPath, res);
+      return res.response(ifNoneMatch);
+    } catch {
+      // Serve index.html for client-side routing
+      const cached = cache.get("index.html");
+      if (cached) {
+        return cached.response(ifNoneMatch);
+      }
+      const indexPath = path.join(staticRoot, "index.html");
+      const res = await StaticResponse.fromFile(indexPath, deps);
+      cache.set("index.html", res);
+      return res.response(ifNoneMatch);
+    }
+  });
+
+  return router;
+}

--- a/packages/toolshed/routes/shell/shell.index.ts
+++ b/packages/toolshed/routes/shell/shell.index.ts
@@ -3,15 +3,13 @@ import ports from "@commonfabric/ports" with { type: "json" };
 import * as path from "@std/path";
 import { createRouter } from "@/lib/create-app.ts";
 import { cors } from "@hono/hono/cors";
-import { getMimeType } from "@/lib/mime-type.ts";
 import env from "@/env.ts";
 import {
-  compareETags,
-  createCacheHeaders,
-  generateETag,
-} from "@commonfabric/static/etag";
+  createShellStaticRouter,
+  StaticResponse,
+} from "@/routes/shell/shell-static.ts";
 
-// Cache durations for different file types
+export { createShellStaticRouter, StaticResponse };
 
 const router = createRouter();
 
@@ -63,98 +61,8 @@ const COMPILED = await exists(path.join(projectRoot, "COMPILED"));
 const SHELL_URL = Deno.env.get("SHELL_URL");
 
 if (COMPILED) {
-  /**
-   * Encapsulates static file response with ETag-based caching support.
-   * Handles both 200 (full content) and 304 (not modified) responses.
-   */
-  class StaticResponse {
-    mimeType: string;
-    buffer: Uint8Array<ArrayBuffer>;
-    etag: string;
-
-    constructor(
-      buffer: Uint8Array<ArrayBuffer>,
-      mimeType: string,
-      etag: string,
-    ) {
-      this.buffer = buffer;
-      this.mimeType = mimeType;
-      this.etag = etag;
-    }
-
-    static async fromFile(filePath: string) {
-      const buffer = await Deno.readFile(filePath);
-      const mimeType = getMimeType(filePath);
-      const etag = await generateETag(buffer);
-      return new StaticResponse(buffer, mimeType, etag);
-    }
-
-    response(ifNoneMatch?: string | null) {
-      // Check if client has matching ETag
-      if (ifNoneMatch && compareETags(this.etag, ifNoneMatch)) {
-        return new Response(null, {
-          status: 304,
-          headers: {
-            "ETag": this.etag,
-          },
-        });
-      }
-
-      // Simple caching strategy:
-      // Use no-cache + ETag for all files
-      // This means: always validate with server, but use cache if 304
-      const cacheHeaders = createCacheHeaders(this.etag);
-
-      const response = new Response(this.buffer, {
-        status: 200,
-        headers: {
-          "Content-Type": this.mimeType,
-          ...cacheHeaders,
-        },
-      });
-      return response;
-    }
-  }
-
-  const cache = new Map<string, StaticResponse>();
-
   // Production mode - serve static files
-  router.get("/*", async (c) => {
-    let reqPath = c.req.path.slice(1); // Remove leading slash
-
-    // Default to index.html for root path
-    if (!reqPath) {
-      reqPath = "index.html";
-    }
-
-    // Get If-None-Match header for ETag validation
-    const ifNoneMatch = c.req.header("If-None-Match");
-
-    const cached = cache.get(reqPath);
-    if (cached) {
-      return cached.response(ifNoneMatch);
-    }
-
-    try {
-      const filePath = path.join(shellStaticRoot, reqPath);
-      if (!filePath.startsWith(shellStaticRoot)) {
-        throw new Error("Outside of static root range");
-      }
-      const res = await StaticResponse.fromFile(filePath);
-      cache.set(reqPath, res);
-      return res.response(ifNoneMatch);
-    } catch {
-      // Serve index.html for client-side routing
-      const cached = cache.get("index.html");
-      if (cached) {
-        return cached.response(ifNoneMatch);
-      }
-      const indexPath = path.join(shellStaticRoot, "index.html");
-      const res = await StaticResponse.fromFile(indexPath);
-      cache.set("index.html", res);
-      return res.response(ifNoneMatch);
-    }
-  });
+  router.route("/", createShellStaticRouter(shellStaticRoot));
 } else if (SHELL_URL) {
   // Development mode with proxy
 

--- a/packages/toolshed/routes/shell/shell.test.ts
+++ b/packages/toolshed/routes/shell/shell.test.ts
@@ -1,14 +1,63 @@
-import { describe, it } from "@std/testing/bdd";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import * as path from "@std/path";
+import { cors } from "@hono/hono/cors";
 import env from "@/env.ts";
-import createApp from "@/lib/create-app.ts";
+import createApp, { createRouter } from "@/lib/create-app.ts";
 import router from "@/routes/shell/shell.index.ts";
+import {
+  createShellStaticRouter,
+  StaticResponse,
+} from "@/routes/shell/shell-static.ts";
 
 if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");
 }
 
 const app = createApp().route("/", router);
+
+const INDEX_HTML = "<!doctype html><title>shell</title><body>index</body>";
+const APP_JS = "globalThis.__shell = true;\n";
+const APP_CSS = "body { color: rebeccapurple; }\n";
+const SENTINEL = "TOP_SECRET_OUTSIDE_ROOT";
+
+let tempDir: string;
+let sentinelPath: string;
+
+// A static router mounted directly, used for the serving-behavior assertions.
+let staticApp: ReturnType<typeof createApp>;
+// The static router behind the same CORS middleware the shell wires up, mounted
+// on a fully composed app, used to assert middleware applies to a 200 document.
+let composedApp: ReturnType<typeof createApp>;
+
+// Global hooks must be registered before any global describe() below, so the
+// fixture setup for the static-router suites lives here at the top of the file.
+beforeAll(async () => {
+  tempDir = await Deno.makeTempDir();
+  await Deno.writeTextFile(path.join(tempDir, "index.html"), INDEX_HTML);
+  await Deno.writeTextFile(path.join(tempDir, "app.js"), APP_JS);
+  await Deno.writeTextFile(path.join(tempDir, "app.css"), APP_CSS);
+
+  // Sentinel lives outside the static root, in the temp dir's parent, so a
+  // traversal request that escaped the root would expose it.
+  sentinelPath = path.join(path.dirname(tempDir), "shell-sentinel.txt");
+  await Deno.writeTextFile(sentinelPath, SENTINEL);
+
+  staticApp = createApp().route("/", createShellStaticRouter(tempDir));
+
+  const corsRouter = createRouter();
+  corsRouter.use(
+    "/*",
+    cors({ origin: "*", allowMethods: ["GET", "OPTIONS"] }),
+  );
+  corsRouter.route("/", createShellStaticRouter(tempDir));
+  composedApp = createApp().route("/", corsRouter);
+});
+
+afterAll(async () => {
+  await Deno.remove(tempDir, { recursive: true });
+  await Deno.remove(sentinelPath);
+});
 
 // The shell document must stay NON-cross-origin-isolated so that untrusted
 // patterns are never handed SharedArrayBuffer / Atomics or a high-resolution
@@ -108,5 +157,131 @@ describe("Shell dev fallback without a compiled build or proxy", () => {
     expect(response.status).toBe(404);
     expect(/Shell app not available/.test(body)).toBe(true);
     expect(/SHELL_URL=http:\/\/localhost:\d+/.test(body)).toBe(true);
+  });
+});
+
+describe("createShellStaticRouter", () => {
+  it("serves index.html at the root with status 200, text/html, and an ETag", async () => {
+    const response = await staticApp.request("/");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/html");
+    expect(response.headers.get("ETag")).toBeTruthy();
+    expect(await response.text()).toBe(INDEX_HTML);
+  });
+
+  it("serves an asset with a JS MIME type and its own ETag", async () => {
+    const response = await staticApp.request("/app.js");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/javascript");
+    expect(response.headers.get("ETag")).toBeTruthy();
+    expect(await response.text()).toBe(APP_JS);
+
+    // The asset's ETag differs from index.html's (different content).
+    const indexResponse = await staticApp.request("/");
+    expect(response.headers.get("ETag")).not.toBe(
+      indexResponse.headers.get("ETag"),
+    );
+  });
+
+  it("serves a CSS asset with the text/css MIME type", async () => {
+    const response = await staticApp.request("/app.css");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/css");
+    expect(await response.text()).toBe(APP_CSS);
+  });
+
+  it("returns 304 with empty body and the same ETag for If-None-Match", async () => {
+    const first = await staticApp.request("/app.js");
+    const etag = first.headers.get("ETag");
+    expect(etag).toBeTruthy();
+
+    const second = await staticApp.request("/app.js", {
+      headers: { "If-None-Match": etag! },
+    });
+    expect(second.status).toBe(304);
+    expect(await second.text()).toBe("");
+    expect(second.headers.get("ETag")).toBe(etag);
+  });
+
+  it("falls back to index.html for a path with no matching file", async () => {
+    const response = await staticApp.request("/notes/42");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/html");
+    expect(await response.text()).toBe(INDEX_HTML);
+  });
+
+  it("does not serve files outside the static root via traversal", async () => {
+    // The request resolves outside the static root; the traversal guard (and
+    // URL normalization) keep it from reaching the sentinel, so the client-side
+    // routing fallback serves index.html instead.
+    const response = await staticApp.request("/../shell-sentinel.txt");
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toBe(INDEX_HTML);
+    expect(body).not.toContain(SENTINEL);
+  });
+
+  it("returns a stable ETag across repeated requests for the same file", async () => {
+    const first = await staticApp.request("/app.js");
+    const second = await staticApp.request("/app.js");
+    expect(first.headers.get("ETag")).toBe(second.headers.get("ETag"));
+  });
+});
+
+describe("createShellStaticRouter behind composed app middleware", () => {
+  it("applies the cross-origin middleware to a served 200 document", async () => {
+    // Exercises middleware ordering on a real 200 document rather than only on
+    // the dev 404 fallback: the served index.html must still carry the
+    // cross-origin header the shell wires up ahead of the static router.
+    const response = await composedApp.request("/");
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(INDEX_HTML);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});
+
+describe("StaticResponse", () => {
+  const encoder = new TextEncoder();
+
+  // In-memory file set so StaticResponse can be exercised without touching disk.
+  const files: Record<string, Uint8Array> = {
+    "/root/index.html": encoder.encode(INDEX_HTML),
+    "/root/app.js": encoder.encode(APP_JS),
+  };
+  const deps = {
+    readFile: (filePath: string) => {
+      const content = files[filePath];
+      if (!content) return Promise.reject(new Deno.errors.NotFound(filePath));
+      return Promise.resolve(content);
+    },
+    generateETag: (content: Uint8Array) =>
+      Promise.resolve(`"len-${content.byteLength}"`),
+  };
+
+  it("derives MIME type and ETag from the file via injected deps", async () => {
+    const res = await StaticResponse.fromFile("/root/app.js", deps);
+    expect(res.mimeType).toBe("text/javascript");
+    expect(res.etag).toBe(`"len-${files["/root/app.js"].byteLength}"`);
+
+    const response = res.response();
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/javascript");
+    expect(response.headers.get("ETag")).toBe(res.etag);
+    expect(await response.text()).toBe(APP_JS);
+  });
+
+  it("returns 304 with no body when the ETag matches If-None-Match", async () => {
+    const res = await StaticResponse.fromFile("/root/index.html", deps);
+    const response = res.response(res.etag);
+    expect(response.status).toBe(304);
+    expect(response.headers.get("ETag")).toBe(res.etag);
+    expect(await response.text()).toBe("");
+  });
+
+  it("returns 200 when the If-None-Match ETag does not match", async () => {
+    const res = await StaticResponse.fromFile("/root/index.html", deps);
+    const response = res.response('"some-other-etag"');
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(INDEX_HTML);
   });
 });


### PR DESCRIPTION
Makes packages/toolshed/routes/shell testable then adds tests. See the two commits (split and test) for details.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted an injectable static router for the shell frontend and expanded tests for ETag 304s, MIME types, SPA fallback, hardened traversal guard, stable ETags, and CORS on 200s. Static serving behavior stays the same, with a stricter root boundary check.

- **Refactors**
  - Moved static serving and `StaticResponse` to `packages/toolshed/routes/shell/shell-static.ts` as `createShellStaticRouter(staticRoot, deps)` with injectable `readFile` and `generateETag` (defaults to `Deno.readFile` and `@commonfabric/static/etag`), making the serving branch testable without a `COMPILED` marker.
  - Simplified `packages/toolshed/routes/shell/shell.index.ts` to mount `createShellStaticRouter(shellStaticRoot)` and re-export `createShellStaticRouter` and `StaticResponse`; CORS/proxy/fallback wiring unchanged.
  - Hardened static-root traversal guard using `path.relative` to block climbs and sibling dirs; added tests with a temp fixture and a sentinel file, plus unit tests for `StaticResponse` with injected deps.

<sup>Written for commit c10e7f6f939c498694bb20b2d38579db88090910. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: job: Package Integration Tests (shell) = 125s
---END COPY-PASTE---
