### PR TITLE
Mark recursive-traversal FabricValue mishandling sites — second pass (comment-only)

### DIFF
--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -139,6 +139,11 @@ export function toJSONWithLegacyAliases(
       : (value as Record<string, any>);
 
     const result: any = {};
+    // TODO(danfuzz): This `isRecord`-gated `for...in` walk has no
+    // `FabricSpecialObject` guard, so a `FabricPrimitive` (state in private
+    // fields, zero enumerable own-props) flattens to `{}` and a
+    // `FabricInstance` is walked by its internal slots instead of its codec
+    // contents.
     for (const key in valueToProcess as any) {
       const jsonValue = toJSONWithLegacyAliases(
         valueToProcess[key],

--- a/packages/runner/src/builder/node-utils.ts
+++ b/packages/runner/src/builder/node-utils.ts
@@ -122,6 +122,11 @@ function attachCfcToOutputs(
     return;
   } else if (isRecord(outputs)) {
     // Descend into objects and arrays
+    // TODO(danfuzz): This `isRecord`-gated `Object.entries` descent has no
+    // `FabricSpecialObject` guard; a `FabricPrimitive` output is decomposed
+    // (its state is private) and a `FabricInstance` is walked by internal
+    // slots, so CFC labels are not attached to the special object's actual
+    // contents.
     for (const [_, value] of Object.entries(outputs)) {
       attachCfcToOutputs(value, cfc, lubConfidentiality);
     }

--- a/packages/runner/src/cfc/schema-sanitization.ts
+++ b/packages/runner/src/cfc/schema-sanitization.ts
@@ -422,6 +422,12 @@ export const validateAgainstSchema = (
     }
   }
 
+  // TODO(danfuzz): Latent — the enum/const equality arm here compares a runtime
+  // value against a schema constraint with `deepEqual`; schemas don't admit
+  // `Fabric*` values today but will, at which point this mishandles a
+  // `FabricValue` (same-class `FabricPrimitive`s compare equal regardless of
+  // value). Use a Fabric-aware equality when the path becomes live. (The
+  // property-walk in this same function is already marked.)
   if (
     Array.isArray(schema.enum) &&
     !schema.enum.some((entry) => deepEqual(entry, value))

--- a/packages/runner/src/path-utils.ts
+++ b/packages/runner/src/path-utils.ts
@@ -15,6 +15,11 @@ export function setValueAtPath(
     parent = parent[key];
   }
 
+  // TODO(danfuzz): This no-op write gate compares the existing value against
+  // the new value with `deepEqual`, which mishandles `FabricValue` (same-class
+  // `FabricPrimitive`s compare equal regardless of value, since their state
+  // lives in private `#fields` with zero own-props), so a real Fabric-value
+  // change can be dropped as a no-op. Use a Fabric-aware equality.
   if (deepEqual(parent[path[path.length - 1]], value)) return false;
 
   // We just set the values here. If you need to delete elements from an

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -809,6 +809,10 @@ export class Runner {
     ) {
       result = { ...result, [NAME]: previousResult[NAME] };
     }
+    // TODO(danfuzz): This compares a runtime result value with `deepEqual`,
+    // which mishandles `FabricValue` (same-class `FabricPrimitive`s, with state
+    // in private `#fields` and zero own-props, compare equal regardless of
+    // value). Use a Fabric-aware equality for value comparison.
     if (!deepEqual(result, previousResult)) {
       recordSetupProjectionPolicyInputs(
         tx,

--- a/packages/runner/src/scheduler/topology.ts
+++ b/packages/runner/src/scheduler/topology.ts
@@ -41,6 +41,11 @@ export function mapsEqual(
   if (a.size !== b.size) return false;
   for (const [key, val] of a) {
     if (!b.has(key)) return false;
+    // TODO(danfuzz): `mapsEqual` compares map values with `deepEqual`, which
+    // mishandles `FabricValue`; this helper is used on stored read-value maps,
+    // so two same-class `FabricPrimitive`s (state in private `#fields`, zero
+    // own-props) compare equal regardless of value. Use a Fabric-aware
+    // equality.
     if (!deepEqual(val, b.get(key))) return false;
   }
   return true;

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -230,6 +230,12 @@ const matchesConcreteValue = (
   if (!canBranchMatch(resolved, value)) {
     return false;
   }
+  // TODO(danfuzz): Latent — schemas don't admit `Fabric*` values on this
+  // validation path today, but will in the not-too-distant future; at that
+  // point these `deepEqual(const/enum, value)` checks mishandle a
+  // `FabricValue` (same-class `FabricPrimitive`s compare equal regardless of
+  // value). Mark ahead of that; use a Fabric-aware equality when the path
+  // becomes live.
   if (resolved.const !== undefined && !deepEqual(resolved.const, value)) {
     return false;
   }

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -149,6 +149,12 @@ export const claim = (
 
   // Fast path: reference equality check avoids expensive comparison
   // when the replica state hasn't changed since the original read
+  // TODO(danfuzz): This compares a stored document value (the read/attested
+  // value) with `deepEqual`, which mishandles `FabricValue`: two same-class
+  // `FabricPrimitive` values (state in private `#fields`, zero own-props)
+  // compare equal regardless of value, so a changed Fabric value can be
+  // mis-detected as unchanged. Use a Fabric-aware equality for stored-value
+  // comparison.
   if (expected === actual || deepEqual(expected, actual)) {
     return { ok: state };
   } else {


### PR DESCRIPTION
## Summary

A **second-pass** recursive-traversal audit, generalizing the prior marker
sweep ([#4253](https://github.com/commontoolsinc/labs/pull/4253), 39
`TODO(danfuzz)` markers) to two orthogonal shapes that mishandle the special
Fabric classes. Adds **8 NEW `TODO(danfuzz)` markers** across 8 files — all
comment-only, no behavior change. This is **audit output** (a catalog of
fabric-unsafe sites), not a fix.

`FabricPrimitive`/`FabricInstance` keep their state in private `#fields`, so
they expose **zero enumerable own-properties**. Two distinct generic-traversal
idioms therefore silently mishandle them:

- **Own-props equality** (`deepEqual`): two distinct same-class
  `FabricPrimitive` values compare equal regardless of value.
- **Own-keys / structure walks** (`for...in`, `Object.entries`): a special
  object exposes no own-keys, so a walk finds nothing to descend into (a
  `FabricPrimitive` flattens to `{}`; a `FabricInstance` is walked by its
  internal slots instead of its codec contents).

The refined two-shape lens is what surfaced sites the first pass missed — the
same class of miss that [#4265](https://github.com/commontoolsinc/labs/pull/4265)
(CT-1770) found in `differential.ts`'s `collectChangedPaths` (an own-keys walk
that was **not** in #4253's file list).

## The 8 NEW marker sites

**Six reachable today:**

- `storage/transaction/attestation.ts` — stored-value attestation gate.
- `path-utils.ts` — no-op write gate.
- `scheduler/topology.ts` — `mapsEqual` over read-value maps.
- `runner.ts` — result-value gate.
- `builder/json-utils.ts` — `for...in` value walk.
- `builder/node-utils.ts` — CFC-label `Object.entries` descent.

**Two latent** — reachable once schemas admit `Fabric*` values (distinct
latent-phrasing on the marker so it's clearly not a live bug today):

- `schema.ts` — schema enum/const validation arm.
- `cfc/schema-sanitization.ts` — schema enum/const validation arm.

## Sequencing / relationship to prior work

This is a **NEW-only** delta. The 8 sites here are **disjoint** from:

- **#4253**'s 39 markers (the first marker pass).
- **#4265**'s 8 in-flight fixed src files (CT-1770, OPEN/unmerged) — none of
  those files are touched here.

No CFC-atom files and no #4265 files are in this diff. The audit's classification
and NEW-vs-already-marked delta are recorded in the project report at
`coordination/docs/2026-06-20-refined-traversal-fabric-audit.md`.

## Verification

Markers only — no behavior change (every added line is a comment; +42/-0).
`deno fmt --check`, `deno lint`, and `deno check` clean on all 8 changed files.
