### PR TITLE
ci: cache apt .deb packages across all CI shards via a composite action

### DIFF
--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -1,0 +1,70 @@
+name: "Cached apt install"
+description: >
+  Install apt packages, caching the downloaded .deb files so a cache hit
+  installs them from disk without contacting an apt mirror.
+inputs:
+  packages:
+    description: "Space-separated list of apt packages to install."
+    required: true
+  cache-key:
+    description: >
+      Namespace for the package cache. Unrelated installs should pass distinct
+      values so they get separate cache entries.
+    required: false
+    default: "apt"
+runs:
+  using: "composite"
+  steps:
+    - name: 🧮 Resolve apt cache identity
+      id: norm
+      shell: bash
+      env:
+        PACKAGES: ${{ inputs.packages }}
+      run: |
+        # A cache-key-safe id derived from the package set, plus the runner
+        # image id, so the key changes when either the package list or the base
+        # image changes. ImageOS is set in the runner environment but does not
+        # resolve through ${{ env.ImageOS }} inside a composite action, so read
+        # it from the shell environment here.
+        echo "id=$(printf '%s' "$PACKAGES" | tr ' ' '-')" >> "$GITHUB_OUTPUT"
+        echo "image=${ImageOS:-unknown}" >> "$GITHUB_OUTPUT"
+
+    - name: 💾 Cache apt packages
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/apt-deb/${{ inputs.cache-key }}
+        key: apt-deb-${{ inputs.cache-key }}-${{ runner.os }}-${{ steps.norm.outputs.image }}-${{ steps.norm.outputs.id }}
+
+    - name: 📦 Install apt packages
+      shell: bash
+      env:
+        PACKAGES: ${{ inputs.packages }}
+        CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+        CACHE_KEY: ${{ inputs.cache-key }}
+      run: |
+        archives="$HOME/.cache/apt-deb/$CACHE_KEY"
+        mkdir -p "$archives/partial"
+        if [ "$CACHE_HIT" = "true" ]; then
+          # Cache hit: install the cached .deb files directly with dpkg. dpkg
+          # installs from file paths, so it needs no package index and no
+          # mirror; the dependency closure was downloaded on the miss that
+          # populated the cache. An empty cache means the packages are already
+          # on the runner image.
+          shopt -s nullglob
+          debs=("$archives"/*.deb)
+          if [ "${#debs[@]}" -gt 0 ]; then
+            sudo dpkg -i "${debs[@]}"
+          else
+            echo "No cached .deb files; requested packages are already on the runner image."
+          fi
+        else
+          # Cache miss: refresh the package lists and download the .deb files
+          # (and their dependency closure) into the cache directory, then
+          # install them from there.
+          sudo apt-get update
+          sudo apt-get install -y -d -o Dir::Cache::Archives="$archives" $PACKAGES
+          sudo apt-get install -y -o Dir::Cache::Archives="$archives" --no-download $PACKAGES
+          # actions/cache reads the directory as the runner user on save.
+          sudo chown -R "$(id -u):$(id -g)" "$archives"
+        fi

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -84,9 +84,10 @@ jobs:
         run: deno install --frozen=true
 
       - name: 📦 Install Linux FUSE test dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config gcc libfuse3-dev fuse3
+        uses: ./.github/actions/apt-install
+        with:
+          packages: pkg-config gcc libfuse3-dev fuse3
+          cache-key: cfc-pattern-check
 
       - name: 📥 Download Deno dependency binaries
         run: deno task initialize-db
@@ -408,15 +409,14 @@ jobs:
           url: http://localhost:${{ matrix.toolshed_port }}
 
       - name: 📦 Install CLI integration dependencies
-        env:
-          INSTALL_FUSE_DEPS: ${{ matrix.install_fuse_deps }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq
-          if [ "$INSTALL_FUSE_DEPS" = "true" ]; then
-            sudo apt-get install -y fuse3 libfuse3-dev
-            sudo chmod 666 /dev/fuse
-          fi
+        uses: ./.github/actions/apt-install
+        with:
+          packages: ${{ matrix.install_fuse_deps && 'jq fuse3 libfuse3-dev' || 'jq' }}
+          cache-key: cli-integration
+
+      - name: 🔧 Enable FUSE device access
+        if: ${{ matrix.suite_name == 'fuse' }}
+        run: sudo chmod 666 /dev/fuse
 
       - name: 🧪 Run CLI integration suite
         if: ${{ startsWith(matrix.suite_name, 'core-') }}


### PR DESCRIPTION
The CI apt dependency installs ran `apt-get update` followed by `apt-get install` on every run. The update step refreshes every Ubuntu mirror index and is the slow, high-variance part of dependency setup; on 2026-06-18 it spiked from about 12 seconds to between 126 and 182 seconds during transient mirror slowness, which is what made the fuse shard look like it had regressed.

Add a reusable composite action, .github/actions/apt-install, that caches the downloaded .deb files keyed on the runner image and the exact package set. On a cache hit it installs from those files with the source lists and downloads disabled, so it never contacts an apt mirror. On a miss it refreshes the lists once, downloads into the cache, and installs from there.

Use the action for both apt install sites in the CI configuration: the CLI integration dependencies (with the fuse suite's /dev/fuse chmod moved to its own step) and the CFC Pattern Check FUSE test dependencies, which is sharded four ways. These are the only two apt sites; Deno dependencies are already cached by the deno-setup composite action, so no other shard needed a change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache apt .deb packages across all CI shards with a reusable composite action, skipping `apt-get update` on cache hits to remove mirror variance and speed up job setup. Applies to CLI integration and FUSE tests.

- **Refactors**
  - Added `.github/actions/apt-install` that caches `.deb` files keyed by runner OS, `ImageOS`, and package set; installs from cache with `dpkg -i` on a hit, runs `apt-get update`, downloads the dependency closure, and seeds the cache on a miss.
  - Updated `.github/workflows/deno.yml` to use the action for CFC Pattern Check (`pkg-config`, `gcc`, `libfuse3-dev`, `fuse3`) and CLI integration (`jq` with optional `fuse3`/`libfuse3-dev`); moved `sudo chmod 666 /dev/fuse` to a dedicated step for the `fuse` suite; separate cache namespaces `cfc-pattern-check` and `cli-integration`. Deno deps unchanged.

<sup>Written for commit c7e2eba495b199c98324307223c4631398f81cdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

