### PR TITLE
refactor(memory): prune v1-only dead code stranded by the v1 stack removal

### DIFF
--- a/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
+++ b/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
@@ -38,7 +38,7 @@ hardening of module-scope definitions at load time.
 4. **Safe Top-Level Functions**: Standalone top-level functions are allowed
    only when they are direct functions.
 5. **Verified Module-Safe Data**: Any other top-level value must be proven to
-   be a versioned, recursively inert subset of `StorableValue` and then
+   be a versioned, recursively inert subset of `FabricValue` and then
    hardened by a custom checker/freezer. Computing that value via an IIFE is
    allowed only if the final result passes this verifier. Transitional explicit
    snapshot helpers such as `safeDateNow()` and `nonPrivateRandom()` are
@@ -356,7 +356,7 @@ stable SES contract. Pattern authors should call `safeDateNow()` and
 explicit narrow exceptions that yield plain data snapshots.
 
 Version 1 of the allowed domain is a deliberate subset of
-`@commonfabric/memory`'s `StorableValue`:
+`@commonfabric/memory`'s `FabricValue`:
 
 - `null`
 - `undefined`
@@ -373,9 +373,9 @@ Version 1 of the allowed domain is a deliberate subset of
 - exact intrinsic `Set` instances whose elements are allowed values
 
 Future widening of this set beyond the above, including temporal primitives or
-other richer `StorableValue` members, requires an explicit spec revision and
+other richer `FabricValue` members, requires an explicit spec revision and
 validator version bump. The v1 verifier MUST NOT silently widen with upstream
-`StorableValue` changes.
+`FabricValue` changes.
 
 This boundary is about executable behavior and authority, not about forcing
 author data into a JSON-like normal form. Sparse arrays, symbol keys, cyclic
@@ -1064,7 +1064,7 @@ must:
 - recursively validate `Map` keys and values and `Set` values
 - reject intrinsic `RegExp` instances whose `global` or `sticky` flags make
   `lastIndex` observable mutable state
-- reject any `StorableValue` members outside the approved v1 subset
+- reject any `FabricValue` members outside the approved v1 subset
 - allow shape-level cases such as sparse arrays, symbol keys, cycles, reserved
   property names, non-finite numbers, and extra own data properties if the
   surviving snapshot is inert
@@ -1811,10 +1811,10 @@ fail closed.
 #### 2.2 Add custom module-safe-data checker/freezer (Priority: High)
 
 Implement a runtime helper that proves a value is a versioned, recursively inert
-subset of `StorableValue` and then hardens it. This helper is stricter than
+subset of `FabricValue` and then hardens it. This helper is stricter than
 `harden()` alone and stricter than Endo pass-style checks. It must reject
 unsupported runtime kinds such as exotic/custom prototypes and non-approved
-`StorableValue` members, preserve accepted `Map` / `Set` contents while
+`FabricValue` members, preserve accepted `Map` / `Set` contents while
 converting the surviving collection object to immutable semantics rather than
 relying on `harden()` alone, and ensure that the value which escapes module
 load is recursively inert. Shape-level cases such as cycles, symbol keys,

--- a/packages/memory/acl.ts
+++ b/packages/memory/acl.ts
@@ -1,24 +1,8 @@
 import { isRecord } from "@commonfabric/utils/types";
-import {
-  ACL,
-  ACLUser,
-  ANYONE,
-  Capability,
-  DID,
-  DIDKey,
-  MIME,
-} from "./interface.ts";
+import { ACL, ACLUser, ANYONE, Capability, DID, DIDKey } from "./interface.ts";
 import { isDID } from "../identity/src/interface.ts";
 
 export type { ACL, ACLUser, ANYONE, Capability, DID, DIDKey };
-
-/**
- * Well-known MIME type for the Access Control List
- *
- * Syncing requires `"application/json"`, but could be e.g.
- * `"application/acl+json"` in the future.
- */
-export const ACL_TYPE: MIME = "application/json" as const;
 
 export const ANYONE_USER: ANYONE = "*";
 

--- a/packages/memory/fact.ts
+++ b/packages/memory/fact.ts
@@ -4,11 +4,9 @@ import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
 import {
   Assertion,
   Fact,
-  FactSelection,
   Invariant,
   MIME,
   Retraction,
-  Revision,
   State,
   Unclaimed,
 } from "./interface.ts";
