### PR TITLE
fix(ts-transformers): lift scalar nullish-coalescing on reactive operands in array-method callbacks (CT-1779)

### DIFF
--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -51,6 +51,7 @@ import {
   getTypeAtLocationWithFallback,
   getVariableInitializer,
 } from "./utils.ts";
+import { isCollectionType } from "./type-inference.ts";
 
 const BUILDER_SYMBOL_NAMES = COMMONFABRIC_BUILDER_EXPORT_NAMES;
 
@@ -1192,10 +1193,7 @@ function hasReactiveCollectionProvenanceInternal(
         options.typeRegistry,
         options.logger,
       );
-      if (
-        resultType &&
-        (checker.isArrayType(resultType) || checker.isTupleType(resultType))
-      ) {
+      if (isCollectionType(resultType, checker)) {
         return true;
       }
     }

--- a/packages/ts-transformers/src/ast/mod.ts
+++ b/packages/ts-transformers/src/ast/mod.ts
@@ -85,6 +85,7 @@ export {
   isAnyOrUnknownType,
   isAnyType,
   isCellLikeType,
+  isCollectionType,
   isUnknownType,
   isUnresolvedSchemaType,
   registerSyntheticCallType,

--- a/packages/ts-transformers/src/ast/type-inference.ts
+++ b/packages/ts-transformers/src/ast/type-inference.ts
@@ -274,6 +274,35 @@ export function isCellLikeType(
 }
 
 /**
+ * Does this type denote a collection — an array, a tuple, or a union whose
+ * every member is one of those?
+ *
+ * The union arm is the reason this is shared rather than a bare
+ * `checker.isArrayType(t) || checker.isTupleType(t)`: a value built from
+ * differently-typed arrays — e.g. `a ?? b` over `string[] | undefined` and
+ * `number[]` resolves to `string[] | number[]` — is a union that
+ * `checker.isArrayType` returns false for. Every caller that must keep
+ * collection-valued expressions structurally lowered (array-method callback
+ * returns in expression-site-policy, fallback receivers in
+ * expression-site-lowering, derived reactive-collection calls in call-kind)
+ * needs to catch that union, so the logic lives in one place.
+ */
+export function isCollectionType(
+  type: ts.Type | undefined,
+  checker: ts.TypeChecker,
+): boolean {
+  if (!type) return false;
+  if (checker.isArrayType(type) || checker.isTupleType(type)) {
+    return true;
+  }
+  return type.isUnion() &&
+    type.types.length > 0 &&
+    type.types.every((member) =>
+      checker.isArrayType(member) || checker.isTupleType(member)
+    );
+}
+
+/**
  * Unwrap OpaqueRef-like types to get the underlying type
  * Handles unions, intersections, and nested OpaqueRef types
  * @param seen - Set to track visited types and prevent infinite recursion

--- a/packages/ts-transformers/src/transformers/expression-site-lowering.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-lowering.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 import {
   detectCallKind,
+  isCollectionType,
   isFunctionLikeExpression,
   visitEachChildWithJsx,
 } from "../ast/mod.ts";
@@ -96,16 +97,7 @@ function isArrayLikeReceiverType(
   expression: ts.Expression,
   checker: ts.TypeChecker,
 ): boolean {
-  const type = checker.getTypeAtLocation(expression);
-  if (checker.isArrayType(type) || checker.isTupleType(type)) {
-    return true;
-  }
-
-  return type.isUnion() &&
-    type.types.length > 0 &&
-    type.types.every((member) =>
-      checker.isArrayType(member) || checker.isTupleType(member)
-    );
+  return isCollectionType(checker.getTypeAtLocation(expression), checker);
 }
 
 function markSyntheticReactiveCollectionDeclarationIfNeeded(

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -3,7 +3,7 @@ import {
   classifyArrayMethodCall,
   classifyArrayMethodCallSite,
   detectCallKind,
-  hasReactiveCollectionProvenance,
+  getTypeAtLocationWithFallback,
   isEventHandlerJsxAttribute,
   isFunctionLikeExpression,
   isInRestrictedReactiveContext,
@@ -912,6 +912,54 @@ export function isArrayMethodValueLiftOwner(
     owner === "array-method-callback-value";
 }
 
+/**
+ * CT-1779: does a `array-method-callback-value` candidate RESOLVE to a collection?
+ *
+ * The lift must be declined only for COLLECTION-valued callback returns: a
+ * `flatMap(i => i.tags ?? [])` whose `??` resolves to an array MUST stay
+ * structural (`i.key("tags") ?? []`) so the runtime `*WithPattern` flattens the
+ * reactive collection. Keying on the RESULT type — rather than operand provenance,
+ * the CT-1777 stopgap (`hasReactiveCollectionProvenance`, which fired for *any*
+ * `??` over a reactive operand) — is what lets a SCALAR `??` through: a
+ * `map(v => v.name ?? "default")` resolves to `string`, so it is lifted and the
+ * `?? default` fallback runs on the resolved value instead of going inert.
+ * Comparison/arithmetic/unary results are never collections, so they are
+ * unaffected, exactly as before.
+ *
+ * `getTypeAtLocationWithFallback` (not a bare `getTypeAtLocation`) consults the
+ * typeRegistry so the synthetic destructure-lowered lift params the checker types
+ * as `any` (#4244) still resolve. The union arm mirrors `isArrayLikeReceiverType`
+ * in expression-site-lowering.ts: a homogeneous `i.tags ?? []` collapses to a
+ * single `string[]` (caught by the array/tuple arm), but a `??` between
+ * differently-typed arrays — `map(i => i.primary ?? i.fallback)` over
+ * `string[]` / `number[]` — resolves to a union of array members
+ * (`string[] | number[]`) that a bare `isArrayType` returns false for, which
+ * would wrongly lift a collection-valued return.
+ */
+function arrayMethodCallbackValueResolvesToCollection(
+  expression: ts.Expression,
+  context: TransformationContext,
+): boolean {
+  const { checker } = context;
+  const type = getTypeAtLocationWithFallback(
+    expression,
+    checker,
+    context.options.state?.typeRegistry,
+    context.options.logger,
+  );
+  if (!type) {
+    return false;
+  }
+  if (checker.isArrayType(type) || checker.isTupleType(type)) {
+    return true;
+  }
+  return type.isUnion() &&
+    type.types.length > 0 &&
+    type.types.every((member) =>
+      checker.isArrayType(member) || checker.isTupleType(member)
+    );
+}
+
 function classifyHelperOwnedExpressionSiteHandling(
   expression: ts.Expression,
   containerKind: ExpressionContainerKind,
@@ -1140,16 +1188,20 @@ export function classifyExpressionSiteHandling(
   // lowered (the runtime *WithPattern flatten/map depends on it):
   //   - control flow: `!controlFlowRewriteRoot` drops conditionals and logical
   //     `&&`/`||` (they lower via ifElse/unless, which already lift);
-  //   - provenance: `!hasReactiveCollectionProvenance` drops `??` fallbacks whose
-  //     result is a reactive collection (e.g. `flatMap(i => i.tags ?? [])`, which
-  //     must stay `i.key("tags") ?? []`). Comparison/arithmetic/unary results are
-  //     never collections, so this never blocks them.
+  //   - result type (CT-1779): `!arrayMethodCallbackValueResolvesToCollection`
+  //     drops only `??` fallbacks whose RESULT is a reactive collection (e.g.
+  //     `flatMap(i => i.tags ?? [])`, which must stay `i.key("tags") ?? []`), while
+  //     still lifting a SCALAR `??` (`map(v => v.name ?? "default")` resolves to
+  //     `string`, so the `?? default` fallback runs on the resolved value). CT-1777
+  //     keyed this on operand provenance (`hasReactiveCollectionProvenance`), which
+  //     over-excluded scalar `??`; comparison/arithmetic/unary results are never
+  //     collections, so this never blocks them either way.
   if (
     siteInfo.arrayMethodOwned &&
     !siteInfo.controlFlowRewriteRoot &&
     isValueComputationExpressionKind(expression) &&
     hasReactiveComputationToLift(getAnalysis()) &&
-    !hasReactiveCollectionProvenance(expression, context.checker)
+    !arrayMethodCallbackValueResolvesToCollection(expression, context)
   ) {
     return ownedDecision("array-method-callback-value", true);
   }

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -4,6 +4,7 @@ import {
   classifyArrayMethodCallSite,
   detectCallKind,
   getTypeAtLocationWithFallback,
+  isCollectionType,
   isEventHandlerJsxAttribute,
   isFunctionLikeExpression,
   isInRestrictedReactiveContext,
@@ -926,38 +927,25 @@ export function isArrayMethodValueLiftOwner(
  * Comparison/arithmetic/unary results are never collections, so they are
  * unaffected, exactly as before.
  *
- * `getTypeAtLocationWithFallback` (not a bare `getTypeAtLocation`) consults the
- * typeRegistry so the synthetic destructure-lowered lift params the checker types
- * as `any` (#4244) still resolve. The union arm mirrors `isArrayLikeReceiverType`
- * in expression-site-lowering.ts: a homogeneous `i.tags ?? []` collapses to a
- * single `string[]` (caught by the array/tuple arm), but a `??` between
- * differently-typed arrays — `map(i => i.primary ?? i.fallback)` over
- * `string[]` / `number[]` — resolves to a union of array members
- * (`string[] | number[]`) that a bare `isArrayType` returns false for, which
- * would wrongly lift a collection-valued return.
+ * Resolution uses `getTypeAtLocationWithFallback` (not a bare `getTypeAtLocation`)
+ * so the synthetic destructure-lowered lift params the checker types as `any`
+ * (#4244) still resolve; the collection test itself — including the union-of-arrays
+ * case a bare `isArrayType` would miss — is shared with the sibling lowering and
+ * provenance sites via `isCollectionType`.
  */
 function arrayMethodCallbackValueResolvesToCollection(
   expression: ts.Expression,
   context: TransformationContext,
 ): boolean {
-  const { checker } = context;
-  const type = getTypeAtLocationWithFallback(
-    expression,
-    checker,
-    context.options.state?.typeRegistry,
-    context.options.logger,
+  return isCollectionType(
+    getTypeAtLocationWithFallback(
+      expression,
+      context.checker,
+      context.options.state?.typeRegistry,
+      context.options.logger,
+    ),
+    context.checker,
   );
-  if (!type) {
-    return false;
-  }
-  if (checker.isArrayType(type) || checker.isTupleType(type)) {
-    return true;
-  }
-  return type.isUnion() &&
-    type.types.length > 0 &&
-    type.types.every((member) =>
-      checker.isArrayType(member) || checker.isTupleType(member)
-    );
 }
 
 function classifyHelperOwnedExpressionSiteHandling(

--- a/packages/ts-transformers/test/ast/type-inference.test.ts
+++ b/packages/ts-transformers/test/ast/type-inference.test.ts
@@ -1,0 +1,133 @@
+import { assertEquals } from "@std/assert";
+import ts from "typescript";
+
+import { isCollectionType } from "../../src/ast/mod.ts";
+
+function createProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const fileName = "/test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    noLib: true,
+    skipLibCheck: true,
+  };
+
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+  );
+
+  const host = ts.createCompilerHost(compilerOptions, true);
+  host.getSourceFile = (name) => name === fileName ? sourceFile : undefined;
+  host.getCurrentDirectory = () => "/";
+  host.getDirectories = () => [];
+  host.fileExists = (name) => name === fileName;
+  host.readFile = (name) => name === fileName ? source : undefined;
+  host.writeFile = () => {};
+  host.useCaseSensitiveFileNames = () => true;
+  host.getCanonicalFileName = (name) => name;
+  host.getNewLine = () => "\n";
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+/** Resolve the declared type of a top-level `declare const <name>: T`. */
+function declaredType(
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker,
+  name: string,
+): ts.Type {
+  let found: ts.Type | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name
+    ) {
+      found = checker.getTypeAtLocation(node.name);
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) {
+    throw new Error(`Declaration for ${name} not found`);
+  }
+  return found;
+}
+
+// `noLib` is on, so the array forms are recognized only because we declare the
+// global Array/ReadonlyArray interfaces here — mirroring call-kind.test.ts.
+const SOURCE = `
+  interface Array<T> { length: number; }
+  interface ReadonlyArray<T> { length: number; }
+
+  declare const arr: string[];
+  declare const readonlyArr: readonly string[];
+  declare const tuple: [string, number];
+  declare const unionOfArrays: string[] | number[];
+  declare const unionWithScalar: string | string[];
+  declare const scalar: string;
+  declare const obj: { a: number };
+`;
+
+Deno.test("isCollectionType: array and tuple result types are collections", () => {
+  const { sourceFile, checker } = createProgram(SOURCE);
+  assertEquals(
+    isCollectionType(declaredType(sourceFile, checker, "arr"), checker),
+    true,
+  );
+  assertEquals(
+    isCollectionType(declaredType(sourceFile, checker, "readonlyArr"), checker),
+    true,
+  );
+  assertEquals(
+    isCollectionType(declaredType(sourceFile, checker, "tuple"), checker),
+    true,
+  );
+});
+
+Deno.test("isCollectionType: a union whose every member is an array/tuple is a collection", () => {
+  const { sourceFile, checker } = createProgram(SOURCE);
+  // The union arm — `a ?? b` over differently-typed arrays resolves to
+  // `string[] | number[]`, which `checker.isArrayType` returns false for.
+  assertEquals(
+    isCollectionType(
+      declaredType(sourceFile, checker, "unionOfArrays"),
+      checker,
+    ),
+    true,
+  );
+});
+
+Deno.test("isCollectionType: scalars, objects, and mixed unions are not collections", () => {
+  const { sourceFile, checker } = createProgram(SOURCE);
+  assertEquals(
+    isCollectionType(declaredType(sourceFile, checker, "scalar"), checker),
+    false,
+  );
+  assertEquals(
+    isCollectionType(declaredType(sourceFile, checker, "obj"), checker),
+    false,
+  );
+  // A union with even one non-array member is not a collection.
+  assertEquals(
+    isCollectionType(
+      declaredType(sourceFile, checker, "unionWithScalar"),
+      checker,
+    ),
+    false,
+  );
+});
+
+Deno.test("isCollectionType: an undefined type is not a collection", () => {
+  const { checker } = createProgram(SOURCE);
+  assertEquals(isCollectionType(undefined, checker), false);
+});

--- a/packages/ts-transformers/test/fixtures/closures/array-method-scalar-nullish-lift.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/array-method-scalar-nullish-lift.expected.jsx
@@ -1,0 +1,361 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { pattern, UI } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface Row {
+    name?: string;
+    active?: boolean;
+    primary?: string[];
+    fallback: number[];
+}
+const __cfLift_1 = __cfHelpers.lift<{
+    r: {
+        name?: string | undefined;
+    };
+}, string>(({ r }) => r.name ?? "default", {
+    type: "object",
+    properties: {
+        r: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            }
+        }
+    },
+    required: ["r"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const r = __cf_pattern_input.key("element");
+    return __cfLift_1({ r: {
+            name: r.key("name")
+        } }).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Row"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                active: {
+                    type: "boolean"
+                },
+                primary: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                },
+                fallback: {
+                    type: "array",
+                    items: {
+                        type: "number"
+                    }
+                }
+            },
+            required: ["fallback"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_2 = __cfHelpers.lift<{
+    r: {
+        active?: boolean | undefined;
+    };
+}, boolean>(({ r }) => r.active ?? true, {
+    type: "object",
+    properties: {
+        r: {
+            type: "object",
+            properties: {
+                active: {
+                    anyOf: [{
+                            type: "undefined"
+                        }, {
+                            type: "boolean"
+                        }]
+                }
+            }
+        }
+    },
+    required: ["r"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const r = __cf_pattern_input.key("element");
+    return __cfLift_2({ r: {
+            active: r.key("active")
+        } }).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Row"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                active: {
+                    type: "boolean"
+                },
+                primary: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                },
+                fallback: {
+                    type: "array",
+                    items: {
+                        type: "number"
+                    }
+                }
+            },
+            required: ["fallback"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+    const r = __cf_pattern_input.key("element");
+    return <i>{r.key("name")}</i>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Row"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                active: {
+                    type: "boolean"
+                },
+                primary: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                },
+                fallback: {
+                    type: "array",
+                    items: {
+                        type: "number"
+                    }
+                }
+            },
+            required: ["fallback"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
+    const r = __cf_pattern_input.key("element");
+    return r.key("primary") ?? r.key("fallback");
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Row"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                active: {
+                    type: "boolean"
+                },
+                primary: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                },
+                fallback: {
+                    type: "array",
+                    items: {
+                        type: "number"
+                    }
+                }
+            },
+            required: ["fallback"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            type: "array",
+            items: {
+                type: "string"
+            }
+        }, {
+            type: "array",
+            items: {
+                type: "number"
+            }
+        }]
+} as const satisfies __cfHelpers.JSONSchema);
+// FIXTURE: array-method-scalar-nullish-lift
+// Verifies (CT-1779): a SCALAR nullish-coalescing `??` with a reactive operand in the
+// return / predicate position of a reactive map/filter/flatMap callback is value-lifted,
+// so the `?? default` fallback runs on the RESOLVED value. Emitted raw, `v.name ?? "d"`
+// collapses to the bare field projection — an OpaqueRef proxy is never null and `??`
+// can't be trapped — so the default is silently dropped (type-clean, no error).
+//   - scalar string `??`        → mapWithPattern(pattern(... return lift(... r.name ?? "default")))
+//   - scalar boolean `??` (pred) → filterWithPattern(pattern(... return lift(... r.active ?? true)))
+// A COLLECTION-valued `??` must stay structural so the runtime *WithPattern flattens it.
+// CT-1777 keyed the exclusion on operand provenance, which over-excluded scalar `??`;
+// CT-1779 keys it on RESULT type. The homogeneous `i.tags ?? []` case is pinned by
+// filter-flatmap-fallback-chain; here the heterogeneous `r.primary ?? r.fallback`
+// (`string[] | number[]`, a union of array members a bare isArrayType misses) stays
+// structural too.
+export default pattern((__cf_pattern_input) => {
+    const rows = __cf_pattern_input.key("rows");
+    return {
+        [UI]: (<div>
+        {/* scalar string ??: lifted, so "default" is live */}
+        <div>{rows.mapWithPattern(__cfPattern_1, {})}</div>
+        {/* scalar boolean ?? as a filter predicate: lifted */}
+        <div>
+          {rows.filterWithPattern(__cfPattern_2, {}).mapWithPattern(__cfPattern_3, {})}
+        </div>
+        {/* heterogeneous collection ?? (union of array types): stays structural */}
+        <div>{rows.mapWithPattern(__cfPattern_4, {})}</div>
+      </div>),
+    };
+}, {
+    type: "object",
+    properties: {
+        rows: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Row"
+            }
+        }
+    },
+    required: ["rows"],
+    $defs: {
+        Row: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                active: {
+                    type: "boolean"
+                },
+                primary: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                },
+                fallback: {
+                    type: "array",
+                    items: {
+                        type: "number"
+                    }
+                }
+            },
+            required: ["fallback"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $UI: {
+            $ref: "#/$defs/JSXElement"
+        }
+    },
+    required: ["$UI"],
+    $defs: {
+        JSXElement: {
+            anyOf: [{
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }, {
+                    $ref: "#/$defs/UIRenderable"
+                }, {
+                    type: "object",
+                    properties: {}
+                }]
+        },
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1,
+    __cfLift_2,
+    __cfPattern_2,
+    __cfPattern_3,
+    __cfPattern_4
+});

