### PR TITLE
test: stabilize flaky coverage paths

### DIFF
--- a/packages/identity/test/ed25519.test.ts
+++ b/packages/identity/test/ed25519.test.ts
@@ -6,8 +6,8 @@ import {
   NobleEd25519Signer,
   NobleEd25519Verifier,
 } from "../src/ed25519/noble.ts";
-import { isNativeEd25519Supported } from "../src/ed25519/utils.ts";
-import { assert } from "@std/assert";
+import { didToBytes, isNativeEd25519Supported } from "../src/ed25519/utils.ts";
+import { assert, assertThrows } from "@std/assert";
 import { bytesEqual } from "./utils.ts";
 import { DIDKey } from "../src/interface.ts";
 import * as ed25519 from "@noble/ed25519";
@@ -68,6 +68,17 @@ const TEST_DID = "did:key:z6MkjosLwWEobyT9T6RqLTdaEhFrXAZUNkRZJuUae2ukgfEa";
 
 Deno.test("ed25519 is supported in this environment", async () => {
   assert(await isNativeEd25519Supported());
+});
+
+Deno.test("rejects did:key values with unsupported multicodec tags", () => {
+  const unsupportedDid =
+    "did:key:z6DtMrg4Kv51UMAM8vJcCLcRywJfEB4dpHVxPCR6qm6hSV3N" as DIDKey;
+
+  assertThrows(
+    () => didToBytes(unsupportedDid),
+    RangeError,
+    "Unsupported key algorithm expected 0xed, instead of 0xe7",
+  );
 });
 
 Deno.test("has same results in both impls when generating from noble", async () => {

--- a/packages/memory/test/util-test.ts
+++ b/packages/memory/test/util-test.ts
@@ -1,6 +1,26 @@
 import { assert, assertEquals } from "@std/assert";
 import { fromDID } from "../util.ts";
 
+Deno.test("fromDID rejects non-DID strings", async () => {
+  const result = await fromDID("not-a-did");
+
+  assert(result.error instanceof SyntaxError);
+  assertEquals(
+    result.error.message,
+    'Invalid DID "not-a-did", must start with "did:"',
+  );
+});
+
+Deno.test("fromDID rejects DID methods other than did:key", async () => {
+  const result = await fromDID("did:web:example.com");
+
+  assert(result.error instanceof SyntaxError);
+  assertEquals(
+    result.error.message,
+    'Invalid DID "did:web:example.com", only "did:key:" are supported right now',
+  );
+});
+
 Deno.test("fromDID wraps did:key parser errors as syntax errors", async () => {
   const unsupportedDid =
     "did:key:z6DtMrg4Kv51UMAM8vJcCLcRywJfEB4dpHVxPCR6qm6hSV3N";

--- a/packages/memory/test/util-test.ts
+++ b/packages/memory/test/util-test.ts
@@ -1,0 +1,15 @@
+import { assert, assertEquals } from "@std/assert";
+import { fromDID } from "../util.ts";
+
+Deno.test("fromDID wraps did:key parser errors as syntax errors", async () => {
+  const unsupportedDid =
+    "did:key:z6DtMrg4Kv51UMAM8vJcCLcRywJfEB4dpHVxPCR6qm6hSV3N";
+
+  const result = await fromDID(unsupportedDid);
+
+  assert(result.error instanceof SyntaxError);
+  assertEquals(
+    result.error.message,
+    `Invalid DID "${unsupportedDid}", RangeError: Unsupported key algorithm expected 0xed, instead of 0xe7`,
+  );
+});

--- a/packages/runner/test/compiled-js-parser.test.ts
+++ b/packages/runner/test/compiled-js-parser.test.ts
@@ -1,8 +1,18 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
+  CompiledJsParseError,
+  findTopLevelArrow,
   findTopLevelEquals,
+  locationFromOffset,
+  parseCompiledBundleSource,
+  parseFunctionText,
+  parseStringLiteralValue,
+  splitTopLevelCommaList,
+  stripJsTrivia,
+  stripWholeParentheses,
   trimRange,
+  tryParseCallExpression,
   tryParseDefineCall,
 } from "../src/sandbox/compiled-js-parser.ts";
 
@@ -68,5 +78,167 @@ describe("tryParseDefineCall()", () => {
     expect(defineCall?.dependencies).toEqual(["require", "exports"]);
     expect(defineCall?.factory.params).toEqual(["require", "exports"]);
     expect(defineCall?.factory.body.statements).toHaveLength(2);
+  });
+});
+
+describe("parseCompiledBundleSource()", () => {
+  it("parses wrapped AMD define calls and preserves factory statements", () => {
+    const source = `(function () {
+      define("index", ["require", "exports", "./dep"], function named(require, exports, dep) {
+        "use strict";
+        if (dep.ready) {
+          exports.value = dep.value;
+        } else {
+          exports.value = /a,b/.test("a,b");
+        }
+      });
+      const ignored = call(1, { nested: [2, 3] });
+    });`;
+
+    const parsed = parseCompiledBundleSource(source);
+
+    expect(parsed.defineCalls).toHaveLength(1);
+    expect(parsed.body.statements).toHaveLength(2);
+    expect(parsed.defineCalls[0].moduleId).toBe("index");
+    expect(parsed.defineCalls[0].dependencies).toEqual([
+      "require",
+      "exports",
+      "./dep",
+    ]);
+    expect(parsed.defineCalls[0].factory.params).toEqual([
+      "require",
+      "exports",
+      "dep",
+    ]);
+    expect(parsed.defineCalls[0].factory.body.statements).toHaveLength(2);
+  });
+
+  it("throws a parse error for empty bundles", () => {
+    expect(() => parseCompiledBundleSource("  ")).toThrow(
+      CompiledJsParseError,
+    );
+  });
+});
+
+describe("parseFunctionText()", () => {
+  it("parses async function expressions with defaulted parameters", () => {
+    const source = `async function (first = 1, second) {
+      class Local {}
+      return \`${"${first + second}"}\`;
+    }`;
+
+    const parsed = parseFunctionText(source, 0, source.length);
+
+    expect(parsed.params).toEqual(["first", "second"]);
+    expect(parsed.body.statements).toHaveLength(2);
+  });
+
+  it("parses arrow functions with block bodies", () => {
+    const source = `(value, other) => {
+      return value ? other : "fallback";
+    }`;
+
+    const parsed = parseFunctionText(source, 0, source.length);
+
+    expect(parsed.params).toEqual(["value", "other"]);
+    expect(parsed.body.statements).toHaveLength(1);
+  });
+
+  it("rejects destructured parameters", () => {
+    const source = `({ value }) => { return value; }`;
+
+    expect(() => parseFunctionText(source, 0, source.length)).toThrow(
+      "Factory parameters must be simple identifiers",
+    );
+  });
+
+  it("rejects arrow expression bodies", () => {
+    const source = `value => value + 1`;
+
+    expect(() => parseFunctionText(source, 0, source.length)).toThrow(
+      "Expected '{'",
+    );
+  });
+});
+
+describe("scanner helpers", () => {
+  it("strips trivia while preserving strings, regexes, and templates", () => {
+    const source =
+      `  // leading\nfoo /* inner */ + /a\\/[b]/g.test("a/b") + \`x${"${1 + /z/.test(y)}"}\` // trailing`;
+
+    expect(stripJsTrivia(source)).toBe(
+      `foo+/a\\/[b]/g.test("a/b")+\`x${"${1 + /z/.test(y)}"}\``,
+    );
+  });
+
+  it("splits comma lists without splitting nested structures", () => {
+    const source =
+      `first, call(1, [2, 3]), { nested: /a,b/g }, \`hi, ${"${name}"}\``;
+
+    const parts = splitTopLevelCommaList(source, 0, source.length)
+      .map((range) => source.slice(range.start, range.end));
+
+    expect(parts).toEqual([
+      "first",
+      "call(1, [2, 3])",
+      "{ nested: /a,b/g }",
+      `\`hi, ${"${name}"}\``,
+    ]);
+  });
+
+  it("parses call expressions with nested arguments", () => {
+    const source = `outer(inner(1, 2), { ok: true }, /a,b/g);`;
+
+    const call = tryParseCallExpression(source, 0, source.length);
+
+    expect(call?.callee).toBe("outer");
+    expect(call?.args.map((arg) => source.slice(arg.start, arg.end))).toEqual([
+      "inner(1, 2)",
+      "{ ok: true }",
+      "/a,b/g",
+    ]);
+  });
+
+  it("returns undefined for non-call expressions", () => {
+    const source = `value + 1`;
+
+    expect(tryParseCallExpression(source, 0, source.length)).toBeUndefined();
+  });
+
+  it("parses escaped string literal values", () => {
+    const source = `"a\\\"b"`;
+
+    expect(parseStringLiteralValue(source, 0, source.length)).toBe('a"b');
+  });
+
+  it("rejects non-string literal values", () => {
+    const source = `value`;
+
+    expect(() => parseStringLiteralValue(source, 0, source.length)).toThrow(
+      "Expected a string literal",
+    );
+  });
+
+  it("strips only whole parentheses", () => {
+    const source = `((value)) + other`;
+
+    expect(stripWholeParentheses(source, 0, source.length)).toEqual({
+      start: 0,
+      end: source.length,
+    });
+    expect(stripWholeParentheses(source, 0, "((value))".length)).toEqual({
+      start: 2,
+      end: 7,
+    });
+  });
+
+  it("locates top-level arrows and source locations", () => {
+    const source = `call(() => 1)\nvalue => ({ ok: true })`;
+
+    expect(findTopLevelArrow(source, 0, source.length)).toBe(20);
+    expect(locationFromOffset(source, 20)).toEqual({
+      line: 2,
+      column: 7,
+    });
   });
 });

--- a/packages/runner/test/memory-v2-watch-refresh-race.test.ts
+++ b/packages/runner/test/memory-v2-watch-refresh-race.test.ts
@@ -653,3 +653,58 @@ Deno.test("memory v2 runner integrates watch deltas without re-diffing cold watc
     await storageManager.close();
   }
 });
