### PR TITLE
docs(lunch-poll): point DEPLOY-AND-SHARE at the new `rapids` deploy

### DIFF
--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -34,10 +34,31 @@ cells can be copied to another piece via the CLI (see Option B's caveat).
 ## The canonical piece
 
 One shared instance everyone iterates on. **This is a deployment pointer, not a
-stable identifier — current as of 2026-06-15.** A piece is tied to one
+stable identifier — current as of 2026-06-22.** A piece is tied to one
 space/server and can be reset, wedged, or lost; if it 404s, `inspect` fails, or
 it stops responding, re-establish it (see "Recovering" below) and update this
 block.
+
+The poll now lives on **`rapids`** (`rapids.saga-castor.ts.net`), the intended
+successor to `toolshed`. It was established fresh here with `cf piece new` (see
+"Recovering → Re-establishing") — we were the first poll in this space:
+
+```
+space:  team-lunch
+piece:  fid1:2ZMvtKFGBMSem8sp6FskXKro5qLbAhbW6dBLUcX8vu0
+url:    https://rapids.saga-castor.ts.net/team-lunch/fid1:2ZMvtKFGBMSem8sp6FskXKro5qLbAhbW6dBLUcX8vu0
+```
+
+(History: an earlier poll lived in a _space_ literally named `rapids`, back on
+`toolshed` — unrelated to the `rapids` _server_ above, despite the name clash;
+`lunch-2026-05-26` / `lunch-2026-05-29` were earlier space pointers.
+`team-lunch` is a fresh space made to avoid that confusion.)
+
+### Historical: the `toolshed` piece
+
+Before `rapids`, the canonical poll ran on `toolshed`
+(`toolshed.saga-castor.ts.net`). Retained here for reference, and in case the
+`rapids` migration is rolled back:
 
 ```
 space:  team-lunch
@@ -45,16 +66,12 @@ piece:  fid1:zJT0lRy-Hd6p_ZsK_h6CZoK3rLcWOmsqwzqnHCAOlAg
 url:    https://toolshed.saga-castor.ts.net/team-lunch/fid1:zJT0lRy-Hd6p_ZsK_h6CZoK3rLcWOmsqwzqnHCAOlAg
 ```
 
-(History: the `rapids` space held an earlier poll; `lunch-2026-05-26` /
-`lunch-2026-05-29` were earlier pointers. `team-lunch` is a fresh space made to
-avoid that confusion.)
-
 ## Environment setup
 
 ```bash
-export CF_API_URL=https://toolshed.saga-castor.ts.net/   # prod; or http://localhost:8000 for local dev
+export CF_API_URL=https://rapids.saga-castor.ts.net/   # current prod; toolshed.saga-castor.ts.net is the predecessor; http://localhost:8000 for local dev
 export CF_IDENTITY=./your-identity.key
-PIECE=fid1:zJT0lRy-Hd6p_ZsK_h6CZoK3rLcWOmsqwzqnHCAOlAg    # current as of 2026-06-15
+PIECE=fid1:2ZMvtKFGBMSem8sp6FskXKro5qLbAhbW6dBLUcX8vu0    # rapids; current as of 2026-06-22
 SPACE=team-lunch
 ```
 

--- a/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/lunch-poll/DEPLOY-AND-SHARE.md
@@ -39,20 +39,14 @@ space/server and can be reset, wedged, or lost; if it 404s, `inspect` fails, or
 it stops responding, re-establish it (see "Recovering" below) and update this
 block.
 
-The poll now lives on **`rapids`** (`rapids.saga-castor.ts.net`), the intended
-successor to `toolshed`. It was established fresh here with `cf piece new` (see
-"Recovering → Re-establishing") — we were the first poll in this space:
+The poll lives on **`rapids`** (`rapids.saga-castor.ts.net`), the intended
+successor to `toolshed`.
 
 ```
 space:  team-lunch
 piece:  fid1:2ZMvtKFGBMSem8sp6FskXKro5qLbAhbW6dBLUcX8vu0
 url:    https://rapids.saga-castor.ts.net/team-lunch/fid1:2ZMvtKFGBMSem8sp6FskXKro5qLbAhbW6dBLUcX8vu0
 ```
-
-(History: an earlier poll lived in a _space_ literally named `rapids`, back on
-`toolshed` — unrelated to the `rapids` _server_ above, despite the name clash;
-`lunch-2026-05-26` / `lunch-2026-05-29` were earlier space pointers.
-`team-lunch` is a fresh space made to avoid that confusion.)
 
 ### Historical: the `toolshed` piece
 


### PR DESCRIPTION
## What

The lunch poll is now deployed to **`rapids`** (`rapids.saga-castor.ts.net`),
the intended successor to `toolshed`. This updates `lunch-poll/DEPLOY-AND-SHARE.md`
to point at it while preserving the `toolshed` info for history.

New canonical pointer (space `team-lunch`, deployed fresh via `cf piece new` —
we were the first poll in that space on `rapids`):

```
piece: fid1:2ZMvtKFGBMSem8sp6FskXKro5qLbAhbW6dBLUcX8vu0
url:   https://rapids.saga-castor.ts.net/team-lunch/fid1:2ZMvtKFGBMSem8sp6FskXKro5qLbAhbW6dBLUcX8vu0
```

## Changes

- Lead the **canonical piece** block and **Environment setup** with the `rapids`
  pointer (`CF_API_URL`, `PIECE`, dates bumped to 2026-06-22).
- Move the previous `toolshed` pointer into a **`### Historical: the toolshed
  piece`** subsection — kept for reference and in case the `rapids` migration is
  rolled back.
- Disambiguate the history note: an earlier poll lived in a *space* literally
  named `rapids` (on `toolshed`), which is unrelated to the new `rapids`
  *server* despite the name clash.

Docs-only; no code touched. `deno fmt --check` clean.

## Deploy verification

The fresh piece was smoke-tested on `rapids` (join -> addOption -> `logVisit`):
`db.exec` writes landed with no "invalid database handle" error, confirming the
server carries runtime #3967. State was then reset to pristine (empty
options/votes/users, `adminName` cleared, history cleared) so the real team
starts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point `lunch-poll/DEPLOY-AND-SHARE.md` to the new canonical deploy on `rapids` (`team-lunch` at `fid1:2ZMvtKFGBMSem8sp6FskXKro5qLbAhbW6dBLUcX8vu0`), keeping the old `toolshed` pointer as historical. Updated `CF_API_URL` and `PIECE` in the env examples and clarified the old `rapids` space vs the new `rapids` server.

<sup>Written for commit e6e0052a801baf44e8eb2620a904b5adc9268df8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

