### PR TITLE
Guard login until key store is ready

### DIFF
--- a/packages/shell/integration/login.test.ts
+++ b/packages/shell/integration/login.test.ts
@@ -13,6 +13,53 @@ describe("shell login tests", () => {
   const shell = new ShellIntegration();
   shell.bindLifecycle();
 
+  it("waits for key store before showing login controls", async () => {
+    const page = shell.page();
+
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { spaceName: "common-knowledge" },
+    });
+
+    const result = await page.evaluate(async () => {
+      await customElements.whenDefined("x-login-view");
+
+      const login = document.createElement("x-login-view") as HTMLElement & {
+        keyStore?: unknown;
+        updateComplete: Promise<unknown>;
+      };
+      document.body.append(login);
+      await login.updateComplete;
+
+      const snapshot = () => {
+        const root = login.shadowRoot;
+        return {
+          hasLoading: root?.textContent?.includes(
+            "Preparing secure storage...",
+          ) ?? false,
+          hasRegister: !!root?.querySelector('[test-id="register-new-key"]'),
+        };
+      };
+
+      const beforeKeyStore = snapshot();
+      login.keyStore = {
+        get: () => Promise.resolve(undefined),
+        set: () => Promise.resolve(undefined),
+        clear: () => Promise.resolve(undefined),
+      };
+      await login.updateComplete;
+      const afterKeyStore = snapshot();
+      login.remove();
+
+      return { beforeKeyStore, afterKeyStore };
+    });
+
+    assert(result.beforeKeyStore.hasLoading);
+    assert(!result.beforeKeyStore.hasRegister);
+    assert(!result.afterKeyStore.hasLoading);
+    assert(result.afterKeyStore.hasRegister);
+  });
+
   it("can create a new user via passphrase", async () => {
     const page = shell.page();
     const spaceName = "common-knowledge";

--- a/packages/shell/src/views/LoginView.ts
+++ b/packages/shell/src/views/LoginView.ts
@@ -1,5 +1,5 @@
 import { css, html } from "lit";
-import { state } from "lit/decorators.js";
+import { property, state } from "lit/decorators.js";
 
 import { Identity, KeyStore, PassKey } from "@commonfabric/identity";
 
@@ -199,7 +199,7 @@ export class XLoginView extends BaseView {
     getStoredCredential();
   @state()
   private accessor copied = false;
-  @state()
+  @property({ attribute: false })
   private accessor keyStore: KeyStore | undefined = undefined;
 
   private availableMethods: AuthMethod[] = [];
@@ -783,6 +783,44 @@ export class XLoginView extends BaseView {
   }
 
   override render() {
+    const content = !this.keyStore
+      ? html`
+        <div class="loading">
+          <p>Preparing secure storage...</p>
+        </div>
+      `
+      : this.error
+      ? html`
+        <div class="error">
+          ${this.error}
+        </div>
+      `
+      : this.isProcessing
+      ? html`
+        <div class="loading">
+          <p>Please follow the browser's prompts to continue...</p>
+        </div>
+      `
+      : this.mnemonic
+      ? this.renderMnemonicDisplay()
+      : this.registrationSuccess
+      ? this.renderSuccess()
+      : this.flow === null
+      ? this.renderInitial()
+      : this.method === null
+      ? this.renderMethodSelection()
+      : this.method === AUTH_METHOD_PASSPHRASE
+      ? this.renderPassphraseAuth()
+      : this.method === AUTH_METHOD_KEYFILE
+      ? this.renderKeyFileImport()
+      : this.method === AUTH_METHOD_PASSKEY
+      ? html`
+        <div class="loading">
+          <p>Please follow the browser's prompts to continue...</p>
+        </div>
+      `
+      : "";
+
     return html`
       <div class="login-container">
         <div class="logo-container">
@@ -795,37 +833,7 @@ export class XLoginView extends BaseView {
         </div>
 
         <div class="auth-action-container">
-          ${this.error
-            ? html`
-              <div class="error">
-                ${this.error}
-              </div>
-            `
-            : ""} ${this.isProcessing
-            ? html`
-              <div class="loading">
-                <p>Please follow the browser's prompts to continue...</p>
-              </div>
-            `
-            : this.mnemonic
-            ? this.renderMnemonicDisplay()
-            : this.registrationSuccess
-            ? this.renderSuccess()
-            : this.flow === null
-            ? this.renderInitial()
-            : this.method === null
-            ? this.renderMethodSelection()
-            : this.method === AUTH_METHOD_PASSPHRASE
-            ? this.renderPassphraseAuth()
-            : this.method === AUTH_METHOD_KEYFILE
-            ? this.renderKeyFileImport()
-            : this.method === AUTH_METHOD_PASSKEY
-            ? html`
-              <div class="loading">
-                <p>Please follow the browser's prompts to continue...</p>
-              </div>
-            `
-            : ""}
+          ${content}
         </div>
       </div>
     `;

--- a/packages/shell/test/login-view.test.ts
+++ b/packages/shell/test/login-view.test.ts
@@ -1,0 +1,167 @@
+import { assert, assertStringIncludes } from "@std/assert";
+import {
+  AUTH_METHOD_KEYFILE,
+  AUTH_METHOD_PASSKEY,
+  AUTH_METHOD_PASSPHRASE,
+} from "../src/lib/credentials.ts";
+
+type LoginView =
+  & InstanceType<
+    typeof import("../src/views/LoginView.ts").XLoginView
+  >
+  & Record<string, unknown>;
+
+type TemplateResultLike = {
+  strings?: readonly string[];
+  values?: readonly unknown[];
+};
+
+function installBrowserGlobals(): () => void {
+  const originals = new Map<string, PropertyDescriptor | undefined>();
+
+  function setGlobal(name: string, value: unknown): void {
+    originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    });
+  }
+
+  class TestHTMLElement extends EventTarget {}
+
+  setGlobal("window", globalThis);
+  setGlobal("HTMLElement", TestHTMLElement);
+  setGlobal("customElements", {
+    define() {},
+    get() {},
+    whenDefined: () => Promise.resolve(),
+  });
+  setGlobal("document", {
+    documentElement: { style: {} },
+    createElement: () => ({
+      style: {},
+      setAttribute() {},
+      append() {},
+      appendChild() {},
+    }),
+    createTreeWalker: () => ({}),
+  });
+  setGlobal("devicePixelRatio", 1);
+  setGlobal("screen", { deviceXDPI: 1, logicalXDPI: 1 });
+  setGlobal("navigator", { platform: "", userAgent: "deno" });
+  setGlobal("location", {
+    protocol: "http:",
+    host: "localhost:8000",
+    hostname: "localhost",
+    href: "http://localhost:8000/common-knowledge",
+  });
+
+  return () => {
+    for (const [name, descriptor] of originals) {
+      if (descriptor) {
+        Object.defineProperty(globalThis, name, descriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, name);
+      }
+    }
+  };
+}
+
+function templateText(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(templateText).join("");
+  if (typeof value !== "object") return "";
+
+  const result = value as TemplateResultLike;
+  return [
+    ...(result.strings ?? []),
+    ...((result.values ?? []).map(templateText)),
+  ].join("");
+}
+
+function renderText(view: LoginView): string {
+  return templateText(view.render());
+}
+
+function setState(
+  view: LoginView,
+  state: Record<string, unknown>,
+): LoginView {
+  Object.assign(view, state);
+  return view;
+}
+
+Deno.test("login view renders each key store ready state", async () => {
+  const restore = installBrowserGlobals();
+  try {
+    const { XLoginView } = await import("../src/views/LoginView.ts");
+    const keyStore = {
+      get: () => Promise.resolve(undefined),
+      set: () => Promise.resolve(undefined),
+      clear: () => Promise.resolve(undefined),
+    };
+
+    const view = (state: Record<string, unknown> = {}) =>
+      setState(new XLoginView() as LoginView, {
+        keyStore,
+        storedCredential: null,
+        ...state,
+      });
+
+    const waitingForKeyStore = renderText(
+      setState(new XLoginView() as LoginView, { storedCredential: null }),
+    );
+    assertStringIncludes(waitingForKeyStore, "Preparing secure storage...");
+    assert(!waitingForKeyStore.includes('test-id="register-new-key"'));
+
+    assertStringIncludes(
+      renderText(view({ error: "Nope" })),
+      '<div class="error">',
+    );
+    assertStringIncludes(
+      renderText(view({ isProcessing: true })),
+      "Please follow the browser's prompts to continue...",
+    );
+    assertStringIncludes(
+      renderText(view({ mnemonic: "alpha beta gamma" })),
+      "Your Secret Recovery Phrase:",
+    );
+    assertStringIncludes(
+      renderText(view({ registrationSuccess: true })),
+      "successfully registered!",
+    );
+    assertStringIncludes(
+      renderText(view()),
+      'test-id="register-new-key"',
+    );
+    assertStringIncludes(
+      renderText(view({ flow: "register", method: null })),
+      "Register with",
+    );
+    assertStringIncludes(
+      renderText(view({
+        flow: "register",
+        method: AUTH_METHOD_PASSPHRASE,
+      })),
+      'test-id="generate-passphrase"',
+    );
+    assertStringIncludes(
+      renderText(view({
+        flow: "register",
+        method: AUTH_METHOD_KEYFILE,
+      })),
+      "Import Key",
+    );
+    assertStringIncludes(
+      renderText(view({
+        flow: "register",
+        method: AUTH_METHOD_PASSKEY,
+      })),
+      "Please follow the browser's prompts to continue...",
+    );
+  } finally {
+    restore();
+  }
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Guard the login flow until the key store is ready. Show “Preparing secure storage...” and hide all auth controls until secure storage initializes.

- **Bug Fixes**
  - Guard `x-login-view` until `keyStore` is set; render “Preparing secure storage...” first, then show normal flows.
  - Expose `keyStore` as a `@property({ attribute: false })` for explicit host injection.
  - Add an integration test to verify loading appears before `keyStore`, and the register control appears after.
  - Add a unit test covering `x-login-view` render states (pre-`keyStore`, error, processing, mnemonic, success, and method selection for passphrase/keyfile/passkey).

<sup>Written for commit 2868d7b3b1c7129f03ecaa5bc307c928359a51e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