@@ -85,37 +83,11 @@ export const retract = (assertion: Assertion): Retraction => ({
   cause: hashOf(normalizeFact(assertion)),
 });
 
-export const claim = (fact: Fact): Invariant => ({
-  the: fact.the,
-  of: fact.of,
-  fact: hashOf(normalizeFact(fact)),
-});
-
 export const claimState = (state: State): Invariant => ({
   the: state.the,
   of: state.of,
   fact: hashOf(state.cause ? normalizeFact(state) : unclaimed(state)),
 });
-
-export const iterate = function* (
-  selection: FactSelection,
-): Iterable<Revision<Fact>> {
-  for (const [of, attributes] of Object.entries(selection)) {
-    for (const [the, changes] of Object.entries(attributes)) {
-      const [change] = Object.entries(changes);
-      if (change) {
-        const [cause, { is, since }] = change;
-        yield {
-          the: the as MIME,
-          of: of as URI,
-          cause: FabricHash.fromString(cause),
-          since,
-          ...(is ? { is } : undefined),
-        };
-      }
-    }
-  }
-};
 
 // Take an object that is loosely a fact (specifically, its cause might not
 // conform), and convert it to a proper fact.
@@ -193,7 +165,3 @@ export function normalizeFact<
     }) as Retraction<T, Of, Is>;
   }
 }
-
-export const factReference = (fact: Fact): FabricHash => {
-  return hashOf(normalizeFact(fact));
-};

--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -4,21 +4,9 @@ import type { FabricHash } from "@commonfabric/data-model/fabric-primitives";
 import type { SchemaPathSelector } from "@commonfabric/api";
 export type { SchemaPathSelector };
 
-// Backward-compat aliases for branches that still import the older storage
-// naming from the memory package surface.
-export type StorableDatum = FabricValue;
-export type StorableValue = FabricValue;
 export type { FabricValue };
 
 export type { JSONValue };
