### PR TITLE
fix(ts-transformers): capture required primitives gated only in boolean-condition positions

### DIFF
--- a/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
@@ -123,9 +123,11 @@ export function isLiftAppliedCall(
 function getFirstParameterCapabilitySummary(
   callback: ts.ArrowFunction | ts.FunctionExpression,
   checker: ts.TypeChecker,
+  typeRegistry?: WeakMap<ts.Node, ts.Type>,
 ): CapabilityParamSummary | undefined {
   const summary = analyzeFunctionCapabilities(callback, {
     checker,
+    typeRegistry,
     includeNestedCallbacks: true,
   });
   const parameter = callback.parameters[0];
@@ -543,6 +545,7 @@ export function transformLiftAppliedCall(
   const inputParamSummary = getFirstParameterCapabilitySummary(
     newCallback,
     checker,
+    options.state?.typeRegistry,
   );
   if (inputParamSummary) {
     inputTypeNode = applyShrinkAndWrap(

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -26,6 +26,14 @@ export interface CapabilityAnalysisOptions {
   readonly includeNestedCallbacks?: boolean;
   readonly summaryCache?: WeakMap<ts.Node, FunctionCapabilitySummary>;
   readonly inProgress?: WeakSet<ts.Node>;
+  /**
+   * Transformer-known types for nodes the checker can't resolve. Required for
+   * synthetic callbacks (e.g. the destructure-lowered lift-applied param, whose
+   * bindings type as `any`): without it, type-based heuristics like
+   * `isPrimitiveLikeExpression` answer wrong in a fixed direction and the
+   * capability summary mis-shapes or drops inputs. Consulted before the checker.
+   */
+  readonly typeRegistry?: WeakMap<ts.Node, ts.Type>;
 }
 
 interface MutableCapabilityState {
@@ -1087,6 +1095,7 @@ export function analyzeFunctionCapabilities(
   inProgress.add(fn);
   try {
     const checker = options?.checker;
+    const typeRegistry = options?.typeRegistry;
     const interprocedural = !!options?.interprocedural && !!checker;
     const includeNestedCallbacks = !!options?.includeNestedCallbacks;
     const summarySourceFile = fn.getSourceFile();
@@ -1248,10 +1257,16 @@ export function analyzeFunctionCapabilities(
     };
 
     const isPrimitiveLikeExpression = (expr: ts.Expression): boolean => {
-      if (!checker) {
+      // Prefer the transformer-known type: on synthetic callbacks (e.g. the
+      // destructure-lowered lift-applied param) the checker resolves bindings
+      // to `any`, whose flags match none of the primitive families below — so
+      // relying on the checker alone would mis-classify a real primitive as
+      // non-primitive and let the presence-only skip drop it from the schema.
+      const type = typeRegistry?.get(expr) ??
+        (checker ? checker.getTypeAtLocation(expr) : undefined);
+      if (!type) {
         return false;
       }
-      const type = checker.getTypeAtLocation(expr);
       const flags = type.flags;
       return !!(
         flags &
@@ -1924,6 +1939,7 @@ export function analyzeFunctionCapabilities(
 
       return analyzeFunctionCapabilities(declaration, {
         checker,
+        typeRegistry,
         interprocedural: true,
         summaryCache,
         inProgress,
@@ -2155,8 +2171,18 @@ export function analyzeFunctionCapabilities(
                 !isPrimitiveLikeExpression(usage)) &&
               isBooleanConditionUsage(usage)
             ) {
-              // Truthiness checks on local aliases of source properties only
-              // require presence, not the aliased payload shape.
+              // Truthiness checks on a non-primitive source property only
+              // require presence, not the aliased payload shape. Recording
+              // nothing keeps such a (typically nullable, possibly
+              // transiently-undefined) reactive value out of the required input
+              // set, so an action/lift gated on it still runs when it is absent.
+              //
+              // Primitives are handled differently: their value *is* their
+              // presence and a required primitive is never legitimately
+              // `undefined`, so dropping it would be a real bug (lunch-poll
+              // `isAdmin`). `isPrimitiveLikeExpression` — now type-registry
+              // aware so it sees through synthetic `any` params — routes
+              // primitives to the full read above instead of into this skip.
             } else if (
               !(
                 parent &&

--- a/packages/ts-transformers/src/transformers/pattern-callback-transform.ts
+++ b/packages/ts-transformers/src/transformers/pattern-callback-transform.ts
@@ -94,6 +94,7 @@ export function registerCapabilitySummary(
 
   const summary = analyzeFunctionCapabilities(callback, {
     checker: context.checker,
+    typeRegistry: context.options.state?.typeRegistry,
     interprocedural,
   });
 

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -241,6 +241,7 @@ function findCapabilitySummaryForParameter(
   const summary = options?.includeNestedCallbacks
     ? analyzeFunctionCapabilities(fn, {
       checker: options.checker,
+      typeRegistry: context?.options.state?.typeRegistry,
       includeNestedCallbacks: true,
       summaryCache: context
         ? capabilitySummaryMemoFor(context).nested
@@ -250,6 +251,7 @@ function findCapabilitySummaryForParameter(
     ? (context.lookupCapabilitySummary(fn) ??
       analyzeFunctionCapabilities(fn, {
         checker: context.checker,
+        typeRegistry: context.options.state?.typeRegistry,
         summaryCache: capabilitySummaryMemoFor(context).fallback,
       }))
     : analyzeFunctionCapabilities(fn, {

--- a/packages/ts-transformers/test/fixtures/closures/computed-all-literal-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-all-literal-types.expected.jsx
@@ -15,6 +15,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     numLiteral: number;
     floatLiteral: number;
+    boolLiteral: boolean;
     strLiteral: string;
 }, string>(({ value, numLiteral, floatLiteral, boolLiteral, strLiteral }) => {
     // Use all captured literals to ensure they're all widened
@@ -33,11 +34,14 @@ const __cfLift_1 = __cfHelpers.lift<{
         floatLiteral: {
             type: "number"
         },
+        boolLiteral: {
+            type: "boolean"
+        },
         strLiteral: {
             type: "string"
         }
     },
-    required: ["value", "numLiteral", "floatLiteral", "strLiteral"]
+    required: ["value", "numLiteral", "floatLiteral", "boolLiteral", "strLiteral"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
@@ -12,11 +12,15 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
+    showHistory: boolean;
     messageCount: number;
     dismissedIndex: __cfHelpers.ReadonlyCell<number>;
 }, boolean>(({ showHistory, messageCount, dismissedIndex }) => showHistory && messageCount !== dismissedIndex.get(), {
     type: "object",
     properties: {
+        showHistory: {
+            type: "boolean"
+        },
         messageCount: {
             type: "number"
         },
@@ -25,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             asCell: ["readonly"]
         }
     },
-    required: ["messageCount", "dismissedIndex"]
+    required: ["showHistory", "messageCount", "dismissedIndex"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
@@ -64,15 +64,19 @@ export const PatternLogicalAnd = pattern((__cf_pattern_input) => {
     }
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_1 = __cfHelpers.lift<{
+    foo: boolean;
     bar: string;
 }, string | false>(({ foo, bar }) => foo && bar, {
     type: "object",
     properties: {
+        foo: {
+            type: "boolean"
+        },
         bar: {
             type: "string"
         }
     },
-    required: ["bar"]
+    required: ["foo", "bar"]
 } as const satisfies __cfHelpers.JSONSchema, {
     anyOf: [{
             type: "string"


### PR DESCRIPTION
## What

Upstream transformer fix for the dependency-capture gap Dan flagged to `@mathpirate` in #4235 (the lunch-poll generated-art thumbnails that never rendered). That PR worked around it pattern-side by routing the `isAdmin` gate through a helper; this fixes the root cause in the transformer.

## The bug

A `computed`/`lift` body that reads a captured reactive prop **only** in a boolean-condition position — `!x`, an `if`/`while`/`for`/ternary condition, or the **left** operand of `&&` — lowered to a lift whose **call-site args passed the prop** but whose **emitted input JSONSchema omitted it**. The schema governs runtime materialization, so the prop arrived as `undefined`.

For a **required primitive** (`isAdmin: boolean`) this is silently wrong: `!undefined` is always `true`, so the gated branch never runs — no type error, no runtime error. (`||`/`??`-left and `===` were already captured correctly; this was specific to the truthiness/`&&`-left family.)

## Root cause

The capability analysis that drives schema shrinking runs on the **synthetic destructure-lowered lift parameter**, whose bindings the type-checker resolves to `any`. `isPrimitiveLikeExpression` relied solely on `checker.getTypeAtLocation`, so a real `boolean` matched none of the primitive `TypeFlags`, was treated as non-primitive, fell into the presence-only boolean-condition skip (which records nothing), and was dropped by the shrink — while the lexical capture set still passed it at the call site. The two derivations (captures → call args; capability shrink → schema) diverged.

## The fix

Make `isPrimitiveLikeExpression` consult the transformer's `typeRegistry` — which already holds the unwrapped capture type — **before** falling back to the checker, and thread `typeRegistry` through every site that analyzes a synthetic callback:

- `lift-applied-strategy.ts` (origin shrink)
- `capability-analysis.ts` (predicate + interprocedural recursion)
- `pattern-callback-transform.ts` (summary recording)
- `schema-injection.ts` (dual-schema re-entry, which re-runs the analysis fresh)

Primitives are now classified correctly → routed to a full read → present in the schema **with their precise type** (`isAdmin: boolean`, not `unknown`). The same predicate fix also closes the inverse mis-classification that over-wrapped `any`-typed primitives as `asCell`.

## Scope: why only primitives

This deliberately does **not** force every dropped boolean-condition operand into the schema. Verification (running the full runtime suite, not just goldens) showed that **nullable non-primitive guard values are dropped *by design*** — they are legitimately absent at runtime and the guard handles it; forcing them to be required inputs stops an action/lift gated on them from ever running. A required *primitive*, by contrast, is never legitimately `undefined`, so its drop is unambiguously a bug. The fix targets exactly that line. (A broader "record presence for all drops" attempt regressed `card-piles`, `do-list`, and `note-md`; this scoping is what keeps it correct.)

## Tests

- `ts-transformers` unit suite: **294 passed, 0 failed**
- `deno task integration pattern-tests`: **all 68 passed** (incl. lunch-poll `poll-option-card` / `generated-art` / `multi-user`)
- 3 fixtures that had baked in the drop are updated — each is an **additive** restoration of the dropped primitive (`foo` / `showHistory` / `boolLiteral`), consistent with each fixture's own call-site (and, for `computed-all-literal-types`, its documented intent). `schema-generator` (70 goldens) and `runner` golden suites: unchanged.

## Follow-up (not in this PR)

A transform-time backstop ("every call-site input appears in the schema") would catch this class loudly at compile time, but the naive invariant is false for legitimately-nullable captures — a correct version must flag only **non-nullable** drops (the one remaining latent edge: a non-nullable object used truthiness-only; no current pattern hits it). Worth doing as a deliberate, nullability-aware follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a transformer bug where required primitives used only in boolean conditions were omitted from the emitted input schema, causing them to arrive as undefined at runtime. Ensures values like `isAdmin: boolean` are captured and typed correctly so gated branches run as expected.

- **Bug Fixes**
  - Use the transformer's `typeRegistry` before the TS checker to classify primitives in synthetic callbacks.
  - Thread `typeRegistry` through `lift-applied-strategy`, `capability-analysis`, `pattern-callback-transform`, and `schema-injection`.
  - Include boolean-gated primitives in the input schema with precise types; avoids incorrect `asCell` wrapping of `any`.
  - Keep nullable non-primitives presence-only to avoid blocking gated actions.
  - Updated 3 fixtures; all `ts-transformers` unit and integration tests pass.

<sup>Written for commit 478d4893a89f75406c9eb9db6153117c3d0d34a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

