### PR TITLE
refactor(runner): prune dead sigil-link predicates + the never-minted absolute-cell legacy alias

### DIFF
--- a/packages/html/test/worker-reconciler-cell-props.test.ts
+++ b/packages/html/test/worker-reconciler-cell-props.test.ts
@@ -1100,71 +1100,6 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
     );
 
     await t.step(
-      "renderer VDOM schema preserves legacy alias child render nodes",
-      async () => {
-        const collector = createOpsCollector();
-        const reconciler = new WorkerReconciler({
-          onOps: collector.onOps,
-        });
-
-        const tx = runtime.edit();
-        const linkedChild = runtime.getCell(
-          signer.did(),
-          "renderer-schema-legacy-alias-child",
-          undefined,
-          tx,
-        );
-        linkedChild.setRawUntyped({
-          type: "vnode",
-          name: "cf-card",
-          props: { id: "legacy-alias-child-card" },
-          children: ["Legacy alias child"],
-        });
-        const rootCell = runtime.getCell(
-          signer.did(),
-          "renderer-schema-legacy-alias-child-root",
-          undefined,
-          tx,
-        );
-        rootCell.setRawUntyped({
-          type: "vnode",
-          name: "cf-vstack",
-          props: {},
-          children: [{
-            $alias: {
-              cell: {
-                "/": linkedChild.getAsNormalizedFullLink().id.replace(
-                  /^of:/,
-                  "",
-                ),
-              },
-              path: [],
-            },
-          }],
-        });
-        const commitResult = await tx.commit();
-        assertEquals(commitResult.ok !== undefined, true);
-
-        const rootVDOMCell = runtime.getCell(
-          signer.did(),
-          "renderer-schema-legacy-alias-child-root",
-        ).asSchema(rendererVDOMSchema);
-        const cancel = reconciler.mount(rootVDOMCell as never);
-        try {
-          await new Promise((resolve) => setTimeout(resolve, 10));
-
-          const createdTags = collector.getOpsOfType("create-element").map(
-            (op) => (op as Extract<VDomOp, { op: "create-element" }>).tagName,
-          );
-          assertEquals(createdTags.includes("cf-vstack"), true);
-          assertEquals(createdTags.includes("cf-card"), true);
-        } finally {
-          cancel();
-        }
-      },
-    );
-
-    await t.step(
       "renderer VDOM schema preserves nested render node children",
       async () => {
         const collector = createOpsCollector();
@@ -1206,17 +1141,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
                 props: { id: "nested-inline-card" },
                 children: ["Nested inline child"],
               },
-              {
-                $alias: {
-                  cell: {
-                    "/": linkedChild.getAsNormalizedFullLink().id.replace(
-                      /^of:/,
-                      "",
-                    ),
-                  },
-                  path: [],
-                },
-              },
+              linkedChild.getAsLink({ keepAsCell: true }),
             ],
           }],
         });

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -106,16 +106,6 @@ export function isSigilLink(value: any): value is SigilLink {
   return (isSigilValue(value) && LINK_V1_TAG in value["/"]);
 }
 
