### PR TITLE
refactor: gather the link@1 envelope behind a LinkRef chokepoint

### DIFF
--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -6,7 +6,7 @@
 
 import { isRecord } from "@commonfabric/utils/types";
 import { FabricHash } from "@/fabric-primitives/index.ts";
-import type { FabricValue } from "@/interface.ts";
+import type { FabricObject } from "@/interface.ts";
 
 //
 // Configuration flags
@@ -121,17 +121,17 @@ export const LINK_V1_TAG = "link@1" as const;
  * localized edit here rather than a tree-wide change.
  *
  * When that dispatch lands, this type becomes a union (`FabricLink | { "/": …
- * }`) mirroring {@link EntityRef}. `Inner` is bounded by {@link FabricValue}
- * (the payload is stored/serialized fabric data) but otherwise open, so this
- * layer needn't know the exact field types (URI / MemorySpace / JSONSchema —
- * those stay in `runner`).
+ * }`) mirroring {@link EntityRef}. `Inner` is bounded by {@link FabricObject}
+ * (the payload is always a stored/serialized fabric record) but otherwise open,
+ * so this layer needn't know the exact field types (URI / MemorySpace /
+ * JSONSchema — those stay in `runner`).
  */
-export type LinkRef<Inner extends FabricValue> = {
+export type LinkRef<Inner extends FabricObject> = {
   "/": { [LINK_V1_TAG]: Inner };
 };
 
 /** Wraps a link payload in the link-ref envelope. */
-export function linkRefFrom<Inner extends FabricValue>(
+export function linkRefFrom<Inner extends FabricObject>(
   inner: Inner,
 ): LinkRef<Inner> {
   return { "/": { [LINK_V1_TAG]: inner } };
@@ -141,7 +141,7 @@ export function linkRefFrom<Inner extends FabricValue>(
  * Recognizes a {@link LinkRef}: the `{ "/": { "link@1": … } }` envelope, no
  * other props.
  */
-export function isLinkRef(value: unknown): value is LinkRef<FabricValue> {
+export function isLinkRef(value: unknown): value is LinkRef<FabricObject> {
   return isRecord(value) &&
     Object.keys(value).length === 1 &&
     isRecord(value["/"]) &&
@@ -152,7 +152,7 @@ export function isLinkRef(value: unknown): value is LinkRef<FabricValue> {
  * Extracts the inner link payload from a {@link LinkRef}. Throws if the value
  * is not a link reference.
  */
-export function linkRefInner<Inner extends FabricValue>(
+export function linkRefInner<Inner extends FabricObject>(
   value: LinkRef<Inner>,
 ): Inner {
   if (isLinkRef(value)) return value["/"][LINK_V1_TAG] as Inner;

--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -103,7 +103,7 @@ export function entityRefToString(value: EntityRef): string {
 /**
  * The link-sigil tag. This module is the sole place that names the literal;
  * everything else routes through {@link linkRefFrom} / {@link isLinkRef} /
- * {@link linkRefInner}.
+ * {@link linkRefPayload}.
  */
 export const LINK_V1_TAG = "link@1" as const;
 
@@ -112,7 +112,7 @@ export const LINK_V1_TAG = "link@1" as const;
  * link payload.
  *
  * Construction ({@link linkRefFrom}), recognition ({@link isLinkRef}) and
- * extraction ({@link linkRefInner}) are gathered here so that this chokepoint
+ * extraction ({@link linkRefPayload}) are gathered here so that this chokepoint
  * can later become the seam at which the modern cell representation dispatches
  * the envelope to a Fabric primitive (provisionally `FabricLink`) — the link
  * analog of {@link EntityRef}'s `{ "/": string }` → {@link FabricHash}. That
@@ -121,20 +121,20 @@ export const LINK_V1_TAG = "link@1" as const;
  * localized edit here rather than a tree-wide change.
  *
  * When that dispatch lands, this type becomes a union (`FabricLink | { "/": …
- * }`) mirroring {@link EntityRef}. `Inner` is bounded by {@link FabricObject}
+ * }`) mirroring {@link EntityRef}. `Payload` is bounded by {@link FabricObject}
  * (the payload is always a stored/serialized fabric record) but otherwise open,
  * so this layer needn't know the exact field types (URI / MemorySpace /
  * JSONSchema — those stay in `runner`).
  */
