### PR TITLE
revert(lunch-poll): restore `votes.filter` swatch render now that CT-1777 is fixed

### DIFF
--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -219,9 +219,11 @@ export default pattern(() => {
       v?.voterName === "Alex";
   });
 
-  // The "All options" overview renders one swatch per voter, sourced from the
-  // per-option `tally.voters` list. Regression guard for the filter/map bug
-  // where the swatches silently stopped rendering: after Alex's green vote, his
+  // The "All options" overview renders one swatch per voter, sourced from a
+  // per-option `votes.filter((v) => v.optionId === oid)`. Regression guard for
+  // the transformer filter/map lift bug (CT-1777) where the predicate compiled
+  // to a proxy-vs-proxy `===` (always false), so the filter dropped every vote
+  // and the swatches silently stopped rendering: after Alex's green vote, his
   // swatch must appear in the rendered UI tree.
   const assert_alex_swatch_renders = computed(() =>
     findNodeByProp(poll[UI], "data-vote-swatch-name", "Alex") !== undefined

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -751,87 +751,6 @@ const EMPTY_OPTIONS: Option[] = [];
 const EMPTY_VOTES: Vote[] = [];
 const EMPTY_USERS: User[] = [];
 
-interface OptionSummaryRowInput {
-  title: string;
-  voters: readonly { name: string; voteType: VoteColor; color: string }[];
-  me: string;
-}
-
-interface OptionSummaryRowOutput {
-  [NAME]: string;
-  [UI]: VNode;
-}
-
-// One row of the compact "All options" overview: the option title plus a
-// swatch per voter who picked it. `voters` is the pattern input — a top-level
-// reactive binding — so `voters.map(...)` lowers to a reactive mapping. The
-// parent feeds each row a single option's voters (from `ranked`), so the
-// chips count the actual votes rather than options × votes. Mapping a per-item
-// field of `ranked` inline (e.g. `tally.voters.map(...)`) instead is rejected
-// at runtime — `OpaqueRef.map` has no stable per-item identity to lower.
-const OptionSummaryRow = pattern<OptionSummaryRowInput, OptionSummaryRowOutput>(
-  ({ title, voters, me }) => ({
-    [NAME]: "Option summary row",
-    [UI]: (
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "8px",
-          padding: "6px 10px",
-          backgroundColor: "white",
-          border: "1px solid #e5e7eb",
-          borderRadius: "6px",
-        }}
-      >
-        <div
-          style={{
-            flex: 1,
-            fontSize: "13px",
-            fontWeight: 500,
-            color: "#111827",
-          }}
-        >
-          {title}
-        </div>
-        <div
-          style={{
-            display: "flex",
-            gap: "4px",
-            flexWrap: "wrap",
-            justifyContent: "flex-end",
-          }}
-        >
-          {voters.map((voter) => (
-            <span
-              title={voter.name}
-              data-vote-swatch-name={voter.name}
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                justifyContent: "center",
-                minWidth: "22px",
-                height: "22px",
-                padding: "0 6px",
-                borderRadius: "9999px",
-                backgroundColor: VOTE_SWATCH[voter.voteType],
-                color: "white",
-                fontSize: "11px",
-                fontWeight: 700,
-                boxShadow: voter.name === me
-                  ? "0 0 0 2px white, 0 0 0 3px #111827"
-                  : "none",
-              }}
-            >
-              {getInitials(voter.name)}
-            </span>
-          ))}
-        </div>
-      </div>
-    ),
-  }),
-);
-
 export default pattern<CozyPollInput, CozyPollOutput>(
   (
     {
@@ -1297,13 +1216,75 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                           gap: "4px",
                         }}
                       >
-                        {ranked.map((tally) => (
-                          <OptionSummaryRow
-                            title={tally.option.title}
-                            voters={tally.voters}
-                            me={me}
-                          />
-                        ))}
+                        {options.map((option) => {
+                          const oid = option.id;
+                          const summaryRank = computed(() => {
+                            const idx = ranked.findIndex(
+                              (t) => t.option.id === oid,
+                            );
+                            return idx >= 0 ? idx + 1 : 9999;
+                          });
+                          return (
+                            <div
+                              style={{
+                                order: summaryRank,
+                                display: "flex",
+                                alignItems: "center",
+                                gap: "8px",
+                                padding: "6px 10px",
+                                backgroundColor: "white",
+                                border: "1px solid #e5e7eb",
+                                borderRadius: "6px",
+                              }}
+                            >
+                              <div
+                                style={{
+                                  flex: 1,
+                                  fontSize: "13px",
+                                  fontWeight: 500,
+                                  color: "#111827",
+                                }}
+                              >
+                                {option.title}
+                              </div>
+                              <div
+                                style={{
+                                  display: "flex",
+                                  gap: "4px",
+                                  flexWrap: "wrap",
+                                  justifyContent: "flex-end",
+                                }}
+                              >
+                                {votes.filter((vote) => vote.optionId === oid)
+                                  .map((vote) => (
+                                    <span
+                                      title={vote.voterName}
+                                      data-vote-swatch-name={vote.voterName}
+                                      style={{
+                                        display: "inline-flex",
+                                        alignItems: "center",
+                                        justifyContent: "center",
+                                        minWidth: "22px",
+                                        height: "22px",
+                                        padding: "0 6px",
+                                        borderRadius: "9999px",
+                                        backgroundColor:
+                                          VOTE_SWATCH[vote.voteType],
+                                        color: "white",
+                                        fontSize: "11px",
+                                        fontWeight: 700,
+                                        boxShadow: vote.voterName === me
+                                          ? "0 0 0 2px white, 0 0 0 3px #111827"
+                                          : "none",
+                                      }}
+                                    >
+                                      {getInitials(vote.voterName)}
+                                    </span>
+                                  ))}
+                              </div>
+                            </div>
+                          );
+                        })}
                       </div>
                     </div>
                   )


