### PR TITLE
fix(runtime-client): last-write-wins UI writes — blind-vs-CAS by method (set/push)

### DIFF
--- a/docs/specs/memory-v2/cellset-lww-context.md
+++ b/docs/specs/memory-v2/cellset-lww-context.md
@@ -1,0 +1,249 @@
+# Cellset last-write-wins for scalar `$value` writes — context & status
+
+**PR:** [#4245](https://github.com/commontoolsinc/labs/pull/4245) (draft) ·
+**branch:** `fix/cellset-blind-leaf-write` ·
+**supersedes:** #4126 (closed), #4196 (closed)
+
+This is a working-context document for picking the PR back up cold. It records
+the bug, the fix, *why the fix is shaped the way it is*, how it's verified, how
+it relates to the conflict-handling work that landed while it was parked, and
+the open questions for the area owner (Robin / ubik2).
+
+---
+
+## TL;DR
+
+A scalar `$value`/`$checked` UI write was committed as a **compare-and-set**, so
+under concurrent same-user edits it lost an own-write race, was rejected and
+rolled back, and the edit silently vanished — the `cfc-group-chat-demo`
+"Name not set" flake. The fix makes a scalar `$value` write a **precondition-free
+last-write-wins leaf overwrite**: `handleCellSet` marks its transaction so the
+write records no concurrency precondition. Structured (array/object) values are
+left alone (they're often read-modify-write). Verified by a headless
+multi-runtime regression test (fails-without / passes-with) plus a real
+two-browser run, and confirmed to **still add value** after rebasing onto the
+new conflict-handling world (#4220/#4210/#4343/#4366/#4367).
+
+---
+
+## 1. The bug
+
+The `cfc-group-chat-demo` two-browser CI flake — a user's profile name stays
+**"Name not set"** under contention — had two independent mechanisms:
+
+1. **Handler-delivery** (lost trusted click / cross-thread handler retirement) —
+   fixed separately in **#4146**. Not this PR.
+2. **Cell-write drop** — this PR.
+
+**Mechanism #2, root cause.** Writing a scalar `$value` goes
+`UI → CellHandle.set → CellSet IPC → RuntimeProcessor.handleCellSet → Cell.set →
+diffAndUpdate → normalizeAndDiff`. To diff, `normalizeAndDiff` **reads the write
+target** (`packages/runner/src/data-updating.ts`, the `tx.readValueOrThrow(link)`
+on the value being written). That read is recorded as a **commit precondition**
+two ways:
+
+- engine side — it becomes a `reads.confirmed` entry (via `buildReads` in
+  `packages/runner/src/storage/v2.ts`), checked by `validateConfirmedReads` →
+  `findConflictSeq` in `packages/memory/v2/engine.ts`;
+- client side — `V2StorageTransaction.read()` marks the doc `validated`, which
+  `validate()` turns into a compare-and-swap `claim()`.
+
+So a `$value` write is "only apply if the target is unchanged since I read it."
+Under an **own-write race** — two sessions/tabs of one user sharing the PerUser
+`profileDraft`, **or** the typed `$value` set racing the save handler's own
+`nameDraft.set` ([`trusted.tsx:533`](../../../packages/patterns/cfc-group-chat-demo/trusted.tsx))
+— the write-target read is baselined at a stale seq and loses:
+`ConflictError: stale confirmed read: <id> at seq N conflicted with seq M`. The
+write is **rejected and rolled back**, the draft reverts, and the save handler
+(`commitTrustedProfileSave`, which reads
+[`draftText(nameDraft)` at `trusted.tsx:530`](../../../packages/patterns/cfc-group-chat-demo/trusted.tsx))
+reads the wrong/empty draft → the typed name is lost.
+
+**The conflict is tier-2 (patch path-overlap) on the *same* leaf path**
+`["value","profileDraft"]` — both writers patch the same leaf. (An early model
+called it tier-1 path-blind; instrumentation on the multi-runtime probe corrected
+that — it's same-leaf tier-2.)
+
+---
+
+## 2. The fix
+
+`RuntimeProcessor.handleCellSet`
+([`runtime-processor.ts:689`](../../../packages/runtime-client/backends/runtime-processor.ts))
+marks its transaction as a **blind-leaf-write**, but only:
+
+- **for scalar values** (`typeof === "string" | "number" | "boolean"`,
+  line 703), and
+- **around the `cell.set()` call only** — mark at line 705, **unmark at line 707**
+  before `prepareTxForCommit`.
+
+While the tx is marked, `V2StorageTransaction.read()`
+([`v2-transaction.ts:1335`](../../../packages/runner/src/storage/v2-transaction.ts)):
+tags every read with `ignoreReadForCommit` and **skips setting `doc.validated`**;
+and `buildReads` ([`v2.ts:2170`](../../../packages/runner/src/storage/v2.ts))
+**drops** `ignoreReadForCommit` reads from `reads.confirmed`. Net: the write
+carries **no concurrency precondition** on either side → precondition-free
+last-write-wins, which is correct for raw scalar UI input.
+
+The marker registry lives in
+[`reactivity-log.ts`](../../../packages/runner/src/storage/reactivity-log.ts):
+`markUiInputBlindWriteTx` / `unmarkUiInputBlindWriteTx` / `isUiInputBlindWriteTx`
+(lines 122/125/128) + the `ignoreReadForCommit` metadata marker (line 50). The
+mark walks the tx wrapper chain so both the `ExtendedStorageTransaction` and the
+inner `V2StorageTransaction` are marked.
+
+### Why it's shaped this way (the load-bearing decisions)
+
+These came out of a 3-agent audit that **blocked** the first (whole-transaction)
+prototype:
+
+- **Scalar-only, not all of `handleCellSet`.** `CellHandle.set` is the *sole*
+  `CellSet` sender, but it is *also* the read-modify-write path —
+  `CellHandle.push`, `cf-autocomplete` multi-select, `ArrayCellController`
+  (add/remove/update). Blind LWW on those reintroduces **lost updates** on
+  concurrent array appends. Scalars are full overwrites (LWW-safe); array/object
+  values may be RMW, so they **keep compare-and-set**. The value type is the
+  reliable partition — a flag at `cell-controller.defaultSetValue` does *not*
+  work, because autocomplete's RMW routes through that same setter.
+- **Around `set()` only, not the whole tx.** `prepareTxForCommit → prepareCfc →
+  prepareBoundaryCommit` persists CFC label / `cid:` schema docs as
+  **read-then-write in the same tx**. Marking the whole tx would strip *those*
+  preconditions too, letting a concurrent label/classification change be
+  clobbered. Unmarking before `prepareTxForCommit` keeps them.
+- **Preserved invariants (verified):** CFC enforcement rides `attemptedWrites`
+  (the `markReadAsAttemptedWrite` read, kept) — not `reads.confirmed`/`validated`
+  — so it's intact. Reactivity/subscriptions ride `ignoreReadForScheduling`,
+  which the fix never sets, so the self-subscription is intact.
+
+### Things tried and dropped
+
+- **No-op-suppression bypass / force-write** (making a same-value re-set still
+  send). Dropped: precondition removal *alone* fixes the real data loss (a
+  genuine concurrent edit has a delta and now commits); a same-value *echo* of
+  the stale local value is not data loss, and forcing it is both a debatable
+  policy and blocked by a third commit-assembly delta gate.
+- **Whole-transaction blind write** — blocked by the audit (see above).
+
+---
+
+## 3. Coverage / verification
+
+**Regression test:** `packages/patterns/integration/cellset-lww.test.ts`
+(headless multi-runtime: Deno workers + in-process `StandaloneMemoryServer`,
+~6s, no browser, CI-ready). Three steps:
+
+1. concurrent same-user scalar sets → **0 conflicts**;
+2. structured (array/object) writes → **still hit compare-and-set** (guards the
+   narrowing — proves blind-write does *not* apply to non-scalars);
+3. e2e — a typed name survives the own-write race **through `saveProfile`**
+   (the actual symptom).
+
+All three **fail with the fix disabled and pass with it on** (verified by
+toggling the worker mark — fails-without/passes-with). The harness gained a
+`set` command (`multi-runtime-{worker,harness}.ts`) mirroring `handleCellSet`;
+it was previously missing a UI-input `$value` write path and is reusable infra.
+
+**Production-fidelity:** the real two-browser integration
+(`deno task integration patterns two-browsers`, real chromium) ran **13/13 PASS,
+`commitRejected=0`** every run on the fix branch (contention happened —
+`commitConflicts≈25/run` from handler/machinery writes that recover via retry —
+but the `$value` writes were never rejected).
+
+**Diff size:** ~100 lines of fix, ~165 test, ~55 harness infra (8 files).
+
+---
+
+## 4. The "new world" — landed conflict-handling PRs and how ours relates
+
+The branch is rebased onto main as of late June 2026, which includes:
+
+- **#4220** *(conflict-granularity)* — the closest neighbor. It built a
+  conflict-read filtering system in `buildReads`: an `excludeReadFromConflict`
+  marker (**nonRecursive-gated** — drops reference/topology reads like asCell
+  shape resolution), a "mergeable op" concept, CFC-label-path dropping, and a
+  **leaf-only conflict matcher**. **Complementary, not redundant:** the leaf-only
+  matcher *preserves* same-leaf conflicts (our race is same-leaf), and
+  `excludeReadFromConflict` is nonRecursive-only while our write-target read is
+  **recursive (by-value)** — so #4220 never drops it. Our `ignoreReadForCommit`
+  is the *first* filter in that same `buildReads` loop, sitting alongside theirs.
+- **#4210** *(reactive computes don't re-queue on commit conflict)* and
+  **#4343** *(re-queue reactive computes stranded by a commit conflict — Hixie's
+  fix for the #4210 strand)*. Both live in `scheduler/action-run.ts` +
+  `storage/rejection.ts` — the **reactive compute** recovery path, **orthogonal**
+  to the `handleCellSet` `$value` write (which is a single un-retried commit, not
+  a reactive compute). See the `reference_reactive_conflict_strand_repro` note
+  (the #4210/#4343 strand only reproduces under real async load).
+- **#4366** *(VDOM list child settling)* and **#4367** *(reload churn read
+  resume)* — rendering/reload level, orthogonal to the cellset write path.
+
+**Rebase mechanics:** one trivial conflict (an import block in `v2.ts`, both
+#4220 and we import from `reactivity-log.ts`); everything else auto-merged,
+including `v2-transaction.ts read()` and `reactivity-log.ts`. Post-rebase:
+type-check clean, `cellset-lww` 3/3, 47 conflict/commit/storage/runtime-processor
+regression tests green.
+
+**Still adds value — confirmed empirically.** With the fix disabled on the *new*
+base (which already includes all five PRs), the own-write race still fails
+identically (`stale confirmed read … conflicted`), and the e2e still drops the
+typed name. None of the landed work addresses the scalar `$value` own-write race.
+
+---
+
+## 5. Open questions for Robin (ubik2) — flagged in the PR body
+
+1. **Patch-replay edge.** A nested scalar `$value` set emits a *patch* op.
+   Precondition-free, a patch whose ancestor path was concurrently removed (a
+   whole-doc delete racing a `$value` set — rare, and **not** the PerUser
+   own-write race this fixes) would throw at **read-materialization** rather than
+   be rejected at commit. Should we keep a structural (entity/parent-present)
+   precondition even when dropping the value-equality one?
+2. **Trigger choice.** Value-type heuristic (scalar → blind) vs an explicit
+   signal — and whether the blind-leaf-write belongs expressed in #4220's newer
+   "mergeable op / `excludeReadFromConflict`" vocabulary (conceptually adjacent;
+   functionally distinct today). Possible unification opportunity.
+
+This supersedes the **recovery**-based approaches (#4196 per-key commit queue,
+#4126 reapply-latest) by removing the conflict at the source (**prevention**).
+
+---
+
+## 6. Repro & commands
+
+```bash
+# Worktree / branch
+cd labs/.claude/worktrees/cellset-probe            # branch: fix/cellset-blind-leaf-write
+
+# Regression test (fast, headless) — should be 3/3
+deno test -A packages/patterns/integration/cellset-lww.test.ts
+
+# See the flake: disable the fix and re-run → steps 1 & 3 fail with
+# "stale confirmed read … conflicted". In multi-runtime-worker.ts set(),
+# change `const blindLeafWrite = …` to `false && (…)`, run, then revert.
+
+# Production-fidelity (real chromium; loop for a flake-rate)
+deno task integration patterns two-browsers
+
+# Conflict/commit regression (coexistence with #4220/#4210/#4343)
+deno test -A \
+  packages/runner/test/conflict-repro.test.ts \
+  packages/runner/test/compute-conflict-recovery.test.ts \
+  packages/runner/test/effect-conflict-recovery.test.ts \
+  packages/runtime-client/backends/runtime-processor.test.ts
+```
+
+The original instrumented prototype (env-gated `CSPROBE` probes that confirmed
+the mechanism) is preserved on `origin/scratch/cellset-conflict-probe`.
+
+---
+
+## 7. Key files (with the fix)
+
+| File | Role |
+|------|------|
+| `packages/runtime-client/backends/runtime-processor.ts` | `handleCellSet` trigger: scalar check + mark/unmark around `set()` |
+| `packages/runner/src/storage/reactivity-log.ts` | `markUiInputBlindWriteTx` / `unmark` / `is` + `ignoreReadForCommit` marker |
+| `packages/runner/src/storage/v2-transaction.ts` | `read()` tags reads + skips `doc.validated` when blind |
+| `packages/runner/src/storage/v2.ts` | `buildReads` drops `ignoreReadForCommit` reads from `reads.confirmed` |
+| `packages/runner/src/index.ts` | exports the marker fns |
+| `packages/patterns/integration/cellset-lww.test.ts` | regression test (3 steps) |
+| `packages/patterns/integration/multi-runtime-{worker,harness}.ts` | `set` harness command (UI-input write path) |

--- a/docs/specs/memory-v2/cellset-lww-context.md
+++ b/docs/specs/memory-v2/cellset-lww-context.md
@@ -13,16 +13,26 @@ the open questions for the area owner (Robin / ubik2).
 
 ## TL;DR
 
-A scalar `$value`/`$checked` UI write was committed as a **compare-and-set**, so
-under concurrent same-user edits it lost an own-write race, was rejected and
-rolled back, and the edit silently vanished — the `cfc-group-chat-demo`
-"Name not set" flake. The fix makes a scalar `$value` write a **precondition-free
-last-write-wins leaf overwrite**: `handleCellSet` marks its transaction so the
-write records no concurrency precondition. Structured (array/object) values are
-left alone (they're often read-modify-write). Verified by a headless
-multi-runtime regression test (fails-without / passes-with) plus a real
-two-browser run, and confirmed to **still add value** after rebasing onto the
-new conflict-handling world (#4220/#4210/#4343/#4366/#4367).
+A `$value`/`$checked` UI write was committed as a **compare-and-set** (the diff
+read of the write target became a commit precondition), so under concurrent
+same-user edits it lost an own-write race, was rejected and rolled back, and the
+edit silently vanished — the `cfc-group-chat-demo` "Name not set" flake.
+
+**The fix (as landed):** decide blind-vs-CAS by **method**, not value type. A
+`CellHandle.set` → `CellSet` is a **blind last-write-wins** write (any value
+type); a `CellHandle.push` → new `CellPush` → `handleCellPush` keeps
+**compare-and-set**. A blind `set` carries no value-equality precondition — in its
+place `handleCellSet` threads **one structural precondition at the cell's parent**,
+so a concurrent whole-doc delete *or ancestor reshape* is a clean `ConflictError`
+rather than a raw "not traversable" throw. Verified headless (multi-runtime +
+engine-level) and green in regression.
+
+> **Reading this doc:** §§1–4 and §6 trace how the fix got here and describe its
+> two *earlier* forms — a precondition-free scalar blind write (value-type
+> narrowing), then an entity-root structural read. The design evolved twice:
+> value-type → **method-based** (per Robin's review) and entity-root → **parent**.
+> Each mechanism section below is written in the current form; **§5** records the
+> investigation and **§5.3 is the authoritative account of the landed design.**
 
 ---
 
@@ -68,43 +78,45 @@ that — it's same-leaf tier-2.)
 
 ## 2. The fix
 
-`RuntimeProcessor.handleCellSet`
-([`runtime-processor.ts:689`](../../../packages/runtime-client/backends/runtime-processor.ts))
-marks its transaction as a **blind-leaf-write**, but only:
+The blind-vs-compare-and-set decision is made by **method** (which request type
+the client sent), not by the value's shape. Both handlers share `applyCellWrite`.
 
-- **for scalar values** (`typeof === "string" | "number" | "boolean"`,
-  line 703), and
-- **around the `cell.set()` call only** — mark at line 705, **unmark at line 707**
-  before `prepareTxForCommit`.
-
-While the tx is marked, `V2StorageTransaction.read()`
-([`v2-transaction.ts:1335`](../../../packages/runner/src/storage/v2-transaction.ts)):
-tags every read with `ignoreReadForCommit` and **skips setting `doc.validated`**;
-and `buildReads` ([`v2.ts:2170`](../../../packages/runner/src/storage/v2.ts))
-**drops** `ignoreReadForCommit` reads from `reads.confirmed`. Net: the write
-carries **no concurrency precondition** on either side → precondition-free
-last-write-wins, which is correct for raw scalar UI input.
+- **`CellHandle.set` → `CellSet` → `RuntimeProcessor.handleCellSet`**
+  ([`runtime-processor.ts`](../../../packages/runtime-client/backends/runtime-processor.ts))
+  is a **blind last-write-wins** write (any value type). It marks its transaction
+  as a blind-leaf-write **around the `cell.set()` call only** (cleared before
+  `prepareTxForCommit`). While marked, `V2StorageTransaction.read()`
+  ([`v2-transaction.ts`](../../../packages/runner/src/storage/v2-transaction.ts))
+  tags every read `ignoreReadForCommit` and **skips `doc.validated`**, so the leaf
+  carries no value-equality precondition. In its place, `handleCellSet` threads
+  the cell's resolved **parent** address (`setBlindStructuralTarget`, via
+  `resolveAsCell().getAsNormalizedFullLink()`), and `buildReads`
+  ([`v2.ts`](../../../packages/runner/src/storage/v2.ts)) emits **one
+  `nonRecursive` read at that parent** — catching a concurrent whole-doc delete or
+  ancestor reshape as a clean `ConflictError` (see §5.3).
+- **`CellHandle.push` → `CellPush` → `handleCellPush`** is read-modify-write: it
+  is *not* marked blind, so the read of the current value stays a commit
+  precondition (compare-and-set) and a concurrent push aborts rather than being
+  clobbered.
 
 The marker registry lives in
 [`reactivity-log.ts`](../../../packages/runner/src/storage/reactivity-log.ts):
-`markUiInputBlindWriteTx` / `unmarkUiInputBlindWriteTx` / `isUiInputBlindWriteTx`
-(lines 122/125/128) + the `ignoreReadForCommit` metadata marker (line 50). The
-mark walks the tx wrapper chain so both the `ExtendedStorageTransaction` and the
-inner `V2StorageTransaction` are marked.
+`markUiInputBlindWriteTx` / `unmark` / `is` + the `ignoreReadForCommit` marker,
+plus `setBlindStructuralTarget` / `getBlindStructuralTarget` (the parent target
+threaded from `handleCellSet` to `buildReads`). The mark walks the tx wrapper
+chain so both the `ExtendedStorageTransaction` and the inner
+`V2StorageTransaction` are covered.
 
 ### Why it's shaped this way (the load-bearing decisions)
 
-These came out of a 3-agent audit that **blocked** the first (whole-transaction)
-prototype:
-
-- **Scalar-only, not all of `handleCellSet`.** `CellHandle.set` is the *sole*
-  `CellSet` sender, but it is *also* the read-modify-write path —
-  `CellHandle.push`, `cf-autocomplete` multi-select, `ArrayCellController`
-  (add/remove/update). Blind LWW on those reintroduces **lost updates** on
-  concurrent array appends. Scalars are full overwrites (LWW-safe); array/object
-  values may be RMW, so they **keep compare-and-set**. The value type is the
-  reliable partition — a flag at `cell-controller.defaultSetValue` does *not*
-  work, because autocomplete's RMW routes through that same setter.
+- **By method, not value type.** `CellHandle.set` is the sole `CellSet` sender,
+  but read-modify-write ops (`CellHandle.push`, `cf-autocomplete` multi-select,
+  `ArrayCellController`) also route through it. The *earlier* form partitioned by
+  value type (scalar → blind, array/object → CAS) as a proxy for "RMW". Per
+  Robin's review this is now explicit: `push` is its own request type (keeps CAS),
+  and `set` is always blind. Trade-off: an array *overwrite* via `set` is now
+  blind, where the value-type form kept it on CAS — the concurrency-safe path for
+  list mutations is `push` (or the deferred server-side mergeable-op work).
 - **Around `set()` only, not the whole tx.** `prepareTxForCommit → prepareCfc →
   prepareBoundaryCommit` persists CFC label / `cid:` schema docs as
   **read-then-write in the same tx**. Marking the whole tx would strip *those*
@@ -129,27 +141,32 @@ prototype:
 ## 3. Coverage / verification
 
 **Regression test:** `packages/patterns/integration/cellset-lww.test.ts`
-(headless multi-runtime: Deno workers + in-process `StandaloneMemoryServer`,
-~6s, no browser, CI-ready). Three steps:
+(headless multi-runtime: Deno workers + in-process `StandaloneMemoryServer`, no
+browser, CI-ready). Four steps:
 
-1. concurrent same-user scalar sets → **0 conflicts**;
-2. structured (array/object) writes → **still hit compare-and-set** (guards the
-   narrowing — proves blind-write does *not* apply to non-scalars);
-3. e2e — a typed name survives the own-write race **through `saveProfile`**
-   (the actual symptom).
+1. concurrent same-user scalar sets → **0 conflicts** (blind);
+2. a structured (array) set → **also 0 conflicts** (the trigger is the method, not
+   the value type);
+3. concurrent `push`es → **still compare-and-set** (guards the method split);
+4. e2e — a typed name survives the own-write race **through `saveProfile`** (the
+   actual symptom).
 
-All three **fail with the fix disabled and pass with it on** (verified by
-toggling the worker mark — fails-without/passes-with). The harness gained a
-`set` command (`multi-runtime-{worker,harness}.ts`) mirroring `handleCellSet`;
-it was previously missing a UI-input `$value` write path and is reusable infra.
+**Ancestor-reshape guarantee:**
+`packages/memory/test/cellset-structural-precondition.test.ts` (engine-level) pins
+that a precondition-free nested patch on a retyped ancestor throws raw "not
+traversable"; an **entity-root** structural read still throws raw (insufficient);
+the **parent** read converts it to a clean `ConflictError`. (The in-process
+harness can't reproduce this end to end — synchronous propagation, no
+stale-but-navigable replica — hence the engine test.)
 
-**Production-fidelity:** the real two-browser integration
+The harness mirrors `handleCellSet`/`handleCellPush` with `set` (always blind) and
+`push` (CAS) commands (`multi-runtime-{worker,harness}.ts`) — reusable infra.
+
+**Production-fidelity (earlier form):** the real two-browser integration
 (`deno task integration patterns two-browsers`, real chromium) ran **13/13 PASS,
-`commitRejected=0`** every run on the fix branch (contention happened —
-`commitConflicts≈25/run` from handler/machinery writes that recover via retry —
-but the `$value` writes were never rejected).
-
-**Diff size:** ~100 lines of fix, ~165 test, ~55 harness infra (8 files).
+`commitRejected=0`** on the original scalar-blind branch. The method-based redesign
+has not been re-run under two-browser locally; the full pattern-integration suite
+runs it in CI.
 
 ---
 
@@ -164,8 +181,9 @@ The branch is rebased onto main as of late June 2026, which includes:
   **leaf-only conflict matcher**. **Complementary, not redundant:** the leaf-only
   matcher *preserves* same-leaf conflicts (our race is same-leaf), and
   `excludeReadFromConflict` is nonRecursive-only while our write-target read is
-  **recursive (by-value)** — so #4220 never drops it. Our `ignoreReadForCommit`
-  is the *first* filter in that same `buildReads` loop, sitting alongside theirs.
+  **recursive (by-value)** — so #4220 never drops it. Our blind reads are the
+  *first* filter in that same `buildReads` loop; they are dropped and replaced by
+  one structural **parent** read (§5.3), sitting alongside #4220's filters.
 - **#4210** *(reactive computes don't re-queue on commit conflict)* and
   **#4343** *(re-queue reactive computes stranded by a commit conflict — Hixie's
   fix for the #4210 strand)*. Both live in `scheduler/action-run.ts` +
@@ -363,15 +381,15 @@ This supersedes the **recovery**-based approaches (#4196 per-key commit queue,
 # Worktree / branch
 cd labs/.claude/worktrees/cellset-probe            # branch: fix/cellset-blind-leaf-write
 
-# Regression test (fast, headless) — should be 3/3
+# Regression test (fast, headless) — should be 4/4
 deno test -A packages/patterns/integration/cellset-lww.test.ts
 
-# See the flake: disable the fix and re-run → steps 1 & 3 fail with
-# "stale confirmed read … conflicted". In multi-runtime-worker.ts set(),
-# change `const blindLeafWrite = …` to `false && (…)`, run, then revert.
+# Ancestor-reshape guarantee (engine-level structural precondition)
+deno test -A packages/memory/test/cellset-structural-precondition.test.ts
 
-# Production-fidelity (real chromium; loop for a flake-rate)
-deno task integration patterns two-browsers
+# See the flake: disable the blind path and re-run → steps 1/2/4 fail with
+# "stale confirmed read … conflicted". In multi-runtime-worker.ts set(), remove
+# the markUiInputBlindWriteTx / setBlindStructuralTarget calls, run, then revert.
 
 # Conflict/commit regression (coexistence with #4220/#4210/#4343)
 deno test -A \
@@ -390,10 +408,13 @@ the mechanism) is preserved on `origin/scratch/cellset-conflict-probe`.
 
 | File | Role |
 |------|------|
-| `packages/runtime-client/backends/runtime-processor.ts` | `handleCellSet` trigger: scalar check + mark/unmark around `set()` |
-| `packages/runner/src/storage/reactivity-log.ts` | `markUiInputBlindWriteTx` / `unmark` / `is` + `ignoreReadForCommit` marker |
+| `packages/runtime-client/protocol/types.ts` | `CellPush` request type + `Commands` entry |
+| `packages/runtime-client/backends/runtime-processor.ts` | `handleCellSet` (blind) / `handleCellPush` (CAS) → shared `applyCellWrite`; threads the parent via `setBlindStructuralTarget` |
+| `packages/runtime-client/cell-handle.ts` | `push` emits `CellPush` (shared `#applyLocalAndSend`) |
+| `packages/runner/src/storage/reactivity-log.ts` | blind-write marker + `ignoreReadForCommit` + `setBlindStructuralTarget` / `getBlindStructuralTarget` (parent-target registry) |
 | `packages/runner/src/storage/v2-transaction.ts` | `read()` tags reads + skips `doc.validated` when blind |
-| `packages/runner/src/storage/v2.ts` | `buildReads` handling of `ignoreReadForCommit` reads — **now downgrades** each to a `nonRecursive` entity-root existence read (was: dropped). See §5.1 |
-| `packages/runner/src/index.ts` | exports the marker fns |
-| `packages/patterns/integration/cellset-lww.test.ts` | regression test (3 steps) |
-| `packages/patterns/integration/multi-runtime-{worker,harness}.ts` | `set` harness command (UI-input write path) |
+| `packages/runner/src/storage/v2.ts` | `buildReads` drops blind reads, emits one `nonRecursive` read at the threaded **parent** (§5.3) |
+| `packages/runner/src/index.ts` | exports the marker + structural-target fns |
+| `packages/patterns/integration/cellset-lww.test.ts` | regression test (4 steps: scalar/array blind, push CAS, e2e) |
+| `packages/memory/test/cellset-structural-precondition.test.ts` | engine-level ancestor-reshape guarantee (parent vs root) |
+| `packages/patterns/integration/multi-runtime-{worker,harness}.ts` | `set` (blind) + `push` (CAS) harness commands |

--- a/docs/specs/memory-v2/cellset-lww-context.md
+++ b/docs/specs/memory-v2/cellset-lww-context.md
@@ -299,17 +299,56 @@ the leaf value read, **keep a structural parent/root read** — closes Q1 *and*
 moves the trigger toward #4220's **per-read** vocabulary, partially answering the
 unification question. The two questions are not independent.
 
-### 5.3 Status (2026-06-29)
+### 5.3 Redesign after Robin's review (2026-06-30) — LANDED
 
-The §5.1 mitigation is **committed on `fix/cellset-blind-leaf-write` and pushed**
-to PR [#4245](https://github.com/commontoolsinc/labs/pull/4245) so Robin can
-review the final form — it is **not merged**; the tradeoff above is his call. It
-**supersedes the "drop-all" framing** still used narratively in §§2/4 and the §7
-table: blind `$value` reads are now **downgraded to a structural entity-root
-existence read**, not dropped, so the write is *structural-precondition-only*
-rather than fully *precondition-free*. The original drop-all form is recoverable
-from history (the `fix(runtime-client): precondition-free…` commit) if the
-tradeoff is rejected.
+Robin reviewed the entity-root form and endorsed the "semi-blind write" direction
+(value-blind + a structural precondition), with two changes now on
+`fix/cellset-blind-leaf-write`. Both **supersede** the "value-type narrowing" /
+"entity-root" framing in §§2/4/7 and the §5.1 mitigation.
+
+1. **Trigger by METHOD, not value type.** The scalar-vs-structured heuristic is
+   replaced by an explicit request type: `CellHandle.set` → `CellSet` → always a
+   blind last-write-wins write (any value type); `CellHandle.push` → new
+   **`CellPush`** → `handleCellPush` → read-modify-write that keeps
+   compare-and-set. The value-type check in `handleCellSet` is gone; both handlers
+   share `applyCellWrite(request, blind)`. Intent-explicit, and it lets an array
+   *overwrite* be blind while an array *push* captures reads. (Robin: push stays
+   CAS-retry at the browser→worker seam; a mergeable `append` is a deferred larger
+   change — index-shift surprises.) Files: `protocol/types.ts` (CellPush +
+   Commands), `runtime-processor.ts`, `cell-handle.ts`. Test: `cellset-lww.test.ts`
+   now covers scalar-set-blind, array-set-blind (trigger is the method),
+   push-keeps-CAS, and the e2e save.
+
+2. **Structural read anchored at the cell's PARENT, not the entity root.** Robin
+   wanted a write to `["notes","today"]` to fail if someone wrote `false` to
+   `["notes"]` (an ancestor *reshape*, à la Ian's
+   [#4406](https://github.com/commontoolsinc/labs/pull/4406)). The entity-root read
+   only caught a whole-doc delete (TIER-1); an intermediate-ancestor reshape (a
+   TIER-2 patch) slipped past and threw a raw "not traversable" at
+   commit-materialization. Now `handleCellSet` threads the cell's resolved PARENT
+   address (`setBlindStructuralTarget`, via
+   `resolveAsCell().getAsNormalizedFullLink()` — the logical write path is known
+   only there; `buildReads` sees the optimized element-level diff), and
+   `buildReads` emits one nonRecursive read at that parent. A concurrent ancestor
+   reshape is now a clean ConflictError; a same-/sibling-leaf value write (below
+   the parent) stays conflict-free; array element writes (below the parent) keep
+   array-set blind. For a linked/scalar cell the parent *is* the entity root, so
+   this reduces to the earlier form. Files: `reactivity-log.ts` (persistent target
+   registry), `runtime-processor.ts`, `index.ts`, `v2.ts`.
+
+**Verification.** cellset-lww 4/4; conflict/commit/runtime-processor/precondition
+regression + broader sweep green (109 tests); fmt/lint/type-check clean. The
+ancestor-reshape guarantee is a dedicated ENGINE-level test,
+`packages/memory/test/cellset-structural-precondition.test.ts`: precondition-free →
+raw throw; entity-root read → *still* raw throw (root is insufficient); PARENT read
+→ clean ConflictError. The in-process multi-runtime harness can't reproduce this
+end to end — it propagates shared state synchronously, so a session can't hold a
+*stale-but-navigable* replica (navigation into a retyped ancestor fails locally
+before any commit) — hence the engine-level test.
+
+**Not merged**; still PR [#4245](https://github.com/commontoolsinc/labs/pull/4245)
+for Robin's review. The array-CAS drop (a `set` of an array is now blind, unlike
+the old value-type form) is the one behavior change to flag to him explicitly.
 
 ---
 

--- a/docs/specs/memory-v2/cellset-lww-context.md
+++ b/docs/specs/memory-v2/cellset-lww-context.md
@@ -418,3 +418,74 @@ the mechanism) is preserved on `origin/scratch/cellset-conflict-probe`.
 | `packages/patterns/integration/cellset-lww.test.ts` | regression test (4 steps: scalar/array blind, push CAS, e2e) |
 | `packages/memory/test/cellset-structural-precondition.test.ts` | engine-level ancestor-reshape guarantee (parent vs root) |
 | `packages/patterns/integration/multi-runtime-{worker,harness}.ts` | `set` (blind) + `push` (CAS) harness commands |
+
+---
+
+## 8. Status & handoff (2026-07-01, session end)
+
+**PR:** [#4245](https://github.com/commontoolsinc/labs/pull/4245), branch
+`fix/cellset-blind-leaf-write`, worktree `labs/.claude/worktrees/cellset-probe`.
+Rebased onto latest main; HEAD `405c07dbd`, 11 ahead / 0 behind. The full design
+is §5.3; §§1–7 describe it in the landed (method-based + parent) form.
+
+### Robin's review
+He **endorsed the direction** on Discord (method-based trigger + a structural
+precondition), is **OK with the array-CAS drop** (a `set` of an array is now blind
+— flagged explicitly; concurrency-safe list edits go through `push` or the
+deferred mergeable-op work), and tagged **Ben** for a second opinion. His **formal
+PR re-review is pending** — that's the next inbound. When it lands, respond on the
+PR (findings-to-chat-first if it's a discussion; direct if it's a code nit).
+
+### CI — one open failure: runner coverage-debt (+2)
+Everything else is green (Runner/Pattern/Generated/CFC/Package integration, Check,
+Test, wall-time). The **Performance Check** fails only on the coverage-debt
+ratchet: `packages/runner` **7864 → 7866 (+2)**. memory (−4) and runtime-client
+(−3) are OK (fixed by the rebase catching up to main's coverage).
+
+**The puzzle to resolve next session:** the `+2` is the new structural-target
+registry — `setBlindStructuralTarget` / `getBlindStructuralTarget`
+([reactivity-log.ts](../../../packages/runner/src/storage/reactivity-log.ts) 160–176)
+and the `buildReads` emission block
+([v2.ts](../../../packages/runner/src/storage/v2.ts) ~2315–2345) — uncovered
+because runner's own suite never marks a tx blind. I added
+`packages/runner/test/blind-write-structural-precondition.test.ts`, and it
+**covers those exact lines locally** (verified DA hits: 160–167, 173, 2317–2340 all
+>0). **But CI still reports +2 on `405c07dbd` (the run that includes the test).**
+So the test's coverage isn't reaching the runner coverage-debt metric. Likely
+causes to check:
+1. **Which job/shard collects `packages/runner` coverage** — see
+   [docs/development/COVERAGE.md](../../development/COVERAGE.md). If my test file
+   isn't in that job's run (or its V8 coverage lands in a shard whose LCOV isn't
+   the runner-debt source), it won't count. Confirm the test is actually executed
+   *by the coverage-collecting runner job*.
+2. **Whether the +2 is different lines** than I covered — run the *full* runner
+   suite locally with `--coverage` and list the still-uncovered new lines in
+   `reactivity-log.ts` / `v2.ts` (my local check ran only the one test file).
+   There may be ~2 uncovered new lines elsewhere (e.g. the `pending`-branch of the
+   emission block, or a `getBlindStructuralTarget` chain edge).
+
+**Fallback if it's genuinely not coverable by the runner job:** the sanctioned
+override — the perf log emits the exact marker
+`NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 7866 lines`
+(placed per [CI_PERFORMANCE.md](../../development/CI_PERFORMANCE.md) §"Coverage Debt
+Baselines"). Prefer real coverage; use the marker only if (1)/(2) show the lines
+can't be reached from the runner coverage job.
+
+### Deferred / follow-ups (not this PR)
+- **Mergeable-op array RMW** (Robin's idea): `ArrayCellController.remove/update`
+  route through `set` and are now blind; the concurrency-safe fix is server-side
+  `remove-by-value`/`splice` mergeable ops. Larger, separate change.
+- **Two-browser** integration not re-run locally on the method-based form (CI
+  covers it).
+
+### Pick-up commands
+```bash
+cd labs/.claude/worktrees/cellset-probe      # branch fix/cellset-blind-leaf-write
+git fetch origin && git log --oneline -3     # confirm HEAD vs origin
+gh pr view 4245 --json state,reviewDecision  # Robin's review state
+gh pr checks 4245                            # CI (Performance Check = the open one)
+gh pr view 4245 --comments                   # cubic / bot / review comments
+# reproduce the runner coverage question:
+deno test --coverage=/tmp/cov -A packages/runner/test/   # full runner suite
+deno coverage /tmp/cov --lcov | awk '/reactivity-log|storage\/v2\.ts/'  # inspect DA
+```

--- a/docs/specs/memory-v2/cellset-lww-context.md
+++ b/docs/specs/memory-v2/cellset-lww-context.md
@@ -189,18 +189,129 @@ typed name. None of the landed work addresses the scalar `$value` own-write race
 
 ---
 
-## 5. Open questions for Robin (ubik2) — flagged in the PR body
+## 5. Open questions for Robin (ubik2) — investigated 2026-06-29
 
-1. **Patch-replay edge.** A nested scalar `$value` set emits a *patch* op.
-   Precondition-free, a patch whose ancestor path was concurrently removed (a
-   whole-doc delete racing a `$value` set — rare, and **not** the PerUser
-   own-write race this fixes) would throw at **read-materialization** rather than
-   be rejected at commit. Should we keep a structural (entity/parent-present)
-   precondition even when dropping the value-equality one?
-2. **Trigger choice.** Value-type heuristic (scalar → blind) vs an explicit
-   signal — and whether the blind-leaf-write belongs expressed in #4220's newer
-   "mergeable op / `excludeReadFromConflict`" vocabulary (conceptually adjacent;
-   functionally distinct today). Possible unification opportunity.
+Both questions from the PR body were dug into directly (engine-level repros +
+load-bearing reads). The original framing, then what we found.
+
+### 5.1 Q1 — Patch-replay edge: **verified real, bounded, with a tested mitigation**
+
+> *Original:* a nested scalar `$value` set emits a *patch* op; precondition-free,
+> a patch whose ancestor path was concurrently removed (a whole-doc delete racing
+> a `$value` set — rare, **not** the PerUser own-write race) would throw at
+> read-materialization rather than be rejected at commit. Keep a structural
+> (entity/parent-present) precondition even when dropping the value-equality one?
+
+**Reproduced at the engine level** (crafted set→delete→blind-patch commits via
+`applyCommit`, mirroring `packages/memory/test/v2-commit-preconditions.test.ts`):
+
+- **The edge is real.** A precondition-free nested-scalar `replace` patch whose
+  doc was concurrently whole-doc-deleted throws **`Error: missing path
+  /value/profileDraft`**. `reconstructPatchedDocument`
+  ([engine.ts:4147](../../../packages/memory/v2/engine.ts)) reads the delete as
+  its base (`SELECT_LATEST_BASE` is `op IN ('set','delete')`), so the doc is
+  `emptyEntityDocument() = {}`, and `replaceAtPath` → `thawSpine`
+  ([patch.ts:107](../../../packages/memory/v2/patch.ts)) can't descend.
+- **Why the fix exposes it.** Same scenario *pre-fix* (compare-and-set) is caught
+  cleanly as `ConflictError: stale confirmed read … conflicted with seq 2` — the
+  concurrent delete fires **TIER-1 (set/delete), which is path-blind**, and the
+  value-equality precondition we drop was the *only* carrier of that catch. The
+  engine has **no `entity-present` precondition** at all — only
+  `origin-committed` / `receipt-exists` / `entity-absent`
+  ([engine.ts:3446](../../../packages/memory/v2/engine.ts)).
+- **Blast radius is bounded.** The throw fires inside commit-time
+  `materializeSnapshots` (calls `readStateForScopeKey` unconditionally), which is
+  inside `engine.database.transaction(applyCommitTransaction).immediate(...)`
+  ([engine.ts:1542](../../../packages/memory/v2/engine.ts)) → **the commit rolls
+  back**; the doc is **not** durably poisoned (observed `read = null` after). The
+  harm is a *raw `Error` instead of a `ConflictError`* — ungraceful failure, not
+  corruption or silent loss. (A blind **`add`** of a fresh key instead silently
+  *resurrects* the doc — manifestation is op-shape-dependent.)
+- **End-to-end reachability** is rarer than the own-write race: it needs a real
+  flow that whole-doc-deletes a draft doc concurrent with a scalar set. The
+  *engine* mechanism is verified; an end-to-end pattern repro was not built.
+
+**Mitigation (prototype — uncommitted on the working tree; see §5.3).** Instead
+of dropping every blind read, `buildReads` **downgrades** each to a single
+`nonRecursive` existence read at the **entity root**
+([v2.ts:2165](../../../packages/runner/src/storage/v2.ts)). TIER-1 is path-blind
+→ a concurrent whole-doc delete/replace still yields a clean `ConflictError`;
+TIER-2 `nonRecursive` overlap fires only at-or-above the read path
+(`patchOverlapsNonRecursiveRead`, [engine.ts:3914](../../../packages/memory/v2/engine.ts)),
+and the dropped leaf value read sits strictly **below** the root, so the same-leaf
+own-write race stays conflict-free. Verified:
+
+- engine probes — structural-read + delete → `ConflictError` (graceful); structural
+  read + same-leaf race → no conflict;
+- `cellset-lww` **3/3** (own-write race preserved through the real stack);
+- conflict/commit/runtime-processor/precondition regression **34 tests / 63 steps**;
+- the downgrade is **live, not a no-op** — observed 314× on the real blind-set
+  path (gated `CSPROBE_STRUCT` instrumentation, since removed);
+- type-check clean.
+
+**Tradeoff (observed).** The mitigation re-introduces a *narrow* conflict class:
+a scalar `$value` set now conflicts with a concurrent **whole-doc set or delete
+of the same entity**. Behavior becomes **uniform** — both whole-doc races yield a
+clean `ConflictError` (which conflict-recovery already handles) instead of the
+current split (silent apply-on-top for a whole-doc set; raw throw for a delete).
+The same-leaf own-write race is untouched. Whether that uniformity is worth the
+extra conflicts is **Robin's call**.
+
+**Pre-land gaps for the mitigation:** (a) no single end-to-end delete-race test
+(harness has no whole-doc-delete primitive — established by composition: observed
+emission + proven engine semantics); (b) broad pattern-integration suites (68 +
+147) not run — the proportionate gate, since a scalar UI write now pins entity-root
+existence for every pattern; (c) client-side `validated` left unchanged
+(engine-authoritative); (d) root `[]` vs immediate-parent granularity is a design
+choice.
+
+### 5.2 Q2 — Trigger shape / #4220 unification: distinct today; Q1 points at the seam
+
+> *Original:* value-type heuristic (scalar → blind) vs an explicit signal — and
+> whether the blind-leaf-write belongs expressed in #4220's "mergeable op /
+> `excludeReadFromConflict`" vocabulary. Possible unification.
+
+The three drop-from-conflict filters now sit as siblings in one `buildReads` loop
+([v2.ts:2157](../../../packages/runner/src/storage/v2.ts)), at **three different
+granularities**:
+
+| Filter | Owner | Granularity | Keeps |
+|---|---|---|---|
+| `isReadIgnoredForCommit` | #4245 (ours) | **tx-wide**, unconditional | (now) a structural root read |
+| `isReadExcludedFromConflict && nonRecursive` | #4220 | **per-read**, nonRecursive-gated | recursive value reads |
+| mergeable-op block | #4220 | **per-op/entity** | recursive read *at* the op path |
+
+Neither #4220 marker can absorb ours as-is: `excludeReadFromConflict` is
+`nonRecursive`-gated but our write-target read is **recursive** (by-value,
+[data-updating.ts:666](../../../packages/runner/src/data-updating.ts)) — confirmed
+by code *and* empirically (with #4220 present, disabling our fix still fails the
+race); `mergeableOpRead` *deliberately keeps* the recursive read at the op path
+(so conditional mergeable writes still conflict) — exactly the read we must drop —
+and a mergeable op is apply-on-top *merge*, not LWW *overwrite*. The reason they
+differ: #4220's markers serve txs that **mix** droppable machinery reads with kept
+handler reads (so they're per-read); `handleCellSet`'s tx is **single-purpose**,
+which is what justifies the tx-wide approach.
+
+**Synthesis — Q1 and Q2 share one lever: granularity.** The tx-wide "drop
+everything" is precisely what *creates* the Q1 edge (it discards the structural
+delete-catcher with the value-equality precondition). The §5.1 mitigation — drop
+the leaf value read, **keep a structural parent/root read** — closes Q1 *and*
+moves the trigger toward #4220's **per-read** vocabulary, partially answering the
+unification question. The two questions are not independent.
+
+### 5.3 Status (2026-06-29)
+
+The §5.1 mitigation is **committed on `fix/cellset-blind-leaf-write` and pushed**
+to PR [#4245](https://github.com/commontoolsinc/labs/pull/4245) so Robin can
+review the final form — it is **not merged**; the tradeoff above is his call. It
+**supersedes the "drop-all" framing** still used narratively in §§2/4 and the §7
+table: blind `$value` reads are now **downgraded to a structural entity-root
+existence read**, not dropped, so the write is *structural-precondition-only*
+rather than fully *precondition-free*. The original drop-all form is recoverable
+from history (the `fix(runtime-client): precondition-free…` commit) if the
+tradeoff is rejected.
+
+---
 
 This supersedes the **recovery**-based approaches (#4196 per-key commit queue,
 #4126 reapply-latest) by removing the conflict at the source (**prevention**).
@@ -243,7 +354,7 @@ the mechanism) is preserved on `origin/scratch/cellset-conflict-probe`.
 | `packages/runtime-client/backends/runtime-processor.ts` | `handleCellSet` trigger: scalar check + mark/unmark around `set()` |
 | `packages/runner/src/storage/reactivity-log.ts` | `markUiInputBlindWriteTx` / `unmark` / `is` + `ignoreReadForCommit` marker |
 | `packages/runner/src/storage/v2-transaction.ts` | `read()` tags reads + skips `doc.validated` when blind |
-| `packages/runner/src/storage/v2.ts` | `buildReads` drops `ignoreReadForCommit` reads from `reads.confirmed` |
+| `packages/runner/src/storage/v2.ts` | `buildReads` handling of `ignoreReadForCommit` reads — **now downgrades** each to a `nonRecursive` entity-root existence read (was: dropped). See §5.1 |
 | `packages/runner/src/index.ts` | exports the marker fns |
 | `packages/patterns/integration/cellset-lww.test.ts` | regression test (3 steps) |
 | `packages/patterns/integration/multi-runtime-{worker,harness}.ts` | `set` harness command (UI-input write path) |

--- a/packages/memory/test/cellset-structural-precondition.test.ts
+++ b/packages/memory/test/cellset-structural-precondition.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Regression for the blind-`$value` write STRUCTURAL precondition (the
+ * ancestor-shape check).
+ *
+ * A blind UI-input `set` drops the value-equality precondition on its write
+ * target so it can't lose the own-write race. In its place, handleCellSet threads
+ * the cell's PARENT address, which buildReads turns into one nonRecursive read.
+ * This test pins WHY that read must be at the parent, not the entity root: it
+ * exercises the exact race the parent read exists for — a stale nested patch
+ * whose ANCESTOR was concurrently retyped (object -> scalar).
+ *
+ * - precondition-free: the patch replays onto the retyped base at
+ *   commit-materialization and throws a raw "not traversable" (ungraceful; rolls
+ *   back inside the commit's SQLite tx, so no durable corruption);
+ * - an entity-ROOT structural read does NOT catch it (a TIER-2 patch that retypes
+ *   an intermediate ancestor doesn't overlap a root read) — still a raw throw;
+ * - the PARENT structural read (what handleCellSet threads) converts it into a
+ *   clean ConflictError, which the conflict-recovery path handles gracefully.
+ *
+ * The in-process multi-runtime harness can't reproduce this end to end: it
+ * propagates shared state synchronously, so a session can't hold a stale-but-
+ * navigable replica (its navigation into the retyped ancestor fails locally
+ * before any commit). Hence this engine-level test.
+ */
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { toFileUrl } from "@std/path";
+import {
+  applyCommit,
+  close,
+  ConflictError,
+  type Engine,
+  open,
+  read,
+} from "../v2/engine.ts";
+import { type EntityDocument, toDocumentPath } from "../v2.ts";
+import type { FabricValue } from "@commonfabric/api";
+
+const toEntityDocument = (value: FabricValue): EntityDocument => ({ value });
+
+const createEngine = async (): Promise<{ engine: Engine; path: string }> => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const engine = await open({ url: toFileUrl(path) });
+  return { engine, path };
+};
+
+// seq 1: a doc with a nested object ancestor `notes`. seq 2: writer B retypes
+// `notes` from an object to a scalar (a blind patch). Leaves the engine with a
+// retyped ancestor that a stale nested patch cannot replay onto.
+const setupReshape = (engine: Engine): void => {
+  applyCommit(engine, {
+    sessionId: "session:setup",
+    commit: {
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "set",
+        id: "entity:doc",
+        value: toEntityDocument({ notes: { today: "x" } }),
+      }],
+    },
+  });
+  applyCommit(engine, {
+    sessionId: "session:reshaper",
+    commit: {
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{
+        op: "patch",
+        id: "entity:doc",
+        patches: [{ op: "replace", path: "/value/notes", value: false }],
+      }],
+    },
+  });
+};
+
+// Writer A's stale nested patch (replace /value/notes/today), based on seq 1,
+// carrying the given structural read (or none).
+const aliceNestedPatch = (
+  structuralRead?: {
+    id: string;
+    path: ReturnType<typeof toDocumentPath>;
+    seq: number;
+    nonRecursive: true;
+  },
+) => ({
+  sessionId: "session:alice",
+  commit: {
+    localSeq: 1,
+    reads: {
+      confirmed: structuralRead ? [structuralRead] : [],
+      pending: [],
+    },
+    operations: [{
+      op: "patch" as const,
+      id: "entity:doc",
+      patches: [{
+        op: "replace" as const,
+        path: "/value/notes/today",
+        value: "typed",
+      }],
+    }],
+  },
+});
+
+Deno.test("blind $value structural precondition vs a concurrent ancestor reshape", async (t) => {
+  await t.step(
+    "precondition-free: a nested patch on a retyped ancestor throws a raw non-Conflict error, rolled back",
+    async () => {
+      const { engine, path } = await createEngine();
+      try {
+        setupReshape(engine);
+        const err = assertThrows(
+          () => applyCommit(engine, aliceNestedPatch()),
+          Error,
+          "not traversable",
+        );
+        assertEquals(
+          err instanceof ConflictError,
+          false,
+          "must be a raw error, not a clean ConflictError",
+        );
+        // Rolled back inside the commit's SQLite tx: no durable corruption.
+        assertEquals(read(engine, { id: "entity:doc" }), {
+          value: { notes: false },
+        });
+      } finally {
+        close(engine);
+        await Deno.remove(path);
+      }
+    },
+  );
+
+  await t.step(
+    "entity-root structural read does NOT catch the reshape (still a raw throw)",
+    async () => {
+      const { engine, path } = await createEngine();
+      try {
+        setupReshape(engine);
+        const err = assertThrows(
+          () =>
+            applyCommit(
+              engine,
+              aliceNestedPatch({
+                id: "entity:doc",
+                path: toDocumentPath([]),
+                seq: 1,
+                nonRecursive: true,
+              }),
+            ),
+          Error,
+          "not traversable",
+        );
+        assertEquals(
+          err instanceof ConflictError,
+          false,
+          "an entity-root read must not convert the reshape into a conflict — " +
+            "it is why the structural read must be at the write's parent",
+        );
+      } finally {
+        close(engine);
+        await Deno.remove(path);
+      }
+    },
+  );
+
+  await t.step(
+    "parent structural read converts the reshape into a clean ConflictError",
+    async () => {
+      const { engine, path } = await createEngine();
+      try {
+        setupReshape(engine);
+        const err = assertThrows(
+          () =>
+            applyCommit(
+              engine,
+              aliceNestedPatch({
+                id: "entity:doc",
+                path: toDocumentPath(["value", "notes"]),
+                seq: 1,
+                nonRecursive: true,
+              }),
+            ),
+          ConflictError,
+          "stale confirmed read",
+        );
+        assertEquals(err.name, "ConflictError");
+      } finally {
+        close(engine);
+        await Deno.remove(path);
+      }
+    },
+  );
+});

--- a/packages/patterns/integration/cellset-lww.test.ts
+++ b/packages/patterns/integration/cellset-lww.test.ts
@@ -36,6 +36,11 @@ const PROGRAM_PATH = join(
 const ROOT_PATH = join(import.meta.dirname!, "..");
 const DRAFT: (string | number)[] = ["profileDraft"];
 
+// Trusted surface/action for the profile save (inlined from
+// cfc-group-chat-demo/trusted.tsx, as the multi-runtime demo test does).
+const PROFILE_SURFACE = "TrustedGroupChatProfileSurface";
+const SAVE_PROFILE_ACTION = "TrustedGroupChatSaveProfile";
+
 const isConflict = (error?: { name?: string; message?: string }): boolean =>
   error?.name === "ConflictError" ||
   (error?.message?.includes("stale confirmed read") ?? false);
@@ -127,5 +132,34 @@ describe("cellset last-write-wins for scalar $value (own-write race)", () => {
       "concurrent structured writes must still hit compare-and-set conflicts " +
         "(blind-leaf-write must not apply to non-scalar values)",
     );
+  });
+
+  it("end-to-end: a typed name survives the own-write race through save", async () => {
+    // The original cfc-group-chat-demo "Name not set" flake, end to end: a user
+    // types a profile name (a scalar `$value` write to the PerUser draft), then
+    // saves. The save handler (commitTrustedProfileSave) reads draftText(nameDraft).
+    // Pre-fix, the draft `$value` write loses the own-write race, is rejected and
+    // rolled back to its prior (empty) value, so the save reads the wrong/empty
+    // draft and the profile name is not the one the user typed. With the fix the
+    // scalar write is precondition-free, lands, and the save reads it.
+    for (let i = 0; i < 5; i++) {
+      await harness.settle();
+      // Another concurrent write bumps the shared PerUser draft's seq…
+      await aliceTab2.set([...DRAFT], `tab2-${i}`, { idle: false });
+      // …so alice's later typed name commits against a stale baseline.
+      const typed = `alice-typed-${i}`;
+      await alice.set([...DRAFT], typed, { idle: false });
+      // Save the profile via the trusted action (reads draftText(nameDraft)).
+      await alice.send("saveProfile", {}, {
+        surface: PROFILE_SURFACE,
+        action: SAVE_PROFILE_ACTION,
+      });
+      await harness.settle();
+      assertEquals(
+        await alice.read(["currentProfileName"]),
+        typed,
+        `the name alice typed must be the saved profile name (iter ${i})`,
+      );
+    }
   });
 });

--- a/packages/patterns/integration/cellset-lww.test.ts
+++ b/packages/patterns/integration/cellset-lww.test.ts
@@ -1,16 +1,17 @@
 /**
- * Regression test: scalar `$value` UI input is a precondition-free
- * last-write-wins leaf write (supersedes the #4126 cellset-silent-rollback
- * queue work).
+ * Regression test: a UI `set` is a blind last-write-wins leaf write; a `push` is
+ * read-modify-write and keeps compare-and-set. The blind-vs-CAS choice is made by
+ * METHOD (the request type the client sends), not by the value's shape.
  *
- * A scalar `$value`/`$checked` edit is a full leaf overwrite. `handleCellSet`
- * marks its transaction as a blind-leaf-write (around the `set` only), so the
- * write carries no concurrency precondition. Under concurrent same-user edits it
- * therefore no longer hits the "stale confirmed read" conflict that rolled the
- * write back and silently dropped a profile/draft edit — the cfc-group-chat-demo
- * "Name not set" flake. Structured (array/object) writes are NOT marked blind —
- * they may be read-modify-write (CellHandle.push, multi-select, list edits) — and
- * retain compare-and-set so concurrent list mutations still cannot lose updates.
+ * `handleCellSet` marks its transaction as a blind-leaf-write, so the set's reads
+ * carry no value-equality precondition (only a structural existence read at the
+ * entity root survives, to catch a concurrent whole-doc delete/replace). Under
+ * concurrent same-user edits a `set` therefore no longer hits the
+ * "stale confirmed read" conflict that rolled the write back and silently dropped
+ * a profile/draft edit — the cfc-group-chat-demo "Name not set" flake. A `push`
+ * routes through `handleCellPush`, which is NOT blind, so concurrent list
+ * mutations still cannot lose updates. (Supersedes the #4126 cellset-silent-
+ * rollback queue work.)
  *
  * profileDraft is PerUser, so two sessions of the same identity share the doc
  * (≈ two browser tabs of one user): the own-write race.
@@ -89,23 +90,52 @@ describe("cellset last-write-wins for scalar $value (own-write race)", () => {
     }
   });
 
-  it("structured (non-scalar) writes retain compare-and-set", async () => {
-    // The narrowing that keeps read-modify-write safe: an array/object value is
-    // not a blind leaf write, so concurrent same-user structured writes still
-    // hit the own-write-race conflict (compare-and-set), preventing lost updates.
-    let conflicts = 0;
+  it("a structured (array) set is blind too — trigger is the method, not the value type", async () => {
+    // Pre-redesign this compare-and-set: a value-type heuristic kept array/object
+    // values on the CAS path. With the method-based trigger, ANY `set` is blind,
+    // so concurrent same-user array-value sets no longer conflict either — only
+    // `push` keeps compare-and-set (next test).
     for (let i = 0; i < 8; i++) {
       await harness.settle();
       const [a, b] = await Promise.all([
         alice.set([...DRAFT], [`alice-${i}`], { idle: false }),
         aliceTab2.set([...DRAFT], [`tab2-${i}`], { idle: false }),
       ]);
+      assert(
+        a.ok,
+        `alice array set ${i} should be a blind write (no conflict): ${
+          JSON.stringify(a.error)
+        }`,
+      );
+      assert(
+        b.ok,
+        `tab2 array set ${i} should be a blind write (no conflict): ${
+          JSON.stringify(b.error)
+        }`,
+      );
+    }
+  });
+
+  it("concurrent pushes retain compare-and-set (push keeps its read precondition)", async () => {
+    // A `push` is read-modify-write: it routes through CellPush/handleCellPush,
+    // which is NOT blind, so the read of the current array stays a commit
+    // precondition. Concurrent same-user pushes against the shared draft therefore
+    // still conflict (compare-and-set), guarding against lost updates — the safety
+    // the old value-type narrowing approximated, now keyed on the method.
+    await alice.set([...DRAFT], [], {}); // array baseline (itself a blind set)
+    let conflicts = 0;
+    for (let i = 0; i < 8; i++) {
+      await harness.settle();
+      const [a, b] = await Promise.all([
+        alice.push([...DRAFT], `alice-${i}`, { idle: false }),
+        aliceTab2.push([...DRAFT], `tab2-${i}`, { idle: false }),
+      ]);
       if (isConflict(a.error) || isConflict(b.error)) conflicts++;
     }
     assert(
       conflicts > 0,
-      "concurrent structured writes must still hit compare-and-set conflicts " +
-        "(blind-leaf-write must not apply to non-scalar values)",
+      "concurrent pushes must still hit compare-and-set conflicts " +
+        "(push must keep its read precondition, unlike a blind set)",
     );
   });
 

--- a/packages/patterns/integration/cellset-lww.test.ts
+++ b/packages/patterns/integration/cellset-lww.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression test: scalar `$value` UI input is a precondition-free
+ * last-write-wins leaf write (supersedes the #4126 cellset-silent-rollback
+ * queue work).
+ *
+ * A scalar `$value`/`$checked` edit is a full leaf overwrite. `handleCellSet`
+ * marks its transaction as a blind-leaf-write (around the `set` only), so the
+ * write carries no concurrency precondition. Under concurrent same-user edits it
+ * therefore no longer hits the "stale confirmed read" conflict that rolled the
+ * write back and silently dropped a profile/draft edit — the cfc-group-chat-demo
+ * "Name not set" flake. Structured (array/object) writes are NOT marked blind —
+ * they may be read-modify-write (CellHandle.push, multi-select, list edits) — and
+ * retain compare-and-set so concurrent list mutations still cannot lose updates.
+ *
+ * profileDraft is PerUser, so two sessions of the same identity share the doc
+ * (≈ two browser tabs of one user): the own-write race.
+ *
+ * No toolshed or browser required (Deno workers + in-process storage server).
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import { Identity } from "@commonfabric/identity";
+import {
+  MultiRuntimeHarness,
+  type MultiRuntimeSession,
+} from "./multi-runtime-harness.ts";
+
+const PROGRAM_PATH = join(
+  import.meta.dirname!,
+  "..",
+  "cfc-group-chat-demo",
+  "main.tsx",
+);
+const ROOT_PATH = join(import.meta.dirname!, "..");
+const DRAFT: (string | number)[] = ["profileDraft"];
+
+const isConflict = (error?: { name?: string; message?: string }): boolean =>
+  error?.name === "ConflictError" ||
+  (error?.message?.includes("stale confirmed read") ?? false);
+
+describe("cellset last-write-wins for scalar $value (own-write race)", () => {
+  let harness: MultiRuntimeHarness;
+  let alice: MultiRuntimeSession;
+  let aliceTab2: MultiRuntimeSession;
+
+  beforeAll(async () => {
+    const aliceId = await Identity.fromPassphrase("cellset-lww alice", {
+      implementation: "noble",
+    });
+    harness = await MultiRuntimeHarness.create({
+      programPath: PROGRAM_PATH,
+      rootPath: ROOT_PATH,
+      sessions: [
+        { label: "alice", identity: aliceId },
+        // Same user as alice, separate session ≈ second browser tab.
+        { label: "alice-tab2", identity: aliceId },
+      ],
+    });
+    alice = harness.session("alice");
+    aliceTab2 = harness.session("alice-tab2");
+  });
+
+  afterAll(async () => {
+    await harness?.dispose();
+  });
+
+  it("concurrent same-user scalar sets never conflict", async () => {
+    for (let i = 0; i < 8; i++) {
+      await harness.settle(); // converge both sessions to one baseline seq
+      const [a, b] = await Promise.all([
+        alice.set([...DRAFT], `alice-${i}`, { idle: false }),
+        aliceTab2.set([...DRAFT], `tab2-${i}`, { idle: false }),
+      ]);
+      assert(
+        a.ok,
+        `alice scalar set ${i} should not conflict: ${JSON.stringify(a.error)}`,
+      );
+      assert(
+        b.ok,
+        `tab2 scalar set ${i} should not conflict: ${JSON.stringify(b.error)}`,
+      );
+    }
+  });
+
+  it("a genuine later scalar edit against a stale baseline wins LWW", async () => {
+    for (let i = 0; i < 8; i++) {
+      // 1) baseline both sessions.
+      await alice.set([...DRAFT], `base-${i}`);
+      await harness.settle();
+      // 2) tab2 writes a new value; do NOT settle alice — her local stays stale.
+      await aliceTab2.set([...DRAFT], `remote-${i}`, { idle: false });
+      // 3) alice's later genuine edit must commit and win. Pre-fix it was lost:
+      //    her write-target read at the stale seq conflicted with tab2's patch,
+      //    rolling her edit back.
+      const edit = `alice-edit-${i}`;
+      const res = await alice.set([...DRAFT], edit, { idle: false });
+      assert(
+        res.ok,
+        `alice edit ${i} should commit: ${JSON.stringify(res.error)}`,
+      );
+      await harness.settle();
+      assertEquals(
+        await alice.read([...DRAFT]),
+        edit,
+        `alice's later edit ${i} must win LWW, not be dropped`,
+      );
+    }
+  });
+
+  it("structured (non-scalar) writes retain compare-and-set", async () => {
+    // The narrowing that keeps read-modify-write safe: an array/object value is
+    // not a blind leaf write, so concurrent same-user structured writes still
+    // hit the own-write-race conflict (compare-and-set), preventing lost updates.
+    let conflicts = 0;
+    for (let i = 0; i < 8; i++) {
+      await harness.settle();
+      const [a, b] = await Promise.all([
+        alice.set([...DRAFT], [`alice-${i}`], { idle: false }),
+        aliceTab2.set([...DRAFT], [`tab2-${i}`], { idle: false }),
+      ]);
+      if (isConflict(a.error) || isConflict(b.error)) conflicts++;
+    }
+    assert(
+      conflicts > 0,
+      "concurrent structured writes must still hit compare-and-set conflicts " +
+        "(blind-leaf-write must not apply to non-scalar values)",
+    );
+  });
+});

--- a/packages/patterns/integration/cellset-lww.test.ts
+++ b/packages/patterns/integration/cellset-lww.test.ts
@@ -89,31 +89,6 @@ describe("cellset last-write-wins for scalar $value (own-write race)", () => {
     }
   });
 
-  it("a genuine later scalar edit against a stale baseline wins LWW", async () => {
-    for (let i = 0; i < 8; i++) {
-      // 1) baseline both sessions.
-      await alice.set([...DRAFT], `base-${i}`);
-      await harness.settle();
-      // 2) tab2 writes a new value; do NOT settle alice — her local stays stale.
-      await aliceTab2.set([...DRAFT], `remote-${i}`, { idle: false });
-      // 3) alice's later genuine edit must commit and win. Pre-fix it was lost:
-      //    her write-target read at the stale seq conflicted with tab2's patch,
-      //    rolling her edit back.
-      const edit = `alice-edit-${i}`;
-      const res = await alice.set([...DRAFT], edit, { idle: false });
-      assert(
-        res.ok,
-        `alice edit ${i} should commit: ${JSON.stringify(res.error)}`,
-      );
-      await harness.settle();
-      assertEquals(
-        await alice.read([...DRAFT]),
-        edit,
-        `alice's later edit ${i} must win LWW, not be dropped`,
-      );
-    }
-  });
-
   it("structured (non-scalar) writes retain compare-and-set", async () => {
     // The narrowing that keeps read-modify-write safe: an array/object value is
     // not a blind leaf write, so concurrent same-user structured writes still

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -177,6 +177,24 @@ export class MultiRuntimeSession {
     }) as { ok: boolean; error?: { name?: string; message?: string } };
   }
 
+  /**
+   * Append `value` to the array cell reached by `path`, exactly like a
+   * `CellHandle.push`: read-modify-write that keeps its read as a compare-and-set
+   * precondition (the `handleCellPush` path), so a concurrent push conflicts
+   * rather than being clobbered — unlike the blind `set` above.
+   */
+  async push(
+    path: (string | number)[],
+    value: unknown,
+    opts: { idle?: boolean } = {},
+  ): Promise<{ ok: boolean; error?: { name?: string; message?: string } }> {
+    return await this.#client.call("push", {
+      path,
+      value,
+      idle: opts.idle,
+    }) as { ok: boolean; error?: { name?: string; message?: string } };
+  }
+
   /** Read a value from the piece result, pulling fresh state first. */
   async read(path: (string | number)[] = []): Promise<unknown> {
     return await this.#client.call("read", { path });

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -158,6 +158,25 @@ export class MultiRuntimeSession {
     await this.#client.call("send", { handler, event, trustedUi });
   }
 
+  /**
+   * Set a cell reached from the piece result by `path`, exactly like a UI
+   * `$value` binding: one fresh edit tx and a single un-retried commit (the
+   * `handleCellSet` path). Returns the commit outcome so tests can observe
+   * conflicts. Pass `idle: false` to leave this runtime un-settled (preserves
+   * a stale local replica for own-write-race / no-op repros).
+   */
+  async set(
+    path: (string | number)[],
+    value: unknown,
+    opts: { idle?: boolean } = {},
+  ): Promise<{ ok: boolean; error?: { name?: string; message?: string } }> {
+    return await this.#client.call("set", {
+      path,
+      value,
+      idle: opts.idle,
+    }) as { ok: boolean; error?: { name?: string; message?: string } };
+  }
+
   /** Read a value from the piece result, pulling fresh state first. */
   async read(path: (string | number)[] = []): Promise<unknown> {
     return await this.#client.call("read", { path });

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -10,6 +10,7 @@ import type { Cell } from "@commonfabric/runner";
 import type { SchedulerGraphSnapshot } from "@commonfabric/runner";
 import {
   markUiInputBlindWriteTx,
+  setBlindStructuralTarget,
   unmarkUiInputBlindWriteTx,
 } from "@commonfabric/runner";
 import { markRendererTrustedEvent } from "@commonfabric/runner/cfc";
@@ -170,13 +171,14 @@ const handlers: Record<
     return {};
   },
 
-  // Faithful mirror of RuntimeProcessor.handleCellSet — the path a UI `$value`
-  // binding takes: ONE fresh edit tx, a single un-retried commit, with the
-  // blind-leaf-write mark applied (around the set only) for scalar values and
-  // withheld for structured/RMW values, exactly as handleCellSet does. We
-  // additionally await the commit so the test can observe the outcome (a
-  // conflict surfaces as a Result error). Pass `idle: false` to leave this
-  // runtime un-settled, so its local replica stays stale (own-write-race repro).
+  // Faithful mirror of RuntimeProcessor.handleCellSet — the path a UI binding
+  // takes for a plain `set`: ONE fresh edit tx, a single un-retried commit,
+  // marked as a blind leaf write. The blind-vs-CAS choice is by METHOD, not value
+  // shape: a `set` is ALWAYS blind (last-write-wins); read-modify-write goes
+  // through `push` (below), which keeps compare-and-set. We await the commit so
+  // the test can observe the outcome (a conflict surfaces as a Result error).
+  // Pass `idle: false` to leave this runtime un-settled, so its local replica
+  // stays stale (own-write-race repro).
   async set({ path, value, idle: doIdle }) {
     const runtime = controller().manager().runtime;
     const tx = runtime.edit();
@@ -184,11 +186,47 @@ const handlers: Record<
     for (const segment of (path ?? []) as (string | number)[]) {
       cell = cell.key(segment as never) as Cell<any>;
     }
-    const blindLeafWrite = typeof value === "string" ||
-      typeof value === "number" || typeof value === "boolean";
-    if (blindLeafWrite) markUiInputBlindWriteTx(tx);
+    markUiInputBlindWriteTx(tx);
+    // Mirror handleCellSet: thread the cell's PARENT address as the structural
+    // existence/shape precondition for the blind write.
+    const link = cell.withTx(tx).resolveAsCell().getAsNormalizedFullLink();
+    setBlindStructuralTarget(tx, {
+      id: link.id,
+      space: link.space,
+      scope: link.scope,
+      path: link.path.slice(0, -1),
+    });
     cell.withTx(tx).set(value as never);
-    if (blindLeafWrite) unmarkUiInputBlindWriteTx(tx);
+    unmarkUiInputBlindWriteTx(tx);
+    runtime.prepareTxForCommit(tx);
+    const res = await tx.commit() as {
+      error?: { name?: string; message?: string };
+    };
+    if (doIdle !== false) await idle();
+    return sanitizeForTransfer({
+      ok: !res?.error,
+      error: res?.error
+        ? { name: res.error.name, message: res.error.message }
+        : undefined,
+    });
+  },
+
+  // Faithful mirror of RuntimeProcessor.handleCellPush / CellHandle.push: a
+  // read-modify-write append, NOT blind — the set's diff read of the current
+  // array is kept as a commit precondition (compare-and-set), so a concurrent
+  // push aborts rather than being clobbered by a blind overwrite. Reads the
+  // current value from the local replica (no pull), mirroring CellHandle.push
+  // reading its cache.
+  async push({ path, value, idle: doIdle }) {
+    const runtime = controller().manager().runtime;
+    let cell = result();
+    for (const segment of (path ?? []) as (string | number)[]) {
+      cell = cell.key(segment as never) as Cell<any>;
+    }
+    const currentRaw = cell.get();
+    const current = Array.isArray(currentRaw) ? currentRaw : [];
+    const tx = runtime.edit();
+    cell.withTx(tx).set([...current, value] as never);
     runtime.prepareTxForCommit(tx);
     const res = await tx.commit() as {
       error?: { name?: string; message?: string };

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -8,6 +8,10 @@
 
 import type { Cell } from "@commonfabric/runner";
 import type { SchedulerGraphSnapshot } from "@commonfabric/runner";
+import {
+  markUiInputBlindWriteTx,
+  unmarkUiInputBlindWriteTx,
+} from "@commonfabric/runner";
 import { markRendererTrustedEvent } from "@commonfabric/runner/cfc";
 import { Identity, type KeyPairRaw } from "@commonfabric/identity";
 import {
@@ -164,6 +168,38 @@ const handlers: Record<
     }
     await idle();
     return {};
+  },
+
+  // Faithful mirror of RuntimeProcessor.handleCellSet — the path a UI `$value`
+  // binding takes: ONE fresh edit tx, a single un-retried commit, with the
+  // blind-leaf-write mark applied (around the set only) for scalar values and
+  // withheld for structured/RMW values, exactly as handleCellSet does. We
+  // additionally await the commit so the test can observe the outcome (a
+  // conflict surfaces as a Result error). Pass `idle: false` to leave this
+  // runtime un-settled, so its local replica stays stale (own-write-race repro).
+  async set({ path, value, idle: doIdle }) {
+    const runtime = controller().manager().runtime;
+    const tx = runtime.edit();
+    let cell = result();
+    for (const segment of (path ?? []) as (string | number)[]) {
+      cell = cell.key(segment as never) as Cell<any>;
+    }
+    const blindLeafWrite = typeof value === "string" ||
+      typeof value === "number" || typeof value === "boolean";
+    if (blindLeafWrite) markUiInputBlindWriteTx(tx);
+    cell.withTx(tx).set(value as never);
+    if (blindLeafWrite) unmarkUiInputBlindWriteTx(tx);
+    runtime.prepareTxForCommit(tx);
+    const res = await tx.commit() as {
+      error?: { name?: string; message?: string };
+    };
+    if (doIdle !== false) await idle();
+    return sanitizeForTransfer({
+      ok: !res?.error,
+      error: res?.error
+        ? { name: res.error.name, message: res.error.message }
+        : undefined,
+    });
   },
 
   async read({ path }) {

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -70,6 +70,10 @@ export {
   writePatternCoverageLcov,
 } from "./pattern-coverage.ts";
 export { addCommonIDfromObjectID } from "./data-updating.ts";
+export {
+  markUiInputBlindWriteTx,
+  unmarkUiInputBlindWriteTx,
+} from "./storage/reactivity-log.ts";
 export { resolveLink } from "./link-resolution.ts";
 export {
   areLinksSame,

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -71,7 +71,9 @@ export {
 } from "./pattern-coverage.ts";
 export { addCommonIDfromObjectID } from "./data-updating.ts";
 export {
+  type BlindStructuralTarget,
   markUiInputBlindWriteTx,
+  setBlindStructuralTarget,
   unmarkUiInputBlindWriteTx,
 } from "./storage/reactivity-log.ts";
 export { resolveLink } from "./link-resolution.ts";

--- a/packages/runner/src/storage/reactivity-log.ts
+++ b/packages/runner/src/storage/reactivity-log.ts
@@ -10,6 +10,19 @@ const ignoreReadForSchedulingMarker: unique symbol = Symbol(
   "ignoreReadForSchedulingMarker",
 );
 
+// A read tagged with this marker is still recorded for CFC/scheduling, but is
+// EXCLUDED from the commit's concurrency preconditions: buildReads omits it from
+// `reads.confirmed`, and read() does not mark its document `validated` (so the
+// client validate()/claim() pass skips it too). Set transaction-wide by the
+// UI-input blind-leaf-write mode (see markUiInputBlindWriteTx) so a scalar
+// `$value` overwrite is a precondition-free last-write-wins write — removing the
+// own-write-race "stale confirmed read" conflict. Orthogonal to scheduling:
+// reactivity/subscriptions are unaffected (only ignoreReadForScheduling gates
+// those).
+const ignoreReadForCommitMarker: unique symbol = Symbol(
+  "ignoreReadForCommitMarker",
+);
+
 const markReadAsAttemptedWriteMarker: unique symbol = Symbol(
   "markReadAsAttemptedWriteMarker",
 );
@@ -32,6 +45,10 @@ const mergeableOpReadMarker: unique symbol = Symbol(
 
 export const ignoreReadForScheduling: Metadata = {
   [ignoreReadForSchedulingMarker]: true,
+};
+
+export const ignoreReadForCommit: Metadata = {
+  [ignoreReadForCommitMarker]: true,
 };
 
 export const markReadAsAttemptedWrite: Metadata = {
@@ -74,6 +91,42 @@ export const mergeableOpRead: Metadata = {
 
 export function isReadIgnoredForScheduling(meta?: Metadata): boolean {
   return meta?.[ignoreReadForSchedulingMarker] === true;
+}
+
+export function isReadIgnoredForCommit(meta?: Metadata): boolean {
+  return meta?.[ignoreReadForCommitMarker] === true;
+}
+
+// Transaction-level UI-input "blind leaf overwrite" mode. handleCellSet marks
+// the transaction around a scalar `$value` set (and unmarks before
+// prepareTxForCommit, so CFC boundary-commit read-then-writes keep their
+// preconditions); while marked, read() tags every read with `ignoreReadForCommit`
+// and skips `validated`, so the write carries no concurrency precondition
+// (last-write-wins, which is correct for raw scalar UI input). Read-modify-write
+// and structured (array/object) writes are NOT marked and retain compare-and-set.
+// Both the wrapper and the inner storage transaction(s) are marked, since
+// read()/buildReads run on the inner one; the chain walk tolerates extra wrapper
+// layers.
+const uiInputBlindWriteTxs = new WeakSet<object>();
+
+function* blindWriteTxChain(tx: object): Generator<object> {
+  let current: object | undefined = tx;
+  const seen = new Set<object>();
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    yield current;
+    current = (current as { tx?: object }).tx;
+  }
+}
+
+export function markUiInputBlindWriteTx(tx: object): void {
+  for (const layer of blindWriteTxChain(tx)) uiInputBlindWriteTxs.add(layer);
+}
+export function unmarkUiInputBlindWriteTx(tx: object): void {
+  for (const layer of blindWriteTxChain(tx)) uiInputBlindWriteTxs.delete(layer);
+}
+export function isUiInputBlindWriteTx(tx: object): boolean {
+  return uiInputBlindWriteTxs.has(tx);
 }
 
 export function isReadMarkedAsAttemptedWrite(meta?: Metadata): boolean {

--- a/packages/runner/src/storage/reactivity-log.ts
+++ b/packages/runner/src/storage/reactivity-log.ts
@@ -10,15 +10,20 @@ const ignoreReadForSchedulingMarker: unique symbol = Symbol(
   "ignoreReadForSchedulingMarker",
 );
 
-// A read tagged with this marker is still recorded for CFC/scheduling, but is
-// EXCLUDED from the commit's concurrency preconditions: buildReads omits it from
-// `reads.confirmed`, and read() does not mark its document `validated` (so the
-// client validate()/claim() pass skips it too). Set transaction-wide by the
-// UI-input blind-leaf-write mode (see markUiInputBlindWriteTx) so a scalar
-// `$value` overwrite is a precondition-free last-write-wins write — removing the
-// own-write-race "stale confirmed read" conflict. Orthogonal to scheduling:
-// reactivity/subscriptions are unaffected (only ignoreReadForScheduling gates
-// those).
+// A read tagged with this marker is still recorded for CFC/scheduling, but
+// carries NO value-equality concurrency precondition: read() does not mark its
+// document `validated` (so the client validate()/claim() pass skips it), and
+// buildReads DOWNGRADES it — rather than dropping the read outright, it replaces
+// it with a nonRecursive existence read at the entity ROOT. Set transaction-wide
+// by the UI-input blind-leaf-write mode (see markUiInputBlindWriteTx) so a scalar
+// `$value` overwrite is a last-write-wins write on its leaf value (removing the
+// own-write-race "stale confirmed read" conflict: a deep same-leaf patch sits
+// below the root read, so TIER-2 nonRecursive overlap does not fire) while still
+// failing fast on a concurrent WHOLE-DOC delete/replace (TIER-1 set/delete is
+// path-blind, so the structural read yields a clean ConflictError instead of a
+// raw "missing path" throw at patch read-materialization). Orthogonal to
+// scheduling: reactivity/subscriptions are unaffected (only ignoreReadForScheduling
+// gates those).
 const ignoreReadForCommitMarker: unique symbol = Symbol(
   "ignoreReadForCommitMarker",
 );
@@ -101,8 +106,10 @@ export function isReadIgnoredForCommit(meta?: Metadata): boolean {
 // the transaction around a scalar `$value` set (and unmarks before
 // prepareTxForCommit, so CFC boundary-commit read-then-writes keep their
 // preconditions); while marked, read() tags every read with `ignoreReadForCommit`
-// and skips `validated`, so the write carries no concurrency precondition
-// (last-write-wins, which is correct for raw scalar UI input). Read-modify-write
+// and skips `validated`, so the write carries no value-equality precondition on
+// its leaf (last-write-wins, which is correct for raw scalar UI input) — buildReads
+// downgrades the tagged reads to a single nonRecursive entity-root existence read,
+// which still catches a concurrent whole-doc delete/replace. Read-modify-write
 // and structured (array/object) writes are NOT marked and retain compare-and-set.
 // Both the wrapper and the inner storage transaction(s) are marked, since
 // read()/buildReads run on the inner one; the chain walk tolerates extra wrapper

--- a/packages/runner/src/storage/reactivity-log.ts
+++ b/packages/runner/src/storage/reactivity-log.ts
@@ -136,6 +136,45 @@ export function isUiInputBlindWriteTx(tx: object): boolean {
   return uiInputBlindWriteTxs.has(tx);
 }
 
+// The structural existence/shape precondition for a blind UI-input write: the
+// PARENT address of the cell being set. handleCellSet computes it from the cell's
+// resolved write link — where the LOGICAL write path is known — because buildReads
+// only sees the optimized, sometimes element-level diff and cannot recover it.
+// Stored persistently (NOT cleared by unmark, unlike the blind mark) so buildReads
+// can read it at commit time and emit one nonRecursive read there: that conflicts
+// with a concurrent whole-doc delete (TIER-1, path-blind) and with a reshape of
+// the parent or any ancestor (TIER-2 nonRecursive overlap fires at-or-above the
+// read path) as a clean ConflictError, while a write to the cell's own subtree
+// (its value, including array elements) sits BELOW the parent and does not
+// conflict — keeping the own-write race conflict-free.
+export type BlindStructuralTarget = {
+  id: string;
+  space: string;
+  scope?: unknown;
+  // The cell's parent path (the leaf path with its last segment dropped); `[]`
+  // for a write at the entity root.
+  path: readonly (string | number)[];
+};
+const blindStructuralTargets = new WeakMap<object, BlindStructuralTarget>();
+
+export function setBlindStructuralTarget(
+  tx: object,
+  target: BlindStructuralTarget,
+): void {
+  for (const layer of blindWriteTxChain(tx)) {
+    blindStructuralTargets.set(layer, target);
+  }
+}
+export function getBlindStructuralTarget(
+  tx: object,
+): BlindStructuralTarget | undefined {
+  for (const layer of blindWriteTxChain(tx)) {
+    const target = blindStructuralTargets.get(layer);
+    if (target !== undefined) return target;
+  }
+  return undefined;
+}
+
 export function isReadMarkedAsAttemptedWrite(meta?: Metadata): boolean {
   return meta?.[markReadAsAttemptedWriteMarker] === true;
 }

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -72,9 +72,11 @@ import {
   WriteIsolationError,
 } from "./transaction.ts";
 import {
+  ignoreReadForCommit,
   isMutableTransactionReadAllowed,
   isReadIgnoredForScheduling,
   isReadMarkedAsAttemptedWrite,
+  isUiInputBlindWriteTx,
 } from "./reactivity-log.ts";
 import { hasValueAtPath, readValueAtPath } from "./v2-path.ts";
 import { recordWriteStackTrace } from "./write-stack-trace.ts";
@@ -1323,6 +1325,14 @@ export class V2StorageTransaction implements IStorageTransaction {
     const { doc } = this.document(branch, address);
     const current = currentDocument(doc);
     const readMeta = options?.meta ?? EMPTY_META;
+    // In a UI-input blind-leaf-write tx (a scalar `$value` overwrite), every read
+    // is recorded for CFC/scheduling but excluded from commit preconditions: tag
+    // each activity with `ignoreReadForCommit` (so buildReads drops it from
+    // `reads.confirmed`) and skip marking the doc `validated` (so the client
+    // validate()/claim() pass skips it too). The mode is scoped to the user
+    // `set()` call only — CFC boundary-commit reads run after the tx is unmarked
+    // and keep their preconditions.
+    const skipCommitPrecondition = isUiInputBlindWriteTx(this);
     const { space: _, ...memoryAddress } = address;
 
     if (!address.id.startsWith("data:")) {
@@ -1331,14 +1341,16 @@ export class V2StorageTransaction implements IStorageTransaction {
         scope: normalizeCellScope(address.scope),
         id: address.id,
         path: address.path,
-        meta: readMeta,
+        meta: skipCommitPrecondition
+          ? { ...readMeta, ...ignoreReadForCommit }
+          : readMeta,
         ...(options?.nonRecursive === true ? { nonRecursive: true } : {}),
       };
       this.#readActivities.push(readActivity);
       this.invalidateReactivityLog();
     }
     if (options?.trackReadWithoutLoad === true) {
-      if (!address.id.startsWith("data:")) {
+      if (!address.id.startsWith("data:") && !skipCommitPrecondition) {
         doc.validated = true;
       }
       return { ok: { address, value: undefined } };
@@ -1347,7 +1359,8 @@ export class V2StorageTransaction implements IStorageTransaction {
     if (isMutableTransactionReadAllowed(readMeta)) {
       if (
         !address.id.startsWith("data:") &&
-        !doc.validated
+        !doc.validated &&
+        !skipCommitPrecondition
       ) {
         doc.validated = true;
       }
@@ -1373,7 +1386,8 @@ export class V2StorageTransaction implements IStorageTransaction {
     const result = readAttestation(current, memoryAddress);
     if (
       !address.id.startsWith("data:") &&
-      !doc.validated
+      !doc.validated &&
+      !skipCommitPrecondition
     ) {
       doc.validated = true;
     }

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1326,9 +1326,10 @@ export class V2StorageTransaction implements IStorageTransaction {
     const current = currentDocument(doc);
     const readMeta = options?.meta ?? EMPTY_META;
     // In a UI-input blind-leaf-write tx (a scalar `$value` overwrite), every read
-    // is recorded for CFC/scheduling but excluded from commit preconditions: tag
-    // each activity with `ignoreReadForCommit` (so buildReads drops it from
-    // `reads.confirmed`) and skip marking the doc `validated` (so the client
+    // is recorded for CFC/scheduling but carries no value-equality commit
+    // precondition: tag each activity with `ignoreReadForCommit` (so buildReads
+    // downgrades it to a nonRecursive entity-root existence read instead of a
+    // leaf-value precondition) and skip marking the doc `validated` (so the client
     // validate()/claim() pass skips it too). The mode is scoped to the user
     // `set()` call only — CFC boundary-commit reads run after the tx is unmarked
     // and keep their preconditions.

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2236,11 +2236,45 @@ class SpaceReplica implements ISpaceReplica {
         continue;
       }
       // A read tagged `ignoreReadForCommit` (UI-input blind-leaf-write mode) is
-      // not a concurrency precondition — exclude it from confirmed/pending so a
-      // scalar `$value` set cannot lose the own-write race on its own
-      // write-target read. (Done before compaction; in a blind tx all reads are
-      // tagged, so confirmed/pending are simply empty.)
+      // not a VALUE-EQUALITY concurrency precondition: a scalar `$value` set must
+      // not lose the own-write race on its own write-target read. But dropping the
+      // read entirely also drops the only thing that catches a concurrent
+      // WHOLE-DOC delete/replace — the TIER-1 (set/delete) conflict check rides any
+      // confirmed read on the entity — which would leave a precondition-free patch
+      // to throw "missing path" at read-materialization (a stale nested patch
+      // replayed onto a deleted/empty base). So instead of dropping, DOWNGRADE to a
+      // structural existence precondition: a nonRecursive read at the entity ROOT.
+      // TIER-1 is path-blind, so a concurrent whole-doc delete still yields a clean
+      // ConflictError instead of a raw throw; TIER-2 nonRecursive overlap only fires
+      // at-or-above the read path, and the dropped leaf value read sits strictly
+      // BELOW the root, so the same-leaf own-write race stays conflict-free.
+      // Per-entity duplicates collapse in compactCommitReads.
       if (isReadIgnoredForCommit(read.meta)) {
+        const scope = normalizeCellScope(read.scope);
+        const record = this.#docs.get(docKey(read.id as URI, scope));
+        const pendingLocalSeq = record?.pending
+          .filter((version) => version.localSeq < localSeq)
+          .at(-1)?.localSeq;
+        const rootPath = toCommitReadPath([]);
+        if (pendingLocalSeq !== undefined) {
+          pending.push({
+            id: read.id as URI,
+            scope,
+            path: rootPath,
+            localSeq: pendingLocalSeq,
+            nonRecursive: true,
+          });
+        } else {
+          confirmed.push({
+            id: read.id as URI,
+            scope,
+            path: rootPath,
+            seq: typeof read.meta?.seq === "number"
+              ? read.meta.seq
+              : record?.confirmed.seq ?? 0,
+            nonRecursive: true,
+          });
+        }
         continue;
       }
 

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -85,6 +85,7 @@ import {
   getDirectTransactionReadActivities,
 } from "./transaction-inspection.ts";
 import {
+  getBlindStructuralTarget,
   isMergeableOpRead,
   isReadExcludedFromConflict,
   isReadIgnoredForCommit,
@@ -2206,6 +2207,11 @@ class SpaceReplica implements ISpaceReplica {
       );
     }
 
+    // For a blind UI-input write, handleCellSet threads the cell's PARENT address
+    // here; its `ignoreReadForCommit` reads are dropped below and replaced by one
+    // nonRecursive read at this parent (emitted after the loop).
+    const structuralTarget = getBlindStructuralTarget(source);
+
     // A mergeable op resolves against durable state, so it does not depend on
     // the document's prior value. On an entity touched by a mergeable op, the
     // reads the op ITSELF issues are dropped from conflict detection — its own
@@ -2235,46 +2241,13 @@ class SpaceReplica implements ISpaceReplica {
       ) {
         continue;
       }
-      // A read tagged `ignoreReadForCommit` (UI-input blind-leaf-write mode) is
-      // not a VALUE-EQUALITY concurrency precondition: a scalar `$value` set must
-      // not lose the own-write race on its own write-target read. But dropping the
-      // read entirely also drops the only thing that catches a concurrent
-      // WHOLE-DOC delete/replace — the TIER-1 (set/delete) conflict check rides any
-      // confirmed read on the entity — which would leave a precondition-free patch
-      // to throw "missing path" at read-materialization (a stale nested patch
-      // replayed onto a deleted/empty base). So instead of dropping, DOWNGRADE to a
-      // structural existence precondition: a nonRecursive read at the entity ROOT.
-      // TIER-1 is path-blind, so a concurrent whole-doc delete still yields a clean
-      // ConflictError instead of a raw throw; TIER-2 nonRecursive overlap only fires
-      // at-or-above the read path, and the dropped leaf value read sits strictly
-      // BELOW the root, so the same-leaf own-write race stays conflict-free.
-      // Per-entity duplicates collapse in compactCommitReads.
+      // A read tagged `ignoreReadForCommit` (UI-input blind-leaf-write mode) is not
+      // a value-equality concurrency precondition: a blind `set` must not lose the
+      // own-write race on its own write-target read. Drop it from the conflict set.
+      // Its structural replacement — one nonRecursive read at the cell's PARENT — is
+      // emitted once after the loop from the threaded `structuralTarget`, since the
+      // logical write path is known only at handleCellSet, not from this diff.
       if (isReadIgnoredForCommit(read.meta)) {
-        const scope = normalizeCellScope(read.scope);
-        const record = this.#docs.get(docKey(read.id as URI, scope));
-        const pendingLocalSeq = record?.pending
-          .filter((version) => version.localSeq < localSeq)
-          .at(-1)?.localSeq;
-        const rootPath = toCommitReadPath([]);
-        if (pendingLocalSeq !== undefined) {
-          pending.push({
-            id: read.id as URI,
-            scope,
-            path: rootPath,
-            localSeq: pendingLocalSeq,
-            nonRecursive: true,
-          });
-        } else {
-          confirmed.push({
-            id: read.id as URI,
-            scope,
-            path: rootPath,
-            seq: typeof read.meta?.seq === "number"
-              ? read.meta.seq
-              : record?.confirmed.seq ?? 0,
-            nonRecursive: true,
-          });
-        }
         continue;
       }
 
@@ -2331,6 +2304,44 @@ class SpaceReplica implements ISpaceReplica {
             ? read.meta.seq
             : record?.confirmed.seq ?? 0,
           ...(read.nonRecursive === true ? { nonRecursive: true } : {}),
+        });
+      }
+    }
+    // The blind UI-input write's single structural existence/shape precondition: a
+    // nonRecursive read at the cell's PARENT (threaded from handleCellSet). It
+    // conflicts with a concurrent whole-doc delete/replace (TIER-1, path-blind) and
+    // with a reshape of the parent or any ancestor (TIER-2 nonRecursive overlap
+    // fires at-or-above the read path), but NOT with a write to the cell's own
+    // value (which sits below the parent, including array elements) — so the
+    // own-write race stays conflict-free.
+    if (
+      structuralTarget !== undefined &&
+      structuralTarget.space === this.#space
+    ) {
+      const scope = normalizeCellScope(
+        structuralTarget.scope as Parameters<typeof normalizeCellScope>[0],
+      );
+      const id = structuralTarget.id as URI;
+      const record = this.#docs.get(docKey(id, scope));
+      const pendingLocalSeq = record?.pending
+        .filter((version) => version.localSeq < localSeq)
+        .at(-1)?.localSeq;
+      const path = toCommitReadPath(structuralTarget.path);
+      if (pendingLocalSeq !== undefined) {
+        pending.push({
+          id,
+          scope,
+          path,
+          localSeq: pendingLocalSeq,
+          nonRecursive: true,
+        });
+      } else {
+        confirmed.push({
+          id,
+          scope,
+          path,
+          seq: record?.confirmed.seq ?? 0,
+          nonRecursive: true,
         });
       }
     }

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2212,6 +2212,36 @@ class SpaceReplica implements ISpaceReplica {
     // nonRecursive read at this parent (emitted after the loop).
     const structuralTarget = getBlindStructuralTarget(source);
 
+    // Emit one commit read for `id`, baselined against the most recent in-flight
+    // local version of that doc below this commit's localSeq if one exists, else
+    // the confirmed seq (or an explicit `confirmedSeq` override, e.g. a read that
+    // carries its own `meta.seq`). Shared by the per-read loop below and the blind
+    // write's structural precondition so the two emission sites stay in lockstep.
+    const pushCommitRead = (
+      id: URI,
+      scope: CellScope | undefined,
+      path: DocumentPath,
+      nonRecursive: boolean,
+      confirmedSeq?: number,
+    ) => {
+      const record = this.#docs.get(docKey(id, scope));
+      const pendingLocalSeq = record?.pending
+        .filter((version) => version.localSeq < localSeq)
+        .at(-1)?.localSeq;
+      const shape = nonRecursive ? { nonRecursive: true } : {};
+      if (pendingLocalSeq !== undefined) {
+        pending.push({ id, scope, path, localSeq: pendingLocalSeq, ...shape });
+      } else {
+        confirmed.push({
+          id,
+          scope,
+          path,
+          seq: confirmedSeq ?? record?.confirmed.seq ?? 0,
+          ...shape,
+        });
+      }
+    };
+
     // A mergeable op resolves against durable state, so it does not depend on
     // the document's prior value. On an entity touched by a mergeable op, the
     // reads the op ITSELF issues are dropped from conflict detection — its own
@@ -2283,29 +2313,13 @@ class SpaceReplica implements ISpaceReplica {
       ) {
         continue;
       }
-      const record = this.#docs.get(docKey(read.id as URI, scope));
-      const pendingLocalSeq = record?.pending
-        .filter((version) => version.localSeq < localSeq)
-        .at(-1)?.localSeq;
-      if (pendingLocalSeq !== undefined) {
-        pending.push({
-          id: read.id as URI,
-          scope,
-          path: toCommitReadPath(read.path),
-          localSeq: pendingLocalSeq,
-          ...(read.nonRecursive === true ? { nonRecursive: true } : {}),
-        });
-      } else {
-        confirmed.push({
-          id: read.id as URI,
-          scope,
-          path: toCommitReadPath(read.path),
-          seq: typeof read.meta?.seq === "number"
-            ? read.meta.seq
-            : record?.confirmed.seq ?? 0,
-          ...(read.nonRecursive === true ? { nonRecursive: true } : {}),
-        });
-      }
+      pushCommitRead(
+        read.id as URI,
+        scope,
+        toCommitReadPath(read.path),
+        read.nonRecursive === true,
+        typeof read.meta?.seq === "number" ? read.meta.seq : undefined,
+      );
     }
     // The blind UI-input write's single structural existence/shape precondition: a
     // nonRecursive read at the cell's PARENT (threaded from handleCellSet). It
@@ -2318,32 +2332,14 @@ class SpaceReplica implements ISpaceReplica {
       structuralTarget !== undefined &&
       structuralTarget.space === this.#space
     ) {
-      const scope = normalizeCellScope(
-        structuralTarget.scope as Parameters<typeof normalizeCellScope>[0],
+      pushCommitRead(
+        structuralTarget.id as URI,
+        normalizeCellScope(
+          structuralTarget.scope as Parameters<typeof normalizeCellScope>[0],
+        ),
+        toCommitReadPath(structuralTarget.path),
+        true,
       );
-      const id = structuralTarget.id as URI;
-      const record = this.#docs.get(docKey(id, scope));
-      const pendingLocalSeq = record?.pending
-        .filter((version) => version.localSeq < localSeq)
-        .at(-1)?.localSeq;
-      const path = toCommitReadPath(structuralTarget.path);
-      if (pendingLocalSeq !== undefined) {
-        pending.push({
-          id,
-          scope,
-          path,
-          localSeq: pendingLocalSeq,
-          nonRecursive: true,
-        });
-      } else {
-        confirmed.push({
-          id,
-          scope,
-          path,
-          seq: record?.confirmed.seq ?? 0,
-          nonRecursive: true,
-        });
-      }
     }
     // Keep the nonRecursive flag on the reads sent to the engine (it was
     // historically stripped here). The engine applies shallow (shape-only)

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -87,6 +87,7 @@ import {
 import {
   isMergeableOpRead,
   isReadExcludedFromConflict,
+  isReadIgnoredForCommit,
   isReadMarkedAsAttemptedWrite,
 } from "./reactivity-log.ts";
 
@@ -2232,6 +2233,14 @@ class SpaceReplica implements ISpaceReplica {
         (read.type ?? DOCUMENT_MIME) !== DOCUMENT_MIME ||
         read.id.startsWith("data:")
       ) {
+        continue;
+      }
+      // A read tagged `ignoreReadForCommit` (UI-input blind-leaf-write mode) is
+      // not a concurrency precondition — exclude it from confirmed/pending so a
+      // scalar `$value` set cannot lose the own-write race on its own
+      // write-target read. (Done before compaction; in a blind tx all reads are
+      // tagged, so confirmed/pending are simply empty.)
+      if (isReadIgnoredForCommit(read.meta)) {
         continue;
       }
 

--- a/packages/runner/test/blind-write-structural-precondition.test.ts
+++ b/packages/runner/test/blind-write-structural-precondition.test.ts
@@ -1,0 +1,78 @@
+import { assert } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import {
+  markUiInputBlindWriteTx,
+  setBlindStructuralTarget,
+  unmarkUiInputBlindWriteTx,
+} from "../src/storage/reactivity-log.ts";
+
+const signer = await Identity.fromPassphrase("blind-write-structural");
+const space = signer.did();
+
+const schema = {
+  type: "object",
+  properties: {
+    box: {
+      type: "object",
+      properties: { leaf: { type: "string" } },
+    },
+  },
+} as const;
+
+// Runner-level coverage for the blind UI-input write path (the runtime-client's
+// handleCellSet / the multi-runtime worker mirror it, but runner's own suite
+// otherwise never marks a tx blind). Drives a blind nested write: mark the tx
+// blind, thread the cell's PARENT as the structural precondition
+// (setBlindStructuralTarget), write, and commit — so buildReads drops the
+// value-equality read and emits the nonRecursive structural read at the parent.
+Deno.test("a blind UI-input write threads a structural precondition at the cell's parent", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  try {
+    // Establish a nested doc: { box: { leaf: "x" } }.
+    const setup = runtime.edit();
+    const cell = runtime.getCell<{ box: { leaf: string } }>(
+      space,
+      "blind-structural",
+      schema,
+      setup,
+    );
+    cell.withTx(setup).set({ box: { leaf: "x" } });
+    await setup.commit();
+    await runtime.idle();
+
+    // Blind write to the nested leaf `box.leaf`.
+    const tx = runtime.edit();
+    const leaf = cell.key("box").key("leaf");
+    markUiInputBlindWriteTx(tx);
+    const link = leaf.withTx(tx).resolveAsCell().getAsNormalizedFullLink();
+    setBlindStructuralTarget(tx, {
+      id: link.id,
+      space: link.space,
+      scope: link.scope,
+      path: link.path.slice(0, -1),
+    });
+    leaf.withTx(tx).set("typed");
+    unmarkUiInputBlindWriteTx(tx);
+    runtime.prepareTxForCommit(tx);
+    const result = await tx.commit();
+    await runtime.idle();
+
+    assert(
+      !result.error,
+      `blind write should commit cleanly: ${JSON.stringify(result.error)}`,
+    );
+    assert(
+      cell.get()?.box?.leaf === "typed",
+      "the blind leaf write should land",
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1486,9 +1486,21 @@ describe("RuntimeProcessor CFC commit preparation", () => {
       send: (value: unknown) => {
         expect(value).toBe("new value");
       },
+      // A blind `set` resolves the write target to thread its parent as the
+      // structural precondition (see applyCellWrite).
+      resolveAsCell: () => ({
+        getAsNormalizedFullLink: () => ({
+          id: ref.id,
+          space: ref.space,
+          scope: ref.scope,
+          path: ref.path,
+        }),
+      }),
     };
     return {
       processor: {
+        // handleCellSet/handleCellPush delegate to the shared applyCellWrite.
+        applyCellWrite: RuntimeProcessor.prototype.applyCellWrite,
         runtime: {
           edit: () => tx,
           prepareTxForCommit: (candidate: unknown) => {

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1531,6 +1531,16 @@ describe("RuntimeProcessor CFC commit preparation", () => {
     });
   });
 
+  it("prepares cell push transactions before committing (non-blind path)", async () => {
+    const { processor } = createProcessor();
+
+    await RuntimeProcessor.prototype.handleCellPush.call(processor, {
+      type: RequestType.CellPush,
+      cell: ref,
+      value: "new value",
+    });
+  });
+
   it("prepares cell send transactions before committing", async () => {
     const { processor } = createProcessor();
 

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -22,11 +22,13 @@ import {
   getPatternIdentityRef,
   isCell,
   isCellResult,
+  markUiInputBlindWriteTx,
   Runtime,
   RuntimeTelemetry,
   RuntimeTelemetryEvent,
   setPatternEnvironment,
   type SigilLink,
+  unmarkUiInputBlindWriteTx,
 } from "@commonfabric/runner";
 import { linkRefPayload } from "@commonfabric/runner/shared";
 import {
@@ -689,7 +691,21 @@ export class RuntimeProcessor {
     const tx = this.runtime.edit();
     const cell = getCell(this.runtime, request.cell);
     const value = mapCellRefsToSigilLinks(request.value);
+    // A scalar `$value`/`$checked` overwrite (string/number/boolean) is a
+    // last-write-wins leaf write: mark the tx so the set's reads carry no
+    // concurrency precondition, removing the own-write-race "stale confirmed
+    // read" conflict (and the rolled-back, silently-dropped edit it caused).
+    // Structured (array/object) values are excluded — they are often
+    // read-modify-write (CellHandle.push, multi-select, list edits) and must
+    // keep compare-and-set to avoid lost updates. The mark is cleared before
+    // prepareTxForCommit so CFC boundary-commit read-then-writes retain their
+    // preconditions.
+    const raw = request.value;
+    const blindLeafWrite = typeof raw === "string" ||
+      typeof raw === "number" || typeof raw === "boolean";
+    if (blindLeafWrite) markUiInputBlindWriteTx(tx);
     cell.withTx(tx).set(value);
+    if (blindLeafWrite) unmarkUiInputBlindWriteTx(tx);
     this.runtime.prepareTxForCommit(tx);
     // Local visibility is established by commit(); the promise tracks remote
     // confirmation/rollback and must not block cell IPC.

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -693,8 +693,10 @@ export class RuntimeProcessor {
     const value = mapCellRefsToSigilLinks(request.value);
     // A scalar `$value`/`$checked` overwrite (string/number/boolean) is a
     // last-write-wins leaf write: mark the tx so the set's reads carry no
-    // concurrency precondition, removing the own-write-race "stale confirmed
-    // read" conflict (and the rolled-back, silently-dropped edit it caused).
+    // value-equality precondition on the leaf (only a structural entity-root
+    // existence read survives, to catch a concurrent whole-doc delete), removing
+    // the own-write-race "stale confirmed read" conflict (and the rolled-back,
+    // silently-dropped edit it caused).
     // Structured (array/object) values are excluded — they are often
     // read-modify-write (CellHandle.push, multi-select, list edits) and must
     // keep compare-and-set to avoid lost updates. The mark is cleared before

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -26,6 +26,7 @@ import {
   Runtime,
   RuntimeTelemetry,
   RuntimeTelemetryEvent,
+  setBlindStructuralTarget,
   setPatternEnvironment,
   type SigilLink,
   unmarkUiInputBlindWriteTx,
@@ -49,6 +50,7 @@ import {
   type CellGetCfcLabelRequest,
   type CellGetRequest,
   type CellGetResponse,
+  type CellPushRequest,
   type CellResolveAsCellRequest,
   CellResponse,
   type CellSendRequest,
@@ -687,27 +689,53 @@ export class RuntimeProcessor {
     };
   }
 
+  // A `CellHandle.set` is a blind leaf overwrite (last-write-wins); a
+  // `CellHandle.push` is read-modify-write and keeps compare-and-set. The
+  // blind-vs-CAS decision is made by METHOD — which request type the client sent
+  // — not by inspecting the value's shape. Both carry the whole already-resolved
+  // value on the wire.
   handleCellSet(request: CellSetRequest): void {
+    this.applyCellWrite(request, /* blind */ true);
+  }
+
+  handleCellPush(request: CellPushRequest): void {
+    this.applyCellWrite(request, /* blind */ false);
+  }
+
+  // Shared write path for CellSet/CellPush. In blind mode the set's reads carry no
+  // value-equality precondition, so a UI overwrite is last-write-wins and no
+  // longer loses the own-write race that rolled the edit back. In their place we
+  // thread ONE structural precondition — the cell's PARENT address — which
+  // buildReads turns into a nonRecursive read: that catches a concurrent whole-doc
+  // delete or an ancestor reshape (so a stale nested patch can't throw at
+  // read-materialization) without conflicting on a concurrent write to the cell's
+  // own value. We compute the parent here, at handleCellSet, because the logical
+  // write path is known only here — buildReads sees the optimized element-level
+  // diff. In non-blind (push) mode the read-target stays a commit precondition, so
+  // a concurrent push aborts rather than being clobbered. The blind mark is
+  // cleared before prepareTxForCommit so CFC boundary-commit read-then-writes
+  // retain their preconditions.
+  applyCellWrite(
+    request: CellSetRequest | CellPushRequest,
+    blind: boolean,
+  ): void {
     const tx = this.runtime.edit();
     const cell = getCell(this.runtime, request.cell);
     const value = mapCellRefsToSigilLinks(request.value);
-    // A scalar `$value`/`$checked` overwrite (string/number/boolean) is a
-    // last-write-wins leaf write: mark the tx so the set's reads carry no
-    // value-equality precondition on the leaf (only a structural entity-root
-    // existence read survives, to catch a concurrent whole-doc delete), removing
-    // the own-write-race "stale confirmed read" conflict (and the rolled-back,
-    // silently-dropped edit it caused).
-    // Structured (array/object) values are excluded — they are often
-    // read-modify-write (CellHandle.push, multi-select, list edits) and must
-    // keep compare-and-set to avoid lost updates. The mark is cleared before
-    // prepareTxForCommit so CFC boundary-commit read-then-writes retain their
-    // preconditions.
-    const raw = request.value;
-    const blindLeafWrite = typeof raw === "string" ||
-      typeof raw === "number" || typeof raw === "boolean";
-    if (blindLeafWrite) markUiInputBlindWriteTx(tx);
+    if (blind) {
+      markUiInputBlindWriteTx(tx);
+      // The resolved storage address of the write target; its parent is the
+      // structural existence/shape precondition for the blind write.
+      const link = cell.withTx(tx).resolveAsCell().getAsNormalizedFullLink();
+      setBlindStructuralTarget(tx, {
+        id: link.id,
+        space: link.space,
+        scope: link.scope,
+        path: link.path.slice(0, -1),
+      });
+    }
     cell.withTx(tx).set(value);
-    if (blindLeafWrite) unmarkUiInputBlindWriteTx(tx);
+    if (blind) unmarkUiInputBlindWriteTx(tx);
     this.runtime.prepareTxForCommit(tx);
     // Local visibility is established by commit(); the promise tracks remote
     // confirmation/rollback and must not block cell IPC.
@@ -1303,6 +1331,8 @@ export class RuntimeProcessor {
         return this.handleCellGet(request);
       case RequestType.CellSet:
         return this.handleCellSet(request);
+      case RequestType.CellPush:
+        return this.handleCellPush(request);
       case RequestType.CellSend:
         return this.handleCellSend(request);
       case RequestType.CellSubscribe:

--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -485,3 +485,49 @@ describe("CellHandle disposal-raced writes", () => {
     expect(spy.calls.length).toBe(0);
   });
 });
+
+describe("CellHandle push (read-modify-write)", () => {
+  const ref: CellRef = {
+    id: "of:push-cell" as CellRef["id"],
+    space: "did:key:test" as CellRef["space"],
+    scope: "space",
+    path: [],
+  };
+
+  const runtimeCapturing = (requests: unknown[]): RuntimeClient =>
+    ({
+      [$conn]: () => ({
+        request: (request: unknown) => {
+          requests.push(request);
+          return Promise.resolve({});
+        },
+        subscribe: () => Promise.resolve(),
+        unsubscribe: () => Promise.resolve(),
+        signal: { aborted: false },
+      }),
+    }) as unknown as RuntimeClient;
+
+  it("sends a CellPush carrying the appended array (not a blind CellSet)", () => {
+    const requests: unknown[] = [];
+    const cell = new CellHandle<number[]>(runtimeCapturing(requests), ref);
+    // Seed the local cache so push has an array to read-modify-write.
+    cell[$onCellUpdate]([1, 2]);
+
+    cell.push(3);
+
+    expect(requests.length).toBe(1);
+    const request = requests[0] as { type: unknown; value: unknown };
+    // Routed as CellPush (compare-and-set) rather than the blind CellSet, and
+    // it carries the whole client-computed array.
+    expect(request.type).toBe(RequestType.CellPush);
+    expect(request.value).toEqual([1, 2, 3]);
+  });
+
+  it("throws when the cell is not an array", () => {
+    const cell = new CellHandle<number[]>(runtimeCapturing([]), ref);
+    cell[$onCellUpdate]("not an array" as unknown as number[]);
+    expect(() => cell.push(1)).toThrow(
+      "push() can only be used on array cells",
+    );
+  });
+});

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -113,24 +113,44 @@ export class CellHandle<T = unknown> {
    */
   async set(value: T): Promise<void> {
     this.#requireSchema("set");
+    // A plain set is a blind last-write-wins overwrite (CellSet).
+    await this.#applyLocalAndSend(value, RequestType.CellSet);
+  }
+
+  // Optimistic local update (mirrors the old set()) plus the remote write. The
+  // request TYPE encodes the intent: CellSet is a blind overwrite, CellPush is a
+  // read-modify-write append that the runtime keeps as compare-and-set.
+  #applyLocalAndSend(
+    value: T,
+    type: RequestType.CellSet | RequestType.CellPush,
+  ): Promise<void> {
     this.#value = value;
 
     for (const callback of this.#callbacks.values()) {
       try {
-        // Optimistic local set doesn't change the label; carry the current one.
+        // Optimistic local update doesn't change the label; carry the current one.
         callback(value as Readonly<T>, this.#cfcLabel);
       } catch (error) {
         console.error("[CellHandle] Callback error:", error);
       }
     }
 
-    await this.#conn.request<RequestType.CellSet>({
-      type: RequestType.CellSet,
-      cell: this.ref(),
-      value: CellHandle.serialize(value),
-    }).catch((error) => {
+    const cell = this.ref();
+    const serialized = CellHandle.serialize(value);
+    const request = type === RequestType.CellPush
+      ? this.#conn.request<RequestType.CellPush>({
+        type: RequestType.CellPush,
+        cell,
+        value: serialized,
+      })
+      : this.#conn.request<RequestType.CellSet>({
+        type: RequestType.CellSet,
+        cell,
+        value: serialized,
+      });
+    return request.catch((error) => {
       if (!this.#conn.signal.aborted) {
-        console.error("[CellHandle] Set failed:", error);
+        console.error("[CellHandle] Write failed:", error);
       }
     });
   }
@@ -168,6 +188,10 @@ export class CellHandle<T = unknown> {
     return child;
   }
 
+  // A push is read-modify-write: build the appended array locally, then send it
+  // as a CellPush (not CellSet) so the runtime keeps the read-target as a commit
+  // precondition (compare-and-set) — a concurrent push aborts rather than being
+  // clobbered by a blind overwrite.
   push<U>(
     this: CellHandle<U[]>,
     ...values: T extends (infer U)[] ? U[] : never
@@ -176,7 +200,10 @@ export class CellHandle<T = unknown> {
     if (!Array.isArray(current)) {
       throw new Error("push() can only be used on array cells");
     }
-    this.set([...current, ...values] as unknown as U[]);
+    void this.#applyLocalAndSend(
+      [...current, ...values] as unknown as U[],
+      RequestType.CellPush,
+    );
   }
 
   /**

--- a/packages/runtime-client/integration/client.test.ts
+++ b/packages/runtime-client/integration/client.test.ts
@@ -238,6 +238,33 @@ describe("RuntimeClient", () => {
       cancel2();
     });
 
+    it("dispatches CellHandle.push as a CellPush (read-modify-write append)", async () => {
+      const session = await createTestSession();
+      await using rt = await createRuntimeClient(session);
+
+      const schema = {
+        type: "array",
+        items: { type: "string" },
+      } as const satisfies JSONSchema;
+
+      const cell = await rt.getCell<string[]>(
+        session.space,
+        "test-push-" + Date.now(),
+        schema,
+      );
+      await cell.set(["a"]);
+      await rt.idle();
+      await cell.sync();
+
+      // push routes through CellPush -> handleCellPush (read-modify-write),
+      // appending to the current array rather than blindly overwriting it.
+      cell.push("b");
+      await rt.idle();
+      await cell.sync();
+
+      assertEquals(cell.get(), ["a", "b"]);
+    });
+
     it("late subscribers receive initial value from existing subscription", async () => {
       // Regression test for bug where text interpolation {value} would show blank
       // when used alongside cf-input bound to the same cell. The issue was that

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -39,6 +39,7 @@ export enum RequestType {
   // Cell operations (main -> worker)
   CellGet = "cell:get",
   CellSet = "cell:set",
+  CellPush = "cell:push",
   CellSend = "cell:send",
   CellSubscribe = "cell:subscribe",
   CellUnsubscribe = "cell:unsubscribe",
@@ -207,6 +208,16 @@ export interface CellGetRequest extends BaseRequest {
 
 export interface CellSetRequest extends BaseRequest {
   type: RequestType.CellSet;
+  cell: CellRef;
+  value: JSONValue;
+}
+
+// A read-modify-write append (`CellHandle.push`). Same wire shape as CellSet —
+// it carries the whole already-appended array — but routed as its own request so
+// the runtime keeps the read-target as a commit precondition (compare-and-set),
+// rather than the blind last-write-wins of CellSet.
+export interface CellPushRequest extends BaseRequest {
+  type: RequestType.CellPush;
   cell: CellRef;
   value: JSONValue;
 }
@@ -685,6 +696,7 @@ export type IPCClientRequest =
   | DisposeRequest
   | CellGetRequest
   | CellSetRequest
+  | CellPushRequest
   | CellSendRequest
   | CellSubscribeRequest
   | CellUnsubscribeRequest
@@ -984,6 +996,10 @@ export type Commands = {
   };
   [RequestType.CellSet]: {
     request: CellSetRequest;
+    response: EmptyResponse;
+  };
+  [RequestType.CellPush]: {
+    request: CellPushRequest;
     response: EmptyResponse;
   };
   [RequestType.CellSend]: {


### PR DESCRIPTION
## Why

A `$value`/`$checked` UI edit committed as a **compare-and-set**: `normalizeAndDiff`
reads the write target to diff it, and that read became a commit precondition.
Under concurrent same-user edits — two tabs/sessions sharing one `PerUser` cell —
the read lost the own-write race (`stale confirmed read … conflicted`), so the
write was **rejected and rolled back and the edit silently vanished**. This is the
`cfc-group-chat-demo` "profile name stays 'Name not set'" flake.

## What this does

A UI `set` is a **blind last-write-wins** leaf write; a `push` is read-modify-write
and keeps **compare-and-set**. The choice is made by **METHOD** (the request type
the client sends), not by the value's shape:

- **`CellHandle.set` → `CellSet` → `handleCellSet`:** always blind (any value
  type). The set's reads carry no value-equality precondition, so a concurrent
  same-user edit no longer loses the own-write race. In their place we keep **one
  structural precondition** — a `nonRecursive` read at the **cell's parent**
  (threaded from `handleCellSet`, where the logical write path is known;
  `buildReads` only sees the optimized diff). That catches a concurrent whole-doc
  delete **or an ancestor reshape** as a clean `ConflictError`, rather than letting
  a stale nested patch throw a raw "not traversable" at commit-materialization. A
  write to the cell's own value (a sibling leaf, or an array element) sits below
  the parent and does not conflict.
- **`CellHandle.push` → new `CellPush` → `handleCellPush`:** read-modify-write; the
  read of the current value stays a commit precondition, so a concurrent push
  **aborts** rather than being clobbered.

Both handlers share `applyCellWrite(request, blind)`. Making the decision explicit
at the protocol level (rather than inferring "structured ⇒ RMW" from the value)
lets an array *overwrite* be blind while an array *push* captures reads. CFC
enforcement (rides `attemptedWrites`) and reactivity/subscriptions (ride
`ignoreReadForScheduling`) are untouched; the blind mark clears before
`prepareTxForCommit` so CFC boundary-commit read-then-writes keep their
preconditions.

Supersedes the recovery-based approaches to this flake (#4196 commit-queue, #4126
reapply-latest) by removing the conflict at the source.

## Tests

- `packages/patterns/integration/cellset-lww.test.ts` (multi-runtime, same-identity
  two-session own-write race): concurrent scalar sets never conflict; a
  **structured (array) set is blind too** (the trigger is the method, not the value
  type); concurrent **pushes keep compare-and-set**; and a typed name survives the
  race end-to-end through save.
- `packages/memory/test/cellset-structural-precondition.test.ts` (engine-level):
  a precondition-free nested patch on a retyped ancestor throws a raw "not
  traversable"; an **entity-root** structural read does *not* catch it (still a raw
  throw); the **parent** structural read converts it to a clean `ConflictError`.
  (The in-process harness can't reproduce this end-to-end — it propagates shared
  state synchronously, so a session can't hold a stale-but-navigable replica —
  hence the engine-level test.)

Regression: conflict/commit/runtime-processor/precondition suites + a broader
conflict sweep green (109 tests); fmt/lint/type-check clean.

## Behavior change

A `set` of an **array/object** value is now blind (last-write-wins), where the
earlier value-type form kept it on compare-and-set. Concurrency-safe list
mutations go through `push` (CAS), or the deferred server-side mergeable-op path.
This is the one place the method-based trigger changes prior behavior.

## Design notes for review (@ubik2 — your area)

This is the shape from your review: decide blind-vs-CAS by the **method** (a
`CellPush` request type) rather than the value-type heuristic, and keep a
**structural** precondition — anchored at the cell's parent so an ancestor reshape
is caught (the `["notes"]`-retyped case, à la #4406), not just a whole-doc delete.
Push stays CAS-retry at the browser→worker seam; a mergeable `append` is left as a
deferred, larger change.


## Coverage-debt override (packages/runner)

The Performance Check flags `packages/runner` coverage-debt at +2, but this is a
cross-file attribution artifact, **not** new untested logic. Verified by
replicating the metric over the CI coverage artifacts (reproduces the gate's
7852 → 7854 exactly), deterministically across 5 runs:

- This PR's changed source adds **zero** uncovered lines — `storage/v2.ts` (254
  uncovered) and `storage/reactivity-log.ts` (7) are identical on this branch and
  `main`.
- The +2 is: `data-updating.ts` **−10** (the new blind-write test legitimately
  covers more of the diff path) **+** `sandbox/compiled-bundle-verifier.ts`
  **+12** — a bracket-quoted path-parser branch (lines 1632–1653) covered only by
  the generated-patterns integration job, which this PR's *runtime* change stops
  reaching. All generated patterns still pass; that branch is an existing utility,
  not new code here.

Accepting the metric per CI_PERFORMANCE.md's narrow per-metric form:

NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 7854 lines
