### PR TITLE
refactor(runner): redefine SigilWriteRedirectLink via cell-rep's LinkRef

### DIFF
--- a/packages/runner/src/sigil-types.ts
+++ b/packages/runner/src/sigil-types.ts
@@ -5,15 +5,6 @@ import { LINK_V1_TAG, type LinkRef } from "@commonfabric/data-model/cell-rep";
 
 export type { URI } from "@commonfabric/memory/interface";
 
-/**
- * Generic sigil value type for future extensions
- */
-export type SigilValue<T> = { "/": T };
-
-/**
- * Link sigil value v1
- */
-
 // The link-ref envelope (`{ "/": { "link@1": … } }`) and its tag are owned by
 // `data-model/cell-rep`, the chokepoint that will later flag-dispatch the form.
 // Re-exported here (the historical home) for existing importers.
@@ -33,13 +24,6 @@ export type CellLinkRefPayload = {
   overwrite?: "redirect" | "this"; // default is "this"
 };
 
-export type LinkV1 = {
-  [LINK_V1_TAG]: CellLinkRefPayload;
-};
-
-export type WriteRedirectV1 = LinkV1 & {
-  [LINK_V1_TAG]: { overwrite: "redirect" };
-};
 /**
  * Sigil link type.
  *
@@ -56,10 +40,12 @@ export type WriteRedirectV1 = LinkV1 & {
 export type SigilLink<P extends CellLinkRefPayload = CellLinkRefPayload> =
   LinkRef<P>;
 /**
- * Sigil alias type - uses LinkV1 with overwrite field
+ * A {@link SigilLink} whose payload is a write redirect (an alias) — its
+ * `overwrite` is fixed to `"redirect"`.
  */
-
-export type SigilWriteRedirectLink = SigilValue<WriteRedirectV1>;
+export type SigilWriteRedirectLink = LinkRef<
+  CellLinkRefPayload & { overwrite: "redirect" }
+>;
 
 /****************
  * Legacy types *


### PR DESCRIPTION
## What

Routes `SigilWriteRedirectLink` through the `data-model/cell-rep` chokepoint, the
same way `SigilLink` already is.

```ts
// before
export type SigilWriteRedirectLink = SigilValue<WriteRedirectV1>;
// after
export type SigilWriteRedirectLink = LinkRef<
  CellLinkRefPayload & { overwrite: "redirect" }
>;
```

The two are **structurally identical** (`SigilValue<WriteRedirectV1>` expands to
`{ "/": { "link@1": CellLinkRefPayload & { overwrite: "redirect" } } }`, which is
exactly `LinkRef<CellLinkRefPayload & { overwrite: "redirect" }>`), so this is
type-only and behavior-neutral. The `cell.ts` / `link-types.ts` consumers are
unchanged.

## Cleanup

This was the **last** use of `SigilValue`, `LinkV1`, and `WriteRedirectV1` — all
three were confined to `sigil-types.ts` and exported nowhere — so they're removed.
(`LINK_V1_TAG`'s `V1` legitimately versions the wire tag and stays.)

## Verification

- Workspace `deno check` clean (the change is type-only; the cast in
  `cell.ts` and the `FabricObject` bound on the intersection both hold).
- Runner suite green (646 passed, 0 failed); `lint` / `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145FPGZjJRRwpucbP6VR4aP


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `SigilWriteRedirectLink` through `@commonfabric/data-model/cell-rep`’s `LinkRef`, matching `SigilLink`. This is a type-only change with no runtime impact.

- **Refactors**
  - Redefined `SigilWriteRedirectLink` as `LinkRef<CellLinkRefPayload & { overwrite: "redirect" }>`.
  - Removed `SigilValue`, `LinkV1`, and `WriteRedirectV1` from `sigil-types.ts`.

<sup>Written for commit de0a79aa68553c9cb9b7ab2f86c01d2d3ab4319d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

