### PR TITLE
Parse hashtags using shared international conventions

### DIFF
--- a/packages/data-model/src/schema-tags.ts
+++ b/packages/data-model/src/schema-tags.ts
@@ -9,11 +9,18 @@
 
 import type { JSONSchema } from "@commonfabric/api";
 
-const HASHTAG_PATTERN = /#([a-z0-9-]+)/gi;
+// A hashtag is `#` followed by a run of Unicode letters, combining marks,
+// numbers, and underscores. This matches the convention shared across social
+// platforms: letters from any script are accepted (Latin with diacritics, CJK,
+// Cyrillic, Arabic, and so on), not just unaccented a-z. Any other character,
+// including a hyphen, whitespace, or the end of the text, terminates the tag.
+const HASHTAG_PATTERN = /#([\p{L}\p{M}\p{N}_]+)/gu;
 
 /**
- * Extract hashtag tokens from free text. Returns the tokens lowercased,
- * without the leading `#`, deduplicated, in order of first appearance.
+ * Extract hashtag tokens from free text. A token starts at `#` and runs through
+ * Unicode letters, combining marks, numbers, and underscores; a hyphen, space,
+ * or other punctuation ends it. Returns the tokens lowercased, without the
+ * leading `#`, deduplicated, in order of first appearance.
  */
 export function extractHashtags(text: string): string[] {
   const tags: string[] = [];

--- a/packages/data-model/test/schema-tags.test.ts
+++ b/packages/data-model/test/schema-tags.test.ts
@@ -6,9 +6,9 @@ import { extractHashtags, tagsFromSchema } from "@/schema-tags.ts";
 
 describe("extractHashtags", () => {
   it("extracts tags lowercased without the leading #", () => {
-    expect(extractHashtags("A #Note about #quick-capture")).toEqual([
+    expect(extractHashtags("A #Note about #capture")).toEqual([
       "note",
-      "quick-capture",
+      "capture",
     ]);
   });
 
@@ -16,8 +16,25 @@ describe("extractHashtags", () => {
     expect(extractHashtags("#b then #a then #B again")).toEqual(["b", "a"]);
   });
 
-  it("stops tokens at characters outside [a-z0-9-]", () => {
-    expect(extractHashtags("#todo_list")).toEqual(["todo"]);
+  it("includes underscores in a token", () => {
+    expect(extractHashtags("#todo_list")).toEqual(["todo_list"]);
+  });
+
+  it("ends a token at a hyphen", () => {
+    expect(extractHashtags("#quick-capture")).toEqual(["quick"]);
+  });
+
+  it("accepts letters from non-Latin scripts and diacritics", () => {
+    expect(extractHashtags("#café #日本語 #привет #مرحبا")).toEqual([
+      "café",
+      "日本語",
+      "привет",
+      "مرحبا",
+    ]);
+  });
+
+  it("ends a token at whitespace and punctuation", () => {
+    expect(extractHashtags("#todo, and #done!")).toEqual(["todo", "done"]);
   });
 
   it("returns empty for text without hashtags", () => {

--- a/packages/patterns/activity-log/activity-log.tsx
+++ b/packages/patterns/activity-log/activity-log.tsx
@@ -40,7 +40,7 @@ interface ActivityLogInput {
   mentioned?: Writable<MentionablePiece[] | Default<[]>>;
 }
 
-/** An #activity-log for recording structured agent events. */
+/** An #activityLog for recording structured agent events. */
 export interface ActivityLogOutput {
   [NAME]: string;
   [UI]: VNode;

--- a/packages/patterns/agent/agent.tsx
+++ b/packages/patterns/agent/agent.tsx
@@ -99,7 +99,7 @@ export default pattern<AgentInput, AgentOutput>(
   }) => {
     // Discover activity-log (optional — null-checked before use)
     const activityLogWish = wish<ActivityLogPiece>({
-      query: "#activity-log",
+      query: "#activityLog",
       headless: true,
     });
     const activityLog = activityLogWish.result;

--- a/packages/patterns/experimental/folksonomy-aggregator.tsx
+++ b/packages/patterns/experimental/folksonomy-aggregator.tsx
@@ -4,8 +4,8 @@
  * This charm collects tag usage events from folksonomy-tags instances and
  * computes community suggestions ranked by usage count (preferential attachment).
  *
- * SETUP: After deploying, FAVORITE this charm with tag "folksonomy-aggregator"
- * so that folksonomy-tags instances can discover it via wish("#folksonomy-aggregator").
+ * SETUP: After deploying, FAVORITE this charm with tag "folksonomyAggregator"
+ * so that folksonomy-tags instances can discover it via wish("#folksonomyAggregator").
  *
  * HOW IT WORKS:
  * 1. folksonomy-tags instances post events via the postEvent stream
@@ -57,9 +57,9 @@ interface Input {
 }
 
 /**
- * A #folksonomy-aggregator that collects tag usage events and serves community suggestions.
+ * A #folksonomyAggregator that collects tag usage events and serves community suggestions.
  *
- * The #folksonomy-aggregator tag is how folksonomy-tags instances discover this charm via wish().
+ * The #folksonomyAggregator tag is how folksonomy-tags instances discover this charm via wish().
  */
 export interface Output {
   events: TagEvent[];
@@ -172,7 +172,7 @@ export default pattern<Input, Output>(({ events }) => {
           <h2 style={{ margin: 0 }}>🏷️ Folksonomy Aggregator</h2>
           <p style={{ color: "#666", margin: 0, fontSize: "14px" }}>
             Community tag telemetry collector. Favorite this charm with tag
-            "folksonomy-aggregator" for discovery.
+            "folksonomyAggregator" for discovery.
           </p>
         </cf-vstack>
 

--- a/packages/patterns/experimental/folksonomy-demo.tsx
+++ b/packages/patterns/experimental/folksonomy-demo.tsx
@@ -7,7 +7,7 @@
  *
  * SETUP:
  * 1. Deploy folksonomy-aggregator.tsx first
- * 2. Favorite the aggregator with tag "folksonomy-aggregator"
+ * 2. Favorite the aggregator with tag "folksonomyAggregator"
  * 3. Deploy this demo pattern
  * 4. Add tags in one section, see them appear as suggestions in another
  * 5. Check the aggregator charm to see events flowing in
@@ -48,7 +48,7 @@ export default pattern<Input, Output>(
       suggestions: Record<string, unknown[]>;
       postEvent: unknown;
     }>({
-      query: "#folksonomy-aggregator",
+      query: "#folksonomyAggregator",
       scope: ["~", "."],
     });
     const hasAggregator = aggregatorWish.result != null;
@@ -111,7 +111,7 @@ export default pattern<Input, Output>(
               <span>
                 {hasAggregator
                   ? "Connected to folksonomy-aggregator - community features active!"
-                  : "Aggregator not found. Deploy and favorite folksonomy-aggregator with tag 'folksonomy-aggregator' for community features."}
+                  : "Aggregator not found. Deploy and favorite folksonomy-aggregator with tag 'folksonomyAggregator' for community features."}
               </span>
             </cf-hstack>
           </div>

--- a/packages/patterns/experimental/folksonomy-tags.tsx
+++ b/packages/patterns/experimental/folksonomy-tags.tsx
@@ -20,7 +20,7 @@
  * ```
  *
  * AGGREGATOR DISCOVERY:
- * This pattern auto-discovers the aggregator using wish("#folksonomy-aggregator").
+ * This pattern auto-discovers the aggregator using wish("#folksonomyAggregator").
  * Deploy and favorite the folksonomy-aggregator charm for community features.
  * Without the aggregator, falls back to local-only mode.
  *
@@ -285,7 +285,7 @@ export const FolksonomyTags = pattern<
     // Use injected aggregator if provided, otherwise discover via wish()
     // Search both favorites (~) and current space mentionables (.)
     const aggregatorWish = wish<AggregatorCharm>({
-      query: "#folksonomy-aggregator",
+      query: "#folksonomyAggregator",
       scope: ["~", "."],
     });
 

--- a/packages/patterns/gideon-tests/test-cross-charm-client.tsx
+++ b/packages/patterns/gideon-tests/test-cross-charm-client.tsx
@@ -103,7 +103,7 @@ export default pattern<Input, Output>(
       invocationLog: string[];
       incrementCounter: Stream<void>;
     }>({
-      query: "#cross-piece-test-server",
+      query: "#crossPieceTestServer",
     });
 
     // Access the result from the wish (WishState has a result property)

--- a/packages/patterns/gideon-tests/test-cross-charm-server.tsx
+++ b/packages/patterns/gideon-tests/test-cross-charm-server.tsx
@@ -4,7 +4,7 @@
  * Exposes a Stream that increments a counter when invoked from another piece.
  * Used with test-cross-piece-client.tsx to verify cross-piece stream invocation.
  *
- * IMPORTANT: The #cross-piece-test-server tag is in the JSDoc on the Output
+ * IMPORTANT: The #crossPieceTestServer tag is in the JSDoc on the Output
  * interface below (not here) - that's where wish() looks for tags.
  *
  * SETUP: After deploying, you must FAVORITE this piece for wish() to find it.
@@ -27,7 +27,7 @@ interface Input {
   invocationLog: string[] | Default<[]>;
 }
 
-/** A #cross-piece-test-server that exposes a stream for testing cross-piece invocation. */
+/** A #crossPieceTestServer that exposes a stream for testing cross-piece invocation. */
 export interface Output {
   counter: number;
   invocationLog: string[];
@@ -63,7 +63,7 @@ export default pattern<Input, Output>(({ counter, invocationLog }) => {
       >
         <h2>Cross-Piece Test Server</h2>
         <p style={{ fontStyle: "italic", color: "#666" }}>
-          Tag: #cross-piece-test-server
+          Tag: #crossPieceTestServer
         </p>
 
         <div style={{ marginTop: "16px" }}>

--- a/packages/patterns/pattern-index.tsx
+++ b/packages/patterns/pattern-index.tsx
@@ -2,7 +2,7 @@ import { computed, type Default, NAME, pattern, UI } from "commonfabric";
 
 type Input = { url: string | Default<"/api/patterns/index.md"> };
 
-/** A URL to a #pattern-index */
+/** A URL to a #patternIndex */
 export type Output = { url: string };
 
 const PatternIndexUrl = pattern<Input, Output>(

--- a/packages/patterns/self.tsx
+++ b/packages/patterns/self.tsx
@@ -8,7 +8,7 @@
  * self-model: values, neurotype, and meaning-alignment answers.
  *
  * Usage from other patterns:
- *   const self = wish<SelfOutput>({ query: "#self-model" });
+ *   const self = wish<SelfOutput>({ query: "#selfModel" });
  */
 import {
   computed,
@@ -301,7 +301,7 @@ interface SelfInput {
   selfModel?: Writable<SelfModel | Default<typeof EMPTY_SELF_MODEL>>;
 }
 
-/** Private self-model — the user's values, neurotype, and reflective answers. #self-model */
+/** Private self-model — the user's values, neurotype, and reflective answers. #selfModel */
 export interface SelfOutput {
   [NAME]: string;
   [UI]: VNode;

--- a/packages/patterns/system/common-fabric.tsx
+++ b/packages/patterns/system/common-fabric.tsx
@@ -415,7 +415,7 @@ type ListPatternIndexInput = Record<string, never>;
 export const listPatternIndex = pattern<ListPatternIndexInput>(
   ({ _ }) => {
     const patternIndexUrl = wish<{ url: Writable<string> }>({
-      query: "#pattern-index",
+      query: "#patternIndex",
     });
 
     const resolvedUrl = new Writable<string>("/api/patterns/index.md");

--- a/packages/patterns/system/omnibox-fab.tsx
+++ b/packages/patterns/system/omnibox-fab.tsx
@@ -127,7 +127,7 @@ export default pattern<OmniboxFABInput>(
     const profile = wish<string>({ query: "#learnedSummary" });
 
     const patternIndexUrl = wish<{ url: Writable<string> }>({
-      query: "#pattern-index",
+      query: "#patternIndex",
     });
     const resolvedPatternUrl = new Writable<string>("/api/patterns/index.md");
     computed(() => {

--- a/packages/patterns/system/profile-home.test.tsx
+++ b/packages/patterns/system/profile-home.test.tsx
@@ -36,7 +36,7 @@ export default pattern(() => {
     profile.addElement.send({
       catalogId: "profile-card",
       title: "Profile card",
-      tag: "profile-card",
+      tag: "#profileCard",
       userTags: ["person"],
     });
   });
@@ -78,7 +78,7 @@ export default pattern(() => {
   const assert_added_element = computed(() => {
     const element = profile.elements[0];
     return profile.elements.length === 1 &&
-      element?.tag === "profile-card" &&
+      element?.tag === "#profileCard" &&
       element?.title === "Profile card" &&
       element?.userTags.includes("person") === true;
   });

--- a/packages/patterns/system/profile-home.tsx
+++ b/packages/patterns/system/profile-home.tsx
@@ -293,7 +293,7 @@ const mutateElements = handler<
         ),
         source: "catalog",
         title: "Profile card",
-        tag: "profile-card",
+        tag: "#profileCard",
         userTags,
       }, state.elements);
       return;

--- a/packages/patterns/system/suggestion.tsx
+++ b/packages/patterns/system/suggestion.tsx
@@ -121,7 +121,7 @@ export default pattern<
   const suggestionHistory = SuggestionHistory({});
 
   const patternIndexUrl = wish<{ url: Writable<string> }>({
-    query: "#pattern-index",
+    query: "#patternIndex",
   });
   const resolvedPatternUrl = new Writable<string>("/api/patterns/index.md");
   computed(() => {

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -25,6 +25,7 @@ import {
   internSchema,
 } from "@commonfabric/data-model/schema-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { extractHashtags } from "@commonfabric/data-model/schema-tags";
 import { getPatternEnvironment } from "../env.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 import {
@@ -206,8 +207,8 @@ export function tagMatchesHashtag(
   tag: string | undefined,
   searchTermWithoutHash: string,
 ): boolean {
-  const hashtags = tag?.toLowerCase().matchAll(/#([a-z0-9-]+)/g) ?? [];
-  return [...hashtags].some((m) => m[1] === searchTermWithoutHash);
+  if (tag === undefined) return false;
+  return extractHashtags(tag).includes(searchTermWithoutHash);
 }
 
 type WishContext = {

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -2811,7 +2811,7 @@ describe("wish built-in", () => {
         avatar: "",
         elements: [{
           cell: profileCard,
-          tag: "#profile-card",
+          tag: "#profileCard",
           userTags: ["person"],
           title: "Profile Card",
         }],
@@ -2837,7 +2837,7 @@ describe("wish built-in", () => {
 
       const wishPattern = pattern(() => ({
         byUserTag: wish({ query: "#person", scope: ["profile"] }),
-        byTag: wish({ query: "#profile-card", scope: ["profile"] }),
+        byTag: wish({ query: "#profileCard", scope: ["profile"] }),
       }));
 
       const resultCell = runtime.getCell<Record<string, any>>(
@@ -3445,10 +3445,19 @@ describe("tagMatchesHashtag", () => {
     expect(tagMatchesHashtag("#pattern for dinner", "pattern")).toBe(true);
   });
 
-  it("matches hashtag portion before special characters", () => {
-    // The hashtag #todo_list is parsed as #todo (underscore ends the hashtag)
-    expect(tagMatchesHashtag("#todo_list", "todo")).toBe(true);
-    expect(tagMatchesHashtag("#todo_list", "todo_list")).toBe(false);
+  it("includes underscores in the hashtag", () => {
+    expect(tagMatchesHashtag("#todo_list", "todo_list")).toBe(true);
+    expect(tagMatchesHashtag("#todo_list", "todo")).toBe(false);
+  });
+
+  it("ends the hashtag at a hyphen", () => {
+    expect(tagMatchesHashtag("#todo-list", "todo")).toBe(true);
+    expect(tagMatchesHashtag("#todo-list", "todo-list")).toBe(false);
+  });
+
+  it("matches hashtags written in non-Latin scripts", () => {
+    expect(tagMatchesHashtag("一篇 #日本語 笔记", "日本語")).toBe(true);
+    expect(tagMatchesHashtag("café au #café", "café")).toBe(true);
   });
 });
 

--- a/packages/schema-generator/test/fixtures/schema/descriptions-hashtag-tags.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-hashtag-tags.expected.json
@@ -1,5 +1,5 @@
 {
-  "description": "A #note the user took, discoverable via #quick-capture.",
+  "description": "A #note the user took, discoverable via #quickCapture.",
   "properties": {
     "annotations": {
       "description": "Linked #annotation entries.",
@@ -22,7 +22,7 @@
   ],
   "tags": [
     "note",
-    "quick-capture"
+    "quickcapture"
   ],
   "type": "object"
 }

--- a/packages/schema-generator/test/fixtures/schema/descriptions-hashtag-tags.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-hashtag-tags.input.ts
@@ -1,4 +1,4 @@
-/** A #note the user took, discoverable via #quick-capture. */
+/** A #note the user took, discoverable via #quickCapture. */
 interface SchemaRoot {
   /** The note body. */
   content: string;

--- a/packages/schema-generator/test/fixtures/schema/descriptions-intersection-hashtag-tags.expected.json
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-intersection-hashtag-tags.expected.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Docs inherited from intersection constituents. Sources: RecipeBase, Schedulable.",
-  "description": "A #recipe with ingredients.\n\nSchedulable on the #meal-plan.",
+  "description": "A #recipe with ingredients.\n\nSchedulable on the #mealPlan.",
   "properties": {
     "ingredients": {
       "items": {
@@ -18,7 +18,7 @@
   ],
   "tags": [
     "recipe",
-    "meal-plan"
+    "mealplan"
   ],
   "type": "object"
 }

--- a/packages/schema-generator/test/fixtures/schema/descriptions-intersection-hashtag-tags.input.ts
+++ b/packages/schema-generator/test/fixtures/schema/descriptions-intersection-hashtag-tags.input.ts
@@ -3,7 +3,7 @@ type RecipeBase = {
   ingredients: string[];
 };
 
-/** Schedulable on the #meal-plan. */
+/** Schedulable on the #mealPlan. */
 type Schedulable = {
   plannedFor: string;
 };


### PR DESCRIPTION
Make hashtag detection follow the convention used across social platforms: a tag is `#` followed by Unicode letters from any script, combining marks, numbers, and underscores, and it ends at a hyphen, whitespace, or other punctuation. The previous pattern only accepted unaccented a-z, wrongly included hyphens, and excluded underscores and every non-Latin script.

Keep detection in one place: schema-tags `extractHashtags` is the single source, and `tagMatchesHashtag` in the wish builtin now delegates to it instead of carrying its own copy of the regex.

Because a hyphen now ends a tag, rename the discovery hashtags that relied on hyphens to CamelCase on both the publishing JSDoc tag and every wish() query that resolves it: folksonomy-aggregator, pattern-index, self-model, activity-log, and the cross-charm test pair.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopted international hashtag parsing and centralized detection via `extractHashtags`. Renamed hyphenated discovery tags to CamelCase and made the profile card discoverable via `#profileCard`.

- **New Features**
  - Unicode-aware parser in `@commonfabric/data-model` `extractHashtags`: accepts letters from any script, combining marks, numbers, and underscores; hyphen/space/punctuation end the tag.
  - `@commonfabric/runner` wish (`tagMatchesHashtag`) now delegates to `extractHashtags`.

- **Migration**
  - Rename discovery tags and queries: `#folksonomy-aggregator` → `#folksonomyAggregator`, `#pattern-index` → `#patternIndex`, `#self-model` → `#selfModel`, `#activity-log` → `#activityLog`, `#cross-piece-test-server` → `#crossPieceTestServer`.
  - Update docs/schema examples: `#quick-capture` → `#quickCapture`, `#meal-plan` → `#mealPlan` (tokens become `quickcapture`, `mealplan`).
  - Profile catalog: stamp the card with `#profileCard` (was `profile-card`) so it’s discoverable.

<sup>Written for commit 84457d1fc08ca201458f4688cc491f9390aa01ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

