### PR TITLE
docs(specs): spec-sync EntityId/EntityRef to the branded-FabricHash arc

### DIFF
--- a/docs/specs/space-model/1-data-model.md
+++ b/docs/specs/space-model/1-data-model.md
@@ -186,8 +186,11 @@ version of the data. Hashes are primarily used for:
 
 The `"/"` sigil convention is reused as a general escape mechanism for special
 object shapes, not specifically tied to IPLD/IPFS semantics. The legacy
-`{ "/": string }` bare-string link form has been removed from recognition;
-current link formats use structured objects under the `"/"` key.
+`{ "/": string }` bare-string *link* form has been removed from recognition;
+current link formats use structured objects under the `"/"` key. (This does not
+cover the serialized entity-id *reference* form, which still uses a
+`{ "/": "<tag>:<hash>" }` shape under the current cell representation — see
+[Identity and References](./3-identity-and-references.md#serialized-entity-id-reference-form).)
 
 ### Concerns: IPFS Conventions Without IPFS Benefits
 

--- a/docs/specs/space-model/3-identity-and-references.md
+++ b/docs/specs/space-model/3-identity-and-references.md
@@ -64,20 +64,69 @@ from write and recognition code paths. The type definition still exists in
 `sigil-types.ts`, and backwards-compatible reading of previously persisted data
 is retained, but no code produces or actively recognizes this format.
 
-**Bare string link** (`{ "/": string }` with a plain string value) — removed
-from recognition entirely.
+**Bare string link** (`{ "/": string }` with a plain string value, used as a
+*generic* link) — removed from recognition entirely. This is distinct from the
+serialized entity-id reference form below, which uses the same `{ "/": string }`
+shape to carry a tagged entity-id hash and is still actively produced (see
+[Serialized Entity-Id Reference Form](#serialized-entity-id-reference-form)).
 
 ### Entity Identifiers
 
-Entities are identified by content-derived hashes computed via the `hashOf()`
-function. See [Data Model](./1-data-model.md#hashing-and-content-addressing) for
-details on the hashing mechanism.
+An entity is identified by an `EntityId`: a content-derived hash that names a
+cell/document within a space. An `EntityId` is a **branded `FabricHash`** — at
+runtime it is just a `FabricHash` (see [Data Model](./1-data-model.md)), and the
+brand is a type-only marker that distinguishes "this hash is an entity id" from
+an arbitrary content/value/schema hash:
 
-The `hashOf()` function is used for:
+```typescript
+// At runtime an `EntityId` is a `FabricHash`; the brand is type-only.
+type EntityId = FabricHash & { readonly [ENTITY_ID_BRAND]: true };
+```
+
+`EntityId`s are produced by `createRef()`, which derives a stable id from a
+source value (and an optional `cause`) via `hashOf()`, and by `entityIdFrom()`,
+which brands an existing content-hash string or `FabricHash`. A `FabricHash` has
+a tagged string form, `<tag>:<hash>` (e.g. `fid1:…`); construct one from that
+string via `FabricHash.fromString()`.
+
+The underlying `hashOf()` function — see
+[Data Model](./1-data-model.md#hashing-and-content-addressing) for the hashing
+mechanism — is also used directly for:
 - Pattern ID generation: `hashOf({ causal: { patternId, type: "pattern" } })`
 - Request deduplication: `hashOf(llmParams).toString()`
 - Cache keys: `hashOf(JSON.stringify(selector)).toString()`
 - Causal chain references
+
+### Serialized Entity-Id Reference Form
+
+When an entity id is serialized as a reference to another cell — for example as
+the value of `Cell.entityId`, or as extracted by `getEntityId()` — its concrete
+shape is **flag-dispatched** by the nascent "modern cell representation"
+(`modernCellRep`), a single gate that selects between two regimes:
+
+- **Modern cell representation _off_ (the current default):** the reference is
+  a plain `{ "/": "<tag>:<hash>" }` object — the legacy DAG-JSON-flavored form.
+- **Modern cell representation _on_:** the reference is a straight `FabricHash`.
+
+This is the one place that describes the flag bifurcation; the `EntityRef` type
+captures both regimes:
+
+```typescript
+type EntityRef = FabricHash | { "/": string };
+```
+
+Production and recognition route through a small chokepoint —
+`entityRefFromString()` / `entityRefFrom()` produce a reference, and
+`isEntityRef()` / `entityRefToString()` recognize and extract one. Recognition
+is **strict**: it accepts only the form for the currently active regime, never
+both. This is deliberate — a stored hash carries no record of which input form
+produced it, so the legacy and modern hash regimes are a clean break and never
+intermix within one regime.
+
+> The flag is not currently flipped: it is the plumbing wedge ahead of a future
+> hash-changing storage migration. Until it is flipped, every serialized
+> entity-id reference is the `{ "/": "<tag>:<hash>" }` form, byte-identical to
+> the prior behavior.
 
 ### Internal Representation
 


### PR DESCRIPTION
## Summary

Reconciles the informal space-model specs to Dan's post-086 solo
**EntityId → branded-`FabricHash`** arc (#4204 / #4209 / #4213 / #4227 / #4234 /
#4238). **Doc-only** — two files under `docs/specs/space-model/`, +60/-8, and
**no wire / byte / tag change**: the `modernCellRep` flag is default-off, so a
serialized entity-id reference is still byte-identically `{ "/": "<tag>:<hash>" }`.

## What changed

- **`3-identity-and-references.md` "Entity Identifiers":** describe an `EntityId`
  as a **branded `FabricHash`** (type-only brand; at runtime just a
  `FabricHash`), produced via `createRef()` / `entityIdFrom()`, with the
  `<tag>:<hash>` tagged string form + `FabricHash.fromString()`.
- **New "Serialized Entity-Id Reference Form" section:** documents the
  flag-dispatched `EntityRef` (`modernCellRep` off → `{ "/": string }`; on →
  `FabricHash`) and the `entityRefFromString` / `entityRefFrom` / `isEntityRef`
  / `entityRefToString` chokepoint. Written **future-tense** (the flag is not
  flipped) with the flag bifurcation documented in exactly one place, per the
  per-layer spec-sync recipe.
- **Bare-string-link vs. entity-id-reference precision clause:** disambiguates
  the bare-string *link* form (removed from recognition) from the entity-id
  *reference* form (still actively produced) in both
  `3-identity-and-references.md` and `1-data-model.md`.

## Scope / review note

Doc-only. **No wire / byte / tag change.** `modernCellRep` is default-off, so
the serialized entity-id reference remains byte-identically
`{ "/": "<tag>:<hash>" }`; the new "Serialized Entity-Id Reference Form" section
documents the future flag-on regime in future tense as plumbing ahead of a
hash-changing storage migration, not a live behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNv3rzpEfRtwZfzUy2edoT


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs-only update aligning `EntityId` to a branded `FabricHash` and documenting `EntityRef` serialization behind the `modernCellRep` flag. No behavior change: `modernCellRep` stays off, references remain `{ "/": "<tag>:<hash>" }`, and we clarify bare-string links versus entity-id references.

<sup>Written for commit c5cbae4f383da6cc19b782af9e89bab98e4a5a09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