-export interface Clock {
-  now(): UTCUnixTimestampInSeconds;
-}
-
-export type SubscriberCommand = {
-  watch?: Query;
-  unwatch?: Query;
-};
 
 /**
  * Some principal identified via DID identifier.
@@ -86,17 +74,6 @@ export interface AuthorizationError extends Error {
   name: "AuthorizationError";
 }
 
-export type Call<
-  Ability extends string = The,
-  Of extends DID = DID,
-  Args extends NonNullable<unknown> = NonNullable<unknown>,
-> = {
-  cmd: Ability;
-  sub: Of;
-  args: Command;
-  nonce?: Uint8Array;
-};
-
 export type Command<
   Ability extends string = The,
   Of extends DID = DID,
@@ -134,7 +111,6 @@ export type Invocation<
 export type Delegation = never;
 
 export type UTCUnixTimestampInSeconds = number;
-export type Seconds = number;
 
 export type Protocol<Space extends MemorySpace = MemorySpace> = {
   [Subject in Space]: {
@@ -266,30 +242,6 @@ type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends
   (k: infer I) => void ? I
   : never;
 
-export type Provider<Protocol extends NonNullable<unknown>> = {
-  perform(command: ProviderCommand<Protocol>): AwaitResult<Unit, SystemError>;
-};
-
-export interface ConsumerSession<TheProtocol extends Proto>
-  extends
-    TransformStream<
-      ProviderCommand<Protocol>,
-      UCAN<ConsumerCommandInvocation<Protocol>>
-    > {
-}
-
-export interface ProviderChannel<Protocol extends Proto>
-  extends
-    TransformStream<
-      UCAN<ConsumerCommandInvocation<Protocol>>,
-      ProviderCommand<Protocol>
-    > {
-}
-export interface ProviderSession<Protocol extends Proto>
-  extends ProviderChannel<Protocol> {
-  close(): CloseResult;
-}
-
 export type ProviderCommand<Protocol extends Proto> =
   ProtocolMethod<Protocol> extends {
     ProviderCommand: Receipt<infer Command, infer Result, infer Effect>;
@@ -314,54 +266,6 @@ export type ConsumerCommandInvocation<
 } ? Method["ConsumerInvocation"]
   : never;
 
-export type ConsumerCommandFor<Ability, Protocol extends Proto> =
-  & MethodFor<
-    Ability,
-    Protocol
-  >["ConsumerCommand"]
-  & { cmd: Ability };
-
-export type ProviderCommandFor<Ability, Protocol extends Proto> = MethodFor<
-  Ability,
-  Protocol
->["ProviderCommand"];
-
-export type ConsumerInvocationFor<Ability, Protocol extends Proto> =
-  & MethodFor<
-    Ability,
-    Protocol
-  >["ConsumerInvocation"]
-  & { cmd: Ability };
-
-export type ConsumerInputFor<Ability, Protocol extends Proto> = MethodFor<
-  Ability,
-  Protocol
->["In"];
-
-export type ConsumerEffectFor<Ability, Protocol extends Proto> = MethodFor<
-  Ability,
-  Protocol
->["Effect"];
-
-export type ConsumerSpaceFor<Ability, Protocol extends Proto> = MethodFor<
-  Ability,
-  Protocol
->["Of"];
-
-export type MethodFor<
-  Ability,
-  Protocol extends Proto,
-  Case = ProtocolMethod<Protocol>,
-> = Case extends
-  Method<Protocol, Ability & The, infer In, infer Out, infer Effect>
-  ? Method<Protocol, Ability & The, In, Out, Effect>
-  : never;
-
-export type ConsumerResultFor<Ability, Protocol extends Proto> = MethodFor<
-  Ability,
-  Protocol
->["Out"];
-
 export interface InvocationView<
   Source extends Invocation,
   Return extends NonNullable<unknown>,
@@ -375,32 +279,6 @@ export interface InvocationView<
 }
 
 export type Task<Return, Command = never> = Iterable<Command, Return>;
-
-export type Job<
-  Command extends NonNullable<unknown> = NonNullable<unknown>,
-  Return extends FabricValue = FabricValue,
-  Effect = unknown,
-> = {
-  invoke: Command;
-  return: Return;
-  effect: Effect;
-};
-
-export type WatchTask<Space extends MemorySpace> = Job<
-  { watch: Query<Space>; unwatch?: undefined },
-  QueryResult<Space>,
-  Transaction<Space>
->;
-
-export type UnwatchTask<Space extends MemorySpace> = Job<
-  { unwatch: Query<Space>; watch?: undefined },
-  Unit,
-  never
->;
-
-export type SessionTask<Space extends MemorySpace> =
-  | UnwatchTask<Space>
-  | WatchTask<Space>;
 
 export type Receipt<
   Command extends NonNullable<unknown>,
@@ -434,90 +312,6 @@ export type Return<
   run?: undefined;
 };
 
-export type SubscriptionCommand<Space extends MemorySpace = MemorySpace> = {
-  transact?: Transaction<Space>;
-  brief?: Brief<Space>;
-};
-
-export type Brief<Space extends MemorySpace = MemorySpace> = {
-  sub: Space;
-  args: {
-    selector: Selector;
-    selection: Selection<Space>;
-  };
-  meta?: Meta;
-};
-
-export interface Session<Space extends MemorySpace = MemorySpace> {
-  /**
-   * Transacts can be used to assert or retract a document from the repository.
-   * If `version` asserted / retracted does not match version of the document
-   * transaction fails with `ConflictError`. Otherwise document is updated to
-   * the new value.
-   */
-  transact(transact: Transaction<Space>): TransactionResult<Space>;
-
-  /**
-   * Queries space for matching entities based on provided selector.
-   */
-  query(source: Query<Space>): QueryResult<Space>;
-
-  /**
-   * Queries space for matching entities based on provided selector.
-   */
-  querySchema(source: SchemaQuery<Space>): QueryResult<Space>;
-
-  close(): CloseResult;
-}
-
-export interface SpaceSession<Space extends MemorySpace = MemorySpace>
-  extends Session {
-  subject: Space;
-
-  transact(
-    transact: Transaction<Space>,
-  ): Result<Commit<Space>, ConflictError | TransactionError>;
-  query(source: Query<Space>): Result<Selection<Space>, QueryError>;
-  close(): Result<Unit, SystemError>;
-}
-
-export interface MemorySession<Space extends MemorySpace = MemorySpace>
-  extends Session<Space> {
-  subscribe(subscriber: Subscriber<Space>): SubscribeResult;
-  unsubscribe(subscriber: Subscriber<Space>): SubscribeResult;
-  serviceDid(): DID;
-}
-
-export interface Subscriber<Space extends MemorySpace = MemorySpace> {
-  /**
-   * Notifies a subscriber of a commit that has been applied.
-   *
-   * @param commit - The commit data to be processed and broadcast to listeners.
-   * @param labels - Label facts associated with documents in this commit. Used
-   *   to redact classified content before broadcasting to listeners who lack the
-   *   appropriate claims.
-   */
-  commit(
-    commit: Commit<Space>,
-    labels?: FactSelection,
-  ): AwaitResult<Unit, SystemError>;
-
-  close(): AwaitResult<Unit, SystemError>;
-}
-
-export type SubscribeResult = AwaitResult<Unit, SystemError>;
-
-/**
- * Represents a subscription controller that can be used to publish commands or
- * to close subscription.
- */
-export interface SubscriptionController {
-  open: boolean;
-  close(): void;
-  transact(source: Transaction): void;
-  brief(source: Brief): void;
-}
-
 /**
  * Unique identifier for the memory space.
  */
