### PR TITLE
git ignore coverage directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ lib
 __pycache__
 cache
 artifact
+coverage
 _deno.lock
 .claude-prompt.tmp
 .bg-charm-service.pid


### PR DESCRIPTION
Agents love to create a coverage directory to test coverage now, so exclude that as well.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `coverage/` to `.gitignore` to ignore test coverage output and avoid accidental commits. Keeps the repo clean across tools that generate `coverage` directories.

<sup>Written for commit bb0fbcd05964da538e753176d6f333f9f6b69e3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