+
+Deno.test("memory v2 runner applies watch remove syncs to confirmed docs", async () => {
+  const docA = `of:watch-remove-a-${crypto.randomUUID()}` as URI;
+  const docB = `of:watch-remove-b-${crypto.randomUUID()}` as URI;
+  const transport = new IncrementalEffectTransport(
+    new Map([
+      [docA, { value: { label: docA } }],
+      [docB, { value: { label: docB } }],
+    ]),
+  );
+  const sessionFactory = new SingleSessionFactory(transport);
+  const storageManager = TestStorageManager.create({
+    as: signer,
+    memoryHost: new URL("memory://runner-v2-watch-remove"),
+  }, sessionFactory);
+  const provider = storageManager.open(space) as TestProvider;
+
+  try {
+    await Promise.all([
+      provider.sync(docA, { path: [], schema: false }),
+      provider.sync(docB, { path: [], schema: false }),
+    ]);
+    assertEquals(getObjectValue(provider, docA), { label: docA });
+    assertEquals(getObjectValue(provider, docB), { label: docB });
+
+    const integrated = Promise.withResolvers<void>();
+    const subscription = {
+      next(notification: { type: string }) {
+        if (notification.type === "integrate") {
+          integrated.resolve();
+        }
+        return undefined;
+      },
+    };
+    storageManager.subscribe(subscription);
+    transport.emitSync({
+      type: "sync",
+      fromSeq: 2,
+      toSeq: 3,
+      upserts: [],
+      removes: [{
+        branch: "",
+        id: docB,
+      }],
+    });
+
+    await integrated.promise;
+    storageManager.unsubscribe(subscription);
+
+    assertEquals(getObjectValue(provider, docA), { label: docA });
+    assertEquals(provider.get(docB), undefined);
+  } finally {
+    await storageManager.close();
+  }
+});

