### PR TITLE
Webhook cell-link wire: self-describing fcl1: addressing payload (clean break)

### DIFF
--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -4,7 +4,7 @@
  * entity-id reference form.
  */
 
-import { isRecord } from "@commonfabric/utils/types";
+import { isPlainObject, isRecord } from "@commonfabric/utils/types";
 import { FabricHash } from "@/fabric-primitives/index.ts";
 import type { FabricObject } from "@/interface.ts";
 
@@ -157,4 +157,91 @@ export function linkRefPayload<Payload extends FabricObject>(
 ): Payload {
   if (isLinkRef(value)) return value["/"][LINK_V1_TAG] as Payload;
   throw new Error("Not a link reference.");
+}
+
+//
+// Wire serialization of a (plain) link payload
+//
+
+/**
+ * The wire-format prefix tagging a serialized cell-link payload — `fcl1:` for
+ * "Fabric Cell Link v1". Like codec-json's `fvj1:`, it makes the format
+ * self-identifying (so a decoder can reject anything else) and reserves room
+ * for a future versioned migration. Owned here alongside the chokepoint.
+ */
+const CELL_LINK_WIRE_PREFIX = "fcl1:";
+
+/**
+ * A cell-link payload in its wire-transmissible form: a plain object whose every
+ * property value is a string or an array of strings. This is the subset of a
+ * link payload that is provably plain JSON — the addressing fields (id, space,
+ * scope, path, overwrite). Richer payload fields (a `schema`, which can carry an
+ * arbitrary {@link FabricValue} default, or cfc side-channels) are deliberately
+ * NOT in this form: they are not plain JSON and have no role at a string
+ * boundary. The exact field set is a consumer concern (e.g. runner's
+ * `WebhookCellLinkRefPayload`); this layer enforces only the generic shape.
+ */
+export type WireLinkRefPayload = {
+  readonly [key: string]: string | readonly string[];
+};
+
+/**
+ * Validates that `value` is a well-formed {@link WireLinkRefPayload}: a plain
+ * object with no prototype-pollution keys whose every value is a string or an
+ * array of strings. Throws otherwise. This is the generic guard that makes the
+ * wire round-trip safe — it rejects, loudly and at the boundary, any payload
+ * carrying a non-plain-JSON value (an object, a `bigint`, a Fabric special).
+ */
+function assertWireLinkRefPayloadShape(
+  value: unknown,
+): asserts value is WireLinkRefPayload {
+  if (!isPlainObject(value)) {
+    throw new Error("Cell-link wire payload must be a plain object.");
+  }
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    if (key === "__proto__" || key === "constructor") {
+      throw new Error(`Cell-link wire payload has a forbidden key: "${key}".`);
+    }
+    const ok = typeof val === "string" ||
+      (Array.isArray(val) && val.every((e) => typeof e === "string"));
+    if (!ok) {
+      throw new Error(
+        `Cell-link wire payload field "${key}" must be a string or an ` +
+          `array of strings.`,
+      );
+    }
+  }
+}
+
+/**
+ * Serializes a link payload to a wire string for transport across a string
+ * boundary (e.g. an HTTP body), tagged with the `fcl1:` prefix. The payload
+ * must satisfy {@link WireLinkRefPayload}; throws otherwise (so a non-transmissible
+ * payload fails here, at the producer, rather than corrupting silently).
+ */
+export function linkRefPayloadToString(payload: WireLinkRefPayload): string {
+  assertWireLinkRefPayloadShape(payload);
+  return CELL_LINK_WIRE_PREFIX + JSON.stringify(payload);
+}
+
+/**
+ * Decodes a wire string produced by {@link linkRefPayloadToString} back to a
+ * {@link WireLinkRefPayload}. Requires the `fcl1:` prefix, valid JSON, and the
+ * generic wire-payload shape; throws on any violation. Field-level validation
+ * (which keys, which kinds) is the consumer's concern, applied on top.
+ */
+export function linkRefPayloadFromString(wire: string): WireLinkRefPayload {
+  if (!wire.startsWith(CELL_LINK_WIRE_PREFIX)) {
+    throw new Error(
+      `Not a cell-link wire string (missing "${CELL_LINK_WIRE_PREFIX}" prefix).`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(wire.slice(CELL_LINK_WIRE_PREFIX.length));
+  } catch {
+    throw new Error("Cell-link wire string is not valid JSON.");
+  }
+  assertWireLinkRefPayloadShape(parsed);
+  return parsed;
 }

--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -4,7 +4,11 @@
  * entity-id reference form.
  */
 
-import { isPlainObject, isRecord } from "@commonfabric/utils/types";
+import {
+  isPlainObject,
+  isRecord,
+  isUnsafeObjectKey,
+} from "@commonfabric/utils/types";
 import { FabricHash } from "@/fabric-primitives/index.ts";
 import type { FabricObject } from "@/interface.ts";
 
@@ -199,7 +203,7 @@ function assertWireLinkRefPayloadShape(
     throw new Error("Cell-link wire payload must be a plain object.");
   }
   for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
-    if (key === "__proto__" || key === "constructor") {
+    if (isUnsafeObjectKey(key)) {
       throw new Error(`Cell-link wire payload has a forbidden key: "${key}".`);
     }
     const ok = typeof val === "string" ||

--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -210,8 +210,8 @@ function assertWireLinkRefPayloadShape(
       (Array.isArray(val) && val.every((e) => typeof e === "string"));
     if (!ok) {
       throw new Error(
-        `Cell-link wire payload field "${key}" must be a string or an ` +
-          `array of strings.`,
+        `Cell-link wire payload field "${key}" must be a \`string\` or ` +
+          `\`string[]\`.`,
       );
     }
   }

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -10,7 +10,8 @@ import { CODEC_TYPE_TAGS } from "@/codec-common/codec-type-tags.ts";
 import { FrozenSet } from "@/frozen-builtins.ts";
 import { EmptyReconstructionContext } from "@/codec-common/EmptyReconstructionContext.ts";
 import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
-import { errorClassFromType, UNSAFE_KEYS } from "@/native-conversion.ts";
+import { errorClassFromType } from "@/native-conversion.ts";
+import { isUnsafeObjectKey } from "@commonfabric/utils/types";
 
 /**
  * Reserved key set for `FabricError`'s extras bag: these names belong to the
@@ -123,7 +124,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
           ? extras as Iterable<readonly [string, FabricValue]>
           : Object.entries(extras as Record<string, FabricValue>);
       for (const [key, value] of entries) {
-        if (UNSAFE_KEYS.has(key) || FABRIC_ERROR_RESERVED_KEYS.has(key)) {
+        if (isUnsafeObjectKey(key) || FABRIC_ERROR_RESERVED_KEYS.has(key)) {
           continue;
         }
         this.#extras.set(key, value);
@@ -142,7 +143,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
     const name = error.name === type ? null : error.name;
     const extras: Array<[string, FabricValue]> = [];
     for (const key of Object.keys(error)) {
-      if (UNSAFE_KEYS.has(key) || FABRIC_ERROR_RESERVED_KEYS.has(key)) {
+      if (isUnsafeObjectKey(key) || FABRIC_ERROR_RESERVED_KEYS.has(key)) {
         continue;
       }
       extras.push([
@@ -179,7 +180,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
     if (Object.isFrozen(this)) {
       throw new Error("Cannot modify frozen FabricError");
     }
-    if (UNSAFE_KEYS.has(key)) {
+    if (isUnsafeObjectKey(key)) {
       throw new Error(`Cannot use unsafe key in FabricError extras: ${key}`);
     }
     if (FABRIC_ERROR_RESERVED_KEYS.has(key)) {
@@ -373,7 +374,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
 
         const extras: Array<[string, FabricValue]> = [];
         for (const key of Object.keys(s)) {
-          if (FABRIC_ERROR_RESERVED_KEYS.has(key) || UNSAFE_KEYS.has(key)) {
+          if (FABRIC_ERROR_RESERVED_KEYS.has(key) || isUnsafeObjectKey(key)) {
             continue;
           }
           extras.push([key, s[key]]);

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -1,4 +1,8 @@
-import { isInstance, isRecord } from "@commonfabric/utils/types";
+import {
+  isInstance,
+  isRecord,
+  isUnsafeObjectKey,
+} from "@commonfabric/utils/types";
 import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
 
 import {
@@ -16,7 +20,6 @@ import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { cloneHelper } from "./value-clone.ts";
 import { isDeepFrozenFabricValue } from "./deep-freeze.ts";
-import { FrozenSet } from "./frozen-builtins.ts";
 
 /**
  * Helper for `shallowFabricFromNativeValue()`, which rejects native objects
@@ -54,12 +57,6 @@ export function isConvertibleNativeInstance(value: object): boolean {
       return false;
   }
 }
-
-/** Keys that must never be copied to prevent prototype pollution. */
-export const UNSAFE_KEYS: FrozenSet<string> = new FrozenSet([
-  "__proto__",
-  "constructor",
-]);
 
 /** Map from Error subclass name to its constructor. */
 const ERROR_CLASS_BY_TYPE: ReadonlyMap<string, ErrorConstructor> = new Map([
@@ -619,7 +616,7 @@ export function nativeFromFabricValue(
 
   const result: Record<string, unknown> = {};
   for (const [key, val] of Object.entries(value)) {
-    if (!UNSAFE_KEYS.has(key)) {
+    if (!isUnsafeObjectKey(key)) {
       result[key] = nativeFromFabricValue(val, frozen);
     }
   }

--- a/packages/data-model/test/cell-rep.test.ts
+++ b/packages/data-model/test/cell-rep.test.ts
@@ -8,8 +8,15 @@ import {
   entityRefFromString,
   entityRefToString,
   isEntityRef,
+  isLinkRef,
+  LINK_V1_TAG,
+  linkRefFrom,
+  linkRefPayload,
+  linkRefPayloadFromString,
+  linkRefPayloadToString,
   resetModernCellRepConfig,
   setModernCellRepConfig,
+  type WireLinkRefPayload,
 } from "@/cell-rep.ts";
 
 /** A fixed 32-byte hash for deterministic tests. */
@@ -88,5 +95,104 @@ describe("cell-rep entity-id reference", () => {
       expect(entityRefToString(entityRefFrom(HASH))).toBe(TAGGED);
       resetModernCellRepConfig();
     }
+  });
+});
+
+describe("cell-rep link-ref envelope", () => {
+  const PAYLOAD = { id: "of:abc", path: ["x", "y"] };
+
+  it('wraps a payload in the `{ "/": { "link@1": … } }` envelope', () => {
+    expect(linkRefFrom(PAYLOAD)).toEqual({ "/": { [LINK_V1_TAG]: PAYLOAD } });
+  });
+
+  it("recognizes the link-ref envelope", () => {
+    expect(isLinkRef(linkRefFrom(PAYLOAD))).toBe(true);
+  });
+
+  it("rejects everything that is not a link-ref envelope", () => {
+    // The `{ "/": string }` entity-ref form is deliberately NOT a link ref.
+    expect(isLinkRef({ "/": "fid1:abc" })).toBe(false);
+    // Envelope with extra keys, or missing the tag, or wrong shape.
+    expect(isLinkRef({ "/": { [LINK_V1_TAG]: PAYLOAD }, extra: 1 })).toBe(
+      false,
+    );
+    expect(isLinkRef({ "/": {} })).toBe(false);
+    expect(isLinkRef({ other: { [LINK_V1_TAG]: PAYLOAD } })).toBe(false);
+    expect(isLinkRef(undefined)).toBe(false);
+    expect(isLinkRef("link")).toBe(false);
+    expect(isLinkRef([])).toBe(false);
+  });
+
+  it("extracts the payload from an envelope", () => {
+    expect(linkRefPayload(linkRefFrom(PAYLOAD))).toEqual(PAYLOAD);
+  });
+
+  it("throws extracting a payload from a non-envelope", () => {
+    expect(() => linkRefPayload({ "/": "fid1:abc" } as never)).toThrow(
+      "Not a link reference",
+    );
+    expect(() => linkRefPayload({} as never)).toThrow("Not a link reference");
+  });
+});
+
+describe("cell-rep link-ref payload wire serialization", () => {
+  it("round-trips a payload of strings and string arrays", () => {
+    const payload = { id: "of:abc", space: "did:key:z6Mk", path: ["a", "b"] };
+    const wire = linkRefPayloadToString(payload);
+    expect(wire.startsWith("fcl1:")).toBe(true);
+    expect(linkRefPayloadFromString(wire)).toEqual(payload);
+  });
+
+  it("tags the output with the fcl1: prefix followed by the JSON", () => {
+    expect(linkRefPayloadToString({ id: "of:abc" })).toBe(
+      'fcl1:{"id":"of:abc"}',
+    );
+  });
+
+  describe("linkRefPayloadToString validation", () => {
+    const bad = (p: unknown) =>
+      expect(() => linkRefPayloadToString(p as WireLinkRefPayload)).toThrow();
+
+    it("throws on a non-plain-object payload", () => {
+      bad([]);
+      bad("of:abc");
+      bad(null);
+    });
+
+    it("throws on a value that is neither string nor array-of-strings", () => {
+      bad({ n: 1 }); // number
+      bad({ o: { k: "v" } }); // nested object (e.g. a `schema`)
+      bad({ a: ["ok", 2] }); // array with a non-string element
+    });
+  });
+
+  describe("linkRefPayloadFromString validation", () => {
+    it("throws without the fcl1: prefix", () => {
+      expect(() => linkRefPayloadFromString('{"id":"of:abc"}')).toThrow();
+      expect(() => linkRefPayloadFromString("of:abc")).toThrow();
+    });
+
+    it("throws on invalid JSON after the prefix", () => {
+      expect(() => linkRefPayloadFromString("fcl1:not json")).toThrow();
+    });
+
+    it("throws when the decoded value is not a plain object", () => {
+      expect(() => linkRefPayloadFromString('fcl1:"x"')).toThrow();
+      expect(() => linkRefPayloadFromString("fcl1:[]")).toThrow();
+      expect(() => linkRefPayloadFromString("fcl1:null")).toThrow();
+    });
+
+    it("throws when a decoded value is not a string or array-of-strings", () => {
+      expect(() => linkRefPayloadFromString('fcl1:{"n":1}')).toThrow();
+      expect(() => linkRefPayloadFromString('fcl1:{"o":{"k":"v"}}')).toThrow();
+      expect(() => linkRefPayloadFromString('fcl1:{"a":["ok",2]}')).toThrow();
+    });
+
+    it("rejects prototype-pollution keys carried on the wire", () => {
+      expect(() => linkRefPayloadFromString('fcl1:{"__proto__":"x"}'))
+        .toThrow();
+      expect(() => linkRefPayloadFromString('fcl1:{"constructor":"x"}'))
+        .toThrow();
+    });
   });
 });

--- a/packages/runner/src/shared.ts
+++ b/packages/runner/src/shared.ts
@@ -15,8 +15,17 @@ export {
   type LinkRef,
   linkRefFrom,
   linkRefPayload,
+  linkRefPayloadFromString,
+  linkRefPayloadToString,
+  type WireLinkRefPayload,
 } from "@commonfabric/data-model/cell-rep";
-export { LINK_V1_TAG, type SigilLink, type URI } from "./sigil-types.ts";
+export {
+  assertWebhookCellLinkRefPayload,
+  LINK_V1_TAG,
+  type SigilLink,
+  type URI,
+  type WebhookCellLinkRefPayload,
+} from "./sigil-types.ts";
 export {
   CHIP_UI,
   ID,

--- a/packages/runner/src/sigil-types.ts
+++ b/packages/runner/src/sigil-types.ts
@@ -6,6 +6,7 @@ import {
   type LinkRef,
   type WireLinkRefPayload,
 } from "@commonfabric/data-model/cell-rep";
+import { isLinkScope } from "./scope.ts";
 
 export type { URI } from "@commonfabric/memory/interface";
 
@@ -49,9 +50,9 @@ const WEBHOOK_LINK_KEYS = [
 /**
  * Validates the field-level shape of a decoded {@link WireLinkRefPayload} as a
  * {@link WebhookCellLinkRefPayload}: only the known addressing keys, each of the
- * expected kind (scalar string vs. string array). This layers on top of
- * cell-rep's generic guard, which has already ensured every value is a plain
- * string or array of strings.
+ * expected kind — `id`/`space` strings, `path` an array, and `scope`/`overwrite`
+ * actual enum members. This layers on top of cell-rep's generic guard, which has
+ * already ensured every value is a plain string or array of strings.
  */
 export function assertWebhookCellLinkRefPayload(
   payload: WireLinkRefPayload,
@@ -64,10 +65,24 @@ export function assertWebhookCellLinkRefPayload(
   if (payload.path !== undefined && !Array.isArray(payload.path)) {
     throw new Error('Cell-link "path" must be an array of strings.');
   }
-  for (const key of ["id", "space", "scope", "overwrite"] as const) {
+  for (const key of ["id", "space"] as const) {
     if (payload[key] !== undefined && typeof payload[key] !== "string") {
       throw new Error(`Cell-link "${key}" must be a string.`);
     }
+  }
+  // Validate the enum-valued fields against their actual members, not merely
+  // "is a string" — otherwise this assertion would be unsound (e.g. a bogus
+  // `scope` would pass and then be typed as a valid `LinkScope`).
+  if (payload.scope !== undefined && !isLinkScope(payload.scope)) {
+    throw new Error(
+      'Cell-link "scope" must be one of "inherit", "space", "user", "session".',
+    );
+  }
+  if (
+    payload.overwrite !== undefined &&
+    payload.overwrite !== "redirect" && payload.overwrite !== "this"
+  ) {
+    throw new Error('Cell-link "overwrite" must be "redirect" or "this".');
   }
 }
 

--- a/packages/runner/src/sigil-types.ts
+++ b/packages/runner/src/sigil-types.ts
@@ -1,7 +1,11 @@
 import type { JSONSchema, JSONValue, LinkScope } from "@commonfabric/api";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import type { URI } from "@commonfabric/memory/interface";
-import { LINK_V1_TAG, type LinkRef } from "@commonfabric/data-model/cell-rep";
+import {
+  LINK_V1_TAG,
+  type LinkRef,
+  type WireLinkRefPayload,
+} from "@commonfabric/data-model/cell-rep";
 
 export type { URI } from "@commonfabric/memory/interface";
 
@@ -23,6 +27,49 @@ export type CellLinkRefPayload = {
   schema?: JSONSchema;
   overwrite?: "redirect" | "this"; // default is "this"
 };
+
+/**
+ * The subset of a {@link CellLinkRefPayload} that is safe to carry across a
+ * string boundary (the webhook wire): only the addressing fields, every one of
+ * which is a string or an array of strings. `schema` is dropped — it can carry
+ * an arbitrary `FabricValue` default (not plain JSON), and the webhook consumer
+ * imposes its own schema regardless. cfc's `cfcLabelView` is likewise absent (it
+ * is not part of the base payload, and stream/set operations never read it).
+ */
+export type WebhookCellLinkRefPayload = Omit<CellLinkRefPayload, "schema">;
+
+const WEBHOOK_LINK_KEYS = [
+  "id",
+  "space",
+  "scope",
+  "path",
+  "overwrite",
+] as const;
+
+/**
+ * Validates the field-level shape of a decoded {@link WireLinkRefPayload} as a
+ * {@link WebhookCellLinkRefPayload}: only the known addressing keys, each of the
+ * expected kind (scalar string vs. string array). This layers on top of
+ * cell-rep's generic guard, which has already ensured every value is a plain
+ * string or array of strings.
+ */
+export function assertWebhookCellLinkRefPayload(
+  payload: WireLinkRefPayload,
+): asserts payload is WebhookCellLinkRefPayload {
+  for (const key of Object.keys(payload)) {
+    if (!(WEBHOOK_LINK_KEYS as readonly string[]).includes(key)) {
+      throw new Error(`Unexpected cell-link field: "${key}".`);
+    }
+  }
+  if (payload.path !== undefined && !Array.isArray(payload.path)) {
+    throw new Error('Cell-link "path" must be an array of strings.');
+  }
+  for (const key of ["id", "space", "scope", "overwrite"] as const) {
+    if (payload[key] !== undefined && typeof payload[key] !== "string") {
+      throw new Error(`Cell-link "${key}" must be a string.`);
+    }
+  }
+}
 
 /**
  * Sigil link type.

--- a/packages/runner/test/sigil-types.test.ts
+++ b/packages/runner/test/sigil-types.test.ts
@@ -1,0 +1,65 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { assertWebhookCellLinkRefPayload } from "../src/sigil-types.ts";
+
+describe("assertWebhookCellLinkRefPayload", () => {
+  it("accepts an addressing payload with valid fields", () => {
+    expect(() =>
+      assertWebhookCellLinkRefPayload({
+        id: "of:abc",
+        space: "did:key:z6Mk",
+        path: ["a", "b"],
+        scope: "space",
+        overwrite: "redirect",
+      })
+    ).not.toThrow();
+  });
+
+  it("accepts an empty payload (every field is optional)", () => {
+    expect(() => assertWebhookCellLinkRefPayload({})).not.toThrow();
+  });
+
+  it("accepts every valid scope", () => {
+    for (const scope of ["inherit", "space", "user", "session"]) {
+      expect(() => assertWebhookCellLinkRefPayload({ scope })).not.toThrow();
+    }
+  });
+
+  it("accepts both overwrite values", () => {
+    for (const overwrite of ["redirect", "this"]) {
+      expect(() => assertWebhookCellLinkRefPayload({ overwrite })).not
+        .toThrow();
+    }
+  });
+
+  it("rejects an unexpected field (e.g. a smuggled schema)", () => {
+    expect(() => assertWebhookCellLinkRefPayload({ schema: "x" })).toThrow(
+      "Unexpected cell-link field",
+    );
+  });
+
+  it("rejects an invalid scope (unsound assertion otherwise)", () => {
+    expect(() => assertWebhookCellLinkRefPayload({ scope: "bogus" })).toThrow(
+      'Cell-link "scope"',
+    );
+  });
+
+  it("rejects an invalid overwrite", () => {
+    expect(() => assertWebhookCellLinkRefPayload({ overwrite: "nope" }))
+      .toThrow(
+        'Cell-link "overwrite"',
+      );
+  });
+
+  it("rejects a non-array path", () => {
+    expect(() => assertWebhookCellLinkRefPayload({ path: "a" })).toThrow(
+      'Cell-link "path"',
+    );
+  });
+
+  it("rejects a non-string id", () => {
+    expect(() => assertWebhookCellLinkRefPayload({ id: ["x"] })).toThrow(
+      'Cell-link "id"',
+    );
+  });
+});

--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -175,6 +175,33 @@ describe("CellHandle CFC label IPC", () => {
     });
   });
 
+  it("carries overwrite onto the wire when set", () => {
+    const runtime = {
+      [$conn]: () => ({
+        request: () => Promise.resolve({}),
+        subscribe: () => Promise.resolve(),
+        unsubscribe: () => Promise.resolve(),
+      }),
+    } as unknown as RuntimeClient;
+    // Exercises toWireString's `overwrite` conditional (the other tests leave
+    // it unset).
+    const cell = new CellHandle(runtime, {
+      id: "of:wire-cell-2" as CellRef["id"],
+      space: "did:key:test" as CellRef["space"],
+      scope: "space",
+      path: ["value"],
+      overwrite: "redirect",
+    } as CellRef);
+
+    expect(linkRefPayloadFromString(cell.toWireString())).toEqual({
+      id: "of:wire-cell-2",
+      space: "did:key:test",
+      scope: "space",
+      path: ["value"],
+      overwrite: "redirect",
+    });
+  });
+
   it("uses carried label views in subscription keys", () => {
     const first: CellRef = {
       id: "of:cfc-label-cell" as CellRef["id"],

--- a/packages/runtime-client/cell-handle.test.ts
+++ b/packages/runtime-client/cell-handle.test.ts
@@ -9,10 +9,7 @@ import {
   type RuntimeClient,
 } from "./mod.ts";
 import { cellRefToKey } from "./shared/utils.ts";
-import {
-  seemsLikeJsonEncodedFabricValue,
-  valueFromJson,
-} from "@commonfabric/data-model/codec-json";
+import { linkRefPayloadFromString } from "@commonfabric/runner/shared";
 
 describe("CellHandle CFC label IPC", () => {
   it("queries the runtime for the label view behind a cell", async () => {
@@ -144,7 +141,7 @@ describe("CellHandle CFC label IPC", () => {
     });
   });
 
-  it("encodes its link to a codec wire string that round-trips", () => {
+  it("encodes its link to an fcl1: wire string with only addressing fields", () => {
     const runtime = {
       [$conn]: () => ({
         request: () => Promise.resolve({}),
@@ -157,13 +154,25 @@ describe("CellHandle CFC label IPC", () => {
       space: "did:key:test" as CellRef["space"],
       scope: "space",
       path: ["value"],
+      // Neither of these may cross the wire.
+      schema: { type: "object" },
+      cfcLabelView: {
+        version: 1 as const,
+        entries: [{ path: [], label: { integrity: ["selected-by-alice"] } }],
+      },
     } as CellRef);
 
     const wire = cell.toWireString();
-    // It's the codec form, not raw JSON.
-    expect(seemsLikeJsonEncodedFabricValue(wire)).toBe(true);
-    // ...and decodes back to the same link toJSON() produces.
-    expect(valueFromJson(wire)).toEqual(cell.toJSON());
+    // It's the fcl1: cell-link form, not raw JSON.
+    expect(wire.startsWith("fcl1:")).toBe(true);
+    // ...and decodes back to only the plain addressing fields: `schema` and
+    // `cfcLabelView` are dropped.
+    expect(linkRefPayloadFromString(wire)).toEqual({
+      id: "of:wire-cell",
+      space: "did:key:test",
+      scope: "space",
+      path: ["value"],
+    });
   });
 
   it("uses carried label views in subscription keys", () => {

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -9,6 +9,7 @@ import {
   type JSONSchema,
   linkRefFrom,
   linkRefPayload,
+  linkRefPayloadToString,
   type SigilLink,
 } from "@commonfabric/runner/shared";
 import {
@@ -16,7 +17,6 @@ import {
   rebaseCfcLabelView,
 } from "@commonfabric/runner/cfc/label-view-core";
 import { type CfcCellLinkRefPayload } from "@commonfabric/runner/cfc";
-import { jsonFromValue } from "@commonfabric/data-model/codec-json";
 import { $conn, type RuntimeClient } from "./runtime-client.ts";
 import { isRuntimeDisposedError } from "./shared/disposed-error.ts";
 import {
@@ -357,12 +357,21 @@ export class CellHandle<T = unknown> {
   }
 
   /**
-   * Encodes this cell's link to a wire string, in the `data-model/codec-json`
-   * (`fvj1:…`) form, for transport across a string boundary (e.g. an HTTP body)
-   * from which it will be decoded back to a link.
+   * Encodes this cell's link to a wire string (the `fcl1:` cell-link form) for
+   * transport across a string boundary (e.g. an HTTP body) from which it will
+   * be decoded back to a link. Only the plain addressing fields cross the wire;
+   * `schema` and the cfc label view are deliberately omitted (see
+   * {@link linkRefPayloadToString}).
    */
   toWireString(): string {
-    return jsonFromValue(this.toJSON());
+    return linkRefPayloadToString({
+      id: this.#ref.id,
+      space: this.#ref.space,
+      ...(this.#ref.scope !== undefined && { scope: this.#ref.scope }),
+      path: this.#ref.path,
+      ...(this.#ref.overwrite !== undefined &&
+        { overwrite: this.#ref.overwrite }),
+    });
   }
 
   // Called when cell has been updated from the backend with

--- a/packages/toolshed/routes/webhooks/webhooks.delivery.test.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.delivery.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { Runtime } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import {
+  assertWebhookCellLinkRefPayload,
+  type JSONSchema,
+  linkRefFrom,
+  linkRefPayloadFromString,
+  linkRefPayloadToString,
+} from "@commonfabric/runner/shared";
+
+// End-to-end check of the part of the webhook flow this PR actually changes: a
+// cell link serialized to the `fcl1:` wire string (as `CellHandle.toWireString`
+// produces it) must decode, resolve to the right cell, and deliver a payload to
+// that cell's inbox stream. This mirrors `sendToStream`'s decode -> resolve ->
+// send path; that function reaches the `@/index.ts` runtime singleton (which is
+// uninitialized in tests), so it can't be called directly here, but the logic
+// exercised is identical, against the house in-memory `StorageManager.emulate`
+// runtime.
+
+const STREAM_SCHEMA: JSONSchema = {
+  asCell: ["stream"],
+  type: "object",
+  properties: { data: { type: "string" } },
+};
+
+describe("webhook cell-link wire delivery (fcl1: -> resolve -> stream)", () => {
+  let signer: Identity;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: ReturnType<Runtime["edit"]>;
+
+  beforeEach(async () => {
+    signer = await Identity.fromPassphrase("webhook delivery test");
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://webhook-test.invalid"),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  it("delivers a payload to the inbox stream addressed by its fcl1: link", async () => {
+    const space = signer.did();
+
+    // The pattern-side inbox stream the webhook targets, plus a plain cell the
+    // event handler writes into so we can observe what was delivered.
+    const inbox = runtime.getCell(space, "webhook-inbox", STREAM_SCHEMA, tx);
+    const received = runtime.getCell<unknown>(
+      space,
+      "webhook-received",
+      undefined,
+      tx,
+    );
+    received.set(null);
+    await tx.commit();
+    tx = runtime.edit();
+
+    runtime.scheduler.addEventHandler((eventTx, event) => {
+      received.withTx(eventTx).send(event);
+    }, inbox.getAsNormalizedFullLink());
+
+    // Mint the wire string exactly as `CellHandle.toWireString` does, from the
+    // inbox's addressing fields only.
+    const link = inbox.getAsNormalizedFullLink();
+    const wire = linkRefPayloadToString({
+      id: link.id,
+      space: link.space,
+      path: link.path.map((p) => String(p)),
+      ...(link.scope !== undefined ? { scope: link.scope } : {}),
+    });
+    expect(wire.startsWith("fcl1:")).toBe(true);
+
+    // Decode + resolve + send, mirroring `sendToStream`.
+    const payload = linkRefPayloadFromString(wire);
+    assertWebhookCellLinkRefPayload(payload);
+    const streamCell = runtime.getCellFromLink(linkRefFrom(payload))
+      .asSchema({ asCell: ["stream"] });
+    streamCell.withTx(tx).send({ data: "hello-webhook" });
+    await tx.commit();
+    tx = runtime.edit();
+    await runtime.scheduler.idle();
+
+    expect(await received.pull()).toEqual({ data: "hello-webhook" });
+  });
+});

--- a/packages/toolshed/routes/webhooks/webhooks.routes.test.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.routes.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import env from "@/env.ts";
+import app from "@/app.ts";
+
+if (env.ENV !== "test") {
+  throw new Error("ENV must be 'test'");
+}
+
+// Smoke tests: confirm each route is mounted and its first-line validation
+// returns a sensible error. These deliberately hit only the fast-fail paths
+// (bad input / missing auth) that reject *before* any runtime/storage access,
+// so they need no runtime fixture. End-to-end delivery is covered separately.
+//
+// Driven through the real `app` (not a freshly-mounted router) because the
+// webhook handlers import the `runtime` singleton from `@/index.ts`, which
+// imports `@/app.ts` — re-mounting the router standalone hits that import cycle.
+
+describe("Webhook routes (smoke: wired up + error paths)", () => {
+  it("POST /api/webhooks rejects an invalid cellLink with 400", async () => {
+    const res = await app.request("/api/webhooks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "x",
+        cellLink: "not-a-cell-link",
+        confidentialCellLink: "fcl1:{}",
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /api/webhooks rejects a malformed body with 422", async () => {
+    const res = await app.request("/api/webhooks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      // Missing `cellLink` and `confidentialCellLink` -> schema validation.
+      body: JSON.stringify({ name: "x" }),
+    });
+    expect(res.status).toBe(422);
+  });
+
+  it("POST /api/webhooks/:id without a bearer token is 401", async () => {
+    const res = await app.request("/api/webhooks/wh_nope", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ any: "payload" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/webhooks without a space is rejected (422)", async () => {
+    const res = await app.request("/api/webhooks", { method: "GET" });
+    expect(res.status).toBe(422);
+  });
+
+  it("DELETE /api/webhooks/:id without a space is rejected (422)", async () => {
+    const res = await app.request("/api/webhooks/wh_nope", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(422);
+  });
+});

--- a/packages/toolshed/routes/webhooks/webhooks.test.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import env from "@/env.ts";
 import { sha256 } from "@/lib/sha2.ts";
-import { jsonFromValue } from "@commonfabric/data-model/codec-json";
+import { linkRefPayloadToString } from "@commonfabric/runner/shared";
 import {
   extractSpaceFromCellLink,
   generateWebhookId,
@@ -79,56 +79,25 @@ describe("Webhook Utilities", () => {
   });
 
   describe("extractSpaceFromCellLink", () => {
-    it("extracts space from link@1 cell link", () => {
-      const cellLink = JSON.stringify({
-        "/": {
-          "link@1": {
-            id: "of:bafe123",
-            space: "did:key:z6Mktest123",
-            path: ["webhooks", "github"],
-          },
-        },
+    it("extracts space from an fcl1: cell link", () => {
+      const cellLink = linkRefPayloadToString({
+        id: "of:bafe123",
+        space: "did:key:z6Mktest123",
+        path: ["webhooks", "github"],
       });
+      // Sanity: it really is the fcl1: wire form, not raw JSON.
+      expect(cellLink.startsWith("fcl1:")).toBe(true);
       const space = extractSpaceFromCellLink(cellLink);
       expect(space).toBe("did:key:z6Mktest123");
     });
 
-    it("extracts space from a codec-encoded (fvj1:) cell link", () => {
-      // The same link emitted in the codec wire form: it round-trips losslessly
-      // and extracts the same space as the legacy raw-JSON form above.
-      const cellLink = jsonFromValue({
-        "/": {
-          "link@1": {
-            id: "of:bafe123",
-            space: "did:key:z6Mktest123",
-            path: ["webhooks", "github"],
-          },
-        },
-      });
-      // Sanity: it really is the codec form, not legacy raw JSON.
-      expect(cellLink.startsWith("{")).toBe(false);
-      const space = extractSpaceFromCellLink(cellLink);
-      expect(space).toBe("did:key:z6Mktest123");
-    });
-
-    it("throws for invalid JSON", () => {
+    it("throws for a string without the fcl1: prefix", () => {
       expect(() => extractSpaceFromCellLink("not json")).toThrow();
-    });
-
-    it("throws for missing link data", () => {
-      expect(() => extractSpaceFromCellLink(JSON.stringify({}))).toThrow(
-        "Invalid cell link format",
-      );
+      expect(() => extractSpaceFromCellLink(JSON.stringify({}))).toThrow();
     });
 
     it("throws for missing space", () => {
-      const cellLink = JSON.stringify({
-        "/": {
-          "link@1": {
-            id: "of:bafe123",
-          },
-        },
-      });
+      const cellLink = linkRefPayloadToString({ id: "of:bafe123" });
       expect(() => extractSpaceFromCellLink(cellLink)).toThrow(
         "Cell link missing space",
       );

--- a/packages/toolshed/routes/webhooks/webhooks.utils.ts
+++ b/packages/toolshed/routes/webhooks/webhooks.utils.ts
@@ -4,14 +4,11 @@ import { runtime } from "@/index.ts";
 import { identity } from "@/lib/identity.ts";
 import { WebhookConfigSchema } from "@commonfabric/runner";
 import {
-  isLinkRef,
+  assertWebhookCellLinkRefPayload,
   linkRefFrom,
   linkRefPayload,
+  linkRefPayloadFromString,
 } from "@commonfabric/runner/shared";
-import {
-  seemsLikeJsonEncodedFabricValue,
-  valueFromJson,
-} from "@commonfabric/data-model/codec-json";
 
 const _logger = getLogger("webhooks.utils");
 
@@ -101,17 +98,13 @@ function serviceCellLink(entityId: string) {
   });
 }
 
-// Parse a cell-link wire string. Accepts both the codec-encoded (`fvj1:…`) form
-// and the legacy raw `{ "/": { "link@1": … } }` JSON form, discriminated by
-// `seemsLikeJsonEncodedFabricValue`. The legacy branch exists only so links
-// serialized the old way still resolve.
-//
-// TODO(danfuzz): once every deployed server emits the codec form, drop the
-// legacy branch and decode with `valueFromJson(cellLink)` only.
+// Parse a cell-link wire string (the `fcl1:` addressing-payload form) back into
+// a link the runtime can resolve. The wire carries only the plain addressing
+// payload; the link envelope is reconstructed locally via `linkRefFrom`.
 function parseCellLink(cellLink: string) {
-  return seemsLikeJsonEncodedFabricValue(cellLink)
-    ? valueFromJson(cellLink)
-    : JSON.parse(cellLink);
+  const payload = linkRefPayloadFromString(cellLink);
+  assertWebhookCellLinkRefPayload(payload);
+  return linkRefFrom(payload);
 }
 
 // Read a cell from toolshed's service space, returning its value.
@@ -246,12 +239,10 @@ export async function sendToStream(
   if (error) throw error;
 }
 
-// Extract space DID from a serialized cell link
+// Extract space DID from a serialized cell link. `parseCellLink` already
+// guarantees a well-formed link (or throws), so this only needs the space.
 export function extractSpaceFromCellLink(cellLink: string): string {
-  const parsed = parseCellLink(cellLink);
-  if (!isLinkRef(parsed)) throw new Error("Invalid cell link format");
-
-  const space = linkRefPayload(parsed).space;
+  const space = linkRefPayload(parseCellLink(cellLink)).space;
   if (!space) throw new Error("Cell link missing space");
 
   return space as string;

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -136,3 +136,14 @@ export type Immutable<T> = T extends ReadonlyArray<infer U>
 
 /** Standard type meaning constructor function, a/k/a "class object." */
 export type Constructor<T = unknown> = abstract new (...args: any[]) => T;
+
+const UNSAFE_OBJECT_KEYS = new Set(["__proto__", "constructor"]);
+
+/**
+ * Indicates whether `key` must never be copied onto an object from untrusted
+ * input, because assigning it can pollute the prototype chain. Use at boundaries
+ * where external data enters the system (deserialization, structural copying).
+ */
+export function isUnsafeObjectKey(key: string): boolean {
+  return UNSAFE_OBJECT_KEYS.has(key);
+}

--- a/packages/utils/test/types.test.ts
+++ b/packages/utils/test/types.test.ts
@@ -11,6 +11,7 @@ import {
   isPlainObject,
   isRecord,
   isString,
+  isUnsafeObjectKey,
   Mutable,
 } from "@commonfabric/utils/types";
 
@@ -340,6 +341,29 @@ describe("types", () => {
       expect(isBoolean("true")).toBe(false);
       expect(isBoolean(null)).toBe(false);
       expect(isBoolean(undefined)).toBe(false);
+    });
+  });
+
+  describe("isUnsafeObjectKey", () => {
+    it("returns true for prototype-pollution keys", () => {
+      expect(isUnsafeObjectKey("__proto__")).toBe(true);
+      expect(isUnsafeObjectKey("constructor")).toBe(true);
+    });
+
+    it("returns false for ordinary keys", () => {
+      expect(isUnsafeObjectKey("id")).toBe(false);
+      expect(isUnsafeObjectKey("space")).toBe(false);
+      expect(isUnsafeObjectKey("path")).toBe(false);
+      expect(isUnsafeObjectKey("")).toBe(false);
+    });
+
+    it("returns false for near-miss keys that are not in the set", () => {
+      // Only `__proto__` and `constructor` are unsafe — not every
+      // prototype-adjacent name.
+      expect(isUnsafeObjectKey("prototype")).toBe(false);
+      expect(isUnsafeObjectKey("proto")).toBe(false);
+      expect(isUnsafeObjectKey("toString")).toBe(false);
+      expect(isUnsafeObjectKey("hasOwnProperty")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## What & why

Migrates the webhook cell-link wire to a self-describing **`fcl1:`** ("Fabric Cell Link v1") string and **divorces it from the data-model JSON value codec** (the `fvj1:` form from the prior staged migration). The wire now carries only the **plain addressing payload** of a link — `id`, `space`, `scope`, `path`, `overwrite` — `JSON.stringify`'d behind a chokepoint, with the link envelope reconstructed locally on the receiver via `linkRefFrom`.

This is a **clean break**: both the codec (`fvj1:`) and legacy raw-JSON branches are dropped, so `fcl1:` is the sole produced/recognized form on this boundary. Confirmed safe — there are no live registrations that depend on the old forms.

### Why payload-only (and why it's the right shape)

- The link *payload's* addressing fields are provably plain JSON (strings + a string-array `path`) forever, so a naive `JSON.stringify`/`JSON.parse` round-trip is sound — no codec needed.
- `schema` and the cfc `cfcLabelView` are **deliberately dropped** from the wire: `schema` can carry an arbitrary `FabricValue` default (not plain JSON), and neither is consumed by the webhook's stream-send / config-write paths. Dropping `schema` is in fact a *hardening* — toolshed unconditionally imposes its own classification-bearing `WebhookConfigSchema` (which carries the credential-secret `ifc`) on the confidential write, instead of letting a producer-supplied schema win.
- The validating chokepoint restricts a wire payload to a plain object of `string | string[]` values (rejecting non-plain-JSON values and prototype-pollution keys), so a non-transmissible payload fails loudly at the boundary.

## Shape of the change (layered commits)

1. **data-model** — `linkRefPayloadToString` / `linkRefPayloadFromString` chokepoint in `cell-rep` (the `fcl1:` prefix + generic guard).
2. **runner** — `WebhookCellLinkRefPayload` (= `Omit<CellLinkRefPayload, "schema">`) + `assertWebhookCellLinkRefPayload` field validator.
3. **runtime-client + toolshed** — producer (`CellHandle.toWireString`) emits the addressing payload; toolshed `parseCellLink` decodes + asserts + rebuilds the envelope. Both old branches removed.
4. **utils** — `isUnsafeObjectKey` predicate, DRYing the `__proto__`/`constructor` guards (retires data-model's `UNSAFE_KEYS`).

## Significantly improved test coverage

Webhooks previously had **essentially no integration coverage** — only crypto/ID helpers and string parsing were unit-tested; the handlers and the entire wire→resolve→deliver path were untested. This PR meaningfully closes that gap:

- **`cell-rep` wire round-trip + validation** tests, plus backfilled tests for the previously-untested `linkRefFrom` / `isLinkRef` / `linkRefPayload` envelope functions.
- **`isUnsafeObjectKey`** unit test.
- **Webhook route smoke tests** — all four routes (`create`, `ingest`, `list`, `remove`) are confirmed mounted and fast-failing on bad input (400/401/422) before any runtime access.
- **End-to-end delivery test** — mints an `fcl1:` link for an inbox stream cell, runs `sendToStream`'s exact decode→`getCellFromLink`→stream-`send` path against an in-memory `StorageManager.emulate` runtime, and asserts the payload reaches the stream. This is executable proof that the clean-break wire resolves to the right cell and that dropping `schema`/`cfcLabelView` doesn't break delivery.

### Known residual gap

The literal HTTP `create→ingest` lifecycle through the handlers (registration + secret verification) is still not exercised end-to-end — that requires a runtime-init seam in `toolshed/index.ts`, a pattern with no precedent in this corner of the system. That machinery is unchanged by this PR and is now smoke-tested for wiring/errors, so it's left as a deliberate fast-follow.

## Verification

Type-check, `deno fmt`, `deno lint`, and the full-workspace `deno task test` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the webhook cell-link wire to a self‑describing `fcl1:` string that carries only the plain addressing payload and drops the `fvj1:`/raw JSON forms. Adds a single serializer/validator chokepoint and verifies decode→resolve→deliver end to end.

- **Migration**
  - Breaking change: only `fcl1:` is produced and accepted.
  - Wire includes only `id`, `space`, `scope`, `path`, `overwrite`; `schema` and cfc label view are omitted.
  - Consumers should decode with `linkRefPayloadFromString` → `assertWebhookCellLinkRefPayload` → `linkRefFrom`.

- **Refactors**
  - `@commonfabric/data-model`: added `linkRefPayloadToString`/`linkRefPayloadFromString` and `WireLinkRefPayload` with a plain‑JSON guard.
  - `@commonfabric/runner`: introduced `WebhookCellLinkRefPayload` and `assertWebhookCellLinkRefPayload`; tightened validation to enforce valid `scope`/`overwrite` enum members; re‑exported wire helpers.
  - `@commonfabric/runtime-client`: `CellHandle.toWireString()` now emits the `fcl1:` addressing payload; tests cover the `overwrite` branch.
  - `@commonfabric/toolshed`: `parseCellLink` updated to the new flow; added route smoke tests and an end‑to‑end delivery test.
  - `@commonfabric/utils`: new `isUnsafeObjectKey`; adopted in `data-model` and `FabricError`.

<sup>Written for commit 6c14ebb469d9ae5f11145e3de67e0c9f40804e60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

