### PR TITLE
test(runner): deterministically cover coverage-jitter regions

### DIFF
--- a/packages/runner/test/cell-get-slow-warning.test.ts
+++ b/packages/runner/test/cell-get-slow-warning.test.ts
@@ -1,0 +1,75 @@
+// Deterministic coverage for the slow-get warning branch in Cell.get(). After
+// timing the read, get() warns when the elapsed time exceeds 50ms. The elapsed
+// time is real wall-clock, so this branch only fires when a get happens to be
+// slow, which is pure timing jitter. Here the "cell" logger's timeEnd is stubbed
+// to report an elapsed time above the threshold for one get, so the warning
+// branch always runs.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { getLogger } from "@commonfabric/utils/logger";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("cell-get-slow-warning");
+const space = signer.did();
+
+describe("Cell.get slow-path warning", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("warns when a get exceeds the 50ms threshold", () => {
+    const c = runtime.getCell<number>(
+      space,
+      "warns when a get exceeds the 50ms threshold",
+      undefined,
+      tx,
+    );
+    c.set(10);
+
+    // The "cell" logger is a process-wide singleton; get() reuses this same
+    // instance. Report an elapsed time above the threshold for the next
+    // cell/get span and silence the warning so it doesn't print.
+    const cellLogger = getLogger("cell");
+    const loggerWithTimeEnd = cellLogger as unknown as {
+      timeEnd?: (...keys: string[]) => number | undefined;
+    };
+    const realTimeEnd = cellLogger.timeEnd.bind(cellLogger);
+    const originalLevel = cellLogger.level;
+    const warnsBefore = cellLogger.counts.warn;
+
+    cellLogger.level = "silent";
+    loggerWithTimeEnd.timeEnd = (...keys: string[]) => {
+      const elapsed = realTimeEnd(...keys);
+      return keys.join("/") === "cell/get" ? 100 : elapsed;
+    };
+
+    try {
+      expect(c.get()).toBe(10);
+    } finally {
+      delete loggerWithTimeEnd.timeEnd;
+      cellLogger.level = originalLevel;
+    }
+
+    // The warning branch ran exactly once for this get.
+    expect(cellLogger.counts.warn).toBe(warnsBefore + 1);
+  });
+});

