### PR TITLE
feat(ui): adopt UI variants across product surfaces; remove old-way rendering (CT-1764)

### DIFF
--- a/packages/patterns/activity-log/activity-log.tsx
+++ b/packages/patterns/activity-log/activity-log.tsx
@@ -178,7 +178,7 @@ export default pattern<ActivityLogInput, ActivityLogOutput>(
                         )
                         : null}
                       {event.pieceRef
-                        ? <cf-cell-link $cell={event.pieceRef} />
+                        ? <cf-render variant="chip" $cell={event.pieceRef} />
                         : null}
                     </cf-hstack>
                     {event.note

--- a/packages/patterns/notes/note-md.tsx
+++ b/packages/patterns/notes/note-md.tsx
@@ -7,6 +7,7 @@ import {
   navigateTo,
   pattern,
   type Stream,
+  TILE_UI,
   UI,
   type VNode,
   wish,
@@ -35,8 +36,8 @@ export interface NoteMdOutput {
   isHidden: true;
   /** Excluded from mentions autocomplete (notes in notebooks may be hidden but still mentionable) */
   isMentionable: false;
-  /** Minimal UI for embedding in other patterns */
-  embeddedUI: VNode;
+  /** Tile variant (CT-1764): minimal embedded UI for `<cf-render variant="tile">`. */
+  [TILE_UI]: VNode;
   /** Processed content with wiki-links converted to markdown links */
   processedContent: string;
   /** Stream to toggle checkboxes in content */
@@ -203,7 +204,7 @@ export default pattern<NoteMdInput, NoteMdOutput>(
       note,
       isHidden: true,
       isMentionable: false,
-      embeddedUI: markdownViewer,
+      [TILE_UI]: markdownViewer,
       processedContent,
       checkboxToggle: handleCheckboxToggle,
       hasBacklinks,

--- a/packages/patterns/notes/note.tsx
+++ b/packages/patterns/notes/note.tsx
@@ -14,6 +14,7 @@ import {
   type PatternToolResult,
   SELF,
   type Stream,
+  TILE_UI,
   toCompactDebugString,
   UI,
   type VNode,
@@ -52,8 +53,9 @@ export interface NoteOutput extends NotePiece {
   createNewNote: Stream<void>;
   /** Parent notebook reference, null if not in a notebook */
   parentNotebook: NotebookPiece | null;
-  /** Minimal UI for embedding in containers like Record (read directly as `.embeddedUI`). */
-  embeddedUI: VNode;
+  /** Tile variant (CT-1764): the minimal embedded UI used when a container
+   * (e.g. Record) renders this note via `<cf-render variant="tile">`. */
+  [TILE_UI]: VNode;
   // Test-accessible state
   menuOpen: boolean;
   isEditingTitle: boolean;
@@ -579,7 +581,7 @@ const Note = pattern<NoteInput, NoteOutput>(
       setTitle,
       appendLink,
       createNewNote,
-      embeddedUI: editorUI,
+      [TILE_UI]: editorUI,
       // Test-accessible state
       menuOpen,
       isEditingTitle,

--- a/packages/patterns/record.tsx
+++ b/packages/patterns/record.tsx
@@ -152,7 +152,7 @@ const initializeRecord = lift<{
   recordPatternJson,
 }) => {
   if ((currentPieces || []).length === 0) {
-    // Create Note as default module (rendered via its `.embeddedUI` export)
+    // Create Note as default module (rendered via cf-render variant="tile" → its [TILE_UI])
     // Pass recordPatternJson so [[wiki-links]] create Record pieces instead of Note pieces
     const notesPiece = Note({ linkPattern: recordPatternJson });
 
@@ -276,7 +276,7 @@ const addSubPiece = handler<
   const nextLabel = getNextUnusedLabel(type, current);
   const initialValues = nextLabel ? { label: nextLabel } : undefined;
 
-  // Special case: create Note (rendered via its `.embeddedUI` export)
+  // Special case: create Note (rendered via cf-render variant="tile" → its [TILE_UI])
   // Pass recordPatternJson so [[wiki-links]] create Record pieces instead of Note pieces
   // Special case: create ExtractorModule as controller with parent Cells and title
   const piece = type === "notes"
@@ -1388,12 +1388,10 @@ const Record = pattern<RecordInput, RecordOutput>(
                                 minHeight: isExpanded ? "0" : "auto",
                               }}
                             >
-                              {computed(() => {
-                                const piece = entry.piece as any;
-                                // Use embeddedUI if available, otherwise fall back to cf-render for default [UI]
-                                return piece?.embeddedUI ??
-                                  <cf-render $cell={entry.piece} />;
-                              })}
+                              <cf-render
+                                variant={isExpanded ? "full" : "tile"}
+                                $cell={entry.piece}
+                              />
                             </div>,
                             null,
                           )}
@@ -1682,12 +1680,10 @@ const Record = pattern<RecordInput, RecordOutput>(
                                   minHeight: isExpanded ? "0" : "auto",
                                 }}
                               >
-                                {computed(() => {
-                                  const piece = entry.piece as any;
-                                  // Use embeddedUI if available, otherwise fall back to cf-render for default [UI]
-                                  return piece?.embeddedUI ??
-                                    <cf-render $cell={entry.piece} />;
-                                })}
+                                <cf-render
+                                  variant={isExpanded ? "full" : "tile"}
+                                  $cell={entry.piece}
+                                />
                               </div>,
                               null,
                             )}
@@ -1969,12 +1965,10 @@ const Record = pattern<RecordInput, RecordOutput>(
                               minHeight: isExpanded ? "0" : "auto",
                             }}
                           >
-                            {computed(() => {
-                              const piece = entry.piece as any;
-                              // Use embeddedUI if available, otherwise fall back to cf-render for default [UI]
-                              return piece?.embeddedUI ??
-                                <cf-render $cell={entry.piece} />;
-                            })}
+                            <cf-render
+                              variant={isExpanded ? "full" : "tile"}
+                              $cell={entry.piece}
+                            />
                           </div>,
                           null,
                         )}

