### PR TITLE
fix(runtime): add runtime.settled() that waits for async builtin work (stabilize lunch-poll sqlite flake)

### DIFF
--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -64,6 +64,7 @@ export interface ParticipantInitResult {
 }
 
 const SETUP_CAUSE = "multi-user-test-setup";
+const SETTLE_FAST_MS = 2;
 
 let runtime: Runtime | undefined;
 let storageManager:
@@ -88,11 +89,12 @@ function rt(): Runtime {
 }
 
 async function settle(maxIterations = 20): Promise<void> {
-  // `settled()` drains the scheduler (idle), storage (synced) AND every
-  // in-flight async builtin operation (sqlite query RPC + writeback, fetch,
-  // llm) that `idle()` returns before — so a participant's assertion never
-  // reads a query result while its post-commit flush is still in flight.
-  await rt().settled(maxIterations);
+  for (let i = 0; i < maxIterations; i++) {
+    const start = performance.now();
+    await rt().idle();
+    await storageManager!.synced();
+    if (performance.now() - start < SETTLE_FAST_MS) return;
+  }
 }
 
 const stepPeekSchema = {

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -64,7 +64,6 @@ export interface ParticipantInitResult {
 }
 
 const SETUP_CAUSE = "multi-user-test-setup";
-const SETTLE_FAST_MS = 2;
 
 let runtime: Runtime | undefined;
 let storageManager:
@@ -89,12 +88,11 @@ function rt(): Runtime {
 }
 
 async function settle(maxIterations = 20): Promise<void> {
-  for (let i = 0; i < maxIterations; i++) {
-    const start = performance.now();
-    await rt().idle();
-    await storageManager!.synced();
-    if (performance.now() - start < SETTLE_FAST_MS) return;
-  }
+  // `settled()` drains the scheduler (idle), storage (synced) AND every
+  // in-flight async builtin operation (sqlite query RPC + writeback, fetch,
+  // llm) that `idle()` returns before — so a participant's assertion never
+  // reads a query result while its post-commit flush is still in flight.
+  await rt().settled(maxIterations);
 }
 
 const stepPeekSchema = {

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -1217,27 +1217,11 @@ export async function runTestPattern(
       // `{ settle: true }` step: wait for FULL settlement (scheduler + storage +
       // in-flight async builtin I/O — sqlite query RPC + writeback, fetch / llm)
       // before the next step. A test inserts this before an assertion that reads
-      // an async-builtin result so it never observes a half-settled state.
+      // an async-builtin result so it never observes a half-settled state. The
+      // step is transparent — it produces no result. A settle timeout propagates
+      // to the outer handler and fails the whole run (a stuck settle is fatal).
       if (isSettle) {
-        if (stepValue.skip || stepValue.settle === false) {
-          if (options.verbose) console.log(`  ⊘ settle (skipped)`);
-          continue;
-        }
-        if (options.verbose) console.log(`  ⏳ settle`);
-        try {
-          await settleFully(i);
-        } catch (err) {
-          // Surface a settle timeout as a failed step so the run fails loudly.
-          results.push({
-            name: `settle_${i}`,
-            passed: false,
-            afterAction: lastActionIndex !== null
-              ? `action_${actionCount}`
-              : null,
-            error: err instanceof Error ? err.message : String(err),
-            durationMs: performance.now() - itemStart,
-          });
-        }
+        if (!stepValue.skip) await settleFully(i);
         continue;
       }
 

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -101,7 +101,7 @@ async function withPhase<T>(
 }
 
 /**
- * A test step is an object with either an 'assertion' or 'action' property.
+ * A test step is an object with an 'assertion', 'action', or 'settle' property.
  * This discriminated union avoids TypeScript trying to unify incompatible Cell/Stream types.
  * Add `skip: true` to temporarily disable a step (like it.skip in other frameworks).
  *
@@ -110,6 +110,12 @@ async function withPhase<T>(
  * renderer-trusted DOM provenance for that surface/action — the headless
  * equivalent of the user clicking the trusted surface — which CFC
  * `TrustedActionWrite` policies require under enforcement.
+ *
+ * A `{ settle: true }` step waits for FULL settlement (the scheduler, storage,
+ * and every in-flight async builtin operation — a `db.query` RPC + writeback, a
+ * fetch / llm call) via `runtime.settled()`. The light per-action settle returns
+ * before that I/O lands, so insert `{ settle: true }` before an assertion that
+ * reads an async-builtin result to keep the read deterministic under load.
  */
 export type TestStep =
   | { assertion: OpaqueRef<boolean>; skip?: boolean }
@@ -118,7 +124,8 @@ export type TestStep =
     event?: unknown;
     trustedUi?: TrustedUiDescriptor;
     skip?: boolean;
-  };
+  }
+  | { settle: true; skip?: boolean };
 
 type HarnessTestStepMeta = {
   action?: unknown;
@@ -126,6 +133,9 @@ type HarnessTestStepMeta = {
   event?: unknown;
   trustedUi?: unknown;
   skip?: boolean;
+  // `{ settle: true }` step: wait for full settlement (scheduler + storage +
+  // in-flight async builtin I/O) via `runtime.settled()` before the next step.
+  settle?: boolean;
 };
 
 type HarnessTestStepCell = Cell<unknown>;
@@ -145,6 +155,7 @@ const testStepPeekSchema = internSchema(
         },
       },
       skip: { type: "boolean" },
+      settle: { type: "boolean" },
     },
   },
 );
