### PR TITLE
fix(lunch-poll): capture isAdmin in generated-art lifts so thumbnails render

### DIFF
--- a/packages/patterns/lunch-poll/poll-option-card.tsx
+++ b/packages/patterns/lunch-poll/poll-option-card.tsx
@@ -79,6 +79,21 @@ const homePageLookupUrlFor = (
     ? endpoint
     : "";
 
+// Host-only art-generation gate. Passing `isAdmin` as a function argument
+// (rather than a bare `!isAdmin` inside a computed) ensures the transformer
+// captures it as a lift input — see homePageLookupUrlFor for the same idiom.
+const mayGenerateArt = (
+  isAdmin: boolean,
+  storedImageUrl: string | undefined,
+): boolean => isAdmin && !safeImageUrl(storedImageUrl);
+
+const artRequestUrlFor = (
+  isAdmin: boolean,
+  storedImageUrl: string | undefined,
+  title: string,
+): string =>
+  mayGenerateArt(isAdmin, storedImageUrl) ? generatedImageUrlFor(title) : "";
+
 const homePageVerifierSystem =
   "You verify restaurant website search results. Choose the restaurant's own " +
   "official website only when it is clear from the candidate URL, title, and " +
@@ -254,11 +269,9 @@ export default pattern<PollOptionCardInput, PollOptionCardOutput>(
     const storedImageDisplay = computed(() =>
       safeImageUrl(option.imageUrl) ? "block" : "none"
     );
-    const generatedArtRequestUrl = computed(() => {
-      if (safeImageUrl(option.imageUrl)) return "";
-      if (!isAdmin) return "";
-      return generatedImageUrlFor(option.title);
-    });
+    const generatedArtRequestUrl = computed(() =>
+      artRequestUrlFor(isAdmin, option.imageUrl, option.title)
+    );
     const generatedArt = fetchData<string>({
       url: generatedArtRequestUrl,
       mode: "dataUrl",
@@ -271,7 +284,7 @@ export default pattern<PollOptionCardInput, PollOptionCardOutput>(
     // URL. Other viewers render the stored value without running image-gen.
     const artSyncState = computed(() => {
       if (safeImageUrl(option.imageUrl)) return "stored";
-      if (!isAdmin) return "";
+      if (!mayGenerateArt(isAdmin, option.imageUrl)) return "";
       const generatedUrl = safeImageUrl(generatedArt.result ?? "");
       if (generatedUrl) {
         setOptionImage.send({


### PR DESCRIPTION
## What

Generated food thumbnails never rendered on deployed lunch-poll pieces — the
`/api/ai/img` request never even fired. Root cause is a transformer
dependency-capture gap (details below); the pattern-side fix routes the
`isAdmin` gate through a helper function so the transformer captures it as a lift
input.

## The bug

`poll-option-card.tsx` gated generated-art on `isAdmin` with a bare unary
negation inside a `computed`:

```ts
const generatedArtRequestUrl = computed(() => {
  if (safeImageUrl(option.imageUrl)) return "";
  if (!isAdmin) return "";
  return generatedImageUrlFor(option.title);
});
```

`isAdmin` is a destructured reactive prop. The transformer lowers the computed to
a `lift` whose arrow **destructures `isAdmin`**, but **omits it from the emitted
input schema** and doesn't pass it at the call site — so at runtime `isAdmin` is
`undefined`, `!isAdmin` is always `true`, and the computed returns `""`. The
image `fetchData` gets an empty URL and never fires. No type error, no runtime
error: just silently wrong. The same omission affected the `artSyncState`
persist computed (which is why even forcing the fetch wouldn't have stuck the
result into `option.imageUrl`).

## The fix

Route both gates through helpers (`mayGenerateArt` / `artRequestUrlFor`) that
take `isAdmin` as an argument — the form the sibling homepage path
(`homePageLookupUrlFor(isAdmin, …)`) already uses and which the transformer
captures correctly. After the change the emitted lift schema includes
`required: ["isAdmin", "option"]`, and the fetch fires → generates → persists →
renders. Verified end-to-end on a deployed prod piece: 3/3 options now carry a
persisted `data:image/…` URL.

## @mathpirate — transformer dependency-capture bug

This is fundamentally a lift dependency-capture bug worth a fix upstream. A
`computed`/lift body that references a destructured reactive prop **only** in a
bare unary position (`!isAdmin` / `if (!isAdmin)`) lowers to a lift whose arrow
destructures the name but whose emitted input JSONSchema omits it — so it is
`undefined` at runtime. The tell is a lift whose param destructures a name absent
from its schema:

```ts
const __cfLift_5 = __cfHelpers.lift<{ option: {imageUrl?; title} }, string>(
  ({ option, isAdmin }) => {            // isAdmin destructured…
    if (safeImageUrl(option.imageUrl)) return "";
    if (!isAdmin) return "";
    return generatedImageUrlFor(option.title);
  },
  { type: "object", properties: { option: {…} }, required: ["option"] } // …but no isAdmin
);
```

It only happens when the prop appears solely inside a `UnaryExpression`; the same
prop is captured correctly when used as a function argument or member base. The
pre-fix commit of this PR is a live repro — reverting the helper indirection back
to a bare `!isAdmin` reproduces it.

## Tests

`deno task cf test` over `poll-option-card` / `main` / `multi-user`: 39 passed,
0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GDmo7ZSk7zGLivu9hkgEg

## Coverage Baseline

We accept a modest increase in uncovered lines:

NEW_COVERAGE_BASELINE



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing generated thumbnails in lunch polls by ensuring `isAdmin` is captured as a lift input. Routes the admin gate through helpers so image requests run, persist, and render.

- **Bug Fixes**
  - Replaced bare `!isAdmin` checks in computeds with `mayGenerateArt` and `artRequestUrlFor` that take `isAdmin` as an argument.
  - Transformer now includes `isAdmin` in lift inputs, so generated images fetch and persist to `option.imageUrl` for hosts only.

<sup>Written for commit 25f64f7c4f6b73b034048174af65618285cf37ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

