### PR TITLE
ci: skip apt-get update for CFC Pattern Check FUSE deps

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -85,8 +85,21 @@ jobs:
 
       - name: 📦 Install Linux FUSE test dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config gcc libfuse3-dev fuse3
+          # gcc and pkg-config ship on the GitHub-hosted Ubuntu image;
+          # libfuse3-dev and fuse3 do not. Collect only the packages that are
+          # actually missing so the common case installs just the FUSE bits.
+          pkgs=()
+          command -v gcc >/dev/null 2>&1 || pkgs+=(gcc)
+          command -v pkg-config >/dev/null 2>&1 || pkgs+=(pkg-config)
+          pkgs+=(libfuse3-dev fuse3)
+          if [ "${#pkgs[@]}" -gt 0 ]; then
+            # Install against the image's prebaked package lists first. apt-get
+            # update refreshes every mirror index and is the slow, high-variance
+            # part of this step, so only run it as a fallback when the direct
+            # install misses (e.g. stale lists).
+            sudo apt-get install -y "${pkgs[@]}" \
+              || { sudo apt-get update && sudo apt-get install -y "${pkgs[@]}"; }
+          fi
 
       - name: 📥 Download Deno dependency binaries
         run: deno task initialize-db


### PR DESCRIPTION
The "Install Linux FUSE test dependencies" step ran apt-get update before every install. That refresh of every Ubuntu mirror index is the slow, high-variance part of the step (normally ~12s, spiking to 1-3 min during transient mirror slowness).

Collect only the missing packages and install against the runner image's prebaked package lists, falling back to apt-get update only when the direct install misses. gcc and pkg-config ship on the image, so they are added only when absent; libfuse3-dev and fuse3 do not ship and are always collected.

Mirrors the pattern applied to the cli-integration-test step.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up the CFC Pattern Check by skipping apt-get update in the Linux FUSE deps step and installing only missing packages against the runner’s prebaked lists, with apt-get update as a fallback. Always install `libfuse3-dev` and `fuse3`; add `gcc` and `pkg-config` only when absent, reducing variance and avoiding 1–3 min spikes, matching the cli-integration-test pattern.

<sup>Written for commit 942e734b0392cc3f9135d450c775b4b49f43ab63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

