### PR TITLE
refactor(fuse): route link sniffers through the cell-rep chokepoint

### DIFF
--- a/packages/fuse/annotations.ts
+++ b/packages/fuse/annotations.ts
@@ -1,5 +1,6 @@
 import { CFC_FUSE_ATOM_CLASS, cfcAtom } from "@commonfabric/api/cfc";
 import { sha256 } from "@commonfabric/content-hash";
+import { isLinkRef } from "@commonfabric/runner/shared";
 import { encodeHex } from "@std/encoding/hex";
 import type { CallableKind } from "./callables.ts";
 
@@ -424,15 +425,9 @@ function labelViewEntriesAt(
     .map((entry) => cloneLabel(entry.label));
 }
 
-function isSigilLinkValue(value: unknown): boolean {
-  if (!isRecord(value) || Object.keys(value).length !== 1) return false;
-  const inner = value["/"];
-  return isRecord(inner) && "link@1" in inner;
-}
-
 function isLeafValue(value: unknown): boolean {
   return value === null || value === undefined ||
-    typeof value !== "object" || isSigilLinkValue(value);
+    typeof value !== "object" || isLinkRef(value);
 }
 
 export function cfcDirectoryEntryKind(
@@ -584,7 +579,7 @@ export class CfcProjectionAnnotator {
       );
     }
 