### PR DESCRIPTION
## What

Undoes the pattern-side workaround from **#4295** now that the underlying
ts-transformer bug it dodged is fixed upstream in **#4297 (CT-1777)**. This is
the end-to-end validation that #4297 repairs the real-world pattern — not just
the unit fixtures.

## Background

- **#4291** changed the "All options" overview swatches from a `map`-with-ternary
  to `votes.filter((vote) => vote.optionId === oid).map(...)` (to avoid an
  options × votes cartesian product).
- That tripped a transformer gap: a reactive `.filter()` predicate compiled to a
  raw `===` between two `OpaqueRef` proxies — reference equality, always `false`
  — so the filter dropped **every** vote and no swatches rendered (silent, type-clean).
- **#4295** (Dan) worked around it by sourcing each row from the precomputed
  `ranked` tally through an `OptionSummaryRow` subpattern (the subpattern was
  needed because `tally.voters.map(...)`, a `.map` on a per-item member field, is
  rejected at runtime).
- **#4297 (CT-1777)** fixed the transformer: bare reactive value-expressions in
  `map`/`filter`/`flatMap` callbacks are now lifted to value level.

## This change

Restores the natural #4291 form and removes the workaround scaffolding:

- `ranked.map(<OptionSummaryRow .../>)` → `options.map(...)` +
  `votes.filter((vote) => vote.optionId === oid).map(...)` inline again.
- Deletes the `OptionSummaryRow` subpattern and its `OptionSummaryRowInput` /
  `OptionSummaryRowOutput` interfaces.
- Keeps Dan's `assert_alex_swatch_renders` regression guard, re-applying the
  `data-vote-swatch-name` hook to the restored span — it now validates the
  transformer fix end-to-end.

**One tradeoff to flag:** iterating `options` again reintroduces the
`order: summaryRank` CSS ordering that #4295's `ranked` iteration had incidentally
dropped (it's intrinsic to the `votes`-sourced form — `options` is insertion-ordered,
so rank order needs the CSS `order`). I kept the faithful `votes.filter` restore
because it puts the exact expression the bug broke back into the pattern, which is
the whole point of validating CT-1777. If we'd rather keep the cleaner pre-sorted
`ranked` iteration, the alternative is to leave #4295's outer loop and only inline
the filter — happy to switch on review.

## Validation

- **Structural** (`deno task cf check … --show-transformed --no-run`): the
  predicate now lowers to
  `lift(({ vote, oid }) => vote.optionId === oid)` over resolved `string` values
  (the #4297 "after" form), instead of the bug's proxy-vs-proxy
  `return vote.key("optionId") === oid`.
- **Runtime**: full `deno task integration pattern-tests` green — **68/68**,
  including all 6 lunch-poll files (48 assertions).
- **Negative control**: forcing the filter to match nothing turns **exactly** the
  swatch assertion red (1 of 20 in `main.test.tsx`), proving the guard has teeth
  and that its passing genuinely means swatches render.
- `deno fmt --check` + `deno lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the lunch-poll “All options” swatch rendering by reverting to `options.map(...)` + `votes.filter(...)` now that CT-1777 fixed the transformer lifting bug. Removes the `OptionSummaryRow` workaround and keeps rank ordering via CSS.

- **Bug Fixes**
  - Reinstate `votes.filter((v) => v.optionId === oid).map(...)` for per-option swatches; validates the CT-1777 fix.
  - Keep the `assert_alex_swatch_renders` guard and reapply `data-vote-swatch-name` to the swatch span.

- **Refactors**
  - Remove `OptionSummaryRow` and its interfaces; inline the row UI.
  - Compute `summaryRank` per option and use CSS `order` to preserve ranked display.

<sup>Written for commit 39251861a2427a0b7f3add1ab4df1306d465dd48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

