### PR TITLE
Normalize cf element registration

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -6,8 +6,8 @@ security constraints.
 
 ## 🚀 Features
 
-- **The Full v2 Component Set** - Production-ready implementation of a
-  shadcn/ui-inspired component library (see `src/v2/components/`)
+- **The `cf-*` Component Set** - Production-ready implementation of a
+  shadcn/ui-inspired component library
 - **Security-First Design** - Built for sandboxed environments with strict
   isolation
 - **Zero External Dependencies** - No remote resources, fully self-contained
@@ -19,34 +19,43 @@ security constraints.
 
 ```
 src/
-├── index.ts          # Main entry (exports both v1 and v2, with v2 as default)
-└── v2/              # New shadcn-inspired components (cf- prefix)
-    ├── components/  # 39 modern components
+├── index.ts         # Public package entrypoint
+└── v2/              # cf-* component implementation
+    ├── components/  # Component directories
     ├── core/        # Base element class
     ├── styles/      # Design tokens and shared styles
     └── utils/       # Utilities and helpers
 ```
+
+TODO(ui-path-cleanup): Rename the `src/v2` path now that it is the only UI
+component implementation.
 
 ## 🎯 Quick Start
 
 ### Installation with Deno
 
 ```typescript
-// Import v2 components (default)
+// Importing from the public package entrypoint registers all exported cf-* elements.
 import { CFButton, CFCard, CFInput } from "@commonfabric/ui";
 
-// Or import specific versions
-import { v2 } from "@commonfabric/ui";
+// Use a side-effect import when you only need the elements registered.
+import "@commonfabric/ui";
+```
 
-// Auto-register all v2 components
-import { registerAllComponents } from "@commonfabric/ui/v2";
-registerAllComponents();
+`@commonfabric/ui` is the public package entrypoint. It re-exports the component
+directory indexes, so importing it registers all exported `cf-*` elements.
+
+Repository-local code can import a single component by using that component's
+directory index:
+
+```typescript
+import { CFButton } from "./src/v2/components/cf-button/index.ts";
 ```
 
 ### Use in HTML
 
 ```html
-<!-- V2 Components (cf- prefix) -->
+<!-- cf-* components -->
 <cf-button variant="primary">Click Me</cf-button>
 <cf-input type="email" placeholder="Enter email"></cf-input>
 <cf-card>
@@ -68,32 +77,99 @@ Useful references:
 - `../../docs/common/patterns/style.md`
 - `../../docs/common/components/COMPONENTS.md`
 
-## 📖 V2 Components (39 total)
+## 📖 Components
 
-### Core UI Components (23)
+### Forms And Inputs
 
-- **Forms**: `cf-button`, `cf-input`, `cf-textarea`, `cf-checkbox`, `cf-radio`,
-  `cf-switch`, `cf-toggle`, `cf-slider`
-- **Layout**: `cf-card`, `cf-separator`, `cf-accordion`, `cf-collapsible`,
-  `cf-tabs`, `cf-scroll-area`
-- **Feedback**: `cf-alert`, `cf-badge`, `cf-progress`, `cf-skeleton`, `cf-label`
-- **Data**: `cf-table`, `cf-form`, `cf-input-otp`
-- **Display**: `cf-aspect-ratio`, `cf-resizable-panel-group`
+| Element           | Element     | Element           | Element          |
+| ----------------- | ----------- | ----------------- | ---------------- |
+| `cf-autocomplete` | `cf-button` | `cf-calendar`     | `cf-checkbox`    |
+| `cf-code-editor`  | `cf-field`  | `cf-form`         | `cf-input`       |
+| `cf-input-otp`    | `cf-picker` | `cf-radio`        | `cf-radio-group` |
+| `cf-select`       | `cf-slider` | `cf-switch`       | `cf-tags`        |
+| `cf-textarea`     | `cf-toggle` | `cf-toggle-group` | `cf-voice-input` |
 
-### Layout Components (8)
+### Files And Media
 
-- **Flexbox**: `cf-hstack`, `cf-vstack`, `cf-hgroup`, `cf-vgroup`
-- **Scrolling**: `cf-hscroll`, `cf-vscroll`
-- **Grid**: `cf-grid`, `cf-table`
+| Element              | Element               | Element          | Element            |
+| -------------------- | --------------------- | ---------------- | ------------------ |
+| `cf-attachments-bar` | `cf-audio-visualizer` | `cf-canvas`      | `cf-file-download` |
+| `cf-file-input`      | `cf-iframe`           | `cf-image-input` | `cf-svg`           |
+
+### Layout And Structure
+
+| Element               | Element              | Element                    | Element         |
+| --------------------- | -------------------- | -------------------------- | --------------- |
+| `cf-accordion`        | `cf-accordion-item`  | `cf-aspect-ratio`          | `cf-autolayout` |
+| `cf-card`             | `cf-collapsible`     | `cf-fragment`              | `cf-grid`       |
+| `cf-hgroup`           | `cf-hscroll`         | `cf-hstack`                | `cf-list-item`  |
+| `cf-resizable-handle` | `cf-resizable-panel` | `cf-resizable-panel-group` | `cf-screen`     |
+| `cf-scroll-area`      | `cf-separator`       | `cf-table`                 | `cf-tile`       |
+| `cf-vgroup`           | `cf-vscroll`         | `cf-vstack`                |                 |
+
+### Display And Text
+
+| Element      | Element    | Element    | Element          |
+| ------------ | ---------- | ---------- | ---------------- |
+| `cf-avatar`  | `cf-badge` | `cf-chip`  | `cf-copy-button` |
+| `cf-heading` | `cf-kbd`   | `cf-label` | `cf-markdown`    |
+| `cf-text`    | `cf-theme` |            |                  |
+
+### Feedback And Overlays
+
+| Element    | Element             | Element       | Element       |
+| ---------- | ------------------- | ------------- | ------------- |
+| `cf-alert` | `cf-empty-state`    | `cf-fab`      | `cf-loader`   |
+| `cf-modal` | `cf-modal-provider` | `cf-progress` | `cf-skeleton` |
+| `cf-toast` | `cf-toast-provider` |               |               |
+
+### Charts And Maps
+
+| Element        | Element       | Element    | Element       |
+| -------------- | ------------- | ---------- | ------------- |
+| `cf-area-mark` | `cf-bar-mark` | `cf-chart` | `cf-dot-mark` |
+| `cf-line-mark` | `cf-map`      |            |               |
+
+### Messaging And AI
+
+| Element           | Element           | Element            | Element            |
+| ----------------- | ----------------- | ------------------ | ------------------ |
+| `cf-chat`         | `cf-chat-message` | `cf-message-beads` | `cf-message-input` |
+| `cf-prompt-input` | `cf-question`     | `cf-tool-call`     | `cf-tools-chip`    |
+
+### Identity And Integrations
+
+| Element             | Element            | Element            | Element      |
+| ------------------- | ------------------ | ------------------ | ------------ |
+| `cf-cfc-authorship` | `cf-cfc-label`     | `cf-google-oauth`  | `cf-oauth`   |
+| `cf-plaid-link`     | `cf-profile-badge` | `cf-secret-viewer` | `cf-webhook` |
+
+### Navigation And Routing
+
+| Element             | Element         | Element           | Element       |
+| ------------------- | --------------- | ----------------- | ------------- |
+| `cf-chevron-button` | `cf-link`       | `cf-link-preview` | `cf-location` |
+| `cf-router`         | `cf-space-link` | `cf-tab`          | `cf-tab-bar`  |
+| `cf-tab-bar-item`   | `cf-tab-list`   | `cf-tab-panel`    | `cf-tabs`     |
+
+### Runtime And Interaction
+
+| Element        | Element           | Element        | Element          |
+| -------------- | ----------------- | -------------- | ---------------- |
+| `cf-autostart` | `cf-cell-context` | `cf-cell-link` | `cf-drag-source` |
+| `cf-draggable` | `cf-drop-zone`    | `cf-keybind`   | `cf-piece`       |
+| `cf-render`    | `cf-toolbar`      | `cf-updater`   |                  |
 
 ## 🔒 Security Constraints
 
-Both v1 and v2 components are designed for secure, sandboxed environments:
+Components are designed for secure, sandboxed environments:
 
-- **No External Resources** - No images, SVGs, or remote fetching
+- **No Implicit Remote Fetching** - Media and SVG components render
+  caller-provided data
 - **DOM Isolation** - Components cannot access DOM outside their Shadow DOM
 - **Limited Events** - Only keyboard, mouse, focus, and form events allowed
-- **No Navigation** - No anchor tags or external links
+- **Controlled Navigation** - Navigation components expose explicit routing and
+  link behavior
 - **Visual Containment** - Components render within parent bounds
 
 ## 🤖 LLM Integration
@@ -104,7 +180,7 @@ guide includes:
 
 - Complete component API reference
 - Attribute types and event specifications
-- Usage examples for all 39 v2 components
+- Usage examples for `cf-*` components
 - Security constraints and best practices
 - Component composition patterns
 
@@ -116,20 +192,14 @@ usage.
 ### Commands
 
 ```bash
-# Type checking
-deno task check        # Check all files
-deno task check:v2     # Check v2 only
+# Type checking from the repository root
+deno check packages/ui/src/index.ts
 
-# Linting & Formatting
-deno task lint         # Lint all files
-deno task lint:v2      # Lint v2 only
-deno task fmt          # Format code
+# Formatting from the repository root
+deno fmt packages/ui
 
-# Testing
-deno task test         # Run tests
-
-# Clean
-deno task clean        # Remove build artifacts
+# Testing from packages/ui
+deno task test
 ```
 
 ### Project Structure Details
@@ -141,18 +211,27 @@ packages/ui/
 ├── LLM-COMPONENT-INSTRUCTIONS.md  # AI assistant guide
 ├── src/
 │   ├── index.ts             # Main exports
-│   ├── v1/                  # Legacy components
-│   │   ├── components/      # common-* components
-│   │   └── index.ts
-│   └── v2/                  # Modern components
+│   └── v2/                  # cf-* component implementation
 │       ├── components/      # cf-* components
 │       ├── core/            # BaseElement class
 │       ├── styles/          # Shared styles
 │       ├── utils/           # Utilities
 │       ├── types/           # TypeScript types
-│       ├── register-all.ts  # Auto-registration
 │       └── index.ts
 ```
+
+### Component Registration
+
+Each `cf-*` component directory owns registration in `index.ts`.
+
+The component implementation file exports the class. The directory `index.ts`
+imports the class, checks `customElements.get("<tag>")`, defines the tag when it
+is missing, and exports the class plus an element type alias.
+
+Use value imports from the directory `index.ts` when code relies on
+registration. The package root imports every exported component index and
+registers all exported `cf-*` elements at once. Use type-only imports for type
+references.
 
 ## 📚 Examples
 
@@ -202,7 +281,7 @@ packages/ui/
 ### Event Handling
 
 ```javascript
-// V2 events (cf- prefix)
+// cf-* events
 document.querySelector("cf-button").addEventListener("cf-click", (e) => {
   console.log("Button clicked:", e.detail);
 });
@@ -273,7 +352,7 @@ MIT License - see LICENSE file for details
 
 ## 🙏 Acknowledgments
 
-- v2 design system based on [shadcn/ui](https://ui.shadcn.com/)
+- Design system based on [shadcn/ui](https://ui.shadcn.com/)
 - Built with [Lit](https://lit.dev/) web components
 - Optimized for [Deno](https://deno.land/) runtime
 - Secured for sandboxed environments

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * Common UI Web Components Library
  *
- * Main entry point that provides access to both v1 and v2 components
+ * Public package entrypoint for the cf-* component library.
  */
 
 export * from "./v2/index.ts";

--- a/packages/ui/src/v2/MIGRATION_SUMMARY.md
+++ b/packages/ui/src/v2/MIGRATION_SUMMARY.md
@@ -1,5 +1,8 @@
 # Lit Migration Summary
 
+TODO(ui-migration-doc-cleanup): Remove this migration summary when migration
+notes no longer belong in the component source tree.
+
 ## Components Migrated (12 total)
 
 ### Layout Components (4)
@@ -29,11 +32,12 @@ For each component, the following changes were made:
 
 1. **Imports**
    - Added Lit imports: `html`, `css`, `PropertyValues`
-   - Added decorators: `@customElement`, `@property`, `@query`, `@state`
+   - Added decorators: `@property`, `@query`, `@state`
    - Added directives as needed: `classMap`, `styleMap`, `repeat`
 
 2. **Class Declaration**
-   - Added `@customElement` decorator
+   - Component files export their classes
+   - Component directory `index.ts` files register elements
    - Changed styles to static with `css` template literal
    - Removed `observedAttributes` (handled by `@property`)
 

--- a/packages/ui/src/v2/components/cf-accordion-item/cf-accordion-item.ts
+++ b/packages/ui/src/v2/components/cf-accordion-item/cf-accordion-item.ts
@@ -274,5 +274,3 @@ export class CFAccordionItem extends BaseElement {
     }
   }
 }
-
-globalThis.customElements.define("cf-accordion-item", CFAccordionItem);

--- a/packages/ui/src/v2/components/cf-accordion-item/index.ts
+++ b/packages/ui/src/v2/components/cf-accordion-item/index.ts
@@ -1,9 +1,8 @@
 import { CFAccordionItem } from "./cf-accordion-item.ts";
 
-// Register the custom element
 if (!customElements.get("cf-accordion-item")) {
   customElements.define("cf-accordion-item", CFAccordionItem);
 }
 
-// Export the component class
+export type { CFAccordionItem as CFAccordionItemElement } from "./cf-accordion-item.ts";
 export { CFAccordionItem };

--- a/packages/ui/src/v2/components/cf-accordion/cf-accordion.ts
+++ b/packages/ui/src/v2/components/cf-accordion/cf-accordion.ts
@@ -197,5 +197,3 @@ export class CFAccordion extends BaseElement {
     this.value = this.type === "single" ? "" : [];
   }
 }
-
-globalThis.customElements.define("cf-accordion", CFAccordion);

--- a/packages/ui/src/v2/components/cf-accordion/index.ts
+++ b/packages/ui/src/v2/components/cf-accordion/index.ts
@@ -1,8 +1,12 @@
-import { AccordionType, CFAccordion } from "./cf-accordion.ts";
+import { CFAccordion } from "./cf-accordion.ts";
+
+import { AccordionType } from "./cf-accordion.ts";
 
 if (!customElements.get("cf-accordion")) {
   customElements.define("cf-accordion", CFAccordion);
 }
+
+export type { CFAccordion as CFAccordionElement } from "./cf-accordion.ts";
 
 export { CFAccordion };
 export type { AccordionType };

--- a/packages/ui/src/v2/components/cf-alert/cf-alert.ts
+++ b/packages/ui/src/v2/components/cf-alert/cf-alert.ts
@@ -352,5 +352,3 @@ export class CFAlert extends BaseElement {
     this.emit("cf-alert-dismiss", detail);
   };
 }
-
-globalThis.customElements.define("cf-alert", CFAlert);

--- a/packages/ui/src/v2/components/cf-alert/index.ts
+++ b/packages/ui/src/v2/components/cf-alert/index.ts
@@ -3,11 +3,14 @@
  */
 
 import { CFAlert } from "./cf-alert.ts";
+
 import type { StatusIntent } from "../theme-context.ts";
 
 if (!customElements.get("cf-alert")) {
   customElements.define("cf-alert", CFAlert);
 }
+
+export type { CFAlert as CFAlertElement } from "./cf-alert.ts";
 
 export { CFAlert };
 export type { StatusIntent };

--- a/packages/ui/src/v2/components/cf-aspect-ratio/cf-aspect-ratio.ts
+++ b/packages/ui/src/v2/components/cf-aspect-ratio/cf-aspect-ratio.ts
@@ -72,5 +72,3 @@ export class CFAspectRatio extends BaseElement {
     return (height / width) * 100;
   }
 }
-
-globalThis.customElements.define("cf-aspect-ratio", CFAspectRatio);

--- a/packages/ui/src/v2/components/cf-aspect-ratio/index.ts
+++ b/packages/ui/src/v2/components/cf-aspect-ratio/index.ts
@@ -1,9 +1,12 @@
 import { CFAspectRatio } from "./cf-aspect-ratio.ts";
+
 import { aspectRatioStyles } from "./styles.ts";
 
 if (!customElements.get("cf-aspect-ratio")) {
   customElements.define("cf-aspect-ratio", CFAspectRatio);
 }
+
+export type { CFAspectRatio as CFAspectRatioElement } from "./cf-aspect-ratio.ts";
 
 export { CFAspectRatio };
 export { aspectRatioStyles };

--- a/packages/ui/src/v2/components/cf-attachments-bar/cf-attachments-bar.ts
+++ b/packages/ui/src/v2/components/cf-attachments-bar/cf-attachments-bar.ts
@@ -1,7 +1,7 @@
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
 import { BaseElement } from "../../core/base-element.ts";
-import "../cf-chip/cf-chip.ts";
+import "../cf-chip/index.ts";
 import { isCellHandle } from "@commonfabric/runtime-client";
 
 /**
@@ -136,5 +136,3 @@ export class CFAttachmentsBar extends BaseElement {
     `;
   }
 }
-
-customElements.define("cf-attachments-bar", CFAttachmentsBar);

--- a/packages/ui/src/v2/components/cf-attachments-bar/index.ts
+++ b/packages/ui/src/v2/components/cf-attachments-bar/index.ts
@@ -1,0 +1,8 @@
+import { CFAttachmentsBar } from "./cf-attachments-bar.ts";
+
+if (!customElements.get("cf-attachments-bar")) {
+  customElements.define("cf-attachments-bar", CFAttachmentsBar);
+}
+
+export { CFAttachmentsBar };
+export type { CFAttachmentsBar as CFAttachmentsBarElement } from "./cf-attachments-bar.ts";

