### PR TITLE
fix(ts-transformers): lift reactive value-expressions in map/filter/flatMap callbacks (CT-1777)

### DIFF
--- a/packages/ts-transformers/src/transformers/expression-rewrite/emitters/helper-owned-expression.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/emitters/helper-owned-expression.ts
@@ -8,16 +8,8 @@ import {
   findPendingComputeWrapCandidate,
   isJsxLocalRewriteContainer,
 } from "./compute-wrap-invariants.ts";
+import { isValueComputationExpressionKind } from "../../../utils/expression.ts";
 import type { Emitter } from "../types.ts";
-
-function isHelperOwnedComputationExpression(
-  expression: ts.Expression,
-): boolean {
-  return ts.isBinaryExpression(expression) ||
-    ts.isPrefixUnaryExpression(expression) ||
-    ts.isPostfixUnaryExpression(expression) ||
-    ts.isConditionalExpression(expression);
-}
 
 function isHelperOwnedCellGetExpression(
   expression: ts.Expression,
@@ -132,7 +124,7 @@ export function rewriteHelperOwnedExpression(
   if (
     relevantDataFlows.length > 0 &&
     (
-      isHelperOwnedComputationExpression(expression) ||
+      isValueComputationExpressionKind(expression) ||
       isHelperOwnedCellGetExpression(expression, context)
     )
   ) {

--- a/packages/ts-transformers/src/transformers/expression-site-lowering.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-lowering.ts
@@ -13,6 +13,7 @@ import {
   findLowerableExpressionSite,
   findPreferredNestedLowerableExpressionSite,
   getExpressionContainerKind,
+  isArrayMethodValueLiftOwner,
   isControlFlowRewriteExpression,
   isDirectArrayMethodRootExpression,
   shouldPreferArrayMethodSharedCallRootSite,
@@ -761,7 +762,7 @@ export function rewriteArrayMethodCallbackExpressionSites(
     );
     if (
       handling.kind !== "owned" ||
-      handling.owner !== "array-method-receiver-method" ||
+      !isArrayMethodValueLiftOwner(handling.owner) ||
       !handling.lowerable
     ) {
       return undefined;

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -3,6 +3,7 @@ import {
   classifyArrayMethodCall,
   classifyArrayMethodCallSite,
   detectCallKind,
+  hasReactiveCollectionProvenance,
   isEventHandlerJsxAttribute,
   isFunctionLikeExpression,
   isInRestrictedReactiveContext,
@@ -10,7 +11,10 @@ import {
   type ReactiveContextInfo,
 } from "../ast/mod.ts";
 import type { TransformationContext } from "../core/mod.ts";
-import { unwrapExpression } from "../utils/expression.ts";
+import {
+  isValueComputationExpressionKind,
+  unwrapExpression,
+} from "../utils/expression.ts";
 import { getKnownComputedKeyExpression } from "../utils/reactive-keys.ts";
 import { getCallbackBoundarySemantics } from "../policy/callback-boundary.ts";
 import {
@@ -56,6 +60,19 @@ type JsxExpressionSiteSkipReason =
   | "deferred-jsx-array-method-root"
   | "not-shared-jsx-root-kind";
 
+/**
+ * Who owns a lowered expression site — i.e. which lowering pass wraps it.
+ * `array-method-receiver-method` and `array-method-callback-value` both route
+ * to the array-method value-lift path (a receiver-method call vs a bare
+ * value-expression such as `a === b`); see {@link isArrayMethodValueLiftOwner}.
+ */
+export type ExpressionSiteOwner =
+  | "helper"
+  | "array-method-callback-jsx"
+  | "array-method-receiver-method"
+  | "array-method-callback-value"
+  | "jsx-root";
+
 export type ExpressionSiteHandlingDecision =
   | {
     kind: "shared";
@@ -64,11 +81,7 @@ export type ExpressionSiteHandlingDecision =
   }
   | {
     kind: "owned";
-    owner:
-      | "helper"
-      | "array-method-callback-jsx"
-      | "array-method-receiver-method"
-      | "jsx-root";
+    owner: ExpressionSiteOwner;
     lowerable: boolean;
   }
   | {
@@ -858,6 +871,18 @@ function isExpressionSiteLowerable(
     );
 }
 
+/**
+ * The lowerable signal shared by the reactive-boundary value-lift classifiers
+ * (helper-owned and array-method-owned): the expression reads a reactive value
+ * (`containsOpaqueRef`) and the dataflow analysis says it must be rewritten to
+ * resolve those reads (`requiresRewrite`).
+ */
+function hasReactiveComputationToLift(
+  analysis: ReturnType<AnalyzeFn>,
+): boolean {
+  return analysis.containsOpaqueRef && analysis.requiresRewrite;
+}
+
 function createSharedExpressionSiteDecision(
   lowerable: boolean,
   jsxRoute?: "shared-pre-closure" | "shared-post-closure",
@@ -868,14 +893,23 @@ function createSharedExpressionSiteDecision(
 }
 
 function createOwnedExpressionSiteDecision(
-  owner:
-    | "helper"
-    | "array-method-callback-jsx"
-    | "array-method-receiver-method"
-    | "jsx-root",
+  owner: ExpressionSiteOwner,
   lowerable: boolean,
 ): ExpressionSiteHandlingDecision {
   return { kind: "owned", owner, lowerable };
+}
+
+/**
+ * The two owners that route to the array-method value-lift lowering: a
+ * receiver-method call (`v.foo()`) and a bare value-expression (`v.x === y`,
+ * `!x`, `a + b`). Both are wrapped by createReactiveWrapperForExpression, so the
+ * array-method-callback lowering pass treats them identically.
+ */
+export function isArrayMethodValueLiftOwner(
+  owner: ExpressionSiteOwner,
+): boolean {
+  return owner === "array-method-receiver-method" ||
+    owner === "array-method-callback-value";
 }
 
 function classifyHelperOwnedExpressionSiteHandling(
@@ -897,10 +931,7 @@ function classifyHelperOwnedExpressionSiteHandling(
 
   const supportedCallRootKind = getSupportedCallRootKind(callRootPolicy);
   if (
-    !ts.isBinaryExpression(expression) &&
-    !ts.isPrefixUnaryExpression(expression) &&
-    !ts.isPostfixUnaryExpression(expression) &&
-    !ts.isConditionalExpression(expression) &&
+    !isValueComputationExpressionKind(expression) &&
     supportedCallRootKind !== "helper-owned-explicit-read" &&
     supportedCallRootKind !== "helper-owned-receiver-method"
   ) {
@@ -909,7 +940,7 @@ function classifyHelperOwnedExpressionSiteHandling(
 
   return createOwnedExpressionSiteDecision(
     "helper",
-    analysis.containsOpaqueRef && analysis.requiresRewrite,
+    hasReactiveComputationToLift(analysis),
   );
 }
 
@@ -951,11 +982,7 @@ export function classifyExpressionSiteHandling(
   ): ExpressionSiteHandlingDecision =>
     createSharedExpressionSiteDecision(sharedLowerable(), jsxRoute);
   const ownedDecision = (
-    owner:
-      | "helper"
-      | "array-method-callback-jsx"
-      | "array-method-receiver-method"
-      | "jsx-root",
+    owner: ExpressionSiteOwner,
     lowerable: boolean,
   ): ExpressionSiteHandlingDecision =>
     createOwnedExpressionSiteDecision(owner, lowerable);
@@ -1100,6 +1127,33 @@ export function classifyExpressionSiteHandling(
     return sharedDecision();
   }
 
+  // CT-1777: array-method-owned analog of classifyHelperOwnedExpressionSiteHandling.
+  // A bare reactive VALUE-expression — a comparison `a === b`, an arithmetic/concat
+  // `a + b`, a unary `!x`, etc. — in the return / object-property / array-element
+  // position of a reactive map/filter/flatMap callback (lowered to *WithPattern)
+  // must be lifted to operate on RESOLVED values, exactly as the same expression is
+  // lifted inside a helper body or a JSX value site. Without this it is emitted raw
+  // on OpaqueRef proxies: a filter predicate `v.optionId === oid` becomes
+  // proxy-vs-proxy `===` → a constant `false`.
+  //
+  // Two guards keep COLLECTION-valued expressions out, so they stay structurally
+  // lowered (the runtime *WithPattern flatten/map depends on it):
+  //   - control flow: `!controlFlowRewriteRoot` drops conditionals and logical
+  //     `&&`/`||` (they lower via ifElse/unless, which already lift);
+  //   - provenance: `!hasReactiveCollectionProvenance` drops `??` fallbacks whose
+  //     result is a reactive collection (e.g. `flatMap(i => i.tags ?? [])`, which
+  //     must stay `i.key("tags") ?? []`). Comparison/arithmetic/unary results are
+  //     never collections, so this never blocks them.
+  if (
+    siteInfo.arrayMethodOwned &&
+    !siteInfo.controlFlowRewriteRoot &&
+    isValueComputationExpressionKind(expression) &&
+    hasReactiveComputationToLift(getAnalysis()) &&
+    !hasReactiveCollectionProvenance(expression, context.checker)
+  ) {
+    return ownedDecision("array-method-callback-value", true);
+  }
+
   if (siteInfo.arrayMethodOwned && !siteInfo.controlFlowRewriteRoot) {
     return { kind: "skip", reason: "not-lowerable" };
   }
@@ -1201,7 +1255,7 @@ export function findLowerableExpressionSite(
           } as const;
           if (
             decision.kind === "owned" &&
-            decision.owner === "array-method-receiver-method"
+            isArrayMethodValueLiftOwner(decision.owner)
           ) {
             deferredArrayMethodReceiverSite ??= site;
             current = current.parent;

--- a/packages/ts-transformers/src/utils/expression.ts
+++ b/packages/ts-transformers/src/utils/expression.ts
@@ -41,3 +41,24 @@ export function unwrapExpression(
     return current;
   }
 }
+
+/**
+ * True for the syntactic shapes that compute a *value* from their operands —
+ * binary (`a === b`, `a + b`, `a ?? b`), prefix/postfix unary (`!x`, `-x`,
+ * `x++`), and conditional (`a ? b : c`). These are the expressions a reactive
+ * boundary (a helper body, or a map/filter/flatMap callback) lifts to value
+ * level so they operate on resolved values rather than OpaqueRef proxies.
+ *
+ * It is a purely syntactic kind check — it does NOT decide lowerability
+ * (reactivity, control-flow routing, and collection-vs-value distinctions are
+ * the caller's concern). Conditionals and logical `&&`/`||` are included here
+ * but are typically peeled off earlier by control-flow lowering.
+ */
+export function isValueComputationExpressionKind(
+  expression: ts.Expression,
+): boolean {
+  return ts.isBinaryExpression(expression) ||
+    ts.isPrefixUnaryExpression(expression) ||
+    ts.isPostfixUnaryExpression(expression) ||
+    ts.isConditionalExpression(expression);
+}

--- a/packages/ts-transformers/test/fixtures/closures/array-method-value-lift.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/array-method-value-lift.expected.jsx
@@ -1,0 +1,372 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { pattern, UI } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface Vote {
+    optionId: string;
+    voterName: string;
+}
+const __cfLift_1 = __cfHelpers.lift<{
+    v: {
+        optionId: string;
+    };
+    oid: string;
+}, boolean>(({ v, oid }) => v.optionId === oid, {
+    type: "object",
+    properties: {
+        v: {
+            type: "object",
+            properties: {
+                optionId: {
+                    type: "string"
+                }
+            },
+            required: ["optionId"]
+        },
+        oid: {
+            type: "string"
+        }
+    },
+    required: ["v", "oid"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const v = __cf_pattern_input.key("element");
+    const oid = __cf_pattern_input.key("params", "oid");
+    return __cfLift_1({
+        v: {
+            optionId: v.key("optionId")
+        },
+        oid: oid
+    }).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Vote"
+        },
+        params: {
+            type: "object",
+            properties: {
+                oid: {
+                    type: "string"
+                }
+            },
+            required: ["oid"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Vote: {
+            type: "object",
+            properties: {
+                optionId: {
+                    type: "string"
+                },
+                voterName: {
+                    type: "string"
+                }
+            },
+            required: ["optionId", "voterName"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const v = __cf_pattern_input.key("element");
+    return <i>{v.key("voterName")}</i>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Vote"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Vote: {
+            type: "object",
+            properties: {
+                optionId: {
+                    type: "string"
+                },
+                voterName: {
+                    type: "string"
+                }
+            },
+            required: ["optionId", "voterName"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_2 = __cfHelpers.lift<{
+    v: {
+        optionId: string;
+    };
+    oid: string;
+}, boolean>(({ v, oid }) => v.optionId === oid, {
+    type: "object",
+    properties: {
+        v: {
+            type: "object",
+            properties: {
+                optionId: {
+                    type: "string"
+                }
+            },
+            required: ["optionId"]
+        },
+        oid: {
+            type: "string"
+        }
+    },
+    required: ["v", "oid"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+    const v = __cf_pattern_input.key("element");
+    const oid = __cf_pattern_input.key("params", "oid");
+    return __cfLift_2({
+        v: {
+            optionId: v.key("optionId")
+        },
+        oid: oid
+    }).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Vote"
+        },
+        params: {
+            type: "object",
+            properties: {
+                oid: {
+                    type: "string"
+                }
+            },
+            required: ["oid"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Vote: {
+            type: "object",
+            properties: {
+                optionId: {
+                    type: "string"
+                },
+                voterName: {
+                    type: "string"
+                }
+            },
+            required: ["optionId", "voterName"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_3 = __cfHelpers.lift<{
+    v: {
+        optionId: string;
+    };
+    oid: string;
+}, boolean>(({ v, oid }) => v.optionId === oid, {
+    type: "object",
+    properties: {
+        v: {
+            type: "object",
+            properties: {
+                optionId: {
+                    type: "string"
+                }
+            },
+            required: ["optionId"]
+        },
+        oid: {
+            type: "string"
+        }
+    },
+    required: ["v", "oid"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
+    const v = __cf_pattern_input.key("element");
+    const oid = __cf_pattern_input.key("params", "oid");
+    return [__cfLift_3({
+            v: {
+                optionId: v.key("optionId")
+            },
+            oid: oid
+        }).for(["__patternResult", 0], true)];
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Vote"
+        },
+        params: {
+            type: "object",
+            properties: {
+                oid: {
+                    type: "string"
+                }
+            },
+            required: ["oid"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Vote: {
+            type: "object",
+            properties: {
+                optionId: {
+                    type: "string"
+                },
+                voterName: {
+                    type: "string"
+                }
+            },
+            required: ["optionId", "voterName"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        type: "boolean"
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// FIXTURE: array-method-value-lift
+// Verifies (CT-1777): a bare reactive VALUE-expression in the return position of a
+// reactive map/filter/flatMap callback is lifted to a value-level lift, so it runs on
+// resolved values instead of being emitted raw on OpaqueRef proxies. Before CT-1777 a
+// filter predicate `v.optionId === oid` compiled to a proxy-vs-proxy `===` — reference
+// equality, i.e. a constant `false` — so the filter matched nothing (silent, type-clean).
+//   - filter predicate comparison      → filterWithPattern(pattern(... return lift(...)(...)))
+//   - map -> non-JSX comparison        → mapWithPattern(pattern(... return lift(...)(...)))
+//   - flatMap -> array-element compare → flatMapWithPattern(pattern(... return [lift(...)(...)]))
+// Collection-valued `??` fallbacks and logical `&&`/`||` stay structural / control-flow
+// lowered; see filter-flatmap-fallback-chain for the structural-collection counterpart.
+export default pattern((__cf_pattern_input) => {
+    const votes = __cf_pattern_input.key("votes");
+    const oid = __cf_pattern_input.key("oid");
+    return {
+        [UI]: (<div>
+        {/* filter predicate: the comparison must be lifted to value level */}
+        <div>
+          {votes.filterWithPattern(__cfPattern_1, {
+                oid: oid
+            }).mapWithPattern(__cfPattern_2, {})}
+        </div>
+        {/* map to a bare non-JSX boolean: the comparison must be lifted */}
+        <div>{votes.mapWithPattern(__cfPattern_3, {
+            oid: oid
+        })}</div>
+        {/* flatMap returning an array whose element is a comparison: must be lifted */}
+        <div>{votes.flatMapWithPattern(__cfPattern_4, {
+            oid: oid
+        })}</div>
+      </div>),
+    };
+}, {
+    type: "object",
+    properties: {
+        votes: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Vote"
+            }
+        },
+        oid: {
+            type: "string"
+        }
+    },
+    required: ["votes", "oid"],
+    $defs: {
+        Vote: {
+            type: "object",
+            properties: {
+                optionId: {
+                    type: "string"
+                },
+                voterName: {
+                    type: "string"
+                }
+            },
+            required: ["optionId", "voterName"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $UI: {
+            $ref: "#/$defs/JSXElement"
+        }
+    },
+    required: ["$UI"],
+    $defs: {
+        JSXElement: {
+            anyOf: [{
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }, {
+                    $ref: "#/$defs/UIRenderable"
+                }, {
+                    type: "object",
+                    properties: {}
+                }]
+        },
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1,
+    __cfPattern_2,
+    __cfLift_2,
+    __cfPattern_3,
+    __cfLift_3,
+    __cfPattern_4
+});

--- a/packages/ts-transformers/test/fixtures/closures/array-method-value-lift.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/array-method-value-lift.input.tsx
@@ -1,0 +1,36 @@
+import { pattern, UI } from "commonfabric";
+
+interface Vote {
+  optionId: string;
+  voterName: string;
+}
+
+// FIXTURE: array-method-value-lift
+// Verifies (CT-1777): a bare reactive VALUE-expression in the return position of a
+// reactive map/filter/flatMap callback is lifted to a value-level lift, so it runs on
+// resolved values instead of being emitted raw on OpaqueRef proxies. Before CT-1777 a
+// filter predicate `v.optionId === oid` compiled to a proxy-vs-proxy `===` — reference
+// equality, i.e. a constant `false` — so the filter matched nothing (silent, type-clean).
+//   - filter predicate comparison      → filterWithPattern(pattern(... return lift(...)(...)))
+//   - map -> non-JSX comparison        → mapWithPattern(pattern(... return lift(...)(...)))
+//   - flatMap -> array-element compare → flatMapWithPattern(pattern(... return [lift(...)(...)]))
+// Collection-valued `??` fallbacks and logical `&&`/`||` stay structural / control-flow
+// lowered; see filter-flatmap-fallback-chain for the structural-collection counterpart.
+export default pattern<{ votes: Vote[]; oid: string }>(({ votes, oid }) => {
+  return {
+    [UI]: (
+      <div>
+        {/* filter predicate: the comparison must be lifted to value level */}
+        <div>
+          {votes
+            .filter((v) => v.optionId === oid)
+            .map((v) => <i>{v.voterName}</i>)}
+        </div>
+        {/* map to a bare non-JSX boolean: the comparison must be lifted */}
+        <div>{votes.map((v) => v.optionId === oid)}</div>
+        {/* flatMap returning an array whose element is a comparison: must be lifted */}
+        <div>{votes.flatMap((v) => [v.optionId === oid])}</div>
+      </div>
+    ),
+  };
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
@@ -11,10 +11,31 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfLift_1 = __cfHelpers.lift<{
+    n: number;
+    multiplier: __cfHelpers.Cell<number>;
+}, number>(({ n, multiplier }) => n * multiplier.get(), {
+    type: "object",
+    properties: {
+        n: {
+            type: "number"
+        },
+        multiplier: {
+            type: "number",
+            asCell: ["readonly"]
+        }
+    },
+    required: ["n", "multiplier"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const n = __cf_pattern_input.key("element");
     const multiplier = __cf_pattern_input.key("params", "multiplier");
-    return n * multiplier.get();
+    return __cfLift_1({
+        n: n,
+        multiplier: multiplier
+    }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -36,7 +57,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_1 = __cfHelpers.lift<{
+const __cfLift_2 = __cfHelpers.lift<{
     numbers: __cfHelpers.ReadonlyCell<number[]>;
     multiplier: __cfHelpers.ReadonlyCell<number>;
 }, number[]>(({ numbers, multiplier }) => numbers.mapWithPattern(__cfPattern_1, {
@@ -83,7 +104,7 @@ export default pattern(() => {
     // The computed gets transformed to the lift-applied form lift(() => numbers.map(...))({})
     // Inside a lift-applied computation, .map on a closed-over Cell should STILL be transformed to mapWithPattern
     // because Cells need the pattern-based mapping even when unwrapped
-    const doubled = __cfLift_1({
+    const doubled = __cfLift_2({
         numbers: numbers,
         multiplier: multiplier
     }).for("doubled", true);
@@ -98,6 +119,7 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    __cfLift_1,
     __cfPattern_1,
-    __cfLift_1
+    __cfLift_2
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
@@ -68,9 +68,22 @@ const __cfLift_2 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_3 = __cfHelpers.lift<{
+    item: string;
+}, string>(({ item }) => item + "!", {
+    type: "object",
+    properties: {
+        item: {
+            type: "string"
+        }
+    },
+    required: ["item"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return item + "!";
+    return __cfLift_3({ item: item }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -82,7 +95,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_3 = __cfHelpers.lift<{
+const __cfLift_4 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => {
     const foo = __cfLift_2({ inner: inner }).for("foo", true);
@@ -104,9 +117,22 @@ const __cfLift_3 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_5 = __cfHelpers.lift<{
+    item: string;
+}, string>(({ item }) => item + "!", {
+    type: "object",
+    properties: {
+        item: {
+            type: "string"
+        }
+    },
+    required: ["item"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return item + "!";
+    return __cfLift_5({ item: item }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -118,7 +144,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_4 = __cfHelpers.lift<{
+const __cfLift_6 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => {
     const foo = passthrough(inner).for("foo", true);
@@ -140,9 +166,22 @@ const __cfLift_4 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_7 = __cfHelpers.lift<{
+    item: string;
+}, string>(({ item }) => item + "!", {
+    type: "object",
+    properties: {
+        item: {
+            type: "string"
+        }
+    },
+    required: ["item"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return item + "!";
+    return __cfLift_7({ item: item }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -154,7 +193,7 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift(() => {
+const __cfLift_8 = __cfHelpers.lift(() => {
     const foo = wish<Default<string[], [
     ]>>({ query: "#items" }, {
         type: "array",
@@ -165,7 +204,7 @@ const __cfLift_5 = __cfHelpers.lift(() => {
     } as const satisfies __cfHelpers.JSONSchema).result!;
     return foo.mapWithPattern(__cfPattern_3, {});
 }, false);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_9 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => inner, {
     type: "object",
@@ -184,9 +223,32 @@ const __cfLift_6 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_10 = __cfHelpers.lift<{
+    item: {
+        length: number;
+    };
+}, boolean>(({ item }) => item.length > 1, {
+    type: "object",
+    properties: {
+        item: {
+            type: "object",
+            properties: {
+                length: {
+                    type: "number"
+                }
+            },
+            required: ["length"]
+        }
+    },
+    required: ["item"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return item.key("length") > 1;
+    return __cfLift_10({ item: {
+            length: item.key("length")
+        } }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -198,9 +260,22 @@ const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_11 = __cfHelpers.lift<{
+    item: string;
+}, string>(({ item }) => item + "!", {
+    type: "object",
+    properties: {
+        item: {
+            type: "string"
+        }
+    },
+    required: ["item"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_5 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return item + "!";
+    return __cfLift_11({ item: item }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -212,10 +287,10 @@ const __cfPattern_5 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_7 = __cfHelpers.lift<{
+const __cfLift_12 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => {
-    const foo = __cfLift_6({ inner: inner }).for("foo", true);
+    const foo = __cfLift_9({ inner: inner }).for("foo", true);
     const filtered = foo.filterWithPattern(__cfPattern_4, {}).for("filtered", true);
     return filtered.mapWithPattern(__cfPattern_5, {});
 }, {
@@ -235,7 +310,7 @@ const __cfLift_7 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_8 = __cfHelpers.lift<{
+const __cfLift_13 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => inner, {
     type: "object",
@@ -254,9 +329,32 @@ const __cfLift_8 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_14 = __cfHelpers.lift<{
+    item: {
+        length: number;
+    };
+}, boolean>(({ item }) => item.length > 1, {
+    type: "object",
+    properties: {
+        item: {
+            type: "object",
+            properties: {
+                length: {
+                    type: "number"
+                }
+            },
+            required: ["length"]
+        }
+    },
+    required: ["item"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_6 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return item.key("length") > 1;
+    return __cfLift_14({ item: {
+            length: item.key("length")
+        } }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -268,7 +366,7 @@ const __cfPattern_6 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_9 = __cfHelpers.lift<{
+const __cfLift_15 = __cfHelpers.lift<{
     item: string;
 }, string>(({ item }) => item.toUpperCase(), {
     type: "object",
@@ -283,7 +381,7 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_7 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
-    return __cfLift_9({ item: item }).for("__patternResult", true);
+    return __cfLift_15({ item: item }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -295,10 +393,10 @@ const __cfPattern_7 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_10 = __cfHelpers.lift<{
+const __cfLift_16 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>(({ inner }) => {
-    const foo = __cfLift_8({ inner: inner }).for("foo", true);
+    const foo = __cfLift_13({ inner: inner }).for("foo", true);
     const filtered = foo.filterWithPattern(__cfPattern_6, {}).for("filtered", true);
     return filtered.mapWithPattern(__cfPattern_7, {});
 }, {
@@ -334,11 +432,11 @@ export default pattern((state) => {
     const inner = __cfLift_1({ state: {
             items: state.key("items")
         } }).for("inner", true);
-    const fromComputed = __cfLift_3({ inner: inner }).for("fromComputed", true);
-    const fromLift = __cfLift_4({ inner: inner }).for("fromLift", true);
-    const fromWish = __cfLift_5().for("fromWish", true);
-    const fromFiltered = __cfLift_7({ inner: inner }).for("fromFiltered", true);
-    const fromFilteredReceiverMethod = __cfLift_10({ inner: inner }).for("fromFilteredReceiverMethod", true);
+    const fromComputed = __cfLift_4({ inner: inner }).for("fromComputed", true);
+    const fromLift = __cfLift_6({ inner: inner }).for("fromLift", true);
+    const fromWish = __cfLift_8().for("fromWish", true);
+    const fromFiltered = __cfLift_12({ inner: inner }).for("fromFiltered", true);
+    const fromFilteredReceiverMethod = __cfLift_16({ inner: inner }).for("fromFilteredReceiverMethod", true);
     return {
         fromComputed,
         fromLift,
@@ -400,19 +498,25 @@ __cfReg({
     passthrough,
     __cfLift_1,
     __cfLift_2,
-    __cfPattern_1,
     __cfLift_3,
-    __cfPattern_2,
+    __cfPattern_1,
     __cfLift_4,
-    __cfPattern_3,
     __cfLift_5,
+    __cfPattern_2,
     __cfLift_6,
-    __cfPattern_4,
-    __cfPattern_5,
     __cfLift_7,
+    __cfPattern_3,
     __cfLift_8,
-    __cfPattern_6,
     __cfLift_9,
+    __cfLift_10,
+    __cfPattern_4,
+    __cfLift_11,
+    __cfPattern_5,
+    __cfLift_12,
+    __cfLift_13,
+    __cfLift_14,
+    __cfPattern_6,
+    __cfLift_15,
     __cfPattern_7,
-    __cfLift_10
+    __cfLift_16
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
@@ -128,10 +128,40 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_5 = __cfHelpers.lift<{
+    x: number;
+    state: {
+        threshold: number;
+    };
+}, boolean>(({ x, state }) => x > state.threshold, {
+    type: "object",
+    properties: {
+        x: {
+            type: "number"
+        },
+        state: {
+            type: "object",
+            properties: {
+                threshold: {
+                    type: "number"
+                }
+            },
+            required: ["threshold"]
+        }
+    },
+    required: ["x", "state"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const x = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
-    return x > state.key("threshold");
+    return __cfLift_5({
+        x: x,
+        state: {
+            threshold: state.key("threshold")
+        }
+    }).for("__patternResult", true);
 }, {
     type: "object",
     properties: {
@@ -158,7 +188,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift<{
+const __cfLift_6 = __cfHelpers.lift<{
     x: number;
     state: {
         factor: number;
@@ -186,7 +216,7 @@ const __cfLift_5 = __cfHelpers.lift<{
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const x = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
-    return (<li>Value: {__cfLift_5({
+    return (<li>Value: {__cfLift_6({
         x: x,
         state: {
             factor: state.key("factor")
@@ -236,7 +266,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_6 = __cfHelpers.lift<{
+const __cfLift_7 = __cfHelpers.lift<{
     state: {
         items: number[];
         start: number;
@@ -268,7 +298,7 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_7 = __cfHelpers.lift<{
+const __cfLift_8 = __cfHelpers.lift<{
     state: {
         items: number[];
         start: number;
@@ -300,7 +330,7 @@ const __cfLift_7 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_8 = __cfHelpers.lift<{
+const __cfLift_9 = __cfHelpers.lift<{
     state: {
         names: string[];
         prefix: string;
@@ -328,7 +358,7 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_9 = __cfHelpers.lift<{
+const __cfLift_10 = __cfHelpers.lift<{
     state: {
         names: string[];
         searchTerm: string;
@@ -356,7 +386,7 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_10 = __cfHelpers.lift<{
+const __cfLift_11 = __cfHelpers.lift<{
     name: string;
 }, string>(({ name }) => name.trim().toLowerCase().replace(" ", "-"), {
     type: "object",
@@ -371,7 +401,7 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const name = __cf_pattern_input.key("element");
-    return (<li>{__cfLift_10({ name: name })}</li>);
+    return (<li>{__cfLift_11({ name: name })}</li>);
 }, {
     type: "object",
     properties: {
@@ -401,7 +431,7 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_11 = __cfHelpers.lift<{
+const __cfLift_12 = __cfHelpers.lift<{
     state: {
         prices: number[];
         discount: number;
@@ -429,7 +459,7 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_12 = __cfHelpers.lift<{
+const __cfLift_13 = __cfHelpers.lift<{
     state: {
         items: number[];
         factor: number;
@@ -458,7 +488,7 @@ const __cfLift_12 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_13 = __cfHelpers.lift<{
+const __cfLift_14 = __cfHelpers.lift<{
     state: {
         prices: number[];
         discount: number;
@@ -486,7 +516,7 @@ const __cfLift_13 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_14 = __cfHelpers.lift<{
+const __cfLift_15 = __cfHelpers.lift<{
     state: {
         text: string;
         prefix: string;
@@ -511,7 +541,7 @@ const __cfLift_14 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_15 = __cfHelpers.lift<{
+const __cfLift_16 = __cfHelpers.lift<{
     state: {
         text: string;
         prefix: string;
@@ -537,7 +567,7 @@ const __cfLift_15 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_16 = __cfHelpers.lift<{
+const __cfLift_17 = __cfHelpers.lift<{
     state: {
         users: { name: string; age: number; active: boolean; }[];
         minAge: number;
@@ -574,7 +604,7 @@ const __cfLift_16 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_17 = __cfHelpers.lift<{
+const __cfLift_18 = __cfHelpers.lift<{
     u: {
         name: string;
     };
@@ -595,7 +625,7 @@ const __cfLift_17 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_18 = __cfHelpers.lift<{
+const __cfLift_19 = __cfHelpers.lift<{
     u: {
         name: string;
     };
@@ -626,9 +656,9 @@ const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "string"
-    } as const satisfies __cfHelpers.JSONSchema, u.key("active"), __cfLift_17({ u: {
+    } as const satisfies __cfHelpers.JSONSchema, u.key("active"), __cfLift_18({ u: {
             name: u.key("name")
-        } }), __cfLift_18({ u: {
+        } }), __cfLift_19({ u: {
             name: u.key("name")
         } }))}</li>);
 }, {
@@ -672,7 +702,7 @@ const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_19 = __cfHelpers.lift<{
+const __cfLift_20 = __cfHelpers.lift<{
     state: {
         users: { name: string; age: number; active: boolean; }[];
         minAge: number;
@@ -706,7 +736,7 @@ const __cfLift_19 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_20 = __cfHelpers.lift<{
+const __cfLift_21 = __cfHelpers.lift<{
     state: {
         users: { name: string; age: number; active: boolean; }[];
     };
@@ -736,7 +766,7 @@ const __cfLift_20 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_21 = __cfHelpers.lift<{
+const __cfLift_22 = __cfHelpers.lift<{
     state: {
         text: string;
         prefix: string;
@@ -761,7 +791,7 @@ const __cfLift_21 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_22 = __cfHelpers.lift<{
+const __cfLift_23 = __cfHelpers.lift<{
     state: {
         text: string;
         threshold: number;
@@ -786,7 +816,7 @@ const __cfLift_22 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_23 = __cfHelpers.lift<{
+const __cfLift_24 = __cfHelpers.lift<{
     state: {
         words: string[];
         separator: string;
@@ -872,7 +902,7 @@ export default pattern((state) => {
         {/* Multiple filters */}
         <p>
           Double filter count:{" "}
-          {__cfLift_6({ state: {
+          {__cfLift_7({ state: {
                 items: state.key("items"),
                 start: state.key("start"),
                 end: state.key("end")
@@ -882,7 +912,7 @@ export default pattern((state) => {
         <h3>Methods with Reactive Arguments</h3>
         {/* Slice with reactive indices */}
         <p>
-          Sliced items: {__cfLift_7({ state: {
+          Sliced items: {__cfLift_8({ state: {
                 items: state.key("items"),
                 start: state.key("start"),
                 end: state.key("end")
@@ -892,7 +922,7 @@ export default pattern((state) => {
         {/* String methods with reactive args */}
         <p>
           Starts with:{" "}
-          {__cfLift_8({ state: {
+          {__cfLift_9({ state: {
                 names: state.key("names"),
                 prefix: state.key("prefix")
             } })}
@@ -900,7 +930,7 @@ export default pattern((state) => {
 
         {/* Array find with reactive predicate */}
         <p>
-          First match: {__cfLift_9({ state: {
+          First match: {__cfLift_10({ state: {
                 names: state.key("names"),
                 searchTerm: state.key("searchTerm")
             } })}
@@ -914,7 +944,7 @@ export default pattern((state) => {
 
         {/* Reduce with reactive accumulator */}
         <p>
-          Total with discount: {__cfLift_11({ state: {
+          Total with discount: {__cfLift_12({ state: {
                 prices: state.key("prices"),
                 discount: state.key("discount")
             } })}
@@ -923,7 +953,7 @@ export default pattern((state) => {
         {/* Method result used in computation */}
         <p>
           Average * factor:{" "}
-          {__cfLift_12({ state: {
+          {__cfLift_13({ state: {
                 items: state.key("items"),
                 factor: state.key("factor")
             } })}
@@ -932,7 +962,7 @@ export default pattern((state) => {
         <h3>Methods on Computed Values</h3>
         {/* Method on binary expression result */}
         <p>
-          Formatted price: {__cfLift_13({ state: {
+          Formatted price: {__cfLift_14({ state: {
                 prices: state.key("prices"),
                 discount: state.key("discount")
             } })}
@@ -941,7 +971,7 @@ export default pattern((state) => {
         {/* Method on conditional result */}
         <p>
           Conditional trim:{" "}
-          {__cfLift_14({ state: {
+          {__cfLift_15({ state: {
                 text: state.key("text"),
                 prefix: state.key("prefix")
             } })}
@@ -950,7 +980,7 @@ export default pattern((state) => {
         {/* Method chain on computed value */}
         <p>
           Complex:{" "}
-          {__cfLift_15({ state: {
+          {__cfLift_16({ state: {
                 text: state.key("text"),
                 prefix: state.key("prefix")
             } })}
@@ -960,7 +990,7 @@ export default pattern((state) => {
         {/* Filter with multiple conditions */}
         <p>
           Active adults:{" "}
-          {__cfLift_16({ state: {
+          {__cfLift_17({ state: {
                 users: state.key("users"),
                 minAge: state.key("minAge")
             } })}
@@ -982,7 +1012,7 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Yes", "No"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_19({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_20({ state: {
                 users: state.key("users"),
                 minAge: state.key("minAge")
             } }), "Yes", "No")}
@@ -995,14 +1025,14 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Yes", "No"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_20({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_21({ state: {
                 users: state.key("users")
             } }), "Yes", "No")}</p>
 
         <h3>Method Calls in Expressions</h3>
         {/* Method result in arithmetic */}
         <p>
-          Length sum: {__cfLift_21({ state: {
+          Length sum: {__cfLift_22({ state: {
                 text: state.key("text"),
                 prefix: state.key("prefix")
             } })}
@@ -1018,14 +1048,14 @@ export default pattern((state) => {
             type: "string"
         } as const satisfies __cfHelpers.JSONSchema, {
             "enum": ["Yes", "No"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_22({ state: {
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_23({ state: {
                 text: state.key("text"),
                 threshold: state.key("threshold")
             } }), "Yes", "No")}
         </p>
 
         {/* Multiple method results combined */}
-        <p>Joined: {__cfLift_23({ state: {
+        <p>Joined: {__cfLift_24({ state: {
                 words: state.key("words"),
                 separator: state.key("separator")
             } })}</p>
@@ -1149,16 +1179,16 @@ __cfReg({
     __cfLift_2,
     __cfLift_3,
     __cfLift_4,
-    __cfPattern_1,
     __cfLift_5,
-    __cfPattern_2,
+    __cfPattern_1,
     __cfLift_6,
+    __cfPattern_2,
     __cfLift_7,
     __cfLift_8,
     __cfLift_9,
     __cfLift_10,
-    __cfPattern_3,
     __cfLift_11,
+    __cfPattern_3,
     __cfLift_12,
     __cfLift_13,
     __cfLift_14,
@@ -1166,10 +1196,11 @@ __cfReg({
     __cfLift_16,
     __cfLift_17,
     __cfLift_18,
-    __cfPattern_4,
     __cfLift_19,
+    __cfPattern_4,
     __cfLift_20,
     __cfLift_21,
     __cfLift_22,
-    __cfLift_23
+    __cfLift_23,
+    __cfLift_24
 });


### PR DESCRIPTION
## What

Lifts bare reactive **value**-expressions in reactive `map`/`filter`/`flatMap` callbacks so comparisons / arithmetic / unary run on **resolved values** instead of raw `OpaqueRef` proxies.

Fixes **CT-1777**. Discovered via #4295 (Dan): the lunch-poll "All options" per-voter swatches stopped rendering after #4291 moved `vote.optionId === oid` out of a JSX value position (lifted → worked) into a `.filter()` predicate (not lifted → proxy-vs-proxy `===` → constant `false` → empty filter, silent and type-clean). That PR worked around it pattern-side; this is the upstream transformer fix.

## The bug

The value-level lift is driven by the expression-site policy. A `.map()` callback that returns JSX has its embedded comparisons lifted (JSX sites). A `.filter()` predicate returns a *bare boolean*, which fell through to a "not-lowerable" skip and was emitted raw:

```js
// before
const __cfPattern = pattern(input => {
  const vote = input.key("element");
  const oid  = input.key("params", "oid");
  return vote.key("optionId") === oid;   // two proxies → always false
});
```

Confirmed the same gap across all three collection-returning families (`filter` predicate, `map`→non-JSX value, `flatMap`→array element). `find`/`findIndex`/`reduce` are scalar → value-level `lift` already, out of scope.

## The fix

Add the array-method analog of `classifyHelperOwnedExpressionSiteHandling`: a bare reactive value-computation in an array-method callback is lifted the same way it is inside a helper body or a JSX value site.

```js
// after
const __cfLift = lift(({ vote, oid }) => vote.optionId === oid, /* … */);
const __cfPattern = pattern(input => {
  const vote = input.key("element"); const oid = input.key("params", "oid");
  return __cfLift({ vote: { optionId: vote.key("optionId") }, oid }).for("__patternResult", true);
});
```

Collection-valued expressions deliberately stay **structural** (the runtime `*WithPattern` flatten/map depends on it): control flow (`&&`/`||`, ternary) via the existing `controlFlowRewriteRoot` guard, and `??` fallbacks whose result is a reactive collection (e.g. `flatMap(i => i.tags ?? [])`) via `!hasReactiveCollectionProvenance`. Covered by the preserved `filter-flatmap-fallback-chain` fixture.

## Refactor (review feedback)

The fix surfaced existing duplication, factored out here:
- `isValueComputationExpressionKind` — shared predicate (was inlined in 3 places, incl. an unexported local in the helper-owned emitter)
- `hasReactiveComputationToLift` — named lowerable signal (`containsOpaqueRef && requiresRewrite`)
- `ExpressionSiteOwner` — named type (the owner union was inlined in 3 places)
- a dedicated `array-method-callback-value` owner, routed alongside receiver-method calls via `isArrayMethodValueLiftOwner` (so the decision name no longer lies)

## Not the same as #4244

#4244 (`!isAdmin`) fixed schema-shrinking dropping an already-lifted **required-primitive capture**. This is a **missing lift**, not a dropped capture — a disjoint subsystem (expression-site policy vs capability-analysis / schema-injection).

## Known limitation → CT-1779

Scalar `??` on a reactive operand (`v.name ?? "default"`) is conservatively **not** lifted — the collection guard keys on operand provenance, not result type. It stays a valid field projection (correct `string` schema, no error); only the `?? default` fallback is inert. Tracked as CT-1779; not a regression (pre-existing).

## Tests

- `ts-transformers` unit suite: **295 passed, 0 failed**
- `deno task integration pattern-tests`: **all 68 passed** (runtime, incl. lunch-poll)
- New `array-method-value-lift` fixture pins the filter/map/flatMap value-lifts; three existing goldens updated to the (additive) lifted form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1777 by lifting bare reactive value expressions in `map`/`filter`/`flatMap` callbacks in `ts-transformers` so comparisons, arithmetic, and unary ops run on resolved values instead of `OpaqueRef` proxies. Restores correct behavior for cases like the lunch‑poll filter.

- **Bug Fixes**
  - Lift comparisons, arithmetic, and unary expressions in return/object-property/array-element positions of array-method callbacks, matching helper/JSX behavior.
  - Applies to `.filter` predicates, `.map` non-JSX returns, and `.flatMap` array elements; fixes proxy-vs-proxy `===` always-false bugs.
  - Keeps control-flow and reactive-collection `??` fallbacks structural to preserve `*WithPattern` semantics.
  - Adds `array-method-value-lift` fixture and updates affected goldens.

- **Refactors**
  - Extracts `isValueComputationExpressionKind`, `hasReactiveComputationToLift`, and `ExpressionSiteOwner`.
  - Adds `array-method-callback-value` owner and `isArrayMethodValueLiftOwner`; uses shared predicate in helper-owned emitter and array-method site lowering.

<sup>Written for commit cb38cb74f6f1ac877dc4b9313cbb96f613282f13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

