### PR TITLE
perf(patterns): run "Compile all patterns" against in-memory storage

### DIFF
--- a/packages/patterns/integration/all.test.ts
+++ b/packages/patterns/integration/all.test.ts
@@ -5,6 +5,7 @@ import { join } from "@std/path";
 import { assert } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
 const { API_URL } = env;
 
@@ -54,10 +55,17 @@ describe("Compile all patterns", () => {
       // The PatternManager caches compiled patterns indefinitely, so we need a
       // fresh Runtime (via PiecesController) each time to avoid OOM in CI
       const identity = await Identity.generate();
+      // Back each controller with an in-memory emulated storage manager rather
+      // than the toolshed. Compiling and instantiating a pattern exercises the
+      // same runtime path either way; this only swaps the storage transport, so
+      // the suite no longer creates a persisted space or makes storage
+      // round-trips per pattern. dispose() closes the emulated server, keeping
+      // memory bounded.
       const cc = await PiecesController.initialize({
         spaceName: `${name}-${crypto.randomUUID()}`,
         apiUrl: new URL(API_URL),
         identity: identity,
+        storageManager: StorageManager.emulate({ as: identity }),
       });
 
       try {

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -145,15 +145,20 @@ export class PiecesController<T = unknown> {
     }
   }
 
-  static async initialize({ apiUrl, identity, spaceName }: {
+  static async initialize({ apiUrl, identity, spaceName, storageManager }: {
     apiUrl: URL;
     identity: Identity;
     spaceName: string;
+    // When provided, this storage manager is used instead of opening a
+    // toolshed-backed one against apiUrl. Tests pass an in-memory emulated
+    // manager so they neither create persisted spaces nor make storage
+    // round-trips.
+    storageManager?: Runtime["storageManager"];
   }): Promise<PiecesController> {
     const session = await createSession({ identity, spaceName });
     const runtime = new Runtime({
       apiUrl: new URL(apiUrl),
-      storageManager: StorageManager.open({
+      storageManager: storageManager ?? StorageManager.open({
         as: session.as,
         memoryHost: new URL(apiUrl),
         spaceIdentity: session.spaceIdentity,


### PR DESCRIPTION
The "Compile all patterns" suite creates a fresh controller for each authored pattern. Each controller used to open a storage connection to the toolshed and create a brand-new persisted space. With around 59 patterns, that meant around 59 space creations against disk-backed toolshed storage on CI, which dominated the suite's wall time.

Each controller is now backed by an in-memory emulated storage manager instead. Compiling and instantiating a pattern runs through the same runtime path either way; only the storage transport changes. The suite no longer creates a persisted space or makes any storage round-trip per pattern, so it no longer depends on the toolshed at all.

PiecesController.initialize gains an optional storageManager parameter. When a caller passes one, it is used as is; otherwise the toolshed-backed manager is opened exactly as before, so production callers are unaffected.

The suite still creates a fresh controller per pattern, so the compiled patterns that the PatternManager caches are dropped after each pattern and memory stays bounded. dispose() closes the emulated server, so the in-memory data for a pattern is freed once that pattern's test finishes.

Verified locally: the full suite passes for every pattern with an unreachable API_URL, which proves the toolshed dependency is gone; a pattern that fails to compile and a pattern that throws during setup both still fail the suite, which proves the compile-and-instantiate coverage is intact; peak resident memory stays around 1.5 GB, well under the 4 GB CI limit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the "Compile all patterns" suite against in-memory storage to remove toolshed I/O and speed up CI. Adds an optional storage manager to the controller while keeping production defaults unchanged.

- **Refactors**
  - `PiecesController.initialize` accepts an optional `storageManager`; otherwise it opens the toolshed-backed manager as before.
  - Tests use an in-memory storage per pattern and dispose after each run, avoiding persisted spaces and storage round-trips.

<sup>Written for commit bb4a739aeb01612c9a86577fdcd86352b7d5d978. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

