### PR TITLE
fix(data-model): arm isDeepFrozenInProgress for FabricInstance private slots

### DIFF
--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -94,7 +94,19 @@ function isDeepFrozenInProgress(
 
   let result = true;
 
-  if (Array.isArray(obj)) {
+  if (obj instanceof FabricInstance) {
+    // A `FabricInstance`'s logical contents are not its enumerable own-props
+    // (e.g. a `FabricError` keeps its custom properties in a private extras
+    // `Map`), so it answers the deep-frozen question via its `[IS_DEEP_FROZEN]`
+    // protocol member -- the side-effect-free sibling of `[DEEP_FREEZE]` --
+    // recursing into each nested `FabricValue` through the callback so this
+    // call's cycle state is shared. Gating on `instanceof` against the abstract
+    // base keeps this generic; the member is abstract on `FabricInstance`, so
+    // every instance implements it. (A `FabricPrimitive` is necessarily frozen
+    // with no outbound references, so the `Object.values` arm below answers it
+    // correctly by accident -- its empty enumerable props yield `true`.)
+    result = obj[IS_DEEP_FROZEN]((v) => isDeepFrozenInProgress(v, inProgress));
+  } else if (Array.isArray(obj)) {
     for (let i = 0; i < obj.length; i++) {
       if (!(i in obj)) continue; // sparse hole
       if (!isDeepFrozenInProgress(obj[i], inProgress)) {
@@ -103,12 +115,6 @@ function isDeepFrozenInProgress(
       }
     }
   } else {
-    // TODO(danfuzz): Unlike its siblings `deepFreezeInProgress` and
-    // `isDeepFrozenFabricValue`, this checker has no `instanceof FabricInstance`
-    // arm delegating to `[IS_DEEP_FROZEN]`; a frozen-in-place `FabricInstance`
-    // is checked by its native/internal own-props instead of its logical
-    // contents, so it can return a wrong frozen-status (reached via
-    // `FabricError.deepClone`'s `isDeepFrozen(this)` fast path).
     for (const v of Object.values(obj)) {
       if (!isDeepFrozenInProgress(v, inProgress)) {
         result = false;

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -205,11 +205,13 @@ describe("deep-freeze", () => {
     // Coverage for `isDeepFrozen` on `FabricInstance` and `FabricPrimitive`
     // inputs, including a `FabricInstance` participating in a circular
     // reference. `isDeepFrozen` delegates to `isDeepFrozenInProgress` (which
-    // threads `inProgress: Set<object>` for cycle-safety) and treats a
-    // `FabricInstance` as a plain JS object whose enumerable values are
-    // recursively inspected; this is distinct from `isDeepFrozenFabricValue`'s
-    // protocol-aware type-guard semantics, which has its own coverage in the
-    // sibling `isDeepFrozenFabricValue with FabricInstance` describe below.
+    // threads `inProgress: Set<object>` for cycle-safety) and answers a
+    // `FabricInstance` via its `[IS_DEEP_FROZEN]` protocol member -- inspecting
+    // its logical contents, not its enumerable own-props -- so values held in
+    // non-enumerable slots (such as `FabricError`'s private extras `Map`) are
+    // checked too. (`isDeepFrozenFabricValue` uses the same protocol dispatch
+    // but additionally type-guards the value as a `FabricValue`; it has its own
+    // coverage in the sibling describe below.)
     describe("`FabricInstance` and `FabricPrimitive`", () => {
       it("returns `true` for a `FabricPrimitive` (self-frozen at construction)", () => {
         const epoch = new FabricEpochNsec(1234567890n);
@@ -237,6 +239,20 @@ describe("deep-freeze", () => {
         const fe = FabricError.fromNativeError(err);
         Object.freeze(fe);
         // Cause is not frozen -> recursive walk discovers an unfrozen child.
+        expect(isDeepFrozen(fe)).toBe(false);
+      });
+
+      it("returns `false` when an unfrozen value lives in a non-enumerable slot (extras bag)", () => {
+        // A `FabricInstance`'s logical contents are not all enumerable
+        // own-props: `FabricError` keeps its custom properties in a private
+        // extras `Map`. A generic `Object.values` walk can't see them, so the
+        // frozen-status must be answered via the instance's `[IS_DEEP_FROZEN]`
+        // protocol member, which inspects the extras bag. Here the wrapper is
+        // frozen and every enumerable slot is a frozen primitive, but the
+        // extras bag holds a mutable array -> not deep-frozen.
+        const fe = FabricError.fromNativeError(new Error("has-extras"));
+        fe.setExtra("payload", [1, 2, 3] as unknown as FabricValue);
+        Object.freeze(fe);
         expect(isDeepFrozen(fe)).toBe(false);
       });
 


### PR DESCRIPTION
## Summary

Fixes a frozen-status bug in `isDeepFrozenInProgress` (`data-model`): a
deep-frozen check on a `FabricInstance` walked its enumerable own-props instead
of its logical contents, so a frozen `FabricInstance` whose **non-enumerable
slots** held unfrozen values was wrongly reported deep-frozen.

This is the audit's §3.1.3 finding (see
`coordination/docs/2026-06-18-recursive-traversal-fabric-audit.md`). The fix
also removes the `TODO(danfuzz)` marker that #4253 placed at this site — the
mark is now resolved by construction.

## The bug

`isDeepFrozenInProgress` had no `instanceof FabricInstance` arm, unlike its two
siblings `deepFreezeInProgress` and `isDeepFrozenFabricValue`. It fell through
to the generic `Object.values(obj)` walk, which can't see a `FabricInstance`'s
logical contents held in private slots — e.g. `FabricError` keeps its custom
properties in a private extras `Map`. A frozen `FabricError` whose extras bag
held a mutable value would report `true` (deep-frozen) when it is not. This is
reachable via `FabricError.deepClone`'s `if (frozen && isDeepFrozen(this))
return this;` fast-path, which would then wrongly skip the clone.

## The fix

Add the lockstep `obj instanceof FabricInstance` arm that delegates to the
instance's `[IS_DEEP_FROZEN]` protocol member (the side-effect-free sibling of
`[DEEP_FREEZE]`), recursing into each nested `FabricValue` through the callback
so this call's `inProgress` cycle state is shared. Gating on `instanceof`
against the abstract base keeps it generic — `[IS_DEEP_FROZEN]` is abstract on
`FabricInstance`, so every instance implements it. (A `FabricPrimitive` is
necessarily frozen with no outbound references, so the existing `Object.values`
arm already answers it correctly.)

## The test

A red-green regression test: a frozen `FabricError` whose private extras `Map`
holds a mutable array — `isDeepFrozen` returned `true` before, returns `false`
now. RED-confirmed on `ebdf920b5`, GREEN after the fix.

## Scope

2-file diff (`deep-freeze.ts` + `deep-freeze.test.ts`), +34/-12. Targeted fix +
regression test; no other behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNv3rzpEfRtwZfzUy2edoT

Co-Authored-By: coder-cedar (Claude Opus 4.8 (1M context)) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deep-freeze checks in `data-model` so `FabricInstance` inspects its private slots, avoiding false “deep-frozen” results. Prevents `FabricError.deepClone` from skipping clones when internals aren’t fully frozen.

- **Bug Fixes**
  - Added `obj instanceof FabricInstance` branch in `isDeepFrozenInProgress` delegating to `[IS_DEEP_FROZEN]`, sharing the `inProgress` cycle state.
  - Now inspects non-enumerable slots (e.g., `FabricError` extras `Map`), not just enumerable props.
  - Added regression test: a frozen `FabricError` with a mutable extras array now returns `false`.

<sup>Written for commit c894aee6a0325f25c31f0d879b63ff24fc0e59a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