@@ -538,11 +332,6 @@ export type The = MIME;
 export type InvocationURL<T> = `job:${string}` & {
   toString(): InvocationURL<T>;
 };
-
-export interface FactAddress {
-  the: MIME;
-  of: URI;
-}
 
 /**
  * Describes not yet claimed memory. It describes a lack of fact about memory.
@@ -631,24 +420,6 @@ export type State = Fact | Unclaimed;
 
 export type Revision<T = Unit> = T & { since: number };
 
-export type Assert = {
-  assert: Assertion;
-  retract?: undefined;
-  claim?: undefined;
-};
-
-export type Retract = {
-  retract: Retraction;
-  assert?: undefined;
-  claim?: undefined;
-};
-
-export type Claim = {
-  claim: Invariant;
-  assert?: undefined;
-  retract?: undefined;
-};
-
 // This is essentially an OfTheCause tree with one special record whose value is another OfTheCause tree.
 export type Commit<Subject extends string = MemorySpace> = {
   [of in Subject]: {
@@ -670,12 +441,6 @@ export type CommitData = {
   transaction: Transaction;
 };
 
-export type CommitFact<Subject extends MemorySpace = MemorySpace> = Assertion<
-  "application/commit+json",
-  Subject,
-  CommitData
->;
-
 // This allows a consumer to check that their entities match the current cause
 // state before making local changes that would be discarded on conflict.
 export type ClaimFact = true;
@@ -685,14 +450,6 @@ export type ClaimFact = true;
 // and previously defaulted to `JSONValue`).
 export type RetractFact = { is?: void };
 export type AssertFact<Is extends FabricValue = FabricValue> = { is: Is };
-// This is the structure of a bunch of our objects
-export type OfTheCause<T> = {
-  [of in URI]: {
-    [the in MIME]: {
-      [cause in CauseString]: T;
-    };
-  };
-};
 
 export type Changes<
   T extends string = MIME,
@@ -758,12 +515,6 @@ export type Transaction<Space extends MemorySpace = MemorySpace> = Invocation<
   Space,
   { changes: Changes }
 >;
-
-export type TransactionResult<Space extends MemorySpace = MemorySpace> =
-  AwaitResult<
-    Commit<Space>,
-    ConflictError | TransactionError | ConnectionError | AuthorizationError
-  >;
 
 export type QueryArgs = { select: Selector; since?: number };
 
@@ -837,26 +588,6 @@ export type Operation =
   | Subscribe
   | Unsubscribe;
 
-export type QueryResult<Space extends MemorySpace = MemorySpace> = AwaitResult<
-  Selection<Space>,
-  AuthorizationError | QueryError | ConnectionError
->;
-
-export type CloseResult = AwaitResult<Unit, SystemError>;
-
-export type WatchResult = AwaitResult<Unit, QueryError | ConnectionError>;
-
-export type SubscriptionQuery = {
-  iss: DID;
-  sub: MemorySpace;
-  cmd: "/memory/query";
-  args: {
-    select: Selector;
-    since?: number;
-  };
-};
-
-export type SelectAll = "_";
 export type Select<Key extends string, Match> =
   & {
     [key in Key]: Match;
@@ -948,10 +679,6 @@ export type Conflict = {
    * Actual history
    */
   history: Revision<Fact>[];
