### PR TITLE
test(cfc): make browser integration waits notification-driven, not polled

### DIFF
--- a/packages/integration/page.ts
+++ b/packages/integration/page.ts
@@ -229,6 +229,45 @@ export class Page extends EventTarget {
     await this.page!.waitForFunction(func, evaluateOptions);
   }
 
+  // Expose a CDP binding named `name` on the page's global object. Calling
+  // `globalThis[name](payload)` in the page produces a `Runtime.bindingCalled`
+  // notification that `onBindingCalled` delivers to the test process. This is
+  // how an in-page notifier signals the moment a condition holds without the
+  // test polling the DOM.
+  async addBinding(name: string): Promise<void> {
+    this.checkIsOk();
+    await this.page!.unsafelyGetCelestialBindings().Runtime.addBinding({
+      name,
+    });
+  }
+
+  // Unsubscribe the current connection from a binding's notifications. The
+  // bound function may remain on the page's global object; the unique per-wait
+  // name keeps that harmless.
+  async removeBinding(name: string): Promise<void> {
+    this.checkIsOk();
+    await this.page!.unsafelyGetCelestialBindings().Runtime.removeBinding({
+      name,
+    });
+  }
+
+  // Subscribe to every `Runtime.bindingCalled` notification, invoking `listener`
+  // with the binding name and its payload. Returns an unsubscribe function.
+  onBindingCalled(
+    listener: (name: string, payload: string) => void,
+  ): () => void {
+    this.checkIsOk();
+    const celestial = this.page!.unsafelyGetCelestialBindings();
+    const handler: EventListener = (event) => {
+      const { name, payload } =
+        (event as CustomEvent<{ name: string; payload: string }>).detail;
+      listener(name, payload);
+    };
+    celestial.addEventListener("Runtime.bindingCalled", handler);
+    return () =>
+      celestial.removeEventListener("Runtime.bindingCalled", handler);
+  }
+
   // Passthru of `@astral/astral`'s `Page#$`
   async $(
     selector: string,

--- a/packages/integration/utils.ts
+++ b/packages/integration/utils.ts
@@ -71,3 +71,302 @@ export const awaitViewSettled = async (page: Page): Promise<boolean> => {
     return true;
   });
 };
