### PR TITLE
fix(runner,data-model): make FabricPrimitive values updatable in place (CT-1770)

### DIFF
--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -34,13 +34,83 @@ export {
   shallowFabricFromNativeValue,
 } from "./native-conversion.ts";
 
-import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { isRecord } from "@commonfabric/utils/types";
+import { FabricSpecialObject } from "./interface.ts";
+import { hashStringOf } from "./value-hash.ts";
 
 /**
- * Compares two fabric values for equality.
+ * Compares two `FabricValue`s for logical (content) equality.
+ *
+ * This is the `data-model`-aware equality that the storage layer's no-op /
+ * change-detection gates need. It mirrors `deepEqual()`'s structural recursion
+ * for plain objects and arrays (including its hole-vs-stored-`undefined`
+ * handling), but defers to canonical content hashing for any
+ * `FabricSpecialObject` (`FabricPrimitive` leaves like `FabricBytes` /
+ * `FabricRegExp` / `FabricEpoch*` / `FabricHash`, and `FabricInstance`
+ * wrappers). Those carry their state in private `#fields` with zero enumerable
+ * own-properties, so `deepEqual()` conflates every distinct same-class instance
+ * as equal — the CT-1770 bug. Hashing sees their real contents.
+ *
+ * Plain containers may *contain* special objects nested arbitrarily deep, so
+ * the recursion checks every node; the hash fast-path only fires once a special
+ * object is actually reached, leaving the common all-plain-data case on the
+ * same fast, short-circuiting path as `deepEqual()`.
  */
 export function valueEqual(a: unknown, b: unknown): boolean {
-  // TODO(danfuzz): This needs to be a `data-model`-aware function.
-  // `deepEqual()` is not that.
-  return deepEqual(a, b);
+  if (Object.is(a, b)) return true;
+
+  // Either side a special object: compare by canonical content hash, the
+  // logical identity for every `FabricValue`. (A special object and a plain
+  // value can never share a hash — distinct type tags — so this also correctly
+  // reports them unequal.)
+  if (a instanceof FabricSpecialObject || b instanceof FabricSpecialObject) {
+    return hashStringOf(a) === hashStringOf(b);
+  }
+
+  if (!(isRecord(a) && isRecord(b))) return false;
+  if (a.constructor !== b.constructor) return false;
+
+  const keysA = Object.keys(a);
+  const keysALength = keysA.length;
+  if (keysALength !== Object.keys(b).length) return false;
+
+  const aIsArray = Array.isArray(a);
+  const bIsArray = Array.isArray(b);
+  if (!(aIsArray || bIsArray)) {
+    return checkSpecificProps(a, b, keysA);
+  }
+  if (!(aIsArray && bIsArray)) return false;
+
+  const lengthA = (a as unknown[]).length;
+  if (lengthA !== (b as unknown[]).length) return false;
+
+  let indexCount = 0;
+  for (let i = 0; i < lengthA; i++) {
+    const aValue = (a as unknown[])[i];
+    const bValue = (b as unknown[])[i];
+    indexCount++;
+    if (!valueEqual(aValue, bValue)) return false;
+    if (aValue === undefined) {
+      const aHasIt = Object.hasOwn(a, i);
+      const bHasIt = Object.hasOwn(b, i);
+      if (aHasIt !== bHasIt) return false;
+      if (!aHasIt && !bHasIt) indexCount--;
+    }
+  }
+
+  if (indexCount === keysALength) return true;
+  return checkSpecificProps(a, b, keysA.slice(indexCount));
+}
+
+function checkSpecificProps(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+  keysToCheck: string[],
+): boolean {
+  for (const key of keysToCheck) {
+    const aValue = a[key];
+    if (!valueEqual(aValue, b[key])) return false;
+    if (aValue === undefined && !Object.hasOwn(b, key)) return false;
+  }
+  return true;
 }

