### PR TITLE
fix(lunch-poll): restore per-voter swatches in the "All options" overview

### DIFF
--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -219,6 +219,14 @@ export default pattern(() => {
       v?.voterName === "Alex";
   });
 
+  // The "All options" overview renders one swatch per voter, sourced from the
+  // per-option `tally.voters` list. Regression guard for the filter/map bug
+  // where the swatches silently stopped rendering: after Alex's green vote, his
+  // swatch must appear in the rendered UI tree.
+  const assert_alex_swatch_renders = computed(() =>
+    findNodeByProp(poll[UI], "data-vote-swatch-name", "Alex") !== undefined
+  );
+
   const assert_changed_to_yellow = computed(() => {
     const v = poll.votes[0];
     return poll.votes.length === 1 &&
@@ -348,6 +356,7 @@ export default pattern(() => {
       // Vote green → yellow → red (covers all three colors)
       { action: action_vote_green_first },
       { assertion: assert_green_vote_recorded },
+      { assertion: assert_alex_swatch_renders },
       { action: action_vote_yellow_first },
       { assertion: assert_changed_to_yellow },
       { action: action_vote_red_first },

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -751,6 +751,87 @@ const EMPTY_OPTIONS: Option[] = [];
 const EMPTY_VOTES: Vote[] = [];
 const EMPTY_USERS: User[] = [];
 
+interface OptionSummaryRowInput {
+  title: string;
+  voters: readonly { name: string; voteType: VoteColor; color: string }[];
+  me: string;
+}
+
+interface OptionSummaryRowOutput {
+  [NAME]: string;
+  [UI]: VNode;
+}
+
+// One row of the compact "All options" overview: the option title plus a
+// swatch per voter who picked it. `voters` is the pattern input — a top-level
+// reactive binding — so `voters.map(...)` lowers to a reactive mapping. The
+// parent feeds each row a single option's voters (from `ranked`), so the
+// chips count the actual votes rather than options × votes. Mapping a per-item
+// field of `ranked` inline (e.g. `tally.voters.map(...)`) instead is rejected
+// at runtime — `OpaqueRef.map` has no stable per-item identity to lower.
+const OptionSummaryRow = pattern<OptionSummaryRowInput, OptionSummaryRowOutput>(
+  ({ title, voters, me }) => ({
+    [NAME]: "Option summary row",
+    [UI]: (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          padding: "6px 10px",
+          backgroundColor: "white",
+          border: "1px solid #e5e7eb",
+          borderRadius: "6px",
+        }}
+      >
+        <div
+          style={{
+            flex: 1,
+            fontSize: "13px",
+            fontWeight: 500,
+            color: "#111827",
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            gap: "4px",
+            flexWrap: "wrap",
+            justifyContent: "flex-end",
+          }}
+        >
+          {voters.map((voter) => (
+            <span
+              title={voter.name}
+              data-vote-swatch-name={voter.name}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                minWidth: "22px",
+                height: "22px",
+                padding: "0 6px",
+                borderRadius: "9999px",
+                backgroundColor: VOTE_SWATCH[voter.voteType],
+                color: "white",
+                fontSize: "11px",
+                fontWeight: 700,
+                boxShadow: voter.name === me
+                  ? "0 0 0 2px white, 0 0 0 3px #111827"
+                  : "none",
+              }}
+            >
+              {getInitials(voter.name)}
+            </span>
+          ))}
+        </div>
+      </div>
+    ),
+  }),
+);
+
 export default pattern<CozyPollInput, CozyPollOutput>(
   (
     {
@@ -1216,74 +1297,13 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                           gap: "4px",
                         }}
                       >
-                        {options.map((option) => {
-                          const oid = option.id;
-                          const summaryRank = computed(() => {
-                            const idx = ranked.findIndex(
-                              (t) => t.option.id === oid,
-                            );
-                            return idx >= 0 ? idx + 1 : 9999;
-                          });
-                          return (
-                            <div
-                              style={{
-                                order: summaryRank,
-                                display: "flex",
-                                alignItems: "center",
-                                gap: "8px",
-                                padding: "6px 10px",
-                                backgroundColor: "white",
-                                border: "1px solid #e5e7eb",
-                                borderRadius: "6px",
-                              }}
-                            >
-                              <div
-                                style={{
-                                  flex: 1,
-                                  fontSize: "13px",
-                                  fontWeight: 500,
-                                  color: "#111827",
-                                }}
-                              >
-                                {option.title}
-                              </div>
-                              <div
-                                style={{
-                                  display: "flex",
-                                  gap: "4px",
-                                  flexWrap: "wrap",
-                                  justifyContent: "flex-end",
-                                }}
-                              >
-                                {votes.filter((vote) => vote.optionId === oid)
-                                  .map((vote) => (
-                                    <span
-                                      title={vote.voterName}
-                                      style={{
-                                        display: "inline-flex",
-                                        alignItems: "center",
-                                        justifyContent: "center",
-                                        minWidth: "22px",
-                                        height: "22px",
-                                        padding: "0 6px",
-                                        borderRadius: "9999px",
-                                        backgroundColor:
-                                          VOTE_SWATCH[vote.voteType],
-                                        color: "white",
-                                        fontSize: "11px",
-                                        fontWeight: 700,
-                                        boxShadow: vote.voterName === me
-                                          ? "0 0 0 2px white, 0 0 0 3px #111827"
-                                          : "none",
-                                      }}
-                                    >
-                                      {getInitials(vote.voterName)}
-                                    </span>
-                                  ))}
-                              </div>
-                            </div>
-                          );
-                        })}
+                        {ranked.map((tally) => (
+                          <OptionSummaryRow
+                            title={tally.option.title}
+                            voters={tally.voters}
+                            me={me}
+                          />
+                        ))}
                       </div>
                     </div>
                   )


