### PR TITLE
fix(ts-transformers): recognize derived reactive collections across helper-function boundaries (CT-1778)

### DIFF
--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -159,6 +159,15 @@ export interface ReactiveCollectionProvenanceOptions {
   readonly typeRegistry?: WeakMap<ts.Node, ts.Type>;
   readonly syntheticReactiveCollectionRegistry?: WeakSet<ts.Symbol>;
   readonly logger?: (message: string) => void;
+  /**
+   * True once the walk has descended into a variable declaration's initializer
+   * (CT-1778). The derived-reactive-collection-call recognition is gated on this
+   * because only a `const x = helper(reactiveArgs)` *binding* is lift-wrapped into
+   * a reactive collection; the same call used inline as a `.map` receiver
+   * (`helper(reactiveArgs).map(...)`) is NOT wrapped and stays a plain array, so
+   * lowering its `.map` would emit a `.mapWithPattern` the runtime value lacks.
+   */
+  readonly viaVariableInitializer?: boolean;
 }
 
 export type ArrayCallbackContainerCallKind =
@@ -259,7 +268,8 @@ function usesDefaultReactiveCollectionProvenanceOptions(
     options.sameScope === undefined &&
     options.typeRegistry === undefined &&
     options.syntheticReactiveCollectionRegistry === undefined &&
-    options.logger === undefined;
+    options.logger === undefined &&
+    options.viaVariableInitializer === undefined;
 }
 
 export function detectCallKind(
@@ -1134,6 +1144,62 @@ function hasReactiveCollectionProvenanceInternal(
       return true;
     }
 
+    // CT-1778: a non-reactive-origin call that reads a pattern-level reactive value
+    // and returns a collection — e.g. `tallyOptions(options, votes): OptionTally[]`,
+    // where `options`/`votes` are the pattern's reactive parameters — is lift-wrapped
+    // by the transformer into a reactive collection (`const ranked = __cfLift_N(...)`).
+    // That wrap, and the symbol's registration in syntheticReactiveCollectionRegistry,
+    // happen in a later pass than the array-method lowering decision, so a nested
+    // `.map`/`.filter` over the result's elements would otherwise race the registration
+    // and be emitted raw (-> "OpaqueRef.map(fn) is no longer supported" at runtime).
+    // Recognizing the shape structurally here makes the receiver provably reactive at
+    // decision time, exactly as the inline `options.map(...)` form already is.
+    //
+    // Gated on an argument that is reactive via a PARAMETER BINDING or a DERIVATION
+    // from one — recursing through the same provenance walk with
+    // `allowTypeBasedRoot: false`. Dropping the type root is what excludes values that
+    // are reactive only by static type: a reactive-typed parameter of a standalone
+    // (hardened) function is reactive-typed but is neither an implicit reactive
+    // parameter nor has a reactive initializer to walk, so it is rejected — which keeps
+    // this from firing inside standalone functions, where `helper(x).map(...)` is an
+    // eager, non-reactive map that PatternContextValidation (correctly) forbids from
+    // lowering. The same recursion also covers chained derivations, e.g.
+    // `const a = tallyOptions(options); const b = enrich(a); b.map(t => t.x.map(...))`.
+    // Only when reached through a variable initializer (`const x = call(...)`),
+    // never for a call used inline as a `.map` receiver — see
+    // `viaVariableInitializer` above. `viaVariableInitializer: false` on the
+    // argument recursion keeps the same restriction for chained args: a const
+    // argument re-establishes it through its own initializer walk, while an inline
+    // call argument does not.
+    if (
+      options.viaVariableInitializer &&
+      target.arguments.some((arg) =>
+        hasReactiveCollectionProvenanceInternal(
+          stripWrappers(arg),
+          checker,
+          {
+            ...options,
+            allowTypeBasedRoot: false,
+            viaVariableInitializer: false,
+          },
+          seenSymbols,
+        )
+      )
+    ) {
+      const resultType = getTypeAtLocationWithFallback(
+        target,
+        checker,
+        options.typeRegistry,
+        options.logger,
+      );
+      if (
+        resultType &&
+        (checker.isArrayType(resultType) || checker.isTupleType(resultType))
+      ) {
+        return true;
+      }
+    }
+
     const directBuilder = detectDirectBuilderCall(target, checker);
     return !!directBuilder &&
       COMMONFABRIC_REACTIVE_ORIGIN_BUILDER_NAMES.has(directBuilder.builderName);
@@ -1188,7 +1254,7 @@ function hasReactiveCollectionProvenanceInternal(
         hasReactiveCollectionProvenanceInternal(
           declaration.initializer,
           checker,
-          options,
+          { ...options, viaVariableInitializer: true },
           seenSymbols,
         )
       ) {
@@ -1216,7 +1282,7 @@ function hasReactiveCollectionProvenanceInternal(
       hasReactiveCollectionProvenanceInternal(
         parent.initializer,
         checker,
-        options,
+        { ...options, viaVariableInitializer: true },
         seenSymbols,
       )
     ) {

--- a/packages/ts-transformers/test/fixtures/closures/nested-map-derived-collection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-map-derived-collection.expected.jsx
@@ -1,0 +1,511 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { pattern, UI } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface Vote {
+    optionId: string;
+    voterName: string;
+}
+interface Option {
+    id: string;
+}
+interface OptionTally {
+    option: Option;
+    voters: Array<{
+        name: string;
+    }>;
+}
+// FIXTURE: nested-map-derived-collection
+// Verifies (CT-1778): a reactive collection produced by a non-reactive-origin helper
+// over reactive parameters — `tallyOptions(options, votes): OptionTally[]` — is
+// recognized as reactive at array-method-decision time, so a nested `.map` over a
+// per-item field (`tally.voters.map(...)`) lowers to `.mapWithPattern` instead of being
+// emitted raw (which throws "OpaqueRef.map(fn) is no longer supported" at runtime,
+// because the receiver is an OpaqueRef). Before the fix the inner map raced the helper
+// result's late lift-wrap registration and stayed raw.
+//
+// Covers both shapes:
+//   - direct receiver: `ranked = tallyOptions(options, votes)`
+//   - chained derivation: `enriched = enrichTallies(ranked)` (a derived const passed to
+//     another helper), exercising the recursive provenance walk through const args.
+const tallyOptions = __cfHardenFn((options: Option[], votes: Vote[]): OptionTally[] => options.map((option): OptionTally => ({
+    option,
+    voters: votes.map((v) => ({ name: v.voterName })),
+})));
+const enrichTallies = __cfHardenFn((tallies: OptionTally[]): OptionTally[] => tallies.map((t): OptionTally => ({ option: t.option, voters: t.voters })));
+const __cfLift_1 = __cfHelpers.lift<{
+    options: Option[];
+    votes: Vote[];
+}, OptionTally[]>(({ options, votes }) => tallyOptions(options, votes), {
+    type: "object",
+    properties: {
+        options: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Option"
+            }
+        },
+        votes: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Vote"
+            }
+        }
+    },
+    required: ["options", "votes"],
+    $defs: {
+        Vote: {
+            type: "object",
+            properties: {
+                optionId: {
+                    type: "string"
+                },
+                voterName: {
+                    type: "string"
+                }
+            },
+            required: ["optionId", "voterName"]
+        },
+        Option: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                }
+            },
+            required: ["id"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        $ref: "#/$defs/OptionTally"
+    },
+    $defs: {
+        OptionTally: {
+            type: "object",
+            properties: {
+                option: {
+                    $ref: "#/$defs/Option"
+                },
+                voters: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: {
+                            name: {
+                                type: "string"
+                            }
+                        },
+                        required: ["name"]
+                    }
+                }
+            },
+            required: ["option", "voters"]
+        },
+        Option: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                }
+            },
+            required: ["id"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_2 = __cfHelpers.lift<{
+    ranked: OptionTally[];
+}, OptionTally[]>(({ ranked }) => enrichTallies(ranked), {
+    type: "object",
+    properties: {
+        ranked: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/OptionTally"
+            }
+        }
+    },
+    required: ["ranked"],
+    $defs: {
+        OptionTally: {
+            type: "object",
+            properties: {
+                option: {
+                    $ref: "#/$defs/Option"
+                },
+                voters: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: {
+                            name: {
+                                type: "string"
+                            }
+                        },
+                        required: ["name"]
+                    }
+                }
+            },
+            required: ["option", "voters"]
+        },
+        Option: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                }
+            },
+            required: ["id"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        $ref: "#/$defs/OptionTally"
+    },
+    $defs: {
+        OptionTally: {
+            type: "object",
+            properties: {
+                option: {
+                    $ref: "#/$defs/Option"
+                },
+                voters: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: {
+                            name: {
+                                type: "string"
+                            }
+                        },
+                        required: ["name"]
+                    }
+                }
+            },
+            required: ["option", "voters"]
+        },
+        Option: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                }
+            },
+            required: ["id"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const voter = __cf_pattern_input.key("element");
+    return <span>{voter.key("name")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const tally = __cf_pattern_input.key("element");
+    return (<div>{tally.key("voters").mapWithPattern(__cfPattern_1, {})}</div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/OptionTally"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        OptionTally: {
+            type: "object",
+            properties: {
+                option: {
+                    $ref: "#/$defs/Option"
+                },
+                voters: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: {
+                            name: {
+                                type: "string"
+                            }
+                        },
+                        required: ["name"]
+                    }
+                }
+            },
+            required: ["option", "voters"]
+        },
+        Option: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                }
+            },
+            required: ["id"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+    const voter = __cf_pattern_input.key("element");
+    return <span>{voter.key("name")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
+    const tally = __cf_pattern_input.key("element");
+    return (<div>{tally.key("voters").mapWithPattern(__cfPattern_3, {})}</div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/OptionTally"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        OptionTally: {
+            type: "object",
+            properties: {
+                option: {
+                    $ref: "#/$defs/Option"
+                },
+                voters: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: {
+                            name: {
+                                type: "string"
+                            }
+                        },
+                        required: ["name"]
+                    }
+                }
+            },
+            required: ["option", "voters"]
+        },
+        Option: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                }
+            },
+            required: ["id"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+export default pattern((__cf_pattern_input) => {
+    const votes = __cf_pattern_input.key("votes");
+    const options = __cf_pattern_input.key("options");
+    const ranked = __cfLift_1({
+        options: options,
+        votes: votes
+    }).for("ranked", true);
+    const enriched = __cfLift_2({ ranked: ranked }).for("enriched", true);
+    return {
+        [UI]: (<div>
+          <div>
+            {ranked.mapWithPattern(__cfPattern_2, {})}
+          </div>
+          <div>
+            {enriched.mapWithPattern(__cfPattern_4, {})}
+          </div>
+        </div>),
+    };
+}, {
+    type: "object",
+    properties: {
+        votes: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Vote"
+            }
+        },
+        options: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Option"
+            }
+        }
+    },
+    required: ["votes", "options"],
+    $defs: {
+        Option: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                }
+            },
+            required: ["id"]
+        },
+        Vote: {
+            type: "object",
+            properties: {
+                optionId: {
+                    type: "string"
+                },
+                voterName: {
+                    type: "string"
+                }
+            },
+            required: ["optionId", "voterName"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $UI: {
+            $ref: "#/$defs/JSXElement"
+        }
+    },
+    required: ["$UI"],
+    $defs: {
+        JSXElement: {
+            anyOf: [{
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }, {
+                    $ref: "#/$defs/UIRenderable"
+                }, {
+                    type: "object",
+                    properties: {}
+                }]
+        },
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1,
+    __cfPattern_2,
+    __cfPattern_3,
+    __cfPattern_4
+});

