### PR TITLE
feat(cli,runner): pattern-test fetch mocking via injectable runtime.fetch (CT-1768)

### DIFF
--- a/packages/cli/lib/fetch-mock.ts
+++ b/packages/cli/lib/fetch-mock.ts
@@ -85,7 +85,9 @@ export function makeMockResponse(entry: FetchMockEntry): Response {
  * so a request matching an entry resolves to a mocked `Response`, and anything
  * else falls through to `realFetch`. A matched entry's `delayMs` is awaited
  * before the response is returned; like a real `fetch`, an aborted request
- * (via `init.signal`) rejects with the signal's reason instead of resolving.
+ * rejects with the signal's reason instead of resolving. The abort signal is
+ * taken from `init.signal`, falling back to a `Request` input's own signal
+ * (init.signal wins, mirroring `fetch`).
  */
 export function makeMockFetch(
   getEntries: () => FetchMockEntry[] | undefined,
@@ -94,7 +96,8 @@ export function makeMockFetch(
   return async (input, init) => {
     const entry = matchFetchMock(getEntries(), input);
     if (!entry) return realFetch(input as RequestInfo | URL, init);
-    const signal = init?.signal;
+    const signal = init?.signal ??
+      (input instanceof Request ? input.signal : null);
     if (signal?.aborted) throw signal.reason;
     if (typeof entry.delayMs === "number" && entry.delayMs > 0) {
       await delayOrAbort(entry.delayMs, signal);

--- a/packages/cli/lib/fetch-mock.ts
+++ b/packages/cli/lib/fetch-mock.ts
@@ -1,0 +1,90 @@
+/**
+ * Fetch mocking for pattern-tests (CT-1768).
+ *
+ * A test opts in by exporting a module-scope `fetchMocks: FetchMockEntry[]`. The
+ * runner reads it after compile and injects {@link makeMockFetch} as the
+ * runtime's `fetch` (`RuntimeOptions.fetch`), so a `fetchData` resolves against
+ * the mock instead of the network. Driving the in-flight request to completion
+ * stays the harness's job via the `{ settle: true }` step (`runtime.settled()`).
+ *
+ * This is the generic-HTTP (`fetchData`) seam; LLM calls
+ * (`generateText`/`generateObject`) mock separately at the `LLMClient` layer
+ * (`@commonfabric/llm`).
+ */
+
+/**
+ * One declarative fetch mock. The first entry whose `urlIncludes` is a substring
+ * of a request URL wins; `base64Body` takes precedence over `body` (for binary
+ * payloads like images).
+ */
+export interface FetchMockEntry {
+  urlIncludes: string;
+  status?: number;
+  contentType?: string;
+  body?: string;
+  base64Body?: string;
+}
+
+/** Read & validate a test's `fetchMocks` export from the compiled module namespace. */
+export function readFetchMocks(main: unknown): FetchMockEntry[] | undefined {
+  const raw = (main as Record<string, unknown> | null | undefined)?.fetchMocks;
+  if (!Array.isArray(raw)) return undefined;
+  const entries = raw.filter((i): i is FetchMockEntry =>
+    !!i && typeof i === "object" &&
+    typeof (i as { urlIncludes?: unknown }).urlIncludes === "string"
+  );
+  return entries.length > 0 ? entries : undefined;
+}
+
+/** Resolve a `fetch` request input to its URL string. */
+export function fetchInputUrl(input: unknown): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  if (input instanceof Request) return input.url;
+  const url = (input as { url?: unknown } | null | undefined)?.url;
+  return typeof url === "string" ? url : "";
+}
+
+/** First mock entry matching the request URL, or undefined. */
+export function matchFetchMock(
+  entries: FetchMockEntry[] | undefined,
+  input: unknown,
+): FetchMockEntry | undefined {
+  if (!entries) return undefined;
+  const url = fetchInputUrl(input);
+  return entries.find((e) => url.includes(e.urlIncludes));
+}
+
+/** Build a `Response` from a mock entry. */
+export function makeMockResponse(entry: FetchMockEntry): Response {
+  const init: ResponseInit = {
+    status: entry.status ?? 200,
+    headers: { "content-type": entry.contentType ?? "application/json" },
+  };
+  if (typeof entry.base64Body === "string") {
+    const bytes = Uint8Array.from(
+      atob(entry.base64Body),
+      (c) => c.charCodeAt(0),
+    );
+    return new Response(bytes, init);
+  }
+  return new Response(entry.body ?? "", init);
+}
+
+/**
+ * Build the `fetch` to inject as `RuntimeOptions.fetch`. Reads the (late-bound)
+ * mock entries on each call — they're populated after compile, before the run —
+ * so a request matching an entry resolves to a mocked `Response`, and anything
+ * else falls through to `realFetch`.
+ */
+export function makeMockFetch(
+  getEntries: () => FetchMockEntry[] | undefined,
+  realFetch: typeof globalThis.fetch,
+): typeof globalThis.fetch {
+  return (input, init) => {
+    const entry = matchFetchMock(getEntries(), input);
+    return entry
+      ? Promise.resolve(makeMockResponse(entry))
+      : realFetch(input as RequestInfo | URL, init);
+  };
+}

--- a/packages/cli/lib/fetch-mock.ts
+++ b/packages/cli/lib/fetch-mock.ts
@@ -84,7 +84,8 @@ export function makeMockResponse(entry: FetchMockEntry): Response {
  * mock entries on each call — they're populated after compile, before the run —
  * so a request matching an entry resolves to a mocked `Response`, and anything
  * else falls through to `realFetch`. A matched entry's `delayMs` is awaited
- * before the response is returned.
+ * before the response is returned; like a real `fetch`, an aborted request
+ * (via `init.signal`) rejects with the signal's reason instead of resolving.
  */
 export function makeMockFetch(
   getEntries: () => FetchMockEntry[] | undefined,
@@ -93,9 +94,36 @@ export function makeMockFetch(
   return async (input, init) => {
     const entry = matchFetchMock(getEntries(), input);
     if (!entry) return realFetch(input as RequestInfo | URL, init);
+    const signal = init?.signal;
+    if (signal?.aborted) throw signal.reason;
     if (typeof entry.delayMs === "number" && entry.delayMs > 0) {
-      await new Promise((resolve) => setTimeout(resolve, entry.delayMs));
+      await delayOrAbort(entry.delayMs, signal);
     }
     return makeMockResponse(entry);
   };
+}
+
+/**
+ * Resolve after `ms`, or — mirroring `fetch` — reject with the signal's reason if
+ * the request is aborted first. Cleans up its timer/listener either way.
+ */
+function delayOrAbort(
+  ms: number,
+  signal: AbortSignal | null | undefined,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!signal) {
+      setTimeout(resolve, ms);
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }

--- a/packages/cli/lib/fetch-mock.ts
+++ b/packages/cli/lib/fetch-mock.ts
@@ -16,6 +16,12 @@
  * One declarative fetch mock. The first entry whose `urlIncludes` is a substring
  * of a request URL wins; `base64Body` takes precedence over `body` (for binary
  * payloads like images).
+ *
+ * `delayMs` holds the response for a fixed real-time delay before returning, so a
+ * `fetchData` isn't resolved instantly — useful for tests that depend on *when* a
+ * fetch resolves. It stays deterministic: `runtime.settled()` awaits the actual
+ * (delayed) fetch promise. (Precise, manually-released ordering — a "gate" — needs
+ * a SES-clean harness mechanism; tracked as a follow-up, see CT-1768.)
  */
 export interface FetchMockEntry {
   urlIncludes: string;
@@ -23,6 +29,8 @@ export interface FetchMockEntry {
   contentType?: string;
   body?: string;
   base64Body?: string;
+  /** Fixed real-time delay (ms) before the mock returns. */
+  delayMs?: number;
 }
 
 /** Read & validate a test's `fetchMocks` export from the compiled module namespace. */
@@ -75,16 +83,19 @@ export function makeMockResponse(entry: FetchMockEntry): Response {
  * Build the `fetch` to inject as `RuntimeOptions.fetch`. Reads the (late-bound)
  * mock entries on each call — they're populated after compile, before the run —
  * so a request matching an entry resolves to a mocked `Response`, and anything
- * else falls through to `realFetch`.
+ * else falls through to `realFetch`. A matched entry's `delayMs` is awaited
+ * before the response is returned.
  */
 export function makeMockFetch(
   getEntries: () => FetchMockEntry[] | undefined,
   realFetch: typeof globalThis.fetch,
 ): typeof globalThis.fetch {
-  return (input, init) => {
+  return async (input, init) => {
     const entry = matchFetchMock(getEntries(), input);
-    return entry
-      ? Promise.resolve(makeMockResponse(entry))
-      : realFetch(input as RequestInfo | URL, init);
+    if (!entry) return realFetch(input as RequestInfo | URL, init);
+    if (typeof entry.delayMs === "number" && entry.delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, entry.delayMs));
+    }
+    return makeMockResponse(entry);
   };
 }

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -62,6 +62,11 @@ import {
   runMultiUserTestPattern,
 } from "./multi-user-test-runner.ts";
 import {
+  type FetchMockEntry,
+  makeMockFetch,
+  readFetchMocks,
+} from "./fetch-mock.ts";
+import {
   type CDFPoint,
   getLogger,
   getLoggerCountsBreakdown,
@@ -859,67 +864,6 @@ function printActionStatsTable(runtime: Runtime): void {
 }
 
 /**
- * One declarative fetch mock for `fetchData`. A test opts in by exporting a
- * module-scope `fetchMocks: FetchMockEntry[]`. The first entry whose
- * `urlIncludes` is a substring of a request URL wins; `base64Body` takes
- * precedence over `body` (for binary payloads like images). LLM calls
- * (`generateText`/`generateObject`) mock separately via `@commonfabric/llm`.
- */
-export interface FetchMockEntry {
-  urlIncludes: string;
-  status?: number;
-  contentType?: string;
-  body?: string;
-  base64Body?: string;
-}
-
-/** Read & validate a test's `fetchMocks` export from the compiled module namespace. */
-function readFetchMocks(main: unknown): FetchMockEntry[] | undefined {
-  const raw = (main as Record<string, unknown> | null | undefined)?.fetchMocks;
-  if (!Array.isArray(raw)) return undefined;
-  const entries = raw.filter((i): i is FetchMockEntry =>
-    !!i && typeof i === "object" &&
-    typeof (i as { urlIncludes?: unknown }).urlIncludes === "string"
-  );
-  return entries.length > 0 ? entries : undefined;
-}
-
-/** Resolve a request input to its URL string. */
-function fetchInputUrl(input: unknown): string {
-  if (typeof input === "string") return input;
-  if (input instanceof URL) return input.href;
-  if (input instanceof Request) return input.url;
-  const url = (input as { url?: unknown } | null | undefined)?.url;
-  return typeof url === "string" ? url : "";
-}
-
-/** First mock entry matching the request URL, or undefined. */
-function matchFetchMock(
-  entries: FetchMockEntry[] | undefined,
-  input: unknown,
-): FetchMockEntry | undefined {
-  if (!entries) return undefined;
-  const url = fetchInputUrl(input);
-  return entries.find((e) => url.includes(e.urlIncludes));
-}
-
-/** Build a Response from a mock entry. */
-function makeMockResponse(entry: FetchMockEntry): Response {
-  const init: ResponseInit = {
-    status: entry.status ?? 200,
-    headers: { "content-type": entry.contentType ?? "application/json" },
-  };
-  if (typeof entry.base64Body === "string") {
-    const bytes = Uint8Array.from(
-      atob(entry.base64Body),
-      (c) => c.charCodeAt(0),
-    );
-    return new Response(bytes, init);
-  }
-  return new Response(entry.body ?? "", init);
-}
-
-/**
  * Run a single test pattern file.
  */
 export async function runTestPattern(
@@ -982,12 +926,7 @@ export async function runTestPattern(
   // action's settle) calls `runtime.settled()`, which awaits the fetch chain.
   const realFetch = globalThis.fetch.bind(globalThis);
   let fetchMockEntries: FetchMockEntry[] | undefined;
-  const mockFetch: typeof globalThis.fetch = (input, init) => {
-    const entry = matchFetchMock(fetchMockEntries, input);
-    return entry
-      ? Promise.resolve(makeMockResponse(entry))
-      : realFetch(input as RequestInfo | URL, init);
-  };
+  const mockFetch = makeMockFetch(() => fetchMockEntries, realFetch);
 
   const runtime = await withPhase(
     ["runTestPattern", "runtime"],

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -859,6 +859,67 @@ function printActionStatsTable(runtime: Runtime): void {
 }
 
 /**
+ * One declarative fetch mock for `fetchData`. A test opts in by exporting a
+ * module-scope `fetchMocks: FetchMockEntry[]`. The first entry whose
+ * `urlIncludes` is a substring of a request URL wins; `base64Body` takes
+ * precedence over `body` (for binary payloads like images). LLM calls
+ * (`generateText`/`generateObject`) mock separately via `@commonfabric/llm`.
+ */
+export interface FetchMockEntry {
+  urlIncludes: string;
+  status?: number;
+  contentType?: string;
+  body?: string;
+  base64Body?: string;
+}
+
+/** Read & validate a test's `fetchMocks` export from the compiled module namespace. */
+function readFetchMocks(main: unknown): FetchMockEntry[] | undefined {
+  const raw = (main as Record<string, unknown> | null | undefined)?.fetchMocks;
+  if (!Array.isArray(raw)) return undefined;
+  const entries = raw.filter((i): i is FetchMockEntry =>
+    !!i && typeof i === "object" &&
+    typeof (i as { urlIncludes?: unknown }).urlIncludes === "string"
+  );
+  return entries.length > 0 ? entries : undefined;
+}
+
+/** Resolve a request input to its URL string. */
+function fetchInputUrl(input: unknown): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  if (input instanceof Request) return input.url;
+  const url = (input as { url?: unknown } | null | undefined)?.url;
+  return typeof url === "string" ? url : "";
+}
+
+/** First mock entry matching the request URL, or undefined. */
+function matchFetchMock(
+  entries: FetchMockEntry[] | undefined,
+  input: unknown,
+): FetchMockEntry | undefined {
+  if (!entries) return undefined;
+  const url = fetchInputUrl(input);
+  return entries.find((e) => url.includes(e.urlIncludes));
+}
+
+/** Build a Response from a mock entry. */
+function makeMockResponse(entry: FetchMockEntry): Response {
+  const init: ResponseInit = {
+    status: entry.status ?? 200,
+    headers: { "content-type": entry.contentType ?? "application/json" },
+  };
+  if (typeof entry.base64Body === "string") {
+    const bytes = Uint8Array.from(
+      atob(entry.base64Body),
+      (c) => c.charCodeAt(0),
+    );
+    return new Response(bytes, init);
+  }
+  return new Response(entry.body ?? "", init);
+}
+
+/**
  * Run a single test pattern file.
  */
 export async function runTestPattern(
@@ -913,11 +974,29 @@ export async function runTestPattern(
   const navigations: NavigationEvent[] = [];
   let currentActionIndex = -1;
 
+  // Fetch mocking: a test opts in by exporting a module-scope `fetchMocks` array.
+  // We can't read it until after compile, so the injected fetch closes over a
+  // late-populated `fetchMockEntries` and falls through to the real fetch until
+  // (and unless) the test declares mocks. Driving the in-flight fetchData to
+  // completion is the harness's existing job — a `{ settle: true }` step (or any
+  // action's settle) calls `runtime.settled()`, which awaits the fetch chain.
+  const realFetch = globalThis.fetch.bind(globalThis);
+  let fetchMockEntries: FetchMockEntry[] | undefined;
+  const mockFetch: typeof globalThis.fetch = (input, init) => {
+    const entry = matchFetchMock(fetchMockEntries, input);
+    return entry
+      ? Promise.resolve(makeMockResponse(entry))
+      : realFetch(input as RequestInfo | URL, init);
+  };
+
   const runtime = await withPhase(
     ["runTestPattern", "runtime"],
     () =>
       new Runtime({
         storageManager,
+        // Inject a fetch that honors test-declared `fetchMocks` (scoped to this
+        // runtime; no process-global mutation).
+        fetch: mockFetch,
         // Match the production runtime default: enforce explicitly declared
         // `ifc` policies so pattern tests act as a regression net for CFC.
         // Patterns without CFC annotations are unaffected; tests that need a
@@ -991,6 +1070,12 @@ export async function runTestPattern(
         `Test pattern must export a pattern function as default`,
       );
     }
+
+    // Read the test's opt-in fetch mocks now (after compile, before the run):
+    // a fetchData with a non-empty URL fires during the initial settle, so the
+    // entries must be in place before `runtime.run(...)` below. `main` is the
+    // module namespace, so a named `fetchMocks` export is reachable.
+    fetchMockEntries = readFetchMocks(main);
 
     // Multi-user tests export a descriptor ({ setup?, participants }) as the
     // default export. They run in worker-isolated runtimes against a shared

--- a/packages/cli/test/fetch-mock.test.ts
+++ b/packages/cli/test/fetch-mock.test.ts
@@ -163,4 +163,50 @@ describe("makeMockFetch", () => {
     expect(done).toBe(false);
     expect(await (await p).text()).toBe("slow");
   });
+
+  const realStub =
+    (() => Promise.resolve(new Response("real"))) as typeof globalThis.fetch;
+
+  it("resolves a delayed response when the signal is present but not aborted", async () => {
+    const ac = new AbortController();
+    const fetch = makeMockFetch(
+      () => [{ urlIncludes: "/slow", body: "ok", delayMs: 10 }],
+      realStub,
+    );
+    const res = await fetch("https://x.test/slow", { signal: ac.signal });
+    expect(await res.text()).toBe("ok");
+  });
+
+  it("rejects a delayed response if the signal aborts during the delay", async () => {
+    const ac = new AbortController();
+    const fetch = makeMockFetch(
+      () => [{ urlIncludes: "/slow", body: "ok", delayMs: 1000 }],
+      realStub,
+    );
+    const p = fetch("https://x.test/slow", { signal: ac.signal });
+    ac.abort(new Error("cancelled"));
+    let err: unknown;
+    try {
+      await p;
+    } catch (e) {
+      err = e;
+    }
+    expect((err as Error)?.message).toBe("cancelled");
+  });
+
+  it("rejects immediately when the signal is already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort(new Error("pre-aborted"));
+    const fetch = makeMockFetch(
+      () => [{ urlIncludes: "/x", body: "ok" }],
+      realStub,
+    );
+    let err: unknown;
+    try {
+      await fetch("https://x.test/x", { signal: ac.signal });
+    } catch (e) {
+      err = e;
+    }
+    expect((err as Error)?.message).toBe("pre-aborted");
+  });
 });

--- a/packages/cli/test/fetch-mock.test.ts
+++ b/packages/cli/test/fetch-mock.test.ts
@@ -149,4 +149,18 @@ describe("makeMockFetch", () => {
       "now-mocked",
     );
   });
+
+  const tick = () => new Promise((r) => setTimeout(r, 0));
+
+  it("waits for delayMs before returning", async () => {
+    const fetch = makeMockFetch(
+      () => [{ urlIncludes: "/slow", body: "slow", delayMs: 40 }],
+      (() => Promise.resolve(new Response("real"))) as typeof globalThis.fetch,
+    );
+    let done = false;
+    const p = fetch("https://x.test/slow").then((r) => (done = true, r));
+    await tick(); // a 0ms timer fires before the 40ms delay
+    expect(done).toBe(false);
+    expect(await (await p).text()).toBe("slow");
+  });
 });

--- a/packages/cli/test/fetch-mock.test.ts
+++ b/packages/cli/test/fetch-mock.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit coverage for the pattern-test fetch-mocking helpers (CT-1768): parsing a
+ * test's `fetchMocks` export, resolving request URLs, matching entries, building
+ * mock Responses, and the injected `fetch` wrapper.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  fetchInputUrl,
+  makeMockFetch,
+  makeMockResponse,
+  matchFetchMock,
+  readFetchMocks,
+} from "../lib/fetch-mock.ts";
+
+describe("readFetchMocks", () => {
+  it("returns valid entries from a module's fetchMocks export", () => {
+    const entries = readFetchMocks({
+      fetchMocks: [{ urlIncludes: "/a" }, { urlIncludes: "/b", status: 201 }],
+    });
+    expect(entries?.length).toBe(2);
+    expect(entries?.[1].status).toBe(201);
+  });
+
+  it("returns undefined when fetchMocks is absent or not an array", () => {
+    expect(readFetchMocks(undefined)).toBeUndefined();
+    expect(readFetchMocks(null)).toBeUndefined();
+    expect(readFetchMocks({})).toBeUndefined();
+    expect(readFetchMocks({ fetchMocks: "nope" })).toBeUndefined();
+  });
+
+  it("filters out malformed entries, returning undefined if none remain", () => {
+    expect(readFetchMocks({ fetchMocks: [{}, { urlIncludes: 5 }, null] }))
+      .toBeUndefined();
+    const mixed = readFetchMocks({
+      fetchMocks: [{ urlIncludes: "/ok" }, { nope: true }],
+    });
+    expect(mixed?.length).toBe(1);
+    expect(mixed?.[0].urlIncludes).toBe("/ok");
+  });
+});
+
+describe("fetchInputUrl", () => {
+  it("resolves strings, URLs, Requests, and {url} objects", () => {
+    expect(fetchInputUrl("https://x.test/a")).toBe("https://x.test/a");
+    expect(fetchInputUrl(new URL("https://x.test/b"))).toBe("https://x.test/b");
+    expect(fetchInputUrl(new Request("https://x.test/c"))).toBe(
+      "https://x.test/c",
+    );
+    expect(fetchInputUrl({ url: "https://x.test/d" })).toBe("https://x.test/d");
+  });
+
+  it("returns empty string for inputs with no usable URL", () => {
+    expect(fetchInputUrl(42)).toBe("");
+    expect(fetchInputUrl(null)).toBe("");
+    expect(fetchInputUrl({})).toBe("");
+  });
+});
+
+describe("matchFetchMock", () => {
+  const entries = [{ urlIncludes: "/api/a" }, { urlIncludes: "/api/b" }];
+
+  it("returns undefined when there are no entries", () => {
+    expect(matchFetchMock(undefined, "https://x.test/api/a")).toBeUndefined();
+  });
+
+  it("matches the first entry whose urlIncludes is a substring", () => {
+    expect(matchFetchMock(entries, "https://x.test/api/b?q=1")?.urlIncludes)
+      .toBe("/api/b");
+  });
+
+  it("returns undefined when nothing matches", () => {
+    expect(matchFetchMock(entries, "https://x.test/other")).toBeUndefined();
+  });
+});
+
+describe("makeMockResponse", () => {
+  it("defaults to 200 + application/json and a string body", async () => {
+    const res = makeMockResponse({ urlIncludes: "/x", body: '{"ok":true}' });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/json");
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("honors status and contentType, and empty body by default", async () => {
+    const res = makeMockResponse({
+      urlIncludes: "/x",
+      status: 404,
+      contentType: "text/plain",
+    });
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toBe("text/plain");
+    expect(await res.text()).toBe("");
+  });
+
+  it("decodes base64Body (taking precedence over body) to bytes", async () => {
+    // base64("hi") === "aGk="
+    const res = makeMockResponse({
+      urlIncludes: "/x",
+      base64Body: "aGk=",
+      body: "ignored",
+    });
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(
+      new Uint8Array([104, 105]),
+    );
+  });
+});
+
+describe("makeMockFetch", () => {
+  it("returns a mocked Response for a matching request without calling realFetch", async () => {
+    let realCalled = false;
+    const realFetch = (() => {
+      realCalled = true;
+      return Promise.resolve(new Response("real"));
+    }) as typeof globalThis.fetch;
+    const fetch = makeMockFetch(
+      () => [{ urlIncludes: "/mock", body: "mocked" }],
+      realFetch,
+    );
+    const res = await fetch("https://x.test/mock");
+    expect(await res.text()).toBe("mocked");
+    expect(realCalled).toBe(false);
+  });
+
+  it("falls through to realFetch (with init) when nothing matches", async () => {
+    let seen: { input: unknown; init: unknown } | undefined;
+    const realFetch = ((input: unknown, init: unknown) => {
+      seen = { input, init };
+      return Promise.resolve(new Response("real"));
+    }) as typeof globalThis.fetch;
+    const fetch = makeMockFetch(() => [{ urlIncludes: "/mock" }], realFetch);
+    const res = await fetch("https://x.test/other", { method: "POST" });
+    expect(await res.text()).toBe("real");
+    expect(seen?.input).toBe("https://x.test/other");
+    expect((seen?.init as RequestInit).method).toBe("POST");
+  });
+
+  it("reads entries late-bound on each call", async () => {
+    let entries: { urlIncludes: string; body?: string }[] | undefined;
+    const fetch = makeMockFetch(
+      () => entries,
+      (() => Promise.resolve(new Response("real"))) as typeof globalThis.fetch,
+    );
+    expect(await (await fetch("https://x.test/late")).text()).toBe("real");
+    entries = [{ urlIncludes: "/late", body: "now-mocked" }];
+    expect(await (await fetch("https://x.test/late")).text()).toBe(
+      "now-mocked",
+    );
+  });
+});

--- a/packages/cli/test/fetch-mock.test.ts
+++ b/packages/cli/test/fetch-mock.test.ts
@@ -136,13 +136,15 @@ describe("makeMockFetch", () => {
   });
 
   it("reads entries late-bound on each call", async () => {
-    let entries: { urlIncludes: string; body?: string }[] | undefined;
+    // `const` holder mutated by property (not a reassigned `let`) so the closure
+    // sees the later value without tripping deno-lint's prefer-const.
+    const holder: { entries?: { urlIncludes: string; body?: string }[] } = {};
     const fetch = makeMockFetch(
-      () => entries,
+      () => holder.entries,
       (() => Promise.resolve(new Response("real"))) as typeof globalThis.fetch,
     );
     expect(await (await fetch("https://x.test/late")).text()).toBe("real");
-    entries = [{ urlIncludes: "/late", body: "now-mocked" }];
+    holder.entries = [{ urlIncludes: "/late", body: "now-mocked" }];
     expect(await (await fetch("https://x.test/late")).text()).toBe(
       "now-mocked",
     );

--- a/packages/cli/test/fetch-mock.test.ts
+++ b/packages/cli/test/fetch-mock.test.ts
@@ -209,4 +209,21 @@ describe("makeMockFetch", () => {
     }
     expect((err as Error)?.message).toBe("pre-aborted");
   });
+
+  it("honors a Request input's own signal when init has none", async () => {
+    const ac = new AbortController();
+    const fetch = makeMockFetch(
+      () => [{ urlIncludes: "/r", body: "ok", delayMs: 1000 }],
+      realStub,
+    );
+    const p = fetch(new Request("https://x.test/r", { signal: ac.signal }));
+    ac.abort(new Error("req-cancelled"));
+    let err: unknown;
+    try {
+      await p;
+    } catch (e) {
+      err = e;
+    }
+    expect((err as Error)?.message).toBe("req-cancelled");
+  });
 });

--- a/packages/patterns/examples/fetch-data-delay.test.tsx
+++ b/packages/patterns/examples/fetch-data-delay.test.tsx
@@ -1,0 +1,27 @@
+// Pattern-test for the CT-1768 fetch-mock `delayMs` (Robin/ubik2's suggestion):
+// a mock can return after a fixed real-time delay, so a fetchData isn't resolved
+// instantly. `runtime.settled()` (driven by `{ settle: true }`) still awaits the
+// delayed fetch, so the result is observed deterministically once it lands.
+import { computed, fetchData, pattern } from "commonfabric";
+
+export const fetchMocks = [
+  {
+    urlIncludes: "/api/slow",
+    contentType: "application/json",
+    body: '{"v":7}',
+    delayMs: 50,
+  },
+];
+
+export default pattern(() => {
+  const url = computed(() => "https://example.test/api/slow");
+  const fetched = fetchData<{ v: number }>({ url, mode: "json" });
+  const result_is_7 = computed(() => fetched.result?.v === 7);
+  return {
+    tests: [
+      { settle: true }, // awaits the delayed fetch to completion
+      { assertion: result_is_7 },
+    ],
+    fetched,
+  };
+});

--- a/packages/patterns/examples/fetch-data-mock.test.tsx
+++ b/packages/patterns/examples/fetch-data-mock.test.tsx
@@ -1,0 +1,49 @@
+// Pattern-test for the CT-1768 fetch-mocking harness support: a test declares an
+// outbound fetch mock via the `fetchMocks` named export, and the runner injects
+// it into `runtime.fetch` so a `fetchData` resolves against the mock instead of
+// the network. The async fetch chain is driven to completion by the harness's
+// existing `{ settle: true }` step (`runtime.settled()`), after which a value
+// computed from the `fetchData` result is observable — which it was not before.
+//
+// LLM calls (generateText/generateObject) mock separately via @commonfabric/llm;
+// this seam is for generic `fetchData` HTTP.
+import { computed, fetchData, pattern } from "commonfabric";
+
+export const fetchMocks = [
+  {
+    urlIncludes: "/api/example",
+    contentType: "application/json",
+    body: '{"answer":42,"label":"mocked"}',
+  },
+];
+
+export default pattern(() => {
+  const url = computed(() => "https://example.test/api/example");
+  const fetched = fetchData<{ answer: number; label: string }>({
+    url,
+    mode: "json",
+  });
+
+  // Values gated on the `fetchData` result — observable only once the mocked
+  // request is driven to completion. Inline-boolean assertions so the reads are
+  // reliable (an intermediate observer computed would infer `unknown`).
+  const result_answer_is_42 = computed(() => fetched.result?.answer === 42);
+  const result_label_is_mocked = computed(() =>
+    fetched.result?.label === "mocked"
+  );
+  const not_pending = computed(() => fetched.pending === false);
+  const no_error = computed(() => fetched.error === undefined);
+
+  return {
+    tests: [
+      // Drive the in-flight fetchData (mutex -> mock fetch -> result write) to
+      // completion before the assertions read the result.
+      { settle: true },
+      { assertion: result_answer_is_42 },
+      { assertion: result_label_is_mocked },
+      { assertion: not_pending },
+      { assertion: no_error },
+    ],
+    fetched,
+  };
+});

--- a/packages/runner/src/builtins/fetch-data.ts
+++ b/packages/runner/src/builtins/fetch-data.ts
@@ -473,7 +473,7 @@ async function startFetch(
       apiBase,
       options,
     );
-    const response = await fetch(
+    const response = await runtime.fetch(
       resolvedUrl,
       {
         signal: abortSignal,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -263,6 +263,13 @@ export interface RuntimeOptions {
    * {@link ModuleByteCache}.
    */
   moduleByteCache?: ModuleByteCache;
+  /**
+   * Override for the outbound `fetch` used by network builtins (`fetchData`).
+   * Defaults to the host `globalThis.fetch`. Scoped to this runtime instance, so
+   * a test harness can inject a deterministic mock without mutating process
+   * globals. (LLM calls mock separately, at the `LLMClient` layer.)
+   */
+  fetch?: typeof globalThis.fetch;
 }
 
 export interface CfcRuntimeStats {
@@ -379,6 +386,12 @@ export class Runtime {
   readonly commitBackpressure: CommitBackpressurePolicy;
   readonly apiUrl: URL;
   readonly spaceHostMap?: Record<string, string>;
+  /**
+   * Outbound `fetch` used by network builtins (e.g. `fetchData`). Defaults to
+   * the host `globalThis.fetch`; a test harness can inject a mock via
+   * `RuntimeOptions.fetch`.
+   */
+  readonly fetch: typeof globalThis.fetch;
   /** Runtime-learned host hints (site table); see registerSpaceHost. */
   #dynamicHosts = new Map<string, string>();
   readonly userIdentityDID: DID;
@@ -448,6 +461,12 @@ export class Runtime {
     this.spaceHostMap = options.spaceHostMap
       ? Object.freeze({ ...options.spaceHostMap })
       : undefined;
+    // Default is a late-bound wrapper that reads `globalThis.fetch` at call time,
+    // preserving the existing behavior where a test overrides the global AFTER
+    // constructing the runtime (e.g. fetch-data-mutex.test.ts). An injected mock
+    // is used as-is.
+    this.fetch = options.fetch ??
+      ((input, init) => globalThis.fetch(input, init));
     this.staticCache = isDeno()
       ? new StaticCacheFS()
       : new StaticCacheHTTP(new URL("/static", this.apiUrl));


### PR DESCRIPTION
## Why

`fetchData` (generic HTTP) had no test seam: a pattern-test could not observe a value computed from a `fetchData` result without hitting the real network. LLM calls already mock at the `LLMClient` layer (`@commonfabric/llm` `enableMockMode`); `fetchData` did not. This adds the complementary fetch-mocking layer for `fetchData`.

> **Scope note (rebased & slimmed).** This PR originally also added a deterministic "wait for in-flight async builtin work" drive. That mechanism landed independently on main as `runtime.settled()` + `trackAsyncWork` (#4270), so this PR has been rebased onto current main and slimmed to **just the fetch-mock layer**, built on top of `settled()`. (The old, larger commit is preserved on the branch reflog.)

## What

- **runtime**: `RuntimeOptions.fetch` — injectable outbound fetch for network builtins (`fetchData`). Late-bound default so an existing `globalThis.fetch` override still works (e.g. `fetch-data-mutex.test.ts`); scoped to the runtime instance, no process-global mutation. Exposed as `runtime.fetch`.
- **fetch-data**: route the bare `fetch` through `runtime.fetch`.
- **test-runner**: read a test's opt-in `fetchMocks` named export (after compile, before run) and inject a scoped mock fetch. Driving the request to completion stays the harness's existing job — a `{ settle: true }` step (`runtime.settled()`) awaits the fetch chain.

A test opts in declaratively:
```ts
export const fetchMocks = [
  { urlIncludes: "/api/example", contentType: "application/json", body: '{"answer":42}' },
];
// ...
tests: [
  { settle: true },                       // drive the mocked fetchData (runtime.settled())
  { assertion: computed(() => fetched.result?.answer === 42) },
]
```

## Test / verification

- `packages/patterns/examples/fetch-data-mock.test.tsx`: declares a mock, drives it with `{ settle: true }`, asserts the `fetchData` result materializes.
- **Load-bearing (red→green):** with the mock URL not matching (falls through to a real fetch), the result-gated assertions go red.
- `fetch-data-mutex` 16/16 (confirms the late-bound default preserves `globalThis.fetch` overrides), full `pattern-tests` suite **68/68**, `deno check` clean.

Relates to CT-1768. Follow-up CT-1769 (observing fetchData-result-gated *persist side-effects*) remains, and is now even more clearly downstream of main's settle model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)