--- a/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
+++ b/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
@@ -1,0 +1,176 @@
+// Deterministic coverage for the "removes" arm of applySessionSync in
+// storage/v2.ts. A watch refresh / sync batch can carry removals when a watched
+// doc is deleted upstream. Most tests only deliver upserts, so the removes path
+// runs intermittently. Here the scripted transport answers the watch.add with a
+// sync that upserts two docs and removes one of them in the same batch, so the
+// removes loop always runs while provider.sync() is awaited.
+
+import { assertEquals } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import type { URI } from "@commonfabric/memory/interface";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import {
+  decodeMemoryBoundary,
+  encodeMemoryBoundary,
+  type EntityDocument,
+  getMemoryProtocolFlags,
+  type SessionSync,
+  type SessionSyncUpsert,
+} from "@commonfabric/memory/v2";
+import type { IStorageProviderWithReplica } from "../src/storage/interface.ts";
+import {
+  SingleSessionFactory,
+  TestStorageManager,
+} from "./memory-v2-test-utils.ts";
+
+const signer = await Identity.fromPassphrase("memory-v2-watch-remove-coverage");
+const space = signer.did();
+const HELLO_OK = {
+  type: "hello.ok",
+  protocol: "memory",
+  flags: getMemoryProtocolFlags(),
+} as const;
+
+type TestProvider = IStorageProviderWithReplica & {
+  get(uri: URI): EntityDocument | undefined;
+  sync(
+    uri: URI,
+    selector?: { path: string[]; schema: unknown },
+  ): Promise<unknown>;
+};
+
+const doc = (
+  id: URI,
+  seq: number,
+  doc: SessionSyncUpsert["doc"],
+): SessionSyncUpsert => ({
+  branch: "",
+  id,
+  seq,
+  doc,
+});
+
+const getObjectValue = (
+  provider: TestProvider,
+  uri: URI,
+): Record<string, unknown> | undefined => {
+  const value = provider.get(uri)?.value;
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+};
+
+// Answers the watch.add with a sync that upserts every requested root and then
+// removes `removedId` in the same batch, simulating a watched doc deleted
+// upstream as the watch is established.
+class WatchAddRemoveTransport implements MemoryV2Client.Transport {
+  #receiver: (payload: string) => void = () => {};
+  #closeReceiver: (error?: Error) => void = () => {};
+
+  constructor(private readonly removedId: URI) {}
+
+  setReceiver(receiver: (payload: string) => void): void {
+    this.#receiver = receiver;
+  }
+
+  setCloseReceiver(receiver: (error?: Error) => void): void {
+    this.#closeReceiver = receiver;
+  }
+
+  send(payload: string): Promise<void> {
+    const message = decodeMemoryBoundary(payload) as {
+      type: string;
+      requestId?: string;
+      watches?: Array<{
+        query?: { roots?: Array<{ id: string }> };
+      }>;
+    };
+
+    switch (message.type) {
+      case "hello":
+        this.#respond(HELLO_OK);
+        return Promise.resolve();
+      case "session.open":
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            sessionId: "session:watch-remove-coverage",
+            serverSeq: 0,
+          },
+        });
+        return Promise.resolve();
+      case "session.ack":
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            serverSeq: 5,
+          },
+        });
+        return Promise.resolve();
+      case "session.watch.add": {
+        const roots =
+          message.watches?.flatMap((watch) =>
+            watch.query?.roots?.map((root) => root.id as URI) ?? []
+          ) ?? [];
+        const toSeq = roots.length + 1;
+        this.#respond({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            serverSeq: toSeq,
+            sync: {
+              type: "sync",
+              fromSeq: 0,
+              toSeq,
+              upserts: roots.map((id, index) =>
+                doc(id, index + 1, { value: { label: id } })
+              ),
+              removes: [{ branch: "", id: this.removedId }],
+            } satisfies SessionSync,
+          },
+        });
+        return Promise.resolve();
+      }
+      default:
+        throw new Error(`Unhandled scripted message: ${message.type}`);
+    }
+  }
+
+  close(): Promise<void> {
+    this.#closeReceiver();
+    return Promise.resolve();
+  }
+
+  #respond(message: FabricValue): void {
+    this.#receiver(encodeMemoryBoundary(message));
+  }
+}
+
+Deno.test("memory v2 runner applies removes carried in a watch refresh batch", async () => {
+  const docA = `of:watch-remove-keep-${crypto.randomUUID()}` as URI;
+  const docB = `of:watch-remove-drop-${crypto.randomUUID()}` as URI;
+  const transport = new WatchAddRemoveTransport(docB);
+  const sessionFactory = new SingleSessionFactory(transport);
+  const storageManager = TestStorageManager.create({
+    as: signer,
+    memoryHost: new URL("memory://runner-v2-watch-remove-coverage"),
+  }, sessionFactory);
+  const provider = storageManager.open(space) as TestProvider;
+
+  try {
+    await Promise.all([
+      provider.sync(docA, { path: [], schema: false }),
+      provider.sync(docB, { path: [], schema: false }),
+    ]);
+
+    // docA was upserted and kept; docB was upserted in the same sync and then
+    // removed, so the removes loop must have reset it back to absent.
+    assertEquals(getObjectValue(provider, docA), { label: docA });
+    assertEquals(provider.get(docB), undefined);
+  } finally {
+    await storageManager.close();
+  }
+});


### PR DESCRIPTION
Two regions in packages/runner flap between covered and uncovered across identical-source runs, intermittently tripping the coverage-debt gate. Both only run under conditions most tests don't create, so whether they're covered depends on timing and test mix. Add test-only coverage that always exercises them.

Region A: the slow-get warning in Cell.get() (cell.ts). The warning fires only when the timed read exceeds 50ms, which is pure wall-clock jitter. The new test stubs the process-wide "cell" logger's timeEnd to report an elapsed time above the threshold for one get, silences the warning, and asserts the warn count incremented by exactly one. The stub and level are restored in a finally so the singleton doesn't leak to other tests.

Region B: the removes arm of applySessionSync (storage/v2.ts). It runs only when a sync batch carries removals; most tests deliver only upserts. The new test drives the synchronous seam -- watchAddSync returns the response sync verbatim and refreshWatchSet applies it before provider.sync() resolves -- with a scripted transport that upserts two watched docs and removes one in the same batch. The removed doc was upserted in that same sync, so asserting it ends up absent proves the removes loop overrode the upsert.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two deterministic tests to exercise jitter-prone branches in the runner, stabilizing the coverage gate. One forces the slow-get warning in Cell.get() by stubbing the process-wide `cell` logger’s `timeEnd`; the other covers the “removes” arm of applySessionSync by scripting a watch refresh that upserts two docs and removes one in the same batch.

<sup>Written for commit 1d1e26ee6ff7a92acd7d25b7934ad9cc9e81e44d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