+
+/**
+ * Shadow-piercing DOM helpers handed to a {@link waitForCondition} predicate.
+ * They run in the page, where the app is a tree of web components with nested
+ * shadow roots, so a predicate can find elements and read their visible text
+ * without re-implementing the traversal each time.
+ */
+export interface ProbeApi {
+  /** Every element matching `selector`, descending through shadow roots. */
+  collect(selector: string): Element[];
+  /** Whether `element` is on-screen and not display/visibility hidden. */
+  isVisible(element: Element): boolean;
+  /** Visible text of `root` plus its shadow and slotted descendants. */
+  deepText(root: ParentNode): string;
+}
+
+/**
+ * A predicate evaluated in the page. It receives a {@link ProbeApi} plus the
+ * `args` passed to {@link waitForCondition}, and returns whether the awaited
+ * condition holds. It may be async (for example to await `rt.idle()`).
+ */
+export type PageCondition<A extends readonly unknown[]> = (
+  probe: ProbeApi,
+  ...args: A
+) => boolean | Promise<boolean>;
+
+/**
+ * Installed in the page by {@link waitForCondition}. Re-evaluates `predicate`
+ * whenever the UI could have changed — a shared pulse hub observes the document
+ * and every shadow root (subtree, character data, and attributes), including
+ * shadow roots created after the wait began, so the predicate runs the instant
+ * the DOM reflects new state instead of on a fixed timer. When the predicate
+ * holds, it calls the CDP binding `bindingName`, which wakes the awaiting test
+ * process. An async predicate that awaits a runtime signal (such as
+ * `rt.idle()`) resolves the moment that signal fires, with no DOM change
+ * required.
+ *
+ * Self-contained: it is serialized and run in the page, so it closes over none
+ * of the module scope. `predicateSource` is the predicate's source text,
+ * reconstructed here because a function cannot cross the evaluate boundary as a
+ * callable value.
+ */
+function installWaiter(
+  bindingName: string,
+  predicateSource: string,
+  predicateArgs: unknown[],
+): void {
+  type Probe = {
+    collect: (selector: string) => Element[];
+    isVisible: (element: Element) => boolean;
+    deepText: (root: ParentNode) => string;
+  };
+
+  const probe: Probe = {
+    collect(selector) {
+      const out: Element[] = [];
+      const walk = (root: Document | ShadowRoot) => {
+        for (const el of root.querySelectorAll("*")) {
+          try {
+            if (el.matches(selector)) out.push(el);
+          } catch {
+            // An invalid selector matches nothing.
+          }
+          if (el.shadowRoot) walk(el.shadowRoot);
+        }
+      };
+      walk(document);
+      return out;
+    },
+    isVisible(element) {
+      const rect = element.getBoundingClientRect();
+      const style = globalThis.getComputedStyle(element);
+      return rect.width > 0 && rect.height > 0 &&
+        rect.bottom >= 0 && rect.right >= 0 &&
+        rect.top <= globalThis.innerHeight &&
+        rect.left <= globalThis.innerWidth &&
+        style.visibility !== "hidden" && style.display !== "none";
+    },
+    deepText(root) {
+      const parts: string[] = [];
+      const visit = (node: ParentNode) => {
+        if (node instanceof HTMLElement) {
+          const style = globalThis.getComputedStyle(node);
+          const hidden = node instanceof HTMLStyleElement ||
+            node instanceof HTMLScriptElement || node.hidden ||
+            style.visibility === "hidden" || style.display === "none";
+          if (!hidden) {
+            const innerText = node.innerText ?? "";
+            parts.push(
+              innerText.trim().length > 0 ? innerText : node.textContent ?? "",
+            );
+          }
+          if (node instanceof HTMLSlotElement) {
+            for (const assigned of node.assignedElements({ flatten: true })) {
+              visit(assigned);
+            }
+          }
+          if (node.shadowRoot) visit(node.shadowRoot);
+        } else if (node instanceof Document || node instanceof ShadowRoot) {
+          for (const child of node.children) {
+            if (child instanceof HTMLElement) visit(child);
+          }
+        }
+        for (const el of node.querySelectorAll("*")) {
+          if (el.shadowRoot) visit(el.shadowRoot);
+        }
+      };
+      visit(root);
+      return parts.join(" ");
+    },
+  };
+
+  const predicate = new Function("return (" + predicateSource + ")")() as (
+    probe: Probe,
+    ...args: unknown[]
+  ) => unknown;
+
+  // Shared pulse hub, installed once per document. A document-level
+  // MutationObserver cannot see inside shadow roots, so the hub also observes
+  // every shadow root — those present now and those created later, caught by
+  // wrapping Element.prototype.attachShadow — and fans a "DOM may have changed"
+  // pulse out to every active waiter. Without this, a deep text change inside a
+  // shadow root created after the wait began would go unnoticed.
+  const hub = ((globalThis as typeof globalThis & {
+    __cfcPulseHub?: { listeners: Set<() => void> };
+  }).__cfcPulseHub ??= (() => {
+    const listeners = new Set<() => void>();
+    const observed = new WeakSet<Document | ShadowRoot>();
+    const notify = () => {
+      for (const listener of listeners) listener();
+    };
+    const observe = (root: Document | ShadowRoot) => {
+      if (observed.has(root)) return;
+      observed.add(root);
+      new MutationObserver(notify).observe(root, {
+        subtree: true,
+        childList: true,
+        characterData: true,
+        attributes: true,
+      });
+    };
+    const scan = (root: Document | ShadowRoot) => {
+      for (const el of root.querySelectorAll("*")) {
+        if (el.shadowRoot) {
+          observe(el.shadowRoot);
+          scan(el.shadowRoot);
+        }
+      }
+    };
+    observe(document);
+    const proto = Element.prototype as Element & {
+      attachShadow: (init: ShadowRootInit) => ShadowRoot;
+    };
+    const original = proto.attachShadow;
+    proto.attachShadow = function (
+      this: Element,
+      init: ShadowRootInit,
+    ): ShadowRoot {
+      const root = original.call(this, init);
+      observe(root);
+      // Content may be set synchronously right after attachShadow, so pulse.
+      notify();
+      return root;
+    };
+    scan(document);
+    return { listeners };
+  })());
+
+  const registry = ((globalThis as typeof globalThis & {
+    __cfcWaiters?: Map<string, () => void>;
+  }).__cfcWaiters ??= new Map<string, () => void>());
+  // A leftover waiter under this name would only exist after a name collision;
+  // dispose it so its pulse stops running.
+  registry.get(bindingName)?.();
+
+  let stopped = false;
+  let signalled = false;
+  let running = false;
+  let rerun = false;
+
+  const fire = (): boolean => {
+    const notify = (globalThis as Record<string, unknown>)[bindingName];
+    if (typeof notify !== "function") return false;
+    signalled = true;
+    (notify as (payload: string) => void)("ok");
+    return true;
+  };
+
+  const stop = () => {
+    if (stopped) return;
+    stopped = true;
+    hub.listeners.delete(pulse);
+    registry.delete(bindingName);
+  };
+
+  const onConditionMet = () => {
+    if (stopped) return;
+    stopped = true;
+    hub.listeners.delete(pulse);
+    // The binding is added and awaited before this script installs, so the
+    // bound function is normally present; retry on the macrotask queue in case
+    // it has not yet attached to this execution context.
+    const tryFire = () => {
+      if (signalled) return;
+      if (fire()) registry.delete(bindingName);
+      else setTimeout(tryFire, 0);
+    };
+    tryFire();
+  };
+
+  const evaluate = () => {
+    if (stopped || running) {
+      if (running) rerun = true;
+      return;
+    }
+    running = true;
+    Promise.resolve()
+      .then(() => predicate(probe, ...predicateArgs))
+      .then((ok) => {
+        running = false;
+        if (stopped) return;
+        if (ok) onConditionMet();
+        else if (rerun) {
+          rerun = false;
+          evaluate();
+        }
+      })
+      .catch(() => {
+        running = false;
+        if (!stopped && rerun) {
+          rerun = false;
+          evaluate();
+        }
+      });
+  };
+
+  function pulse() {
+    evaluate();
+  }
+
+  registry.set(bindingName, stop);
+  hub.listeners.add(pulse);
+  // Check immediately; the condition may already hold.
+  evaluate();
+}
+
+/**
+ * Block until an in-page `predicate` holds, resolving the instant it does
+ * rather than on a polling tick. A notifier installed in the page
+ * (see {@link installWaiter}) re-checks the predicate whenever the DOM could
+ * have changed and signals the test process over a CDP binding, so an awaited
+ * step idles until its condition is actually satisfied — like `select(2)` or
+ * `wait` — and then proceeds immediately.
+ *
+ * On timeout it throws; callers add the context and rich probe for the failure
+ * message. `timeout` is a safety net for a genuinely stuck condition, not the
+ * common-case latency.
+ */
+export const waitForCondition = async <A extends readonly unknown[]>(
+  page: Page,
+  predicate: PageCondition<A>,
+  { timeout = 60_000, args }: { timeout?: number; args?: A } = {},
+): Promise<void> => {
+  const bindingName = `__cfcWait_${crypto.randomUUID().replace(/-/g, "")}`;
+  let resolveSignal!: () => void;
+  const signalled = new Promise<void>((resolve) => {
+    resolveSignal = resolve;
+  });
+  const unsubscribe = page.onBindingCalled((name) => {
+    if (name === bindingName) resolveSignal();
+  });
+  await page.addBinding(bindingName);
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await page.evaluate(installWaiter, {
+      args: [bindingName, predicate.toString(), (args ?? []) as unknown[]],
+    });
+    const timedOut = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () =>
+          reject(
+            new Error(`waitForCondition did not resolve within ${timeout}ms`),
+          ),
+        timeout,
+      );
+    });
+    await Promise.race([signalled, timedOut]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    unsubscribe();
+    await page.removeBinding(bindingName).catch(() => {});
+    await page.evaluate((name: string) => {
+      (globalThis as typeof globalThis & {
+        __cfcWaiters?: Map<string, () => void>;
+      }).__cfcWaiters?.get(name)?.();
+    }, { args: [bindingName] }).catch(() => {});
+  }
+};

