### PR TITLE
refactor(runner): createRef traverse guard via chokepoint predicates + atomic FabricPrimitives

### DIFF
--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -61,9 +61,8 @@ export function createRef(
 ): EntityId {
   const seen = new Set<any>();
 
-  // Unwrap query result proxies, replace docs with their ids and remove
-  // functions and undefined values, since our data model doesn't support them.
-  // TODO(danfuzz): Revisit this when `undefined` is fully supported.
+  // Unwrap query result proxies and replace docs with their ids; functions are
+  // stringified, since our data model doesn't support them as values.
   function traverse(obj: any): any {
     // Avoid cycles — only track objects/arrays/functions (not primitives).
     // Primitives use value equality in Set, so repeated strings like
@@ -138,7 +137,6 @@ export function createRef(
         Object.entries(obj).map(([key, value]) => [key, traverse(value)]),
       );
     } else if (typeof obj === "function") return obj.toString();
-    else if (obj === undefined) return null;
     else return obj;
   }
 

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -1,9 +1,13 @@
 import { hashOf } from "@commonfabric/data-model/value-hash";
-import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
+import {
+  BaseFabricPrimitive,
+  FabricHash,
+} from "@commonfabric/data-model/fabric-primitives";
 import {
   type EntityRef,
   entityRefFrom,
   entityRefFromString,
+  isEntityRef,
 } from "@commonfabric/data-model/cell-rep";
 import { isRecord } from "@commonfabric/utils/types";
 import { isOpaqueRef } from "./builder/types.ts";
@@ -13,7 +17,7 @@ import {
 } from "./query-result-proxy.ts";
 import { isCell } from "./cell.ts";
 import { fromURI } from "./uri-utils.ts";
-import { parseLink } from "./link-utils.ts";
+import { isSigilLink, parseLink } from "./link-utils.ts";
 
 declare const ENTITY_ID_BRAND: unique symbol;
 
@@ -72,10 +76,21 @@ export function createRef(
       seen.add(obj);
     }
 
-    // Don't traverse into ids (a `FabricHash` is an entity id; a `{ "/": ... }`
-    // object is a serialized one).
-    if (obj instanceof FabricHash) return obj;
-    if (isRecord(obj) && "/" in obj) return obj;
+    // Don't traverse into atomic values or already-serialized references. A
+    // `FabricPrimitive` (a `FabricHash` id, `FabricBytes`, a date, …) is an
+    // atomic value and must be hashed via its own codec — descending into one
+    // would decompose it to its (empty) enumerable props and collide distinct
+    // values. A serialized entity-ref or sigil link is a reference to another
+    // cell, recognized through the cell-rep / sigil chokepoint predicates rather
+    // than the raw `{ "/": ... }` shape.
+    //
+    // TODO(danfuzz): the other data-model special-object type, `FabricInstance`
+    // (a container that holds other values), is not handled here. Unlike a
+    // primitive it *does* need descending into — but by its actual contents,
+    // which the generic enumerable-prop traversal below won't do correctly. This
+    // site will need attention once FabricInstances see real use.
+    if (obj instanceof BaseFabricPrimitive) return obj;
+    if (isSigilLink(obj) || isEntityRef(obj)) return obj;
 
     // If there is a .toJSON method, replace obj with it, then descend.
     // TODO(seefeld): We have to accept functions for now as the pattern factory
@@ -105,7 +120,7 @@ export function createRef(
       obj = getCellOrThrow(obj);
     }
 
