### PR TITLE
fix(perf-check): report PR-specific reduction in resolved coverage su…

### DIFF
--- a/tasks/perf-check.test.ts
+++ b/tasks/perf-check.test.ts
@@ -251,10 +251,15 @@ Deno.test("valid merged PR baseline override metadata is parsed", () => {
   assertEquals(overrides?.metrics.get("job: Check"), 7);
 });
 
-function coverageRow(metric: string, current: number, median?: number): Row {
+function coverageRow(
+  metric: string,
+  current: number,
+  median?: number,
+  status: Row["status"] = median === undefined ? "n/a" : "OK",
+): Row {
   return {
     metric,
-    status: median === undefined ? "n/a" : "OK",
+    status,
     current,
     median,
     n: 1,
@@ -301,22 +306,42 @@ Deno.test("writeCoverageComment writes a regression payload when coverage fails"
   );
 });
 
-Deno.test("writeCoverageComment writes a resolved payload when coverage is acceptable", async () => {
+Deno.test("writeCoverageComment writes a resolved payload reporting the gated reduction", async () => {
   const rows = [
-    coverageRow("coverage-debt: workspace uncovered lines", 2948, 2953),
-    coverageRow("coverage-debt: tasks uncovered lines", 4, 4),
+    // The workspace aggregate is never gated (status "excl"), so its large
+    // delta must not count toward the PR's reported reduction.
+    coverageRow("coverage-debt: workspace uncovered lines", 2948, 2953, "excl"),
+    // A gated group the PR touched, now 5 lines below its baseline.
+    coverageRow("coverage-debt: tasks uncovered lines", 4, 9),
   ];
   const payload = await payloadFrom(() =>
     writeCoverageComment(4211, [], rows, [], "")
   );
 
   assertEquals(payload?.state, "resolved");
-  // Net reduction in the overall metric: 2953 - 2948 = 5 lines.
+  // Only the gated group counts: 9 - 4 = 5 lines; the workspace delta is excluded.
   assertEquals(payload?.improvedLines, 5);
 });
 
-Deno.test("writeCoverageResolved reports zero improvement without a workspace baseline", async () => {
-  const rows = [coverageRow("coverage-debt: workspace uncovered lines", 100)];
+Deno.test("writeCoverageResolved sums gated groups and ignores workspace and overrides", async () => {
+  const rows = [
+    coverageRow("coverage-debt: workspace uncovered lines", 1000, 2000, "excl"),
+    coverageRow("coverage-debt: memory uncovered lines", 1680, 1686), // -6
+    coverageRow("coverage-debt: runner uncovered lines", 8860, 8868), // -8
+    // An overridden group accepted its debt, so it does not count as a reduction.
+    coverageRow("coverage-debt: identity uncovered lines", 50, 60, "ovrd"),
+  ];
+  const payload = await payloadFrom(() => writeCoverageResolved(4211, rows));
+
+  assertEquals(payload?.state, "resolved");
+  assertEquals(payload?.improvedLines, 14); // 6 + 8
+});
+
+Deno.test("writeCoverageResolved reports zero improvement when gated groups sit at baseline", async () => {
+  const rows = [
+    coverageRow("coverage-debt: workspace uncovered lines", 2948, 2953, "excl"),
+    coverageRow("coverage-debt: tasks uncovered lines", 4, 4),
+  ];
   const payload = await payloadFrom(() => writeCoverageResolved(4211, rows));
 
   assertEquals(payload?.state, "resolved");

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -1011,20 +1011,23 @@ export async function writeCoverageDebtSuggestion(
  * comment exists, nor what files earlier commits on the PR changed, so it defers
  * that to the poster, which no-ops when there is nothing to update.
  *
- * `improvedLines` is the net reduction in the overall (workspace) uncovered-line
- * count versus its `main` baseline — the previously-uncovered lines the PR now
- * covers. Never throws — best-effort, like the regression path.
+ * `improvedLines` is the reduction this PR makes to the coverage debt it is
+ * gated on: summed across the per-package groups whose files it changed, how far
+ * each now sits below its `main` ratchet baseline. A passing gated group has
+ * status "OK"; the workspace aggregate and untouched groups are "excl" and
+ * overridden groups are "ovrd", so leaving everything but "OK" out keeps the
+ * number to the debt this PR removed in the code it actually touched — not the
+ * whole-workspace drift the gate never attributes to the PR. Never throws —
+ * best-effort, like the regression path.
  */
 export async function writeCoverageResolved(
   prNumber: number,
   coverageRows: Row[],
 ): Promise<void> {
-  const workspaceRow = coverageRows.find(
-    (row) => coverageMetricGroupName(row.metric) === "workspace",
-  );
-  const improvedLines = workspaceRow?.median === undefined
-    ? 0
-    : Math.max(0, Math.round(workspaceRow.median - workspaceRow.current));
+  const improvedLines = coverageRows.reduce((sum, row) => {
+    if (row.status !== "OK" || row.median === undefined) return sum;
+    return sum + Math.max(0, Math.round(row.median - row.current));
+  }, 0);
 
   try {
     const payload: CoverageCommentPayload = {


### PR DESCRIPTION
…mmary

The resolved coverage-debt comment took its "reduced by N lines" summary from the workspace-wide uncovered-line aggregate. That group is never gated and its delta is dominated by drift across packages the PR never touched, so a test-only PR could claim a 13339-line reduction.

Compute improvedLines by summing the reduction across the coverage groups the PR is actually gated on: for each touched package (status "OK"), how far it now sits below its main ratchet baseline. The workspace aggregate, untouched groups, and overridden groups are left out, so the number reflects only the debt removed in the code this PR changed. This matches the payload's documented contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the coverage-resolved summary to report PR-specific reduction by summing reductions across gated groups the PR changed, not the workspace aggregate. This avoids inflated “reduced by N lines” numbers caused by workspace drift.

- **Bug Fixes**
  - Compute improvedLines by summing max(median − current, 0) for per-package gated groups with status "OK".
  - Exclude the workspace aggregate ("excl") and overridden groups ("ovrd") so only touched code counts.
  - Expanded tests to verify gated-only sums, exclusion of workspace/overrides, and zero improvement at baseline.

<sup>Written for commit c039fb10dcc20c27a88cabd30383dc9f21e6a364. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

