### PR TITLE
ci: cache Deno installs before tasks

### DIFF
--- a/.github/actions/deno-install/action.yml
+++ b/.github/actions/deno-install/action.yml
@@ -1,0 +1,45 @@
+name: "Cached Deno install"
+description: >
+  Install Deno project dependencies from the restored cache when it is complete.
+  Fetch dependencies with retries when the cache is incomplete.
+inputs:
+  frozen:
+    description: "Pass --frozen to deno install."
+    required: false
+    default: "true"
+runs:
+  using: "composite"
+  steps:
+    - name: 📦 Install Deno dependencies
+      shell: bash
+      env:
+        FROZEN: ${{ inputs.frozen }}
+      run: |
+        set -euo pipefail
+
+        frozen_arg=()
+        if [ "$FROZEN" = "true" ]; then
+          frozen_arg=(--frozen=true)
+        elif [ "$FROZEN" = "false" ]; then
+          frozen_arg=(--frozen=false)
+        else
+          echo "::error::frozen must be true or false"
+          exit 1
+        fi
+
+        if deno install --cached-only "${frozen_arg[@]}"; then
+          echo "Deno dependencies are available in the local cache."
+          exit 0
+        fi
+
+        echo "Deno cache is incomplete; fetching dependencies."
+        delays=(10 30 60)
+        for delay in "${delays[@]}"; do
+          if deno install "${frozen_arg[@]}"; then
+            exit 0
+          fi
+          echo "::warning::deno install failed; retrying in ${delay}s."
+          sleep "$delay"
+        done
+
+        deno install "${frozen_arg[@]}"

--- a/.github/actions/deno-setup/action.yml
+++ b/.github/actions/deno-setup/action.yml
@@ -18,10 +18,14 @@ runs:
 
     # Cache version: bump to invalidate all caches (e.g., v2 -> v3)
     - name: 📦 Cache Deno dependencies
-      if: inputs.cache
-      uses: actions/cache@v3
+      if: inputs.cache == 'true'
+      uses: actions/cache@v4
       with:
         path: |
           ~/.deno
           ~/.cache/deno
-        key: v3-${{ runner.os }}-deno-${{ inputs.deno-version }}-${{ hashFiles('**/deno.json', '**/deno.lock') }}
+          ~/Library/Caches/deno
+        key: deno-deps-v4-${{ runner.os }}-${{ runner.arch }}-${{ inputs.deno-version }}-${{ hashFiles('**/deno.json', '**/deno.lock') }}
+        restore-keys: |
+          deno-deps-v4-${{ runner.os }}-${{ runner.arch }}-${{ inputs.deno-version }}-
+          deno-deps-v4-${{ runner.os }}-${{ runner.arch }}-

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -19,7 +19,7 @@ jobs:
         uses: ./.github/actions/deno-setup
 
       - name: 🔍 Verify lock file & install dependencies
-        run: deno install --frozen=true
+        uses: ./.github/actions/deno-install
 
       - name: 📥 Download Deno dependency binaries
         run: deno task initialize-db

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/deno-setup
 
       - name: 🔍 Verify lock file & install dependencies
-        run: deno install --frozen=true
+        uses: ./.github/actions/deno-install
 
       - name: 🔎 Check codebase formatting
         run: deno fmt --check
@@ -66,7 +66,7 @@ jobs:
         uses: ./.github/actions/deno-setup
 
       - name: 🔍 Verify lock file & install dependencies
-        run: deno install --frozen=true
+        uses: ./.github/actions/deno-install
 
       - name: 🔎 Check Common Fabric patterns
         env:
@@ -85,7 +85,7 @@ jobs:
         uses: ./.github/actions/deno-setup
 
       - name: 🔍 Verify lock file & install dependencies
-        run: deno install --frozen=true
+        uses: ./.github/actions/deno-install
 
       - name: 📦 Install Linux FUSE test dependencies
         uses: ./.github/actions/apt-install
@@ -136,7 +136,7 @@ jobs:
         uses: ./.github/actions/deno-setup
 
       - name: 🔍 Verify lock file & install dependencies
-        run: deno install --frozen=true
+        uses: ./.github/actions/deno-install
 
       - name: 📥 Download Deno dependency binaries
         run: deno task initialize-db