--- a/packages/ts-transformers/test/fixtures/closures/array-method-scalar-nullish-lift.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/array-method-scalar-nullish-lift.input.tsx
@@ -1,0 +1,39 @@
+import { pattern, UI } from "commonfabric";
+
+interface Row {
+  name?: string;
+  active?: boolean;
+  primary?: string[];
+  fallback: number[];
+}
+
+// FIXTURE: array-method-scalar-nullish-lift
+// Verifies (CT-1779): a SCALAR nullish-coalescing `??` with a reactive operand in the
+// return / predicate position of a reactive map/filter/flatMap callback is value-lifted,
+// so the `?? default` fallback runs on the RESOLVED value. Emitted raw, `v.name ?? "d"`
+// collapses to the bare field projection — an OpaqueRef proxy is never null and `??`
+// can't be trapped — so the default is silently dropped (type-clean, no error).
+//   - scalar string `??`        → mapWithPattern(pattern(... return lift(... r.name ?? "default")))
+//   - scalar boolean `??` (pred) → filterWithPattern(pattern(... return lift(... r.active ?? true)))
+// A COLLECTION-valued `??` must stay structural so the runtime *WithPattern flattens it.
+// CT-1777 keyed the exclusion on operand provenance, which over-excluded scalar `??`;
+// CT-1779 keys it on RESULT type. The homogeneous `i.tags ?? []` case is pinned by
+// filter-flatmap-fallback-chain; here the heterogeneous `r.primary ?? r.fallback`
+// (`string[] | number[]`, a union of array members a bare isArrayType misses) stays
+// structural too.
+export default pattern<{ rows: Row[] }>(({ rows }) => {
+  return {
+    [UI]: (
+      <div>
+        {/* scalar string ??: lifted, so "default" is live */}
+        <div>{rows.map((r) => r.name ?? "default")}</div>
+        {/* scalar boolean ?? as a filter predicate: lifted */}
+        <div>
+          {rows.filter((r) => r.active ?? true).map((r) => <i>{r.name}</i>)}
+        </div>
+        {/* heterogeneous collection ?? (union of array types): stays structural */}
+        <div>{rows.map((r) => r.primary ?? r.fallback)}</div>
+      </div>
+    ),
+  };
+});


