### PR TITLE
Filter votes before mapping over them, so we don't have the cartesian  product

### DIFF
--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -1255,32 +1255,31 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                                   justifyContent: "flex-end",
                                 }}
                               >
-                                {votes.filter((vote) =>
-                                  vote.optionId === oid
-                                ).map((vote) => (
-                                  <span
-                                    title={vote.voterName}
-                                    style={{
-                                      display: "inline-flex",
-                                      alignItems: "center",
-                                      justifyContent: "center",
-                                      minWidth: "22px",
-                                      height: "22px",
-                                      padding: "0 6px",
-                                      borderRadius: "9999px",
-                                      backgroundColor:
-                                        VOTE_SWATCH[vote.voteType],
-                                      color: "white",
-                                      fontSize: "11px",
-                                      fontWeight: 700,
-                                      boxShadow: vote.voterName === me
-                                        ? "0 0 0 2px white, 0 0 0 3px #111827"
-                                        : "none",
-                                    }}
-                                  >
-                                    {getInitials(vote.voterName)}
-                                  </span>
-                                ))}
+                                {votes.filter((vote) => vote.optionId === oid)
+                                  .map((vote) => (
+                                    <span
+                                      title={vote.voterName}
+                                      style={{
+                                        display: "inline-flex",
+                                        alignItems: "center",
+                                        justifyContent: "center",
+                                        minWidth: "22px",
+                                        height: "22px",
+                                        padding: "0 6px",
+                                        borderRadius: "9999px",
+                                        backgroundColor:
+                                          VOTE_SWATCH[vote.voteType],
+                                        color: "white",
+                                        fontSize: "11px",
+                                        fontWeight: 700,
+                                        boxShadow: vote.voterName === me
+                                          ? "0 0 0 2px white, 0 0 0 3px #111827"
+                                          : "none",
+                                      }}
+                                    >
+                                      {getInitials(vote.voterName)}
+                                    </span>
+                                  ))}
                               </div>
                             </div>
                           );

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -1255,34 +1255,32 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                                   justifyContent: "flex-end",
                                 }}
                               >
-                                {votes.map((vote) =>
+                                {votes.filter((vote) =>
                                   vote.optionId === oid
-                                    ? (
-                                      <span
-                                        title={vote.voterName}
-                                        style={{
-                                          display: "inline-flex",
-                                          alignItems: "center",
-                                          justifyContent: "center",
-                                          minWidth: "22px",
-                                          height: "22px",
-                                          padding: "0 6px",
-                                          borderRadius: "9999px",
-                                          backgroundColor:
-                                            VOTE_SWATCH[vote.voteType],
-                                          color: "white",
-                                          fontSize: "11px",
-                                          fontWeight: 700,
-                                          boxShadow: vote.voterName === me
-                                            ? "0 0 0 2px white, 0 0 0 3px #111827"
-                                            : "none",
-                                        }}
-                                      >
-                                        {getInitials(vote.voterName)}
-                                      </span>
-                                    )
-                                    : null
-                                )}
+                                ).map((vote) => (
+                                  <span
+                                    title={vote.voterName}
+                                    style={{
+                                      display: "inline-flex",
+                                      alignItems: "center",
+                                      justifyContent: "center",
+                                      minWidth: "22px",
+                                      height: "22px",
+                                      padding: "0 6px",
+                                      borderRadius: "9999px",
+                                      backgroundColor:
+                                        VOTE_SWATCH[vote.voteType],
+                                      color: "white",
+                                      fontSize: "11px",
+                                      fontWeight: 700,
+                                      boxShadow: vote.voterName === me
+                                        ? "0 0 0 2px white, 0 0 0 3px #111827"
+                                        : "none",
+                                    }}
+                                  >
+                                    {getInitials(vote.voterName)}
+                                  </span>
+                                ))}
                               </div>
                             </div>
                           );


### PR DESCRIPTION
Without this change, 10 options x 42 votes results in 420 items, and we make 6 cells for each, so we have 2520 cells just for this aspect of the UI. With this change, it's only 42 items (252 cells), so 90% of them go away.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filter votes by option before rendering in the lunch poll to eliminate the options × votes cartesian product and speed up rendering. In a 10-option, 42-vote case, items drop from 420 to 42 and cells from 2,520 to 252 (~90% fewer DOM nodes); also cleaned up formatting.

<sup>Written for commit 6251809841bfbad5d65113b8cf0c9cc6426ab331. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

