### PR TITLE
fix(patterns): settle cross-space sync around home profile creation

### DIFF
--- a/packages/patterns/integration/home-profile.test.ts
+++ b/packages/patterns/integration/home-profile.test.ts
@@ -7,6 +7,7 @@ import {
   clickTrustedAction,
   fillCfInput,
   waitForRuntimeIdle,
+  waitForRuntimeSynced,
   waitForText,
 } from "./cfc-browser-helpers.ts";
 
@@ -63,8 +64,16 @@ async function ensureProfileTabActive(page: any) {
 // deno-lint-ignore no-explicit-any
 async function createProfile(page: any, name: string) {
   await ensureProfileTabActive(page);
+  // Each profile lives in its own `inSpace` child space, so appending one is a
+  // cross-space commit. `waitForRuntimeIdle` returns once the scheduler queue
+  // drains; `waitForRuntimeSynced` additionally awaits every opened space to
+  // reconcile. Settle fully before submitting so the append does not interleave
+  // with commits still in flight from a prior navigation's rehydration, and
+  // again after so it reconciles before the caller navigates or appends again.
+  await waitForRuntimeSynced(page);
   await fillCfInput(page, "#wish-profile-picker-name-input", name);
   await clickTrustedAction(page, TRUSTED_PROFILE_CREATE_ACTION);
+  await waitForRuntimeSynced(page);
 }
 
 // Regression coverage for creating a profile directly from the home space's


### PR DESCRIPTION
The "creates a second profile from the picker (multi-profile append)" test reloads the home space (which already holds a profile from the prior step) and then creates more profiles. Reloading a home with persisted profiles rehydrates its reactive state through a burst of commits that are still in flight after rt.idle() returns: idle reports the scheduler queue is drained, not that every opened space has synced. A profile append is a cross-space commit (each profile lives in its own inSpace child space); an append submitted in that window is reverted by the in-flight churn and, being a one-shot event-handler write, is not replayed, so the new profile is durably lost and never reaches the picker.

createProfile now waits for waitForRuntimeSynced (rt.allSynced) before submitting and again after, so each append happens against a reconciled state and commits durably before the next navigation or append.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure profile creation from the home picker runs against a fully synced runtime so cross-space appends aren’t lost after a reload. The test now awaits `waitForRuntimeSynced` before submit and again after to let commits reconcile.

- **Bug Fixes**
  - In `packages/patterns/integration/home-profile.test.ts`, `createProfile` now calls `waitForRuntimeSynced` before and after the append (instead of relying on `waitForRuntimeIdle`).
  - Fixes a race where rehydration after reloading the home space could revert the new profile in the multi-profile picker flow.

<sup>Written for commit 13ecaf920975b19bc6f1e616e0aab3186e688375. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