### PR DESCRIPTION
## Summary

Follow-up to CT-1777 (#4297) and CT-1778 (#4299) — the third PR in that line. Fixes an inert scalar `??` fallback in reactive array-method callbacks.

A scalar nullish-coalescing expression with a reactive operand inside a reactive `map`/`filter`/`flatMap` callback — e.g. `items.map(v => v.name ?? "default")` — was not value-lifted; it stayed raw (`v.key("name") ?? "default"`). Because an `OpaqueRef` proxy is never null/undefined and `??` can't be trapped by a proxy, it collapsed to the bare field projection — so the `?? default` fallback was **silently inert** (valid shape, correct schema, wrong runtime value; no crash, no diagnostic). Falsy defaults (`?? 0`, `?? ""`) usually coincide with intent; a meaningful default (`?? "default"`, `?? 5`) silently yielded `undefined`.

## Root cause

CT-1777's `array-method-callback-value` lift guarded collection-valued expressions with `!hasReactiveCollectionProvenance`. That predicate keys on **operand** provenance, so it fires for *any* `??` whose operand traces to a reactive value — it can't distinguish:

- a **scalar** `??` (`v.name ?? "default"` → should lift), from
- a **collection** `??` (`flatMap(i => i.tags ?? [])` → must stay structural so the runtime `*WithPattern` flattens the reactive collection).

To stay safe it excluded both. (`||`/`&&` are out of scope — they lower via `ifElse`/`unless` and already lift correctly.)

## Fix (commit 1)

Refine the guard to key on **result type** instead of operand provenance — the exact mechanism CT-1778 added next door: `getTypeAtLocationWithFallback` (typeRegistry-aware, so the synthetic destructure-lowered lift params the checker types as `any` per #4244 still resolve) + `isArrayType`/`isTupleType`. Decline the lift only when the result resolves to a collection; a scalar `??` lifts and its default runs on the resolved value. Comparison/arithmetic/unary returns are never collections, so they are unaffected.

**Union arm.** Beyond CT-1778's bare check, the result-type test also accepts a union whose every member is an array/tuple. A `??` between differently-typed optional arrays (`map(i => i.primary ?? i.fallback)`) resolves to `string[] | number[]` — a union that `isArrayType` returns false for; without the arm that collection-valued return would be wrongly lifted. (`flatMap` rejects heterogeneous arrays at the type level, so this shape only arises under `.map`.)

## DRY consolidation (commit 2)

Three sites had independently open-coded the same "array, tuple, or union of those" test: the new CT-1779 guard, `isArrayLikeReceiverType` (expression-site-lowering), and CT-1778's derived-reactive-collection check (call-kind). Hoisted into a single `isCollectionType(type, checker)` in `ast/type-inference.ts` (alongside `isCellLikeType` et al.); all three now route through it. Each site keeps its own intentional type *resolution* (fallback-aware vs plain vs already-computed) and shares only the predicate. call-kind's check gains the union arm in the process — strictly more correct.

## Tests

- New fixture `array-method-scalar-nullish-lift`: scalar string `??` → lift, scalar boolean predicate `??` → lift, heterogeneous union-array `??` → structural.
- New unit test `test/ast/type-inference.test.ts` (commit 3): direct branch coverage for `isCollectionType` (array / readonly array / tuple / union-of-arrays / mixed union / scalar / object / undefined) — also clears the coverage-debt ratchet for the extracted predicate.
- `filter-flatmap-fallback-chain` (the collection-stays-structural landmine) is **byte-unchanged**.

## Verification

- ts-transformers unit: **299 passed**
- integration pattern-tests: **68 passed**
- generated-patterns: **147 passed**
- `deno fmt --check`, `deno lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