--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -41,20 +41,21 @@ import { hashStringOf } from "./value-hash.ts";
 /**
  * Compares two `FabricValue`s for logical (content) equality.
  *
- * This is the `data-model`-aware equality that the storage layer's no-op /
- * change-detection gates need. It mirrors `deepEqual()`'s structural recursion
- * for plain objects and arrays (including its hole-vs-stored-`undefined`
- * handling), but defers to canonical content hashing for any
- * `FabricSpecialObject` (`FabricPrimitive` leaves like `FabricBytes` /
+ * This is the `data-model`-aware equality the storage layer's no-op /
+ * change-detection gates need, and the fix for what `deepEqual()` gets wrong:
+ * any `FabricSpecialObject` (`FabricPrimitive` leaves like `FabricBytes` /
  * `FabricRegExp` / `FabricEpoch*` / `FabricHash`, and `FabricInstance`
- * wrappers). Those carry their state in private `#fields` with zero enumerable
+ * wrappers) keeps its state in private `#fields` with zero enumerable
  * own-properties, so `deepEqual()` conflates every distinct same-class instance
- * as equal — the CT-1770 bug. Hashing sees their real contents.
+ * as equal (the CT-1770 bug). Here such values are compared by canonical
+ * content hash instead.
  *
- * Plain containers may *contain* special objects nested arbitrarily deep, so
- * the recursion checks every node; the hash fast-path only fires once a special
- * object is actually reached, leaving the common all-plain-data case on the
- * same fast, short-circuiting path as `deepEqual()`.
+ * Everything else is the ordinary structural recursion over the JSON-shaped
+ * `FabricValue` space — plain objects, arrays (including sparse holes vs a
+ * stored `undefined`), and primitives via `Object.is` — recursing through every
+ * node so a special object nested arbitrarily deep is still hashed. (Unlike
+ * `deepEqual()` it does not handle non-`Fabric` class instances or named
+ * properties on arrays: those are not representable as `FabricValue`s.)
  */
 export function valueEqual(a: unknown, b: unknown): boolean {
   if (Object.is(a, b)) return true;
@@ -67,50 +68,26 @@ export function valueEqual(a: unknown, b: unknown): boolean {
     return hashStringOf(a) === hashStringOf(b);
   }
 
+  const aIsArray = Array.isArray(a);
+  if (aIsArray || Array.isArray(b)) {
+    if (!aIsArray || !Array.isArray(b) || a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      // A hole and a stored `undefined` are different states.
+      if ((i in a) !== (i in b)) return false;
+      if (i in a && !valueEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+
   if (!(isRecord(a) && isRecord(b))) return false;
-  if (a.constructor !== b.constructor) return false;
 
   const keysA = Object.keys(a);
-  const keysALength = keysA.length;
-  if (keysALength !== Object.keys(b).length) return false;
-
-  const aIsArray = Array.isArray(a);
-  const bIsArray = Array.isArray(b);
-  if (!(aIsArray || bIsArray)) {
-    return checkSpecificProps(a, b, keysA);
-  }
-  if (!(aIsArray && bIsArray)) return false;
-
-  const lengthA = (a as unknown[]).length;
-  if (lengthA !== (b as unknown[]).length) return false;
-
-  let indexCount = 0;
-  for (let i = 0; i < lengthA; i++) {
-    const aValue = (a as unknown[])[i];
-    const bValue = (b as unknown[])[i];
-    indexCount++;
-    if (!valueEqual(aValue, bValue)) return false;
-    if (aValue === undefined) {
-      const aHasIt = Object.hasOwn(a, i);
-      const bHasIt = Object.hasOwn(b, i);
-      if (aHasIt !== bHasIt) return false;
-      if (!aHasIt && !bHasIt) indexCount--;
-    }
-  }
-
-  if (indexCount === keysALength) return true;
-  return checkSpecificProps(a, b, keysA.slice(indexCount));
-}
-
-function checkSpecificProps(
-  a: Record<string, unknown>,
-  b: Record<string, unknown>,
-  keysToCheck: string[],
-): boolean {
-  for (const key of keysToCheck) {
-    const aValue = a[key];
-    if (!valueEqual(aValue, b[key])) return false;
-    if (aValue === undefined && !Object.hasOwn(b, key)) return false;
+  if (keysA.length !== Object.keys(b).length) return false;
+  for (const key of keysA) {
+    // A present `undefined` and an absent key are different states, so require
+    // the key on `b` (not just an equal looked-up value).
+    if (!Object.hasOwn(b, key)) return false;
+    if (!valueEqual(a[key], b[key])) return false;
   }
   return true;
 }

--- a/packages/data-model/test/fabric-value.test.ts
+++ b/packages/data-model/test/fabric-value.test.ts
@@ -2,6 +2,9 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { valueEqual } from "@/fabric-value.ts";
+import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
+import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
+import { FabricEpochDays } from "@/fabric-primitives/FabricEpochDays.ts";
 
 describe("fabric-value", () => {
   describe("valueEqual()", () => {
@@ -48,6 +51,42 @@ describe("fabric-value", () => {
       expect(valueEqual({ x: { y: [1, 2] } }, { x: { y: [1, 3] } })).toBe(
         false,
       );
+    });
+
+    // CT-1770: FabricPrimitives keep their state in private fields, so a
+    // generic enumerable-own-prop comparison (`deepEqual`) conflates every
+    // distinct same-class instance. `valueEqual` compares them by content.
+    describe("FabricSpecialObject values (CT-1770)", () => {
+      it("distinguishes FabricBytes by content", () => {
+        const a = new FabricBytes(new Uint8Array([1, 2, 3, 4]));
+        const b = new FabricBytes(new Uint8Array([9, 8, 7, 6]));
+        expect(valueEqual(a, b)).toBe(false);
+        expect(valueEqual(a, new FabricBytes(new Uint8Array([1, 2, 3, 4]))))
+          .toBe(true);
+      });
+
+      it("distinguishes FabricRegExp and FabricEpochDays by content", () => {
+        expect(valueEqual(new FabricRegExp(/a/g), new FabricRegExp(/b/g)))
+          .toBe(false);
+        expect(valueEqual(new FabricRegExp(/a/g), new FabricRegExp(/a/g)))
+          .toBe(true);
+        expect(valueEqual(new FabricEpochDays(1n), new FabricEpochDays(2n)))
+          .toBe(false);
+      });
+
+      it("distinguishes a FabricPrimitive nested inside a plain container", () => {
+        const wrap = (bytes: number[]) => ({
+          v: [new FabricBytes(new Uint8Array(bytes))],
+        });
+        expect(valueEqual(wrap([1, 2]), wrap([3, 4]))).toBe(false);
+        expect(valueEqual(wrap([1, 2]), wrap([1, 2]))).toBe(true);
+      });
+
+      it("a special object never equals a plain value", () => {
+        expect(valueEqual(new FabricBytes(new Uint8Array([1])), { 0: 1 }))
+          .toBe(false);
+        expect(valueEqual(new FabricBytes(new Uint8Array([])), {})).toBe(false);
+      });
     });
   });
 });

--- a/packages/data-model/test/fabric-value.test.ts
+++ b/packages/data-model/test/fabric-value.test.ts
@@ -53,6 +53,23 @@ describe("fabric-value", () => {
       );
     });
 
+    it("returns `false` across mismatched shapes", () => {
+      expect(valueEqual([1, 2], { 0: 1, 1: 2 })).toBe(false); // array vs object
+      expect(valueEqual([1, 2], 5)).toBe(false); // array vs primitive
+      expect(valueEqual({ a: 1 }, 5)).toBe(false); // object vs primitive
+    });
+
+    it("distinguishes object key count and present-undefined vs absent", () => {
+      expect(valueEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+      expect(valueEqual({ a: undefined }, {})).toBe(false);
+      expect(valueEqual({ a: undefined }, { a: undefined })).toBe(true);
+    });
+
+    it("distinguishes an array hole from a stored `undefined`", () => {
+      expect(valueEqual([1, , 3], [1, undefined, 3])).toBe(false);
+      expect(valueEqual([1, , 3], [1, , 3])).toBe(true);
+    });
+
     // CT-1770: FabricPrimitives keep their state in private fields, so a
     // generic enumerable-own-prop comparison (`deepEqual`) conflates every
     // distinct same-class instance. `valueEqual` compares them by content.

--- a/packages/runner/src/reactive-dependencies.ts
+++ b/packages/runner/src/reactive-dependencies.ts
@@ -1,6 +1,8 @@
 import { isRecord } from "@commonfabric/utils/types";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import {
+  type FabricValue,
+  valueEqual,
+} from "@commonfabric/data-model/fabric-value";
 import { isPrimitiveCellLink } from "./link-utils.ts";
 import { normalizeCellScope } from "./scope.ts";
 import { arrayEqual } from "./path-utils.ts";
@@ -192,7 +194,7 @@ export function determineTriggeredActions(
         // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
         // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so
         // migrate to a `Fabric`-aware equality once available.
-        hasChanged = !deepEqual(
+        hasChanged = !valueEqual(
           beforeValues[targetPath.length],
           afterValues[targetPath.length],
         );
@@ -281,7 +283,7 @@ function shallowEqual(
   // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to a
   // `Fabric`-aware equality once available.
   if (isPrimitiveCellLink(before) || isPrimitiveCellLink(after)) {
-    return deepEqual(before, after);
+    return valueEqual(before, after);
   }
 
   if (isRecord(before) && isRecord(after)) {
@@ -299,7 +301,7 @@ function shallowEqual(
   // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
   // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to a
   // `Fabric`-aware equality once available.
-  return deepEqual(before, after);
+  return valueEqual(before, after);
 }
 
 function comparePaths(

--- a/packages/runner/src/reactive-dependencies.ts
+++ b/packages/runner/src/reactive-dependencies.ts
@@ -191,9 +191,6 @@ export function determineTriggeredActions(
           afterValues[targetPath.length],
         );
       } else {
-        // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
-        // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so
-        // migrate to a `Fabric`-aware equality once available.
         hasChanged = !valueEqual(
           beforeValues[targetPath.length],
           afterValues[targetPath.length],
@@ -279,9 +276,6 @@ function shallowEqual(
   after: FabricValue,
 ): boolean {
   // Links compare by full identity — a different link target matters.
-  // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
-  // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to a
-  // `Fabric`-aware equality once available.
   if (isPrimitiveCellLink(before) || isPrimitiveCellLink(after)) {
     return valueEqual(before, after);
   }
@@ -298,9 +292,6 @@ function shallowEqual(
   }
 
   // Primitives (null, number, string, boolean, undefined)
-  // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
-  // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to a
-  // `Fabric`-aware equality once available.
   return valueEqual(before, after);
 }
 

--- a/packages/runner/src/scheduler/diagnosis.ts
+++ b/packages/runner/src/scheduler/diagnosis.ts
@@ -1,4 +1,4 @@
-import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { valueEqual } from "@commonfabric/data-model/fabric-value";
 import { isRecord } from "@commonfabric/utils/types";
 import type {
   IExtendedStorageTransaction,
@@ -145,7 +145,7 @@ export function findDifferingWriteKeys(
       differingKeys.push(key);
       continue;
     }
-    if (!deepEqual(previousWrites.get(key), latestWrites.get(key))) {
+    if (!valueEqual(previousWrites.get(key), latestWrites.get(key))) {
       differingKeys.push(key);
     }
   }
@@ -240,7 +240,7 @@ function readInvariantMovedExternally(
     // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
     // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to
     // a `Fabric`-aware equality once available.
-    if (deepEqual(previous.value, value)) continue;
+    if (valueEqual(previous.value, value)) continue;
     // Cover writes of EITHER run: run1's commit moving its own read is the
     // accumulator pattern, and a write-then-read inside the recheck run is
     // nondeterminism, not external interference — both must stay flagged.

--- a/packages/runner/src/scheduler/diagnosis.ts
+++ b/packages/runner/src/scheduler/diagnosis.ts
@@ -237,9 +237,6 @@ function readInvariantMovedExternally(
     const previous = before.get(key);
     // Only reads both runs performed are comparable.
     if (!previous) continue;
-    // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
-    // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to
-    // a `Fabric`-aware equality once available.
     if (valueEqual(previous.value, value)) continue;
     // Cover writes of EITHER run: run1's commit moving its own read is the
     // accumulator pattern, and a write-then-read inside the recheck run is

--- a/packages/runner/src/scheduler/write-propagation.ts
+++ b/packages/runner/src/scheduler/write-propagation.ts
@@ -1,4 +1,4 @@
-import { deepEqual } from "@commonfabric/utils/deep-equal";
+import { valueEqual } from "@commonfabric/data-model/fabric-value";
 import { sortAndCompactPaths } from "../reactive-dependencies.ts";
 import type {
   IExtendedStorageTransaction,
@@ -40,7 +40,7 @@ export function collectChangedWritesForTransaction(
       // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
       // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate
       // to a `Fabric`-aware equality once available.
-      if (!deepEqual(detail.previousValue, detail.value)) {
+      if (!valueEqual(detail.previousValue, detail.value)) {
         changedWrites.push(detail.address);
       }
     }

--- a/packages/runner/src/scheduler/write-propagation.ts
+++ b/packages/runner/src/scheduler/write-propagation.ts
@@ -37,9 +37,6 @@ export function collectChangedWritesForTransaction(
 
   for (const space of spaces) {
     for (const detail of getTransactionWriteDetails(tx, space)) {
-      // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
-      // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate
-      // to a `Fabric`-aware equality once available.
       if (!valueEqual(detail.previousValue, detail.value)) {
         changedWrites.push(detail.address);
       }

--- a/packages/runner/src/storage/differential.ts
+++ b/packages/runner/src/storage/differential.ts
@@ -79,12 +79,22 @@ const collectChangedPaths = (
       return;
     }
 
-    // A `FabricSpecialObject` (`FabricPrimitive` leaf / `FabricInstance`
-    // wrapper) is atomic: its state is private, so the key-walk below sees
-    // zero own-keys and would wrongly report "no change". `valueEqual` above
-    // already established they differ, so record a change at this path and
-    // don't decompose. (CT-1770: a `FabricBytes` value updated in place
-    // otherwise never reaches reactive consumers.)
+    // A `FabricSpecialObject` keeps its state in private fields, so the
+    // key-walk below sees zero own-keys and would wrongly report "no change"
+    // even though `valueEqual` above already established they differ. Record a
+    // change at this path and don't decompose. (CT-1770: a `FabricBytes` value
+    // updated in place otherwise never reaches reactive consumers.)
+    //
+    // The `FabricPrimitive` vs `FabricInstance` distinction matters here even
+    // though both are handled the same way: a `FabricPrimitive` genuinely IS an
+    // atomic frozen leaf (no outgoing references), so emitting a single change
+    // at its path is exactly correct. A `FabricInstance` is neither necessarily
+    // frozen nor a leaf — it can hold outgoing references to other
+    // memory-tracked objects, so a fully correct walk would descend into them
+    // (cf. `codecOf()` in cell.ts) and emit per-reference change paths. Lumping
+    // it in as a leaf here is a safe approximation only because nothing in the
+    // system stores `FabricInstance`s yet; revisit when that part of the system
+    // (still in flux) gels.
     if (
       before instanceof FabricSpecialObject ||
       after instanceof FabricSpecialObject

--- a/packages/runner/src/storage/differential.ts
+++ b/packages/runner/src/storage/differential.ts
@@ -1,5 +1,8 @@
 import { unclaimed } from "@commonfabric/memory/fact";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
+import {
+  FabricSpecialObject,
+  valueEqual,
+} from "@commonfabric/data-model/fabric-value";
 import { isRecord } from "@commonfabric/utils/types";
 import type {
   IMemoryAddress,
@@ -72,7 +75,21 @@ const collectChangedPaths = (
   }
 
   if (isRecord(before) && isRecord(after)) {
-    if (deepEqual(before, after)) {
+    if (valueEqual(before, after)) {
+      return;
+    }
+
+    // A `FabricSpecialObject` (`FabricPrimitive` leaf / `FabricInstance`
+    // wrapper) is atomic: its state is private, so the key-walk below sees
+    // zero own-keys and would wrongly report "no change". `valueEqual` above
+    // already established they differ, so record a change at this path and
+    // don't decompose. (CT-1770: a `FabricBytes` value updated in place
+    // otherwise never reaches reactive consumers.)
+    if (
+      before instanceof FabricSpecialObject ||
+      after instanceof FabricSpecialObject
+    ) {
+      pushChangedPath(paths, currentPath, depth);
       return;
     }
 
@@ -173,7 +190,7 @@ const collectChangedPaths = (
     return;
   }
 
-  if (!deepEqual(before, after)) {
+  if (!valueEqual(before, after)) {
     pushChangedPath(paths, currentPath, depth);
   }
 };
@@ -184,7 +201,7 @@ const addStateChange = (
   before: State["is"] | undefined,
   after: State["is"] | undefined,
 ): void => {
-  if (deepEqual(before, after)) {
+  if (valueEqual(before, after)) {
     return;
   }
 

--- a/packages/runner/src/storage/transaction/chronicle.ts
+++ b/packages/runner/src/storage/transaction/chronicle.ts
@@ -1,5 +1,7 @@
-import { fabricFromNativeValue } from "@commonfabric/data-model/fabric-value";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
+import {
+  fabricFromNativeValue,
+  valueEqual,
+} from "@commonfabric/data-model/fabric-value";
 import { normalizeFact, unclaimed } from "@commonfabric/memory/fact";
 import type {
   Assertion,
@@ -365,7 +367,7 @@ export class Chronicle {
           },
         );
 
-        if (deepEqual(alignedMerged, normalizedLoaded)) {
+        if (valueEqual(alignedMerged, normalizedLoaded)) {
           // Values are deeply equal after normalization - no change needed.
           edit.claim(loaded);
         } else if (alignedMerged === undefined) {

--- a/packages/runner/src/storage/transaction/mutable-path-write.ts
+++ b/packages/runner/src/storage/transaction/mutable-path-write.ts
@@ -14,9 +14,11 @@ import {
   cloneForMutation,
   CloneForMutationError,
 } from "@commonfabric/data-model/value-clone";
-import { type FabricValue } from "@commonfabric/data-model/fabric-value";
+import {
+  type FabricValue,
+  valueEqual,
+} from "@commonfabric/data-model/fabric-value";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isRecord } from "@commonfabric/utils/types";
 import type {
   IMemoryAddress,
@@ -101,7 +103,7 @@ export const applyMutablePathWrite = (
       ok: {
         root: nextRoot,
         previousValue: currentRoot,
-        changed: !deepEqual(currentRoot, nextRoot),
+        changed: !valueEqual(currentRoot, nextRoot),
       },
     };
   }
@@ -193,7 +195,7 @@ export const applyMutablePathWrite = (
     // Presence-aware no-op detection: a hole and a stored `undefined` are
     // different states, so equal values only short-circuit when the slot
     // actually exists.
-    if (slot in parent && deepEqual(previousValue, value)) {
+    if (slot in parent && valueEqual(previousValue, value)) {
       return { ok: { root: newRoot, previousValue, changed: false } };
     }
     parent[slot] = value;
@@ -210,7 +212,7 @@ export const applyMutablePathWrite = (
     delete obj[leafKey];
     return { ok: { root: newRoot, previousValue, changed: true } };
   }
-  if (leafKey in obj && deepEqual(previousValue, value)) {
+  if (leafKey in obj && valueEqual(previousValue, value)) {
     return { ok: { root: newRoot, previousValue, changed: false } };
   }
   obj[leafKey] = value as FabricValue;
@@ -232,7 +234,7 @@ const applyArrayLengthWrite = (
   value: FabricValue | undefined,
 ): Result<MutableWriteResult, ITypeMismatchError> => {
   const previousValue = parent.length;
-  if (deepEqual(previousValue, value)) {
+  if (valueEqual(previousValue, value)) {
     return { ok: { root: newRoot, previousValue, changed: false } };
   }
   // Funnel non-numbers (and `undefined`, which arises from

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1,4 +1,7 @@
-import { cloneIfNecessary } from "@commonfabric/data-model/fabric-value";
+import {
+  cloneIfNecessary,
+  valueEqual,
+} from "@commonfabric/data-model/fabric-value";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { unclaimed } from "@commonfabric/memory/fact";
 import type {
@@ -9,7 +12,6 @@ import type {
 import { encodePointer, pathsOverlap } from "../../../memory/v2/path.ts";
 import { PathKeyMap } from "@commonfabric/utils/path-key-map";
 import type { FabricValue } from "@commonfabric/api";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isRecord } from "@commonfabric/utils/types";
 import type {
@@ -465,7 +467,7 @@ const buildValuePatchCandidate = (
   // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
   // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to a
   // `Fabric`-aware equality once available.
-  if (valuePresent === previousPresent && deepEqual(value, previousValue)) {
+  if (valuePresent === previousPresent && valueEqual(value, previousValue)) {
     return null;
   }
 
@@ -516,7 +518,7 @@ const buildArrayPatchCandidates = (
   // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
   // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to a
   // `Fabric`-aware equality once available.
-  if (beforePresent === afterPresent && deepEqual(before, after)) {
+  if (beforePresent === afterPresent && valueEqual(before, after)) {
     return [];
   }
 
@@ -563,7 +565,7 @@ const buildArrayPatchCandidates = (
     // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
     // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to
     // a `Fabric`-aware equality once available.
-    if (deepEqual(nextValue, previousValue)) {
+    if (valueEqual(nextValue, previousValue)) {
       continue;
     }
 
@@ -660,7 +662,7 @@ const shallowStructureChanged = (
   // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
   // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to a
   // `Fabric`-aware equality once available.
-  return !deepEqual(before, after);
+  return !valueEqual(before, after);
 };
 
 const compareDocPaths = (
@@ -690,7 +692,7 @@ const buildReactivityPathsForChange = (
   // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
   // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to a
   // `Fabric`-aware equality once available.
-  if (deepEqual(beforeValue, afterValue)) {
+  if (valueEqual(beforeValue, afterValue)) {
     return [];
   }
 
@@ -999,7 +1001,7 @@ export class V2StorageTransaction implements IStorageTransaction {
       // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
       // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate
       // to a `Fabric`-aware equality once available.
-      if (deepEqual(doc.current.value, doc.initial.value)) {
+      if (valueEqual(doc.current.value, doc.initial.value)) {
         continue;
       }
 
@@ -1321,7 +1323,7 @@ export class V2StorageTransaction implements IStorageTransaction {
       // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate
       // to a `Fabric`-aware equality once available.
       if (
-        isDelete ? !present : (present && deepEqual(previous.value, value))
+        isDelete ? !present : (present && valueEqual(previous.value, value))
       ) {
         return { ok: current };
       }
@@ -1466,7 +1468,7 @@ export class V2StorageTransaction implements IStorageTransaction {
       if (
         isDelete
           ? !present
-          : (present && deepEqual(previousValue, isolatedValue))
+          : (present && valueEqual(previousValue, isolatedValue))
       ) {
         continue;
       }
@@ -2147,7 +2149,7 @@ export class V2StorageTransaction implements IStorageTransaction {
       // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate
       // to a `Fabric`-aware equality once available.
       if (
-        valuePresent === previousPresent && deepEqual(value, previousValue)
+        valuePresent === previousPresent && valueEqual(value, previousValue)
       ) {
         continue;
       }

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -464,9 +464,6 @@ const buildValuePatchCandidate = (
   valuePresent: boolean = value !== undefined,
   previousPresent: boolean = previousValue !== undefined,
 ): PatchDraftCandidate | null => {
-  // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
-  // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to a
-  // `Fabric`-aware equality once available.
   if (valuePresent === previousPresent && valueEqual(value, previousValue)) {
     return null;
   }
@@ -515,9 +512,6 @@ const buildArrayPatchCandidates = (
   beforePresent: boolean = before !== undefined,
   afterPresent: boolean = after !== undefined,
 ): PatchDraftCandidate[] => {
-  // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
-  // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to a
-  // `Fabric`-aware equality once available.
   if (beforePresent === afterPresent && valueEqual(before, after)) {
     return [];
   }
@@ -562,9 +556,6 @@ const buildArrayPatchCandidates = (
 
     const nextValue = after[index] as FabricValue | undefined;
     const previousValue = before[index] as FabricValue | undefined;
-    // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
-    // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to
-    // a `Fabric`-aware equality once available.
     if (valueEqual(nextValue, previousValue)) {
       continue;
     }
@@ -659,9 +650,6 @@ const shallowStructureChanged = (
     return !beforeKeys.every((key) => Object.hasOwn(after, key));
   }
 
-  // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
-  // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to a
-  // `Fabric`-aware equality once available.
   return !valueEqual(before, after);
 };
 
@@ -689,9 +677,6 @@ const buildReactivityPathsForChange = (
   const afterValue = readValueAtPath(afterRoot, path, {
     allowArrayLength: true,
   });
-  // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
-  // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate to a
-  // `Fabric`-aware equality once available.
   if (valueEqual(beforeValue, afterValue)) {
     return [];
   }
@@ -998,9 +983,6 @@ export class V2StorageTransaction implements IStorageTransaction {
       if (doc.writeDetails.size === 0) {
         continue;
       }
-      // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
-      // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate
-      // to a `Fabric`-aware equality once available.
       if (valueEqual(doc.current.value, doc.initial.value)) {
         continue;
       }
@@ -1319,9 +1301,6 @@ export class V2StorageTransaction implements IStorageTransaction {
       const present = hasValueAtPath(current.value, address.path, {
         allowArrayLength: true,
       });
-      // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
-      // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate
-      // to a `Fabric`-aware equality once available.
       if (
         isDelete ? !present : (present && valueEqual(previous.value, value))
       ) {
@@ -1462,9 +1441,6 @@ export class V2StorageTransaction implements IStorageTransaction {
       const present = hasValueAtPath(nextRoot, address.path, {
         allowArrayLength: true,
       });
-      // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
-      // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate
-      // to a `Fabric`-aware equality once available.
       if (
         isDelete
           ? !present
@@ -2145,9 +2121,6 @@ export class V2StorageTransaction implements IStorageTransaction {
         detail.address.path,
         { allowArrayLength: true },
       );
-      // TODO(danfuzz): `deepEqual` mishandles `FabricValue` (see
-      // `utils/deep-equal.ts`); this compares stored `FabricValue`s, so migrate
-      // to a `Fabric`-aware equality once available.
       if (
         valuePresent === previousPresent && valueEqual(value, previousValue)
       ) {

--- a/packages/runner/test/fabric-primitive-cell-update.test.ts
+++ b/packages/runner/test/fabric-primitive-cell-update.test.ts
@@ -1,0 +1,104 @@
+// CT-1770: FabricPrimitive values (e.g. FabricBytes) must be updatable in
+// place. Before the fix, the storage no-op gates and the reactivity
+// change-detection compared two distinct same-class FabricPrimitives via
+// `deepEqual`, which sees zero enumerable own-props and reports them equal —
+// so the write was diffed away and reactive consumers never re-ran.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { getTransactionWriteDetails } from "../src/storage/transaction-inspection.ts";
+
+const signer = await Identity.fromPassphrase("ct1770 operator");
+const space = signer.did();
+
+const bytesOf = (cell: { get(): { bytes: { slice(): Uint8Array } } }) =>
+  Array.from(cell.get().bytes.slice());
+
+describe("FabricPrimitive cell updates (CT-1770)", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("updates a FabricBytes value via keyed set()", async () => {
+    const c = runtime.getCell<{ bytes: Uint8Array }>(
+      space,
+      "keyed",
+      undefined,
+      tx,
+    );
+    c.set({ bytes: new Uint8Array([1, 2, 3, 4]) });
+    await tx.commit();
+    tx = runtime.edit();
+
+    c.withTx(tx).key("bytes").set(new Uint8Array([9, 8, 7, 6]));
+    const writes = [...getTransactionWriteDetails(tx, space)];
+    await tx.commit();
+
+    expect(writes.map((w) => w.address.path.join("/"))).toContain(
+      "value/bytes",
+    );
+    expect(bytesOf(c)).toEqual([9, 8, 7, 6]);
+  });
+
+  it("updates a FabricBytes value via whole-object set()", async () => {
+    const c = runtime.getCell<{ bytes: Uint8Array }>(
+      space,
+      "whole",
+      undefined,
+      tx,
+    );
+    c.set({ bytes: new Uint8Array([1, 2, 3, 4]) });
+    await tx.commit();
+    tx = runtime.edit();
+
+    c.withTx(tx).set({ bytes: new Uint8Array([5, 5, 5, 5]) });
+    await tx.commit();
+
+    expect(bytesOf(c)).toEqual([5, 5, 5, 5]);
+  });
+
+  it("re-fires reactive consumers when a FabricBytes value changes", async () => {
+    const c = runtime.getCell<{ bytes: Uint8Array }>(
+      space,
+      "react",
+      undefined,
+      tx,
+    );
+    c.set({ bytes: new Uint8Array([1, 2, 3, 4]) });
+    await tx.commit();
+
+    const seen: string[] = [];
+    const cancel = c.key("bytes").sink((value: unknown) => {
+      const v = value as { slice(): Uint8Array };
+      seen.push(Array.from(v.slice()).join(","));
+    });
+    await runtime.idle();
+
+    tx = runtime.edit();
+    c.withTx(tx).key("bytes").set(new Uint8Array([9, 8, 7, 6]));
+    await tx.commit();
+    await runtime.idle();
+    cancel();
+
+    expect(seen).toEqual(["1,2,3,4", "9,8,7,6"]);
+  });
+});

--- a/packages/runner/test/mutable-path-write-noop.test.ts
+++ b/packages/runner/test/mutable-path-write-noop.test.ts
@@ -1,0 +1,43 @@
+// Covers the no-op (unchanged-value) branches of applyMutablePathWrite,
+// including Fabric-aware equality for FabricPrimitive elements (CT-1770): an
+// equal FabricBytes must be recognized as a no-op, and a different one as a
+// change.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { applyMutablePathWrite } from "../src/storage/transaction/mutable-path-write.ts";
+import type { IMemoryAddress } from "../src/storage/interface.ts";
+
+const addr = (path: string[]): IMemoryAddress => ({ id: "of:mpw-noop", path });
+
+describe("applyMutablePathWrite no-op detection", () => {
+  it("reports changed=false writing an array element with its current value", () => {
+    const res = applyMutablePathWrite([5, 6, 7], addr(["1"]), 6);
+    expect(res.ok?.changed).toBe(false);
+  });
+
+  it("is Fabric-aware for array elements: equal FabricBytes is a no-op", () => {
+    const root = [new FabricBytes(new Uint8Array([1, 2, 3]))];
+
+    const same = applyMutablePathWrite(
+      root,
+      addr(["0"]),
+      new FabricBytes(new Uint8Array([1, 2, 3])),
+    );
+    expect(same.ok?.changed).toBe(false);
+
+    const different = applyMutablePathWrite(
+      root,
+      addr(["0"]),
+      new FabricBytes(new Uint8Array([9, 9, 9])),
+    );
+    expect(different.ok?.changed).toBe(true);
+  });
+
+  it("reports changed=false writing array length with its current length", () => {
+    const res = applyMutablePathWrite([5, 6, 7], addr(["length"]), 3);
+    expect(res.ok?.changed).toBe(false);
+  });
+});


### PR DESCRIPTION
# Why

Updating a `FabricBytes` (and any other `FabricPrimitive`: `FabricRegExp`,
`FabricEpochNsec`/`Days`, `FabricHash`) value stored in a cell is silently a
**no-op**. Both keyed and whole-object `set()` are diffed away, the stored value
never changes, and reactive consumers never re-run.

```ts
const c = runtime.getCell<{ bytes: Uint8Array }>(space, "p", undefined, tx);
c.set({ bytes: new Uint8Array([1, 2, 3, 4]) });
await tx.commit(); tx = runtime.edit();

c.withTx(tx).key("bytes").set(new Uint8Array([9, 8, 7, 6]));
await tx.commit();
c.get().bytes.slice();   // → [1, 2, 3, 4]   (the write was dropped)
```

A plain value (a number) at a sibling key updates and re-triggers consumers
correctly in the same harness, so this is **primitive-specific** and
**schema-independent**. Fixes [CT-1770](https://linear.app/common-tools/issue/CT-1770).

# Root cause

The diff layer is innocent — `normalizeAndDiff` correctly emits a change for a
`FabricBytes` set (its `FabricSpecialObject` branch is unconditional). The value
is lost **downstream**, and there are **two distinct failure mechanisms**, both
rooted in code that treats a `FabricPrimitive` as if it were a plain object:

**1. Equality conflation.** `FabricPrimitive`s keep their state in private
`#fields`, so they have **zero enumerable own-properties**. `deepEqual` (and
therefore `valueEqual`, which today just forwards to it) compares class
instances by enumerable own-props, so **any two same-class `FabricPrimitive`s
compare equal regardless of value**:

```
deepEqual(FabricBytes([1,2,3,4]), FabricBytes([9,8,7,6])) === true   // the bug
hashOf(...) of those two differ                          === true   // hashing is fine
```

Every storage no-op gate and reactivity change-detection gate that compares
stored `FabricValue`s via `deepEqual` therefore sees "unchanged":

- Write-time no-op — `v2-transaction.ts` `writeWithinBranch` (returns before the
  write is even drafted).
- Commit-time no-op — `v2-transaction.ts` (skips committing the doc).
- Write propagation — `write-propagation.ts` (the write isn't classified as a
  change, so subscribers aren't scheduled).
- Reactive-dependency change detection — `reactive-dependencies.ts`.
- Plus the chronicle commit path and the shared mutable-path-write helper.

**2. Value-walk decomposition.** `differential.ts`'s `collectChangedPaths`
(which produces the per-path change set that drives reactivity) recurses into
records by walking their `Object.keys`. A `FabricBytes` is `typeof === "object"`
but has no own keys, so the walk finds nothing to recurse into and returns
**without recording a change** — even once equality (1) is fixed. This is a
distinct bug class from (1): the value is being *decomposed*, not *compared*.

Both mechanisms must be fixed for the end-to-end symptom (write lands **and**
reactive consumers re-fire) to go away — verified independently with a
plain-number control that re-fires while the `FabricBytes` sibling does not.

# Relationship to #4253 (Dan's lead)

[#4253](https://github.com/commontoolsinc/labs/pull/4253) merged the morning
this was filed. It is **markers-only** (162 insertions, 0 deletions, all
comments — "no behavior change") — a systematic catalog of the fabric-unsafe
sites, explicitly naming "`deepEqual` itself" and "the fabric-carrying
`deepEqual` callers (transaction change-detection, reactive-dependencies,
write-propagation, diagnosis…), pointing at the migration to a Fabric-aware
equality."

So CT-1770 is **not a regression from #4253** — it's a pre-existing latent bug
#4253 annotated (latent because storing/updating a `FabricBytes` in a cell is a
rare path), and the fix here is exactly the migration #4253 points to. Two notes
for the audit: `differential.ts` was **not** in #4253's file list, and it needed
**both** fix classes — the equality swap *and* the value-walk leaf-guard.

# The fix

1. **`data-model/fabric-value.ts` — make `valueEqual` Fabric-aware** (the
   chokepoint #4253's TODOs point to). Same structural recursion as `deepEqual`
   for plain objects/arrays, but defers to canonical `hashOf` for any
   `FabricSpecialObject`. The hash fast-path fires **only** when a special
   object is actually reached, so all-plain-data stays on the same fast,
   short-circuiting path as before.

2. **Migrate the fabric-carrying change-detection gates** from `deepEqual` →
   `valueEqual`: `v2-transaction.ts`, `transaction/mutable-path-write.ts`,
   `transaction/chronicle.ts`, `differential.ts`, `reactive-dependencies.ts`,
   `scheduler/write-propagation.ts`, `scheduler/diagnosis.ts`. (Only sites that
   compare stored `FabricValue`s — schema/path/CFC-atom `deepEqual` callers are
   deliberately left alone.)

3. **`differential.ts` `collectChangedPaths` — treat a `FabricSpecialObject` as
   an atomic leaf** (don't decompose it via `Object.keys`); record a change at
   its path when `valueEqual` says it differs.

# Verification

- New unit tests: `data-model/test/fabric-value.test.ts` — `valueEqual` on
  `FabricBytes`/`FabricRegExp`/`FabricEpochDays`, nested-in-plain-container, and
  special-vs-plain.
- New e2e regression: `runner/test/fabric-primitive-cell-update.test.ts` — keyed
  set, whole-object set, and reactive re-fire.
- Regression: full **runner** suite `647 passed (3309 steps), 0 failed`; full
  **data-model** suite `18 files, 1164 steps, 0 failed`. Typecheck + fmt + lint
  clean on all changed files.

# Scope boundaries

- Touches only `deepEqual` sites that compare stored `FabricValue`s. The many
  `deepEqual` callers comparing schemas, paths, partial-cause descriptors, or
  CFC atoms/labels are **unchanged**.
- `differential.ts`'s leaf-guard is the only value-walk-decomposition site fixed
  here (it's on the reactivity path). #4253's other value-walk sites
  (builder/runner/piece value walks, `SchemaObjectTraverser`, `traverse.ts`,
  `addCommonIDfromObjectID`) are **not** addressed — they can mishandle
  `FabricPrimitive`s in *other* scenarios and are out of scope for CT-1770.

# Open questions / decisions for @danfuzz

1. **Performance.** `valueEqual` hashes (SHA-256) when it reaches a
   `FabricSpecialObject`, on the write/commit/reactivity hot paths. The common
   all-plain-data case is unaffected (fast short-circuit), and frozen stored
   values' hashes are `WeakMap`-cached — but the *incoming* value isn't. Is
   hashing acceptable here, or do you want per-type structural equality (e.g.
   byte-compare for `FabricBytes`) to avoid SHA-256 on the hot path? This is the
   one that probably needs a CI-perf check.
2. **`valueEqual` design / home.** Is hash-based equality the intended shape for
   the canonical `valueEqual`, or did you have a different design in mind? Should
   it stay in `data-model/fabric-value.ts`?
3. **Migration scope.** Did I classify the FabricValue-comparison sites
   correctly — anything I over-included (e.g. `diagnosis.ts`, included for
   consistency) or missed? Should the non-storage gates
   (`reactive-dependencies`, `write-propagation`, `diagnosis`) ship together
   with the storage ones or separately?
4. **Other value-walk sites.** `differential.ts` showed the equality fix alone
   is insufficient where a private-state primitive is *walked*. Are the other
   #4253 value-walk sites reachable for `FabricPrimitive`s today, and do you want
   them folded in here or tracked separately?
5. **Chronicle vs v2 paths.** I fixed both, but the repro only exercises the v2
   native-commit path. Is the chronicle path still live (worth the fix) or
   legacy?


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1770: updates to `FabricPrimitive` values (e.g. `FabricBytes`) now apply in place and correctly re-trigger reactive consumers. Resolves equality conflation and path-diff omissions that treated primitives as plain objects.

- **Bug Fixes**
  - Implemented `valueEqual`: Fabric-aware equality that hashes any `FabricSpecialObject`, and correctly handles array holes vs `undefined` and key presence.
  - Replaced `deepEqual` with `valueEqual` in `v2-transaction`, `mutable-path-write`, `chronicle`, `differential`, `reactive-dependencies`, `write-propagation`, `diagnosis`.
  - In `differential`, treat `FabricSpecialObject` as an atomic leaf and emit a change at its path.
  - Tests: unit coverage for `FabricBytes`/`FabricRegExp`/`FabricEpochDays`; e2e for keyed/whole-object sets and reactive re-fire; new runner test for `applyMutablePathWrite` no-op branches (Fabric-aware array element and array-length cases).

<sup>Written for commit 18cc8b29500f43b6529338b23cc4c29c253f7163. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

