### PR TITLE
fix(memory): gate conflict retries on caught-up local seq

### DIFF
--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -959,6 +959,8 @@ export interface ConflictError extends Error {
 
   transaction: Transaction;
   conflict: Conflict;
+  retryAfterSeq?: number;
+  readyToRetry?: () => Promise<void>;
 }
 
 export interface SystemError extends Error {

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -465,6 +465,59 @@ Deno.test("memory v2 client readyToRetry rejects when session ID changes on rest
   }
 });
 
+Deno.test("memory v2 client readyToRetry rejects when same session ID is not resumed", async () => {
+  const transport = new ConflictReadyFreshSameSessionTransport();
+  const client = await connect({ transport });
+  const session = await client.mount(
+    "did:key:z6Mk-memory-v2-ready-fresh-same-session",
+  );
+
+  try {
+    const error = await assertRejects(
+      () =>
+        session.transact({
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "of:doc:1",
+            value: { value: { version: 2 } },
+          }],
+        }),
+      Error,
+      "conflict",
+    );
+    const readyToRetry = (error as Error & {
+      readyToRetry?: () => Promise<void>;
+    }).readyToRetry;
+    assertExists(readyToRetry);
+
+    let settled = false;
+    const readyPromise = readyToRetry().then(
+      () => "resolved",
+      (error) => error instanceof Error ? error.message : String(error),
+    ).finally(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    assertEquals(settled, false);
+
+    await session.restore();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assertEquals(settled, true);
+    assertEquals(
+      await readyPromise,
+      "session replaced without resume: session:fresh-same-session",
+    );
+    assertEquals(session.sessionId, "session:fresh-same-session");
+  } finally {
+    await client.close();
+  }
+});
+
 Deno.test("memory v2 client coalesces watch ack bursts", async () => {
   const transport = new AckCountingTransport();
   const client = await connect({ transport });
@@ -1079,6 +1132,63 @@ class ConflictReadySessionChangingTransport implements Transport {
       default:
         throw new Error(
           `Unhandled conflict-ready session-changing message: ${message.type}`,
+        );
+    }
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  #respond(message: FabricValue): void {
+    this.#receiver(encodeMemoryBoundary(message));
+  }
+}
+
+class ConflictReadyFreshSameSessionTransport implements Transport {
+  #receiver: (payload: string) => void = () => {};
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(): void {}
+
+  send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as {
+      type: string;
+      requestId?: string;
+    };
+
+    switch (message.type) {
+      case "hello":
+        this.#respond(HELLO_OK);
+        return Promise.resolve();
+      case "session.open":
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            sessionId: "session:fresh-same-session",
+            sessionToken: "token:fresh-same-session",
+            serverSeq: 0,
+          },
+        });
+        return Promise.resolve();
+      case "transact":
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          error: {
+            name: "ConflictError",
+            message: "conflict",
+            retryAfterSeq: 2,
+          },
+        });
+        return Promise.resolve();
+      default:
+        throw new Error(
+          `Unhandled conflict-ready fresh-session message: ${message.type}`,
         );
     }
   }

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -332,7 +332,7 @@ Deno.test("memory v2 client conflict errors expose readiness after caught-up syn
   }
 });
 
-Deno.test("memory v2 client readyToRetry waits for caught-up session effect", async () => {
+Deno.test("memory v2 client readyToRetry waits for caught-up local sequence", async () => {
   const transport = new ConflictReadyTransport();
   const client = await connect({ transport });
   const session = await client.mount("did:key:z6Mk-memory-v2-ready-delay");
@@ -366,6 +366,16 @@ Deno.test("memory v2 client readyToRetry waits for caught-up session effect", as
     assertEquals(ready, false);
 
     transport.emitCatchUp();
+    await Promise.resolve();
+    await Promise.resolve();
+    assertEquals(ready, false);
+
+    transport.emitCatchUp(0);
+    await Promise.resolve();
+    await Promise.resolve();
+    assertEquals(ready, false);
+
+    transport.emitCatchUp(1);
     await readyPromise;
     assertEquals(ready, true);
   } finally {
@@ -946,7 +956,7 @@ class ConflictReadyTransport implements Transport {
     }
   }
 
-  emitCatchUp(): void {
+  emitCatchUp(caughtUpLocalSeq?: number): void {
     this.#respond({
       type: "session/effect",
       space: this.#space,
@@ -955,6 +965,7 @@ class ConflictReadyTransport implements Transport {
         type: "sync",
         fromSeq: 0,
         toSeq: 2,
+        ...(caughtUpLocalSeq !== undefined ? { caughtUpLocalSeq } : {}),
         upserts: [],
         removes: [],
       },
@@ -1424,6 +1435,142 @@ Deno.test(
     }
   },
 );
+
+Deno.test("memory v2 client emits empty caught-up syncs after resume", async () => {
+  const transport = new EmptyCaughtUpResumeTransport();
+  const client = await connect({ transport });
+  const session = await client.mount("did:key:z6Mk-empty-caught-up-resume");
+
+  try {
+    const view = await session.watchSet([{
+      id: "root",
+      kind: "graph",
+      query: {
+        roots: [{
+          id: "of:doc:1",
+          selector: {
+            path: [],
+            schema: false,
+          },
+        }],
+      },
+    }]);
+    const syncs = view.subscribeSync();
+
+    transport.disconnect();
+    await waitFor(() => transport.openCount >= 2);
+
+    const caughtUp = await nextWithTimeout(syncs);
+    assertEquals(caughtUp.done, false);
+    assertEquals(caughtUp.value, {
+      type: "sync",
+      fromSeq: 0,
+      toSeq: 0,
+      caughtUpLocalSeq: 1,
+      upserts: [],
+      removes: [],
+    });
+  } finally {
+    await client.close();
+  }
+});
+
+class EmptyCaughtUpResumeTransport implements Transport {
+  openCount = 0;
+  #receiver: (payload: string) => void = () => {};
+  #closeReceiver: (error?: Error) => void = () => {};
+  #openedSession = false;
+  #closed = false;
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(receiver: (error?: Error) => void): void {
+    this.#closeReceiver = receiver;
+  }
+
+  send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as {
+      type: string;
+      requestId?: string;
+    };
+
+    switch (message.type) {
+      case "hello":
+        this.openCount += 1;
+        this.#closed = false;
+        this.#receiver(encodeMemoryBoundary(HELLO_OK));
+        return Promise.resolve();
+      case "session.open": {
+        const resumed = this.#openedSession;
+        this.#openedSession = true;
+        this.#receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            sessionId: "session:empty-caught-up-resume",
+            sessionToken: "token:empty-caught-up-resume",
+            serverSeq: 0,
+            ...(resumed
+              ? {
+                resumed: true,
+                caughtUpLocalSeq: 1,
+                sync: {
+                  type: "sync",
+                  fromSeq: 0,
+                  toSeq: 0,
+                  caughtUpLocalSeq: 1,
+                  upserts: [],
+                  removes: [],
+                },
+              }
+              : {}),
+          },
+        }));
+        return Promise.resolve();
+      }
+      case "session.watch.set":
+        this.#receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            serverSeq: 0,
+            sync: {
+              type: "sync",
+              fromSeq: 0,
+              toSeq: 0,
+              upserts: [],
+              removes: [],
+            },
+          },
+        }));
+        return Promise.resolve();
+      case "session.ack":
+        this.#receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId!,
+          ok: { serverSeq: 0 },
+        }));
+        return Promise.resolve();
+      default:
+        throw new Error(`Unhandled empty-caught-up message: ${message.type}`);
+    }
+  }
+
+  disconnect(): void {
+    if (this.#closed) {
+      return;
+    }
+    this.#closed = true;
+    this.#closeReceiver(new Error("disconnect"));
+  }
+
+  close(): Promise<void> {
+    this.disconnect();
+    return Promise.resolve();
+  }
+}
 
 Deno.test(
   "memory v2 client does not restore a closed session after reconnect",

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -415,6 +415,56 @@ Deno.test("memory v2 client readyToRetry rejects after session close", async () 
   );
 });
 
+Deno.test("memory v2 client readyToRetry rejects when session ID changes on restore", async () => {
+  const transport = new ConflictReadySessionChangingTransport();
+  const client = await connect({ transport });
+  const session = await client.mount(
+    "did:key:z6Mk-memory-v2-ready-session-change",
+  );
+
+  try {
+    const error = await assertRejects(
+      () =>
+        session.transact({
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "of:doc:1",
+            value: { value: { version: 2 } },
+          }],
+        }),
+      Error,
+      "conflict",
+    );
+    const readyToRetry = (error as Error & {
+      readyToRetry?: () => Promise<void>;
+    }).readyToRetry;
+    assertExists(readyToRetry);
+
+    let settled = false;
+    const readyPromise = readyToRetry().then(
+      () => "resolved",
+      (error) => error instanceof Error ? error.message : String(error),
+    ).finally(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    assertEquals(settled, false);
+
+    await session.restore();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assertEquals(settled, true);
+    assertEquals(await readyPromise, "session changed: session-A -> session-B");
+    assertEquals(session.sessionId, "session-B");
+  } finally {
+    await client.close();
+  }
+});
+
 Deno.test("memory v2 client coalesces watch ack bursts", async () => {
   const transport = new AckCountingTransport();
   const client = await connect({ transport });
@@ -970,6 +1020,67 @@ class ConflictReadyTransport implements Transport {
         removes: [],
       },
     });
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  #respond(message: FabricValue): void {
+    this.#receiver(encodeMemoryBoundary(message));
+  }
+}
+
+class ConflictReadySessionChangingTransport implements Transport {
+  #receiver: (payload: string) => void = () => {};
+  #openCount = 0;
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(): void {}
+
+  send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as {
+      type: string;
+      requestId?: string;
+    };
+
+    switch (message.type) {
+      case "hello":
+        this.#respond(HELLO_OK);
+        return Promise.resolve();
+      case "session.open": {
+        this.#openCount += 1;
+        const sessionId = this.#openCount === 1 ? "session-A" : "session-B";
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            sessionId,
+            sessionToken: `token:${sessionId}`,
+            serverSeq: 0,
+          },
+        });
+        return Promise.resolve();
+      }
+      case "transact":
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          error: {
+            name: "ConflictError",
+            message: "conflict",
+            retryAfterSeq: 2,
+          },
+        });
+        return Promise.resolve();
+      default:
+        throw new Error(
+          `Unhandled conflict-ready session-changing message: ${message.type}`,
+        );
+    }
   }
 
   close(): Promise<void> {

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -248,6 +248,163 @@ Deno.test("memory v2 client watch views expose incremental sync effects", async 
   }
 });
 
+Deno.test("memory v2 client conflict errors expose readiness after caught-up sync", async () => {
+  const server = new Server({
+    store: new URL("memory://memory-v2-client-conflict-ready-to-retry"),
+    subscriptionRefreshDelayMs: 20,
+  });
+  const client = await connect({
+    transport: loopback(server),
+  });
+  const session = await client.mount(
+    "did:key:z6Mk-memory-v2-client-conflict-ready-to-retry",
+  );
+
+  try {
+    await session.watchSet([{
+      id: "root",
+      kind: "graph",
+      query: {
+        roots: [{
+          id: "of:doc:1",
+          selector: {
+            path: [],
+            schema: false,
+          },
+        }],
+      },
+    }]);
+
+    await session.transact({
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: "of:doc:1",
+        value: { value: { version: 1 } },
+      }],
+    });
+    await session.transact({
+      localSeq: 2,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: "of:doc:1",
+        value: { value: { version: 3 } },
+      }],
+    });
+
+    const error = await assertRejects(
+      () =>
+        session.transact({
+          localSeq: 3,
+          reads: {
+            confirmed: [{
+              id: "of:doc:1",
+              path: toDocumentPath([]),
+              seq: 1,
+            }],
+            pending: [],
+          },
+          operations: [{
+            op: "set",
+            id: "of:doc:1",
+            value: { value: { version: 2 } },
+          }],
+        }),
+      Error,
+      "stale confirmed read: of:doc:1 at seq 1 conflicted with seq 2",
+    );
+
+    assertEquals(error.name, "ConflictError");
+    assertEquals(
+      (error as Error & { retryAfterSeq?: number }).retryAfterSeq,
+      2,
+    );
+    const readyToRetry = (error as Error & {
+      readyToRetry?: () => Promise<void>;
+    }).readyToRetry;
+    assertExists(readyToRetry);
+    await readyToRetry();
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 client readyToRetry waits for caught-up session effect", async () => {
+  const transport = new ConflictReadyTransport();
+  const client = await connect({ transport });
+  const session = await client.mount("did:key:z6Mk-memory-v2-ready-delay");
+
+  try {
+    const error = await assertRejects(
+      () =>
+        session.transact({
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: "of:doc:1",
+            value: { value: { version: 2 } },
+          }],
+        }),
+      Error,
+      "conflict",
+    );
+    const readyToRetry = (error as Error & {
+      readyToRetry?: () => Promise<void>;
+    }).readyToRetry;
+    assertExists(readyToRetry);
+
+    let ready = false;
+    const readyPromise = readyToRetry().then(() => {
+      ready = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    assertEquals(ready, false);
+
+    transport.emitCatchUp();
+    await readyPromise;
+    assertEquals(ready, true);
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client readyToRetry rejects after session close", async () => {
+  const transport = new ConflictReadyTransport();
+  const client = await connect({ transport });
+  const session = await client.mount("did:key:z6Mk-memory-v2-ready-close");
+
+  const error = await assertRejects(
+    () =>
+      session.transact({
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:doc:1",
+          value: { value: { version: 2 } },
+        }],
+      }),
+    Error,
+    "conflict",
+  );
+  const readyToRetry = (error as Error & {
+    readyToRetry?: () => Promise<void>;
+  }).readyToRetry;
+  assertExists(readyToRetry);
+
+  await client.close();
+  await assertRejects(
+    () => readyToRetry(),
+    Error,
+    "memory session closed",
+  );
+});
+
 Deno.test("memory v2 client coalesces watch ack bursts", async () => {
   const transport = new AckCountingTransport();
   const client = await connect({ transport });
@@ -719,6 +876,89 @@ class DelayedTransactTransport implements Transport {
   releaseNext(): void {
     const next = this.#heldResponses.shift();
     next?.();
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  #respond(message: FabricValue): void {
+    this.#receiver(encodeMemoryBoundary(message));
+  }
+}
+
+class ConflictReadyTransport implements Transport {
+  #receiver: (payload: string) => void = () => {};
+  #space = "";
+  #sessionId = "session:conflict-ready";
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(): void {}
+
+  send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as {
+      type: string;
+      requestId?: string;
+      space?: string;
+    };
+    if (message.space !== undefined) {
+      this.#space = message.space;
+    }
+
+    switch (message.type) {
+      case "hello":
+        this.#respond(HELLO_OK);
+        return Promise.resolve();
+      case "session.open":
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            sessionId: this.#sessionId,
+            sessionToken: "token:conflict-ready",
+            serverSeq: 0,
+          },
+        });
+        return Promise.resolve();
+      case "session.ack":
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: { serverSeq: 2 },
+        });
+        return Promise.resolve();
+      case "transact":
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          error: {
+            name: "ConflictError",
+            message: "conflict",
+            retryAfterSeq: 2,
+          },
+        });
+        return Promise.resolve();
+      default:
+        throw new Error(`Unhandled conflict-ready message: ${message.type}`);
+    }
+  }
+
+  emitCatchUp(): void {
+    this.#respond({
+      type: "session/effect",
+      space: this.#space,
+      sessionId: this.#sessionId,
+      effect: {
+        type: "sync",
+        fromSeq: 0,
+        toSeq: 2,
+        upserts: [],
+        removes: [],
+      },
+    });
   }
 
   close(): Promise<void> {

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -1586,6 +1586,138 @@ Deno.test("memory v2 client emits empty caught-up syncs after resume", async () 
   }
 });
 
+Deno.test("memory v2 client forwards a top-level-only caught-up seq on resume", async () => {
+  // Regression for the dual-channel strand: when a resume promotes
+  // caughtUpLocalSeq via the top-level SessionOpenResult field but NOT via a
+  // sync (the server already drained the pending catch-up before the lost
+  // send), WatchView subscribers (runner storage) must still observe it, or
+  // their conflict-retry read-repair waiters strand forever.
+  const transport = new TopLevelCaughtUpResumeTransport();
+  const client = await connect({ transport });
+  const session = await client.mount("did:key:z6Mk-top-level-caught-up-resume");
+
+  try {
+    const view = await session.watchSet([{
+      id: "root",
+      kind: "graph",
+      query: {
+        roots: [{
+          id: "of:doc:1",
+          selector: {
+            path: [],
+            schema: false,
+          },
+        }],
+      },
+    }]);
+    const syncs = view.subscribeSync();
+
+    transport.disconnect();
+    await waitFor(() => transport.openCount >= 2);
+
+    const caughtUp = await nextWithTimeout(syncs);
+    assertEquals(caughtUp.done, false);
+    assertEquals(caughtUp.value, {
+      type: "sync",
+      fromSeq: 0,
+      toSeq: 0,
+      caughtUpLocalSeq: 4,
+      upserts: [],
+      removes: [],
+    });
+  } finally {
+    await client.close();
+  }
+});
+
+class TopLevelCaughtUpResumeTransport implements Transport {
+  openCount = 0;
+  #receiver: (payload: string) => void = () => {};
+  #closeReceiver: (error?: Error) => void = () => {};
+  #openedSession = false;
+  #closed = false;
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(receiver: (error?: Error) => void): void {
+    this.#closeReceiver = receiver;
+  }
+
+  send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as {
+      type: string;
+      requestId?: string;
+    };
+
+    switch (message.type) {
+      case "hello":
+        this.openCount += 1;
+        this.#closed = false;
+        this.#receiver(encodeMemoryBoundary(HELLO_OK));
+        return Promise.resolve();
+      case "session.open": {
+        const resumed = this.#openedSession;
+        this.#openedSession = true;
+        this.#receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            sessionId: "session:top-level-caught-up-resume",
+            sessionToken: "token:top-level-caught-up-resume",
+            serverSeq: 0,
+            // Resume carries the caught-up marker ONLY at the top level — no
+            // sync — exactly the case that previously stranded the runner.
+            ...(resumed ? { resumed: true, caughtUpLocalSeq: 4 } : {}),
+          },
+        }));
+        return Promise.resolve();
+      }
+      case "session.watch.set":
+        this.#receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            serverSeq: 0,
+            sync: {
+              type: "sync",
+              fromSeq: 0,
+              toSeq: 0,
+              upserts: [],
+              removes: [],
+            },
+          },
+        }));
+        return Promise.resolve();
+      case "session.ack":
+        this.#receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId!,
+          ok: { serverSeq: 0 },
+        }));
+        return Promise.resolve();
+      default:
+        throw new Error(
+          `Unhandled top-level-caught-up message: ${message.type}`,
+        );
+    }
+  }
+
+  disconnect(): void {
+    if (this.#closed) {
+      return;
+    }
+    this.#closed = true;
+    this.#closeReceiver(new Error("disconnect"));
+  }
+
+  close(): Promise<void> {
+    this.disconnect();
+    return Promise.resolve();
+  }
+}
+
 class EmptyCaughtUpResumeTransport implements Transport {
   openCount = 0;
   #receiver: (payload: string) => void = () => {};

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -1876,7 +1876,7 @@ Deno.test("memory v2 server does not echo same-session operation docs through wa
   }
 });
 