--- a/packages/ts-transformers/test/fixtures/closures/nested-map-derived-collection.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-map-derived-collection.input.tsx
@@ -1,0 +1,58 @@
+import { pattern, UI } from "commonfabric";
+
+interface Vote {
+  optionId: string;
+  voterName: string;
+}
+interface Option {
+  id: string;
+}
+interface OptionTally {
+  option: Option;
+  voters: Array<{ name: string }>;
+}
+
+// FIXTURE: nested-map-derived-collection
+// Verifies (CT-1778): a reactive collection produced by a non-reactive-origin helper
+// over reactive parameters — `tallyOptions(options, votes): OptionTally[]` — is
+// recognized as reactive at array-method-decision time, so a nested `.map` over a
+// per-item field (`tally.voters.map(...)`) lowers to `.mapWithPattern` instead of being
+// emitted raw (which throws "OpaqueRef.map(fn) is no longer supported" at runtime,
+// because the receiver is an OpaqueRef). Before the fix the inner map raced the helper
+// result's late lift-wrap registration and stayed raw.
+//
+// Covers both shapes:
+//   - direct receiver: `ranked = tallyOptions(options, votes)`
+//   - chained derivation: `enriched = enrichTallies(ranked)` (a derived const passed to
+//     another helper), exercising the recursive provenance walk through const args.
+const tallyOptions = (options: Option[], votes: Vote[]): OptionTally[] =>
+  options.map((option): OptionTally => ({
+    option,
+    voters: votes.map((v) => ({ name: v.voterName })),
+  }));
+
+const enrichTallies = (tallies: OptionTally[]): OptionTally[] =>
+  tallies.map((t): OptionTally => ({ option: t.option, voters: t.voters }));
+
+export default pattern<{ votes: Vote[]; options: Option[] }>(
+  ({ votes, options }) => {
+    const ranked = tallyOptions(options, votes);
+    const enriched = enrichTallies(ranked);
+    return {
+      [UI]: (
+        <div>
+          <div>
+            {ranked.map((tally) => (
+              <div>{tally.voters.map((voter) => <span>{voter.name}</span>)}</div>
+            ))}
+          </div>
+          <div>
+            {enriched.map((tally) => (
+              <div>{tally.voters.map((voter) => <span>{voter.name}</span>)}</div>
+            ))}
+          </div>
+        </div>
+      ),
+    };
+  },
+);