-    if (isRecord(value) && !isSigilLinkValue(value)) {
+    if (isRecord(value) && !isLinkRef(value)) {
       const keys = Object.keys(value);
       if (keys.length === 0) return this.labelAt(path);
       return joinLabels(...keys.map((key) => this.labelAt([...path, key])));

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -6,6 +6,7 @@
 
 import type { Cell } from "@commonfabric/runner";
 import { schemaToTypeString } from "@commonfabric/runner";
+import { linkRefPayload } from "@commonfabric/runner/shared";
 import { nameSchema } from "@commonfabric/runner/schemas";
 import { cfcLabelViewForCell } from "@commonfabric/runner/cfc";
 import {
@@ -3052,11 +3053,7 @@ export class CellBridge {
       // Stream cells are rendered as .handler files, not symlinks.
       if (isHandlerCell(value)) return null;
 
-      const inner = (value as Record<string, unknown>)["/"] as Record<
-        string,
-        unknown
-      >;
-      const rawLinkData = inner["link@1"];
+      const rawLinkData: unknown = linkRefPayload(value);
       if (
         typeof rawLinkData !== "object" || rawLinkData === null ||
         Array.isArray(rawLinkData)

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -65,6 +65,7 @@ import {
   O_WRONLY,
   readCString,
 } from "./platform.ts";
+import { linkRefFrom } from "@commonfabric/runner/shared";
 import { FsTree } from "./tree.ts";
 import {
   handleHasBufferedContent,
@@ -3096,7 +3097,7 @@ export async function main(argv: string[] = Deno.args) {
       }
 
       // Construct sigil link value and write to cell
-      const sigilValue = { "/": { "link@1": sigil } };
+      const sigilValue = linkRefFrom(sigil);
       const writePath = {
         ...parentPath,
         jsonPath: appendDecodedJsonPath(parentPath.jsonPath, name),

--- a/packages/fuse/tree-builder.ts
+++ b/packages/fuse/tree-builder.ts
@@ -9,6 +9,7 @@ import {
 import type { CfcJsonAnnotationContext } from "./annotations.ts";
 import { FsTree } from "./tree.ts";
 import { encodeFuseComponent } from "./path-codec.ts";
+import { isLinkRef, type SigilLink } from "@commonfabric/runner/shared";
 
 type JsonPropName = "input" | "result";
 type PendingJsonRootName = ".input.pending" | ".result.pending";
@@ -70,17 +71,12 @@ export function transformStreamValues(value: unknown): unknown {
 /**
  * Detect sigil link values: { "/": { "link@1": { ... } } }
  *
- * Inline implementation to avoid importing @commonfabric/runner.
+ * Routes through the data-model cell-rep chokepoint so fuse recognizes links
+ * the same way the runtime does (and follows it through the eventual
+ * flag-dispatched representation).
  */
-export function isSigilLink(v: unknown): boolean {
-  if (typeof v !== "object" || v === null || Array.isArray(v)) return false;
-  const obj = v as Record<string, unknown>;
-  if (!("/" in obj) || Object.keys(obj).length !== 1) return false;
-  const inner = obj["/"];
-  if (typeof inner !== "object" || inner === null || Array.isArray(inner)) {
-    return false;
-  }
-  return "link@1" in (inner as Record<string, unknown>);
+export function isSigilLink(v: unknown): v is SigilLink {
+  return isLinkRef(v);
 }
 
 export { isHandlerCell, isStreamValue } from "./callables.ts";


### PR DESCRIPTION
## What

Routes fuse's four hand-rolled `{ "/": { "link@1": … } }` sniffer/producer sites
through the data-model cell-rep chokepoint (`isLinkRef` / `linkRefPayload` /
`linkRefFrom`, via `@commonfabric/runner/shared`), so they follow the link
representation through the eventual flag-dispatched (modern `FabricLink`) form
instead of breaking when there are no more `link@1` envelopes to sniff.

This is a follow-on to #4254 (which built the chokepoint and routed the runtime +
runtime-client). It picks up the boundary "sniffers" that PR deliberately left out
of scope.

## Why fuse is a clean case (no `codec-json` needed)

fuse is **in-process**: it uses `PieceManager`/`PiecesController` from
`@commonfabric/piece`, holds real `Cell` objects, and reads in-memory values via
`cell.get()` / `piece.result.get()`. There is no serialization boundary in its
read path (which is exactly why fuse uses no `codec-json`). It therefore shares
the runtime's in-memory representation directly — when nested links become
`FabricLink`s in a flag-on world, `cell.get()` hands fuse those `FabricLink`s and
the chokepoint's dispatch recognizes them. Deferring to the chokepoint is the
whole fix.

(The `codec-json` requirement is specific to the webhook path — `ui/cf-webhook`
serializing a link to an HTTP string and toolshed `JSON.parse`-ing it back — which
is a separate follow-up.)

## Sites

- `tree-builder.isSigilLink` → delegates to `isLinkRef`. Its "inline to avoid
  importing `@commonfabric/runner`" comment dated to fuse's first commit
  (`85e9481c8`) — a birth-time "keep fuse runner-free" goal that has since been
  abandoned: `cell-bridge.ts` and `cfc-writeback.ts` import runner directly, and
  `cell-bridge` (the consumer of this very function) already pulls it, so the
  isolation was illusory.
- `cell-bridge` symlink resolver → extracts the payload via `linkRefPayload`.
- `annotations` → `isLinkRef` (dropped the duplicated local `isSigilLinkValue`).
- `mod.ts` symlink write → constructs via `linkRefFrom`.

No behavior change.

## Out of scope (next: the webhook wire)

`toolshed/webhooks` + `ui/cf-webhook` ship a link as an HTTP *string*
(`JSON.stringify(CellHandle.toJSON())` → `JSON.parse` → `getCellFromLink`). That's
a genuine serialization boundary: a flag-on `FabricLink` won't survive naive
`JSON.parse`, so it needs `data-model/codec-json` on both ends. Handled in a
follow-up PR.

## Verification

- fuse suite green (197 passed, 0 failed).
- Full workspace `deno task test` green ("All tests passing!").
- `deno check` / `lint` / `fmt` clean.
- **Ad-hoc live test**: mounted via FUSE-T against a local toolshed and browsed a
  real space of note pieces. fuse's JSON projection of a note's UI correctly
  recognized and preserved live `link@1` cell-reference envelopes (e.g. an
  `onbacklink-click` ref to `of:fid1:…`) — that projection runs through the changed
  `tree-builder.isSigilLink` → `isLinkRef` path during tree construction, so a
  broken recognizer would have mangled them into `/`-directories instead. Confirms
  the recognition/extraction path end-to-end on live data; the symlink-create
  producer (`mod.ts` → `linkRefFrom`) wasn't exercisable ad-hoc (schema-constrained
  note inputs reject a stray `ln -s`) and stays unit-covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145FPGZjJRRwpucbP6VR4aP
