### PR TITLE
docs: record CI timing access and local browser-test server setup

### DIFF
--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -51,6 +51,17 @@ failure by itself.
 Good CI optimization PRs should reduce critical-path wall time without making
 the workflow harder to reason about.
 
+## Pulling Timing Data
+
+The labs repository is public, so the GitHub Actions REST API returns run, job,
+and per-step timings unauthenticated — no `gh` or token needed. Logs and
+artifacts do need an admin token, so the per-test timings in the `test-timing-*`
+artifacts are not reachable this way; measure those locally.
+
+Jobs and steps for a run:
+`GET /repos/commontoolsinc/labs/actions/runs/<run-id>/jobs?per_page=100` — each
+job and step carries `started_at` and `completed_at`.
+
 ## Coverage Debt Baselines
 
 Performance Check also tracks coverage debt as uncovered source lines. Coverage

--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -256,6 +256,14 @@ never poll-and-pray, and never re-click.
 4. **Use pierce strategy as fallback**: It remains useful for components that
    have not been updated with host semantics
 
+## Running the Tests Locally
+
+`deno task integration` starts the servers for you. These are browser tests, so
+the toolshed must serve the shell frontend, not just the API: a bare `deno task
+dev` toolshed returns `404` for the UI and the test times out. To run a single
+file by hand, point it at the compiled binary (`deno task build-binaries`, then
+`./dist/toolshed`) or a source toolshed with `SHELL_URL` set.
+
 ## Environment Variables
 
 | Variable | Description |


### PR DESCRIPTION
Audience: people and agents working on this repo's CI performance and on its pattern browser integration tests. Both notes live in docs that AGENTS.md already points agents to, so they surface in the context where they are needed.

Why these were added: each captures a non-obvious fact that is not quickly derivable from the code and that was repeatedly rediscovered during CI wall-time and flaky-test investigations. Writing them down once saves the next person the same detour.

docs/development/CI_PERFORMANCE.md gains a "Pulling Timing Data" note. Because the labs repository is public, the GitHub Actions REST API returns run, job, and per-step timings unauthenticated, with no token or gh CLI. Logs and artifacts still need an admin token. Knowing this avoids both assuming authentication is required and wasting time trying to download the per-test timing artifacts, which are only reachable with auth and are better measured locally.

docs/development/UI_TESTING.md gains a "Running the Tests Locally" note. These are browser tests that load the shell UI, so the toolshed they talk to must serve the frontend, not just the API. A toolshed started from source with "deno task dev" answers the API but returns 404 for the UI, which presents as a test that simply times out. The note records that "deno task integration" already starts the servers correctly, and that a hand-started single-file run needs either the compiled binary or a source toolshed with SHELL_URL set.

Both notes are kept short on purpose: they hold only the facts worth the tokens an agent spends reading them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two short docs notes to speed up CI analysis and prevent local browser-test timeouts. Documents how to pull GitHub Actions timing data without auth and how to start the right servers for UI tests.

- **Docs**
  - CI_PERFORMANCE: "Pulling Timing Data" — for this public repo, run/job/step timings are available via GitHub Actions REST API without auth; logs/artifacts still need an admin token. Example: `GET /repos/commontoolsinc/labs/actions/runs/<run-id>/jobs?per_page=100`.
  - UI_TESTING: "Running the Tests Locally" — use `deno task integration` to start servers. `deno task dev` serves API only and causes timeouts. For single-file runs, use the built binary (`deno task build-binaries` then `./dist/toolshed`) or a source toolshed with `SHELL_URL` set.

<sup>Written for commit 81e0a0e939edfb34892fe3dc55613ed58516bb3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

