### PR TITLE
refactor(runner): collapse residual { "/": … } sites onto the cell-rep chokepoint

### DIFF
--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@commonfabric/utils/types";
+import { isEntityRef } from "@commonfabric/data-model/cell-rep";
 import type { CellScope, JSONSchema } from "../builder/types.ts";
 import {
   findAndInlineDataURILinks,
@@ -545,15 +546,8 @@ const eventEnvelopePayloads = (
   return payloads;
 };
 
-const aliasCellId = (cell: unknown): string | undefined => {
-  try {
-    return isRecord(cell) && typeof cell["/"] === "string"
-      ? toURI(cell)
-      : undefined;
-  } catch {
-    return undefined;
-  }
-};
+const aliasCellId = (cell: unknown): string | undefined =>
+  isEntityRef(cell) ? toURI(cell) : undefined;
 
 const contractCandidatesFromEventContext = (
   event: unknown,

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -4,8 +4,6 @@ import {
   type EntityRef,
   entityRefFrom,
   entityRefFromString,
-  entityRefToString,
-  isEntityRef,
 } from "@commonfabric/data-model/cell-rep";
 import { isRecord } from "@commonfabric/utils/types";
 import { isOpaqueRef } from "./builder/types.ts";
@@ -139,15 +137,6 @@ export function getEntityId(value: any): EntityRef | undefined {
   if (typeof value === "string") {
     // Handle URI format with "of:" prefix
     if (value.startsWith("of:")) value = fromURI(value);
-    if (value.startsWith("{")) {
-      // A JSON-serialized serialized entity-ref; recognize and extract its
-      // tagged-hash string through the cell-rep chokepoint. (Only the legacy
-      // `{ "/": … }` object serializes this way; a modern `FabricHash` does
-      // not survive JSON as a ref, hence the `undefined` fall-through.)
-      const parsed = JSON.parse(value);
-      if (!isEntityRef(parsed)) return undefined;
-      value = entityRefToString(parsed);
-    }
     return entityRefFromString(value);
   }
 

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -4,6 +4,8 @@ import {
   type EntityRef,
   entityRefFrom,
   entityRefFromString,
+  entityRefToString,
+  isEntityRef,
 } from "@commonfabric/data-model/cell-rep";
 import { isRecord } from "@commonfabric/utils/types";
 import { isOpaqueRef } from "./builder/types.ts";
@@ -137,9 +139,16 @@ export function getEntityId(value: any): EntityRef | undefined {
   if (typeof value === "string") {
     // Handle URI format with "of:" prefix
     if (value.startsWith("of:")) value = fromURI(value);
-    return value.startsWith("{")
-      ? entityRefFromString(JSON.parse(value)["/"])
-      : entityRefFromString(value);
+    if (value.startsWith("{")) {
+      // A JSON-serialized serialized entity-ref; recognize and extract its
+      // tagged-hash string through the cell-rep chokepoint. (Only the legacy
+      // `{ "/": … }` object serializes this way; a modern `FabricHash` does
+      // not survive JSON as a ref, hence the `undefined` fall-through.)
+      const parsed = JSON.parse(value);
+      if (!isEntityRef(parsed)) return undefined;
+      value = entityRefToString(parsed);
+    }
+    return entityRefFromString(value);
   }
 
   const link = parseLink(value);

--- a/packages/runner/src/uri-utils.ts
+++ b/packages/runner/src/uri-utils.ts
@@ -1,7 +1,10 @@
 import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
-import { isRecord } from "@commonfabric/utils/types";
+import {
+  entityRefToString,
+  isEntityRef,
+} from "@commonfabric/data-model/cell-rep";
 import type { URI } from "./sigil-types.ts";
 
 /**
@@ -9,9 +12,14 @@ import type { URI } from "./sigil-types.ts";
  */
 export function toURI(value: unknown): URI {
   if (value instanceof FabricHash) {
+    // The live id form (an `EntityId`/`createRef` result) is a `FabricHash` in
+    // either cell-rep regime.
     return `of:${value}`;
-  } else if (isRecord(value) && typeof value["/"] === "string") {
-    return `of:${value["/"]}`;
+  } else if (isEntityRef(value)) {
+    // A serialized entity-ref for the active regime. With the modern cell
+    // representation on, that form is the `FabricHash` handled above; the
+    // `{ "/": … }` object only arises in legacy mode.
+    return `of:${entityRefToString(value)}`;
   } else if (typeof value === "string") {
     // Already has prefix with colon
     if (value.includes(":")) {

--- a/packages/runner/test/doc-map.test.ts
+++ b/packages/runner/test/doc-map.test.ts
@@ -31,32 +31,17 @@ describe("getEntityId (string forms)", () => {
     resetModernCellRepConfig();
   });
 
-  it("reads a bare id string", () => {
-    setModernCellRepConfig(false);
-    expect(entityRefToString(getEntityId(tagged)!)).toBe(tagged);
-  });
+  for (const modernCellRep of [false, true]) {
+    it(`reads a bare id string (modernCellRep=${modernCellRep})`, () => {
+      setModernCellRepConfig(modernCellRep);
+      expect(entityRefToString(getEntityId(tagged)!)).toBe(tagged);
+    });
 
-  it("reads an `of:`-prefixed id string", () => {
-    setModernCellRepConfig(false);
-    expect(entityRefToString(getEntityId(`of:${tagged}`)!)).toBe(tagged);
-  });
-
-  it("reads a JSON-serialized legacy ref in legacy mode", () => {
-    setModernCellRepConfig(false);
-    const json = JSON.stringify({ "/": tagged });
-    expect(getEntityId(json)).toEqual(getEntityId(tagged));
-    expect(entityRefToString(getEntityId(json)!)).toBe(tagged);
-  });
-
-  it('returns undefined for a JSON `{ "/": … }` ref in modern mode', () => {
-    setModernCellRepConfig(true);
-    expect(getEntityId(JSON.stringify({ "/": tagged }))).toBeUndefined();
-  });
-
-  it("returns undefined for a JSON object that isn't a ref", () => {
-    setModernCellRepConfig(false);
-    expect(getEntityId(JSON.stringify({ not: "a ref" }))).toBeUndefined();
-  });
+    it(`reads an \`of:\`-prefixed id string (modernCellRep=${modernCellRep})`, () => {
+      setModernCellRepConfig(modernCellRep);
+      expect(entityRefToString(getEntityId(`of:${tagged}`)!)).toBe(tagged);
+    });
+  }
 });
 
 describe("cell-map", () => {

--- a/packages/runner/test/doc-map.test.ts
+++ b/packages/runner/test/doc-map.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createRef, entityIdFrom, getEntityId } from "../src/create-ref.ts";
-import { entityRefToString } from "@commonfabric/data-model/cell-rep";
+import {
+  entityRefToString,
+  resetModernCellRepConfig,
+  setModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { Runtime } from "../src/runtime.ts";
@@ -17,6 +21,41 @@ describe("hashOf", () => {
     const ref = hashOf({ hello: "world" });
     const ref2 = hashOf({ hello: "world" });
     expect(ref.taggedHashString).toEqual(ref2.taggedHashString);
+  });
+});
+
+describe("getEntityId (string forms)", () => {
+  const tagged = hashOf({ test: "get-entity-id" }).taggedHashString;
+
+  afterEach(() => {
+    resetModernCellRepConfig();
+  });
+
+  it("reads a bare id string", () => {
+    setModernCellRepConfig(false);
+    expect(entityRefToString(getEntityId(tagged)!)).toBe(tagged);
+  });
+
+  it("reads an `of:`-prefixed id string", () => {
+    setModernCellRepConfig(false);
+    expect(entityRefToString(getEntityId(`of:${tagged}`)!)).toBe(tagged);
+  });
+
+  it("reads a JSON-serialized legacy ref in legacy mode", () => {
+    setModernCellRepConfig(false);
+    const json = JSON.stringify({ "/": tagged });
+    expect(getEntityId(json)).toEqual(getEntityId(tagged));
+    expect(entityRefToString(getEntityId(json)!)).toBe(tagged);
+  });
+
+  it('returns undefined for a JSON `{ "/": … }` ref in modern mode', () => {
+    setModernCellRepConfig(true);
+    expect(getEntityId(JSON.stringify({ "/": tagged }))).toBeUndefined();
+  });
+
+  it("returns undefined for a JSON object that isn't a ref", () => {
+    setModernCellRepConfig(false);
+    expect(getEntityId(JSON.stringify({ not: "a ref" }))).toBeUndefined();
   });
 });
 

--- a/packages/runner/test/storage-mixed-query-refresh.bench.ts
+++ b/packages/runner/test/storage-mixed-query-refresh.bench.ts
@@ -1,14 +1,30 @@
 import { Identity } from "@commonfabric/identity";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import {
+  entityRefFrom,
+  setModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+// Run with the modern cell representation when the env flag is set, so the
+// bench exercises whichever serialized entity-ref form (`FabricHash` vs the
+// `{ "/": … }` object) the active regime would actually store.
+setModernCellRepConfig(
+  Deno.env.get("EXPERIMENTAL_MODERN_CELL_REP") === "true",
+);
 
 const signer = await Identity.fromPassphrase("bench mixed query refresh");
 const space = signer.did();
 const DOC_COUNT = 96;
 const UPDATE_COUNT = 5;
-const BASE_SOURCES = [
-  "of:mixed-query-source-1",
-  "of:mixed-query-source-2",
-] as const;
+
+// Synthetic source ids are real `FabricHash`es (valid entity references in
+// either cell-rep regime); each `of:` URI and the `source` pointer that
+// targets it derive from the same hash so the topology stays consistent.
+const BASE_HASHES = [0, 1].map((index) =>
+  hashOf({ causal: { bench: "mixed-query", source: index } })
+);
+const BASE_SOURCES = BASE_HASHES.map((hash) => `of:${hash.taggedHashString}`);
 
 type TestProvider = ReturnType<typeof StorageManager.emulate> extends {
   open(space: string): infer T;
@@ -88,7 +104,7 @@ const buildDoc = (
   version: number,
   sourceIndex: number,
 ) => ({
-  source: { "/": BASE_SOURCES[sourceIndex]!.replace("of:", "") },
+  source: entityRefFrom(BASE_HASHES[sourceIndex]!),
   value: {
     $UI: {
       kind: "mixed-query-refresh",

--- a/packages/runner/test/storage-mixed-query-refresh.bench.ts
+++ b/packages/runner/test/storage-mixed-query-refresh.bench.ts
@@ -6,11 +6,15 @@ import {
 } from "@commonfabric/data-model/cell-rep";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
-// Run with the modern cell representation when the env flag is set, so the
-// bench exercises whichever serialized entity-ref form (`FabricHash` vs the
-// `{ "/": … }` object) the active regime would actually store.
+// Select the cell-rep regime from the env flag, mirroring how the product reads
+// EXPERIMENTAL_MODERN_CELL_REP: unset means "accept the default" (a no-op, since
+// `setModernCellRepConfig(undefined)` leaves the default in place), "false"
+// forces legacy, anything else forces modern. The bench then exercises whichever
+// serialized entity-ref form (`FabricHash` vs the `{ "/": … }` object) that
+// regime stores.
+const modernCellRepEnv = Deno.env.get("EXPERIMENTAL_MODERN_CELL_REP");
 setModernCellRepConfig(
-  Deno.env.get("EXPERIMENTAL_MODERN_CELL_REP") === "true",
+  modernCellRepEnv === undefined ? undefined : modernCellRepEnv !== "false",
 );
 
 const signer = await Identity.fromPassphrase("bench mixed query refresh");

--- a/packages/runner/test/storage-source-topology-refresh.bench.ts
+++ b/packages/runner/test/storage-source-topology-refresh.bench.ts
@@ -6,11 +6,15 @@ import {
 } from "@commonfabric/data-model/cell-rep";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
-// Run with the modern cell representation when the env flag is set, so the
-// bench exercises whichever serialized entity-ref form (`FabricHash` vs the
-// `{ "/": … }` object) the active regime would actually store.
+// Select the cell-rep regime from the env flag, mirroring how the product reads
+// EXPERIMENTAL_MODERN_CELL_REP: unset means "accept the default" (a no-op, since
+// `setModernCellRepConfig(undefined)` leaves the default in place), "false"
+// forces legacy, anything else forces modern. The bench then exercises whichever
+// serialized entity-ref form (`FabricHash` vs the `{ "/": … }` object) that
+// regime stores.
+const modernCellRepEnv = Deno.env.get("EXPERIMENTAL_MODERN_CELL_REP");
 setModernCellRepConfig(
-  Deno.env.get("EXPERIMENTAL_MODERN_CELL_REP") === "true",
+  modernCellRepEnv === undefined ? undefined : modernCellRepEnv !== "false",
 );
 
 const signer = await Identity.fromPassphrase("bench source topology refresh");

--- a/packages/runner/test/storage-source-topology-refresh.bench.ts
+++ b/packages/runner/test/storage-source-topology-refresh.bench.ts
@@ -1,21 +1,38 @@
 import { Identity } from "@commonfabric/identity";
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import {
+  entityRefFrom,
+  setModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+// Run with the modern cell representation when the env flag is set, so the
+// bench exercises whichever serialized entity-ref form (`FabricHash` vs the
+// `{ "/": … }` object) the active regime would actually store.
+setModernCellRepConfig(
+  Deno.env.get("EXPERIMENTAL_MODERN_CELL_REP") === "true",
+);
 
 const signer = await Identity.fromPassphrase("bench source topology refresh");
 const space = signer.did();
 const SUBSCRIPTION_COUNT = 256;
 const UPDATE_COUNT = 5;
-const PROCESS_URI = "of:source-topology-process" as const;
-const BASE_URIS = [
-  "of:source-topology-base-1",
-  "of:source-topology-base-2",
-] as const;
+
+// Synthetic ids are real `FabricHash`es so they're valid entity references in
+// either cell-rep regime; each `of:` URI and its `source` pointer derive from
+// the same hash so the topology stays consistent.
+const idHash = (name: string) =>
+  hashOf({ causal: { bench: "source-topology", name } });
+
+const PROCESS_HASH = idHash("process");
+const BASE_HASHES = [idHash("base-1"), idHash("base-2")] as const;
+const PROCESS_URI = `of:${PROCESS_HASH.taggedHashString}`;
+const BASE_URIS = BASE_HASHES.map((hash) => `of:${hash.taggedHashString}`);
 const PATTERN_ID = "bench-pattern:source-topology";
 const PATTERN_URI = `of:${
   hashOf({ causal: { patternId: PATTERN_ID, type: "pattern" } })
     .taggedHashString
-}` as const;
+}`;
 
 type TestProvider = ReturnType<typeof StorageManager.emulate> extends {
   open(space: string): infer T;
@@ -23,16 +40,16 @@ type TestProvider = ReturnType<typeof StorageManager.emulate> extends {
   : never;
 
 const pieceUri = (index: number) =>
-  `of:source-topology-piece-${index}` as const;
+  `of:${idHash(`piece-${index}`).taggedHashString}`;
 
 const pieceValue = (withPatternLink: boolean) =>
   withPatternLink
     ? {
-      source: { "/": "source-topology-process" },
+      source: entityRefFrom(PROCESS_HASH),
       value: { $TYPE: PATTERN_ID },
     }
     : {
-      source: { "/": "source-topology-process" },
+      source: entityRefFrom(PROCESS_HASH),
     };
 
 const setup = async (withPatternLink: boolean) => {
@@ -57,7 +74,7 @@ const setup = async (withPatternLink: boolean) => {
     {
       uri: PROCESS_URI,
       value: {
-        source: { "/": "source-topology-base-1" },
+        source: entityRefFrom(BASE_HASHES[0]),
       },
     },
     ...(withPatternLink
@@ -99,11 +116,9 @@ const runRetargetLoop = async (
     await (provider as any).send([{
       uri: PROCESS_URI,
       value: {
-        source: {
-          "/": version % 2 === 0
-            ? "source-topology-base-2"
-            : "source-topology-base-1",
-        },
+        source: entityRefFrom(
+          version % 2 === 0 ? BASE_HASHES[1] : BASE_HASHES[0],
+        ),
       },
     }]);
     await storageManager.synced();

--- a/packages/runner/test/storage-subscription-refresh.bench.ts
+++ b/packages/runner/test/storage-subscription-refresh.bench.ts
@@ -6,11 +6,15 @@ import {
 } from "@commonfabric/data-model/cell-rep";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
-// Run with the modern cell representation when the env flag is set, so the
-// bench exercises whichever serialized entity-ref form (`FabricHash` vs the
-// `{ "/": … }` object) the active regime would actually store.
+// Select the cell-rep regime from the env flag, mirroring how the product reads
+// EXPERIMENTAL_MODERN_CELL_REP: unset means "accept the default" (a no-op, since
+// `setModernCellRepConfig(undefined)` leaves the default in place), "false"
+// forces legacy, anything else forces modern. The bench then exercises whichever
+// serialized entity-ref form (`FabricHash` vs the `{ "/": … }` object) that
+// regime stores.
+const modernCellRepEnv = Deno.env.get("EXPERIMENTAL_MODERN_CELL_REP");
 setModernCellRepConfig(
-  Deno.env.get("EXPERIMENTAL_MODERN_CELL_REP") === "true",
+  modernCellRepEnv === undefined ? undefined : modernCellRepEnv !== "false",
 );
 
 const signer = await Identity.fromPassphrase("bench subscription refresh");

--- a/packages/runner/test/storage-subscription-refresh.bench.ts
+++ b/packages/runner/test/storage-subscription-refresh.bench.ts
@@ -1,11 +1,27 @@
 import { Identity } from "@commonfabric/identity";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import {
+  entityRefFrom,
+  setModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+
+// Run with the modern cell representation when the env flag is set, so the
+// bench exercises whichever serialized entity-ref form (`FabricHash` vs the
+// `{ "/": … }` object) the active regime would actually store.
+setModernCellRepConfig(
+  Deno.env.get("EXPERIMENTAL_MODERN_CELL_REP") === "true",
+);
 
 const signer = await Identity.fromPassphrase("bench subscription refresh");
 const space = signer.did();
 const SUBSCRIPTION_COUNT = 256;
 const UPDATE_COUNT = 5;
-const SOURCE_LINK = { "/": "bench:source" } as const;
+// A real `FabricHash` so the source pointer is a valid entity reference in
+// either cell-rep regime.
+const SOURCE_LINK = entityRefFrom(
+  hashOf({ causal: { bench: "subscription-refresh", source: true } }),
+);
 
 type TestProvider = ReturnType<typeof StorageManager.emulate> extends {
   open(space: string): infer T;

--- a/packages/runner/test/uri-utils.test.ts
+++ b/packages/runner/test/uri-utils.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import {
+  entityRefFrom,
+  resetModernCellRepConfig,
+  setModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
+import { toURI } from "../src/uri-utils.ts";
+
+const hash = hashOf({ causal: { test: "uri-utils" } });
+const tagged = hash.taggedHashString;
+
+describe("toURI", () => {
+  afterEach(() => {
+    resetModernCellRepConfig();
+  });
+
+  // The live id form (an `EntityId`/`createRef` result) is a `FabricHash` in
+  // either regime, so it must convert the same way regardless of the flag.
+  for (const modernCellRep of [false, true]) {
+    it(`converts a FabricHash (modernCellRep=${modernCellRep})`, () => {
+      setModernCellRepConfig(modernCellRep);
+      expect(toURI(hash)).toBe(`of:${tagged}`);
+    });
+
+    it(`converts the active-regime serialized ref (modernCellRep=${modernCellRep})`, () => {
+      setModernCellRepConfig(modernCellRep);
+      // `entityRefFrom` yields the regime's serialized form: the `{ "/": … }`
+      // object in legacy mode, the `FabricHash` itself in modern mode.
+      expect(toURI(entityRefFrom(hash))).toBe(`of:${tagged}`);
+    });
+  }
+
+  it('converts the legacy `{ "/": … }` object in legacy mode', () => {
+    setModernCellRepConfig(false);
+    expect(toURI({ "/": tagged })).toBe(`of:${tagged}`);
+  });
+
+  // Per the modern-cell-rep invariant, every stored/wire content-id hash is a
+  // `FabricHash`, so a bare `{ "/": … }` is never a content-id ref in modern
+  // mode — it is not recognized, and so is rejected rather than mishandled.
+  it('rejects a `{ "/": … }` object in modern mode', () => {
+    setModernCellRepConfig(true);
+    expect(() => toURI({ "/": tagged })).toThrow();
+  });
+
+  it("passes through an already-prefixed `of:` URI", () => {
+    expect(toURI(`of:${tagged}`)).toBe(`of:${tagged}`);
+  });
+
+  it("passes through a `data:` URI", () => {
+    const uri = "data:application/json,{}";
+    expect(toURI(uri)).toBe(uri);
+  });
+
+  it("prefixes a bare id string", () => {
+    expect(toURI("bare-id")).toBe("of:bare-id");
+  });
+
+  it("rejects a non-`of:`/`data:` prefixed string", () => {
+    expect(() => toURI("http:example")).toThrow();
+  });
+
+  it("rejects a value that is not an id", () => {
+    expect(() => toURI({ not: "an id" })).toThrow();
+  });
+});


### PR DESCRIPTION
Continues the `FabricHash` / `{ "/": … }` arc by routing the remaining direct
detect/access sites of the **legacy serialized entity-ref shape** through
`cell-rep.ts`'s chokepoint (`isEntityRef` / `entityRefToString` / `entityRefFrom`).

A repo sweep first confirmed that **no production site constructs the bare
`{ "/": … }` hash shape outside the chokepoint** anymore (`cell.entityId`,
`getEntityId`, lib-shell all route through it) — the residuals are detect/access.

### The invariant that makes this clean
With the modern cell representation on, **all db contents and network comms for
content-id hashes are `FabricHash`es**, so "modern regime AND a `{ "/": … }`
object" never co-occurs. Each consumer therefore keeps its `FabricHash` branch
(the live `EntityId`/`createRef` form is a `FabricHash` in *either* regime — not a
"maybe-`/`" concern) and routes only the maybe-`{ "/": … }` part through the
chokepoint. A bare `{ "/": … }` in modern mode is cleanly **rejected** rather
than mishandled — that's the intended clean break.

### Changes
- **Storage benches** (`storage-source-topology-refresh`, `-mixed-query-refresh`,
  `-subscription-refresh`) made flag-agnostic. They hand-rolled
  `{ "/": <bare-slug> }` `source` pointers (only model legacy; bare slugs aren't
  valid `FabricHash`es). Now every synthetic id derives from `hashOf(...)` (each
  `of:` URI and the `source` targeting it share one hash → topology consistent),
  and `source` is built via `entityRefFrom` — no explicit flag-branching in the
  bench logic. A one-line env bridge (`EXPERIMENTAL_MODERN_CELL_REP`) selects the
  regime. Verified green under **both** flag states.
- **`uri-utils.toURI`** — serialized-ref branch now uses `isEntityRef` +
  `entityRefToString` (keeps the `FabricHash` branch). New `uri-utils.test.ts`.
- **`cfc/ui-contract.aliasCellId`** — `isEntityRef(cell) ? toURI(cell) : undefined`;
  dropped the now-dead try/catch. Bonus: resolves a modern `FabricHash` alias cell
  that the old object-only guard silently dropped to `undefined`.
- **`create-ref.getEntityId`** — **removed** the `value.startsWith("{")` /
  `JSON.parse(value)["/"]` branch outright (rather than consolidating it).
  *Why:* a caller trace showed it is unreachable. The three `Cell`-passing
  callers in `piece/manager.ts` go through the object/`parseLink` path; the one
  string caller passes `link.id`, typed `URI`, which `parseLink`/`toURI`/`fromURI`
  normalize to `of:…`/`data:…`/bare — never a JSON `{…}` string. The branch was a
  vestige of an era when ids were passed around JSON-serialized. Deleting it
  removes the last direct `["/"]` access here instead of carrying dead code that
  reaches into the legacy shape. Added coverage for the live string forms (bare
  id, `of:` URI) across both regimes — previously untested.

### Verification
- `deno check` / `lint` / `fmt` clean on all touched files.
- Full runner suite green after each change (final: **636 passed, 0 failed**).
- New tests exercise both flag states directly.

### Not included (follow-ups)
- `create-ref.ts:78` — the `createRef`/`traverse` "already a serialized id" guard.
  Delicate: the object's shape is itself a hash input, so any change must stay
  byte-equivalent at the `createRef`/`hashOf` boundary. Deserves its own PR.
- `patterns/notes/note.tsx:296` — `resolved?.entityId?.["/"]`, a pattern-layer
  consumer that hardcodes the legacy shape; separate pace layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