-    // If referencing other docs, return their ids (or random as fallback).
+    // If referencing other docs, return their ids.
     if (isCell(obj)) {
       const id = obj.entityId;
       if (id == null) {

--- a/packages/runner/test/doc-map.test.ts
+++ b/packages/runner/test/doc-map.test.ts
@@ -77,9 +77,9 @@ describe("cell-map", () => {
     });
 
     it("hashes FabricPrimitive values atomically (distinct values → distinct ids)", () => {
-      // Regression: a FabricPrimitive has no enumerable own props, so descending
-      // into one collapsed it to `{}` and collided otherwise-distinct values.
-      // (A fixed cause keeps the id determined by the source, not random.)
+      // A FabricPrimitive has no enumerable own props, so it must be hashed
+      // atomically via its codec rather than descended into. A fixed cause keeps
+      // the id determined by the source rather than random.
       const a = createRef(
         { data: new FabricBytes(new Uint8Array([1, 2, 3])) },
         "c",
@@ -102,6 +102,13 @@ describe("cell-map", () => {
         );
       expect(createRef({ ref: link("of:fid1:aaa") }, "c").taggedHashString)
         .toEqual(createRef({ ref: link("of:fid1:aaa") }, "c").taggedHashString);
+    });
+
+    it("distinguishes `null` from `undefined` in the source", () => {
+      const id = (x: unknown) => createRef({ x }, "c").taggedHashString;
+      expect(id(null)).not.toEqual(id(undefined));
+      expect(id([null])).not.toEqual(id([undefined]));
+      expect(id({ y: null })).not.toEqual(id({ y: undefined }));
     });
   });
 

--- a/packages/runner/test/doc-map.test.ts
+++ b/packages/runner/test/doc-map.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@commonfabric/data-model/cell-rep";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { Runtime } from "../src/runtime.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
@@ -73,6 +74,34 @@ describe("cell-map", () => {
       const ref = createRef(source, cause);
       const ref2 = createRef(source);
       expect(ref.taggedHashString).not.toEqual(ref2.taggedHashString);
+    });
+
+    it("hashes FabricPrimitive values atomically (distinct values → distinct ids)", () => {
+      // Regression: a FabricPrimitive has no enumerable own props, so descending
+      // into one collapsed it to `{}` and collided otherwise-distinct values.
+      // (A fixed cause keeps the id determined by the source, not random.)
+      const a = createRef(
+        { data: new FabricBytes(new Uint8Array([1, 2, 3])) },
+        "c",
+      );
+      const b = createRef(
+        { data: new FabricBytes(new Uint8Array([4, 5, 6])) },
+        "c",
+      );
+      expect(a.taggedHashString).not.toEqual(b.taggedHashString);
+    });
+
+    it("treats a sigil link in the source as an atomic reference", () => {
+      const link = (id: string) => ({
+        "/": { [LINK_V1_TAG]: { id, path: [] } },
+      });
+      // Distinct links → distinct ids; the same link → a stable id.
+      expect(createRef({ ref: link("of:fid1:aaa") }, "c").taggedHashString)
+        .not.toEqual(
+          createRef({ ref: link("of:fid1:bbb") }, "c").taggedHashString,
+        );
+      expect(createRef({ ref: link("of:fid1:aaa") }, "c").taggedHashString)
+        .toEqual(createRef({ ref: link("of:fid1:aaa") }, "c").taggedHashString);
     });
   });
 


### PR DESCRIPTION
Two changes to `createRef`'s `traverse` atomic-id guard (the hash-input boundary
that feeds derived cell ids). This is the (b) follow-up to the `{ "/": … }` arc.

### 1. Route `{ "/": … }` recognition through the chokepoint predicates
`if (isRecord(obj) && "/" in obj) return obj;` →
`if (isSigilLink(obj) || isEntityRef(obj)) return obj;`

The raw `{ "/": … }` shape check becomes the cell-rep / sigil chokepoint
predicates — `isSigilLink` for `link@1` object sigils, `isEntityRef` for legacy
`{ "/": string }` refs (the `FabricHash` id case is already handled by the line
above). **Byte-equivalent** for every form the system produces, in both cell-rep
regimes; only junk `{ "/": <non-string | multi-key> }` shapes — which nothing
produces, and which `/` being a reserved sigil prefix shouldn't carry — differ.

### 2. Treat all `FabricPrimitive`s atomically (bug fix)
`if (obj instanceof FabricHash)` → `if (obj instanceof BaseFabricPrimitive)`

This fixes a **value-collision bug**. A `FabricPrimitive` stores its data in
`#private` fields with prototype getters, so it has **no enumerable own
properties**. Only `FabricHash` was special-cased; any other primitive
(`FabricBytes`, dates, regexps) fell through to the generic object branch and got
decomposed via `Object.fromEntries(Object.entries(obj))` → **`{}`**, collapsing
otherwise-distinct values to a single derived id. `FabricPrimitive`s are atomic
and must be hashed via their own codec.

This *changes derived ids* for sources containing non-`FabricHash` primitives —
but those values are not widely used yet, so the storage-key churn is acceptable
(may surprise non-fresh DBs; confirmed worth doing).

### 3. Stop coercing `undefined` → `null`
The structural content-hash no longer throws on `undefined`, so `traverse` need
not coerce it to `null`. `undefined` now passes through and hashes distinctly
from `null` (top-level and nested in arrays/objects). Also a derived-id change,
in the same not-widely-used-yet / fresh-db-caveat territory as #2.

### Also
- `TODO(danfuzz)`: the other special-object type, `FabricInstance` (a container),
  is not handled here. Unlike a primitive it *does* need descending into — but by
  its actual contents, which the generic enumerable-prop traversal won't do
  correctly. Needs attention once FabricInstances see real use.
- Dropped a stale `(or random as fallback)` comment — the code fails closed.

### Verification
- Full workspace `deno task test` — all passing.
- New regression test: distinct `FabricBytes` in a createRef source now derive
  distinct ids (collided pre-fix); sigil-link source treated as an atomic ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Coverage Baseline

We accept the 12 additional uncovered lines.

NEW_COVERAGE_BASELINE