-Deno.test("memory v2 server flushes session sync before returning conflicts", async () => {
+Deno.test("memory v2 server returns conflicts before deferred caught-up session sync", async () => {
   const server = createServer("memory://memory-v2-server-conflict-flush", 20);
   const messages: ServerMessage[] = [];
   const connection = server.connect((message) => messages.push(message));
@@ -1984,7 +1984,19 @@ Deno.test("memory v2 server flushes session sync before returning conflicts", as
       },
     }));
 
+    const rejected = assertResponse<any>(shiftMessage(messages));
+    assertEquals(rejected.requestId, "tx-3");
+    assertEquals(rejected.error, {
+      name: "ConflictError",
+      message: "stale confirmed read: of:doc:1 at seq 1 conflicted with seq 2",
+      retryAfterSeq: 2,
+    });
+    assertEquals(messages.length, 0);
+
+    await server.flushSessions([space]);
+
     const effect = assertEffect(shiftMessage(messages));
+    assertEquals(effect.effect.caughtUpLocalSeq, 3);
     assertEquals(effect.effect.toSeq, 2);
     assertEquals(effect.effect.upserts, [{
       branch: "",
@@ -1995,14 +2007,6 @@ Deno.test("memory v2 server flushes session sync before returning conflicts", as
         value: { version: 3 },
       },
     }]);
-
-    const rejected = assertResponse<any>(shiftMessage(messages));
-    assertEquals(rejected.requestId, "tx-3");
-    assertEquals(rejected.error, {
-      name: "ConflictError",
-      message: "stale confirmed read: of:doc:1 at seq 1 conflicted with seq 2",
-      retryAfterSeq: 2,
-    });
     assertEquals(messages.length, 0);
   } finally {
     await server.close();
@@ -2129,7 +2133,19 @@ Deno.test("memory v2 server processes back-to-back websocket messages in receive
 
     assertEquals(assertResponse<any>(shiftMessage(messages)).requestId, "tx-2");
 
+    const rejected = assertResponse<any>(shiftMessage(messages));
+    assertEquals(rejected.requestId, "tx-3");
+    assertEquals(rejected.error, {
+      name: "ConflictError",
+      message: "stale confirmed read: of:doc:1 at seq 1 conflicted with seq 2",
+      retryAfterSeq: 2,
+    });
+    assertEquals(messages.length, 0);
+
+    await server.flushSessions([space]);
+
     const effect = assertEffect(shiftMessage(messages));
+    assertEquals(effect.effect.caughtUpLocalSeq, 3);
     assertEquals(effect.effect.toSeq, 2);
     assertEquals(effect.effect.upserts, [{
       branch: "",
@@ -2140,14 +2156,6 @@ Deno.test("memory v2 server processes back-to-back websocket messages in receive
         value: { version: 3 },
       },
     }]);
-
-    const rejected = assertResponse<any>(shiftMessage(messages));
-    assertEquals(rejected.requestId, "tx-3");
-    assertEquals(rejected.error, {
-      name: "ConflictError",
-      message: "stale confirmed read: of:doc:1 at seq 1 conflicted with seq 2",
-      retryAfterSeq: 2,
-    });
     assertEquals(messages.length, 0);
   } finally {
     await server.close();

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -1941,7 +1941,10 @@ Deno.test("memory v2 server returns conflicts before deferred caught-up session 
         }],
       },
     }));
-    assertEquals(assertResponse<any>(shiftMessage(messages)).requestId, "tx-1");
+    assertEquals(
+      assertResponse<unknown>(shiftMessage(messages)).requestId,
+      "tx-1",
+    );
 
     await connection.receive(encodeMemoryBoundary({
       type: "transact",
@@ -1984,7 +1987,7 @@ Deno.test("memory v2 server returns conflicts before deferred caught-up session 
       },
     }));
 
-    const rejected = assertResponse<any>(shiftMessage(messages));
+    const rejected = assertResponse<unknown>(shiftMessage(messages));
     assertEquals(rejected.requestId, "tx-3");
     assertEquals(rejected.error, {
       name: "ConflictError",
@@ -2007,6 +2010,90 @@ Deno.test("memory v2 server returns conflicts before deferred caught-up session 
         value: { version: 3 },
       },
     }]);
