### PR TITLE
perf(memory): intern schemas in sync frames

### DIFF
--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -1,0 +1,230 @@
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
+import type { JSONSchema } from "@commonfabric/api";
+import {
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  MEMORY_PROTOCOL,
+  type ResponseMessage,
+  type ServerMessage,
+  type SessionEffectMessage,
+  type SessionOpenResult,
+  type SessionSync,
+  type WatchAddResult,
+} from "../v2.ts";
+import { Server } from "../v2/server.ts";
+import {
+  compressServerMessageSchemas,
+  expandServerMessageSchemas,
+  type SchemaTableSessionSync,
+} from "../v2/sync-schema-table.ts";
+
+const textEncoder = new TextEncoder();
+
+const encodedBytes = (value: ServerMessage): number =>
+  textEncoder.encode(encodeMemoryBoundary(value)).byteLength;
+
+const largeSchema = (): JSONSchema => ({
+  type: "object",
+  $defs: Object.fromEntries(
+    Array.from({ length: 48 }, (_, index) => [
+      `Definition${index}`,
+      {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          title: { type: "string" },
+          summary: { type: "string" },
+          count: { type: "number" },
+          active: { type: "boolean" },
+        },
+        required: ["id", "title"],
+      },
+    ]),
+  ),
+  properties: Object.fromEntries(
+    Array.from({ length: 24 }, (_, index) => [
+      `field${index}`,
+      { $ref: `#/$defs/Definition${index % 48}` },
+    ]),
+  ),
+});
+
+const repeatedSchemaSync = (
+  count = 128,
+): SessionSync => {
+  const schema = largeSchema();
+  return {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: Array.from({ length: count }, (_, index) => ({
+      branch: "",
+      id: `of:test-${index}`,
+      scope: "space" as const,
+      seq: 1,
+      doc: {
+        value: {
+          title: `Document ${index}`,
+          primary: linkRefFrom({
+            id: `of:target-${index}`,
+            path: [],
+            schema,
+          }),
+          secondary: linkRefFrom({
+            id: `of:secondary-${index}`,
+            path: ["nested"],
+            schema,
+          }),
+        },
+      },
+    })),
+    removes: [],
+  };
+};
+
+const syncEffect = (effect: SessionSync): SessionEffectMessage => ({
+  type: "session/effect",
+  space: "did:key:z6Mk-sync-schema-table",
+  sessionId: "session:sync-schema-table",
+  effect,
+});
+
+const shiftMessage = (messages: ServerMessage[]): ServerMessage => {
+  const message = messages.shift();
+  assertExists(message, "expected a server message");
+  return message;
+};
+
+const assertResponse = <Result>(
+  message: ServerMessage,
+): ResponseMessage<Result> => {
+  assertEquals(message.type, "response");
+  return message as ResponseMessage<Result>;
+};
+
+Deno.test("sync schema table experiment captures repeated schema savings", () => {
+  const sync = repeatedSchemaSync();
+  const message = syncEffect(sync);
+  const bytes = encodedBytes(message);
+  const schemaMarkerCount =
+    encodeMemoryBoundary(message).split("$defs").length -
+    1;
+  const compressed = compressServerMessageSchemas(message);
+  const compressedBytes = encodedBytes(compressed);
+  const compressedSchemaMarkerCount = encodeMemoryBoundary(compressed)
+    .split("$defs").length - 1;
+  const expanded = expandServerMessageSchemas(compressed);
+
+  console.log(
+    JSON.stringify({
+      fixture: "repeated-schema-sync",
+      upserts: sync.upserts.length,
+      before: {
+        schemaOccurrences: schemaMarkerCount,
+        encodedBytes: bytes,
+      },
+      after: {
+        schemaOccurrences: compressedSchemaMarkerCount,
+        encodedBytes: compressedBytes,
+      },
+      encodedByteReduction: Number((1 - compressedBytes / bytes).toFixed(4)),
+    }),
+  );
+
+  assertEquals(expanded, message);
+  assert(
+    schemaMarkerCount >= sync.upserts.length,
+    "baseline fixture should repeat schema definitions across many upserts",
+  );
+  assert(
+    compressedBytes < bytes / 5,
+    "schema-table encoding should materially reduce repeated schema frames",
+  );
+});
+
+Deno.test("memory server negotiates schema-table sync frames per connection", async () => {
+  const flags = getMemoryProtocolFlags();
+  const run = async (syncSchemaTable: boolean) => {
+    const server = new Server({
+      store: new URL(
+        `memory://sync-schema-table-negotiation-${syncSchemaTable}`,
+      ),
+    });
+    const messages: ServerMessage[] = [];
+    const connection = server.connect((message) => messages.push(message));
+    const space = `did:key:z6Mk-sync-schema-table-${syncSchemaTable}`;
+
+    try {
+      await connection.receive(encodeMemoryBoundary({
+        type: "hello",
+        protocol: MEMORY_PROTOCOL,
+        flags: syncSchemaTable ? flags : {
+          modernCellRep: flags.modernCellRep,
+          persistentSchedulerState: flags.persistentSchedulerState,
+          commitPreconditions: flags.commitPreconditions,
+        },
+      }));
+      shiftMessage(messages);
+
+      await connection.receive(encodeMemoryBoundary({
+        type: "session.open",
+        requestId: "open",
+        space,
+        session: {},
+      }));
+      const opened = assertResponse<SessionOpenResult>(
+        shiftMessage(messages),
+      );
+      assertExists(opened.ok);
+
+      const upsert = repeatedSchemaSync(1).upserts[0];
+      await connection.receive(encodeMemoryBoundary({
+        type: "transact",
+        requestId: "write",
+        space,
+        sessionId: opened.ok.sessionId,
+        commit: {
+          localSeq: 1,
+          reads: { confirmed: [], pending: [] },
+          operations: [{
+            op: "set",
+            id: upsert.id,
+            value: upsert.doc,
+          }],
+        },
+      }));
+      shiftMessage(messages);
+
+      await connection.receive(encodeMemoryBoundary({
+        type: "session.watch.add",
+        requestId: "watch",
+        space,
+        sessionId: opened.ok.sessionId,
+        watches: [{
+          id: "root",
+          kind: "graph",
+          query: {
+            roots: [{
+              id: upsert.id,
+              selector: {
+                path: [],
+                schema: false,
+              },
+            }],
+          },
+        }],
+      }));
+
+      const watched = assertResponse<WatchAddResult>(shiftMessage(messages));
+      assertExists(watched.ok);
+      return (watched.ok.sync as SchemaTableSessionSync).schemaTable;
+    } finally {
+      connection.close();
+      await server.close();
+    }
+  };
+
+  assertExists(await run(true));
+  assertEquals(await run(false), undefined);
+});

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -6,6 +6,7 @@ import {
   assertThrows,
 } from "@std/assert";
 import { LINK_V1_TAG, linkRefFrom } from "@commonfabric/data-model/cell-rep";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type { JSONSchema } from "@commonfabric/api";
 import {
   encodeMemoryBoundary,
@@ -191,12 +192,13 @@ Deno.test("sync schema table round-trips legacy aliases nested in arrays", () =>
   const compressedAliases =
     (compressed.upserts[0].doc?.value as Record<string, unknown>)
       .aliases as Record<string, unknown>[];
+  const schemaHash = internSchema(schema, true).taggedHashString;
 
   assertExists(compressed.schemaTable);
-  assertEquals(compressed.schemaTable.length, 1);
+  assertEquals(Object.keys(compressed.schemaTable), [schemaHash]);
   assertEquals(
     (compressedAliases[0].$alias as Record<string, unknown>).schema,
-    "schema-ref@1:0",
+    `schema-ref@1:${schemaHash}`,
   );
   assertEquals(
     (compressedAliases[1].$alias as Record<string, unknown>).schema,
@@ -247,7 +249,7 @@ Deno.test("sync schema table leaves syncs without compressible schemas unchanged
     ],
     removes: [],
   };
-  const emptyTableSync: SchemaTableSessionSync = { ...sync, schemaTable: [] };
+  const emptyTableSync: SchemaTableSessionSync = { ...sync, schemaTable: {} };
 
   assertStrictEquals(compressSessionSyncSchemas(sync), sync);
   assertStrictEquals(expandSessionSyncSchemas(sync), sync);
@@ -256,6 +258,7 @@ Deno.test("sync schema table leaves syncs without compressible schemas unchanged
 
 Deno.test("sync schema table expands unused tables and rejects bad refs", () => {
   const schema: JSONSchema = { type: "string" };
+  const schemaHash = internSchema(schema, true).taggedHashString;
   const syncWithUnusedTable: SchemaTableSessionSync = {
     type: "sync",
     fromSeq: 0,
@@ -296,7 +299,7 @@ Deno.test("sync schema table expands unused tables and rejects bad refs", () => 
       },
     ],
     removes: [],
-    schemaTable: [schema],
+    schemaTable: { [schemaHash]: schema },
   };
 
   const expanded = expandSessionSyncSchemas(syncWithUnusedTable);
@@ -304,7 +307,8 @@ Deno.test("sync schema table expands unused tables and rejects bad refs", () => 
     syncWithUnusedTable;
   assertEquals(expanded, syncWithoutTable);
   assertEquals(
-    (expanded as unknown as { schemaTable?: JSONSchema[] }).schemaTable,
+    (expanded as unknown as { schemaTable?: Record<string, JSONSchema> })
+      .schemaTable,
     undefined,
   );
   assert(Object.isFrozen(expanded));
@@ -325,7 +329,7 @@ Deno.test("sync schema table expands unused tables and rejects bad refs", () => 
                   [LINK_V1_TAG]: {
                     id: "of:bad-ref-target",
                     path: [],
-                    schema: "schema-ref@1:99",
+                    schema: "schema-ref@1:sha256:missing",
                   },
                 },
               },
@@ -335,6 +339,35 @@ Deno.test("sync schema table expands unused tables and rejects bad refs", () => 
       }),
     Error,
     "Invalid sync schema table reference",
+  );
+
+  assertThrows(
+    () =>
+      expandSessionSyncSchemas({
+        ...syncWithUnusedTable,
+        upserts: [{
+          branch: "",
+          id: "of:poisoned-ref",
+          scope: "space",
+          seq: 1,
+          doc: {
+            value: {
+              ref: {
+                "/": {
+                  [LINK_V1_TAG]: {
+                    id: "of:poisoned-ref-target",
+                    path: [],
+                    schema: `schema-ref@1:${schemaHash}`,
+                  },
+                },
+              },
+            },
+          },
+        }],
+        schemaTable: { [schemaHash]: { type: "number" } },
+      }),
+    Error,
+    "Invalid sync schema table content",
   );
 });
 

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -130,6 +130,10 @@ Deno.test("sync schema table experiment captures repeated schema savings", () =>
     "baseline fixture should repeat schema definitions across many upserts",
   );
   assert(
+    compressedSchemaMarkerCount < schemaMarkerCount / 100,
+    "schema-table encoding should remove almost all repeated schema definitions",
+  );
+  assert(
     compressedBytes < bytes / 5,
     "schema-table encoding should materially reduce repeated schema frames",
   );

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -198,7 +198,7 @@ Deno.test("sync schema table round-trips legacy aliases nested in arrays", () =>
   assertEquals(Object.keys(compressed.schemaTable), [schemaHash]);
   assertEquals(
     (compressedAliases[0].$alias as Record<string, unknown>).schema,
-    `schema-ref@1:${schemaHash}`,
+    `schema-ref@2:${schemaHash}`,
   );
   assertEquals(
     (compressedAliases[1].$alias as Record<string, unknown>).schema,
@@ -212,6 +212,71 @@ Deno.test("sync schema table round-trips legacy aliases nested in arrays", () =>
     ).schema,
     undefined,
   );
+  assertEquals(expandSessionSyncSchemas(compressed), sync);
+});
+
+Deno.test("sync schema table continues through sibling fields after link payloads", () => {
+  const primarySchema: JSONSchema = {
+    type: "object",
+    properties: { title: { type: "string" } },
+  };
+  const siblingSchema: JSONSchema = {
+    type: "object",
+    properties: { count: { type: "number" } },
+  };
+  const sync: SessionSync = {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [{
+      branch: "",
+      id: "of:link-with-sibling",
+      scope: "space",
+      seq: 1,
+      doc: {
+        value: {
+          compound: {
+            "/": {
+              [LINK_V1_TAG]: {
+                id: "of:primary",
+                path: [],
+                schema: primarySchema,
+              },
+            },
+            sibling: linkRefFrom({
+              id: "of:sibling",
+              path: [],
+              schema: siblingSchema,
+            }),
+          },
+        },
+      },
+    }],
+    removes: [],
+  };
+
+  const compressed = compressSessionSyncSchemas(sync) as SchemaTableSessionSync;
+  const compressedCompound =
+    (compressed.upserts[0].doc?.value as Record<string, unknown>)
+      .compound as Record<string, unknown>;
+  const compressedPayload =
+    (compressedCompound["/"] as Record<string, unknown>)[
+      LINK_V1_TAG
+    ] as Record<string, unknown>;
+  const compressedSiblingPayload =
+    ((compressedCompound.sibling as Record<string, unknown>)[
+      "/"
+    ] as Record<string, unknown>)[LINK_V1_TAG] as Record<string, unknown>;
+  const primaryHash = internSchema(primarySchema, true).taggedHashString;
+  const siblingHash = internSchema(siblingSchema, true).taggedHashString;
+
+  assertExists(compressed.schemaTable);
+  assertEquals(
+    Object.keys(compressed.schemaTable).sort(),
+    [primaryHash, siblingHash].sort(),
+  );
+  assertEquals(compressedPayload.schema, `schema-ref@2:${primaryHash}`);
+  assertEquals(compressedSiblingPayload.schema, `schema-ref@2:${siblingHash}`);
   assertEquals(expandSessionSyncSchemas(compressed), sync);
 });
 
