### PR TITLE
refactor(ui): webhook cell-link wire migration, stage 2 (switch sender)

### DIFF
--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -9,6 +9,10 @@ import {
   type RuntimeClient,
 } from "./mod.ts";
 import { cellRefToKey } from "./shared/utils.ts";
+import {
+  seemsLikeJsonEncodedFabricValue,
+  valueFromJson,
+} from "@commonfabric/data-model/codec-json";
 
 describe("CellHandle CFC label IPC", () => {
   it("queries the runtime for the label view behind a cell", async () => {
@@ -138,6 +142,28 @@ describe("CellHandle CFC label IPC", () => {
         },
       },
     });
+  });
+
+  it("encodes its link to a codec wire string that round-trips", () => {
+    const runtime = {
+      [$conn]: () => ({
+        request: () => Promise.resolve({}),
+        subscribe: () => Promise.resolve(),
+        unsubscribe: () => Promise.resolve(),
+      }),
+    } as unknown as RuntimeClient;
+    const cell = new CellHandle(runtime, {
+      id: "of:wire-cell" as CellRef["id"],
+      space: "did:key:test" as CellRef["space"],
+      scope: "space",
+      path: ["value"],
+    } as CellRef);
+
+    const wire = cell.toWireString();
+    // It's the codec form, not raw JSON.
+    expect(seemsLikeJsonEncodedFabricValue(wire)).toBe(true);
+    // ...and decodes back to the same link toJSON() produces.
+    expect(valueFromJson(wire)).toEqual(cell.toJSON());
   });
 
   it("uses carried label views in subscription keys", () => {

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -16,6 +16,7 @@ import {
   rebaseCfcLabelView,
 } from "@commonfabric/runner/cfc/label-view-core";
 import { type CfcCellLinkRefPayload } from "@commonfabric/runner/cfc";
+import { jsonFromValue } from "@commonfabric/data-model/codec-json";
 import { $conn, type RuntimeClient } from "./runtime-client.ts";
 import { isRuntimeDisposedError } from "./shared/disposed-error.ts";
 import {
@@ -353,6 +354,15 @@ export class CellHandle<T = unknown> {
         cfcLabelView: this.#ref.cfcLabelView,
       }),
     });
+  }
+
+  /**
+   * Encodes this cell's link to a wire string, in the `data-model/codec-json`
+   * (`fvj1:…`) form, for transport across a string boundary (e.g. an HTTP body)
+   * from which it will be decoded back to a link.
+   */
+  toWireString(): string {
+    return jsonFromValue(this.toJSON());
   }
 
   // Called when cell has been updated from the backend with

--- a/packages/ui/src/v2/components/cf-webhook/cf-webhook.ts
+++ b/packages/ui/src/v2/components/cf-webhook/cf-webhook.ts
@@ -103,17 +103,15 @@ export class CFWebhook extends BaseElement {
     this._error = "";
 
     try {
-      const inboxJson = this.inbox?.toJSON?.() as Record<string, unknown>;
-      if (!inboxJson?.["/"]) {
+      if (!this.inbox) {
         throw new Error("inbox is not a valid cell link");
       }
-      const cellLink = JSON.stringify(inboxJson);
+      const cellLink = this.inbox.toWireString();
 
-      const configJson = this.config?.toJSON?.() as Record<string, unknown>;
-      if (!configJson?.["/"]) {
+      if (!this.config) {
         throw new Error("config is not a valid cell link");
       }
-      const confidentialCellLink = JSON.stringify(configJson);
+      const confidentialCellLink = this.config.toWireString();
 
       const response = await fetch("/api/webhooks", {
         method: "POST",
@@ -160,10 +158,8 @@ export class CFWebhook extends BaseElement {
     this._error = "";
 
     try {
-      // Extract space DID from inbox cell link for ownership verification
-      const inboxLink = this.inbox?.toJSON?.() as any;
-      const linkData = inboxLink?.["/"]?.["link@1"];
-      const space = linkData?.space ?? "";
+      // Space DID from the inbox handle, for ownership verification.
+      const space = this.inbox?.space() ?? "";
       const params = new URLSearchParams({ space });
 
       const response = await fetch(


### PR DESCRIPTION
## What

**Stage 2 of the webhook cell-link wire migration** (Parallel-Change /
tolerant-reader). Stage 1 — the tolerant acceptor — is #4262.

The sender now emits the **codec (`fvj1:…`) wire form** that toolshed already
accepts, so the webhook cell link survives the HTTP string boundary as a real
`FabricLink` once the modern cell representation is enabled (a flag-on
`FabricLink` cannot survive naive `JSON.parse`).

## Changes

- **`CellHandle.toWireString()`** — new method that codec-encodes the link via
  `data-model/codec-json` (`jsonFromValue(this.toJSON())`). The wire format is
  encapsulated in the handle, so `ui` takes **no new dependency** (it already
  depends on `runtime-client`).
- **`ui/cf-webhook`**:
  - create → posts `inbox.toWireString()` / `config.toWireString()`
  - delete → reads the space via `inbox.space()` (straight from the handle)
    instead of indexing `["/"]["link@1"].space`
  - The component no longer hardcodes the `link@1` / `["/"]` envelope shape at
    all.

## Ordering

This relies on Stage 1's tolerant acceptor being **deployed** before senders
start emitting `fvj1:` — which the normal review/deploy cadence covers (Stage 1
merged ahead of this). The acceptor keeps its legacy-format branch until Stage 3
(the `TODO(danfuzz)` narrow), to be done once all senders have rolled out.

## Verification

- New test: `CellHandle.toWireString()` produces the codec form
  (`seemsLikeJsonEncodedFabricValue` true) and decodes back via `valueFromJson`
  to the same link as `toJSON()`.
- runtime-client suite green; full workspace `deno task test` green; `check` /
  `lint` / `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145FPGZjJRRwpucbP6VR4aP


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the webhook sender to emit codec `fvj1:` wire strings for cell links so they survive HTTP and decode back to real links. Adds `CellHandle.toWireString()` and updates `cf-webhook` to use it and read space from the handle.

- **Refactors**
  - Add `CellHandle.toWireString()` using `jsonFromValue` from `@commonfabric/data-model/codec-json`.
  - Update `ui/src/v2/components/cf-webhook` to post `inbox.toWireString()` / `config.toWireString()` and to read space via `inbox.space()`. Removes reliance on the `["/"]["link@1"]` envelope.
  - Test ensures the codec form round-trips and matches `toJSON()`.

- **Migration**
  - Deploy after the tolerant acceptor from stage 1 is live. The acceptor keeps the legacy branch until stage 3.

<sup>Written for commit 7eee39de396b5325cdf9e67756f9bcdbf3e40014. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