@@ -1111,20 +1122,72 @@ export async function runTestPattern(
       stepLabel: string,
       maxSettle = 20,
     ): Promise<void> => {
-      // `runtime.settled()` drains the scheduler (idle), storage (synced), AND
-      // every in-flight async builtin operation — the sqlite query RPC + result
-      // writeback, fetch / llm calls — that `idle()` alone returns before. That
-      // last part is what stabilizes the sqlite-backed assertions: without it a
-      // step's assertion could read the query result while its post-commit flush
-      // was still in flight (got `{ pending: true }`).
       await withPhase(
         ["runTestPattern", "step", stepLabel, "settle"],
         () =>
           Promise.race([
-            runtime.settled(maxSettle),
+            (async () => {
+              for (let settle = 0; settle < maxSettle; settle++) {
+                const iterStart = performance.now();
+                await withPhase(
+                  [
+                    "runTestPattern",
+                    "step",
+                    stepLabel,
+                    "settle",
+                    `iter-${settle}`,
+                    "idle",
+                  ],
+                  () => runtime.idle(),
+                );
+                await withPhase(
+                  [
+                    "runTestPattern",
+                    "step",
+                    stepLabel,
+                    "settle",
+                    `iter-${settle}`,
+                    "synced",
+                  ],
+                  () => storageManager.synced(),
+                );
+                const totalMs = performance.now() - iterStart;
+                if (options.verbose && totalMs > 1) {
+                  console.log(
+                    `      settle[${settle}]: ${fmtMs(totalMs)}`,
+                  );
+                }
+                // If both resolved nearly instantly, the system is settled.
+                // synced() has ~1ms of overhead even when idle, so use 2ms.
+                if (settle > 0 && totalMs < 2) break;
+              }
+              await withPhase(
+                ["runTestPattern", "step", stepLabel, "settle", "finalIdle"],
+                () => runtime.idle(),
+              );
+            })(),
             timeout(
               TIMEOUT,
               `Action at index ${stepIndex} timed out after ${TIMEOUT}ms`,
+            ),
+          ]),
+      );
+    };
+
+    // Explicit `{ settle: true }` test step: in addition to the light per-action
+    // settle above, wait for ALL in-flight async builtin work — the sqlite query
+    // RPC + result writeback, fetch / llm calls — via `runtime.settled()`. A test
+    // that asserts on an async-builtin result (e.g. a `db.query`) inserts this
+    // before the assertion so it never reads a half-settled `{ pending: true }`.
+    const settleFully = async (stepIndex: number): Promise<void> => {
+      await withPhase(
+        ["runTestPattern", "step", `settle_${stepIndex}`, "settled"],
+        () =>
+          Promise.race([
+            runtime.settled(),
+            timeout(
+              TIMEOUT,
+              `Settle step at index ${stepIndex} timed out after ${TIMEOUT}ms`,
             ),
           ]),
       );
@@ -1146,15 +1209,44 @@ export async function runTestPattern(
       const stepValue = stepCell.asSchema(testStepPeekSchema)
         .get() as HarnessTestStepMeta;
 
-      // Check if this step has 'action' or 'assertion' key
+      // Check if this step has 'action', 'assertion', or 'settle' key
       const isAction = Object.hasOwn(stepValue, "action");
       const isAssertion = Object.hasOwn(stepValue, "assertion");
+      const isSettle = Object.hasOwn(stepValue, "settle");
+
+      // `{ settle: true }` step: wait for FULL settlement (scheduler + storage +
+      // in-flight async builtin I/O — sqlite query RPC + writeback, fetch / llm)
+      // before the next step. A test inserts this before an assertion that reads
+      // an async-builtin result so it never observes a half-settled state.
+      if (isSettle) {
+        if (stepValue.skip || stepValue.settle === false) {
+          if (options.verbose) console.log(`  ⊘ settle (skipped)`);
+          continue;
+        }
+        if (options.verbose) console.log(`  ⏳ settle`);
+        try {
+          await settleFully(i);
+        } catch (err) {
+          // Surface a settle timeout as a failed step so the run fails loudly.
+          results.push({
+            name: `settle_${i}`,
+            passed: false,
+            afterAction: lastActionIndex !== null
+              ? `action_${actionCount}`
+              : null,
+            error: err instanceof Error ? err.message : String(err),
+            durationMs: performance.now() - itemStart,
+          });
+        }
+        continue;
+      }
 
       if (!isAction && !isAssertion) {
         throw new Error(
-          `Test step at index ${i} must have either 'action' or 'assertion' key. Got: ${
-            toCompactDebugString(Object.keys(stepValue))
-          }`,
+          `Test step at index ${i} must have an 'action', 'assertion', or ` +
+            `'settle' key. Got: ${
+              toCompactDebugString(Object.keys(stepValue))
+            }`,
         );
       }
 

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -1111,50 +1111,17 @@ export async function runTestPattern(
       stepLabel: string,
       maxSettle = 20,
     ): Promise<void> => {
+      // `runtime.settled()` drains the scheduler (idle), storage (synced), AND
+      // every in-flight async builtin operation — the sqlite query RPC + result
+      // writeback, fetch / llm calls — that `idle()` alone returns before. That
+      // last part is what stabilizes the sqlite-backed assertions: without it a
+      // step's assertion could read the query result while its post-commit flush
+      // was still in flight (got `{ pending: true }`).
       await withPhase(
         ["runTestPattern", "step", stepLabel, "settle"],
         () =>
           Promise.race([
-            (async () => {
-              for (let settle = 0; settle < maxSettle; settle++) {
-                const iterStart = performance.now();
-                await withPhase(
-                  [
-                    "runTestPattern",
-                    "step",
-                    stepLabel,
-                    "settle",
-                    `iter-${settle}`,
-                    "idle",
-                  ],
-                  () => runtime.idle(),
-                );
-                await withPhase(
-                  [
-                    "runTestPattern",
-                    "step",
-                    stepLabel,
-                    "settle",
-                    `iter-${settle}`,
-                    "synced",
-                  ],
-                  () => storageManager.synced(),
-                );
-                const totalMs = performance.now() - iterStart;
-                if (options.verbose && totalMs > 1) {
-                  console.log(
-                    `      settle[${settle}]: ${fmtMs(totalMs)}`,
-                  );
-                }
-                // If both resolved nearly instantly, the system is settled.
-                // synced() has ~1ms of overhead even when idle, so use 2ms.
-                if (settle > 0 && totalMs < 2) break;
-              }
-              await withPhase(
-                ["runTestPattern", "step", stepLabel, "settle", "finalIdle"],
-                () => runtime.idle(),
-              );
-            })(),
+            runtime.settled(maxSettle),
             timeout(
               TIMEOUT,
               `Action at index ${stepIndex} timed out after ${TIMEOUT}ms`,

--- a/packages/cli/test/fixtures/settle/invalid-step.test.tsx
+++ b/packages/cli/test/fixtures/settle/invalid-step.test.tsx
@@ -1,0 +1,12 @@
+/**
+ * Fixture: a step with no `action` / `assertion` / `settle` key. The runner must
+ * reject it; the error surfaces as a file-level error on the run result.
+ */
+import { pattern } from "commonfabric";
+
+export default pattern(() => {
+  return {
+    // deno-lint-ignore no-explicit-any
+    tests: [{ notAValidStep: true } as any],
+  };
+});

--- a/packages/cli/test/fixtures/settle/settle-step.test.tsx
+++ b/packages/cli/test/fixtures/settle/settle-step.test.tsx
@@ -1,0 +1,24 @@
+/**
+ * Fixture for the `{ settle: true }` test step. Exercises the runner's settle
+ * handling — a full `runtime.settled()` between steps — plus a skipped settle
+ * step. The settle step is transparent: it produces no assertion result and the
+ * run passes.
+ */
+import { action, computed, pattern, Writable } from "commonfabric";
+
+export default pattern(() => {
+  const flag = new Writable(false);
+  const setFlag = action(() => flag.set(true));
+  const isSet = computed(() => flag.get() === true);
+
+  return {
+    tests: [
+      { action: setFlag },
+      // Full settle between the action and the assertion.
+      { settle: true },
+      { assertion: isSet },
+      // A skipped settle step is a no-op.
+      { settle: true, skip: true },
+    ],
+  };
+});

--- a/packages/cli/test/test-runner-settle.test.ts
+++ b/packages/cli/test/test-runner-settle.test.ts
@@ -33,5 +33,15 @@ describe(
         true,
       );
     });
+
+    it("rejects a step with no action/assertion/settle key", async () => {
+      const { results } = await runTests(
+        fixture("invalid-step.test.tsx"),
+        { root: FIXTURES },
+      );
+      expect(results[0].error ?? "").toContain(
+        "must have an 'action', 'assertion', or 'settle'",
+      );
+    });
   },
 );

--- a/packages/cli/test/test-runner-settle.test.ts
+++ b/packages/cli/test/test-runner-settle.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Guard for the `{ settle: true }` test step: the runner waits for full
+ * settlement (`runtime.settled()`) between steps, honors `skip`, and the step is
+ * transparent to the reported results (it is neither an action nor an
+ * assertion). Mirrors test-runner-console-capture.test.ts.
+ */
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { resolve } from "@std/path";
+import { runTests } from "../lib/test-runner.ts";
+
+const FIXTURES = resolve(import.meta.dirname!, "fixtures/settle");
+
+function fixture(name: string): string {
+  return resolve(FIXTURES, name);
+}
+
+describe(
+  "`{ settle: true }` test step",
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    it("runs a full settle between steps and is transparent to results", async () => {
+      const { passed, failed, results } = await runTests(
+        fixture("settle-step.test.tsx"),
+        { root: FIXTURES },
+      );
+      // Only the single assertion is reported; the settle steps add nothing.
+      expect(failed).toBe(0);
+      expect(passed).toBe(1);
+      const stepResults = results.flatMap((r) => r.results);
+      expect(stepResults.length).toBe(1);
+      expect(stepResults.every((r) => !r.name.startsWith("settle_"))).toBe(
+        true,
+      );
+    });
+  },
+);

--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -369,17 +369,29 @@ export default pattern(() => {
       // Log the surviving option by title → one visit row, attributed to host,
       // plus one vote_history snapshot row for the green vote.
       { action: action_log_thai },
+      // The history assertions read the `recentVisits` / count `db.query`
+      // results, which resolve from an async post-commit flush (a sqlite RPC +
+      // writeback). The light per-action settle returns before that I/O lands,
+      // so under load the assertion could read a half-settled `{ pending }`
+      // result. `{ settle: true }` waits for the full settlement
+      // (runtime.settled()) so the read is deterministic.
+      { settle: true },
       { assertion: assert_thai_logged },
       { assertion: assert_recent_visit_row_renders },
       { assertion: assert_vote_snapshot },
       // A second, backdated, explicit log → two entries (proves backdating).
       { action: action_log_visit_chipotle_backdated },
+      { settle: true },
       { assertion: assert_two_history },
-      // Delete a single entry (host) → the other remains.
+      // Delete a single entry (host) → the other remains. The remove handler
+      // reads recentVisits.result[0].id, so settle BEFORE it too (the settle
+      // above this assertion covers that — recentVisits is unchanged between).
       { action: action_remove_first_history },
+      { settle: true },
       { assertion: assert_one_history_after_remove },
       // Clear all → empty (visits AND vote_history).
       { action: action_clear_history },
+      { settle: true },
       { assertion: assert_history_cleared },
     ],
     poll,

--- a/packages/runner/src/builtins/fetch-data.ts
+++ b/packages/runner/src/builtins/fetch-data.ts
@@ -309,7 +309,7 @@ export function fetchData(
         "fetchData-start",
         () => {
           // Try to claim mutex - returns immediately if another tab is processing.
-          // Registered as async builtin work so `runtime.settled()` / `Cell.pull()`
+          // Registered as async builtin work so `runtime.settled()`
           // wait for the fetch (and its result writeback) to land; `idle()` does
           // not, so the handler never blocks on network I/O.
           const work = tryClaimMutex(

--- a/packages/runner/src/builtins/fetch-data.ts
+++ b/packages/runner/src/builtins/fetch-data.ts
@@ -308,8 +308,11 @@ export function fetchData(
         inputsSnapshot,
         "fetchData-start",
         () => {
-          // Try to claim mutex - returns immediately if another tab is processing
-          void tryClaimMutex(
+          // Try to claim mutex - returns immediately if another tab is processing.
+          // Registered as async builtin work so `runtime.settled()` / `Cell.pull()`
+          // wait for the fetch (and its result writeback) to land; `idle()` does
+          // not, so the handler never blocks on network I/O.
+          const work = tryClaimMutex(
             runtime,
             inputsCell,
             pending,
@@ -325,7 +328,7 @@ export function fetchData(
             inputHash,
             mutexTimeoutMs,
           ).then(
-            ({ claimed }) => {
+            async ({ claimed }) => {
               if (!claimed) {
                 // Another tab is handling this, we're done
                 return;
@@ -361,7 +364,7 @@ export function fetchData(
 
               // We claimed the mutex, start the fetch
               myRequestId = newRequestId;
-              startFetch(
+              await startFetch(
                 runtime,
                 inputsCell,
                 url,
@@ -376,6 +379,7 @@ export function fetchData(
               );
             },
           );
+          runtime.trackAsyncWork(work);
         },
       );
     }

--- a/packages/runner/src/builtins/fetch-program.ts
+++ b/packages/runner/src/builtins/fetch-program.ts
@@ -279,7 +279,7 @@ export function fetchProgram(
         "fetchProgram-start",
         () => {
           // Start fetch asynchronously only after the transaction commits.
-          // Tracked as async builtin work so `runtime.settled()` / `Cell.pull()`
+          // Tracked as async builtin work so `runtime.settled()`
           // wait for the program resolve + writeback; `idle()` does not.
           myRequestId = requestId;
           abortController = new AbortController();

--- a/packages/runner/src/builtins/fetch-program.ts
+++ b/packages/runner/src/builtins/fetch-program.ts
@@ -279,16 +279,18 @@ export function fetchProgram(
         "fetchProgram-start",
         () => {
           // Start fetch asynchronously only after the transaction commits.
+          // Tracked as async builtin work so `runtime.settled()` / `Cell.pull()`
+          // wait for the program resolve + writeback; `idle()` does not.
           myRequestId = requestId;
           abortController = new AbortController();
-          startFetch(
+          runtime.trackAsyncWork(startFetch(
             runtime,
             cache,
             inputHash,
             url,
             requestId,
             abortController.signal,
-          );
+          ));
         },
       );
     } else if (state.type === "fetching") {

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -2715,7 +2715,7 @@ export function llmDialog(
 
               abortController = new AbortController();
               // Track the dialog turn (LLM call + writeback) as async builtin
-              // work so `runtime.settled()` / `Cell.pull()` wait for the result;
+              // work so `runtime.settled()` wait for the result;
               // `idle()` does not, so the handler never blocks on the LLM call.
               runtime.trackAsyncWork(startRequest(
                 runtime,

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -2714,7 +2714,10 @@ export function llmDialog(
               }
 
               abortController = new AbortController();
-              startRequest(
+              // Track the dialog turn (LLM call + writeback) as async builtin
+              // work so `runtime.settled()` / `Cell.pull()` wait for the result;
+              // `idle()` does not, so the handler never blocks on the LLM call.
+              runtime.trackAsyncWork(startRequest(
                 runtime,
                 parentCell.space,
                 cause,
@@ -2726,7 +2729,7 @@ export function llmDialog(
                 nextRequestId,
                 abortController.signal,
                 capturedRequest,
-              );
+              ));
             },
           );
         },

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -675,7 +675,7 @@ export function llm(
         })();
 
         // Track the call (loop + writeback) as async builtin work so
-        // `runtime.settled()` / `Cell.pull()` wait for the result to land;
+        // `runtime.settled()` wait for the result to land;
         // `idle()` does not, so the handler never blocks on the LLM call.
         runtime.trackAsyncWork(
           resultPromise.catch((e) =>
@@ -1001,7 +1001,7 @@ export function generateText(
         })();
 
         // Track the call (loop + writeback) as async builtin work so
-        // `runtime.settled()` / `Cell.pull()` wait for the result to land;
+        // `runtime.settled()` wait for the result to land;
         // `idle()` does not, so the handler never blocks on the LLM call.
         runtime.trackAsyncWork(
           resultPromise.catch((e) =>

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -674,24 +674,29 @@ export function llm(
           }
         })();
 
-        resultPromise.catch((e) =>
-          handleLLMError(
-            e,
-            runtime,
-            resultCell.key("pending"),
-            resultCell.key("result"),
-            resultCell.key("error"),
-            resultCell.key("partial"),
-            resultCell.key("requestHash"),
-            hash,
-            getRunForCancellation,
-            thisRun,
-            () => {
-              // Only clear if this is still the current request; a newer request
-              // may have already set previousCallHash to its own hash.
-              if (hash === previousCallHash) previousCallHash = undefined;
-            },
-          )
+        // Track the call (loop + writeback) as async builtin work so
+        // `runtime.settled()` / `Cell.pull()` wait for the result to land;
+        // `idle()` does not, so the handler never blocks on the LLM call.
+        runtime.trackAsyncWork(
+          resultPromise.catch((e) =>
+            handleLLMError(
+              e,
+              runtime,
+              resultCell.key("pending"),
+              resultCell.key("result"),
+              resultCell.key("error"),
+              resultCell.key("partial"),
+              resultCell.key("requestHash"),
+              hash,
+              getRunForCancellation,
+              thisRun,
+              () => {
+                // Only clear if this is still the current request; a newer request
+                // may have already set previousCallHash to its own hash.
+                if (hash === previousCallHash) previousCallHash = undefined;
+              },
+            )
+          ),
         );
       },
     );
@@ -995,24 +1000,29 @@ export function generateText(
           }
         })();
 
-        resultPromise.catch((e) =>
-          handleLLMError(
-            e,
-            runtime,
-            resultCell.key("pending"),
-            resultCell.key("result"),
-            resultCell.key("error"),
-            resultCell.key("partial"),
-            resultCell.key("requestHash"),
-            hash,
-            getRunForCancellation,
-            thisRun,
-            () => {
-              // Only clear if this is still the current request; a newer request
-              // may have already set previousCallHash to its own hash.
-              if (hash === previousCallHash) previousCallHash = undefined;
-            },
-          )
+        // Track the call (loop + writeback) as async builtin work so
+        // `runtime.settled()` / `Cell.pull()` wait for the result to land;
+        // `idle()` does not, so the handler never blocks on the LLM call.
+        runtime.trackAsyncWork(
+          resultPromise.catch((e) =>
+            handleLLMError(
+              e,
+              runtime,
+              resultCell.key("pending"),
+              resultCell.key("result"),
+              resultCell.key("error"),
+              resultCell.key("partial"),
+              resultCell.key("requestHash"),
+              hash,
+              getRunForCancellation,
+              thisRun,
+              () => {
+                // Only clear if this is still the current request; a newer request
+                // may have already set previousCallHash to its own hash.
+                if (hash === previousCallHash) previousCallHash = undefined;
+              },
+            )
+          ),
         );
       },
     );

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -469,40 +469,25 @@ export class Runtime {
   }
 
   // In-flight async builtin operations — the work the async builtins (fetchData,
-  // fetchProgram, llm/llmDialog, streamData, and reactive sqlite queries) perform
-  // AFTER their handler returns, from a post-commit outbox flush: a network / LLM
-  // call or a sqlite RPC, plus the result writeback. `idle()` deliberately does
-  // NOT wait for these (a handler must never block on network I/O); `settled()`
-  // and the `Cell.pull()` convergence loop do.
+  // fetchProgram, llm/llmDialog, and reactive sqlite queries) perform AFTER their
+  // handler returns, from a post-commit outbox flush: a network / LLM call or a
+  // sqlite RPC, plus the result writeback. `idle()` deliberately does NOT wait
+  // for these (a handler must never block on network I/O); `settled()` does.
   #pendingAsyncWork = new Set<Promise<unknown>>();
 
   /**
-   * Register an in-flight async builtin operation so `settled()` (and
-   * `Cell.pull()`) wait for it instead of racing the post-commit flush. The
-   * scheduler registers an effect-bearing commit's promise here (a race-free
-   * barrier — the flush runs inside that commit), and the fire-and-forget
-   * builtins register their network/LLM promise. Normalized to always resolve
-   * (failures are settled, not thrown) and auto-removed once it settles, so a
-   * rejecting promise is safe and never leaks.
+   * Register an in-flight async builtin operation so `settled()` waits for it
+   * instead of racing the post-commit flush. The scheduler registers an
+   * effect-bearing commit's promise here (a race-free barrier — the flush runs
+   * inside that commit), and the fire-and-forget builtins register their
+   * network/LLM promise. Normalized to always resolve (failures are settled, not
+   * thrown) and auto-removed once it settles, so a rejecting promise is safe and
+   * never leaks.
    */
   trackAsyncWork(promise: Promise<unknown>): void {
     const tracked = promise.then(() => {}, () => {});
     this.#pendingAsyncWork.add(tracked);
     tracked.finally(() => this.#pendingAsyncWork.delete(tracked));
-  }
-
-  /** Number of in-flight async builtin operations (see `trackAsyncWork`). */
-  pendingAsyncWorkCount(): number {
-    return this.#pendingAsyncWork.size;
-  }
-
-  /** Settle the currently-pending async builtin operations (without the full
-   *  scheduler/storage drain `settled()` does). Used by `Cell.pull()`'s
-   *  convergence loop. */
-  async asyncWorkSettled(): Promise<void> {
-    while (this.#pendingAsyncWork.size > 0) {
-      await Promise.allSettled([...this.#pendingAsyncWork]);
-    }
   }
 
   /**

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -468,6 +468,61 @@ export class Runtime {
     return this.scheduler.idle();
   }
 
+  // In-flight async builtin operations — the work the async builtins (fetchData,
+  // fetchProgram, llm/llmDialog, streamData, and reactive sqlite queries) perform
+  // AFTER their handler returns, from a post-commit outbox flush: a network / LLM
+  // call or a sqlite RPC, plus the result writeback. `idle()` deliberately does
+  // NOT wait for these (a handler must never block on network I/O); `settled()`
+  // and the `Cell.pull()` convergence loop do.
+  #pendingAsyncWork = new Set<Promise<unknown>>();
+
+  /**
+   * Register an in-flight async builtin operation so `settled()` (and
+   * `Cell.pull()`) wait for it instead of racing the post-commit flush. The
+   * scheduler registers an effect-bearing commit's promise here (a race-free
+   * barrier — the flush runs inside that commit), and the fire-and-forget
+   * builtins register their network/LLM promise. Normalized to always resolve
+   * (failures are settled, not thrown) and auto-removed once it settles, so a
+   * rejecting promise is safe and never leaks.
+   */
+  trackAsyncWork(promise: Promise<unknown>): void {
+    const tracked = promise.then(() => {}, () => {});
+    this.#pendingAsyncWork.add(tracked);
+    tracked.finally(() => this.#pendingAsyncWork.delete(tracked));
+  }
+
+  /** Number of in-flight async builtin operations (see `trackAsyncWork`). */
+  pendingAsyncWorkCount(): number {
+    return this.#pendingAsyncWork.size;
+  }
+
+  /** Settle the currently-pending async builtin operations (without the full
+   *  scheduler/storage drain `settled()` does). Used by `Cell.pull()`'s
+   *  convergence loop. */
+  async asyncWorkSettled(): Promise<void> {
+    while (this.#pendingAsyncWork.size > 0) {
+      await Promise.allSettled([...this.#pendingAsyncWork]);
+    }
+  }
+
+  /**
+   * Wait until the runtime is fully settled: the scheduler is idle, storage is
+   * synced, AND every in-flight async builtin operation (`trackAsyncWork`) has
+   * completed — including the reactive cascade its result writeback triggers.
+   * This is the "wait for everything, including async builtin I/O" companion to
+   * `idle()` (which intentionally returns before that I/O so handlers don't
+   * block on the network). Bounded: a builtin whose result re-triggers more
+   * async work converges in a few rounds.
+   */
+  async settled(maxRounds = 50): Promise<void> {
+    for (let round = 0; round < maxRounds; round++) {
+      await this.scheduler.idle();
+      await this.storageManager.synced();
+      if (this.#pendingAsyncWork.size === 0) return;
+      await Promise.allSettled([...this.#pendingAsyncWork]);
+    }
+  }
+
   /**
    * Proactively checks all computations for idempotency by force-dirtying
    * and re-executing them, then comparing write snapshots.

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -459,13 +459,13 @@ function finalizeReactiveActionCommit(
   if (!log) {
     throw new Error("scheduler action commit did not build a reactivity log");
   }
-  // Track the commit as in-flight async builtin work so `runtime.settled()` /
-  // `Cell.pull()` wait for its post-commit outbox flush (the sqlite query RPC +
-  // writeback; the barrier that guarantees a fire-and-forget builtin's flush
-  // has registered its own network/LLM work). Registered before this run's
-  // running promise resolves, so a reader observes the settled result rather
-  // than racing the flush. `idle()` deliberately stays free of this. Commits
-  // with no post-commit effects keep the fire-and-forget fast path.
+  // Track the commit as in-flight async builtin work so `runtime.settled()`
+  // waits for its post-commit outbox flush (the sqlite query RPC + writeback;
+  // also the barrier that guarantees a fire-and-forget builtin's flush has
+  // registered its own network/LLM work). Registered before this run's running
+  // promise resolves, so a reader observes the settled result rather than racing
+  // the flush. `idle()` deliberately stays free of this. Commits with no
+  // post-commit effects keep the fire-and-forget fast path.
   if (hasPostCommitEffects) {
     state.runtime.trackAsyncWork(commitPromise);
   }

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -441,6 +441,10 @@ function finalizeReactiveActionCommit(
   // retry logic below will have re-scheduled this action, so
   // topological sorting should move it before the dependencies.
   let log: ReactivityLog | undefined;
+  // Captured at commit kickoff (after prepareTxForCommit populates the CFC
+  // outbox, before the async flush clears it): does this commit have
+  // asynchronous post-commit work that `settled()` must wait on?
+  let hasPostCommitEffects = false;
   const commitPromise = startReactiveActionCommit({
     runtime: state.runtime,
     tx: args.tx,
@@ -449,10 +453,21 @@ function finalizeReactiveActionCommit(
       log = txToReactivityLog(args.tx);
       warnOnWriteSurfaceViolations(state, args, log);
       attachSchedulerActionObservation(state, args, log);
+      hasPostCommitEffects = args.tx.hasPendingPostCommitEffects();
     },
   });
   if (!log) {
     throw new Error("scheduler action commit did not build a reactivity log");
+  }
+  // Track the commit as in-flight async builtin work so `runtime.settled()` /
+  // `Cell.pull()` wait for its post-commit outbox flush (the sqlite query RPC +
+  // writeback; the barrier that guarantees a fire-and-forget builtin's flush
+  // has registered its own network/LLM work). Registered before this run's
+  // running promise resolves, so a reader observes the settled result rather
+  // than racing the flush. `idle()` deliberately stays free of this. Commits
+  // with no post-commit effects keep the fire-and-forget fast path.
+  if (hasPostCommitEffects) {
+    state.runtime.trackAsyncWork(commitPromise);
   }
   const committedLog = log;
   const changedComputationWrites = state.recordChangedComputationWrites(

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -463,6 +463,10 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.cfcState.outbox.push(effect);
   }
 
+  hasPendingPostCommitEffects(): boolean {
+    return this.cfcState.outbox.length > 0;
+  }
+
   private buildPreparedDigestInput(): PreparedDigestInput {
     // Each pushed record is deepFrozen so that every CfcAddress (and every
     // path inside one) that flows into the digest input is immutable from
@@ -1171,6 +1175,10 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
 
   enqueuePostCommitEffect(effect: PostCommitSideEffect): void {
     this.wrapped.enqueuePostCommitEffect(effect);
+  }
+
+  hasPendingPostCommitEffects(): boolean {
+    return this.wrapped.hasPendingPostCommitEffects();
   }
 
   enableMultiSpaceWrites(order?: readonly MemorySpace[]): void {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -907,6 +907,15 @@ export interface IExtendedStorageTransaction
   enqueuePostCommitEffect(effect: PostCommitSideEffect): void;
 
   /**
+   * True when this transaction still carries un-flushed post-commit side
+   * effects (the CFC outbox is non-empty). The scheduler uses this to decide
+   * whether `commit()` does asynchronous work after the inner storage commit
+   * (e.g. a sqlite query RPC + writeback) that `idle()` must wait on — a plain
+   * commit with no effects keeps its existing fire-and-forget fast path.
+   */
+  hasPendingPostCommitEffects(): boolean;
+
+  /**
    * Add a callback to be called when the transaction commit completes.
    * The callback receives the transaction as a parameter and is called
    * regardless of whether the commit succeeded or failed.

--- a/packages/runner/test/sqlite-builtins.test.ts
+++ b/packages/runner/test/sqlite-builtins.test.ts
@@ -104,9 +104,15 @@ describe("sqlite builtins (Phase 0 wiring)", () => {
     try {
       const queryPattern = cf.pattern(() => {
         const db = cf.sqliteDatabase({
-          tables: { notes: cf.table({ id: "integer primary key", body: "text" }) },
+          tables: {
+            notes: cf.table({ id: "integer primary key", body: "text" }),
+          },
         });
-        return cf.sqliteQuery({ db, sql: "SELECT body FROM notes", reactOn: db });
+        return cf.sqliteQuery({
+          db,
+          sql: "SELECT body FROM notes",
+          reactOn: db,
+        });
       });
       const resultCell = runtime.getCell(
         space,
@@ -120,14 +126,17 @@ describe("sqlite builtins (Phase 0 wiring)", () => {
       // Observe the result so the effect runs in pull mode. `idle()` returns
       // before the latency-bounded flush completes (still pending); `settled()`
       // waits for it.
-      const cancel = (result as { sink: (f: () => void) => () => void })
-        .sink(() => {});
+      const view = result as unknown as {
+        get: () => QueryState;
+        sink: (f: () => void) => () => void;
+      };
+      const cancel = view.sink(() => {});
       try {
         await runtime.idle();
-        expect((result as { get: () => QueryState }).get().pending).toBe(true);
+        expect(view.get().pending).toBe(true);
 
         await runtime.settled();
-        const v = (result as { get: () => QueryState }).get();
+        const v = view.get();
         expect(v.pending).toBe(false);
         expect(v.error).toBeUndefined();
         expect(v.result).toEqual([]);

--- a/packages/runner/test/sqlite-builtins.test.ts
+++ b/packages/runner/test/sqlite-builtins.test.ts
@@ -81,6 +81,64 @@ describe("sqlite builtins (Phase 0 wiring)", () => {
     expect(q.result).toEqual([]);
   });
 
+  it("settled() waits for an in-flight reactive query flush (no stale read)", async () => {
+    // Regression for the lunch-poll CI flake (assertions read a sqlite query
+    // result before it settled under load). A reactive `sqliteQuery` issues its
+    // server read from a POST-COMMIT outbox flush (an async RPC + result
+    // writeback). `idle()` deliberately returns before that I/O, so a reader
+    // must use `runtime.settled()` — which waits for the in-flight async builtin
+    // work — to observe a settled result rather than `{ pending: true }`.
+    //
+    // We make the server read unmistakably slow so the flush is guaranteed
+    // in-flight. `idle()` alone resolves against the half-settled
+    // `{ pending: true }` state; `settled()` stays open until the flush writes
+    // the result back.
+    const provider = runtime.storageManager.open(space) as unknown as {
+      sqliteQuery: (...a: unknown[]) => Promise<unknown>;
+    };
+    const original = provider.sqliteQuery.bind(provider);
+    provider.sqliteQuery = async (...a) => {
+      await new Promise((r) => setTimeout(r, 50));
+      return await original(...a);
+    };
+    try {
+      const queryPattern = cf.pattern(() => {
+        const db = cf.sqliteDatabase({
+          tables: { notes: cf.table({ id: "integer primary key", body: "text" }) },
+        });
+        return cf.sqliteQuery({ db, sql: "SELECT body FROM notes", reactOn: db });
+      });
+      const resultCell = runtime.getCell(
+        space,
+        "sqlite-settled",
+        queryPattern.resultSchema,
+        tx,
+      );
+      const result = runtime.run(tx, queryPattern, {}, resultCell);
+      await tx.commit();
+
+      // Observe the result so the effect runs in pull mode. `idle()` returns
+      // before the latency-bounded flush completes (still pending); `settled()`
+      // waits for it.
+      const cancel = (result as { sink: (f: () => void) => () => void })
+        .sink(() => {});
+      try {
+        await runtime.idle();
+        expect((result as { get: () => QueryState }).get().pending).toBe(true);
+
+        await runtime.settled();
+        const v = (result as { get: () => QueryState }).get();
+        expect(v.pending).toBe(false);
+        expect(v.error).toBeUndefined();
+        expect(v.result).toEqual([]);
+      } finally {
+        cancel();
+      }
+    } finally {
+      provider.sqliteQuery = original;
+    }
+  });
+
   // The db's on-disk file is the server's job; what the *runner* must get right
   // is forwarding the author-declared scope to the wire. `.asScope("user")` is
   // what the transformer lowers `const db: PerUser<SqliteDb> = sqliteDatabase()`


### PR DESCRIPTION
## Problem

`packages/patterns/lunch-poll/main.test.tsx` flakes in the "Pattern Unit Tests" CI shard: the SQLite-backed history assertions — `assert_two_history`, `assert_one_history_after_remove`, `assert_history_cleared` — intermittently report `Expected true, got false`. Passes in isolation; fails under the shard's heavier CPU/IO load. Pre-existing on `main` (reproduced on a clean checkout), surfaced while shepherding #4203.

## Root cause

The async builtins — reactive sqlite queries (`db.query`), `fetchData`, `fetchProgram`, `llm` / `llmDialog` — perform their real I/O (a network/LLM call or a sqlite RPC, plus the result writeback) from a **post-commit outbox flush**, *after* the handler returns. `scheduler.idle()` deliberately does **not** wait for that I/O — a handler must never block on the network — and nothing else did either. So a reader settling with `idle()` could observe a query result while its flush was still in flight and read a stale `{ pending: true }`.

## Approach

**Runtime — a dedicated "fully settled" path (`idle()` is untouched):**
- `Runtime` gains a `#pendingAsyncWork` registry, `trackAsyncWork()`, and **`settled()`** — `settled()` drains the scheduler (idle), storage (synced), **and** every in-flight async builtin operation, looping until quiescent.
- The async builtins register their in-flight I/O via `trackAsyncWork`:
  - The **scheduler** registers an effect-bearing commit's promise — a race-free barrier (the sqlite query flush runs inside that commit and awaits its RPC + writeback, and it guarantees a fire-and-forget builtin's flush has run and registered its own work). Gated by a new `hasPendingPostCommitEffects()` on the transaction; plain commits keep the fire-and-forget fast path.
  - **`fetchData` / `fetchProgram` / `llm` / `generateText` / `generateObject` / `llmDialog`** register their network/LLM promise. **`streamData` is intentionally not tracked** — an SSE stream is long-lived and has no "done".

**cf test — an opt-in `{ settle: true }` step (not a blanket per-action settle):**
- The per-action settle stays the light `idle()` + `synced()` loop. A new **`{ settle: true }` step** waits for full settlement via `runtime.settled()`. A test that asserts on an async-builtin result inserts it before the assertion.
- `lunch-poll/main.test.tsx` inserts `{ settle: true }` before its SQLite-backed history assertions. The other sqlite patterns (`cfc-row-label-*`) passed on `main` with the light settle, so they're unaffected.

## Tests

- **Deterministic regression test** in `sqlite-builtins.test.ts`: with the server read slowed, `idle()` still returns `{ pending: true }`, while `runtime.settled()` settles the reactive query to `{ pending: false }`. Red without the registration, green with it.
- Full runner suite **633 passed, 0 failed**; fetch/llm/stream outbox suites green.
- CI-faithful repro (lunch-poll alone under load from *other* pattern-test processes — different spaces, no shared cell-db): **30/30 pass** vs. repeated `assertion_17/18/19` failures on pristine `main`.

> Note: running the same test file in N concurrent processes is **not** a valid repro — cf test cell-dbs are files at `$TMPDIR/cf-cell-<hash(space)>-<hash(id)>.sqlite`, so same-file concurrency shares one db and contaminates results. CI never does this (different test files → different spaces); its concurrency is parallel shards.

---

### Coverage

`NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 8535 lines`

The +6 uncovered lines are the `runtime.trackAsyncWork(...)` wrappers in the `fetchData` / `fetchProgram` / `llm` / `llmDialog` post-commit flushes — they wrap network/LLM I/O that only the integration suites exercise, not the unit-coverage artifact. Accepting the narrow ratchet bump per docs/development/CI_PERFORMANCE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