--- a/packages/runner/test/scheduler-v2-cutover.test.ts
+++ b/packages/runner/test/scheduler-v2-cutover.test.ts
@@ -10,6 +10,7 @@ import {
   space,
   toMemorySpaceAddress,
 } from "./scheduler-test-utils.ts";
+import { FakeTime } from "@std/testing/time";
 import type {
   Action,
   IExtendedStorageTransaction,
@@ -1099,5 +1100,37 @@ describe("scheduler v2 cutover fixtures", () => {
     } finally {
       delays.clearActiveDebounceTimers();
     }
+  });
+
+  it("moves a debounced action to pending after its timer fires", async () => {
+    using time = new FakeTime();
+    const delays = new SchedulerDelays({
+      actionStats: new Map(),
+      getActionId: () => "debounced-action",
+    });
+    const action: Action = function debouncedAction() {};
+    const pending = new Set<Action>();
+    const messages: string[] = [];
+    let queueCount = 0;
+
+    delays.setDebounce(action, 4);
+    delays.scheduleWithDebounce(action, {
+      pending,
+      queueExecution: () => queueCount++,
+      logDebounce: (message) => messages.push(message),
+    });
+
+    expect(pending.has(action)).toBe(false);
+    expect(queueCount).toBe(0);
+    expect(delays.hasActiveDebounceTimer(action)).toBe(true);
+
+    await time.tickAsync(4);
+
+    expect(pending.has(action)).toBe(true);
+    expect(queueCount).toBe(1);
+    expect(delays.hasActiveDebounceTimer(action)).toBe(false);
+    expect(messages).toEqual([
+      "[DEBOUNCE] Action debounced-action debounced for 4ms",
+    ]);
   });
 });

