### PR TITLE
fix(patterns): note appendLink reads entityId via the cell-rep chokepoint

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2683,6 +2683,16 @@ export type GetEntityIdFunction = (
 ) => { "/": string } | FabricHash | undefined;
 export declare const getEntityId: GetEntityIdFunction;
 
+/**
+ * Convert an entity-id reference — as produced by {@link getEntityId} or a
+ * cell's `entityId` — to its tagged-hash string, in whichever form the active
+ * cell representation uses (a `{ "/": "id-string" }` object or a `FabricHash`).
+ */
+export type EntityRefToStringFunction = (
+  value: { "/": string } | FabricHash,
+) => string;
+export declare const entityRefToString: EntityRefToStringFunction;
+
 export declare const schema: SchemaFunction;
 export declare const toSchema: ToSchemaFunction;
 export declare const __cf_data: CfDataFunction;

--- a/packages/patterns/integration/note-append-link.test.ts
+++ b/packages/patterns/integration/note-append-link.test.ts
@@ -1,3 +1,16 @@
+/**
+ * Verifies that a piece id seen from *inside* a pattern corresponds to the same
+ * piece id seen from *outside* it.
+ *
+ * The note pattern's `appendLink` builds a `[[name (id)]]` wiki-link whose id is
+ * derived internally — `entityRefToString` over a cell's `entityId`. This test
+ * invokes `appendLink` from outside the pattern and asserts the embedded id is
+ * exactly `target.id`, the same piece's id as reported by `create` (the
+ * runtime's external-facing identity). It thus guards against the in-pattern id
+ * being self-consistent yet disagreeing with the external view — a mismatch an
+ * in-pattern assertion can't catch, since it only has the same internal
+ * machinery to recompute the id with.
+ */
 import { env } from "@commonfabric/integration";
 import { PieceController, PiecesController } from "@commonfabric/piece/ops";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";

--- a/packages/patterns/integration/note-append-link.test.ts
+++ b/packages/patterns/integration/note-append-link.test.ts
@@ -1,0 +1,67 @@
+import { env } from "@commonfabric/integration";
+import { PieceController, PiecesController } from "@commonfabric/piece/ops";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import { assert, assertStringIncludes } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+
+const { API_URL } = env;
+const SPACE_NAME = "note-append-link-" + Date.now().toString(36);
+
+describe("note appendLink integration", () => {
+  let identity: Identity;
+  let cc: PiecesController;
+  let host: PieceController;
+  let target: PieceController;
+  const cancels: Array<() => void> = [];
+
+  beforeAll(async () => {
+    identity = await Identity.generate({ implementation: "noble" });
+    cc = await PiecesController.initialize({
+      spaceName: SPACE_NAME,
+      apiUrl: new URL(API_URL),
+      identity,
+    });
+    const sourcePath = join(import.meta.dirname!, "..", "notes", "note.tsx");
+    const program = await cc.manager().runtime.harness.resolve(
+      new FileSystemProgramResolver(sourcePath),
+    );
+    host = await cc.create(program, {
+      input: { title: "Host Note", content: "" },
+      start: true,
+    });
+    target = await cc.create(program, {
+      input: { title: "Target Note", content: "" },
+      start: true,
+    });
+    // Keep both pieces reactive (pull mode) so handlers run on send.
+    cancels.push(cc.manager().getResult(host.getCell()).sink(() => {}));
+    cancels.push(cc.manager().getResult(target.getCell()).sink(() => {}));
+  });
+
+  afterAll(async () => {
+    for (const c of cancels) c();
+    if (cc) await cc.dispose();
+  });
+
+  it("appends a [[name (id)]] link carrying the target's real id", async () => {
+    // Invoke appendLink (a Stream) by setting its event on the result cell,
+    // passing the target piece's cell as the mentionable.
+    await host.result.set(
+      { piece: target.getCell() },
+      ["appendLink"],
+    );
+    await cc.manager().runtime.idle();
+    await cc.manager().synced();
+
+    const content = await host.result.get(["content"]) as string;
+    assert(typeof content === "string", "content is not a string");
+
+    // External oracle: the id embedded in the wiki-link must be the target's
+    // authoritative id (`target.id` from create) — confirming the pattern's
+    // entityRefToString output agrees with the runtime's id seen from *outside*
+    // the pattern, not just with itself.
+    assertStringIncludes(content, `[[📝 Target Note (${target.id})]]`);
+  });
+});

--- a/packages/patterns/notes/note.test.tsx
+++ b/packages/patterns/notes/note.test.tsx
@@ -59,6 +59,14 @@ export default pattern(() => {
     isHidden: false,
   });
 
+  // A piece to link to via appendLink.
+  const linkTarget = Note({
+    title: "Link Target",
+    content: "I am linkable",
+
+    isHidden: false,
+  });
+
   // ==========================================================================
   // Actions - Content Editing
   // ==========================================================================
