### PR TITLE
perf(ci): drop apt-get update and redundant jq install from CLI integ…

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -411,10 +411,23 @@ jobs:
         env:
           INSTALL_FUSE_DEPS: ${{ matrix.install_fuse_deps }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y jq
+          # jq ships on the GitHub-hosted Ubuntu image; fuse3/libfuse3-dev do
+          # not. Collect only the packages that are actually missing so the
+          # common case installs nothing.
+          pkgs=()
+          command -v jq >/dev/null 2>&1 || pkgs+=(jq)
           if [ "$INSTALL_FUSE_DEPS" = "true" ]; then
-            sudo apt-get install -y fuse3 libfuse3-dev
+            pkgs+=(fuse3 libfuse3-dev)
+          fi
+          if [ "${#pkgs[@]}" -gt 0 ]; then
+            # Install against the image's prebaked package lists first. apt-get
+            # update refreshes every mirror index and is the slow, high-variance
+            # part of this step, so only run it as a fallback when the direct
+            # install misses (e.g. stale lists).
+            sudo apt-get install -y "${pkgs[@]}" \
+              || { sudo apt-get update && sudo apt-get install -y "${pkgs[@]}"; }
+          fi
+          if [ "$INSTALL_FUSE_DEPS" = "true" ]; then
             sudo chmod 666 /dev/fuse
           fi
 


### PR DESCRIPTION
…ration setup

The "CLI Integration Tests" jobs ran `apt-get update` and then `apt-get install` on every run. The update step refreshes every Ubuntu mirror index and is the slow, high-variance part of dependency setup. It normally costs about 12 seconds, but on 2026-06-18 it spiked to between 126 and 182 seconds during transient Ubuntu mirror slowness. That spike is what made the fuse shard look like it had regressed; the FUSE test work itself stayed steady at about 46 seconds.

Install only the packages that are actually missing. jq already ships on the GitHub-hosted Ubuntu image, so the three core CLI suites now install nothing. The fuse suite installs fuse3 and libfuse3-dev directly against the image's prebaked package lists, and only falls back to apt-get update when that direct install misses (for example, when the lists are stale).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up CLI integration test setup by skipping apt-get update and avoiding a redundant `jq` install. Install only missing packages and update only as fallback, typically saving ~12s and avoiding 2–3 min spikes from mirror slowness.

- **Refactors**
  - Detect and install only missing packages; rely on preinstalled `jq`.
  - For the FUSE shard, install `fuse3` and `libfuse3-dev` using prebaked lists; run apt-get update only if that install fails.
  - Preserve the /dev/fuse permission step.

<sup>Written for commit 1293ef4b2973ca413dca6a134bd96edb54321b2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