--- a/packages/ui/src/v2/components/cf-audio-visualizer/cf-audio-visualizer.ts
+++ b/packages/ui/src/v2/components/cf-audio-visualizer/cf-audio-visualizer.ts
@@ -197,5 +197,3 @@ export class CFAudioVisualizer extends BaseElement {
     `;
   }
 }
-
-customElements.define("cf-audio-visualizer", CFAudioVisualizer);

--- a/packages/ui/src/v2/components/cf-audio-visualizer/index.ts
+++ b/packages/ui/src/v2/components/cf-audio-visualizer/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-audio-visualizer")) {
   customElements.define("cf-audio-visualizer", CFAudioVisualizer);
 }
 
+export type { CFAudioVisualizer as CFAudioVisualizerElement } from "./cf-audio-visualizer.ts";
+
 export { CFAudioVisualizer };

--- a/packages/ui/src/v2/components/cf-autocomplete/cf-autocomplete.ts
+++ b/packages/ui/src/v2/components/cf-autocomplete/cf-autocomplete.ts
@@ -1168,5 +1168,3 @@ export class CFAutocomplete extends BaseElement {
     this._close();
   }
 }
-
-globalThis.customElements.define("cf-autocomplete", CFAutocomplete);

--- a/packages/ui/src/v2/components/cf-autocomplete/index.ts
+++ b/packages/ui/src/v2/components/cf-autocomplete/index.ts
@@ -1,8 +1,12 @@
-import { type AutocompleteItem, CFAutocomplete } from "./cf-autocomplete.ts";
+import { CFAutocomplete } from "./cf-autocomplete.ts";
+
+import { type AutocompleteItem } from "./cf-autocomplete.ts";
 
 if (!customElements.get("cf-autocomplete")) {
   customElements.define("cf-autocomplete", CFAutocomplete);
 }
+
+export type { CFAutocomplete as CFAutocompleteElement } from "./cf-autocomplete.ts";
 
 export { CFAutocomplete };
 export type { AutocompleteItem };

--- a/packages/ui/src/v2/components/cf-autolayout/cf-autolayout.ts
+++ b/packages/ui/src/v2/components/cf-autolayout/cf-autolayout.ts
@@ -679,5 +679,3 @@ export class CFAutoLayout extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-autolayout", CFAutoLayout);

--- a/packages/ui/src/v2/components/cf-autolayout/index.ts
+++ b/packages/ui/src/v2/components/cf-autolayout/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-autolayout")) {
   customElements.define("cf-autolayout", CFAutoLayout);
 }
 
+export type { CFAutoLayout as CFAutoLayoutElement } from "./cf-autolayout.ts";
+
 export { CFAutoLayout };

--- a/packages/ui/src/v2/components/cf-autostart/index.ts
+++ b/packages/ui/src/v2/components/cf-autostart/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-autostart")) {
   customElements.define("cf-autostart", CFAutostart);
 }
 
+export type { CFAutostart as CFAutostartElement } from "./cf-autostart.ts";
+
 export { CFAutostart };

--- a/packages/ui/src/v2/components/cf-avatar/cf-avatar.test.ts
+++ b/packages/ui/src/v2/components/cf-avatar/cf-avatar.test.ts
@@ -5,7 +5,7 @@ import {
   initialsForName,
   isAvatarImageUrl,
   isRemoteLikeSource,
-} from "./cf-avatar.ts";
+} from "./index.ts";
 
 describe("CFAvatar", () => {
   it("registers the custom element", () => {

--- a/packages/ui/src/v2/components/cf-avatar/cf-avatar.ts
+++ b/packages/ui/src/v2/components/cf-avatar/cf-avatar.ts
@@ -215,10 +215,6 @@ export class CFAvatar extends BaseElement {
   };
 }
 
-if (!globalThis.customElements.get("cf-avatar")) {
-  globalThis.customElements.define("cf-avatar", CFAvatar);
-}
-
 declare global {
   interface HTMLElementTagNameMap {
     "cf-avatar": CFAvatar;

--- a/packages/ui/src/v2/components/cf-avatar/index.ts
+++ b/packages/ui/src/v2/components/cf-avatar/index.ts
@@ -4,6 +4,12 @@ if (!customElements.get("cf-avatar")) {
   customElements.define("cf-avatar", CFAvatar);
 }
 
+export type { CFAvatar as CFAvatarElement } from "./cf-avatar.ts";
+export {
+  initialsForName,
+  isAvatarImageUrl,
+  isRemoteLikeSource,
+} from "./cf-avatar.ts";
+
 export { CFAvatar };
 export type { AvatarShape, AvatarSize } from "./cf-avatar.ts";
-export { initialsForName, isAvatarImageUrl } from "./cf-avatar.ts";

--- a/packages/ui/src/v2/components/cf-badge/cf-badge.ts
+++ b/packages/ui/src/v2/components/cf-badge/cf-badge.ts
@@ -332,5 +332,3 @@ export class CFBadge extends BaseElement {
     });
   }
 }
-
-globalThis.customElements.define("cf-badge", CFBadge);

--- a/packages/ui/src/v2/components/cf-badge/index.ts
+++ b/packages/ui/src/v2/components/cf-badge/index.ts
@@ -1,8 +1,12 @@
-import { BadgeVariant, CFBadge } from "./cf-badge.ts";
+import { CFBadge } from "./cf-badge.ts";
+
+import { BadgeVariant } from "./cf-badge.ts";
 
 if (!customElements.get("cf-badge")) {
   customElements.define("cf-badge", CFBadge);
 }
+
+export type { CFBadge as CFBadgeElement } from "./cf-badge.ts";
 
 export { CFBadge };
 export type { BadgeVariant };

--- a/packages/ui/src/v2/components/cf-button/cf-button.test.ts
+++ b/packages/ui/src/v2/components/cf-button/cf-button.test.ts
@@ -3,7 +3,7 @@
  */
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { CFButton } from "./cf-button.ts";
+import { CFButton } from "./index.ts";
 
 describe("CFButton", () => {
   it("should be defined", () => {

--- a/packages/ui/src/v2/components/cf-button/cf-button.ts
+++ b/packages/ui/src/v2/components/cf-button/cf-button.ts
@@ -270,5 +270,3 @@ export class CFButton extends BaseElement {
     }
   }
 }
-
-globalThis.customElements.define("cf-button", CFButton);

--- a/packages/ui/src/v2/components/cf-button/index.ts
+++ b/packages/ui/src/v2/components/cf-button/index.ts
@@ -1,9 +1,13 @@
-import { ButtonSize, ButtonVariant, CFButton } from "./cf-button.ts";
+import { CFButton } from "./cf-button.ts";
+
+import { ButtonSize, ButtonVariant } from "./cf-button.ts";
 import type { ColorIntent } from "../theme-context.ts";
 
 if (!customElements.get("cf-button")) {
   customElements.define("cf-button", CFButton);
 }
+
+export type { CFButton as CFButtonElement } from "./cf-button.ts";
 
 export { CFButton };
 export type { ButtonSize, ButtonVariant, ColorIntent };

--- a/packages/ui/src/v2/components/cf-calendar/index.ts
+++ b/packages/ui/src/v2/components/cf-calendar/index.ts
@@ -1,5 +1,9 @@
 import { CFCalendar } from "./cf-calendar.ts";
+
 if (!customElements.get("cf-calendar")) {
   customElements.define("cf-calendar", CFCalendar);
 }
+
+export type { CFCalendar as CFCalendarElement } from "./cf-calendar.ts";
+
 export { CFCalendar };

--- a/packages/ui/src/v2/components/cf-canvas/cf-canvas.ts
+++ b/packages/ui/src/v2/components/cf-canvas/cf-canvas.ts
@@ -1,8 +1,7 @@
 import { css, html } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { property } from "lit/decorators.js";
 import { BaseElement } from "../../core/base-element.ts";
 
-@customElement("cf-canvas")
 export class CFCanvas extends BaseElement {
   @property({ type: Number })
   accessor width = 800;

--- a/packages/ui/src/v2/components/cf-canvas/index.ts
+++ b/packages/ui/src/v2/components/cf-canvas/index.ts
@@ -1,1 +1,8 @@
-export * from "./cf-canvas.ts";
+import { CFCanvas } from "./cf-canvas.ts";
+
+if (!customElements.get("cf-canvas")) {
+  customElements.define("cf-canvas", CFCanvas);
+}
+
+export { CFCanvas };
+export type { CFCanvas as CFCanvasElement } from "./cf-canvas.ts";

--- a/packages/ui/src/v2/components/cf-card/cf-card.ts
+++ b/packages/ui/src/v2/components/cf-card/cf-card.ts
@@ -356,5 +356,3 @@ export class CFCard extends BaseElement {
     card?.blur();
   }
 }
-
-globalThis.customElements.define("cf-card", CFCard);

--- a/packages/ui/src/v2/components/cf-card/index.ts
+++ b/packages/ui/src/v2/components/cf-card/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-card")) {
   customElements.define("cf-card", CFCard);
 }
 
+export type { CFCard as CFCardElement } from "./cf-card.ts";
+
 export { CFCard };

--- a/packages/ui/src/v2/components/cf-cell-context/cf-cell-context.ts
+++ b/packages/ui/src/v2/components/cf-cell-context/cf-cell-context.ts
@@ -302,8 +302,6 @@ export class CFCellContext extends BaseElement {
   }
 }
 
-globalThis.customElements.define("cf-cell-context", CFCellContext);
-
 declare global {
   interface HTMLElementTagNameMap {
     "cf-cell-context": CFCellContext;

--- a/packages/ui/src/v2/components/cf-cell-context/index.ts
+++ b/packages/ui/src/v2/components/cf-cell-context/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-cell-context")) {
   customElements.define("cf-cell-context", CFCellContext);
 }
 
+export type { CFCellContext as CFCellContextElement } from "./cf-cell-context.ts";
+
 export { CFCellContext };

--- a/packages/ui/src/v2/components/cf-cell-link/cf-cell-link.test.ts
+++ b/packages/ui/src/v2/components/cf-cell-link/cf-cell-link.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { CFCellLink } from "./cf-cell-link.ts";
+import { CFCellLink } from "./index.ts";
 import type { CellRef } from "@commonfabric/runtime-client";
 
 function deferred<T>() {

--- a/packages/ui/src/v2/components/cf-cell-link/cf-cell-link.ts
+++ b/packages/ui/src/v2/components/cf-cell-link/cf-cell-link.ts
@@ -2,7 +2,7 @@ import { css, html, PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import { consume } from "@lit/context";
 import { BaseElement } from "../../core/base-element.ts";
-import "../cf-chip/cf-chip.ts";
+import "../cf-chip/index.ts";
 import {
   type CellHandle,
   CellRef,
@@ -421,8 +421,6 @@ export class CFCellLink extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-cell-link", CFCellLink);
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/ui/src/v2/components/cf-cell-link/index.ts
+++ b/packages/ui/src/v2/components/cf-cell-link/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-cell-link")) {
   customElements.define("cf-cell-link", CFCellLink);
 }
 
+export type { CFCellLink as CFCellLinkElement } from "./cf-cell-link.ts";
+
 export { CFCellLink };

--- a/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.test.ts
+++ b/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.test.ts
@@ -4,7 +4,7 @@ import {
   authorshipStateForLabel,
   CFCFCAuthorship,
   integrityAtomMatchesAuthor,
-} from "./cf-cfc-authorship.ts";
+} from "./index.ts";
 
 describe("CFCFCAuthorship", () => {
   it("registers the custom element", () => {

--- a/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.ts
+++ b/packages/ui/src/v2/components/cf-cfc-authorship/cf-cfc-authorship.ts
@@ -1,6 +1,6 @@
 import { css, html } from "lit";
 import { BaseElement } from "../../core/base-element.ts";
-import { initialsForName } from "../cf-avatar/cf-avatar.ts";
+import { initialsForName } from "../cf-avatar/index.ts";
 import type { CfcLabelView } from "@commonfabric/runner/cfc";
 
 export type CfcAuthorshipState = "verified" | "unverified" | "unknown";
@@ -878,10 +878,6 @@ export class CFCFCAuthorship extends BaseElement {
       </section>
     `;
   }