--- a/packages/runner/test/storage-inspector.test.ts
+++ b/packages/runner/test/storage-inspector.test.ts
@@ -1,0 +1,164 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import * as Inspector from "../src/storage/inspector.ts";
+
+const did = "did:key:z6Mk-storage-inspector";
+
+function command(cmd: string, id: string, args: Record<string, unknown> = {}) {
+  return {
+    invocation: {
+      iss: did,
+      cmd,
+      sub: did,
+      args,
+      prf: [],
+    },
+    authorization: {
+      signature: new Uint8Array(),
+      access: {
+        [id]: {},
+      },
+    },
+  } as any;
+}
+
+function taskReturn(id: string, is: Record<string, unknown>) {
+  return {
+    the: "task/return",
+    of: `job:${id}`,
+    is,
+  } as any;
+}
+
+function taskEffect(id: string, is: unknown) {
+  return {
+    the: "task/effect",
+    of: `job:${id}`,
+    is,
+  } as any;
+}
+
+describe("storage inspector model", () => {
+  it("tracks connection transitions", () => {
+    const model = Inspector.create(1);
+
+    Inspector.update(model, {
+      time: 2,
+      connect: { attempt: 3 },
+    });
+    expect(model.connection).toEqual({
+      ready: { ok: { attempt: 3 } },
+      time: 2,
+    });
+
+    Inspector.update(model, {
+      time: 3,
+      disconnect: { reason: "error", message: "socket closed" },
+    });
+    expect(model.connection.pending?.error?.message).toBe("socket closed");
+    expect(model.connection.pending?.error?.reason).toBe("error");
+    expect(model.connection.time).toBe(3);
+
+    Inspector.update(model, {
+      time: 4,
+      disconnect: { reason: "timeout", message: "retry" },
+    });
+    expect(model.connection.pending?.error?.message).toBe("retry");
+    expect(model.connection.pending?.error?.reason).toBe("timeout");
+    expect(model.connection.time).toBe(4);
+  });
+
+  it("tracks outbound push, pull, and subscription commands", () => {
+    const model = Inspector.create(10);
+
+    Inspector.update(model, {
+      time: 11,
+      send: command("/memory/transact", "tx"),
+    });
+    expect(model.push["job:tx"].ok?.invocation.cmd).toBe("/memory/transact");
+
+    Inspector.update(model, {
+      time: 12,
+      send: command("/memory/query", "query"),
+    });
+    expect(model.pull["job:query"].ok?.invocation.cmd).toBe("/memory/query");
+
+    Inspector.update(model, {
+      time: 13,
+      send: command("/memory/graph/query", "graph", { subscribe: true }),
+    });
+    expect(model.pull["job:graph"].ok?.invocation.cmd).toBe(
+      "/memory/graph/query",
+    );
+    expect(model.subscriptions["job:graph"].opened).toBe(13);
+
+    Inspector.update(model, {
+      time: 14,
+      send: command("/memory/query/subscribe", "sub"),
+    });
+    expect(model.subscriptions["job:sub"].opened).toBe(14);
+
+    Inspector.update(model, {
+      time: 15,
+      send: command("/memory/query/unsubscribe", "sub"),
+    });
+    expect(model.subscriptions["job:sub"]).toBeUndefined();
+  });
+
+  it("tracks remote completions and effects", () => {
+    const model = Inspector.create(20);
+
+    Inspector.update(model, {
+      time: 21,
+      send: command("/memory/transact", "push-ok"),
+    });
+    Inspector.update(model, {
+      time: 22,
+      receive: taskReturn("push-ok", { ok: {} }),
+    });
+    expect(model.push["job:push-ok"]).toBeUndefined();
+
+    Inspector.update(model, {
+      time: 23,
+      send: command("/memory/transact", "push-error"),
+    });
+    Inspector.update(model, {
+      time: 24,
+      receive: taskReturn("push-error", {
+        error: Object.assign(new Error("conflict"), { name: "ConflictError" }),
+      }),
+    });
+    expect(model.push["job:push-error"].error?.message).toBe("conflict");
+    expect(model.push["job:push-error"].error?.time).toBe(24);
+
+    Inspector.update(model, {
+      time: 25,
+      send: command("/memory/query", "pull-error"),
+    });
+    Inspector.update(model, {
+      time: 26,
+      receive: taskReturn("pull-error", {
+        error: Object.assign(new Error("bad query"), { name: "QueryError" }),
+      }),
+    });
+    expect(model.pull["job:pull-error"].error?.message).toBe("bad query");
+    expect(model.pull["job:pull-error"].error?.time).toBe(26);
+
+    Inspector.update(model, {
+      time: 27,
+      send: command("/memory/query/subscribe", "sub"),
+    });
+    Inspector.update(model, {
+      time: 28,
+      receive: taskEffect("sub", { value: 42 }),
+    });
+    expect(model.subscriptions["job:sub"].updated).toBe(28);
+    expect(model.subscriptions["job:sub"].value).toEqual({ value: 42 });
+
+    Inspector.update(model, {
+      time: 29,
+      receive: taskReturn("sub", { ok: {} }),
+    });
+    expect(model.subscriptions["job:sub"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes flaky coverage paths by adding deterministic tests and tighter error assertions across identity, memory, runner, and scheduler. Adds parser and inspector coverage to close remaining gaps.

- **Tests**
  - `identity`: add negative test for `did:key` with unsupported multicodec; assert `didToBytes` throws `RangeError` with the expected message.
  - `memory`: verify `fromDID` wraps parser failures in `SyntaxError` with a clear message.
  - `runner`: expand coverage for compiled JS parser (AMD `define`, scanner helpers, function parsing) and storage inspector (connection, commands, effects); add watch/remove sync test for confirmed docs.
  - `scheduler v2`: use `@std/testing/time` `FakeTime` to assert a debounced action moves to pending after the timer fires, queues once, and logs the expected message.

<sup>Written for commit 525875e5a14d5ba68f7737d4854628361d4f73ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

