### PR TITLE
test(deno-web-test): cover the bundle retry path deterministically

### DIFF
--- a/packages/deno-web-test/test/bundle-retry.test.ts
+++ b/packages/deno-web-test/test/bundle-retry.test.ts
@@ -1,0 +1,146 @@
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import {
+  BUNDLE_RETRYABLE_ESBUILD_COPY,
+  BUNDLE_RETRYABLE_ETXTBSY,
+  isRetryableBundleFailure,
+  runBundleWithRetry,
+  sleepForRetry,
+} from "../utils.ts";
+
+const encoder = new TextEncoder();
+
+// Replaces the global setTimeout with one that fires the callback
+// synchronously and records each requested delay, for the duration of `fn`.
+// This keeps the backoff-driven tests instant while letting them assert the
+// delays that were requested.
+async function withInstantTimers(
+  fn: (delays: number[]) => Promise<void>,
+): Promise<void> {
+  const delays: number[] = [];
+  const original = globalThis.setTimeout;
+  globalThis.setTimeout =
+    ((cb: (...args: unknown[]) => void, delay?: number) => {
+      delays.push(delay ?? 0);
+      cb();
+      return 0;
+    }) as typeof setTimeout;
+  try {
+    await fn(delays);
+  } finally {
+    globalThis.setTimeout = original;
+  }
+}
+
+Deno.test("isRetryableBundleFailure detects the ETXTBSY race marker", () => {
+  assert(
+    isRetryableBundleFailure(
+      `error: ${BUNDLE_RETRYABLE_ETXTBSY} while spawning esbuild`,
+    ),
+  );
+});
+
+Deno.test("isRetryableBundleFailure detects the esbuild copy marker", () => {
+  assert(
+    isRetryableBundleFailure(
+      `deno: ${BUNDLE_RETRYABLE_ESBUILD_COPY} to the cache dir`,
+    ),
+  );
+});
+
+Deno.test("isRetryableBundleFailure rejects unrelated bundle errors", () => {
+  assertEquals(
+    isRetryableBundleFailure("error: Module not found 'jsr:@foo/bar'"),
+    false,
+  );
+});
+
+Deno.test("sleepForRetry resolves and backs off exponentially", async () => {
+  await withInstantTimers(async (delays) => {
+    await sleepForRetry(1);
+    await sleepForRetry(2);
+    await sleepForRetry(3);
+    assertEquals(delays, [250, 500, 1000]);
+  });
+});
+
+Deno.test(
+  "runBundleWithRetry retries a retryable failure then succeeds",
+  async () => {
+    await withInstantTimers(async (delays) => {
+      const outcomes = [
+        { success: false, stderr: encoder.encode(BUNDLE_RETRYABLE_ETXTBSY) },
+        { success: true, stderr: new Uint8Array() },
+      ];
+      let calls = 0;
+      let succeeded = 0;
+      await runBundleWithRetry(
+        () => {
+          calls++;
+          return Promise.resolve(outcomes.shift()!);
+        },
+        () => {
+          succeeded++;
+          return Promise.resolve();
+        },
+        "fixture.test.ts",
+      );
+      assertEquals(calls, 2);
+      assertEquals(succeeded, 1);
+      assertEquals(delays, [250]);
+    });
+  },
+);
+
+Deno.test(
+  "runBundleWithRetry throws immediately on a non-retryable failure",
+  async () => {
+    await withInstantTimers(async (delays) => {
+      let calls = 0;
+      await assertRejects(
+        () =>
+          runBundleWithRetry(
+            () => {
+              calls++;
+              return Promise.resolve({
+                success: false,
+                stderr: encoder.encode("error: Module not found"),
+              });
+            },
+            () => Promise.resolve(),
+            "fixture.test.ts",
+          ),
+        Error,
+        "Failed to bundle fixture.test.ts",
+      );
+      assertEquals(calls, 1);
+      assertEquals(delays, []);
+    });
+  },
+);
+
+Deno.test(
+  "runBundleWithRetry gives up after the retry budget is exhausted",
+  async () => {
+    await withInstantTimers(async (delays) => {
+      let calls = 0;
+      await assertRejects(
+        () =>
+          runBundleWithRetry(
+            () => {
+              calls++;
+              return Promise.resolve({
+                success: false,
+                stderr: encoder.encode(BUNDLE_RETRYABLE_ETXTBSY),
+              });
+            },
+            () => Promise.resolve(),
+            "fixture.test.ts",
+          ),
+        Error,
+        "Failed to bundle",
+      );
+      assertEquals(calls, 5);
+      assertEquals(delays, [250, 500, 1000, 2000]);
+    });
+  },
+);

--- a/packages/deno-web-test/utils.ts
+++ b/packages/deno-web-test/utils.ts
@@ -6,8 +6,8 @@ import { Summary, TestFileResults } from "./interface.ts";
 export const tsToJs = (path: string): string => path.replace(/\.ts$/, ".js");
 
 const BUNDLE_RETRY_ATTEMPTS = 5;
