### PR TITLE
ci: make pattern-reload-integration-test a tier-0 job

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -566,7 +566,6 @@ jobs:
   pattern-reload-integration-test:
     name: "Pattern Reload Integration Tests"
     runs-on: ubuntu-latest
-    needs: ["build-binaries"]
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The pattern-reload-integration-test job declared needs: ["build-binaries"] but never used the built binaries. Unlike the tier-1 integration jobs, it has no "Download built binaries" step, no initialize-db, and never sets CF_BINARY or references ./common-binaries/. Its patterns-reload target runs deno task integration:reload in packages/patterns, which builds everything it needs from source.

The dependency only forced the job to wait ~61s for build-binaries and lumped it into the group of jobs that all become runnable at once and contend for the GitHub-hosted runner pool. Removing it lets the job start at the run's beginning.

Downstream jobs attest-binaries and deploy-shell-staging still list pattern-reload-integration-test in their own needs, so they continue to wait for it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `pattern-reload-integration-test` a tier-0 CI job by removing its unused `needs: ["build-binaries"]`, so it starts immediately and avoids runner contention. Downstream jobs still depend on it, so their order is unchanged.

- Refactors
  - Removed `needs: ["build-binaries"]` from `pattern-reload-integration-test`.
  - Safe because it builds from source via `deno task integration:reload` in `packages/patterns` and never uses built binaries or `CF_BINARY`.
  - Expected impact: ~60s faster start; less queueing; `attest-binaries` and `deploy-shell-staging` continue to wait on it.

<sup>Written for commit 531629eade507c761417d5abdfb6be375ff06afd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

