### PR TITLE
feat(ui): UI variants — cf-render full/chip/tile with failover defaults (CT-1321)

### DIFF
--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -146,7 +146,7 @@ cell means none confirmed — check the component source before assuming.
 | `cf-question` | Asks a single question and collects the answer | |
 | `cf-radio` | Single radio button used within `cf-radio-group` | |
 | `cf-radio-group` | Radio group; declarative `items` or slotted `cf-radio` | `$value` |
-| `cf-render` | Renders a cell containing a piece pattern (see [cf-render](#cf-render)) | `$cell` |
+| `cf-render` | Renders a cell containing a piece pattern at a UI variant — `full`/`chip`/`tile` (see [cf-render](#cf-render)) | `$cell`, `variant` |
 | `cf-resizable-handle` | Drag handle between resizable panels | |
 | `cf-resizable-panel` | Individual panel within a resizable panel group | |
 | `cf-resizable-panel-group` | Container managing resizable panels and handles | |
@@ -360,6 +360,54 @@ const gridView = GridView({ items });
 ```
 
 See [composition](../patterns/composition.md) for more on pattern composition.
+
+### UI variants (CT-1321)
+
+A piece can expose a **size spectrum** of renderings as optional sibling output
+keys, addressed by symbols vended from `commonfabric`:
+
+| Variant | Output key | Symbol | Use |
+| --- | --- | --- | --- |
+| `full` | `"$UI"` | `UI` | Standalone rendering — the default, and the universal floor. |
+| `chip` | `"$CHIP_UI"` | `CHIP_UI` | Inline rendering for text and lists. |
+| `tile` | `"$TILE_UI"` | `TILE_UI` | Gallery/grid card. |
+
+Pick a variant with the `variant` attribute (default `"full"`):
+
+```tsx
+<cf-render $cell={piece} variant="full" />   // default — standalone
+<cf-render $cell={piece} variant="chip" />   // inline
+<cf-render $cell={piece} variant="tile" />   // gallery/grid tile
+```
+
+**Failover — every piece renders at every variant.** When a piece doesn't
+export the requested variant key, `cf-render` substitutes a per-variant platform
+default:
+
+- `chip` → a `cf-cell-link` bound to the piece (renders it by its `[NAME]`).
+- `tile` → the full `[UI]` rendered small at ~0.5 scale.
+
+Because `full`/`[UI]` is the universal floor, a piece that exports only `[UI]`
+still renders correctly at `chip` and `tile`.
+
+A pattern exports the spectrum by returning the sibling keys:
+
+```tsx
+import { CHIP_UI, NAME, pattern, TILE_UI, UI } from "commonfabric";
+
+export default pattern(({ title }) => ({
+  [NAME]: title,
+  [UI]: <FullView title={title} />,      // standalone (always provide this)
+  [CHIP_UI]: <InlineChip title={title} />, // optional inline
+  [TILE_UI]: <GridTile title={title} />,   // optional gallery tile
+}));
+```
+
+See `packages/patterns/examples/ui-variants-demo.tsx` for a full example.
+
+> Note: `sidebarUI`/`fabUI`/`settingsUI` are shell composition **slots**, a
+> separate concept — not size variants. A vended `uiVariant()` helper for
+> render paths outside `cf-render` is a planned follow-up and does not exist yet.
 
 ---
 

--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -385,7 +385,8 @@ export the requested variant key, `cf-render` substitutes a per-variant platform
 default:
 
 - `chip` → a `cf-cell-link` bound to the piece (renders it by its `[NAME]`).
-- `tile` → the full `[UI]` rendered small at ~0.5 scale.
+- `tile` → the full `[UI]` rendered small at ~0.5 scale, clipped to a static
+  preview and clickable to navigate to the piece (like `cf-cell-link`).
 
 Because `full`/`[UI]` is the universal floor, a piece that exports only `[UI]`
 still renders correctly at `chip` and `tile`.

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -149,6 +149,9 @@ export declare const ID_FIELD: unique symbol;
 export declare const TYPE: "$TYPE";
 export declare const NAME: "$NAME";
 export declare const UI: "$UI";
+// UI variants (CT-1321): optional sibling renderings addressed alongside [UI].
+export declare const TILE_UI: "$TILE_UI";
+export declare const CHIP_UI: "$CHIP_UI";
 export declare const FS: "$FS";
 
 // Symbol for accessing self-reference in patterns

--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -3561,14 +3561,8 @@ interface CFIframeAttributes<T> extends CFHTMLAttributes<T> {
 
 interface CFRenderAttributes<T> extends CFHTMLAttributes<T> {
   "$cell": CellLike<any>;
-  "variant"?:
-    | "default"
-    | "preview"
-    | "thumbnail"
-    | "sidebar"
-    | "fab"
-    | "settings"
-    | "embedded";
+  // CT-1321 UI-variant spectrum (see cf-render.ts UIVariant).
+  "variant"?: "full" | "chip" | "tile";
 }
 
 interface CFCellContextAttributes<T> extends CFHTMLAttributes<T> {

--- a/packages/patterns/catalog/catalog.tsx
+++ b/packages/patterns/catalog/catalog.tsx
@@ -125,6 +125,7 @@ interface CatalogInput {
         name: "Patterns";
         items: [
           { id: "note"; label: "Note" },
+          { id: "render"; label: "Render (UI Variants)" },
           { id: "vignette-recipe"; label: "Vignette: Recipe" },
           { id: "vignette-finance"; label: "Vignette: Finance" },
           { id: "vignette-mobile-app"; label: "Vignette: Mobile App" },

--- a/packages/patterns/catalog/stories/cf-render-story.tsx
+++ b/packages/patterns/catalog/stories/cf-render-story.tsx
@@ -1,0 +1,149 @@
+import { NAME, pattern, UI, type VNode } from "commonfabric";
+
+import UIVariantsDemo from "../../examples/ui-variants-demo.tsx";
+
+// deno-lint-ignore no-empty-interface
+interface RenderStoryInput {}
+export interface RenderStoryOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  controls: VNode;
+}
+
+interface SingleUIInput {
+  label: string;
+}
+export interface SingleUIOutput {
+  [NAME]: string;
+  [UI]: VNode;
+}
+
+/**
+ * A piece that exports ONLY [UI] — no [CHIP_UI]/[TILE_UI]. Used to demonstrate
+ * the cf-render platform defaults (chip → cf-cell-link by [NAME]; tile → the
+ * full [UI] scaled to ~0.5).
+ */
+const SingleUIPiece = pattern<SingleUIInput, SingleUIOutput>(({ label }) => ({
+  [NAME]: label,
+  [UI]: (
+    <div
+      style={{
+        padding: "16px",
+        borderRadius: "8px",
+        border: "1px solid #e5e7eb",
+        background: "#ffffff",
+      }}
+    >
+      <strong>{label}</strong>
+      <div style={{ fontSize: "13px", color: "#6b7280" }}>
+        This piece exports only [UI].
+      </div>
+    </div>
+  ),
+}));
+
+const cellStyle = {
+  border: "1px dashed #cbd5e1",
+  borderRadius: "8px",
+  padding: "12px",
+  background: "#fafafa",
+  minHeight: "80px",
+};
+
+const labelStyle = {
+  fontSize: "12px",
+  fontWeight: "700",
+  color: "#64748b",
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  marginBottom: "8px",
+};
+
+const sectionTitleStyle = {
+  fontSize: "15px",
+  fontWeight: "700",
+  color: "#0f172a",
+  margin: "8px 0",
+};
+
+const noteStyle = {
+  fontSize: "13px",
+  color: "#64748b",
+  marginBottom: "12px",
+};
+
+export default pattern<RenderStoryInput, RenderStoryOutput>(() => {
+  // A piece exporting the full variant spectrum ([UI], [CHIP_UI], [TILE_UI]).
+  const demo = UIVariantsDemo({ title: "UI Variants Demo" });
+
+  // A piece exporting only [UI], to exercise the platform-default failover.
+  const single = SingleUIPiece({ label: "Single-UI Piece" });
+
+  return {
+    [NAME]: "cf-render Story",
+    [UI]: (
+      <div style={{ padding: "1rem", maxWidth: "640px" }}>
+        <div style={sectionTitleStyle}>Exported variants (CT-1321)</div>
+        <div style={noteStyle}>
+          {"<cf-render>"}{" "}
+          renders the piece's matching variant key when the piece exports it:
+          [UI] for full, [CHIP_UI] for chip, [TILE_UI] for tile.
+        </div>
+
+        <div style={{ display: "grid", gap: "16px" }}>
+          <div>
+            <div style={labelStyle}>variant="full" (default)</div>
+            <div style={cellStyle}>
+              <cf-render $cell={demo} variant="full" />
+            </div>
+          </div>
+
+          <div>
+            <div style={labelStyle}>variant="chip"</div>
+            <div style={cellStyle}>
+              <cf-render $cell={demo} variant="chip" />
+            </div>
+          </div>
+
+          <div>
+            <div style={labelStyle}>variant="tile"</div>
+            <div style={{ ...cellStyle, width: "220px", height: "120px" }}>
+              <cf-render $cell={demo} variant="tile" />
+            </div>
+          </div>
+        </div>
+
+        <div style={{ ...sectionTitleStyle, marginTop: "24px" }}>
+          Platform defaults (failover)
+        </div>
+        <div style={noteStyle}>
+          A piece that exports only [UI] still renders at every variant via the
+          per-variant platform default: chip falls over to a cf-cell-link (by
+          [NAME]); tile falls over to the full [UI] scaled to ~0.5.
+        </div>
+
+        <div style={{ display: "grid", gap: "16px" }}>
+          <div>
+            <div style={labelStyle}>variant="chip" → cf-cell-link default</div>
+            <div style={cellStyle}>
+              <cf-render $cell={single} variant="chip" />
+            </div>
+          </div>
+
+          <div>
+            <div style={labelStyle}>variant="tile" → scaled [UI] default</div>
+            <div style={{ ...cellStyle, width: "220px", height: "120px" }}>
+              <cf-render $cell={single} variant="tile" />
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+    controls: (
+      <div style={{ color: "#6b7280", fontSize: "13px", padding: "8px 12px" }}>
+        No interactive controls. This story renders {"<cf-render>"}{" "}
+        at each UI variant for a full-spectrum piece and a single-[UI] piece.
+      </div>
+    ),
+  };
+});

--- a/packages/patterns/catalog/ui/story-renderer.tsx
+++ b/packages/patterns/catalog/ui/story-renderer.tsx
@@ -44,6 +44,7 @@ import TabBarStory from "../stories/cf-tab-bar-story.tsx";
 import TabsStory from "../stories/cf-tabs-story.tsx";
 import ChartStory from "../stories/cf-chart-story.tsx";
 import NoteStory from "../stories/note-story.tsx";
+import RenderStory from "../stories/cf-render-story.tsx";
 import KitchenSinkStory from "../stories/kitchen-sink-story.tsx";
 import ChatStory from "../stories/cf-chat-story.tsx";
 import CalendarStory from "../stories/cf-calendar-story.tsx";
@@ -169,6 +170,8 @@ export default pattern<StoryRendererInput, StoryRendererOutput>(
           return ChartStory({});
         case "note":
           return NoteStory({});
+        case "render":
+          return RenderStory({});
         case "kitchen-sink":
           return KitchenSinkStory({});
         case "chat":

--- a/packages/patterns/examples/ui-variants-demo.tsx
+++ b/packages/patterns/examples/ui-variants-demo.tsx
@@ -1,0 +1,55 @@
+import { CHIP_UI, Default, NAME, pattern, TILE_UI, UI } from "commonfabric";
+
+/**
+ * CT-1321 UI-variants demo. Exports the full size spectrum:
+ * - [UI]      full standalone rendering
+ * - [CHIP_UI] inline chip
+ * - [TILE_UI] gallery/grid tile
+ *
+ * Render any variant with `<cf-render variant="chip|tile|full" .cell=... />`.
+ * A piece that omits [CHIP_UI]/[TILE_UI] still renders at those variants via
+ * the platform defaults (cf-cell-link for chip, the full [UI] scaled for tile).
+ */
+export default pattern<{ title: string | Default<"UI Variants Demo"> }>(
+  ({ title }) => ({
+    [NAME]: title,
+    [UI]: (
+      <div style={{ padding: "16px", border: "1px solid #e5e7eb" }}>
+        <h1 style={{ margin: "0 0 8px" }}>{title}</h1>
+        <p style={{ margin: "0", color: "#6b7280" }}>
+          Full standalone [UI] — the universal floor.
+        </p>
+      </div>
+    ),
+    [CHIP_UI]: (
+      <span
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "4px",
+          padding: "2px 8px",
+          borderRadius: "999px",
+          background: "#eef2ff",
+          color: "#4338ca",
+          fontSize: "13px",
+        }}
+      >
+        🔖 {title}
+      </span>
+    ),
+    [TILE_UI]: (
+      <div
+        style={{
+          padding: "12px",
+          borderRadius: "8px",
+          border: "1px solid #e5e7eb",
+          background: "#fafafa",
+        }}
+      >
+        <strong>{title}</strong>
+        <div style={{ fontSize: "12px", color: "#6b7280" }}>tile variant</div>
+      </div>
+    ),
+    title,
+  }),
+);

--- a/packages/patterns/examples/ui-variants-host.tsx
+++ b/packages/patterns/examples/ui-variants-host.tsx
@@ -1,0 +1,74 @@
+import { NAME, pattern, UI } from "commonfabric";
+import Demo from "./ui-variants-demo.tsx";
+import Counter from "../counter/counter.tsx";
+
+/**
+ * CT-1321 browser verification host. Renders one piece that exports all three
+ * variants (Demo) and one that exports only [UI] (Counter) through
+ * `<cf-render variant=…>`, so we can eyeball the exported variants AND the
+ * platform-default failover (chip → cf-cell-link, tile → full [UI] scaled).
+ */
+const box = {
+  border: "1px dashed #c7d2fe",
+  borderRadius: "8px",
+  padding: "8px",
+};
+
+export default pattern(() => {
+  const demo = Demo({ title: "Demo Piece" });
+  const plain = Counter({});
+
+  return {
+    [NAME]: "UI Variants Host",
+    [UI]: (
+      <div
+        style={{
+          padding: "16px",
+          display: "flex",
+          flexDirection: "column",
+          gap: "24px",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <section>
+          <h3>Piece exports all three variants</h3>
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "12px" }}
+          >
+            <div style={box}>
+              <em>chip:</em> <cf-render variant="chip" $cell={demo} />
+            </div>
+            <div style={box}>
+              <em>tile:</em>
+              <div style={{ width: "220px", height: "120px" }}>
+                <cf-render variant="tile" $cell={demo} />
+              </div>
+            </div>
+            <div style={box}>
+              <em>full:</em>
+              <cf-render variant="full" $cell={demo} />
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h3>Piece exports only [UI] → platform defaults</h3>
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "12px" }}
+          >
+            <div style={box}>
+              <em>chip default (cf-cell-link):</em>{" "}
+              <cf-render variant="chip" $cell={plain} />
+            </div>
+            <div style={box}>
+              <em>tile default (full [UI] scaled):</em>
+              <div style={{ width: "220px", height: "120px" }}>
+                <cf-render variant="tile" $cell={plain} />
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    ),
+  };
+});

--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -52,7 +52,7 @@ export interface NoteOutput extends NotePiece {
   createNewNote: Stream<void>;
   /** Parent notebook reference, null if not in a notebook */
   parentNotebook: NotebookPiece | null;
-  /** Minimal UI for embedding in containers like Record. Use via cf-render variant="embedded". */
+  /** Minimal UI for embedding in containers like Record (read directly as `.embeddedUI`). */
   embeddedUI: VNode;
   // Test-accessible state
   menuOpen: boolean;

--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -152,7 +152,7 @@ const initializeRecord = lift<{
   recordPatternJson,
 }) => {
   if ((currentPieces || []).length === 0) {
-    // Create Note as default module (rendered via cf-render variant="embedded")
+    // Create Note as default module (rendered via its `.embeddedUI` export)
     // Pass recordPatternJson so [[wiki-links]] create Record pieces instead of Note pieces
     const notesPiece = Note({ linkPattern: recordPatternJson });
 
@@ -276,7 +276,7 @@ const addSubPiece = handler<
   const nextLabel = getNextUnusedLabel(type, current);
   const initialValues = nextLabel ? { label: nextLabel } : undefined;
 
-  // Special case: create Note (rendered via cf-render variant="embedded")
+  // Special case: create Note (rendered via its `.embeddedUI` export)
   // Pass recordPatternJson so [[wiki-links]] create Record pieces instead of Note pieces
   // Special case: create ExtractorModule as controller with parent Cells and title
   const piece = type === "notes"

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -13,12 +13,14 @@ import {
   AsStream,
   AsWriteonlyCell,
   AuthSchema,
+  CHIP_UI,
   FS,
   ID,
   ID_FIELD,
   NAME,
   schema as schemaIdentity,
   SELF,
+  TILE_UI,
   TYPE,
   UI,
   WebhookConfigSchema,
@@ -238,6 +240,8 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
     TYPE,
     NAME,
     UI,
+    TILE_UI,
+    CHIP_UI,
     FS,
 
     // Schema utilities

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -80,6 +80,11 @@ export const ID_FIELD: typeof IDFieldSymbol = Symbol(
 export const TYPE = "$TYPE";
 export const NAME = "$NAME";
 export const UI = "$UI";
+// UI variants (CT-1321): optional sibling renderings addressed alongside [UI].
+// chip = inline, tile = gallery/grid card; absent variants fail over to a
+// per-variant default (see uiVariant()), with [UI] as the universal floor.
+export const TILE_UI = "$TILE_UI";
+export const CHIP_UI = "$CHIP_UI";
 export const FS = "$FS";
 
 // Symbol for accessing self-reference in patterns
@@ -358,6 +363,8 @@ export interface BuilderFunctionsAndConstants {
   TYPE: typeof TYPE;
   NAME: typeof NAME;
   UI: typeof UI;
+  TILE_UI: typeof TILE_UI;
+  CHIP_UI: typeof CHIP_UI;
   FS: typeof FS;
 
   // Schema utilities

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -101,6 +101,7 @@ export {
 export {
   AuthSchema,
   type Cell as BuilderCell,
+  CHIP_UI,
   type Frame,
   FS,
   type FsProjection,
@@ -130,6 +131,7 @@ export {
   schema,
   type SchemaWithoutCell,
   type StreamValue,
+  TILE_UI,
   type toJSON,
   TYPE,
   UI,

--- a/packages/runner/src/shared.ts
+++ b/packages/runner/src/shared.ts
@@ -12,11 +12,13 @@ export {
 } from "./link-types.ts";
 export { LINK_V1_TAG, type SigilLink, type URI } from "./sigil-types.ts";
 export {
+  CHIP_UI,
   ID,
   type JSONSchema,
   type JSONValue,
   NAME,
   type Schema,
+  TILE_UI,
   TYPE,
   UI,
 } from "./builder/types.ts";

--- a/packages/ui/src/v2/components/cf-picker/cf-picker.ts
+++ b/packages/ui/src/v2/components/cf-picker/cf-picker.ts
@@ -332,7 +332,7 @@ export class CFPicker extends BaseElement {
               >
                 <cf-render
                   .cell="${this._getItemAt(currentIndex)}"
-                  variant="preview"
+                  variant="tile"
                 ></cf-render>
               </div>
               ${hasMultipleItems

--- a/packages/ui/src/v2/components/cf-render/cf-render.test.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createMockCellHandle } from "../../test-utils/mock-cell-handle.ts";
 import type { CellHandle } from "@commonfabric/runtime-client";
-import { CFRender } from "./cf-render.ts";
+import { CFRender, hasVariantValue, normalizeVariant } from "./cf-render.ts";
 
 // NOTE: Full rendering lifecycle tests (cell swap cleanup, subscription
 // management, render-into-container) require a real DOM with document.body
@@ -64,6 +64,39 @@ describe("CFRender variant handling", () => {
       element.variant = variant;
       expect(element.variant).toBe(variant);
     }
+  });
+});
+
+describe("normalizeVariant", () => {
+  it("passes through the known spectrum", () => {
+    expect(normalizeVariant("full")).toBe("full");
+    expect(normalizeVariant("chip")).toBe("chip");
+    expect(normalizeVariant("tile")).toBe("tile");
+  });
+
+  it("falls back to full for undefined and unknown/legacy values", () => {
+    expect(normalizeVariant(undefined)).toBe("full");
+    expect(normalizeVariant("")).toBe("full");
+    expect(normalizeVariant("default")).toBe("full");
+    expect(normalizeVariant("preview")).toBe("full");
+    expect(normalizeVariant("embedded")).toBe("full");
+  });
+});
+
+describe("hasVariantValue", () => {
+  it("is true only when the key holds a renderable value", () => {
+    expect(hasVariantValue({ "$CHIP_UI": { type: "vnode" } }, "$CHIP_UI"))
+      .toBe(true);
+    expect(hasVariantValue({ "$UI": {} }, "$TILE_UI")).toBe(false);
+    expect(hasVariantValue({ "$TILE_UI": undefined }, "$TILE_UI")).toBe(false);
+    expect(hasVariantValue({ "$TILE_UI": null }, "$TILE_UI")).toBe(false);
+  });
+
+  it("is false for non-object / empty values (failover to default)", () => {
+    expect(hasVariantValue(undefined, "$CHIP_UI")).toBe(false);
+    expect(hasVariantValue(null, "$CHIP_UI")).toBe(false);
+    expect(hasVariantValue("nope", "$CHIP_UI")).toBe(false);
+    expect(hasVariantValue({}, "$CHIP_UI")).toBe(false);
   });
 });
 

--- a/packages/ui/src/v2/components/cf-render/cf-render.test.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.test.ts
@@ -46,27 +46,19 @@ describe("CFRender", () => {
 describe("CFRender variant handling", () => {
   it("should accept variant property", () => {
     const element = new CFRender();
-    element.variant = "preview";
-    expect(element.variant).toBe("preview");
+    element.variant = "chip";
+    expect(element.variant).toBe("chip");
   });
 
-  it("should accept embedded variant", () => {
+  it("should accept tile variant", () => {
     const element = new CFRender();
-    element.variant = "embedded";
-    expect(element.variant).toBe("embedded");
+    element.variant = "tile";
+    expect(element.variant).toBe("tile");
   });
 
   it("should accept all valid variants", () => {
     const element = new CFRender();
-    const variants = [
-      "default",
-      "preview",
-      "thumbnail",
-      "sidebar",
-      "fab",
-      "embedded",
-      "settings",
-    ] as const;
+    const variants = ["full", "chip", "tile"] as const;
 
     for (const variant of variants) {
       element.variant = variant;
@@ -80,7 +72,7 @@ describe("CFRender disconnectedCallback", () => {
     const element = new CFRender();
     const cell = createMockCellHandle({ name: "test" });
     element.cell = cell as CellHandle;
-    element.variant = "preview";
+    element.variant = "chip";
 
     // disconnectedCallback should clean up internal state without throwing
     element.disconnectedCallback();
@@ -90,7 +82,7 @@ describe("CFRender disconnectedCallback", () => {
     // The internal _renderingCellId and _hasRendered are reset though.
     // We verify it doesn't throw and the element is still usable.
     expect(element.cell).toBe(cell);
-    expect(element.variant).toBe("preview");
+    expect(element.variant).toBe("chip");
   });
 
   it("should handle disconnect when no cell was set", () => {

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -4,54 +4,27 @@ import { state } from "lit/decorators.js";
 import { BaseElement } from "../../core/base-element.ts";
 import { render } from "@commonfabric/html/client";
 import type { CellHandle } from "@commonfabric/runtime-client";
-import { type VNode } from "@commonfabric/runtime-client";
+import { CHIP_UI, TILE_UI, type VNode } from "@commonfabric/runtime-client";
 import "../cf-loader/cf-loader.ts";
+import "../cf-cell-link/cf-cell-link.ts";
 
 // Set to true to enable debug logging
 const DEBUG_LOGGING = false;
 
 /**
- * UI variant types for rendering different representations of a piece.
- * Each variant maps to a property name that patterns can export.
+ * UI variants (CT-1321): the size/representation spectrum a piece can expose.
+ * Each variant is an optional sibling key on the piece output, addressed by a
+ * vended symbol; absent variants fail over to a per-variant platform default,
+ * with the full [UI] as the universal floor. Patterns that export only [UI]
+ * still render correctly at every variant.
  *
- * - `default`: The main [UI] export. Full standalone rendering.
- * - `preview`: Compact preview for pickers/lists (e.g., cf-picker). Maps to `previewUI`.
- * - `thumbnail`: Icon/thumbnail view for grid displays. Maps to `thumbnailUI`.
- * - `sidebar`: Optimized layout for sidebar/navigation contexts. Maps to `sidebarUI`.
- * - `fab`: Floating action button UI. Maps to `fabUI`.
- * - `embedded`: Minimal UI without chrome for embedding in containers. Maps to `embeddedUI`.
- *              Used when a pattern is rendered as a module inside another pattern (e.g., Note in Record).
+ * - `full`   — the main [UI] export; standalone rendering (default).
+ * - `chip`   — inline-block in text/lists. Key: [CHIP_UI].
+ *              Default: a `cf-cell-link` bound to the piece (renders by [NAME]).
+ * - `tile`   — gallery/grid card. Key: [TILE_UI].
+ *              Default: the full [UI] rendered small at ~0.5 scale.
  */
-export type UIVariant =
-  | "default"
-  | "preview"
-  | "thumbnail"
-  | "sidebar"
-  | "fab"
-  | "embedded"
-  | "settings";
-
-/**
- * Maps variant names to the property key to look for on the piece.
- * null means use the default [UI] rendering via render().
- */
-const _VARIANT_TO_KEY: Record<UIVariant, VariantCellKey | null> = {
-  default: null,
-  preview: "previewUI",
-  thumbnail: "thumbnailUI",
-  sidebar: "sidebarUI",
-  fab: "fabUI",
-  embedded: "embeddedUI",
-  settings: "settingsUI",
-};
-
-type VariantCellKey =
-  | "previewUI"
-  | "thumbnailUI"
-  | "sidebarUI"
-  | "fabUI"
-  | "embeddedUI"
-  | "settingsUI";
+export type UIVariant = "full" | "chip" | "tile";
 
 /**
  * CFRender - Renders a cell that contains a piece pattern with UI
@@ -59,21 +32,22 @@ type VariantCellKey =
  * @element cf-render
  *
  * @property {CellHandle} cell - The cell containing the piece to render
- * @property {UIVariant} variant - UI variant to render: "default" | "preview" | "thumbnail" | "sidebar" | "fab" | "settings" | "embedded"
- *   Each variant maps to a property on the piece (e.g., "preview" -> "previewUI", "embedded" -> "embeddedUI").
- *   Falls back to default [UI] if the variant property doesn't exist.
+ * @property {UIVariant} variant - UI variant to render: "full" | "chip" | "tile"
+ *   (default "full"). Renders the piece's matching variant key ([CHIP_UI] /
+ *   [TILE_UI]) when exported, otherwise the per-variant platform default. The
+ *   full [UI] is the universal floor, so every piece renders at every variant.
  *
  * @example
- * // Default rendering
+ * // Full standalone rendering (default)
  * <cf-render .cell=${myPieceCell}></cf-render>
  *
  * @example
- * // Render preview variant (uses previewUI if available, falls back to [UI])
- * <cf-render .cell=${myPieceCell} variant="preview"></cf-render>
+ * // Chip: inline, renders [CHIP_UI] or a cf-cell-link default
+ * <cf-render .cell=${myPieceCell} variant="chip"></cf-render>
  *
  * @example
- * // Render embedded variant (uses embeddedUI - minimal UI without chrome)
- * <cf-render .cell=${notePiece} variant="embedded"></cf-render>
+ * // Tile: gallery card, renders [TILE_UI] or the full [UI] at ~0.5 scale
+ * <cf-render .cell=${myPieceCell} variant="tile"></cf-render>
  */
 export class CFRender extends BaseElement {
   static override styles = css`
@@ -90,6 +64,16 @@ export class CFRender extends BaseElement {
       width: 100%;
       height: 100%;
       overflow: auto;
+    }
+
+    /* Tile default: the full [UI] laid out at 2x then scaled to 0.5 so it
+      fills the tile box while showing a compact, glanceable rendering. */
+    .tile-default {
+      width: 200%;
+      height: 200%;
+      transform: scale(0.5);
+      transform-origin: top left;
+      pointer-events: none;
     }
 
     .loading-spinner {
@@ -212,18 +196,43 @@ export class CFRender extends BaseElement {
         return;
       }
 
-      // only await when using variants
-      if (this.variant && this.variant !== "default") {
-        await this._startPromise;
-        await this.cell.sync();
+      // Normalize to the size spectrum; anything unknown renders full.
+      const kind: UIVariant = this.variant === "chip"
+        ? "chip"
+        : this.variant === "tile"
+        ? "tile"
+        : "full";
+
+      // Full is the universal floor: render the piece's [UI] chain directly.
+      if (kind === "full") {
+        this._log("rendering full [UI] into container");
+        this._cleanup = render(container, this.cell as CellHandle<VNode>);
+        this._hasRendered = true;
+        return;
       }
 
-      // @TODO(runtime-worker-refactor): We must type all renderable cells
-      // as potentially having these variant keys?
-      const variantKey = undefined; //VARIANT_TO_KEY[this.variant ?? "default"];
-      const renderCell = variantKey ? this.cell.key(variantKey) : this.cell;
-      this._log("rendering UI into container");
-      this._cleanup = render(container, renderCell as CellHandle<VNode>);
+      // chip/tile: the variant key may materialize asynchronously
+      // (cross-space), so sync before probing for it.
+      await this._startPromise;
+      await this.cell.sync();
+      if (this._renderingCellId !== cellId) return;
+
+      const variantKey = kind === "chip" ? CHIP_UI : TILE_UI;
+      if (this._cellHasKey(variantKey)) {
+        this._log(`rendering exported ${variantKey}`);
+        this._cleanup = render(
+          container,
+          (this.cell as CellHandle<Record<string, VNode>>)
+            .key(variantKey) as CellHandle<VNode>,
+        );
+        this._hasRendered = true;
+        return;
+      }
+
+      // Failover to the per-variant platform default.
+      this._cleanup = kind === "chip"
+        ? this._renderChipDefault(container)
+        : this._renderTileDefault(container);
       this._hasRendered = true;
     } catch (error) {
       // Only show error if we're still rendering this cell
@@ -231,6 +240,39 @@ export class CFRender extends BaseElement {
         this._handleRenderError(error);
       }
     }
+  }
+
+  /** True when the piece output exports a value at `key` (e.g. a variant UI). */
+  private _cellHasKey(key: string): boolean {
+    try {
+      const value = (this.cell as unknown as { get?: () => unknown }).get?.();
+      return !!(value && typeof value === "object" &&
+        (value as Record<string, unknown>)[key]);
+    } catch {
+      return false;
+    }
+  }
+
+  /** Chip default: a cf-cell-link bound to the piece (renders by [NAME]). */
+  private _renderChipDefault(container: HTMLElement): () => void {
+    const link = globalThis.document.createElement(
+      "cf-cell-link",
+    ) as HTMLElement & { cell?: CellHandle };
+    link.cell = this.cell;
+    container.appendChild(link);
+    return () => link.remove();
+  }
+
+  /** Tile default: the full [UI] rendered small at ~0.5 scale. */
+  private _renderTileDefault(container: HTMLElement): () => void {
+    const scaler = globalThis.document.createElement("div");
+    scaler.className = "tile-default";
+    container.appendChild(scaler);
+    const inner = render(scaler, this.cell as CellHandle<VNode>);
+    return () => {
+      inner?.();
+      scaler.remove();
+    };
   }
 
   private _cleanupRender() {

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -33,6 +33,24 @@ const DEBUG_LOGGING = false;
 export type UIVariant = "full" | "chip" | "tile";
 
 /**
+ * Normalize the `variant` attribute to the size spectrum. Anything unrecognized
+ * (undefined, legacy values) resolves to "full", the universal floor.
+ */
+export function normalizeVariant(variant: string | undefined): UIVariant {
+  return variant === "chip" ? "chip" : variant === "tile" ? "tile" : "full";
+}
+
+/**
+ * True when a piece output value carries a renderable variant at `key` (e.g.
+ * `"$CHIP_UI"`). Used to decide whether to render the exported variant or fall
+ * over to the platform default.
+ */
+export function hasVariantValue(value: unknown, key: string): boolean {
+  return !!(value && typeof value === "object" &&
+    (value as Record<string, unknown>)[key]);
+}
+
+/**
  * CFRender - Renders a cell that contains a piece pattern with UI
  *
  * @element cf-render
@@ -213,11 +231,7 @@ export class CFRender extends BaseElement {
       }
 
       // Normalize to the size spectrum; anything unknown renders full.
-      const kind: UIVariant = this.variant === "chip"
-        ? "chip"
-        : this.variant === "tile"
-        ? "tile"
-        : "full";
+      const kind = normalizeVariant(this.variant);
 
       // Full is the universal floor: render the piece's [UI] chain directly.
       if (kind === "full") {
@@ -261,9 +275,7 @@ export class CFRender extends BaseElement {
   /** True when the piece output exports a value at `key` (e.g. a variant UI). */
   private _cellHasKey(key: string): boolean {
     try {
-      const value = (this.cell as unknown as { get?: () => unknown }).get?.();
-      return !!(value && typeof value === "object" &&
-        (value as Record<string, unknown>)[key]);
+      return hasVariantValue(this.cell.get(), key);
     } catch {
       return false;
     }

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -5,6 +5,12 @@ import { BaseElement } from "../../core/base-element.ts";
 import { render } from "@commonfabric/html/client";
 import type { CellHandle } from "@commonfabric/runtime-client";
 import { CHIP_UI, TILE_UI, type VNode } from "@commonfabric/runtime-client";
+import {
+  appViewToUrlPath,
+  navigate,
+  preserveAppViewMode,
+  urlToAppView,
+} from "@commonfabric/shell/shared";
 import "../cf-loader/cf-loader.ts";
 import "../cf-cell-link/cf-cell-link.ts";
 
@@ -66,13 +72,23 @@ export class CFRender extends BaseElement {
       overflow: auto;
     }
 
-    /* Tile default: the full [UI] laid out at 2x then scaled to 0.5 so it
-      fills the tile box while showing a compact, glanceable rendering. */
+    /* Tile default: a fixed, clickable preview that navigates to the piece.
+      The clip box pins the viewport (no panning/scrolling); the inner box is
+      laid out at 2x then scaled to 0.5 so the full [UI] fills the tile. */
+    .tile-clip {
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      cursor: pointer;
+    }
+
     .tile-default {
       width: 200%;
       height: 200%;
       transform: scale(0.5);
       transform-origin: top left;
+      /* Clicks fall through to .tile-clip so the whole tile navigates,
+        rather than activating controls inside the embedded UI. */
       pointer-events: none;
     }
 
@@ -263,16 +279,51 @@ export class CFRender extends BaseElement {
     return () => link.remove();
   }
 
-  /** Tile default: the full [UI] rendered small at ~0.5 scale. */
+  /**
+   * Tile default: the full [UI] rendered small at ~0.5 scale, clipped to a
+   * fixed preview (no panning) and clickable to navigate to the piece —
+   * mirroring cf-cell-link's navigation.
+   */
   private _renderTileDefault(container: HTMLElement): () => void {
+    const clip = globalThis.document.createElement("div");
+    clip.className = "tile-clip";
     const scaler = globalThis.document.createElement("div");
     scaler.className = "tile-default";
-    container.appendChild(scaler);
+    clip.appendChild(scaler);
+    container.appendChild(clip);
     const inner = render(scaler, this.cell as CellHandle<VNode>);
+    const onClick = (e: MouseEvent) => this._navigateToPiece(e);
+    clip.addEventListener("click", onClick);
     return () => {
+      clip.removeEventListener("click", onClick);
       inner?.();
-      scaler.remove();
+      clip.remove();
     };
+  }
+
+  /** Navigate to the rendered piece (same behavior as cf-cell-link). */
+  private _navigateToPiece(e: MouseEvent) {
+    e.stopPropagation();
+    try {
+      const view = {
+        spaceDid: this.cell.space(),
+        pieceId: this.cell.id(),
+      };
+      // Cmd (Mac) / Ctrl (Win/Linux) opens in a new tab.
+      if (e.metaKey || e.ctrlKey) {
+        const url = appViewToUrlPath(
+          preserveAppViewMode(
+            urlToAppView(new URL(globalThis.location.href)),
+            view,
+          ),
+        );
+        globalThis.open(url, "_blank");
+      } else {
+        navigate(view);
+      }
+    } catch (error) {
+      console.error("[cf-render] tile navigation failed:", error);
+    }
   }
 
   private _cleanupRender() {


### PR DESCRIPTION
## What

Formalizes the UI-variant system (CT-1321). A piece can expose a **size spectrum** of renderings as optional sibling output keys, addressed by symbols vended from `commonfabric`, replacing the vestigial half-built mechanism in `cf-render`.

| variant | symbol | use | default if unset |
| --- | --- | --- | --- |
| `full` | `UI` (`$UI`) | standalone (today's default) | the `[UI]` itself — universal floor |
| `chip` | `CHIP_UI` (`$CHIP_UI`) | inline in text/lists | `cf-cell-link` (renders by `[NAME]`) |
| `tile` | `TILE_UI` (`$TILE_UI`) | gallery/grid card | the full `[UI]` at `scale(0.5)` |

**Failover = per-variant default, full as the floor.** A piece exporting only `[UI]` still renders at every variant.

## Changes

- Vend `TILE_UI`/`CHIP_UI` alongside `UI` (builder/api/factory/jsx). Transparent passthrough — no transformer or schema-generator changes.
- Rebuild `cf-render` with real `variant="full|chip|tile"` resolution + defaults; delete the dead `UIVariant` enum / `_VARIANT_TO_KEY`.
- Sync the stale `cf-render` `variant` JSX typing; migrate `cf-picker` `preview` → `tile`.
- Catalog story (**Render (UI Variants)**), example patterns (`ui-variants-demo`, `ui-variants-host`), and COMPONENTS.md docs.

## Verification

- `deno check` + `deno lint` + `deno fmt --check` clean across the changeset; `cf-render` unit tests pass; demo pattern compiles with the right `$UI`/`$CHIP_UI`/`$TILE_UI` schema.
- **Browser E2E** (deployed host piece, 0 console errors): exported chip/tile/full **and** the chip/tile failover defaults all render correctly.

## Out of scope / follow-up

- `sidebarUI`/`fabUI`/`settingsUI` are shell composition **slots**, a separate concept — untouched.
- **Phase B:** a vended `uiVariant()` helper for render paths outside `cf-render`. Investigation pinned it must be a runner **builtin** (the defaults need `h`/`getAsLink` cross-boundary cell-binding, which lives above the builder layer). Tracked for a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `full`, `chip`, and `tile` variants to `cf-render` with per-variant failover defaults to meet CT-1321. Tile default shows a clipped 0.5x preview and navigates to the piece on click; adds tests for variant normalization/failover and cleans up stale "embedded" comments.

- **New Features**
  - Vend `TILE_UI` and `CHIP_UI` alongside `UI` across `@commonfabric` builder/API/JSX.
  - `cf-render` resolves `variant="full|chip|tile"`: renders exported `CHIP_UI`/`TILE_UI` when present; defaults to `cf-cell-link` for `chip` and a scaled `[UI]` for `tile` (clipped preview; click navigates, cmd/ctrl-click opens a new tab).
  - Updated JSX typing for `variant`; added catalog story, examples (`ui-variants-demo`, `ui-variants-host`), and docs.

- **Migration**
  - Use `variant="full" | "chip" | "tile"` on `cf-render` (default `full`).
  - `cf-picker` now uses `variant="tile"` (was `preview`).
  - No schema changes; pieces exporting only `UI` still render via failover.

<sup>Written for commit 51ce3523722e8ce332875d2797698f606fe6f2b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