@@ -186,7 +186,7 @@ jobs:
         uses: ./.github/actions/deno-setup
 
       - name: 🔍 Verify lock file & install dependencies
-        run: deno install --frozen=true
+        uses: ./.github/actions/deno-install
 
       - name: 🏗️ Build application binaries
         run: deno task build-binaries
@@ -219,7 +219,7 @@ jobs:
         uses: ./.github/actions/deno-setup
 
       - name: 🔍 Verify lock file & install dependencies
-        run: deno install --frozen=true
+        uses: ./.github/actions/deno-install
 
       - name: 📥 Download Deno dependency binaries
         run: deno task initialize-db
@@ -296,6 +296,9 @@ jobs:
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
+
+      - name: 🔍 Verify lock file & install dependencies
+        uses: ./.github/actions/deno-install
 
       - name: 📥 Download built binaries
         uses: actions/download-artifact@v4
@@ -391,6 +394,9 @@ jobs:
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
+
+      - name: 🔍 Verify lock file & install dependencies
+        uses: ./.github/actions/deno-install
 
       - name: 📥 Download built binaries
         uses: actions/download-artifact@v4
@@ -494,6 +500,9 @@ jobs:
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
 
+      - name: 🔍 Verify lock file & install dependencies
+        uses: ./.github/actions/deno-install
+
       - name: 📥 Download built binaries
         uses: actions/download-artifact@v4
 
@@ -561,6 +570,9 @@ jobs:
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
 
+      - name: 🔍 Verify lock file & install dependencies
+        uses: ./.github/actions/deno-install
+
       # For Astral
       # https://github.com/lino-levan/astral/blob/f5ef833b2c5bde3783564a6b925073d5d46bb4b8/README.md#no-usable-sandbox-with-user-namespace-cloning-enabled
       - name: 🛡️ Disable AppArmor for browser tests
@@ -613,7 +625,7 @@ jobs:
         uses: ./.github/actions/deno-setup
 
       - name: 🔍 Verify lock file & install dependencies
-        run: deno install --frozen=true
+        uses: ./.github/actions/deno-install
 
       - name: 📥 Download Deno dependency binaries
         run: deno task initialize-db
@@ -681,8 +693,9 @@ jobs:
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
-        with:
-          cache: false
+
+      - name: 🔍 Verify lock file & install dependencies
+        uses: ./.github/actions/deno-install
 
       - name: 📊 Run performance check
         env:
@@ -982,6 +995,9 @@ jobs:
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
+
+      - name: 🔍 Verify lock file & install dependencies
+        uses: ./.github/actions/deno-install
 
       - name: 🏗️ Build shell with staging API URL
         working-directory: packages/shell

--- a/tasks/check.sh
+++ b/tasks/check.sh
@@ -100,8 +100,8 @@ fi
 echo "Type checking ${#FILES_TO_CHECK[@]} paths..."
 
 reloadArg=()
-if [[ "${GITHUB_ACTION}" != '' ]]; then
-    echo 'Running in a CI environment; rechecking from scratch...'
+if [[ "${DENO_CHECK_RELOAD:-}" != '' ]]; then
+    echo 'Reloading Deno dependencies before checking...'
     reloadArg=(--reload)
 fi
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a cached Deno install step in CI that installs from cache first and retries fetches when needed. This speeds up jobs and reduces flakes from upstream network issues.

- **New Features**
  - Added `.github/actions/deno-install`: runs `deno install --cached-only` first, then retries with backoff if needed; supports `--frozen`.

- **Refactors**
  - Replaced inline `deno install` steps across workflows with the new action and added it where missing.
  - Improved caching in `.github/actions/deno-setup`: upgraded to `actions/cache@v4`, included macOS cache path, added restore keys, and keyed by OS, arch, Deno version, and `deno.json`/`deno.lock`.
  - `tasks/check.sh`: `--reload` now controlled by `DENO_CHECK_RELOAD` env var instead of always reloading in CI.

<sup>Written for commit af8989f309f5cac2641a1f2c0b0adceec2d21fd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: job: CLI Integration Tests (core-piece-call) = 61s
NEW_PERF_BASELINE: job: CLI Integration Tests (fuse) = 89s
---END COPY-PASTE---
