### PR TITLE
fix(runtime-client): warn when a VDOM event has no handler to dispatch to

### DIFF
--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -1874,3 +1874,95 @@ describe("RuntimeProcessor vdom mount render policy", () => {
     expect(policy.maxConfidentiality).toBeUndefined();
   });
 });
+
+// handleVDomEvent forwards a main-thread DOM event to the owning mount's
+// reconciler. The reconciler's dispatchEvent returns false when no handler is
+// registered for the handlerId, meaning the event was dropped. The processor
+// surfaces that drop as a console.warn carrying the mountId and handlerId so a
+// silently-dropped click is traceable.
+describe("RuntimeProcessor handleVDomEvent dropped-event warning", () => {
+  const handleVDomEvent = (RuntimeProcessor.prototype as any).handleVDomEvent;
+
+  function makeState(dispatchResult: boolean, calls: unknown[][]) {
+    return {
+      vdomMounts: new Map<number, { reconciler: unknown }>([
+        [
+          7,
+          {
+            reconciler: {
+              dispatchEvent(handlerId: number, event: unknown): boolean {
+                calls.push([handlerId, event]);
+                return dispatchResult;
+              },
+            },
+          },
+        ],
+      ]),
+    };
+  }
+
+  function captureWarn(run: () => void): string[] {
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map((a) => String(a)).join(" "));
+    };
+    try {
+      run();
+    } finally {
+      console.warn = original;
+    }
+    return warnings;
+  }
+
+  it("warns with mountId and handlerId when the handler is missing", () => {
+    const calls: unknown[][] = [];
+    const state = makeState(false, calls);
+    const warnings = captureWarn(() =>
+      handleVDomEvent.call(state, {
+        type: RequestType.VDomEvent,
+        mountId: 7,
+        handlerId: 42,
+        event: { type: "click" },
+        nodeId: 3,
+      })
+    );
+    expect(calls).toEqual([[42, { type: "click" }]]);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("No handler found for mountId: 7");
+    expect(warnings[0]).toContain("handlerId: 42");
+  });
+
+  it("does not warn when the reconciler dispatches the event", () => {
+    const calls: unknown[][] = [];
+    const state = makeState(true, calls);
+    const warnings = captureWarn(() =>
+      handleVDomEvent.call(state, {
+        type: RequestType.VDomEvent,
+        mountId: 7,
+        handlerId: 99,
+        event: { type: "input" },
+        nodeId: 5,
+      })
+    );
+    expect(calls).toEqual([[99, { type: "input" }]]);
+    expect(warnings.length).toBe(0);
+  });
+
+  it("warns when no mount exists for the event's mountId", () => {
+    const calls: unknown[][] = [];
+    const state = makeState(true, calls);
+    const warnings = captureWarn(() =>
+      handleVDomEvent.call(state, {
+        type: RequestType.VDomEvent,
+        mountId: 404,
+        handlerId: 1,
+        event: { type: "click" },
+        nodeId: 0,
+      })
+    );
+    expect(calls).toEqual([]);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("No mount found for mountId: 404");
+  });
+});

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -1394,10 +1394,15 @@ export class RuntimeProcessor {
       return;
     }
 
-    mount.reconciler.dispatchEvent(
+    const dispatched = mount.reconciler.dispatchEvent(
       request.handlerId,
       request.event,
     );
+    if (!dispatched) {
+      console.warn(
+        `[RuntimeProcessor] No handler found for mountId: ${request.mountId}, handlerId: ${request.handlerId}`,
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
RuntimeProcessor.handleVDomEvent routes a DOM event from the main thread to the worker-side reconciler that owns the handler, by calling mount.reconciler.dispatchEvent(handlerId, event). WorkerReconciler's dispatchEvent returns true when it found and invoked the handler, and false when no handler is registered for that handlerId — meaning the event was dropped because the handler is missing or stale (for example, a click on a freshly-rendered control whose handler is not bound yet).

The caller discarded that boolean, so a dropped event produced no signal at all. That silent drop is a root cause of hard-to-diagnose integration test UI flakes, where a click appears to do nothing and leaves no trace.

Capture the return value and emit a console.warn when it is false, including the mountId and handlerId so a dropped event is traceable. The wording and format mirror the adjacent "No mount found for mountId" warn in the same method. Dispatch behavior is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warn when a VDOM event has no handler, so dropped events are visible during tests and debugging. `handleVDomEvent` now checks `dispatchEvent`’s boolean result and logs a console.warn with mountId and handlerId when false; behavior is unchanged, and tests cover the warn, no-warn, and no-mount cases.

<sup>Written for commit 7ab206504e087125ef7065f8871b5cbbc518c3ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

