### PR TITLE
revert(lunch-poll): drop isAdmin art-gate workaround + add regression coverage

### DIFF
--- a/packages/patterns/lunch-poll/poll-option-card.test.tsx
+++ b/packages/patterns/lunch-poll/poll-option-card.test.tsx
@@ -166,6 +166,32 @@ export default pattern(() => {
     setOptionHomePageUrl,
     setOptionImage,
   });
+  // Host viewing an option with no stored image — the one combination that
+  // should open the generated-art gate. This is exactly what the transformer
+  // dependency-capture bug silently broke: `isAdmin` was dropped from the lift
+  // schema, read `undefined` at runtime, so `!isAdmin` was always true and the
+  // request URL came back "". The cards above don't exercise it (stored image →
+  // the gate short-circuits earlier; non-host → gate shut by design).
+  const hostNoImageCard = PollOptionCard({
+    option: EMPTY_IMAGE_OPTION,
+    rank: 3,
+    me: "Alex",
+    isJoined: true,
+    isAdmin: true,
+    votes,
+    cityLabel: "Berkeley, CA",
+    searchEndpoint: "",
+    homePageRefresh,
+    linkEditTarget,
+    linkDraft,
+    removeConfirmTarget,
+    castVote,
+    removeOption,
+    logVisit,
+    setOptionUrl,
+    setOptionHomePageUrl,
+    setOptionImage,
+  });
 
   const assert_my_green_vote_label_renders = computed(() =>
     findNodeByProp(
@@ -225,8 +251,21 @@ export default pattern(() => {
   const assert_host_did_not_rewrite_stored_art = computed(() =>
     lastImageUrl.get() === ""
   );
-  const assert_missing_art_is_not_marked_stored = computed(() =>
-    propValue(noImageViewerCard[UI], "data-art-sync") !== "stored"
+  // Regression guard for the isAdmin dependency-capture bug: a host viewing an
+  // option with no stored image must open the art gate and produce a non-empty
+  // request URL. With the bug, `isAdmin` read `undefined`, the gate stayed shut,
+  // and the URL was "" — so `/api/ai/img` never fired and no thumbnail rendered.
+  // `generatedArtRequestUrl` is the gate's direct, fetch-independent signal (it
+  // does not depend on the `fetchData` result, which is unobservable in the
+  // pattern-test harness — see the PR description).
+  const assert_host_requests_art_for_missing_image = computed(() =>
+    hostNoImageCard.generatedArtRequestUrl !== ""
+  );
+  // The non-host viewer must NOT request art even with no stored image — the
+  // gate is shut by `isAdmin`. (Previously asserted `data-art-sync !== "stored"`,
+  // which read `undefined` and so passed vacuously.)
+  const assert_viewer_does_not_request_art = computed(() =>
+    noImageViewerCard.generatedArtRequestUrl === ""
   );
 
   return {
@@ -237,7 +276,8 @@ export default pattern(() => {
       { assertion: assert_host_controls_render },
       { assertion: assert_stored_art_renders },
       { assertion: assert_host_did_not_rewrite_stored_art },
-      { assertion: assert_missing_art_is_not_marked_stored },
+      { assertion: assert_viewer_does_not_request_art },
+      { assertion: assert_host_requests_art_for_missing_image },
     ],
     card,
   };

--- a/packages/patterns/lunch-poll/poll-option-card.tsx
+++ b/packages/patterns/lunch-poll/poll-option-card.tsx
@@ -79,21 +79,6 @@ const homePageLookupUrlFor = (
     ? endpoint
     : "";
 
-// Host-only art-generation gate. Passing `isAdmin` as a function argument
-// (rather than a bare `!isAdmin` inside a computed) ensures the transformer
-// captures it as a lift input — see homePageLookupUrlFor for the same idiom.
-const mayGenerateArt = (
-  isAdmin: boolean,
-  storedImageUrl: string | undefined,
-): boolean => isAdmin && !safeImageUrl(storedImageUrl);
-
-const artRequestUrlFor = (
-  isAdmin: boolean,
-  storedImageUrl: string | undefined,
-  title: string,
-): string =>
-  mayGenerateArt(isAdmin, storedImageUrl) ? generatedImageUrlFor(title) : "";
-
 const homePageVerifierSystem =
   "You verify restaurant website search results. Choose the restaurant's own " +
   "official website only when it is clear from the candidate URL, title, and " +
@@ -269,9 +254,11 @@ export default pattern<PollOptionCardInput, PollOptionCardOutput>(
     const storedImageDisplay = computed(() =>
       safeImageUrl(option.imageUrl) ? "block" : "none"
     );
-    const generatedArtRequestUrl = computed(() =>
-      artRequestUrlFor(isAdmin, option.imageUrl, option.title)
-    );
+    const generatedArtRequestUrl = computed(() => {
+      if (safeImageUrl(option.imageUrl)) return "";
+      if (!isAdmin) return "";
+      return generatedImageUrlFor(option.title);
+    });
     const generatedArt = fetchData<string>({
       url: generatedArtRequestUrl,
       mode: "dataUrl",
@@ -284,7 +271,7 @@ export default pattern<PollOptionCardInput, PollOptionCardOutput>(
     // URL. Other viewers render the stored value without running image-gen.
     const artSyncState = computed(() => {
       if (safeImageUrl(option.imageUrl)) return "stored";
-      if (!mayGenerateArt(isAdmin, option.imageUrl)) return "";
+      if (!isAdmin) return "";
       const generatedUrl = safeImageUrl(generatedArt.result ?? "");
       if (generatedUrl) {
         setOptionImage.send({

--- a/packages/patterns/lunch-poll/poll-option-card.tsx
+++ b/packages/patterns/lunch-poll/poll-option-card.tsx
@@ -219,6 +219,16 @@ export interface PollOptionCardOutput {
   /** Admin-side generated art persistence state. */
   artSyncState: PollOptionArtSyncState;
 
+  /**
+   * The art-generation request URL the host-only gate produces: the
+   * `/api/ai/img` endpoint when a host views an option with no stored image,
+   * and `""` otherwise (non-host, or a stored image already present). Unlike
+   * `artSyncState` this does not depend on the `fetchData` result, so it is the
+   * directly-observable signal that the `isAdmin` gate opened — exposed so tests
+   * can guard the dependency-capture fix without a live image endpoint.
+   */
+  generatedArtRequestUrl: string;
+
   /** Display homepage URL after stored, edited, or verified lookup resolution. */
   homePageUrl: string;
 }
@@ -704,6 +714,7 @@ export default pattern<PollOptionCardInput, PollOptionCardOutput>(
         </div>
       ),
       artSyncState,
+      generatedArtRequestUrl,
       homePageUrl: displayHomePageUrl,
     };
   },


### PR DESCRIPTION
## What

Now that the underlying transformer dependency-capture bug is fixed upstream in #4244, this removes the pattern-side workaround Dan added in #4235 and replaces it with direct regression coverage for the bug it papered over.

- **Drop the workaround** — reverts #4235's `mayGenerateArt` / `artRequestUrlFor` helper indirection back to the natural bare `!isAdmin` form. The transformer now captures `isAdmin` as a lift input on its own (verified: both `generatedArtRequestUrl` and `artSyncState` emit `required: ["option", "isAdmin"]`).
- **Add regression coverage** — exercises the exact combination the bug broke and guards against its return.

## Background

#4235 worked around a transformer bug where a captured reactive prop read only in a boolean-condition position (`!isAdmin`) was dropped from the emitted lift input schema → `undefined` at runtime → the host-only generated-art gate stayed shut and `/api/ai/img` never fired. #4244 fixed the root cause (the capability analysis now sees through synthetic `any` params). With that in, the workaround is dead weight.

## The new test

The bug's downstream signals (`artSyncState`, the `setOptionImage` persist) all flow through a `fetchData` **result**, and **fetchData-result-gated computeds do not materialize in the pattern-test harness** — even the stored-image card's `artSyncState` reads back `undefined`, with or without a fetch mock. So rather than try to settle a live/mocked fetch, the test observes `generatedArtRequestUrl` — the gate's **direct, fetch-independent** signal (it depends only on `isAdmin + option`), newly exposed as a card output alongside the already-exposed `artSyncState`:

```
host + empty image → generatedArtRequestUrl !== ""   (gate opens)      [regression guard]
non-host + empty   → generatedArtRequestUrl === ""   (gate stays shut)
```

Verified **load-bearing**: reverting #4244 (simulating the bug) flips the host assertion red (URL `""`); restoring it flips it green. This also replaces the prior `data-art-sync !== "stored"` assertion, which read `undefined` from the same fetchData-gated computed and so **passed vacuously**.

## The harness gap (follow-up)

The inability to assert on anything downstream of `fetchData` in pattern-tests is a general harness limitation, not specific to this bug. I prototyped a host-side fetch-mock + real-time drain in the test-runner; it made the request fire but could not make the result observable (the result-gated lift never materializes). That investigation — whether the harness can be updated to support fetch mocking + observing fetchData results — is tracked separately (Linear, CommonTools).

## Tests

- `lunch-poll` runtime pattern-tests: all 6 files pass on the bare form.
- New regression assertion verified red↔green against the presence/absence of the #4244 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `isAdmin` art-gate workaround in lunch-poll and restores the simple gate now that the transformer correctly captures `isAdmin`. Adds targeted regression coverage by exposing `generatedArtRequestUrl` so tests can assert the host-only gate opens when an option has no image.

- **Bug Fixes**
  - Removed `mayGenerateArt`/`artRequestUrlFor`; inline logic now: if no stored image and `isAdmin`, use `generatedImageUrlFor(title)`, else "".
  - Exposed `generatedArtRequestUrl` as a card output; `artSyncState` remains, and both lifts require `option` and `isAdmin`.
  - Tests: replaced the vacuous `data-art-sync` check with explicit gate assertions — host + no image → non-empty request URL; non-host + no image → empty URL.

<sup>Written for commit 5f7b3c4010c9e2d108282b2031bd4df1917da1bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

