### PR TITLE
Performance / Coverfage check: Hide "Baseline source runs" in a foldable group.

### DIFF
--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -337,7 +337,7 @@ export function logBaselineSourceRuns(
   contexts: BaselineRunContext[],
   currentRunCreatedAt: string,
 ): void {
-  console.log("Baseline source runs:");
+  console.log("\n::group::Baseline source runs:\n");
   for (
     const { run, artifacts, pr, prLookupError, commitsBehindMain } of contexts
   ) {
@@ -363,6 +363,7 @@ export function logBaselineSourceRuns(
         `${ageLabel}; ${prLabel}; ${artifactLabel}`,
     );
   }
+  console.log("\n::endgroup::\n");
 }
 
 export interface BaselinePRLookupSummary {


### PR DESCRIPTION
This PR reduces visual clutter in the perf check log (which is commonly read by humans), hiding the list of "baseline source runs" in a foldable group.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapse the "Baseline source runs" output in `perf-check.ts` into a foldable GitHub Actions log group. This reduces clutter and makes perf/coverage logs easier to scan.

<sup>Written for commit 7d2ab23e47bc2ac17d3015acd32bb94bccabeeee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

