### PR TITLE
test(data-model): deterministic coverage for toIndentedDebugString

### DIFF
--- a/packages/data-model/test/value-debug-indented.test.ts
+++ b/packages/data-model/test/value-debug-indented.test.ts
@@ -1,0 +1,83 @@
+// Focused coverage guard for the public `toIndentedDebugString` wrapper.
+//
+// `toIndentedDebugString` is a one-line public function that forwards to the
+// module-private `renderDebugString(value, 2)`. This file calls it directly on
+// a spread of representative values so the wrapper is exercised on its own,
+// independent of whichever larger suite happens to reach it indirectly.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { toCompactDebugString, toIndentedDebugString } from "@/value-debug.ts";
+import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
+
+describe("toIndentedDebugString (direct wrapper coverage)", () => {
+  it("returns a non-empty string for a plain nested object", () => {
+    const result = toIndentedDebugString({ a: 1, nested: { b: 2 } });
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("indents nested object structure with 2 spaces", () => {
+    // Two leading spaces before the first key confirm `indent === 2` reached
+    // `JSON.stringify`. A deeper key carries four spaces.
+    const result = toIndentedDebugString({ a: 1, nested: { b: 2 } });
+    expect(result).toContain('\n  "a"');
+    expect(result).toContain('\n    "b"');
+  });
+
+  it("indents array elements with 2 spaces", () => {
+    const result = toIndentedDebugString([1, 2, 3]);
+    expect(result).toBe("[\n  1,\n  2,\n  3\n]");
+  });
+
+  it("renders a top-level primitive as a bare string", () => {
+    expect(toIndentedDebugString(42)).toBe("42");
+    expect(toIndentedDebugString("hello")).toBe('"hello"');
+    expect(toIndentedDebugString(true)).toBe("true");
+    expect(toIndentedDebugString(null)).toBe("null");
+  });
+
+  it("delegates with `indent === 2`, matching the equivalent JSON layout", () => {
+    // For JSON-native values the wrapper's output equals the two-space
+    // `JSON.stringify` of the same value, which is what the private
+    // `renderDebugString(value, 2)` produces. This pins the forwarded indent.
+    for (const value of [{ a: 1, b: { c: 2 } }, [1, [2, 3]], "x", 7, false]) {
+      expect(toIndentedDebugString(value)).toBe(JSON.stringify(value, null, 2));
+    }
+  });
+
+  it("applies indentation that the compact form omits", () => {
+    // The indented and compact wrappers share the same renderer; the only
+    // difference is the forwarded indent, so a nested structure must differ.
+    const value = { a: 1, nested: { b: 2 } };
+    expect(toIndentedDebugString(value)).not.toBe(toCompactDebugString(value));
+  });
+
+  it("renders an exotic (non-plain) value without throwing", () => {
+    const inst = new FabricEpochNsec(123456789n);
+    expect(() => toIndentedDebugString(inst)).not.toThrow();
+    expect(toIndentedDebugString(inst)).toBe("/EpochNsec(...)");
+  });
+
+  it("renders a circular reference as `<circle>` rather than throwing", () => {
+    const a: Record<string, unknown> = { x: 1 };
+    a.self = a;
+    expect(() => toIndentedDebugString(a)).not.toThrow();
+    expect(toIndentedDebugString(a)).toBe(
+      '{\n  "x": 1,\n  "self": <circle>\n}',
+    );
+  });
+
+  it("falls back to the unrenderable string instead of throwing", () => {
+    // The docstring promises a literal fallback string when stringification
+    // cannot complete (here, a throwing `toJSON()`).
+    const value = {
+      toJSON: () => {
+        throw new Error("nope");
+      },
+    };
+    expect(() => toIndentedDebugString(value)).not.toThrow();
+    expect(toIndentedDebugString(value)).toBe("<unrenderable debug string>");
+  });
+});


### PR DESCRIPTION
The one-line public wrapper `toIndentedDebugString` forwards to the module-private `renderDebugString(value, 2)`. It is loaded by many test workers (its sibling helpers are widely imported) but only called in the single worker running its tests, so V8's per-worker coverage ranges merge nondeterministically and the wrapper's lines flap between covered and uncovered, intermittently tripping the coverage-debt gate.

Add a focused test file that calls `toIndentedDebugString` directly on a plain object, an array, primitives, an exotic non-plain value, a circular reference, and an unrenderable (throwing-`toJSON`) value. Assertions pin the 2-space indentation, the forwarded `indent === 2` (matched against the equivalent `JSON.stringify` layout), and the documented non-throwing fallback. Test-only; no source or assertion changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add focused tests for `toIndentedDebugString` to make coverage deterministic and stop intermittent coverage gate failures. The suite covers plain objects, arrays, primitives, exotic values, circular references, and throwing `toJSON`, asserting 2-space indentation, parity with `JSON.stringify` for JSON-native values, and the documented non-throwing fallback.

<sup>Written for commit b6278862e8e963c9809612c772ef26afbb5d39f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