-/**
- * Check if value is a sigil alias (link with overwrite field).
- */
-export function isSigilWriteRedirectLink(
-  value: any,
-): value is SigilWriteRedirectLink {
-  return isSigilLink(value) &&
-    value["/"][LINK_V1_TAG].overwrite === "redirect";
-}
-
 export function isPrimitiveCellLink(
   value: any,
 ): value is PrimitiveCellLink {

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -91,11 +91,11 @@ export type PrimitiveCellLink =
   | LegacyAlias; // @deprecated
 
 /**
- * Check if value is a sigil value with any type
- *
- * Any object that is strictly `{ "/": Record<string, any> }`, no other props
+ * Check if value is a sigil value with any type: an object that is strictly
+ * `{ "/": Record<string, any> }`, no other props. Internal helper for
+ * {@link isSigilLink}.
  */
-export function isSigilValue(value: any): value is SigilValue<any> {
+function isSigilValue(value: any): value is SigilValue<any> {
   return isRecord(value) &&
     "/" in value &&
     Object.keys(value).length === 1 &&

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -123,11 +123,14 @@ export function isNormalizedLink(value: any): value is NormalizedLink {
 }
 
 /**
- * Check if value is a normalized link.
+ * Check if value is a normalized full link.
  *
  * Beware: Unlike all the other types that `isLink` is checking for, this could
  * appear in regular data and not actually be meant as a link. So only use this
  * if you know for sure that the value is a link.
+ *
+ * We don't verify that the id and space are URI or MemorySpace, but we do
+ * verify that they are strings.
  */
 export function isNormalizedFullLink(value: any): value is NormalizedFullLink {
   return (

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -13,7 +13,6 @@ import {
   type SigilWriteRedirectLink,
   type URI,
 } from "./sigil-types.ts";
-import { toURI } from "./uri-utils.ts";
 import { arrayEqual } from "./path-utils.ts";
 import type {
   IMemorySpaceAddress,
@@ -208,19 +207,9 @@ export function parseLinkPrimitive(
     };
   } else if (isLegacyAlias(value)) {
     const alias = value.$alias;
-    let id: URI | undefined;
-
-    // If cell is provided, convert to URI
-    if (alias.cell) {
-      if (isRecord(alias.cell) && "/" in alias.cell) {
-        id = toURI(alias.cell);
-      }
-    }
-
-    // If no cell provided, use base cell's document
-    if (!id && base) {
-      id = base.id;
-    }
+    // Named-cell ("argument"/"result") and partialCause aliases carry no
+    // absolute id of their own here, so resolve to the base cell's document.
+    const id = base?.id;
 
     return {
       ...(id && { id }),

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -30,6 +30,7 @@ import {
 } from "./storage/interface.ts";
 import type { Runtime } from "./runtime.ts";
 import {
+  isNormalizedFullLink,
   isNormalizedLink,
   isPrimitiveCellLink,
   NormalizedFullLink,
@@ -62,27 +63,6 @@ export function isCellLink(
     isCellResultForDereferencing(value) ||
     isPrimitiveCellLink(value) ||
     isCell(value)
-  );
-}
-
-/**
- * Check if value is a normalized link.
- *
- * Beware: Unlike all the other types that `isLink` is checking for, this could
- * appear in regular data and not actually be meant as a link. So only use this
- * if you know for sure that the value is a link.
- *
- * We don't verify that the id and space are URI or MemorySpace, but we do
- * verify that they are strings.
- */
-export function isNormalizedFullLink(value: any): value is NormalizedFullLink {
-  return (
-    isRecord(value) &&
-    typeof value.id === "string" &&
-    typeof value.space === "string" &&
-    (value.scope === "space" || value.scope === "user" ||
-      value.scope === "session") &&
-    Array.isArray(value.path)
   );
 }
 

--- a/packages/runner/src/sigil-types.ts
+++ b/packages/runner/src/sigil-types.ts
@@ -67,12 +67,6 @@ type LegacyAliasNamedCell = LegacyAliasBase & {
   defer?: number;
 };
 
-type LegacyAliasAbsoluteCell = LegacyAliasBase & {
-  cell: { "/": string };
-  partialCause?: never;
-  defer?: never;
-};
-
 /**
  * These are partial bindings that may not be applicable to the current
  * pattern. We track the defer count, and each time we unwrap bindings,
@@ -89,6 +83,5 @@ type LegacyAliasPartialCause = LegacyAliasBase & {
 export type LegacyAlias = {
   $alias:
     | LegacyAliasNamedCell
-    | LegacyAliasAbsoluteCell
     | LegacyAliasPartialCause;
 };

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -11,7 +11,7 @@ import {
   encodeJsonPointer,
   isCellLink,
   isLegacyAlias,
-  isSigilValue,
+  isSigilLink,
   isWriteRedirectLink,
   type NormalizedLink,
   parseLink,
@@ -51,80 +51,46 @@ describe("link-utils", () => {
     await storageManager?.close();
   });
 
-  describe("isSigilValue", () => {
-    it("should identify valid sigil values", () => {
-      const validSigil = { "/": { someKey: "someValue" } };
-      expect(isSigilValue(validSigil)).toBe(true);
+  describe("isSigilLink", () => {
+    it("should identify a link@1 sigil", () => {
+      const link = { "/": { [LINK_V1_TAG]: { id: "of:test", path: [] } } };
+      expect(isSigilLink(link)).toBe(true);
     });
 
-    it("should identify sigil values with empty record", () => {
-      const emptySigil = { "/": {} };
-      expect(isSigilValue(emptySigil)).toBe(true);
+    it("should not identify a single-key `/` sigil that isn't a link@1", () => {
+      expect(isSigilLink({ "/": { someKey: "someValue" } })).toBe(false);
+      expect(isSigilLink({ "/": {} })).toBe(false);
+      expect(isSigilLink({ "/": { nested: { deep: "value" } } })).toBe(false);
     });
 
-    it("should identify sigil values with nested objects", () => {
-      const nestedSigil = { "/": { nested: { deep: "value" } } };
-      expect(isSigilValue(nestedSigil)).toBe(true);
+    it("should not identify objects with `/` and other properties", () => {
+      expect(isSigilLink({ "/": { [LINK_V1_TAG]: {} }, otherProp: "v" }))
+        .toBe(false);
+      expect(isSigilLink({ "/": { key: "value" }, extra: 123 })).toBe(false);
+      expect(isSigilLink({ "/": { key: "value" }, "/extra": "value" }))
+        .toBe(false);
     });
 
-    it("should not identify objects with / and other properties", () => {
-      const invalidSigil1 = { "/": { key: "value" }, otherProp: "value" };
-      expect(isSigilValue(invalidSigil1)).toBe(false);
-
-      const invalidSigil2 = { "/": { key: "value" }, extra: 123 };
-      expect(isSigilValue(invalidSigil2)).toBe(false);
-
-      const invalidSigil3 = {
-        "/": { key: "value" },
-        nested: { prop: "value" },
-      };
-      expect(isSigilValue(invalidSigil3)).toBe(false);
+    it("should not identify objects without a `/` property", () => {
+      expect(isSigilLink({ otherProp: "value" })).toBe(false);
+      expect(isSigilLink({})).toBe(false);
     });
 
-    it("should not identify objects without / property", () => {
-      const noSlash = { otherProp: "value" };
-      expect(isSigilValue(noSlash)).toBe(false);
-
-      const emptyObject = {};
-      expect(isSigilValue(emptyObject)).toBe(false);
-    });
-
-    it("should not identify objects where / is not a record", () => {
-      const stringSlash = { "/": "not a record" };
-      expect(isSigilValue(stringSlash)).toBe(false);
-
-      const numberSlash = { "/": 123 };
-      expect(isSigilValue(numberSlash)).toBe(false);
-
-      const arraySlash = { "/": ["not", "a", "record"] };
-      expect(isSigilValue(arraySlash)).toBe(false);
-
-      const nullSlash = { "/": null };
-      expect(isSigilValue(nullSlash)).toBe(false);
-
-      const undefinedSlash = { "/": undefined };
-      expect(isSigilValue(undefinedSlash)).toBe(false);
+    it("should not identify objects where `/` is not a record", () => {
+      expect(isSigilLink({ "/": "not a record" })).toBe(false);
+      expect(isSigilLink({ "/": 123 })).toBe(false);
+      expect(isSigilLink({ "/": ["not", "a", "record"] })).toBe(false);
+      expect(isSigilLink({ "/": null })).toBe(false);
+      expect(isSigilLink({ "/": undefined })).toBe(false);
     });
 
     it("should not identify non-objects", () => {
-      expect(isSigilValue("string")).toBe(false);
-      expect(isSigilValue(123)).toBe(false);
-      expect(isSigilValue(true)).toBe(false);
-      expect(isSigilValue(null)).toBe(false);
-      expect(isSigilValue(undefined)).toBe(false);
-      expect(isSigilValue([])).toBe(false);
-    });
-
-    it("should handle edge cases with multiple properties", () => {
-      const multipleProps = {
-        "/": { key: "value" },
-        prop1: "value1",
-        prop2: "value2",
-      };
-      expect(isSigilValue(multipleProps)).toBe(false);
-
-      const onlySlashButMultiple = { "/": { key: "value" }, "/extra": "value" };
-      expect(isSigilValue(onlySlashButMultiple)).toBe(false);
+      expect(isSigilLink("string")).toBe(false);
+      expect(isSigilLink(123)).toBe(false);
+      expect(isSigilLink(true)).toBe(false);
+      expect(isSigilLink(null)).toBe(false);
+      expect(isSigilLink(undefined)).toBe(false);
+      expect(isSigilLink([])).toBe(false);
     });
   });
 

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -9,7 +9,6 @@ import {
   type JSONSchema,
   LINK_V1_TAG,
   type SigilLink,
-  type URI,
 } from "@commonfabric/runner/shared";
 import {
   cfcLabelViewsEqual,
@@ -591,16 +590,10 @@ function parseAsCellRef(
     const alias = value.$alias;
     const aliasPath = alias.path.map((p) => String(p));
 
-    let entityId: URI;
-    if (alias.cell && typeof alias.cell === "object" && "/" in alias.cell) {
-      const rawId = (alias.cell as { "/": string })["/"];
-      entityId = (rawId.startsWith("of:") ? rawId : `of:${rawId}`) as URI;
-    } else {
-      entityId = from.id;
-    }
-
+    // Named-cell/partialCause aliases carry no absolute id of their own;
+    // resolve to the base cell's document.
     return {
-      id: entityId,
+      id: from.id,
       space: from.space,
       scope: from.scope,
       path: aliasPath,


### PR DESCRIPTION
Pre-cleaning of the sigil/legacy-link surface ahead of the `create-ref` traverse-guard
work — pruning dead predicates, a duplicate, and a never-minted ultra-legacy form so
`link@1` and the genuinely-live alias variants are the minimal actually-used shape.

### Changes
- **Remove dead `isSigilWriteRedirectLink`** — zero references anywhere (no prod, no
  tests, not even internal; `isWriteRedirectLink` inlines the same check). Its return
  type `SigilWriteRedirectLink` stays (used by `cell.ts` + `isWriteRedirectLink`).
- **Un-export `isSigilValue`** into a module-private helper — no production callers,
  only internal use by `isSigilLink` + a direct test. Its shape-rejection coverage
  migrates to a new `isSigilLink` describe block (observable through `isSigilLink`,
  which gates on it).
- **Drop the never-minted absolute-cell legacy-alias form** (`$alias: { cell: { "/": string } }`).
  No source mints it — every alias-construction site produces the named-cell
  (`"argument"`/`"result"`) or `partialCause` variant. It's an ultra-legacy form like
  `link-v0.1`: recognized on read, never produced (and `pattern-binding` already throws
  on a non-string cell). Removes the union arm plus the two `{ "/": … }`-cell readers
  (`parseLinkPrimitive`, runtime-client `cell-handle` — both already fell back to the
  base cell's document for every produced variant), and the now-unused `toURI`/`URI`
  imports. The CFC ui-contract path is unaffected (it resolves alias cells via
  `isEntityRef`, independent of this type).
- **De-duplicate `isNormalizedFullLink`** — it was defined byte-identically in both
  `link-types.ts` and `link-utils.ts`, with the local `link-utils.ts` copy silently
  shadowing the `export *` re-export (two definitions of one predicate, free to drift).
  Consolidated onto the canonical `link-types.ts` definition.

### Not touched (all load-bearing)
`isSigilLink`, `isPrimitiveCellLink`, `isWriteRedirectLink`, `isLegacyAlias`,
`isNormalizedLink` all have real production callers; the live alias variants (named-cell,
partialCause) and `link@1` are the minimal shape that remains.

### Verification
- `deno check` / `lint` / `fmt` clean on all touched files (runner + runtime-client).
- Full runner suite green after each change (637 passed, 0 failed).
- `isSigilValue`'s migrated coverage runs via the new `isSigilLink` block; the
  `cfc-ui-contract` test (which exercises a `{ "/": … }` alias cell in event context)
  still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pruned unused sigil/legacy-link predicates and removed the never-minted absolute-cell legacy alias to reduce surface area. Kept `link@1` and the live alias variants (named-cell, `partialCause`) as the only supported shapes, and consolidated normalized-link checks; updated reconciler tests to use the modern link form.

- **Refactors**
  - Removed dead `isSigilWriteRedirectLink`; its type remains.
  - Scoped `isSigilValue` to the module; coverage moved under `isSigilLink` tests.
  - Dropped absolute-cell legacy alias (`$alias: { cell: { "/": string } }`); runner and runtime now resolve legacy aliases to the base cell’s document; removed unused `toURI`/`URI` imports.
  - Consolidated `isNormalizedFullLink` in `link-types.ts`; removed duplicate from `link-utils.ts`.
  - Updated HTML reconciler tests to use `getAsLink({ keepAsCell: true })` for cross-cell children and removed the redundant legacy-alias case.

<sup>Written for commit d5abf29609964d315291c00c9705aa5d6113d255. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