### PR DESCRIPTION
## What

A reactive collection produced by a **non-reactive-origin helper over reactive parameters** — e.g. `const ranked = tallyOptions(options, votes): OptionTally[]` — is recognized as reactive at array-method-lowering time, so a **nested `.map`/`.filter` over a per-item field** (`ranked.map(t => t.voters.map(...))`) lowers to `.mapWithPattern` instead of being emitted raw.

Fixes **CT-1778**. Reported via #4295 (Dan): the lunch-poll `tallyOptions(...)` tally drove a `ranked.map(tally => tally.voters.map(...))` that threw `OpaqueRef.map(fn) is no longer supported` at runtime; that PR worked around it with an `OptionSummaryRow` subpattern whose `voters` is a top-level input.

## Root cause — a pass-ordering race (instrumented)

`ranked = tallyOptions(options, votes)` is **not structurally reactive** (a plain user-function call returning a plain `OptionTally[]`). It becomes reactive only by being lift-wrapped (`__cfLift_N(...)`) and registered in `syntheticReactiveCollectionRegistry` — which happens in a *later* pass (expression-site-lowering) than the array-method lowering decision (ClosureTransformer). An instrumented probe confirmed the inner `tally.voters.map` is decided **before** `ranked` is registered, while `tally` is still a callback `Parameter`, so `hasReactiveCollectionProvenance(ranked)` returns false and the inner map stays raw. It is never revisited. (The inline `ranked = options.map(...)` form works because `options.map(...)` is structurally reactive and recognized immediately.)

