### PR TITLE
test(memory): cover fromDID success arm to stop coverage jitter

### DIFF
--- a/packages/memory/test/util-test.ts
+++ b/packages/memory/test/util-test.ts
@@ -1,5 +1,7 @@
 import { assert, assertEquals } from "@std/assert";
+import { VerifierIdentity } from "@commonfabric/identity";
 import { fromDID } from "../util.ts";
+import { alice } from "./principal.ts";
 
 Deno.test("fromDID rejects non-DID strings", async () => {
   const result = await fromDID("not-a-did");
@@ -32,4 +34,13 @@ Deno.test("fromDID wraps did:key parser errors as syntax errors", async () => {
     result.error.message,
     `Invalid DID "${unsupportedDid}", RangeError: Unsupported key algorithm expected 0xed, instead of 0xe7`,
   );
+});
+
+Deno.test("fromDID parses a valid did:key into a verifier", async () => {
+  const did = alice.did();
+
+  const result = await fromDID(did);
+
+  assert(result.ok instanceof VerifierIdentity);
+  assertEquals(result.ok.did(), did);
 });


### PR DESCRIPTION
The error branches of fromDID already had deterministic tests, but the success arm of the try (the { ok: await VerifierIdentity.fromDid(...) } return) was only exercised when another test happened to push a valid did:key: through fromDID during a run. That left ~13 lines flapping between covered and uncovered across runs with identical source.

Add a test that round-trips a valid did:key: from the alice principal, pinning the success path to always-covered. util.ts now reports 100% line, branch, and function coverage in isolation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a deterministic test for the fromDID success path by round-tripping a valid did:key from the alice principal. This removes coverage jitter and keeps util.ts at 100% line/branch/function coverage.

<sup>Written for commit c71a7559a5a6e40261dc3bf6636d67a1d0527f7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

