### PR TITLE
refactor(data-model): dedup deep-freeze walks + hoist recursion closures

### DIFF
--- a/packages/data-model/bench/value-identity-shapes.bench.ts
+++ b/packages/data-model/bench/value-identity-shapes.bench.ts
@@ -5,7 +5,7 @@
  * (docs/development/performance/default-app-note-create.md): in steady-state
  * note creation, ~29% of runtime-worker busy CPU is value hashing
  * (`feedPlainObject` + wasm SHA-256) and ~12% is deep-freeze walks
- * (`deepFreezeInProgress`/`checkValue`).
+ * (`deepFreeze()`/`isDeepFrozen()`).
  *
  * Both subsystems cache by OBJECT IDENTITY (`WeakMap`/`WeakSet`), so any
  * fresh-identity but structurally-equal value — e.g. query results, specs, or

--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -59,75 +59,73 @@ function isNecessarilyOrKnownDeepFrozen(value: unknown): boolean {
  * Handles circular references and sparse arrays.
  */
 export function isDeepFrozen(value: unknown): boolean {
-  return isDeepFrozenInProgress(value);
-}
-
-/**
- * Performs the recursive deep-frozen check with cycle detection.
- */
-function isDeepFrozenInProgress(
-  value: unknown,
-  inProgress?: Set<object>,
-): boolean {
+  // Fast leaf paths first, so a primitive or already-cached value answers
+  // without allocating the cycle-tracking set or the recursion closure below.
   if (isNecessarilyOrKnownDeepFrozen(value)) {
     return true;
   } else if (!Object.isFrozen(value)) {
     return false;
   }
 
-  const obj = value as object;
+  // We have non-leaf structure to walk. Allocate the cycle-tracking set and
+  // build the recursion callback ONCE here, reusing the same closure at every
+  // layer rather than allocating an equivalent `(v) => …` per descent.
+  const inProgress = new Set<object>();
+  const check = (value: unknown): boolean => {
+    if (isNecessarilyOrKnownDeepFrozen(value)) {
+      return true;
+    } else if (!Object.isFrozen(value)) {
+      return false;
+    }
 
-  if (inProgress) {
-    // We're in a recursive call, so notice if we're in fact already checking
-    // `value`. If so, treat it as frozen for the sake of the rest of the check.
-    // It will only end up getting marked as actually deep-frozen if the rest
-    // of the call actually confirms.
+    const obj = value as object;
+
+    // If we're already checking `obj` higher in the recursion, treat it as
+    // frozen for the rest of this check: it only ends up marked actually
+    // deep-frozen if the outer check confirms.
     if (inProgress.has(obj)) return true;
-  } else {
-    // This is the base non-recursive call, and we have to set up the
-    // `inProgress` set. This isn't done by default exactly so that the quick
-    // checks at the top of this function don't incur object-creation overhead.
-    inProgress = new Set<object>();
-  }
+    inProgress.add(obj);
 
-  inProgress.add(obj);
+    let result = true;
 
-  let result = true;
-
-  if (obj instanceof FabricInstance) {
-    // A `FabricInstance`'s logical contents are not its enumerable own-props
-    // (e.g. a `FabricError` keeps its custom properties in a private extras
-    // `Map`), so it answers the deep-frozen question via its `[IS_DEEP_FROZEN]`
-    // protocol member -- the side-effect-free sibling of `[DEEP_FREEZE]` --
-    // recursing into each nested `FabricValue` through the callback so this
-    // call's cycle state is shared. Gating on `instanceof` against the abstract
-    // base keeps this generic; the member is abstract on `FabricInstance`, so
-    // every instance implements it. (A `FabricPrimitive` is necessarily frozen
-    // with no outbound references, so the `Object.values` arm below answers it
-    // correctly by accident -- its empty enumerable props yield `true`.)
-    result = obj[IS_DEEP_FROZEN]((v) => isDeepFrozenInProgress(v, inProgress));
-  } else if (Array.isArray(obj)) {
-    for (let i = 0; i < obj.length; i++) {
-      if (!(i in obj)) continue; // sparse hole
-      if (!isDeepFrozenInProgress(obj[i], inProgress)) {
-        result = false;
-        break;
+    if (obj instanceof FabricInstance) {
+      // A `FabricInstance`'s logical contents are not its enumerable own-props
+      // (e.g. a `FabricError` keeps its custom properties in a private extras
+      // `Map`), so it answers the deep-frozen question via its
+      // `[IS_DEEP_FROZEN]` protocol member -- the side-effect-free sibling of
+      // `[DEEP_FREEZE]` -- recursing into each nested `FabricValue` through
+      // `check`, which shares this call's cycle state. Gating on `instanceof`
+      // against the abstract base keeps this generic; the member is abstract on
+      // `FabricInstance`, so every instance implements it. (A `FabricPrimitive`
+      // is necessarily frozen with no outbound references, so the
+      // `Object.values` arm below answers it correctly by accident -- its empty
+      // enumerable props yield `true`.)
+      result = obj[IS_DEEP_FROZEN](check);
+    } else if (Array.isArray(obj)) {
+      for (let i = 0; i < obj.length; i++) {
+        if (!(i in obj)) continue; // sparse hole
+        if (!check(obj[i])) {
+          result = false;
+          break;
+        }
+      }
+    } else {
+      for (const v of Object.values(obj)) {
+        if (!check(v)) {
+          result = false;
+          break;
+        }
       }
     }
-  } else {
-    for (const v of Object.values(obj)) {
-      if (!isDeepFrozenInProgress(v, inProgress)) {
-        result = false;
-        break;
-      }
-    }
-  }
 
-  inProgress.delete(obj);
-  if (result) {
-    addToDeepFrozenCache(obj);
-  }
-  return result;
+    inProgress.delete(obj);
+    if (result) {
+      addToDeepFrozenCache(obj);
+    }
+    return result;
+  };
+
+  return check(value);
 }
 
 /**
@@ -158,48 +156,41 @@ function isDeepFrozenInProgress(
  * recursing infinitely.
  */
 export function deepFreeze<T>(value: T): T {
-  return deepFreezeInProgress(value);
-}
-
-/**
- * Performs the recursive deep-freeze with shared cycle-detection state. When
- * `inProgress` is omitted (the top-level entry) a fresh set is allocated;
- * recursive calls (both arm 4 children and the arm 3 protocol callback)
- * thread the same set through so a cycle back to a value already being
- * deep-frozen by an outer call short-circuits.
- *
- * The arm 3 callback `(v) => deepFreezeInProgress(v, inProgress)` threads
- * the shared cycle state into participating `FabricInstance`s: each impl
- * invokes `subFreeze` on its nested `FabricValue`s, and that closure
- * carries the shared `inProgress` so the impl's recursion is cycle-safe by
- * construction. This mirrors the `subIsDeepFrozen`/`checkValue`-closure
- * pattern already used by `isDeepFrozenFabricValue` for the
- * `[IS_DEEP_FROZEN]` side.
- *
- * Unlike `isDeepFrozenInProgress` (which removes values from its
- * `inProgress` set after sub-checks complete -- because the question
- * "deep-frozen?" is local to each subtree), this function does NOT remove
- * values from `inProgress`. A value being deep-frozen stays-the-course: the
- * outer call owns the freeze, every cycle-arrival defers to it.
- */
-function deepFreezeInProgress<T>(value: T, inProgress?: Set<object>): T {
   // Arm 1: necessarily- or already-known-deep-frozen.
   if (isNecessarilyOrKnownDeepFrozen(value)) {
     return value;
   }
 
   // Arm 2: `FabricPrimitive`s are by definition frozen (they self-freeze at
-  // construction) and have no outbound references.
+  // construction) and have no outbound references. Handling arms 1 and 2 here,
+  // before allocating the cycle-tracking set or the recursion closure below,
+  // keeps primitives and `FabricPrimitive`s off the heavyweight path.
   if (value instanceof FabricPrimitive) {
     return value;
   }
 
-  const obj = value as object;
+  // We have non-leaf structure to freeze. Allocate the shared cycle-detection
+  // set and build the recursion callback ONCE here, reusing the same closure
+  // at every layer -- including as the `subFreeze` passed into participating
+  // `FabricInstance`s' `[DEEP_FREEZE]` impls -- rather than allocating an
+  // equivalent `(v) => …` per descent.
+  //
+  // The closure does NOT remove values from `inProgress` (unlike the
+  // deep-frozen *check*, whose answer is local to each subtree): a value being
+  // deep-frozen stays-the-course, so the outer call owns the freeze and every
+  // cycle-arrival defers to it.
+  const inProgress = new Set<object>();
+  const freeze = <U>(value: U): U => {
+    // Leaf short-circuits, repeated for nested values reached by recursion.
+    if (isNecessarilyOrKnownDeepFrozen(value)) {
+      return value;
+    }
+    if (value instanceof FabricPrimitive) {
+      return value;
+    }
 
-  // Cycle check / set up the shared in-progress set. Done after the leaf
-  // short-circuits (arms 1 and 2) so primitives and FabricPrimitives don't
-  // incur set-membership overhead.
-  if (inProgress) {
+    const obj = value as object;
+
     if (inProgress.has(obj)) {
       // A cycle back to a value the outer call is already deep-freezing.
       // Short-circuit: the outer call owns the freeze; recursing here would
@@ -207,44 +198,41 @@ function deepFreezeInProgress<T>(value: T, inProgress?: Set<object>): T {
       // children.
       return value;
     }
-  } else {
-    inProgress = new Set<object>();
-  }
-  inProgress.add(obj);
+    inProgress.add(obj);
 
-  // Arm 3: a `FabricInstance` freezes itself in place via its `[DEEP_FREEZE]`
-  // protocol member. The `subFreeze` callback closes over `inProgress` so the
-  // impl's recursion into nested `FabricValue`s shares cycle state with this
-  // call: the participating `FabricInstance` doesn't need to be
-  // `inProgress`-aware in its own signature; the callback carries the shared
-  // state transparently.
-  if (value instanceof FabricInstance) {
-    const result = value[DEEP_FREEZE](
-      (v) => deepFreezeInProgress(v, inProgress),
-    ) as T;
-    // Cache the now-deep-frozen result so subsequent `isDeepFrozen()` checks
-    // short-circuit in O(1), mirroring arm 4's cache-write below.
-    addToDeepFrozenCache(result as object);
-    return result;
-  }
-
-  // Arm 4: plain object or array -- recurse into children, then freeze.
-  const alreadyFrozen = Object.isFrozen(value);
-
-  if (Array.isArray(value)) {
-    for (let i = 0; i < value.length; i++) {
-      if (i in value) deepFreezeInProgress(value[i], inProgress);
+    // Arm 3: a `FabricInstance` freezes itself in place via its `[DEEP_FREEZE]`
+    // protocol member. `freeze` is handed in as the `subFreeze` callback: it
+    // closes over `inProgress`, so the impl's recursion into nested
+    // `FabricValue`s shares cycle state with this call -- the participating
+    // instance doesn't need to be `inProgress`-aware in its own signature.
+    if (value instanceof FabricInstance) {
+      const result = value[DEEP_FREEZE](freeze) as U;
+      // Cache the now-deep-frozen result so subsequent `isDeepFrozen()` checks
+      // short-circuit in O(1), mirroring arm 4's cache-write below.
+      addToDeepFrozenCache(result as object);
+      return result;
     }
-  } else {
-    const o = value as Record<string, unknown>;
-    for (const key of Object.keys(o)) {
-      deepFreezeInProgress(o[key], inProgress);
-    }
-  }
 
-  if (!alreadyFrozen) Object.freeze(value);
-  addToDeepFrozenCache(value as object);
-  return value;
+    // Arm 4: plain object or array -- recurse into children, then freeze.
+    const alreadyFrozen = Object.isFrozen(value);
+
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        if (i in value) freeze(value[i]);
+      }
+    } else {
+      const o = value as Record<string, unknown>;
+      for (const key of Object.keys(o)) {
+        freeze(o[key]);
+      }
+    }
+
+    if (!alreadyFrozen) Object.freeze(value);
+    addToDeepFrozenCache(value as object);
+    return value;
+  };
+
+  return freeze(value);
 }
 
 /**
@@ -304,7 +292,7 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
       // `instanceof` against the abstract base keeps this guard generic; the
       // `[IS_DEEP_FROZEN]` member is abstract on `FabricInstance`, so every
       // instance is guaranteed to implement it.
-      return item[IS_DEEP_FROZEN]((v) => checkValue(v));
+      return item[IS_DEEP_FROZEN](checkValue);
     } else if (Array.isArray(item)) {
       // Arrays with enumerable named properties have no fabric representation.
       if (!isArrayWithOnlyIndexProperties(item)) return false;

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -204,13 +204,13 @@ describe("deep-freeze", () => {
 
     // Coverage for `isDeepFrozen` on `FabricInstance` and `FabricPrimitive`
     // inputs, including a `FabricInstance` participating in a circular
-    // reference. `isDeepFrozen` delegates to `isDeepFrozenInProgress` (which
-    // threads `inProgress: Set<object>` for cycle-safety) and answers a
-    // `FabricInstance` via its `[IS_DEEP_FROZEN]` protocol member -- inspecting
-    // its logical contents, not its enumerable own-props -- so values held in
-    // non-enumerable slots (such as `FabricError`'s private extras `Map`) are
-    // checked too. (`isDeepFrozenFabricValue` uses the same protocol dispatch
-    // but additionally type-guards the value as a `FabricValue`; it has its own
+    // reference. `isDeepFrozen`'s recursion threads an `inProgress: Set<object>`
+    // for cycle-safety and answers a `FabricInstance` via its `[IS_DEEP_FROZEN]`
+    // protocol member -- inspecting its logical contents, not its enumerable
+    // own-props -- so values held in non-enumerable slots (such as
+    // `FabricError`'s private extras `Map`) are checked too.
+    // (`isDeepFrozenFabricValue` uses the same protocol dispatch but
+    // additionally type-guards the value as a `FabricValue`; it has its own
     // coverage in the sibling describe below.)
     describe("`FabricInstance` and `FabricPrimitive`", () => {
       it("returns `true` for a `FabricPrimitive` (self-frozen at construction)", () => {
@@ -269,8 +269,8 @@ describe("deep-freeze", () => {
         const fe = FabricError.fromNativeError(err);
         wrapper.fe = fe;
         deepFreeze(wrapper);
-        // `isDeepFrozen` must terminate (its own `inProgress`-threading in
-        // `isDeepFrozenInProgress` handles the cycle) and report true.
+        // `isDeepFrozen` must terminate (its own `inProgress`-threading
+        // recursion handles the cycle) and report true.
         expect(() => isDeepFrozen(wrapper)).not.toThrow();
         expect(isDeepFrozen(wrapper)).toBe(true);
         expect(isDeepFrozen(fe)).toBe(true);


### PR DESCRIPTION
## Summary

Behavior-preserving quality refactor of `deep-freeze.ts`: reduces duplication
and per-layer closure re-allocation across the deep-freeze recursion walks.
No behavior change — the existing deep-freeze suite (including the #4255
private-slot regression and the cycle tests) is the proof.

## What

- **Hoist the recursion closures.** `isDeepFrozen` and `deepFreeze` now build
  their recursion callback **once per walk** (an inner closure over the stable
  `inProgress` set) and reuse it at every layer, instead of re-allocating an
  equivalent `(v) => someCall(v, inProgress)` at each recursion level.
- **Fold the helpers into their public entries.** The
  `isDeepFrozenInProgress` / `deepFreezeInProgress` helpers fold into the
  public `isDeepFrozen` / `deepFreeze` entries.
- **`checkValue` cleanup.** `(v) => checkValue(v)` → `checkValue`.

## Why

Dan's observation about recursion-closure re-allocation per layer, plus the
DRY of the sibling instance-dispatch walks (the three walks that each carry an
`instanceof FabricInstance` → protocol-dispatch arm). The hoist serves both.
The lazy-`Set` allocation optimization is preserved.

## Behavior-preserving

No behavior change and no new tests. The existing `deep-freeze` suite (incl.
the #4255 private-slot regression + cycle tests), `data-model`, and `runner`
suites all pass. The test/bench edits in this PR are **comment-only** — they
reword internal references to match the post-fold public surface; no assertion
is added, removed, or weakened.

## Scope

3-file diff, +121/-133 (net negative = dedup): `deep-freeze.ts` (the refactor),
`deep-freeze.test.ts` (comment rewording), and one bench doc-comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNv3rzpEfRtwZfzUy2edoT

Co-Authored-By: coder-cedar (Claude Opus 4.8 (1M context)) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `isDeepFrozen` and `deepFreeze` to build and reuse one recursion closure per walk and allocate the cycle-tracking set once, reducing duplicate closures and code paths. No behavior change; existing tests remain green.

- **Refactors**
  - Hoist recursion closures; share a single `inProgress` Set across recursion and protocol callbacks.
  - Fold `isDeepFrozenInProgress` and `deepFreezeInProgress` into the public functions.
  - Preserve lazy Set allocation and deep-frozen cache writes.
  - Simplify `isDeepFrozenFabricValue`: pass `checkValue` directly to `[IS_DEEP_FROZEN]`.
  - Update bench/test comments to reflect the folded public surface.

<sup>Written for commit 89da87bc1f494b6fec1545679da3c174f5259f0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