-}
-
-if (!globalThis.customElements.get("cf-cfc-authorship")) {
-  globalThis.customElements.define("cf-cfc-authorship", CFCFCAuthorship);
 }
 
 declare global {

--- a/packages/ui/src/v2/components/cf-cfc-authorship/index.ts
+++ b/packages/ui/src/v2/components/cf-cfc-authorship/index.ts
@@ -4,5 +4,10 @@ if (!customElements.get("cf-cfc-authorship")) {
   customElements.define("cf-cfc-authorship", CFCFCAuthorship);
 }
 
-export { CFCFCAuthorship } from "./cf-cfc-authorship.ts";
 export type { CFCFCAuthorship as CFCFCAuthorshipElement } from "./cf-cfc-authorship.ts";
+export {
+  authorshipStateForLabel,
+  integrityAtomMatchesAuthor,
+} from "./cf-cfc-authorship.ts";
+
+export { CFCFCAuthorship } from "./cf-cfc-authorship.ts";

--- a/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.test.ts
+++ b/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.test.ts
@@ -1,10 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import {
-  CFCFCLabel,
-  filterCfcLabelView,
-  formatCfcLabelAtom,
-} from "./cf-cfc-label.ts";
+import { CFCFCLabel, filterCfcLabelView, formatCfcLabelAtom } from "./index.ts";
 
 describe("CFCFCLabel", () => {
   it("registers the custom element", () => {

--- a/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
+++ b/packages/ui/src/v2/components/cf-cfc-label/cf-cfc-label.ts
@@ -350,10 +350,6 @@ export class CFCFCLabel extends BaseElement {
   }
 }
 
-if (!globalThis.customElements.get("cf-cfc-label")) {
-  globalThis.customElements.define("cf-cfc-label", CFCFCLabel);
-}
-
 declare global {
   interface HTMLElementTagNameMap {
     "cf-cfc-label": CFCFCLabel;

--- a/packages/ui/src/v2/components/cf-cfc-label/index.ts
+++ b/packages/ui/src/v2/components/cf-cfc-label/index.ts
@@ -4,5 +4,7 @@ if (!customElements.get("cf-cfc-label")) {
   customElements.define("cf-cfc-label", CFCFCLabel);
 }
 
-export { CFCFCLabel };
 export type { CFCFCLabel as CFCFCLabelElement } from "./cf-cfc-label.ts";
+export { filterCfcLabelView, formatCfcLabelAtom } from "./cf-cfc-label.ts";
+
+export { CFCFCLabel };

--- a/packages/ui/src/v2/components/cf-chart/cf-chart.ts
+++ b/packages/ui/src/v2/components/cf-chart/cf-chart.ts
@@ -49,12 +49,6 @@ import {
   type NearestResult,
 } from "./lib/interaction.ts";
 
-// Import mark elements to ensure they're registered
-import "./marks/cf-line-mark.ts";
-import "./marks/cf-area-mark.ts";
-import "./marks/cf-bar-mark.ts";
-import "./marks/cf-dot-mark.ts";
-
 const RESIZE_DEBOUNCE_MS = 100;
 const DEFAULT_HEIGHT = 200;
 
@@ -434,8 +428,6 @@ export class CFChart extends BaseElement {
     }
   }
 }
-
-customElements.define("cf-chart", CFChart);
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/ui/src/v2/components/cf-chart/index.ts
+++ b/packages/ui/src/v2/components/cf-chart/index.ts
@@ -2,13 +2,13 @@
  * CF Chart Component Export and Registration
  */
 
-import { CFChart } from "./cf-chart.ts";
-import { MarkElement } from "./marks/base-mark.ts";
-import { CFLineMark } from "./marks/cf-line-mark.ts";
 import { CFAreaMark } from "./marks/cf-area-mark.ts";
 import { CFBarMark } from "./marks/cf-bar-mark.ts";
+import { CFChart } from "./cf-chart.ts";
 import { CFDotMark } from "./marks/cf-dot-mark.ts";
+import { CFLineMark } from "./marks/cf-line-mark.ts";
 
+import { MarkElement } from "./marks/base-mark.ts";
 import type {
   AxisConfig,
   AxisOption,
@@ -22,21 +22,31 @@ import type {
   YScaleType,
 } from "./types.ts";
 
-if (!customElements.get("cf-chart")) {
-  customElements.define("cf-chart", CFChart);
-}
-if (!customElements.get("cf-line-mark")) {
-  customElements.define("cf-line-mark", CFLineMark);
-}
 if (!customElements.get("cf-area-mark")) {
   customElements.define("cf-area-mark", CFAreaMark);
 }
+
 if (!customElements.get("cf-bar-mark")) {
   customElements.define("cf-bar-mark", CFBarMark);
 }
+
+if (!customElements.get("cf-chart")) {
+  customElements.define("cf-chart", CFChart);
+}
+
 if (!customElements.get("cf-dot-mark")) {
   customElements.define("cf-dot-mark", CFDotMark);
 }
+
+if (!customElements.get("cf-line-mark")) {
+  customElements.define("cf-line-mark", CFLineMark);
+}
+
+export type { CFAreaMark as CFAreaMarkElement } from "./marks/cf-area-mark.ts";
+export type { CFBarMark as CFBarMarkElement } from "./marks/cf-bar-mark.ts";
+export type { CFChart as CFChartElement } from "./cf-chart.ts";
+export type { CFDotMark as CFDotMarkElement } from "./marks/cf-dot-mark.ts";
+export type { CFLineMark as CFLineMarkElement } from "./marks/cf-line-mark.ts";
 
 export { CFAreaMark, CFBarMark, CFChart, CFDotMark, CFLineMark, MarkElement };
 

--- a/packages/ui/src/v2/components/cf-chart/marks/cf-area-mark.ts
+++ b/packages/ui/src/v2/components/cf-chart/marks/cf-area-mark.ts
@@ -34,8 +34,6 @@ export class CFAreaMark extends MarkElement {
   }
 }
 
-customElements.define("cf-area-mark", CFAreaMark);
-
 declare global {
   interface HTMLElementTagNameMap {
     "cf-area-mark": CFAreaMark;

--- a/packages/ui/src/v2/components/cf-chart/marks/cf-bar-mark.ts
+++ b/packages/ui/src/v2/components/cf-chart/marks/cf-bar-mark.ts
@@ -28,8 +28,6 @@ export class CFBarMark extends MarkElement {
   }
 }
 
-customElements.define("cf-bar-mark", CFBarMark);
-
 declare global {
   interface HTMLElementTagNameMap {
     "cf-bar-mark": CFBarMark;

--- a/packages/ui/src/v2/components/cf-chart/marks/cf-dot-mark.ts
+++ b/packages/ui/src/v2/components/cf-chart/marks/cf-dot-mark.ts
@@ -25,8 +25,6 @@ export class CFDotMark extends MarkElement {
   }
 }
 
-customElements.define("cf-dot-mark", CFDotMark);
-
 declare global {
   interface HTMLElementTagNameMap {
     "cf-dot-mark": CFDotMark;

--- a/packages/ui/src/v2/components/cf-chart/marks/cf-line-mark.ts
+++ b/packages/ui/src/v2/components/cf-chart/marks/cf-line-mark.ts
@@ -28,8 +28,6 @@ export class CFLineMark extends MarkElement {
   }
 }
 
-customElements.define("cf-line-mark", CFLineMark);
-
 declare global {
   interface HTMLElementTagNameMap {
     "cf-line-mark": CFLineMark;

--- a/packages/ui/src/v2/components/cf-chat-message/cf-chat-message.test.ts
+++ b/packages/ui/src/v2/components/cf-chat-message/cf-chat-message.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { CFChatMessage } from "./cf-chat-message.ts";
+import { CFChatMessage } from "./index.ts";
 import { createMockCellHandle } from "../../test-utils/mock-cell-handle.ts";
 
 describe("cf-chat-message", () => {

--- a/packages/ui/src/v2/components/cf-chat-message/cf-chat-message.ts
+++ b/packages/ui/src/v2/components/cf-chat-message/cf-chat-message.ts
@@ -2,10 +2,10 @@ import { css, html } from "lit";
 import { property } from "lit/decorators.js";
 import { consume } from "@lit/context";
 import { BaseElement } from "../../core/base-element.ts";
-import "../cf-tool-call/cf-tool-call.ts";
-import "../cf-button/cf-button.ts";
-import "../cf-copy-button/cf-copy-button.ts";
-import "../cf-markdown/cf-markdown.ts";
+import "../cf-tool-call/index.ts";
+import "../cf-button/index.ts";
+import "../cf-copy-button/index.ts";
+import "../cf-markdown/index.ts";
 import type {
   BuiltInLLMContent,
   BuiltInLLMTextPart,
@@ -409,5 +409,3 @@ export class CFChatMessage extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-chat-message", CFChatMessage);

--- a/packages/ui/src/v2/components/cf-chat-message/index.ts
+++ b/packages/ui/src/v2/components/cf-chat-message/index.ts
@@ -1,3 +1,9 @@
 import { CFChatMessage } from "./cf-chat-message.ts";
 
+if (!customElements.get("cf-chat-message")) {
+  customElements.define("cf-chat-message", CFChatMessage);
+}
+
+export type { CFChatMessage as CFChatMessageElement } from "./cf-chat-message.ts";
+
 export { CFChatMessage };

--- a/packages/ui/src/v2/components/cf-chat/cf-chat.ts
+++ b/packages/ui/src/v2/components/cf-chat/cf-chat.ts
@@ -4,8 +4,8 @@ import { consume } from "@lit/context";
 import { BaseElement } from "../../core/base-element.ts";
 import { type CellHandle, type JSONSchema } from "@commonfabric/runtime-client";
 import { createCellController } from "../../core/cell-controller.ts";
-import "../cf-chat-message/cf-chat-message.ts";
-import "../cf-tool-call/cf-tool-call.ts";
+import "../cf-chat-message/index.ts";
+import "../cf-tool-call/index.ts";
 import type {
   BuiltInLLMMessage,
   BuiltInLLMToolCallPart,
@@ -450,5 +450,3 @@ export class CFChat extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-chat", CFChat);

--- a/packages/ui/src/v2/components/cf-chat/index.ts
+++ b/packages/ui/src/v2/components/cf-chat/index.ts
@@ -1,1 +1,9 @@
+import { CFChat } from "./cf-chat.ts";
+
+if (!customElements.get("cf-chat")) {
+  customElements.define("cf-chat", CFChat);
+}
+
+export type { CFChat as CFChatElement } from "./cf-chat.ts";
+
 export { CFChat } from "./cf-chat.ts";

--- a/packages/ui/src/v2/components/cf-checkbox/cf-checkbox.test.ts
+++ b/packages/ui/src/v2/components/cf-checkbox/cf-checkbox.test.ts
@@ -3,7 +3,7 @@
  */
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { CFCheckbox } from "./cf-checkbox.ts";
+import { CFCheckbox } from "./index.ts";
 
 describe("CFCheckbox", () => {
   it("should be defined", () => {

--- a/packages/ui/src/v2/components/cf-checkbox/cf-checkbox.ts
+++ b/packages/ui/src/v2/components/cf-checkbox/cf-checkbox.ts
@@ -385,5 +385,3 @@ export class CFCheckbox extends BaseElement {
       super.blur();
     }
   }
-
-  globalThis.customElements.define("cf-checkbox", CFCheckbox);

--- a/packages/ui/src/v2/components/cf-checkbox/index.ts
+++ b/packages/ui/src/v2/components/cf-checkbox/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-checkbox")) {
   customElements.define("cf-checkbox", CFCheckbox);
 }
 
+export type { CFCheckbox as CFCheckboxElement } from "./cf-checkbox.ts";
+
 export { CFCheckbox };

--- a/packages/ui/src/v2/components/cf-chevron-button/cf-chevron-button.ts
+++ b/packages/ui/src/v2/components/cf-chevron-button/cf-chevron-button.ts
@@ -200,7 +200,3 @@ export class CFChevronButton extends BaseElement {
     `;
   }
 }
-
-if (!globalThis.customElements.get("cf-chevron-button")) {
-  globalThis.customElements.define("cf-chevron-button", CFChevronButton);
-}

--- a/packages/ui/src/v2/components/cf-chevron-button/index.ts
+++ b/packages/ui/src/v2/components/cf-chevron-button/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-chevron-button")) {
   customElements.define("cf-chevron-button", CFChevronButton);
 }
 
+export type { CFChevronButton as CFChevronButtonElement } from "./cf-chevron-button.ts";
+
 export { CFChevronButton };

--- a/packages/ui/src/v2/components/cf-chip/cf-chip.ts
+++ b/packages/ui/src/v2/components/cf-chip/cf-chip.ts
@@ -317,5 +317,3 @@ export class CFChip extends BaseElement {
     `;
   }
 }
-
-customElements.define("cf-chip", CFChip);

--- a/packages/ui/src/v2/components/cf-chip/index.ts
+++ b/packages/ui/src/v2/components/cf-chip/index.ts
@@ -1,0 +1,8 @@
+import { CFChip } from "./cf-chip.ts";
+
+if (!customElements.get("cf-chip")) {
+  customElements.define("cf-chip", CFChip);
+}
+
+export { CFChip };
+export type { CFChip as CFChipElement } from "./cf-chip.ts";

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { CFCodeEditor, MimeType } from "./cf-code-editor.ts";
+import { CFCodeEditor, MimeType } from "./index.ts";
 
 describe("CFCodeEditor", () => {
   it("should create element instance", () => {

--- a/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/cf-code-editor.ts
@@ -1837,5 +1837,3 @@ export class CFCodeEditor extends BaseElement {
     });
   }
 }
-
-globalThis.customElements.define("cf-code-editor", CFCodeEditor);

--- a/packages/ui/src/v2/components/cf-code-editor/index.ts
+++ b/packages/ui/src/v2/components/cf-code-editor/index.ts
@@ -1,8 +1,12 @@
-import { CFCodeEditor, MimeType } from "./cf-code-editor.ts";
+import { CFCodeEditor } from "./cf-code-editor.ts";
+
+import { MimeType } from "./cf-code-editor.ts";
 
 if (!customElements.get("cf-code-editor")) {
   customElements.define("cf-code-editor", CFCodeEditor);
 }
+
+export type { CFCodeEditor as CFCodeEditorElement } from "./cf-code-editor.ts";
 
 export { CFCodeEditor, MimeType };
 export type { MimeType as MimeTypeType };

--- a/packages/ui/src/v2/components/cf-collapsible/cf-collapsible.ts
+++ b/packages/ui/src/v2/components/cf-collapsible/cf-collapsible.ts
@@ -255,5 +255,3 @@ export class CFCollapsible extends BaseElement {
     }
   }
 }
-
-globalThis.customElements.define("cf-collapsible", CFCollapsible);

--- a/packages/ui/src/v2/components/cf-collapsible/index.ts
+++ b/packages/ui/src/v2/components/cf-collapsible/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-collapsible")) {
   customElements.define("cf-collapsible", CFCollapsible);
 }
 
+export type { CFCollapsible as CFCollapsibleElement } from "./cf-collapsible.ts";
+
 export { CFCollapsible };

--- a/packages/ui/src/v2/components/cf-copy-button/cf-copy-button.test.ts
+++ b/packages/ui/src/v2/components/cf-copy-button/cf-copy-button.test.ts
@@ -3,7 +3,7 @@
  */
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { CFCopyButton } from "./cf-copy-button.ts";
+import { CFCopyButton } from "./index.ts";
 
 describe("CFCopyButton", () => {
   it("should be defined", () => {

--- a/packages/ui/src/v2/components/cf-copy-button/cf-copy-button.ts
+++ b/packages/ui/src/v2/components/cf-copy-button/cf-copy-button.ts
@@ -196,5 +196,3 @@ export class CFCopyButton extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-copy-button", CFCopyButton);

--- a/packages/ui/src/v2/components/cf-copy-button/index.ts
+++ b/packages/ui/src/v2/components/cf-copy-button/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-copy-button")) {
   customElements.define("cf-copy-button", CFCopyButton);
 }
 
+export type { CFCopyButton as CFCopyButtonElement } from "./cf-copy-button.ts";
+
 export { CFCopyButton };

--- a/packages/ui/src/v2/components/cf-drag-source/cf-drag-source.ts
+++ b/packages/ui/src/v2/components/cf-drag-source/cf-drag-source.ts
@@ -8,7 +8,7 @@ import {
   updateDragPointer,
 } from "../../core/drag-state.ts";
 import type { CellHandle } from "@commonfabric/runtime-client";
-import "../cf-cell-context/cf-cell-context.ts";
+import "../cf-cell-context/index.ts";
 
 /**
  * CFDragSource - Wraps draggable content and initiates drag operations
@@ -251,8 +251,6 @@ export class CFDragSource extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-drag-source", CFDragSource);
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/ui/src/v2/components/cf-drag-source/index.ts
+++ b/packages/ui/src/v2/components/cf-drag-source/index.ts
@@ -1,1 +1,9 @@
+import { CFDragSource } from "./cf-drag-source.ts";
+
+if (!customElements.get("cf-drag-source")) {
+  customElements.define("cf-drag-source", CFDragSource);
+}
+
+export type { CFDragSource as CFDragSourceElement } from "./cf-drag-source.ts";
+
 export { CFDragSource } from "./cf-drag-source.ts";

--- a/packages/ui/src/v2/components/cf-draggable/cf-draggable.ts
+++ b/packages/ui/src/v2/components/cf-draggable/cf-draggable.ts
@@ -1,8 +1,7 @@
 import { css, html } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { property, state } from "lit/decorators.js";
 import { BaseElement } from "../../core/base-element.ts";
 
-@customElement("cf-draggable")
 export class CFDraggable extends BaseElement {
   @property({ type: Number })
   accessor x = 0;

--- a/packages/ui/src/v2/components/cf-draggable/index.ts
+++ b/packages/ui/src/v2/components/cf-draggable/index.ts
@@ -1,1 +1,8 @@
-export * from "./cf-draggable.ts";
+import { CFDraggable } from "./cf-draggable.ts";
+
+if (!customElements.get("cf-draggable")) {
+  customElements.define("cf-draggable", CFDraggable);
+}
+
+export { CFDraggable };
+export type { CFDraggable as CFDraggableElement } from "./cf-draggable.ts";

--- a/packages/ui/src/v2/components/cf-drop-zone/cf-drop-zone.ts
+++ b/packages/ui/src/v2/components/cf-drop-zone/cf-drop-zone.ts
@@ -197,8 +197,6 @@ export class CFDropZone extends BaseElement {
   }
 }
 
-globalThis.customElements.define("cf-drop-zone", CFDropZone);
-
 declare global {
   interface HTMLElementTagNameMap {
     "cf-drop-zone": CFDropZone;

--- a/packages/ui/src/v2/components/cf-drop-zone/index.ts
+++ b/packages/ui/src/v2/components/cf-drop-zone/index.ts
@@ -1,1 +1,9 @@
+import { CFDropZone } from "./cf-drop-zone.ts";
+
+if (!customElements.get("cf-drop-zone")) {
+  customElements.define("cf-drop-zone", CFDropZone);
+}
+
+export type { CFDropZone as CFDropZoneElement } from "./cf-drop-zone.ts";
+
 export { CFDropZone } from "./cf-drop-zone.ts";

--- a/packages/ui/src/v2/components/cf-empty-state/cf-empty-state.test.ts
+++ b/packages/ui/src/v2/components/cf-empty-state/cf-empty-state.test.ts
@@ -3,7 +3,7 @@
  */
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { CFEmptyState } from "./cf-empty-state.ts";
+import { CFEmptyState } from "./index.ts";
 
 describe("CFEmptyState", () => {
   it("should be defined", () => {

--- a/packages/ui/src/v2/components/cf-empty-state/cf-empty-state.ts
+++ b/packages/ui/src/v2/components/cf-empty-state/cf-empty-state.ts
@@ -146,5 +146,3 @@ export class CFEmptyState extends BaseElement {
     this._hasAction = slot.assignedElements().length > 0;
   };
 }
-
-globalThis.customElements.define("cf-empty-state", CFEmptyState);

--- a/packages/ui/src/v2/components/cf-empty-state/index.ts
+++ b/packages/ui/src/v2/components/cf-empty-state/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-empty-state")) {
   customElements.define("cf-empty-state", CFEmptyState);
 }
 
+export type { CFEmptyState as CFEmptyStateElement } from "./cf-empty-state.ts";
+
 export { CFEmptyState };

--- a/packages/ui/src/v2/components/cf-fab/cf-fab.ts
+++ b/packages/ui/src/v2/components/cf-fab/cf-fab.ts
@@ -6,7 +6,7 @@ import { isCellHandle } from "@commonfabric/runtime-client";
 import { fabAnimations } from "./styles.ts";
 import { stringSchema } from "@commonfabric/runner/schemas";
 // Side-effect import to ensure cf-message-beads is registered
-import "../cf-message-beads/cf-message-beads.ts";
+import "../cf-message-beads/index.ts";
 
 /**
  * A morphing floating action button that expands into a panel.
@@ -690,8 +690,4 @@ export class CFFab extends BaseElement {
         : nothing}
     `;
   }
-}
-
-if (!globalThis.customElements.get("cf-fab")) {
-  globalThis.customElements.define("cf-fab", CFFab);
 }

--- a/packages/ui/src/v2/components/cf-fab/index.ts
+++ b/packages/ui/src/v2/components/cf-fab/index.ts
@@ -4,5 +4,6 @@ if (!customElements.get("cf-fab")) {
   customElements.define("cf-fab", CFFab);
 }
 
+export type { CFFab as CFFabElement } from "./cf-fab.ts";
+
 export { CFFab };
-export type { CFFab as CFFabElement };

--- a/packages/ui/src/v2/components/cf-field/cf-field.test.ts
+++ b/packages/ui/src/v2/components/cf-field/cf-field.test.ts
@@ -3,7 +3,7 @@
  */
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { CFField } from "./cf-field.ts";
+import { CFField } from "./index.ts";
 
 describe("CFField", () => {
   it("should be defined", () => {

--- a/packages/ui/src/v2/components/cf-field/cf-field.ts
+++ b/packages/ui/src/v2/components/cf-field/cf-field.ts
@@ -179,5 +179,3 @@ export class CFField extends BaseElement {
     return (assigned[0] as HTMLElement) ?? null;
   }
 }
-
-globalThis.customElements.define("cf-field", CFField);

--- a/packages/ui/src/v2/components/cf-field/index.ts
+++ b/packages/ui/src/v2/components/cf-field/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-field")) {
   customElements.define("cf-field", CFField);
 }
 
+export type { CFField as CFFieldElement } from "./cf-field.ts";
+
 export { CFField };

--- a/packages/ui/src/v2/components/cf-file-download/cf-file-download.test.ts
+++ b/packages/ui/src/v2/components/cf-file-download/cf-file-download.test.ts
@@ -3,7 +3,7 @@
  */
 import { expect } from "@std/expect";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
-import { CFFileDownload } from "./cf-file-download.ts";
+import { CFFileDownload } from "./index.ts";
 
 /**
  * Interface for accessing private members of CFFileDownload in tests.

--- a/packages/ui/src/v2/components/cf-file-download/cf-file-download.ts
+++ b/packages/ui/src/v2/components/cf-file-download/cf-file-download.ts
@@ -3,7 +3,7 @@ import { state } from "lit/decorators.js";
 import { BaseElement } from "../../core/base-element.ts";
 import { type CellHandle } from "@commonfabric/runtime-client";
 import { createStringCellController } from "../../core/cell-controller.ts";
-import "../cf-button/cf-button.ts";
+import "../cf-button/index.ts";
 
 /**
  * File System Access API types
@@ -815,5 +815,3 @@ export class CFFileDownload extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-file-download", CFFileDownload);

--- a/packages/ui/src/v2/components/cf-file-download/index.ts
+++ b/packages/ui/src/v2/components/cf-file-download/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-file-download")) {
   customElements.define("cf-file-download", CFFileDownload);
 }
 
+export type { CFFileDownload as CFFileDownloadElement } from "./cf-file-download.ts";
+
 export { CFFileDownload };

--- a/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
+++ b/packages/ui/src/v2/components/cf-file-input/cf-file-input.ts
@@ -18,7 +18,7 @@ import {
   type StoreFileOptions,
   uploadFile,
 } from "../../utils/file-cell-storage.ts";
-import "../cf-button/cf-button.ts";
+import "../cf-button/index.ts";
 
 export type FileData = StoredFile;
 
@@ -519,5 +519,3 @@ export class CFFileInput extends BaseElement {
     `;
   }
 }
-
-customElements.define("cf-file-input", CFFileInput);

--- a/packages/ui/src/v2/components/cf-file-input/index.ts
+++ b/packages/ui/src/v2/components/cf-file-input/index.ts
@@ -1,1 +1,9 @@
+import { CFFileInput } from "./cf-file-input.ts";
+
+if (!customElements.get("cf-file-input")) {
+  customElements.define("cf-file-input", CFFileInput);
+}
+
+export type { CFFileInput as CFFileInputElement } from "./cf-file-input.ts";
+
 export { CFFileInput, type FileData } from "./cf-file-input.ts";

--- a/packages/ui/src/v2/components/cf-fragment/cf-fragment.ts
+++ b/packages/ui/src/v2/components/cf-fragment/cf-fragment.ts
@@ -28,5 +28,3 @@ export class CFFragment extends HTMLElement {
     this.style.display = "contents";
   }
 }
-
-globalThis.customElements.define("cf-fragment", CFFragment);

--- a/packages/ui/src/v2/components/cf-fragment/index.ts
+++ b/packages/ui/src/v2/components/cf-fragment/index.ts
@@ -1,1 +1,9 @@
+import { CFFragment } from "./cf-fragment.ts";
+
+if (!customElements.get("cf-fragment")) {
+  customElements.define("cf-fragment", CFFragment);
+}
+
+export type { CFFragment as CFFragmentElement } from "./cf-fragment.ts";
+
 export * from "./cf-fragment.ts";

--- a/packages/ui/src/v2/components/cf-google-oauth/cf-google-oauth.ts
+++ b/packages/ui/src/v2/components/cf-google-oauth/cf-google-oauth.ts
@@ -1,4 +1,4 @@
-import { CFOAuth } from "../cf-oauth/cf-oauth.ts";
+import { CFOAuth } from "../cf-oauth/index.ts";
 import type { OAuthData } from "../cf-oauth/cf-oauth.ts";
 
 /**
@@ -29,5 +29,3 @@ export class CFGoogleOAuth extends CFOAuth {
     this.tokenField = "token";
   }
 }
-
-globalThis.customElements.define("cf-google-oauth", CFGoogleOAuth);

--- a/packages/ui/src/v2/components/cf-google-oauth/index.ts
+++ b/packages/ui/src/v2/components/cf-google-oauth/index.ts
@@ -1,1 +1,9 @@
+import { CFGoogleOAuth } from "./cf-google-oauth.ts";
+
+if (!customElements.get("cf-google-oauth")) {
+  customElements.define("cf-google-oauth", CFGoogleOAuth);
+}
+
+export type { CFGoogleOAuth as CFGoogleOAuthElement } from "./cf-google-oauth.ts";
+
 export * from "./cf-google-oauth.ts";

--- a/packages/ui/src/v2/components/cf-grid/cf-grid.ts
+++ b/packages/ui/src/v2/components/cf-grid/cf-grid.ts
@@ -266,5 +266,3 @@ export class CFGrid extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-grid", CFGrid);

--- a/packages/ui/src/v2/components/cf-grid/index.ts
+++ b/packages/ui/src/v2/components/cf-grid/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-grid")) {
   customElements.define("cf-grid", CFGrid);
 }
 
+export type { CFGrid as CFGridElement } from "./cf-grid.ts";
+
 export { CFGrid };

--- a/packages/ui/src/v2/components/cf-heading/cf-heading.ts
+++ b/packages/ui/src/v2/components/cf-heading/cf-heading.ts
@@ -124,7 +124,3 @@ export class CFHeading extends BaseElement {
     `;
   }
 }
-
-if (!customElements.get("cf-heading")) {
-  customElements.define("cf-heading", CFHeading);
-}

--- a/packages/ui/src/v2/components/cf-heading/index.ts
+++ b/packages/ui/src/v2/components/cf-heading/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-heading")) {
   customElements.define("cf-heading", CFHeading);
 }
 
+export type { CFHeading as CFHeadingElement } from "./cf-heading.ts";
+
 export { CFHeading };

--- a/packages/ui/src/v2/components/cf-hgroup/cf-hgroup.ts
+++ b/packages/ui/src/v2/components/cf-hgroup/cf-hgroup.ts
@@ -124,5 +124,3 @@ export class CFHGroup extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-hgroup", CFHGroup);

--- a/packages/ui/src/v2/components/cf-hgroup/index.ts
+++ b/packages/ui/src/v2/components/cf-hgroup/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-hgroup")) {
   customElements.define("cf-hgroup", CFHGroup);
 }
 
+export type { CFHGroup as CFHGroupElement } from "./cf-hgroup.ts";
+
 export { CFHGroup };

--- a/packages/ui/src/v2/components/cf-host-accessibility.browser.test.ts
+++ b/packages/ui/src/v2/components/cf-host-accessibility.browser.test.ts
@@ -1,8 +1,8 @@
 import { assertEquals, assertInstanceOf } from "@std/assert";
-import { CFButton } from "./cf-button/cf-button.ts";
-import { CFInput } from "./cf-input/cf-input.ts";
-import { CFSelect } from "./cf-select/cf-select.ts";
-import { CFTextarea } from "./cf-textarea/cf-textarea.ts";
+import { CFButton } from "./cf-button/index.ts";
+import { CFInput } from "./cf-input/index.ts";
+import { CFSelect } from "./cf-select/index.ts";
+import { CFTextarea } from "./cf-textarea/index.ts";
 
 const nextFrame = () =>
   new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));

--- a/packages/ui/src/v2/components/cf-hscroll/cf-hscroll.ts
+++ b/packages/ui/src/v2/components/cf-hscroll/cf-hscroll.ts
@@ -261,5 +261,3 @@ export class CFHScroll extends BaseElement {
     }
   }
 }
-
-globalThis.customElements.define("cf-hscroll", CFHScroll);

--- a/packages/ui/src/v2/components/cf-hscroll/index.ts
+++ b/packages/ui/src/v2/components/cf-hscroll/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-hscroll")) {
   customElements.define("cf-hscroll", CFHScroll);
 }
 
+export type { CFHScroll as CFHScrollElement } from "./cf-hscroll.ts";
+
 export { CFHScroll };

--- a/packages/ui/src/v2/components/cf-hstack/cf-hstack.test.ts
+++ b/packages/ui/src/v2/components/cf-hstack/cf-hstack.test.ts
@@ -3,7 +3,7 @@
  */
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { CFHStack } from "./cf-hstack.ts";
+import { CFHStack } from "./index.ts";
 
 /**
  * Extracts the class info object passed to classMap in render().

--- a/packages/ui/src/v2/components/cf-hstack/cf-hstack.ts
+++ b/packages/ui/src/v2/components/cf-hstack/cf-hstack.ts
@@ -171,5 +171,3 @@ export class CFHStack extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-hstack", CFHStack);

--- a/packages/ui/src/v2/components/cf-hstack/index.ts
+++ b/packages/ui/src/v2/components/cf-hstack/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-hstack")) {
   customElements.define("cf-hstack", CFHStack);
 }
 
+export type { CFHStack as CFHStackElement } from "./cf-hstack.ts";
+
 export { CFHStack };

--- a/packages/ui/src/v2/components/cf-iframe/cf-iframe.ts
+++ b/packages/ui/src/v2/components/cf-iframe/cf-iframe.ts
@@ -207,5 +207,3 @@ export class CFIframe extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-iframe", CFIframe);

--- a/packages/ui/src/v2/components/cf-iframe/index.ts
+++ b/packages/ui/src/v2/components/cf-iframe/index.ts
@@ -1,1 +1,9 @@
+import { CFIframe } from "./cf-iframe.ts";
+
+if (!customElements.get("cf-iframe")) {
+  customElements.define("cf-iframe", CFIframe);
+}
+
+export type { CFIframe as CFIframeElement } from "./cf-iframe.ts";
+
 export * from "./cf-iframe.ts";

--- a/packages/ui/src/v2/components/cf-image-input/cf-image-input.ts
+++ b/packages/ui/src/v2/components/cf-image-input/cf-image-input.ts
@@ -1,7 +1,7 @@
 import { html, type TemplateResult } from "lit";
 import { property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
-import { CFFileInput } from "../cf-file-input/cf-file-input.ts";
+import { CFFileInput } from "../cf-file-input/index.ts";
 import type { StoredFile } from "../../utils/file-cell-storage.ts";
 import {
   compressImage,
@@ -226,5 +226,3 @@ function readImageDimensions(
     img.src = objectUrl;
   });
 }
-
-customElements.define("cf-image-input", CFImageInput);

--- a/packages/ui/src/v2/components/cf-image-input/index.ts
+++ b/packages/ui/src/v2/components/cf-image-input/index.ts
@@ -4,5 +4,7 @@ if (!customElements.get("cf-image-input")) {
   customElements.define("cf-image-input", CFImageInput);
 }
 
+export type { CFImageInput as CFImageInputElement } from "./cf-image-input.ts";
+
 export { CFImageInput };
 export type { ExifData, ImageData } from "./cf-image-input.ts";

--- a/packages/ui/src/v2/components/cf-input-otp/cf-input-otp.ts
+++ b/packages/ui/src/v2/components/cf-input-otp/cf-input-otp.ts
@@ -272,5 +272,3 @@ export class CFInputOTP extends BaseElement {
     this.focus();
   }
 }
-
-globalThis.customElements.define("cf-input-otp", CFInputOTP);

--- a/packages/ui/src/v2/components/cf-input-otp/index.ts
+++ b/packages/ui/src/v2/components/cf-input-otp/index.ts
@@ -4,5 +4,6 @@ if (!customElements.get("cf-input-otp")) {
   customElements.define("cf-input-otp", CFInputOTP);
 }
 
-export { CFInputOTP };
 export type { CFInputOTP as CFInputOTPElement } from "./cf-input-otp.ts";
+
+export { CFInputOTP };

--- a/packages/ui/src/v2/components/cf-input/cf-input.test.ts
+++ b/packages/ui/src/v2/components/cf-input/cf-input.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createMockCellHandle } from "../../test-utils/mock-cell-handle.ts";
-import { CFInput, INPUT_PATTERNS } from "./cf-input.ts";
+import { CFInput, INPUT_PATTERNS } from "./index.ts";
 
 // NOTE: Full DOM interaction tests (input events, Cell two-way binding,
 // timing strategy integration, validation UI) require Lit's rendering

--- a/packages/ui/src/v2/components/cf-input/cf-input.ts
+++ b/packages/ui/src/v2/components/cf-input/cf-input.ts
@@ -989,5 +989,3 @@ export class CFInput extends BaseElement {
     this.input?.setCustomValidity(message);
   }
 }
-
-globalThis.customElements.define("cf-input", CFInput);

--- a/packages/ui/src/v2/components/cf-input/index.ts
+++ b/packages/ui/src/v2/components/cf-input/index.ts
@@ -1,8 +1,13 @@
-import { CFInput, InputType } from "./cf-input.ts";
+import { CFInput } from "./cf-input.ts";
+
+import { InputType } from "./cf-input.ts";
 
 if (!customElements.get("cf-input")) {
   customElements.define("cf-input", CFInput);
 }
+
+export type { CFInput as CFInputElement } from "./cf-input.ts";
+export { INPUT_PATTERNS } from "./cf-input.ts";
 
 export { CFInput };
 export type { InputType };

--- a/packages/ui/src/v2/components/cf-kbd/cf-kbd.ts
+++ b/packages/ui/src/v2/components/cf-kbd/cf-kbd.ts
@@ -48,5 +48,3 @@ export class CFKbd extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-kbd", CFKbd);

--- a/packages/ui/src/v2/components/cf-kbd/index.ts
+++ b/packages/ui/src/v2/components/cf-kbd/index.ts
@@ -4,4 +4,5 @@ if (!customElements.get("cf-kbd")) {
   customElements.define("cf-kbd", CFKbd);
 }
 
+export { CFKbd };
 export type { CFKbd as CFKbdElement } from "./cf-kbd.ts";

--- a/packages/ui/src/v2/components/cf-keybind/cf-keybind.ts
+++ b/packages/ui/src/v2/components/cf-keybind/cf-keybind.ts
@@ -214,5 +214,3 @@ export class CFKeybind extends BaseElement {
     };
   }
 }
-
-globalThis.customElements.define("cf-keybind", CFKeybind);

--- a/packages/ui/src/v2/components/cf-keybind/index.ts
+++ b/packages/ui/src/v2/components/cf-keybind/index.ts
@@ -4,5 +4,6 @@ if (!customElements.get("cf-keybind")) {
   customElements.define("cf-keybind", CFKeybind);
 }
 
-export { CFKeybind };
 export type { CFKeybind as CFKeybindElement } from "./cf-keybind.ts";
+
+export { CFKeybind };

--- a/packages/ui/src/v2/components/cf-label/cf-label.ts
+++ b/packages/ui/src/v2/components/cf-label/cf-label.ts
@@ -165,5 +165,3 @@ export class CFLabel extends BaseElement {
     }
   }
 }
-
-globalThis.customElements.define("cf-label", CFLabel);

--- a/packages/ui/src/v2/components/cf-label/index.ts
+++ b/packages/ui/src/v2/components/cf-label/index.ts
@@ -4,5 +4,6 @@ if (!customElements.get("cf-label")) {
   customElements.define("cf-label", CFLabel);
 }
 
-export { CFLabel };
 export type { CFLabel as CFLabelElement } from "./cf-label.ts";
+
+export { CFLabel };

--- a/packages/ui/src/v2/components/cf-link-preview/cf-link-preview.ts
+++ b/packages/ui/src/v2/components/cf-link-preview/cf-link-preview.ts
@@ -341,5 +341,3 @@ export class CFLinkPreview extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-link-preview", CFLinkPreview);

--- a/packages/ui/src/v2/components/cf-link-preview/index.ts
+++ b/packages/ui/src/v2/components/cf-link-preview/index.ts
@@ -4,5 +4,6 @@ if (!customElements.get("cf-link-preview")) {
   customElements.define("cf-link-preview", CFLinkPreview);
 }
 
-export { CFLinkPreview };
 export type { CFLinkPreview as CFLinkPreviewElement } from "./cf-link-preview.ts";
+
+export { CFLinkPreview };

--- a/packages/ui/src/v2/components/cf-list-item/cf-list-item.ts
+++ b/packages/ui/src/v2/components/cf-list-item/cf-list-item.ts
@@ -334,5 +334,3 @@ export class CFListItem extends BaseElement {
     this._hasDetail = slot.assignedElements().length > 0;
   };
 }
-
-globalThis.customElements.define("cf-list-item", CFListItem);

--- a/packages/ui/src/v2/components/cf-list-item/index.ts
+++ b/packages/ui/src/v2/components/cf-list-item/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-list-item")) {
   customElements.define("cf-list-item", CFListItem);
 }
 
+export type { CFListItem as CFListItemElement } from "./cf-list-item.ts";
+
 export { CFListItem };

--- a/packages/ui/src/v2/components/cf-loader/cf-loader.ts
+++ b/packages/ui/src/v2/components/cf-loader/cf-loader.ts
@@ -305,5 +305,3 @@ export class CFLoader extends BaseElement {
     this._elapsedMs = 0;
   }
 }
-
-globalThis.customElements.define("cf-loader", CFLoader);

--- a/packages/ui/src/v2/components/cf-loader/index.ts
+++ b/packages/ui/src/v2/components/cf-loader/index.ts
@@ -1,8 +1,12 @@
-import { CFLoader, LoaderSize } from "./cf-loader.ts";
+import { CFLoader } from "./cf-loader.ts";
+
+import { LoaderSize } from "./cf-loader.ts";
 
 if (!customElements.get("cf-loader")) {
   customElements.define("cf-loader", CFLoader);
 }
+
+export type { CFLoader as CFLoaderElement } from "./cf-loader.ts";
 
 export { CFLoader };
 export type { LoaderSize };

--- a/packages/ui/src/v2/components/cf-location/index.ts
+++ b/packages/ui/src/v2/components/cf-location/index.ts
@@ -4,5 +4,7 @@ if (!customElements.get("cf-location")) {
   customElements.define("cf-location", CFLocation);
 }
 
+export type { CFLocation as CFLocationElement } from "./cf-location.ts";
+
 export { CFLocation };
 export type { LocationData } from "./cf-location.ts";

--- a/packages/ui/src/v2/components/cf-map/cf-map.ts
+++ b/packages/ui/src/v2/components/cf-map/cf-map.ts
@@ -24,7 +24,7 @@ import type {
   MapPolyline,
   MapValue,
 } from "./types.ts";
-import "../cf-render/cf-render.ts";
+import "../cf-render/index.ts";
 
 // Default map configuration
 const DEFAULT_CENTER: LatLng = { lat: 37.7749, lng: -122.4194 }; // San Francisco

--- a/packages/ui/src/v2/components/cf-map/index.ts
+++ b/packages/ui/src/v2/components/cf-map/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { CFMap } from "./cf-map.ts";
+
 import type {
   Bounds,
   CfBoundsChangeDetail,
@@ -20,6 +21,8 @@ import type {
 if (!customElements.get("cf-map")) {
   customElements.define("cf-map", CFMap);
 }
+
+export type { CFMap as CFMapElement } from "./cf-map.ts";
 
 export { CFMap };
 export type {

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { CFMarkdown } from "./cf-markdown.ts";
+import { CFMarkdown } from "./index.ts";
 import {
   createMockCellHandle,
   pushUpdate,

--- a/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
+++ b/packages/ui/src/v2/components/cf-markdown/cf-markdown.ts
@@ -5,8 +5,8 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { classMap } from "lit/directives/class-map.js";
 import { marked } from "marked";
 import { BaseElement } from "../../core/base-element.ts";
-import "../cf-copy-button/cf-copy-button.ts";
-import "../cf-cell-link/cf-cell-link.ts";
+import "../cf-copy-button/index.ts";
+import "../cf-cell-link/index.ts";
 import {
   applyThemeToElement,
   type CFTheme,
@@ -626,5 +626,3 @@ export class CFMarkdown extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-markdown", CFMarkdown);

--- a/packages/ui/src/v2/components/cf-markdown/index.ts
+++ b/packages/ui/src/v2/components/cf-markdown/index.ts
@@ -4,6 +4,7 @@ if (!customElements.get("cf-markdown")) {
   customElements.define("cf-markdown", CFMarkdown);
 }
 
-export { CFMarkdown };
 export type { CFMarkdown as CFMarkdownElement } from "./cf-markdown.ts";
+
+export { CFMarkdown };
 export type { MarkdownVariant } from "./cf-markdown.ts";

--- a/packages/ui/src/v2/components/cf-message-beads/cf-message-beads.ts
+++ b/packages/ui/src/v2/components/cf-message-beads/cf-message-beads.ts
@@ -374,6 +374,4 @@ export class CFMessageBeads extends BaseElement {
   }
 }
 
-globalThis.customElements.define("cf-message-beads", CFMessageBeads);
-
 export type { CFMessageBeads as CFMessageBeadsElement };

--- a/packages/ui/src/v2/components/cf-message-beads/index.ts
+++ b/packages/ui/src/v2/components/cf-message-beads/index.ts
@@ -1,1 +1,9 @@
+import { CFMessageBeads } from "./cf-message-beads.ts";
+
+if (!customElements.get("cf-message-beads")) {
+  customElements.define("cf-message-beads", CFMessageBeads);
+}
+
+export type { CFMessageBeads as CFMessageBeadsElement } from "./cf-message-beads.ts";
+
 export { CFMessageBeads } from "./cf-message-beads.ts";

--- a/packages/ui/src/v2/components/cf-message-input/cf-message-input.ts
+++ b/packages/ui/src/v2/components/cf-message-input/cf-message-input.ts
@@ -135,5 +135,3 @@ export class CFMessageInput extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-message-input", CFMessageInput);

--- a/packages/ui/src/v2/components/cf-message-input/index.ts
+++ b/packages/ui/src/v2/components/cf-message-input/index.ts
@@ -1,3 +1,9 @@
 import { CFMessageInput } from "./cf-message-input.ts";
 
+if (!customElements.get("cf-message-input")) {
+  customElements.define("cf-message-input", CFMessageInput);
+}
+
+export type { CFMessageInput as CFMessageInputElement } from "./cf-message-input.ts";
+
 export { CFMessageInput };

--- a/packages/ui/src/v2/components/cf-modal-provider/cf-modal-provider.ts
+++ b/packages/ui/src/v2/components/cf-modal-provider/cf-modal-provider.ts
@@ -154,5 +154,3 @@ export class CFModalProvider extends LitElement {
     `;
   }
 }
-
-customElements.define("cf-modal-provider", CFModalProvider);

--- a/packages/ui/src/v2/components/cf-modal-provider/index.ts
+++ b/packages/ui/src/v2/components/cf-modal-provider/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-modal-provider")) {
   customElements.define("cf-modal-provider", CFModalProvider);
 }
 
+export type { CFModalProvider as CFModalProviderElement } from "./cf-modal-provider.ts";
+
 export { CFModalProvider };

--- a/packages/ui/src/v2/components/cf-modal/cf-modal.ts
+++ b/packages/ui/src/v2/components/cf-modal/cf-modal.ts
@@ -510,5 +510,3 @@ export class CFModal extends BaseElement {
     `;
   }
 }
-
-customElements.define("cf-modal", CFModal);

--- a/packages/ui/src/v2/components/cf-modal/index.ts
+++ b/packages/ui/src/v2/components/cf-modal/index.ts
@@ -4,5 +4,7 @@ if (!customElements.get("cf-modal")) {
   customElements.define("cf-modal", CFModal);
 }
 
+export type { CFModal as CFModalElement } from "./cf-modal.ts";
+
 export { CFModal };
 export { modalStyles } from "./styles.ts";

--- a/packages/ui/src/v2/components/cf-oauth/cf-oauth.ts
+++ b/packages/ui/src/v2/components/cf-oauth/cf-oauth.ts
@@ -1,7 +1,7 @@
 import { css, html } from "lit";
 import { BaseElement } from "../../core/base-element.ts";
 import type { CellHandle } from "@commonfabric/runtime-client";
-import { CFPiece } from "../cf-piece/cf-piece.ts";
+import { CFPiece } from "../cf-piece/index.ts";
 
 export interface OAuthData {
   accessToken?: string;
@@ -373,5 +373,3 @@ export class CFOAuth extends BaseElement {
     `,
   ];
 }
-
-globalThis.customElements.define("cf-oauth", CFOAuth);

--- a/packages/ui/src/v2/components/cf-oauth/index.ts
+++ b/packages/ui/src/v2/components/cf-oauth/index.ts
@@ -1,1 +1,10 @@
+import { CFOAuth } from "./cf-oauth.ts";
+
+if (!customElements.get("cf-oauth")) {
+  customElements.define("cf-oauth", CFOAuth);
+}
+
+export type { CFOAuth as CFOAuthElement } from "./cf-oauth.ts";
+export type { OAuthData } from "./cf-oauth.ts";
+
 export * from "./cf-oauth.ts";

--- a/packages/ui/src/v2/components/cf-picker/cf-picker.test.ts
+++ b/packages/ui/src/v2/components/cf-picker/cf-picker.test.ts
@@ -3,7 +3,7 @@
  */
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { CFPicker } from "./cf-picker.ts";
+import { CFPicker } from "./index.ts";
 
 describe("CFPicker", () => {
   it("should be defined", () => {

--- a/packages/ui/src/v2/components/cf-picker/cf-picker.ts
+++ b/packages/ui/src/v2/components/cf-picker/cf-picker.ts
@@ -6,7 +6,7 @@ import {
 } from "../../core/cell-controller.ts";
 import { type CellHandle } from "@commonfabric/runtime-client";
 import { numberSchema } from "@commonfabric/runner/schemas";
-import "../cf-render/cf-render.ts";
+import "../cf-render/index.ts";
 
 /**
  * CFPicker - Simple carousel selection component for cells with UI
@@ -505,8 +505,6 @@ export class CFPicker extends BaseElement {
     this._selectIndex(index);
   }
 }
-
-globalThis.customElements.define("cf-picker", CFPicker);
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/ui/src/v2/components/cf-picker/index.ts
+++ b/packages/ui/src/v2/components/cf-picker/index.ts
@@ -1,1 +1,9 @@
+import { CFPicker } from "./cf-picker.ts";
+
+if (!customElements.get("cf-picker")) {
+  customElements.define("cf-picker", CFPicker);
+}
+
+export type { CFPicker as CFPickerElement } from "./cf-picker.ts";
+
 export { CFPicker } from "./cf-picker.ts";

--- a/packages/ui/src/v2/components/cf-piece/cf-piece.ts
+++ b/packages/ui/src/v2/components/cf-piece/cf-piece.ts
@@ -63,5 +63,3 @@ export class CFPiece extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-piece", CFPiece);

--- a/packages/ui/src/v2/components/cf-piece/index.ts
+++ b/packages/ui/src/v2/components/cf-piece/index.ts
@@ -1,1 +1,9 @@
+import { CFPiece } from "./cf-piece.ts";
+
+if (!customElements.get("cf-piece")) {
+  customElements.define("cf-piece", CFPiece);
+}
+
+export type { CFPiece as CFPieceElement } from "./cf-piece.ts";
+
 export * from "./cf-piece.ts";

--- a/packages/ui/src/v2/components/cf-plaid-link/cf-plaid-link.ts
+++ b/packages/ui/src/v2/components/cf-plaid-link/cf-plaid-link.ts
@@ -1,7 +1,7 @@
 import { css, html } from "lit";
 import { BaseElement } from "../../core/base-element.ts";
 import { CellHandle } from "@commonfabric/runtime-client";
-import { CFPiece } from "../cf-piece/cf-piece.ts";
+import { CFPiece } from "../cf-piece/index.ts";
 
 declare global {
   var Plaid: any;
@@ -623,5 +623,3 @@ export class CFPlaidLink extends BaseElement {
     `,
   ];
 }
-
-globalThis.customElements.define("cf-plaid-link", CFPlaidLink);

--- a/packages/ui/src/v2/components/cf-plaid-link/index.ts
+++ b/packages/ui/src/v2/components/cf-plaid-link/index.ts
@@ -1,1 +1,9 @@
+import { CFPlaidLink } from "./cf-plaid-link.ts";
+
+if (!customElements.get("cf-plaid-link")) {
+  customElements.define("cf-plaid-link", CFPlaidLink);
+}
+
+export type { CFPlaidLink as CFPlaidLinkElement } from "./cf-plaid-link.ts";
+
 export * from "./cf-plaid-link.ts";

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
@@ -5,7 +5,7 @@ import {
   CFProfileBadge,
   profileDisplayFromValue,
   profileTooltipFromValue,
-} from "./cf-profile-badge.ts";
+} from "./index.ts";
 import { identitySeal } from "./identity-seal.ts";
 
 const OWNER_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -2,7 +2,7 @@ import { css, html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import { consume } from "@lit/context";
 import { BaseElement } from "../../core/base-element.ts";
-import "../cf-avatar/cf-avatar.ts";
+import "../cf-avatar/index.ts";
 import type { AvatarSize } from "../cf-avatar/cf-avatar.ts";
 import {
   type CellHandle,
@@ -883,10 +883,6 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
       </span>
     `;
   }
-}
-
-if (!globalThis.customElements.get("cf-profile-badge")) {
-  globalThis.customElements.define("cf-profile-badge", CFProfileBadge);
 }
 
 declare global {

--- a/packages/ui/src/v2/components/cf-profile-badge/index.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/index.ts
@@ -4,9 +4,14 @@ if (!customElements.get("cf-profile-badge")) {
   customElements.define("cf-profile-badge", CFProfileBadge);
 }
 
+export type { CFProfileBadge as CFProfileBadgeElement } from "./cf-profile-badge.ts";
+export {
+  profileDisplayFromValue,
+  profileTooltipFromValue,
+} from "./cf-profile-badge.ts";
+
 export { CFProfileBadge };
 export type {
   ProfileBadgeDisplay,
   ProfileBadgeState,
 } from "./cf-profile-badge.ts";
-export { profileDisplayFromValue } from "./cf-profile-badge.ts";

--- a/packages/ui/src/v2/components/cf-progress/cf-progress.ts
+++ b/packages/ui/src/v2/components/cf-progress/cf-progress.ts
@@ -185,5 +185,3 @@ export class CFProgress extends BaseElement {
     this.indeterminate = false;
   }
 }
-
-globalThis.customElements.define("cf-progress", CFProgress);

--- a/packages/ui/src/v2/components/cf-progress/index.ts
+++ b/packages/ui/src/v2/components/cf-progress/index.ts
@@ -4,5 +4,6 @@ if (!customElements.get("cf-progress")) {
   customElements.define("cf-progress", CFProgress);
 }
 
+export type { CFProgress as CFProgressElement } from "./cf-progress.ts";
+
 export { CFProgress };
-export type { CFProgress as CFProgressElement };

--- a/packages/ui/src/v2/components/cf-prompt-input/cf-prompt-input.ts
+++ b/packages/ui/src/v2/components/cf-prompt-input/cf-prompt-input.ts
@@ -23,9 +23,9 @@ import {
 import { MentionController } from "../../core/mention-controller.ts";
 import { createCellController } from "../../core/cell-controller.ts";
 import { hasIncompleteUpload, toSendAttachment } from "./send-attachments.ts";
-import "../cf-button/cf-button.ts";
-import "../cf-chip/cf-chip.ts";
-import "../cf-voice-input/cf-voice-input.ts";
+import "../cf-button/index.ts";
+import "../cf-chip/index.ts";
+import "../cf-voice-input/index.ts";
 
 /**
  * Attachment data structure
@@ -1452,5 +1452,3 @@ export class CFPromptInput extends BaseElement {
     return !!this.value?.trim();
   }
 }
-
-globalThis.customElements.define("cf-prompt-input", CFPromptInput);

--- a/packages/ui/src/v2/components/cf-prompt-input/index.ts
+++ b/packages/ui/src/v2/components/cf-prompt-input/index.ts
@@ -1,1 +1,9 @@
+import { CFPromptInput } from "./cf-prompt-input.ts";
+
+if (!customElements.get("cf-prompt-input")) {
+  customElements.define("cf-prompt-input", CFPromptInput);
+}
+
+export type { CFPromptInput as CFPromptInputElement } from "./cf-prompt-input.ts";
+
 export * from "./cf-prompt-input.ts";

--- a/packages/ui/src/v2/components/cf-question/cf-question.ts
+++ b/packages/ui/src/v2/components/cf-question/cf-question.ts
@@ -251,5 +251,3 @@ export class CFQuestion extends BaseElement {
     `;
   }
 }
-
-customElements.define("cf-question", CFQuestion);

--- a/packages/ui/src/v2/components/cf-question/index.ts
+++ b/packages/ui/src/v2/components/cf-question/index.ts
@@ -1,0 +1,8 @@
+import { CFQuestion } from "./cf-question.ts";
+
+if (!customElements.get("cf-question")) {
+  customElements.define("cf-question", CFQuestion);
+}
+
+export { CFQuestion };
+export type { CFQuestion as CFQuestionElement } from "./cf-question.ts";

--- a/packages/ui/src/v2/components/cf-radio-group/cf-radio-group.ts
+++ b/packages/ui/src/v2/components/cf-radio-group/cf-radio-group.ts
@@ -441,8 +441,6 @@ export class CFRadioGroup extends BaseElement {
   }
 }
 
-globalThis.customElements.define("cf-radio-group", CFRadioGroup);
-
 /** Simple value equality for comparing radio values (strings, numbers, etc.) */
 function areLinksSame(a: any, b: any): boolean {
   if (a === b) return true;

--- a/packages/ui/src/v2/components/cf-radio-group/index.ts
+++ b/packages/ui/src/v2/components/cf-radio-group/index.ts
@@ -1,9 +1,12 @@
 import { CFRadioGroup } from "./cf-radio-group.ts";
+
 import { radioGroupStyles } from "./styles.ts";
 
 if (!customElements.get("cf-radio-group")) {
   customElements.define("cf-radio-group", CFRadioGroup);
 }
+
+export type { CFRadioGroup as CFRadioGroupElement } from "./cf-radio-group.ts";
 
 export { CFRadioGroup, radioGroupStyles };
 export type { RadioGroupOrientation, RadioItem } from "./cf-radio-group.ts";

--- a/packages/ui/src/v2/components/cf-radio/cf-radio.ts
+++ b/packages/ui/src/v2/components/cf-radio/cf-radio.ts
@@ -291,5 +291,3 @@ export class CFRadio extends BaseElement {
     super.blur();
   }
 }
-
-globalThis.customElements.define("cf-radio", CFRadio);

--- a/packages/ui/src/v2/components/cf-radio/index.ts
+++ b/packages/ui/src/v2/components/cf-radio/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-radio")) {
   customElements.define("cf-radio", CFRadio);
 }
 
+export type { CFRadio as CFRadioElement } from "./cf-radio.ts";
+
 export { CFRadio };

--- a/packages/ui/src/v2/components/cf-render/cf-render.test.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createMockCellHandle } from "../../test-utils/mock-cell-handle.ts";
 import type { CellHandle } from "@commonfabric/runtime-client";
-import { CFRender, hasVariantValue, normalizeVariant } from "./cf-render.ts";
+import { CFRender, hasVariantValue, normalizeVariant } from "./index.ts";
 
 // NOTE: Full rendering lifecycle tests (cell swap cleanup, subscription
 // management, render-into-container) require a real DOM with document.body

--- a/packages/ui/src/v2/components/cf-render/cf-render.ts
+++ b/packages/ui/src/v2/components/cf-render/cf-render.ts
@@ -11,8 +11,8 @@ import {
   preserveAppViewMode,
   urlToAppView,
 } from "@commonfabric/shell/shared";
-import "../cf-loader/cf-loader.ts";
-import "../cf-cell-link/cf-cell-link.ts";
+import "../cf-loader/index.ts";
+import "../cf-cell-link/index.ts";
 
 // Set to true to enable debug logging
 const DEBUG_LOGGING = false;
@@ -403,5 +403,3 @@ export class CFRender extends BaseElement {
     this._cleanupRender();
   }
 }
-
-globalThis.customElements.define("cf-render", CFRender);

--- a/packages/ui/src/v2/components/cf-render/index.ts
+++ b/packages/ui/src/v2/components/cf-render/index.ts
@@ -1,1 +1,10 @@
+import { CFRender } from "./cf-render.ts";
+
+if (!customElements.get("cf-render")) {
+  customElements.define("cf-render", CFRender);
+}
+
+export type { CFRender as CFRenderElement } from "./cf-render.ts";
+export { hasVariantValue, normalizeVariant } from "./cf-render.ts";
+
 export * from "./cf-render.ts";

--- a/packages/ui/src/v2/components/cf-resizable-handle/cf-resizable-handle.ts
+++ b/packages/ui/src/v2/components/cf-resizable-handle/cf-resizable-handle.ts
@@ -248,5 +248,3 @@ export class CFResizableHandle extends BaseElement {
     this.emit("cf-handle-adjust", { delta });
   }
 }
-
-globalThis.customElements.define("cf-resizable-handle", CFResizableHandle);

--- a/packages/ui/src/v2/components/cf-resizable-handle/index.ts
+++ b/packages/ui/src/v2/components/cf-resizable-handle/index.ts
@@ -1,8 +1,11 @@
 import { CFResizableHandle } from "./cf-resizable-handle.ts";
+
 import { resizableHandleStyles } from "./styles.ts";
 
 if (!customElements.get("cf-resizable-handle")) {
   customElements.define("cf-resizable-handle", CFResizableHandle);
 }
+
+export type { CFResizableHandle as CFResizableHandleElement } from "./cf-resizable-handle.ts";
 
 export { CFResizableHandle, resizableHandleStyles };

--- a/packages/ui/src/v2/components/cf-resizable-panel-group/cf-resizable-panel-group.ts
+++ b/packages/ui/src/v2/components/cf-resizable-panel-group/cf-resizable-panel-group.ts
@@ -397,8 +397,3 @@ export class CFResizablePanelGroup extends BaseElement {
     });
   }
 }
-
-globalThis.customElements.define(
-  "cf-resizable-panel-group",
-  CFResizablePanelGroup,
-);

--- a/packages/ui/src/v2/components/cf-resizable-panel-group/index.ts
+++ b/packages/ui/src/v2/components/cf-resizable-panel-group/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-resizable-panel-group")) {
   customElements.define("cf-resizable-panel-group", CFResizablePanelGroup);
 }
 
+export type { CFResizablePanelGroup as CFResizablePanelGroupElement } from "./cf-resizable-panel-group.ts";
+
 export { CFResizablePanelGroup };

--- a/packages/ui/src/v2/components/cf-resizable-panel/cf-resizable-panel.ts
+++ b/packages/ui/src/v2/components/cf-resizable-panel/cf-resizable-panel.ts
@@ -146,5 +146,3 @@ export class CFResizablePanel extends BaseElement {
     }
   }
 }
-
-globalThis.customElements.define("cf-resizable-panel", CFResizablePanel);

--- a/packages/ui/src/v2/components/cf-resizable-panel/index.ts
+++ b/packages/ui/src/v2/components/cf-resizable-panel/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-resizable-panel")) {
   customElements.define("cf-resizable-panel", CFResizablePanel);
 }
 
+export type { CFResizablePanel as CFResizablePanelElement } from "./cf-resizable-panel.ts";
+
 export { CFResizablePanel };

--- a/packages/ui/src/v2/components/cf-router/cf-link.ts
+++ b/packages/ui/src/v2/components/cf-router/cf-link.ts
@@ -27,5 +27,3 @@ export class CFLink extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-link", CFLink);

--- a/packages/ui/src/v2/components/cf-router/cf-router.ts
+++ b/packages/ui/src/v2/components/cf-router/cf-router.ts
@@ -33,5 +33,3 @@ export class CFRouter extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-router", CFRouter);

--- a/packages/ui/src/v2/components/cf-router/index.ts
+++ b/packages/ui/src/v2/components/cf-router/index.ts
@@ -1,12 +1,15 @@
-import { CFRouter } from "./cf-router.ts";
 import { CFLink } from "./cf-link.ts";
+import { CFRouter } from "./cf-router.ts";
+
+if (!customElements.get("cf-link")) {
+  customElements.define("cf-link", CFLink);
+}
 
 if (!customElements.get("cf-router")) {
   customElements.define("cf-router", CFRouter);
 }
 
-if (!customElements.get("cf-link")) {
-  customElements.define("cf-link", CFLink);
-}
+export type { CFLink as CFLinkElement } from "./cf-link.ts";
+export type { CFRouter as CFRouterElement } from "./cf-router.ts";
 
 export { CFLink, CFRouter };

--- a/packages/ui/src/v2/components/cf-screen/cf-screen.ts
+++ b/packages/ui/src/v2/components/cf-screen/cf-screen.ts
@@ -112,5 +112,3 @@ export class CFScreen extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-screen", CFScreen);

--- a/packages/ui/src/v2/components/cf-screen/index.ts
+++ b/packages/ui/src/v2/components/cf-screen/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-screen")) {
   customElements.define("cf-screen", CFScreen);
 }
 
+export type { CFScreen as CFScreenElement } from "./cf-screen.ts";
+
 export { CFScreen };

--- a/packages/ui/src/v2/components/cf-scroll-area/cf-scroll-area.ts
+++ b/packages/ui/src/v2/components/cf-scroll-area/cf-scroll-area.ts
@@ -496,5 +496,3 @@ export class CFScrollArea extends BaseElement {
     );
   };
 }
-
-globalThis.customElements.define("cf-scroll-area", CFScrollArea);

--- a/packages/ui/src/v2/components/cf-scroll-area/index.ts
+++ b/packages/ui/src/v2/components/cf-scroll-area/index.ts
@@ -1,8 +1,12 @@
-import { CFScrollArea, ScrollOrientation } from "./cf-scroll-area.ts";
+import { CFScrollArea } from "./cf-scroll-area.ts";
+
+import { ScrollOrientation } from "./cf-scroll-area.ts";
 
 if (!customElements.get("cf-scroll-area")) {
   customElements.define("cf-scroll-area", CFScrollArea);
 }
+
+export type { CFScrollArea as CFScrollAreaElement } from "./cf-scroll-area.ts";
 
 export { CFScrollArea };
 export type { ScrollOrientation };

--- a/packages/ui/src/v2/components/cf-secret-viewer/cf-secret-viewer.ts
+++ b/packages/ui/src/v2/components/cf-secret-viewer/cf-secret-viewer.ts
@@ -1,7 +1,7 @@
 import { css, html } from "lit";
 import { BaseElement } from "../../core/base-element.ts";
-import "../cf-button/cf-button.ts";
-import "../cf-copy-button/cf-copy-button.ts";
+import "../cf-button/index.ts";
+import "../cf-copy-button/index.ts";
 
 const AUTO_HIDE_MS = 30_000;
 
@@ -166,8 +166,4 @@ export class CFSecretViewer extends BaseElement {
       </div>
     `;
   }
-}
-
-if (!globalThis.customElements.get("cf-secret-viewer")) {
-  globalThis.customElements.define("cf-secret-viewer", CFSecretViewer);
 }

--- a/packages/ui/src/v2/components/cf-secret-viewer/index.ts
+++ b/packages/ui/src/v2/components/cf-secret-viewer/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-secret-viewer")) {
   customElements.define("cf-secret-viewer", CFSecretViewer);
 }
 
+export type { CFSecretViewer as CFSecretViewerElement } from "./cf-secret-viewer.ts";
+
 export { CFSecretViewer };

--- a/packages/ui/src/v2/components/cf-select/cf-select.test.ts
+++ b/packages/ui/src/v2/components/cf-select/cf-select.test.ts
@@ -3,7 +3,7 @@
  */
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { CFSelect, type SelectItem } from "./cf-select.ts";
+import { CFSelect, type SelectItem } from "./index.ts";
 
 describe("CFSelect", () => {
   it("should be defined", () => {

--- a/packages/ui/src/v2/components/cf-select/cf-select.ts
+++ b/packages/ui/src/v2/components/cf-select/cf-select.ts
@@ -524,5 +524,3 @@ export class CFSelect extends BaseElement {
     }
   }
 }
-
-globalThis.customElements.define("cf-select", CFSelect);

--- a/packages/ui/src/v2/components/cf-select/index.ts
+++ b/packages/ui/src/v2/components/cf-select/index.ts
@@ -8,6 +8,14 @@
  */
 
 import { CFSelect } from "./cf-select.ts";
+
 import { selectStyles } from "./styles.ts";
+
+if (!customElements.get("cf-select")) {
+  customElements.define("cf-select", CFSelect);
+}
+
+export type { CFSelect as CFSelectElement } from "./cf-select.ts";
+export type { SelectItem } from "./cf-select.ts";
 
 export { CFSelect, selectStyles };

--- a/packages/ui/src/v2/components/cf-separator/cf-separator.ts
+++ b/packages/ui/src/v2/components/cf-separator/cf-separator.ts
@@ -107,5 +107,3 @@ export class CFSeparator extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-separator", CFSeparator);

--- a/packages/ui/src/v2/components/cf-separator/index.ts
+++ b/packages/ui/src/v2/components/cf-separator/index.ts
@@ -1,8 +1,12 @@
-import { CFSeparator, SeparatorOrientation } from "./cf-separator.ts";
+import { CFSeparator } from "./cf-separator.ts";
+
+import { SeparatorOrientation } from "./cf-separator.ts";
 
 if (!customElements.get("cf-separator")) {
   customElements.define("cf-separator", CFSeparator);
 }
+
+export type { CFSeparator as CFSeparatorElement } from "./cf-separator.ts";
 
 export { CFSeparator };
 export type { SeparatorOrientation };

--- a/packages/ui/src/v2/components/cf-skeleton/cf-skeleton.ts
+++ b/packages/ui/src/v2/components/cf-skeleton/cf-skeleton.ts
@@ -175,5 +175,3 @@ export class CFSkeleton extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-skeleton", CFSkeleton);

--- a/packages/ui/src/v2/components/cf-skeleton/index.ts
+++ b/packages/ui/src/v2/components/cf-skeleton/index.ts
@@ -1,9 +1,13 @@
-import { CFSkeleton, SkeletonVariant } from "./cf-skeleton.ts";
+import { CFSkeleton } from "./cf-skeleton.ts";
+
+import { SkeletonVariant } from "./cf-skeleton.ts";
 import { skeletonStyles } from "./styles.ts";
 
 if (!customElements.get("cf-skeleton")) {
   customElements.define("cf-skeleton", CFSkeleton);
 }
+
+export type { CFSkeleton as CFSkeletonElement } from "./cf-skeleton.ts";
 
 export { CFSkeleton, skeletonStyles };
 export type { SkeletonVariant };

--- a/packages/ui/src/v2/components/cf-slider/cf-slider.ts
+++ b/packages/ui/src/v2/components/cf-slider/cf-slider.ts
@@ -627,5 +627,3 @@ export class CFSlider extends BaseElement {
     this.setValue(this.value - this.step);
   }
 }
-
-globalThis.customElements.define("cf-slider", CFSlider);

--- a/packages/ui/src/v2/components/cf-slider/index.ts
+++ b/packages/ui/src/v2/components/cf-slider/index.ts
@@ -1,8 +1,12 @@
-import { CFSlider, SliderOrientation } from "./cf-slider.ts";
+import { CFSlider } from "./cf-slider.ts";
+
+import { SliderOrientation } from "./cf-slider.ts";
 
 if (!customElements.get("cf-slider")) {
   customElements.define("cf-slider", CFSlider);
 }
+
+export type { CFSlider as CFSliderElement } from "./cf-slider.ts";
 
 export { CFSlider };
 export type { SliderOrientation };

--- a/packages/ui/src/v2/components/cf-space-link/cf-space-link.ts
+++ b/packages/ui/src/v2/components/cf-space-link/cf-space-link.ts
@@ -1,7 +1,7 @@
 import { css, html } from "lit";
 import { property } from "lit/decorators.js";
 import { BaseElement } from "../../core/base-element.ts";
-import "../cf-chip/cf-chip.ts";
+import "../cf-chip/index.ts";
 import type { DID } from "@commonfabric/identity";
 import { navigate } from "@commonfabric/shell/shared";
 
@@ -80,8 +80,6 @@ export class CFSpaceLink extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-space-link", CFSpaceLink);
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/ui/src/v2/components/cf-space-link/index.ts
+++ b/packages/ui/src/v2/components/cf-space-link/index.ts
@@ -1,1 +1,9 @@
+import { CFSpaceLink } from "./cf-space-link.ts";
+
+if (!customElements.get("cf-space-link")) {
+  customElements.define("cf-space-link", CFSpaceLink);
+}
+
+export type { CFSpaceLink as CFSpaceLinkElement } from "./cf-space-link.ts";
+
 export * from "./cf-space-link.ts";

--- a/packages/ui/src/v2/components/cf-svg/cf-svg.ts
+++ b/packages/ui/src/v2/components/cf-svg/cf-svg.ts
@@ -111,5 +111,3 @@ export class CFSvg extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-svg", CFSvg);

--- a/packages/ui/src/v2/components/cf-svg/index.ts
+++ b/packages/ui/src/v2/components/cf-svg/index.ts
@@ -4,5 +4,6 @@ if (!customElements.get("cf-svg")) {
   customElements.define("cf-svg", CFSvg);
 }
 
-export { CFSvg };
 export type { CFSvg as CFSvgElement } from "./cf-svg.ts";
+
+export { CFSvg };

--- a/packages/ui/src/v2/components/cf-switch/cf-switch.ts
+++ b/packages/ui/src/v2/components/cf-switch/cf-switch.ts
@@ -327,5 +327,3 @@ export class CFSwitch extends BaseElement {
     super.blur();
   }
 }
-
-globalThis.customElements.define("cf-switch", CFSwitch);

--- a/packages/ui/src/v2/components/cf-switch/index.ts
+++ b/packages/ui/src/v2/components/cf-switch/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-switch")) {
   customElements.define("cf-switch", CFSwitch);
 }
 
+export type { CFSwitch as CFSwitchElement } from "./cf-switch.ts";
+
 export { CFSwitch };

--- a/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar-item.ts
+++ b/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar-item.ts
@@ -210,5 +210,3 @@ export class CFTabBarItem extends BaseElement {
     this.button?.blur();
   }
 }
-
-globalThis.customElements.define("cf-tab-bar-item", CFTabBarItem);

--- a/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar-layout.browser.test.ts
+++ b/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar-layout.browser.test.ts
@@ -1,7 +1,5 @@
 import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
-import "../cf-screen/cf-screen.ts";
-import "./cf-tab-bar.ts";
-import "./cf-tab-bar-item.ts";
+import "../cf-screen/index.ts";
 
 type UpdatingElement = HTMLElement & {
   updateComplete: Promise<unknown>;

--- a/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
+++ b/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
@@ -426,5 +426,3 @@ export class CFTabBar extends BaseElement {
     this._cellController.setValue(value);
   }
 }
-
-globalThis.customElements.define("cf-tab-bar", CFTabBar);

--- a/packages/ui/src/v2/components/cf-tab-bar/index.ts
+++ b/packages/ui/src/v2/components/cf-tab-bar/index.ts
@@ -9,4 +9,7 @@ if (!customElements.get("cf-tab-bar-item")) {
   customElements.define("cf-tab-bar-item", CFTabBarItem);
 }
 
+export type { CFTabBar as CFTabBarElement } from "./cf-tab-bar.ts";
+export type { CFTabBarItem as CFTabBarItemElement } from "./cf-tab-bar-item.ts";
+
 export { CFTabBar, CFTabBarItem };

--- a/packages/ui/src/v2/components/cf-tab-list/cf-tab-list.test.ts
+++ b/packages/ui/src/v2/components/cf-tab-list/cf-tab-list.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { CFTabList } from "./cf-tab-list.ts";
+import { CFTabList } from "./index.ts";
 
 describe("CFTabList", () => {
   it("should have default properties", () => {

--- a/packages/ui/src/v2/components/cf-tab-list/cf-tab-list.ts
+++ b/packages/ui/src/v2/components/cf-tab-list/cf-tab-list.ts
@@ -191,5 +191,3 @@ export class CFTabList extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-tab-list", CFTabList);

--- a/packages/ui/src/v2/components/cf-tab-list/index.ts
+++ b/packages/ui/src/v2/components/cf-tab-list/index.ts
@@ -1,8 +1,11 @@
 import { CFTabList } from "./cf-tab-list.ts";
+
 import { tabListStyles } from "./styles.ts";
 
 if (!customElements.get("cf-tab-list")) {
   customElements.define("cf-tab-list", CFTabList);
 }
+
+export type { CFTabList as CFTabListElement } from "./cf-tab-list.ts";
 
 export { CFTabList, tabListStyles };

--- a/packages/ui/src/v2/components/cf-tab-panel/cf-tab-panel.ts
+++ b/packages/ui/src/v2/components/cf-tab-panel/cf-tab-panel.ts
@@ -155,5 +155,3 @@ export class CFTabPanel extends BaseElement {
     this.hidden = !this.hidden;
   }
 }
-
-globalThis.customElements.define("cf-tab-panel", CFTabPanel);

--- a/packages/ui/src/v2/components/cf-tab-panel/index.ts
+++ b/packages/ui/src/v2/components/cf-tab-panel/index.ts
@@ -1,8 +1,11 @@
 import { CFTabPanel } from "./cf-tab-panel.ts";
+
 import { tabPanelStyles } from "./styles.ts";
 
 if (!customElements.get("cf-tab-panel")) {
   customElements.define("cf-tab-panel", CFTabPanel);
 }
+
+export type { CFTabPanel as CFTabPanelElement } from "./cf-tab-panel.ts";
 
 export { CFTabPanel, tabPanelStyles };

--- a/packages/ui/src/v2/components/cf-tab/cf-tab.ts
+++ b/packages/ui/src/v2/components/cf-tab/cf-tab.ts
@@ -239,5 +239,3 @@ export class CFTab extends BaseElement {
     this.button?.blur();
   }
 }
-
-globalThis.customElements.define("cf-tab", CFTab);

--- a/packages/ui/src/v2/components/cf-tab/index.ts
+++ b/packages/ui/src/v2/components/cf-tab/index.ts
@@ -1,8 +1,11 @@
 import { CFTab } from "./cf-tab.ts";
+
 import { tabStyles } from "./styles.ts";
 
 if (!customElements.get("cf-tab")) {
   customElements.define("cf-tab", CFTab);
 }
+
+export type { CFTab as CFTabElement } from "./cf-tab.ts";
 
 export { CFTab, tabStyles };

--- a/packages/ui/src/v2/components/cf-table/cf-table.ts
+++ b/packages/ui/src/v2/components/cf-table/cf-table.ts
@@ -258,5 +258,3 @@ export class CFTable extends BaseElement {
     });
   }
 }
-
-globalThis.customElements.define("cf-table", CFTable);

--- a/packages/ui/src/v2/components/cf-table/index.ts
+++ b/packages/ui/src/v2/components/cf-table/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-table")) {
   customElements.define("cf-table", CFTable);
 }
 
+export type { CFTable as CFTableElement } from "./cf-table.ts";
+
 export { CFTable };

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.test.ts
@@ -144,7 +144,7 @@ import {
   pushUpdate,
 } from "../../test-utils/mock-cell-handle.ts";
 import type { CellHandle } from "@commonfabric/runtime-client";
-import { CFTabs } from "./cf-tabs.ts";
+import { CFTabs } from "./index.ts";
 
 /**
  * Build a CFTabs instance wired to fake tabs/panels and a mock cell, with its

--- a/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
+++ b/packages/ui/src/v2/components/cf-tabs/cf-tabs.ts
@@ -469,5 +469,3 @@ export class CFTabs extends BaseElement {
     }
   }
 }
-
-globalThis.customElements.define("cf-tabs", CFTabs);

--- a/packages/ui/src/v2/components/cf-tabs/index.ts
+++ b/packages/ui/src/v2/components/cf-tabs/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-tabs")) {
   customElements.define("cf-tabs", CFTabs);
 }
 
+export type { CFTabs as CFTabsElement } from "./cf-tabs.ts";
+
 export { CFTabs };

--- a/packages/ui/src/v2/components/cf-tags/cf-tags.ts
+++ b/packages/ui/src/v2/components/cf-tags/cf-tags.ts
@@ -460,5 +460,3 @@ export class CFTags extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-tags", CFTags);

--- a/packages/ui/src/v2/components/cf-tags/index.ts
+++ b/packages/ui/src/v2/components/cf-tags/index.ts
@@ -1,1 +1,9 @@
+import { CFTags } from "./cf-tags.ts";
+
+if (!customElements.get("cf-tags")) {
+  customElements.define("cf-tags", CFTags);
+}
+
+export type { CFTags as CFTagsElement } from "./cf-tags.ts";
+
 export * from "./cf-tags.ts";

--- a/packages/ui/src/v2/components/cf-text/cf-text-truncate.browser.test.ts
+++ b/packages/ui/src/v2/components/cf-text/cf-text-truncate.browser.test.ts
@@ -1,6 +1,5 @@
 import { assert, assertEquals } from "@std/assert";
-import "../cf-hstack/cf-hstack.ts";
-import "./cf-text.ts";
+import "../cf-hstack/index.ts";
 
 type UpdatingElement = HTMLElement & {
   updateComplete: Promise<unknown>;

--- a/packages/ui/src/v2/components/cf-text/cf-text.test.ts
+++ b/packages/ui/src/v2/components/cf-text/cf-text.test.ts
@@ -3,7 +3,7 @@
  */
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { CFText } from "./cf-text.ts";
+import { CFText } from "./index.ts";
 
 function stylesText(): string {
   return (CFText.styles as Array<{ cssText: string }>)

--- a/packages/ui/src/v2/components/cf-text/cf-text.ts
+++ b/packages/ui/src/v2/components/cf-text/cf-text.ts
@@ -175,5 +175,3 @@ export class CFText extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-text", CFText);

--- a/packages/ui/src/v2/components/cf-text/index.ts
+++ b/packages/ui/src/v2/components/cf-text/index.ts
@@ -4,5 +4,7 @@ if (!customElements.get("cf-text")) {
   customElements.define("cf-text", CFText);
 }
 
+export type { CFText as CFTextElement } from "./cf-text.ts";
+
 export { CFText };
 export type { TextTone, TextVariant } from "./cf-text.ts";

--- a/packages/ui/src/v2/components/cf-textarea/cf-textarea.test.ts
+++ b/packages/ui/src/v2/components/cf-textarea/cf-textarea.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createMockCellHandle } from "../../test-utils/mock-cell-handle.ts";
-import { CFTextarea } from "./cf-textarea.ts";
+import { CFTextarea } from "./index.ts";
 
 // NOTE: Full DOM interaction tests (input events, Cell two-way binding,
 // auto-resize, timing strategy integration) require Lit's rendering

--- a/packages/ui/src/v2/components/cf-textarea/cf-textarea.ts
+++ b/packages/ui/src/v2/components/cf-textarea/cf-textarea.ts
@@ -761,5 +761,3 @@ export class CFTextarea extends BaseElement {
     this.textarea?.setCustomValidity(message);
   }
 }
-
-globalThis.customElements.define("cf-textarea", CFTextarea);

--- a/packages/ui/src/v2/components/cf-textarea/index.ts
+++ b/packages/ui/src/v2/components/cf-textarea/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-textarea")) {
   customElements.define("cf-textarea", CFTextarea);
 }
 
+export type { CFTextarea as CFTextareaElement } from "./cf-textarea.ts";
+
 export { CFTextarea };

--- a/packages/ui/src/v2/components/cf-theme/cf-theme.test.ts
+++ b/packages/ui/src/v2/components/cf-theme/cf-theme.test.ts
@@ -4,10 +4,7 @@ import {
   createMockCellHandle,
   pushUpdate,
 } from "../../test-utils/mock-cell-handle.ts";
-import {
-  subscribeToThemeCellValues,
-  unwrapThemeCellValues,
-} from "./cf-theme.ts";
+import { subscribeToThemeCellValues, unwrapThemeCellValues } from "./index.ts";
 
 describe("cf-theme reactive theme values", () => {
   it("unwraps top-level CellHandle values before theme merge", () => {

--- a/packages/ui/src/v2/components/cf-theme/cf-theme.ts
+++ b/packages/ui/src/v2/components/cf-theme/cf-theme.ts
@@ -191,5 +191,3 @@ export class CFThemeProvider extends BaseElement {
     `;
   }
 }
-
-customElements.define("cf-theme", CFThemeProvider);

--- a/packages/ui/src/v2/components/cf-theme/index.ts
+++ b/packages/ui/src/v2/components/cf-theme/index.ts
@@ -4,4 +4,11 @@ if (!customElements.get("cf-theme")) {
   customElements.define("cf-theme", CFThemeProvider);
 }
 
+export { CFThemeProvider };
+export type { CFThemeProvider as CFThemeProviderElement } from "./cf-theme.ts";
+export {
+  subscribeToThemeCellValues,
+  unwrapThemeCellValues,
+} from "./cf-theme.ts";
+
 export type { CFThemeProvider as CFThemeElement } from "./cf-theme.ts";

--- a/packages/ui/src/v2/components/cf-tile/cf-tile.ts
+++ b/packages/ui/src/v2/components/cf-tile/cf-tile.ts
@@ -162,5 +162,3 @@ export class CFTile extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-tile", CFTile);

--- a/packages/ui/src/v2/components/cf-tile/index.ts
+++ b/packages/ui/src/v2/components/cf-tile/index.ts
@@ -1,1 +1,9 @@
+import { CFTile } from "./cf-tile.ts";
+
+if (!customElements.get("cf-tile")) {
+  customElements.define("cf-tile", CFTile);
+}
+
+export type { CFTile as CFTileElement } from "./cf-tile.ts";
+
 export * from "./cf-tile.ts";

--- a/packages/ui/src/v2/components/cf-toast/cf-toast-provider.ts
+++ b/packages/ui/src/v2/components/cf-toast/cf-toast-provider.ts
@@ -177,5 +177,3 @@ export class CFToastProvider extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-toast-provider", CFToastProvider);

--- a/packages/ui/src/v2/components/cf-toast/cf-toast.ts
+++ b/packages/ui/src/v2/components/cf-toast/cf-toast.ts
@@ -390,5 +390,3 @@ export class CFToast extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-toast", CFToast);

--- a/packages/ui/src/v2/components/cf-toast/index.ts
+++ b/packages/ui/src/v2/components/cf-toast/index.ts
@@ -9,4 +9,7 @@ if (!customElements.get("cf-toast-provider")) {
   customElements.define("cf-toast-provider", CFToastProvider);
 }
 
+export type { CFToast as CFToastElement } from "./cf-toast.ts";
+export type { CFToastProvider as CFToastProviderElement } from "./cf-toast-provider.ts";
+
 export { CFToast, CFToastProvider };

--- a/packages/ui/src/v2/components/cf-toggle-group/cf-toggle-group.ts
+++ b/packages/ui/src/v2/components/cf-toggle-group/cf-toggle-group.ts
@@ -247,5 +247,3 @@ export class CFToggleGroup extends BaseElement {
     this.value = values;
   }
 }
-
-globalThis.customElements.define("cf-toggle-group", CFToggleGroup);

--- a/packages/ui/src/v2/components/cf-toggle-group/index.ts
+++ b/packages/ui/src/v2/components/cf-toggle-group/index.ts
@@ -1,8 +1,12 @@
-import { CFToggleGroup, ToggleGroupType } from "./cf-toggle-group.ts";
+import { CFToggleGroup } from "./cf-toggle-group.ts";
+
+import { ToggleGroupType } from "./cf-toggle-group.ts";
 
 if (!customElements.get("cf-toggle-group")) {
   customElements.define("cf-toggle-group", CFToggleGroup);
 }
+
+export type { CFToggleGroup as CFToggleGroupElement } from "./cf-toggle-group.ts";
 
 export { CFToggleGroup };
 export type { ToggleGroupType };

--- a/packages/ui/src/v2/components/cf-toggle/cf-toggle.ts
+++ b/packages/ui/src/v2/components/cf-toggle/cf-toggle.ts
@@ -183,5 +183,3 @@ export class CFToggle extends BaseElement {
     super.blur();
   }
 }
-
-globalThis.customElements.define("cf-toggle", CFToggle);

--- a/packages/ui/src/v2/components/cf-toggle/index.ts
+++ b/packages/ui/src/v2/components/cf-toggle/index.ts
@@ -1,8 +1,12 @@
-import { CFToggle, ToggleSize, ToggleVariant } from "./cf-toggle.ts";
+import { CFToggle } from "./cf-toggle.ts";
+
+import { ToggleSize, ToggleVariant } from "./cf-toggle.ts";
 
 if (!customElements.get("cf-toggle")) {
   customElements.define("cf-toggle", CFToggle);
 }
+
+export type { CFToggle as CFToggleElement } from "./cf-toggle.ts";
 
 export { CFToggle };
 export type { ToggleSize, ToggleVariant };

--- a/packages/ui/src/v2/components/cf-tool-call/cf-tool-call.ts
+++ b/packages/ui/src/v2/components/cf-tool-call/cf-tool-call.ts
@@ -368,5 +368,3 @@ export class CFToolCall extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-tool-call", CFToolCall);

--- a/packages/ui/src/v2/components/cf-tool-call/index.ts
+++ b/packages/ui/src/v2/components/cf-tool-call/index.ts
@@ -1,1 +1,9 @@
+import { CFToolCall } from "./cf-tool-call.ts";
+
+if (!customElements.get("cf-tool-call")) {
+  customElements.define("cf-tool-call", CFToolCall);
+}
+
+export type { CFToolCall as CFToolCallElement } from "./cf-tool-call.ts";
+
 export { CFToolCall } from "./cf-tool-call.ts";

--- a/packages/ui/src/v2/components/cf-toolbar/cf-toolbar.ts
+++ b/packages/ui/src/v2/components/cf-toolbar/cf-toolbar.ts
@@ -118,5 +118,3 @@ export class CFToolbar extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-toolbar", CFToolbar);

--- a/packages/ui/src/v2/components/cf-toolbar/index.ts
+++ b/packages/ui/src/v2/components/cf-toolbar/index.ts
@@ -4,4 +4,5 @@ if (!customElements.get("cf-toolbar")) {
   customElements.define("cf-toolbar", CFToolbar);
 }
 
+export { CFToolbar };
 export type { CFToolbar as CFToolbarElement } from "./cf-toolbar.ts";

--- a/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
+++ b/packages/ui/src/v2/components/cf-tools-chip/cf-tools-chip.ts
@@ -733,6 +733,4 @@ export class CFToolsChip extends BaseElement {
   }
 }
 
-globalThis.customElements.define("cf-tools-chip", CFToolsChip);
-
 export type { CFToolsChip as CFToolsChipElement };

--- a/packages/ui/src/v2/components/cf-tools-chip/index.ts
+++ b/packages/ui/src/v2/components/cf-tools-chip/index.ts
@@ -4,5 +4,7 @@ if (!customElements.get("cf-tools-chip")) {
   customElements.define("cf-tools-chip", CFToolsChip);
 }
 
+export type { CFToolsChip as CFToolsChipElement } from "./cf-tools-chip.ts";
+
 export { CFToolsChip };
 export type { ToolsChipTool } from "./cf-tools-chip.ts";

--- a/packages/ui/src/v2/components/cf-updater/cf-updater.ts
+++ b/packages/ui/src/v2/components/cf-updater/cf-updater.ts
@@ -1,6 +1,6 @@
 import { css, html } from "lit";
 import { BaseElement } from "../../core/base-element.ts";
-import { CFPiece } from "../cf-piece/cf-piece.ts";
+import { CFPiece } from "../cf-piece/index.ts";
 import { CellHandle } from "@commonfabric/runtime-client";
 
 /**
@@ -160,5 +160,3 @@ export class CFUpdater extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-updater", CFUpdater);

--- a/packages/ui/src/v2/components/cf-updater/index.ts
+++ b/packages/ui/src/v2/components/cf-updater/index.ts
@@ -1,1 +1,9 @@
+import { CFUpdater } from "./cf-updater.ts";
+
+if (!customElements.get("cf-updater")) {
+  customElements.define("cf-updater", CFUpdater);
+}
+
+export type { CFUpdater as CFUpdaterElement } from "./cf-updater.ts";
+
 export * from "./cf-updater.ts";

--- a/packages/ui/src/v2/components/cf-vgroup/cf-vgroup.ts
+++ b/packages/ui/src/v2/components/cf-vgroup/cf-vgroup.ts
@@ -107,5 +107,3 @@ export class CFVGroup extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-vgroup", CFVGroup);

--- a/packages/ui/src/v2/components/cf-vgroup/index.ts
+++ b/packages/ui/src/v2/components/cf-vgroup/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-vgroup")) {
   customElements.define("cf-vgroup", CFVGroup);
 }
 
+export type { CFVGroup as CFVGroupElement } from "./cf-vgroup.ts";
+
 export { CFVGroup };

--- a/packages/ui/src/v2/components/cf-voice-input/cf-voice-input.ts
+++ b/packages/ui/src/v2/components/cf-voice-input/cf-voice-input.ts
@@ -13,7 +13,7 @@ import {
   defaultTheme,
 } from "../theme-context.ts";
 import { classMap } from "lit/directives/class-map.js";
-import "../cf-audio-visualizer/cf-audio-visualizer.ts";
+import "../cf-audio-visualizer/index.ts";
 import type { CFAudioVisualizer } from "../cf-audio-visualizer/cf-audio-visualizer.ts";
 import { convertToWav } from "../../utils/audio-conversion.ts";
 
@@ -780,5 +780,3 @@ export class CFVoiceInput extends BaseElement {
     `;
   }
 }
-
-customElements.define("cf-voice-input", CFVoiceInput);

--- a/packages/ui/src/v2/components/cf-voice-input/index.ts
+++ b/packages/ui/src/v2/components/cf-voice-input/index.ts
@@ -4,6 +4,8 @@ if (!customElements.get("cf-voice-input")) {
   customElements.define("cf-voice-input", CFVoiceInput);
 }
 
+export type { CFVoiceInput as CFVoiceInputElement } from "./cf-voice-input.ts";
+
 export { CFVoiceInput };
 export type {
   TranscriptionChunk,

--- a/packages/ui/src/v2/components/cf-vscroll/cf-vscroll.ts
+++ b/packages/ui/src/v2/components/cf-vscroll/cf-vscroll.ts
@@ -346,5 +346,3 @@ export class CFVScroll extends BaseElement {
     }
   }
 }
-
-globalThis.customElements.define("cf-vscroll", CFVScroll);

--- a/packages/ui/src/v2/components/cf-vscroll/index.ts
+++ b/packages/ui/src/v2/components/cf-vscroll/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-vscroll")) {
   customElements.define("cf-vscroll", CFVScroll);
 }
 
+export type { CFVScroll as CFVScrollElement } from "./cf-vscroll.ts";
+
 export { CFVScroll };

--- a/packages/ui/src/v2/components/cf-vstack/cf-vstack-padding.browser.test.ts
+++ b/packages/ui/src/v2/components/cf-vstack/cf-vstack-padding.browser.test.ts
@@ -1,5 +1,4 @@
 import { assertEquals } from "@std/assert";
-import "./cf-vstack.ts";
 
 type UpdatingElement = HTMLElement & {
   updateComplete: Promise<unknown>;

--- a/packages/ui/src/v2/components/cf-vstack/cf-vstack.test.ts
+++ b/packages/ui/src/v2/components/cf-vstack/cf-vstack.test.ts
@@ -4,7 +4,7 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { layoutSpacingUtilityStyles } from "../../styles/layout-spacing.ts";
-import { CFVStack } from "./cf-vstack.ts";
+import { CFVStack } from "./index.ts";
 
 /**
  * Extracts the class info object passed to classMap in render().

--- a/packages/ui/src/v2/components/cf-vstack/cf-vstack.ts
+++ b/packages/ui/src/v2/components/cf-vstack/cf-vstack.ts
@@ -157,5 +157,3 @@ export class CFVStack extends BaseElement {
     `;
   }
 }
-
-globalThis.customElements.define("cf-vstack", CFVStack);

--- a/packages/ui/src/v2/components/cf-vstack/index.ts
+++ b/packages/ui/src/v2/components/cf-vstack/index.ts
@@ -4,4 +4,6 @@ if (!customElements.get("cf-vstack")) {
   customElements.define("cf-vstack", CFVStack);
 }
 
+export type { CFVStack as CFVStackElement } from "./cf-vstack.ts";
+
 export { CFVStack };

--- a/packages/ui/src/v2/components/cf-webhook/cf-webhook.ts
+++ b/packages/ui/src/v2/components/cf-webhook/cf-webhook.ts
@@ -1,8 +1,8 @@
 import { css, html } from "lit";
 import { BaseElement } from "../../core/base-element.ts";
 import { CellHandle } from "@commonfabric/runtime-client";
-import "../cf-button/cf-button.ts";
-import "../cf-secret-viewer/cf-secret-viewer.ts";
+import "../cf-button/index.ts";
+import "../cf-secret-viewer/index.ts";
 
 // Design spec: docs/specs/webhook-ingress/README.md
 
@@ -284,8 +284,4 @@ export class CFWebhook extends BaseElement {
       }
     `,
   ];
-}
-
-if (!globalThis.customElements.get("cf-webhook")) {
-  globalThis.customElements.define("cf-webhook", CFWebhook);
 }

--- a/packages/ui/src/v2/components/cf-webhook/index.ts
+++ b/packages/ui/src/v2/components/cf-webhook/index.ts
@@ -1,1 +1,9 @@
+import { CFWebhook } from "./cf-webhook.ts";
+
+if (!customElements.get("cf-webhook")) {
+  customElements.define("cf-webhook", CFWebhook);
+}
+
+export type { CFWebhook as CFWebhookElement } from "./cf-webhook.ts";
+
 export * from "./cf-webhook.ts";

--- a/packages/ui/src/v2/components/form/cf-form.ts
+++ b/packages/ui/src/v2/components/form/cf-form.ts
@@ -1,5 +1,5 @@
 import { css, html } from "lit";
-import { customElement, property, query } from "lit/decorators.js";
+import { property, query } from "lit/decorators.js";
 import { provide } from "@lit/context";
 import { BaseElement } from "../../core/base-element.ts";
 import {
@@ -45,7 +45,6 @@ import {
  * </cf-form>
  * ```
  */
-@customElement("cf-form")
 export class CFForm extends BaseElement {
   static override styles = css`
     :host {

--- a/packages/ui/src/v2/components/form/index.ts
+++ b/packages/ui/src/v2/components/form/index.ts
@@ -4,8 +4,9 @@ if (!customElements.get("cf-form")) {
   customElements.define("cf-form", CFForm);
 }
 
+export type { CFForm as CFFormElement } from "./cf-form.ts";
+
 export { CFForm };
-export type { CFForm as CFFormElement };
 
 // Re-export form context types and utilities
 export {

--- a/packages/ui/src/v2/core/drag-state.ts
+++ b/packages/ui/src/v2/core/drag-state.ts
@@ -5,7 +5,7 @@ import {
 } from "@commonfabric/runtime-client";
 import { render } from "@commonfabric/html/client";
 import { mayContainCfcRenderBoundary } from "./cfc-render-boundary-scan.ts";
-import "../components/cf-cell-link/cf-cell-link.ts";
+import "../components/cf-cell-link/index.ts";
 
 /**
  * State information for an active drag operation.

--- a/packages/ui/src/v2/index.ts
+++ b/packages/ui/src/v2/index.ts
@@ -1,7 +1,10 @@
 /**
- * Web Components Library v2
+ * Web components library entrypoint.
  *
- * Main entry point for the v2 web components library
+ * Re-exports the component directory indexes under src/v2.
+ *
+ * TODO(ui-path-cleanup): Rename this path now that it is the only UI component
+ * implementation.
  */
 
 // Core exports
@@ -107,7 +110,7 @@ export * from "./components/cf-voice-input/index.ts";
 export * from "./components/cf-vscroll/index.ts";
 export * from "./components/cf-vstack/index.ts";
 export * from "./components/cf-select/index.ts";
-export * from "./components/cf-message-input/cf-message-input.ts";
+export * from "./components/cf-message-input/index.ts";
 export * from "./components/cf-prompt-input/index.ts";
 export * from "./components/cf-keybind/index.ts";
 export * from "./components/cf-tools-chip/index.ts";
@@ -116,11 +119,11 @@ export * from "./components/keyboard-router.ts";
 export * from "./components/modal-context.ts";
 export * from "./components/cf-modal-provider/index.ts";
 export * from "./components/cf-modal/index.ts";
-export * from "./components/cf-attachments-bar/cf-attachments-bar.ts";
-export * from "./components/cf-chip/cf-chip.ts";
+export * from "./components/cf-attachments-bar/index.ts";
+export * from "./components/cf-chip/index.ts";
 export * from "./components/cf-cfc-authorship/index.ts";
 export * from "./components/cf-cfc-label/index.ts";
-export * from "./components/cf-question/cf-question.ts";
+export * from "./components/cf-question/index.ts";
 export * from "./components/cf-cell-link/index.ts";
 export * from "./components/cf-cell-context/index.ts";
 export * from "./components/cf-space-link/index.ts";

--- a/packages/ui/test/package-root-registration.test.ts
+++ b/packages/ui/test/package-root-registration.test.ts
@@ -1,0 +1,311 @@
+import { assert, assertEquals } from "@std/assert";
+import { join, relative, toFileUrl } from "@std/path";
+
+const UI_ROOT = join(import.meta.dirname!, "..");
+const COMPONENTS_ROOT = join(UI_ROOT, "src", "v2", "components");
+const PACKAGE_ENTRYPOINT = join(UI_ROOT, "src", "index.ts");
+const README = join(UI_ROOT, "README.md");
+const V2_ENTRYPOINT = join(UI_ROOT, "src", "v2", "index.ts");
+
+type Registration = {
+  tag: string;
+  exportPath: string;
+};
+
+async function collectComponentRegistrations(): Promise<Registration[]> {
+  const registrations: Registration[] = [];
+
+  for await (const entry of Deno.readDir(COMPONENTS_ROOT)) {
+    if (!entry.isDirectory) {
+      continue;
+    }
+
+    const indexPath = join(COMPONENTS_ROOT, entry.name, "index.ts");
+
+    let source: string;
+    try {
+      source = await Deno.readTextFile(indexPath);
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) {
+        continue;
+      }
+      throw error;
+    }
+
+    const exportPath = `./components/${entry.name}/index.ts`;
+
+    for (const match of source.matchAll(/customElements\.define\("([^"]+)"/g)) {
+      const tag = match[1];
+      if (tag.startsWith("cf-")) {
+        registrations.push({ tag, exportPath });
+      }
+    }
+  }
+
+  registrations.sort((left, right) => left.tag.localeCompare(right.tag));
+
+  return registrations;
+}
+
+async function collectRegistrationDecorators(
+  dir: string,
+): Promise<string[]> {
+  const files: string[] = [];
+
+  for await (const entry of Deno.readDir(dir)) {
+    const path = join(dir, entry.name);
+
+    if (entry.isDirectory) {
+      files.push(...await collectRegistrationDecorators(path));
+      continue;
+    }
+
+    if (
+      !entry.isFile || !entry.name.endsWith(".ts") ||
+      entry.name.endsWith(".test.ts") ||
+      entry.name.endsWith(".browser.test.ts")
+    ) {
+      continue;
+    }
+
+    const source = await Deno.readTextFile(path);
+    if (source.includes("@customElement(")) {
+      files.push(relative(UI_ROOT, path).replaceAll("\\", "/"));
+    }
+  }
+
+  return files.sort();
+}
+
+function duplicateTags(registrations: Registration[]): string[] {
+  const counts = new Map<string, number>();
+  for (const { tag } of registrations) {
+    counts.set(tag, (counts.get(tag) ?? 0) + 1);
+  }
+
+  return Array.from(counts)
+    .filter(([, count]) => count > 1)
+    .map(([tag]) => tag)
+    .sort();
+}
+
+function duplicateStrings(values: string[]): string[] {
+  const counts = new Map<string, number>();
+  for (const value of values) {
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+
+  return Array.from(counts)
+    .filter(([, count]) => count > 1)
+    .map(([value]) => value)
+    .sort();
+}
+
+function decode(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
+}
+
+Deno.test("package root exports every component registrar", async () => {
+  const registrations = await collectComponentRegistrations();
+  const packageSource = await Deno.readTextFile(PACKAGE_ENTRYPOINT);
+  const v2Source = await Deno.readTextFile(V2_ENTRYPOINT);
+  const duplicateTagNames = duplicateTags(registrations);
+
+  assert(registrations.length > 0, "expected cf-* component registrations");
+  assertEquals(duplicateTagNames, []);
+  assert(
+    packageSource.includes('export * from "./v2/index.ts";'),
+    "package root should re-export the UI component entrypoint",
+  );
+
+  const expectedExports = Array.from(
+    new Set(registrations.map(({ exportPath }) => exportPath)),
+  ).sort();
+  const missingExports = expectedExports.filter((exportPath) =>
+    !v2Source.includes(`export * from "${exportPath}";`)
+  );
+
+  assertEquals(missingExports, []);
+});
+
+Deno.test("README component list matches registered cf elements", async () => {
+  const registrations = await collectComponentRegistrations();
+  const expectedTags = registrations.map(({ tag }) => tag);
+  const readme = await Deno.readTextFile(README);
+  const section = readme.match(
+    /## 📖 Components\n(?<body>[\s\S]*?)\n## 🔒 Security Constraints/,
+  )?.groups?.body;
+
+  assert(section, "README should have a Components section");
+
+  const documentedTags = Array.from(
+    section.matchAll(/`(cf-[a-z0-9-]+)`/g),
+    (match) => match[1],
+  ).sort();
+
+  assertEquals(duplicateStrings(documentedTags), []);
+  assertEquals(documentedTags, expectedTags);
+});
+
+Deno.test("component files do not self-register with customElement decorators", async () => {
+  const decoratorFiles = await collectRegistrationDecorators(COMPONENTS_ROOT);
+
+  assertEquals(decoratorFiles, []);
+});
+
+Deno.test("package root registers every exported cf element", async () => {
+  const registrations = await collectComponentRegistrations();
+  const expectedTags = registrations.map(({ tag }) => tag);
+  const entrypointUrl = toFileUrl(PACKAGE_ENTRYPOINT).href;
+
+  const checkScript = `
+const expectedTags = ${JSON.stringify(expectedTags)};
+const entrypointUrl = ${JSON.stringify(entrypointUrl)};
+
+class HTMLElementStub extends EventTarget {
+  style = {};
+
+  attachShadow() {
+    return { appendChild() {} };
+  }
+}
+
+function makeElement(tag = "div") {
+  return {
+    tagName: tag.toUpperCase(),
+    style: {},
+    children: [],
+    childNodes: [],
+    appendChild() {},
+    removeChild() {},
+    setAttribute() {},
+    removeAttribute() {},
+    getAttribute() {
+      return null;
+    },
+    cloneNode() {
+      return makeElement(tag);
+    },
+    getContext() {
+      return null;
+    },
+    content: {
+      cloneNode() {
+        return makeElement("fragment");
+      },
+    },
+  };
+}
+
+const documentStub = {
+  documentElement: makeElement("html"),
+  createElement: makeElement,
+  createElementNS(_namespace, tag) {
+    return makeElement(tag);
+  },
+  createTreeWalker(root) {
+    return {
+      currentNode: root,
+      nextNode() {
+        return null;
+      },
+    };
+  },
+  createComment() {
+    return makeElement("comment");
+  },
+  createTextNode() {
+    return makeElement("text");
+  },
+  body: makeElement("body"),
+  head: makeElement("head"),
+  addEventListener() {},
+  removeEventListener() {},
+  hidden: false,
+};
+const navigatorStub = { userAgent: "", platform: "" };
+const windowStub = {
+  document: documentStub,
+  navigator: navigatorStub,
+  screen: {},
+  requestAnimationFrame(callback) {
+    return setTimeout(callback, 0);
+  },
+  cancelAnimationFrame: clearTimeout,
+  addEventListener() {},
+  removeEventListener() {},
+  devicePixelRatio: 1,
+};
+
+Object.assign(windowStub, {
+  HTMLElement: HTMLElementStub,
+  SVGElement: HTMLElementStub,
+  Element: HTMLElementStub,
+});
+
+const registry = new Map();
+const customElementsStub = {
+  define(tag, constructor) {
+    if (registry.has(tag)) {
+      throw new Error(\`Duplicate custom element registration: \${tag}\`);
+    }
+    registry.set(tag, constructor);
+  },
+  get(tag) {
+    return registry.get(tag);
+  },
+  whenDefined(tag) {
+    const constructor = registry.get(tag);
+    return constructor
+      ? Promise.resolve(constructor)
+      : Promise.reject(new Error(\`Custom element is not defined: \${tag}\`));
+  },
+};
+
+for (const [key, value] of Object.entries({
+  HTMLElement: HTMLElementStub,
+  Element: HTMLElementStub,
+  SVGElement: HTMLElementStub,
+  window: windowStub,
+  document: documentStub,
+  navigator: navigatorStub,
+  customElements: customElementsStub,
+  NodeFilter: { SHOW_ELEMENT: 1, SHOW_COMMENT: 128, SHOW_TEXT: 4 },
+})) {
+  Object.defineProperty(globalThis, key, { value, configurable: true });
+}
+
+await import(entrypointUrl);
+
+const missing = expectedTags.filter((tag) => !customElements.get(tag));
+const registeredCfTags = Array.from(registry.keys())
+  .filter((tag) => tag.startsWith("cf-"))
+  .sort();
+const unexpected = registeredCfTags.filter((tag) => !expectedTags.includes(tag));
+console.log(JSON.stringify({ missing, registeredCfTags, unexpected }));
+`;
+
+  const output = await new Deno.Command(Deno.execPath(), {
+    args: ["eval", checkScript],
+    cwd: UI_ROOT,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+
+  if (!output.success) {
+    console.error(decode(output.stdout));
+    console.error(decode(output.stderr));
+  }
+
+  assert(output.success, "package root import should complete");
+
+  const result = JSON.parse(decode(output.stdout)) as {
+    missing: string[];
+    registeredCfTags: string[];
+    unexpected: string[];
+  };
+
+  assertEquals(result.missing, []);
+  assertEquals(result.unexpected, []);
+  assertEquals(result.registeredCfTags.length, expectedTags.length);
+});


### PR DESCRIPTION
Split into three commits for ease of review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized `cf-*` custom element registration by moving defines to guarded component index files and making `@commonfabric/ui` register all components on import. This prevents double-registration, simplifies imports, and clarifies usage; docs updated.

- **Refactors**
  - Moved `customElements.define(...)` from component classes to `index.ts` with `customElements.get(...)` guards.
  - Added `export type { <Class> as <Class>Element }` from component indexes for element typing.
  - Updated internal imports/tests to import from component `index.ts` so value imports register elements; fixed side-effect imports (e.g., chart marks, chips).
  - Package root now serves as the public entrypoint and re-exports component indexes; README reorganized with component catalog and registration guidance.

- **Migration**
  - To register everything: import `@commonfabric/ui` (or use a side-effect import).
  - To use one component: import from its directory index, e.g. `import { CFButton } from "@commonfabric/ui/src/v2/components/cf-button/index.ts";` (repo-local) or from `@commonfabric/ui` if published.
  - Use type-only imports for types; rely on value imports for registration.

<sup>Written for commit 0ba6df7670d35328aa5437b0b831b29b7947be25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

