### PR TITLE
Restyle coverage-debt PR comment as a collapsible details block

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -22,11 +22,14 @@ permissions:
 jobs:
   post-coverage-comment:
     name: "Post Coverage Comment"
-    # Only PR runs that failed can carry a coverage regression (the gate exits
-    # non-zero), so skip the all-green and push runs.
+    # Runs on both outcomes of a PR run: a failed run may carry a coverage
+    # regression to post, and a passing run may need to update an earlier
+    # regression comment to its resolved state. Other conclusions (cancelled,
+    # skipped) carry nothing to do.
     if: >-
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'failure'
+      (github.event.workflow_run.conclusion == 'failure' ||
+      github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository

--- a/tasks/perf-check.test.ts
+++ b/tasks/perf-check.test.ts
@@ -86,7 +86,7 @@ Deno.test("writeCoverageComment writes a regression payload when coverage fails"
   // Over by 8 - 4 = 4 lines.
   assertStringIncludes(
     payload?.body ?? "",
-    "<summary>Test coverage regressed by 4 lines</summary>",
+    "<summary><h3>🕵🏻‍♀️ Test coverage regressed by 4 lines</h3></summary>",
   );
 });
 

--- a/tasks/perf-check.test.ts
+++ b/tasks/perf-check.test.ts
@@ -1,5 +1,16 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
-import { parseMergedBaselineOverrides } from "./perf-check.ts";
+import * as path from "@std/path";
+import {
+  parseMergedBaselineOverrides,
+  type Row,
+  writeCoverageComment,
+  writeCoverageDebtSuggestion,
+  writeCoverageResolved,
+} from "./perf-check.ts";
+import {
+  COVERAGE_SUGGESTION_MARKER,
+  type CoverageCommentPayload,
+} from "./perf-lib.ts";
 
 Deno.test("invalid merged PR baseline override metadata is ignored", () => {
   const warnings: string[] = [];
@@ -27,4 +38,87 @@ Deno.test("valid merged PR baseline override metadata is parsed", () => {
   });
 
   assertEquals(overrides?.metrics.get("job: Check"), 7);
+});
+
+function coverageRow(metric: string, current: number, median?: number): Row {
+  return {
+    metric,
+    status: median === undefined ? "n/a" : "OK",
+    current,
+    median,
+    n: 1,
+  };
+}
+
+/**
+ * Run a writer with the coverage-comment output redirected to a temp file, then
+ * return the parsed payload (or null when the writer produced no file).
+ */
+async function payloadFrom(
+  write: () => Promise<void>,
+): Promise<CoverageCommentPayload | null> {
+  const dir = await Deno.makeTempDir({ prefix: "perf-check-comment-" });
+  const file = path.join(dir, "coverage-comment.json");
+  Deno.env.set("COVERAGE_COMMENT_FILE", file);
+  try {
+    await write();
+    try {
+      return JSON.parse(await Deno.readTextFile(file));
+    } catch {
+      return null;
+    }
+  } finally {
+    Deno.env.delete("COVERAGE_COMMENT_FILE");
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+Deno.test("writeCoverageComment writes a regression payload when coverage fails", async () => {
+  const failures = [
+    coverageRow("coverage-debt: tasks uncovered lines", 8, 4),
+  ];
+  const payload = await payloadFrom(() =>
+    writeCoverageComment(4211, failures, failures, [], "")
+  );
+
+  assertEquals(payload?.state, "regressed");
+  assertStringIncludes(payload?.body ?? "", COVERAGE_SUGGESTION_MARKER);
+  // Over by 8 - 4 = 4 lines.
+  assertStringIncludes(
+    payload?.body ?? "",
+    "<summary>Test coverage regressed by 4 lines</summary>",
+  );
+});
+
+Deno.test("writeCoverageComment writes a resolved payload when coverage is acceptable", async () => {
+  const rows = [
+    coverageRow("coverage-debt: workspace uncovered lines", 2948, 2953),
+    coverageRow("coverage-debt: tasks uncovered lines", 4, 4),
+  ];
+  const payload = await payloadFrom(() =>
+    writeCoverageComment(4211, [], rows, [], "")
+  );
+
+  assertEquals(payload?.state, "resolved");
+  // Net reduction in the overall metric: 2953 - 2948 = 5 lines.
+  assertEquals(payload?.improvedLines, 5);
+});
+
+Deno.test("writeCoverageResolved reports zero improvement without a workspace baseline", async () => {
+  const rows = [coverageRow("coverage-debt: workspace uncovered lines", 100)];
+  const payload = await payloadFrom(() => writeCoverageResolved(4211, rows));
+
+  assertEquals(payload?.state, "resolved");
+  assertEquals(payload?.improvedLines, 0);
+});
+
+Deno.test("writeCoverageDebtSuggestion writes nothing when no coverage group resolves", async () => {
+  const failures: Row[] = [
+    { metric: "job: Check", status: "OVER", current: 5, median: 3, n: 1 },
+  ];
+  const payload = await payloadFrom(() =>
+    writeCoverageDebtSuggestion(4211, failures, [], "")
+  );
+
+  assertEquals(payload, null);
 });

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -251,7 +251,7 @@ async function readCombinedLcov(lcovDir: string): Promise<string> {
 }
 
 type TableAlign = "left" | "right";
-type Status = "OVER" | "CLOSE" | "OK" | "ovrd" | "excl" | "n/a";
+export type Status = "OVER" | "CLOSE" | "OK" | "ovrd" | "excl" | "n/a";
 
 function printTextTable(
   headers: string[],
@@ -336,7 +336,7 @@ function metricDisplayParts(metric: string): { task: string; metric: string } {
   return { task: kind, metric: rest };
 }
 
-interface Row {
+export interface Row {
   metric: string;
   status: Status;
   current: number;
@@ -454,14 +454,45 @@ async function extractCoverageDebtSamples(
   return { samples: metrics, lcov };
 }
 
+/** File the coverage-comment payload is written to; tests override via env. */
+function coverageCommentOutputPath(): string {
+  return Deno.env.get("COVERAGE_COMMENT_FILE") ?? COVERAGE_COMMENT_FILE;
+}
+
 /**
- * Write the once-per-PR coverage-debt comment to a file for a later workflow to
+ * Decide and write the coverage-debt comment payload for a PR. A coverage
+ * regression writes a "regressed" body; an acceptable run writes a "resolved"
+ * payload so the poster can collapse any earlier comment. Done for every real PR
+ * run, pass or fail, so a fixed regression is reflected even when the run still
+ * fails for other reasons.
+ */
+export async function writeCoverageComment(
+  prNumber: number,
+  coverageFailures: Row[],
+  coverageRows: Row[],
+  prFiles: PRFile[],
+  lcov: string,
+): Promise<void> {
+  if (coverageFailures.length > 0) {
+    await writeCoverageDebtSuggestion(
+      prNumber,
+      coverageFailures,
+      prFiles,
+      lcov,
+    );
+  } else {
+    await writeCoverageResolved(prNumber, coverageRows);
+  }
+}
+
+/**
+ * Write the coverage-debt regression comment to a file for a later workflow to
  * post. The gate runs on `pull_request`, where fork PRs get a read-only token
  * and cannot comment, so the `coverage-comment` workflow_run job posts this from
  * the base-repo context instead. Never throws — this is best-effort so it cannot
  * mask the regression failure itself.
  */
-async function writeCoverageDebtSuggestion(
+export async function writeCoverageDebtSuggestion(
   prNumber: number,
   coverageFailures: Row[],
   prFiles: PRFile[],
@@ -518,12 +549,10 @@ async function writeCoverageDebtSuggestion(
       state: "regressed",
       body,
     };
-    await Deno.writeTextFile(
-      COVERAGE_COMMENT_FILE,
-      JSON.stringify(payload, null, 2),
-    );
+    const outputFile = coverageCommentOutputPath();
+    await Deno.writeTextFile(outputFile, JSON.stringify(payload, null, 2));
     console.log(
-      `Wrote ${COVERAGE_COMMENT_FILE} for PR #${prNumber}; the coverage-comment workflow will post or update it.`,
+      `Wrote ${outputFile} for PR #${prNumber}; the coverage-comment workflow will post or update it.`,
     );
   } catch (error) {
     console.warn(
@@ -543,7 +572,7 @@ async function writeCoverageDebtSuggestion(
  * count versus its `main` baseline — the previously-uncovered lines the PR now
  * covers. Never throws — best-effort, like the regression path.
  */
-async function writeCoverageResolved(
+export async function writeCoverageResolved(
   prNumber: number,
   coverageRows: Row[],
 ): Promise<void> {
@@ -560,12 +589,10 @@ async function writeCoverageResolved(
       state: "resolved",
       improvedLines,
     };
-    await Deno.writeTextFile(
-      COVERAGE_COMMENT_FILE,
-      JSON.stringify(payload, null, 2),
-    );
+    const outputFile = coverageCommentOutputPath();
+    await Deno.writeTextFile(outputFile, JSON.stringify(payload, null, 2));
     console.log(
-      `Wrote ${COVERAGE_COMMENT_FILE} (resolved, net ${improvedLines} line(s) covered) for PR #${prNumber}; the coverage-comment workflow will update any existing comment.`,
+      `Wrote ${outputFile} (resolved, net ${improvedLines} line(s) covered) for PR #${prNumber}; the coverage-comment workflow will update any existing comment.`,
     );
   } catch (error) {
     console.warn(
@@ -1309,25 +1336,17 @@ async function main() {
   );
 
   // Coverage-debt PR comment, written for the coverage-comment workflow to post
-  // (fork PRs get a read-only token on pull_request and cannot comment here). A
-  // regression earns a comment pointing the author at the uncovered lines; once
-  // coverage is acceptable again the poster collapses and rewrites any earlier
-  // comment. Done before the exit branches so it runs whether the run passes or
-  // fails for other reasons.
+  // (fork PRs get a read-only token on pull_request and cannot comment here).
+  // Done before the exit branches so it runs whether the run passes or fails for
+  // other reasons.
   if (prNumber) {
-    if (coverageFailures.length > 0) {
-      await writeCoverageDebtSuggestion(
-        parseInt(prNumber),
-        coverageFailures,
-        prFiles,
-        coverageLcov,
-      );
-    } else {
-      await writeCoverageResolved(
-        parseInt(prNumber),
-        rows.filter((row) => isCoverageDebtMetric(row.metric)),
-      );
-    }
+    await writeCoverageComment(
+      parseInt(prNumber),
+      coverageFailures,
+      rows.filter((row) => isCoverageDebtMetric(row.metric)),
+      prFiles,
+      coverageLcov,
+    );
   }
 
   if (failures.length === 0) {

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -513,17 +513,63 @@ async function writeCoverageDebtSuggestion(
 
   try {
     const body = buildCoverageDebtSuggestionComment({ groups, files });
-    const payload: CoverageCommentPayload = { prNumber, body };
+    const payload: CoverageCommentPayload = {
+      prNumber,
+      state: "regressed",
+      body,
+    };
     await Deno.writeTextFile(
       COVERAGE_COMMENT_FILE,
       JSON.stringify(payload, null, 2),
     );
     console.log(
-      `Wrote ${COVERAGE_COMMENT_FILE} for PR #${prNumber}; the coverage-comment workflow will post it.`,
+      `Wrote ${COVERAGE_COMMENT_FILE} for PR #${prNumber}; the coverage-comment workflow will post or update it.`,
     );
   } catch (error) {
     console.warn(
       `  Warning: could not write coverage suggestion comment for PR #${prNumber}: ${error}`,
+    );
+  }
+}
+
+/**
+ * Write a "resolved" coverage-comment payload so the coverage-comment workflow
+ * can collapse and rewrite an earlier regression comment on the PR. The payload
+ * is always written when coverage is acceptable: a run cannot tell whether a
+ * comment exists, nor what files earlier commits on the PR changed, so it defers
+ * that to the poster, which no-ops when there is nothing to update.
+ *
+ * `improvedLines` is the net reduction in the overall (workspace) uncovered-line
+ * count versus its `main` baseline — the previously-uncovered lines the PR now
+ * covers. Never throws — best-effort, like the regression path.
+ */
+async function writeCoverageResolved(
+  prNumber: number,
+  coverageRows: Row[],
+): Promise<void> {
+  const workspaceRow = coverageRows.find(
+    (row) => coverageMetricGroupName(row.metric) === "workspace",
+  );
+  const improvedLines = workspaceRow?.median === undefined
+    ? 0
+    : Math.max(0, Math.round(workspaceRow.median - workspaceRow.current));
+
+  try {
+    const payload: CoverageCommentPayload = {
+      prNumber,
+      state: "resolved",
+      improvedLines,
+    };
+    await Deno.writeTextFile(
+      COVERAGE_COMMENT_FILE,
+      JSON.stringify(payload, null, 2),
+    );
+    console.log(
+      `Wrote ${COVERAGE_COMMENT_FILE} (resolved, net ${improvedLines} line(s) covered) for PR #${prNumber}; the coverage-comment workflow will update any existing comment.`,
+    );
+  } catch (error) {
+    console.warn(
+      `  Warning: could not write resolved coverage comment for PR #${prNumber}: ${error}`,
     );
   }
 }
@@ -1255,6 +1301,35 @@ async function main() {
     console.log("\nInformational Only:");
   }
 
+  const coverageFailures = failures.filter((f) =>
+    isCoverageDebtMetric(f.metric)
+  );
+  const perMetricFailures = failures.filter((f) =>
+    !isCoverageDebtMetric(f.metric)
+  );
+
+  // Coverage-debt PR comment, written for the coverage-comment workflow to post
+  // (fork PRs get a read-only token on pull_request and cannot comment here). A
+  // regression earns a comment pointing the author at the uncovered lines; once
+  // coverage is acceptable again the poster collapses and rewrites any earlier
+  // comment. Done before the exit branches so it runs whether the run passes or
+  // fails for other reasons.
+  if (prNumber) {
+    if (coverageFailures.length > 0) {
+      await writeCoverageDebtSuggestion(
+        parseInt(prNumber),
+        coverageFailures,
+        prFiles,
+        coverageLcov,
+      );
+    } else {
+      await writeCoverageResolved(
+        parseInt(prNumber),
+        rows.filter((row) => isCoverageDebtMetric(row.metric)),
+      );
+    }
+  }
+
   if (failures.length === 0) {
     console.log("\nAll metrics within normal range.");
     Deno.exit(0);
@@ -1263,13 +1338,6 @@ async function main() {
     console.log("This build would fail if it were a PR.");
     Deno.exit(0);
   }
-
-  const coverageFailures = failures.filter((f) =>
-    isCoverageDebtMetric(f.metric)
-  );
-  const perMetricFailures = failures.filter((f) =>
-    !isCoverageDebtMetric(f.metric)
-  );
 
   if (coverageFailures.length > 0) {
     const verb = coverageBaselineAvailable ? "reset" : "bootstrap";
@@ -1304,19 +1372,6 @@ async function main() {
       console.log(`NEW_PERF_BASELINE: ${f.metric} = ${suggested}`);
     }
     console.log("---END COPY-PASTE---");
-  }
-
-  // A coverage regression on a real PR earns a once-per-PR comment pointing the
-  // author at the uncovered lines and how to cover them. The gate only writes
-  // the comment here; the coverage-comment workflow posts it (fork PRs get a
-  // read-only token on pull_request and cannot comment directly).
-  if (coverageFailures.length > 0 && prNumber) {
-    await writeCoverageDebtSuggestion(
-      parseInt(prNumber),
-      coverageFailures,
-      prFiles,
-      coverageLcov,
-    );
   }
 
   Deno.exit(1);

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -30,6 +30,7 @@ import {
   parseBaselineOverrides,
   parsePerfMetricsBackfillFile,
   parsePerfMetricsFile,
+  resolveCoverageDebtComment,
   serializePerfMetrics,
   serializePerfMetricsBackfill,
   shouldGateCoverageDebtMetric,
@@ -859,8 +860,17 @@ Deno.test("buildCoverageDebtSuggestionComment lists files (not lines), command, 
     ],
   });
 
-  // Posted-once marker so a later run can detect it.
+  // Marker so a later run can detect and update it.
   assertStringIncludes(comment, COVERAGE_SUGGESTION_MARKER);
+  // The body is wrapped in an open <details> summarizing the over-by total
+  // (15 - 12 = 3 lines), with no standalone header.
+  assertStringIncludes(comment, "<details open>");
+  assertStringIncludes(
+    comment,
+    "<summary>Test coverage regressed by 3 lines</summary>",
+  );
+  assertStringIncludes(comment, "</details>");
+  assertFalse(comment.includes("## 🧪 Test coverage regressed"));
   // The regressed group with its target and current value.
   assertStringIncludes(comment, "`packages/runner`");
   assertStringIncludes(comment, "| 12 | 15 | +3 |");
@@ -889,6 +899,72 @@ Deno.test("buildCoverageDebtSuggestionComment handles a regression with no pinne
   assertStringIncludes(
     comment,
     "coverage-debt: tasks uncovered lines  <=  0",
+  );
+});
+
+Deno.test("buildCoverageDebtSuggestionComment sums Over by across groups in the summary", () => {
+  const comment = buildCoverageDebtSuggestionComment({
+    groups: [
+      { group: "packages/runner", target: 12, current: 15 },
+      { group: "tasks", target: 4, current: 8 },
+    ],
+    files: [],
+  });
+
+  // 3 + 4 = 7 over baseline.
+  assertStringIncludes(
+    comment,
+    "<summary>Test coverage regressed by 7 lines</summary>",
+  );
+});
+
+Deno.test("buildCoverageDebtSuggestionComment uses the singular for a one-line regression", () => {
+  const comment = buildCoverageDebtSuggestionComment({
+    groups: [
+      { group: "tasks", target: 4, current: 5 },
+    ],
+    files: [],
+  });
+
+  assertStringIncludes(
+    comment,
+    "<summary>Test coverage regressed by 1 line</summary>",
+  );
+});
+
+Deno.test("resolveCoverageDebtComment collapses the details and reports the reduction", () => {
+  const regressed = buildCoverageDebtSuggestionComment({
+    groups: [{ group: "packages/runner", target: 12, current: 15 }],
+    files: [],
+  });
+
+  const resolved = resolveCoverageDebtComment(regressed, 5);
+
+  // The details collapses (no `open`) and the summary celebrates the reduction.
+  assertFalse(resolved.includes("<details open>"));
+  assertStringIncludes(resolved, "<details>");
+  assertStringIncludes(
+    resolved,
+    "<summary>Code coverage debt reduced by 5 lines!</summary>",
+  );
+  assertFalse(resolved.includes("Test coverage regressed by"));
+  // The body (marker, table) is preserved for context.
+  assertStringIncludes(resolved, COVERAGE_SUGGESTION_MARKER);
+  assertStringIncludes(resolved, "| 12 | 15 | +3 |");
+});
+
+Deno.test("resolveCoverageDebtComment notes resolution when there is no net reduction", () => {
+  const regressed = buildCoverageDebtSuggestionComment({
+    groups: [{ group: "tasks", target: 4, current: 8 }],
+    files: [],
+  });
+
+  const resolved = resolveCoverageDebtComment(regressed, 0);
+
+  assertFalse(resolved.includes("<details open>"));
+  assertStringIncludes(
+    resolved,
+    "<summary>Code coverage regression resolved.</summary>",
   );
 });
 

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -867,7 +867,7 @@ Deno.test("buildCoverageDebtSuggestionComment lists files (not lines), command, 
   assertStringIncludes(comment, "<details open>");
   assertStringIncludes(
     comment,
-    "<summary>Test coverage regressed by 3 lines</summary>",
+    "<summary><h3>🕵🏻‍♀️ Test coverage regressed by 3 lines</h3></summary>",
   );
   assertStringIncludes(comment, "</details>");
   assertFalse(comment.includes("## 🧪 Test coverage regressed"));
@@ -914,7 +914,7 @@ Deno.test("buildCoverageDebtSuggestionComment sums Over by across groups in the 
   // 3 + 4 = 7 over baseline.
   assertStringIncludes(
     comment,
-    "<summary>Test coverage regressed by 7 lines</summary>",
+    "<summary><h3>🕵🏻‍♀️ Test coverage regressed by 7 lines</h3></summary>",
   );
 });
 
@@ -928,7 +928,7 @@ Deno.test("buildCoverageDebtSuggestionComment uses the singular for a one-line r
 
   assertStringIncludes(
     comment,
-    "<summary>Test coverage regressed by 1 line</summary>",
+    "<summary><h3>🕵🏻‍♀️ Test coverage regressed by 1 line</h3></summary>",
   );
 });
 
@@ -945,7 +945,7 @@ Deno.test("resolveCoverageDebtComment collapses the details and reports the redu
   assertStringIncludes(resolved, "<details>");
   assertStringIncludes(
     resolved,
-    "<summary>Code coverage debt reduced by 5 lines!</summary>",
+    "<summary><h3>🕵🏻‍♀️ Code coverage debt reduced by 5 lines!</h3></summary>",
   );
   assertFalse(resolved.includes("Test coverage regressed by"));
   // The body (marker, table) is preserved for context.
@@ -964,7 +964,7 @@ Deno.test("resolveCoverageDebtComment notes resolution when there is no net redu
   assertFalse(resolved.includes("<details open>"));
   assertStringIncludes(
     resolved,
-    "<summary>Code coverage regression resolved.</summary>",
+    "<summary><h3>🕵🏻‍♀️ Code coverage regression resolved.</h3></summary>",
   );
 });
 

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -1560,6 +1560,14 @@ function uncoveredLineCount(count: number): string {
   return `${count} ${count === 1 ? "line" : "lines"}`;
 }
 
+/**
+ * Render the disclosure `<summary>`. An `<h3>` makes the line a little larger
+ * and bold so it stands out when collapsed; the detective emoji leads it.
+ */
+function coverageSummary(text: string): string {
+  return `<summary><h3>🕵🏻‍♀️ ${text}</h3></summary>`;
+}
+
 function formatTargetList(groups: CoverageSuggestionGroup[]): string[] {
   return groups.map((group) =>
     `  ${COVERAGE_METRIC_PREFIX} ${group.group} uncovered lines  <=  ${group.target}   (this PR: ${group.current})`
@@ -1640,9 +1648,7 @@ export function buildCoverageDebtSuggestionComment(
 
   out.push("<details open>");
   out.push(
-    `<summary>Test coverage regressed by ${
-      uncoveredLineCount(overBy)
-    }</summary>`,
+    coverageSummary(`Test coverage regressed by ${uncoveredLineCount(overBy)}`),
   );
   out.push("");
   out.push(
@@ -1717,7 +1723,7 @@ export function resolveCoverageDebtComment(
     : "Code coverage regression resolved.";
   return body
     .replace("<details open>", "<details>")
-    .replace(/<summary>[\s\S]*?<\/summary>/, `<summary>${summary}</summary>`);
+    .replace(/<summary>[\s\S]*?<\/summary>/, () => coverageSummary(summary));
 }
 
 /** Escape a string for use inside a Markdown table cell. */

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -35,10 +35,23 @@ export const COVERAGE_SUGGESTION_MARKER = "<!-- coverage-debt-suggestion -->";
 export const COVERAGE_COMMENT_ARTIFACT_NAME = "coverage-comment";
 export const COVERAGE_COMMENT_FILE = "coverage-comment.json";
 
-/** Pending PR comment handed from the gate to the posting workflow. */
+/**
+ * Pending coverage-debt comment handed from the gate to the posting workflow.
+ *
+ * - `state: "regressed"` carries the full comment `body`. The poster posts it as
+ *   a new comment, or updates an existing coverage comment in place.
+ * - `state: "resolved"` carries `improvedLines`, the net reduction in uncovered
+ *   lines versus baseline across the changed, gated coverage groups. The poster
+ *   collapses an existing comment's `<details>` and rewrites its `<summary>`; it
+ *   does nothing when there is no existing comment to update.
+ */
 export interface CoverageCommentPayload {
   prNumber: number;
-  body: string;
+  state: "regressed" | "resolved";
+  /** Present when `state` is "regressed". */
+  body?: string;
+  /** Present when `state` is "resolved". */
+  improvedLines?: number;
 }
 
 /**
@@ -1619,9 +1632,18 @@ export function buildCoverageDebtSuggestionComment(
   input: CoverageDebtSuggestionInput,
 ): string {
   const { files, omitted } = limitSuggestionFiles(input.files);
+  const overBy = input.groups.reduce(
+    (sum, group) => sum + (group.current - group.target),
+    0,
+  );
   const out: string[] = [COVERAGE_SUGGESTION_MARKER];
 
-  out.push("## 🧪 Test coverage regressed");
+  out.push("<details open>");
+  out.push(
+    `<summary>Test coverage regressed by ${
+      uncoveredLineCount(overBy)
+    }</summary>`,
+  );
   out.push("");
   out.push(
     "This PR adds source lines that no test exercises, so the coverage gate in " +
@@ -1673,8 +1695,29 @@ export function buildCoverageDebtSuggestionComment(
   out.push("````text");
   out.push(...buildCoverageSuggestionPrompt(input, files, omitted));
   out.push("````");
+  out.push("");
+  out.push("</details>");
 
   return out.join("\n");
+}
+
+/**
+ * Update a previously-posted coverage-debt comment to reflect that the gate now
+ * passes. Drops the `open` attribute from its `<details>` so the body collapses,
+ * and rewrites the `<summary>`. `improvedLines` is the net reduction in
+ * uncovered lines versus baseline: when positive, the summary reports the
+ * reduction; when zero, it just notes the regression is resolved.
+ */
+export function resolveCoverageDebtComment(
+  body: string,
+  improvedLines: number,
+): string {
+  const summary = improvedLines > 0
+    ? `Code coverage debt reduced by ${uncoveredLineCount(improvedLines)}!`
+    : "Code coverage regression resolved.";
+  return body
+    .replace("<details open>", "<details>")
+    .replace(/<summary>[\s\S]*?<\/summary>/, `<summary>${summary}</summary>`);
 }
 
 /** Escape a string for use inside a Markdown table cell. */

--- a/tasks/post-coverage-comment.test.ts
+++ b/tasks/post-coverage-comment.test.ts
@@ -1,26 +1,27 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import * as path from "@std/path";
 import { COVERAGE_SUGGESTION_MARKER } from "./perf-lib.ts";
 import { postCoverageComment } from "./post-coverage-comment.ts";
 
-interface PostedComment {
+interface RecordedRequest {
+  method: string;
   url: string;
   body: string;
 }
 
 /**
  * Run postCoverageComment with a payload file and a fetch mock that returns the
- * given existing comments for the GET and records any POST.
+ * given existing comments for the GET and records any POST/PATCH.
  */
 async function runWithPayload(
   payload: unknown,
   existingCommentBodies: string[],
-): Promise<PostedComment[]> {
+): Promise<RecordedRequest[]> {
   const dir = await Deno.makeTempDir({ prefix: "coverage-comment-test-" });
   const file = path.join(dir, "coverage-comment.json");
   await Deno.writeTextFile(file, JSON.stringify(payload));
 
-  const posted: PostedComment[] = [];
+  const requests: RecordedRequest[] = [];
   const originalFetch = globalThis.fetch;
   Deno.env.set("COVERAGE_COMMENT_FILE", file);
 
@@ -28,11 +29,13 @@ async function runWithPayload(
     const url = typeof input === "string" ? input : input.toString();
     const method = init?.method ?? "GET";
 
-    if (method === "POST") {
+    if (method === "POST" || method === "PATCH") {
       const parsed = JSON.parse(String(init?.body));
-      posted.push({ url, body: parsed.body });
+      requests.push({ method, url, body: parsed.body });
       return Promise.resolve(
-        new Response(JSON.stringify({ id: 1 }), { status: 201 }),
+        new Response(JSON.stringify({ id: 1 }), {
+          status: method === "POST" ? 201 : 200,
+        }),
       );
     }
 
@@ -54,33 +57,90 @@ async function runWithPayload(
     await Deno.remove(dir, { recursive: true });
   }
 
-  return posted;
+  return requests;
 }
 
 Deno.test("postCoverageComment posts when no marked comment exists", async () => {
   const body = `${COVERAGE_SUGGESTION_MARKER}\nCover these lines.`;
-  const posted = await runWithPayload({ prNumber: 4211, body }, [
-    "a normal review comment",
-  ]);
+  const requests = await runWithPayload(
+    { prNumber: 4211, state: "regressed", body },
+    ["a normal review comment"],
+  );
 
-  assertEquals(posted.length, 1);
+  assertEquals(requests.length, 1);
+  assertEquals(requests[0].method, "POST");
   assertEquals(
-    posted[0].url,
+    requests[0].url,
     "https://api.github.com/repos/commontoolsinc/labs/issues/4211/comments",
   );
-  assertEquals(posted[0].body, body);
+  assertEquals(requests[0].body, body);
 });
 
-Deno.test("postCoverageComment skips when a marked comment already exists", async () => {
-  const posted = await runWithPayload(
-    { prNumber: 4211, body: `${COVERAGE_SUGGESTION_MARKER}\nCover these.` },
-    [`${COVERAGE_SUGGESTION_MARKER}\nan earlier run already said this`],
+Deno.test("postCoverageComment updates the existing comment in place", async () => {
+  const body = `${COVERAGE_SUGGESTION_MARKER}\nCover these.`;
+  const requests = await runWithPayload(
+    { prNumber: 4211, state: "regressed", body },
+    [`${COVERAGE_SUGGESTION_MARKER}\nan earlier run said this`],
   );
 
-  assertEquals(posted.length, 0);
+  assertEquals(requests.length, 1);
+  assertEquals(requests[0].method, "PATCH");
+  assertEquals(
+    requests[0].url,
+    "https://api.github.com/repos/commontoolsinc/labs/issues/comments/1",
+  );
+  assertEquals(requests[0].body, body);
+});
+
+Deno.test("postCoverageComment leaves an up-to-date comment untouched", async () => {
+  const body = `${COVERAGE_SUGGESTION_MARKER}\nidentical.`;
+  const requests = await runWithPayload(
+    { prNumber: 4211, state: "regressed", body },
+    [body],
+  );
+
+  assertEquals(requests.length, 0);
+});
+
+Deno.test("postCoverageComment resolves an existing comment when coverage is acceptable", async () => {
+  const existing = [
+    COVERAGE_SUGGESTION_MARKER,
+    "<details open>",
+    "<summary>Test coverage regressed by 3 lines</summary>",
+    "",
+    "table goes here",
+    "",
+    "</details>",
+  ].join("\n");
+
+  const requests = await runWithPayload(
+    { prNumber: 4211, state: "resolved", improvedLines: 5 },
+    [existing],
+  );
+
+  assertEquals(requests.length, 1);
+  assertEquals(requests[0].method, "PATCH");
+  assertEquals(
+    requests[0].url,
+    "https://api.github.com/repos/commontoolsinc/labs/issues/comments/1",
+  );
+  assertStringIncludes(requests[0].body, "<details>");
+  assertStringIncludes(
+    requests[0].body,
+    "<summary>Code coverage debt reduced by 5 lines!</summary>",
+  );
+});
+
+Deno.test("postCoverageComment does nothing to resolve when no comment exists", async () => {
+  const requests = await runWithPayload(
+    { prNumber: 4211, state: "resolved", improvedLines: 5 },
+    ["a normal review comment"],
+  );
+
+  assertEquals(requests.length, 0);
 });
 
 Deno.test("postCoverageComment skips an invalid payload without posting", async () => {
-  const posted = await runWithPayload({ prNumber: "not-a-number" }, []);
-  assertEquals(posted.length, 0);
+  const requests = await runWithPayload({ prNumber: "not-a-number" }, []);
+  assertEquals(requests.length, 0);
 });

--- a/tasks/post-coverage-comment.test.ts
+++ b/tasks/post-coverage-comment.test.ts
@@ -16,6 +16,7 @@ interface RecordedRequest {
 async function runWithPayload(
   payload: unknown,
   existingCommentBodies: string[],
+  options: { getStatus?: number } = {},
 ): Promise<RecordedRequest[]> {
   const dir = await Deno.makeTempDir({ prefix: "coverage-comment-test-" });
   const file = path.join(dir, "coverage-comment.json");
@@ -39,7 +40,15 @@ async function runWithPayload(
       );
     }
 
-    // GET comments — one page, fewer than per_page so pagination stops.
+    // GET comments. A non-200 status (404 is non-retryable) makes the lookup
+    // throw, exercising the best-effort error path.
+    const getStatus = options.getStatus ?? 200;
+    if (getStatus !== 200) {
+      return Promise.resolve(
+        new Response("not found", { status: getStatus }),
+      );
+    }
+    // One page, fewer than per_page so pagination stops.
     const comments = existingCommentBodies.map((body, index) => ({
       id: index + 1,
       body,
@@ -135,6 +144,55 @@ Deno.test("postCoverageComment does nothing to resolve when no comment exists", 
   const requests = await runWithPayload(
     { prNumber: 4211, state: "resolved", improvedLines: 5 },
     ["a normal review comment"],
+  );
+
+  assertEquals(requests.length, 0);
+});
+
+Deno.test("postCoverageComment leaves an already-resolved comment untouched", async () => {
+  const existing = [
+    COVERAGE_SUGGESTION_MARKER,
+    "<details>",
+    "<summary>Code coverage regression resolved.</summary>",
+    "",
+    "</details>",
+  ].join("\n");
+
+  const requests = await runWithPayload(
+    { prNumber: 4211, state: "resolved", improvedLines: 0 },
+    [existing],
+  );
+
+  assertEquals(requests.length, 0);
+});
+
+Deno.test("postCoverageComment treats a legacy body-only payload as a regression", async () => {
+  const body = `${COVERAGE_SUGGESTION_MARKER}\nlegacy comment.`;
+  const requests = await runWithPayload({ prNumber: 4211, body }, []);
+
+  assertEquals(requests.length, 1);
+  assertEquals(requests[0].method, "POST");
+  assertEquals(requests[0].body, body);
+});
+
+Deno.test("postCoverageComment skips a regression payload with an empty body", async () => {
+  const requests = await runWithPayload(
+    { prNumber: 4211, state: "regressed", body: "" },
+    [],
+  );
+
+  assertEquals(requests.length, 0);
+});
+
+Deno.test("postCoverageComment swallows a comment-lookup failure", async () => {
+  const requests = await runWithPayload(
+    {
+      prNumber: 4211,
+      state: "regressed",
+      body: `${COVERAGE_SUGGESTION_MARKER}\nbody.`,
+    },
+    [],
+    { getStatus: 404 },
   );
 
   assertEquals(requests.length, 0);

--- a/tasks/post-coverage-comment.test.ts
+++ b/tasks/post-coverage-comment.test.ts
@@ -115,7 +115,7 @@ Deno.test("postCoverageComment resolves an existing comment when coverage is acc
   const existing = [
     COVERAGE_SUGGESTION_MARKER,
     "<details open>",
-    "<summary>Test coverage regressed by 3 lines</summary>",
+    "<summary><h3>🕵🏻‍♀️ Test coverage regressed by 3 lines</h3></summary>",
     "",
     "table goes here",
     "",
@@ -136,7 +136,7 @@ Deno.test("postCoverageComment resolves an existing comment when coverage is acc
   assertStringIncludes(requests[0].body, "<details>");
   assertStringIncludes(
     requests[0].body,
-    "<summary>Code coverage debt reduced by 5 lines!</summary>",
+    "<summary><h3>🕵🏻‍♀️ Code coverage debt reduced by 5 lines!</h3></summary>",
   );
 });
 
@@ -153,7 +153,7 @@ Deno.test("postCoverageComment leaves an already-resolved comment untouched", as
   const existing = [
     COVERAGE_SUGGESTION_MARKER,
     "<details>",
-    "<summary>Code coverage regression resolved.</summary>",
+    "<summary><h3>🕵🏻‍♀️ Code coverage regression resolved.</h3></summary>",
     "",
     "</details>",
   ].join("\n");

--- a/tasks/post-coverage-comment.ts
+++ b/tasks/post-coverage-comment.ts
@@ -9,9 +9,11 @@
  * `coverage-comment` workflow_run workflow runs this script from the base-repo
  * context with a write token to actually post it.
  *
- * No-ops when the file is absent (no regression). Posts at most once per PR by
- * skipping when a comment carrying the marker already exists. Best-effort: a
- * posting failure is logged, not fatal, so the workflow stays green.
+ * No-ops when the file is absent. Keeps a single comment per PR: posts when none
+ * exists, otherwise updates the existing one in place. When the payload says
+ * coverage is resolved, it collapses and rewrites the existing comment (and does
+ * nothing if there is none). Best-effort: a failure is logged, not fatal, so the
+ * workflow stays green.
  *
  * Environment:
  *   GITHUB_TOKEN           - Required.
@@ -24,15 +26,17 @@ import {
   COVERAGE_SUGGESTION_MARKER,
   type CoverageCommentPayload,
   fetchIssueComments,
+  githubPatch,
   githubPost,
   REPO,
+  resolveCoverageDebtComment,
   TOKEN,
 } from "./perf-lib.ts";
 
 /**
- * Read the pending comment payload and post it, skipping when the file is
- * absent or a marked comment already exists. Best-effort: a posting failure is
- * logged, not thrown, so the workflow stays green.
+ * Read the pending comment payload and post or update the PR's coverage
+ * comment. No-ops when the file is absent. Best-effort: a failure is logged, not
+ * thrown, so the workflow stays green.
  */
 export async function postCoverageComment(): Promise<void> {
   const file = Deno.env.get("COVERAGE_COMMENT_FILE") ?? COVERAGE_COMMENT_FILE;
@@ -53,22 +57,61 @@ export async function postCoverageComment(): Promise<void> {
     return;
   }
 
-  const { prNumber, body } = payload;
-  if (typeof prNumber !== "number" || typeof body !== "string" || !body) {
+  const { prNumber } = payload;
+  // Tolerate older payloads that carried only `body` (no explicit state).
+  const state = payload.state ?? (payload.body ? "regressed" : undefined);
+  if (typeof prNumber !== "number" || !state) {
     console.error(`Invalid coverage comment payload in ${file}.`);
     return;
   }
 
   try {
     const existing = await fetchIssueComments(prNumber);
-    if (
-      existing.some((comment) =>
-        comment.body.includes(COVERAGE_SUGGESTION_MARKER)
-      )
-    ) {
-      console.log(
-        `Coverage suggestion comment already present on PR #${prNumber}; not posting again.`,
+    const marked = existing.find((comment) =>
+      comment.body.includes(COVERAGE_SUGGESTION_MARKER)
+    );
+
+    if (state === "resolved") {
+      if (!marked) {
+        console.log(
+          `No coverage comment on PR #${prNumber}; nothing to resolve.`,
+        );
+        return;
+      }
+      const updated = resolveCoverageDebtComment(
+        marked.body,
+        payload.improvedLines ?? 0,
       );
+      if (updated === marked.body) {
+        console.log(
+          `Coverage comment on PR #${prNumber} already reflects resolution.`,
+        );
+        return;
+      }
+      await githubPatch(`/repos/${REPO}/issues/comments/${marked.id}`, {
+        body: updated,
+      });
+      console.log(`Updated coverage comment on PR #${prNumber} to resolved.`);
+      return;
+    }
+
+    const { body } = payload;
+    if (typeof body !== "string" || !body) {
+      console.error(`Invalid coverage comment payload in ${file}.`);
+      return;
+    }
+
+    if (marked) {
+      if (marked.body === body) {
+        console.log(
+          `Coverage comment on PR #${prNumber} already up to date.`,
+        );
+        return;
+      }
+      await githubPatch(`/repos/${REPO}/issues/comments/${marked.id}`, {
+        body,
+      });
+      console.log(`Updated coverage suggestion comment on PR #${prNumber}.`);
       return;
     }
 
@@ -76,7 +119,7 @@ export async function postCoverageComment(): Promise<void> {
     console.log(`Posted coverage suggestion comment to PR #${prNumber}.`);
   } catch (error) {
     console.warn(
-      `  Warning: could not post coverage suggestion comment to PR #${prNumber}: ${error}`,
+      `  Warning: could not post or update coverage comment on PR #${prNumber}: ${error}`,
     );
   }
 }


### PR DESCRIPTION
Rework the once-per-PR coverage-debt comment and how the gate maintains it.

- Drop the "Test coverage regressed" heading. The comment body is now wrapped in `<details open>` with a `<summary>` reading "Test coverage regressed by N lines", where N is the sum of the per-group "Over by" amounts.
- When a coverage comment already exists, update it in place instead of skipping. The gate's payload carries a `state` ("regressed" or "resolved"), and the poster patches the existing comment or posts a new one.
- When coverage becomes acceptable, the poster collapses the `<details>` (drops the `open` attribute) and rewrites the `<summary>` to "Code coverage debt reduced by N lines!", or "Code coverage regression resolved." when there is no net improvement. N is the net reduction in the overall (workspace) uncovered-line count versus its main baseline.

The gate writes a resolved payload whenever coverage is acceptable, making no assumption about whether a comment exists or what earlier commits on the PR changed; the poster no-ops when there is nothing to update. The coverage-comment workflow now runs on passing PR runs too, so a fixed regression gets its comment collapsed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restyles the once-per-PR coverage-debt comment into a collapsible details block and makes the bot keep it updated or resolve it in place. The workflow now runs on failed and successful PR runs so fixed regressions get collapsed with a clear, larger summary.

- **New Features**
  - Comment body is wrapped in `<details open>` with `<summary><h3>🕵🏻‍♀️ Test coverage regressed by N line(s)</h3></summary>`; N sums “Over by” across groups.
  - Keeps a single comment per PR: posts when missing, patches in place when content changes, and skips when already up to date; when coverage is acceptable, collapses the `<details>` and rewrites the summary to “Code coverage debt reduced by N line(s)!” or “Code coverage regression resolved.”
  - Gate always writes a payload with `state: "regressed" | "resolved"` (and `improvedLines` for resolved); the coverage-comment workflow triggers on PR `failure` and `success` to keep the comment in sync.

- **Refactors**
  - Extracted writer entrypoint `writeCoverageComment` and exported `writeCoverageDebtSuggestion`, `writeCoverageResolved`, `Row`, and `Status`; writers honor `COVERAGE_COMMENT_FILE` from env for testability.
  - Poster supports legacy body-only payloads, updates existing comments via `PATCH`, no-ops on empty/up-to-date/resolved cases, and tolerates lookup failures; added tests covering writer and poster paths.

<sup>Written for commit a8ee6dc0d8ce701cb98ab630d462e8dd0067716e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