-export type LinkRef<Inner extends FabricObject> = {
-  "/": { [LINK_V1_TAG]: Inner };
+export type LinkRef<Payload extends FabricObject> = {
+  "/": { [LINK_V1_TAG]: Payload };
 };
 
 /** Wraps a link payload in the link-ref envelope. */
-export function linkRefFrom<Inner extends FabricObject>(
-  inner: Inner,
-): LinkRef<Inner> {
-  return { "/": { [LINK_V1_TAG]: inner } };
+export function linkRefFrom<Payload extends FabricObject>(
+  payload: Payload,
+): LinkRef<Payload> {
+  return { "/": { [LINK_V1_TAG]: payload } };
 }
 
 /**
@@ -149,12 +149,12 @@ export function isLinkRef(value: unknown): value is LinkRef<FabricObject> {
 }
 
 /**
- * Extracts the inner link payload from a {@link LinkRef}. Throws if the value
- * is not a link reference.
+ * Extracts the link payload from a {@link LinkRef}. Throws if the value is not
+ * a link reference.
  */
-export function linkRefInner<Inner extends FabricObject>(
-  value: LinkRef<Inner>,
-): Inner {
-  if (isLinkRef(value)) return value["/"][LINK_V1_TAG] as Inner;
+export function linkRefPayload<Payload extends FabricObject>(
+  value: LinkRef<Payload>,
+): Payload {
+  if (isLinkRef(value)) return value["/"][LINK_V1_TAG] as Payload;
   throw new Error("Not a link reference.");
 }

--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -96,46 +96,46 @@ export function entityRefToString(value: EntityRef): string {
 }
 
 //
-// Cell reference form (the link sigil envelope)
+// Link reference form (the link sigil envelope)
 //
 
 /**
  * The link-sigil tag. This module is the sole place that names the literal;
- * everything else routes through {@link cellRefFrom} / {@link isCellRef} /
- * {@link cellRefInner}.
+ * everything else routes through {@link linkRefFrom} / {@link isLinkRef} /
+ * {@link linkRefInner}.
  */
 export const LINK_V1_TAG = "link@1" as const;
 
 /**
- * A cell reference: today the `{ "/": { "link@1": … } }` envelope wrapping a
+ * A link reference: today the `{ "/": { "link@1": … } }` envelope wrapping a
  * link payload.
  *
- * Construction ({@link cellRefFrom}), recognition ({@link isCellRef}) and
- * extraction ({@link cellRefInner}) are gathered here so that this chokepoint
+ * Construction ({@link linkRefFrom}), recognition ({@link isLinkRef}) and
+ * extraction ({@link linkRefInner}) are gathered here so that this chokepoint
  * can later become the seam at which the modern cell representation dispatches
- * the envelope to a Fabric primitive (provisionally `FabricRef`) — the link
+ * the envelope to a Fabric primitive (provisionally `FabricLink`) — the link
  * analog of {@link EntityRef}'s `{ "/": string }` → {@link FabricHash}. That
  * dispatch is intentionally NOT wired up yet: this pass only collapses the
  * scattered envelope sites onto these functions, so the eventual flag flip is a
  * localized edit here rather than a tree-wide change.
  *
- * When that dispatch lands, this type becomes a union (`FabricRef | { "/": …
+ * When that dispatch lands, this type becomes a union (`FabricLink | { "/": …
  * }`) mirroring {@link EntityRef}. `Inner` is left open so this layer needn't
  * know the link payload's field types (URI / MemorySpace / JSONSchema — those
  * stay in `runner`).
  */
-export type CellRef<Inner = unknown> = { "/": { [LINK_V1_TAG]: Inner } };
+export type LinkRef<Inner = unknown> = { "/": { [LINK_V1_TAG]: Inner } };
 
-/** Wraps a link payload in the cell-ref envelope. */
-export function cellRefFrom<Inner>(inner: Inner): CellRef<Inner> {
+/** Wraps a link payload in the link-ref envelope. */
+export function linkRefFrom<Inner>(inner: Inner): LinkRef<Inner> {
   return { "/": { [LINK_V1_TAG]: inner } };
 }
 
 /**
- * Recognizes a {@link CellRef}: the `{ "/": { "link@1": … } }` envelope, no
+ * Recognizes a {@link LinkRef}: the `{ "/": { "link@1": … } }` envelope, no
  * other props.
  */
-export function isCellRef(value: unknown): value is CellRef {
+export function isLinkRef(value: unknown): value is LinkRef {
   return isRecord(value) &&
     Object.keys(value).length === 1 &&
     isRecord(value["/"]) &&
@@ -143,10 +143,10 @@ export function isCellRef(value: unknown): value is CellRef {
 }
 
 /**
- * Extracts the inner link payload from a {@link CellRef}. Throws if the value
- * is not a cell reference.
+ * Extracts the inner link payload from a {@link LinkRef}. Throws if the value
+ * is not a link reference.
  */
-export function cellRefInner<Inner = unknown>(value: CellRef<Inner>): Inner {
-  if (isCellRef(value)) return value["/"][LINK_V1_TAG] as Inner;
-  throw new Error("Not a cell reference.");
+export function linkRefInner<Inner = unknown>(value: LinkRef<Inner>): Inner {
+  if (isLinkRef(value)) return value["/"][LINK_V1_TAG] as Inner;
+  throw new Error("Not a link reference.");
 }

--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -6,6 +6,7 @@
 
 import { isRecord } from "@commonfabric/utils/types";
 import { FabricHash } from "@/fabric-primitives/index.ts";
+import type { FabricValue } from "@/interface.ts";
 
 //
 // Configuration flags
@@ -120,14 +121,19 @@ export const LINK_V1_TAG = "link@1" as const;
  * localized edit here rather than a tree-wide change.
  *
  * When that dispatch lands, this type becomes a union (`FabricLink | { "/": …
- * }`) mirroring {@link EntityRef}. `Inner` is left open so this layer needn't
- * know the link payload's field types (URI / MemorySpace / JSONSchema — those
- * stay in `runner`).
+ * }`) mirroring {@link EntityRef}. `Inner` is bounded by {@link FabricValue}
+ * (the payload is stored/serialized fabric data) but otherwise open, so this
+ * layer needn't know the exact field types (URI / MemorySpace / JSONSchema —
+ * those stay in `runner`).
  */
-export type LinkRef<Inner = unknown> = { "/": { [LINK_V1_TAG]: Inner } };
+export type LinkRef<Inner extends FabricValue> = {
+  "/": { [LINK_V1_TAG]: Inner };
+};
 
 /** Wraps a link payload in the link-ref envelope. */
-export function linkRefFrom<Inner>(inner: Inner): LinkRef<Inner> {
+export function linkRefFrom<Inner extends FabricValue>(
+  inner: Inner,
+): LinkRef<Inner> {
   return { "/": { [LINK_V1_TAG]: inner } };
 }
 
@@ -135,7 +141,7 @@ export function linkRefFrom<Inner>(inner: Inner): LinkRef<Inner> {
  * Recognizes a {@link LinkRef}: the `{ "/": { "link@1": … } }` envelope, no
  * other props.
  */
-export function isLinkRef(value: unknown): value is LinkRef {
+export function isLinkRef(value: unknown): value is LinkRef<FabricValue> {
   return isRecord(value) &&
     Object.keys(value).length === 1 &&
     isRecord(value["/"]) &&
@@ -146,7 +152,9 @@ export function isLinkRef(value: unknown): value is LinkRef {
  * Extracts the inner link payload from a {@link LinkRef}. Throws if the value
  * is not a link reference.
  */
-export function linkRefInner<Inner = unknown>(value: LinkRef<Inner>): Inner {
+export function linkRefInner<Inner extends FabricValue>(
+  value: LinkRef<Inner>,
+): Inner {
   if (isLinkRef(value)) return value["/"][LINK_V1_TAG] as Inner;
   throw new Error("Not a link reference.");
 }

--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -94,3 +94,59 @@ export function entityRefToString(value: EntityRef): string {
     "Not an entity-id reference for the active cell-rep regime.",
   );
 }
+
+//
+// Cell reference form (the link sigil envelope)
+//
+
+/**
+ * The link-sigil tag. This module is the sole place that names the literal;
+ * everything else routes through {@link cellRefFrom} / {@link isCellRef} /
+ * {@link cellRefInner}.
+ */
+export const LINK_V1_TAG = "link@1" as const;
+
+/**
+ * A cell reference: today the `{ "/": { "link@1": … } }` envelope wrapping a
+ * link payload.
+ *
+ * Construction ({@link cellRefFrom}), recognition ({@link isCellRef}) and
+ * extraction ({@link cellRefInner}) are gathered here so that this chokepoint
+ * can later become the seam at which the modern cell representation dispatches
+ * the envelope to a Fabric primitive (provisionally `FabricRef`) — the link
+ * analog of {@link EntityRef}'s `{ "/": string }` → {@link FabricHash}. That
+ * dispatch is intentionally NOT wired up yet: this pass only collapses the
+ * scattered envelope sites onto these functions, so the eventual flag flip is a
+ * localized edit here rather than a tree-wide change.
+ *
+ * When that dispatch lands, this type becomes a union (`FabricRef | { "/": …
+ * }`) mirroring {@link EntityRef}. `Inner` is left open so this layer needn't
+ * know the link payload's field types (URI / MemorySpace / JSONSchema — those
+ * stay in `runner`).
+ */
+export type CellRef<Inner = unknown> = { "/": { [LINK_V1_TAG]: Inner } };
+
+/** Wraps a link payload in the cell-ref envelope. */
+export function cellRefFrom<Inner>(inner: Inner): CellRef<Inner> {
+  return { "/": { [LINK_V1_TAG]: inner } };
+}
+
+/**
+ * Recognizes a {@link CellRef}: the `{ "/": { "link@1": … } }` envelope, no
+ * other props.
+ */
+export function isCellRef(value: unknown): value is CellRef {
+  return isRecord(value) &&
+    Object.keys(value).length === 1 &&
+    isRecord(value["/"]) &&
+    LINK_V1_TAG in value["/"];
+}
+
+/**
+ * Extracts the inner link payload from a {@link CellRef}. Throws if the value
+ * is not a cell reference.
+ */
+export function cellRefInner<Inner = unknown>(value: CellRef<Inner>): Inner {
+  if (isCellRef(value)) return value["/"][LINK_V1_TAG] as Inner;
+  throw new Error("Not a cell reference.");
+}

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -16,7 +16,6 @@ import {
   type EntityRef,
   entityRefFromString,
   linkRefFrom,
-  linkRefInner,
 } from "@commonfabric/data-model/cell-rep";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import {
@@ -136,6 +135,7 @@ import {
   mergeCfcLabelViews,
   rebaseCfcLabelView,
 } from "./cfc/label-view-state.ts";
+import { setLinkCfcLabelView } from "./cfc/link-label-view.ts";
 import { listResultSchema } from "./builtins/list-result-schema.ts";
 import { propagateRendererTrustedEvent } from "./cfc/ui-contract.ts";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -2756,8 +2756,7 @@ export function convertCellsToLinks(
     if (options.includeCfcLabelView) {
       const cfcLabelView = getCarriedCfcLabelView(cell);
       if (cfcLabelView) {
-        (linkRefInner(link) as { cfcLabelView?: CfcLabelView })
-          .cfcLabelView = cfcLabelView;
+        setLinkCfcLabelView(link, cfcLabelView);
       }
     }
     return link;
@@ -2766,8 +2765,7 @@ export function convertCellsToLinks(
     if (options.includeCfcLabelView) {
       const cfcLabelView = getCarriedCfcLabelView(value);
       if (cfcLabelView) {
-        (linkRefInner(link) as { cfcLabelView?: CfcLabelView })
-          .cfcLabelView = cfcLabelView;
+        setLinkCfcLabelView(link, cfcLabelView);
       }
     }
     return link;

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -13,10 +13,10 @@ import {
 } from "@commonfabric/data-model/fabric-value";
 import { codecOf } from "@commonfabric/data-model/codec-common";
 import {
-  cellRefFrom,
-  cellRefInner,
   type EntityRef,
   entityRefFromString,
+  linkRefFrom,
+  linkRefInner,
 } from "@commonfabric/data-model/cell-rep";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import {
@@ -2741,7 +2741,7 @@ export function convertCellsToLinks(
   seen: Map<any, string[]> = new Map(),
 ): any {
   if (seen.has(value)) {
-    return cellRefFrom({ path: seen.get(value) });
+    return linkRefFrom({ path: seen.get(value) });
   }
 
   // Early-return cases
@@ -2751,7 +2751,7 @@ export function convertCellsToLinks(
     if (options.includeCfcLabelView) {
       const cfcLabelView = getCarriedCfcLabelView(cell);
       if (cfcLabelView) {
-        (cellRefInner(link) as { cfcLabelView?: CfcLabelView })
+        (linkRefInner(link) as { cfcLabelView?: CfcLabelView })
           .cfcLabelView = cfcLabelView;
       }
     }
@@ -2761,7 +2761,7 @@ export function convertCellsToLinks(
     if (options.includeCfcLabelView) {
       const cfcLabelView = getCarriedCfcLabelView(value);
       if (cfcLabelView) {
-        (cellRefInner(link) as { cfcLabelView?: CfcLabelView })
+        (linkRefInner(link) as { cfcLabelView?: CfcLabelView })
           .cfcLabelView = cfcLabelView;
       }
     }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -13,6 +13,8 @@ import {
 } from "@commonfabric/data-model/fabric-value";
 import { codecOf } from "@commonfabric/data-model/codec-common";
 import {
+  cellRefFrom,
+  cellRefInner,
   type EntityRef,
   entityRefFromString,
 } from "@commonfabric/data-model/cell-rep";
@@ -95,7 +97,6 @@ import {
 import { toURI } from "./uri-utils.ts";
 import { createRef } from "./create-ref.ts";
 import {
-  LINK_V1_TAG,
   type SigilLink,
   type SigilWriteRedirectLink,
   type URI,
@@ -2740,11 +2741,7 @@ export function convertCellsToLinks(
   seen: Map<any, string[]> = new Map(),
 ): any {
   if (seen.has(value)) {
-    return {
-      "/": {
-        [LINK_V1_TAG]: { path: seen.get(value) },
-      },
-    };
+    return cellRefFrom({ path: seen.get(value) });
   }
 
   // Early-return cases
@@ -2754,7 +2751,7 @@ export function convertCellsToLinks(
     if (options.includeCfcLabelView) {
       const cfcLabelView = getCarriedCfcLabelView(cell);
       if (cfcLabelView) {
-        (link["/"][LINK_V1_TAG] as { cfcLabelView?: CfcLabelView })
+        (cellRefInner(link) as { cfcLabelView?: CfcLabelView })
           .cfcLabelView = cfcLabelView;
       }
     }
@@ -2764,7 +2761,7 @@ export function convertCellsToLinks(
     if (options.includeCfcLabelView) {
       const cfcLabelView = getCarriedCfcLabelView(value);
       if (cfcLabelView) {
-        (link["/"][LINK_V1_TAG] as { cfcLabelView?: CfcLabelView })
+        (cellRefInner(link) as { cfcLabelView?: CfcLabelView })
           .cfcLabelView = cfcLabelView;
       }
     }

--- a/packages/runner/src/cfc/link-label-view.ts
+++ b/packages/runner/src/cfc/link-label-view.ts
@@ -1,0 +1,28 @@
+import { linkRefInner } from "@commonfabric/data-model/cell-rep";
+import type { CellLinkRefPayload, SigilLink } from "../sigil-types.ts";
+import type { CfcLabelView } from "./label-view-core.ts";
+
+/**
+ * A cell-link payload that additionally carries a CFC label view. The label
+ * view is a CFC-owned side-channel smuggled on the link inner: producers write
+ * it and the flow-control machinery reads it back. Keeping it out of the base
+ * {@link CellLinkRefPayload} (and confined to this cfc module) is deliberate —
+ * it is not part of the link's addressing identity, and link normalization /
+ * equality ignore it.
+ */
+export type CfcCellLinkRefPayload = CellLinkRefPayload & {
+  cfcLabelView?: CfcLabelView;
+};
+
+/** Reads the CFC label view carried on a sigil link, if any. */
+export function linkCfcLabelView(link: SigilLink): CfcLabelView | undefined {
+  return (linkRefInner(link) as CfcCellLinkRefPayload).cfcLabelView;
+}
+
+/** Attaches a CFC label view to a sigil link's inner, in place. */
+export function setLinkCfcLabelView(
+  link: SigilLink,
+  view: CfcLabelView,
+): void {
+  (linkRefInner(link) as CfcCellLinkRefPayload).cfcLabelView = view;
+}

--- a/packages/runner/src/cfc/link-label-view.ts
+++ b/packages/runner/src/cfc/link-label-view.ts
@@ -1,4 +1,4 @@
-import { linkRefInner } from "@commonfabric/data-model/cell-rep";
+import { linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import type { CellLinkRefPayload, SigilLink } from "../sigil-types.ts";
 import type { CfcLabelView } from "./label-view-core.ts";
 
@@ -16,7 +16,7 @@ export type CfcCellLinkRefPayload = CellLinkRefPayload & {
 
 /** Reads the CFC label view carried on a sigil link, if any. */
 export function linkCfcLabelView(link: SigilLink): CfcLabelView | undefined {
-  return (linkRefInner(link) as CfcCellLinkRefPayload).cfcLabelView;
+  return (linkRefPayload(link) as CfcCellLinkRefPayload).cfcLabelView;
 }
 
 /** Attaches a CFC label view to a sigil link's inner, in place. */
@@ -24,5 +24,5 @@ export function setLinkCfcLabelView(
   link: SigilLink,
   view: CfcLabelView,
 ): void {
-  (linkRefInner(link) as CfcCellLinkRefPayload).cfcLabelView = view;
+  (linkRefPayload(link) as CfcCellLinkRefPayload).cfcLabelView = view;
 }

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -1,5 +1,10 @@
 export type { CfcLabelView, CfcLabelViewEntry } from "./label-view.ts";
 export {
+  type CfcCellLinkRefPayload,
+  linkCfcLabelView,
+  setLinkCfcLabelView,
+} from "./link-label-view.ts";
+export {
   cfcLabelViewForCell,
   cfcLabelViewForDereference,
   cfcLabelViewForDereferenceTraces,

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -67,7 +67,7 @@ import {
   CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
   type CfcAddress,
 } from "./cfc/types.ts";
-import { cellRefFrom, cellRefInner } from "@commonfabric/data-model/cell-rep";
+import { linkRefFrom, linkRefInner } from "@commonfabric/data-model/cell-rep";
 
 const diffLogger = getLogger("normalizeAndDiff", {
   enabled: false,
@@ -238,7 +238,7 @@ const cfcLabelViewForPrimitiveLink = (
     return undefined;
   }
   return cloneCfcLabelView(
-    (cellRefInner(value) as { cfcLabelView?: CfcLabelView })
+    (linkRefInner(value) as { cfcLabelView?: CfcLabelView })
       .cfcLabelView,
   );
 };
@@ -251,8 +251,8 @@ const attachCfcLabelViewToSigilLink = (
   if (!clonedView || !isSigilLink(value)) {
     return value;
   }
-  return cellRefFrom({
-    ...cellRefInner(value),
+  return linkRefFrom({
+    ...linkRefInner(value),
     cfcLabelView: clonedView,
   });
 };
@@ -261,14 +261,14 @@ const stripCfcLabelViewFromPrimitiveLink = (value: unknown): unknown => {
   if (!isSigilLink(value)) {
     return value;
   }
-  const inner = cellRefInner(value) as
+  const inner = linkRefInner(value) as
     & Record<string, unknown>
     & { cfcLabelView?: CfcLabelView };
   if (inner.cfcLabelView === undefined) {
     return value;
   }
   const { cfcLabelView: _cfcLabelView, ...cleanInner } = inner;
-  return cellRefFrom(cleanInner);
+  return linkRefFrom(cleanInner);
 };
 
 /**

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -37,6 +37,7 @@ import {
   type NormalizedFullLink,
   parseLink,
 } from "./link-utils.ts";
+import { type LinkV1Inner } from "./sigil-types.ts";
 import {
   getCellOrThrow,
   isCellResultForDereferencing,
@@ -262,7 +263,7 @@ const stripCfcLabelViewFromPrimitiveLink = (value: unknown): unknown => {
     return value;
   }
   const inner = linkRefInner(value) as
-    & Record<string, unknown>
+    & LinkV1Inner
     & { cfcLabelView?: CfcLabelView };
   if (inner.cfcLabelView === undefined) {
     return value;

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -37,7 +37,10 @@ import {
   type NormalizedFullLink,
   parseLink,
 } from "./link-utils.ts";
-import { type CellLinkRefPayload } from "./sigil-types.ts";
+import {
+  type CfcCellLinkRefPayload,
+  linkCfcLabelView,
+} from "./cfc/link-label-view.ts";
 import {
   getCellOrThrow,
   isCellResultForDereferencing,
@@ -238,10 +241,7 @@ const cfcLabelViewForPrimitiveLink = (
   if (!isSigilLink(value)) {
     return undefined;
   }
-  return cloneCfcLabelView(
-    (linkRefInner(value) as { cfcLabelView?: CfcLabelView })
-      .cfcLabelView,
-  );
+  return cloneCfcLabelView(linkCfcLabelView(value));
 };
 
 const attachCfcLabelViewToSigilLink = (
@@ -252,7 +252,7 @@ const attachCfcLabelViewToSigilLink = (
   if (!clonedView || !isSigilLink(value)) {
     return value;
   }
-  return linkRefFrom({
+  return linkRefFrom<CfcCellLinkRefPayload>({
     ...linkRefInner(value),
     cfcLabelView: clonedView,
   });
@@ -262,9 +262,7 @@ const stripCfcLabelViewFromPrimitiveLink = (value: unknown): unknown => {
   if (!isSigilLink(value)) {
     return value;
   }
-  const inner = linkRefInner(value) as
-    & CellLinkRefPayload
-    & { cfcLabelView?: CfcLabelView };
+  const inner = linkRefInner(value) as CfcCellLinkRefPayload;
   if (inner.cfcLabelView === undefined) {
     return value;
   }

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -71,7 +71,7 @@ import {
   CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
   type CfcAddress,
 } from "./cfc/types.ts";
-import { linkRefFrom, linkRefInner } from "@commonfabric/data-model/cell-rep";
+import { linkRefFrom, linkRefPayload } from "@commonfabric/data-model/cell-rep";
 
 const diffLogger = getLogger("normalizeAndDiff", {
   enabled: false,
@@ -253,7 +253,7 @@ const attachCfcLabelViewToSigilLink = (
     return value;
   }
   return linkRefFrom<CfcCellLinkRefPayload>({
-    ...linkRefInner(value),
+    ...linkRefPayload(value),
     cfcLabelView: clonedView,
   });
 };
@@ -262,7 +262,7 @@ const stripCfcLabelViewFromPrimitiveLink = (value: unknown): unknown => {
   if (!isSigilLink(value)) {
     return value;
   }
-  const inner = linkRefInner(value) as CfcCellLinkRefPayload;
+  const inner = linkRefPayload(value) as CfcCellLinkRefPayload;
   if (inner.cfcLabelView === undefined) {
     return value;
   }

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -37,7 +37,7 @@ import {
   type NormalizedFullLink,
   parseLink,
 } from "./link-utils.ts";
-import { type LinkV1Inner } from "./sigil-types.ts";
+import { type CellLinkRefPayload } from "./sigil-types.ts";
 import {
   getCellOrThrow,
   isCellResultForDereferencing,
@@ -263,7 +263,7 @@ const stripCfcLabelViewFromPrimitiveLink = (value: unknown): unknown => {
     return value;
   }
   const inner = linkRefInner(value) as
-    & LinkV1Inner
+    & CellLinkRefPayload
     & { cfcLabelView?: CfcLabelView };
   if (inner.cfcLabelView === undefined) {
     return value;

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -67,7 +67,7 @@ import {
   CFC_STRUCTURAL_PROVENANCE_SEED_MATERIALIZATION,
   type CfcAddress,
 } from "./cfc/types.ts";
-import { LINK_V1_TAG } from "./sigil-types.ts";
+import { cellRefFrom, cellRefInner } from "@commonfabric/data-model/cell-rep";
 
 const diffLogger = getLogger("normalizeAndDiff", {
   enabled: false,
@@ -238,7 +238,7 @@ const cfcLabelViewForPrimitiveLink = (
     return undefined;
   }
   return cloneCfcLabelView(
-    (value["/"][LINK_V1_TAG] as { cfcLabelView?: CfcLabelView })
+    (cellRefInner(value) as { cfcLabelView?: CfcLabelView })
       .cfcLabelView,
   );
 };
@@ -251,32 +251,24 @@ const attachCfcLabelViewToSigilLink = (
   if (!clonedView || !isSigilLink(value)) {
     return value;
   }
-  return {
-    "/": {
-      [LINK_V1_TAG]: {
-        ...value["/"][LINK_V1_TAG],
-        cfcLabelView: clonedView,
-      },
-    },
-  };
+  return cellRefFrom({
+    ...cellRefInner(value),
+    cfcLabelView: clonedView,
+  });
 };
 
 const stripCfcLabelViewFromPrimitiveLink = (value: unknown): unknown => {
   if (!isSigilLink(value)) {
     return value;
   }
-  const inner = value["/"][LINK_V1_TAG] as
+  const inner = cellRefInner(value) as
     & Record<string, unknown>
     & { cfcLabelView?: CfcLabelView };
   if (inner.cfcLabelView === undefined) {
     return value;
   }
   const { cfcLabelView: _cfcLabelView, ...cleanInner } = inner;
-  return {
-    "/": {
-      [LINK_V1_TAG]: cleanInner,
-    },
-  };
+  return cellRefFrom(cleanInner);
 };
 
 /**

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -2,7 +2,7 @@ import { isRecord } from "@commonfabric/utils/types";
 import { getLogger } from "@commonfabric/utils/logger";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
-import { LINK_V1_TAG, type LinkV1Inner } from "./sigil-types.ts";
+import { type CellLinkRefPayload, LINK_V1_TAG } from "./sigil-types.ts";
 import {
   type CellLink,
   createDataCellURI,
@@ -173,7 +173,7 @@ export function resolveLink(
       isRecord(sigilProbe.ok.value) &&
       lastNode !== "top" &&
       (lastNode !== "writeRedirect" ||
-        (sigilProbe.ok.value as LinkV1Inner).overwrite === "redirect")
+        (sigilProbe.ok.value as CellLinkRefPayload).overwrite === "redirect")
     ) {
       // Read the full value at this path to ensure correct reactivity logging
       // (we need to be reactive to siblings that could invalidate the link)

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -1,4 +1,5 @@
-import { isObject, isRecord } from "@commonfabric/utils/types";
+import { isRecord } from "@commonfabric/utils/types";
+import { cellRefInner, isCellRef } from "@commonfabric/data-model/cell-rep";
 import {
   type CellScope,
   type JSONSchema,
@@ -7,9 +8,7 @@ import {
 import { type MemorySpace } from "./cell.ts";
 import {
   type LegacyAlias,
-  LINK_V1_TAG,
   type SigilLink,
-  type SigilValue,
   type SigilWriteRedirectLink,
   type URI,
 } from "./sigil-types.ts";
@@ -89,20 +88,8 @@ export type PrimitiveCellLink =
   | SigilLink
   | LegacyAlias; // @deprecated
 
-/**
- * Check if value is a sigil value with any type: an object that is strictly
- * `{ "/": Record<string, any> }`, no other props. Internal helper for
- * {@link isSigilLink}.
- */
-function isSigilValue(value: any): value is SigilValue<any> {
-  return isRecord(value) &&
-    "/" in value &&
-    Object.keys(value).length === 1 &&
-    isObject(value["/"]);
-}
-
 export function isSigilLink(value: any): value is SigilLink {
-  return (isSigilValue(value) && LINK_V1_TAG in value["/"]);
+  return isCellRef(value);
 }
 
 export function isPrimitiveCellLink(
@@ -156,7 +143,7 @@ export function isWriteRedirectLink(
 
   // Check new sigil format (link@1 with overwrite field)
   if (isSigilLink(value)) {
-    return value["/"][LINK_V1_TAG].overwrite === "redirect";
+    return cellRefInner(value).overwrite === "redirect";
   }
 
   return false;
@@ -185,7 +172,7 @@ export function parseLinkPrimitive(
   base?: NormalizedLink,
 ): NormalizedLink {
   if (isSigilLink(value)) {
-    const link = value["/"][LINK_V1_TAG];
+    const link = cellRefInner(value);
 
     // Resolve relative references
     let id = link.id;

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -1,5 +1,5 @@
 import { isRecord } from "@commonfabric/utils/types";
-import { isLinkRef, linkRefInner } from "@commonfabric/data-model/cell-rep";
+import { isLinkRef, linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import {
   type CellScope,
   type JSONSchema,
@@ -143,7 +143,7 @@ export function isWriteRedirectLink(
 
   // Check new sigil format (link@1 with overwrite field)
   if (isSigilLink(value)) {
-    return linkRefInner(value).overwrite === "redirect";
+    return linkRefPayload(value).overwrite === "redirect";
   }
 
   return false;
@@ -172,7 +172,7 @@ export function parseLinkPrimitive(
   base?: NormalizedLink,
 ): NormalizedLink {
   if (isSigilLink(value)) {
-    const link = linkRefInner(value);
+    const link = linkRefPayload(value);
 
     // Resolve relative references
     let id = link.id;

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -1,5 +1,5 @@
 import { isRecord } from "@commonfabric/utils/types";
-import { cellRefInner, isCellRef } from "@commonfabric/data-model/cell-rep";
+import { isLinkRef, linkRefInner } from "@commonfabric/data-model/cell-rep";
 import {
   type CellScope,
   type JSONSchema,
@@ -89,7 +89,7 @@ export type PrimitiveCellLink =
   | LegacyAlias; // @deprecated
 
 export function isSigilLink(value: any): value is SigilLink {
-  return isCellRef(value);
+  return isLinkRef(value);
 }
 
 export function isPrimitiveCellLink(
@@ -143,7 +143,7 @@ export function isWriteRedirectLink(
 
   // Check new sigil format (link@1 with overwrite field)
   if (isSigilLink(value)) {
-    return cellRefInner(value).overwrite === "redirect";
+    return linkRefInner(value).overwrite === "redirect";
   }
 
   return false;
@@ -172,7 +172,7 @@ export function parseLinkPrimitive(
   base?: NormalizedLink,
 ): NormalizedLink {
   if (isSigilLink(value)) {
-    const link = cellRefInner(value);
+    const link = linkRefInner(value);
 
     // Resolve relative references
     let id = link.id;

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -14,7 +14,8 @@ import {
   type MemorySpace,
   type Stream,
 } from "./cell.ts";
-import { LINK_V1_TAG, type SigilLink, type URI } from "./sigil-types.ts";
+import { type LinkV1Inner, type SigilLink, type URI } from "./sigil-types.ts";
+import { cellRefFrom, cellRefInner } from "@commonfabric/data-model/cell-rep";
 import { getJSONFromDataURI, toURI } from "./uri-utils.ts";
 import { arrayEqual } from "./path-utils.ts";
 import {
@@ -209,15 +210,11 @@ export function createSigilLinkFromParsedLink(
   } & SanitizeSchemaForLinksOptions = {},
 ): SigilLink {
   // Create the base structure
-  const sigil: SigilLink = {
-    "/": {
-      [LINK_V1_TAG]: {
-        path: link.path.map((p) => p.toString()),
-      },
-    },
-  };
+  const sigil: SigilLink = cellRefFrom<LinkV1Inner>({
+    path: link.path.map((p) => p.toString()),
+  });
 
-  const reference = sigil["/"][LINK_V1_TAG];
+  const reference = cellRefInner(sigil);
 
   // Handle base cell for relative references
   if (options.base) {

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -14,7 +14,11 @@ import {
   type MemorySpace,
   type Stream,
 } from "./cell.ts";
-import { type LinkV1Inner, type SigilLink, type URI } from "./sigil-types.ts";
+import {
+  type CellLinkRefPayload,
+  type SigilLink,
+  type URI,
+} from "./sigil-types.ts";
 import { linkRefFrom, linkRefInner } from "@commonfabric/data-model/cell-rep";
 import { getJSONFromDataURI, toURI } from "./uri-utils.ts";
 import { arrayEqual } from "./path-utils.ts";
@@ -210,7 +214,7 @@ export function createSigilLinkFromParsedLink(
   } & SanitizeSchemaForLinksOptions = {},
 ): SigilLink {
   // Create the base structure
-  const sigil: SigilLink = linkRefFrom<LinkV1Inner>({
+  const sigil: SigilLink = linkRefFrom<CellLinkRefPayload>({
     path: link.path.map((p) => p.toString()),
   });
 

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -19,7 +19,7 @@ import {
   type SigilLink,
   type URI,
 } from "./sigil-types.ts";
-import { linkRefFrom, linkRefInner } from "@commonfabric/data-model/cell-rep";
+import { linkRefFrom, linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import { getJSONFromDataURI, toURI } from "./uri-utils.ts";
 import { arrayEqual } from "./path-utils.ts";
 import {
@@ -218,7 +218,7 @@ export function createSigilLinkFromParsedLink(
     path: link.path.map((p) => p.toString()),
   });
 
-  const reference = linkRefInner(sigil);
+  const reference = linkRefPayload(sigil);
 
   // Handle base cell for relative references
   if (options.base) {

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -15,7 +15,7 @@ import {
   type Stream,
 } from "./cell.ts";
 import { type LinkV1Inner, type SigilLink, type URI } from "./sigil-types.ts";
-import { cellRefFrom, cellRefInner } from "@commonfabric/data-model/cell-rep";
+import { linkRefFrom, linkRefInner } from "@commonfabric/data-model/cell-rep";
 import { getJSONFromDataURI, toURI } from "./uri-utils.ts";
 import { arrayEqual } from "./path-utils.ts";
 import {
@@ -210,11 +210,11 @@ export function createSigilLinkFromParsedLink(
   } & SanitizeSchemaForLinksOptions = {},
 ): SigilLink {
   // Create the base structure
-  const sigil: SigilLink = cellRefFrom<LinkV1Inner>({
+  const sigil: SigilLink = linkRefFrom<LinkV1Inner>({
     path: link.path.map((p) => p.toString()),
   });
 
-  const reference = cellRefInner(sigil);
+  const reference = linkRefInner(sigil);
 
   // Handle base cell for relative references
   if (options.base) {

--- a/packages/runner/src/runner-utils.ts
+++ b/packages/runner/src/runner-utils.ts
@@ -2,6 +2,7 @@ import {
   type FabricValue,
   shallowMutableClone,
 } from "@commonfabric/data-model/fabric-value";
+import { cellRefFrom } from "@commonfabric/data-model/cell-rep";
 import { isRecord } from "@commonfabric/utils/types";
 import {
   isModule,
@@ -11,7 +12,7 @@ import {
   type Pattern,
 } from "./builder/types.ts";
 import { isCellLink } from "./link-utils.ts";
-import { LINK_V1_TAG, type SigilLink, type URI } from "./sigil-types.ts";
+import { type SigilLink, type URI } from "./sigil-types.ts";
 
 export function setRunnableName<T extends object & { src?: string }>(
   target: T,
@@ -34,7 +35,7 @@ export function sanitizeDebugLabel(label?: string): string | undefined {
 }
 
 export function getSigilLink(id: URI): SigilLink {
-  return { "/": { [LINK_V1_TAG]: { id } } };
+  return cellRefFrom({ id });
 }
 
 export function describePatternOrModule(

--- a/packages/runner/src/runner-utils.ts
+++ b/packages/runner/src/runner-utils.ts
@@ -2,7 +2,7 @@ import {
   type FabricValue,
   shallowMutableClone,
 } from "@commonfabric/data-model/fabric-value";
-import { cellRefFrom } from "@commonfabric/data-model/cell-rep";
+import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
 import { isRecord } from "@commonfabric/utils/types";
 import {
   isModule,
@@ -35,7 +35,7 @@ export function sanitizeDebugLabel(label?: string): string | undefined {
 }
 
 export function getSigilLink(id: URI): SigilLink {
-  return cellRefFrom({ id });
+  return linkRefFrom({ id });
 }
 
 export function describePatternOrModule(

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -15,6 +15,7 @@ import type {
 } from "./builder/types.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import {
+  cellRefInner,
   getModernCellRepConfig,
   resetModernCellRepConfig,
   setModernCellRepConfig,
@@ -57,7 +58,6 @@ import {
   NormalizedLink,
   parseLink,
 } from "./link-utils.ts";
-import { LINK_V1_TAG } from "./sigil-types.ts";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import {
   type CfcEnforcementMode,
@@ -934,7 +934,7 @@ export class Runtime {
   ): Cell<any> {
     const carriedLabelView = cfcLabelView ??
       (isSigilLink(cellLink)
-        ? (cellLink["/"][LINK_V1_TAG] as { cfcLabelView?: CfcLabelView })
+        ? (cellRefInner(cellLink) as { cfcLabelView?: CfcLabelView })
           .cfcLabelView
         : isNormalizedFullLink(cellLink)
         ? (cellLink as NormalizedLink & { cfcLabelView?: CfcLabelView })

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -15,8 +15,8 @@ import type {
 } from "./builder/types.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import {
-  cellRefInner,
   getModernCellRepConfig,
+  linkRefInner,
   resetModernCellRepConfig,
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
@@ -934,7 +934,7 @@ export class Runtime {
   ): Cell<any> {
     const carriedLabelView = cfcLabelView ??
       (isSigilLink(cellLink)
-        ? (cellRefInner(cellLink) as { cfcLabelView?: CfcLabelView })
+        ? (linkRefInner(cellLink) as { cfcLabelView?: CfcLabelView })
           .cfcLabelView
         : isNormalizedFullLink(cellLink)
         ? (cellLink as NormalizedLink & { cfcLabelView?: CfcLabelView })

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -16,7 +16,6 @@ import type {
 import { ContextualFlowControl } from "./cfc.ts";
 import {
   getModernCellRepConfig,
-  linkRefInner,
   resetModernCellRepConfig,
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
@@ -66,6 +65,7 @@ import {
   DEFAULT_SINK_MAX_CONFIDENTIALITY,
   flowLabelWorkExists,
   gatedSinkRequestExists,
+  linkCfcLabelView,
   type SinkMaxConfidentiality,
   type TrustSnapshot,
 } from "./cfc/mod.ts";
@@ -934,8 +934,7 @@ export class Runtime {
   ): Cell<any> {
     const carriedLabelView = cfcLabelView ??
       (isSigilLink(cellLink)
-        ? (linkRefInner(cellLink) as { cfcLabelView?: CfcLabelView })
-          .cfcLabelView
+        ? linkCfcLabelView(cellLink)
         : isNormalizedFullLink(cellLink)
         ? (cellLink as NormalizedLink & { cfcLabelView?: CfcLabelView })
           .cfcLabelView

--- a/packages/runner/src/shared.ts
+++ b/packages/runner/src/shared.ts
@@ -14,7 +14,7 @@ export {
   isLinkRef,
   type LinkRef,
   linkRefFrom,
-  linkRefInner,
+  linkRefPayload,
 } from "@commonfabric/data-model/cell-rep";
 export { LINK_V1_TAG, type SigilLink, type URI } from "./sigil-types.ts";
 export {

--- a/packages/runner/src/shared.ts
+++ b/packages/runner/src/shared.ts
@@ -10,6 +10,12 @@ export {
   type NormalizedFullLink,
   parseLLMFriendlyLink,
 } from "./link-types.ts";
+export {
+  isLinkRef,
+  type LinkRef,
+  linkRefFrom,
+  linkRefInner,
+} from "@commonfabric/data-model/cell-rep";
 export { LINK_V1_TAG, type SigilLink, type URI } from "./sigil-types.ts";
 export {
   CHIP_UI,

--- a/packages/runner/src/sigil-types.ts
+++ b/packages/runner/src/sigil-types.ts
@@ -1,7 +1,7 @@
 import type { JSONSchema, JSONValue, LinkScope } from "@commonfabric/api";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import type { URI } from "@commonfabric/memory/interface";
-import { type CellRef, LINK_V1_TAG } from "@commonfabric/data-model/cell-rep";
+import { LINK_V1_TAG, type LinkRef } from "@commonfabric/data-model/cell-rep";
 
 export type { URI } from "@commonfabric/memory/interface";
 
@@ -14,7 +14,7 @@ export type SigilValue<T> = { "/": T };
  * Link sigil value v1
  */
 
-// The cell-ref envelope (`{ "/": { "link@1": … } }`) and its tag are owned by
+// The link-ref envelope (`{ "/": { "link@1": … } }`) and its tag are owned by
 // `data-model/cell-rep`, the chokepoint that will later flag-dispatch the form.
 // Re-exported here (the historical home) for existing importers.
 export { LINK_V1_TAG };
@@ -41,13 +41,13 @@ export type WriteRedirectV1 = LinkV1 & {
 /**
  * Sigil link type.
  *
- * Transitional alias for {@link CellRef}: structurally the same envelope, but
+ * Transitional alias for {@link LinkRef}: structurally the same envelope, but
  * named through the chokepoint that will later flag-dispatch the form. Once a
  * modern (non-envelope) representation exists, `SigilLink` (which _is_ the
- * envelope) and `CellRef` (which spans both forms) diverge and this alias gets
+ * envelope) and `LinkRef` (which spans both forms) diverge and this alias gets
  * cleaned up.
  */
-export type SigilLink = CellRef<LinkV1Inner>;
+export type SigilLink = LinkRef<LinkV1Inner>;
 /**
  * Sigil alias type - uses LinkV1 with overwrite field
  */

--- a/packages/runner/src/sigil-types.ts
+++ b/packages/runner/src/sigil-types.ts
@@ -20,9 +20,11 @@ export type SigilValue<T> = { "/": T };
 export { LINK_V1_TAG };
 
 /**
- * Inner value of a LinkV1 sigil (the object at the LINK_V1_TAG key)
+ * The payload of a cell-link {@link LinkRef} — the object at the
+ * {@link LINK_V1_TAG} key. (The `link@1` tag versions the wire envelope; this
+ * payload shape is version-agnostic and expected to outlive it.)
  */
-export type LinkV1Inner = {
+export type CellLinkRefPayload = {
   id?: URI;
   path?: readonly string[];
   space?: MemorySpace;
@@ -32,7 +34,7 @@ export type LinkV1Inner = {
 };
 
 export type LinkV1 = {
-  [LINK_V1_TAG]: LinkV1Inner;
+  [LINK_V1_TAG]: CellLinkRefPayload;
 };
 
 export type WriteRedirectV1 = LinkV1 & {
@@ -47,7 +49,7 @@ export type WriteRedirectV1 = LinkV1 & {
  * envelope) and `LinkRef` (which spans both forms) diverge and this alias gets
  * cleaned up.
  */
-export type SigilLink = LinkRef<LinkV1Inner>;
+export type SigilLink = LinkRef<CellLinkRefPayload>;
 /**
  * Sigil alias type - uses LinkV1 with overwrite field
  */

--- a/packages/runner/src/sigil-types.ts
+++ b/packages/runner/src/sigil-types.ts
@@ -1,6 +1,7 @@
 import type { JSONSchema, JSONValue, LinkScope } from "@commonfabric/api";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import type { URI } from "@commonfabric/memory/interface";
+import { type CellRef, LINK_V1_TAG } from "@commonfabric/data-model/cell-rep";
 
 export type { URI } from "@commonfabric/memory/interface";
 
@@ -13,7 +14,10 @@ export type SigilValue<T> = { "/": T };
  * Link sigil value v1
  */
 
-export const LINK_V1_TAG = "link@1" as const;
+// The cell-ref envelope (`{ "/": { "link@1": … } }`) and its tag are owned by
+// `data-model/cell-rep`, the chokepoint that will later flag-dispatch the form.
+// Re-exported here (the historical home) for existing importers.
+export { LINK_V1_TAG };
 
 /**
  * Inner value of a LinkV1 sigil (the object at the LINK_V1_TAG key)
@@ -35,10 +39,15 @@ export type WriteRedirectV1 = LinkV1 & {
   [LINK_V1_TAG]: { overwrite: "redirect" };
 };
 /**
- * Sigil link type
+ * Sigil link type.
+ *
+ * Transitional alias for {@link CellRef}: structurally the same envelope, but
+ * named through the chokepoint that will later flag-dispatch the form. Once a
+ * modern (non-envelope) representation exists, `SigilLink` (which _is_ the
+ * envelope) and `CellRef` (which spans both forms) diverge and this alias gets
+ * cleaned up.
  */
-
-export type SigilLink = SigilValue<LinkV1>;
+export type SigilLink = CellRef<LinkV1Inner>;
 /**
  * Sigil alias type - uses LinkV1 with overwrite field
  */

--- a/packages/runner/src/sigil-types.ts
+++ b/packages/runner/src/sigil-types.ts
@@ -48,8 +48,13 @@ export type WriteRedirectV1 = LinkV1 & {
  * modern (non-envelope) representation exists, `SigilLink` (which _is_ the
  * envelope) and `LinkRef` (which spans both forms) diverge and this alias gets
  * cleaned up.
+ *
+ * Parameterized on the payload so a producer can advertise a richer payload
+ * (e.g. cfc's `CfcCellLinkRefPayload`); defaults to the base
+ * {@link CellLinkRefPayload}, so bare `SigilLink` is unchanged.
  */
-export type SigilLink = LinkRef<CellLinkRefPayload>;
+export type SigilLink<P extends CellLinkRefPayload = CellLinkRefPayload> =
+  LinkRef<P>;
 /**
  * Sigil alias type - uses LinkV1 with overwrite field
  */

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -78,7 +78,7 @@ import {
 import type { LastNode } from "./link-resolution.ts";
 import type { IAttestation, IMemoryAddress } from "./storage/interface.ts";
 import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
-import { type LinkV1Inner, SigilLink } from "./sigil-types.ts";
+import { type CellLinkRefPayload, SigilLink } from "./sigil-types.ts";
 import {
   recordTraverseInvocation,
   wrapTxForTraverseCapture,
@@ -2093,7 +2093,7 @@ function cfcMetaToSigilLink(obj: unknown): SigilLink | undefined {
   if (isRecord(obj) && "schemaHash" in obj) {
     const schemaHash = obj["schemaHash"];
     if (typeof schemaHash === "string" && schemaHash.length > 0) {
-      return linkRefFrom<LinkV1Inner>({ id: `cid:${schemaHash}` });
+      return linkRefFrom<CellLinkRefPayload>({ id: `cid:${schemaHash}` });
     }
   }
   return undefined;

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -77,7 +77,8 @@ import {
 } from "./link-types.ts";
 import type { LastNode } from "./link-resolution.ts";
 import type { IAttestation, IMemoryAddress } from "./storage/interface.ts";
-import { SigilLink } from "./sigil-types.ts";
+import { cellRefFrom } from "@commonfabric/data-model/cell-rep";
+import { type LinkV1Inner, SigilLink } from "./sigil-types.ts";
 import {
   recordTraverseInvocation,
   wrapTxForTraverseCapture,
@@ -2092,7 +2093,7 @@ function cfcMetaToSigilLink(obj: unknown): SigilLink | undefined {
   if (isRecord(obj) && "schemaHash" in obj) {
     const schemaHash = obj["schemaHash"];
     if (typeof schemaHash === "string" && schemaHash.length > 0) {
-      return { "/": { "link@1": { id: `cid:${obj["schemaHash"]}` } } };
+      return cellRefFrom<LinkV1Inner>({ id: `cid:${schemaHash}` });
     }
   }
   return undefined;

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -77,7 +77,7 @@ import {
 } from "./link-types.ts";
 import type { LastNode } from "./link-resolution.ts";
 import type { IAttestation, IMemoryAddress } from "./storage/interface.ts";
-import { cellRefFrom } from "@commonfabric/data-model/cell-rep";
+import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
 import { type LinkV1Inner, SigilLink } from "./sigil-types.ts";
 import {
   recordTraverseInvocation,
@@ -2093,7 +2093,7 @@ function cfcMetaToSigilLink(obj: unknown): SigilLink | undefined {
   if (isRecord(obj) && "schemaHash" in obj) {
     const schemaHash = obj["schemaHash"];
     if (typeof schemaHash === "string" && schemaHash.length > 0) {
-      return cellRefFrom<LinkV1Inner>({ id: `cid:${schemaHash}` });
+      return linkRefFrom<LinkV1Inner>({ id: `cid:${schemaHash}` });
     }
   }
   return undefined;

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -27,6 +27,7 @@ import {
   setPatternEnvironment,
   type SigilLink,
 } from "@commonfabric/runner";
+import { linkRefInner } from "@commonfabric/runner/shared";
 import {
   cfcLabelViewForCell,
   redactCaveatSourcesForDisplay,
@@ -173,7 +174,7 @@ export function runtimeOptionsFromInitializationData(
 function formatCellLink(cell: Cell<unknown>): string {
   try {
     const link: SigilLink = cell.getAsLink();
-    const inner = link["/"]["link@1"];
+    const inner = linkRefInner(link);
     const pathStr = inner.path?.length ? `/${inner.path.join("/")}` : "";
     return `[Cell: ${inner.id ?? "?"}${pathStr}]`;
   } catch {

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -27,7 +27,7 @@ import {
   setPatternEnvironment,
   type SigilLink,
 } from "@commonfabric/runner";
-import { linkRefInner } from "@commonfabric/runner/shared";
+import { linkRefPayload } from "@commonfabric/runner/shared";
 import {
   cfcLabelViewForCell,
   redactCaveatSourcesForDisplay,
@@ -174,7 +174,7 @@ export function runtimeOptionsFromInitializationData(
 function formatCellLink(cell: Cell<unknown>): string {
   try {
     const link: SigilLink = cell.getAsLink();
-    const inner = linkRefInner(link);
+    const inner = linkRefPayload(link);
     const pathStr = inner.path?.length ? `/${inner.path.join("/")}` : "";
     return `[Cell: ${inner.id ?? "?"}${pathStr}]`;
   } catch {

--- a/packages/runtime-client/backends/utils.ts
+++ b/packages/runtime-client/backends/utils.ts
@@ -2,7 +2,7 @@ import { Cell, JSONSchema, parseLink, SigilLink } from "@commonfabric/runner";
 import { cfcLabelViewForCell } from "@commonfabric/runner/cfc";
 import { CellRef, PageRef } from "../protocol/types.ts";
 import { Runtime } from "@commonfabric/runner";
-import { LINK_V1_TAG } from "@commonfabric/runner/shared";
+import { linkRefFrom } from "@commonfabric/runner/shared";
 import { isCellRef } from "../protocol/mod.ts";
 
 export function mapCellRefsToSigilLinks(value: unknown): any {
@@ -26,21 +26,17 @@ export function mapCellRefsToSigilLinks(value: unknown): any {
 }
 
 export function cellRefToSigilLink(cell: CellRef): SigilLink {
-  return {
-    "/": {
-      [LINK_V1_TAG]: {
-        id: cell.id,
-        space: cell.space,
-        scope: cell.scope,
-        path: cell.path,
-        ...(cell.schema !== undefined && { schema: cell.schema }),
-        ...(cell.overwrite !== undefined && { overwrite: cell.overwrite }),
-        ...(cell.cfcLabelView !== undefined && {
-          cfcLabelView: cell.cfcLabelView,
-        }),
-      } as never,
-    },
-  };
+  return linkRefFrom({
+    id: cell.id,
+    space: cell.space,
+    scope: cell.scope,
+    path: cell.path,
+    ...(cell.schema !== undefined && { schema: cell.schema }),
+    ...(cell.overwrite !== undefined && { overwrite: cell.overwrite }),
+    ...(cell.cfcLabelView !== undefined && {
+      cfcLabelView: cell.cfcLabelView,
+    }),
+  } as never);
 }
 
 export function createCellRef(cell: Cell<unknown>, schema?: unknown): CellRef {

--- a/packages/runtime-client/backends/utils.ts
+++ b/packages/runtime-client/backends/utils.ts
@@ -3,6 +3,7 @@ import { cfcLabelViewForCell } from "@commonfabric/runner/cfc";
 import { CellRef, PageRef } from "../protocol/types.ts";
 import { Runtime } from "@commonfabric/runner";
 import { linkRefFrom } from "@commonfabric/runner/shared";
+import { type CfcCellLinkRefPayload } from "@commonfabric/runner/cfc";
 import { isCellRef } from "../protocol/mod.ts";
 
 export function mapCellRefsToSigilLinks(value: unknown): any {
@@ -26,7 +27,7 @@ export function mapCellRefsToSigilLinks(value: unknown): any {
 }
 
 export function cellRefToSigilLink(cell: CellRef): SigilLink {
-  return linkRefFrom({
+  return linkRefFrom<CfcCellLinkRefPayload>({
     id: cell.id,
     space: cell.space,
     scope: cell.scope,
@@ -36,7 +37,7 @@ export function cellRefToSigilLink(cell: CellRef): SigilLink {
     ...(cell.cfcLabelView !== undefined && {
       cfcLabelView: cell.cfcLabelView,
     }),
-  } as never);
+  });
 }
 
 export function createCellRef(cell: Cell<unknown>, schema?: unknown): CellRef {

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -7,7 +7,8 @@ import {
   isLegacyAlias,
   isSigilLink,
   type JSONSchema,
-  LINK_V1_TAG,
+  linkRefFrom,
+  linkRefInner,
   type SigilLink,
 } from "@commonfabric/runner/shared";
 import {
@@ -339,22 +340,18 @@ export class CellHandle<T = unknown> {
   toJSON(): SigilLink {
     // Wrap in sigil link format so the runtime recognizes this as a link
     // and dereferences it (e.g., when passed through event.detail.sourceCell)
-    return {
-      "/": {
-        [LINK_V1_TAG]: {
-          id: this.#ref.id,
-          space: this.#ref.space,
-          scope: this.#ref.scope,
-          path: this.#ref.path,
-          ...(this.#ref.schema !== undefined && { schema: this.#ref.schema }),
-          ...(this.#ref.overwrite !== undefined &&
-            { overwrite: this.#ref.overwrite }),
-          ...(this.#ref.cfcLabelView !== undefined && {
-            cfcLabelView: this.#ref.cfcLabelView,
-          }),
-        } as never,
-      },
-    };
+    return linkRefFrom({
+      id: this.#ref.id,
+      space: this.#ref.space,
+      scope: this.#ref.scope,
+      path: this.#ref.path,
+      ...(this.#ref.schema !== undefined && { schema: this.#ref.schema }),
+      ...(this.#ref.overwrite !== undefined &&
+        { overwrite: this.#ref.overwrite }),
+      ...(this.#ref.cfcLabelView !== undefined && {
+        cfcLabelView: this.#ref.cfcLabelView,
+      }),
+    } as never);
   }
 
   // Called when cell has been updated from the backend with
@@ -569,7 +566,7 @@ function parseAsCellRef(
   from: CellRef,
 ): CellRef | undefined {
   if (isSigilLink(value)) {
-    const linkData = value["/"][LINK_V1_TAG];
+    const linkData = linkRefInner(value);
 
     return {
       id: linkData.id ?? from.id,

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -8,7 +8,7 @@ import {
   isSigilLink,
   type JSONSchema,
   linkRefFrom,
-  linkRefInner,
+  linkRefPayload,
   type SigilLink,
 } from "@commonfabric/runner/shared";
 import {
@@ -567,7 +567,7 @@ function parseAsCellRef(
   from: CellRef,
 ): CellRef | undefined {
   if (isSigilLink(value)) {
-    const linkData = linkRefInner(value);
+    const linkData = linkRefPayload(value);
 
     return {
       id: linkData.id ?? from.id,

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -15,6 +15,7 @@ import {
   cfcLabelViewsEqual,
   rebaseCfcLabelView,
 } from "@commonfabric/runner/cfc/label-view-core";
+import { type CfcCellLinkRefPayload } from "@commonfabric/runner/cfc";
 import { $conn, type RuntimeClient } from "./runtime-client.ts";
 import { isRuntimeDisposedError } from "./shared/disposed-error.ts";
 import {
@@ -340,7 +341,7 @@ export class CellHandle<T = unknown> {
   toJSON(): SigilLink {
     // Wrap in sigil link format so the runtime recognizes this as a link
     // and dereferences it (e.g., when passed through event.detail.sourceCell)
-    return linkRefFrom({
+    return linkRefFrom<CfcCellLinkRefPayload>({
       id: this.#ref.id,
       space: this.#ref.space,
       scope: this.#ref.scope,
@@ -351,7 +352,7 @@ export class CellHandle<T = unknown> {
       ...(this.#ref.cfcLabelView !== undefined && {
         cfcLabelView: this.#ref.cfcLabelView,
       }),
-    } as never);
+    });
   }
 
   // Called when cell has been updated from the backend with


### PR DESCRIPTION
## What

Gathers every `{ "/": { "link@1": … } }` cell-link envelope site in the runtime
behind a single chokepoint in `data-model/cell-rep.ts` — `linkRefFrom` /
`isLinkRef` / `linkRefInner` (+ the `LINK_V1_TAG` literal, now owned here). After
the entity-ref / content-id arc (#4227–#4241), the `link@1` sigil was the **only**
remaining single-`/`-key `{ "/": … }` plain-object form in the tree (the
data-model JSON codec's `{ "/<type-tag>": … }` sigils are a different, opaque form
that intentionally stays).

This is **step 1 of a flag-dispatch wedge**, mirroring the entity-ref
`{ "/": string }` → `FabricHash` work: pure plumbing, **no behavior change**, no
flag dispatch yet. By funneling construction/recognition/extraction through these
three functions now, the eventual modern-cell-rep flip — dispatching the envelope
to a Fabric primitive (the provisional `FabricLink` class) — becomes a localized
edit in `cell-rep.ts` rather than a tree-wide change. The parallel:
`EntityRef`/`FabricHash` ↔ `LinkRef`/`FabricLink`.

## Commits

1. `a87a4a141` — introduce the chokepoint; `SigilLink` becomes a transitional
   `LinkRef<LinkV1Inner>` alias; tag relocated to cell-rep (still exported).
2. `0f88f59cc` — recognition: `isSigilLink` → `isLinkRef`; drop the dead local
   `isSigilValue`.
3. `2f5d13a20` — producers → `linkRefFrom` (`runner-utils`, `traverse`,
   `createSigilLinkFromParsedLink`).
4. `33c8cc099` — reach-in consumers → `linkRefInner` (`cell.ts`, `runtime.ts`,
   `data-updating.ts`).
5. `d1824d409` — rename `CellRef` → `LinkRef`. The first name collided with two
   sibling concepts one layer up (runner's `CellLink` union and runtime-client's
   `CellRef` normalized address); `LinkRef` is free and keeps the entity/link
   parallel.
6. `4aa96e9b2` — runtime-client (`cell-handle`, `backends/utils`,
   `backends/runtime-processor`) via a new `runner/shared` re-export.

## Out of scope (deliberately)

The fuse / toolshed / ui boundary recognizers that sniff *serialized* JSON at the
edge and hardcode `"link@1"` without coupling to the runtime. Whether edge code
should depend on the runtime chokepoint at all is a separate question.

## Follow-ups (separate PRs)

- Make `LINK_V1_TAG` fully private to `cell-rep.ts` (blocked on
  `link-resolution.ts`'s use of the tag as a JSON-pointer *path segment*, plus the
  `sigil-types.ts` type literals and test fixtures).
- The payoff: the `FabricLink` class + flag dispatch inside the three chokepoint
  functions (step 2 of the wedge).

## Verification

- Runner suite green (646 passed, 0 failed) at each runner-side step.
- Full workspace `deno task test` green ("All tests passing!", 134s) for the
  cross-package step — the `runtime-client` / `html` / `shell` link-resolution
  paths.
- `deno check` / `lint` / `fmt` clean throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145FPGZjJRRwpucbP6VR4aP

## Coverage Baseline

We accept the four new nominally-uncovered lines.

NEW_COVERAGE_BASELINE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes all `{ "/": { "link@1": … } }` link handling behind a `LinkRef` chokepoint in `@commonfabric/data-model` with `linkRefFrom`, `isLinkRef`, and `linkRefPayload`, and tightens types by bounding the payload to `FabricObject`. No behavior change; this sets up a clean seam for future flag-dispatch to a `FabricLink` primitive.

- **Refactors**
  - Data model: added `LINK_V1_TAG`, `LinkRef<Payload extends FabricObject>`, and `linkRefFrom` / `isLinkRef` / `linkRefPayload` in `data-model/cell-rep.ts`.
  - Runner: `isSigilLink` delegates to `isLinkRef`; producers use `linkRefFrom`; consumers read via `linkRefPayload`; renamed `LinkV1Inner` → `CellLinkRefPayload`; parameterized `SigilLink<P extends CellLinkRefPayload = CellLinkRefPayload>`.
  - CFC: new `cfc/link-label-view.ts` with `CfcCellLinkRefPayload`, `linkCfcLabelView`, and `setLinkCfcLabelView`; applied in `cell.ts`, `runtime.ts`, and `data-updating.ts` to replace inline casts and direct envelope indexing.
  - Re-exports and clients: chokepoint re-exported from `@commonfabric/runner/shared`; `runtime-client` (`cell-handle`, `backends/utils`, `backends/runtime-processor`) now uses `linkRefFrom` / `linkRefPayload`. Public surface remains stable: `SigilLink` is the same envelope via `LinkRef` (defaulting to `CellLinkRefPayload`) and `LINK_V1_TAG` stays re-exported.

<sup>Written for commit 94577ab2eb3a6497644ed0ccc6a43b7bc876c709. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

