### PR TITLE
refactor: remove the ultra-legacy link-v0.1 cell-link form

### DIFF
--- a/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.routes.ts
+++ b/packages/toolshed/routes/integrations/oauth2-common/oauth2-common.routes.ts
@@ -32,7 +32,7 @@ export function createOAuth2Routes(providerName: string) {
               .openapi({
                 example: {
                   authCellId:
-                    '{"/" : {"link-v0.1" : {"id" : "of:bafe...", "space" : "did:key:bafe...", "path" : ["path", "to", "value"]}}}',
+                    '{"/" : {"link@1" : {"id" : "of:bafe...", "space" : "did:key:bafe...", "path" : ["path", "to", "value"]}}}',
                   integrationPieceId: "integration-piece-123",
                 },
               }),
@@ -194,7 +194,7 @@ export function createOAuth2Routes(providerName: string) {
               .openapi({
                 example: {
                   authCellId:
-                    '{"/" : {"link-v0.1" : {"id" : "of:bafe...", "space" : "did:key:bafe...", "path" : ["path", "to", "value"]}}}',
+                    '{"/" : {"link@1" : {"id" : "of:bafe...", "space" : "did:key:bafe...", "path" : ["path", "to", "value"]}}}',
                 },
               }),
           },

--- a/packages/toolshed/routes/webhooks/webhooks.test.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.test.ts
@@ -92,20 +92,6 @@ describe("Webhook Utilities", () => {
       expect(space).toBe("did:key:z6Mktest123");
     });
 
-    it("extracts space from legacy link-v0.1 cell link", () => {
-      const cellLink = JSON.stringify({
-        "/": {
-          "link-v0.1": {
-            id: "of:bafe123",
-            space: "did:key:z6Mktest123",
-            path: ["webhooks", "github"],
-          },
-        },
-      });
-      const space = extractSpaceFromCellLink(cellLink);
-      expect(space).toBe("did:key:z6Mktest123");
-    });
-
     it("throws for invalid JSON", () => {
       expect(() => extractSpaceFromCellLink("not json")).toThrow();
     });

--- a/packages/toolshed/routes/webhooks/webhooks.utils.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.utils.ts
@@ -234,7 +234,7 @@ export function extractSpaceFromCellLink(cellLink: string): string {
   const link = parsed["/"];
   if (!link) throw new Error("Invalid cell link format");
 
-  const linkData = link["link@1"] ?? link["link-v0.1"];
+  const linkData = link["link@1"];
   if (!linkData?.space) throw new Error("Cell link missing space");
 
   return linkData.space;

--- a/packages/ui/src/v2/components/cf-webhook/cf-webhook.ts
+++ b/packages/ui/src/v2/components/cf-webhook/cf-webhook.ts
@@ -162,8 +162,7 @@ export class CFWebhook extends BaseElement {
     try {
       // Extract space DID from inbox cell link for ownership verification
       const inboxLink = this.inbox?.toJSON?.() as any;
-      const linkData = inboxLink?.["/"]?.["link@1"] ??
-        inboxLink?.["/"]?.["link-v0.1"];
+      const linkData = inboxLink?.["/"]?.["link@1"];
       const space = linkData?.space ?? "";
       const params = new URLSearchParams({ space });
 


### PR DESCRIPTION
Removes the **ultra-legacy** `link-v0.1` serialized cell-link form.

`link-v0.1` is an ultra-legacy tag with **no producer** anywhere in the system —
a whole-repo search turns up only read-side fallbacks, two OpenAPI doc examples,
and one test. Nothing has minted it in a very long time, so there are no live
serialized instances in any database that matters.

### Changes
- Drop the read-side fallbacks so `link@1` is the only recognized form:
  - `cf-webhook` inbox-link parsing (`… ["link@1"] ?? … ["link-v0.1"]`)
  - toolshed `extractSpaceFromCellLink` (same fallback)
- Update the two `oauth2-common` route OpenAPI examples to `link@1`.
- Remove the `extractSpaceFromCellLink` legacy-`link-v0.1` test case.

### Why now
This is preparatory cleanup for the `create-ref` traverse-guard work: with the
ultra-legacy form gone, `link@1` is the **sole** object-valued `{ "/": … }` sigil
tag, which lets the guard be expressed as `isEntityRef(obj) || isAnySigilLink(obj)`
without a catch-all.

### Verification
- No `link-v0.1` references remain repo-wide.
- `deno check` / `lint` / `fmt` clean on all touched files.
- toolshed `webhooks.test.ts` green (the `link@1` extraction + error cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

This PR removes code and so should have no effect on integration test time. So the following accounts for a spurious perf check failure:

NEW_PERF_BASELINE: job: CLI Integration Tests (fuse) = 124s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the ultra-legacy `link-v0.1` cell-link form so `link@1` is the only supported tag. This simplifies link parsing and prepares the create-ref traverse-guard cleanup.

- **Refactors**
  - Dropped read-side fallbacks in `cf-webhook` and toolshed `extractSpaceFromCellLink`; now only `link@1` is accepted.
  - Updated `oauth2-common` route OpenAPI examples to `link@1`.
  - Removed the legacy `link-v0.1` extraction test.

<sup>Written for commit 4665ab997391c346942029479699c9aa4a744e47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