--- a/packages/patterns/system/backlinks-index.tsx
+++ b/packages/patterns/system/backlinks-index.tsx
@@ -137,7 +137,7 @@ const EntryRow = pattern<Entry, { [UI]: VNode }>(({ piece, backlinks }) => {
     [UI]: (
       <cf-card>
         <cf-vstack gap="1">
-          <cf-cell-link $cell={piece} />
+          <cf-render variant="chip" $cell={piece} />
           <cf-hstack gap="2" style={{ paddingLeft: "8px", flexWrap: "wrap" }}>
             {backlinks.map((link) => (
               <cf-cell-link

--- a/packages/patterns/system/default-app-ben.tsx
+++ b/packages/patterns/system/default-app-ben.tsx
@@ -468,7 +468,7 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
                           <tr>
                             <td>
                               <cf-cell-context $cell={piece}>
-                                <cf-cell-link $cell={piece} />
+                                <cf-render variant="chip" $cell={piece} />
                               </cf-cell-context>
                             </td>
                           </tr>
@@ -498,7 +498,7 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
                       const link = (
                         <cf-drag-source $cell={piece} type="note">
                           <cf-cell-context $cell={piece}>
-                            <cf-cell-link $cell={piece} />
+                            <cf-render variant="chip" $cell={piece} />
                           </cf-cell-context>
                         </cf-drag-source>
                       );

--- a/packages/patterns/system/default-app.tsx
+++ b/packages/patterns/system/default-app.tsx
@@ -285,7 +285,7 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
                         <tr>
                           <td>
                             <cf-cell-context $cell={piece}>
-                              <cf-cell-link $cell={piece} />
+                              <cf-render variant="chip" $cell={piece} />
                             </cf-cell-context>
                           </td>
                         </tr>
@@ -315,7 +315,7 @@ export default pattern<PiecesListInput, PiecesListOutput>((_) => {
                     const link = (
                       <cf-drag-source $cell={piece} type="note">
                         <cf-cell-context $cell={piece}>
-                          <cf-cell-link $cell={piece} />
+                          <cf-render variant="chip" $cell={piece} />
                         </cf-cell-context>
                       </cf-drag-source>
                     );

--- a/packages/patterns/system/piece-grid.tsx
+++ b/packages/patterns/system/piece-grid.tsx
@@ -33,28 +33,15 @@ export default pattern<Input>(({ pieces, [SELF]: self }) => {
               overflow: "hidden",
             }}
           >
-            <div
-              style={{
-                width: "100%",
-                height: "200px",
-                overflow: "hidden",
-                position: "relative",
-              }}
-            >
-              <div
-                style={{
-                  transform: "scale(0.4)",
-                  transformOrigin: "top left",
-                  width: "250%",
-                  height: "250%",
-                  pointerEvents: "none",
-                }}
-              >
-                <cf-render $cell={piece} />
-              </div>
+            {
+              /* Tile variant: cf-render owns the scaled, clipped,
+                click-to-navigate preview (no hand-rolled scaling). */
+            }
+            <div style={{ width: "100%", height: "200px" }}>
+              <cf-render variant="tile" $cell={piece} />
             </div>
             <div style={{ padding: "8px" }}>
-              <cf-cell-link $cell={piece} />
+              <cf-render variant="chip" $cell={piece} />
             </div>
           </div>
         ))}

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -535,33 +535,38 @@ export default pattern<ProfileHomeInput, ProfileHomeOutput>(
                   null,
                 )}
 
-                <cf-vstack gap="2">
+                {
+                  /* Pinned patterns render as tile variants (clickable,
+                    navigate to the piece); the user's title/tags annotate the
+                    footer. The old bespoke card + cf-cell-link "Open" is gone. */
+                }
+                <cf-grid columns="2" gap="3">
                   {elements.map((element) => (
                     <div
                       style={{
                         border:
                           "0.5px solid var(--cf-theme-color-border, #e5e5e7)",
                         borderRadius: "12px",
-                        padding: "12px 14px",
+                        overflow: "hidden",
                       }}
                     >
-                      <cf-hstack justify="between" align="center" gap="2">
-                        <cf-vstack gap="1">
-                          <strong>{element.title ?? element.tag}</strong>
-                          <div
-                            style={{
-                              color: "var(--cf-theme-color-text-secondary)",
-                              fontSize: "13px",
-                            }}
-                          >
-                            {element.userTags.map((tag) => `#${tag}`).join(" ")}
-                          </div>
-                        </cf-vstack>
-                        <cf-cell-link $cell={element.cell}>Open</cf-cell-link>
-                      </cf-hstack>
+                      <div style={{ width: "100%", height: "160px" }}>
+                        <cf-render variant="tile" $cell={element.cell} />
+                      </div>
+                      <div style={{ padding: "10px 14px" }}>
+                        <strong>{element.title ?? element.tag}</strong>
+                        <div
+                          style={{
+                            color: "var(--cf-theme-color-text-secondary)",
+                            fontSize: "13px",
+                          }}
+                        >
+                          {element.userTags.map((tag) => `#${tag}`).join(" ")}
+                        </div>
+                      </div>
                     </div>
                   ))}
-                </cf-vstack>
+                </cf-grid>
 
                 {
                   /* Only the owner gets the edit affordance; a visitor sees a

--- a/packages/patterns/system/profile-picker.tsx
+++ b/packages/patterns/system/profile-picker.tsx
@@ -95,7 +95,12 @@ export default pattern<
         {profiles.map((p) => (
           <cf-hstack gap="2" align="center">
             <div style={{ flex: "1" }}>
-              <cf-render variant="chip" $cell={p as any} />
+              {
+                /* Profiles are identities — rendered via cf-cell-link (the
+                  identity idiom is cf-profile-badge), not the generic piece
+                  chip variant. */
+              }
+              <cf-cell-link $cell={p as any} />
             </div>
             {ifElse(
               computed(() => {

--- a/packages/patterns/system/profile-picker.tsx
+++ b/packages/patterns/system/profile-picker.tsx
@@ -95,7 +95,7 @@ export default pattern<
         {profiles.map((p) => (
           <cf-hstack gap="2" align="center">
             <div style={{ flex: "1" }}>
-              <cf-cell-link $cell={p as any} />
+              <cf-render variant="chip" $cell={p as any} />
             </div>
             {ifElse(
               computed(() => {

--- a/packages/patterns/system/summary-index.tsx
+++ b/packages/patterns/system/summary-index.tsx
@@ -122,7 +122,7 @@ const SummaryIndex = pattern<Input, Output>(() => {
               {filtered.map((entry) => (
                 <tr>
                   <td style={{ fontWeight: "500", whiteSpace: "nowrap" }}>
-                    <cf-cell-link $cell={entry.piece} />
+                    <cf-render variant="chip" $cell={entry.piece} />
                   </td>
                   <td
                     style={{

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -398,6 +398,7 @@ export class CFRender extends BaseElement {
     this._log("disconnectedCallback called");
     super.disconnectedCallback();
     this._renderingCellId = undefined;
+    this._resolvedCell = undefined;
     this._hasRendered = false;
     this._cleanupRender();
   }

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -82,12 +82,28 @@ export class CFRender extends BaseElement {
       overflow: hidden;
     }
 
+    /* Chip is an inline, content-sized rendering for text/list/row contexts —
+      not a full-size block. */
+    :host([variant="chip"]) {
+      display: inline-block;
+      width: auto;
+      height: auto;
+      overflow: visible;
+    }
+
     .render-container {
       display: flex;
       flex-direction: column;
       width: 100%;
       height: 100%;
       overflow: auto;
+    }
+
+    :host([variant="chip"]) .render-container {
+      display: inline-block;
+      width: auto;
+      height: auto;
+      overflow: visible;
     }
 
     /* Tile default: a fixed, clickable preview that navigates to the piece.
@@ -128,7 +144,8 @@ export class CFRender extends BaseElement {
 
   static override properties = {
     cell: { attribute: false },
-    variant: { type: String },
+    // Reflected so the host can size itself per variant (chip is inline).
+    variant: { type: String, reflect: true },
   };
 
   declare cell: CellHandle;
@@ -158,8 +175,10 @@ export class CFRender extends BaseElement {
   protected override render() {
     // Note: cf-cell-context is now auto-injected by the renderer when
     // traversing [UI] with a CellHandle, so we don't need to wrap here
+    // Chip is inline and resolves to a lightweight default fast — a full-size
+    // spinner would reserve the wrong space, so skip it for chip.
     return html`
-      ${!this._hasRendered
+      ${!this._hasRendered && this.variant !== "chip"
         ? html`
           <div class="loading-spinner">
             <cf-loader size="lg"></cf-loader>

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -157,6 +157,9 @@ export class CFRender extends BaseElement {
   private _cleanup?: () => void;
   // Track the cell ID we're currently rendering to detect stale renders
   private _renderingCellId?: string;
+  // The root piece cell after resolving the (possibly link) `cell` — used for
+  // chip/tile rendering and navigation. Reset whenever `cell` changes.
+  private _resolvedCell?: CellHandle;
 
   @state()
   private accessor _hasRendered = false;
@@ -210,6 +213,7 @@ export class CFRender extends BaseElement {
         if (shouldRerender) {
           // Reset render state when cell changes - ensures we'll render the new cell
           this._hasRendered = false;
+          this._resolvedCell = undefined;
         }
       }
 
@@ -260,18 +264,24 @@ export class CFRender extends BaseElement {
         return;
       }
 
-      // chip/tile: the variant key may materialize asynchronously
-      // (cross-space), so sync before probing for it.
+      // Pieces passed through patterns (e.g. piece-grid) arrive as LINKS, not
+      // the root piece cell. Rendering or navigating the raw link yields a
+      // blank tile and a dead click, and hides the exported variant key.
+      // Resolve to the root cell first — exactly as cf-cell-link does — then
+      // sync so we can read the variant key.
       await this._startPromise;
-      await this.cell.sync();
+      const resolved = await this.cell.resolveAsCell();
+      if (this._renderingCellId !== cellId) return;
+      this._resolvedCell = resolved;
+      await resolved.sync();
       if (this._renderingCellId !== cellId) return;
 
       const variantKey = kind === "chip" ? CHIP_UI : TILE_UI;
-      if (this._cellHasKey(variantKey)) {
+      if (this._cellHasKey(resolved, variantKey)) {
         this._log(`rendering exported ${variantKey}`);
         this._cleanup = render(
           container,
-          (this.cell as CellHandle<Record<string, VNode>>)
+          (resolved as CellHandle<Record<string, VNode>>)
             .key(variantKey) as CellHandle<VNode>,
         );
         this._hasRendered = true;
@@ -280,8 +290,8 @@ export class CFRender extends BaseElement {
 
       // Failover to the per-variant platform default.
       this._cleanup = kind === "chip"
-        ? this._renderChipDefault(container)
-        : this._renderTileDefault(container);
+        ? this._renderChipDefault(container, resolved)
+        : this._renderTileDefault(container, resolved);
       this._hasRendered = true;
     } catch (error) {
       // Only show error if we're still rendering this cell
@@ -292,20 +302,23 @@ export class CFRender extends BaseElement {
   }
 
   /** True when the piece output exports a value at `key` (e.g. a variant UI). */
-  private _cellHasKey(key: string): boolean {
+  private _cellHasKey(cell: CellHandle, key: string): boolean {
     try {
-      return hasVariantValue(this.cell.get(), key);
+      return hasVariantValue(cell.get(), key);
     } catch {
       return false;
     }
   }
 
   /** Chip default: a cf-cell-link bound to the piece (renders by [NAME]). */
-  private _renderChipDefault(container: HTMLElement): () => void {
+  private _renderChipDefault(
+    container: HTMLElement,
+    cell: CellHandle,
+  ): () => void {
     const link = globalThis.document.createElement(
       "cf-cell-link",
     ) as HTMLElement & { cell?: CellHandle };
-    link.cell = this.cell;
+    link.cell = cell;
     container.appendChild(link);
     return () => link.remove();
   }
@@ -315,14 +328,17 @@ export class CFRender extends BaseElement {
    * fixed preview (no panning) and clickable to navigate to the piece —
    * mirroring cf-cell-link's navigation.
    */
-  private _renderTileDefault(container: HTMLElement): () => void {
+  private _renderTileDefault(
+    container: HTMLElement,
+    cell: CellHandle,
+  ): () => void {
     const clip = globalThis.document.createElement("div");
     clip.className = "tile-clip";
     const scaler = globalThis.document.createElement("div");
     scaler.className = "tile-default";
     clip.appendChild(scaler);
     container.appendChild(clip);
-    const inner = render(scaler, this.cell as CellHandle<VNode>);
+    const inner = render(scaler, cell as CellHandle<VNode>);
     const onClick = (e: MouseEvent) => this._navigateToPiece(e);
     clip.addEventListener("click", onClick);
     return () => {
@@ -336,9 +352,10 @@ export class CFRender extends BaseElement {
   private _navigateToPiece(e: MouseEvent) {
     e.stopPropagation();
     try {
+      const target = this._resolvedCell ?? this.cell;
       const view = {
-        spaceDid: this.cell.space(),
-        pieceId: this.cell.id(),
+        spaceDid: target.space(),
+        pieceId: target.id(),
       };
       // Cmd (Mac) / Ctrl (Win/Linux) opens in a new tab.
       if (e.metaKey || e.ctrlKey) {


### PR DESCRIPTION
Implements [CT-1764](https://linear.app/common-tools/issue/CT-1764) — adopt the CT-1321 `<cf-render variant="tile|chip">` system across the surfaces that display pieces, and remove the old ad-hoc rendering. Follow-up to #4240.

## Done
**Tile (grid/card):**
- `piece-grid.tsx` — hand-rolled `scale(0.4)` preview + raw `cf-cell-link` → `variant="tile"` + `variant="chip"` label.
- `profile-home.tsx` — pinned patterns → a **tile gallery** (clickable/navigating), user's title/tags as footer; bespoke card + "Open" link gone.
- `record.tsx` ×3 — `embeddedUI ?? <cf-render>` → `variant={isExpanded ? "full" : "tile"}` (card shows the tile, expanded shows full).

**Producer rename:** `note.tsx` / `note-md.tsx` `embeddedUI` → `[TILE_UI]` (the curated minimal UI is the note's tile). `embeddedUI` is now fully removed from the repo.

**Chip (lists/rows — piece-as-itself displays):** `default-app.tsx` + `default-app-ben.tsx` recent/all-pieces lists, `profile-picker`, `backlinks-index` (main), `summary-index`, `activity-log`.

**`cf-render` chip made inline** — reflect `variant`, inline-block host styling for chip, skip the full-size spinner for chip. (Chip was a full-width block before — unusable inline.) Browser-verified as inline pills.

## Principle applied
`cf-cell-link` stays for **navigation links with custom labels/chrome** (toolbar "Mentions"/"Search", "view as grid" toggles) and **styled sub-chips** (backlink chips with custom font/color). The variant system replaces **piece-as-itself** displays.

## Deferred (separate sweep — coupled to a producer rename)
`email-pattern-dreamer`/`launcher` read `previewUI` from ~15 google/airtable/tools extractor patterns. Migrating those consumers to `variant="tile"` requires renaming those producers' `previewUI` → `[TILE_UI]` first. Left for a focused follow-up.

## Verification
All changed files `cf check` + `deno lint` clean. `cf-render` chip-inline browser-verified. Full per-surface browser pass pending (deployed-home surfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)