### PR TITLE
Fix favorites tab display fallback

### DIFF
--- a/packages/home-schemas/favorites.ts
+++ b/packages/home-schemas/favorites.ts
@@ -14,6 +14,9 @@ export const favoriteEntrySchema = {
     // Discovery tags snapshotted from the piece's schema when favorited
     // (lowercased, without the leading `#`). Matched by wish() tag search.
     tags: { type: "array", items: { type: "string" }, default: [] },
+    // Display name snapshotted when favorited. Used as a fallback when the
+    // linked piece cannot be resolved quickly in the home favorites tab.
+    name: { type: "string" },
     userTags: { type: "array", items: { type: "string" }, default: [] },
     spaceName: { type: "string" },
   },

--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -3374,6 +3374,7 @@ interface CFScrollAttributes<T> extends CFHTMLAttributes<T> {
 
 interface CFCellLinkAttributes<T> extends CFHTMLAttributes<T> {
   "link"?: string;
+  "label"?: string;
   "$cell": CellLike<any>;
   "spaceName"?: string;
 }

--- a/packages/patterns/system/favorites-manager.tsx
+++ b/packages/patterns/system/favorites-manager.tsx
@@ -13,7 +13,8 @@ import {
 
 type Favorite = {
   cell: Writable<{ [NAME]?: string }>;
-  tag: string;
+  tags: string[];
+  name?: string;
   userTags: Writable<string[]>;
   spaceName?: string;
 };
@@ -50,7 +51,11 @@ export default pattern<Record<string, never>>((_) => {
           <cf-cell-context $cell={item.cell}>
             <cf-vstack gap="2">
               <cf-hstack gap="2" align="center">
-                <cf-cell-link $cell={item.cell} spaceName={item.spaceName} />
+                <cf-cell-link
+                  $cell={item.cell}
+                  label={item.name}
+                  spaceName={item.spaceName}
+                />
                 <cf-button
                   variant="destructive"
                   size="sm"

--- a/packages/patterns/system/home-ben.tsx
+++ b/packages/patterns/system/home-ben.tsx
@@ -17,6 +17,9 @@ type Favorite = {
   cell: { [NAME]?: string };
   // Discovery tags snapshotted from the piece's schema when favorited.
   tags: string[];
+  // Display name snapshotted when favorited, used as a fallback if the link is
+  // slow or impossible to resolve from the favorites tab.
+  name?: string;
   userTags: string[];
   spaceName?: string;
 };
@@ -92,9 +95,14 @@ function captureSnapshot(
 
 // Handler to add a favorite
 const addFavorite = handler<
-  { piece: Writable<{ [NAME]?: string }>; tags?: string[]; spaceName?: string },
+  {
+    piece: Writable<{ [NAME]?: string }>;
+    tags?: string[];
+    name?: string;
+    spaceName?: string;
+  },
   { favorites: Writable<Favorite[]>; journal: Writable<JournalEntry[]> }
->(({ piece, tags, spaceName }, { favorites, journal }) => {
+>(({ piece, tags, name, spaceName }, { favorites, journal }) => {
   const current = favorites.get();
   if (!current.some((f) => f && equals(f.cell, piece))) {
     // Discovery tags are derived by the client and passed in; the handler
@@ -105,6 +113,7 @@ const addFavorite = handler<
     favorites.push({
       cell: piece,
       tags: finalTags,
+      name,
       userTags: [],
       spaceName,
     });

--- a/packages/patterns/system/home.tsx
+++ b/packages/patterns/system/home.tsx
@@ -25,6 +25,9 @@ type Favorite = {
   cell: { [NAME]?: string };
   // Discovery tags snapshotted from the piece's schema when favorited.
   tags: string[];
+  // Display name snapshotted when favorited, used as a fallback if the link is
+  // slow or impossible to resolve from the favorites tab.
+  name?: string;
   userTags: string[];
   spaceName?: string;
 };
@@ -60,9 +63,14 @@ export type HomeOutput = {
 
 // Handler to add a favorite
 const addFavorite = handler<
-  { piece: Writable<{ [NAME]?: string }>; tags?: string[]; spaceName?: string },
+  {
+    piece: Writable<{ [NAME]?: string }>;
+    tags?: string[];
+    name?: string;
+    spaceName?: string;
+  },
   { favorites: Writable<Favorite[]> }
->(({ piece, tags, spaceName }, { favorites }) => {
+>(({ piece, tags, name, spaceName }, { favorites }) => {
   const current = favorites.get();
   if (!current.some((f) => f && equals(f.cell, piece))) {
     // Discovery tags are derived by the client (which can see the piece's
@@ -70,6 +78,7 @@ const addFavorite = handler<
     favorites.push({
       cell: piece,
       tags: tags ?? [],
+      name,
       userTags: [],
       spaceName,
     });

--- a/packages/runner/test/home-add-favorite.test.ts
+++ b/packages/runner/test/home-add-favorite.test.ts
@@ -10,7 +10,12 @@ import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 const signer = await Identity.fromPassphrase("home add-favorite tests");
 const space = signer.did();
 
-type FavoriteEntry = { tags?: string[]; tag?: string; userTags?: string[] };
+type FavoriteEntry = {
+  tags?: string[];
+  tag?: string;
+  name?: string;
+  userTags?: string[];
+};
 
 // Compiles and runs the real home pattern, then drives its addFavorite handler
 // the way the runtime client does after deriving tags: it sends the tags as
@@ -61,6 +66,7 @@ describe("home addFavorite handler", () => {
     (home.key("addFavorite") as any).send({
       piece: target.getAsLink(),
       tags: ["alpha", "beta"],
+      name: "Favorite Target",
       spaceName: "test-space",
     });
 
@@ -75,6 +81,7 @@ describe("home addFavorite handler", () => {
 
     expect(favorites.length).toBe(1);
     expect(favorites[0].tags).toEqual(["alpha", "beta"]);
+    expect(favorites[0].name).toEqual("Favorite Target");
     expect(favorites[0].userTags).toEqual([]);
   });
 });

--- a/packages/runtime-client/favorites-manager.test.ts
+++ b/packages/runtime-client/favorites-manager.test.ts
@@ -10,6 +10,7 @@ const space = "did:key:test-space" as DID;
 
 interface StubOptions {
   schema?: JSONSchema; // schema carried on the resolved piece ref
+  name?: string; // value returned by the resolved piece's $NAME cell
   getPageThrows?: boolean; // make getPage reject (derivation error path)
   favorites?: unknown; // value returned by the favorites cell
   ensureThrows?: boolean; // make ensureHomePatternRunning reject
@@ -55,7 +56,12 @@ function makeStub(opts: StubOptions = {}) {
       return opts.getPageThrows
         ? Promise.reject(new Error("getPage failed"))
         : Promise.resolve({
-          cell: () => ({ ref: () => ({ schema: opts.schema }) }),
+          cell: () => ({
+            ref: () => ({ schema: opts.schema }),
+            asSchema: () => ({
+              sync: () => Promise.resolve({ $NAME: opts.name }),
+            }),
+          }),
         });
     },
   } as unknown as RuntimeClient;
@@ -80,9 +86,11 @@ describe("FavoritesManager.addFavorite tag derivation", () => {
         description: "A #note",
         tags: ["search", "go"],
       },
+      name: "Search Piece",
     });
     await new FavoritesManager(stub.rt).addFavorite(space, "piece-1");
     expect(stub.sent[0].tags).toEqual(["search", "go"]);
+    expect(stub.sent[0].name).toEqual("Search Piece");
     expect(stub.sent[0].piece).toMatchObject({ id: "of:piece-1", space });
   });
 

--- a/packages/runtime-client/favorites-manager.ts
+++ b/packages/runtime-client/favorites-manager.ts
@@ -9,6 +9,7 @@ import { DID } from "@commonfabric/identity";
 import { CellHandle } from "./cell-handle.ts";
 import { RuntimeClient } from "./runtime-client.ts";
 import type { CellRef } from "./protocol/types.ts";
+import { NAME } from "@commonfabric/runner/shared";
 import {
   FavoriteEntry,
   favoriteListSchema,
@@ -50,34 +51,53 @@ export class FavoritesManager {
   ): Promise<void> {
     const handler = await this.#getHandler("addFavorite");
     const pieceCellRef = this.#createPieceRef(space, pieceId);
-    const tags = await this.#deriveTags(space, pieceId, tag);
-    await handler.send({ piece: pieceCellRef, tags, spaceName });
+    const { tags, name } = await this.#getFavoriteMetadata(
+      space,
+      pieceId,
+      tag,
+    );
+    const event: {
+      piece: CellRef;
+      tags: string[];
+      name?: string;
+      spaceName?: string;
+    } = { piece: pieceCellRef, tags, spaceName };
+    if (name !== undefined) event.name = name;
+    await handler.send(event);
   }
 
   /**
-   * Derive the discovery tags for a piece. An explicit tag wins; otherwise
-   * read the piece's result schema (carried on its resolved cell ref) and
-   * extract its tags. Returns `[]` when no schema is available — a tagless
-   * favorite that later code can heal.
+   * Read display metadata for a favorite. An explicit tag wins and avoids the
+   * page read; otherwise read the piece's result schema (carried on its
+   * resolved cell ref) and extract its tags. Missing schema or name is not a
+   * failure: the stored favorite can still be followed and later healed.
    */
-  async #deriveTags(
+  async #getFavoriteMetadata(
     space: DID,
     pieceId: string,
     explicitTag?: string,
-  ): Promise<string[]> {
-    if (explicitTag) return [explicitTag.toLowerCase().replace(/^#/, "")];
+  ): Promise<{ tags: string[]; name?: string }> {
+    if (explicitTag) {
+      return { tags: [explicitTag.toLowerCase().replace(/^#/, "")] };
+    }
     try {
       // `getPage` resolves the piece's cell ref, which the backend serializes
       // with its result schema (`getAsLink({ includeSchema: true })`). It does
       // not start the piece (runIt defaults to false), so a piece that is not
       // already running may resolve without a schema and yield no tags — a
       // tagless favorite that later code can heal.
-      const page = await this.#rt.getPage(pieceId, space);
-      const schema = page?.cell().ref().schema;
-      return schema ? tagsFromSchema(schema) : [];
+      const cell = (await this.#rt.getPage(pieceId, space))?.cell();
+      const schema = cell?.ref().schema;
+      const namedCell = cell?.asSchema<{ [NAME]?: string }>({
+        type: "object",
+        properties: { [NAME]: { type: "string" } },
+      });
+      const value = await namedCell?.sync();
+      const name = typeof value?.[NAME] === "string" ? value[NAME] : undefined;
+      return { tags: schema ? tagsFromSchema(schema) : [], name };
     } catch {
-      // A missing or unreadable piece schema yields no tags, not a failure.
-      return [];
+      // Missing or unreadable metadata yields a minimal favorite, not a failure.
+      return { tags: [] };
     }
   }
 
@@ -94,7 +114,7 @@ export class FavoritesManager {
 
   /**
    * Get all favorites.
-   * @returns Array of favorite entries with cell, tag, and userTags
+   * @returns Array of favorite entries with cell, tags, name, and userTags
    */
   async getFavorites(): Promise<readonly FavoriteEntry[]> {
     const defaultPattern = await this.#getHomePattern();


### PR DESCRIPTION
## Problem

Favoriting a piece updates the shell header immediately and survives page refresh, so the favorite record is being stored. The failure shows up later in the home/profile Favorites tab: the tab can render blank content instead of showing the saved favorite or the empty-state message.

The Favorites tab currently renders each favorite by resolving the stored target cell live and relying on `cf-cell-link` to read the target piece's `$NAME`. If that target resolution/name read is slow, missing, or otherwise unavailable from the home-space view, the stored favorite has no display fallback even though the favorite entry itself exists.

## Motivation

Favorites are a cross-space navigation surface. Once the user saves a favorite, the profile/home tab should be able to show a stable row for it without depending entirely on the target piece resolving in that exact render path. The shell already has enough context at favorite time to capture display metadata, so we should store a small snapshot alongside the existing cell ref and schema-derived tags.

## Solution

- Snapshot the target piece `$NAME` in `FavoritesManager.addFavorite`.
- Store that optional `name` on the home favorite entry in both home patterns.
- Pass the stored name to `cf-cell-link` as its `label` in the Favorites tab, while keeping the original cell link for navigation.
- Add the missing JSX typing for the existing `cf-cell-link` `label` property.
- Extend focused tests so the runtime client sends the name and the home handler persists it.

Existing favorites remain valid. Favorites created before this change may not have a stored `name`, so they will still fall back to the old live-resolution behavior until re-favorited.

## Verification

- `deno test --allow-all packages/runtime-client/favorites-manager.test.ts packages/runner/test/home-add-favorite.test.ts`
- `deno task cf check packages/patterns/system/home.tsx --no-run`
- `deno task cf check packages/patterns/system/home-ben.tsx --no-run`
- `deno task cf check packages/patterns/system/favorites-manager.tsx --no-run`
- `git diff --check`

Also verified manually in an isolated local toolshed instance with agent-browser: created a piece, favorited it, refreshed, opened `/`, selected Favorites, and confirmed the favorite row rendered with the snapshotted label and no browser errors.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank rows in the Favorites tab by snapshotting a piece’s name when it’s favorited and using it as a fallback label if live resolution is slow or unavailable. Existing favorites still work; older entries without a stored name keep the old behavior until re-favorited.

- **Bug Fixes**
  - Store optional `name` on favorite entries in the home schema.
  - `FavoritesManager.addFavorite` now reads `$NAME` and tags, and sends both to the home handler.
  - Home handlers persist `name`; Favorites tab passes it to `cf-cell-link` via its `label` prop.
  - Add missing `label` typing to `cf-cell-link`.
  - Extend tests to cover name capture and persistence.

<sup>Written for commit dff1901376cb97149e0abe0a1eb1dc9779f4882e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