@@ -119,6 +127,14 @@ export default pattern(() => {
 
   const action_create_from_parented = action(() => {
     noteWithParent.createNewNote.send();
+  });
+
+  // ==========================================================================
+  // Actions - Append wiki-link
+  // ==========================================================================
+
+  const action_append_link = action(() => {
+    note.appendLink.send({ piece: linkTarget });
   });
 
   // ==========================================================================
@@ -258,6 +274,20 @@ export default pattern(() => {
   );
 
   // ==========================================================================
+  // Assertions - Append wiki-link
+  // ==========================================================================
+
+  // appendLink appends `[[<NAME> (<entityId>)]]` to the content, with the
+  // target's entityId stringified via the cell-rep chokepoint, and pushes the
+  // target onto `mentioned`.
+  const assert_link_appended = computed(() =>
+    /\[\[📝 Link Target \([^)]+\)\]\]/.test(note.content)
+  );
+  const assert_mentioned_after_link = computed(
+    () => note.mentioned.length === 1,
+  );
+
+  // ==========================================================================
   // Test Sequence
   // ==========================================================================
   return {
@@ -321,10 +351,16 @@ export default pattern(() => {
       { assertion: assert_note_unchanged_after_create },
       { action: action_create_from_parented },
       { assertion: assert_parented_note_unchanged },
+
+      // === Append wiki-link ===
+      { action: action_append_link },
+      { assertion: assert_link_appended },
+      { assertion: assert_mentioned_after_link },
     ],
     note,
     noteWithParent,
     noteInNotebookB,
     noteNoParent,
+    linkTarget,
   };
 });

--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -2,6 +2,7 @@ import {
   action,
   computed,
   type Default,
+  entityRefToString,
   equals,
   FS,
   type FsProjection,
@@ -293,7 +294,8 @@ const Note = pattern<NoteInput, NoteOutput>(
       ({ piece }: { piece: Writable<MentionablePiece> }) => {
         const name = piece.get()[NAME] ?? "";
         const resolved = (piece as any).resolveAsCell();
-        const entityId = resolved?.entityId?.["/"];
+        const ref = resolved?.entityId;
+        const entityId = ref ? entityRefToString(ref) : undefined;
         if (!name || !entityId) return;
 
         const link = `[[${name} (${entityId})]]`;

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -60,6 +60,7 @@ import {
 } from "@commonfabric/memory/sqlite/row-label";
 import { cellConstructorFactory } from "../cell.ts";
 import { getEntityId } from "../create-ref.ts";
+import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import { getPatternEnvironment } from "./env.ts";
 import type { RuntimeProgram } from "../harness/types.ts";
 import { isTrustedPattern, setPatternProgram } from "./pattern-metadata.ts";
@@ -230,6 +231,7 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
 
     // Entity utilities
     getEntityId,
+    entityRefToString,
 
     // Constants
     ID,

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -18,6 +18,7 @@ import type {
   CfSqliteHelpers,
   CompileAndRunFunction,
   ComputedFunction,
+  EntityRefToStringFunction,
   EqualsFunction,
   FetchDataFunction,
   FetchProgramFunction,
@@ -350,6 +351,7 @@ export interface BuilderFunctionsAndConstants {
 
   // Entity utilities
   getEntityId: GetEntityIdFunction;
+  entityRefToString: EntityRefToStringFunction;
 
   // Constants
   ID: typeof ID;


### PR DESCRIPTION
The last `{ "/": … }` residual — and the only one in the pattern (end-user
program) layer.

The note pattern's `appendLink` built its `[[name (id)]]` wiki-link from
`resolved.entityId["/"]`. That only works with the modern cell representation
**off** — with it **on**, a cell's `entityId` is a `FabricHash` (no `["/"]`), so
the id resolved to `undefined` and the link was **silently dropped** (the
`if (!name || !entityId) return` guard). `notes/note.tsx` is the baseline note
piece, so this would bite real users on the flag flip.

### Fix
Expose `entityRefToString` to the pattern global environment, mirroring
`getEntityId`:
- declared in `@commonfabric/api` (`EntityRefToStringFunction` + `entityRefToString`),
- listed in `BuilderFunctionsAndConstants` (`builder/types.ts`),
- wired in the builder factory from `@commonfabric/data-model/cell-rep`.

Then `note.tsx` extracts the id string through it — regime-correct in both
representations (the `{ "/": string }` object's string, or the `FabricHash`'s
tagged-hash string).

### Verification
- `cf check packages/patterns/notes/note.tsx` — typechecks against the new api surface.
- `cf test note.test.tsx` — 29 passed; confirms the pattern loads and
  `entityRefToString` resolves at pattern runtime (not just at type level).
- Full workspace `deno task test` — green (api + runner changes).
- Added `appendLink` coverage to `note.test.tsx` (31 passed): in-pattern smoke
  test that the content gains a `[[name (<id>)]]` link and the target lands on
  `mentioned`.
- Added a **headless integration test** (`integration/note-append-link.test.ts`):
  creates a host + target note via `PiecesController`, invokes `appendLink`, and
  asserts the embedded id is exactly `target.id` — the target's authoritative id
  seen from **outside** the pattern. This is the real external oracle: an
  in-pattern recomputation of the id can't serve as one (it resolves differently
  than the handler's runtime piece). Verified locally against a toolshed.

Note: the in-pattern test runs the harness's default (legacy) regime, so it is
creation-path coverage, **not** a modern-cell-rep regression guard — the original
bug only manifests with the modern flag on. The integration test validates the
id is correct (legacy-ref) end to end against the runtime's external view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Coverage Baseline

We accept the modest increase in uncovered lines. In fact, this PR adds an integration test which covers the functionality modified by the main-code portion of the PR.

NEW_COVERAGE_BASELINE