-};
-
-export type ToJSON<T> = T & {
-  toJSON(): T;
 };
 
 export interface ConflictError extends Error {

--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -1,12 +1,10 @@
-import type { FabricValue, JSONValue } from "@commonfabric/api";
+import type { FabricValue } from "@commonfabric/api";
 import type { FabricHash } from "@commonfabric/data-model/fabric-primitives";
 
 import type { SchemaPathSelector } from "@commonfabric/api";
 export type { SchemaPathSelector };
 
 export type { FabricValue };
-
-export type { JSONValue };
 
 /**
  * Some principal identified via DID identifier.
@@ -428,8 +426,7 @@ export type CommitData = {
 export type ClaimFact = true;
 
 // ⚠️ Note we use `void` as opposed to `undefined` because the latter makes it
-// incompatible with the `Is` type parameter (which defaults to `FabricValue`
-// and previously defaulted to `JSONValue`).
+// incompatible with the `Is` type parameter (which defaults to `FabricValue`).
 export type RetractFact = { is?: void };
 export type AssertFact<Is extends FabricValue = FabricValue> = { is: Is };
 

--- a/packages/memory/interface.ts
+++ b/packages/memory/interface.ts
@@ -15,15 +15,6 @@ export interface Principal<ID extends DID = DID> {
   did(): ID;
 }
 
-/**
- * Principal capable of issuing an {@link Authorization}.
- */
-export interface Authority extends Principal {
-  authorize<T extends FabricValue>(
-    access: Iterable<FabricHash | T>,
-  ): AwaitResult<Authorization<T>, AuthorizationError>;
-}
-
 export interface Verifier<ID extends DID = DID> extends Principal<ID> {
   verify(authorization: {
     payload: Uint8Array;
@@ -354,11 +345,8 @@ export interface Unclaimed<T extends string = MIME, Of extends string = URI> {
 }
 
 /**
- * `Assertion` is just like a {@link Statement} except the value MUST be inline
- * {@link FabricValue} as opposed to reference to one. {@link Assertion}s are
- * used to assert facts, while {@link Statement}s are used to retract them. This
- * allows retracting over the wire without having to send JSON values back and
- * forth.
+ * Asserts a fact: the value MUST be an inline {@link FabricValue} as opposed to
+ * a reference to one.
  */
 export interface Assertion<
   T extends string = MIME,
@@ -409,12 +397,6 @@ export type Fact<
   Of extends string = URI,
   Is extends FabricValue = FabricValue,
 > = Assertion<T, Of, Is> | Retraction<T, Of, Is>;
-
-export type Statement<
-  T extends string = MIME,
-  Of extends string = URI,
-  Is extends FabricValue = FabricValue,
-> = Assertion<T, Of, Is> | Retraction<T, Of, Is> | Invariant<T, Of, Is>;
 
 export type State = Fact | Unclaimed;
 
@@ -580,13 +562,6 @@ export type SchemaSelector = Select<
   URI,
   Select<MIME, Select<CauseString, SchemaPathSelector>>
 >;
-
-export type Operation =
-  | Transaction
-  | Query
-  | SchemaQuery
-  | Subscribe
-  | Unsubscribe;
 
 export type Select<Key extends string, Match> =
   & {

--- a/packages/memory/lib.ts
+++ b/packages/memory/lib.ts
@@ -1,8 +1,2 @@
 export * from "./interface.ts";
-export * as Type from "./interface.ts";
-export * as Fact from "./fact.ts";
-export * as V2 from "./v2.ts";
-export * as V2Client from "./v2/client.ts";
-export * as V2Engine from "./v2/engine.ts";
-export * as V2Server from "./v2/server.ts";
 export * from "./acl.ts";

--- a/packages/memory/util.ts
+++ b/packages/memory/util.ts
@@ -1,18 +1,5 @@
-import * as Path from "@std/path";
 import { AsyncResult, DID, DIDKey } from "./interface.ts";
 import { VerifierIdentity } from "@commonfabric/identity";
-
-/**
- * Returns file URL for the current working directory.
- */
-export const baseURL = () => asDirectory(Path.toFileUrl(Deno.cwd()));
-
-export const createTemporaryDirectory = async () =>
-  asDirectory(Path.toFileUrl(await Deno.makeTempDir()));
-
-export const asDirectory = (
-  url: URL,
-) => (url.href.endsWith("/") ? url : new URL(`${url.href}/`));
 
 const DID_PREFIX = "did:";
 const DID_KEY_PREFIX = `did:key:`;


### PR DESCRIPTION
Follow-on to #4236 (which retired the memory v1 stack). Removing the v1 modules left a sizable surface of exported symbols in the *kept* files (`interface.ts`, `fact.ts`, `acl.ts`, `util.ts`) referenced only by the now-deleted v1 code — dead, but not flagged by the compiler since they were still exported. This branch prunes that residue and the now-unused barrel namespace re-exports, then fixes the one doc that referenced a removed symbol.

Net: **−365 lines** across 6 files. The entire **v2 stack is untouched** (treated as nascent, not dead).

### What was removed

- **`interface.ts` (~46 symbols)** — the v1 consumer/provider protocol layer: `Provider`, `ConsumerSession`, `Provider{Channel,Session}`, the `Consumer*For`/`ProviderCommandFor`/`MethodFor` cluster, `Session`/`SpaceSession`/`MemorySession`/`Subscriber`/`Subscription*`/`SubscribeResult`, `Watch/Unwatch/SessionTask`/`Job`, `Brief`, `Call`, `Assert`/`Retract`/`Claim`, `Clock`, `SubscriberCommand`, `FactAddress`, `CommitFact`, `OfTheCause`, `TransactionResult`, `QueryResult`, `CloseResult`, `WatchResult`, `SelectAll`, `ToJSON`, `Seconds`, `Operation`, `Statement`, `Authority`, and the `StorableDatum`/`StorableValue` back-compat aliases.
- **`fact.ts`** — `claim`, `iterate`, `factReference` (live surface `assert`/`unclaimed`/`retract`/`claimState`/`normalizeFact` stays).
- **`acl.ts`** — `ACL_TYPE` (`isACL`/`isCapable` kept — used by `v2/server.ts`).
- **`util.ts`** — `baseURL`, `createTemporaryDirectory`, `asDirectory` (`fromDID` stays).
- **`lib.ts`** — the six unused namespace re-exports (`Type`/`Fact`/`V2`/`V2Client`/`V2Engine`/`V2Server`); consumers reach fact.ts and v2 via their dedicated `deno.json` subpaths, and interface.ts types via the flat `export *`.

A second, block-comment-aware reachability pass caught three more (`Operation`, `Statement`, `Authority`) that survived the first pass only via `{@link}` mentions in doc comments.

### Docs

- `docs/specs/sandboxing/SES_SANDBOXING_SPEC.md` named "`@commonfabric/memory`'s `StorableValue`" (8×). Retargeted to `FabricValue` — the type the removed alias resolved to, still re-exported by `@commonfabric/memory`.
- Deliberately left alone (self-contained spec vocabulary / live v2 symbols, **not** references to removed code): `MemorySession` and `CommitFact` in the memory-v2/verifiable-execution specs, and `Operation`/`QueryResult`/`SpaceSession` which name live **v2** types.

### Verification

- Workspace `deno task check` — **clean** (exit 0); no consumer references any removed symbol.
- Memory `check` / `fmt` / `lint` — clean.
- Memory tests — **212 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes v1-only exports and helpers left after the v1 stack removal, drops unused barrel namespace re-exports, and removes the dead `JSONValue` re-export to shrink the public surface. V2 code is untouched.

- **Refactors**
  - Removed v1 protocol-layer types and utilities from `interface.ts`, `fact.ts`, `acl.ts`, and `util.ts` (e.g., Provider/Consumer/Session types, subscription and job types, `claim`/`iterate`/`factReference`, `ACL_TYPE`, temp-dir helpers).
  - Dropped unused namespace re-exports from `lib.ts`; consumers use subpath exports and flat `export *` instead.
  - Removed the unused `JSONValue` re-export from `interface.ts` and trimmed the related comment.
  - Kept live API only (`assert`, `unclaimed`, `retract`, `claimState`, `normalizeFact`, `isACL`, `isCapable`, and all v2 modules).

- **Docs**
  - Replaced `StorableValue` with `FabricValue` in `docs/specs/sandboxing/SES_SANDBOXING_SPEC.md` to match the current `@commonfabric/memory` surface.

<sup>Written for commit bba46c39a97de55e67683c8af58997c863547588. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