-const BUNDLE_RETRYABLE_ESBUILD_COPY = "failed to copy esbuild binary";
-const BUNDLE_RETRYABLE_ETXTBSY = "Text file busy (os error 26)";
+export const BUNDLE_RETRYABLE_ESBUILD_COPY = "failed to copy esbuild binary";
+export const BUNDLE_RETRYABLE_ETXTBSY = "Text file busy (os error 26)";
 
 // Given a `Manifest`, moves harness code and bundled
 // tests to the manifest's `serverDir`.
@@ -91,16 +91,32 @@ async function bundleTestFile(
 
   args.push(input);
 
+  await runBundleWithRetry(
+    () =>
+      new Deno.Command(Deno.execPath(), {
+        args,
+        cwd: manifest.projectDir,
+        stdout: "piped",
+        stderr: "piped",
+      }).output(),
+    () => downlevelBundleIfNeeded(output, manifest),
+    testPath,
+  );
+}
+
+// Runs `runBundle` until it succeeds, retrying on the transient esbuild
+// helper-copy / ETXTBSY races that Deno hits while bundling in CI. On success
+// `onSuccess` runs once; a non-retryable failure or the last attempt throws.
+export async function runBundleWithRetry(
+  runBundle: () => Promise<{ success: boolean; stderr: Uint8Array }>,
+  onSuccess: () => Promise<void>,
+  describeTarget: string,
+): Promise<void> {
   const decoder = new TextDecoder();
   for (let attempt = 1; attempt <= BUNDLE_RETRY_ATTEMPTS; attempt++) {
-    const result = await new Deno.Command(Deno.execPath(), {
-      args,
-      cwd: manifest.projectDir,
-      stdout: "piped",
-      stderr: "piped",
-    }).output();
+    const result = await runBundle();
     if (result.success) {
-      await downlevelBundleIfNeeded(output, manifest);
+      await onSuccess();
       return;
     }
 
@@ -108,7 +124,7 @@ async function bundleTestFile(
     if (
       attempt === BUNDLE_RETRY_ATTEMPTS || !isRetryableBundleFailure(stderr)
     ) {
-      throw new Error(`Failed to bundle ${testPath}: ${stderr}`);
+      throw new Error(`Failed to bundle ${describeTarget}: ${stderr}`);
     }
 
     // Deno can race while copying the esbuild helper binary in CI.
@@ -237,12 +253,12 @@ async function resolveWorkspacePackageImports(
   return imports;
 }
 
-async function sleepForRetry(attempt: number): Promise<void> {
+export async function sleepForRetry(attempt: number): Promise<void> {
   const delayMs = 250 * 2 ** (attempt - 1);
   await new Promise((resolve) => setTimeout(resolve, delayMs));
 }
 
-function isRetryableBundleFailure(stderr: string): boolean {
+export function isRetryableBundleFailure(stderr: string): boolean {
   return stderr.includes(BUNDLE_RETRYABLE_ETXTBSY) ||
     stderr.includes(BUNDLE_RETRYABLE_ESBUILD_COPY);
 }


### PR DESCRIPTION
The bundling retry branch in utils.ts (the ETXTBSY / esbuild helper-copy race handling) only ran when CI happened to hit the race, so coverage of those lines jittered run to run and intermittently tripped the coverage-debt gate.

Add deterministic unit tests that always exercise those lines:

- Export the retryable-failure markers, `sleepForRetry`, and `isRetryableBundleFailure` so tests can drive them directly.
- Extract the retry loop out of `bundleTestFile` into `runBundleWithRetry`, taking the command runner and success action as parameters. This mirrors the existing `launchWithRetry` seam in browser.ts and lets a test inject a runner that fails with a retryable stderr once, then succeeds.

The tests stub setTimeout to keep the backoff instant while asserting the delays, and cover the retry, fatal-failure, and budget-exhausted paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deterministic tests for the bundle retry path in `packages/deno-web-test` to stabilize CI coverage. Refactors bundling to expose `runBundleWithRetry` and retry helpers so tests can simulate transient failures and assert backoff.

- **Refactors**
  - Extracted retry loop from `bundleTestFile` to `runBundleWithRetry(runBundle, onSuccess, describeTarget)`.
  - Exported `BUNDLE_RETRYABLE_ETXTBSY`, `BUNDLE_RETRYABLE_ESBUILD_COPY`, `sleepForRetry`, and `isRetryableBundleFailure`.
  - Tests cover retry, non-retryable error, and exhausted retry budget using instant timers (verifying exponential backoff).

<sup>Written for commit 5f6ab4855e64c7d1afc00cabc4451b89591a27d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: job: CLI Integration Tests (fuse) = 93s
---END COPY-PASTE---