## The fix

Recognize the shape **structurally** in `hasReactiveCollectionProvenanceInternal` (`ast/call-kind.ts`): a non-reactive-origin call whose result type is a collection **and** that reads a reactive value reachable through a **parameter binding** — recursing with `allowTypeBasedRoot: false` — is a reactive collection. This makes the receiver provably reactive at decision time, the same way the inline form already is, without touching pipeline order or adding a pass.

The `allowTypeBasedRoot: false` is the crux. It draws the line between:
- **reactive via a binding or a derivation from one** (a pattern parameter, or a const chained from one) → recognized;
- **reactive only by static type** (a reactive-typed parameter of a standalone/hardened function) → rejected.

So it **cannot fire inside standalone functions**, where `helper(x).map(...)` is an eager, non-reactive map that `PatternContextValidation` correctly forbids from lowering. (An earlier, broader version — recognizing any reactive-*valued* arg — over-matched exactly those standalone-function maps and failed 4 integration patterns; the binding-based gate is what fixes it. The unit suite couldn't see it; the runtime suite did.)

The recursion also covers **chained derivations**: `const a = tallyOptions(options); const b = enrich(a); b.map(t => t.voters.map(...))` lowers too.

## Scope / known limitation

Recognition flows through const/parameter bindings; a value reactive *only* by static type (e.g. a bare `cell.get()` passed directly as an argument) is intentionally not recognized here. Covers the lunch-poll case and arbitrary const-chaining.

## Tests

- `ts-transformers` unit suite: **295 passed, 0 failed**
- `deno task integration pattern-tests`: **all 68 passed** (runtime, incl. the standalone-function patterns that pinned the over-match guard)
- New `nested-map-derived-collection` fixture pins **both** the direct (`ranked`) and chained (`enriched`) shapes lowering to `.mapWithPattern`

Stacks conceptually alongside CT-1777 (#4297); both were flagged together in #4295 but are independent fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recognizes reactive collections returned by non-reactive helpers over reactive inputs when assigned to a `const`, so nested array maps lower to `.mapWithPattern` and avoid the “OpaqueRef.map(fn) is no longer supported” error. Fixes CT-1778 and the lunch‑poll case.

- **Bug Fixes**
  - In `hasReactiveCollectionProvenanceInternal` (`packages/ts-transformers/src/ast/call-kind.ts`), added `viaVariableInitializer` gating: treat a call as reactive only when used as a variable initializer, its result type is an array/tuple, and it reads a reactive value via a parameter/const binding; recurse with `allowTypeBasedRoot: false` to block standalone-function false positives and support chained derivations. Inline `helper(...).map(...)` remains non-lowering by design.
  - Added `nested-map-derived-collection` fixture to pin both direct and chained shapes lowering to `.mapWithPattern`. Tests pass: 295 unit, 68 integration, 147 generated-patterns.

<sup>Written for commit b2e8aaffb895927d82da34319e6f762431b1feb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

