### PR TITLE
Summarize coverage change in resolved gate comment

### DIFF
--- a/tasks/perf-check.test.ts
+++ b/tasks/perf-check.test.ts
@@ -343,6 +343,25 @@ Deno.test("writeCoverageResolved omits groups the PR did not change", async () =
   assertEquals(payload?.groups, []);
 });
 
+Deno.test("writeCoverageResolved flags a changed group whose debt was overridden", async () => {
+  const rows = [
+    coverageRow("coverage-debt: workspace uncovered lines", 2948, 2953, "excl"),
+    // The PR changed `tasks` and accepted its regression with an override.
+    coverageRow("coverage-debt: tasks uncovered lines", 15, 12, "ovrd"),
+  ];
+  const payload = await payloadFrom(() =>
+    writeCoverageResolved(4211, rows, [{ filename: "tasks/foo.ts" }])
+  );
+
+  assertEquals(payload?.state, "resolved");
+  assertEquals(payload?.overridden, true);
+  // An override contributes no reduction, but the group still appears.
+  assertEquals(payload?.improvedLines, 0);
+  assertEquals(payload?.groups, [
+    { group: "tasks", baseline: 12, current: 15 },
+  ]);
+});
+
 Deno.test("writeCoverageResolved sums gated groups and ignores workspace and overrides", async () => {
   const rows = [
     coverageRow("coverage-debt: workspace uncovered lines", 1000, 2000, "excl"),
@@ -358,6 +377,8 @@ Deno.test("writeCoverageResolved sums gated groups and ignores workspace and ove
   assertEquals(payload?.state, "resolved");
   assertEquals(payload?.improvedLines, 14); // 6 + 8
   assertEquals(payload?.groups, []);
+  // The overridden group is not one this PR changed, so it is not flagged.
+  assertEquals(payload?.overridden, false);
 });
 
 Deno.test("writeCoverageResolved reports zero improvement when gated groups sit at baseline", async () => {

--- a/tasks/perf-check.test.ts
+++ b/tasks/perf-check.test.ts
@@ -315,12 +315,32 @@ Deno.test("writeCoverageComment writes a resolved payload reporting the gated re
     coverageRow("coverage-debt: tasks uncovered lines", 4, 9),
   ];
   const payload = await payloadFrom(() =>
-    writeCoverageComment(4211, [], rows, [], "")
+    writeCoverageComment(4211, [], rows, [{ filename: "tasks/foo.ts" }], "")
   );
 
   assertEquals(payload?.state, "resolved");
   // Only the gated group counts: 9 - 4 = 5 lines; the workspace delta is excluded.
   assertEquals(payload?.improvedLines, 5);
+  // The changed `tasks` group is summarized; workspace stays out of it.
+  assertEquals(payload?.groups, [
+    { group: "tasks", baseline: 9, current: 4 },
+  ]);
+});
+
+Deno.test("writeCoverageResolved omits groups the PR did not change", async () => {
+  const rows = [
+    coverageRow("coverage-debt: workspace uncovered lines", 2948, 2953, "excl"),
+    coverageRow("coverage-debt: tasks uncovered lines", 4, 6),
+  ];
+  // No changed files map to a coverage group, so there is no per-group summary.
+  const payload = await payloadFrom(() =>
+    writeCoverageResolved(4211, rows, [{ filename: "README.md" }])
+  );
+
+  assertEquals(payload?.state, "resolved");
+  // Only the gated `tasks` group counts: 6 - 4 = 2 lines.
+  assertEquals(payload?.improvedLines, 2);
+  assertEquals(payload?.groups, []);
 });
 
 Deno.test("writeCoverageResolved sums gated groups and ignores workspace and overrides", async () => {
@@ -331,10 +351,13 @@ Deno.test("writeCoverageResolved sums gated groups and ignores workspace and ove
     // An overridden group accepted its debt, so it does not count as a reduction.
     coverageRow("coverage-debt: identity uncovered lines", 50, 60, "ovrd"),
   ];
-  const payload = await payloadFrom(() => writeCoverageResolved(4211, rows));
+  const payload = await payloadFrom(() =>
+    writeCoverageResolved(4211, rows, [])
+  );
 
   assertEquals(payload?.state, "resolved");
   assertEquals(payload?.improvedLines, 14); // 6 + 8
+  assertEquals(payload?.groups, []);
 });
 
 Deno.test("writeCoverageResolved reports zero improvement when gated groups sit at baseline", async () => {
@@ -342,10 +365,24 @@ Deno.test("writeCoverageResolved reports zero improvement when gated groups sit 
     coverageRow("coverage-debt: workspace uncovered lines", 2948, 2953, "excl"),
     coverageRow("coverage-debt: tasks uncovered lines", 4, 4),
   ];
-  const payload = await payloadFrom(() => writeCoverageResolved(4211, rows));
+  const payload = await payloadFrom(() =>
+    writeCoverageResolved(4211, rows, [])
+  );
 
   assertEquals(payload?.state, "resolved");
   assertEquals(payload?.improvedLines, 0);
+  assertEquals(payload?.groups, []);
+});
+
+Deno.test("writeCoverageResolved reports zero improvement without a workspace baseline", async () => {
+  const rows = [coverageRow("coverage-debt: workspace uncovered lines", 100)];
+  const payload = await payloadFrom(() =>
+    writeCoverageResolved(4211, rows, [])
+  );
+
+  assertEquals(payload?.state, "resolved");
+  assertEquals(payload?.improvedLines, 0);
+  assertEquals(payload?.groups, []);
 });
 
 Deno.test("writeCoverageDebtSuggestion writes nothing when no coverage group resolves", async () => {

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -30,6 +30,7 @@ import {
   coverageGroupForChangedFile,
   coverageGroupsForChangedFiles,
   coverageMetricGroupName,
+  type CoverageResolvedGroup,
   type CoverageSuggestionFileLines,
   type CoverageSuggestionGroup,
   downloadAndExtractArtifact,
@@ -924,7 +925,7 @@ export async function writeCoverageComment(
       lcov,
     );
   } else {
-    await writeCoverageResolved(prNumber, coverageRows);
+    await writeCoverageResolved(prNumber, coverageRows, prFiles);
   }
 }
 
@@ -1017,23 +1018,46 @@ export async function writeCoverageDebtSuggestion(
  * status "OK"; the workspace aggregate and untouched groups are "excl" and
  * overridden groups are "ovrd", so leaving everything but "OK" out keeps the
  * number to the debt this PR removed in the code it actually touched — not the
- * whole-workspace drift the gate never attributes to the PR. Never throws —
+ * whole-workspace drift the gate never attributes to the PR. `groups` is the
+ * per-group baseline-versus-this-PR breakdown for the source groups this PR
+ * changed, the same groups the gate ratchets, so the collapsed comment can show
+ * where the PR left coverage. Never throws —
  * best-effort, like the regression path.
  */
 export async function writeCoverageResolved(
   prNumber: number,
   coverageRows: Row[],
+  prFiles: PRFile[],
 ): Promise<void> {
   const improvedLines = coverageRows.reduce((sum, row) => {
     if (row.status !== "OK" || row.median === undefined) return sum;
     return sum + Math.max(0, Math.round(row.median - row.current));
   }, 0);
 
+  // Summarize the source groups this PR changed — the per-group ratchet the
+  // gate evaluates. Workspace is the aggregate behind `improvedLines`, so it
+  // stays out of the per-group breakdown.
+  const changedGroups = coverageGroupsForChangedFiles(
+    prFiles.map((prFile) => prFile.filename),
+  );
+  const groups: CoverageResolvedGroup[] = coverageRows
+    .map((row) => ({
+      group: coverageMetricGroupName(row.metric),
+      baseline: Math.round(row.median ?? 0),
+      current: Math.round(row.current),
+    }))
+    .filter((group): group is CoverageResolvedGroup =>
+      group.group !== null &&
+      group.group !== "workspace" &&
+      changedGroups.has(group.group)
+    );
+
   try {
     const payload: CoverageCommentPayload = {
       prNumber,
       state: "resolved",
       improvedLines,
+      groups,
     };
     const outputFile = coverageCommentOutputPath();
     await Deno.writeTextFile(outputFile, JSON.stringify(payload, null, 2));

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -1052,12 +1052,22 @@ export async function writeCoverageResolved(
       changedGroups.has(group.group)
     );
 
+  // The gate passed because a changed group's debt was accepted with a
+  // per-metric override or the reset marker (status "ovrd"), not because the
+  // new code is covered.
+  const overridden = coverageRows.some((row) => {
+    if (row.status !== "ovrd") return false;
+    const group = coverageMetricGroupName(row.metric);
+    return group !== null && group !== "workspace" && changedGroups.has(group);
+  });
+
   try {
     const payload: CoverageCommentPayload = {
       prNumber,
       state: "resolved",
       improvedLines,
       groups,
+      overridden,
     };
     const outputFile = coverageCommentOutputPath();
     await Deno.writeTextFile(outputFile, JSON.stringify(payload, null, 2));

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -9,6 +9,7 @@ import {
   applyBaselineOverrides,
   type Artifact,
   buildCoverageDebtSuggestionComment,
+  buildCoverageResolvedComment,
   computeBaseline,
   computeCiWallTimeRevisitSignals,
   COVERAGE_BASELINE_RESET_MARKER,
@@ -30,7 +31,6 @@ import {
   parseBaselineOverrides,
   parsePerfMetricsBackfillFile,
   parsePerfMetricsFile,
-  resolveCoverageDebtComment,
   serializePerfMetrics,
   serializePerfMetricsBackfill,
   shouldGateCoverageDebtMetric,
@@ -932,39 +932,81 @@ Deno.test("buildCoverageDebtSuggestionComment uses the singular for a one-line r
   );
 });
 
-Deno.test("resolveCoverageDebtComment collapses the details and reports the reduction", () => {
-  const regressed = buildCoverageDebtSuggestionComment({
-    groups: [{ group: "packages/runner", target: 12, current: 15 }],
-    files: [],
-  });
+Deno.test("buildCoverageResolvedComment collapses the details and summarizes the reduction", () => {
+  const resolved = buildCoverageResolvedComment(5, [
+    { group: "packages/runner", baseline: 15, current: 12 },
+  ]);
 
-  const resolved = resolveCoverageDebtComment(regressed, 5);
-
-  // The details collapses (no `open`) and the summary celebrates the reduction.
+  // The disclosure stays collapsed (no `open`) and the summary celebrates the
+  // reduction; none of the stale regression copy survives.
   assertFalse(resolved.includes("<details open>"));
   assertStringIncludes(resolved, "<details>");
   assertStringIncludes(
     resolved,
-    "<summary><h3>🕵🏻‍♀️ Code coverage debt reduced by 5 lines!</h3></summary>",
+    "<summary><strong>🕵🏻‍♀️ Code coverage debt reduced by 5 lines!</strong></summary>",
   );
   assertFalse(resolved.includes("Test coverage regressed by"));
-  // The body (marker, table) is preserved for context.
+  assertFalse(resolved.includes("Prompt for an AI coding agent"));
+  // The body keeps the marker and summarizes the per-group before-and-after.
   assertStringIncludes(resolved, COVERAGE_SUGGESTION_MARKER);
-  assertStringIncludes(resolved, "| 12 | 15 | +3 |");
+  assertStringIncludes(
+    resolved,
+    "| Source group | Baseline (`main`) | This PR | Change |",
+  );
+  assertStringIncludes(
+    resolved,
+    "| `packages/runner` | 15 | 12 | 3 lines fewer |",
+  );
 });
 
-Deno.test("resolveCoverageDebtComment notes resolution when there is no net reduction", () => {
-  const regressed = buildCoverageDebtSuggestionComment({
-    groups: [{ group: "tasks", target: 4, current: 8 }],
-    files: [],
-  });
-
-  const resolved = resolveCoverageDebtComment(regressed, 0);
+Deno.test("buildCoverageResolvedComment notes resolution when there is no net reduction", () => {
+  const resolved = buildCoverageResolvedComment(0, [
+    { group: "tasks", baseline: 8, current: 8 },
+  ]);
 
   assertFalse(resolved.includes("<details open>"));
   assertStringIncludes(
     resolved,
-    "<summary><h3>🕵🏻‍♀️ Code coverage regression resolved.</h3></summary>",
+    "<summary><strong>🕵🏻‍♀️ Code coverage regression resolved.</strong></summary>",
+  );
+  assertStringIncludes(resolved, "| `tasks` | 8 | 8 | no change |");
+});
+
+Deno.test("buildCoverageResolvedComment uses a single line of one uncovered line", () => {
+  const resolved = buildCoverageResolvedComment(1, [
+    { group: "tasks", baseline: 5, current: 4 },
+  ]);
+
+  assertStringIncludes(
+    resolved,
+    "<summary><strong>🕵🏻‍♀️ Code coverage debt reduced by 1 line!</strong></summary>",
+  );
+  assertStringIncludes(resolved, "| `tasks` | 5 | 4 | 1 line fewer |");
+});
+
+Deno.test("buildCoverageResolvedComment reports a group that gained uncovered lines", () => {
+  // A changed group can reach the resolved comment with more uncovered lines
+  // than `main` when the regression was accepted with a per-metric override or
+  // the coverage reset marker. The table reports the increase rather than
+  // hiding it.
+  const resolved = buildCoverageResolvedComment(0, [
+    { group: "packages/runner", baseline: 12, current: 15 },
+  ]);
+
+  assertStringIncludes(
+    resolved,
+    "| `packages/runner` | 12 | 15 | 3 lines more |",
+  );
+});
+
+Deno.test("buildCoverageResolvedComment falls back to a sentence with no groups", () => {
+  const resolved = buildCoverageResolvedComment(3, []);
+
+  assertStringIncludes(resolved, "<details>");
+  assertFalse(resolved.includes("| Source group |"));
+  assertStringIncludes(
+    resolved,
+    "Every changed source group is at or below its `main` baseline",
   );
 });
 

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -999,6 +999,32 @@ Deno.test("buildCoverageResolvedComment reports a group that gained uncovered li
   );
 });
 
+Deno.test("buildCoverageResolvedComment says the debt was overridden, not improved", () => {
+  // The gate passed because the debt was accepted, so the summary must not
+  // imply the new code is covered, even when a group also improved.
+  const resolved = buildCoverageResolvedComment(
+    4,
+    [{ group: "packages/runner", baseline: 12, current: 15 }],
+    true,
+  );
+
+  assertStringIncludes(
+    resolved,
+    "<summary><strong>🕵🏻‍♀️ Code coverage debt accepted with an override.</strong></summary>",
+  );
+  assertStringIncludes(
+    resolved,
+    "accepted with an override rather than covered by new tests",
+  );
+  assertFalse(resolved.includes("Code coverage debt reduced by"));
+  assertFalse(resolved.includes("no test reached on"));
+  // The table still shows the real per-group numbers.
+  assertStringIncludes(
+    resolved,
+    "| `packages/runner` | 12 | 15 | 3 lines more |",
+  );
+});
+
 Deno.test("buildCoverageResolvedComment falls back to a sentence with no groups", () => {
   const resolved = buildCoverageResolvedComment(3, []);
 

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -41,9 +41,10 @@ export const COVERAGE_COMMENT_FILE = "coverage-comment.json";
  * - `state: "regressed"` carries the full comment `body`. The poster posts it as
  *   a new comment, or updates an existing coverage comment in place.
  * - `state: "resolved"` carries `improvedLines`, the net reduction in uncovered
- *   lines versus baseline across the changed, gated coverage groups. The poster
- *   collapses an existing comment's `<details>` and rewrites its `<summary>`; it
- *   does nothing when there is no existing comment to update.
+ *   lines versus baseline across the changed, gated coverage groups, and
+ *   `groups`, the per-group baseline-versus-this-PR breakdown. The poster
+ *   rebuilds an existing comment into a collapsed summary of where the PR left
+ *   coverage; it does nothing when there is no existing comment to update.
  */
 export interface CoverageCommentPayload {
   prNumber: number;
@@ -52,6 +53,9 @@ export interface CoverageCommentPayload {
   body?: string;
   /** Present when `state` is "resolved". */
   improvedLines?: number;
+  /** Present when `state` is "resolved": the changed source groups and where
+   * this PR left each one's uncovered-line count. */
+  groups?: CoverageResolvedGroup[];
 }
 
 /**
@@ -1533,6 +1537,15 @@ export interface CoverageSuggestionFileLines {
   uncoveredCount: number;
 }
 
+/** A changed source group and where this PR left its uncovered-line count. */
+export interface CoverageResolvedGroup {
+  group: string;
+  /** Uncovered-line count from latest `main`. */
+  baseline: number;
+  /** Uncovered-line count this PR produced. */
+  current: number;
+}
+
 export interface CoverageDebtSuggestionInput {
   groups: CoverageSuggestionGroup[];
   files: CoverageSuggestionFileLines[];
@@ -1561,11 +1574,16 @@ function uncoveredLineCount(count: number): string {
 }
 
 /**
- * Render the disclosure `<summary>`. An `<h3>` makes the line a little larger
- * and bold so it stands out when collapsed; the detective emoji leads it.
+ * Render the disclosure `<summary>`, leading with the detective emoji. The
+ * regression comment wraps the line in an `<h3>` so it stands out while the
+ * details are open; the resolved comment uses `<strong>`, a quieter weight that
+ * suits a collapsed, already-handled note.
  */
-function coverageSummary(text: string): string {
-  return `<summary><h3>🕵🏻‍♀️ ${text}</h3></summary>`;
+function coverageSummary(
+  text: string,
+  emphasis: "h3" | "strong" = "h3",
+): string {
+  return `<summary><${emphasis}>🕵🏻‍♀️ ${text}</${emphasis}></summary>`;
 }
 
 function formatTargetList(groups: CoverageSuggestionGroup[]): string[] {
@@ -1708,22 +1726,71 @@ export function buildCoverageDebtSuggestionComment(
 }
 
 /**
- * Update a previously-posted coverage-debt comment to reflect that the gate now
- * passes. Drops the `open` attribute from its `<details>` so the body collapses,
- * and rewrites the `<summary>`. `improvedLines` is the net reduction in
- * uncovered lines versus baseline: when positive, the summary reports the
- * reduction; when zero, it just notes the regression is resolved.
+ * Describe how a group's uncovered-line count moved between its `main` baseline
+ * and this PR, for the "Change" column of the resolved comment's table.
  */
-export function resolveCoverageDebtComment(
-  body: string,
+function coverageChangeText(baseline: number, current: number): string {
+  const delta = baseline - current;
+  if (delta === 0) return "no change";
+  const magnitude = uncoveredLineCount(Math.abs(delta));
+  return delta > 0 ? `${magnitude} fewer` : `${magnitude} more`;
+}
+
+/**
+ * Build the Markdown body of the coverage comment once the gate passes again
+ * after an earlier regression. Leads with the same hidden marker so the poster
+ * keeps finding the one comment, keeps the disclosure collapsed (no `open`), and
+ * replaces the regression body with a short summary of where the PR left
+ * coverage.
+ *
+ * `improvedLines` is the net reduction in the overall (workspace) uncovered-line
+ * count versus its `main` baseline: when positive the summary reports the
+ * reduction, otherwise it just notes the regression is resolved. `groups` lists
+ * the changed source groups the gate ratchets, each with its `main` baseline and
+ * the count this PR produced, rendered as a before-and-after table.
+ */
+export function buildCoverageResolvedComment(
   improvedLines: number,
+  groups: CoverageResolvedGroup[],
 ): string {
   const summary = improvedLines > 0
     ? `Code coverage debt reduced by ${uncoveredLineCount(improvedLines)}!`
     : "Code coverage regression resolved.";
-  return body
-    .replace("<details open>", "<details>")
-    .replace(/<summary>[\s\S]*?<\/summary>/, () => coverageSummary(summary));
+
+  const out: string[] = [COVERAGE_SUGGESTION_MARKER];
+  out.push("<details>");
+  out.push(coverageSummary(summary, "strong"));
+  out.push("");
+  out.push(
+    improvedLines > 0
+      ? "The coverage gate in the **Performance Check** job passes again. This " +
+        `PR now covers ${uncoveredLineCount(improvedLines)} that no test ` +
+        "reached on `main`. Here is where it left each changed source group:"
+      : "The coverage gate in the **Performance Check** job passes again. Here " +
+        "is where this PR left each changed source group:",
+  );
+  out.push("");
+
+  if (groups.length > 0) {
+    out.push("| Source group | Baseline (`main`) | This PR | Change |");
+    out.push("| --- | ---: | ---: | ---: |");
+    for (const group of groups) {
+      out.push(
+        `| \`${group.group}\` | ${group.baseline} | ${group.current} | ${
+          coverageChangeText(group.baseline, group.current)
+        } |`,
+      );
+    }
+  } else {
+    out.push(
+      "Every changed source group is at or below its `main` baseline for " +
+        "uncovered lines.",
+    );
+  }
+  out.push("");
+  out.push("</details>");
+
+  return out.join("\n");
 }
 
 /** Escape a string for use inside a Markdown table cell. */

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -42,7 +42,8 @@ export const COVERAGE_COMMENT_FILE = "coverage-comment.json";
  *   a new comment, or updates an existing coverage comment in place.
  * - `state: "resolved"` carries `improvedLines`, the net reduction in uncovered
  *   lines versus baseline across the changed, gated coverage groups, and
- *   `groups`, the per-group baseline-versus-this-PR breakdown. The poster
+ *   `groups`, the per-group baseline-versus-this-PR breakdown. When the gate
+ *   passed only because the debt was accepted, `overridden` is set. The poster
  *   rebuilds an existing comment into a collapsed summary of where the PR left
  *   coverage; it does nothing when there is no existing comment to update.
  */
@@ -56,6 +57,10 @@ export interface CoverageCommentPayload {
   /** Present when `state` is "resolved": the changed source groups and where
    * this PR left each one's uncovered-line count. */
   groups?: CoverageResolvedGroup[];
+  /** Present when `state` is "resolved": true when the gate passed because a
+   * changed group's debt was accepted with a per-metric override or the reset
+   * marker, not because the new code is covered. */
+  overridden?: boolean;
 }
 
 /**
@@ -1747,13 +1752,19 @@ function coverageChangeText(baseline: number, current: number): string {
  * count versus its `main` baseline: when positive the summary reports the
  * reduction, otherwise it just notes the regression is resolved. `groups` lists
  * the changed source groups the gate ratchets, each with its `main` baseline and
- * the count this PR produced, rendered as a before-and-after table.
+ * the count this PR produced, rendered as a before-and-after table. When
+ * `overridden` is set the gate passed only because the debt was accepted with an
+ * override or the reset marker, so the summary says the metric was overridden
+ * rather than implying the new code is covered.
  */
 export function buildCoverageResolvedComment(
   improvedLines: number,
   groups: CoverageResolvedGroup[],
+  overridden = false,
 ): string {
-  const summary = improvedLines > 0
+  const summary = overridden
+    ? "Code coverage debt accepted with an override."
+    : improvedLines > 0
     ? `Code coverage debt reduced by ${uncoveredLineCount(improvedLines)}!`
     : "Code coverage regression resolved.";
 
@@ -1762,7 +1773,11 @@ export function buildCoverageResolvedComment(
   out.push(coverageSummary(summary, "strong"));
   out.push("");
   out.push(
-    improvedLines > 0
+    overridden
+      ? "The coverage gate in the **Performance Check** job passes because this " +
+        "PR's coverage debt was accepted with an override rather than covered " +
+        "by new tests. Here is where it left each changed source group:"
+      : improvedLines > 0
       ? "The coverage gate in the **Performance Check** job passes again. This " +
         `PR now covers ${uncoveredLineCount(improvedLines)} that no test ` +
         "reached on `main`. Here is where it left each changed source group:"

--- a/tasks/post-coverage-comment.test.ts
+++ b/tasks/post-coverage-comment.test.ts
@@ -1,6 +1,9 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import * as path from "@std/path";
-import { COVERAGE_SUGGESTION_MARKER } from "./perf-lib.ts";
+import {
+  buildCoverageResolvedComment,
+  COVERAGE_SUGGESTION_MARKER,
+} from "./perf-lib.ts";
 import { postCoverageComment } from "./post-coverage-comment.ts";
 
 interface RecordedRequest {
@@ -119,11 +122,18 @@ Deno.test("postCoverageComment resolves an existing comment when coverage is acc
     "",
     "table goes here",
     "",
+    "### Prompt for an AI coding agent",
+    "",
     "</details>",
   ].join("\n");
 
   const requests = await runWithPayload(
-    { prNumber: 4211, state: "resolved", improvedLines: 5 },
+    {
+      prNumber: 4211,
+      state: "resolved",
+      improvedLines: 5,
+      groups: [{ group: "packages/runner", baseline: 15, current: 12 }],
+    },
     [existing],
   );
 
@@ -136,7 +146,16 @@ Deno.test("postCoverageComment resolves an existing comment when coverage is acc
   assertStringIncludes(requests[0].body, "<details>");
   assertStringIncludes(
     requests[0].body,
-    "<summary><h3>🕵🏻‍♀️ Code coverage debt reduced by 5 lines!</h3></summary>",
+    "<summary><strong>🕵🏻‍♀️ Code coverage debt reduced by 5 lines!</strong></summary>",
+  );
+  // The stale regression body is replaced by a per-group coverage summary.
+  assertStringIncludes(
+    requests[0].body,
+    "| `packages/runner` | 15 | 12 | 3 lines fewer |",
+  );
+  assertEquals(
+    requests[0].body.includes("Prompt for an AI coding agent"),
+    false,
   );
 });
 
@@ -150,16 +169,12 @@ Deno.test("postCoverageComment does nothing to resolve when no comment exists", 
 });
 
 Deno.test("postCoverageComment leaves an already-resolved comment untouched", async () => {
-  const existing = [
-    COVERAGE_SUGGESTION_MARKER,
-    "<details>",
-    "<summary><h3>🕵🏻‍♀️ Code coverage regression resolved.</h3></summary>",
-    "",
-    "</details>",
-  ].join("\n");
+  const groups = [{ group: "tasks", baseline: 8, current: 8 }];
+  // A comment already carrying exactly what this run would write is left alone.
+  const existing = buildCoverageResolvedComment(0, groups);
 
   const requests = await runWithPayload(
-    { prNumber: 4211, state: "resolved", improvedLines: 0 },
+    { prNumber: 4211, state: "resolved", improvedLines: 0, groups },
     [existing],
   );
 

--- a/tasks/post-coverage-comment.test.ts
+++ b/tasks/post-coverage-comment.test.ts
@@ -159,6 +159,32 @@ Deno.test("postCoverageComment resolves an existing comment when coverage is acc
   );
 });
 
+Deno.test("postCoverageComment reports an overridden metric rather than improved coverage", async () => {
+  const existing =
+    `${COVERAGE_SUGGESTION_MARKER}\n<details open>\nregression\n</details>`;
+
+  const requests = await runWithPayload(
+    {
+      prNumber: 4211,
+      state: "resolved",
+      improvedLines: 0,
+      groups: [{ group: "packages/runner", baseline: 12, current: 15 }],
+      overridden: true,
+    },
+    [existing],
+  );
+
+  assertEquals(requests.length, 1);
+  assertStringIncludes(
+    requests[0].body,
+    "<summary><strong>🕵🏻‍♀️ Code coverage debt accepted with an override.</strong></summary>",
+  );
+  assertEquals(
+    requests[0].body.includes("Code coverage debt reduced by"),
+    false,
+  );
+});
+
 Deno.test("postCoverageComment does nothing to resolve when no comment exists", async () => {
   const requests = await runWithPayload(
     { prNumber: 4211, state: "resolved", improvedLines: 5 },

--- a/tasks/post-coverage-comment.ts
+++ b/tasks/post-coverage-comment.ts
@@ -11,9 +11,9 @@
  *
  * No-ops when the file is absent. Keeps a single comment per PR: posts when none
  * exists, otherwise updates the existing one in place. When the payload says
- * coverage is resolved, it collapses and rewrites the existing comment (and does
- * nothing if there is none). Best-effort: a failure is logged, not fatal, so the
- * workflow stays green.
+ * coverage is resolved, it rewrites the existing comment into a collapsed
+ * summary of where the PR left coverage (and does nothing if there is none).
+ * Best-effort: a failure is logged, not fatal, so the workflow stays green.
  *
  * Environment:
  *   GITHUB_TOKEN           - Required.
@@ -22,6 +22,7 @@
  */
 
 import {
+  buildCoverageResolvedComment,
   COVERAGE_COMMENT_FILE,
   COVERAGE_SUGGESTION_MARKER,
   type CoverageCommentPayload,
@@ -29,7 +30,6 @@ import {
   githubPatch,
   githubPost,
   REPO,
-  resolveCoverageDebtComment,
   TOKEN,
 } from "./perf-lib.ts";
 
@@ -78,9 +78,9 @@ export async function postCoverageComment(): Promise<void> {
         );
         return;
       }
-      const updated = resolveCoverageDebtComment(
-        marked.body,
+      const updated = buildCoverageResolvedComment(
         payload.improvedLines ?? 0,
+        payload.groups ?? [],
       );
       if (updated === marked.body) {
         console.log(

--- a/tasks/post-coverage-comment.ts
+++ b/tasks/post-coverage-comment.ts
@@ -81,6 +81,7 @@ export async function postCoverageComment(): Promise<void> {
       const updated = buildCoverageResolvedComment(
         payload.improvedLines ?? 0,
         payload.groups ?? [],
+        payload.overridden ?? false,
       );
       if (updated === marked.body) {
         console.log(


### PR DESCRIPTION
When the coverage gate passes after an earlier regression, the resolved comment rewrote only the \<summary>; the collapsed \<details> kept the stale regression complaint, the over-by table, and the AI-agent prompt. A contributor who expanded it saw misleading text.

Replace that body with a summary of where the PR left coverage: a per-group table of the changed source groups, each showing its `main` baseline, the count this PR produced, and the change. The "resolved" payload now carries that per-group breakdown, computed from the coverage rows the gate already has, and the poster rebuilds the comment from it.

The resolved summary line also moves from \<h3> to \<strong>: it is collapsed and already handled, so it no longer needs the heading weight the open regression comment uses. coverageSummary takes an emphasis argument; the regression builder keeps \<h3>.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds resolved coverage comments to replace stale regression text with a collapsed, per‑group summary scoped to changed source groups. The comment now calls out when debt was accepted with an override and uses <strong> in the summary.

- Bug Fixes
  - Rebuild the existing comment on resolution: collapse the disclosure and replace the body (removes stale regression copy and AI prompt).
  - Show a per-group table only for changed source groups (baseline on `main`, this PR, “N lines fewer/more”); fall back to a single sentence when none.
  - Extend the resolved payload with `groups` and `overridden`; `writeCoverageResolved(prNumber, rows, prFiles)` computes both and sums only gated improvements in `improvedLines`.
  - Use `buildCoverageResolvedComment` in `postCoverageComment` and `strong` in the summary; no-op when no comment exists or content already matches.

<sup>Written for commit b45f9d720f725e67bb6a935ca6755f8bc22c8a10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