@@ -329,7 +394,7 @@ Deno.test("sync schema table expands unused tables and rejects bad refs", () => 
                   [LINK_V1_TAG]: {
                     id: "of:bad-ref-target",
                     path: [],
-                    schema: "schema-ref@1:sha256:missing",
+                    schema: "schema-ref@2:sha256:missing",
                   },
                 },
               },
@@ -357,7 +422,7 @@ Deno.test("sync schema table expands unused tables and rejects bad refs", () => 
                   [LINK_V1_TAG]: {
                     id: "of:poisoned-ref-target",
                     path: [],
-                    schema: `schema-ref@1:${schemaHash}`,
+                    schema: `schema-ref@2:${schemaHash}`,
                   },
                 },
               },
@@ -437,27 +502,31 @@ Deno.test("server schema table helpers expand response sync payloads", () => {
   assertEquals(expanded.ok?.sync, sync);
 });
 
-Deno.test("memory server negotiates schema-table sync frames per connection", async () => {
+Deno.test("memory server negotiates schema-table v2 sync frames per connection", async () => {
   const flags = getMemoryProtocolFlags();
-  const run = async (syncSchemaTable: boolean) => {
+  const run = async (
+    mode: "v2" | "legacy" | "off",
+  ) => {
     const server = new Server({
       store: new URL(
-        `memory://sync-schema-table-negotiation-${syncSchemaTable}`,
+        `memory://sync-schema-table-negotiation-${mode}`,
       ),
     });
     const messages: ServerMessage[] = [];
     const connection = server.connect((message) => messages.push(message));
-    const space = `did:key:z6Mk-sync-schema-table-${syncSchemaTable}`;
+    const space = `did:key:z6Mk-sync-schema-table-${mode}`;
+    const clientFlags = mode === "v2" ? flags : {
+      modernCellRep: flags.modernCellRep,
+      persistentSchedulerState: flags.persistentSchedulerState,
+      commitPreconditions: flags.commitPreconditions,
+      ...(mode === "legacy" ? { syncSchemaTable: true } : {}),
+    };
 
     try {
       await connection.receive(encodeMemoryBoundary({
         type: "hello",
         protocol: MEMORY_PROTOCOL,
-        flags: syncSchemaTable ? flags : {
-          modernCellRep: flags.modernCellRep,
-          persistentSchedulerState: flags.persistentSchedulerState,
-          commitPreconditions: flags.commitPreconditions,
-        },
+        flags: clientFlags,
       }));
       shiftMessage(messages);
 
@@ -519,6 +588,7 @@ Deno.test("memory server negotiates schema-table sync frames per connection", as
     }
   };
 
-  assertExists(await run(true));
-  assertEquals(await run(false), undefined);
+  assertExists(await run("v2"));
+  assertEquals(await run("legacy"), undefined);
+  assertEquals(await run("off"), undefined);
 });

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -1,5 +1,11 @@
-import { assert, assertEquals, assertExists } from "@std/assert";
-import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertStrictEquals,
+  assertThrows,
+} from "@std/assert";
+import { LINK_V1_TAG, linkRefFrom } from "@commonfabric/data-model/cell-rep";
 import type { JSONSchema } from "@commonfabric/api";
 import {
   encodeMemoryBoundary,
@@ -15,7 +21,9 @@ import {
 import { Server } from "../v2/server.ts";
 import {
   compressServerMessageSchemas,
+  compressSessionSyncSchemas,
   expandServerMessageSchemas,
+  expandSessionSyncSchemas,
   type SchemaTableSessionSync,
 } from "../v2/sync-schema-table.ts";
 
@@ -116,22 +124,6 @@ Deno.test("sync schema table experiment captures repeated schema savings", () =>
     .split("$defs").length - 1;
   const expanded = expandServerMessageSchemas(compressed);
 
-  console.log(
-    JSON.stringify({
-      fixture: "repeated-schema-sync",
-      upserts: sync.upserts.length,
-      before: {
-        schemaOccurrences: schemaMarkerCount,
-        encodedBytes: bytes,
-      },
-      after: {
-        schemaOccurrences: compressedSchemaMarkerCount,
-        encodedBytes: compressedBytes,
-      },
-      encodedByteReduction: Number((1 - compressedBytes / bytes).toFixed(4)),
-    }),
-  );
-
   assertEquals(expanded, message);
   assert(
     schemaMarkerCount >= sync.upserts.length,
@@ -141,6 +133,271 @@ Deno.test("sync schema table experiment captures repeated schema savings", () =>
     compressedBytes < bytes / 5,
     "schema-table encoding should materially reduce repeated schema frames",
   );
+});
+
+Deno.test("sync schema table round-trips legacy aliases nested in arrays", () => {
+  const schema: JSONSchema = {
+    type: "object",
+    properties: {
+      title: { type: "string" },
+    },
+  };
+  const sync: SessionSync = {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [{
+      branch: "",
+      id: "of:legacy-alias-source",
+      scope: "space",
+      seq: 1,
+      doc: {
+        value: {
+          aliases: [
+            {
+              $alias: {
+                id: "of:legacy-target",
+                path: [],
+                schema,
+              },
+            },
+            {
+              $alias: {
+                id: "of:string-schema-target",
+                path: [],
+                schema: "opaque-schema-name",
+              },
+            },
+            {
+              "/": {
+                [LINK_V1_TAG]: {
+                  id: "of:no-schema-target",
+                  path: [],
+                },
+              },
+            },
+          ],
+        },
+      },
+    }],
+    removes: [],
+  };
+
+  const compressed = compressSessionSyncSchemas(sync) as SchemaTableSessionSync;
+  const compressedAliases =
+    (compressed.upserts[0].doc?.value as Record<string, unknown>)
+      .aliases as Record<string, unknown>[];
+
+  assertExists(compressed.schemaTable);
+  assertEquals(compressed.schemaTable.length, 1);
+  assertEquals(
+    (compressedAliases[0].$alias as Record<string, unknown>).schema,
+    "schema-ref@1:0",
+  );
+  assertEquals(
+    (compressedAliases[1].$alias as Record<string, unknown>).schema,
+    "opaque-schema-name",
+  );
+  assertEquals(
+    (
+      (compressedAliases[2]["/"] as Record<string, unknown>)[
+        LINK_V1_TAG
+      ] as Record<string, unknown>
+    ).schema,
+    undefined,
+  );
+  assertEquals(expandSessionSyncSchemas(compressed), sync);
+});
+
+Deno.test("sync schema table leaves syncs without compressible schemas unchanged", () => {
+  const sync: SessionSync = {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [
+      {
+        branch: "",
+        id: "of:missing-doc",
+        scope: "space",
+        seq: 1,
+      },
+      {
+        branch: "",
+        id: "of:no-compressible-schema",
+        scope: "space",
+        seq: 1,
+        doc: {
+          value: {
+            ref: {
+              "/": {
+                [LINK_V1_TAG]: {
+                  id: "of:string-schema",
+                  path: [],
+                  schema: "opaque-schema-name",
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+    removes: [],
+  };
+  const emptyTableSync: SchemaTableSessionSync = { ...sync, schemaTable: [] };
+
+  assertStrictEquals(compressSessionSyncSchemas(sync), sync);
+  assertStrictEquals(expandSessionSyncSchemas(sync), sync);
+  assertStrictEquals(expandSessionSyncSchemas(emptyTableSync), emptyTableSync);
+});
+
+Deno.test("sync schema table expands unused tables and rejects bad refs", () => {
+  const schema: JSONSchema = { type: "string" };
+  const syncWithUnusedTable: SchemaTableSessionSync = {
+    type: "sync",
+    fromSeq: 0,
+    toSeq: 1,
+    upserts: [
+      {
+        branch: "",
+        id: "of:missing-doc",
+        scope: "space",
+        seq: 1,
+      },
+      {
+        branch: "",
+        id: "of:non-ref-schema",
+        scope: "space",
+        seq: 1,
+        doc: {
+          value: {
+            ref: {
+              "/": {
+                [LINK_V1_TAG]: {
+                  id: "of:non-ref-schema-target",
+                  path: [],
+                  schema: "opaque-schema-name",
+                },
+              },
+            },
+            refWithoutSchema: {
+              "/": {
+                [LINK_V1_TAG]: {
+                  id: "of:no-schema-target",
+                  path: [],
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+    removes: [],
+    schemaTable: [schema],
+  };
+
+  const expanded = expandSessionSyncSchemas(syncWithUnusedTable);
+  const { schemaTable: _unusedSchemaTable, ...syncWithoutTable } =
+    syncWithUnusedTable;
+  assertEquals(expanded, syncWithoutTable);
+  assertEquals(
+    (expanded as unknown as { schemaTable?: JSONSchema[] }).schemaTable,
+    undefined,
+  );
+  assert(Object.isFrozen(expanded));
+
+  assertThrows(
+    () =>
+      expandSessionSyncSchemas({
+        ...syncWithUnusedTable,
+        upserts: [{
+          branch: "",
+          id: "of:bad-ref",
+          scope: "space",
+          seq: 1,
+          doc: {
+            value: {
+              ref: {
+                "/": {
+                  [LINK_V1_TAG]: {
+                    id: "of:bad-ref-target",
+                    path: [],
+                    schema: "schema-ref@1:99",
+                  },
+                },
+              },
+            },
+          },
+        }],
+      }),
+    Error,
+    "Invalid sync schema table reference",
+  );
+});
+
+Deno.test("server schema table helpers ignore non-sync messages", () => {
+  const hello = {
+    type: "hello.ok",
+    protocol: MEMORY_PROTOCOL,
+    flags: getMemoryProtocolFlags(),
+  } satisfies ServerMessage;
+  const responseWithoutOk = {
+    type: "response",
+    requestId: "without-ok",
+  } satisfies ServerMessage;
+  const responseWithPrimitiveOk = {
+    type: "response",
+    requestId: "primitive-ok",
+    ok: "done",
+  } satisfies ServerMessage;
+  const responseWithNonSyncOk = {
+    type: "response",
+    requestId: "non-sync",
+    ok: { sync: { type: "not-sync" } },
+  } satisfies ServerMessage;
+
+  assertStrictEquals(compressServerMessageSchemas(hello), hello);
+  assertStrictEquals(
+    compressServerMessageSchemas(responseWithoutOk),
+    responseWithoutOk,
+  );
+  assertStrictEquals(
+    compressServerMessageSchemas(responseWithPrimitiveOk),
+    responseWithPrimitiveOk,
+  );
+  assertStrictEquals(
+    compressServerMessageSchemas(responseWithNonSyncOk),
+    responseWithNonSyncOk,
+  );
+
+  assertStrictEquals(
+    expandServerMessageSchemas("not-an-object"),
+    "not-an-object",
+  );
+  assertStrictEquals(
+    expandServerMessageSchemas(responseWithoutOk),
+    responseWithoutOk,
+  );
+  assertStrictEquals(
+    expandServerMessageSchemas(responseWithNonSyncOk),
+    responseWithNonSyncOk,
+  );
+});
+
+Deno.test("server schema table helpers expand response sync payloads", () => {
+  const sync = repeatedSchemaSync(1);
+  const response = {
+    type: "response",
+    requestId: "sync-response",
+    ok: {
+      sync: compressSessionSyncSchemas(sync),
+    },
+  } satisfies ServerMessage;
+
+  const expanded = expandServerMessageSchemas(response) as ResponseMessage<{
+    sync: SessionSync;
+  }>;
+
+  assertEquals(expanded.ok?.sync, sync);
 });
 
 Deno.test("memory server negotiates schema-table sync frames per connection", async () => {

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -140,6 +140,7 @@ describe("memory v2 flags", () => {
       persistentSchedulerState: false,
       commitPreconditions: false,
       syncSchemaTable: false,
+      syncSchemaTableV2: false,
     });
 
     setModernCellRepConfig(true);
@@ -151,7 +152,8 @@ describe("memory v2 flags", () => {
       modernCellRep: true,
       persistentSchedulerState: true,
       commitPreconditions: true,
-      syncSchemaTable: true,
+      syncSchemaTable: false,
+      syncSchemaTableV2: true,
     });
 
     resetModernCellRepConfig();
@@ -167,12 +169,14 @@ describe("memory v2 flags", () => {
         persistentSchedulerState: true,
         commitPreconditions: true,
         syncSchemaTable: true,
+        syncSchemaTableV2: true,
       },
       {
         modernCellRep: true,
         persistentSchedulerState: false,
         commitPreconditions: false,
         syncSchemaTable: false,
+        syncSchemaTableV2: false,
       },
     ));
   });
@@ -185,12 +189,14 @@ describe("parseMemoryProtocolFlags", () => {
       persistentSchedulerState: false,
       commitPreconditions: false,
       syncSchemaTable: false,
+      syncSchemaTableV2: false,
     });
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: false }), {
       modernCellRep: false,
       persistentSchedulerState: false,
       commitPreconditions: false,
       syncSchemaTable: false,
+      syncSchemaTableV2: false,
     });
   });
 
@@ -204,6 +210,7 @@ describe("parseMemoryProtocolFlags", () => {
         persistentSchedulerState: true,
         commitPreconditions: false,
         syncSchemaTable: false,
+        syncSchemaTableV2: false,
       },
     );
   });
@@ -218,11 +225,12 @@ describe("parseMemoryProtocolFlags", () => {
         persistentSchedulerState: false,
         commitPreconditions: true,
         syncSchemaTable: false,
+        syncSchemaTableV2: false,
       },
     );
   });
 
-  it("accepts the canonical syncSchemaTable key", () => {
+  it("accepts the legacy syncSchemaTable key", () => {
     assertEquals(
       parseMemoryProtocolFlags({
         syncSchemaTable: true,
@@ -232,6 +240,22 @@ describe("parseMemoryProtocolFlags", () => {
         persistentSchedulerState: false,
         commitPreconditions: false,
         syncSchemaTable: true,
+        syncSchemaTableV2: false,
+      },
+    );
+  });
+
+  it("accepts the canonical syncSchemaTableV2 key", () => {
+    assertEquals(
+      parseMemoryProtocolFlags({
+        syncSchemaTableV2: true,
+      }),
+      {
+        modernCellRep: false,
+        persistentSchedulerState: false,
+        commitPreconditions: false,
+        syncSchemaTable: false,
+        syncSchemaTableV2: true,
       },
     );
   });
@@ -243,6 +267,7 @@ describe("parseMemoryProtocolFlags", () => {
     assertEquals(parseMemoryProtocolFlags([true]), null);
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: "true" }), null);
     assertEquals(parseMemoryProtocolFlags({ syncSchemaTable: "true" }), null);
+    assertEquals(parseMemoryProtocolFlags({ syncSchemaTableV2: "true" }), null);
     assertEquals(
       parseMemoryProtocolFlags({
         modernCellRep: true,

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -16,8 +16,10 @@ import {
   parseMemoryProtocolFlags,
   resetCommitPreconditionsConfig,
   resetPersistentSchedulerStateConfig,
+  resetSyncSchemaTableConfig,
   setCommitPreconditionsConfig,
   setPersistentSchedulerStateConfig,
+  setSyncSchemaTableConfig,
   toDocumentPath,
   toDocumentSelector,
   toValuePath,
@@ -106,42 +108,50 @@ describe("memory v2 flags", () => {
     resetModernCellRepConfig();
     resetPersistentSchedulerStateConfig();
     resetCommitPreconditionsConfig();
+    resetSyncSchemaTableConfig();
     setModernCellRepConfig(false);
     setPersistentSchedulerStateConfig(false);
     setCommitPreconditionsConfig(false);
+    setSyncSchemaTableConfig(false);
 
     assertEquals(getMemoryProtocolFlags(), {
       modernCellRep: false,
       persistentSchedulerState: false,
       commitPreconditions: false,
+      syncSchemaTable: false,
     });
 
     setModernCellRepConfig(true);
     setPersistentSchedulerStateConfig(true);
     setCommitPreconditionsConfig(true);
+    setSyncSchemaTableConfig(true);
 
     assertEquals(getMemoryProtocolFlags(), {
       modernCellRep: true,
       persistentSchedulerState: true,
       commitPreconditions: true,
+      syncSchemaTable: true,
     });
 
     resetModernCellRepConfig();
     resetPersistentSchedulerStateConfig();
     resetCommitPreconditionsConfig();
+    resetSyncSchemaTableConfig();
   });
 
-  it("treats scheduler-state persistence as an optional capability", () => {
+  it("treats non-wire-shape flags as optional capabilities", () => {
     assert(compatibleMemoryProtocolFlags(
       {
         modernCellRep: true,
         persistentSchedulerState: true,
         commitPreconditions: true,
+        syncSchemaTable: true,
       },
       {
         modernCellRep: true,
         persistentSchedulerState: false,
         commitPreconditions: false,
+        syncSchemaTable: false,
       },
     ));
   });
@@ -153,11 +163,13 @@ describe("parseMemoryProtocolFlags", () => {
       modernCellRep: true,
       persistentSchedulerState: false,
       commitPreconditions: false,
+      syncSchemaTable: false,
     });
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: false }), {
       modernCellRep: false,
       persistentSchedulerState: false,
       commitPreconditions: false,
+      syncSchemaTable: false,
     });
   });
 
@@ -170,6 +182,7 @@ describe("parseMemoryProtocolFlags", () => {
         modernCellRep: false,
         persistentSchedulerState: true,
         commitPreconditions: false,
+        syncSchemaTable: false,
       },
     );
   });
@@ -183,6 +196,21 @@ describe("parseMemoryProtocolFlags", () => {
         modernCellRep: false,
         persistentSchedulerState: false,
         commitPreconditions: true,
+        syncSchemaTable: false,
+      },
+    );
+  });
+
+  it("accepts the canonical syncSchemaTable key", () => {
+    assertEquals(
+      parseMemoryProtocolFlags({
+        syncSchemaTable: true,
+      }),
+      {
+        modernCellRep: false,
+        persistentSchedulerState: false,
+        commitPreconditions: false,
+        syncSchemaTable: true,
       },
     );
   });
@@ -193,6 +221,7 @@ describe("parseMemoryProtocolFlags", () => {
     assertEquals(parseMemoryProtocolFlags("modernCellRep"), null);
     assertEquals(parseMemoryProtocolFlags([true]), null);
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: "true" }), null);
+    assertEquals(parseMemoryProtocolFlags({ syncSchemaTable: "true" }), null);
     assertEquals(
       parseMemoryProtocolFlags({
         modernCellRep: true,

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -11,6 +11,8 @@ import {
   decodeMemoryBoundary,
   DEFAULT_BRANCH,
   encodeMemoryBoundary,
+  type EntityDocument,
+  getEntityDocumentMetadata,
   getMemoryProtocolFlags,
   MEMORY_PROTOCOL,
   parseMemoryProtocolFlags,
@@ -70,6 +72,25 @@ describe("memory v2 documents", () => {
       }),
       {
         value: { hello: "world" },
+      },
+    );
+  });
+
+  it("extracts document metadata without value", () => {
+    const source = entityRefFromString("abc123");
+    const document: EntityDocument = {
+      value: { hello: "world" },
+      source,
+      label: "example",
+      count: 2,
+    };
+
+    assertEquals(
+      getEntityDocumentMetadata(document),
+      {
+        source,
+        label: "example",
+        count: 2,
       },
     );
   });

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -202,6 +202,7 @@ export interface MemoryProtocolFlags {
   modernCellRep: boolean;
   persistentSchedulerState: boolean;
   commitPreconditions: boolean;
+  syncSchemaTable: boolean;
 }
 
 /**
@@ -211,6 +212,7 @@ export type WireMemoryProtocolFlags = {
   modernCellRep?: boolean;
   persistentSchedulerState?: boolean;
   commitPreconditions?: boolean;
+  syncSchemaTable?: boolean;
 };
 
 export interface HelloMessage {
@@ -574,6 +576,7 @@ const memoryReconstructionContext = new EmptyReconstructionContext(
 
 let persistentSchedulerStateEnabled = false;
 let commitPreconditionsEnabled = false;
+let syncSchemaTableEnabled = true;
 
 /**
  * Ambient runtime flag for persistent scheduler observations and rehydration.
@@ -608,10 +611,28 @@ export function resetCommitPreconditionsConfig(): void {
   commitPreconditionsEnabled = false;
 }
 
+/**
+ * Ambient protocol capability for frame-local schema tables in sync payloads.
+ * This is a wire-size optimization only; peers that do not advertise it keep
+ * receiving the historical fully-expanded `SessionSync` shape.
+ */
+export function setSyncSchemaTableConfig(enabled?: boolean): void {
+  syncSchemaTableEnabled = enabled ?? true;
+}
+
+export function getSyncSchemaTableConfig(): boolean {
+  return syncSchemaTableEnabled;
+}
+
+export function resetSyncSchemaTableConfig(): void {
+  syncSchemaTableEnabled = true;
+}
+
 export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   modernCellRep: getModernCellRepConfig(),
   persistentSchedulerState: getPersistentSchedulerStateConfig(),
   commitPreconditions: getCommitPreconditionsConfig(),
+  syncSchemaTable: getSyncSchemaTableConfig(),
 });
 
 /**
@@ -660,10 +681,19 @@ export const parseMemoryProtocolFlags = (
     return null;
   }
 
+  const syncSchemaTable = value.syncSchemaTable;
+  if (
+    syncSchemaTable !== undefined &&
+    typeof syncSchemaTable !== "boolean"
+  ) {
+    return null;
+  }
+
   return {
     modernCellRep: modernCellRep === true,
     persistentSchedulerState: persistentSchedulerState === true,
     commitPreconditions: commitPreconditions === true,
+    syncSchemaTable: syncSchemaTable === true,
   };
 };
 
@@ -676,6 +706,7 @@ export const wireMemoryProtocolFlags = (
   modernCellRep: flags.modernCellRep,
   persistentSchedulerState: flags.persistentSchedulerState,
   commitPreconditions: flags.commitPreconditions,
+  syncSchemaTable: flags.syncSchemaTable,
 });
 
 export const encodeMemoryBoundary = (value: FabricValue): string =>

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -202,7 +202,10 @@ export interface MemoryProtocolFlags {
   modernCellRep: boolean;
   persistentSchedulerState: boolean;
   commitPreconditions: boolean;
+  /** Legacy CT-1775 draft capability: index-keyed per-frame schema table. */
   syncSchemaTable: boolean;
+  /** Hash-keyed per-frame schema table. */
+  syncSchemaTableV2: boolean;
 }
 
 /**
@@ -213,6 +216,7 @@ export type WireMemoryProtocolFlags = {
   persistentSchedulerState?: boolean;
   commitPreconditions?: boolean;
   syncSchemaTable?: boolean;
+  syncSchemaTableV2?: boolean;
 };
 
 export interface HelloMessage {
@@ -612,9 +616,10 @@ export function resetCommitPreconditionsConfig(): void {
 }
 
 /**
- * Ambient protocol capability for frame-local schema tables in sync payloads.
- * This is a wire-size optimization only; peers that do not advertise it keep
- * receiving the historical fully-expanded `SessionSync` shape.
+ * Ambient protocol capability for hash-keyed frame-local schema tables in sync
+ * payloads. This is a wire-size optimization only; peers that do not advertise
+ * the v2 capability keep receiving the historical fully-expanded `SessionSync`
+ * shape.
  */
 export function setSyncSchemaTableConfig(enabled?: boolean): void {
   syncSchemaTableEnabled = enabled ?? true;
@@ -632,7 +637,8 @@ export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   modernCellRep: getModernCellRepConfig(),
   persistentSchedulerState: getPersistentSchedulerStateConfig(),
   commitPreconditions: getCommitPreconditionsConfig(),
-  syncSchemaTable: getSyncSchemaTableConfig(),
+  syncSchemaTable: false,
+  syncSchemaTableV2: getSyncSchemaTableConfig(),
 });
 
 /**
@@ -689,11 +695,20 @@ export const parseMemoryProtocolFlags = (
     return null;
   }
 
+  const syncSchemaTableV2 = value.syncSchemaTableV2;
+  if (
+    syncSchemaTableV2 !== undefined &&
+    typeof syncSchemaTableV2 !== "boolean"
+  ) {
+    return null;
+  }
+
   return {
     modernCellRep: modernCellRep === true,
     persistentSchedulerState: persistentSchedulerState === true,
     commitPreconditions: commitPreconditions === true,
     syncSchemaTable: syncSchemaTable === true,
+    syncSchemaTableV2: syncSchemaTableV2 === true,
   };
 };
 
@@ -707,6 +722,7 @@ export const wireMemoryProtocolFlags = (
   persistentSchedulerState: flags.persistentSchedulerState,
   commitPreconditions: flags.commitPreconditions,
   syncSchemaTable: flags.syncSchemaTable,
+  syncSchemaTableV2: flags.syncSchemaTableV2,
 });
 
 export const encodeMemoryBoundary = (value: FabricValue): string =>

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -29,6 +29,7 @@ import {
 import type { Server } from "./server.ts";
 import type { AppliedCommit } from "./engine.ts";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
+import { expandServerMessageSchemas } from "./sync-schema-table.ts";
 
 export interface Transport {
   send(payload: string): Promise<void>;
@@ -211,6 +212,7 @@ export class Client {
     let message: unknown;
     try {
       message = decodeMemoryBoundary(payload);
+      message = expandServerMessageSchemas(message);
     } catch (cause) {
       const error = new Error("Unable to parse memory server message", {
         cause,

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -68,6 +68,7 @@ import {
   trackGraph,
 } from "./query.ts";
 import { respondToHello } from "./handshake.ts";
+import { compressServerMessageSchemas } from "./sync-schema-table.ts";
 import {
   buildDiffSync,
   buildFullSync,
@@ -308,6 +309,7 @@ type DirtyOrigin = {
 class Connection {
   #ready = false;
   #closed = false;
+  #syncSchemaTable = false;
   #sessions = new Map<string, SessionHandle>();
   #receiving: Promise<void> = Promise.resolve();
   #pendingReceives = 0;
@@ -316,8 +318,14 @@ class Connection {
   constructor(
     readonly id: string,
     private readonly server: Server,
-    private readonly send: Send,
+    private readonly sendRaw: Send,
   ) {}
+
+  private send(message: ServerMessage): void {
+    this.sendRaw(
+      this.#syncSchemaTable ? compressServerMessageSchemas(message) : message,
+    );
+  }
 
   hasSession(space: string, sessionId: string): boolean {
     return this.#sessions.has(sessionKey(space, sessionId));
@@ -446,6 +454,9 @@ class Connection {
       if (response.type !== "hello.ok") {
         return;
       }
+      this.#syncSchemaTable =
+        parseMemoryProtocolFlags(parsed.flags)?.syncSchemaTable === true &&
+        parseMemoryProtocolFlags(response.flags)?.syncSchemaTable === true;
       this.#ready = true;
       return;
     }

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -454,9 +454,10 @@ class Connection {
       if (response.type !== "hello.ok") {
         return;
       }
-      this.#syncSchemaTable =
-        parseMemoryProtocolFlags(parsed.flags)?.syncSchemaTable === true &&
-        parseMemoryProtocolFlags(response.flags)?.syncSchemaTable === true;
+      const clientFlags = parseMemoryProtocolFlags(parsed.flags);
+      const serverFlags = parseMemoryProtocolFlags(response.flags);
+      this.#syncSchemaTable = clientFlags?.syncSchemaTableV2 === true &&
+        serverFlags?.syncSchemaTableV2 === true;
       this.#ready = true;
       return;
     }

--- a/packages/memory/v2/sync-schema-table.ts
+++ b/packages/memory/v2/sync-schema-table.ts
@@ -9,7 +9,7 @@ import type {
 } from "../v2.ts";
 import { isPlainObject } from "@commonfabric/utils/types";
 
-const SCHEMA_REF_PREFIX = "schema-ref@1:";
+const SCHEMA_REF_PREFIX = "schema-ref@2:";
 
 type SchemaTable = Record<string, JSONSchema>;
 
@@ -118,18 +118,21 @@ const rewriteValue = (value: unknown, state: RewriteState): unknown => {
   }
 
   const linkEnvelope = value["/"];
+  let rewrittenValue = value;
+  let changed = false;
   if (isPlainRecord(linkEnvelope)) {
     const payload = linkEnvelope[LINK_V1_TAG];
     if (isPlainRecord(payload)) {
       const nextPayload = rewriteLinkPayload(payload, state);
       if (nextPayload !== payload) {
-        return {
-          ...value,
+        rewrittenValue = {
+          ...rewrittenValue,
           "/": {
             ...linkEnvelope,
             [LINK_V1_TAG]: nextPayload,
           },
         };
+        changed = true;
       }
     }
   }
@@ -138,13 +141,13 @@ const rewriteValue = (value: unknown, state: RewriteState): unknown => {
   if (isPlainRecord(legacyAlias)) {
     const nextAlias = rewriteLinkPayload(legacyAlias, state);
     if (nextAlias !== legacyAlias) {
-      return { ...value, $alias: nextAlias };
+      rewrittenValue = { ...rewrittenValue, $alias: nextAlias };
+      changed = true;
     }
   }
 
-  let changed = false;
   const rewritten: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(value)) {
+  for (const [key, child] of Object.entries(rewrittenValue)) {
     const next = rewriteValue(child, state);
     changed ||= next !== child;
     rewritten[key] = next;
@@ -171,18 +174,21 @@ const expandValue = (
   }
 
   const linkEnvelope = value["/"];
+  let expandedValue = value;
+  let changed = false;
   if (isPlainRecord(linkEnvelope)) {
     const payload = linkEnvelope[LINK_V1_TAG];
     if (isPlainRecord(payload)) {
       const nextPayload = expandLinkPayload(payload, schemas);
       if (nextPayload !== payload) {
-        return {
-          ...value,
+        expandedValue = {
+          ...expandedValue,
           "/": {
             ...linkEnvelope,
             [LINK_V1_TAG]: nextPayload,
           },
         };
+        changed = true;
       }
     }
   }
@@ -191,13 +197,13 @@ const expandValue = (
   if (isPlainRecord(legacyAlias)) {
     const nextAlias = expandLinkPayload(legacyAlias, schemas);
     if (nextAlias !== legacyAlias) {
-      return { ...value, $alias: nextAlias };
+      expandedValue = { ...expandedValue, $alias: nextAlias };
+      changed = true;
     }
   }
 
-  let changed = false;
   const expanded: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(value)) {
+  for (const [key, child] of Object.entries(expandedValue)) {
     const next = expandValue(child, schemas);
     changed ||= next !== child;
     expanded[key] = next;

--- a/packages/memory/v2/sync-schema-table.ts
+++ b/packages/memory/v2/sync-schema-table.ts
@@ -1,0 +1,325 @@
+import type { JSONSchema } from "@commonfabric/api";
+import { LINK_V1_TAG } from "@commonfabric/data-model/cell-rep";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import type {
+  ServerMessage,
+  SessionEffectMessage,
+  SessionSync,
+} from "../v2.ts";
+import { isPlainObject } from "@commonfabric/utils/types";
+
+const SCHEMA_REF_PREFIX = "schema-ref@1:";
+
+export type SchemaTableSessionSync = SessionSync & {
+  schemaTable?: JSONSchema[];
+};
+
+type RewriteState = {
+  schemas: JSONSchema[];
+  schemaIndexes: Map<string, number>;
+  changed: boolean;
+};
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+  isPlainObject(value);
+
+const isCompressibleSchema = (value: unknown): value is JSONSchema =>
+  value === true || value === false || isPlainRecord(value);
+
+const schemaRefFor = (
+  schema: JSONSchema,
+  state: RewriteState,
+): string => {
+  const schemaAndHash = internSchema(schema, true);
+  const hash = schemaAndHash.taggedHashString;
+  const existing = state.schemaIndexes.get(hash);
+  if (existing !== undefined) {
+    return `${SCHEMA_REF_PREFIX}${existing}`;
+  }
+
+  const index = state.schemas.length;
+  state.schemaIndexes.set(hash, index);
+  state.schemas.push(schemaAndHash.schema);
+  return `${SCHEMA_REF_PREFIX}${index}`;
+};
+
+const expandSchemaRef = (
+  value: unknown,
+  schemas: readonly JSONSchema[] | undefined,
+): JSONSchema | undefined => {
+  if (typeof value !== "string" || !value.startsWith(SCHEMA_REF_PREFIX)) {
+    return undefined;
+  }
+  const index = Number(value.slice(SCHEMA_REF_PREFIX.length));
+  if (!Number.isInteger(index) || index < 0 || schemas?.[index] === undefined) {
+    throw new Error(`Invalid sync schema table reference: ${value}`);
+  }
+  return internSchema(schemas[index]);
+};
+
+const rewriteSchemaValue = (
+  value: unknown,
+  state: RewriteState,
+): unknown => {
+  if (isCompressibleSchema(value)) {
+    state.changed = true;
+    return schemaRefFor(value, state);
+  }
+  return value;
+};
+
+const expandSchemaValue = (
+  value: unknown,
+  schemas: readonly JSONSchema[] | undefined,
+): unknown => expandSchemaRef(value, schemas) ?? value;
+
+const rewriteLinkPayload = (
+  payload: Record<string, unknown>,
+  state: RewriteState,
+): Record<string, unknown> => {
+  if (!Object.hasOwn(payload, "schema")) {
+    return payload;
+  }
+  const schema = rewriteSchemaValue(payload.schema, state);
+  return schema === payload.schema ? payload : { ...payload, schema };
+};
+
+const expandLinkPayload = (
+  payload: Record<string, unknown>,
+  schemas: readonly JSONSchema[] | undefined,
+): Record<string, unknown> => {
+  if (!Object.hasOwn(payload, "schema")) {
+    return payload;
+  }
+  const schema = expandSchemaValue(payload.schema, schemas);
+  return schema === payload.schema ? payload : { ...payload, schema };
+};
+
+const rewriteValue = (value: unknown, state: RewriteState): unknown => {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const rewritten = value.map((item) => {
+      const next = rewriteValue(item, state);
+      changed ||= next !== item;
+      return next;
+    });
+    return changed ? rewritten : value;
+  }
+
+  if (!isPlainRecord(value)) {
+    return value;
+  }
+
+  const linkEnvelope = value["/"];
+  if (isPlainRecord(linkEnvelope)) {
+    const payload = linkEnvelope[LINK_V1_TAG];
+    if (isPlainRecord(payload)) {
+      const nextPayload = rewriteLinkPayload(payload, state);
+      if (nextPayload !== payload) {
+        return {
+          ...value,
+          "/": {
+            ...linkEnvelope,
+            [LINK_V1_TAG]: nextPayload,
+          },
+        };
+      }
+    }
+  }
+
+  const legacyAlias = value.$alias;
+  if (isPlainRecord(legacyAlias)) {
+    const nextAlias = rewriteLinkPayload(legacyAlias, state);
+    if (nextAlias !== legacyAlias) {
+      return { ...value, $alias: nextAlias };
+    }
+  }
+
+  let changed = false;
+  const rewritten: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    const next = rewriteValue(child, state);
+    changed ||= next !== child;
+    rewritten[key] = next;
+  }
+  return changed ? rewritten : value;
+};
+
+const expandValue = (
+  value: unknown,
+  schemas: readonly JSONSchema[] | undefined,
+): unknown => {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const expanded = value.map((item) => {
+      const next = expandValue(item, schemas);
+      changed ||= next !== item;
+      return next;
+    });
+    return changed ? expanded : value;
+  }
+
+  if (!isPlainRecord(value)) {
+    return value;
+  }
+
+  const linkEnvelope = value["/"];
+  if (isPlainRecord(linkEnvelope)) {
+    const payload = linkEnvelope[LINK_V1_TAG];
+    if (isPlainRecord(payload)) {
+      const nextPayload = expandLinkPayload(payload, schemas);
+      if (nextPayload !== payload) {
+        return {
+          ...value,
+          "/": {
+            ...linkEnvelope,
+            [LINK_V1_TAG]: nextPayload,
+          },
+        };
+      }
+    }
+  }
+
+  const legacyAlias = value.$alias;
+  if (isPlainRecord(legacyAlias)) {
+    const nextAlias = expandLinkPayload(legacyAlias, schemas);
+    if (nextAlias !== legacyAlias) {
+      return { ...value, $alias: nextAlias };
+    }
+  }
+
+  let changed = false;
+  const expanded: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    const next = expandValue(child, schemas);
+    changed ||= next !== child;
+    expanded[key] = next;
+  }
+  return changed ? expanded : value;
+};
+
+export const compressSessionSyncSchemas = (
+  sync: SessionSync,
+): SessionSync | SchemaTableSessionSync => {
+  const state: RewriteState = {
+    schemas: [],
+    schemaIndexes: new Map(),
+    changed: false,
+  };
+  const upserts = sync.upserts.map((upsert) => {
+    if (upsert.doc === undefined) {
+      return upsert;
+    }
+    const doc = rewriteValue(upsert.doc, state);
+    return doc === upsert.doc ? upsert : {
+      ...upsert,
+      doc: doc as typeof upsert.doc,
+    };
+  });
+
+  if (!state.changed) {
+    return sync;
+  }
+
+  return {
+    ...sync,
+    upserts,
+    schemaTable: state.schemas,
+  };
+};
+
+export const expandSessionSyncSchemas = (
+  sync: SessionSync | SchemaTableSessionSync,
+): SessionSync => {
+  const schemas = (sync as SchemaTableSessionSync).schemaTable;
+  if (schemas === undefined || schemas.length === 0) {
+    return sync;
+  }
+
+  const upserts = sync.upserts.map((upsert) => {
+    if (upsert.doc === undefined) {
+      return upsert;
+    }
+    const doc = expandValue(upsert.doc, schemas);
+    return doc === upsert.doc ? upsert : {
+      ...upsert,
+      doc: doc as typeof upsert.doc,
+    };
+  });
+
+  const withExpandedUpserts: SchemaTableSessionSync = {
+    ...sync,
+    upserts,
+  };
+  const { schemaTable: _schemaTable, ...expanded } = withExpandedUpserts;
+  return deepFreeze(expanded as SessionSync);
+};
+
+const compressResponseSync = (message: ServerMessage): ServerMessage => {
+  if (message.type !== "response" || message.ok === undefined) {
+    return message;
+  }
+  if (!isPlainRecord(message.ok)) {
+    return message;
+  }
+  const sync = message.ok.sync;
+  if (!isPlainRecord(sync) || sync.type !== "sync") {
+    return message;
+  }
+
+  return {
+    ...message,
+    ok: {
+      ...message.ok,
+      sync: compressSessionSyncSchemas(sync as unknown as SessionSync),
+    },
+  };
+};
+
+const expandResponseSync = (message: unknown): unknown => {
+  if (!isPlainRecord(message) || message.type !== "response") {
+    return message;
+  }
+  if (!isPlainRecord(message.ok)) {
+    return message;
+  }
+  const sync = message.ok.sync;
+  if (!isPlainRecord(sync) || sync.type !== "sync") {
+    return message;
+  }
+
+  return {
+    ...message,
+    ok: {
+      ...message.ok,
+      sync: expandSessionSyncSchemas(
+        sync as unknown as SchemaTableSessionSync,
+      ),
+    },
+  };
+};
+
+export const compressServerMessageSchemas = (
+  message: ServerMessage,
+): ServerMessage => {
+  if (message.type === "session/effect") {
+    return {
+      ...message,
+      effect: compressSessionSyncSchemas(message.effect),
+    } as SessionEffectMessage;
+  }
+  return compressResponseSync(message);
+};
+
+export const expandServerMessageSchemas = (message: unknown): unknown => {
+  if (isPlainRecord(message) && message.type === "session/effect") {
+    return {
+      ...message,
+      effect: expandSessionSyncSchemas(
+        message.effect as SchemaTableSessionSync,
+      ),
+    };
+  }
+  return expandResponseSync(message);
+};

--- a/packages/memory/v2/sync-schema-table.ts
+++ b/packages/memory/v2/sync-schema-table.ts
@@ -11,13 +11,14 @@ import { isPlainObject } from "@commonfabric/utils/types";
 
 const SCHEMA_REF_PREFIX = "schema-ref@1:";
 
+type SchemaTable = Record<string, JSONSchema>;
+
 export type SchemaTableSessionSync = SessionSync & {
-  schemaTable?: JSONSchema[];
+  schemaTable?: SchemaTable;
 };
 
 type RewriteState = {
-  schemas: JSONSchema[];
-  schemaIndexes: Map<string, number>;
+  schemas: Map<string, JSONSchema>;
   changed: boolean;
 };
 
@@ -33,29 +34,34 @@ const schemaRefFor = (
 ): string => {
   const schemaAndHash = internSchema(schema, true);
   const hash = schemaAndHash.taggedHashString;
-  const existing = state.schemaIndexes.get(hash);
-  if (existing !== undefined) {
-    return `${SCHEMA_REF_PREFIX}${existing}`;
+  if (!state.schemas.has(hash)) {
+    state.schemas.set(hash, schemaAndHash.schema);
   }
-
-  const index = state.schemas.length;
-  state.schemaIndexes.set(hash, index);
-  state.schemas.push(schemaAndHash.schema);
-  return `${SCHEMA_REF_PREFIX}${index}`;
+  return `${SCHEMA_REF_PREFIX}${hash}`;
 };
 
 const expandSchemaRef = (
   value: unknown,
-  schemas: readonly JSONSchema[] | undefined,
+  schemas: SchemaTable | undefined,
 ): JSONSchema | undefined => {
   if (typeof value !== "string" || !value.startsWith(SCHEMA_REF_PREFIX)) {
     return undefined;
   }
-  const index = Number(value.slice(SCHEMA_REF_PREFIX.length));
-  if (!Number.isInteger(index) || index < 0 || schemas?.[index] === undefined) {
+  const hash = value.slice(SCHEMA_REF_PREFIX.length);
+  if (
+    hash.length === 0 || schemas === undefined ||
+    !Object.hasOwn(schemas, hash)
+  ) {
     throw new Error(`Invalid sync schema table reference: ${value}`);
   }
-  return internSchema(schemas[index]);
+  const schema = schemas[hash];
+  const schemaAndHash = internSchema(schema, true);
+  if (schemaAndHash.taggedHashString !== hash) {
+    throw new Error(
+      `Invalid sync schema table content for reference: ${value}`,
+    );
+  }
+  return schemaAndHash.schema;
 };
 
 const rewriteSchemaValue = (
@@ -71,7 +77,7 @@ const rewriteSchemaValue = (
 
 const expandSchemaValue = (
   value: unknown,
-  schemas: readonly JSONSchema[] | undefined,
+  schemas: SchemaTable | undefined,
 ): unknown => expandSchemaRef(value, schemas) ?? value;
 
 const rewriteLinkPayload = (
@@ -87,7 +93,7 @@ const rewriteLinkPayload = (
 
 const expandLinkPayload = (
   payload: Record<string, unknown>,
-  schemas: readonly JSONSchema[] | undefined,
+  schemas: SchemaTable | undefined,
 ): Record<string, unknown> => {
   if (!Object.hasOwn(payload, "schema")) {
     return payload;
@@ -148,7 +154,7 @@ const rewriteValue = (value: unknown, state: RewriteState): unknown => {
 
 const expandValue = (
   value: unknown,
-  schemas: readonly JSONSchema[] | undefined,
+  schemas: SchemaTable | undefined,
 ): unknown => {
   if (Array.isArray(value)) {
     let changed = false;
@@ -203,8 +209,7 @@ export const compressSessionSyncSchemas = (
   sync: SessionSync,
 ): SessionSync | SchemaTableSessionSync => {
   const state: RewriteState = {
-    schemas: [],
-    schemaIndexes: new Map(),
+    schemas: new Map(),
     changed: false,
   };
   const upserts = sync.upserts.map((upsert) => {
@@ -225,7 +230,7 @@ export const compressSessionSyncSchemas = (
   return {
     ...sync,
     upserts,
-    schemaTable: state.schemas,
+    schemaTable: Object.fromEntries(state.schemas),
   };
 };
 
@@ -233,7 +238,7 @@ export const expandSessionSyncSchemas = (
   sync: SessionSync | SchemaTableSessionSync,
 ): SessionSync => {
   const schemas = (sync as SchemaTableSessionSync).schemaTable;
-  if (schemas === undefined || schemas.length === 0) {
+  if (schemas === undefined || Object.keys(schemas).length === 0) {
     return sync;
   }
 


### PR DESCRIPTION
## Summary

- add negotiated memory v2 schema tables for schema-bearing link payloads
- use hash-keyed content-addressed schema refs: `schema-ref@2:<tagged schema hash>`
- expand schema refs client-side before WatchView/storage consumption, preserving old `SessionSync` shape for runtime users
- keep old expanded frames for peers that do not advertise `syncSchemaTableV2`

## Snapshot

Synthetic repeated-schema sync fixture on the current branch:

- before: 128 upserts, 6400 schema marker occurrences, 2,814,847 encoded bytes
- after: 25 schema marker occurrences, 61,743 encoded bytes
- reduction: 97.81% encoded bytes on the fixture

The earlier numeric-ref draft measured 49,660 encoded bytes after compression. The current hash-ref format is slightly larger, but it makes the frame-local schema ids content-addressed and self-validating.

## Cubic feedback addressed

- P2 sibling traversal: fixed schema-table rewrite/expand so a link payload rewrite does not skip schema-bearing sibling fields in the same object.
- P1 mixed-version compatibility: moved the hash-keyed wire shape behind `syncSchemaTableV2` and `schema-ref@2:`. Legacy `syncSchemaTable`-only peers now fall back to fully-expanded frames instead of attempting to decode hash refs as numeric refs.

## Verification

- `mise exec -- deno fmt packages/memory/v2.ts packages/memory/v2/server.ts packages/memory/v2/sync-schema-table.ts packages/memory/test/v2-sync-schema-table-test.ts packages/memory/test/v2-test.ts`
- `mise exec -- deno lint packages/memory/v2.ts packages/memory/v2/server.ts packages/memory/v2/sync-schema-table.ts packages/memory/test/v2-sync-schema-table-test.ts packages/memory/test/v2-test.ts`
- `mise exec -- deno test --allow-read --allow-write --allow-net --allow-ffi --allow-env packages/memory/test/v2-sync-schema-table-test.ts packages/memory/test/v2-test.ts`
- `mise exec -- deno task check` in `packages/memory`

Refs CT-1775
Follow-up for global schema-store architecture: CT-1781
