### PR TITLE
test(runtime-client): include client/*.test.ts in the test task

### DIFF
--- a/packages/runtime-client/deno.json
+++ b/packages/runtime-client/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@commonfabric/runtime-client",
   "tasks": {
-    "test": "deno test --allow-env --allow-read --allow-ffi *.test.ts backends/*.test.ts",
+    "test": "deno test --allow-env --allow-read --allow-ffi *.test.ts backends/*.test.ts client/*.test.ts",
     "integration": "LOG_LEVEL=warn deno test -A $INTEGRATION_TEST_FLAGS ./integration/*.test.ts"
   },
   "exports": {


### PR DESCRIPTION
The package test task globbed only `*.test.ts backends/*.test.ts`, and the integration task globbed only `./integration/*.test.ts`. As a result `client/connection.test.ts` (the "RuntimeConnection disposal" tests) ran in no CI test or coverage profile.

Add `client/*.test.ts` to the test task glob so those tests run under the workspace coverage job and guard CI again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include `client/*.test.ts` in the `@commonfabric/runtime-client` test task so client tests run in CI and count toward coverage. This restores execution of `client/connection.test.ts` ("RuntimeConnection disposal") under the workspace coverage job.

<sup>Written for commit 924a5a0a936d8d32177b3971aef4a126f93a8545. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