### PR DESCRIPTION
## What

The per-voter swatches in the lunch poll's **"All options"** overview stopped
rendering. Root cause: **#4291** ("Filter votes before mapping over them") hit a
ts-transformer gap. This restores the feature without reintroducing the
options × votes cartesian product #4291 was trimming.

Before/after: each option row should show one colored initial-chip per person
who voted on it. After #4291 the row rendered empty.

## Root cause

#4291 changed the swatch source from:

```tsx
votes.map((vote) => vote.optionId === oid ? <span/> : null)   // worked
```

to:

```tsx
votes.filter((vote) => vote.optionId === oid).map((vote) => <span/>)   // broke
```

The transformer compiles a reactive `.filter()` predicate into a `pattern` body,
where the comparison stays as a **raw `===` between two `OpaqueRef` proxies**:

```js
const __cfPattern_2 = __cfHelpers.pattern((__cf_pattern_input) => {
  const vote = __cf_pattern_input.key("element");
  const oid  = __cf_pattern_input.key("params", "oid");
  return vote.key("optionId") === oid;   // two distinct proxies → always false
}, /* … boolean schema … */);
```

`vote.key("optionId")` and `oid` are different proxy objects, so `===` is
reference equality → constant `false`. The filter matches **zero** votes, the
`.map()` gets an empty list, and no swatches render. Silent — no type or runtime
error.

The pre-#4291 `.map`-with-ternary form worked because the transformer lifted the
same comparison to **value level** — `({ vote, oid }) => vote.optionId === oid`,
operating on resolved values.

## The fix

Render each row from the already-computed `ranked` tally (`tallyOptions`), which
carries a per-option `voters: { name, voteType, color }[]` list — so there is no
`===`, no filter, and the chip count is the actual votes, not options × votes.

One wrinkle: the runtime rejects `OpaqueRef.map` on an **inline per-item field**
(`tally.voters.map(...)` throws "OpaqueRef.map(fn) is no longer supported"),
because the transformer only lowers `.map` → `.mapWithPattern` for a top-level
reactive binding, not a member access. So the row is a small `OptionSummaryRow`
subpattern whose `voters` **input** is a top-level binding; inside it,
`voters.map(...)` lowers correctly. Iterating `ranked` (already sorted) also lets
us drop the `order: summaryRank` CSS hack.

## Tests

- New `assert_alex_swatch_renders` locates the voter swatch in the rendered UI
  tree via a `data-vote-swatch-name` hook.
- **Red/green verified:** the assertion *fails* against the #4291 filter form
  (with the same hook added, so the only failure cause is the empty filter) and
  *passes* on this fix.
- Full lunch-poll suite green (47 passed): `main`, `multi-user`,
  `poll-option-card`, `lunch-stats`, `generated-art`, `participant-identity-card`.

## @mathpirate — transformer gap (predicate lifting)

Flagging a transformer issue, in the same family as the `!isAdmin` unary-capture
gap I reported earlier (both are about reactive predicates not being lowered to
value level):

1. **Comparisons inside a reactive `.filter()`/`.find()` predicate are not
   lifted.** They compile to a `pattern` body where `a === b` between two
   `OpaqueRef`s is raw JS reference equality — silently constant (here `false`).
   Contrast: the *same* comparison in a JSX value position (e.g. the boxShadow
   `vote.voterName === me` two lines away) **is** lifted to a `__cfLift`
   (resolved values) and works. So the transformer knows how to lift comparisons
   — it just doesn't do so for filter/find predicate bodies. A `.filter(v => v.x
   === y)` that silently matches nothing is a sharp, type-clean footgun.

2. **Secondary, possibly related:** `OpaqueRef.map` on a per-item field
   (`item.field.map(...)`) is rejected at runtime; only a top-level reactive
   binding's `.map` is lowered to `.mapWithPattern`. Nested reactive lists over a
   derived item field therefore require a subpattern hop. If lowering `.map`/
   `.filter` on member-access receivers (not just identifiers) is feasible, it'd
   remove both papercuts.

Repro for (1): `deno task cf check packages/patterns/lunch-poll/main.tsx
--show-transformed --no-run` on the parent of this branch and grep for
`vote.key("optionId") === oid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance / Coverage

We blithely accept regressions for the sake of short-term expedience:

NEW_COVERAGE_BASELINE
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/main.test.tsx = 38s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores per-voter swatches in the lunch poll “All options” overview. Fixes a regression from #4291 by sourcing swatches from the computed `ranked` tally instead of filtering votes at render time.

- **Bug Fixes**
  - Use a new `OptionSummaryRow` that consumes `ranked.voters` as a top-level input, so `.map` lowers correctly and avoids the options × votes cartesian product.
  - Remove the broken `.filter(v => v.optionId === oid)` path that compared `OpaqueRef`s by reference and matched nothing.
  - Iterate `ranked` directly, dropping the `order: summaryRank` CSS hack.

- **Tests**
  - Add `assert_alex_swatch_renders` using a `data-vote-swatch-name` hook to verify a voter swatch appears after voting.

<sup>Written for commit 3389a2324a8ea12df85305324e5109d84343987d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

