### PR TITLE
Guard perf checks against stale baseline data

### DIFF
--- a/tasks/perf-check.test.ts
+++ b/tasks/perf-check.test.ts
@@ -1,12 +1,44 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import * as path from "@std/path";
-import type { PRInfo } from "./perf-lib.ts";
 import {
+  type Artifact,
+  PERF_METRICS_ARTIFACT_NAME,
+  PERF_METRICS_BACKFILL_ARTIFACT_NAME,
+  type PRInfo,
+  type TimingSample,
+  type WorkflowRun,
+} from "./perf-lib.ts";
+import {
+  addPerfMetricsFromArtifacts,
+  type BaselineRunContext,
+  buildBaselineRunContexts,
+  buildExtraBackfillContexts,
+  currentWorkflowRunFromEvent,
+  fetchArtifactsForRunBestEffort,
+  fetchBaselineRunsForCheck,
+  fetchCommitsBehindMain,
+  fetchMainHeadSha,
+  fetchPRForCommitWithError,
   formatBaselineSourceRunAge,
   formatCommitDistance,
+  formatErrorForLog,
+  formatMetricDelta,
+  formatMetricValueForTable,
   formatRelativeAge,
   formatRelativeDuration,
+  githubApiOrSkip,
+  logBaselineSourceRuns,
+  main,
+  metricDisplayParts,
+  metricTableRows,
+  newestArtifactNamed,
   parseMergedBaselineOverrides,
+  parsePerfMetricBackfillFromArtifacts,
+  parsePerfMetricsFromArtifacts,
+  printMetricTable,
+  reportBaselineContextResults,
+  reportBaselineRunAvailability,
+  reportPRLookupResults,
   type Row,
   selectMergedPRForCommit,
   summarizeBaselinePRLookups,
@@ -20,6 +52,176 @@ import {
   COVERAGE_SUGGESTION_MARKER,
   type CoverageCommentPayload,
 } from "./perf-lib.ts";
+
+const SHA_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const SHA_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const SHA_C = "cccccccccccccccccccccccccccccccccccccccc";
+
+function makeRun(
+  id: number,
+  headSha = SHA_A,
+  createdAt = "2026-06-18T10:00:00Z",
+): WorkflowRun {
+  return {
+    id,
+    html_url: `https://github.com/commontoolsinc/labs/actions/runs/${id}`,
+    head_sha: headSha,
+    created_at: createdAt,
+    conclusion: "success",
+    event: "push",
+  };
+}
+
+function makeArtifact(
+  id: number,
+  name: string,
+  expired = false,
+): Artifact {
+  return {
+    id,
+    name,
+    size_in_bytes: 12,
+    expired,
+  };
+}
+
+function makeSample(run = makeRun(1)): TimingSample {
+  return {
+    runId: run.id,
+    runUrl: run.html_url,
+    sha: run.head_sha,
+    createdAt: run.created_at,
+    durationSeconds: 1.5,
+  };
+}
+
+function makePR(number: number, mergedAt: string | null = null): PRInfo {
+  return {
+    number,
+    title: `PR ${number}`,
+    html_url: `https://github.com/commontoolsinc/labs/pull/${number}`,
+    body: null,
+    merged_at: mergedAt,
+  };
+}
+
+type FetchInput = Parameters<typeof fetch>[0];
+type FetchInit = Parameters<typeof fetch>[1];
+
+async function withMockFetch<T>(
+  handler: (input: FetchInput, init: FetchInit) => Response | Promise<Response>,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch =
+    ((input: FetchInput, init?: FetchInit) =>
+      Promise.resolve(handler(input, init))) as typeof fetch;
+  try {
+    return await callback();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+function captureConsole<T>(
+  callback: () => T,
+): { result: T; logs: string[]; warnings: string[]; errors: string[] } {
+  const logs: string[] = [];
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+  console.warn = (...args: unknown[]) =>
+    warnings.push(args.map(String).join(" "));
+  console.error = (...args: unknown[]) =>
+    errors.push(args.map(String).join(" "));
+  try {
+    return { result: callback(), logs, warnings, errors };
+  } finally {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+}
+
+async function captureConsoleAsync<T>(
+  callback: () => Promise<T>,
+): Promise<
+  { result: T; logs: string[]; warnings: string[]; errors: string[] }
+> {
+  const logs: string[] = [];
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+  console.warn = (...args: unknown[]) =>
+    warnings.push(args.map(String).join(" "));
+  console.error = (...args: unknown[]) =>
+    errors.push(args.map(String).join(" "));
+  try {
+    return { result: await callback(), logs, warnings, errors };
+  } finally {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+}
+
+async function withEnv<T>(
+  values: Record<string, string | undefined>,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(values)) {
+    previous.set(key, Deno.env.get(key));
+    const value = values[key];
+    if (value === undefined) Deno.env.delete(key);
+    else Deno.env.set(key, value);
+  }
+
+  try {
+    return await callback();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
+    }
+  }
+}
+
+class ExitError extends Error {
+  constructor(readonly code: number) {
+    super(`Deno.exit(${code})`);
+  }
+}
+
+async function withMockExit(
+  callback: () => Promise<void>,
+): Promise<number | null> {
+  const originalExit = Deno.exit;
+  Deno.exit = ((code?: number): never => {
+    throw new ExitError(code ?? 0);
+  }) as typeof Deno.exit;
+  try {
+    await callback();
+    return null;
+  } catch (error) {
+    if (error instanceof ExitError) return error.code;
+    throw error;
+  } finally {
+    Deno.exit = originalExit;
+  }
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    headers: { "content-type": "application/json" },
+  });
+}
 
 Deno.test("invalid merged PR baseline override metadata is ignored", () => {
   const warnings: string[] = [];
@@ -144,6 +346,50 @@ Deno.test("baseline workflow path fetches successful main push runs", () => {
   assertEquals(query.get("created"), null);
 });
 
+Deno.test("fetchMainHeadSha reads the main branch commit", async () => {
+  const result = await withMockFetch(
+    (input) => {
+      assertStringIncludes(
+        String(input),
+        "/repos/commontoolsinc/labs/branches/main",
+      );
+      return new Response(JSON.stringify({ commit: { sha: SHA_A } }));
+    },
+    () => fetchMainHeadSha(),
+  );
+
+  assertEquals(result, SHA_A);
+});
+
+Deno.test("fetchBaselineRunsForCheck fetches main head and baseline runs", async () => {
+  const logs: string[] = [];
+  const requests: string[] = [];
+  const run = makeRun(101, SHA_A);
+  const result = await withMockFetch(
+    (input) => {
+      const url = String(input);
+      requests.push(url);
+      if (url.endsWith("/branches/main")) {
+        return new Response(JSON.stringify({ commit: { sha: SHA_A } }));
+      }
+      if (url.includes("/actions/workflows/deno.yml/runs?")) {
+        return new Response(JSON.stringify({ workflow_runs: [run] }));
+      }
+      return new Response("unexpected request", { status: 404 });
+    },
+    () =>
+      fetchBaselineRunsForCheck(new Map(), 1, (message) => logs.push(message)),
+  );
+
+  assertEquals(result, { mainHeadSha: SHA_A, baselineRuns: [run] });
+  assertEquals(requests.length, 2);
+  assertStringIncludes(requests[1], "branch=main");
+  assertStringIncludes(requests[1], "status=success");
+  assertStringIncludes(requests[1], "event=push");
+  assertStringIncludes(requests[1], "per_page=1");
+  assertStringIncludes(logs.join("\n"), "Current main head");
+});
+
 Deno.test("relative duration formatting uses two readable parts", () => {
   assertEquals(formatRelativeDuration(45), "45 seconds");
   assertEquals(formatRelativeDuration(65), "1 minute 5 seconds");
@@ -155,6 +401,7 @@ Deno.test("relative duration formatting uses two readable parts", () => {
     formatRelativeDuration(3 * 24 * 60 * 60 + 2 * 60 * 60),
     "3 days 2 hours",
   );
+  assertEquals(formatRelativeDuration(Number.NaN), "unknown");
 });
 
 Deno.test("relative age formatting compares two timestamps", () => {
@@ -187,6 +434,334 @@ Deno.test("baseline source run age combines time and commit distance", () => {
     ),
     "created 2 hours 3 minutes ago; 7 commits behind current main",
   );
+  assertEquals(
+    formatBaselineSourceRunAge("not a date", "2026-06-18T12:03:04Z", null),
+    "age unknown; an unknown number of commits behind current main",
+  );
+});
+
+Deno.test("fetchCommitsBehindMain reports zero for the current main commit", async () => {
+  assertEquals(await fetchCommitsBehindMain(SHA_A, SHA_A), 0);
+});
+
+Deno.test("fetchCommitsBehindMain reads GitHub compare distance", async () => {
+  const result = await withMockFetch(
+    (input) => {
+      assertStringIncludes(String(input), `/compare/${SHA_A}...${SHA_B}`);
+      return new Response(JSON.stringify({ ahead_by: 3 }));
+    },
+    () => fetchCommitsBehindMain(SHA_A, SHA_B),
+  );
+
+  assertEquals(result, 3);
+});
+
+Deno.test("fetchCommitsBehindMain treats malformed compare data as unknown", async () => {
+  const result = await withMockFetch(
+    () => new Response(JSON.stringify({ ahead_by: "3" })),
+    () => fetchCommitsBehindMain(SHA_A, SHA_B),
+  );
+
+  assertEquals(result, null);
+});
+
+Deno.test("fetchCommitsBehindMain warns and continues after compare failure", async () => {
+  const captured = await captureConsoleAsync(() =>
+    withMockFetch(
+      () => new Response("missing", { status: 404 }),
+      () => fetchCommitsBehindMain(SHA_A, SHA_B),
+    )
+  );
+
+  assertEquals(captured.result, null);
+  assertStringIncludes(
+    captured.warnings.join("\n"),
+    "could not compare baseline",
+  );
+  assertStringIncludes(captured.warnings.join("\n"), SHA_A.slice(0, 8));
+});
+
+Deno.test("fetchPRForCommitWithError returns selected PR metadata", async () => {
+  const pr = makePR(42, "2026-06-18T00:00:00Z");
+  const result = await withMockFetch(
+    (input) => {
+      assertStringIncludes(String(input), `/commits/${SHA_A}/pulls`);
+      return new Response(JSON.stringify([pr]));
+    },
+    () => fetchPRForCommitWithError(SHA_A),
+  );
+
+  assertEquals(result, { pr, error: null });
+});
+
+Deno.test("fetchPRForCommitWithError captures lookup errors", async () => {
+  const result = await withMockFetch(
+    () => new Response("missing", { status: 404 }),
+    () => fetchPRForCommitWithError(SHA_A),
+  );
+
+  assertEquals(result.pr, null);
+  assertStringIncludes(String(result.error), "GitHub API 404");
+});
+
+Deno.test("newestArtifactNamed filters expired artifacts and keeps newest id", () => {
+  assertEquals(
+    newestArtifactNamed(
+      [
+        makeArtifact(1, PERF_METRICS_ARTIFACT_NAME),
+        makeArtifact(3, PERF_METRICS_ARTIFACT_NAME, true),
+        makeArtifact(2, PERF_METRICS_ARTIFACT_NAME),
+        makeArtifact(4, "other"),
+      ],
+      PERF_METRICS_ARTIFACT_NAME,
+    )?.id,
+    2,
+  );
+  assertEquals(newestArtifactNamed([], PERF_METRICS_ARTIFACT_NAME), null);
+});
+
+Deno.test("formatErrorForLog keeps the first line only", () => {
+  assertEquals(formatErrorForLog(new Error("first\nsecond")), "first");
+  assertEquals(formatErrorForLog("plain\nsecond"), "plain");
+});
+
+Deno.test("githubApiOrSkip writes metrics and exits on rate limits", async () => {
+  const metrics = new Map<string, TimingSample>([["job: Check", makeSample()]]);
+
+  try {
+    const captured = await captureConsoleAsync(() =>
+      withMockExit(() =>
+        githubApiOrSkip(
+          "collecting test data",
+          () => Promise.reject(new Error("rate limit exceeded")),
+          metrics,
+        ).then(() => {})
+      )
+    );
+
+    assertEquals(captured.result, 0);
+    assertStringIncludes(captured.warnings.join("\n"), "rate limit");
+    assertStringIncludes(captured.logs.join("\n"), "Wrote perf-metrics.json");
+    const file = JSON.parse(await Deno.readTextFile("perf-metrics.json"));
+    assertEquals(file.metrics[0].name, "job: Check");
+  } finally {
+    await Deno.remove("perf-metrics.json").catch(() => {});
+  }
+});
+
+Deno.test("githubApiOrSkip rethrows non-rate-limit errors", async () => {
+  await assertRejects(
+    () =>
+      githubApiOrSkip(
+        "collecting test data",
+        () => Promise.reject(new Error("plain failure")),
+        new Map(),
+      ),
+    Error,
+    "plain failure",
+  );
+});
+
+Deno.test("metric table helpers format task and metric details", () => {
+  const coverageRow = {
+    metric: "coverage-debt: tasks uncovered lines",
+    status: "OK" as const,
+    current: 12.4,
+    median: 10,
+    variance: 0,
+    stddev: 0,
+    threshold: 10,
+    n: 5,
+    pctIncrease: 24,
+  };
+  const pendingRow = {
+    metric: "job: Check",
+    status: "n/a" as const,
+    current: 9,
+    n: 0,
+  };
+
+  assertEquals(
+    formatMetricValueForTable(coverageRow.metric, coverageRow.current),
+    "12",
+  );
+  assertEquals(formatMetricValueForTable("job: Check", undefined), "-");
+  assertEquals(formatMetricDelta("job: Check", pendingRow), "-");
+  assertEquals(
+    formatMetricDelta(coverageRow.metric, coverageRow),
+    "+2 (+24%)",
+  );
+  assertEquals(metricDisplayParts("test: runner > file.test.ts"), {
+    task: "runner",
+    metric: "file.test.ts",
+  });
+  assertEquals(metricDisplayParts("coverage-debt: tasks uncovered lines"), {
+    task: "coverage-debt",
+    metric: "tasks",
+  });
+  assertEquals(metricDisplayParts("coverage-debt: custom metric"), {
+    task: "coverage-debt",
+    metric: "custom metric",
+  });
+  assertEquals(metricDisplayParts("uncategorized"), {
+    task: "other",
+    metric: "uncategorized",
+  });
+  assertEquals(metricDisplayParts("job: Check"), {
+    task: "job",
+    metric: "Check",
+  });
+  assertEquals(metricTableRows([coverageRow], true)[0][0], "OK");
+  assertEquals(metricTableRows([coverageRow], false)[0][0], "10");
+});
+
+Deno.test("printMetricTable renders status and non-status tables", () => {
+  const row = {
+    metric: "job: Check",
+    status: "OK" as const,
+    current: 9,
+    median: 8,
+    variance: 0,
+    stddev: 0,
+    threshold: 10,
+    n: 5,
+    pctIncrease: 12.5,
+  };
+
+  const withStatus = captureConsole(() => printMetricTable([row], true));
+  assertStringIncludes(withStatus.logs.join("\n"), "Status");
+  assertStringIncludes(withStatus.logs.join("\n"), "OK");
+
+  const withoutStatus = captureConsole(() => printMetricTable([row], false));
+  assertStringIncludes(withoutStatus.logs.join("\n"), "Baseline");
+  assertEquals(withoutStatus.logs.join("\n").includes("Status"), false);
+});
+
+Deno.test("currentWorkflowRunFromEvent reads event and environment metadata", () => {
+  const previousSha = Deno.env.get("GITHUB_SHA");
+  const previousEventName = Deno.env.get("GITHUB_EVENT_NAME");
+  try {
+    Deno.env.set("GITHUB_SHA", SHA_B);
+    Deno.env.set("GITHUB_EVENT_NAME", "push");
+    assertEquals(
+      currentWorkflowRunFromEvent(
+        { pull_request: { head: { sha: SHA_A } } },
+        7,
+      ).head_sha,
+      SHA_A,
+    );
+    const fallback = currentWorkflowRunFromEvent(undefined, 8);
+    assertEquals(fallback.head_sha, SHA_B);
+    assertEquals(fallback.event, "push");
+    Deno.env.delete("GITHUB_EVENT_NAME");
+    assertEquals(currentWorkflowRunFromEvent(undefined, 9).event, "");
+  } finally {
+    if (previousSha === undefined) Deno.env.delete("GITHUB_SHA");
+    else Deno.env.set("GITHUB_SHA", previousSha);
+    if (previousEventName === undefined) Deno.env.delete("GITHUB_EVENT_NAME");
+    else Deno.env.set("GITHUB_EVENT_NAME", previousEventName);
+  }
+});
+
+Deno.test("logBaselineSourceRuns prints age, PR, lookup, and artifact details", () => {
+  const contexts: BaselineRunContext[] = [
+    {
+      run: makeRun(1, SHA_A, "2026-06-18T10:00:00Z"),
+      artifacts: [
+        makeArtifact(1, PERF_METRICS_ARTIFACT_NAME),
+        makeArtifact(3, PERF_METRICS_ARTIFACT_NAME, true),
+        makeArtifact(2, PERF_METRICS_ARTIFACT_NAME),
+      ],
+      pr: makePR(10, "2026-06-18T00:00:00Z"),
+      prLookupError: null,
+      commitsBehindMain: 0,
+    },
+    {
+      run: makeRun(2, SHA_B, "2026-06-18T11:00:00Z"),
+      artifacts: [],
+      pr: null,
+      prLookupError: new Error("lookup failed\nsecond line"),
+      commitsBehindMain: null,
+    },
+    {
+      run: makeRun(3, SHA_C, "2026-06-18T11:30:00Z"),
+      artifacts: [],
+      pr: null,
+      prLookupError: null,
+      commitsBehindMain: 5,
+    },
+  ];
+
+  const captured = captureConsole(() =>
+    logBaselineSourceRuns(contexts, "2026-06-18T12:00:00Z")
+  );
+  const output = captured.logs.join("\n");
+
+  assertStringIncludes(output, "Baseline source runs:");
+  assertStringIncludes(
+    output,
+    "created 2 hours ago; 0 commits behind current main",
+  );
+  assertStringIncludes(output, "PR #10");
+  assertStringIncludes(output, "perf-metrics artifact 2");
+  assertStringIncludes(output, "PR lookup failed");
+  assertStringIncludes(
+    output,
+    "an unknown number of commits behind current main",
+  );
+  assertStringIncludes(output, "no PR found");
+  assertStringIncludes(output, "no perf-metrics artifact");
+});
+
+Deno.test("reportPRLookupResults logs clean and failed lookup summaries", () => {
+  const clean = captureConsole(() =>
+    reportPRLookupResults([
+      {
+        run: makeRun(1),
+        artifacts: [],
+        pr: makePR(1),
+        prLookupError: null,
+        commitsBehindMain: 0,
+      },
+    ])
+  );
+  assertEquals(clean.result, 0);
+  assertStringIncludes(clean.logs.join("\n"), "0 failed");
+
+  const failed = captureConsole(() =>
+    reportPRLookupResults([
+      {
+        run: makeRun(2, SHA_B),
+        artifacts: [],
+        pr: null,
+        prLookupError: new Error("boom\nsecond line"),
+        commitsBehindMain: null,
+      },
+    ])
+  );
+  assertEquals(failed.result, 1);
+  assertStringIncludes(
+    failed.warnings.join("\n"),
+    "failed to fetch PR metadata",
+  );
+  assertStringIncludes(failed.warnings.join("\n"), "boom");
+});
+
+Deno.test("reportBaselineContextResults logs incomplete PR metadata warning", () => {
+  const context: BaselineRunContext = {
+    run: makeRun(1),
+    artifacts: [],
+    pr: null,
+    prLookupError: new Error("lookup failed"),
+    commitsBehindMain: null,
+  };
+
+  const captured = captureConsole(() =>
+    reportBaselineContextResults([context], "2026-06-18T12:00:00Z")
+  );
+
+  assertEquals(captured.result, 1);
+  assertStringIncludes(captured.warnings.join("\n"), "incomplete PR metadata");
 });
 
 Deno.test("baseline main validation reports stale newest run", () => {
@@ -212,6 +787,22 @@ Deno.test("baseline main validation reports stale newest run", () => {
     result.issues.join("\n"),
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   );
+});
+
+Deno.test("baseline main validation reports invalid main head SHA", () => {
+  const result = validateBaselineRunsForMainHead(
+    [
+      {
+        id: 1,
+        head_sha: SHA_A,
+        created_at: "2026-06-18T00:00:00Z",
+      },
+    ],
+    "not-a-sha",
+  );
+
+  assertEquals(result.ok, false);
+  assertStringIncludes(result.issues.join("\n"), "invalid");
 });
 
 Deno.test("baseline main validation reports empty run data", () => {
@@ -242,6 +833,279 @@ Deno.test("baseline main validation accepts current main as newest run", () => {
   );
 
   assertEquals(result, { ok: true, issues: [] });
+});
+
+Deno.test("reportBaselineRunAvailability warns for stale and sparse baselines", () => {
+  const warnings: string[] = [];
+  const result = reportBaselineRunAvailability(
+    [makeRun(1, SHA_A)],
+    SHA_B,
+    5,
+    (message) => warnings.push(message),
+  );
+
+  assertEquals(result.ok, false);
+  assertStringIncludes(warnings.join("\n"), "current main head");
+  assertStringIncludes(warnings.join("\n"), "only 1 baseline runs available");
+});
+
+Deno.test("fetchArtifactsForRunBestEffort returns artifacts or an empty fallback", async () => {
+  const run = makeRun(99);
+  const artifact = makeArtifact(1, PERF_METRICS_ARTIFACT_NAME);
+  const warnings: string[] = [];
+
+  assertEquals(
+    await fetchArtifactsForRunBestEffort(run, (runId) => {
+      assertEquals(runId, 99);
+      return Promise.resolve([artifact]);
+    }, (message) => warnings.push(message)),
+    [artifact],
+  );
+  assertEquals(warnings, []);
+
+  assertEquals(
+    await fetchArtifactsForRunBestEffort(
+      run,
+      () => {
+        throw new Error("artifact API failed");
+      },
+      (message) => warnings.push(message),
+    ),
+    [],
+  );
+  assertStringIncludes(warnings.join("\n"), "artifact API failed");
+});
+
+Deno.test("buildBaselineRunContexts collects artifacts, PRs, and commit distance", async () => {
+  const run = makeRun(11, SHA_A);
+  const artifact = makeArtifact(5, PERF_METRICS_ARTIFACT_NAME);
+  const pr = makePR(11, "2026-06-18T00:00:00Z");
+
+  const contexts = await buildBaselineRunContexts({
+    baselineRuns: [run],
+    mainHeadSha: SHA_B,
+    concurrency: 1,
+    fetchArtifactsForRun: (requestedRun) => {
+      assertEquals(requestedRun, run);
+      return Promise.resolve([artifact]);
+    },
+    fetchPRForCommit: (sha) => {
+      assertEquals(sha, SHA_A);
+      return Promise.resolve({ pr, error: null });
+    },
+    fetchCommitsBehindMain: (baselineSha, mainHeadSha) => {
+      assertEquals(baselineSha, SHA_A);
+      assertEquals(mainHeadSha, SHA_B);
+      return Promise.resolve(4);
+    },
+  });
+
+  assertEquals(contexts, [
+    {
+      run,
+      artifacts: [artifact],
+      pr,
+      prLookupError: null,
+      commitsBehindMain: 4,
+    },
+  ]);
+});
+
+Deno.test("buildExtraBackfillContexts creates context shells", async () => {
+  const run = makeRun(12, SHA_B);
+  const artifact = makeArtifact(6, PERF_METRICS_BACKFILL_ARTIFACT_NAME);
+
+  const contexts = await buildExtraBackfillContexts(
+    [run],
+    (requestedRun) => {
+      assertEquals(requestedRun, run);
+      return Promise.resolve([artifact]);
+    },
+    1,
+  );
+
+  assertEquals(contexts, [
+    {
+      run,
+      artifacts: [artifact],
+      pr: null,
+      prLookupError: null,
+      commitsBehindMain: null,
+    },
+  ]);
+});
+
+Deno.test("parsePerfMetricBackfillFromArtifacts uses newest backfill artifact", async () => {
+  const parsed = new Map<number, Map<string, TimingSample>>([[1, new Map()]]);
+  let parsedArtifactId = 0;
+
+  const result = await parsePerfMetricBackfillFromArtifacts(
+    [
+      makeArtifact(1, PERF_METRICS_BACKFILL_ARTIFACT_NAME),
+      makeArtifact(3, PERF_METRICS_BACKFILL_ARTIFACT_NAME),
+      makeArtifact(4, PERF_METRICS_BACKFILL_ARTIFACT_NAME, true),
+    ],
+    (artifactId) => {
+      parsedArtifactId = artifactId;
+      return Promise.resolve(parsed);
+    },
+  );
+
+  assertEquals(result, parsed);
+  assertEquals(parsedArtifactId, 3);
+  assertEquals(
+    await parsePerfMetricBackfillFromArtifacts([], () => {
+      throw new Error("should not parse without an artifact");
+    }),
+    null,
+  );
+});
+
+Deno.test("parsePerfMetricsFromArtifacts uses newest perf metrics artifact", async () => {
+  const parsed = new Map<string, TimingSample>([["job: Check", makeSample()]]);
+  let parsedArtifactId = 0;
+
+  const result = await parsePerfMetricsFromArtifacts(
+    [
+      makeArtifact(1, PERF_METRICS_ARTIFACT_NAME),
+      makeArtifact(3, PERF_METRICS_ARTIFACT_NAME),
+      makeArtifact(4, PERF_METRICS_ARTIFACT_NAME, true),
+    ],
+    (artifactId) => {
+      parsedArtifactId = artifactId;
+      return Promise.resolve(parsed);
+    },
+  );
+
+  assertEquals(result, parsed);
+  assertEquals(parsedArtifactId, 3);
+  assertEquals(
+    await parsePerfMetricsFromArtifacts([], () => {
+      throw new Error("should not parse without an artifact");
+    }),
+    null,
+  );
+});
+
+Deno.test("addPerfMetricsFromArtifacts adds parsed samples to timelines", async () => {
+  const artifacts = [makeArtifact(1, PERF_METRICS_ARTIFACT_NAME)];
+  const sample = makeSample();
+  const timelines = new Map();
+
+  assertEquals(
+    await addPerfMetricsFromArtifacts(timelines, artifacts, (requested) => {
+      assertEquals(requested, artifacts);
+      return Promise.resolve(new Map([["job: Check", sample]]));
+    }),
+    true,
+  );
+  assertEquals(timelines.get("job: Check")?.samples, [sample]);
+
+  assertEquals(
+    await addPerfMetricsFromArtifacts(
+      timelines,
+      [],
+      () => Promise.resolve(null),
+    ),
+    false,
+  );
+});
+
+Deno.test("main runs informational check with mocked latest baseline data", async () => {
+  const eventPath = await Deno.makeTempFile({ suffix: ".json" });
+  await Deno.writeTextFile(eventPath, JSON.stringify({ after: SHA_C }));
+
+  const currentRunId = 123;
+  const baselineRuns = [
+    makeRun(201, SHA_A, "2026-06-18T10:00:00Z"),
+    makeRun(202, SHA_B, "2026-06-18T09:00:00Z"),
+    makeRun(203, SHA_C, "2026-06-18T08:00:00Z"),
+    makeRun(
+      204,
+      "dddddddddddddddddddddddddddddddddddddddd",
+      "2026-06-18T07:00:00Z",
+    ),
+    makeRun(
+      205,
+      "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "2026-06-18T06:00:00Z",
+    ),
+  ];
+  const jobsForRun = (runId: number) => ({
+    jobs: [
+      {
+        id: runId * 10,
+        name: "Check",
+        started_at: "2026-06-18T12:00:00Z",
+        completed_at: "2026-06-18T12:00:10Z",
+        steps: [
+          {
+            name: "Run checks",
+            started_at: "2026-06-18T12:00:01Z",
+            completed_at: "2026-06-18T12:00:09Z",
+          },
+        ],
+      },
+    ],
+  });
+
+  try {
+    const captured = await captureConsoleAsync(() =>
+      withEnv(
+        {
+          GITHUB_TOKEN: "test-token",
+          GITHUB_RUN_ID: String(currentRunId),
+          GITHUB_EVENT_PATH: eventPath,
+          GITHUB_EVENT_NAME: "workflow_run",
+          GITHUB_SHA: SHA_C,
+          PR_NUMBER: "",
+        },
+        () =>
+          withMockFetch(
+            (input) => {
+              const url = String(input);
+              if (url.endsWith("/branches/main")) {
+                return jsonResponse({ commit: { sha: SHA_A } });
+              }
+              if (url.includes("/actions/workflows/deno.yml/runs?")) {
+                return jsonResponse({ workflow_runs: baselineRuns });
+              }
+              if (url.includes(`/actions/runs/${currentRunId}/jobs`)) {
+                return jsonResponse(jobsForRun(currentRunId));
+              }
+              const baselineRun = baselineRuns.find((run) =>
+                url.includes(`/actions/runs/${run.id}/jobs`)
+              );
+              if (baselineRun) return jsonResponse(jobsForRun(baselineRun.id));
+              if (url.includes("/artifacts?")) {
+                return jsonResponse({ total_count: 0, artifacts: [] });
+              }
+              if (url.includes("/commits/") && url.endsWith("/pulls")) {
+                return jsonResponse([]);
+              }
+              if (url.includes("/compare/")) {
+                return jsonResponse({ ahead_by: 1 });
+              }
+              return new Response(`unexpected request: ${url}`, {
+                status: 404,
+              });
+            },
+            () => withMockExit(() => main()),
+          ),
+      )
+    );
+    const output = captured.logs.join("\n");
+
+    assertEquals(captured.result, 0);
+    assertStringIncludes(output, "Current main head is");
+    assertStringIncludes(output, "Using 5 main-branch runs as baseline.");
+    assertStringIncludes(output, "Baseline source runs:");
+    assertStringIncludes(output, "All metrics within normal range.");
+  } finally {
+    await Deno.remove(eventPath).catch(() => {});
+    await Deno.remove("perf-metrics.json").catch(() => {});
+    await Deno.remove("perf-metrics-backfill.json").catch(() => {});
+  }
 });
 
 Deno.test("selectMergedPRForCommit prefers the merged PR", () => {

--- a/tasks/perf-check.test.ts
+++ b/tasks/perf-check.test.ts
@@ -1,8 +1,17 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import * as path from "@std/path";
+import type { PRInfo } from "./perf-lib.ts";
 import {
+  formatBaselineSourceRunAge,
+  formatCommitDistance,
+  formatRelativeAge,
+  formatRelativeDuration,
   parseMergedBaselineOverrides,
   type Row,
+  selectMergedPRForCommit,
+  summarizeBaselinePRLookups,
+  validateBaselineRunsForMainHead,
+  workflowRunsPathForBaseline,
   writeCoverageComment,
   writeCoverageDebtSuggestion,
   writeCoverageResolved,
@@ -121,4 +130,148 @@ Deno.test("writeCoverageDebtSuggestion writes nothing when no coverage group res
   );
 
   assertEquals(payload, null);
+});
+
+Deno.test("baseline workflow path fetches successful main push runs", () => {
+  const path = workflowRunsPathForBaseline(20);
+  const query = new URLSearchParams(path.split("?")[1]);
+
+  assertStringIncludes(path, "/actions/workflows/deno.yml/runs?");
+  assertEquals(query.get("branch"), "main");
+  assertEquals(query.get("status"), "success");
+  assertEquals(query.get("event"), "push");
+  assertEquals(query.get("per_page"), "20");
+  assertEquals(query.get("created"), null);
+});
+
+Deno.test("relative duration formatting uses two readable parts", () => {
+  assertEquals(formatRelativeDuration(45), "45 seconds");
+  assertEquals(formatRelativeDuration(65), "1 minute 5 seconds");
+  assertEquals(
+    formatRelativeDuration(2 * 60 * 60 + 3 * 60 + 4),
+    "2 hours 3 minutes",
+  );
+  assertEquals(
+    formatRelativeDuration(3 * 24 * 60 * 60 + 2 * 60 * 60),
+    "3 days 2 hours",
+  );
+});
+
+Deno.test("relative age formatting compares two timestamps", () => {
+  assertEquals(
+    formatRelativeAge(
+      "2026-06-18T10:00:00Z",
+      "2026-06-18T12:03:04Z",
+    ),
+    "2 hours 3 minutes",
+  );
+  assertEquals(
+    formatRelativeAge("not a date", "2026-06-18T12:03:04Z"),
+    "unknown",
+  );
+});
+
+Deno.test("commit distance formatting handles known and unknown values", () => {
+  assertEquals(formatCommitDistance(0), "0 commits");
+  assertEquals(formatCommitDistance(1), "1 commit");
+  assertEquals(formatCommitDistance(12), "12 commits");
+  assertEquals(formatCommitDistance(null), "an unknown number of commits");
+});
+
+Deno.test("baseline source run age combines time and commit distance", () => {
+  assertEquals(
+    formatBaselineSourceRunAge(
+      "2026-06-18T10:00:00Z",
+      "2026-06-18T12:03:04Z",
+      7,
+    ),
+    "created 2 hours 3 minutes ago; 7 commits behind current main",
+  );
+});
+
+Deno.test("baseline main validation reports stale newest run", () => {
+  const result = validateBaselineRunsForMainHead(
+    [
+      {
+        id: 1,
+        head_sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        created_at: "2026-06-18T00:00:00Z",
+      },
+      {
+        id: 2,
+        head_sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        created_at: "2026-06-17T00:00:00Z",
+      },
+    ],
+    "cccccccccccccccccccccccccccccccccccccccc",
+  );
+
+  assertEquals(result.ok, false);
+  assertStringIncludes(result.issues.join("\n"), "current main");
+  assertStringIncludes(
+    result.issues.join("\n"),
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  );
+});
+
+Deno.test("baseline main validation reports empty run data", () => {
+  const result = validateBaselineRunsForMainHead(
+    [],
+    "cccccccccccccccccccccccccccccccccccccccc",
+  );
+
+  assertEquals(result.ok, false);
+  assertStringIncludes(result.issues.join("\n"), "No successful main-branch");
+});
+
+Deno.test("baseline main validation accepts current main as newest run", () => {
+  const result = validateBaselineRunsForMainHead(
+    [
+      {
+        id: 1,
+        head_sha: "cccccccccccccccccccccccccccccccccccccccc",
+        created_at: "2026-06-18T00:00:00Z",
+      },
+      {
+        id: 2,
+        head_sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        created_at: "2026-06-17T00:00:00Z",
+      },
+    ],
+    "cccccccccccccccccccccccccccccccccccccccc",
+  );
+
+  assertEquals(result, { ok: true, issues: [] });
+});
+
+Deno.test("selectMergedPRForCommit prefers the merged PR", () => {
+  const prs = [
+    { number: 1, merged_at: null },
+    { number: 2, merged_at: "2026-06-18T00:00:00Z" },
+  ] as unknown as PRInfo[];
+
+  assertEquals(selectMergedPRForCommit(prs)?.number, 2);
+});
+
+Deno.test("selectMergedPRForCommit falls back to the first PR", () => {
+  const prs = [
+    { number: 1, merged_at: null },
+    { number: 2, merged_at: null },
+  ] as unknown as PRInfo[];
+
+  assertEquals(selectMergedPRForCommit(prs)?.number, 1);
+  assertEquals(selectMergedPRForCommit([]), null);
+});
+
+Deno.test("baseline PR lookup summary counts found, missing, and failed lookups", () => {
+  const pr = { number: 1, merged_at: "2026-06-18T00:00:00Z" } as PRInfo;
+
+  assertEquals(
+    summarizeBaselinePRLookups([
+      { pr, prLookupError: null },
+      { pr: null, prLookupError: null },
+      { pr: null, prLookupError: new Error("boom") },
+    ]),
+    { found: 1, noPR: 1, failed: 1 },
+  );
 });

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -66,7 +66,6 @@ import {
   STDDEV_FACTOR,
   timingArtifactLabel,
   type TimingSample,
-  TOKEN,
   walkFiles,
   WORKFLOW_FILE,
   type WorkflowRun,
@@ -87,7 +86,7 @@ const BASELINE_RUNS = 20;
 /** Recent completed workflow runs to scan for fallback backfill artifacts. */
 const BACKFILL_SOURCE_RUNS = 20;
 
-function currentWorkflowRunFromEvent(
+export function currentWorkflowRunFromEvent(
   event: object | undefined,
   runId: number,
 ): WorkflowRun {
@@ -119,7 +118,7 @@ function isGitHubRateLimitError(error: unknown): boolean {
   return /\b(rate limit|rate-limited|ratelimit)\b/i.test(message);
 }
 
-async function githubApiOrSkip<T>(
+export async function githubApiOrSkip<T>(
   description: string,
   operation: () => Promise<T>,
   metricsForArtifact: Map<string, TimingSample>,
@@ -200,7 +199,7 @@ export function validateBaselineRunsForMainHead(
   return { ok: issues.length === 0, issues };
 }
 
-async function fetchMainHeadSha(): Promise<string> {
+export async function fetchMainHeadSha(): Promise<string> {
   const branch = await githubGet<{ commit: { sha: string } }>(
     `/repos/${REPO}/branches/main`,
   );
@@ -265,7 +264,7 @@ interface GitHubCompareResponse {
   ahead_by?: unknown;
 }
 
-async function fetchCommitsBehindMain(
+export async function fetchCommitsBehindMain(
   baselineSha: string,
   mainHeadSha: string,
 ): Promise<number | null> {
@@ -293,12 +292,12 @@ export function selectMergedPRForCommit(prs: PRInfo[]): PRInfo | null {
   return prs.find((pr) => pr.merged_at !== null) ?? prs[0] ?? null;
 }
 
-interface PRLookupResult {
+export interface PRLookupResult {
   pr: PRInfo | null;
   error: unknown | null;
 }
 
-interface BaselineRunContext {
+export interface BaselineRunContext {
   run: WorkflowRun;
   artifacts: Artifact[];
   pr: PRInfo | null;
@@ -306,7 +305,7 @@ interface BaselineRunContext {
   commitsBehindMain: number | null;
 }
 
-async function fetchPRForCommitWithError(
+export async function fetchPRForCommitWithError(
   sha: string,
 ): Promise<PRLookupResult> {
   try {
@@ -319,7 +318,7 @@ async function fetchPRForCommitWithError(
   }
 }
 
-function newestArtifactNamed(
+export function newestArtifactNamed(
   artifacts: Artifact[],
   name: string,
 ): Artifact | null {
@@ -328,12 +327,12 @@ function newestArtifactNamed(
   )[0] ?? null;
 }
 
-function formatErrorForLog(error: unknown): string {
+export function formatErrorForLog(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return message.split("\n")[0];
 }
 
-function logBaselineSourceRuns(
+export function logBaselineSourceRuns(
   contexts: BaselineRunContext[],
   currentRunCreatedAt: string,
 ): void {
@@ -383,7 +382,7 @@ export function summarizeBaselinePRLookups(
   };
 }
 
-function reportPRLookupResults(
+export function reportPRLookupResults(
   contexts: BaselineRunContext[],
 ): number {
   const summary = summarizeBaselinePRLookups(contexts);
@@ -408,6 +407,193 @@ function reportPRLookupResults(
   }
 
   return summary.failed;
+}
+
+export async function fetchArtifactsForRunBestEffort(
+  run: WorkflowRun,
+  fetchArtifacts: (runId: number) => Promise<Artifact[]> = fetchArtifactsForRun,
+  warn: (message: string) => void = console.warn,
+): Promise<Artifact[]> {
+  try {
+    return await fetchArtifacts(run.id);
+  } catch (error) {
+    warn(`  Warning: could not fetch artifacts for run ${run.id}: ${error}`);
+    return [];
+  }
+}
+
+export async function fetchBaselineRunsForCheck(
+  metricsForArtifact: Map<string, TimingSample>,
+  baselineRunCount = BASELINE_RUNS,
+  log: (message: string) => void = console.log,
+): Promise<{ mainHeadSha: string; baselineRuns: WorkflowRun[] }> {
+  log("Fetching current main branch head...");
+  const mainHeadSha = await githubApiOrSkip(
+    "fetching current main branch head",
+    () => fetchMainHeadSha(),
+    metricsForArtifact,
+  );
+  log(`Current main head is ${mainHeadSha}.`);
+  log("Fetching recent main-branch runs for baseline...");
+  const baselineData = await githubApiOrSkip(
+    "fetching recent main-branch runs for baseline",
+    () =>
+      githubGet<{ workflow_runs: WorkflowRun[] }>(
+        workflowRunsPathForBaseline(baselineRunCount),
+      ),
+    metricsForArtifact,
+  );
+  return { mainHeadSha, baselineRuns: baselineData.workflow_runs };
+}
+
+export function reportBaselineRunAvailability(
+  baselineRuns: WorkflowRun[],
+  mainHeadSha: string,
+  minSamples = MIN_SAMPLES,
+  warn: (message: string) => void = console.warn,
+): BaselineMainHeadValidation {
+  const baselineMainHead = validateBaselineRunsForMainHead(
+    baselineRuns,
+    mainHeadSha,
+  );
+  if (!baselineMainHead.ok) {
+    warn(
+      "Warning: newest successful baseline run is not for the current main head.",
+    );
+    for (const issue of baselineMainHead.issues) {
+      warn(`  Warning: ${issue}`);
+    }
+  }
+
+  if (baselineRuns.length < minSamples) {
+    warn(
+      `  Warning: only ${baselineRuns.length} baseline runs available (need ${minSamples}). Metrics with too few samples will be reported as n/a.`,
+    );
+  }
+
+  return baselineMainHead;
+}
+
+export interface BuildBaselineRunContextsOptions {
+  baselineRuns: WorkflowRun[];
+  mainHeadSha: string;
+  fetchArtifactsForRun?: (run: WorkflowRun) => Promise<Artifact[]>;
+  fetchPRForCommit?: (sha: string) => Promise<PRLookupResult>;
+  fetchCommitsBehindMain?: (
+    baselineSha: string,
+    mainHeadSha: string,
+  ) => Promise<number | null>;
+  concurrency?: number;
+}
+
+export async function buildBaselineRunContexts(
+  options: BuildBaselineRunContextsOptions,
+): Promise<BaselineRunContext[]> {
+  const fetchArtifacts = options.fetchArtifactsForRun ??
+    fetchArtifactsForRunBestEffort;
+  const fetchPR = options.fetchPRForCommit ?? fetchPRForCommitWithError;
+  const fetchCommitDistance = options.fetchCommitsBehindMain ??
+    fetchCommitsBehindMain;
+
+  return await mapConcurrent(
+    options.baselineRuns,
+    options.concurrency ?? API_CONCURRENCY,
+    async (run): Promise<BaselineRunContext> => {
+      const [artifacts, prLookup, commitsBehindMain] = await Promise.all([
+        fetchArtifacts(run),
+        fetchPR(run.head_sha),
+        fetchCommitDistance(run.head_sha, options.mainHeadSha),
+      ]);
+      return {
+        run,
+        artifacts,
+        pr: prLookup.pr,
+        prLookupError: prLookup.error,
+        commitsBehindMain,
+      };
+    },
+  );
+}
+
+export async function buildExtraBackfillContexts(
+  runs: WorkflowRun[],
+  fetchArtifactsForRun: (run: WorkflowRun) => Promise<Artifact[]> =
+    fetchArtifactsForRunBestEffort,
+  concurrency = API_CONCURRENCY,
+): Promise<BaselineRunContext[]> {
+  return await mapConcurrent(
+    runs,
+    concurrency,
+    async (run): Promise<BaselineRunContext> => ({
+      run,
+      artifacts: await fetchArtifactsForRun(run),
+      pr: null,
+      prLookupError: null,
+      commitsBehindMain: null,
+    }),
+  );
+}
+
+export function reportBaselineContextResults(
+  contexts: BaselineRunContext[],
+  currentRunCreatedAt: string,
+): number {
+  logBaselineSourceRuns(contexts, currentRunCreatedAt);
+  const prLookupFailures = reportPRLookupResults(contexts);
+  if (prLookupFailures > 0) {
+    console.warn(
+      "  Warning: running performance regression check with incomplete PR metadata. Some merged baseline overrides may be missing.",
+    );
+  }
+  return prLookupFailures;
+}
+
+export async function parsePerfMetricBackfillFromArtifacts(
+  artifacts: Artifact[],
+  parseBackfill: (
+    artifactId: number,
+  ) => Promise<Map<number, Map<string, TimingSample>> | null> =
+    downloadAndParsePerfMetricsBackfill,
+): Promise<Map<number, Map<string, TimingSample>> | null> {
+  const artifact = newestArtifactNamed(
+    artifacts,
+    PERF_METRICS_BACKFILL_ARTIFACT_NAME,
+  );
+  if (!artifact) return null;
+
+  return await parseBackfill(artifact.id);
+}
+
+export async function parsePerfMetricsFromArtifacts(
+  artifacts: Artifact[],
+  parseMetrics: (
+    artifactId: number,
+  ) => Promise<Map<string, TimingSample> | null> = downloadAndParsePerfMetrics,
+): Promise<Map<string, TimingSample> | null> {
+  const artifact = newestArtifactNamed(
+    artifacts,
+    PERF_METRICS_ARTIFACT_NAME,
+  );
+  if (!artifact) return null;
+
+  return await parseMetrics(artifact.id);
+}
+
+export async function addPerfMetricsFromArtifacts(
+  timelines: Map<string, MetricTimeline>,
+  artifacts: Artifact[],
+  parseMetrics: (
+    artifacts: Artifact[],
+  ) => Promise<Map<string, TimingSample> | null> =
+    parsePerfMetricsFromArtifacts,
+): Promise<boolean> {
+  const artifactMetrics = await parseMetrics(artifacts);
+  if (!artifactMetrics) return false;
+
+  for (const [name, sample] of artifactMetrics) {
+    addSample(timelines, name, sample);
+  }
+  return true;
 }
 
 /**
@@ -535,7 +721,7 @@ function trimTrailingZero(value: string): string {
   return value.replace(/\.0(?=[a-z])/g, "");
 }
 
-function formatMetricValueForTable(
+export function formatMetricValueForTable(
   metric: string,
   value: number | undefined,
 ): string {
@@ -544,7 +730,7 @@ function formatMetricValueForTable(
   return trimTrailingZero(formatMetricValue(metric, value));
 }
 
-function formatMetricDelta(metric: string, row: Row): string {
+export function formatMetricDelta(metric: string, row: Row): string {
   if (row.median === undefined || row.pctIncrease === undefined) return "-";
 
   const delta = row.current - row.median;
@@ -562,7 +748,9 @@ function formatMetricDelta(metric: string, row: Row): string {
   }%)`;
 }
 
-function metricDisplayParts(metric: string): { task: string; metric: string } {
+export function metricDisplayParts(
+  metric: string,
+): { task: string; metric: string } {
   const colon = metric.indexOf(":");
   if (colon < 0) return { task: "other", metric };
 
@@ -606,7 +794,10 @@ export interface Row {
   headroomPct?: number;
 }
 
-function metricTableRows(rows: Row[], includeStatus: boolean): string[][] {
+export function metricTableRows(
+  rows: Row[],
+  includeStatus: boolean,
+): string[][] {
   return rows.map((row) => {
     const display = metricDisplayParts(row.metric);
     const cells = [
@@ -620,7 +811,7 @@ function metricTableRows(rows: Row[], includeStatus: boolean): string[][] {
   });
 }
 
-function printMetricTable(rows: Row[], includeStatus = false): void {
+export function printMetricTable(rows: Row[], includeStatus = false): void {
   const headers = includeStatus
     ? ["Status", "Baseline", "Current", "Change", "Task", "Metric"]
     : ["Baseline", "Current", "Change", "Task", "Metric"];
@@ -857,13 +1048,13 @@ export async function writeCoverageResolved(
 // Main
 // ---------------------------------------------------------------------------
 
-async function main() {
+export async function main() {
   const runId = Deno.env.get("GITHUB_RUN_ID");
   const rawPrNumber = Deno.env.get("PR_NUMBER");
   const prNumber = (rawPrNumber === "") ? null : rawPrNumber;
   const informationalOnly = prNumber === null;
 
-  if (!TOKEN) {
+  if (!Deno.env.get("GITHUB_TOKEN")) {
     console.error("GITHUB_TOKEN is required.");
     Deno.exit(1);
   }
@@ -1043,42 +1234,10 @@ async function main() {
   const wallTimeSignals = computeCiWallTimeRevisitSignals(currentJobs);
 
   // 3. Fetch recent main-branch push runs for baseline
-  console.log("Fetching current main branch head...");
-  const mainHeadSha = await githubApiOrSkip(
-    "fetching current main branch head",
-    () => fetchMainHeadSha(),
+  const { mainHeadSha, baselineRuns } = await fetchBaselineRunsForCheck(
     currentMetrics,
   );
-  console.log(`Current main head is ${mainHeadSha}.`);
-  console.log("Fetching recent main-branch runs for baseline...");
-  const baselineData = await githubApiOrSkip(
-    "fetching recent main-branch runs for baseline",
-    () =>
-      githubGet<{ workflow_runs: WorkflowRun[] }>(
-        workflowRunsPathForBaseline(BASELINE_RUNS),
-      ),
-    currentMetrics,
-  );
-  const baselineRuns = baselineData.workflow_runs;
-
-  const baselineMainHead = validateBaselineRunsForMainHead(
-    baselineRuns,
-    mainHeadSha,
-  );
-  if (!baselineMainHead.ok) {
-    console.warn(
-      "Warning: newest successful baseline run is not for the current main head.",
-    );
-    for (const issue of baselineMainHead.issues) {
-      console.warn(`  Warning: ${issue}`);
-    }
-  }
-
-  if (baselineRuns.length < MIN_SAMPLES) {
-    console.warn(
-      `  Warning: only ${baselineRuns.length} baseline runs available (need ${MIN_SAMPLES}). Metrics with too few samples will be reported as n/a.`,
-    );
-  }
+  reportBaselineRunAvailability(baselineRuns, mainHeadSha);
 
   console.log(`Using ${baselineRuns.length} main-branch runs as baseline.`);
 
@@ -1088,50 +1247,13 @@ async function main() {
   const prInfoBySha = new Map<string, PRInfo>();
   const newBackfills = new Map<number, Map<string, TimingSample>>();
 
-  async function fetchArtifactsForRunBestEffort(
-    run: WorkflowRun,
-  ): Promise<Artifact[]> {
-    try {
-      return await fetchArtifactsForRun(run.id);
-    } catch (error) {
-      console.warn(
-        `  Warning: could not fetch artifacts for run ${run.id}: ${error}`,
-      );
-      return [];
-    }
-  }
-
   const baselineContexts = await githubApiOrSkip(
     "fetching baseline run context",
-    () =>
-      mapConcurrent(
-        baselineRuns,
-        API_CONCURRENCY,
-        async (run): Promise<BaselineRunContext> => {
-          const [artifacts, prLookup, commitsBehindMain] = await Promise.all([
-            fetchArtifactsForRunBestEffort(run),
-            fetchPRForCommitWithError(run.head_sha),
-            fetchCommitsBehindMain(run.head_sha, mainHeadSha),
-          ]);
-          return {
-            run,
-            artifacts,
-            pr: prLookup.pr,
-            prLookupError: prLookup.error,
-            commitsBehindMain,
-          };
-        },
-      ),
+    () => buildBaselineRunContexts({ baselineRuns, mainHeadSha }),
     currentMetrics,
   );
 
-  logBaselineSourceRuns(baselineContexts, currentRunInfo.created_at);
-  const prLookupFailures = reportPRLookupResults(baselineContexts);
-  if (prLookupFailures > 0) {
-    console.warn(
-      "  Warning: running performance regression check with incomplete PR metadata. Some merged baseline overrides may be missing.",
-    );
-  }
+  reportBaselineContextResults(baselineContexts, currentRunInfo.created_at);
 
   console.log("Fetching recent perf metric backfills...");
   const backfillSourceData = await githubApiOrSkip(
@@ -1148,18 +1270,7 @@ async function main() {
   );
   const extraBackfillContexts = await githubApiOrSkip(
     "fetching extra perf metric backfill context",
-    () =>
-      mapConcurrent(
-        backfillSourceRuns,
-        API_CONCURRENCY,
-        async (run): Promise<BaselineRunContext> => ({
-          run,
-          artifacts: await fetchArtifactsForRunBestEffort(run),
-          pr: null,
-          prLookupError: null,
-          commitsBehindMain: null,
-        }),
-      ),
+    () => buildExtraBackfillContexts(backfillSourceRuns),
     currentMetrics,
   );
 
@@ -1176,15 +1287,7 @@ async function main() {
       mapConcurrent(
         backfillSourceContexts,
         API_CONCURRENCY,
-        async ({ artifacts }) => {
-          const artifact = newestArtifactNamed(
-            artifacts,
-            PERF_METRICS_BACKFILL_ARTIFACT_NAME,
-          );
-          if (!artifact) return null;
-
-          return await downloadAndParsePerfMetricsBackfill(artifact.id);
-        },
+        ({ artifacts }) => parsePerfMetricBackfillFromArtifacts(artifacts),
       ),
     currentMetrics,
   );
@@ -1221,20 +1324,8 @@ async function main() {
           }
         }
 
-        const perfMetricsArtifact = newestArtifactNamed(
-          artifacts,
-          PERF_METRICS_ARTIFACT_NAME,
-        );
-        if (perfMetricsArtifact) {
-          const metrics = await downloadAndParsePerfMetrics(
-            perfMetricsArtifact.id,
-          );
-          if (metrics) {
-            for (const [name, sample] of metrics) {
-              addSample(timelines, name, sample);
-            }
-            return;
-          }
+        if (await addPerfMetricsFromArtifacts(timelines, artifacts)) {
+          return;
         }
 
         const backfilledMetrics = backfilledMetricsByRunId.get(run.id);

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -42,7 +42,6 @@ import {
   fetchCurrentPRBody,
   fetchJobsForRun,
   fetchPRFiles,
-  fetchPRForCommit,
   formatMetricValue,
   formatOverrideSuggestion,
   githubGet,
@@ -156,6 +155,259 @@ export function parseMergedBaselineOverrides(
     );
     return null;
   }
+}
+
+export function workflowRunsPathForBaseline(
+  perPage: number,
+): string {
+  const params = new URLSearchParams({
+    branch: "main",
+    status: "success",
+    event: "push",
+    per_page: String(perPage),
+  });
+  return `/repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?${params}`;
+}
+
+export interface BaselineMainHeadValidation {
+  ok: boolean;
+  issues: string[];
+}
+
+export function validateBaselineRunsForMainHead(
+  runs: Pick<WorkflowRun, "id" | "head_sha" | "created_at">[],
+  mainHeadSha: string,
+): BaselineMainHeadValidation {
+  const issues: string[] = [];
+
+  if (runs.length === 0) {
+    issues.push("No successful main-branch runs were returned.");
+    return { ok: false, issues };
+  }
+
+  if (!/^[0-9a-f]{40}$/i.test(mainHeadSha)) {
+    issues.push(`Current main head SHA is invalid: ${mainHeadSha}`);
+    return { ok: false, issues };
+  }
+
+  const newest = runs[0];
+  if (newest.head_sha !== mainHeadSha) {
+    issues.push(
+      `Newest successful baseline run ${newest.id} (${newest.created_at}) is for ${newest.head_sha}, but current main is ${mainHeadSha}.`,
+    );
+  }
+
+  return { ok: issues.length === 0, issues };
+}
+
+async function fetchMainHeadSha(): Promise<string> {
+  const branch = await githubGet<{ commit: { sha: string } }>(
+    `/repos/${REPO}/branches/main`,
+  );
+  return branch.commit.sha;
+}
+
+function pluralize(value: number, unit: string): string {
+  return `${value} ${unit}${value === 1 ? "" : "s"}`;
+}
+
+export function formatRelativeDuration(seconds: number): string {
+  if (!Number.isFinite(seconds)) return "unknown";
+
+  let remaining = Math.max(0, Math.floor(seconds));
+  const parts: string[] = [];
+  const units = [
+    { seconds: 24 * 60 * 60, unit: "day" },
+    { seconds: 60 * 60, unit: "hour" },
+    { seconds: 60, unit: "minute" },
+    { seconds: 1, unit: "second" },
+  ];
+
+  for (const unit of units) {
+    const value = Math.floor(remaining / unit.seconds);
+    if (value > 0) {
+      parts.push(pluralize(value, unit.unit));
+      remaining -= value * unit.seconds;
+    }
+    if (parts.length === 2) break;
+  }
+
+  return parts.length > 0 ? parts.join(" ") : "0 seconds";
+}
+
+export function formatRelativeAge(fromIso: string, toIso: string): string {
+  const fromMs = Date.parse(fromIso);
+  const toMs = Date.parse(toIso);
+  if (!Number.isFinite(fromMs) || !Number.isFinite(toMs)) return "unknown";
+
+  return formatRelativeDuration((toMs - fromMs) / 1_000);
+}
+
+export function formatCommitDistance(commitsBehindMain: number | null): string {
+  return commitsBehindMain === null
+    ? "an unknown number of commits"
+    : pluralize(commitsBehindMain, "commit");
+}
+
+export function formatBaselineSourceRunAge(
+  runCreatedAt: string,
+  currentCreatedAt: string,
+  commitsBehindMain: number | null,
+): string {
+  const age = formatRelativeAge(runCreatedAt, currentCreatedAt);
+  const timePart = age === "unknown" ? "age unknown" : `created ${age} ago`;
+  return `${timePart}; ${
+    formatCommitDistance(commitsBehindMain)
+  } behind current main`;
+}
+
+interface GitHubCompareResponse {
+  ahead_by?: unknown;
+}
+
+async function fetchCommitsBehindMain(
+  baselineSha: string,
+  mainHeadSha: string,
+): Promise<number | null> {
+  if (baselineSha === mainHeadSha) return 0;
+
+  try {
+    const comparison = await githubGet<GitHubCompareResponse>(
+      `/repos/${REPO}/compare/${encodeURIComponent(baselineSha)}...${
+        encodeURIComponent(mainHeadSha)
+      }`,
+    );
+    return typeof comparison.ahead_by === "number" ? comparison.ahead_by : null;
+  } catch (error) {
+    console.warn(
+      `  Warning: could not compare baseline ${baselineSha.slice(0, 8)} ` +
+        `to current main ${mainHeadSha.slice(0, 8)}: ${
+          formatErrorForLog(error)
+        }`,
+    );
+    return null;
+  }
+}
+
+export function selectMergedPRForCommit(prs: PRInfo[]): PRInfo | null {
+  return prs.find((pr) => pr.merged_at !== null) ?? prs[0] ?? null;
+}
+
+interface PRLookupResult {
+  pr: PRInfo | null;
+  error: unknown | null;
+}
+
+interface BaselineRunContext {
+  run: WorkflowRun;
+  artifacts: Artifact[];
+  pr: PRInfo | null;
+  prLookupError: unknown | null;
+  commitsBehindMain: number | null;
+}
+
+async function fetchPRForCommitWithError(
+  sha: string,
+): Promise<PRLookupResult> {
+  try {
+    const prs = await githubGet<PRInfo[]>(
+      `/repos/${REPO}/commits/${sha}/pulls`,
+    );
+    return { pr: selectMergedPRForCommit(prs), error: null };
+  } catch (error) {
+    return { pr: null, error };
+  }
+}
+
+function newestArtifactNamed(
+  artifacts: Artifact[],
+  name: string,
+): Artifact | null {
+  return newestArtifactsByName(
+    artifacts.filter((artifact) => artifact.name === name && !artifact.expired),
+  )[0] ?? null;
+}
+
+function formatErrorForLog(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.split("\n")[0];
+}
+
+function logBaselineSourceRuns(
+  contexts: BaselineRunContext[],
+  currentRunCreatedAt: string,
+): void {
+  console.log("Baseline source runs:");
+  for (
+    const { run, artifacts, pr, prLookupError, commitsBehindMain } of contexts
+  ) {
+    const perfMetricsArtifact = newestArtifactNamed(
+      artifacts,
+      PERF_METRICS_ARTIFACT_NAME,
+    );
+    const prLabel = pr
+      ? `PR #${pr.number}`
+      : prLookupError
+      ? "PR lookup failed"
+      : "no PR found";
+    const artifactLabel = perfMetricsArtifact
+      ? `perf-metrics artifact ${perfMetricsArtifact.id}`
+      : "no perf-metrics artifact";
+    const ageLabel = formatBaselineSourceRunAge(
+      run.created_at,
+      currentRunCreatedAt,
+      commitsBehindMain,
+    );
+    console.log(
+      `  ${run.created_at} run ${run.id} ${run.head_sha.slice(0, 8)} ` +
+        `${ageLabel}; ${prLabel}; ${artifactLabel}`,
+    );
+  }
+}
+
+export interface BaselinePRLookupSummary {
+  found: number;
+  noPR: number;
+  failed: number;
+}
+
+export function summarizeBaselinePRLookups(
+  contexts: { pr: PRInfo | null; prLookupError: unknown | null }[],
+): BaselinePRLookupSummary {
+  const failed = contexts.filter((context) => context.prLookupError).length;
+  const found = contexts.filter((context) => context.pr).length;
+  return {
+    found,
+    noPR: contexts.length - found - failed,
+    failed,
+  };
+}
+
+function reportPRLookupResults(
+  contexts: BaselineRunContext[],
+): number {
+  const summary = summarizeBaselinePRLookups(contexts);
+  const failures = contexts.filter((context) => context.prLookupError);
+
+  console.log(
+    `Baseline PR lookup: found ${summary.found}/${contexts.length}; ` +
+      `${summary.noPR} had no associated PR; ${summary.failed} failed.`,
+  );
+
+  if (summary.failed === 0) return 0;
+
+  console.warn(
+    `  Warning: failed to fetch PR metadata for ${summary.failed} baseline run(s).`,
+  );
+  for (const { run, prLookupError } of failures) {
+    console.warn(
+      `  Warning: run ${run.id} (${
+        run.head_sha.slice(0, 8)
+      }) PR lookup failed: ${formatErrorForLog(prLookupError)}`,
+    );
+  }
+
+  return summary.failed;
 }
 
 /**
@@ -791,22 +1043,41 @@ async function main() {
   const wallTimeSignals = computeCiWallTimeRevisitSignals(currentJobs);
 
   // 3. Fetch recent main-branch push runs for baseline
+  console.log("Fetching current main branch head...");
+  const mainHeadSha = await githubApiOrSkip(
+    "fetching current main branch head",
+    () => fetchMainHeadSha(),
+    currentMetrics,
+  );
+  console.log(`Current main head is ${mainHeadSha}.`);
   console.log("Fetching recent main-branch runs for baseline...");
   const baselineData = await githubApiOrSkip(
     "fetching recent main-branch runs for baseline",
     () =>
       githubGet<{ workflow_runs: WorkflowRun[] }>(
-        `/repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?branch=main&status=success&event=push&per_page=${BASELINE_RUNS}`,
+        workflowRunsPathForBaseline(BASELINE_RUNS),
       ),
     currentMetrics,
   );
   const baselineRuns = baselineData.workflow_runs;
 
-  if (baselineRuns.length < MIN_SAMPLES) {
-    console.log(
-      `Only ${baselineRuns.length} baseline runs available (need ${MIN_SAMPLES}). Skipping check.`,
+  const baselineMainHead = validateBaselineRunsForMainHead(
+    baselineRuns,
+    mainHeadSha,
+  );
+  if (!baselineMainHead.ok) {
+    console.warn(
+      "Warning: newest successful baseline run is not for the current main head.",
     );
-    Deno.exit(0);
+    for (const issue of baselineMainHead.issues) {
+      console.warn(`  Warning: ${issue}`);
+    }
+  }
+
+  if (baselineRuns.length < MIN_SAMPLES) {
+    console.warn(
+      `  Warning: only ${baselineRuns.length} baseline runs available (need ${MIN_SAMPLES}). Metrics with too few samples will be reported as n/a.`,
+    );
   }
 
   console.log(`Using ${baselineRuns.length} main-branch runs as baseline.`);
@@ -816,12 +1087,6 @@ async function main() {
   const overridesBySha = new Map<string, BaselineOverrides>();
   const prInfoBySha = new Map<string, PRInfo>();
   const newBackfills = new Map<number, Map<string, TimingSample>>();
-
-  interface BaselineRunContext {
-    run: WorkflowRun;
-    artifacts: Artifact[];
-    pr: PRInfo | null;
-  }
 
   async function fetchArtifactsForRunBestEffort(
     run: WorkflowRun,
@@ -843,22 +1108,37 @@ async function main() {
         baselineRuns,
         API_CONCURRENCY,
         async (run): Promise<BaselineRunContext> => {
-          const [artifacts, pr] = await Promise.all([
+          const [artifacts, prLookup, commitsBehindMain] = await Promise.all([
             fetchArtifactsForRunBestEffort(run),
-            fetchPRForCommit(run.head_sha),
+            fetchPRForCommitWithError(run.head_sha),
+            fetchCommitsBehindMain(run.head_sha, mainHeadSha),
           ]);
-          return { run, artifacts, pr };
+          return {
+            run,
+            artifacts,
+            pr: prLookup.pr,
+            prLookupError: prLookup.error,
+            commitsBehindMain,
+          };
         },
       ),
     currentMetrics,
   );
+
+  logBaselineSourceRuns(baselineContexts, currentRunInfo.created_at);
+  const prLookupFailures = reportPRLookupResults(baselineContexts);
+  if (prLookupFailures > 0) {
+    console.warn(
+      "  Warning: running performance regression check with incomplete PR metadata. Some merged baseline overrides may be missing.",
+    );
+  }
 
   console.log("Fetching recent perf metric backfills...");
   const backfillSourceData = await githubApiOrSkip(
     "fetching recent perf metric backfill sources",
     () =>
       githubGet<{ workflow_runs: WorkflowRun[] }>(
-        `/repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?branch=main&event=push&status=success&per_page=${BACKFILL_SOURCE_RUNS}`,
+        workflowRunsPathForBaseline(BACKFILL_SOURCE_RUNS),
       ),
     currentMetrics,
   );
@@ -876,6 +1156,8 @@ async function main() {
           run,
           artifacts: await fetchArtifactsForRunBestEffort(run),
           pr: null,
+          prLookupError: null,
+          commitsBehindMain: null,
         }),
       ),
     currentMetrics,
@@ -895,8 +1177,9 @@ async function main() {
         backfillSourceContexts,
         API_CONCURRENCY,
         async ({ artifacts }) => {
-          const artifact = artifacts.find(
-            (a) => a.name === PERF_METRICS_BACKFILL_ARTIFACT_NAME && !a.expired,
+          const artifact = newestArtifactNamed(
+            artifacts,
+            PERF_METRICS_BACKFILL_ARTIFACT_NAME,
           );
           if (!artifact) return null;
 
@@ -938,8 +1221,9 @@ async function main() {
           }
         }
 
-        const perfMetricsArtifact = artifacts.find(
-          (a) => a.name === PERF_METRICS_ARTIFACT_NAME && !a.expired,
+        const perfMetricsArtifact = newestArtifactNamed(
+          artifacts,
+          PERF_METRICS_ARTIFACT_NAME,
         );
         if (perfMetricsArtifact) {
           const metrics = await downloadAndParsePerfMetrics(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Guards perf checks against stale baseline data by validating baseline runs against the current `main` head and showing run age and commit drift. Improves resilience with clearer logs, graceful rate-limit handling, and broader test coverage.

- **New Features**
  - Validate newest `main` push run matches current `main` head; warn with clear issues if stale/invalid.
  - Compute commits-behind and relative age for each baseline run; log a concise per-run summary with PR status and perf-metrics artifact.
  - Gracefully handle GitHub API rate limits by writing current metrics to `perf-metrics.json` and skipping the check.
  - Shared helpers: baseline/head fetching, baseline availability reporting, context builders, backfill/metrics parsing, artifact selection, time/commit formatting, and table rendering.

- **Bug Fixes**
  - Do not exit when baseline runs are below the minimum; warn and report affected metrics as n/a.
  - Add extensive unit tests covering baseline fetching/validation, PR selection/lookup summarization, artifact/backfill parsing, formatting/table output, error handling, and main flow.

<sup>Written for commit 3e2aede33333aabfa2f4927eed756fe387793f80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

