### PR TITLE
refactor(toolshed): webhook cell-link wire migration, stage 1 (expand acceptor)

### DIFF
--- a/packages/toolshed/routes/webhooks/webhooks.test.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.test.ts
@@ -94,9 +94,8 @@ describe("Webhook Utilities", () => {
     });
 
     it("extracts space from a codec-encoded (fvj1:) cell link", () => {
-      // Expand-acceptor: the same link, but emitted in the codec wire form a
-      // future sender will use. Round-trips losslessly and extracts the same
-      // space as the legacy raw-JSON form above.
+      // The same link emitted in the codec wire form: it round-trips losslessly
+      // and extracts the same space as the legacy raw-JSON form above.
       const cellLink = jsonFromValue({
         "/": {
           "link@1": {

--- a/packages/toolshed/routes/webhooks/webhooks.test.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import env from "@/env.ts";
 import { sha256 } from "@/lib/sha2.ts";
+import { jsonFromValue } from "@commonfabric/data-model/codec-json";
 import {
   extractSpaceFromCellLink,
   generateWebhookId,
@@ -88,6 +89,25 @@ describe("Webhook Utilities", () => {
           },
         },
       });
+      const space = extractSpaceFromCellLink(cellLink);
+      expect(space).toBe("did:key:z6Mktest123");
+    });
+
+    it("extracts space from a codec-encoded (fvj1:) cell link", () => {
+      // Expand-acceptor: the same link, but emitted in the codec wire form a
+      // future sender will use. Round-trips losslessly and extracts the same
+      // space as the legacy raw-JSON form above.
+      const cellLink = jsonFromValue({
+        "/": {
+          "link@1": {
+            id: "of:bafe123",
+            space: "did:key:z6Mktest123",
+            path: ["webhooks", "github"],
+          },
+        },
+      });
+      // Sanity: it really is the codec form, not legacy raw JSON.
+      expect(cellLink.startsWith("{")).toBe(false);
       const space = extractSpaceFromCellLink(cellLink);
       expect(space).toBe("did:key:z6Mktest123");
     });

--- a/packages/toolshed/routes/webhooks/webhooks.utils.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.utils.ts
@@ -3,6 +3,15 @@ import { sha256 } from "@/lib/sha2.ts";
 import { runtime } from "@/index.ts";
 import { identity } from "@/lib/identity.ts";
 import { WebhookConfigSchema } from "@commonfabric/runner";
+import {
+  isLinkRef,
+  linkRefFrom,
+  linkRefPayload,
+} from "@commonfabric/runner/shared";
+import {
+  seemsLikeJsonEncodedFabricValue,
+  valueFromJson,
+} from "@commonfabric/data-model/codec-json";
 
 const _logger = getLogger("webhooks.utils");
 
@@ -85,15 +94,26 @@ async function spaceIndexEntityId(space: string): Promise<string> {
 
 // Build a cell link targeting toolshed's own service space
 function serviceCellLink(entityId: string) {
-  return {
-    "/": {
-      "link@1": {
-        id: entityId,
-        space: identity.did(),
-        path: ["webhooks"],
-      },
-    },
-  };
+  return linkRefFrom({
+    id: entityId,
+    space: identity.did(),
+    path: ["webhooks"],
+  });
+}
+
+// Parse a cell-link wire string. Accepts either the codec-encoded (`fvj1:…`)
+// form or the legacy raw `{ "/": { "link@1": … } }` JSON form. This is the
+// expand-acceptor stage of the webhook cell-link wire migration: senders still
+// emit the legacy form today; once they all emit the codec form, the legacy
+// branch (and the dependence on the envelope being plain JSON) is dropped.
+//
+// TODO(danfuzz): Stage 3 (narrow acceptor) — once every deployed server is
+// sending the codec form, ratchet this back down to `valueFromJson(cellLink)`
+// only and drop the `JSON.parse` / `seemsLikeJsonEncodedFabricValue` branch.
+function parseCellLink(cellLink: string) {
+  return seemsLikeJsonEncodedFabricValue(cellLink)
+    ? valueFromJson(cellLink)
+    : JSON.parse(cellLink);
 }
 
 // Read a cell from toolshed's service space, returning its value.
@@ -151,7 +171,7 @@ export async function writeConfidentialConfig(
   url: string,
   secret: string,
 ): Promise<void> {
-  const parsedCellLink = JSON.parse(cellLink);
+  const parsedCellLink = parseCellLink(cellLink);
   let cell = runtime.getCellFromLink(parsedCellLink);
   if (!cell.schema) cell = cell.asSchema(WebhookConfigSchema);
   await cell.sync();
@@ -216,7 +236,7 @@ export async function sendToStream(
   cellLink: string,
   payload: unknown,
 ): Promise<void> {
-  const parsedCellLink = JSON.parse(cellLink);
+  const parsedCellLink = parseCellLink(cellLink);
   const cell = runtime.getCellFromLink(parsedCellLink);
   const streamCell = cell.asSchema({ asCell: ["stream"] });
   await streamCell.sync();
@@ -230,12 +250,11 @@ export async function sendToStream(
 
 // Extract space DID from a serialized cell link
 export function extractSpaceFromCellLink(cellLink: string): string {
-  const parsed = JSON.parse(cellLink);
-  const link = parsed["/"];
-  if (!link) throw new Error("Invalid cell link format");
+  const parsed = parseCellLink(cellLink);
+  if (!isLinkRef(parsed)) throw new Error("Invalid cell link format");
 
-  const linkData = link["link@1"];
-  if (!linkData?.space) throw new Error("Cell link missing space");
+  const space = linkRefPayload(parsed).space;
+  if (!space) throw new Error("Cell link missing space");
 
-  return linkData.space;
+  return space as string;
 }

--- a/packages/toolshed/routes/webhooks/webhooks.utils.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.utils.ts
@@ -101,15 +101,13 @@ function serviceCellLink(entityId: string) {
   });
 }
 
-// Parse a cell-link wire string. Accepts either the codec-encoded (`fvj1:…`)
-// form or the legacy raw `{ "/": { "link@1": … } }` JSON form. This is the
-// expand-acceptor stage of the webhook cell-link wire migration: senders still
-// emit the legacy form today; once they all emit the codec form, the legacy
-// branch (and the dependence on the envelope being plain JSON) is dropped.
+// Parse a cell-link wire string. Accepts both the codec-encoded (`fvj1:…`) form
+// and the legacy raw `{ "/": { "link@1": … } }` JSON form, discriminated by
+// `seemsLikeJsonEncodedFabricValue`. The legacy branch exists only so links
+// serialized the old way still resolve.
 //
-// TODO(danfuzz): Stage 3 (narrow acceptor) — once every deployed server is
-// sending the codec form, ratchet this back down to `valueFromJson(cellLink)`
-// only and drop the `JSON.parse` / `seemsLikeJsonEncodedFabricValue` branch.
+// TODO(danfuzz): once every deployed server emits the codec form, drop the
+// legacy branch and decode with `valueFromJson(cellLink)` only.
 function parseCellLink(cellLink: string) {
   return seemsLikeJsonEncodedFabricValue(cellLink)
     ? valueFromJson(cellLink)


### PR DESCRIPTION
## What

**Stage 1 of a Parallel-Change migration** of the webhook `cellLink` wire string.

The webhook ships a cell link as an HTTP **string**: `ui/cf-webhook` does
`JSON.stringify(CellHandle.toJSON())`, and toolshed does `JSON.parse(cellLink)` →
`runtime.getCellFromLink(...)` / space-extraction. That only works today because
the legacy `{ "/": { "link@1": … } }` envelope is plain JSON — a flag-on
`FabricLink` would not survive a naive `JSON.parse` (you'd get a dead plain
object, not a `FabricLink`). So the wire needs `data-model/codec-json` on both
ends.

Rather than a flag-day cutover (which would strand stored registrations), this is
a three-stage tolerant-reader migration:

1. **Expand acceptor** *(this PR)* — toolshed accepts **both** the codec-encoded
   `fvj1:…` form and the legacy raw-JSON form.
2. **Switch sender** — `ui/cf-webhook` emits the codec form.
3. **Narrow acceptor** — drop the legacy branch (marked with a `TODO(danfuzz)`).

At every deployed moment, senders and receivers stay compatible.

## This PR (Stage 1)

- New `parseCellLink` routes the three wire-decode sites
  (`writeConfidentialConfig`, `sendToStream`, `extractSpaceFromCellLink`) through
  a both-formats parse, discriminated by `seemsLikeJsonEncodedFabricValue`
  (purpose-built for exactly this).
- `extractSpaceFromCellLink` now extracts via the `isLinkRef` / `linkRefPayload`
  chokepoint instead of hand-indexing `["/"]["link@1"]`.
- The in-process `serviceCellLink` producer builds via `linkRefFrom` (it feeds
  `getCellFromLink` in-process, so it's format-agnostic — folded in for tidiness).
- **Senders unchanged**, so this is backward-compatible and deploy-order-safe.

## Notes

- **Empty reconstruction context suffices** for decode: no non-empty
  `ReconstructionContext` exists in the system, and the legacy `JSON.parse` path
  reconstructed nothing either — the link is data that `getCellFromLink` resolves
  downstream.
- The codec form is tagged `fvj1:…`, so once Stage 2/3 land the stored wire
  format changes; acceptable since the webhook producer/consumer are both in-repo
  (no external clients).

## Verification

- New test: `extractSpaceFromCellLink` yields the same space from a codec-encoded
  link as from the legacy raw-JSON form.
- Webhooks suite green (24 steps, 0 failed); `deno check` / `lint` / `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145FPGZjJRRwpucbP6VR4aP


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the webhook cell-link acceptor to support both codec-encoded `fvj1:` and legacy raw JSON, moving the wire format to `@commonfabric/data-model/codec-json`. No sender changes; fully backward compatible and deploy-order safe.

- **Refactors**
  - Added `parseCellLink` (uses `seemsLikeJsonEncodedFabricValue` and `valueFromJson`) and routed `writeConfidentialConfig`, `sendToStream`, and `extractSpaceFromCellLink` through it.
  - `extractSpaceFromCellLink` now validates via `isLinkRef`/`linkRefPayload` instead of manual indexing.
  - `serviceCellLink` builds links via `linkRefFrom`; added a test for codec-encoded links.

<sup>Written for commit b1c59614eb257482f5f83f21f135c7472cceb692. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