+    assertEquals(messages.length, 0);
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 server empty caught-up sync preserves previous fromSeq", async () => {
+  const server = createServer(
+    "memory://memory-v2-server-empty-caught-up-from-seq",
+    20,
+  );
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+  const space = "did:key:z6Mk-memory-v2-empty-caught-up-from-seq";
+
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    shiftMessage(messages);
+
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-1",
+      space,
+      session: {},
+    }));
+    const opened = assertResponse<{ sessionId: string }>(
+      shiftMessage(messages),
+    );
+    const sessionId = opened.ok!.sessionId;
+
+    await connection.receive(encodeMemoryBoundary({
+      type: "transact",
+      requestId: "tx-1",
+      space,
+      sessionId,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:doc:1",
+          value: { value: { version: 1 } },
+        }],
+      },
+    }));
+    assertEquals(assertResponse<any>(shiftMessage(messages)).requestId, "tx-1");
+
+    await connection.receive(encodeMemoryBoundary({
+      type: "transact",
+      requestId: "tx-2",
+      space,
+      sessionId,
+      commit: {
+        localSeq: 2,
+        reads: {
+          confirmed: [{
+            id: "of:doc:1",
+            path: [],
+            seq: 0,
+          }],
+          pending: [],
+        },
+        operations: [{
+          op: "set",
+          id: "of:doc:1",
+          value: { value: { version: 2 } },
+        }],
+      },
+    }));
+    const rejected = assertResponse<any>(shiftMessage(messages));
+    assertEquals(rejected.requestId, "tx-2");
+    assertEquals(rejected.error?.name, "ConflictError");
+
+    await server.flushSessions([space]);
+
+    const effect = assertEffect(shiftMessage(messages));
+    assertEquals(effect.effect, {
+      type: "sync",
+      fromSeq: 0,
+      toSeq: 1,
+      upserts: [],
+      removes: [],
+      caughtUpLocalSeq: 2,
+    });
     assertEquals(messages.length, 0);
   } finally {
     await server.close();

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -2001,6 +2001,7 @@ Deno.test("memory v2 server flushes session sync before returning conflicts", as
     assertEquals(rejected.error, {
       name: "ConflictError",
       message: "stale confirmed read: of:doc:1 at seq 1 conflicted with seq 2",
+      retryAfterSeq: 2,
     });
     assertEquals(messages.length, 0);
   } finally {
@@ -2145,6 +2146,7 @@ Deno.test("memory v2 server processes back-to-back websocket messages in receive
     assertEquals(rejected.error, {
       name: "ConflictError",
       message: "stale confirmed read: of:doc:1 at seq 1 conflicted with seq 2",
+      retryAfterSeq: 2,
     });
     assertEquals(messages.length, 0);
   } finally {

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -181,6 +181,7 @@ export interface SessionOpenResult {
   sessionId: SessionId;
   sessionToken: SessionToken;
   serverSeq: number;
+  caughtUpLocalSeq?: number;
   resumed?: boolean;
   sync?: SessionSync;
 }
@@ -286,6 +287,7 @@ export interface SessionSync {
   type: "sync";
   fromSeq: number;
   toSeq: number;
+  caughtUpLocalSeq?: number;
   upserts: SessionSyncUpsert[];
   removes: SessionSyncRemove[];
 }

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -522,6 +522,7 @@ export interface V2Error {
   name: string;
   message: string;
   precondition?: string;
+  retryAfterSeq?: number;
 }
 
 export type V2Result<Value> = { ok: Value } | { error: V2Error };

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -729,13 +729,13 @@ export class SpaceSession {
     this.#closeError = new Error("memory session closed");
     this.#readyOnConnection = false;
     this.client.forgetSession(this);
+    this.rejectCaughtUpLocalSeqWaiters(this.#closeError);
     const background = [...this.#background];
     this.#background.clear();
     await Promise.allSettled(background);
     for (const pending of this.#outstandingCommits.values()) {
       pending.pending.reject(new Error("memory session closed"));
     }
-    this.rejectCaughtUpLocalSeqWaiters(this.#closeError);
     this.#outstandingCommits.clear();
     this.#watchSpecs = [];
     this.#watchView?.close();
@@ -923,18 +923,23 @@ export class SpaceSession {
       sessionToken: this.#sessionToken,
     }, auth);
     const sessionChanged = restored.sessionId !== oldSessionId;
+    const sessionReplaced = sessionChanged || restored.resumed !== true;
     this.#sessionId = restored.sessionId;
     this.#sessionToken = restored.sessionToken ?? this.#sessionToken;
     this.noteResult(restored.serverSeq);
 
-    if (sessionChanged) {
+    if (sessionReplaced) {
       const sessionChangedError = new Error(
-        `session changed: ${oldSessionId} -> ${restored.sessionId}`,
+        sessionChanged
+          ? `session changed: ${oldSessionId} -> ${restored.sessionId}`
+          : `session replaced without resume: ${restored.sessionId}`,
       );
-      for (const pending of this.#outstandingCommits.values()) {
-        pending.pending.reject(sessionChangedError);
+      if (sessionChanged) {
+        for (const pending of this.#outstandingCommits.values()) {
+          pending.pending.reject(sessionChangedError);
+        }
+        this.#outstandingCommits.clear();
       }
-      this.#outstandingCommits.clear();
       this.#caughtUpLocalSeq = 0;
       this.#forwardedCaughtUpLocalSeq = 0;
       this.rejectCaughtUpLocalSeqWaiters(sessionChangedError);

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -160,6 +160,10 @@ export class Client {
         (error as Error & { precondition?: string }).precondition =
           result.error.precondition;
       }
+      if (result.error.retryAfterSeq !== undefined) {
+        (error as Error & { retryAfterSeq?: number }).retryAfterSeq =
+          result.error.retryAfterSeq;
+      }
       throw error;
     }
     return result.ok as Result;
@@ -388,6 +392,10 @@ export class SpaceSession {
   #closeError: Error | null = null;
   #readyOnConnection = true;
   #restoring = false;
+  #serverSeqWaiters: {
+    seq: number;
+    pending: PromiseWithResolvers<void>;
+  }[] = [];
 
   constructor(
     private readonly client: Client,
@@ -704,6 +712,7 @@ export class SpaceSession {
     for (const pending of this.#outstandingCommits.values()) {
       pending.pending.reject(new Error("memory session closed"));
     }
+    this.rejectServerSeqWaiters(this.#closeError);
     this.#outstandingCommits.clear();
     this.#watchSpecs = [];
     this.#watchView?.close();
@@ -723,6 +732,7 @@ export class SpaceSession {
     for (const pending of this.#outstandingCommits.values()) {
       pending.pending.reject(error);
     }
+    this.rejectServerSeqWaiters(error);
     this.#outstandingCommits.clear();
     this.#watchSpecs = [];
     this.#watchView?.close();
@@ -806,6 +816,39 @@ export class SpaceSession {
 
   private noteResult(serverSeq: number): void {
     this.#serverSeq = Math.max(this.#serverSeq, serverSeq);
+    const ready: PromiseWithResolvers<void>[] = [];
+    this.#serverSeqWaiters = this.#serverSeqWaiters.filter((waiter) => {
+      if (waiter.seq <= this.#serverSeq) {
+        ready.push(waiter.pending);
+        return false;
+      }
+      return true;
+    });
+    for (const pending of ready) {
+      pending.resolve();
+    }
+  }
+
+  private waitForServerSeq(seq: number): Promise<void> {
+    if (this.#closed) {
+      return Promise.reject(
+        this.#closeError ?? new Error("memory session closed"),
+      );
+    }
+    if (this.#serverSeq >= seq) {
+      return Promise.resolve();
+    }
+    const pending = Promise.withResolvers<void>();
+    this.#serverSeqWaiters.push({ seq, pending });
+    return pending.promise;
+  }
+
+  private rejectServerSeqWaiters(error: Error | null): void {
+    const waiters = this.#serverSeqWaiters;
+    this.#serverSeqWaiters = [];
+    for (const waiter of waiters) {
+      waiter.pending.reject(error ?? new Error("memory session closed"));
+    }
   }
 
   private async reopen(): Promise<SessionOpenResult> {
@@ -902,6 +945,9 @@ export class SpaceSession {
         if (this.#outstandingCommits.get(localSeq) === pendingCommit) {
           this.#outstandingCommits.delete(localSeq);
         }
+        if (isRetryableConflict(error)) {
+          error.readyToRetry = () => this.waitForServerSeq(error.retryAfterSeq);
+        }
         pendingCommit.pending.reject(
           error instanceof Error ? error : new Error(String(error)),
         );
@@ -910,6 +956,17 @@ export class SpaceSession {
     this.queueBackground(task);
     return task;
   }
+}
+
+type RetryableConflictError = Error & {
+  name: "ConflictError";
+  retryAfterSeq: number;
+  readyToRetry?: () => Promise<void>;
+};
+
+function isRetryableConflict(error: unknown): error is RetryableConflictError {
+  return error instanceof Error && error.name === "ConflictError" &&
+    typeof (error as { retryAfterSeq?: unknown }).retryAfterSeq === "number";
 }
 
 export class WatchView {

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -392,10 +392,6 @@ export class SpaceSession {
   #closeError: Error | null = null;
   #readyOnConnection = true;
   #restoring = false;
-  #serverSeqWaiters: {
-    seq: number;
-    pending: PromiseWithResolvers<void>;
-  }[] = [];
   #caughtUpLocalSeq = 0;
   #caughtUpLocalSeqWaiters: {
     localSeq: number;
@@ -723,7 +719,6 @@ export class SpaceSession {
     for (const pending of this.#outstandingCommits.values()) {
       pending.pending.reject(new Error("memory session closed"));
     }
-    this.rejectServerSeqWaiters(this.#closeError);
     this.rejectCaughtUpLocalSeqWaiters(this.#closeError);
     this.#outstandingCommits.clear();
     this.#watchSpecs = [];
@@ -744,7 +739,6 @@ export class SpaceSession {
     for (const pending of this.#outstandingCommits.values()) {
       pending.pending.reject(error);
     }
-    this.rejectServerSeqWaiters(error);
     this.rejectCaughtUpLocalSeqWaiters(error);
     this.#outstandingCommits.clear();
     this.#watchSpecs = [];
@@ -829,17 +823,6 @@ export class SpaceSession {
 
   private noteResult(serverSeq: number): void {
     this.#serverSeq = Math.max(this.#serverSeq, serverSeq);
-    const ready: PromiseWithResolvers<void>[] = [];
-    this.#serverSeqWaiters = this.#serverSeqWaiters.filter((waiter) => {
-      if (waiter.seq <= this.#serverSeq) {
-        ready.push(waiter.pending);
-        return false;
-      }
-      return true;
-    });
-    for (const pending of ready) {
-      pending.resolve();
-    }
   }
 
   private noteCaughtUpLocalSeq(localSeq: number | undefined): void {
@@ -862,20 +845,6 @@ export class SpaceSession {
     }
   }
 
-  private waitForServerSeq(seq: number): Promise<void> {
-    if (this.#closed) {
-      return Promise.reject(
-        this.#closeError ?? new Error("memory session closed"),
-      );
-    }
-    if (this.#serverSeq >= seq) {
-      return Promise.resolve();
-    }
-    const pending = Promise.withResolvers<void>();
-    this.#serverSeqWaiters.push({ seq, pending });
-    return pending.promise;
-  }
-
   private waitForCaughtUpLocalSeq(localSeq: number): Promise<void> {
     if (this.#closed) {
       return Promise.reject(
@@ -888,14 +857,6 @@ export class SpaceSession {
     const pending = Promise.withResolvers<void>();
     this.#caughtUpLocalSeqWaiters.push({ localSeq, pending });
     return pending.promise;
-  }
-
-  private rejectServerSeqWaiters(error: Error | null): void {
-    const waiters = this.#serverSeqWaiters;
-    this.#serverSeqWaiters = [];
-    for (const waiter of waiters) {
-      waiter.pending.reject(error ?? new Error("memory session closed"));
-    }
   }
 
   private rejectCaughtUpLocalSeqWaiters(error: Error | null): void {

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -393,6 +393,12 @@ export class SpaceSession {
   #readyOnConnection = true;
   #restoring = false;
   #caughtUpLocalSeq = 0;
+  // Highest caughtUpLocalSeq already pushed into the WatchView (via a real sync
+  // or a synthetic forward). Subscribers such as runner storage only advance
+  // their own caught-up seq from emitted syncs, so a resume that promotes
+  // caughtUpLocalSeq via the top-level SessionOpenResult field (no sync) must
+  // be forwarded explicitly or their conflict-retry waiters strand.
+  #forwardedCaughtUpLocalSeq = 0;
   #caughtUpLocalSeqWaiters: {
     localSeq: number;
     pending: PromiseWithResolvers<void>;
@@ -684,12 +690,22 @@ export class SpaceSession {
           restored.sync.caughtUpLocalSeq !== undefined
         ) {
           this.#watchView.emit(restored.sync);
+          if (restored.sync.caughtUpLocalSeq !== undefined) {
+            this.#forwardedCaughtUpLocalSeq = Math.max(
+              this.#forwardedCaughtUpLocalSeq,
+              restored.sync.caughtUpLocalSeq,
+            );
+          }
         }
         this.scheduleAck(restored.serverSeq);
       } else if (restored.resumed === true && this.#watchSpecs.length > 0) {
         this.scheduleAck(restored.serverSeq);
       }
       this.noteCaughtUpLocalSeq(restored.caughtUpLocalSeq);
+      // Forward a top-level-only caught-up marker (resume with no sync) to
+      // WatchView subscribers; the guard above suppresses a duplicate when a
+      // real sync already carried it.
+      this.forwardCaughtUpLocalSeqToWatchers(restored.caughtUpLocalSeq);
       if (restored.resumed !== true && this.#watchSpecs.length > 0) {
         const { view, sync } = await this.watchSetSync(this.#watchSpecs);
         if (!isEmptySync(sync)) {
@@ -845,6 +861,32 @@ export class SpaceSession {
     }
   }
 
+  // Forward a caught-up marker to WatchView subscribers when it was delivered
+  // out-of-band (top-level SessionOpenResult.caughtUpLocalSeq on resume) rather
+  // than via a sync they already observed. Emits an empty caught-up sync so
+  // downstream waiters (notably runner storage's read-repair gate) resolve
+  // instead of stranding after a reconnect.
+  private forwardCaughtUpLocalSeqToWatchers(
+    localSeq: number | undefined,
+  ): void {
+    if (
+      localSeq === undefined ||
+      localSeq <= this.#forwardedCaughtUpLocalSeq ||
+      this.#watchView === null
+    ) {
+      return;
+    }
+    this.#forwardedCaughtUpLocalSeq = localSeq;
+    this.#watchView.emit({
+      type: "sync",
+      fromSeq: this.#serverSeq,
+      toSeq: this.#serverSeq,
+      caughtUpLocalSeq: localSeq,
+      upserts: [],
+      removes: [],
+    });
+  }
+
   private waitForCaughtUpLocalSeq(localSeq: number): Promise<void> {
     if (this.#closed) {
       return Promise.reject(
@@ -894,6 +936,7 @@ export class SpaceSession {
       }
       this.#outstandingCommits.clear();
       this.#caughtUpLocalSeq = 0;
+      this.#forwardedCaughtUpLocalSeq = 0;
       this.rejectCaughtUpLocalSeqWaiters(sessionChangedError);
     }
     this.noteCaughtUpLocalSeq(restored.caughtUpLocalSeq);

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -919,21 +919,23 @@ export class SpaceSession {
       seenSeq: this.#serverSeq,
       sessionToken: this.#sessionToken,
     }, auth);
+    const sessionChanged = restored.sessionId !== oldSessionId;
     this.#sessionId = restored.sessionId;
     this.#sessionToken = restored.sessionToken ?? this.#sessionToken;
     this.noteResult(restored.serverSeq);
-    this.noteCaughtUpLocalSeq(restored.caughtUpLocalSeq);
 
-    if (restored.sessionId !== oldSessionId) {
+    if (sessionChanged) {
+      const sessionChangedError = new Error(
+        `session changed: ${oldSessionId} -> ${restored.sessionId}`,
+      );
       for (const pending of this.#outstandingCommits.values()) {
-        pending.pending.reject(
-          new Error(
-            `session changed: ${oldSessionId} -> ${restored.sessionId}`,
-          ),
-        );
+        pending.pending.reject(sessionChangedError);
       }
       this.#outstandingCommits.clear();
+      this.#caughtUpLocalSeq = 0;
+      this.rejectCaughtUpLocalSeqWaiters(sessionChangedError);
     }
+    this.noteCaughtUpLocalSeq(restored.caughtUpLocalSeq);
 
     return restored;
   }

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -396,6 +396,11 @@ export class SpaceSession {
     seq: number;
     pending: PromiseWithResolvers<void>;
   }[] = [];
+  #caughtUpLocalSeq = 0;
+  #caughtUpLocalSeqWaiters: {
+    localSeq: number;
+    pending: PromiseWithResolvers<void>;
+  }[] = [];
 
   constructor(
     private readonly client: Client,
@@ -635,6 +640,7 @@ export class SpaceSession {
       this.#watchView.applySync(effect, true);
     }
     this.scheduleAck(effect.toSeq);
+    this.noteCaughtUpLocalSeq(effect.caughtUpLocalSeq);
   }
 
   async restore(): Promise<void> {
@@ -671,18 +677,23 @@ export class SpaceSession {
         })
       );
       if (restored.sync) {
+        this.noteCaughtUpLocalSeq(restored.sync.caughtUpLocalSeq);
         if (this.#watchView === null) {
           this.#watchView = WatchView.fromSync(restored.sync);
         } else {
           this.#watchView.applySync(restored.sync, false);
         }
-        if (!isEmptySync(restored.sync)) {
+        if (
+          !isEmptySync(restored.sync) ||
+          restored.sync.caughtUpLocalSeq !== undefined
+        ) {
           this.#watchView.emit(restored.sync);
         }
         this.scheduleAck(restored.serverSeq);
       } else if (restored.resumed === true && this.#watchSpecs.length > 0) {
         this.scheduleAck(restored.serverSeq);
       }
+      this.noteCaughtUpLocalSeq(restored.caughtUpLocalSeq);
       if (restored.resumed !== true && this.#watchSpecs.length > 0) {
         const { view, sync } = await this.watchSetSync(this.#watchSpecs);
         if (!isEmptySync(sync)) {
@@ -713,6 +724,7 @@ export class SpaceSession {
       pending.pending.reject(new Error("memory session closed"));
     }
     this.rejectServerSeqWaiters(this.#closeError);
+    this.rejectCaughtUpLocalSeqWaiters(this.#closeError);
     this.#outstandingCommits.clear();
     this.#watchSpecs = [];
     this.#watchView?.close();
@@ -733,6 +745,7 @@ export class SpaceSession {
       pending.pending.reject(error);
     }
     this.rejectServerSeqWaiters(error);
+    this.rejectCaughtUpLocalSeqWaiters(error);
     this.#outstandingCommits.clear();
     this.#watchSpecs = [];
     this.#watchView?.close();
@@ -829,6 +842,26 @@ export class SpaceSession {
     }
   }
 
+  private noteCaughtUpLocalSeq(localSeq: number | undefined): void {
+    if (localSeq === undefined) {
+      return;
+    }
+    this.#caughtUpLocalSeq = Math.max(this.#caughtUpLocalSeq, localSeq);
+    const ready: PromiseWithResolvers<void>[] = [];
+    this.#caughtUpLocalSeqWaiters = this.#caughtUpLocalSeqWaiters.filter(
+      (waiter) => {
+        if (waiter.localSeq <= this.#caughtUpLocalSeq) {
+          ready.push(waiter.pending);
+          return false;
+        }
+        return true;
+      },
+    );
+    for (const pending of ready) {
+      pending.resolve();
+    }
+  }
+
   private waitForServerSeq(seq: number): Promise<void> {
     if (this.#closed) {
       return Promise.reject(
@@ -843,9 +876,31 @@ export class SpaceSession {
     return pending.promise;
   }
 
+  private waitForCaughtUpLocalSeq(localSeq: number): Promise<void> {
+    if (this.#closed) {
+      return Promise.reject(
+        this.#closeError ?? new Error("memory session closed"),
+      );
+    }
+    if (this.#caughtUpLocalSeq >= localSeq) {
+      return Promise.resolve();
+    }
+    const pending = Promise.withResolvers<void>();
+    this.#caughtUpLocalSeqWaiters.push({ localSeq, pending });
+    return pending.promise;
+  }
+
   private rejectServerSeqWaiters(error: Error | null): void {
     const waiters = this.#serverSeqWaiters;
     this.#serverSeqWaiters = [];
+    for (const waiter of waiters) {
+      waiter.pending.reject(error ?? new Error("memory session closed"));
+    }
+  }
+
+  private rejectCaughtUpLocalSeqWaiters(error: Error | null): void {
+    const waiters = this.#caughtUpLocalSeqWaiters;
+    this.#caughtUpLocalSeqWaiters = [];
     for (const waiter of waiters) {
       waiter.pending.reject(error ?? new Error("memory session closed"));
     }
@@ -867,6 +922,7 @@ export class SpaceSession {
     this.#sessionId = restored.sessionId;
     this.#sessionToken = restored.sessionToken ?? this.#sessionToken;
     this.noteResult(restored.serverSeq);
+    this.noteCaughtUpLocalSeq(restored.caughtUpLocalSeq);
 
     if (restored.sessionId !== oldSessionId) {
       for (const pending of this.#outstandingCommits.values()) {
@@ -946,7 +1002,7 @@ export class SpaceSession {
           this.#outstandingCommits.delete(localSeq);
         }
         if (isRetryableConflict(error)) {
-          error.readyToRetry = () => this.waitForServerSeq(error.retryAfterSeq);
+          error.readyToRetry = () => this.waitForCaughtUpLocalSeq(localSeq);
         }
         pendingCommit.pending.reject(
           error instanceof Error ? error : new Error(String(error)),

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2138,6 +2138,12 @@ export class Server {
       }
       const toSeq = Engine.serverSeq(engine);
       if (upserts.length === 0) {
+        // The watched set was re-evaluated current as of toSeq even though it
+        // produced no net upserts; advance the watermark so a later default
+        // fromSeq is not stale. emptyCatchUp receives the original fromSeq
+        // explicitly, so this does not mutate the bounds of this sync (the
+        // Cubic fix keeps fromSeq pinned to the pre-refresh value).
+        session.lastSyncedSeq = Math.max(session.lastSyncedSeq, toSeq);
         return await emptyCatchUp(fromSeq, toSeq);
       }
       session.lastSyncedSeq = toSeq;

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2053,16 +2053,18 @@ export class Server {
         effect: sync,
       };
     };
-    const emptyCatchUp = async (): Promise<SessionEffectMessage | null> => {
+    const emptyCatchUp = async (
+      fromSeq = session.lastSyncedSeq,
+      toSeq?: number,
+    ): Promise<SessionEffectMessage | null> => {
       if (!hasPendingCatchUp) {
         return null;
       }
-      const engine = await this.openEngine(space);
-      const serverSeq = Engine.serverSeq(engine);
+      const serverSeq = toSeq ?? Engine.serverSeq(await this.openEngine(space));
       session.lastSyncedSeq = Math.max(session.lastSyncedSeq, serverSeq);
       return finishCatchUp({
         type: "sync",
-        fromSeq: session.lastSyncedSeq,
+        fromSeq,
         toSeq: serverSeq,
         upserts: [],
         removes: [],
@@ -2135,10 +2137,10 @@ export class Server {
         }
       }
       const toSeq = Engine.serverSeq(engine);
-      session.lastSyncedSeq = toSeq;
       if (upserts.length === 0) {
-        return await emptyCatchUp();
+        return await emptyCatchUp(fromSeq, toSeq);
       }
+      session.lastSyncedSeq = toSeq;
       recordSlowQueryDuration("session.watch.refresh", space, startedAt, {
         watches: session.watches.length,
       });
@@ -2174,7 +2176,7 @@ export class Server {
     session.trackedIds = trackedIdsFromEntries(entities.values());
     session.lastSyncedSeq = serverSeq;
     if (isEmptySync(sync)) {
-      return await emptyCatchUp();
+      return await emptyCatchUp(sync.fromSeq, sync.toSeq);
     }
     return finishCatchUp(sync);
   }

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -1548,24 +1548,30 @@ export class Server {
         ok: commit,
       };
     } catch (error) {
+      let retryAfterSeq: number | undefined;
       if (error instanceof Engine.ConflictError) {
         this.stageConflictRefreshDirtyIds(message.space, message.commit);
         await this.flushSessions([message.space]);
+        retryAfterSeq = session.lastSyncedSeq;
       }
       const messageText = error instanceof Error
         ? error.message
         : String(error);
       const preconditionError = toPreconditionFailedError(error, messageText);
+      const responseError = preconditionError ? preconditionError : toError(
+        error instanceof Engine.ConflictError
+          ? "ConflictError"
+          : error instanceof Engine.ProtocolError
+          ? "ProtocolError"
+          : "TransactionError",
+        messageText,
+      );
+      if (retryAfterSeq !== undefined) {
+        responseError.retryAfterSeq = retryAfterSeq;
+      }
       return respondTypedError<Engine.AppliedCommit>(
         message.requestId,
-        preconditionError ? preconditionError : toError(
-          error instanceof Engine.ConflictError
-            ? "ConflictError"
-            : error instanceof Engine.ProtocolError
-            ? "ProtocolError"
-            : "TransactionError",
-          messageText,
-        ),
+        responseError,
       );
     }
   }

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -26,6 +26,7 @@ import {
   type SessionOpenRequest,
   type SessionOpenResult,
   type SessionRevokedMessage,
+  type SessionSync,
   type SqliteDbRef,
   type SqliteParamsWire,
   type SqliteQueryRequest,
@@ -1379,6 +1380,7 @@ export class Server {
           sessionId: opened.sessionId,
           sessionToken: opened.sessionToken,
           serverSeq: opened.serverSeq,
+          caughtUpLocalSeq: opened.caughtUpLocalSeq,
           ...(opened.resumed === true ? { resumed: true } : {}),
           ...(catchup ? { sync: catchup.effect } : {}),
         },
@@ -1550,9 +1552,13 @@ export class Server {
     } catch (error) {
       let retryAfterSeq: number | undefined;
       if (error instanceof Engine.ConflictError) {
-        this.stageConflictRefreshDirtyIds(message.space, message.commit);
-        await this.flushSessions([message.space]);
-        retryAfterSeq = session.lastSyncedSeq;
+        this.stageConflictRefreshDirtyIds(
+          message.space,
+          session,
+          message.commit,
+        );
+        const engine = await this.openEngine(message.space);
+        retryAfterSeq = Engine.serverSeq(engine);
       }
       const messageText = error instanceof Error
         ? error.message
@@ -2023,8 +2029,47 @@ export class Server {
     dirtyOrigins?: ReadonlyMap<string, DirtyOrigin>,
   ): Promise<SessionEffectMessage | null> {
     const session = this.#sessions.get(space, sessionId);
-    if (session === null || session.watches.length === 0) {
+    if (session === null) {
       return null;
+    }
+    const pendingCaughtUpLocalSeq = session.pendingCaughtUpLocalSeq;
+    const hasPendingCatchUp =
+      pendingCaughtUpLocalSeq > session.caughtUpLocalSeq;
+    const finishCatchUp = (sync: SessionSync): SessionEffectMessage => {
+      if (hasPendingCatchUp) {
+        session.caughtUpLocalSeq = Math.max(
+          session.caughtUpLocalSeq,
+          pendingCaughtUpLocalSeq,
+        );
+        if (session.pendingCaughtUpLocalSeq <= session.caughtUpLocalSeq) {
+          session.pendingCaughtUpLocalSeq = 0;
+        }
+        sync.caughtUpLocalSeq = session.caughtUpLocalSeq;
+      }
+      return {
+        type: "session/effect",
+        space,
+        sessionId,
+        effect: sync,
+      };
+    };
+    const emptyCatchUp = async (): Promise<SessionEffectMessage | null> => {
+      if (!hasPendingCatchUp) {
+        return null;
+      }
+      const engine = await this.openEngine(space);
+      const serverSeq = Engine.serverSeq(engine);
+      session.lastSyncedSeq = Math.max(session.lastSyncedSeq, serverSeq);
+      return finishCatchUp({
+        type: "sync",
+        fromSeq: session.lastSyncedSeq,
+        toSeq: serverSeq,
+        upserts: [],
+        removes: [],
+      });
+    };
+    if (session.watches.length === 0) {
+      return await emptyCatchUp();
     }
     if (dirtyIds !== undefined) {
       const startedAt = performance.now();
@@ -2036,7 +2081,7 @@ export class Server {
         }
       }
       if (!touched) {
-        return null;
+        return await emptyCatchUp();
       }
 
       const engine = await this.openEngine(space);
@@ -2067,7 +2112,7 @@ export class Server {
       }
 
       if (updates.size === 0) {
-        return null;
+        return await emptyCatchUp();
       }
 
       const upserts: SessionCacheEntry[] = [];
@@ -2092,26 +2137,21 @@ export class Server {
       const toSeq = Engine.serverSeq(engine);
       session.lastSyncedSeq = toSeq;
       if (upserts.length === 0) {
-        return null;
+        return await emptyCatchUp();
       }
       recordSlowQueryDuration("session.watch.refresh", space, startedAt, {
         watches: session.watches.length,
       });
-      return {
-        type: "session/effect",
-        space,
-        sessionId,
-        effect: {
-          type: "sync",
-          fromSeq,
-          toSeq,
-          upserts: upserts.toSorted((left, right) =>
-            left.branch.localeCompare(right.branch) ||
-            left.id.localeCompare(right.id)
-          ),
-          removes: [],
-        },
-      };
+      return finishCatchUp({
+        type: "sync",
+        fromSeq,
+        toSeq,
+        upserts: upserts.toSorted((left, right) =>
+          left.branch.localeCompare(right.branch) ||
+          left.id.localeCompare(right.id)
+        ),
+        removes: [],
+      });
     }
 
     const { serverSeq, graphs, entities } = await this.evaluateWatchSet(
@@ -2134,14 +2174,9 @@ export class Server {
     session.trackedIds = trackedIdsFromEntries(entities.values());
     session.lastSyncedSeq = serverSeq;
     if (isEmptySync(sync)) {
-      return null;
+      return await emptyCatchUp();
     }
-    return {
-      type: "session/effect",
-      space,
-      sessionId,
-      effect: sync,
-    };
+    return finishCatchUp(sync);
   }
 
   markSpaceDirty(
@@ -2178,8 +2213,13 @@ export class Server {
 
   private stageConflictRefreshDirtyIds(
     space: string,
+    session: SessionState,
     commit: ClientCommit,
   ): void {
+    session.pendingCaughtUpLocalSeq = Math.max(
+      session.pendingCaughtUpLocalSeq,
+      commit.localSeq,
+    );
     const ids = new Set<string>();
     for (const operation of commit.operations) {
       if (operation.op === "sqlite") continue; // no entity id

--- a/packages/memory/v2/session-registry.ts
+++ b/packages/memory/v2/session-registry.ts
@@ -18,6 +18,8 @@ export type SessionState = {
   graphs: Map<string, TrackedGraphState>;
   entities: Map<string, SessionCacheEntry>;
   trackedIds: Set<string>;
+  caughtUpLocalSeq: number;
+  pendingCaughtUpLocalSeq: number;
   expiresAt: number | null;
   ownerConnectionId: string | null;
   principal?: string;
@@ -103,6 +105,8 @@ export class SessionRegistry {
       entities: existing?.entities ?? new Map(),
       trackedIds: existing?.trackedIds ??
         trackedIdsFromEntries(existing?.entities?.values() ?? []),
+      caughtUpLocalSeq: existing?.caughtUpLocalSeq ?? 0,
+      pendingCaughtUpLocalSeq: existing?.pendingCaughtUpLocalSeq ?? 0,
       expiresAt: null,
       ownerConnectionId,
       principal: existing?.principal ?? principal,
@@ -111,6 +115,7 @@ export class SessionRegistry {
       sessionId,
       sessionToken,
       serverSeq,
+      caughtUpLocalSeq: existing?.caughtUpLocalSeq ?? 0,
       ...(existing !== undefined ? { resumed: true } : {}),
       ...(revokedConnectionId ? { revokedConnectionId } : {}),
     };

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -184,6 +184,18 @@ export class MultiRuntimeSession {
     return await this.#client.call("diagnostics") as RuntimeDiagnosticsSnapshot;
   }
 
+  /** Per-logger message counts (logger name -> key -> {total,...}). */
+  async loggerCounts(): Promise<
+    Record<string, Record<string, { total: number }>> & { total: number }
+  > {
+    return await this.#client.call("loggerCounts") as
+      & Record<
+        string,
+        Record<string, { total: number }>
+      >
+      & { total: number };
+  }
+
   async disposeSession(): Promise<void> {
     try {
       await this.#client.call("dispose");

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -15,6 +15,7 @@ import {
   PiecesController,
 } from "@commonfabric/piece/ops";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
 
 export interface WorkerRequest {
   id: number;
@@ -211,6 +212,11 @@ const handlers: Record<
         actionRunTrace: scheduler.getActionRunTrace(),
       } satisfies RuntimeDiagnosticsSnapshot,
     );
+  },
+
+  async loggerCounts() {
+    await idle();
+    return getLoggerCountsBreakdown();
   },
 
   async dispose() {

--- a/packages/patterns/tools/lunch-poll-diagnose.ts
+++ b/packages/patterns/tools/lunch-poll-diagnose.ts
@@ -141,6 +141,13 @@ interface PhaseSample {
   sessions: readonly CompactSessionSample[];
 }
 
+interface ChurnTotals {
+  commitConflicts: number;
+  commitPreempted: number;
+  commitReverts: number;
+  commitRejected: number;
+}
+
 interface CaseResult {
   case: {
     users: number;
@@ -148,7 +155,28 @@ interface CaseResult {
     voteRounds: number;
     includeHomepageRefresh: boolean;
   };
+  churn: ChurnTotals;
   phases: PhaseSample[];
+}
+
+async function collectChurn(
+  sessions: readonly MultiRuntimeSession[],
+): Promise<ChurnTotals> {
+  const totals: ChurnTotals = {
+    commitConflicts: 0,
+    commitPreempted: 0,
+    commitReverts: 0,
+    commitRejected: 0,
+  };
+  for (const session of sessions) {
+    const counts = await session.loggerCounts();
+    const storage = counts["storage.v2"] ?? {};
+    totals.commitConflicts += storage["commit-conflict"]?.total ?? 0;
+    totals.commitPreempted += storage["commit-preempted"]?.total ?? 0;
+    totals.commitReverts += storage["commit-revert"]?.total ?? 0;
+    totals.commitRejected += storage["commit-rejected"]?.total ?? 0;
+  }
+  return totals;
 }
 
 const traceCursors = new Map<string, number>();
@@ -587,6 +615,14 @@ async function runCase(config: CaseConfig): Promise<CaseResult> {
       );
     }
 
+    const churn = await collectChurn(sessions);
+    console.error(
+      `[lunch-poll diagnose] churn ${config.optionCount}x${config.userCount} ` +
+        `admission=${Deno.env.get("CF_CONFLICT_ADMISSION") ?? "0"}: ` +
+        `conflicts=${churn.commitConflicts} preempted=${churn.commitPreempted} ` +
+        `reverts=${churn.commitReverts} rejected=${churn.commitRejected}`,
+    );
+
     return {
       case: {
         users: config.userCount,
@@ -594,6 +630,7 @@ async function runCase(config: CaseConfig): Promise<CaseResult> {
         voteRounds: config.voteRounds,
         includeHomepageRefresh: config.includeHomepageRefresh,
       },
+      churn,
       phases,
     };
   } finally {

--- a/packages/patterns/tools/lunch-poll-diagnose.ts
+++ b/packages/patterns/tools/lunch-poll-diagnose.ts
@@ -144,6 +144,8 @@ interface PhaseSample {
 interface ChurnTotals {
   commitConflicts: number;
   commitPreempted: number;
+  commitHeldRevert: number;
+  commitHeldSent: number;
   commitReverts: number;
   commitRejected: number;
 }
@@ -166,6 +168,8 @@ async function collectChurn(
   const totals: ChurnTotals = {
     commitConflicts: 0,
     commitPreempted: 0,
+    commitHeldRevert: 0,
+    commitHeldSent: 0,
     commitReverts: 0,
     commitRejected: 0,
   };
@@ -174,6 +178,8 @@ async function collectChurn(
     const storage = counts["storage.v2"] ?? {};
     totals.commitConflicts += storage["commit-conflict"]?.total ?? 0;
     totals.commitPreempted += storage["commit-preempted"]?.total ?? 0;
+    totals.commitHeldRevert += storage["commit-held-revert"]?.total ?? 0;
+    totals.commitHeldSent += storage["commit-held-sent"]?.total ?? 0;
     totals.commitReverts += storage["commit-revert"]?.total ?? 0;
     totals.commitRejected += storage["commit-rejected"]?.total ?? 0;
   }
@@ -668,6 +674,7 @@ async function runCase(config: CaseConfig): Promise<CaseResult> {
       `[lunch-poll diagnose] churn ${config.optionCount}x${config.userCount} ` +
         `admission=${Deno.env.get("CF_CONFLICT_ADMISSION") ?? "0"}: ` +
         `conflicts=${churn.commitConflicts} preempted=${churn.commitPreempted} ` +
+        `heldRevert=${churn.commitHeldRevert} heldSent=${churn.commitHeldSent} ` +
         `reverts=${churn.commitReverts} rejected=${churn.commitRejected}`,
     );
 

--- a/packages/patterns/tools/lunch-poll-diagnose.ts
+++ b/packages/patterns/tools/lunch-poll-diagnose.ts
@@ -156,6 +156,7 @@ interface CaseResult {
     includeHomepageRefresh: boolean;
   };
   churn: ChurnTotals;
+  convergence: ConvergenceResult;
   phases: PhaseSample[];
 }
 
@@ -177,6 +178,53 @@ async function collectChurn(
     totals.commitRejected += storage["commit-rejected"]?.total ?? 0;
   }
   return totals;
+}
+
+interface ConvergenceResult {
+  converged: boolean;
+  voteCounts: number[];
+  optionCounts: number[];
+  userCounts: number[];
+  fingerprints: string[];
+}
+
+// After heavy conflict churn, every session must agree on the shared poll
+// state. A canonical fingerprint of the (PerSpace) vote set that differs across
+// sessions is a correctness/convergence bug, not just contention.
+async function collectConvergence(
+  sessions: readonly MultiRuntimeSession[],
+): Promise<ConvergenceResult> {
+  const states = await Promise.all(sessions.map(async (session) => {
+    const poll = pollSummary(await session.read());
+    const fingerprint = poll.votes
+      .map((vote) =>
+        `${vote.voterName ?? "?"}|${vote.optionId ?? "?"}|${
+          vote.voteType ?? "?"
+        }`
+      )
+      .sort()
+      .join(",");
+    return {
+      votes: poll.voteCount,
+      options: poll.optionCount,
+      users: poll.userCount,
+      fingerprint,
+    };
+  }));
+  const ref = states[0];
+  const converged = states.every((state) =>
+    state.votes === ref.votes &&
+    state.options === ref.options &&
+    state.users === ref.users &&
+    state.fingerprint === ref.fingerprint
+  );
+  return {
+    converged,
+    voteCounts: states.map((state) => state.votes),
+    optionCounts: states.map((state) => state.options),
+    userCounts: states.map((state) => state.users),
+    fingerprints: states.map((state) => state.fingerprint),
+  };
 }
 
 const traceCursors = new Map<string, number>();
@@ -623,6 +671,22 @@ async function runCase(config: CaseConfig): Promise<CaseResult> {
         `reverts=${churn.commitReverts} rejected=${churn.commitRejected}`,
     );
 
+    // Settle once more, then assert all sessions converged on the shared state.
+    await harness.settle(5);
+    const convergence = await collectConvergence(sessions);
+    console.error(
+      `[lunch-poll diagnose] convergence ${config.optionCount}x${config.userCount}: ` +
+        `converged=${convergence.converged} ` +
+        `votes=[${convergence.voteCounts.join(",")}] ` +
+        `options=[${convergence.optionCounts.join(",")}] ` +
+        `users=[${convergence.userCounts.join(",")}]` +
+        (convergence.converged
+          ? ""
+          : ` DIVERGED fingerprints=${
+            JSON.stringify(convergence.fingerprints)
+          }`),
+    );
+
     return {
       case: {
         users: config.userCount,
@@ -631,6 +695,7 @@ async function runCase(config: CaseConfig): Promise<CaseResult> {
         includeHomepageRefresh: config.includeHomepageRefresh,
       },
       churn,
+      convergence,
       phases,
     };
   } finally {

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -110,7 +110,7 @@ export function watchReactiveActionCommit(state: {
   readonly queueExecution: () => void;
   readonly restoreCfcTriggerReads: () => void;
 }): void {
-  state.commitPromise.then(({ error }) => {
+  state.commitPromise.then(async ({ error }) => {
     // On error, retry up to MAX_RETRIES_FOR_REACTIVE times. Note that
     // on every attempt we still call the re-subscribe below, so that
     // even after we run out of retries, this will be re-triggered when
@@ -127,6 +127,10 @@ export function watchReactiveActionCommit(state: {
       if (
         retries < MAX_RETRIES_FOR_REACTIVE && !isPermanentRejection(error)
       ) {
+        const readyToRetry = readyToRetryPromise(error);
+        if (readyToRetry !== undefined) {
+          await readyToRetry;
+        }
         // Re-schedule the action to run again on conflict failure.
         // Use resubscribe to set up dependencies/triggers from the log,
         // then mark as dirty/pending to ensure it runs again.
@@ -152,6 +156,18 @@ export function watchReactiveActionCommit(state: {
       error,
     );
   });
+}
+
+function readyToRetryPromise(error: unknown): Promise<unknown> | undefined {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+  const candidate = (error as { readyToRetry?: unknown }).readyToRetry;
+  if (typeof candidate !== "function") {
+    return undefined;
+  }
+  const result = candidate.call(error);
+  return Promise.resolve(result);
 }
 
 export function appendActionRunTrace(state: {

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -129,7 +129,25 @@ export function watchReactiveActionCommit(state: {
       ) {
         const readyToRetry = readyToRetryPromise(error);
         if (readyToRetry !== undefined) {
-          await readyToRetry;
+          // The readiness gate rejects by design when the session is closed,
+          // revoked, or replaced (new sessionId) while we are waiting — an
+          // expected control-flow signal, not an error. Swallow it and fall
+          // through to the re-arm below: re-subscribing keeps the action live
+          // so it re-triggers on the next input change. Letting the rejection
+          // escape would skip restoreCfcTriggerReads/resubscribe (stranding the
+          // action) and surface as a spurious console.error from the trailing
+          // .catch.
+          try {
+            await readyToRetry;
+          } catch (readyError) {
+            logger.debug(
+              "retry-readiness-aborted",
+              () => [
+                "conflict retry readiness aborted; re-arming action anyway",
+                readyError,
+              ],
+            );
+          }
         }
         // Re-schedule the action to run again on conflict failure.
         // Use resubscribe to set up dependencies/triggers from the log,
@@ -166,8 +184,13 @@ function readyToRetryPromise(error: unknown): Promise<unknown> | undefined {
   if (typeof candidate !== "function") {
     return undefined;
   }
-  const result = candidate.call(error);
-  return Promise.resolve(result);
+  try {
+    return Promise.resolve(candidate.call(error));
+  } catch (thrown) {
+    // A readyToRetry that throws synchronously is treated the same as one that
+    // returns a rejected promise; the caller swallows the rejection.
+    return Promise.reject(thrown);
+  }
 }
 
 export function appendActionRunTrace(state: {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -114,6 +114,12 @@ function withCommitTiming<T>(
 }
 
 const DATA_URI_SYNC_CACHE_MAX = 10_000;
+// Backstop for the inline conflict read-repair wait. In the connected path the
+// caught-up sync arrives within a refresh cycle; this only fires if the sync is
+// permanently undelivered on a still-open, never-reconnecting session, so the
+// commit cannot hang forever. On expiry we surface the conflict and let the
+// scheduler retry path re-gate on readiness.
+const CONFLICT_READ_REPAIR_TIMEOUT_MS = 30_000;
 const dataURISyncCache = new Map<string, Promise<Cell<any>>>();
 const DOCUMENT_MIME = "application/json" as const;
 const UNCACHED_TRANSACTION_VALUE = Symbol("uncachedTransactionValue");
@@ -2070,14 +2076,28 @@ class SpaceReplica implements ISpaceReplica {
     if (readyToRetry === undefined) {
       return;
     }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timedOut = new Promise<void>((resolve) => {
+      timer = setTimeout(() => {
+        logger.warn(
+          "conflict-read-repair-timeout",
+          "caught-up sync not received within timeout; surfacing conflict",
+        );
+        resolve();
+      }, CONFLICT_READ_REPAIR_TIMEOUT_MS);
+    });
     try {
-      await readyToRetry();
+      await Promise.race([readyToRetry(), timedOut]);
     } catch (error) {
       logger.warn(
         "conflict-read-repair",
         "readyToRetry rejected while preserving original conflict result",
         error,
       );
+    } finally {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
     }
   }
 

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1693,7 +1693,7 @@ class SpaceReplica implements ISpaceReplica {
         }
         return result;
       }, (error) => {
-        const rejection = toRejectedError(error, commit);
+        const rejection = toRejectedError(error, commit, this.#space);
         const result = { error: rejection };
         for (const entry of entries) {
           entry.pending.resolve(result);
@@ -1859,7 +1859,7 @@ class SpaceReplica implements ISpaceReplica {
       this.confirmPending(localSeq, operations, applied);
       return { ok: {} };
     } catch (error) {
-      const rejection = toRejectedError(error, commit);
+      const rejection = toRejectedError(error, commit, this.#space);
       this.attachProviderReadyToRetry(rejection, localSeq);
       // Counted (even while silent) so multi-writer churn can be read back via
       // getLoggerCounts(): "commit-conflict" is a stale-seq-basis rejection that
@@ -2350,6 +2350,7 @@ const toConnectionError = (error: unknown): IConnectionError =>
 const toRejectedError = (
   error: unknown,
   commit: unknown,
+  space: MemorySpace,
 ): StorageTransactionRejected => {
   const message = error instanceof Error ? error.message : String(error);
   const name = error instanceof Error
@@ -2381,8 +2382,12 @@ const toRejectedError = (
       name: "ConflictError",
       message,
       transaction: commit as Transaction,
+      // Diagnostic-only conflict descriptor: the storage layer surfaces a
+      // ConflictError by name/readyToRetry, not by inspecting these fields.
+      // `the`/`expected`/`actual` are placeholders; space and of are filled in
+      // so the debug log is accurate.
       conflict: {
-        space: "" as MemorySpace,
+        space,
         the: DOCUMENT_MIME,
         of: firstOperation?.id ?? "of:unknown",
         expected: null,
@@ -2391,6 +2396,9 @@ const toRejectedError = (
         history: [],
       },
     };
+    // retryAfterSeq is carried for diagnostics; retry gating is by caughtUpLocalSeq
+    // (readyToRetry), and downstream only uses retryAfterSeq's presence to mark
+    // the conflict retryable.
     if (typeof retryAfterSeq === "number") {
       rejected.retryAfterSeq = retryAfterSeq;
     }

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -6,7 +6,6 @@ import {
 import {
   type ConflictError as IConflictError,
   type ConnectionError as IConnectionError,
-  type Entity,
   type FabricValue,
   type MemorySpace,
   type MIME,
@@ -2355,6 +2354,8 @@ const toRejectedError = (
   ) {
     const retryAfterSeq = (error as { retryAfterSeq?: unknown })?.retryAfterSeq;
     const readyToRetry = (error as { readyToRetry?: unknown })?.readyToRetry;
+    const firstOperation = (commit as Partial<NativeStorageCommit>)
+      .operations?.[0];
     const rejected: IConflictError = {
       name: "ConflictError",
       message,
@@ -2362,7 +2363,7 @@ const toRejectedError = (
       conflict: {
         space: "" as MemorySpace,
         the: DOCUMENT_MIME,
-        of: conflictEntity(commit),
+        of: firstOperation?.id ?? "of:unknown",
         expected: null,
         actual: null,
         existsInHistory: false,
@@ -2388,18 +2389,4 @@ const toRejectedError = (
     },
     transaction: commit as Transaction,
   } as unknown as TransactionError;
-};
-
-const conflictEntity = (commit: unknown): Entity => {
-  if (
-    typeof commit === "object" &&
-    commit !== null &&
-    Array.isArray((commit as Partial<NativeStorageCommit>).operations)
-  ) {
-    const first = (commit as Partial<NativeStorageCommit>).operations?.[0];
-    if (first !== undefined) {
-      return first.id;
-    }
-  }
-  return "of:unknown";
 };

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -122,32 +122,61 @@ const DATA_URI_SYNC_CACHE_MAX = 10_000;
 const CONFLICT_READ_REPAIR_TIMEOUT_MS = 30_000;
 
 // Strategy 1 — client-side conflict admission control (EXPERIMENT, default off).
-// Once a commit conflicts, the client knows its read set is behind until the
-// server catches it up. New commits reading those same ids before catch-up are
-// near-certain to conflict too, so when enabled we pre-empt them locally
-// (revert + re-run after catch-up) instead of issuing a doomed round trip.
+// Once a commit conflicts, the client knows its read set is behind on the
+// touched ids until the server catches it up. Two modes gate what we do with a
+// new commit whose reads land on a still-catching-up id:
 //
-// Measured NET-NEGATIVE on the lunch-poll contention workload: those conflicts
-// are genuine cross-session write-write ping-pong (first-conflicts that
-// admission cannot pre-empt), and since conflict responses are already cheap,
-// pre-empting only inserts extra revert+re-run cycles that re-enter the same
-// contention. 5x5 conflicts rose ~1380 -> ~1600 (plus pre-empts). Kept
-// flag-gated as a documented experiment; the real lever for this workload is
-// coalescing commutative ops. Do NOT enable without re-measuring on the target
-// workload.
-let conflictAdmissionConfigOverride: boolean | undefined;
-export function setConflictAdmissionEnabled(value: boolean | undefined): void {
-  conflictAdmissionConfigOverride = value;
+//   "preempt" (coarse): assume it will conflict and pre-empt it locally (revert
+//     + re-run after catch-up) without sending. Measured NET-NEGATIVE on the
+//     lunch-poll workload: the stale floor taints every id a losing tx touched
+//     (incl. write targets), so it pre-empts commits that would have SUCCEEDED,
+//     turning them into extra revert+re-run cycles. 5x5 server conflicts rose
+//     ~1380 -> ~1600 (plus pre-empts), wall time flat (conflicts are cheap).
+//
+//   "hold" (precise): hold the commit until the catch-up is applied, then run
+//     the server's precondition check LOCALLY against the now-current confirmed
+//     seqs. Locally revert only the commits that are genuinely stale; SEND the
+//     rest. Eliminates the coarse mode's false pre-empts and stops sending
+//     knowingly-doomed commits to the server.
+//
+//     Measured NEUTRAL (safe but no win) on lunch-poll: heldRevert ~= 0,
+//     heldSent ~= 70, conflicts ~= baseline. The reason is fundamental — the
+//     staleness here is SERVER-side, not locally knowable: when the action
+//     runs it reads the latest LOCAL confirmed value, which looks current
+//     (read.seq == local confirmed seq), so the local check cannot tell the
+//     commit is behind the server. Only the server (or a not-yet-received sync)
+//     knows. So the precise check correctly SENDS the held commits (no false
+//     pre-empts, unlike coarse) but cannot prevent the server conflict. This
+//     mode only pays off where a client routinely holds commits built against
+//     data its own later syncs have already superseded.
+//
+// Default off. Do NOT enable without re-measuring on the target workload.
+type ConflictAdmissionMode = "off" | "preempt" | "hold";
+let conflictAdmissionModeOverride: ConflictAdmissionMode | undefined;
+export function setConflictAdmissionMode(
+  mode: ConflictAdmissionMode | undefined,
+): void {
+  conflictAdmissionModeOverride = mode;
 }
-function conflictAdmissionEnabled(): boolean {
-  if (conflictAdmissionConfigOverride !== undefined) {
-    return conflictAdmissionConfigOverride;
+// Back-compat for existing tests/callers: true -> coarse preempt, false -> off.
+export function setConflictAdmissionEnabled(value: boolean | undefined): void {
+  conflictAdmissionModeOverride = value === undefined
+    ? undefined
+    : (value ? "preempt" : "off");
+}
+function conflictAdmissionMode(): ConflictAdmissionMode {
+  if (conflictAdmissionModeOverride !== undefined) {
+    return conflictAdmissionModeOverride;
   }
   try {
     const value = Deno.env.get("CF_CONFLICT_ADMISSION");
-    return value === "1" || value === "true";
+    if (value === "hold") return "hold";
+    if (value === "preempt" || value === "1" || value === "true") {
+      return "preempt";
+    }
+    return "off";
   } catch {
-    return false;
+    return "off";
   }
 }
 const dataURISyncCache = new Map<string, Promise<Cell<any>>>();
@@ -1883,24 +1912,55 @@ class SpaceReplica implements ISpaceReplica {
     commit: ClientCommit,
     source?: IStorageTransaction,
   ): Promise<Result<Unit, StorageTransactionRejected>> {
-    // Strategy 1: pre-empt a commit whose read set is known stale rather than
-    // letting it conflict at the server. The retry path is identical to a real
-    // conflict, minus the doomed round trip and the server-side conflict.
-    if (conflictAdmissionEnabled()) {
+    // Strategy 1: a commit whose read set lands on a still-catching-up id.
+    const admissionMode = conflictAdmissionMode();
+    if (admissionMode !== "off") {
       const threshold = this.preemptThreshold(commit);
       if (threshold !== undefined) {
-        const rejection = this.makePreemptRejection(commit, threshold);
-        logger.debug("commit-preempted", () => [
-          `commit preempted: stale until caughtUpLocalSeq>=${threshold}`,
-          { localSeq, operations: operations.length },
-        ]);
-        return await this.finalizeRejection(
-          localSeq,
-          operations,
-          commit,
-          source,
-          rejection,
-        );
+        if (admissionMode === "hold") {
+          // Precise mode: hold until the catch-up is applied, then run the
+          // server's stale-read check locally. Revert only the genuinely stale
+          // commits; fall through to send the ones whose reads still hold.
+          try {
+            await this.waitForCaughtUpLocalSeq(threshold);
+          } catch {
+            // Session/replica closing — fall through to the normal path, which
+            // surfaces the closed-state error cleanly.
+          }
+          if (!this.#closed && this.commitReadsStaleLocally(commit)) {
+            const rejection = this.makePreemptRejection(commit, threshold);
+            logger.debug("commit-held-revert", () => [
+              `held commit reverted (locally stale) at caughtUpLocalSeq>=${threshold}`,
+              { localSeq, operations: operations.length },
+            ]);
+            return await this.finalizeRejection(
+              localSeq,
+              operations,
+              commit,
+              source,
+              rejection,
+            );
+          }
+          logger.debug("commit-held-sent", () => [
+            `held commit sent after catch-up (reads still valid)`,
+            { localSeq, operations: operations.length },
+          ]);
+          // fall through to send
+        } else {
+          // Coarse mode: assume conflict and pre-empt without sending.
+          const rejection = this.makePreemptRejection(commit, threshold);
+          logger.debug("commit-preempted", () => [
+            `commit preempted: stale until caughtUpLocalSeq>=${threshold}`,
+            { localSeq, operations: operations.length },
+          ]);
+          return await this.finalizeRejection(
+            localSeq,
+            operations,
+            commit,
+            source,
+            rejection,
+          );
+        }
       }
     }
     try {
@@ -1924,7 +1984,7 @@ class SpaceReplica implements ISpaceReplica {
     } catch (error) {
       const rejection = toRejectedError(error, commit, this.#space);
       this.attachProviderReadyToRetry(rejection, localSeq);
-      if (conflictAdmissionEnabled() && rejection.name === "ConflictError") {
+      if (admissionMode !== "off" && rejection.name === "ConflictError") {
         this.recordStaleFloor(commit, localSeq);
       }
       // Counted (even while silent) so multi-writer churn can be read back via
@@ -2181,6 +2241,23 @@ class SpaceReplica implements ISpaceReplica {
       consider(read.id, read.scope);
     }
     return threshold;
+  }
+
+  // The server's stale-read precondition check, run LOCALLY against the current
+  // confirmed seqs (use after catch-up has been applied). Returns true only when
+  // a confirmed read is PROVABLY behind our local confirmed base — i.e. the
+  // commit is genuinely going to conflict. Anything we cannot prove stale
+  // (unknown id, no local record, or only pending reads) returns false so the
+  // commit is still sent and the server stays the source of truth.
+  private commitReadsStaleLocally(commit: ClientCommit): boolean {
+    for (const read of commit.reads.confirmed) {
+      const record = this.#docs.get(docKey(read.id as URI, read.scope));
+      const confirmedSeq = record?.confirmed.seq ?? 0;
+      if (read.seq < confirmedSeq) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private makePreemptRejection(

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1602,6 +1602,11 @@ class SpaceReplica implements ISpaceReplica {
 
       const { view, sync } = await session.watchAddSync(watches);
 
+      if (this.#closed) {
+        view.close();
+        return { error: toConnectionError(new Error("memory replica closed")) };
+      }
+
       this.#watchView = view;
       this.applySessionSync(sync, type);
       if (this.#updatePromises.size === 0) {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1885,6 +1885,7 @@ class SpaceReplica implements ISpaceReplica {
           touched.map(({ id, scope }) => snapshotState(this, id, scope)),
         )
         : undefined;
+      await this.waitForConflictReadRepair(rejection);
       this.dropPending(localSeq);
       if (before !== undefined) {
         const changes = before.compare(this);
@@ -2058,6 +2059,26 @@ class SpaceReplica implements ISpaceReplica {
       await readyToRetry();
       await this.waitForCaughtUpLocalSeq(localSeq);
     };
+  }
+
+  private async waitForConflictReadRepair(
+    rejection: StorageTransactionRejected,
+  ): Promise<void> {
+    if (rejection.name !== "ConflictError") {
+      return;
+    }
+    const readyToRetry = rejection.readyToRetry;
+    if (readyToRetry === undefined) {
+      return;
+    }
+    try {
+      await readyToRetry();
+    } catch (error) {
+      logger.warn("conflict-read-repair", () => [
+        "readyToRetry rejected while preserving original conflict result",
+        error,
+      ]);
+    }
   }
 
   private record(id: URI, scope?: CellScope): DocumentRecord {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -6,11 +6,13 @@ import {
 import {
   type ConflictError as IConflictError,
   type ConnectionError as IConnectionError,
+  type Entity,
   type FabricValue,
   type MemorySpace,
   type MIME,
   type SchemaPathSelector,
   type Signer,
+  type Transaction,
   type TransactionError,
   type URI,
 } from "@commonfabric/memory/interface";
@@ -2260,17 +2262,29 @@ const toRejectedError = (
     message.includes("stale confirmed read") ||
     message.includes("pending dependency")
   ) {
-    return {
+    const retryAfterSeq = (error as { retryAfterSeq?: unknown })?.retryAfterSeq;
+    const readyToRetry = (error as { readyToRetry?: unknown })?.readyToRetry;
+    const rejected: IConflictError = {
       name: "ConflictError",
       message,
-      transaction: commit as any,
+      transaction: commit as Transaction,
       conflict: {
+        space: "" as MemorySpace,
+        the: DOCUMENT_MIME,
+        of: conflictEntity(commit),
         expected: null,
         actual: null,
         existsInHistory: false,
         history: [],
       },
-    } as unknown as IConflictError;
+    };
+    if (typeof retryAfterSeq === "number") {
+      rejected.retryAfterSeq = retryAfterSeq;
+    }
+    if (typeof readyToRetry === "function") {
+      rejected.readyToRetry = () => Promise.resolve(readyToRetry.call(error));
+    }
+    return rejected;
   }
 
   return {
@@ -2281,6 +2295,20 @@ const toRejectedError = (
       message,
       code: 500,
     },
-    transaction: commit as any,
+    transaction: commit as Transaction,
   } as unknown as TransactionError;
+};
+
+const conflictEntity = (commit: unknown): Entity => {
+  if (
+    typeof commit === "object" &&
+    commit !== null &&
+    Array.isArray((commit as Partial<NativeStorageCommit>).operations)
+  ) {
+    const first = (commit as Partial<NativeStorageCommit>).operations?.[0];
+    if (first !== undefined) {
+      return first.id;
+    }
+  }
+  return "of:unknown";
 };

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -707,7 +707,6 @@ export class StorageManager implements IStorageManager {
     if (this.#providers.size === 0) {
       return;
     }
-    await this.synced();
     await Promise.all(
       [...this.#providers.values()].map((provider) => provider.destroy()),
     );
@@ -1040,7 +1039,6 @@ class Provider implements IStorageProviderWithReplica {
       return;
     }
     this.#destroyed = true;
-    await this.replica.synced();
     await this.replica.close();
   }
 
@@ -1247,6 +1245,8 @@ class SpaceReplica implements ISpaceReplica {
 
   async close(): Promise<void> {
     this.#closed = true;
+    this.resetConflictAdmissionState();
+    this.rejectCaughtUpLocalSeqWaiters(new Error("memory replica closed"));
     await this.synced();
     this.cancelQueuedWatchRefresh();
     this.#watchView?.close();
@@ -1275,9 +1275,13 @@ class SpaceReplica implements ISpaceReplica {
       }
     }
     await Promise.allSettled([...this.#updatePromises]);
-    this.rejectCaughtUpLocalSeqWaiters(new Error("memory replica closed"));
     this.#syncTasks.clear();
     this.#watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>();
+  }
+
+  private resetConflictAdmissionState(): void {
+    this.#caughtUpLocalSeq = 0;
+    this.#staleFloor.clear();
   }
 
   private noteCaughtUpLocalSeq(localSeq: number | undefined): void {
@@ -1331,6 +1335,7 @@ class SpaceReplica implements ISpaceReplica {
 
   closeNow(): void {
     this.#closed = true;
+    this.resetConflictAdmissionState();
     this.cancelQueuedWatchRefresh();
     this.#watchView?.close();
     this.#watchView = null;
@@ -1559,6 +1564,8 @@ class SpaceReplica implements ISpaceReplica {
   reset(): void {
     this.#docs.clear();
     this.#watchedIds.clear();
+    this.resetConflictAdmissionState();
+    this.rejectCaughtUpLocalSeqWaiters(new Error("memory replica reset"));
     this.cancelQueuedWatchRefresh();
     this.#watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>();
     this.#subscription.next({
@@ -1918,17 +1925,24 @@ class SpaceReplica implements ISpaceReplica {
       const threshold = this.preemptThreshold(commit);
       if (threshold !== undefined) {
         if (admissionMode === "hold") {
+          const rejection = this.makePreemptRejection(commit, threshold);
           // Precise mode: hold until the catch-up is applied, then run the
           // server's stale-read check locally. Revert only the genuinely stale
           // commits; fall through to send the ones whose reads still hold.
           try {
             await this.waitForCaughtUpLocalSeq(threshold);
           } catch {
-            // Session/replica closing — fall through to the normal path, which
-            // surfaces the closed-state error cleanly.
+            // Session/replica closing or reset: do not open/send a new session
+            // while shutdown is in progress. Finalize the held rejection so the
+            // optimistic write is dropped and close can drain promptly.
+            return await this.finalizeRejection(
+              localSeq,
+              operations,
+              source,
+              rejection,
+            );
           }
           if (!this.#closed && this.commitReadsStaleLocally(commit)) {
-            const rejection = this.makePreemptRejection(commit, threshold);
             logger.debug("commit-held-revert", () => [
               `held commit reverted (locally stale) at caughtUpLocalSeq>=${threshold}`,
               { localSeq, operations: operations.length },
@@ -1936,7 +1950,6 @@ class SpaceReplica implements ISpaceReplica {
             return await this.finalizeRejection(
               localSeq,
               operations,
-              commit,
               source,
               rejection,
             );
@@ -1956,7 +1969,6 @@ class SpaceReplica implements ISpaceReplica {
           return await this.finalizeRejection(
             localSeq,
             operations,
-            commit,
             source,
             rejection,
           );
@@ -2004,7 +2016,6 @@ class SpaceReplica implements ISpaceReplica {
       return await this.finalizeRejection(
         localSeq,
         operations,
-        commit,
         source,
         rejection,
       );
@@ -2017,7 +2028,6 @@ class SpaceReplica implements ISpaceReplica {
   private async finalizeRejection(
     localSeq: number,
     operations: NativeCommitOperation[],
-    commit: ClientCommit,
     source: IStorageTransaction | undefined,
     rejection: StorageTransactionRejected,
   ): Promise<Result<Unit, StorageTransactionRejected>> {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1068,6 +1068,12 @@ class SpaceReplica implements ISpaceReplica {
   #watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>();
   #watchedIds = new Set<string>();
   #nextLocalSeq = 1;
+  #closed = false;
+  #caughtUpLocalSeq = 0;
+  #caughtUpLocalSeqWaiters: {
+    localSeq: number;
+    pending: PromiseWithResolvers<void>;
+  }[] = [];
   #queuedWatchRefresh: WatchRefreshBatch | null = null;
   #queuedWatchRefreshScheduled = false;
 
@@ -1172,6 +1178,7 @@ class SpaceReplica implements ISpaceReplica {
   }
 
   async close(): Promise<void> {
+    this.#closed = true;
     await this.synced();
     this.cancelQueuedWatchRefresh();
     this.#watchView?.close();
@@ -1200,11 +1207,53 @@ class SpaceReplica implements ISpaceReplica {
       }
     }
     await Promise.allSettled([...this.#updatePromises]);
+    this.rejectCaughtUpLocalSeqWaiters(new Error("memory replica closed"));
     this.#syncTasks.clear();
     this.#watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>();
   }
 
+  private noteCaughtUpLocalSeq(localSeq: number | undefined): void {
+    if (localSeq === undefined) {
+      return;
+    }
+    this.#caughtUpLocalSeq = Math.max(this.#caughtUpLocalSeq, localSeq);
+    const ready: PromiseWithResolvers<void>[] = [];
+    this.#caughtUpLocalSeqWaiters = this.#caughtUpLocalSeqWaiters.filter(
+      (waiter) => {
+        if (waiter.localSeq <= this.#caughtUpLocalSeq) {
+          ready.push(waiter.pending);
+          return false;
+        }
+        return true;
+      },
+    );
+    for (const pending of ready) {
+      pending.resolve();
+    }
+  }
+
+  private waitForCaughtUpLocalSeq(localSeq: number): Promise<void> {
+    if (this.#closed) {
+      return Promise.reject(new Error("memory replica closed"));
+    }
+    if (this.#caughtUpLocalSeq >= localSeq) {
+      return Promise.resolve();
+    }
+    const pending = Promise.withResolvers<void>();
+    this.#caughtUpLocalSeqWaiters.push({ localSeq, pending });
+    return pending.promise;
+  }
+
+  private rejectCaughtUpLocalSeqWaiters(error: Error): void {
+    const waiters = this.#caughtUpLocalSeqWaiters;
+    this.#caughtUpLocalSeqWaiters = [];
+    for (const waiter of waiters) {
+      waiter.pending.reject(error);
+    }
+  }
+
   closeNow(): void {
+    this.#closed = true;
     this.cancelQueuedWatchRefresh();
     this.#watchView?.close();
     this.#watchView = null;
@@ -1218,6 +1267,7 @@ class SpaceReplica implements ISpaceReplica {
       });
     }
     void Promise.allSettled([...this.#updatePromises]);
+    this.rejectCaughtUpLocalSeqWaiters(new Error("memory replica closed"));
     this.#syncTasks.clear();
     this.#watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>();
   }
@@ -1805,6 +1855,7 @@ class SpaceReplica implements ISpaceReplica {
       return { ok: {} };
     } catch (error) {
       const rejection = toRejectedError(error, commit);
+      this.attachProviderReadyToRetry(rejection, localSeq);
       // Counted (even while silent) so multi-writer churn can be read back via
       // getLoggerCounts(): "commit-conflict" is a stale-seq-basis rejection that
       // drops only the optimistic pending write and re-derives from confirmed
@@ -1928,6 +1979,7 @@ class SpaceReplica implements ISpaceReplica {
     type: "pull" | "integrate",
   ): void {
     if (sync.upserts.length === 0 && sync.removes.length === 0) {
+      this.noteCaughtUpLocalSeq(sync.caughtUpLocalSeq);
       return;
     }
 
@@ -1988,6 +2040,24 @@ class SpaceReplica implements ISpaceReplica {
     } else if (shouldNotifySinks) {
       this.notifySinksForIds(touched);
     }
+    this.noteCaughtUpLocalSeq(sync.caughtUpLocalSeq);
+  }
+
+  private attachProviderReadyToRetry(
+    rejection: StorageTransactionRejected,
+    localSeq: number,
+  ): void {
+    if (rejection.name !== "ConflictError") {
+      return;
+    }
+    const readyToRetry = rejection.readyToRetry;
+    if (readyToRetry === undefined) {
+      return;
+    }
+    rejection.readyToRetry = async () => {
+      await readyToRetry();
+      await this.waitForCaughtUpLocalSeq(localSeq);
+    };
   }
 
   private record(id: URI, scope?: CellScope): DocumentRecord {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -121,12 +121,20 @@ const DATA_URI_SYNC_CACHE_MAX = 10_000;
 // scheduler retry path re-gate on readiness.
 const CONFLICT_READ_REPAIR_TIMEOUT_MS = 30_000;
 
-// Strategy 1 — client-side conflict admission control. Once a commit conflicts,
-// the client knows its read set is behind until the server catches it up. New
-// commits reading those same ids before catch-up are near-certain to conflict
-// too, so when this is enabled we pre-empt them locally (revert + re-run after
-// catch-up) instead of issuing a doomed round trip that generates another
-// server conflict. Gated so the effect can be A/B measured; default off.
+// Strategy 1 — client-side conflict admission control (EXPERIMENT, default off).
+// Once a commit conflicts, the client knows its read set is behind until the
+// server catches it up. New commits reading those same ids before catch-up are
+// near-certain to conflict too, so when enabled we pre-empt them locally
+// (revert + re-run after catch-up) instead of issuing a doomed round trip.
+//
+// Measured NET-NEGATIVE on the lunch-poll contention workload: those conflicts
+// are genuine cross-session write-write ping-pong (first-conflicts that
+// admission cannot pre-empt), and since conflict responses are already cheap,
+// pre-empting only inserts extra revert+re-run cycles that re-enter the same
+// contention. 5x5 conflicts rose ~1380 -> ~1600 (plus pre-empts). Kept
+// flag-gated as a documented experiment; the real lever for this workload is
+// coalescing commutative ops. Do NOT enable without re-measuring on the target
+// workload.
 let conflictAdmissionConfigOverride: boolean | undefined;
 export function setConflictAdmissionEnabled(value: boolean | undefined): void {
   conflictAdmissionConfigOverride = value;

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2073,10 +2073,11 @@ class SpaceReplica implements ISpaceReplica {
     try {
       await readyToRetry();
     } catch (error) {
-      logger.warn("conflict-read-repair", () => [
+      logger.warn(
+        "conflict-read-repair",
         "readyToRetry rejected while preserving original conflict result",
         error,
-      ]);
+      );
     }
   }
 

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -120,6 +120,28 @@ const DATA_URI_SYNC_CACHE_MAX = 10_000;
 // commit cannot hang forever. On expiry we surface the conflict and let the
 // scheduler retry path re-gate on readiness.
 const CONFLICT_READ_REPAIR_TIMEOUT_MS = 30_000;
+
+// Strategy 1 — client-side conflict admission control. Once a commit conflicts,
+// the client knows its read set is behind until the server catches it up. New
+// commits reading those same ids before catch-up are near-certain to conflict
+// too, so when this is enabled we pre-empt them locally (revert + re-run after
+// catch-up) instead of issuing a doomed round trip that generates another
+// server conflict. Gated so the effect can be A/B measured; default off.
+let conflictAdmissionConfigOverride: boolean | undefined;
+export function setConflictAdmissionEnabled(value: boolean | undefined): void {
+  conflictAdmissionConfigOverride = value;
+}
+function conflictAdmissionEnabled(): boolean {
+  if (conflictAdmissionConfigOverride !== undefined) {
+    return conflictAdmissionConfigOverride;
+  }
+  try {
+    const value = Deno.env.get("CF_CONFLICT_ADMISSION");
+    return value === "1" || value === "true";
+  } catch {
+    return false;
+  }
+}
 const dataURISyncCache = new Map<string, Promise<Cell<any>>>();
 const DOCUMENT_MIME = "application/json" as const;
 const UNCACHED_TRANSACTION_VALUE = Symbol("uncachedTransactionValue");
@@ -1079,6 +1101,10 @@ class SpaceReplica implements ISpaceReplica {
     localSeq: number;
     pending: PromiseWithResolvers<void>;
   }[] = [];
+  // docKey -> required caughtUpLocalSeq. An entry means "this id conflicted and
+  // is stale until we observe caughtUpLocalSeq >= value". Pruned as the runner
+  // catches up; only populated while conflict admission control is enabled.
+  #staleFloor = new Map<string, number>();
   #queuedWatchRefresh: WatchRefreshBatch | null = null;
   #queuedWatchRefreshScheduled = false;
 
@@ -1234,6 +1260,15 @@ class SpaceReplica implements ISpaceReplica {
     );
     for (const pending of ready) {
       pending.resolve();
+    }
+    // Ids whose staleness has now been caught up are fresh again; stop
+    // pre-empting commits that read them.
+    if (this.#staleFloor.size > 0) {
+      for (const [key, floor] of this.#staleFloor) {
+        if (floor <= this.#caughtUpLocalSeq) {
+          this.#staleFloor.delete(key);
+        }
+      }
     }
   }
 
@@ -1840,6 +1875,26 @@ class SpaceReplica implements ISpaceReplica {
     commit: ClientCommit,
     source?: IStorageTransaction,
   ): Promise<Result<Unit, StorageTransactionRejected>> {
+    // Strategy 1: pre-empt a commit whose read set is known stale rather than
+    // letting it conflict at the server. The retry path is identical to a real
+    // conflict, minus the doomed round trip and the server-side conflict.
+    if (conflictAdmissionEnabled()) {
+      const threshold = this.preemptThreshold(commit);
+      if (threshold !== undefined) {
+        const rejection = this.makePreemptRejection(commit, threshold);
+        logger.debug("commit-preempted", () => [
+          `commit preempted: stale until caughtUpLocalSeq>=${threshold}`,
+          { localSeq, operations: operations.length },
+        ]);
+        return await this.finalizeRejection(
+          localSeq,
+          operations,
+          commit,
+          source,
+          rejection,
+        );
+      }
+    }
     try {
       if (
         operations.length > 0 &&
@@ -1861,6 +1916,9 @@ class SpaceReplica implements ISpaceReplica {
     } catch (error) {
       const rejection = toRejectedError(error, commit, this.#space);
       this.attachProviderReadyToRetry(rejection, localSeq);
+      if (conflictAdmissionEnabled() && rejection.name === "ConflictError") {
+        this.recordStaleFloor(commit, localSeq);
+      }
       // Counted (even while silent) so multi-writer churn can be read back via
       // getLoggerCounts(): "commit-conflict" is a stale-seq-basis rejection that
       // drops only the optimistic pending write and re-derives from confirmed
@@ -1875,47 +1933,66 @@ class SpaceReplica implements ISpaceReplica {
           { localSeq, operations: operations.length },
         ],
       );
-      const touched = operations.map((operation) => ({
-        id: operation.id,
-        scope: operation.scope,
-      }));
-      const hasSemanticOperations = operations.length > 0;
-      const shouldNotifySubscribers = hasSemanticOperations &&
-        this.hasNotificationSubscribers();
-      const shouldNotifySinks = hasSemanticOperations &&
-        this.hasSinkSubscribers(touched);
-      const before = shouldNotifySubscribers
-        ? Differential.checkout(
-          this,
-          touched.map(({ id, scope }) => snapshotState(this, id, scope)),
-        )
-        : undefined;
-      await this.waitForConflictReadRepair(rejection);
-      this.dropPending(localSeq);
-      if (before !== undefined) {
-        const changes = before.compare(this);
-        // The revert snapshots CURRENT confirmed state (which already includes
-        // any newer seq received by subscription since this commit started) and
-        // drops only this commit's pending write — so it should not stomp newer
-        // data. Counted to verify reverts stay bounded.
-        logger.debug("commit-revert", () => [
-          `revert after ${rejection.name ?? "rejection"}`,
-        ]);
-        this.#subscription.next({
-          type: "revert",
-          space: this.#space,
-          changes,
-          reason: rejection,
-          source,
-        });
-        if (shouldNotifySinks) {
-          this.notifySinks(changes);
-        }
-      } else if (shouldNotifySinks) {
-        this.notifySinksForIds(touched);
-      }
-      return { error: rejection };
+      return await this.finalizeRejection(
+        localSeq,
+        operations,
+        commit,
+        source,
+        rejection,
+      );
     }
+  }
+
+  // Shared rejection tail for both real conflicts and pre-empted commits: wait
+  // for the caught-up read-repair, drop the optimistic pending write, and emit
+  // the revert notification reflecting repaired confirmed state.
+  private async finalizeRejection(
+    localSeq: number,
+    operations: NativeCommitOperation[],
+    commit: ClientCommit,
+    source: IStorageTransaction | undefined,
+    rejection: StorageTransactionRejected,
+  ): Promise<Result<Unit, StorageTransactionRejected>> {
+    const touched = operations.map((operation) => ({
+      id: operation.id,
+      scope: operation.scope,
+    }));
+    const hasSemanticOperations = operations.length > 0;
+    const shouldNotifySubscribers = hasSemanticOperations &&
+      this.hasNotificationSubscribers();
+    const shouldNotifySinks = hasSemanticOperations &&
+      this.hasSinkSubscribers(touched);
+    const before = shouldNotifySubscribers
+      ? Differential.checkout(
+        this,
+        touched.map(({ id, scope }) => snapshotState(this, id, scope)),
+      )
+      : undefined;
+    await this.waitForConflictReadRepair(rejection);
+    this.dropPending(localSeq);
+    if (before !== undefined) {
+      const changes = before.compare(this);
+      // The revert snapshots CURRENT confirmed state (which already includes
+      // any newer seq received by subscription since this commit started) and
+      // drops only this commit's pending write — so it should not stomp newer
+      // data. Counted to verify reverts stay bounded.
+      logger.debug("commit-revert", () => [
+        `revert after ${rejection.name ?? "rejection"}`,
+      ]);
+      this.#subscription.next({
+        type: "revert",
+        space: this.#space,
+        changes,
+        reason: rejection,
+        source,
+      });
+      if (shouldNotifySinks) {
+        this.notifySinks(changes);
+      }
+    } else if (shouldNotifySinks) {
+      this.notifySinksForIds(touched);
+    }
+    return { error: rejection };
   }
 
   private buildReads(
@@ -2047,6 +2124,87 @@ class SpaceReplica implements ISpaceReplica {
       this.notifySinksForIds(touched);
     }
     this.noteCaughtUpLocalSeq(sync.caughtUpLocalSeq);
+  }
+
+  // Mark every id this conflicted commit touched (reads + writes) stale until
+  // the runner observes caughtUpLocalSeq >= the commit's localSeq — the seq the
+  // server stages as the post-conflict catch-up point for these ids.
+  private recordStaleFloor(commit: ClientCommit, localSeq: number): void {
+    const mark = (id: string, scope?: CellScope) => {
+      const key = docKey(id as URI, scope);
+      const current = this.#staleFloor.get(key);
+      if (current === undefined || current < localSeq) {
+        this.#staleFloor.set(key, localSeq);
+      }
+    };
+    for (const operation of commit.operations) {
+      if (operation.op === "sqlite") continue; // no entity id
+      mark(operation.id, operation.scope);
+    }
+    for (const read of commit.reads.confirmed) {
+      mark(read.id, read.scope);
+    }
+    for (const read of commit.reads.pending) {
+      mark(read.id, read.scope);
+    }
+  }
+
+  // If any of this commit's reads are still stale (a recorded floor above our
+  // current caught-up seq), return the highest such floor — the seq we must
+  // reach before a retry can succeed. Only reads gate admission: a stale read
+  // precondition is what the server rejects.
+  private preemptThreshold(commit: ClientCommit): number | undefined {
+    if (this.#staleFloor.size === 0) {
+      return undefined;
+    }
+    let threshold: number | undefined;
+    const consider = (id: string, scope?: CellScope) => {
+      const floor = this.#staleFloor.get(docKey(id as URI, scope));
+      if (floor !== undefined && floor > this.#caughtUpLocalSeq) {
+        threshold = threshold === undefined
+          ? floor
+          : Math.max(threshold, floor);
+      }
+    };
+    for (const read of commit.reads.confirmed) {
+      consider(read.id, read.scope);
+    }
+    for (const read of commit.reads.pending) {
+      consider(read.id, read.scope);
+    }
+    return threshold;
+  }
+
+  private makePreemptRejection(
+    commit: ClientCommit,
+    threshold: number,
+  ): StorageTransactionRejected {
+    let firstId: URI | undefined;
+    for (const operation of commit.operations) {
+      if (operation.op !== "sqlite") {
+        firstId = operation.id as URI;
+        break;
+      }
+    }
+    return {
+      name: "ConflictError",
+      message:
+        `commit preempted: read set stale until caughtUpLocalSeq>=${threshold}`,
+      transaction: commit as unknown as Transaction,
+      conflict: {
+        space: this.#space,
+        the: DOCUMENT_MIME,
+        of: firstId ?? "of:unknown",
+        expected: null,
+        actual: null,
+        existsInHistory: false,
+        history: [],
+      },
+      // The catch-up that clears `threshold` is already in flight from the
+      // earlier conflict; gate the retry directly on it (no provider round trip
+      // to wrap, so we do NOT call attachProviderReadyToRetry here).
+      readyToRetry: () => this.waitForCaughtUpLocalSeq(threshold),
+    };
   }
 
   private attachProviderReadyToRetry(

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -8,8 +8,10 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import type {
   IExtendedStorageTransaction,
+  IReadActivity,
   IStorageNotification,
   StorageNotification,
+  StorageTransactionRejected,
 } from "../src/storage/interface.ts";
 import type { MIME, URI } from "@commonfabric/memory/interface";
 import { createGraphFixture } from "./memory-v2-graph.fixture.ts";
@@ -65,6 +67,56 @@ const visibleIds = (
   provider: { get(uri: URI): { value?: unknown } | undefined },
   ids: readonly URI[],
 ) => ids.filter((id) => provider.get(id)?.value !== undefined).sort();
+
+const staleReadSource = (uri: URI, seq: number) => ({
+  getReadActivities(): Iterable<IReadActivity> {
+    return [{
+      space,
+      id: uri,
+      type: "application/json",
+      path: [],
+      meta: { seq },
+    }];
+  },
+});
+
+type RetryRepairHarness = {
+  noteCaughtUpLocalSeq(localSeq: number | undefined): void;
+  waitForCaughtUpLocalSeq(localSeq: number): Promise<void>;
+  rejectCaughtUpLocalSeqWaiters(error: Error): void;
+  closeNow(): void;
+  waitForConflictReadRepair(
+    rejection: StorageTransactionRejected,
+  ): Promise<void>;
+};
+
+const retryRepairHarness = (replica: unknown): RetryRepairHarness =>
+  replica as RetryRepairHarness;
+
+const syntheticConflict = (
+  uri: URI,
+  readyToRetry: () => Promise<void>,
+): StorageTransactionRejected => ({
+  name: "ConflictError",
+  message: "synthetic conflict",
+  transaction: {
+    iss: space,
+    cmd: "/memory/transact",
+    sub: space,
+    args: { changes: {} },
+    prf: [],
+  },
+  conflict: {
+    space,
+    the: "application/json",
+    of: uri,
+    expected: null,
+    actual: null,
+    existsInHistory: false,
+    history: [],
+  },
+  readyToRetry,
+});
 
 describe("Memory v2 storage notifications", () => {
   let runtime: Runtime;
@@ -264,17 +316,7 @@ describe("Memory v2 storage notifications", () => {
         JSON.stringify({ value: { version: 3 } })
     );
 
-    const source = {
-      getReadActivities() {
-        return [{
-          space,
-          id: uri,
-          type: "application/json",
-          path: [],
-          meta: { seq: 1 },
-        }];
-      },
-    } as any;
+    const source = staleReadSource(uri, 1);
 
     const factAddress = { id: uri, type: "application/json" as MIME };
     if (!replica.commitNative) {
@@ -353,17 +395,7 @@ describe("Memory v2 storage notifications", () => {
       }],
     });
 
-    const source = {
-      getReadActivities() {
-        return [{
-          space,
-          id: uri,
-          type: "application/json",
-          path: [],
-          meta: { seq: 1 },
-        }];
-      },
-    } as any;
+    const source = staleReadSource(uri, 1);
 
     const factAddress = { id: uri, type: "application/json" as MIME };
     if (!replica.commitNative) {
@@ -399,6 +431,104 @@ describe("Memory v2 storage notifications", () => {
     await assertRejects(
       () => reason.readyToRetry?.() ?? Promise.resolve(),
       Error,
+    );
+  });
+
+  it("returns the original conflict when closing during retry read repair", async () => {
+    const subscription = new Subscription();
+    storageManager.subscribe(subscription);
+
+    const provider = storageManager.open(space);
+    const replica = provider.replica as typeof provider.replica & {
+      commitNative: (
+        transaction: unknown,
+        source?: unknown,
+      ) => Promise<{ ok?: unknown; error?: unknown }>;
+    };
+    const firstUri = `of:memory-v2-close-retry-a-${Date.now()}` as URI;
+    const secondUri = `of:memory-v2-close-retry-b-${Date.now()}` as URI;
+    const factAddress = { id: firstUri, type: "application/json" as MIME };
+
+    await remoteSession.transact({
+      localSeq: remoteLocalSeq++,
+      reads: { confirmed: [], pending: [] },
+      operations: [
+        { op: "set", id: firstUri, value: { value: { version: 1 } } },
+        { op: "set", id: secondUri, value: { value: { version: 1 } } },
+      ],
+    });
+    await provider.sync(firstUri);
+    await provider.sync(secondUri);
+
+    await remoteSession.transact({
+      localSeq: remoteLocalSeq++,
+      reads: { confirmed: [], pending: [] },
+      operations: [
+        { op: "set", id: firstUri, value: { value: { version: 2 } } },
+      ],
+    });
+    await remoteSession.transact({
+      localSeq: remoteLocalSeq++,
+      reads: { confirmed: [], pending: [] },
+      operations: [
+        { op: "set", id: secondUri, value: { value: { version: 2 } } },
+      ],
+    });
+
+    const commitPromise = replica.commitNative({
+      operations: [{
+        op: "set",
+        id: firstUri,
+        type: "application/json",
+        value: { value: { version: 3 } },
+      }],
+    }, staleReadSource(firstUri, 1));
+    expect(replica.get(factAddress)?.is).toEqual({ value: { version: 3 } });
+
+    await storageManager.close();
+    const result = await commitPromise;
+    expect(result.ok).toBeFalsy();
+    const reason = subscription.reverts.at(-1)?.reason;
+    if (reason?.name !== "ConflictError") {
+      throw new Error(`Expected ConflictError, got ${reason?.name}`);
+    }
+    expect(result.error).toBe(reason);
+    await assertRejects(
+      () => reason?.readyToRetry?.() ?? Promise.resolve(),
+      Error,
+    );
+  });
+
+  it("rejects pending caught-up waiters when storage closes", async () => {
+    const provider = storageManager.open(space);
+    const harness = retryRepairHarness(provider.replica);
+
+    const readyAtTwo = harness.waitForCaughtUpLocalSeq(2);
+    const readyAtThree = harness.waitForCaughtUpLocalSeq(3);
+    const rejectsAtThree = assertRejects(() => readyAtThree, Error);
+
+    harness.noteCaughtUpLocalSeq(2);
+    await readyAtTwo;
+    harness.closeNow();
+    await rejectsAtThree;
+
+    await assertRejects(
+      () => harness.waitForCaughtUpLocalSeq(1),
+      Error,
+      "memory replica closed",
+    );
+  });
+
+  it("preserves the original conflict when retry read repair rejects", async () => {
+    const provider = storageManager.open(space);
+    const harness = retryRepairHarness(provider.replica);
+    const retryError = new Error("retry unavailable");
+
+    await harness.waitForConflictReadRepair(
+      syntheticConflict(
+        `of:memory-v2-retry-reject-${Date.now()}` as URI,
+        () => Promise.reject(retryError),
+      ),
     );
   });
 

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -525,17 +525,27 @@ describe("Memory v2 storage notifications", () => {
     );
   });
 
-  it("preserves the original conflict when retry read repair rejects", async () => {
+  it("swallows a rejecting readyToRetry during read repair", async () => {
     const provider = storageManager.open(space);
     const harness = retryRepairHarness(provider.replica);
     const retryError = new Error("retry unavailable");
+    let called = 0;
 
+    // A rejecting readyToRetry must be invoked and then swallowed (logged), not
+    // thrown, so the original conflict result is preserved for the caller. If
+    // the repair short-circuited, `called` stays 0; if it rethrew, the await
+    // would reject and fail the test.
     await harness.waitForConflictReadRepair(
       syntheticConflict(
         `of:memory-v2-retry-reject-${Date.now()}` as URI,
-        () => Promise.reject(retryError),
+        () => {
+          called += 1;
+          return Promise.reject(retryError);
+        },
       ),
     );
+
+    expect(called).toBe(1);
   });
 
   it("does not emit duplicate pull notifications for unchanged v2 sync results", async () => {

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -5,6 +5,7 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import type { Server as MemoryV2Server } from "@commonfabric/memory/v2/server";
 import { StorageManager } from "../src/storage/cache.deno.ts";
+import { setConflictAdmissionEnabled } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type {
   IExtendedStorageTransaction,
@@ -546,6 +547,84 @@ describe("Memory v2 storage notifications", () => {
     );
 
     expect(called).toBe(1);
+  });
+
+  it("admission control records, thresholds, and prunes a stale floor", () => {
+    const provider = storageManager.open(space);
+    const replica = provider.replica as unknown as {
+      recordStaleFloor: (commit: unknown, localSeq: number) => void;
+      preemptThreshold: (commit: unknown) => number | undefined;
+      noteCaughtUpLocalSeq: (localSeq: number | undefined) => void;
+    };
+    const uri = `of:admission-floor-${Date.now()}`;
+    const reading = {
+      localSeq: 9,
+      reads: { confirmed: [{ id: uri, path: [], seq: 0 }], pending: [] },
+      operations: [{ op: "set", id: uri, value: { value: { v: 2 } } }],
+    };
+
+    // Nothing stale yet -> the read is admitted.
+    expect(replica.preemptThreshold(reading)).toBeUndefined();
+
+    // A conflict at localSeq 7 marks uri stale until caughtUpLocalSeq >= 7.
+    replica.recordStaleFloor(reading, 7);
+    expect(replica.preemptThreshold(reading)).toBe(7);
+
+    // Catching up to the floor makes the id fresh again -> admitted.
+    replica.noteCaughtUpLocalSeq(7);
+    expect(replica.preemptThreshold(reading)).toBeUndefined();
+  });
+
+  it("pre-empts a known-stale commit instead of round-tripping when enabled", async () => {
+    setConflictAdmissionEnabled(true);
+    try {
+      const provider = storageManager.open(space);
+      const replica = provider.replica as typeof provider.replica & {
+        commitNative: (
+          transaction: unknown,
+          source?: unknown,
+        ) => Promise<
+          { ok?: unknown; error?: { name?: string; message?: string } }
+        >;
+        recordStaleFloor: (commit: unknown, localSeq: number) => void;
+        noteCaughtUpLocalSeq: (localSeq: number | undefined) => void;
+      };
+      const uri = `of:admission-preempt-${Date.now()}` as URI;
+
+      // Simulate a prior conflict that marked uri stale until caughtUpLocalSeq>=5.
+      replica.recordStaleFloor({
+        localSeq: 5,
+        reads: { confirmed: [{ id: uri, path: [], seq: 0 }], pending: [] },
+        operations: [{ op: "set", id: uri, value: { value: { version: 1 } } }],
+      }, 5);
+
+      const commitPromise = replica.commitNative({
+        operations: [{
+          op: "set",
+          id: uri,
+          type: "application/json",
+          value: { value: { version: 2 } },
+        }],
+      }, staleReadSource(uri, 0));
+
+      // The commit is pre-empted (never sent) and held until the catch-up seq
+      // is observed, exactly like a real conflict's retry gate.
+      let settled = false;
+      void commitPromise.then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      replica.noteCaughtUpLocalSeq(5);
+      const result = await commitPromise;
+      expect(result.ok).toBeFalsy();
+      expect(result.error?.name).toBe("ConflictError");
+      expect(result.error?.message).toContain("preempted");
+    } finally {
+      setConflictAdmissionEnabled(undefined);
+    }
   });
 
   it("does not emit duplicate pull notifications for unchanged v2 sync results", async () => {

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { assertRejects } from "@std/assert";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
@@ -312,7 +313,7 @@ describe("Memory v2 storage notifications", () => {
     });
   });
 
-  it("refreshes subscribed state before a conflict revert resolves", async () => {
+  it("refreshes subscribed state before conflict readyToRetry resolves", async () => {
     const subscription = new Subscription();
     storageManager.subscribe(subscription);
 
@@ -380,7 +381,6 @@ describe("Memory v2 storage notifications", () => {
 
     const result = await commitPromise;
     expect(result.ok).toBeFalsy();
-    expect(replica.get(factAddress)?.is).toEqual({ value: { version: 3 } });
     expect(subscription.reverts.at(-1)).toMatchObject({
       type: "revert",
       space,
@@ -393,6 +393,13 @@ describe("Memory v2 storage notifications", () => {
     expect(reason.retryAfterSeq).toBe(2);
     expect(typeof reason.readyToRetry).toBe("function");
     await reason.readyToRetry?.();
+    expect(replica.get(factAddress)?.is).toEqual({ value: { version: 3 } });
+
+    await storageManager.close();
+    await assertRejects(
+      () => reason.readyToRetry?.() ?? Promise.resolve(),
+      Error,
+    );
   });
 
   it("does not emit duplicate pull notifications for unchanged v2 sync results", async () => {

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -5,7 +5,10 @@ import { Identity } from "@commonfabric/identity";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import type { Server as MemoryV2Server } from "@commonfabric/memory/v2/server";
 import { StorageManager } from "../src/storage/cache.deno.ts";
-import { setConflictAdmissionEnabled } from "../src/storage/v2.ts";
+import {
+  setConflictAdmissionEnabled,
+  setConflictAdmissionMode,
+} from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type {
   IExtendedStorageTransaction,
@@ -642,6 +645,98 @@ describe("Memory v2 storage notifications", () => {
     );
 
     expect(called).toBe(1);
+  });
+
+  it("hold-mode local check flags only provably-stale confirmed reads", async () => {
+    const provider = storageManager.open(space);
+    const replica = provider.replica as unknown as {
+      commitReadsStaleLocally: (commit: unknown) => boolean;
+    };
+    const uri = `of:hold-check-${Date.now()}` as URI;
+
+    // Establish a confirmed record with seq > 0.
+    await remoteSession.transact({
+      localSeq: remoteLocalSeq++,
+      reads: { confirmed: [], pending: [] },
+      operations: [{ op: "set", id: uri, value: { value: { v: 1 } } }],
+    });
+    await provider.sync(uri);
+    await waitFor(() =>
+      (provider.replica as unknown as {
+        get(a: { id: URI; type: MIME }): { is?: unknown } | undefined;
+      }).get({ id: uri, type: "application/json" as MIME }) !== undefined
+    );
+
+    const read = (seq: number) => ({
+      reads: { confirmed: [{ id: uri, path: [], seq }], pending: [] },
+      operations: [],
+    });
+    // seq 0 is below the confirmed base -> provably stale.
+    expect(replica.commitReadsStaleLocally(read(0))).toBe(true);
+    // a seq at/above the confirmed base -> not provably stale, so it is sent.
+    expect(replica.commitReadsStaleLocally(read(Number.MAX_SAFE_INTEGER))).toBe(
+      false,
+    );
+  });
+
+  it("hold mode reverts a held commit only when its read is actually stale", async () => {
+    setConflictAdmissionMode("hold");
+    try {
+      const provider = storageManager.open(space);
+      const replica = provider.replica as typeof provider.replica & {
+        commitNative: (
+          transaction: unknown,
+          source?: unknown,
+        ) => Promise<{ ok?: unknown; error?: { name?: string } }>;
+        recordStaleFloor: (commit: unknown, localSeq: number) => void;
+        noteCaughtUpLocalSeq: (localSeq: number | undefined) => void;
+      };
+      const uri = `of:hold-revert-${Date.now()}` as URI;
+
+      await remoteSession.transact({
+        localSeq: remoteLocalSeq++,
+        reads: { confirmed: [], pending: [] },
+        operations: [{ op: "set", id: uri, value: { value: { v: 1 } } }],
+      });
+      await provider.sync(uri);
+      await waitFor(() =>
+        replica.get({ id: uri, type: "application/json" as MIME }) !== undefined
+      );
+
+      // Floor uri so a new commit reading it is held until caughtUpLocalSeq>=5.
+      replica.recordStaleFloor({
+        localSeq: 5,
+        reads: { confirmed: [{ id: uri, path: [], seq: 0 }], pending: [] },
+        operations: [{ op: "set", id: uri, value: { value: { v: 1 } } }],
+      }, 5);
+
+      const commitPromise = replica.commitNative({
+        operations: [{
+          op: "set",
+          id: uri,
+          type: "application/json",
+          value: { value: { v: 2 } },
+        }],
+      }, staleReadSource(uri, 0));
+
+      // Held: not sent, not settled, until we observe the catch-up seq.
+      let settled = false;
+      void commitPromise.then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      replica.noteCaughtUpLocalSeq(5);
+      const result = await commitPromise;
+      // Read seq 0 is below the confirmed base, so the local check reverts it
+      // (instead of sending a doomed commit).
+      expect(result.ok).toBeFalsy();
+      expect(result.error?.name).toBe("ConflictError");
+    } finally {
+      setConflictAdmissionMode(undefined);
+    }
   });
 
   it("admission control records, thresholds, and prunes a stale floor", () => {

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -413,6 +413,12 @@ describe("Memory v2 storage notifications", () => {
 
     const result = await commitPromise;
     expect(result.ok).toBeFalsy();
+    // The inline read-repair (waitForConflictReadRepair) must have applied the
+    // caught-up sync BEFORE the commit resolves — so confirmed state already
+    // reflects version 3 here, without any explicit readyToRetry() call. This
+    // guards the repair-before-revert ordering: removing the inline wait leaves
+    // this at the stale/optimistic value.
+    expect(replica.get(factAddress)?.is).toEqual({ value: { version: 3 } });
     expect(subscription.reverts.at(-1)).toMatchObject({
       type: "revert",
       space,

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -6,8 +6,10 @@ import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import type { Server as MemoryV2Server } from "@commonfabric/memory/v2/server";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import {
+  type SessionFactory,
   setConflictAdmissionEnabled,
   setConflictAdmissionMode,
+  StorageManager as V2StorageManager,
 } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type {
@@ -18,6 +20,7 @@ import type {
   StorageTransactionRejected,
 } from "../src/storage/interface.ts";
 import type { MIME, URI } from "@commonfabric/memory/interface";
+import type { SessionSync } from "@commonfabric/memory/v2";
 import { createGraphFixture } from "./memory-v2-graph.fixture.ts";
 
 const signer = await Identity.fromPassphrase("memory-v2-storage-subscription");
@@ -92,6 +95,16 @@ type RetryRepairHarness = {
   waitForConflictReadRepair(
     rejection: StorageTransactionRejected,
   ): Promise<void>;
+};
+
+type WatchRefreshHarness = {
+  closeNow(): void;
+  refreshWatchSet(
+    entries: Iterable<[
+      { id: URI; type: MIME; scope?: string },
+      { path: string[]; schema: false },
+    ]>,
+  ): Promise<{ ok?: unknown; error?: { message?: string } }>;
 };
 
 const retryRepairHarness = (replica: unknown): RetryRepairHarness =>
@@ -791,6 +804,44 @@ describe("Memory v2 storage notifications", () => {
     } finally {
       setConflictAdmissionMode(undefined);
     }
+  });
+
+  it("closes a watch refresh view that resolves after replica close", async () => {
+    const sync: SessionSync = {
+      type: "sync",
+      fromSeq: 0,
+      toSeq: 0,
+      upserts: [],
+      removes: [],
+    };
+    const view = MemoryV2Client.WatchView.fromSync(sync);
+    const client = {
+      close: () => Promise.resolve(),
+    } as unknown as MemoryV2Client.Client;
+    const session = {
+      watchAddSync: () => Promise.resolve({ view, sync }),
+    } as unknown as MemoryV2Client.SpaceSession;
+    const sessionFactory: SessionFactory = {
+      create: () => Promise.resolve({ client, session }),
+    };
+    class TestStorageManager extends V2StorageManager {
+      constructor() {
+        super({ as: signer, memoryHost: new URL("memory://") }, sessionFactory);
+      }
+    }
+    const testStorageManager = new TestStorageManager();
+    const provider = testStorageManager.open(space);
+    const replica = provider.replica as unknown as WatchRefreshHarness;
+
+    replica.closeNow();
+    const result = await replica.refreshWatchSet([[
+      { id: "of:late-refresh" as URI, type: "application/json" as MIME },
+      { path: [], schema: false },
+    ]]);
+
+    expect(result.error?.message).toBe("memory replica closed");
+    expect((await view.subscribeSync().next()).done).toBe(true);
+    await testStorageManager.closeNow();
   });
 
   it("admission control records, thresholds, and prunes a stale floor", () => {

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -356,6 +356,101 @@ describe("Memory v2 storage notifications", () => {
     });
   });
 
+  it("reverts a non-conflicting sibling write to current while the conflicting doc lands fresh", async () => {
+    // tx writes A and B; only B conflicts. The whole tx is rejected, so A's
+    // optimistic write must roll back (it is NOT in the catch-up sync), while B
+    // must land on the CURRENT confirmed value (fresh), never on past data.
+    const subscription = new Subscription();
+    storageManager.subscribe(subscription);
+
+    const aUri = `of:memory-v2-revert-sibling-a-${Date.now()}` as URI;
+    const bUri = `of:memory-v2-revert-sibling-b-${Date.now()}` as URI;
+    const aAddress = { id: aUri, type: "application/json" as MIME };
+    const bAddress = { id: bUri, type: "application/json" as MIME };
+
+    const provider = storageManager.open(space);
+    const replica = provider.replica as typeof provider.replica & {
+      commitNative: (
+        transaction: unknown,
+        source?: unknown,
+      ) => Promise<{ ok?: unknown; error?: { name?: string } }>;
+    };
+
+    await remoteSession.transact({
+      localSeq: remoteLocalSeq++,
+      reads: { confirmed: [], pending: [] },
+      operations: [
+        { op: "set", id: aUri, value: { value: { a: 1 } } },
+        { op: "set", id: bUri, value: { value: { b: 1 } } },
+      ],
+    });
+    await provider.sync(aUri);
+    await provider.sync(bUri);
+
+    // Another writer advances ONLY B to b:3; A stays at a:1.
+    await remoteSession.transact({
+      localSeq: remoteLocalSeq++,
+      reads: { confirmed: [], pending: [] },
+      operations: [{ op: "set", id: bUri, value: { value: { b: 3 } } }],
+    });
+    await waitFor(() =>
+      JSON.stringify(replica.get(bAddress)?.is) ===
+        JSON.stringify({ value: { b: 3 } })
+    );
+
+    // Local tx writes both A and B optimistically; a stale read of B forces the
+    // conflict. Whole tx is rejected.
+    const result = await replica.commitNative({
+      operations: [
+        {
+          op: "set",
+          id: aUri,
+          type: "application/json",
+          value: { value: { a: 10 } },
+        },
+        {
+          op: "set",
+          id: bUri,
+          type: "application/json",
+          value: { value: { b: 20 } },
+        },
+      ],
+    }, staleReadSource(bUri, 1));
+
+    expect(result.ok).toBeFalsy();
+    expect(result.error?.name).toBe("ConflictError");
+
+    // A rolled back to its confirmed (current) value; B at the fresh current
+    // value — not the optimistic 20 and not the past 1.
+    expect(replica.get(aAddress)?.is).toEqual({ value: { a: 1 } });
+    expect(replica.get(bAddress)?.is).toEqual({ value: { b: 3 } });
+
+    // One revert notification carrying BOTH the sibling rollback and the fresh
+    // value, each reverting to current.
+    expect(subscription.reverts).toHaveLength(1);
+    const changes = [...subscription.reverts[0].changes];
+    expect(changes).toContainEqual({
+      address: {
+        id: aUri,
+        type: "application/json",
+        scope: "space",
+        path: ["value", "a"],
+      },
+      before: { value: { a: 10 } },
+      after: { value: { a: 1 } },
+    });
+    expect(changes).toContainEqual({
+      address: {
+        id: bUri,
+        type: "application/json",
+        scope: "space",
+        path: ["value", "b"],
+      },
+      before: { value: { b: 20 } },
+      after: { value: { b: 3 } },
+    });
+  });
+
   it("refreshes subscribed state before conflict readyToRetry resolves", async () => {
     const subscription = new Subscription();
     storageManager.subscribe(subscription);

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -739,12 +739,67 @@ describe("Memory v2 storage notifications", () => {
     }
   });
 
+  it("public close settles a commit held by conflict admission", async () => {
+    setConflictAdmissionMode("hold");
+    try {
+      const provider = storageManager.open(space);
+      const replica = provider.replica as typeof provider.replica & {
+        commitNative: (
+          transaction: unknown,
+          source?: unknown,
+        ) => Promise<{ ok?: unknown; error?: { name?: string } }>;
+        recordStaleFloor: (commit: unknown, localSeq: number) => void;
+      };
+      const uri = `of:hold-close-${Date.now()}` as URI;
+
+      replica.recordStaleFloor({
+        localSeq: 5,
+        reads: { confirmed: [{ id: uri, path: [], seq: 0 }], pending: [] },
+        operations: [{ op: "set", id: uri, value: { value: { v: 1 } } }],
+      }, 5);
+
+      const commitPromise = replica.commitNative({
+        operations: [{
+          op: "set",
+          id: uri,
+          type: "application/json",
+          value: { value: { v: 2 } },
+        }],
+      }, staleReadSource(uri, 0));
+
+      let settled = false;
+      void commitPromise.then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      const closeAndCommit = Promise.all([
+        storageManager.close(),
+        commitPromise,
+      ]);
+      const [, result] = await Promise.race([
+        closeAndCommit,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("close timed out")), 250)
+        ),
+      ]);
+
+      expect(result.ok).toBeFalsy();
+      expect(result.error?.name).toBe("ConflictError");
+    } finally {
+      setConflictAdmissionMode(undefined);
+    }
+  });
+
   it("admission control records, thresholds, and prunes a stale floor", () => {
     const provider = storageManager.open(space);
     const replica = provider.replica as unknown as {
       recordStaleFloor: (commit: unknown, localSeq: number) => void;
       preemptThreshold: (commit: unknown) => number | undefined;
       noteCaughtUpLocalSeq: (localSeq: number | undefined) => void;
+      reset: () => void;
     };
     const uri = `of:admission-floor-${Date.now()}`;
     const reading = {
@@ -763,6 +818,26 @@ describe("Memory v2 storage notifications", () => {
     // Catching up to the floor makes the id fresh again -> admitted.
     replica.noteCaughtUpLocalSeq(7);
     expect(replica.preemptThreshold(reading)).toBeUndefined();
+
+    // A reset starts a new replica epoch; stale floors from the old epoch must
+    // not hold or pre-empt post-reset commits that read the same id.
+    replica.recordStaleFloor(reading, 8);
+    expect(replica.preemptThreshold(reading)).toBe(8);
+    replica.reset();
+    expect(replica.preemptThreshold(reading)).toBeUndefined();
+  });
+
+  it("reset rejects caught-up waiters from the previous replica epoch", async () => {
+    const provider = storageManager.open(space);
+    const replica = provider.replica as unknown as {
+      waitForCaughtUpLocalSeq: (localSeq: number) => Promise<void>;
+      reset: () => void;
+    };
+
+    const wait = replica.waitForCaughtUpLocalSeq(3);
+    replica.reset();
+
+    await expect(wait).rejects.toThrow("memory replica reset");
   });
 
   it("pre-empts a known-stale commit instead of round-tripping when enabled", async () => {

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -386,7 +386,13 @@ describe("Memory v2 storage notifications", () => {
       space,
       source,
     });
-    expect(subscription.reverts.at(-1)?.reason.name).toBe("ConflictError");
+    const reason = subscription.reverts.at(-1)?.reason;
+    if (reason?.name !== "ConflictError") {
+      throw new Error(`Expected ConflictError, got ${reason?.name}`);
+    }
+    expect(reason.retryAfterSeq).toBe(2);
+    expect(typeof reason.readyToRetry).toBe("function");
+    await reason.readyToRetry?.();
   });
 
   it("does not emit duplicate pull notifications for unchanged v2 sync results", async () => {

--- a/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
+++ b/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
@@ -284,6 +284,34 @@ describe("trigger reads survive failed runs", () => {
     expect(calls).toEqual(["restore", "resubscribe", "dirty", "queue"]);
   });
 
+  it("re-arms the action when conflict readyToRetry rejects", async () => {
+    // readyToRetry rejects by design on session close/revoke/replacement. The
+    // scheduler must still restore trigger reads and re-arm (resubscribe +
+    // requeue) rather than dropping the action and logging an error.
+    const error = Object.assign(new Error("conflict"), {
+      name: "ConflictError",
+      readyToRetry: () => Promise.reject(new Error("session changed: a -> b")),
+    });
+    const calls: string[] = [];
+    let resolveQueued!: () => void;
+    const queued = new Promise<void>((resolve) => {
+      resolveQueued = resolve;
+    });
+    watchWith({
+      error,
+      onRestore: () => calls.push("restore"),
+      onResubscribe: () => calls.push("resubscribe"),
+      onMarkDirectDirty: () => calls.push("dirty"),
+      onQueueExecution: () => {
+        calls.push("queue");
+        resolveQueued();
+      },
+    });
+
+    await queued;
+    expect(calls).toEqual(["restore", "resubscribe", "dirty", "queue"]);
+  });
+
   it("requeues primitive retryable errors without retry readiness", async () => {
     let restored = 0;
     let queued = 0;

--- a/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
+++ b/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
@@ -284,6 +284,18 @@ describe("trigger reads survive failed runs", () => {
     expect(calls).toEqual(["restore", "resubscribe", "dirty", "queue"]);
   });
 
+  it("requeues primitive retryable errors without retry readiness", async () => {
+    let restored = 0;
+    let queued = 0;
+    await watchWith({
+      error: "conflict",
+      onRestore: () => restored++,
+      onQueueExecution: () => queued++,
+    });
+    expect(restored).toBe(1);
+    expect(queued).toBe(1);
+  });
+
   it("does not restore on successful commit", async () => {
     let restored = 0;
     await watchWith({ onRestore: () => restored++ });
@@ -321,9 +333,10 @@ describe("unsubscribe clears pending trigger reads", () => {
       );
       await runtime.idle();
 
-      const cfcTriggerReads =
-        // deno-lint-ignore no-explicit-any
-        (runtime.scheduler as any).cfcTriggerReads as CfcTriggerReads;
+      const scheduler = runtime.scheduler as unknown as {
+        cfcTriggerReads: CfcTriggerReads;
+      };
+      const cfcTriggerReads = scheduler.cfcTriggerReads;
       cfcTriggerReads.set(action, {
         addresses: [{
           space,

--- a/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
+++ b/packages/runner/test/scheduler-cfc-trigger-reads.test.ts
@@ -208,6 +208,9 @@ describe("trigger reads survive failed runs", () => {
     retries?: WeakMap<Action, number>;
     error?: unknown;
     onRestore: () => void;
+    onResubscribe?: () => void;
+    onMarkDirectDirty?: () => void;
+    onQueueExecution?: () => void;
   }): Promise<void> {
     const action: Action = () => {};
     const tx = { tx: {} } as IExtendedStorageTransaction;
@@ -223,21 +226,62 @@ describe("trigger reads survive failed runs", () => {
       retries: args.retries ?? new WeakMap(),
       pending: new Set(),
       commitPromise,
-      resubscribe: () => {},
-      markDirectDirty: () => {},
-      queueExecution: () => {},
+      resubscribe: () => args.onResubscribe?.(),
+      markDirectDirty: () => args.onMarkDirectDirty?.(),
+      queueExecution: () => args.onQueueExecution?.(),
       restoreCfcTriggerReads: args.onRestore,
     });
-    return commitPromise.then(() => undefined);
+    return commitPromise.then(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
   }
 
   it("restores consumed trigger reads when a commit conflict re-runs", async () => {
     let restored = 0;
+    let queued = 0;
     await watchWith({
       error: new Error("conflict"),
       onRestore: () => restored++,
+      onQueueExecution: () => queued++,
     });
     expect(restored).toBe(1);
+    expect(queued).toBe(1);
+  });
+
+  it("waits for conflict readyToRetry before requeueing a reactive action", async () => {
+    let releaseReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      releaseReady = resolve;
+    });
+    const error = Object.assign(new Error("conflict"), {
+      name: "ConflictError",
+      readyToRetry: () => ready,
+    });
+    const calls: string[] = [];
+    let resolveQueued!: () => void;
+    const queued = new Promise<void>((resolve) => {
+      resolveQueued = resolve;
+    });
+    const watched = watchWith({
+      error,
+      onRestore: () => calls.push("restore"),
+      onResubscribe: () => calls.push("resubscribe"),
+      onMarkDirectDirty: () => calls.push("dirty"),
+      onQueueExecution: () => {
+        calls.push("queue");
+        resolveQueued();
+      },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(calls).toEqual([]);
+
+    releaseReady();
+    await queued;
+    await watched;
+    expect(calls).toEqual(["restore", "resubscribe", "dirty", "queue"]);
   });
 
   it("does not restore on successful commit", async () => {


### PR DESCRIPTION
## Why

Lunch-poll style multi-user contention was spending a lot of time in the conflict path itself. Before this stack, a stale commit could be rejected only after the server synchronously flushed session/watch refresh work for the conflicted space. That made every conflict pay for query refresh before the client even got the `ConflictError`, and it scaled poorly when many runtimes were joining, adding options, or voting concurrently.

The goal of this PR is to preserve the correctness guarantee that a retry does not run against stale subscribed state, while moving the expensive refresh out of the conflict response path. The protocol now treats retry readiness as a separate caught-up signal tied to the failed client `localSeq`.

## Previous behavior

- Server conflict handling staged dirty ids and immediately awaited a scoped `flushSessions([space])` before returning the conflict response.
- The conflict's `retryAfterSeq` was tied to the session's synced server sequence, so conflict response latency included watch/query refresh work.
- The client-level `readyToRetry()` was based on server sequence catch-up, which was not precise enough to mean "the failed local commit's post-conflict refresh has been consumed."
- Runner storage could preserve a provider `readyToRetry()` function, but did not guarantee that retry resolution waited until runner-local storage had applied the caught-up sync.

## Current behavior

- Memory v2 adds `caughtUpLocalSeq` to session-open and session-sync protocol payloads.
- The server records the highest conflicted client `localSeq` as `pendingCaughtUpLocalSeq`, returns the `ConflictError` promptly, and lets the scheduled/drained session refresh emit a sync carrying `caughtUpLocalSeq` once the server has caught that session up.
- Empty caught-up syncs are intentional: even if no watched entities changed, the server can still tell the client that a failed local seq is now safe to retry.
- The memory client resolves `ConflictError.readyToRetry()` only after it has observed `caughtUpLocalSeq >= failed localSeq`; close/revoke/session-replacement reject those waiters instead of hanging.
- Runner storage wraps provider readiness so `readyToRetry()` resolves only after runner storage has consumed the caught-up sync locally.
- The scheduler uses that readiness before requeueing conflict retries, preserving trigger-read state until the safe retry point.

## Reviewer notes

- The key invariant is that `caughtUpLocalSeq` means "the failed local commit has been processed through the post-conflict catch-up path," not merely "some server seq was seen."
- Please look closely at ordering in `packages/memory/v2/server.ts`: conflict response returns before the deferred caught-up sync, and `finishCatchUp()` is the only place that promotes `caughtUpLocalSeq` onto outbound syncs.
- Please look closely at empty sync handling in `packages/memory/v2/client.ts` and `packages/runner/src/storage/v2.ts`; empty syncs with `caughtUpLocalSeq` are semantically meaningful even without upserts/removes.
- Please look closely at close/revoke/session-replacement paths: both memory-client waiters and runner-storage waiters must reject rather than survive after shutdown.
- Cubic found two P2 issues after the first review pass; this branch now includes focused fixes and regression tests for both:
  - empty caught-up syncs preserve the previous `fromSeq` instead of using the mutated `lastSyncedSeq`
  - `readyToRetry()` waiters reject/reset when `reopen()` switches to a new session id

## Data we have

All profiling/diagnostic artifacts are outside the repo under `/tmp/opencode/lunch-poll-perf-4237-updated`.

### Current branch scaling, `b1618bc75`, `--rounds=0 --skip-refresh`

| Case | Wall | Conflicts | Scoped conflict flushes | Conflict p95 | Max graph |
| --- | ---: | ---: | ---: | ---: | ---: |
| 2 options x 2 users | 6.3s | 76 | 0 | 0.3ms | 328 nodes / 871 edges |
| 5 options x 2 users | 8.5s | 73 | 0 | 0.7ms | 610 nodes / 1,660 edges |
| 10 options x 2 users | 13.2s | 255 | 0 | 0.8ms | 1,160 nodes / 3,719 edges |
| 2 options x 5 users | 11.9s | 421 | 0 | 0.9ms | 319 nodes / 790 edges |
| 5 options x 5 users | 14.8s | 328 | 0 | 2.8ms | 637 nodes / 1,865 edges |
| 10 options x 5 users | 21.7s | 768 | 0 | 4.3ms | 1,163 nodes / 3,730 edges |
| 15 options x 5 users | 32.1s | 1,980 | 0 | 3.8ms | 1,683 nodes / 5,580 edges |

### Current branch vote sweep, `b1618bc75`

| Case | Wall | Conflicts | Scoped conflict flushes | Conflict p95 | Max graph |
| --- | ---: | ---: | ---: | ---: | ---: |
| 5 options x 5 users, 1 vote round | 23.1s | 1,343 | 0 | 1.6ms | 903 nodes / 2,564 edges |
| 5 options x 5 users, 2 vote rounds | 26.1s | 2,241 | 0 | 1.4ms | 1,168 nodes / 3,229 edges |
| 10 options x 5 users, 1 vote round | 30.9s | 2,785 | 0 | 1.8ms | 1,675 nodes / 5,009 edges |

### Latest-main comparison (`origin/main` `ebdf920b5`), `--rounds=0 --skip-refresh`

| Case | Main wall | Main conflicts | Main scoped flushes | Main conflict p95 | Current wall | Current scoped flushes | Current conflict p95 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 2 options x 2 users | 6.8s | 32 | 32 | 67.3ms | 6.3s | 0 | 0.3ms |
| 5 options x 2 users | 10.7s | 117 | 117 | 46.3ms | 8.5s | 0 | 0.7ms |
| 10 options x 2 users | 23.5s | 409 | 409 | 44.3ms | 13.2s | 0 | 0.8ms |
| 2 options x 5 users | 21.1s | 195 | 195 | 320.1ms | 11.9s | 0 | 0.9ms |
| 5 options x 5 users | 92.2s | 1,169 | 1,169 | 377.3ms | 14.8s | 0 | 2.8ms |

The strongest signal is not just fewer conflicts; it is that conflicts no longer synchronously run scoped session flushes. Current still has conflicts under contention, but conflict responses stay near low-single-digit millisecond p95 in these runs.

### CPU profile, comparable 10 options x 2 users, `--rounds=0 --skip-refresh`

Both CPU profiles were regenerated after rebasing on `origin/main` `ebdf920b5`.

- Main (`ebdf920b5`): `/tmp/opencode/lunch-poll-perf-4237-updated/main-ebdf920b5-10x2-r0-profile/main-ebdf920b5-10x2-r0.cpuprofile`
  - Summary: `/tmp/opencode/lunch-poll-perf-4237-updated/main-ebdf920b5-10x2-r0-profile-summary.json`
  - Wall 22.9s, 333 conflicts, 333 scoped conflict flushes, conflict p95 59.4ms, sampled CPU window 23.0s.
  - Top non-idle self time included GC, JSON wire decode, traversal/meta-linked-doc loading, memory query load, link parsing, and deep-freeze caching.
- Current (`b1618bc75`): `/tmp/opencode/lunch-poll-perf-4237-updated/current-b1618bc75-10x2-r0-profile/current-b1618bc75-10x2-r0.cpuprofile`
  - Summary: `/tmp/opencode/lunch-poll-perf-4237-updated/current-b1618bc75-10x2-r0-profile-summary.json`
  - Wall 13.4s, 154 conflicts, 0 scoped conflict flushes, conflict p95 0.9ms, sampled CPU window 13.6s.
  - Hot spots are broadly the same runtime categories, but less sampled wall is spent overall because conflict responses no longer wait on scoped refreshes.

## Verification

- Branch was rebased onto latest `origin/main` `ebdf920b5` before final commits; latest pushed head is `21babf415`.
- `deno fmt --check packages/memory/v2/server.ts packages/memory/v2/client.ts packages/memory/test/v2-server-test.ts packages/memory/test/v2-client-test.ts` passed.
- LSP diagnostics: no diagnostics on all four Cubic-fix files.
- Latest coverage follow-up verification passed:
  - LSP diagnostics: no diagnostics on `packages/runner/src/storage/v2.ts` and `packages/runner/test/memory-v2-subscription.test.ts`.
  - LSP diagnostics: no diagnostics on `packages/runner/src/scheduler/action-run.ts` and `packages/runner/test/scheduler-cfc-trigger-reads.test.ts`.
  - `deno fmt --check packages/runner/src/storage/v2.ts packages/runner/test/memory-v2-subscription.test.ts` passed.
  - `deno fmt --check packages/runner/test/scheduler-cfc-trigger-reads.test.ts packages/runner/src/scheduler/action-run.ts` passed.
  - `deno test -A --coverage=/tmp/opencode/pr4237-runner-coverage-local packages/runner/test/memory-v2-subscription.test.ts` passed; local LCOV confirms the previously uncovered runner caught-up waiter cleanup and retry-read-repair warning paths are covered.
  - Latest CI LCOV after `50d2b1b69` showed only three remaining uncovered added runner lines, all in `packages/runner/src/scheduler/action-run.ts`'s primitive/non-object retry guard; `21babf415` adds scheduler coverage for that path.
- Targeted post-rebase/post-CI-fix tests passed:
  - `deno test -A packages/memory/test/v2-client-test.ts packages/memory/test/v2-server-test.ts packages/runner/test/memory-v2-subscription.test.ts packages/runner/test/scheduler-cfc-trigger-reads.test.ts`
  - Result: `60 passed (16 steps) | 0 failed`.
- CI failure reproduction and fix verification passed:
  - `deno test -A packages/runner/test/commit-conflict-reconcile.test.ts`
  - `deno test -A packages/runner/test/commit-conflict-reconcile.test.ts packages/runner/test/memory-v2-subscription.test.ts packages/memory/test/v2-client-test.ts packages/memory/test/v2-server-test.ts packages/runner/test/scheduler-cfc-trigger-reads.test.ts`
  - Result after latest coverage follow-up: `61 passed (21 steps) | 0 failed`.
- Manual QA/perf diagnostics above were rerun after the rebase with trace output and summaries under `/tmp/opencode/lunch-poll-perf-4237-updated`.
- Lunch-poll browser stale UI repro was checked separately on clean `origin/main` and the rebased branch; it reproduced on main, so it is not unique to this PR.

## Caveats

- The performance data is manual/bounded, not a statistically rigorous benchmark suite.
- Browser-render validation was limited by local Playwright/Chrome availability; the main-vs-branch browser stale UI repro was performed separately from these runtime/memory diagnostics.


---

## Follow-up: review fixes + perf validation + admission experiment

_Added by @berni (with Claude Code), pushed onto this branch. A multi-agent review of this PR surfaced three high-severity liveness/robustness gaps; this stack fixes them with regression tests, validates the perf thesis against `main`, and adds two flagged-off experiments exploring further conflict reduction._

### Review fixes (liveness / correctness)

- **H1 — reconnect strand → commit hang** (`2eb2a90`). The runner replica advances its caught-up seq only from WatchView syncs, but the memory client delivered a resume's caught-up marker via the top-level `SessionOpenResult.caughtUpLocalSeq` field, which never reached the WatchView when no sync accompanied it. A conflict whose catch-up was promoted+drained server-side just before a dropped send, then resumed on the same session, left the runner's read-repair waiter stranded and the commit promise unresolved forever. Fix: the client forwards a top-level-only caught-up marker into the WatchView (deduped against a real sync; reset on session change).
- **H2 — rejected `readyToRetry` strands the action + spurious `console.error`** (`15aef5d`). The scheduler awaited the readiness gate unguarded; it rejects by design on session close/revoke/replacement, so the rejection escaped into the error-logging `.catch`, skipping `restoreCfcTriggerReads`/resubscribe (stranding the action) and emitting `schedule-error` (which the strict cf-test harness fails on). Fix: swallow the expected rejection and re-arm anyway.
- **H3 — unbounded read-repair wait** (`2eb2a90`). `waitForConflictReadRepair` now races `readyToRetry` against a 30s backstop (timer always cleared) so a permanently-undelivered sync on a live, never-reconnecting session can't hang the commit.
- **Nits** (`007ce98`): `toRejectedError` fills `conflict.space`; `retryAfterSeq` documented as diagnostic; `lastSyncedSeq` zero-upsert watermark drift fixed (Cubic `fromSeq` preserved); strengthened the repair test to assert repaired state before any explicit retry (it was mutation-green); fixed a no-assertion test.

New regression tests cover: the top-level-only caught-up forward on resume; rejecting-`readyToRetry` re-arm; repair-before-revert ordering; and revert-to-current for a non-conflicting sibling write in a multi-doc conflict (only the conflicting doc lands fresh; the sibling rolls back to current, never to past data).

### Perf validation vs `main`

Added conflict + cross-session-convergence counters to `packages/patterns/tools/lunch-poll-diagnose.ts` (a `loggerCounts` worker RPC + a convergence assertion), then ran the full client-count matrix on this branch vs current `origin/main` — identical bench + pattern, `--rounds=1 --skip-refresh`; work = sum of phase wall time:

| case (opt×usr) | branch | main | branch faster | branch cfl | main cfl |
| --- | ---: | ---: | ---: | ---: | ---: |
| 2×2 | 1.9s | 5.4s | 2.9× | 66 | 194 |
| 5×2 | 3.4s | 10.2s | 3.0× | 120 | 339 |
| 10×2 | 7.1s | 28.0s | 3.9× | 340 | 883 |
| 2×5 | 5.5s | 38.0s | 6.9× | 685 | 707 |
| 5×5 | 11.6s | 139.8s | 12.0× | 1591 | 2021 |
| 10×5 | 26.5s | >300s (timed out) | >11× | 2194 | — |

The multiplier grows monotonically with scale, and `main` stops completing from 10×5 up (branch finishes 5×10 in 21.5s and 10×10 in 63.6s; main does not complete either within the time cap). Crucially at 2×5 the conflict counts are ~equal (685 vs 707) yet branch is 6.9× faster — confirming the dominant cost is **per-conflict** (the synchronous scoped flush this PR removes), not the conflict count. Both sides converge correctly (no votes lost; all sessions agree on the final tally). Caveat: one run per case, and lunch-poll has ±15% run-to-run variance — read the multipliers as the trend, not exact values.

### Admission-control experiment (`CF_CONFLICT_ADMISSION`, default off)

The implementation here is **`hold`** — a precise, client-side local precondition check. When a new commit's read lands on a still-catching-up id, hold it until the catch-up is applied, then run the server's stale-read check *locally* against the now-current confirmed seqs: locally revert only the commits a confirmed read *proves* stale, and send the rest. It is **strictly safe** — no false pre-empts (`heldRevert ≈ 0`; it sends the ~70 commits it holds unchanged), convergence preserved — and measured **neutral** on lunch-poll. The neutrality is fundamental, not a defect: lunch-poll's staleness is *server-side* — the action reads the latest *local* confirmed value, which looks current, so a local check cannot predict a conflict caused by another client's not-yet-received write. `hold` would help workloads where local staleness *is* knowable (e.g. a client holding commits that its own later syncs have already superseded); on this workload there is simply nothing locally to catch.

`preempt` is an earlier **coarse** attempt that `hold` supersedes, kept behind the same flag only for comparison — do not enable it. It taints every id a losing tx touched (including write targets) and pre-empts later commits reading them, which also pre-empts commits that would have succeeded, so it measured **net-negative** (extra revert+re-run cycles; and since this PR already makes conflicts cheap, there is no round-trip worth saving).

Both modes are default-off (opt-in via `CF_CONFLICT_ADMISSION=hold|preempt`). Takeaway: client-side admission cannot reduce *server-discovered* conflicts on this workload — the system is already throughput-robust and convergent under conflict — but `hold` is the correct, safe design to carry forward for workloads where local staleness is observable.

---

## CI ratchet baseline

NEW_COVERAGE_BASELINE
NEW_PERF_BASELINE: job: CLI Integration Tests (core-piece-values) = 75s