--- a/packages/integration/utils.ts
+++ b/packages/integration/utils.ts
@@ -199,13 +199,19 @@ function installWaiter(
   }).__cfcPulseHub ??= (() => {
     const listeners = new Set<() => void>();
     const observed = new WeakSet<Document | ShadowRoot>();
+    // Keep observers reachable from JS. A MutationObserver with no script
+    // reference can be collected even while its node lives, which would silently
+    // stop pulses; the array prevents that.
+    const retained: MutationObserver[] = [];
     const notify = () => {
       for (const listener of listeners) listener();
     };
     const observe = (root: Document | ShadowRoot) => {
       if (observed.has(root)) return;
       observed.add(root);
-      new MutationObserver(notify).observe(root, {
+      const mo = new MutationObserver(notify);
+      retained.push(mo);
+      mo.observe(root, {
         subtree: true,
         childList: true,
         characterData: true,
@@ -271,12 +277,23 @@ function installWaiter(
     stopped = true;
     hub.listeners.delete(pulse);
     // The binding is added and awaited before this script installs, so the
-    // bound function is normally present; retry on the macrotask queue in case
-    // it has not yet attached to this execution context.
+    // bound function is normally present; retry a bounded number of times on the
+    // macrotask queue in case it has not yet attached to this execution context.
+    // If it never attaches, report it rather than spinning silently until the
+    // outer timeout.
+    let attempts = 0;
     const tryFire = () => {
       if (signalled) return;
-      if (fire()) registry.delete(bindingName);
-      else setTimeout(tryFire, 0);
+      if (fire()) {
+        registry.delete(bindingName);
+      } else if (++attempts < 100) {
+        setTimeout(tryFire, 0);
+      } else {
+        console.error(
+          `[waitForCondition] binding "${bindingName}" never became callable;` +
+            ` condition held but could not signal the test.`,
+        );
+      }
     };
     tryFire();
   };

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -226,6 +226,43 @@ async function settleView(
   await awaitViewSettled(page);
 }
 
+/**
+ * Wait for `selector` to contain `text` after a stimulus has been dispatched,
+ * driving the shell to settle between checks and resolving the instant the text
+ * appears.
+ *
+ * A freshly dispatched click's effect reaches the DOM only once the worker→main
+ * pipeline runs: the worker settles the reactive graph, pushes a vdom batch,
+ * the main thread applies it, and Lit drains its updates. `awaitViewSettled`
+ * pumps that pipeline. An integration test holds no UI subscription, so nothing
+ * else pumps it — a purely passive wait can sit on a DOM that never changes and
+ * time out even though the effect is ready to apply.
+ *
+ * Each iteration awaits one full view settle, then re-checks. The settle is the
+ * re-evaluation trigger — real asynchronous work (a worker idle round-trip plus
+ * a drained Lit cycle), not a fixed-interval sleep — so the effect is observed
+ * within a settle cycle or two and the wait resolves immediately once it holds.
+ * The settle must be driven from the same call sequence as the check; running
+ * it concurrently with a separate waiter does not help, because the astral CDP
+ * connection serializes evaluations.
+ */
+async function waitForTextWhileSettling(
+  page: Page,
+  selector: string,
+  text: string,
+  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+  if (await textIsPresent(page, selector, text)) return;
+  do {
+    await awaitViewSettled(page);
+    if (await textIsPresent(page, selector, text)) return;
+  } while (Date.now() < deadline);
+  throw new Error(
+    `"${selector}" did not contain "${text}" within ${timeout}ms`,
+  );
+}
+
 export async function clickTrustedAction(
   page: Page,
   action: string,
@@ -300,13 +337,13 @@ export async function clickTrustedActionAndWaitForText(
     );
   }
 
-  // The click is delivered; wait for its effect, notification-driven. The
-  // predicate re-runs whenever the DOM changes — including an optimistic
-  // perUser/perSpace write whose chip trails the commit — without re-clicking.
+  // The click is delivered; wait for its effect, resolving the instant the
+  // text appears while driving the settle that applies it. No re-clicking — an
+  // optimistic perUser/perSpace write whose chip trails the commit is caught by
+  // the same wait.
   try {
-    await waitForCondition(page, textPresent, {
+    await waitForTextWhileSettling(page, selector, text, {
       timeout: remaining(),
-      args: [selector, text],
     });
   } catch (cause) {
     actionProbe ??= await readTrustedActionProbe(page, action).catch(() =>
@@ -538,14 +575,13 @@ export async function clickCfButtonAndWaitForText(
     );
   }
 
-  // The click is delivered; wait for its effect, notification-driven. The
-  // predicate re-runs whenever the DOM changes, so an effect that renders a few
-  // cycles after the click — including an optimistic perUser/perSpace write
+  // The click is delivered; wait for its effect, resolving the instant the text
+  // appears while driving the settle that applies it. An effect that renders a
+  // few cycles after the click — including an optimistic perUser/perSpace write
   // whose chip trails the commit — is captured without ever re-clicking.
   try {
-    await waitForCondition(page, textPresent, {
+    await waitForTextWhileSettling(page, textSelector, text, {
       timeout: remaining(),
-      args: [textSelector, text],
     });
   } catch (cause) {
     textProbe = await readTextProbe(page, textSelector).catch(() => undefined);

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -1,8 +1,230 @@
-import { awaitViewSettled, Page, waitFor } from "@commonfabric/integration";
+import {
+  awaitViewSettled,
+  Page,
+  type ProbeApi,
+  waitForCondition,
+} from "@commonfabric/integration";
 import { toIndentedDebugString } from "@commonfabric/data-model/value-debug";
 
 const DEFAULT_CFC_BROWSER_TIMEOUT = 30_000;
 const CLICK_TARGET_ATTR = "data-cfc-click-target";
+
+// Predicates evaluated in the page by `waitForCondition`. Each is self-contained
+// — it closes over nothing in this module — so it can be serialized and run in
+// the page. `probe` is the shadow-piercing DOM helper set; later parameters are
+// the `args` passed alongside the predicate.
+
+const textPresent = (
+  probe: ProbeApi,
+  selector: string,
+  text: string,
+): boolean =>
+  probe.collect(selector).some((element) =>
+    probe.deepText(element).includes(text)
+  );
+
+const textAbsent = (
+  probe: ProbeApi,
+  selector: string,
+  text: string,
+): boolean =>
+  !probe.collect(selector).some((element) =>
+    probe.deepText(element).includes(text)
+  );
+
+const buttonDisabledIs = (
+  probe: ProbeApi,
+  selector: string,
+  disabled: boolean,
+): boolean => {
+  const element = probe.collect(selector)[0];
+  if (!element) return false;
+  const button = element instanceof HTMLButtonElement
+    ? element
+    : element.shadowRoot?.querySelector("button");
+  return button instanceof HTMLButtonElement
+    ? button.disabled === disabled
+    : false;
+};
+
+const runtimeIdle = async (): Promise<boolean> => {
+  const rt = (globalThis as typeof globalThis & {
+    commonfabric?: { rt?: { idle?: () => Promise<void> } };
+  }).commonfabric?.rt;
+  if (!rt?.idle) return false;
+  await rt.idle();
+  return true;
+};
+
+const runtimeSynced = async (): Promise<boolean> => {
+  const rt = (globalThis as typeof globalThis & {
+    commonfabric?: { rt?: { allSynced?: () => Promise<void> } };
+  }).commonfabric?.rt;
+  if (!rt?.allSynced) return false;
+  await rt.allSynced();
+  return true;
+};
+
+const viewSettledReady = (): boolean =>
+  typeof (globalThis as typeof globalThis & {
+    commonfabric?: { viewSettled?: () => Promise<void> };
+  }).commonfabric?.viewSettled === "function";
+
+// Fill the input behind `selector`, then report whether the value took. Mirrors
+// the prior poll predicate: a not-yet-ready field (absent, hidden, disabled,
+// read-only) reports false without dispatching anything, so a re-check on the
+// next DOM mutation retries the fill; a ready field is filled once and verified.
+const fillAndVerify = async (
+  probe: ProbeApi,
+  selector: string,
+  nextValue: string,
+): Promise<boolean> => {
+  const element = probe.collect(selector)[0];
+  if (!element) return false;
+  const input = element instanceof HTMLInputElement
+    ? element
+    : element.shadowRoot?.querySelector("input");
+  if (!(input instanceof HTMLInputElement)) return false;
+
+  input.scrollIntoView({ block: "center", inline: "center" });
+  await new Promise((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(resolve))
+  );
+  if (!probe.isVisible(input) || input.disabled || input.readOnly) {
+    return false;
+  }
+
+  const root = input.getRootNode();
+  const host = root instanceof ShadowRoot ? root.host : element;
+  const hostWithCell = host as Element & {
+    value?: {
+      get?: () => unknown;
+      set?: (value: string) => Promise<void>;
+      sync?: () => Promise<unknown>;
+    };
+    requestUpdate?: () => void | Promise<void>;
+  };
+  const readCellValue = () =>
+    typeof hostWithCell.value?.get === "function"
+      ? hostWithCell.value.get()
+      : undefined;
+
+  input.focus();
+  const valueSetter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  if (valueSetter) valueSetter.call(input, nextValue);
+  else input.value = nextValue;
+  input.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+  input.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+  input.blur();
+
+  if (typeof hostWithCell.value?.set === "function") {
+    await hostWithCell.value.set(nextValue);
+  }
+  const cellValue = typeof hostWithCell.value?.sync === "function"
+    ? await hostWithCell.value.sync()
+    : readCellValue();
+  if (typeof hostWithCell.requestUpdate === "function") {
+    await hostWithCell.requestUpdate.call(hostWithCell);
+  }
+  await new Promise((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(resolve))
+  );
+
+  return hostWithCell.value !== undefined
+    ? cellValue === nextValue
+    : input.value === nextValue;
+};
+
+// Scroll the cf-button behind `selector` into view and tag its inner click
+// target so the test can resolve and click exactly that element.
+const markForClick = async (
+  probe: ProbeApi,
+  selector: string,
+  token: string,
+  attr: string,
+): Promise<boolean> => {
+  const target = probe.collect(selector)[0] as HTMLElement | undefined;
+  if (!target) return false;
+  target.scrollIntoView({ block: "center", inline: "center" });
+  await new Promise((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(resolve))
+  );
+  const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
+    | HTMLElement
+    | null) ?? target;
+  clickTarget.setAttribute(attr, token);
+  return true;
+};
+
+// Tag the first visible, enabled element carrying `data-ui-action="<action>"`
+// for a single trusted click, and record the next click's provenance so a
+// failure can show whether the dispatch was trusted and where it landed.
+const markTrustedAction = async (
+  probe: ProbeApi,
+  action: string,
+  token: string,
+  attr: string,
+): Promise<boolean> => {
+  const isDisabled = (element: HTMLElement): boolean =>
+    element.hasAttribute("disabled") ||
+    element.getAttribute("aria-disabled") === "true";
+
+  for (const element of probe.collect(`[data-ui-action="${action}"]`)) {
+    const target = element as HTMLElement;
+    target.scrollIntoView({ block: "center", inline: "center" });
+    await new Promise((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(resolve))
+    );
+    const clickTarget = (target.shadowRoot?.querySelector("[data-cf-button]") as
+      | HTMLElement
+      | null) ?? target;
+    if (
+      probe.isVisible(target) && probe.isVisible(clickTarget) &&
+      !isDisabled(target) && !isDisabled(clickTarget)
+    ) {
+      clickTarget.setAttribute(attr, token);
+      clickTarget.addEventListener(
+        "click",
+        (event) => {
+          (globalThis as typeof globalThis & {
+            __lastCfcTrustedActionClick?: TrustedActionProbe["lastClick"];
+          }).__lastCfcTrustedActionClick = {
+            trusted: event.isTrusted,
+            path: event.composedPath().flatMap((node) => {
+              if (!(node instanceof HTMLElement)) return [];
+              const dataset: Record<string, string> = {};
+              for (const key in node.dataset) {
+                dataset[key] = node.dataset[key] ?? "";
+              }
+              return [{
+                tagName: node.tagName.toLowerCase(),
+                id: node.id,
+                dataset,
+              }];
+            }),
+          };
+        },
+        { capture: true, once: true },
+      );
+      return true;
+    }
+  }
+  return false;
+};
+
+// Resolve once the shell's reactive view has caught up to runtime state and is
+// interactive, so a click lands on a bound handler. Waits for the shell to
+// expose `viewSettled` (notification-driven), then awaits the settle.
+async function settleView(
+  page: Page,
+  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
+): Promise<void> {
+  await waitForCondition(page, viewSettledReady, { timeout });
+  await awaitViewSettled(page);
+}
 
 export async function clickTrustedAction(
   page: Page,
@@ -12,25 +234,18 @@ export async function clickTrustedAction(
   const token = `trusted-action-${crypto.randomUUID()}`;
   let probe: TrustedActionProbe | undefined;
   try {
-    await waitFor(async () => {
-      try {
-        const marked = await markVisibleTrustedAction(page, action, token);
-        if (!marked) {
-          probe = await readTrustedActionProbe(page, action);
-          return false;
-        }
-        const button = await page.waitForSelector(
-          `[${CLICK_TARGET_ATTR}="${token}"]`,
-          { strategy: "pierce", timeout: 1_000 },
-        );
-        await button.click();
-        return true;
-      } catch {
-        probe = await readTrustedActionProbe(page, action);
-        await clearTrustedActionMark(page, token).catch(() => {});
-        return false;
-      }
-    }, { timeout, delay: 250 });
+    // Wait until a visible, enabled instance of the action can be marked, then
+    // click it exactly once. Marking attaches the provenance listener, so the
+    // single click is the trusted dispatch we record.
+    await waitForCondition(page, markTrustedAction, {
+      timeout,
+      args: [action, token, CLICK_TARGET_ATTR],
+    });
+    const button = await page.waitForSelector(
+      `[${CLICK_TARGET_ATTR}="${token}"]`,
+      { strategy: "pierce", timeout },
+    );
+    await button.click();
   } catch (cause) {
     probe ??= await readTrustedActionProbe(page, action).catch(() => undefined);
     // Indented for readable test-log output
@@ -52,33 +267,52 @@ export async function clickTrustedActionAndWaitForText(
   text: string,
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
+  // Single timeout budget shared across the fast path, settle, click, and the
+  // wait for the effect.
+  const deadline = Date.now() + timeout;
+  const remaining = () => Math.max(1, deadline - Date.now());
+
   let actionProbe: TrustedActionProbe | undefined;
   let textProbe: TextProbe | undefined;
+
+  // Fast path: the effect may already be present (idempotent re-entry).
+  if (await textIsPresent(page, selector, text)) {
+    return;
+  }
+
+  // Settle the view BEFORE dispatching, then click the trusted action exactly
+  // ONCE. Settling first means the action's handler is bound when the single
+  // trusted click lands; re-dispatching on a later tick is what double-fires
+  // and corrupts the event provenance, so we never re-click.
   try {
-    await waitFor(async () => {
-      if (await textIsPresent(page, selector, text)) {
-        return true;
-      }
-      try {
-        await clickTrustedAction(page, action, { timeout: 2_000 });
-      } catch {
-        actionProbe = await readTrustedActionProbe(page, action).catch(() =>
-          undefined
-        );
-        textProbe = await readTextProbe(page, selector).catch(() => undefined);
-        return false;
-      }
-      const updated = await textIsPresent(page, selector, text);
-      if (!updated) {
-        textProbe = await readTextProbe(page, selector).catch(() => undefined);
-      }
-      return updated;
-    }, { timeout, delay: 1_000 });
+    await settleView(page, { timeout: remaining() });
+    await clickTrustedAction(page, action, { timeout: remaining() });
+  } catch (cause) {
+    actionProbe = await readTrustedActionProbe(page, action).catch(() =>
+      undefined
+    );
+    textProbe = await readTextProbe(page, selector).catch(() => undefined);
+    throw new Error(
+      `Failed to click trusted action "${action}" while waiting for "${selector}" to contain "${text}". Last probes: ${
+        toIndentedDebugString({ actionProbe, textProbe })
+      }`,
+      { cause },
+    );
+  }
+
+  // The click is delivered; wait for its effect, notification-driven. The
+  // predicate re-runs whenever the DOM changes — including an optimistic
+  // perUser/perSpace write whose chip trails the commit — without re-clicking.
+  try {
+    await waitForCondition(page, textPresent, {
+      timeout: remaining(),
+      args: [selector, text],
+    });
   } catch (cause) {
     actionProbe ??= await readTrustedActionProbe(page, action).catch(() =>
       undefined
     );
-    textProbe ??= await readTextProbe(page, selector).catch(() => undefined);
+    textProbe = await readTextProbe(page, selector).catch(() => undefined);
     throw new Error(
       `Timed out clicking trusted action "${action}" until "${selector}" contained "${text}". Last probes: ${
         toIndentedDebugString({ actionProbe, textProbe })
@@ -94,18 +328,13 @@ export async function waitForText(
   text: string,
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
-  let probe: TextProbe | undefined;
   try {
-    await waitFor(async () => {
-      try {
-        return await textIsPresent(page, selector, text);
-      } catch {
-        probe = await readTextProbe(page, selector);
-        return false;
-      }
-    }, { timeout, delay: 250 });
+    await waitForCondition(page, textPresent, {
+      timeout,
+      args: [selector, text],
+    });
   } catch (cause) {
-    probe ??= await readTextProbe(page, selector).catch(() => undefined);
+    const probe = await readTextProbe(page, selector).catch(() => undefined);
     throw new Error(
       `Timed out waiting for "${selector}" to contain "${text}". Last probe: ${
         toIndentedDebugString(probe)
@@ -121,18 +350,13 @@ export async function waitForTextAbsent(
   text: string,
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
-  let probe: TextProbe | undefined;
   try {
-    await waitFor(async () => {
-      try {
-        return !(await textIsPresent(page, selector, text));
-      } catch {
-        probe = await readTextProbe(page, selector);
-        return false;
-      }
-    }, { timeout, delay: 250 });
+    await waitForCondition(page, textAbsent, {
+      timeout,
+      args: [selector, text],
+    });
   } catch (cause) {
-    probe ??= await readTextProbe(page, selector).catch(() => undefined);
+    const probe = await readTextProbe(page, selector).catch(() => undefined);
     throw new Error(
       `Timed out waiting for "${selector}" not to contain "${text}". Last probe: ${
         toIndentedDebugString(probe)
@@ -148,130 +372,13 @@ export async function fillCfInput(
   value: string,
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
-  let probe: CfInputProbe | undefined;
   try {
-    await waitFor(async () => {
-      try {
-        const field = await page.waitForSelector(selector, {
-          strategy: "pierce",
-          timeout: 1_000,
-        });
-        probe = await field.evaluate(
-          async (
-            element: Element,
-            nextValue: string,
-          ): Promise<CfInputProbe> => {
-            const input = element instanceof HTMLInputElement
-              ? element
-              : element.shadowRoot?.querySelector("input");
-            if (!(input instanceof HTMLInputElement)) {
-              return {
-                selector: element.tagName.toLowerCase(),
-                found: false,
-                value: "",
-                cellValue: undefined,
-                hasCell: false,
-                disabled: false,
-                readOnly: false,
-                visible: false,
-                hostTagName: element.tagName.toLowerCase(),
-              };
-            }
-
-            input.scrollIntoView({ block: "center", inline: "center" });
-            await new Promise((resolve) =>
-              requestAnimationFrame(() => requestAnimationFrame(resolve))
-            );
-            const rect = input.getBoundingClientRect();
-            const style = globalThis.getComputedStyle(input);
-            const visible = rect.width > 0 && rect.height > 0 &&
-              rect.bottom >= 0 && rect.right >= 0 &&
-              rect.top <= globalThis.innerHeight &&
-              rect.left <= globalThis.innerWidth &&
-              style.visibility !== "hidden" &&
-              style.display !== "none";
-            const root = input.getRootNode();
-            const host = root instanceof ShadowRoot ? root.host : element;
-            const hostWithCell = host as Element & {
-              value?: {
-                get?: () => unknown;
-                set?: (value: string) => Promise<void>;
-                sync?: () => Promise<unknown>;
-              };
-              requestUpdate?: () => void | Promise<void>;
-            };
-            const readCellValue = () =>
-              typeof hostWithCell.value?.get === "function"
-                ? hostWithCell.value.get()
-                : undefined;
-            if (!visible || input.disabled || input.readOnly) {
-              return {
-                selector: input.tagName.toLowerCase(),
-                found: true,
-                value: input.value,
-                cellValue: readCellValue(),
-                hasCell: hostWithCell.value !== undefined,
-                disabled: input.disabled,
-                readOnly: input.readOnly,
-                visible,
-                hostTagName: hostWithCell.tagName.toLowerCase(),
-              };
-            }
-
-            input.focus();
-            const valueSetter = Object.getOwnPropertyDescriptor(
-              HTMLInputElement.prototype,
-              "value",
-            )?.set;
-            if (valueSetter) {
-              valueSetter.call(input, nextValue);
-            } else {
-              input.value = nextValue;
-            }
-            input.dispatchEvent(
-              new Event("input", { bubbles: true, composed: true }),
-            );
-            input.dispatchEvent(
-              new Event("change", { bubbles: true, composed: true }),
-            );
-            input.blur();
-
-            if (typeof hostWithCell.value?.set === "function") {
-              await hostWithCell.value.set(nextValue);
-            }
-            const syncedCellValue =
-              typeof hostWithCell.value?.sync === "function"
-                ? await hostWithCell.value.sync()
-                : readCellValue();
-            if (typeof hostWithCell.requestUpdate === "function") {
-              await hostWithCell.requestUpdate.call(hostWithCell);
-            }
-            await new Promise((resolve) =>
-              requestAnimationFrame(() => requestAnimationFrame(resolve))
-            );
-
-            return {
-              selector: input.tagName.toLowerCase(),
-              found: true,
-              value: input.value,
-              cellValue: syncedCellValue,
-              hasCell: hostWithCell.value !== undefined,
-              disabled: input.disabled,
-              readOnly: input.readOnly,
-              visible,
-              hostTagName: hostWithCell.tagName.toLowerCase(),
-            };
-          },
-          { args: [value] },
-        );
-        return probe.found && probe.visible && !probe.disabled &&
-          !probe.readOnly &&
-          (probe.hasCell ? probe.cellValue === value : probe.value === value);
-      } catch {
-        return false;
-      }
-    }, { timeout, delay: 250 });
+    await waitForCondition(page, fillAndVerify, {
+      timeout,
+      args: [selector, value],
+    });
   } catch (cause) {
+    const probe = await readCfInputProbe(page, selector).catch(() => undefined);
     throw new Error(
       `Timed out filling cf input "${selector}" with "${value}". Last probe: ${
         toIndentedDebugString(probe)
@@ -315,16 +422,7 @@ export async function waitForRuntimeIdle(
   page: Page,
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
-  await waitFor(async () => {
-    return await page.evaluate(async () => {
-      const rt = (globalThis as typeof globalThis & {
-        commonfabric?: { rt?: { idle?: () => Promise<void> } };
-      }).commonfabric?.rt;
-      if (!rt?.idle) return false;
-      await rt.idle();
-      return true;
-    });
-  }, { timeout, delay: 250 });
+  await waitForCondition(page, runtimeIdle, { timeout });
 }
 
 export async function waitForDisabled(
@@ -333,31 +431,15 @@ export async function waitForDisabled(
   disabled: boolean,
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
-  let probe: { disabled?: boolean; selector: string } | undefined;
   try {
-    await waitFor(async () => {
-      try {
-        const node = await page.waitForSelector(selector, {
-          strategy: "pierce",
-          timeout: 1_000,
-        });
-        probe = await node.evaluate((element: Element) => {
-          const button = element instanceof HTMLButtonElement
-            ? element
-            : element.shadowRoot?.querySelector("button");
-          return {
-            selector: element.tagName.toLowerCase(),
-            disabled: button instanceof HTMLButtonElement
-              ? button.disabled
-              : undefined,
-          };
-        });
-        return probe.disabled === disabled;
-      } catch {
-        return false;
-      }
-    }, { timeout, delay: 250 });
+    await waitForCondition(page, buttonDisabledIs, {
+      timeout,
+      args: [selector, disabled],
+    });
   } catch (cause) {
+    const probe = await readDisabledProbe(page, selector).catch(() =>
+      undefined
+    );
     throw new Error(
       `Timed out waiting for ${selector} disabled=${disabled}. Last probe: ${
         toIndentedDebugString(probe)
@@ -373,45 +455,14 @@ export async function clickCfButton(
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
   const token = `cf-button-${crypto.randomUUID()}`;
-  const mark = async () =>
-    await page.evaluate(async (targetSelector, targetToken, targetAttr) => {
-      function collect(
-        root: Document | ShadowRoot,
-        result: Element[],
-      ): void {
-        for (const element of root.querySelectorAll("*")) {
-          try {
-            if (element.matches(targetSelector)) {
-              result.push(element);
-            }
-          } catch {
-            // Invalid selectors are reported by returning false.
-          }
-          if (element.shadowRoot) {
-            collect(element.shadowRoot, result);
-          }
-        }
-      }
-
-      const matches: Element[] = [];
-      collect(document, matches);
-      const target = matches[0] as HTMLElement | undefined;
-      if (!target) {
-        return false;
-      }
-      target.scrollIntoView({ block: "center", inline: "center" });
-      await new Promise((resolve) =>
-        requestAnimationFrame(() => requestAnimationFrame(resolve))
-      );
-      const clickTarget =
-        (target.shadowRoot?.querySelector("[data-cf-button]") as
-          | HTMLElement
-          | null) ?? target;
-      clickTarget.setAttribute(targetAttr, targetToken);
-      return true;
-    }, { args: [selector, token, CLICK_TARGET_ATTR] });
   try {
-    await waitFor(mark, { timeout, delay: 250 });
+    // Wait until the button exists, then mark its inner click target exactly
+    // once; the mark is the predicate, so the re-check on each DOM mutation
+    // retries finding the button without re-clicking anything.
+    await waitForCondition(page, markForClick, {
+      timeout,
+      args: [selector, token, CLICK_TARGET_ATTR],
+    });
   } catch (cause) {
     throw new Error(`Unable to mark ${selector} for click`, { cause });
   }
@@ -420,7 +471,7 @@ export async function clickCfButton(
       `[${CLICK_TARGET_ATTR}="${token}"]`,
       {
         strategy: "pierce",
-        timeout: 2_000,
+        timeout,
       },
     );
     await clickTarget.click();
@@ -467,7 +518,7 @@ export async function clickCfButtonAndWaitForText(
     return;
   }
 
-  // Settle the view BEFORE clicking, then click exactly ONCE. awaitViewSettled
+  // Settle the view BEFORE clicking, then click exactly ONCE. settleView
   // resolves only once the worker is idle, the vdom batch has been applied to
   // the main thread, and Lit updates have drained — i.e. the button's handler
   // is actually bound. A single settled click is delivered to a live handler,
@@ -475,10 +526,7 @@ export async function clickCfButtonAndWaitForText(
   // can double-fire, and against a dismissable overlay the repeat clicks
   // dismiss it). See docs/development/UI_TESTING.md.
   try {
-    await waitFor(() => awaitViewSettled(page), {
-      timeout: remaining(),
-      delay: 250,
-    });
+    await settleView(page, { timeout: remaining() });
     await clickCfButton(page, buttonSelector, { timeout: remaining() });
   } catch (cause) {
     textProbe = await readTextProbe(page, textSelector).catch(() => undefined);
@@ -490,25 +538,17 @@ export async function clickCfButtonAndWaitForText(
     );
   }
 
-  // The click is delivered; settle the view and wait for its effect. The settle
-  // re-runs each poll, so an effect that renders a few cycles after the click —
-  // including an optimistic perUser/perSpace write whose chip trails the
-  // commit — is captured without ever re-clicking.
+  // The click is delivered; wait for its effect, notification-driven. The
+  // predicate re-runs whenever the DOM changes, so an effect that renders a few
+  // cycles after the click — including an optimistic perUser/perSpace write
+  // whose chip trails the commit — is captured without ever re-clicking.
   try {
-    await waitFor(async () => {
-      await awaitViewSettled(page);
-      if (await textIsPresent(page, textSelector, text)) {
-        return true;
-      }
-      textProbe = await readTextProbe(page, textSelector).catch(() =>
-        undefined
-      );
-      return false;
-    }, { timeout: remaining(), delay: 250 });
+    await waitForCondition(page, textPresent, {
+      timeout: remaining(),
+      args: [textSelector, text],
+    });
   } catch (cause) {
-    textProbe ??= await readTextProbe(page, textSelector).catch(() =>
-      undefined
-    );
+    textProbe = await readTextProbe(page, textSelector).catch(() => undefined);
     throw new Error(
       `Timed out clicking "${buttonSelector}" until "${textSelector}" contained "${text}". Last probe: ${
         toIndentedDebugString(textProbe)
@@ -522,18 +562,9 @@ export async function waitForRuntimeSynced(
   page: Page,
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
 ) {
-  await waitFor(async () => {
-    return await page.evaluate(async () => {
-      const rt = (globalThis as typeof globalThis & {
-        commonfabric?: { rt?: { allSynced?: () => Promise<void> } };
-      }).commonfabric?.rt;
-      // Quiescence isn't a per-space question: allSynced awaits every
-      // space the worker has opened.
-      if (!rt?.allSynced) return false;
-      await rt.allSynced();
-      return true;
-    });
-  }, { timeout, delay: 250 });
+  // Quiescence isn't a per-space question: allSynced awaits every space the
+  // worker has opened.
+  await waitForCondition(page, runtimeSynced, { timeout });
 }
 
 export type SchedulerLoadSummary = {
@@ -1100,89 +1131,113 @@ type CfInputProbe = {
   hostTagName: string;
 };
 
-async function markVisibleTrustedAction(
+async function readCfInputProbe(
   page: Page,
-  action: string,
-  token: string,
-): Promise<boolean> {
-  return await page.evaluate(async (targetAction, targetToken, targetAttr) => {
-    function collect(
-      root: Document | ShadowRoot,
-      result: Element[],
-    ): void {
+  selector: string,
+): Promise<CfInputProbe> {
+  return await page.evaluate((targetSelector) => {
+    function collect(root: Document | ShadowRoot, result: Element[]): void {
       for (const element of root.querySelectorAll("*")) {
-        if (element.getAttribute("data-ui-action") === targetAction) {
-          result.push(element);
+        try {
+          if (element.matches(targetSelector)) result.push(element);
+        } catch {
+          // Invalid selectors are reported through the empty probe.
         }
-        if (element.shadowRoot) {
-          collect(element.shadowRoot, result);
-        }
+        if (element.shadowRoot) collect(element.shadowRoot, result);
       }
-    }
-
-    function isVisible(element: HTMLElement): boolean {
-      const rect = element.getBoundingClientRect();
-      const style = globalThis.getComputedStyle(element);
-      return rect.width > 0 && rect.height > 0 &&
-        rect.bottom >= 0 && rect.right >= 0 &&
-        rect.top <= globalThis.innerHeight &&
-        rect.left <= globalThis.innerWidth &&
-        style.visibility !== "hidden" &&
-        style.display !== "none";
-    }
-
-    function isDisabled(element: HTMLElement): boolean {
-      return element.hasAttribute("disabled") ||
-        element.getAttribute("aria-disabled") === "true";
     }
 
     const matches: Element[] = [];
     collect(document, matches);
-    for (const element of matches) {
-      const target = element as HTMLElement;
-      target.scrollIntoView({ block: "center", inline: "center" });
-      await new Promise((resolve) =>
-        requestAnimationFrame(() => requestAnimationFrame(resolve))
-      );
-      const clickTarget =
-        (target.shadowRoot?.querySelector("[data-cf-button]") as
-          | HTMLElement
-          | null) ?? target;
-      if (
-        isVisible(target) && isVisible(clickTarget) &&
-        !isDisabled(target) && !isDisabled(clickTarget)
-      ) {
-        clickTarget.setAttribute(targetAttr, targetToken);
-        clickTarget.addEventListener(
-          "click",
-          (event) => {
-            (globalThis as typeof globalThis & {
-              __lastCfcTrustedActionClick?: TrustedActionProbe["lastClick"];
-            }).__lastCfcTrustedActionClick = {
-              trusted: event.isTrusted,
-              path: event.composedPath().flatMap((node) => {
-                if (!(node instanceof HTMLElement)) {
-                  return [];
-                }
-                const dataset: Record<string, string> = {};
-                for (const key in node.dataset) {
-                  dataset[key] = node.dataset[key] ?? "";
-                }
-                return [{
-                  tagName: node.tagName.toLowerCase(),
-                  id: node.id,
-                  dataset,
-                }];
-              }),
-            };
-          },
-          { capture: true, once: true },
-        );
-        return true;
+    const element = matches[0];
+    if (!element) {
+      return {
+        selector: targetSelector,
+        found: false,
+        value: "",
+        cellValue: undefined,
+        hasCell: false,
+        disabled: false,
+        readOnly: false,
+        visible: false,
+        hostTagName: "",
+      };
+    }
+    const input = element instanceof HTMLInputElement
+      ? element
+      : element.shadowRoot?.querySelector("input");
+    if (!(input instanceof HTMLInputElement)) {
+      return {
+        selector: element.tagName.toLowerCase(),
+        found: false,
+        value: "",
+        cellValue: undefined,
+        hasCell: false,
+        disabled: false,
+        readOnly: false,
+        visible: false,
+        hostTagName: element.tagName.toLowerCase(),
+      };
+    }
+    const rect = input.getBoundingClientRect();
+    const style = globalThis.getComputedStyle(input);
+    const visible = rect.width > 0 && rect.height > 0 &&
+      rect.bottom >= 0 && rect.right >= 0 &&
+      rect.top <= globalThis.innerHeight &&
+      rect.left <= globalThis.innerWidth &&
+      style.visibility !== "hidden" && style.display !== "none";
+    const root = input.getRootNode();
+    const host = root instanceof ShadowRoot ? root.host : element;
+    const hostWithCell = host as Element & {
+      value?: { get?: () => unknown };
+    };
+    const cellValue = typeof hostWithCell.value?.get === "function"
+      ? hostWithCell.value.get()
+      : undefined;
+    return {
+      selector: input.tagName.toLowerCase(),
+      found: true,
+      value: input.value,
+      cellValue,
+      hasCell: hostWithCell.value !== undefined,
+      disabled: input.disabled,
+      readOnly: input.readOnly,
+      visible,
+      hostTagName: hostWithCell.tagName.toLowerCase(),
+    };
+  }, { args: [selector] });
+}
+
+async function readDisabledProbe(
+  page: Page,
+  selector: string,
+): Promise<{ selector: string; disabled?: boolean }> {
+  return await page.evaluate((targetSelector) => {
+    function collect(root: Document | ShadowRoot, result: Element[]): void {
+      for (const element of root.querySelectorAll("*")) {
+        try {
+          if (element.matches(targetSelector)) result.push(element);
+        } catch {
+          // Invalid selectors are reported through the empty probe.
+        }
+        if (element.shadowRoot) collect(element.shadowRoot, result);
       }
     }
-    return false;
-  }, { args: [action, token, CLICK_TARGET_ATTR] });
+
+    const matches: Element[] = [];
+    collect(document, matches);
+    const element = matches[0];
+    if (!element) return { selector: targetSelector, disabled: undefined };
+    const button = element instanceof HTMLButtonElement
+      ? element
+      : element.shadowRoot?.querySelector("button");
+    return {
+      selector: element.tagName.toLowerCase(),
+      disabled: button instanceof HTMLButtonElement
+        ? button.disabled
+        : undefined,
+    };
+  }, { args: [selector] });
 }
 
 async function clearTrustedActionMark(


### PR DESCRIPTION
The CFC browser helpers discovered state changes by polling the DOM on a fixed timer: the trusted-action save wait re-checked every 1000ms, and the text/visibility/fill/runtime-idle waits every 250ms. A step therefore slept until the next poll tick even after its condition was already satisfied, which floored each save step at ~1000ms regardless of the real latency.

Add an event-driven primitive, waitForCondition(page, predicate, {timeout, args}), in packages/integration/utils.ts. It installs a notifier in the page that re-evaluates the predicate whenever the UI could have changed and signals the test process the instant the condition holds, over a CDP Runtime.addBinding (exposed through new addBinding/removeBinding/onBindingCalled passthroughs on the Page wrapper). The notifier uses a shared pulse hub: a MutationObserver on the document and on every shadow root — including ones created after the wait began, caught by wrapping Element.prototype.attachShadow, since a document-level observer cannot see inside shadow roots. An async predicate that awaits a runtime signal (rt.idle()/allSynced()) resolves the moment that signal fires, with no DOM change required.

Re-point waitForText, waitForTextAbsent, waitForDisabled, fillCfInput, clickCfButton, clickTrustedAction, waitForRuntimeIdle, waitForRuntimeSynced, and the post-click waits in clickCfButtonAndWaitForText / clickTrustedActionAndWaitForText at the new primitive. The trusted-action wait now settles the view, dispatches the click exactly once, then waits notification-driven for the effect — it no longer re-dispatches on a retry tick, preserving click-once semantics and the event provenance handling. The shadow-piercing text/visibility traversal and rich timeout probes are kept. Intratest deadlines (the 1000ms/2000ms inner timeouts and the per-tick delays) are removed; the per-call timeout is the safety net.

Behavior of the tests is unchanged. On the two-browser group-chat demo, the save steps drop from the hard ~1038ms poll floor to ~120-340ms when uncontended (remaining time is genuine cross-browser commit latency, which the old poll rounded up to the next 1000ms tick).

Verified by running the headless browser integration suite (the real Chromium
+ shell + toolshed stack) on local dev servers: the motivating cfc-group-chat-demo-two-browsers test plus counter, cfc-group-chat-demo, cfc-authorized-save, cfc-render-policy-demo, cfc-staged-publish, cfc-spec-gallery, shared-profile, parking-coordinator-admin-view, home-profile, and reload/default-app-notebook all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CFC browser waits from polling to event-driven notifications and make post-click waits settle-driven, cutting 250–1000ms poll floors and fixing hangs when no DOM mutations occur under load.

- **New Features**
  - `waitForCondition(page, predicate, { timeout, args })` in `packages/integration/utils.ts`: in-page notifier re-runs predicates on DOM/runtime changes and signals via CDP binding; shared MutationObserver hub watches document and all shadow roots (including newly attached via wrapped `attachShadow`); predicates get a shadow‑piercing `ProbeApi`; async predicates (e.g. `rt.idle()`/`allSynced()`) resolve on signal.
  - `Page` (`packages/integration/page.ts`) adds `addBinding`, `removeBinding`, `onBindingCalled`. CFC helpers now use `waitForCondition` (`waitForText`, `waitForTextAbsent`, `waitForDisabled`, `fillCfInput`, `clickCfButton`, `clickTrustedAction`, `waitForRuntimeIdle`, `waitForRuntimeSynced`). Per-tick delays removed; steps drop from ~1038ms to ~120–340ms when uncontended.

- **Bug Fixes**
  - Post-click waits (`clickCfButtonAndWaitForText`, `clickTrustedActionAndWaitForText`) now drive the view settle and re-check via `waitForTextWhileSettling` and `settleView`, so effects land reliably without re-clicks and no passive hangs on an idle DOM; fixes the parking admin view flake under CI load.
  - Hardening: binding fire retries and reports if never callable; MutationObservers retained to avoid GC.

<sup>Written for commit 1931483e107bbd235fe242949d9a7b50ef8bc47e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

