### PR TITLE
Fix memory-v2 shallow reads for keyed lunch poll

### DIFF
--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -144,17 +144,23 @@ interface ConfirmedRead {
   branch?: BranchId;
   path: ReadPath;
   seq: number;
+  nonRecursive?: boolean;
 }
 
 interface PendingRead {
   id: EntityId;
   path: ReadPath;
   localSeq: number;
+  nonRecursive?: boolean;
 }
 ```
 
 Confirmed reads are validated against canonical history. Pending reads are
-resolved within the submitting logical session.
+resolved within the submitting logical session. By default, reads are recursive:
+a read of path `P` depends on `P` and descendants of `P`. A read with
+`nonRecursive: true` depends only on `P` itself and ancestors of `P`; descendant
+writes do not invalidate it. Clients use this for topology/schema probes that
+only need to know the container exists, not the container's contents.
 
 ## 3.5 Stacked Pending Commits
 
@@ -202,10 +208,15 @@ Validation is based on overlap, not just entity identity.
 - `delete` overlaps every read path on the same entity
 - `patch` overlaps when any patch op touches the read path, an ancestor of the
   read path, or a descendant of the read path
+- `patch` against a `nonRecursive` read overlaps only when an op touches the
+  read path itself or an ancestor of the read path
 - structural collection edits MAY be treated conservatively as overlapping the
   whole collection subtree in phase 1
 
 Implementations MAY over-approximate overlap. They MUST NOT miss a real overlap.
+Plain object sibling-key `add`/`remove` operations are not real overlaps for
+reads of unrelated sibling keys. Array index edits may remain conservative
+because insertion/removal shifts sibling meaning.
 
 ### 3.6.3 Pending-Read Resolution
 

--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -276,6 +276,10 @@ type TransactResult =
 Path conventions on the wire:
 
 - `ClientCommit` reads and writes use full document paths.
+- `ClientCommit.reads.*[].nonRecursive` is optional and defaults to `false`.
+  When `true`, conflict validation treats the read as path-only/topology
+  evidence: writes to descendants of the read path do not invalidate it, while
+  writes to the path itself or ancestors still do.
 - `readValue` / `writeValue` style helpers are client-side conveniences that
   prepend `"value"` before constructing those commit paths.
 - Inline `data:` document reads are local-only. Clients may read them during

--- a/docs/specs/memory-v2/README.md
+++ b/docs/specs/memory-v2/README.md
@@ -154,12 +154,14 @@ interface ConfirmedRead {
   branch?: BranchId;
   path: ReadPath;
   seq: number;
+  nonRecursive?: boolean;
 }
 
 interface PendingRead {
   id: EntityId;
   path: ReadPath;
   localSeq: number;
+  nonRecursive?: boolean;
 }
 
 interface ClientCommit {

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -171,6 +171,37 @@ export class WorkerReconciler {
     }
   }
 
+  private demandCell<T>(
+    cell: Cell<T>,
+    onResolved?: (value: Readonly<T>) => void,
+  ): void {
+    try {
+      const promise = cell.pull();
+      if (onResolved) {
+        void promise.then((value) => {
+          onResolved(value);
+        }).catch((error) => {
+          logger.warn("demand-cell", () => [
+            "cell pull failed",
+            error instanceof Error ? error.message : String(error),
+          ]);
+        });
+        return;
+      }
+      void promise.catch((error) => {
+        logger.warn("demand-cell", () => [
+          "cell pull failed",
+          error instanceof Error ? error.message : String(error),
+        ]);
+      });
+    } catch (error) {
+      logger.warn("demand-cell", () => [
+        "cell pull failed",
+        error instanceof Error ? error.message : String(error),
+      ]);
+    }
+  }
+
   mount(vnode: WorkerVNode | Cell<WorkerVNode> | Cell<unknown>): Cancel {
     logger.debug(
       "mount",
@@ -2159,6 +2190,7 @@ export class WorkerReconciler {
       ) {
         // Same Cell, leave subscription in place
         logger.debug("children-same-cell", () => ({ nodeId: state.nodeId }));
+        existingState.refresh?.();
         return;
       }
 
@@ -2168,30 +2200,41 @@ export class WorkerReconciler {
       }
 
       // Set up new subscription
-      const cancel = (children as Cell<WorkerRenderNode | WorkerRenderNode[]>)
-        .sink(
-          (resolvedChildren) => {
-            logger.debug("children-update", () => ({
-              nodeId: state.nodeId,
-              count: Array.isArray(resolvedChildren)
-                ? resolvedChildren.length
-                : 1,
-            }));
-            this.updateChildren(
-              ctx,
-              state,
-              resolvedChildren,
-              visited,
-              policy,
-              forceReplace,
-            );
-          },
+      let active = true;
+      const updateResolvedChildren = (
+        resolvedChildren: Readonly<WorkerRenderNode | WorkerRenderNode[]>,
+      ) => {
+        if (!active) return;
+        logger.debug("children-update", () => ({
+          nodeId: state.nodeId,
+          count: Array.isArray(resolvedChildren) ? resolvedChildren.length : 1,
+        }));
+        this.updateChildren(
+          ctx,
+          state,
+          resolvedChildren,
+          visited,
+          policy,
+          forceReplace,
         );
+      };
+      const cancel = (children as Cell<WorkerRenderNode | WorkerRenderNode[]>)
+        .sink(updateResolvedChildren);
 
       state.childrenState = {
         cell: children as Cell<unknown>,
-        cancel,
+        cancel: () => {
+          active = false;
+          cancel();
+        },
       };
+      state.childrenState.refresh = () => {
+        this.demandCell(
+          children as Cell<WorkerRenderNode | WorkerRenderNode[]>,
+          updateResolvedChildren,
+        );
+      };
+      state.childrenState.refresh();
     } else {
       // Static children - cancel any existing Cell subscription
       if (state.childrenState) {
@@ -2809,16 +2852,32 @@ export class WorkerReconciler {
 
     // Handle Cell<children>
     if (isCell(children)) {
+      let active = true;
+      const updateResolvedChildren = (
+        resolvedChildren: Readonly<WorkerRenderNode | WorkerRenderNode[]>,
+      ) => {
+        if (!active) return;
+        this.updateChildren(ctx, state, resolvedChildren, visited, policy);
+      };
       const sinkCancel = (
         children as Cell<WorkerRenderNode | WorkerRenderNode[]>
-      ).sink((resolvedChildren) => {
-        this.updateChildren(ctx, state, resolvedChildren, visited, policy);
-      });
+      ).sink(updateResolvedChildren);
       addCancel(sinkCancel);
+      addCancel(() => {
+        active = false;
+      });
+      const refresh = () => {
+        this.demandCell(
+          children as Cell<WorkerRenderNode | WorkerRenderNode[]>,
+          updateResolvedChildren,
+        );
+      };
+      refresh();
       // Track the children Cell for diffing
       state.childrenState = {
         cell: children as Cell<unknown>,
         cancel: sinkCancel,
+        refresh,
       };
     } else {
       // Static children
@@ -3029,259 +3088,264 @@ export class WorkerReconciler {
     };
 
     let currentCancel: Cancel | undefined;
+    let active = true;
 
-    addCancel(
-      cell.sink((resolvedChild) => {
-        const isInitialRender = childState.nodeId === -1;
+    const renderResolvedChild = (resolvedChild: Readonly<unknown>) => {
+      if (!active) return;
+      const isInitialRender = childState.nodeId === -1;
 
-        // Dedupe updates
-        if (!isInitialRender && resolvedChild === childState.currentValue) {
-          return;
-        }
-        childState.currentValue = resolvedChild;
+      // Dedupe updates
+      if (!isInitialRender && resolvedChild === childState.currentValue) {
+        return;
+      }
+      childState.currentValue = resolvedChild;
 
-        if (!this.canRenderCellUnderPolicy(cell, policy)) {
-          if (!isInitialRender) {
-            if (currentCancel) {
-              currentCancel();
-              currentCancel = undefined;
-            }
-            this.cleanupNodeHandlers(childState);
-            this.queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
-          }
-
-          childState.nodeId = -1;
-          childState.elementState = undefined;
-          childState.isText = false;
-
-          const blockedState = this.createBlockedPlaceholder(ctx, policy);
-          childState.nodeId = blockedState.nodeId;
-          childState.elementState = blockedState;
-          childState.isText = false;
-          currentCancel = blockedState.cancel;
-
-          const beforeId = this.findNextSiblingId(
-            parentState.children,
-            childKey,
-          );
-          this.queueOps([{
-            op: "insert-child",
-            parentId: parentState.nodeId,
-            childId: blockedState.nodeId,
-            beforeId,
-          }]);
-          return;
-        }
-
-        if (this.shouldBlockTextFromCell(resolvedChild, cell, policy)) {
-          if (!isInitialRender) {
-            if (currentCancel) {
-              currentCancel();
-              currentCancel = undefined;
-            }
-            this.cleanupNodeHandlers(childState);
-            this.queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
-          }
-
-          childState.nodeId = -1;
-          childState.elementState = undefined;
-          childState.isText = false;
-
-          const blockedState = this.createBlockedPlaceholder(
-            ctx,
-            policy,
-            "integrity",
-          );
-          childState.nodeId = blockedState.nodeId;
-          childState.elementState = blockedState;
-          childState.isText = false;
-          currentCancel = blockedState.cancel;
-
-          const beforeId = this.findNextSiblingId(
-            parentState.children,
-            childKey,
-          );
-          this.queueOps([{
-            op: "insert-child",
-            parentId: parentState.nodeId,
-            childId: blockedState.nodeId,
-            beforeId,
-          }]);
-          return;
-        }
-
-        // Try to update in place if not initial render
-        if (
-          !isInitialRender &&
-          childState.nodeId !== -1
-        ) {
-          // Case 1: Text update
-          if (
-            childState.isText &&
-            (typeof resolvedChild === "string" ||
-              typeof resolvedChild === "number")
-          ) {
-            this.queueOps([{
-              op: "update-text",
-              nodeId: childState.nodeId,
-              text: String(resolvedChild),
-            }]);
-            return;
-          }
-
-          // Case 2: VNode in-place update (same tag)
-          if (childState.elementState) {
-            const newVNode = this.extractVNode(
-              resolvedChild as WorkerRenderNode,
-            );
-            if (newVNode) {
-              const sanitized = this.sanitizeNode(newVNode);
-              if (
-                sanitized &&
-                sanitized.name === childState.elementState.tagName
-              ) {
-                const childPolicy = this.childRenderPolicyForNode(
-                  sanitized,
-                  policy,
-                  childState.elementState.nodeId,
-                );
-                const policyChildren = this.childrenForRenderPolicy(
-                  sanitized,
-                  childPolicy,
-                );
-                const policyChanged = !this.renderPolicyEquals(
-                  childState.elementState.childRenderPolicy,
-                  childPolicy,
-                ) ||
-                  childState.elementState.childrenBlockedByPolicy !==
-                    policyChildren.blocked;
-                childState.elementState.renderPolicy = policy;
-                childState.elementState.childRenderPolicy = childPolicy;
-                childState.elementState.childrenBlockedByPolicy =
-                  policyChildren.blocked;
-                childState.elementState.sourceChildren = sanitized.children;
-                childState.elementState.sourceProps = sanitized.props;
-                // Same tag - update props in place
-                this.updatePropsInPlace(
-                  ctx,
-                  childState.elementState,
-                  sanitized.props,
-                );
-
-                // Check children: if same, do nothing (sinks active);
-                // if different, tear down and rebuild
-                if (policyChildren.children !== undefined) {
-                  const childrenSame = this.areChildrenSame(
-                    childState.elementState,
-                    policyChildren.children,
-                  );
-                  if (!childrenSame || policyChanged) {
-                    this.resetTextIntegrityBoundary(
-                      childState.elementState,
-                      childPolicy,
-                    );
-                    this.updateChildrenInPlace(
-                      ctx,
-                      childState.elementState,
-                      policyChildren.children,
-                      new Set(),
-                      childPolicy,
-                      policyChanged,
-                    );
-                  }
-                }
-                return;
-              }
-            }
-          }
-        }
-
-        // Fallback: Replace (existing logic)
-        // Clean up previous (skip if initial render - nothing to clean)
+      if (!this.canRenderCellUnderPolicy(cell, policy)) {
         if (!isInitialRender) {
           if (currentCancel) {
             currentCancel();
             currentCancel = undefined;
           }
-          // Clean up event handlers before removing node
           this.cleanupNodeHandlers(childState);
-          // Log replacement
-          logger.debug(
-            "reconcile-cell-child",
-            () => ({
-              id: childState.nodeId,
-              cellId: this.getCellDebugId(cell),
-              type: "replace",
-              reason: "fallback",
-            }),
-          );
           this.queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
         }
 
-        // Reset nodeId
         childState.nodeId = -1;
         childState.elementState = undefined;
         childState.isText = false;
 
-        if (resolvedChild === null || resolvedChild === undefined) {
+        const blockedState = this.createBlockedPlaceholder(ctx, policy);
+        childState.nodeId = blockedState.nodeId;
+        childState.elementState = blockedState;
+        childState.isText = false;
+        currentCancel = blockedState.cancel;
+
+        const beforeId = this.findNextSiblingId(
+          parentState.children,
+          childKey,
+        );
+        this.queueOps([{
+          op: "insert-child",
+          parentId: parentState.nodeId,
+          childId: blockedState.nodeId,
+          beforeId,
+        }]);
+        return;
+      }
+
+      if (this.shouldBlockTextFromCell(resolvedChild, cell, policy)) {
+        if (!isInitialRender) {
+          if (currentCancel) {
+            currentCancel();
+            currentCancel = undefined;
+          }
+          this.cleanupNodeHandlers(childState);
+          this.queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
+        }
+
+        childState.nodeId = -1;
+        childState.elementState = undefined;
+        childState.isText = false;
+
+        const blockedState = this.createBlockedPlaceholder(
+          ctx,
+          policy,
+          "integrity",
+        );
+        childState.nodeId = blockedState.nodeId;
+        childState.elementState = blockedState;
+        childState.isText = false;
+        currentCancel = blockedState.cancel;
+
+        const beforeId = this.findNextSiblingId(
+          parentState.children,
+          childKey,
+        );
+        this.queueOps([{
+          op: "insert-child",
+          parentId: parentState.nodeId,
+          childId: blockedState.nodeId,
+          beforeId,
+        }]);
+        return;
+      }
+
+      // Try to update in place if not initial render
+      if (
+        !isInitialRender &&
+        childState.nodeId !== -1
+      ) {
+        // Case 1: Text update
+        if (
+          childState.isText &&
+          (typeof resolvedChild === "string" ||
+            typeof resolvedChild === "number")
+        ) {
+          this.queueOps([{
+            op: "update-text",
+            nodeId: childState.nodeId,
+            text: String(resolvedChild),
+          }]);
           return;
         }
 
-        // Render new content. Primitive text from a Cell has already passed
-        // source-cell text integrity verification above, so do not reclassify
-        // it as an untrusted literal.
-        const newState = this.hasVisibleTextValue(resolvedChild) &&
-            (typeof resolvedChild === "string" ||
-              typeof resolvedChild === "number" ||
-              typeof resolvedChild === "boolean")
-          ? {
-            nodeId: this.createTextNode(
-              ctx,
-              this.stringifyText(resolvedChild),
-              policy,
-              { trustedText: true },
-            ).nodeId,
-            isText: true,
-            cancel: () => {},
-          }
-          : this.renderChildContent(
-            ctx,
-            resolvedChild,
-            new Set(visited),
-            policy,
+        // Case 2: VNode in-place update (same tag)
+        if (childState.elementState) {
+          const newVNode = this.extractVNode(
+            resolvedChild as WorkerRenderNode,
           );
-        if (newState) {
-          childState.nodeId = newState.nodeId;
-          childState.elementState = newState.elementState;
-          childState.isText = newState.isText;
-          currentCancel = newState.cancel;
+          if (newVNode) {
+            const sanitized = this.sanitizeNode(newVNode);
+            if (
+              sanitized &&
+              sanitized.name === childState.elementState.tagName
+            ) {
+              const childPolicy = this.childRenderPolicyForNode(
+                sanitized,
+                policy,
+                childState.elementState.nodeId,
+              );
+              const policyChildren = this.childrenForRenderPolicy(
+                sanitized,
+                childPolicy,
+              );
+              const policyChanged = !this.renderPolicyEquals(
+                childState.elementState.childRenderPolicy,
+                childPolicy,
+              ) ||
+                childState.elementState.childrenBlockedByPolicy !==
+                  policyChildren.blocked;
+              childState.elementState.renderPolicy = policy;
+              childState.elementState.childRenderPolicy = childPolicy;
+              childState.elementState.childrenBlockedByPolicy =
+                policyChildren.blocked;
+              childState.elementState.sourceChildren = sanitized.children;
+              childState.elementState.sourceProps = sanitized.props;
+              // Same tag - update props in place
+              this.updatePropsInPlace(
+                ctx,
+                childState.elementState,
+                sanitized.props,
+              );
 
-          // Always insert the child into its parent. On initial render,
-          // updateChildren also emits insert-child but may see nodeId=-1
-          // (Cell hasn't resolved yet), making that op a no-op. This
-          // ensures the node is inserted once it actually exists.
-          // Double inserts are harmless (DOM appendChild/insertBefore is idempotent).
-          const beforeId = this.findNextSiblingId(
-            parentState.children,
-            childKey,
-          );
-          this.queueOps([
-            {
-              op: "insert-child",
-              parentId: parentState.nodeId,
-              childId: newState.nodeId,
-              beforeId,
-            },
-          ]);
+              // Refresh child bindings even when the key shape is unchanged:
+              // an existing Cell<children> subscription may still need an
+              // explicit pull-result render for its converged initial value.
+              if (policyChildren.children !== undefined) {
+                const childrenSame = this.areChildrenSame(
+                  childState.elementState,
+                  policyChildren.children,
+                );
+                if (!childrenSame || policyChanged) {
+                  this.resetTextIntegrityBoundary(
+                    childState.elementState,
+                    childPolicy,
+                  );
+                }
+                this.updateChildrenInPlace(
+                  ctx,
+                  childState.elementState,
+                  policyChildren.children,
+                  new Set(),
+                  childPolicy,
+                  policyChanged,
+                );
+              }
+              return;
+            }
+          }
         }
-      }),
-    );
+      }
+
+      // Fallback: Replace (existing logic)
+      // Clean up previous (skip if initial render - nothing to clean)
+      if (!isInitialRender) {
+        if (currentCancel) {
+          currentCancel();
+          currentCancel = undefined;
+        }
+        // Clean up event handlers before removing node
+        this.cleanupNodeHandlers(childState);
+        // Log replacement
+        logger.debug(
+          "reconcile-cell-child",
+          () => ({
+            id: childState.nodeId,
+            cellId: this.getCellDebugId(cell),
+            type: "replace",
+            reason: "fallback",
+          }),
+        );
+        this.queueOps([{ op: "remove-node", nodeId: childState.nodeId }]);
+      }
+
+      // Reset nodeId
+      childState.nodeId = -1;
+      childState.elementState = undefined;
+      childState.isText = false;
+
+      if (resolvedChild === null || resolvedChild === undefined) {
+        return;
+      }
+
+      // Render new content. Primitive text from a Cell has already passed
+      // source-cell text integrity verification above, so do not reclassify
+      // it as an untrusted literal.
+      const newState = this.hasVisibleTextValue(resolvedChild) &&
+          (typeof resolvedChild === "string" ||
+            typeof resolvedChild === "number" ||
+            typeof resolvedChild === "boolean")
+        ? {
+          nodeId: this.createTextNode(
+            ctx,
+            this.stringifyText(resolvedChild),
+            policy,
+            { trustedText: true },
+          ).nodeId,
+          isText: true,
+          cancel: () => {},
+        }
+        : this.renderChildContent(
+          ctx,
+          resolvedChild,
+          new Set(visited),
+          policy,
+        );
+      if (newState) {
+        childState.nodeId = newState.nodeId;
+        childState.elementState = newState.elementState;
+        childState.isText = newState.isText;
+        currentCancel = newState.cancel;
+
+        // Always insert the child into its parent. On initial render,
+        // updateChildren also emits insert-child but may see nodeId=-1
+        // (Cell hasn't resolved yet), making that op a no-op. This
+        // ensures the node is inserted once it actually exists.
+        // Double inserts are harmless (DOM appendChild/insertBefore is idempotent).
+        const beforeId = this.findNextSiblingId(
+          parentState.children,
+          childKey,
+        );
+        this.queueOps([
+          {
+            op: "insert-child",
+            parentId: parentState.nodeId,
+            childId: newState.nodeId,
+            beforeId,
+          },
+        ]);
+      }
+    };
+
+    addCancel(cell.sink(renderResolvedChild));
+    this.demandCell(cell, renderResolvedChild);
 
     // When the cancel group fires (parent teardown), also cancel the current
     // rendered content. Without this, deeper sinks (e.g. children/props of the
     // rendered content) leak because currentCancel is only called on re-fire
     // inside the sink callback, not on teardown.
     addCancel(() => {
+      active = false;
       if (currentCancel) {
         currentCancel();
         currentCancel = undefined;

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -87,6 +87,8 @@ export interface ChildrenState {
   cell: Cell<unknown> | undefined;
   /** Cancel function for the children subscription */
   cancel: Cancel;
+  /** Demand and render the current value without replacing the subscription. */
+  refresh?: () => void;
 }
 
 /**

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -1193,6 +1193,325 @@ Deno.test("memory v2 engine rejects stale confirmed reads and allows non-overlap
   }
 });
 
+Deno.test("memory v2 engine allows stale missing object-key read after sibling add", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:1",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:source",
+          value: toEntityDocument({
+            poll: { answers: {} },
+          }),
+        }],
+      },
+    });
+
+    applyCommit(engine, {
+      sessionId: "session:other",
+      invocation: invocationFor(1, { actor: "other" }),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: {
+          confirmed: [{
+            id: "entity:source",
+            path: toDocumentPath(["value", "poll", "answers", "alice"]),
+            seq: 1,
+          }],
+          pending: [],
+        },
+        operations: [{
+          op: "patch",
+          id: "entity:source",
+          patches: [{
+            op: "add",
+            path: "/value/poll/answers/alice",
+            value: "pizza",
+          }],
+        }],
+      },
+    });
+
+    const allowed = applyCommit(engine, {
+      sessionId: "session:1",
+      invocation: invocationFor(2),
+      authorization,
+      commit: {
+        localSeq: 2,
+        reads: {
+          confirmed: [{
+            id: "entity:source",
+            path: toDocumentPath(["value", "poll", "answers", "bob"]),
+            seq: 1,
+          }],
+          pending: [],
+        },
+        operations: [{
+          op: "set",
+          id: "entity:derived",
+          value: toEntityDocument({ bobWasMissing: true }),
+        }],
+      },
+    });
+
+    assertEquals(allowed.seq, 3);
+    assertEquals(read(engine, { id: "entity:derived" }), {
+      value: { bobWasMissing: true },
+    });
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 engine rejects stale recursive parent read after child add", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:1",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:source",
+          value: toEntityDocument({
+            poll: { answers: {} },
+          }),
+        }],
+      },
+    });
+
+    applyCommit(engine, {
+      sessionId: "session:other",
+      invocation: invocationFor(1, { actor: "other" }),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: {
+          confirmed: [{
+            id: "entity:source",
+            path: toDocumentPath(["value", "poll", "answers", "alice"]),
+            seq: 1,
+          }],
+          pending: [],
+        },
+        operations: [{
+          op: "patch",
+          id: "entity:source",
+          patches: [{
+            op: "add",
+            path: "/value/poll/answers/alice",
+            value: "pizza",
+          }],
+        }],
+      },
+    });
+
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:1",
+          invocation: invocationFor(2),
+          authorization,
+          commit: {
+            localSeq: 2,
+            reads: {
+              confirmed: [{
+                id: "entity:source",
+                path: toDocumentPath(["value", "poll", "answers"]),
+                seq: 1,
+              }],
+              pending: [],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:derived",
+              value: toEntityDocument({ answersWereEmpty: true }),
+            }],
+          },
+        }),
+      Error,
+      "stale confirmed read",
+    );
+    assertEquals(read(engine, { id: "entity:derived" }), null);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 engine allows stale non-recursive parent read after child add", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:1",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:source",
+          value: toEntityDocument({
+            poll: { answers: {} },
+          }),
+        }],
+      },
+    });
+
+    applyCommit(engine, {
+      sessionId: "session:other",
+      invocation: invocationFor(1, { actor: "other" }),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: {
+          confirmed: [{
+            id: "entity:source",
+            path: toDocumentPath(["value", "poll", "answers", "alice"]),
+            seq: 1,
+          }],
+          pending: [],
+        },
+        operations: [{
+          op: "patch",
+          id: "entity:source",
+          patches: [{
+            op: "add",
+            path: "/value/poll/answers/alice",
+            value: "pizza",
+          }],
+        }],
+      },
+    });
+
+    const allowed = applyCommit(engine, {
+      sessionId: "session:1",
+      invocation: invocationFor(2),
+      authorization,
+      commit: {
+        localSeq: 2,
+        reads: {
+          confirmed: [{
+            id: "entity:source",
+            path: toDocumentPath(["value", "poll", "answers"]),
+            seq: 1,
+            nonRecursive: true,
+          }],
+          pending: [],
+        },
+        operations: [{
+          op: "set",
+          id: "entity:derived",
+          value: toEntityDocument({ parentStillExists: true }),
+        }],
+      },
+    });
+
+    assertEquals(allowed.seq, 3);
+    assertEquals(read(engine, { id: "entity:derived" }), {
+      value: { parentStillExists: true },
+    });
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("memory v2 engine keeps array add conflicts conservative", async () => {
+  const { engine, path } = await createEngine();
+
+  try {
+    applyCommit(engine, {
+      sessionId: "session:1",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:source",
+          value: toEntityDocument({
+            poll: { answers: ["bob"] },
+          }),
+        }],
+      },
+    });
+
+    applyCommit(engine, {
+      sessionId: "session:other",
+      invocation: invocationFor(1, { actor: "other" }),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: {
+          confirmed: [{
+            id: "entity:source",
+            path: toDocumentPath(["value", "poll", "answers", "1"]),
+            seq: 1,
+          }],
+          pending: [],
+        },
+        operations: [{
+          op: "patch",
+          id: "entity:source",
+          patches: [{
+            op: "add",
+            path: "/value/poll/answers/1",
+            value: "alice",
+          }],
+        }],
+      },
+    });
+
+    assertThrows(
+      () =>
+        applyCommit(engine, {
+          sessionId: "session:1",
+          invocation: invocationFor(2),
+          authorization,
+          commit: {
+            localSeq: 2,
+            reads: {
+              confirmed: [{
+                id: "entity:source",
+                path: toDocumentPath(["value", "poll", "answers", "0"]),
+                seq: 1,
+              }],
+              pending: [],
+            },
+            operations: [{
+              op: "set",
+              id: "entity:derived",
+              value: toEntityDocument({ firstAnswer: "bob" }),
+            }],
+          },
+        }),
+      Error,
+      "stale confirmed read",
+    );
+    assertEquals(read(engine, { id: "entity:derived" }), null);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
 Deno.test("memory v2 engine resolves pending reads and rejects stale pending reads", async () => {
   const { engine, path } = await createEngine();
 

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -114,6 +114,7 @@ export interface ConfirmedRead {
   branch?: BranchName;
   path: ReadPath;
   seq: number;
+  nonRecursive?: boolean;
 }
 
 export interface PendingRead {
@@ -121,6 +122,7 @@ export interface PendingRead {
   scope?: CellScope;
   path: ReadPath;
   localSeq: number;
+  nonRecursive?: boolean;
 }
 
 export interface SchedulerObservationCommit {

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -3506,6 +3506,7 @@ const validateConfirmedReads = (
       scopeKey,
       read.seq,
       read.path,
+      read.nonRecursive === true,
     );
     if (conflictSeq !== null) {
       throw new ConflictError(
@@ -3551,6 +3552,7 @@ const resolvePendingReads = (
       resolveScopeKey(read.scope, { principal, sessionId }),
       resolution.seq,
       read.path,
+      read.nonRecursive === true,
     );
     if (conflictSeq !== null) {
       throw new ConflictError(
@@ -3569,6 +3571,7 @@ const findConflictSeq = (
   scopeKey: string,
   afterSeq: number,
   readPath: readonly string[],
+  nonRecursive = false,
 ): number | null => {
   const setOrDeleteConflict = engine.statements.selectSetDeleteConflict.get({
     branch,
@@ -3588,13 +3591,23 @@ const findConflictSeq = (
       after_seq: afterSeq,
     }) as Iterable<{
       seq: number;
+      op_index: number;
       data: string | null;
     }>
   ) {
     if (
       patchOverlapsRead(
+        engine,
+        {
+          branch,
+          id,
+          scopeKey,
+          seq: conflict.seq,
+          opIndex: conflict.op_index,
+        },
         decodeStoredPatchList(conflict.data),
         readPath,
+        nonRecursive,
       )
     ) {
       return conflict.seq;
@@ -3867,12 +3880,97 @@ const applySchedulerObservationBatchCommit = (
 };
 
 const patchOverlapsRead = (
+  engine: Engine,
+  options: {
+    branch: BranchName;
+    id: EntityId;
+    scopeKey: string;
+    seq: number;
+    opIndex: number;
+  },
   patches: readonly PatchOp[],
   readPath: readonly string[],
+  nonRecursive = false,
 ): boolean => {
-  return patches.some((patch) =>
-    touchedPathsForPatch(patch).some((path) => pathsOverlap(path, readPath))
-  );
+  if (nonRecursive) {
+    return patches.some((patch) =>
+      changedLeafPathsForPatch(patch).some((path) =>
+        pathIsSameOrAncestor(path, readPath)
+      )
+    );
+  }
+
+  let document: EntityDocument | undefined;
+  for (let index = 0; index < patches.length; index++) {
+    const patch = patches[index]!;
+    switch (patch.op) {
+      case "add":
+      case "remove": {
+        const path = parsePointer(patch.path);
+        if (pathsOverlap(path, readPath)) {
+          return true;
+        }
+
+        const parent = parentPath(path);
+        if (!pathsOverlap(parent, readPath)) {
+          break;
+        }
+
+        if (document === undefined) {
+          document = reconstructPatchedDocument(engine, {
+            ...options,
+            opIndex: options.opIndex - 1,
+            includeSnapshotAtTargetSeq: false,
+          });
+          if (index > 0) {
+            document = applyPatchDocument(
+              document,
+              patches.slice(0, index),
+            );
+          }
+        }
+        if (isArrayAtPath(document, parent)) {
+          return true;
+        }
+        break;
+      }
+      default:
+        if (
+          touchedPathsForPatch(patch).some((path) =>
+            pathsOverlap(path, readPath)
+          )
+        ) {
+          return true;
+        }
+    }
+
+    if (document !== undefined) {
+      document = applyPatchDocument(document, [patch]);
+    }
+  }
+  return false;
+};
+
+const pathIsSameOrAncestor = (
+  candidate: readonly string[],
+  path: readonly string[],
+): boolean =>
+  candidate.length <= path.length &&
+  candidate.every((segment, index) => path[index] === segment);
+
+const changedLeafPathsForPatch = (patch: PatchOp): string[][] => {
+  switch (patch.op) {
+    case "replace":
+    case "add":
+    case "remove":
+    case "splice":
+      return [parsePointer(patch.path)];
+    case "move": {
+      const from = parsePointer(patch.from);
+      const to = parsePointer(patch.path);
+      return [from, to];
+    }
+  }
 };
 
 const touchedPathsForPatch = (patch: PatchOp): string[][] => {
@@ -3892,6 +3990,27 @@ const touchedPathsForPatch = (patch: PatchOp): string[][] => {
     case "splice":
       return [parsePointer(patch.path)];
   }
+};
+
+const isArrayAtPath = (
+  root: FabricValue,
+  path: readonly string[],
+): boolean => {
+  let current = root;
+  for (const segment of path) {
+    if (Array.isArray(current)) {
+      current = current[Number(segment)];
+    } else if (
+      current !== null &&
+      typeof current === "object" &&
+      Object.hasOwn(current, segment)
+    ) {
+      current = (current as Record<string, FabricValue>)[segment];
+    } else {
+      return false;
+    }
+  }
+  return Array.isArray(current);
 };
 
 // Scheduler reader-dirty propagation uses the EXACT changed leaf paths, not the
@@ -4098,6 +4217,7 @@ const reconstructPatchedDocument = (
     branch: BranchName;
     seq: number;
     opIndex: number;
+    includeSnapshotAtTargetSeq?: boolean;
   },
 ): EntityDocument => {
   const { id, scopeKey, branch, seq, opIndex } = options;
@@ -4112,7 +4232,7 @@ const reconstructPatchedDocument = (
     branch,
     id,
     scope_key: scopeKey,
-    seq,
+    seq: options.includeSnapshotAtTargetSeq === false ? seq - 1 : seq,
   }) as SnapshotRow | undefined;
 
   let baseSeq = 0;

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -175,6 +175,11 @@ export class MultiRuntimeSession {
     };
   }
 
+  /** Serialize the cell at `path` as a sigil link suitable for handler events. */
+  async linkValue(path: (string | number)[] = []): Promise<unknown> {
+    return await this.#client.call("linkValue", { path });
+  }
+
   async idle(): Promise<void> {
     await this.#client.call("idle");
   }

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -197,6 +197,21 @@ const handlers: Record<
     });
   },
 
+  /**
+   * Serialize a result cell as the same sigil-link value that pattern code and
+   * UI event payloads use when passing live references across boundaries.
+   */
+  async linkValue({ path }) {
+    const target = result();
+    await target.pull();
+    let cell = target;
+    for (const segment of (path ?? []) as (string | number)[]) {
+      cell = cell.key(segment as never) as Cell<any>;
+    }
+    const resolved = cell.resolveAsCell();
+    return sanitizeForTransfer(resolved.getAsLink({ includeSchema: true }));
+  },
+
   async idle() {
     await idle();
     return {};

--- a/packages/patterns/lunch-poll/HANDOVER-PROPOSAL-2026-06-23.md
+++ b/packages/patterns/lunch-poll/HANDOVER-PROPOSAL-2026-06-23.md
@@ -1,0 +1,209 @@
+# Lunch Poll Multi-User Performance Handover
+
+Owner handoff target: Bernie
+
+## Summary
+
+Lunch poll is dropping accepted-looking user actions under concurrent multi-user
+load. The root cause is not just "the pattern is slow" and not just "the runtime
+is wrong"; it is the interaction between a high-contention pattern shape and a
+runtime/protocol gap.
+
+The current lunch-poll pattern stores hot shared state in arrays:
+
+- `users: User[]`
+- `votes: Vote[]`
+
+Handlers read the aggregate array and then write it back. Under 10 users and
+serial setup, concurrent voting still loses durable votes after the runtime
+patch:
+
+- `main.tsx --cases=3x10 --rounds=3 --skip-refresh --join-mode=serial`
+- Result: `10/10` users, `18/30` votes
+- Churn: `1797` conflicts/reverts
+- Elapsed diagnostic time: `35.9s`
+
+The PR now includes an idiomatic reference-addressed fixture:
+
+- `packages/patterns/lunch-poll/reference-shape-experiment.tsx`
+- No string IDs, generated IDs, `optionId`, or string-keyed mutation maps.
+- Option identity is the option cell.
+- Participant identity is the participant element cell in the shared PerSpace
+  `participants` array.
+- PerUser viewer state stores a live link to that participant element.
+- Vote writes go under the participant child cell, not a global `votes` array.
+- Matching uses `equals()`.
+
+With the same 3x10x3 workload and serial setup:
+
+- Result: `10/10` users, `30/30` votes
+- Churn: `281` conflicts/reverts
+- Elapsed diagnostic time: `7.5s`
+- Final vote-round max workset: `5` versus `24` in current arrays
+
+So this PR is no longer just a runtime speculation. It demonstrates that an
+idiomatic reference shape plus the runtime patch materially improves both
+correctness and performance.
+
+## Local Validation URL
+
+Local patched runtime and diagnostic piece:
+
+```text
+http://localhost:9000/lunch-poll-perf-a587/lunch-poll-reference-runtime-a587
+```
+
+Current deployed piece:
+
+```text
+fid1:KMMXckIrcnJr7P8JdJWTe6nGkfZzPvo-G0pJJzwhO6s
+```
+
+Deployment source:
+
+```text
+packages/patterns/lunch-poll/reference-shape-experiment.tsx
+```
+
+Browser status: the fresh reference URL renders the header,
+`0 joined | 0
+options | 0 votes`, name input, join button, restaurant input, and
+add button. In-app browser automation and
+`cf piece call joinAs '{"name":"Alex"}'` did not mutate durable state, while the
+multi-runtime harness does drive the same handlers successfully. Treat the
+deployed URL as a render/manual-inspection surface; the measured performance
+evidence below comes from the headless multi-runtime harness.
+
+## Evidence
+
+Successful reference fixture with runtime patch:
+
+```bash
+deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --program=reference-shape-experiment.tsx \
+  --cases=3x10 --rounds=3 --skip-refresh \
+  --event-mode=reference --join-mode=serial
+```
+
+Result:
+
+- users: `10/10`
+- votes: `30/30`
+- conflicts/reverts: `281`
+- elapsed: `7.5s`
+- vote round 3 max nodes/edges: `77/145`
+- vote round 3 max workset: `5`
+- rejected commits: `0`
+
+Control against current array-backed `main.tsx` with the same runtime patch and
+same serial setup:
+
+```bash
+deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --program=main.tsx \
+  --cases=3x10 --rounds=3 --skip-refresh \
+  --event-mode=id --join-mode=serial
+```
+
+Result:
+
+- users: `10/10`
+- votes: `18/30`
+- conflicts/reverts: `1797`
+- elapsed: `35.9s`
+- vote round 3 max nodes/edges: `466/1350`
+- vote round 3 max workset: `24`
+
+So the fix is not runtime-only. The pattern must stop using aggregate arrays as
+the hot write path. The reference fixture shows how to do that without
+contradicting Common Fabric's no-string-ID guidance.
+
+## Runtime Finding
+
+The runner records some reads as `nonRecursive: true`. Those reads mean "the
+container/path itself matters, not all descendants." That is appropriate for
+topology/schema/link-probe style reads.
+
+Before this patch, `SpaceReplica.buildReads()` compacted reads and then stripped
+`nonRecursive` before sending `ClientCommit` to memory-v2. This widened shallow
+parent reads such as `value/usersByName` into recursive subtree preconditions.
+
+That caused independent keyed object writes to conflict:
+
+```text
+read value/usersByName as topology
+write value/usersByName/User%208
+```
+
+The runner knew this was shallow; the server did not.
+
+## Proposed Runtime Change
+
+1. Add `nonRecursive?: boolean` to memory-v2 `ConfirmedRead` and `PendingRead`.
+2. Preserve `nonRecursive` through `SpaceReplica.buildReads()`.
+3. Validate non-recursive reads as path/ancestor-only:
+   - writes to the read path conflict
+   - writes to ancestors conflict
+   - writes to descendants do not conflict
+4. Make object-key `add`/`remove` validation type-aware:
+   - unrelated object sibling keys do not conflict
+   - arrays remain conservative because insertion/removal shifts indices
+
+Relevant files:
+
+- `packages/runner/src/storage/v2.ts`
+- `packages/memory/v2.ts`
+- `packages/memory/v2/engine.ts`
+- `docs/specs/memory-v2/03-commit-model.md`
+- `docs/specs/memory-v2/04-protocol.md`
+
+## Proposed Pattern Direction
+
+Do not promote the old keyed-record diagnostic shape into lunch-poll proper. It
+helped isolate the runtime issue, but it relied on synthetic string keys and has
+been removed from the PR.
+
+The product refactor should keep the same performance goal while following the
+documented identity model:
+
+- Store live cell references or child cells for participants/options/votes, not
+  generated `id` fields.
+- Keep participant cells in PerSpace if every viewer must read them. A rejected
+  PerSpace roster of PerUser participant links failed because space-scoped reads
+  cannot follow narrower user-scoped links.
+- Let PerUser viewer state point to the viewer's PerSpace participant element.
+- Pass option references through handlers and compare with `equals()` where
+  lookup is necessary.
+- Keep each user's vote state off the global aggregate hot path by writing below
+  that participant cell and linking to the option cell.
+- Keep output `users: readonly User[]` and `votes: readonly Vote[]` views only
+  as derived compatibility surfaces for existing consumers/harnesses.
+- Preserve existing UI contracts where possible so subcomponents do not need a
+  broad rewrite.
+
+## Risks
+
+- `nonRecursive` must be treated as a protocol-level semantic, not just a runner
+  optimization. Hosted clients and servers need to roll forward together.
+- Object add/remove independence should not be generalized to arrays.
+- Existing deployed lunch-poll state uses arrays. A production migration needs a
+  compatibility/migration plan if we update an existing piece in place.
+- The local keyed-record diagnostic used string-addressed object keys. That
+  source has been removed from the PR because it violates the documented Common
+  Fabric identity model.
+- Browser auth/manual multi-tab verification is still needed before promoting
+  the pattern change. The local URL now renders, but automated clicks have not
+  yet confirmed the browser event path mutates durable state.
+
+## Recommended Next Steps
+
+1. Manually open the local URL and verify the reference poll can be joined/voted
+   in normal browser tabs. This should be a browser event/durability check.
+2. Run a two-browser/two-identity smoke test if practical, after at least one
+   manual click confirms the UI event path is live.
+3. Promote the runtime patch with the focused engine and runner tests.
+4. Convert `packages/patterns/lunch-poll/main.tsx` to a live-reference / child
+   cell storage shape, using `reference-shape-experiment.tsx` as the starting
+   point for the data model rather than the removed string-keyed diagnostic.
+5. Decide whether production lunch-poll should be a fresh piece or an in-place
+   migration from array fields to the new reference-addressed model.

--- a/packages/patterns/lunch-poll/HANDOVER-PROPOSAL-2026-06-23.md
+++ b/packages/patterns/lunch-poll/HANDOVER-PROPOSAL-2026-06-23.md
@@ -9,45 +9,45 @@ load. The root cause is not just "the pattern is slow" and not just "the runtime
 is wrong"; it is the interaction between a high-contention pattern shape and a
 runtime/protocol gap.
 
-The current lunch-poll pattern stores hot shared state in arrays:
+The PR now changes the real lunch poll, `packages/patterns/lunch-poll/main.tsx`:
 
-- `users: User[]`
-- `votes: Vote[]`
+- Live votes are stored under each participant row, `users[n].votes`, instead of
+  a global hot `votes` array.
+- The public `votes` output is still projected for compatibility.
+- Each browser keeps a PerUser append-only participant index, so a vote handler
+  can write directly to the current viewer's participant child cell.
+- The existing `Option.id` / `Vote.optionId` contract remains. This refactor
+  improves the real hot write path, but it does not solve that older identity
+  idiom debt.
 
-Handlers read the aggregate array and then write it back. Under 10 users and
-serial setup, concurrent voting still loses durable votes after the runtime
-patch:
+Measured against the same 3 options x 10 users x 3 vote rounds workload with
+serial join setup:
 
-- `main.tsx --cases=3x10 --rounds=3 --skip-refresh --join-mode=serial`
-- Result: `10/10` users, `18/30` votes
-- Churn: `1797` conflicts/reverts
-- Elapsed diagnostic time: `35.9s`
+| Shape                           | Final users | Final votes | Conflicts/reverts | Elapsed |     Vote round 3 graph | Workset | Trace |
+| ------------------------------- | ----------: | ----------: | ----------------: | ------: | ---------------------: | ------: | ----: |
+| Original `main.tsx` array votes |       10/10 |       18/30 |              1923 |   36.0s | 467 nodes / 1361 edges |      24 |  1680 |
+| Real `main.tsx` child votes     |       10/10 |       30/30 |              1309 |   28.1s | 479 nodes / 1380 edges |      16 |   915 |
 
-The PR now includes an idiomatic reference-addressed fixture:
+That is the merge-relevant evidence: the real lunch poll now preserves all 30
+expected votes in this workload and cuts conflict churn and scheduler work. It
+does not collapse the render graph, so this is not the dramatic result from the
+smaller fixture.
 
-- `packages/patterns/lunch-poll/reference-shape-experiment.tsx`
-- No string IDs, generated IDs, `optionId`, or string-keyed mutation maps.
-- Option identity is the option cell.
-- PerUser viewer state stores the viewer's append-only participant index, not a
-  generated app ID. This is only valid because the diagnostic roster never
-  reorders or removes participants.
-- Vote writes go under the participant child cell, not a global `votes` array.
-- Matching uses `equals()`.
+The PR also keeps `reference-shape-experiment.tsx` as supporting mechanism
+evidence. That fixture demonstrates the lower bound when option identity is a
+live reference and vote writes go under participant child cells:
 
-With the same 3x10x3 workload and serial setup:
+- `10/10` users, `30/30` votes
+- `350` conflicts/reverts
+- `8.0s` elapsed diagnostic time
+- Final vote-round max workset `4`
 
-- Result: `10/10` users, `30/30` votes
-- Churn: `350` conflicts/reverts
-- Elapsed diagnostic time: `8.0s`
-- Final vote-round max workset: `4` versus `24` in current arrays
-
-So this PR is no longer just a runtime speculation. It demonstrates that an
-idiomatic reference shape plus the runtime patch materially improves both
-correctness and performance.
+Treat that fixture as a model for future idiomatic cleanup, not as the primary
+proof that the real product improved.
 
 ## Local Validation URL
 
-Local patched runtime and diagnostic piece:
+Local patched runtime and real lunch poll piece:
 
 ```text
 http://localhost:9000/lunch-poll-perf-a587/lunch-poll-reference-runtime-a587
@@ -62,40 +62,38 @@ fid1:KMMXckIrcnJr7P8JdJWTe6nGkfZzPvo-G0pJJzwhO6s
 Deployment source:
 
 ```text
-packages/patterns/lunch-poll/reference-shape-experiment.tsx
+packages/patterns/lunch-poll/main.tsx
 ```
 
-Browser status: the fresh reference URL renders the header,
-`0 joined | 0 options | 0 votes`, name input, join button, restaurant input, add
-button, and per-option green/yellow/red vote buttons. The previous deployed UI
-had a stripped top-level "Option #" vote control that did not match the
-reference-addressed row path and did not vote manually. The source is now
-redeployed with row-level option-cell vote buttons. The measured performance
-evidence below still comes from the headless multi-runtime harness.
+Browser status: this URL should render the full lunch-poll UI from `main.tsx`,
+not the stripped diagnostic fixture. The measured performance evidence below
+comes from the headless multi-runtime harness, which is the reliable stress
+driver for this workload.
 
 ## Evidence
 
-Successful reference fixture with runtime patch:
+Successful real `main.tsx` child-vote run with runtime patch:
 
 ```bash
 deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
-  --program=reference-shape-experiment.tsx \
+  --program=main.tsx \
   --cases=3x10 --rounds=3 --skip-refresh \
-  --event-mode=reference --join-mode=serial
+  --event-mode=id --join-mode=serial
 ```
 
 Result:
 
 - users: `10/10`
 - votes: `30/30`
-- conflicts/reverts: `350`
-- elapsed: `8.0s`
-- vote round 3 max nodes/edges: `80/186`
-- vote round 3 max workset: `4`
+- conflicts/reverts: `1309`
+- elapsed: `28.1s`
+- vote round 3 max nodes/edges: `479/1380`
+- vote round 3 max workset: `16`
+- vote round 3 trace entries: `915`
 - rejected commits: `0`
 
-Control against current array-backed `main.tsx` with the same runtime patch and
-same serial setup:
+Control against the original array-backed `main.tsx` with the same runtime patch
+and same serial setup:
 
 ```bash
 deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
@@ -108,14 +106,16 @@ Result:
 
 - users: `10/10`
 - votes: `18/30`
-- conflicts/reverts: `1797`
-- elapsed: `35.9s`
-- vote round 3 max nodes/edges: `466/1350`
+- conflicts/reverts: `1923`
+- elapsed: `36.0s`
+- vote round 3 max nodes/edges: `467/1361`
 - vote round 3 max workset: `24`
+- vote round 3 trace entries: `1680`
 
-So the fix is not runtime-only. The pattern must stop using aggregate arrays as
-the hot write path. The reference fixture shows how to do that without
-contradicting Common Fabric's no-string-ID guidance.
+So the fix is not runtime-only. The real pattern had to stop using the global
+`votes` array as the hot write path. The remaining graph size shows that the
+real UI still has substantial reactive read cost, but the vote correctness and
+contention improvements are measured on the production pattern source.
 
 ## Runtime Finding
 
@@ -162,23 +162,23 @@ Do not promote the old keyed-record diagnostic shape into lunch-poll proper. It
 helped isolate the runtime issue, but it relied on synthetic string keys and has
 been removed from the PR.
 
-The product refactor should keep the same performance goal while following the
+This PR implements the first production slice of the storage-shape change by
+moving live votes under participant rows while keeping the existing output
+contract. The longer-term product refactor should keep pushing toward the
 documented identity model:
 
-- Store live cell references or child cells for participants/options/votes, not
-  generated `id` fields.
+- Prefer live cell references or child cells for participants/options/votes over
+  generated `id` fields where the product contract allows it.
 - Keep participant cells in PerSpace if every viewer must read them. A rejected
   PerSpace roster of PerUser participant links failed because space-scoped reads
   cannot follow narrower user-scoped links.
-- Prefer a PerUser pointer to the viewer's PerSpace participant element. In this
-  fixture, the browser-safe version uses an append-only participant index
-  because a nested `ParticipantCell` in PerUser viewer state either materialized
-  as a plain value or failed the current TS/schema surface once votes contained
-  option-cell links.
-- Pass option references through handlers and compare with `equals()` where
-  lookup is necessary.
+- Use a PerUser pointer to the viewer's PerSpace participant element. The real
+  pattern currently uses an append-only participant index because it keeps the
+  deployed UI and schema surface stable.
+- In the next cleanup, pass option references through handlers and compare with
+  `equals()` where lookup is necessary.
 - Keep each user's vote state off the global aggregate hot path by writing below
-  that participant cell and linking to the option cell.
+  that participant cell.
 - Keep output `users: readonly User[]` and `votes: readonly Vote[]` views only
   as derived compatibility surfaces for existing consumers/harnesses.
 - Preserve existing UI contracts where possible so subcomponents do not need a
@@ -191,23 +191,21 @@ documented identity model:
 - Object add/remove independence should not be generalized to arrays.
 - Existing deployed lunch-poll state uses arrays. A production migration needs a
   compatibility/migration plan if we update an existing piece in place.
-- The local keyed-record diagnostic used string-addressed object keys. That
-  source has been removed from the PR because it violates the documented Common
-  Fabric identity model.
+- The real pattern still exposes `optionId` in the public contract. This PR
+  improves the hot vote path without finishing the no-string-ID cleanup.
 - Browser manual multi-tab verification is still needed before promoting the
-  pattern change. The local URL now renders row-level vote controls, but
-  automated clicks have not been reliable enough to prove browser durability.
+  pattern change. The local URL now points at the real UI; the multi-runtime
+  harness is the durability proof.
 
 ## Recommended Next Steps
 
-1. Manually open the local URL and verify the reference poll can be joined/voted
-   in normal browser tabs after refreshing the redeployed source. This should be
-   a browser event/durability check.
+1. Manually open the local URL and verify the real poll can be joined/voted in
+   normal browser tabs after refreshing the redeployed source. This should be a
+   browser event/durability check, not the main performance proof.
 2. Run a two-browser/two-identity smoke test if practical, after at least one
    manual click confirms the UI event path is live.
 3. Promote the runtime patch with the focused engine and runner tests.
-4. Convert `packages/patterns/lunch-poll/main.tsx` to a live-reference / child
-   cell storage shape, using `reference-shape-experiment.tsx` as the starting
-   point for the data model rather than the removed string-keyed diagnostic.
-5. Decide whether production lunch-poll should be a fresh piece or an in-place
-   migration from array fields to the new reference-addressed model.
+4. Decide whether this PR's real-pattern improvement is enough to merge, or
+   whether the option identity cleanup must land in the same PR.
+5. Decide whether existing deployed lunch-poll pieces need an in-place migration
+   for old array-backed vote state.

--- a/packages/patterns/lunch-poll/HANDOVER-PROPOSAL-2026-06-23.md
+++ b/packages/patterns/lunch-poll/HANDOVER-PROPOSAL-2026-06-23.md
@@ -56,7 +56,7 @@ http://localhost:9000/lunch-poll-perf-a587/lunch-poll-reference-runtime-a587
 Current deployed piece:
 
 ```text
-fid1:KMMXckIrcnJr7P8JdJWTe6nGkfZzPvo-G0pJJzwhO6s
+fid1:48HeF0KAyJ0uP14LVRaJMvO6jnYUq4dyCC0CPEOyPDw
 ```
 
 Deployment source:
@@ -65,10 +65,23 @@ Deployment source:
 packages/patterns/lunch-poll/main.tsx
 ```
 
-Browser status: this URL should render the full lunch-poll UI from `main.tsx`,
-not the stripped diagnostic fixture. The measured performance evidence below
-comes from the headless multi-runtime harness, which is the reliable stress
-driver for this workload.
+Browser status: verified on 2026-06-23 after importing `cf.key` into an
+`agent-browser` session. A shadow-DOM text probe after reload found:
+
+- `Where should we eat?`
+- `Join the poll`
+- `No options yet`
+- `Waiting for a host to join.`
+
+Important failure mode from the smoke test: the public slug initially rendered
+only the shell/header because the browser route was observing stale slug/proxy
+state. Repointing `lunch-poll-reference-runtime-a587` with `cf piece set-slug`
+made the slug resolve to the real piece above. Keep this in mind if someone sees
+the title/header but no join widget: first compare the slug-resolved piece with
+the hashed slug cell before assuming the pattern UI is broken.
+
+The measured performance evidence below comes from the headless multi-runtime
+harness, which is the reliable stress driver for this workload.
 
 ## Evidence
 
@@ -193,17 +206,17 @@ documented identity model:
   compatibility/migration plan if we update an existing piece in place.
 - The real pattern still exposes `optionId` in the public contract. This PR
   improves the hot vote path without finishing the no-string-ID cleanup.
-- Browser manual multi-tab verification is still needed before promoting the
-  pattern change. The local URL now points at the real UI; the multi-runtime
-  harness is the durability proof.
+- Browser render smoke verification now confirms the public URL presents the
+  real join UI. A manual join/vote click-through across multiple tabs is still
+  useful before promoting the pattern change. The multi-runtime harness remains
+  the durability and contention proof.
 
 ## Recommended Next Steps
 
-1. Manually open the local URL and verify the real poll can be joined/voted in
-   normal browser tabs after refreshing the redeployed source. This should be a
-   browser event/durability check, not the main performance proof.
-2. Run a two-browser/two-identity smoke test if practical, after at least one
-   manual click confirms the UI event path is live.
+1. Manually click through join and vote in normal browser tabs. The local URL
+   now renders the real UI; this should be a browser event/durability check, not
+   the main performance proof.
+2. Run a two-browser/two-identity smoke test if practical.
 3. Promote the runtime patch with the focused engine and runner tests.
 4. Decide whether this PR's real-pattern improvement is enough to merge, or
    whether the option identity cleanup must land in the same PR.

--- a/packages/patterns/lunch-poll/HANDOVER-PROPOSAL-2026-06-23.md
+++ b/packages/patterns/lunch-poll/HANDOVER-PROPOSAL-2026-06-23.md
@@ -28,18 +28,18 @@ The PR now includes an idiomatic reference-addressed fixture:
 - `packages/patterns/lunch-poll/reference-shape-experiment.tsx`
 - No string IDs, generated IDs, `optionId`, or string-keyed mutation maps.
 - Option identity is the option cell.
-- Participant identity is the participant element cell in the shared PerSpace
-  `participants` array.
-- PerUser viewer state stores a live link to that participant element.
+- PerUser viewer state stores the viewer's append-only participant index, not a
+  generated app ID. This is only valid because the diagnostic roster never
+  reorders or removes participants.
 - Vote writes go under the participant child cell, not a global `votes` array.
 - Matching uses `equals()`.
 
 With the same 3x10x3 workload and serial setup:
 
 - Result: `10/10` users, `30/30` votes
-- Churn: `281` conflicts/reverts
-- Elapsed diagnostic time: `7.5s`
-- Final vote-round max workset: `5` versus `24` in current arrays
+- Churn: `350` conflicts/reverts
+- Elapsed diagnostic time: `8.0s`
+- Final vote-round max workset: `4` versus `24` in current arrays
 
 So this PR is no longer just a runtime speculation. It demonstrates that an
 idiomatic reference shape plus the runtime patch materially improves both
@@ -66,13 +66,12 @@ packages/patterns/lunch-poll/reference-shape-experiment.tsx
 ```
 
 Browser status: the fresh reference URL renders the header,
-`0 joined | 0
-options | 0 votes`, name input, join button, restaurant input, and
-add button. In-app browser automation and
-`cf piece call joinAs '{"name":"Alex"}'` did not mutate durable state, while the
-multi-runtime harness does drive the same handlers successfully. Treat the
-deployed URL as a render/manual-inspection surface; the measured performance
-evidence below comes from the headless multi-runtime harness.
+`0 joined | 0 options | 0 votes`, name input, join button, restaurant input, add
+button, and per-option green/yellow/red vote buttons. The previous deployed UI
+had a stripped top-level "Option #" vote control that did not match the
+reference-addressed row path and did not vote manually. The source is now
+redeployed with row-level option-cell vote buttons. The measured performance
+evidence below still comes from the headless multi-runtime harness.
 
 ## Evidence
 
@@ -89,10 +88,10 @@ Result:
 
 - users: `10/10`
 - votes: `30/30`
-- conflicts/reverts: `281`
-- elapsed: `7.5s`
-- vote round 3 max nodes/edges: `77/145`
-- vote round 3 max workset: `5`
+- conflicts/reverts: `350`
+- elapsed: `8.0s`
+- vote round 3 max nodes/edges: `80/186`
+- vote round 3 max workset: `4`
 - rejected commits: `0`
 
 Control against current array-backed `main.tsx` with the same runtime patch and
@@ -171,7 +170,11 @@ documented identity model:
 - Keep participant cells in PerSpace if every viewer must read them. A rejected
   PerSpace roster of PerUser participant links failed because space-scoped reads
   cannot follow narrower user-scoped links.
-- Let PerUser viewer state point to the viewer's PerSpace participant element.
+- Prefer a PerUser pointer to the viewer's PerSpace participant element. In this
+  fixture, the browser-safe version uses an append-only participant index
+  because a nested `ParticipantCell` in PerUser viewer state either materialized
+  as a plain value or failed the current TS/schema surface once votes contained
+  option-cell links.
 - Pass option references through handlers and compare with `equals()` where
   lookup is necessary.
 - Keep each user's vote state off the global aggregate hot path by writing below
@@ -191,14 +194,15 @@ documented identity model:
 - The local keyed-record diagnostic used string-addressed object keys. That
   source has been removed from the PR because it violates the documented Common
   Fabric identity model.
-- Browser auth/manual multi-tab verification is still needed before promoting
-  the pattern change. The local URL now renders, but automated clicks have not
-  yet confirmed the browser event path mutates durable state.
+- Browser manual multi-tab verification is still needed before promoting the
+  pattern change. The local URL now renders row-level vote controls, but
+  automated clicks have not been reliable enough to prove browser durability.
 
 ## Recommended Next Steps
 
 1. Manually open the local URL and verify the reference poll can be joined/voted
-   in normal browser tabs. This should be a browser event/durability check.
+   in normal browser tabs after refreshing the redeployed source. This should be
+   a browser event/durability check.
 2. Run a two-browser/two-identity smoke test if practical, after at least one
    manual click confirms the UI event path is live.
 3. Promote the runtime patch with the focused engine and runner tests.

--- a/packages/patterns/lunch-poll/PERF-INVESTIGATION-2026-06-23.md
+++ b/packages/patterns/lunch-poll/PERF-INVESTIGATION-2026-06-23.md
@@ -1,0 +1,922 @@
+# Lunch Poll Performance Investigation - 2026-06-23
+
+## Problem
+
+Lunch poll is a representative multi-user, cross-user shared-state workload.
+Recent work reduced some graph/render costs, but the current question is
+broader: under concurrent users, are the slowdowns and dropped updates caused by
+non-idiomatic pattern code, runtime behavior, or an interaction between the two?
+
+This document records evidence before making source changes.
+
+## Scope and Constraints
+
+- Worktree: `/Users/ben/.codex/worktrees/a587/labs`
+- Checked out commit during this pass: `95060a581` (`origin/main`)
+- Pattern under investigation: `packages/patterns/lunch-poll/`
+- Local worktree server:
+  - Toolshed: `http://localhost:9000`
+  - Shell: `http://localhost:6173`
+- Deployed investigation piece:
+  - `http://localhost:9000/lunch-poll-perf-a587/fid1:h3rkJobE_JAna_yV8QSrDM5f1bNftTUMR7A41EwwuSU`
+- Source changes made during this phase:
+  - This investigation log.
+  - `reference-shape-experiment.tsx`, an idiomatic reference-addressed
+    diagnostic pattern included in the PR.
+  - Multi-runtime harness support for serializing result cells as `@link` values
+    so headless events can pass live references.
+  - `lunch-poll-diagnose.ts` support for reference events and serial setup.
+  - The earlier string-keyed `storage-shape-experiment.tsx` diagnostic was
+    removed from the PR because it violated the documented identity model.
+- Local identity file: `cf.key`; ignored by `.gitignore`.
+
+## Prior Context From Git History
+
+Relevant lunch-poll history includes:
+
+- `1f7815684 perf(patterns): add lunch poll scenario diagnostics (#4172)`
+- `7860a7897 feat(lunch-poll): migrate visit + vote history to SQLite (#4144)`
+- `894ba26d8 Refactor lunch poll into subpatterns (#4166)`
+- `c74357002 Fix lunch poll composed UI rendering (#4193)`
+- `5abe477c7 fix(memory): gate conflict retries on caught-up local seq (#4237)`
+- `c63716fb5 fix(memory,runner): refine commit-conflict granularity (leaf-only + nonRecursive shape reads)`
+- `3c482b6c1 Filter votes before mapping... (#4291)`
+- `9785c0709 fix(lunch-poll): restore per-voter swatches... (#4295)`
+- `95060a581 fix(ts-transformers): lift reactive value-expressions in map/filter/flatMap callbacks (CT-1777) (#4297)`
+
+The old branch `origin/perf/shared-state-write-drops` contains useful prior
+analysis. The old evidence identified three cost centers:
+
+- Array vote aggregate graph growth.
+- Per-option AI/homepage enrichment on load.
+- Concurrent-write conflict/retry exhaustion on shared `votes`.
+
+That branch also concluded that moving vote storage to SQLite did not fix the
+core correctness issue because writes still funneled through a shared handle
+revision and could drop under conflict. Current main contains runtime conflict
+granularity improvements after that branch, so all current results below were
+remeasured on `95060a581`.
+
+## Current Pattern Hot Paths
+
+### Join
+
+`packages/patterns/lunch-poll/participant-identity-card.tsx`
+
+```ts
+const existing = users.get();
+if (existing.some((u) => u.name === trimmed)) return;
+const user: User = {
+  name: trimmed,
+  avatar: override ? "" : (profileAvatar ?? "").trim(),
+  color: colorForIndex(existing.length),
+  joinedAt: safeDateNow(),
+};
+users.push(user);
+myName.set(trimmed);
+if (trimmedName(adminName.get()) === "") {
+  adminName.set(trimmed);
+}
+joinName.set("");
+```
+
+Observation: the handler reads the whole shared `users` array, derives
+uniqueness and color from that snapshot, then writes the shared users array and
+per-user/session cells in one event transaction.
+
+### Vote
+
+`packages/patterns/lunch-poll/main.tsx`
+
+```ts
+const current = votes.get();
+const existingIdx = current.findIndex(
+  (v) => v.voterName === me && v.optionId === optionId,
+);
+if (existingIdx >= 0) {
+  const existing = current[existingIdx];
+  if (existing.voteType === voteType) {
+    votes.remove(existing);
+    return;
+  }
+  votes.key(existingIdx).key("voteType").set(voteType);
+  return;
+}
+votes.push({ voterName: me, optionId, voteType });
+```
+
+Observation: the handler reads the whole shared `votes` array, scans it, and
+then mutates the same hot shared array.
+
+## Runtime Event Commit Behavior
+
+`packages/runner/src/scheduler/events.ts` intentionally does not await event
+commits after speculative local apply. Exhausted commit failures are logged, but
+the event caller is not given a normal application-level failure.
+
+Important lines:
+
+- `tx.commit().then(...)` starts at
+  `packages/runner/src/scheduler/events.ts:616`.
+- Event commit telemetry is submitted around
+  `packages/runner/src/scheduler/events.ts:624`.
+- Retry logging occurs around `packages/runner/src/scheduler/events.ts:642`.
+- Exhausted retries log
+  `"Event handler transaction failed after exhausting all retries"` around
+  `packages/runner/src/scheduler/events.ts:661`.
+
+This means a UI can appear to accept work speculatively while durability later
+fails after the retry budget.
+
+## Append vs Whole-Array Reads
+
+There are two distinct "why are we reading the array?" questions.
+
+First, lunch-poll explicitly reads the arrays today:
+
+- `joinAs` calls `users.get()` to check name uniqueness and choose
+  `colorForIndex(existing.length)`.
+- `castVote` calls `votes.get()` to find an existing `(voterName, optionId)`
+  vote so it can toggle/remove/update rather than blindly append.
+
+Those explicit reads make each handler depend on the current aggregate array.
+That is a pattern authorship issue for a concurrent workload.
+
+Second, the generic `Cell.push()` implementation is not currently a read-free
+append either. In `packages/runner/src/cell.ts`, `push()` resolves the link,
+calls `this.tx.readValueOrThrow(resolvedLink)`, builds a combined array, and
+then calls `diffAndUpdate(...)`. The v2 transaction diff can lower the append to
+a tail `splice` patch, but it has already recorded a transaction read of the
+array it appended to.
+
+This is an important runtime/API implication. If the runtime had a true
+append-only operation that recorded "add this item at the array tail" without
+depending on the current array snapshot or concrete pre-append length,
+concurrent append-only joins/votes could be much more commutative. Today, simply
+deleting a pattern-level `votes.get()` before `votes.push(...)` may not be
+enough if `Cell.push()` still widens the transaction read set internally.
+
+For current lunch-poll semantics, a pure append is also not quite enough for
+votes: `castVote` models a current vote per `(voterName, optionId)`, with
+toggle-off and color replacement. That still needs a localized existence read or
+conditional write. The key is that it should read/write the one vote key, not
+the whole `votes` array.
+
+## Tooling Notes
+
+The existing diagnostic harness is the best fast test driver for this issue:
+
+```bash
+env DENO_DIR=/private/tmp/deno-cache-a587 \
+  deno run --cached-only -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --cases=3x10 --rounds=3 --skip-refresh
+```
+
+The script does not implement a conventional `--help`; running it with `--help`
+executes the default matrix. Inside the sandbox that fails because the
+in-process `StandaloneMemoryServer` cannot bind. Run diagnostics outside the
+sandbox.
+
+Browser telemetry can be enabled with:
+
+```js
+localStorage.setItem("telemetryEnabled", "true");
+location.reload();
+```
+
+After importing `cf.key`, `globalThis.commonfabric.rt` is present and the shell
+debugger controller retains telemetry markers.
+
+## Browser Telemetry Snapshot
+
+After opening the deployed piece, importing `cf.key`, and enabling telemetry:
+
+- Browser URL:
+  `http://localhost:9000/lunch-poll-perf-a587/fid1:h3rkJobE_JAna_yV8QSrDM5f1bNftTUMR7A41EwwuSU`
+- `globalThis.commonfabric.rt`: present.
+- Telemetry enabled: true.
+- Retained markers: `761`.
+- Graph snapshot after a browser join attempt: `286` nodes, `457` edges.
+- Marker type counts:
+  - `cell.update`: `324`
+  - `scheduler.dependencies.update`: `279`
+  - `scheduler.subscribe`: `100`
+  - `scheduler.run`: `48`
+  - `scheduler.event.preflight`: `4`
+  - `scheduler.invocation`: `3`
+  - `scheduler.event.commit`: `3`
+
+Negative result: driving the custom input with `agent-browser fill` did not
+faithfully reproduce a human join. The join button fired, but the event commit
+had zero changed writes. Browser telemetry is useful for observing the mounted
+runtime, but the multi-runtime harness is currently the better stress driver.
+
+## Baseline Single-Case Results
+
+### 3 options x 5 users x 3 vote rounds
+
+Command:
+
+```bash
+env DENO_DIR=/private/tmp/deno-cache-a587 \
+  deno run --cached-only -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --cases=3x5 --rounds=3 --skip-refresh
+```
+
+Result:
+
+- Final convergence: true.
+- Final users: `5`.
+- Final votes: `15` expected, `15` observed.
+- Commit conflicts: `856`.
+- Commit reverts: `856`.
+- Retry warnings: `36`.
+- Exhausted event commits: `0`.
+
+Conclusion: this size is correct but already conflict-heavy.
+
+### 3 options x 10 users x 3 vote rounds
+
+Result:
+
+- Final convergence: true across clients, but to the wrong durable state.
+- Final users: `10` expected, `7` observed.
+- Final votes: `30` expected, `18` observed.
+- Commit conflicts: `1309` in the first run, `1723` in the later threshold run.
+- Exhausted event commits: `6`.
+- Exhausted handlers:
+  - `participant-identity-card.tsx:43:2`: `3`
+  - `main.tsx:497:3`: `3`
+
+Conclusion: the failure is durable dropped work, not just delayed UI propagation
+or client divergence.
+
+### `CF_CONFLICT_ADMISSION=hold`
+
+Command:
+
+```bash
+env DENO_DIR=/private/tmp/deno-cache-a587 CF_CONFLICT_ADMISSION=hold \
+  deno run --cached-only -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --cases=3x10 --rounds=3 --skip-refresh
+```
+
+Result:
+
+- Final users: `10` expected, `7` observed.
+- Final votes: `30` expected, `18` observed.
+- Commit conflicts: `1841`.
+- Commit reverts: `1841`.
+- Exhausted event commits: `6`.
+
+Conclusion: `hold` does not mitigate this workload on current main. It increases
+conflict churn and leaves the same durable data loss.
+
+## Threshold Matrix: 3 Options, 3 Vote Rounds
+
+Command:
+
+```bash
+env DENO_DIR=/private/tmp/deno-cache-a587 \
+  deno run --cached-only -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --cases=3x6,3x7,3x8,3x9,3x10 --rounds=3 --skip-refresh
+```
+
+| Users | Expected Users | Final Users | Expected Votes | Final Votes | Conflicts | Retry Warnings | Exhaustions | Exhausted Handlers         |
+| ----: | -------------: | ----------: | -------------: | ----------: | --------: | -------------: | ----------: | -------------------------- |
+|     6 |              6 |           6 |             18 |          18 |       872 |             55 |           0 | none                       |
+|     7 |              7 |           7 |             21 |          18 |      1273 |             75 |           3 | `castVote` x3              |
+|     8 |              8 |           7 |             24 |          18 |      1254 |             80 |           4 | `joinAs` x1, `castVote` x3 |
+|     9 |              9 |           7 |             27 |          18 |      1323 |             85 |           5 | `joinAs` x2, `castVote` x3 |
+|    10 |             10 |           7 |             30 |          18 |      1723 |             90 |           6 | `joinAs` x3, `castVote` x3 |
+
+Observations:
+
+- The current correctness threshold is between 6 and 7 users for concurrent
+  voting.
+- Concurrent join starts dropping durable users at 8 users.
+- Once final durable users cap at 7, final durable votes cap at 18 in these
+  runs.
+- At 7 users, join is still durable, but each vote round loses one `castVote`
+  commit.
+
+## Join-Only Matrix: 3 Options, 0 Vote Rounds
+
+Command:
+
+```bash
+env DENO_DIR=/private/tmp/deno-cache-a587 \
+  deno run --cached-only -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --cases=3x6,3x7,3x8,3x9,3x10 --rounds=0 --skip-refresh
+```
+
+This still runs concurrent join and host option creation, but skips voting.
+
+| Users | Expected Users | Final Users | Final Options | Conflicts | Retry Warnings | Exhaustions | Exhausted Handlers |
+| ----: | -------------: | ----------: | ------------: | --------: | -------------: | ----------: | ------------------ |
+|     6 |              6 |           6 |             3 |       327 |             10 |           0 | none               |
+|     7 |              7 |           7 |             3 |       476 |             15 |           0 | none               |
+|     8 |              8 |           7 |             3 |       603 |             20 |           1 | `joinAs` x1        |
+|     9 |              9 |           7 |             3 |       715 |             25 |           2 | `joinAs` x2        |
+|    10 |             10 |           7 |             3 |       999 |             30 |           3 | `joinAs` x3        |
+
+Conclusion: concurrent join itself is reliable through 7 users and then drops
+one additional user per extra concurrent joiner above 7, under this workload.
+
+## 7-User Vote Depth
+
+Commands:
+
+```bash
+env DENO_DIR=/private/tmp/deno-cache-a587 \
+  deno run --cached-only -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --cases=3x7 --rounds=1 --skip-refresh
+
+env DENO_DIR=/private/tmp/deno-cache-a587 \
+  deno run --cached-only -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --cases=3x7 --rounds=2 --skip-refresh
+```
+
+Combined with the threshold run:
+
+| Vote Rounds | Expected Votes | Final Votes | Conflicts | Retry Warnings | Exhaustions | Exhausted Handlers |
+| ----------: | -------------: | ----------: | --------: | -------------: | ----------: | ------------------ |
+|           1 |              7 |           6 |       935 |             35 |           1 | `castVote` x1      |
+|           2 |             14 |          12 |       963 |             55 |           2 | `castVote` x2      |
+|           3 |             21 |          18 |      1273 |             75 |           3 | `castVote` x3      |
+
+Conclusion: at 7 users, the vote path drops one durable vote per concurrent vote
+round.
+
+## Graph and Read-Site Findings
+
+Across the 6 to 10 user threshold matrix, final graph sizes are almost flat:
+
+| Users | Final Max Nodes | Final Max Edges |
+| ----: | --------------: | --------------: |
+|     6 |             463 |            1342 |
+|     7 |             465 |            1346 |
+|     8 |             464 |            1345 |
+|     9 |             464 |            1346 |
+|    10 |             464 |            1346 |
+
+Top read sites during vote phases are consistently:
+
+- `sink:result`
+- `lunch-poll/poll-option-card`
+- `main.tsx:1055:54` (`homePageLookupUrls = options.map(...)`)
+- `main.tsx:1752:49` / `main.tsx:1753:49` output snapshots for users
+
+Conclusion: graph/read churn is real and should be optimized, but it does not
+explain the durable write loss threshold. The correctness failure correlates
+with event commit conflict exhaustion in specific shared-state handlers.
+
+## Storage Shape Experiment: Keyed Records
+
+To test the "array of links / individual cells" direction without first
+rewriting the product UI, I first added a local diagnostic-only compatible
+variant:
+
+- Local file during investigation: `storage-shape-experiment.tsx`
+- Same external handler names used by the harness: `joinAs`, `addOption`,
+  `castVote`, etc.
+- Same output arrays expected by the harness: `users`, `options`, `votes`.
+- Different hot storage shape:
+  - `usersByName: Record<string, User | null>`
+  - `votesByKey: Record<string, Vote | null>`
+- Handlers use `record.key(stableKey).get()` and
+  `record.key(stableKey).set(...)` instead of whole-array scans.
+- Derived output converts the records back to arrays for harness compatibility.
+
+Important caveat: this experiment used synthetic string keys (`name`,
+`optionId`, compound vote keys) so the existing CLI stress harness could drive
+it. That is not idiomatic Common Fabric pattern identity. The docs explicitly
+prefer live references, `equals()`, and cell links over generated ids or
+string-addressed mutation layers. Treat this experiment as evidence about
+runtime conflict semantics, not as source to promote into production lunch-poll.
+The source file has been removed from the PR.
+
+One setup finding: `Default<Record<PropertyKey, never>>` did not emit a real
+`{}` default in the transformed schema for these record inputs. The first manual
+multi-runtime probe read the pattern result as `undefined` until the inputs were
+changed to `Default<{}>`. That is a separate pattern/schema sharp edge worth
+remembering.
+
+Validation:
+
+```bash
+env DENO_DIR=/private/tmp/deno-cache-a587 \
+  deno task cf check \
+  packages/patterns/lunch-poll/storage-shape-experiment.tsx --no-run
+```
+
+Manual 2-session harness probe after the default fix:
+
+- Initial outputs were real objects, not `undefined`.
+- Host join produced `users=[User 1]`, `adminName=User 1`, host `myName=User 1`.
+- Second user join converged to `users=[User 1, User 2]`.
+- `myName` stayed per-user scoped (`User 1` in session 1, `User 2` in session
+  2).
+
+### 3 options x 10 users x 3 vote rounds
+
+Command:
+
+```bash
+env DENO_DIR=/private/tmp/deno-cache-a587 \
+  deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --program=storage-shape-experiment.tsx \
+  --cases=3x10 --rounds=3 --skip-refresh
+```
+
+Compared with the existing-array baseline:
+
+| Shape          | Final Users | Final Votes | Conflicts | Reverts | Exhaustions |
+| -------------- | ----------: | ----------: | --------: | ------: | ----------: |
+| Current arrays |        7/10 |       18/30 |      1309 |    1309 |           6 |
+| Keyed records  |        7/10 |       18/30 |       368 |     368 |           6 |
+
+Result: keyed records materially reduce conflict churn, but do not fix durable
+write loss. The workload still converges to the same wrong state.
+
+### Threshold matrix: keyed records, 3 options, 3 vote rounds
+
+Command:
+
+```bash
+env DENO_DIR=/private/tmp/deno-cache-a587 \
+  deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --program=storage-shape-experiment.tsx \
+  --cases=3x6,3x7,3x8,3x9,3x10 --rounds=3 --skip-refresh
+```
+
+| Users | Final Users | Final Votes | Conflicts | Baseline Conflicts | Exhaustions | Exhausted Handlers         |
+| ----: | ----------: | ----------: | --------: | -----------------: | ----------: | -------------------------- |
+|     6 |         6/6 |       18/18 |       185 |                872 |           0 | none                       |
+|     7 |         7/7 |       18/21 |       264 |               1273 |           3 | `castVote` x3              |
+|     8 |         7/8 |       18/24 |       342 |               1254 |           4 | `joinAs` x1, `castVote` x3 |
+|     9 |         7/9 |       18/27 |       328 |               1323 |           5 | `joinAs` x2, `castVote` x3 |
+|    10 |        7/10 |       18/30 |       362 |               1723 |           6 | `joinAs` x3, `castVote` x3 |
+
+### Join-only matrix: keyed records, 3 options, 0 vote rounds
+
+Command:
+
+```bash
+env DENO_DIR=/private/tmp/deno-cache-a587 \
+  deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --program=storage-shape-experiment.tsx \
+  --cases=3x6,3x7,3x8,3x9,3x10 --rounds=0 --skip-refresh
+```
+
+| Users | Final Users | Conflicts | Baseline Conflicts | Exhaustions |
+| ----: | ----------: | --------: | -----------------: | ----------: |
+|     6 |         6/6 |        50 |                327 |           0 |
+|     7 |         7/7 |        75 |                476 |           0 |
+|     8 |         7/8 |       105 |                603 |           1 |
+|     9 |         7/9 |       164 |                715 |           2 |
+|    10 |        7/10 |       227 |                999 |           3 |
+
+Conclusion: keying the roster reduces join churn, but the join correctness
+threshold is unchanged.
+
+## Reference-Addressed Pattern Experiment
+
+The PR now includes an idiomatic fixture:
+
+- File: `packages/patterns/lunch-poll/reference-shape-experiment.tsx`
+- No generated `id`, `optionId`, or string-keyed mutation maps.
+- Options are addressed by live option cell references.
+- Participant identity is the participant element cell in the shared
+  `participants` array.
+- Each viewer's PerUser `viewer` state stores a live link to their participant
+  element; vote handlers write below that participant child cell.
+- Vote matching uses `equals(vote.option, option)`.
+
+One rejected intermediate shape stored PerUser participant cells in a shared
+PerSpace roster. That is not valid: a space-scoped read cannot follow a narrower
+user-scoped link, so other clients see `undefined`. The working shape keeps
+participant cells in PerSpace and only stores the per-user pointer from the user
+scope to the wider space scope.
+
+The diagnostic harness was extended with:
+
+- `--event-mode=reference`: send option `@link` values instead of `optionId`.
+- `--join-mode=serial`: make setup deterministic so the measured contention is
+  concurrent voting, not concurrent roster creation.
+- `MultiRuntimeSession.linkValue(path)`: serialize a result cell via
+  `getAsLink({ includeSchema: true })`.
+- Field-by-field result reads when whole-result materialization is `undefined`
+  for reference-heavy outputs.
+
+### 3 options x 10 users x 3 vote rounds, serial setup
+
+Commands:
+
+```bash
+deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --program=main.tsx \
+  --cases=3x10 --rounds=3 --skip-refresh \
+  --event-mode=id --join-mode=serial
+
+deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --program=reference-shape-experiment.tsx \
+  --cases=3x10 --rounds=3 --skip-refresh \
+  --event-mode=reference --join-mode=serial
+```
+
+Results from `/private/tmp/lunch-main-3x10.json` and
+`/private/tmp/lunch-ref-3x10.json`:
+
+| Shape                 | Elapsed | Final Users | Final Votes | Conflicts | Reverts | Vote round 3 max nodes | Vote round 3 max edges | Vote round 3 max workset | Vote round 3 trace |
+| --------------------- | ------: | ----------: | ----------: | --------: | ------: | ---------------------: | ---------------------: | -----------------------: | -----------------: |
+| Current arrays        |   35.9s |       10/10 |       18/30 |      1797 |    1797 |                    466 |                   1350 |                       24 |               1645 |
+| Reference child cells |    7.5s |       10/10 |       30/30 |       281 |     281 |                     77 |                    145 |                        5 |                152 |
+
+Result: the idiomatic reference shape is not speculative. With the same runtime
+patch and deterministic setup, it preserves all expected votes, cuts end-to-end
+diagnostic time by about 4.8x, cuts conflicts/reverts by about 6.4x, and reduces
+the final vote-round scheduler workset by about 4.8x.
+
+This does not mean the runtime work is unnecessary. The reference fixture still
+records conflict/revert churn, and the runtime change is still what lets
+independent object-child writes avoid false conflicts when reads are
+non-recursive. The evidence points to a joint fix: tighten runtime conflict
+semantics and move lunch-poll away from global aggregate hot arrays.
+
+### Keyed-record runtime implication
+
+The warning payloads still show conflicts on the same root entity id, even when
+the handler writes a keyed path:
+
+- `joinAs` (`storage-shape-experiment.tsx:191`) still exhausts at 8+ users.
+- `castVote` (`storage-shape-experiment.tsx:259`) still exhausts one vote per
+  concurrent vote round at 7+ users.
+- The transaction operation is a `patch` on the root record entity, and the
+  conflict reports a stale confirmed read of that same root entity.
+
+So this experiment weakens the idea that simply moving from arrays to keyed
+objects/cells is sufficient under the current runtime semantics. It helps
+performance/churn, but the current conflict detector/retry path still treats
+these point writes as conflicting once the root record read is stale.
+
+## Current Hypotheses
+
+### H1: Hot shared arrays are over-conflicting under concurrent event handlers
+
+Confidence: medium-high.
+
+Evidence:
+
+- `joinAs` reads all `users` and writes the shared users array.
+- `castVote` reads all `votes` and writes the shared votes array.
+- Exhausted handler IDs match those two handlers exactly.
+- Join-only runs fail at 8+ users with `joinAs` exhaustions.
+- 7-user vote-depth runs fail one `castVote` per concurrent vote round.
+- The keyed-record experiment reduces conflicts by roughly 4-5x, so the pattern
+  shape does affect churn.
+
+Counter-evidence:
+
+- The keyed-record experiment does not improve the correctness threshold.
+- Point writes under one record root still exhaust retries.
+
+### H2: Runtime retry behavior turns conflicts into silent durable drops
+
+Confidence: high.
+
+Evidence:
+
+- Exhausted commits log in `scheduler/events.ts`.
+- Event commits are intentionally async after speculative local apply.
+- Harness sessions converge to the same wrong durable state, meaning the state
+  loss is not just propagation lag.
+- `send()`-style interaction does not surface the exhausted durability failure
+  as a normal pattern-level failure.
+- Keyed-record point writes still drop at the same threshold, which points to
+  conflict/retry semantics beyond just non-idiomatic array scans.
+
+### H2b: Current record/path writes are not commutative enough
+
+Confidence: high after the keyed-record experiment.
+
+Evidence:
+
+- `record.key(k).set(v)` reduced conflict count but not durable correctness.
+- Exhausted warnings still identify stale confirmed reads on the root record
+  entity.
+- The runtime reports patch operations on the root record id, not independent
+  child-cell commits that can merge in any order.
+- Engine conflict validation uses
+  `validateConfirmedReads -> findConflictSeq -> patchOverlapsRead`.
+  `patchOverlapsRead` asks whether any touched patch path prefix-overlaps the
+  read path.
+- For `add` and `remove`, `touchedPathsForPatch` returns both the leaf path and
+  the parent path. That means adding `/value/usersByName/Alice` is treated as
+  touching `/value/usersByName` as well as Alice's key.
+- `pathsOverlap` is bidirectional prefix overlap, so the parent touch overlaps
+  every sibling-key read under the same record.
+
+Implication: an "array of links" or keyed-record shape will only fix correctness
+if each concurrent mutation can avoid a stale read dependency on a shared root,
+or if the runtime can merge independent path patches under the same root after a
+stale root read.
+
+### H2c: Distinct object-key inserts currently conflict through the parent path
+
+Confidence: high.
+
+Engine-only probe:
+
+- Seeded `entity:poll` with `{ value: { usersByName: {} } }`.
+- Session A read missing `/value/usersByName/Alice` at seq 1 and patched
+  `add /value/usersByName/Alice`; this committed at seq 2.
+- Session B had independently read missing `/value/usersByName/Bob` at seq 1 and
+  patched `add /value/usersByName/Bob`; this was rejected with
+  `stale confirmed read: entity:poll at seq 1 conflicted with seq 2`.
+- Repeating the same two sibling `add` patches with no confirmed reads allowed
+  both commits. This isolates the failure to stale-read validation, not a
+  write-write inability to replay the patches.
+
+Runner storage probe:
+
+- A missing-child read through `readValueOrThrow` is recorded narrowly:
+  `["value", "usersByName", "Bob"]`.
+- `replica.buildReads(...)` preserves that exact confirmed read path.
+- So the false dependency is not introduced by transaction read compaction or a
+  pattern-level root snapshot for the keyed-record case. The widening occurs
+  when the engine validates an intervening sibling `add` using the parent path.
+
+Spec/history:
+
+- `docs/specs/memory-v2/03-commit-model.md` says path-aware validation should
+  not reject unrelated paths on the same entity, but also says structural
+  collection edits may be treated conservatively as overlapping the whole
+  collection subtree and that implementations may over-approximate overlap.
+- The March path-aware conflict test only covers sibling `replace` writes. It
+  does not cover stale reads of distinct missing sibling keys followed by `add`.
+- Commit `038b36e176` fixed the same parent-path sibling-overlap problem for
+  persisted scheduler dirtying by switching scheduler write extraction to
+  leaf-only paths. Its message explicitly left `patchOverlapsRead` untouched.
+
+Interpretation:
+
+- This is now more runtime/spec than pattern authorship. The array version is
+  non-idiomatic for high-contention writes and creates excessive churn, but the
+  keyed-record version exercises a reasonable CRDT-like expectation: two users
+  inserting different object keys should commute.
+- The current spec permits the runtime to reject that case. For lunch-poll and
+  similar cross-user state, that permissive over-approximation becomes a
+  correctness problem because bounded retries eventually drop accepted user
+  actions.
+- A true child-cell/link design should avoid this specific conflict only if the
+  hot path writes independent child-cell entities and does not also mutate a
+  shared directory/root during the same concurrent phase.
+
+### H3: Render graph/read-site churn is a secondary performance issue
+
+Confidence: medium-high.
+
+Evidence:
+
+- Graph sizes are relatively flat from 6 to 10 users in the failing matrix.
+- Top read sites are stable and dominated by sink/result and option cards.
+- The dropped-work threshold is better predicted by handler conflict exhaustion
+  than by graph size.
+
+This does not mean graph churn is harmless. It likely still affects perceived
+latency and responsiveness, especially with more options or homepage refreshes.
+
+### H4: Homepage enrichment is not the primary dropped-write cause in these runs
+
+Confidence: high for the measured cases.
+
+Evidence:
+
+- All main diagnostic runs above used `--skip-refresh`.
+- `main.tsx:1055:54` still appears as a read site, but homepage refresh/network
+  work was not part of the dropped-write reproduction.
+
+## Ruled Out or Weakened
+
+- `CF_CONFLICT_ADMISSION=hold` as a mitigation for this workload: weakened. It
+  preserved the same wrong durable state and increased conflict churn.
+- Browser-only automation as the main stress driver: weakened. It is useful for
+  telemetry inspection but less reliable for custom input interaction than the
+  multi-runtime harness.
+- Pure graph explosion as the primary correctness bug: weakened. Graph/read
+  churn exists, but the durable loss tracks exhausted event commits.
+
+## Working Theory
+
+Lunch poll currently mixes pattern-level hot shared array writes with runtime
+speculative event commit/retry semantics. The pattern authorship shape causes
+many concurrent handlers to read and then rewrite the same logical aggregate.
+The runtime handles some conflicts with retries, but above the workload
+threshold it exhausts the retry budget. Because event commits are speculative
+and asynchronous, the user-facing action can appear accepted even when
+durability later fails.
+
+The keyed-record experiment refines this: the pattern shape is not irrelevant,
+because narrower writes cut conflict churn sharply. But the current runtime/API
+does not make independent keyed writes commutative enough to preserve
+correctness. Distinct object-key inserts still conflict because `add` is treated
+as touching the shared parent record path.
+
+The result is not random divergence. Clients eventually converge to the same
+wrong state.
+
+## Next Best Experiments Before Editing
+
+1. Add a focused characterization/regression test for object sibling adds: stale
+   read of missing key B should not be invalidated by add of key A if the parent
+   container is a plain object. Keep array insert/remove semantics separate
+   because array index shifts are a real overlap hazard.
+2. Test a true child-cell/link variant where the hot mutation writes a separate
+   cell per user/vote and does not write the shared link array during the hot
+   path. If the link directory still needs mutation, preseed or create it
+   serially so the concurrent phase only writes child cells.
+3. Add a diagnostic mode or temporary script that compares concurrent vs
+   serialized `castVote` after the same 7-user join. This would isolate whether
+   the loss is exclusively concurrency-driven.
+4. Run one larger-option case with low users, for example `10x5`, to separate
+   option-card/read graph costs from write contention.
+5. Run one homepage-refresh case after correctness investigation, because
+   homepage enrichment is a separate cost center and should not be conflated
+   with the dropped-write path.
+
+## Candidate Fix Direction
+
+The keyed-record variant is a useful performance direction but is not a complete
+correctness fix by itself. The most evidence-supported next edit would need one
+of these runtime/API properties:
+
+- Type-aware object `add`/`remove` conflict validation that does not treat
+  unrelated sibling-key reads as stale, while preserving conservative behavior
+  for array index edits.
+- True independent child-cell writes for each user/vote, with no shared
+  directory mutation during the concurrent hot path.
+- A true append/insert operation whose transaction does not depend on a stale
+  aggregate snapshot.
+- Runtime merging for independent path patches under the same root entity.
+
+Pattern-side changes still matter:
+
+- Avoid whole-array scans in hot handlers where a live reference or child cell
+  can address the item directly.
+- Preserve array-shaped outputs for UI compatibility by deriving arrays from
+  reference-addressed or linked storage.
+- Make event handlers idempotent so retries are safe.
+
+Success criteria for the first edit should be:
+
+- `3x10 --rounds=3 --skip-refresh` converges to `10` users and `30` votes.
+- Exhausted event commits are `0`.
+- Conflict churn drops materially or at least no longer causes durable loss.
+- Existing 2-user integration behavior still passes.
+
+## Runtime Experiment: Shallow Reads + Object-Key Adds
+
+After the keyed-record variant still failed, a subagent tried the first
+engine-only half of the theory:
+
+- Preserve object-sibling independence in memory-v2 conflict validation: adding
+  `/value/usersByName/Alice` should not invalidate a stale exact read of
+  `/value/usersByName/Bob`.
+- Keep array adds conservative because array indices shift.
+
+Engine tests passed, but the keyed lunch-poll workload did not improve:
+
+- `3x10 --rounds=3 --skip-refresh` on `storage-shape-experiment.tsx` still
+  converged to `7/10` users and `18/30` votes.
+- Conflict churn was still high (`405` conflicts in that intermediate run).
+
+The next probe instrumented rejected `joinAs` commits and found the missing
+piece:
+
+- Rejected commits still contained a confirmed read of
+  `["value", "usersByName"]`.
+- A targeted `buildReads` log showed that almost all of those parent reads were
+  `nonRecursive: true`.
+- `SpaceReplica.buildReads()` was compacting shallow reads and then explicitly
+  stripping `nonRecursive` before sending the memory-v2 `ClientCommit`.
+- That turned "this parent path only" topology/schema reads into recursive
+  subtree preconditions at the server.
+
+The successful runtime experiment is therefore two-part:
+
+1. Keep object-key `add`/`remove` overlap type-aware in the memory engine:
+   unrelated object sibling keys do not conflict, arrays remain conservative.
+2. Preserve `nonRecursive` through `ClientCommit` and make engine validation
+   treat shallow reads as exact/ancestor-only, not descendant-recursive.
+
+Result:
+
+```bash
+deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --program=storage-shape-experiment.tsx \
+  --cases=3x10 --rounds=3 --skip-refresh
+```
+
+- Convergence: `users=[10,10,10,10,10,10,10,10,10,10]`.
+- Convergence: `votes=[30,30,30,30,30,30,30,30,30,30]`.
+- Churn: `conflicts=243`, `reverts=243`, `rejected=0`.
+- This is the first measured run where the 10-user keyed workload preserves all
+  joins and all votes.
+
+Control run against the original array-backed `main.tsx` after the same runtime
+fix:
+
+```bash
+deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --cases=3x10 --rounds=3 --skip-refresh
+```
+
+- Convergence remained wrong: `users=[7,...]`, `votes=[18,...]`.
+- Churn remained much higher: `conflicts=1517`, `reverts=1517`.
+
+So this is not a free runtime-only fix for the current pattern. The current
+array-backed handlers still read/write hot aggregate arrays. The runtime fix
+makes the diagnostic keyed storage shape work as intended by preserving
+independent object-key mutations and shallow topology reads, but that exact
+diagnostic shape is not the desired production pattern API because it is
+string-keyed.
+
+## Local Browser Deployment Checkpoint
+
+Deployed local URL:
+
+```text
+http://localhost:9000/lunch-poll-perf-a587/lunch-poll-reference-runtime-a587
+```
+
+Piece:
+
+```text
+fid1:KMMXckIrcnJr7P8JdJWTe6nGkfZzPvo-G0pJJzwhO6s
+```
+
+Browser event-path finding:
+
+- The fresh reference URL renders the poll header,
+  `0 joined | 0 options | 0
+  votes`, name input, join button, restaurant input,
+  and add button.
+- In-app browser automation can see and click the controls, but click attempts
+  left CLI-inspected durable state at `userCount=0`.
+- `cf piece call joinAs '{"name":"Alex"}'` also completed without mutating
+  `userCount`, while the multi-runtime harness drives the same handlers
+  successfully.
+- The in-app console log showed only shell `set-identity` / `set-view` entries
+  and no warnings or errors around the click attempts.
+- A separate `agent-browser` session opened the URL but only reached the local
+  auth/register screen, so it was not useful as an authenticated browser client.
+
+Interpretation: the blank UI was a pattern-side deployment issue and is fixed.
+The remaining browser question is narrower: confirm whether a normal manual
+click in an authenticated tab sends the rendered event stream, or whether the
+local shell/runtime event path is dropping clicks for this diagnostic UI. The
+CLI handler smoke tests and multi-runtime stress harness remain the strongest
+durability evidence for the storage/runtime proposal.
+
+Interpretation:
+
+- The pattern's original array shape is still non-idiomatic for high-contention
+  multi-user writes.
+- The keyed-record diagnostic shape showed the runtime issue, but it is not the
+  production target because it relies on synthetic string keys.
+- A production pattern shape should use live references/child cells, and it only
+  works efficiently if the runtime preserves the difference between recursive
+  content reads and shallow topology reads.
+- The bug was emergent: pattern contention exposed a runtime/protocol gap where
+  the runner had precise shallow-read information and the memory engine had
+  path-aware validation, but the protocol boundary erased the shallow-read bit.
+
+## Checkpoint
+
+Current understanding:
+
+- Correctness failure is reproducible on current main.
+- 6 users is correct but conflict-heavy.
+- 7 users loses one vote per concurrent vote round.
+- 8+ users starts losing joins.
+- `hold` mode does not mitigate.
+- Keyed-record storage cuts conflict churn substantially but leaves the same
+  correctness threshold.
+- Engine and runner probes show distinct object-key inserts conflict through
+  `add`'s parent-path footprint, even when transaction reads stay at exact
+  sibling-key paths.
+- The current memory-v2 spec allows this conservative behavior and does not
+  document shallow commit reads; lunch-poll is evidence that the spec is too
+  loose for cross-user insert-heavy state.
+- Preserving `nonRecursive` through `ClientCommit` plus type-aware object-add
+  validation makes the diagnostic keyed 10-user workload preserve all joins and
+  votes.
+- Browser telemetry is wired up, but CLI multi-runtime diagnostics are the most
+  reliable stress driver.
+
+Most likely next step:
+
+- Keep the focused runtime tests, update the memory-v2 spec for shallow reads,
+  and build the real lunch-poll refactor around live references / child cells
+  rather than the string-keyed diagnostic shape.

--- a/packages/patterns/lunch-poll/PERF-INVESTIGATION-2026-06-23.md
+++ b/packages/patterns/lunch-poll/PERF-INVESTIGATION-2026-06-23.md
@@ -917,7 +917,7 @@ http://localhost:9000/lunch-poll-perf-a587/lunch-poll-reference-runtime-a587
 Piece:
 
 ```text
-fid1:KMMXckIrcnJr7P8JdJWTe6nGkfZzPvo-G0pJJzwhO6s
+fid1:48HeF0KAyJ0uP14LVRaJMvO6jnYUq4dyCC0CPEOyPDw
 ```
 
 Current deployment target:
@@ -927,6 +927,27 @@ Current deployment target:
 - The browser check is for real UI smoke testing and event-path confidence.
 - The performance/correctness proof comes from the multi-runtime diagnostic
   harness, which drives the same handler workload across 10 clients.
+
+2026-06-23 browser verification:
+
+- The URL initially rendered only the shell/header in the in-app browser. CLI
+  inspection showed that the slug token resolved to the real piece, but the
+  hashed slug/proxy entity still exposed stale `$UI` at nested paths.
+- Repointed the slug with:
+
+  ```bash
+  CF_API_URL=http://localhost:9000 CF_IDENTITY=cf.key deno task cf piece set-slug \
+    -s lunch-poll-perf-a587 \
+    lunch-poll-reference-runtime-a587 \
+    fid1:48HeF0KAyJ0uP14LVRaJMvO6jnYUq4dyCC0CPEOyPDw
+  ```
+
+- Imported `cf.key` into `agent-browser`, reloaded the public URL, and walked
+  the composed/shadow DOM. The rendered text included `Where should we eat?`,
+  `Join the poll`, `No options yet`, and `Waiting for a host to join.`
+- Takeaway: if this URL shows title/header but no join widget, first verify the
+  slug target and browser identity. Do not treat a stale slug/proxy render as
+  evidence that the real `main.tsx` UI failed.
 
 Interpretation:
 
@@ -964,7 +985,8 @@ Current understanding:
 - Preserving `nonRecursive` through `ClientCommit` plus type-aware object-add
   validation makes the diagnostic keyed 10-user workload preserve all joins and
   votes.
-- Browser telemetry is wired up, but CLI multi-runtime diagnostics are still the
+- Browser render smoke is now verified for the public local URL after slug
+  repointing and CLI-key import. CLI multi-runtime diagnostics are still the
   most reliable stress driver.
 
 Most likely next step:

--- a/packages/patterns/lunch-poll/PERF-INVESTIGATION-2026-06-23.md
+++ b/packages/patterns/lunch-poll/PERF-INVESTIGATION-2026-06-23.md
@@ -7,7 +7,8 @@ Recent work reduced some graph/render costs, but the current question is
 broader: under concurrent users, are the slowdowns and dropped updates caused by
 non-idiomatic pattern code, runtime behavior, or an interaction between the two?
 
-This document records evidence before making source changes.
+This document records the investigation evidence and the measured effect of the
+subsequent real lunch-poll refactor.
 
 ## Scope and Constraints
 
@@ -21,8 +22,12 @@ This document records evidence before making source changes.
   - `http://localhost:9000/lunch-poll-perf-a587/fid1:h3rkJobE_JAna_yV8QSrDM5f1bNftTUMR7A41EwwuSU`
 - Source changes made during this phase:
   - This investigation log.
+  - `main.tsx` now stores live votes under participant rows and projects the
+    public `votes` output from `users[n].votes`.
+  - `participant-identity-card.tsx` now records a PerUser append-only
+    participant index so handlers can write to the current viewer's row.
   - `reference-shape-experiment.tsx`, an idiomatic reference-addressed
-    diagnostic pattern included in the PR.
+    diagnostic pattern included in the PR as mechanism evidence.
   - Multi-runtime harness support for serializing result cells as `@link` values
     so headless events can pass live references.
   - `lunch-poll-diagnose.ts` support for reference events and serial setup.
@@ -480,6 +485,56 @@ env DENO_DIR=/private/tmp/deno-cache-a587 \
 Conclusion: keying the roster reduces join churn, but the join correctness
 threshold is unchanged.
 
+## Real Lunch Poll Child-Vote Refactor
+
+The merge-relevant change is now in `packages/patterns/lunch-poll/main.tsx`, not
+only in a diagnostic fixture.
+
+What changed:
+
+- `User` rows now optionally contain `votes?: UserVote[]`.
+- `castVote` writes to `users.key(myUserIndex).key("votes")` instead of the
+  global `votes` array.
+- `resetVotes`, `clearMyVote`, and `removeOption` clear vote state from
+  participant child cells.
+- `votesForUsers(users)` projects the public `Vote[]` compatibility output.
+- `ParticipantIdentityCard` stores the viewer's append-only participant index in
+  PerUser state during join.
+
+This keeps the existing UI and public `Vote.optionId` shape, so it is not the
+final no-string-ID model. It specifically tests whether moving the hot vote
+write path out of the aggregate `votes` array improves the real lunch poll.
+
+### Real `main.tsx`, 3 options x 10 users x 3 vote rounds, serial setup
+
+Commands:
+
+```bash
+deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
+  --program=main.tsx \
+  --cases=3x10 --rounds=3 --skip-refresh \
+  --event-mode=id --join-mode=serial
+```
+
+Results from `/private/tmp/lunch-main-real-baseline.log` and
+`/private/tmp/lunch-main-real-child-votes.log`:
+
+| Shape                           | Elapsed | Final users | Final votes | Conflicts | Reverts | Vote round 3 max nodes | Vote round 3 max edges | Vote round 3 max workset | Vote round 3 trace |
+| ------------------------------- | ------: | ----------: | ----------: | --------: | ------: | ---------------------: | ---------------------: | -----------------------: | -----------------: |
+| Original `main.tsx` array votes |   36.0s |       10/10 |       18/30 |      1923 |    1923 |                    467 |                   1361 |                       24 |               1680 |
+| Real `main.tsx` child votes     |   28.1s |       10/10 |       30/30 |      1309 |    1309 |                    479 |                   1380 |                       16 |                915 |
+
+Result: the real lunch poll now preserves all expected votes in this workload.
+It also cuts elapsed diagnostic time by about 1.28x, conflicts/reverts by about
+1.47x, final vote-round scheduler workset by 1.5x, and final vote-round trace
+entries by about 1.84x.
+
+This does not prove that the full lunch-poll graph is fixed. The final graph is
+slightly larger after the refactor because the real UI still renders and derives
+through the same broad surfaces. The proof is narrower: removing the global
+`votes` hot array fixes the durable vote loss in this scenario and reduces
+runtime churn on the production pattern source.
+
 ## Reference-Addressed Pattern Experiment
 
 The PR now includes an idiomatic fixture:
@@ -517,7 +572,7 @@ The diagnostic harness was extended with:
 - Field-by-field result reads when whole-result materialization is `undefined`
   for reference-heavy outputs.
 
-### 3 options x 10 users x 3 vote rounds, serial setup
+### Fixture comparison, 3 options x 10 users x 3 vote rounds, serial setup
 
 Commands:
 
@@ -533,7 +588,7 @@ deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
   --event-mode=reference --join-mode=serial
 ```
 
-Results from `/private/tmp/lunch-main-3x10.json` and
+Earlier fixture results from `/private/tmp/lunch-main-3x10.json` and
 `/private/tmp/lunch-ref-3x10.json`:
 
 | Shape                 | Elapsed | Final Users | Final Votes | Conflicts | Reverts | Vote round 3 max nodes | Vote round 3 max edges | Vote round 3 max workset | Vote round 3 trace |
@@ -541,10 +596,11 @@ Results from `/private/tmp/lunch-main-3x10.json` and
 | Current arrays        |   35.9s |       10/10 |       18/30 |      1797 |    1797 |                    466 |                   1350 |                       24 |               1645 |
 | Reference child cells |    8.0s |       10/10 |       30/30 |       350 |     350 |                     80 |                    186 |                        4 |                152 |
 
-Result: the idiomatic reference shape is not speculative. With the same runtime
-patch and deterministic setup, it preserves all expected votes, cuts end-to-end
-diagnostic time by about 4.5x, cuts conflicts/reverts by about 5.1x, and reduces
-the final vote-round scheduler workset by about 6.0x.
+Result: the reference fixture is useful mechanism evidence. With the same
+runtime patch and deterministic setup, it preserves all expected votes, cuts
+end-to-end diagnostic time by about 4.5x, cuts conflicts/reverts by about 5.1x,
+and reduces the final vote-round scheduler workset by about 6.0x. It is not the
+merge proof for lunch poll; the real `main.tsx` result above is.
 
 This does not mean the runtime work is unnecessary. The reference fixture still
 records conflict/revert churn, and the runtime change is still what lets
@@ -864,38 +920,25 @@ Piece:
 fid1:KMMXckIrcnJr7P8JdJWTe6nGkfZzPvo-G0pJJzwhO6s
 ```
 
-Browser event-path finding:
+Current deployment target:
 
-- The fresh reference URL renders the poll header,
-  `0 joined | 0 options | 0
-  votes`, name input, join button, restaurant input,
-  and add button.
-- In-app browser automation can see and click the controls, but click attempts
-  left CLI-inspected durable state at `userCount=0`.
-- `cf piece call joinAs '{"name":"Alex"}'` also completed without mutating
-  `userCount`, while the multi-runtime harness drives the same handlers
-  successfully.
-- The in-app console log showed only shell `set-identity` / `set-view` entries
-  and no warnings or errors around the click attempts.
-- A separate `agent-browser` session opened the URL but only reached the local
-  auth/register screen, so it was not useful as an authenticated browser client.
-
-Interpretation: the blank UI was a pattern-side deployment issue and is fixed.
-The remaining browser question is narrower: confirm whether a normal manual
-click in an authenticated tab sends the rendered event stream, or whether the
-local shell/runtime event path is dropping clicks for this diagnostic UI. The
-CLI handler smoke tests and multi-runtime stress harness remain the strongest
-durability evidence for the storage/runtime proposal.
+- The URL should now be sourced from `packages/patterns/lunch-poll/main.tsx`,
+  not the stripped reference fixture.
+- The browser check is for real UI smoke testing and event-path confidence.
+- The performance/correctness proof comes from the multi-runtime diagnostic
+  harness, which drives the same handler workload across 10 clients.
 
 Interpretation:
 
 - The pattern's original array shape is still non-idiomatic for high-contention
   multi-user writes.
-- The keyed-record diagnostic shape showed the runtime issue, but it is not the
+- The real pattern now stores live votes below participant child cells and
+  preserves all expected votes in the 3x10x3 diagnostic workload.
+- The keyed-record diagnostic shape showed the runtime issue, but it is not a
   production target because it relies on synthetic string keys.
-- A production pattern shape should use live references/child cells, and it only
-  works efficiently if the runtime preserves the difference between recursive
-  content reads and shallow topology reads.
+- A future production shape should move option identity toward live references,
+  and it only works efficiently if the runtime preserves the difference between
+  recursive content reads and shallow topology reads.
 - The bug was emergent: pattern contention exposed a runtime/protocol gap where
   the runner had precise shallow-read information and the memory engine had
   path-aware validation, but the protocol boundary erased the shallow-read bit.
@@ -904,10 +947,11 @@ Interpretation:
 
 Current understanding:
 
-- Correctness failure is reproducible on current main.
-- 6 users is correct but conflict-heavy.
-- 7 users loses one vote per concurrent vote round.
-- 8+ users starts losing joins.
+- The original array-backed `main.tsx` correctness failure is reproducible.
+- The branch's real `main.tsx` child-vote refactor preserves `30/30` votes in
+  the measured 3x10x3 serial-join workload.
+- In the original scaling runs, 6 users is correct but conflict-heavy, 7 users
+  loses one vote per concurrent vote round, and 8+ users starts losing joins.
 - `hold` mode does not mitigate.
 - Keyed-record storage cuts conflict churn substantially but leaves the same
   correctness threshold.
@@ -920,11 +964,11 @@ Current understanding:
 - Preserving `nonRecursive` through `ClientCommit` plus type-aware object-add
   validation makes the diagnostic keyed 10-user workload preserve all joins and
   votes.
-- Browser telemetry is wired up, but CLI multi-runtime diagnostics are the most
-  reliable stress driver.
+- Browser telemetry is wired up, but CLI multi-runtime diagnostics are still the
+  most reliable stress driver.
 
 Most likely next step:
 
 - Keep the focused runtime tests, update the memory-v2 spec for shallow reads,
-  and build the real lunch-poll refactor around live references / child cells
-  rather than the string-keyed diagnostic shape.
+  browser-smoke the real `main.tsx` deployment, and decide whether the remaining
+  option identity cleanup belongs in this PR or a follow-up.

--- a/packages/patterns/lunch-poll/PERF-INVESTIGATION-2026-06-23.md
+++ b/packages/patterns/lunch-poll/PERF-INVESTIGATION-2026-06-23.md
@@ -487,17 +487,25 @@ The PR now includes an idiomatic fixture:
 - File: `packages/patterns/lunch-poll/reference-shape-experiment.tsx`
 - No generated `id`, `optionId`, or string-keyed mutation maps.
 - Options are addressed by live option cell references.
-- Participant identity is the participant element cell in the shared
-  `participants` array.
-- Each viewer's PerUser `viewer` state stores a live link to their participant
-  element; vote handlers write below that participant child cell.
+- Each viewer's PerUser `viewer` state stores an append-only participant index,
+  not a generated app ID. This is safe for the diagnostic fixture because
+  participants are only appended during serial setup.
+- Vote handlers write below that participant child cell rather than mutating a
+  global `votes` array.
 - Vote matching uses `equals(vote.option, option)`.
 
 One rejected intermediate shape stored PerUser participant cells in a shared
 PerSpace roster. That is not valid: a space-scoped read cannot follow a narrower
 user-scoped link, so other clients see `undefined`. The working shape keeps
-participant cells in PerSpace and only stores the per-user pointer from the user
-scope to the wider space scope.
+participant data in PerSpace and stores only the viewer's append-only roster
+position in PerUser state.
+
+Another attempted shape stored the viewer's live `ParticipantCell` directly in
+PerUser state. With the current transformer/schema surface that either
+materialized as a plain participant value, so writes did not reach the shared
+`participants` array, or failed once `Participant` itself contained
+`Vote.option: Cell<Option>`. The current reference fixture keeps the important
+hot-path property, child-cell vote writes, without introducing string IDs.
 
 The diagnostic harness was extended with:
 
@@ -531,12 +539,12 @@ Results from `/private/tmp/lunch-main-3x10.json` and
 | Shape                 | Elapsed | Final Users | Final Votes | Conflicts | Reverts | Vote round 3 max nodes | Vote round 3 max edges | Vote round 3 max workset | Vote round 3 trace |
 | --------------------- | ------: | ----------: | ----------: | --------: | ------: | ---------------------: | ---------------------: | -----------------------: | -----------------: |
 | Current arrays        |   35.9s |       10/10 |       18/30 |      1797 |    1797 |                    466 |                   1350 |                       24 |               1645 |
-| Reference child cells |    7.5s |       10/10 |       30/30 |       281 |     281 |                     77 |                    145 |                        5 |                152 |
+| Reference child cells |    8.0s |       10/10 |       30/30 |       350 |     350 |                     80 |                    186 |                        4 |                152 |
 
 Result: the idiomatic reference shape is not speculative. With the same runtime
 patch and deterministic setup, it preserves all expected votes, cuts end-to-end
-diagnostic time by about 4.8x, cuts conflicts/reverts by about 6.4x, and reduces
-the final vote-round scheduler workset by about 4.8x.
+diagnostic time by about 4.5x, cuts conflicts/reverts by about 5.1x, and reduces
+the final vote-round scheduler workset by about 6.0x.
 
 This does not mean the runtime work is unnecessary. The reference fixture still
 records conflict/revert churn, and the runtime change is still what lets

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -31,9 +31,10 @@
  * there's no MAX_HISTORY cap and "Recently eaten" is a `db.query` (the read
  * bounds itself with LIMIT). Each `logVisit` also snapshots everyone's current
  * vote into a `vote_history` table tied to that visit; the "📊 Lunch stats"
- * card surfaces per-place visit + green/red tallies from it. Live voting stays
- * on the in-cell `votes` array — only the durable record is in SQLite. Both
- * tables carry a frozen TEXT name plus a `cfLink<User>` live profile pointer.
+ * card surfaces per-place visit + green/red tallies from it. Live voting is
+ * stored under each participant row and projected back to the public `votes`
+ * output; only the durable visit record is in SQLite. Both tables carry a
+ * frozen TEXT name plus a `cfLink<User>` live profile pointer.
  *
  * KNOWN ISSUE (open): correct + green in the emulated `cf test` runner, but on a
  * *deployed* piece `db.exec` throws "invalid database handle" (a sqlite-builtin
@@ -71,6 +72,7 @@ export interface User {
   avatar?: string;
   color: string;
   joinedAt: number;
+  votes?: UserVote[] | Default<[]>;
 }
 
 export interface Option {
@@ -89,6 +91,11 @@ export interface Option {
 const WEB_SEARCH_URL = "/api/agent-tools/web-search";
 
 export type VoteColor = "green" | "yellow" | "red";
+
+export interface UserVote {
+  optionId: string;
+  voteType: VoteColor;
+}
 
 export interface Vote {
   voterName: string;
@@ -199,6 +206,7 @@ type OptionsCell = Writable<Option[] | Default<[]>>;
 type VotesCell = Writable<Vote[] | Default<[]>>;
 type UsersCell = Writable<User[] | Default<[]>>;
 type NameCell = Writable<string | Default<"">>;
+type UserIndexCell = Writable<number | Default<-1>>;
 type HomePageRefreshCell = Writable<number>;
 // A monotonic write counter bumped by the sqlite-mutating handlers; the
 // db.query calls react on THIS rather than on `db`. In the test runner,
@@ -476,10 +484,10 @@ const setOptionImage = handler<SetOptionImageEvent, {
 
 const removeOption = handler<RemoveOptionEvent, {
   options: OptionsCell;
-  votes: VotesCell;
+  users: UsersCell;
   myName: NameCell;
   adminName: NameCell;
-}>(({ optionId }, { options, votes, myName, adminName }) => {
+}>(({ optionId }, { options, users, myName, adminName }) => {
   const me = trimmedName(myName.get());
   const admin = trimmedName(adminName.get());
   if (!me || me !== admin) return;
@@ -487,40 +495,61 @@ const removeOption = handler<RemoveOptionEvent, {
   const target = current.find((o) => o.id === optionId);
   if (!target) return;
   options.remove(target);
-  votes.set(votes.get().filter((v) => v.optionId !== optionId));
+  users.get().forEach((_user, userIndex) => {
+    const userVotes = users.key(userIndex).key("votes");
+    const rawVotes = userVotes.get();
+    const currentVotes: readonly UserVote[] = Array.isArray(rawVotes)
+      ? rawVotes as readonly UserVote[]
+      : [];
+    if (currentVotes.length === 0) return;
+    userVotes.set(currentVotes.filter((v) => v.optionId !== optionId));
+  });
 });
 
 const castVote = handler<CastVoteEvent, {
-  votes: VotesCell;
-  myName: NameCell;
-}>(({ optionId, voteType }, { votes, myName }) => {
-  const me = trimmedName(myName.get());
-  if (!me) return;
-  const current = votes.get();
+  users: UsersCell;
+  myUserIndex: UserIndexCell;
+}>(({ optionId, voteType }, { users, myUserIndex }) => {
+  const userIndex = myUserIndex.get();
+  if (!Number.isInteger(userIndex) || userIndex < 0) return;
+  const user = users.key(userIndex);
+  if (!user.get()) return;
+
+  const userVotes = user.key("votes");
+  const rawVotes = userVotes.get();
+  const current: readonly UserVote[] = Array.isArray(rawVotes)
+    ? rawVotes as readonly UserVote[]
+    : [];
+  if (!Array.isArray(rawVotes)) {
+    userVotes.set([]);
+  }
+
   const existingIdx = current.findIndex(
-    (v) => v.voterName === me && v.optionId === optionId,
+    (v) => v.optionId === optionId,
   );
   if (existingIdx >= 0) {
     const existing = current[existingIdx];
     if (existing.voteType === voteType) {
-      votes.remove(existing);
+      userVotes.remove(existing);
       return;
     }
-    votes.key(existingIdx).key("voteType").set(voteType);
+    userVotes.key(existingIdx).key("voteType").set(voteType);
     return;
   }
-  votes.push({ voterName: me, optionId, voteType });
+  userVotes.push({ optionId, voteType });
 });
 
 const resetVotes = handler<ResetVotesEvent, {
-  votes: VotesCell;
+  users: UsersCell;
   myName: NameCell;
   adminName: NameCell;
-}>((_, { votes, myName, adminName }) => {
+}>((_, { users, myName, adminName }) => {
   const me = trimmedName(myName.get());
   const admin = trimmedName(adminName.get());
   if (!me || me !== admin) return;
-  votes.set([]);
+  users.get().forEach((_user, userIndex) => {
+    users.key(userIndex).key("votes").set([]);
+  });
 });
 
 export interface ClearVoteEvent {
@@ -528,17 +557,31 @@ export interface ClearVoteEvent {
 }
 
 const clearMyVote = handler<ClearVoteEvent, {
-  votes: VotesCell;
-  myName: NameCell;
-}>(({ optionId }, { votes, myName }) => {
-  const me = trimmedName(myName.get());
-  if (!me) return;
-  votes.set(
-    votes.get().filter(
-      (v) => !(v.voterName === me && v.optionId === optionId),
-    ),
-  );
+  users: UsersCell;
+  myUserIndex: UserIndexCell;
+}>(({ optionId }, { users, myUserIndex }) => {
+  const userIndex = myUserIndex.get();
+  if (!Number.isInteger(userIndex) || userIndex < 0) return;
+  const user = users.key(userIndex);
+  if (!user.get()) return;
+
+  const userVotes = user.key("votes");
+  const rawVotes = userVotes.get();
+  const currentVotes: readonly UserVote[] = Array.isArray(rawVotes)
+    ? rawVotes as readonly UserVote[]
+    : [];
+  if (currentVotes.length === 0) return;
+  userVotes.set(currentVotes.filter((v) => v.optionId !== optionId));
 });
+
+const votesForUsers = (users: readonly User[]): Vote[] =>
+  users.flatMap((user) =>
+    (user.votes ?? []).map((vote) => ({
+      voterName: user.name,
+      optionId: vote.optionId,
+      voteType: vote.voteType,
+    }))
+  );
 
 // Host-only, same gate as the other mutating admin actions. Logs where the
 // group actually ate — by option id (resolved to its title) or a free title —
@@ -550,7 +593,6 @@ const clearMyVote = handler<ClearVoteEvent, {
 const logVisit = handler<LogVisitEvent, {
   db: SqliteDb;
   options: OptionsCell;
-  votes: VotesCell;
   users: UsersCell;
   myName: NameCell;
   adminName: NameCell;
@@ -559,7 +601,7 @@ const logVisit = handler<LogVisitEvent, {
 }>(
   (
     { optionId, title, wentAt },
-    { db, options, votes, users, myName, adminName, visitDate, rev },
+    { db, options, users, myName, adminName, visitDate, rev },
   ) => {
     const me = trimmedName(myName.get());
     const admin = trimmedName(adminName.get());
@@ -595,7 +637,7 @@ const logVisit = handler<LogVisitEvent, {
     // Snapshot the current live votes tied to this visit. Denormalize the
     // option title (options can be removed later; the title is the record).
     const titleById = new Map(options.get().map((o) => [o.id, o.title]));
-    for (const v of votes.get()) {
+    for (const v of votesForUsers(users.get())) {
       const optTitle = trimmedName(titleById.get(v.optionId));
       if (!optTitle) continue; // vote for an already-removed option → skip
       db.exec(
@@ -692,6 +734,7 @@ export interface CozyPollInput {
   users?: PerSpace<User[] | Default<[]>>;
   adminName?: PerSpace<string | Default<"">>;
   myName?: PerUser<string | Default<"">>;
+  myUserIndex?: PerUser<number | Default<-1>>;
   webSearchUrl?: PerSpace<string | Default<typeof WEB_SEARCH_URL>>;
   // Write counter bumped by the sqlite-mutating handlers; the db.query calls
   // react on this rather than on `db` directly (see RevCell for why).
@@ -748,7 +791,6 @@ export interface CozyPollOutput {
 // Stable empty fallbacks for the output snapshots below — fresh `[]` per
 // recompute would make the computed results non-idempotent.
 const EMPTY_OPTIONS: Option[] = [];
-const EMPTY_VOTES: Vote[] = [];
 const EMPTY_USERS: User[] = [];
 
 interface OptionSummaryRowInput {
@@ -838,10 +880,10 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       question,
       city,
       options,
-      votes,
       users,
       adminName,
       myName,
+      myUserIndex,
       webSearchUrl,
       sqliteRev,
     },
@@ -905,6 +947,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     const participantIdentity = ParticipantIdentityCard({
       users,
       myName,
+      myUserIndex,
       adminName,
     });
     const boundAddOption = addOption({
@@ -915,17 +958,16 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     });
     const boundRemoveOption = removeOption({
       options,
-      votes,
+      users,
       myName,
       adminName,
     });
-    const boundCastVote = castVote({ votes, myName });
-    const boundClearMyVote = clearMyVote({ votes, myName });
-    const boundResetVotes = resetVotes({ votes, myName, adminName });
+    const boundCastVote = castVote({ users, myUserIndex });
+    const boundClearMyVote = clearMyVote({ users, myUserIndex });
+    const boundResetVotes = resetVotes({ users, myName, adminName });
     const boundLogVisit = logVisit({
       db,
       options,
-      votes,
       users,
       myName,
       adminName,
@@ -968,7 +1010,8 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     });
     const userCount = users.length;
     const optionCount = options.length;
-    const voteCount = votes.length;
+    const liveVotes = computed(() => votesForUsers(users));
+    const voteCount = liveVotes.length;
     // The "Recently eaten" card, now a SQLite query. It re-runs when the
     // sqliteRev counter changes — the mutating handlers bump it after each
     // db.exec (we react on the counter, not `db`; see RevCell). The read bounds
@@ -1051,7 +1094,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     const isClearHistoryConfirm = computed(() =>
       clearHistoryConfirmPending.get()
     );
-    const ranked = tallyOptions(options, votes, users);
+    const ranked = tallyOptions(options, liveVotes, users);
     const homePageLookupUrls = options.map((option) =>
       homePageLookupUrlFor(
         isAdmin,
@@ -1372,7 +1415,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                       me={me}
                       isJoined={isJoined}
                       isAdmin={isAdmin}
-                      votes={votes}
+                      votes={liveVotes}
                       cityLabel={cityLabel}
                       searchEndpoint={searchEndpoint}
                       homePageRefresh={homePageRefresh}
@@ -1748,7 +1791,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       // history is no longer a PerSpace input — it lives in SQLite now and is
       // surfaced via `recentVisits`/`mostRecentTitle` below.
       options: computed(() => options ?? EMPTY_OPTIONS),
-      votes: computed(() => votes ?? EMPTY_VOTES),
+      votes: liveVotes,
       users: computed(() => users ?? EMPTY_USERS),
       adminName: computed(() => trimmedName(adminName)),
       myName: participantIdentity.me,

--- a/packages/patterns/lunch-poll/participant-identity-card.test.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.test.tsx
@@ -5,10 +5,12 @@ import type { User } from "./main.tsx";
 export default pattern(() => {
   const users = new Writable<User[] | Default<[]>>([]);
   const myName = new Writable<string | Default<"">>("");
+  const myUserIndex = new Writable<number | Default<-1>>(-1);
   const adminName = new Writable<string | Default<"">>("");
   const participantIdentity = ParticipantIdentityCard({
     users,
     myName,
+    myUserIndex,
     adminName,
   });
 
@@ -26,8 +28,10 @@ export default pattern(() => {
       avatar: "",
       color: "#c2573a",
       joinedAt: 1,
+      votes: [],
     });
     myName.set("Blair");
+    myUserIndex.set(1);
   });
 
   const action_claim_host_as_blair = action(() => {
@@ -46,6 +50,7 @@ export default pattern(() => {
     return currentUsers.length === 1 &&
       currentUsers[0]?.name === "Alex" &&
       myName.get() === "Alex" &&
+      myUserIndex.get() === 0 &&
       adminName.get() === "Alex" &&
       participantIdentity.me === "Alex" &&
       participantIdentity.isJoined === true &&

--- a/packages/patterns/lunch-poll/participant-identity-card.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.tsx
@@ -19,6 +19,9 @@ export type ParticipantIdentityUsersCell = Writable<User[] | Default<[]>>;
 /** Parent-owned viewer/admin name cell. */
 export type ParticipantIdentityNameCell = Writable<string | Default<"">>;
 
+/** Parent-owned per-user pointer into the append-only participant roster. */
+export type ParticipantIdentityUserIndexCell = Writable<number | Default<-1>>;
+
 const PLAYER_COLORS = [
   "#2f8a64",
   "#c2573a",
@@ -34,6 +37,7 @@ const colorForIndex = (i: number) => PLAYER_COLORS[i % PLAYER_COLORS.length];
 const joinAs = handler<JoinEvent, {
   users: ParticipantIdentityUsersCell;
   myName: ParticipantIdentityNameCell;
+  myUserIndex: ParticipantIdentityUserIndexCell;
   adminName: ParticipantIdentityNameCell;
   joinName: ParticipantIdentityNameCell;
   profileName: string;
@@ -41,7 +45,15 @@ const joinAs = handler<JoinEvent, {
 }>(
   (
     { name },
-    { users, myName, adminName, joinName, profileName, profileAvatar },
+    {
+      users,
+      myName,
+      myUserIndex,
+      adminName,
+      joinName,
+      profileName,
+      profileAvatar,
+    },
   ) => {
     const override = trimmedName(name) || trimmedName(joinName.get());
     const trimmed = override || trimmedName(profileName);
@@ -50,14 +62,17 @@ const joinAs = handler<JoinEvent, {
     if (current) return;
     const existing = users.get();
     if (existing.some((u) => u.name === trimmed)) return;
+    const userIndex = existing.length;
     const user: User = {
       name: trimmed,
       avatar: override ? "" : (profileAvatar ?? "").trim(),
-      color: colorForIndex(existing.length),
+      color: colorForIndex(userIndex),
       joinedAt: safeDateNow(),
+      votes: [],
     };
     users.push(user);
     myName.set(trimmed);
+    myUserIndex.set(userIndex);
     if (trimmedName(adminName.get()) === "") {
       adminName.set(trimmed);
     }
@@ -99,6 +114,9 @@ export interface ParticipantIdentityCardInput {
   /** Per-user current viewer name cell. */
   myName: ParticipantIdentityNameCell;
 
+  /** Per-user append-only index of the current viewer's participant row. */
+  myUserIndex: ParticipantIdentityUserIndexCell;
+
   /** Shared admin name cell. */
   adminName: ParticipantIdentityNameCell;
 }
@@ -137,7 +155,7 @@ export default pattern<
   ParticipantIdentityCardInput,
   ParticipantIdentityCardOutput
 >(
-  ({ users, myName, adminName }) => {
+  ({ users, myName, myUserIndex, adminName }) => {
     const joinName = Writable.perSession.of<string>("");
     const profileNameWish = wish<string>({ query: "#profileName" });
     const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
@@ -147,6 +165,7 @@ export default pattern<
     const boundJoin = joinAs({
       users,
       myName,
+      myUserIndex,
       adminName,
       joinName,
       profileName,

--- a/packages/patterns/lunch-poll/reference-shape-experiment.tsx
+++ b/packages/patterns/lunch-poll/reference-shape-experiment.tsx
@@ -1,0 +1,369 @@
+/**
+ * Idiomatic lunch-poll performance fixture.
+ *
+ * This is the reference-addressed version of the contention experiment. It
+ * deliberately avoids app-level string IDs: option identity is the option cell
+ * itself, participant identity is the participant cell itself, and all matching
+ * uses `equals()`.
+ *
+ * Setup still appends participants and options to shared arrays, so the
+ * diagnostic driver runs joins and option creation serially. The measured hot
+ * path is concurrent voting: each user's PerUser state holds a live reference
+ * to their participant element in the shared PerSpace participants array, and
+ * the vote handler writes under that participant child cell.
+ */
+import {
+  type Cell,
+  computed,
+  Default,
+  equals,
+  handler,
+  NAME,
+  pattern,
+  type PerSpace,
+  type PerUser,
+  safeDateNow,
+  Stream,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+export interface Option {
+  title: string;
+  addedByName: string;
+}
+
+export type VoteColor = "green" | "yellow" | "red";
+export type OptionCell = Cell<Option>;
+
+export interface Vote {
+  option: OptionCell;
+  voteType: VoteColor;
+}
+
+export interface Participant {
+  name: string;
+  color: string;
+  joinedAt: number;
+  votes: Vote[] | Default<[]>;
+}
+
+export type ParticipantCell = Writable<Participant>;
+
+export interface ViewerState {
+  participant?: Participant;
+}
+
+export interface JoinEvent {
+  name?: string;
+}
+
+export interface AddOptionEvent {
+  title?: string;
+}
+
+export interface CastVoteEvent {
+  option: OptionCell;
+  voteType: VoteColor;
+}
+
+export type ClearMyVotesEvent = Record<PropertyKey, never>;
+
+type OptionsCell = Writable<Option[] | Default<[]>>;
+type ParticipantsCell = Writable<Participant[] | Default<[]>>;
+type EmptyViewer = Record<PropertyKey, never>;
+type ViewerCell = Writable<ViewerState>;
+type DraftCell = Writable<string | Default<"">>;
+
+interface ParticipantSummary {
+  name: string;
+  color: string;
+  joinedAt: number;
+  voteCount: number;
+}
+
+interface VoteSummary {
+  voterName: string;
+  optionTitle: string;
+  voteType: VoteColor;
+}
+
+const PLAYER_COLORS = [
+  "#2f8a64",
+  "#c2573a",
+  "#3b4a6b",
+  "#a33b35",
+  "#b27722",
+  "#7c3aed",
+];
+
+const VOTE_SWATCH: Record<VoteColor, string> = {
+  green: "#2f8a64",
+  yellow: "#d4a82f",
+  red: "#a33b35",
+};
+
+const trimmed = (value: string | undefined): string => (value ?? "").trim();
+const colorForIndex = (index: number): string =>
+  PLAYER_COLORS[index % PLAYER_COLORS.length];
+
+const optionTitle = (option: OptionCell | undefined): string =>
+  option ? trimmed(option.get()?.title) : "";
+
+const joinAs = handler<JoinEvent, {
+  participants: ParticipantsCell;
+  viewer: ViewerCell;
+  joinDraft: DraftCell;
+}>(({ name }, { participants, viewer, joinDraft }) => {
+  if (viewer.get()?.participant) return;
+  const nextName = trimmed(name) || trimmed(joinDraft.get());
+  if (!nextName) return;
+
+  const current = participants.get();
+  participants.push({
+    name: nextName,
+    color: colorForIndex(current.length),
+    joinedAt: safeDateNow(),
+    votes: [],
+  });
+  viewer.set({ participant: participants.key(current.length) });
+  joinDraft.set("");
+});
+
+const addOption = handler<AddOptionEvent, {
+  options: OptionsCell;
+  optionDraft: DraftCell;
+}>(({ title }, { options, optionDraft }) => {
+  const nextTitle = trimmed(title) || trimmed(optionDraft.get());
+  if (!nextTitle) return;
+  options.push({
+    title: nextTitle,
+    addedByName: "",
+  });
+  optionDraft.set("");
+});
+
+const castVote = handler<CastVoteEvent, { viewer: ViewerCell }>(
+  ({ option, voteType }, { viewer }) => {
+    const participant = viewer.key("participant");
+    if (!participant.get() || !option) return;
+
+    const votes = participant.key("votes");
+    const rawVotes = votes.get();
+    let current: readonly Vote[] = Array.isArray(rawVotes)
+      ? rawVotes as readonly Vote[]
+      : [];
+    if (!Array.isArray(rawVotes)) {
+      votes.set([]);
+    }
+
+    const existingIndex = current.findIndex((vote: Vote) =>
+      equals(vote.option, option)
+    );
+    if (existingIndex >= 0) {
+      const existing = current[existingIndex];
+      if (existing.voteType === voteType) {
+        votes.set(current.toSpliced(existingIndex, 1));
+        return;
+      }
+      votes.key(existingIndex).key("voteType").set(voteType);
+      return;
+    }
+    votes.push({ option, voteType });
+  },
+);
+
+const clearMyVotes = handler<ClearMyVotesEvent, { viewer: ViewerCell }>(
+  (_event, { viewer }) => {
+    const participant = viewer.key("participant");
+    if (!participant.get()) return;
+    participant.key("votes").set([]);
+  },
+);
+
+const participantSummariesFor = (
+  participants: readonly Participant[],
+): ParticipantSummary[] =>
+  participants.map((participant) => ({
+    name: participant.name,
+    color: participant.color,
+    joinedAt: participant.joinedAt,
+    voteCount: participant.votes?.length ?? 0,
+  }));
+
+const voteSummariesFor = (
+  participants: readonly Participant[],
+): VoteSummary[] => {
+  const rows: VoteSummary[] = [];
+  for (const participant of participants) {
+    for (const vote of participant.votes ?? []) {
+      const title = optionTitle(vote.option);
+      if (!title) continue;
+      rows.push({
+        voterName: participant.name,
+        optionTitle: title,
+        voteType: vote.voteType,
+      });
+    }
+  }
+  return rows;
+};
+
+export interface ReferencePollInput {
+  options?: PerSpace<Option[] | Default<[]>>;
+  participants?: PerSpace<Participant[] | Default<[]>>;
+  viewer?: PerUser<ViewerState | Default<EmptyViewer>>;
+}
+
+export interface ReferencePollOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  options: readonly Option[];
+  users: readonly ParticipantSummary[];
+  votes: readonly VoteSummary[];
+  history: readonly never[];
+  adminName: string;
+  myName: string;
+  userCount: number;
+  optionCount: number;
+  voteCount: number;
+  historyCount: number;
+  isJoined: boolean;
+  isAdmin: boolean;
+  homePageLookupUrls: readonly string[];
+  joinAs: Stream<JoinEvent>;
+  addOption: Stream<AddOptionEvent>;
+  castVote: Stream<CastVoteEvent>;
+  clearMyVotes: Stream<ClearMyVotesEvent>;
+}
+
+export default pattern<ReferencePollInput, ReferencePollOutput>(
+  ({ options, participants, viewer }) => {
+    const joinDraft = Writable.perSession.of<string>("");
+    const optionDraft = Writable.perSession.of<string>("");
+    const boundJoinAs = joinAs({ participants, viewer, joinDraft });
+    const boundAddOption = addOption({ options, optionDraft });
+    const boundCastVote = castVote({ viewer });
+    const boundClearMyVotes = clearMyVotes({ viewer });
+
+    const userRows = computed(() => participantSummariesFor(participants));
+    const voteRows = computed(() => voteSummariesFor(participants));
+    const myName = computed(() => trimmed(viewer?.participant?.name));
+    const isJoined = computed(() => viewer?.participant !== undefined);
+
+    return {
+      [NAME]: "Reference lunch poll perf fixture",
+      [UI]: (
+        <cf-theme
+          theme={{
+            colorScheme: "light",
+            borderRadius: "8px",
+            colors: {
+              primary: "#2f6f4e",
+              primaryForeground: "#ffffff",
+              background: "#f1f5ef",
+              surface: "#ffffff",
+              text: "#1d2a1f",
+              textMuted: "#5d6f63",
+              border: "#cbd9cf",
+            },
+          }}
+        >
+          <cf-screen>
+            <div slot="header" style="padding:16px 20px;background:white">
+              <h2 style="margin:0;font-size:20px">Reference lunch poll</h2>
+              <div style="font-size:13px;color:#5d6f63;margin-top:4px">
+                {userRows.length} joined | {options.length} options |{" "}
+                {voteRows.length} votes
+              </div>
+            </div>
+            <div style="padding:16px;display:flex;flex-direction:column;gap:16px">
+              <div style="display:flex;align-items:center;gap:8px">
+                <strong>{myName}</strong>
+                <cf-button
+                  size="sm"
+                  variant="secondary"
+                  onClick={boundClearMyVotes}
+                >
+                  Clear my votes
+                </cf-button>
+              </div>
+
+              <div style="display:flex;gap:8px">
+                <cf-input
+                  $value={joinDraft}
+                  placeholder="Your name"
+                  timing-strategy="immediate"
+                  style="flex:1"
+                />
+                <cf-button onClick={boundJoinAs}>Join</cf-button>
+              </div>
+
+              <div style="display:flex;gap:8px">
+                <cf-input
+                  $value={optionDraft}
+                  placeholder="Restaurant"
+                  timing-strategy="immediate"
+                  style="flex:1"
+                />
+                <cf-button onClick={boundAddOption}>Add</cf-button>
+              </div>
+
+              <div style="display:flex;flex-direction:column;gap:10px">
+                {options.map((option) => (
+                  <div
+                    style={{
+                      background: "white",
+                      border: "1px solid #cbd9cf",
+                      borderRadius: "8px",
+                      padding: "12px",
+                    }}
+                  >
+                    <div style="font-weight:700;margin-bottom:8px">
+                      {option.title}
+                    </div>
+                    <div style="display:flex;gap:8px;flex-wrap:wrap">
+                      {(["green", "yellow", "red"] as const).map((
+                        voteType,
+                      ) => (
+                        <cf-button
+                          size="sm"
+                          style={{
+                            background: VOTE_SWATCH[voteType],
+                            color: "white",
+                          }}
+                          onClick={() =>
+                            boundCastVote.send({ option, voteType })}
+                        >
+                          {voteType}
+                        </cf-button>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </cf-screen>
+        </cf-theme>
+      ),
+      options,
+      users: userRows,
+      votes: voteRows,
+      history: [],
+      adminName: userRows[0]?.name ?? "",
+      myName,
+      userCount: userRows.length,
+      optionCount: options.length,
+      voteCount: voteRows.length,
+      historyCount: 0,
+      isJoined,
+      isAdmin: isJoined,
+      homePageLookupUrls: [],
+      joinAs: boundJoinAs,
+      addOption: boundAddOption,
+      castVote: boundCastVote,
+      clearMyVotes: boundClearMyVotes,
+    };
+  },
+);

--- a/packages/patterns/lunch-poll/reference-shape-experiment.tsx
+++ b/packages/patterns/lunch-poll/reference-shape-experiment.tsx
@@ -3,14 +3,14 @@
  *
  * This is the reference-addressed version of the contention experiment. It
  * deliberately avoids app-level string IDs: option identity is the option cell
- * itself, participant identity is the participant cell itself, and all matching
- * uses `equals()`.
+ * itself, participant rows are addressed through the append-only roster, and
+ * vote matching uses `equals()`.
  *
  * Setup still appends participants and options to shared arrays, so the
  * diagnostic driver runs joins and option creation serially. The measured hot
- * path is concurrent voting: each user's PerUser state holds a live reference
- * to their participant element in the shared PerSpace participants array, and
- * the vote handler writes under that participant child cell.
+ * path is concurrent voting: each user's PerUser state stores their append-only
+ * participant index, and the vote handler writes under that participant child
+ * cell rather than a shared global votes array.
  */
 import {
   type Cell,
@@ -52,7 +52,7 @@ export interface Participant {
 export type ParticipantCell = Writable<Participant>;
 
 export interface ViewerState {
-  participant?: Participant;
+  participantIndex?: number;
 }
 
 export interface JoinEvent {
@@ -116,18 +116,19 @@ const joinAs = handler<JoinEvent, {
   viewer: ViewerCell;
   joinDraft: DraftCell;
 }>(({ name }, { participants, viewer, joinDraft }) => {
-  if (viewer.get()?.participant) return;
+  if (typeof viewer.get()?.participantIndex === "number") return;
   const nextName = trimmed(name) || trimmed(joinDraft.get());
   if (!nextName) return;
 
   const current = participants.get();
+  const participantIndex = current.length;
   participants.push({
     name: nextName,
-    color: colorForIndex(current.length),
+    color: colorForIndex(participantIndex),
     joinedAt: safeDateNow(),
     votes: [],
   });
-  viewer.set({ participant: participants.key(current.length) });
+  viewer.set({ participantIndex });
   joinDraft.set("");
 });
 
@@ -144,14 +145,19 @@ const addOption = handler<AddOptionEvent, {
   optionDraft.set("");
 });
 
-const castVote = handler<CastVoteEvent, { viewer: ViewerCell }>(
-  ({ option, voteType }, { viewer }) => {
-    const participant = viewer.key("participant");
-    if (!participant.get() || !option) return;
+const castVote = handler<CastVoteEvent, {
+  participants: ParticipantsCell;
+  viewer: ViewerCell;
+}>(
+  ({ option, voteType }, { participants, viewer }) => {
+    const participantIndex = viewer.get()?.participantIndex;
+    if (typeof participantIndex !== "number" || !option) return;
+    const participant = participants.key(participantIndex);
+    if (!participant.get()) return;
 
     const votes = participant.key("votes");
     const rawVotes = votes.get();
-    let current: readonly Vote[] = Array.isArray(rawVotes)
+    const current: readonly Vote[] = Array.isArray(rawVotes)
       ? rawVotes as readonly Vote[]
       : [];
     if (!Array.isArray(rawVotes)) {
@@ -174,9 +180,51 @@ const castVote = handler<CastVoteEvent, { viewer: ViewerCell }>(
   },
 );
 
-const clearMyVotes = handler<ClearMyVotesEvent, { viewer: ViewerCell }>(
-  (_event, { viewer }) => {
-    const participant = viewer.key("participant");
+const castOptionVote = handler<ClearMyVotesEvent, {
+  participants: ParticipantsCell;
+  viewer: ViewerCell;
+  option: OptionCell;
+  voteType: VoteColor;
+}>(
+  (_event, { participants, viewer, option, voteType }) => {
+    const participantIndex = viewer.get()?.participantIndex;
+    if (typeof participantIndex !== "number" || !option) return;
+    const participant = participants.key(participantIndex);
+    if (!participant.get()) return;
+
+    const votes = participant.key("votes");
+    const rawVotes = votes.get();
+    const current: readonly Vote[] = Array.isArray(rawVotes)
+      ? rawVotes as readonly Vote[]
+      : [];
+    if (!Array.isArray(rawVotes)) {
+      votes.set([]);
+    }
+
+    const existingIndex = current.findIndex((vote: Vote) =>
+      equals(vote.option, option)
+    );
+    if (existingIndex >= 0) {
+      const existing = current[existingIndex];
+      if (existing.voteType === voteType) {
+        votes.set(current.toSpliced(existingIndex, 1));
+        return;
+      }
+      votes.key(existingIndex).key("voteType").set(voteType);
+      return;
+    }
+    votes.push({ option, voteType });
+  },
+);
+
+const clearMyVotes = handler<ClearMyVotesEvent, {
+  participants: ParticipantsCell;
+  viewer: ViewerCell;
+}>(
+  (_event, { participants, viewer }) => {
+    const participantIndex = viewer.get()?.participantIndex;
+    if (typeof participantIndex !== "number") return;
+    const participant = participants.key(participantIndex);
     if (!participant.get()) return;
     participant.key("votes").set([]);
   },
@@ -244,13 +292,20 @@ export default pattern<ReferencePollInput, ReferencePollOutput>(
     const optionDraft = Writable.perSession.of<string>("");
     const boundJoinAs = joinAs({ participants, viewer, joinDraft });
     const boundAddOption = addOption({ options, optionDraft });
-    const boundCastVote = castVote({ viewer });
-    const boundClearMyVotes = clearMyVotes({ viewer });
+    const boundCastVote = castVote({ participants, viewer });
+    const boundClearMyVotes = clearMyVotes({ participants, viewer });
 
     const userRows = computed(() => participantSummariesFor(participants));
     const voteRows = computed(() => voteSummariesFor(participants));
-    const myName = computed(() => trimmed(viewer?.participant?.name));
-    const isJoined = computed(() => viewer?.participant !== undefined);
+    const myName = computed(() => {
+      const participantIndex = viewer?.participantIndex;
+      return typeof participantIndex === "number"
+        ? trimmed(participants[participantIndex]?.name)
+        : "";
+    });
+    const isJoined = computed(() =>
+      typeof viewer?.participantIndex === "number"
+    );
 
     return {
       [NAME]: "Reference lunch poll perf fixture",
@@ -311,7 +366,7 @@ export default pattern<ReferencePollInput, ReferencePollOutput>(
               </div>
 
               <div style="display:flex;flex-direction:column;gap:10px">
-                {options.map((option) => (
+                {options.map((option, optionIndex) => (
                   <div
                     style={{
                       background: "white",
@@ -320,25 +375,59 @@ export default pattern<ReferencePollInput, ReferencePollOutput>(
                       padding: "12px",
                     }}
                   >
-                    <div style="font-weight:700;margin-bottom:8px">
-                      {option.title}
+                    <div style="font-weight:700">
+                      {optionIndex + 1}. {option.title}
                     </div>
-                    <div style="display:flex;gap:8px;flex-wrap:wrap">
-                      {(["green", "yellow", "red"] as const).map((
-                        voteType,
-                      ) => (
-                        <cf-button
-                          size="sm"
-                          style={{
-                            background: VOTE_SWATCH[voteType],
-                            color: "white",
-                          }}
-                          onClick={() =>
-                            boundCastVote.send({ option, voteType })}
-                        >
-                          {voteType}
-                        </cf-button>
-                      ))}
+                    <div
+                      style={{
+                        display: "flex",
+                        gap: "8px",
+                        flexWrap: "wrap",
+                        marginTop: "8px",
+                      }}
+                    >
+                      <cf-button
+                        size="sm"
+                        style={{
+                          background: VOTE_SWATCH.green,
+                          color: "white",
+                        }}
+                        onClick={castOptionVote({
+                          participants,
+                          viewer,
+                          option,
+                          voteType: "green",
+                        })}
+                      >
+                        green
+                      </cf-button>
+                      <cf-button
+                        size="sm"
+                        style={{
+                          background: VOTE_SWATCH.yellow,
+                          color: "white",
+                        }}
+                        onClick={castOptionVote({
+                          participants,
+                          viewer,
+                          option,
+                          voteType: "yellow",
+                        })}
+                      >
+                        yellow
+                      </cf-button>
+                      <cf-button
+                        size="sm"
+                        style={{ background: VOTE_SWATCH.red, color: "white" }}
+                        onClick={castOptionVote({
+                          participants,
+                          viewer,
+                          option,
+                          voteType: "red",
+                        })}
+                      >
+                        red
+                      </cf-button>
                     </div>
                   </div>
                 ))}

--- a/packages/patterns/tools/lunch-poll-diagnose.ts
+++ b/packages/patterns/tools/lunch-poll-diagnose.ts
@@ -10,6 +10,7 @@ interface PollOutputSummary {
   votes: readonly {
     voterName?: string;
     optionId?: string;
+    optionTitle?: string;
     voteType?: string;
   }[];
   history: readonly unknown[];
@@ -77,6 +78,8 @@ interface MatrixConfig {
   userCounts: readonly number[];
   voteRounds: number;
   includeHomepageRefresh: boolean;
+  eventMode: VoteEventMode;
+  joinMode: JoinMode;
 }
 
 interface CaseConfig {
@@ -84,6 +87,16 @@ interface CaseConfig {
   userCount: number;
   voteRounds: number;
   includeHomepageRefresh: boolean;
+  eventMode: VoteEventMode;
+  joinMode: JoinMode;
+}
+
+type VoteEventMode = "id" | "reference";
+type JoinMode = "concurrent" | "serial";
+
+interface VoteTarget {
+  optionId?: string;
+  option?: unknown;
 }
 
 interface CompactSessionSample {
@@ -156,6 +169,8 @@ interface CaseResult {
     options: number;
     voteRounds: number;
     includeHomepageRefresh: boolean;
+    eventMode: VoteEventMode;
+    joinMode: JoinMode;
   };
   churn: ChurnTotals;
   convergence: ConvergenceResult;
@@ -201,10 +216,10 @@ async function collectConvergence(
   sessions: readonly MultiRuntimeSession[],
 ): Promise<ConvergenceResult> {
   const states = await Promise.all(sessions.map(async (session) => {
-    const poll = pollSummary(await session.read());
+    const poll = await readPollSummary(session);
     const fingerprint = poll.votes
       .map((vote) =>
-        `${vote.voterName ?? "?"}|${vote.optionId ?? "?"}|${
+        `${vote.voterName ?? "?"}|${vote.optionId ?? vote.optionTitle ?? "?"}|${
           vote.voteType ?? "?"
         }`
       )
@@ -282,6 +297,59 @@ function pollSummary(value: unknown): PollOutputSummary {
     isAdmin: asBoolean(value.isAdmin),
     homePageLookupUrls: asStringArray(value.homePageLookupUrls),
   };
+}
+
+async function readPollSummary(
+  session: MultiRuntimeSession,
+): Promise<PollOutputSummary> {
+  const root = await session.read();
+  if (isRecord(root)) return pollSummary(root);
+
+  const [
+    users,
+    options,
+    votes,
+    history,
+    adminName,
+    myName,
+    userCount,
+    optionCount,
+    voteCount,
+    historyCount,
+    isJoined,
+    isAdmin,
+    homePageLookupUrls,
+  ] = await Promise.all([
+    session.read(["users"]),
+    session.read(["options"]),
+    session.read(["votes"]),
+    session.read(["history"]),
+    session.read(["adminName"]),
+    session.read(["myName"]),
+    session.read(["userCount"]),
+    session.read(["optionCount"]),
+    session.read(["voteCount"]),
+    session.read(["historyCount"]),
+    session.read(["isJoined"]),
+    session.read(["isAdmin"]),
+    session.read(["homePageLookupUrls"]),
+  ]);
+
+  return pollSummary({
+    users,
+    options,
+    votes,
+    history,
+    adminName,
+    myName,
+    userCount,
+    optionCount,
+    voteCount,
+    historyCount,
+    isJoined,
+    isAdmin,
+    homePageLookupUrls,
+  });
 }
 
 function pathKey(address: TraceAddressSummary): string {
@@ -556,7 +624,7 @@ async function samplePhase(
   await runActions();
   await harness.settle(3);
   const sessions = await Promise.all(harness.sessions.map(async (session) => {
-    const poll = pollSummary(await session.read());
+    const poll = await readPollSummary(session);
     const diagnostics = diagnosticsSummary(
       session.label,
       await session.diagnostics(),
@@ -578,11 +646,22 @@ async function samplePhase(
   return sample;
 }
 
-async function optionIds(session: MultiRuntimeSession): Promise<string[]> {
-  const poll = pollSummary(await session.read());
-  return poll.options.map((option) => option.id).filter((id): id is string =>
-    typeof id === "string" && id !== ""
-  );
+async function voteTargets(
+  session: MultiRuntimeSession,
+  eventMode: VoteEventMode,
+): Promise<VoteTarget[]> {
+  const poll = await readPollSummary(session);
+  if (eventMode === "reference") {
+    return await Promise.all(
+      poll.options.map((_option, index) =>
+        session.linkValue(["options", index]).then((option) => ({ option }))
+      ),
+    );
+  }
+  return poll.options
+    .map((option) => option.id)
+    .filter((id): id is string => typeof id === "string" && id !== "")
+    .map((optionId) => ({ optionId }));
 }
 
 async function createHarness(config: CaseConfig): Promise<MultiRuntimeHarness> {
@@ -620,11 +699,17 @@ async function runCase(config: CaseConfig): Promise<CaseResult> {
     phases.push(
       await samplePhase("all-users-join", harness, async () => {
         await host.send("joinAs", { name: "User 1" });
-        await Promise.all(
-          sessions.slice(1).map((session, index) =>
-            session.send("joinAs", { name: `User ${index + 2}` })
-          ),
-        );
+        if (config.joinMode === "serial") {
+          for (let index = 1; index < sessions.length; index++) {
+            await sessions[index].send("joinAs", { name: `User ${index + 1}` });
+          }
+        } else {
+          await Promise.all(
+            sessions.slice(1).map((session, index) =>
+              session.send("joinAs", { name: `User ${index + 2}` })
+            ),
+          );
+        }
       }),
     );
 
@@ -642,15 +727,18 @@ async function runCase(config: CaseConfig): Promise<CaseResult> {
           `concurrent-vote-round-${round + 1}`,
           harness,
           async () => {
-            const ids = await optionIds(host);
-            if (ids.length === 0) return;
+            const targets = await voteTargets(host, config.eventMode);
+            if (targets.length === 0) return;
             await Promise.all(
-              sessions.map((session, index) =>
-                session.send("castVote", {
-                  optionId: ids[(round + index) % ids.length],
-                  voteType: VOTE_COLORS[(round + index) % VOTE_COLORS.length],
-                })
-              ),
+              sessions.map((session, index) => {
+                const target = targets[(round + index) % targets.length];
+                return session.send("castVote", {
+                  ...target,
+                  voteType: VOTE_COLORS[
+                    (round + index) % VOTE_COLORS.length
+                  ],
+                });
+              }),
             );
           },
         ),
@@ -700,6 +788,8 @@ async function runCase(config: CaseConfig): Promise<CaseResult> {
         options: config.optionCount,
         voteRounds: config.voteRounds,
         includeHomepageRefresh: config.includeHomepageRefresh,
+        eventMode: config.eventMode,
+        joinMode: config.joinMode,
       },
       churn,
       convergence,
@@ -745,6 +835,18 @@ function stringArg(name: string, fallback: string): string {
   return arg ? arg.slice(prefix.length) : fallback;
 }
 
+function choiceArg<T extends string>(
+  name: string,
+  fallback: T,
+  choices: readonly T[],
+): T {
+  const value = stringArg(name, fallback);
+  if ((choices as readonly string[]).includes(value)) return value as T;
+  throw new Error(
+    `--${name} must be one of ${choices.join(",")}; got ${value}`,
+  );
+}
+
 function explicitCasesArg(
   config: MatrixConfig,
 ): CaseConfig[] | undefined {
@@ -762,6 +864,8 @@ function explicitCasesArg(
       userCount,
       voteRounds: config.voteRounds,
       includeHomepageRefresh: config.includeHomepageRefresh,
+      eventMode: config.eventMode,
+      joinMode: config.joinMode,
     }];
   });
   return cases.length > 0 ? cases : undefined;
@@ -784,6 +888,14 @@ function matrixConfigFromArgs(): MatrixConfig {
     userCounts: numberListArg("users", quick ? [2] : [2, 5], 1),
     voteRounds: numberArg("rounds", quick ? 1 : 3),
     includeHomepageRefresh: !Deno.args.includes("--skip-refresh"),
+    eventMode: choiceArg<VoteEventMode>("event-mode", "id", [
+      "id",
+      "reference",
+    ]),
+    joinMode: choiceArg<JoinMode>("join-mode", "concurrent", [
+      "concurrent",
+      "serial",
+    ]),
   };
 }
 
@@ -799,6 +911,8 @@ function casesFromConfig(config: MatrixConfig): CaseConfig[] {
         userCount,
         voteRounds: config.voteRounds,
         includeHomepageRefresh: config.includeHomepageRefresh,
+        eventMode: config.eventMode,
+        joinMode: config.joinMode,
       });
     }
   }
@@ -819,7 +933,8 @@ async function run(): Promise<void> {
   for (const caseConfig of cases) {
     console.error(
       `[lunch-poll diagnose] case ${caseConfig.optionCount} options x ` +
-        `${caseConfig.userCount} users, rounds=${caseConfig.voteRounds}`,
+        `${caseConfig.userCount} users, rounds=${caseConfig.voteRounds} ` +
+        `eventMode=${caseConfig.eventMode} joinMode=${caseConfig.joinMode}`,
     );
     try {
       results.push({ ok: true, result: await runCase(caseConfig) });

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -331,6 +331,10 @@ export class PieceManager {
         "get.runtime.start",
         () => this.runtime.start(piece),
       );
+      await timePiecePhase(
+        "get.result.pull",
+        () => this.getResult(piece).asSchema(undefined).pull(),
+      );
     } else {
       // Just sync the cell if not running
       await timePiecePhase("get.piece.sync", () => piece.sync());

--- a/packages/runner/src/builtins/if-else.ts
+++ b/packages/runner/src/builtins/if-else.ts
@@ -6,6 +6,13 @@ import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { resolveLink } from "../link-resolution.ts";
 import { resolvedCellScope, scopedCell } from "./scope-policy.ts";
 import { parseLink } from "../link-utils.ts";
+import type { CellScope } from "../builder/types.ts";
+
+const CONDITIONAL_RESULT_SCOPES: readonly CellScope[] = [
+  "space",
+  "user",
+  "session",
+];
 
 export function ifElse(
   inputsCell: Cell<[any, any, any]>,
@@ -15,6 +22,15 @@ export function ifElse(
   parentCell: Cell<any>,
   runtime: Runtime, // Runtime will be injected by the registration function
 ): RawBuiltinResult {
+  const baseResultLink = runtime.getCell<any>(
+    parentCell.space,
+    { ifElse: cause },
+  ).getAsNormalizedFullLink();
+  const materializerWriteEnvelopes = CONDITIONAL_RESULT_SCOPES.map((scope) => ({
+    ...baseResultLink,
+    scope,
+  }));
+
   const readCondition = (
     tx: IExtendedStorageTransaction,
   ): { cell: Cell<any>; value: unknown } => {
@@ -63,5 +79,6 @@ export function ifElse(
   return {
     action,
     populateDependencies,
+    materializerWriteEnvelopes,
   };
 }

--- a/packages/runner/src/builtins/unless.ts
+++ b/packages/runner/src/builtins/unless.ts
@@ -1,10 +1,18 @@
 import { type Cell } from "../cell.ts";
 import { type Action } from "../scheduler.ts";
+import { type RawBuiltinResult } from "../module.ts";
 import { type Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { resolveLink } from "../link-resolution.ts";
 import { resolvedCellScope, scopedCell } from "./scope-policy.ts";
 import { parseLink } from "../link-utils.ts";
+import type { CellScope } from "../builder/types.ts";
+
+const CONDITIONAL_RESULT_SCOPES: readonly CellScope[] = [
+  "space",
+  "user",
+  "session",
+];
 
 /**
  * unless(condition, fallback) - || semantics
@@ -17,8 +25,17 @@ export function unless(
   cause: Cell<any>[],
   parentCell: Cell<any>,
   runtime: Runtime,
-): Action {
-  return (tx: IExtendedStorageTransaction) => {
+): RawBuiltinResult {
+  const baseResultLink = runtime.getCell<any>(
+    parentCell.space,
+    { unless: cause },
+  ).getAsNormalizedFullLink();
+  const materializerWriteEnvelopes = CONDITIONAL_RESULT_SCOPES.map((scope) => ({
+    ...baseResultLink,
+    scope,
+  }));
+
+  const action: Action = (tx: IExtendedStorageTransaction) => {
     const conditionCell = inputsCell.key("condition");
     const resultScope = resolvedCellScope(runtime, tx, conditionCell);
     const baseResult = runtime.getCell<any>(
@@ -44,5 +61,10 @@ export function unless(
     });
 
     resultWithLog.setRawUntyped(serializedRef);
+  };
+
+  return {
+    action,
+    materializerWriteEnvelopes,
   };
 }

--- a/packages/runner/src/module.ts
+++ b/packages/runner/src/module.ts
@@ -25,6 +25,7 @@ export interface RawBuiltinResult {
   action: Action;
   isEffect?: boolean;
   populateDependencies?: PopulateDependencies | ReactivityLog;
+  materializerWriteEnvelopes?: readonly NormalizedFullLink[];
   debounce?: number;
   noDebounce?: boolean;
   throttle?: number;

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3748,17 +3748,27 @@ export class Runner {
             tx,
             result,
           );
+          const outputValue = resultForRawBuiltinOutputBinding(
+            result,
+            outputBindingSchema,
+            builtinIdentity,
+          );
+          const outputScope = isCell(result)
+            ? narrowestScope([
+              tx.getNarrowestReadScope(),
+              result.getAsNormalizedFullLink().scope,
+            ])
+            : tx.getNarrowestReadScope();
           sendValueToBinding(
             tx,
             resultCell,
             argumentCellLink!,
             mappedOutputBindings,
-            resultForRawBuiltinOutputBinding(
-              result,
-              outputBindingSchema,
-              builtinIdentity,
-            ),
-            { preserveLinkOutput: true },
+            outputValue,
+            {
+              preserveLinkOutput: true,
+              narrowestReadScope: outputScope,
+            },
           );
         },
         addCancel,
@@ -3808,6 +3818,9 @@ export class Runner {
     const builtinThrottle = isRawBuiltinResult(builtinResult)
       ? builtinResult.throttle
       : undefined;
+    const builtinMaterializerWriteEnvelopes = isRawBuiltinResult(builtinResult)
+      ? builtinResult.materializerWriteEnvelopes
+      : undefined;
 
     // Name the raw action for debugging - use implementation name or fallback to "raw"
     const impl = module.implementation as ((...args: unknown[]) => Action) & {
@@ -3852,7 +3865,11 @@ export class Runner {
 
     // Seed raw actions with their pattern/module/write metadata so pull-mode
     // scheduling can discover pending computations before their first run.
-    const staticRedirectWriteTargets = module.materializerWriteEnvelopes
+    const materializerWriteEnvelopes = module.materializerWriteEnvelopes ??
+      builtinMaterializerWriteEnvelopes;
+    const hasMaterializerWriteEnvelopes =
+      (materializerWriteEnvelopes?.length ?? 0) > 0;
+    const staticRedirectWriteTargets = hasMaterializerWriteEnvelopes
       ? []
       : this.collectStaticRedirectWriteTargets(tx, outputCells);
     const schedulingWrites = dedupeNormalizedLinks([
@@ -3862,9 +3879,7 @@ export class Runner {
     Object.assign(action, builtinAction, {
       reads: inputCells,
       writes: schedulingWrites,
-      ...(module.materializerWriteEnvelopes
-        ? { materializerWriteEnvelopes: module.materializerWriteEnvelopes }
-        : {}),
+      ...(hasMaterializerWriteEnvelopes ? { materializerWriteEnvelopes } : {}),
       module,
       pattern,
     });

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -2130,12 +2130,8 @@ class SpaceReplica implements ISpaceReplica {
       }
     }
     return {
-      confirmed: compactCommitReads(this.#space, confirmed).map((
-        { nonRecursive: _skip, ...read },
-      ) => read),
-      pending: compactCommitReads(this.#space, pending).map((
-        { nonRecursive: _skip, ...read },
-      ) => read),
+      confirmed: compactCommitReads(this.#space, confirmed),
+      pending: compactCommitReads(this.#space, pending),
     };
   }
 

--- a/packages/runner/test/memory-v2-read-compaction.test.ts
+++ b/packages/runner/test/memory-v2-read-compaction.test.ts
@@ -49,7 +49,11 @@ Deno.test("memory v2 compacts descendant confirmed reads under a recursive ances
 
   const replica = storage.open(space).replica as unknown as {
     buildReads(source: unknown, localSeq: number): {
-      confirmed: Array<{ path: string[]; seq: number }>;
+      confirmed: Array<{
+        path: string[];
+        seq: number;
+        nonRecursive?: boolean;
+      }>;
       pending: Array<{ path: string[]; localSeq: number }>;
     };
   };
@@ -92,7 +96,11 @@ Deno.test("memory v2 keeps descendant reads when the ancestor is non-recursive",
 
   const replica = storage.open(space).replica as unknown as {
     buildReads(source: unknown, localSeq: number): {
-      confirmed: Array<{ path: string[]; seq: number }>;
+      confirmed: Array<{
+        path: string[];
+        seq: number;
+        nonRecursive?: boolean;
+      }>;
       pending: Array<{ path: string[]; localSeq: number }>;
     };
   };
@@ -100,14 +108,19 @@ Deno.test("memory v2 keeps descendant reads when the ancestor is non-recursive",
 
   assertEquals(reads.pending, []);
   assertEquals(
-    reads.confirmed.map((read) => read.path).toSorted((left, right) =>
-      JSON.stringify(left).localeCompare(JSON.stringify(right))
-    ),
+    reads.confirmed
+      .map((read) => ({
+        path: read.path,
+        nonRecursive: read.nonRecursive === true,
+      }))
+      .toSorted((left, right) =>
+        JSON.stringify(left.path).localeCompare(JSON.stringify(right.path))
+      ),
     [
-      ["value"],
-      ["value", "section0", "field0"],
+      { path: ["value"], nonRecursive: true },
+      { path: ["value", "section0", "field0"], nonRecursive: false },
     ].toSorted((left, right) =>
-      JSON.stringify(left).localeCompare(JSON.stringify(right))
+      JSON.stringify(left.path).localeCompare(JSON.stringify(right.path))
     ),
   );
 

--- a/packages/runner/test/pattern-scope.test.ts
+++ b/packages/runner/test/pattern-scope.test.ts
@@ -2230,6 +2230,185 @@ Deno.test("ifElse output follows condition scope", async () => {
   }
 });
 
+Deno.test("child pattern UI materializes null-vs-VNode branch selected by user-scoped condition", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+
+  try {
+    const { h, ifElse, pattern, UI } = createTrustedBuilder(runtime)
+      .commonfabric;
+
+    const joinedBase = runtime.getCell<boolean>(
+      space,
+      "child pattern user scoped join condition",
+      undefined,
+      tx,
+    );
+    const isJoined = createCell<boolean>(
+      runtime,
+      { ...joinedBase.getAsNormalizedFullLink(), scope: "user" },
+      tx,
+    );
+    isJoined.set(false);
+
+    const Child = pattern<{ isJoined: boolean }>(({ isJoined }) => ({
+      [UI]: h(
+        "div",
+        { style: "display:contents" },
+        ifElse(
+          isJoined,
+          null,
+          h("span", { "data-testid": "join-widget" }, "Join the poll"),
+        ),
+      ),
+      isJoined,
+    }));
+
+    const Root = pattern<{ isJoined: boolean }>(({ isJoined }) => {
+      const child = Child({ isJoined });
+      return {
+        [UI]: h("section", null, child[UI]),
+      };
+    });
+
+    const resultCell = runtime.getCell(
+      space,
+      "child pattern user scoped join ui",
+      undefined,
+      tx,
+    );
+
+    const result = runtime.run(tx, Root, { isJoined }, resultCell);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+
+    const ui = result.key(UI).get() as any;
+    assertEquals(
+      ui.children?.[0]?.children?.[0]?.children?.[0],
+      "Join the poll",
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("embedded child pattern UI materializes scoped input derived join branch", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+
+  try {
+    const { h, ifElse, lift, pattern, UI } =
+      createTrustedBuilder(runtime).commonfabric;
+
+    const Child = pattern<{ myName: Cell<string> }>(
+      ({ myName }) => {
+        const isJoined = lift(
+          (name: string | undefined) => (name ?? "").trim() !== "",
+        )(myName);
+        const booleanSchema = { type: "boolean" } as const;
+        const nullSchema = { type: "null" } as const;
+        const vnodeLikeSchema = {
+          anyOf: [{}, { type: "object", properties: {} }],
+        } as const;
+        const maybeVNodeSchema = {
+          anyOf: [{ type: "null" }, {}, { type: "object", properties: {} }],
+        } as const;
+        const ifElseWithSchemas = ifElse as any;
+        return {
+          [UI]: h(
+            "div",
+            { style: "display:contents" },
+            ifElseWithSchemas(
+              booleanSchema,
+              nullSchema,
+              vnodeLikeSchema,
+              maybeVNodeSchema,
+              isJoined,
+              null,
+              h("span", { "data-testid": "join-widget" }, "Join the poll"),
+            ),
+          ),
+          isJoined,
+        };
+      },
+      {
+        type: "object",
+        properties: {
+          myName: { type: "string", default: "", asCell: ["cell"] },
+        },
+        required: ["myName"],
+      },
+    );
+
+    const Root = pattern<{ myName: Cell<string> }>(
+      ({ myName }) => {
+        const child = Child({ myName });
+        return {
+          [UI]: h("section", null, child[UI]),
+        };
+      },
+      {
+        type: "object",
+        properties: {
+          myName: {
+            type: "string",
+            default: "",
+            asCell: [{ kind: "cell", scope: "user" }],
+          },
+        },
+        required: ["myName"],
+      },
+    );
+
+    const resultCell = runtime.getCell(
+      space,
+      "embedded child pattern scoped join ui",
+      undefined,
+      tx,
+    );
+
+    const result = runtime.run(tx, Root, {}, resultCell);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+
+    const rootRawUi = result.key(UI).getRaw() as any;
+    const childUiLink = parseLink(rootRawUi.children?.[0], result.key(UI));
+    const childUiCell = runtime.getCellFromLink(childUiLink!);
+    const childRawUi = childUiCell.getRaw() as any;
+    const joinOutputLink = parseLink(childRawUi.children?.[0], childUiCell);
+    const joinOutputCell = runtime.getCellFromLink(joinOutputLink!);
+    const selectedJoinLink = parseLink(
+      joinOutputCell.getRaw(),
+      joinOutputCell,
+    );
+    assertEquals(selectedJoinLink?.scope, "user");
+
+    const ui = result.key(UI).get() as any;
+    assertEquals(
+      ui.children?.[0]?.children?.[0]?.children?.[0],
+      "Join the poll",
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
 Deno.test("session scoped derived chains update when broad inputs change", async () => {
   const storageManager = StorageManager.emulate({ as: signer });
   const runtime = new Runtime({

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   type CellRef,
   type CfcLabelView,
+  NotificationType,
   RequestType,
 } from "../protocol/mod.ts";
 import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
@@ -21,7 +22,11 @@ import { cellRefToSigilLink } from "./utils.ts";
 import { Runtime } from "@commonfabric/runner";
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import * as V2Storage from "../../runner/src/storage/v2.ts";
-import { parseLink } from "../../runner/src/link-utils.ts";
+import {
+  createDataCellURI,
+  createSigilLinkFromParsedLink,
+  parseLink,
+} from "../../runner/src/link-utils.ts";
 
 const cfcSigner = await Identity.fromPassphrase(
   "runtime-processor-cfc-label-tests",
@@ -1541,6 +1546,62 @@ describe("runtime-client CellRef conversion", () => {
   });
 });
 
+describe("RuntimeProcessor cell value serialization", () => {
+  it("inlines data URI links before returning cell values to the client", () => {
+    const space = "did:key:z6Mk-runtime-processor-data-uri" as CellRef[
+      "space"
+    ];
+    const childLink = createSigilLinkFromParsedLink({
+      id: createDataCellURI({
+        type: "vnode",
+        name: "p",
+        props: {},
+        children: ["Join the poll"],
+      }),
+      space,
+      scope: "space",
+      path: [],
+    });
+    const value = {
+      type: "vnode",
+      name: "section",
+      props: {},
+      children: [childLink],
+    };
+    const ref: CellRef = {
+      id: "of:data-uri-root" as CellRef["id"],
+      space,
+      scope: "space",
+      path: [],
+    };
+    const processor = {
+      runtime: {
+        getCellFromLink(candidate: unknown) {
+          expect(candidate).toEqual(ref);
+          return { get: () => value };
+        },
+      },
+    } as unknown as RuntimeProcessor;
+
+    const response = RuntimeProcessor.prototype.handleCellGet.call(processor, {
+      type: RequestType.CellGet,
+      cell: ref,
+    });
+
+    expect(response.value).toEqual({
+      type: "vnode",
+      name: "section",
+      props: {},
+      children: [{
+        type: "vnode",
+        name: "p",
+        props: {},
+        children: ["Join the poll"],
+      }],
+    });
+  });
+});
+
 describe("runtimeOptionsFromInitializationData", () => {
   it("threads CFC initialization settings into runtime options", () => {
     const telemetry = { marker() {} } as unknown as Parameters<
@@ -1826,7 +1887,7 @@ describe("RuntimeProcessor vdom mount render policy", () => {
     const originalPostMessage = (globalThis as any).postMessage;
     (globalThis as any).postMessage = () => {};
     try {
-      handleVDomMount.call(state, {
+      await handleVDomMount.call(state, {
         type: RequestType.VDomMount,
         mountId: 1,
         cell: cell.getAsNormalizedFullLink() as unknown as CellRef,
@@ -1872,5 +1933,88 @@ describe("RuntimeProcessor vdom mount render policy", () => {
   it("keeps mounts unbounded when no ceiling is configured", async () => {
     const policy = await mountAndGetRootPolicy(undefined);
     expect(policy.maxConfidentiality).toBeUndefined();
+  });
+
+  it("pulls the mounted VNode cell before subscribing so the initial render emits", async () => {
+    const { runtime, storageManager } = createRuntime();
+    const space = cfcSigner.did();
+    const tx = runtime.edit();
+
+    try {
+      const cell = runtime.getCell(
+        space,
+        "vdom mount initial vnode",
+        undefined,
+        tx,
+      );
+      cell.set({
+        type: "vnode",
+        name: "span",
+        props: {},
+        children: ["Join the poll"],
+      });
+      runtime.prepareTxForCommit(tx);
+      await tx.commit();
+      await runtime.idle();
+      await runtime.storageManager.synced();
+
+      const posted: unknown[] = [];
+      const state = {
+        runtime,
+        vdomMounts: new Map<
+          number,
+          { reconciler: unknown; cancel: () => void }
+        >(),
+        vdomBatchIdCounter: 0,
+        renderDeclassificationPolicy: "allow",
+        renderConfidentialityCeiling: undefined,
+        handleVDomUnmount,
+      };
+      const hadPostMessage = "postMessage" in globalThis;
+      const originalPostMessage = (globalThis as any).postMessage;
+      (globalThis as any).postMessage = (message: unknown) => {
+        posted.push(message);
+      };
+      try {
+        await handleVDomMount.call(state, {
+          type: RequestType.VDomMount,
+          mountId: 1,
+          cell: cell.getAsNormalizedFullLink() as unknown as CellRef,
+        });
+        await runtime.idle();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const batches = posted.filter((message): message is {
+          type: NotificationType.VDomBatch;
+          ops: { op: string; text?: string }[];
+        } =>
+          typeof message === "object" &&
+          message !== null &&
+          (message as { type?: unknown }).type === NotificationType.VDomBatch
+        );
+        const textOps = batches.flatMap((batch) =>
+          batch.ops.filter((op) =>
+            (op.op === "create-text" || op.op === "update-text") &&
+            op.text === "Join the poll"
+          )
+        );
+        expect(textOps.length).toBeGreaterThan(0);
+      } finally {
+        if (state.vdomMounts.has(1)) {
+          handleVDomUnmount.call(state, {
+            type: RequestType.VDomUnmount,
+            mountId: 1,
+          });
+        }
+        if (hadPostMessage) {
+          (globalThis as any).postMessage = originalPostMessage;
+        } else {
+          delete (globalThis as any).postMessage;
+        }
+      }
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
   });
 });

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -35,6 +35,7 @@ import {
 import { NameSchema, rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import { StorageManager } from "../../runner/src/storage/cache.ts";
 import {
+  findAndInlineDataURILinks,
   getMetaLink,
   type NormalizedFullLink,
   parseLink,
@@ -134,6 +135,15 @@ import type { JSONValue, RuntimeOptions } from "@commonfabric/runner";
 
 const MAX_SERIALIZATION_DEPTH = 5;
 const blobUploadEncoding = new JsonEncodingContext();
+
+function serializeCellValueForClient(value: unknown): JSONValue | undefined {
+  return convertCellsToLinks(findAndInlineDataURILinks(value), {
+    includeSchema: true,
+    keepAsCell: true,
+    doNotConvertCellResults: true,
+    includeCfcLabelView: true,
+  }) as JSONValue | undefined;
+}
 
 // Split-timing for the CFC label IPC path. Counts/timing are readable via
 // getLoggerCounts(); enabled silently so the hot path pays only the timestamp.
@@ -660,13 +670,7 @@ export class RuntimeProcessor {
         };
       }
     }
-    const value = cell.get();
-    const converted = convertCellsToLinks(value, {
-      includeSchema: true,
-      keepAsCell: true,
-      doNotConvertCellResults: true,
-      includeCfcLabelView: true,
-    });
+    const converted = serializeCellValueForClient(cell.get());
     if (!request.includeCfcLabel) {
       return { value: converted };
     }
@@ -725,12 +729,7 @@ export class RuntimeProcessor {
             `  schema: ${JSON.stringify(request.cell.schema)}`,
         );
       }
-      const converted = convertCellsToLinks(value, {
-        includeSchema: true,
-        keepAsCell: true,
-        doNotConvertCellResults: true,
-        includeCfcLabelView: true,
-      });
+      const converted = serializeCellValueForClient(value);
       // The sink read the raw label on its tracked tx (so cfc writes re-fire
       // it); redact Caveat.source here before it crosses to the main thread.
       const redactedLabel = request.includeCfcLabel
@@ -1371,7 +1370,7 @@ export class RuntimeProcessor {
       case RequestType.VDomEvent:
         return this.handleVDomEvent(request);
       case RequestType.VDomMount:
-        return this.handleVDomMount(request);
+        return await this.handleVDomMount(request);
       case RequestType.VDomUnmount:
         return this.handleVDomUnmount(request);
       case RequestType.VDomBatchApplied:
@@ -1404,7 +1403,9 @@ export class RuntimeProcessor {
    * Handle a request to start VDOM rendering for a cell.
    * Creates a WorkerReconciler, subscribes to the cell, and sends VDomBatch notifications.
    */
-  handleVDomMount(request: VDomMountRequest): VDomMountResponse {
+  async handleVDomMount(
+    request: VDomMountRequest,
+  ): Promise<VDomMountResponse> {
     const { mountId, cell: cellRef } = request;
 
     // Check if already mounted
@@ -1412,10 +1413,9 @@ export class RuntimeProcessor {
       this.handleVDomUnmount({ type: RequestType.VDomUnmount, mountId });
     }
 
-    // Get the cell from the runtime and apply rendererVDOMSchema
-    // The schema has a [UI] property definition that handles VDOM unwrapping
     const rawCell = getCell(this.runtime, cellRef);
     const cell = rawCell.asSchema(rendererVDOMSchema);
+    await cell.pull();
 
     // Create a reconciler that sends ops to the main thread
     const reconciler = new WorkerReconciler({

--- a/packages/runtime-client/cell-handle.ts
+++ b/packages/runtime-client/cell-handle.ts
@@ -532,6 +532,7 @@ function applyValue(
 function cellRefsEqual(a: CellRef, b: CellRef): boolean {
   if (a.id !== b.id) return false;
   if (a.space !== b.space) return false;
+  if (a.scope !== b.scope) return false;
   if (a.path.length !== b.path.length) return false;
   for (let i = 0; i < a.path.length; i++) {
     if (a.path[i] !== b.path[i]) return false;

--- a/packages/runtime-client/integration/client.test.ts
+++ b/packages/runtime-client/integration/client.test.ts
@@ -818,6 +818,229 @@ export default pattern<Input, Output>(({ question, myName }) => {
       }
     });
 
+    it("renders PerUser-scoped ifElse default branch for a second reader", async () => {
+      const scopedIfElsePattern = `import {
+  action,
+  computed,
+  NAME,
+  pattern,
+  UI,
+  Writable,
+} from "commonfabric";
+
+export default pattern(() => {
+  const name = Writable.perUser.of<string>("");
+  const isJoined = computed(() => (name.get() ?? "").trim() !== "");
+  const join = action(() => name.set("Browser user"));
+
+  return {
+    [NAME]: "scoped-ifelse-second-reader",
+    [UI]: (
+      <div>
+        <div>Shared static visible</div>
+        {isJoined
+          ? <div>Joined as {name}</div>
+          : <div>Scoped join visible <button onClick={join}>Join</button></div>}
+      </div>
+    ),
+  };
+});`;
+
+      const scopedIfElseProgram: Program = {
+        main: "/main.tsx",
+        files: [{
+          name: "/main.tsx",
+          contents: scopedIfElsePattern,
+        }],
+      };
+
+      const creatorSession = await createTestSession();
+      await using creator = await createRuntimeClient(creatorSession, {
+        cfcEnforcementMode: "enforce-explicit",
+        trustSnapshot: {
+          id: `principal:${creatorSession.as.did()}`,
+          actingPrincipal: creatorSession.as.did(),
+        },
+      });
+      const page = await creator.createPage(
+        scopedIfElseProgram,
+        creatorSession.space,
+        { run: true },
+      );
+
+      const readerIdentity = await Identity.fromPassphrase(
+        `second-reader-${globalThis.crypto.randomUUID()}`,
+        keyConfig,
+      );
+      const readerSession = {
+        ...creatorSession,
+        as: readerIdentity,
+      } as Session;
+      await using reader = await createRuntimeClient(readerSession, {
+        cfcEnforcementMode: "enforce-explicit",
+        trustSnapshot: {
+          id: `principal:${readerSession.as.did()}`,
+          actingPrincipal: readerSession.as.did(),
+        },
+      });
+      const pageForReader = await reader.getPage(
+        page.id(),
+        creatorSession.space,
+        true,
+      );
+      assertExists(pageForReader);
+
+      const mock = new MockDoc(
+        `<!DOCTYPE html><html><body><div id="root"></div></body></html>`,
+      );
+      const { document, renderOptions } = mock;
+      const root = document.getElementById("root")!;
+      const cancel = render(
+        root,
+        pageForReader.cell() as CellHandle<VNode>,
+        renderOptions,
+      );
+
+      try {
+        await waitFor(
+          () => {
+            const html = root.innerHTML;
+            return Promise.resolve(
+              html.includes("Shared static visible") &&
+                html.includes("Scoped join visible"),
+            );
+          },
+          { timeout: 5000 },
+        );
+      } finally {
+        cancel();
+      }
+    });
+
+    it("renders embedded child pattern UI with a PerUser-scoped default branch", async () => {
+      const embeddedChildPattern = `import {
+  computed,
+  Default,
+  NAME,
+  pattern,
+  type PerUser,
+  UI,
+  type VNode,
+} from "commonfabric";
+
+interface ChildInput {
+  name?: PerUser<string | Default<"">>;
+}
+
+interface ChildOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  isJoined: boolean;
+}
+
+const Child = pattern<ChildInput, ChildOutput>(({ name }) => {
+  const isJoined = computed(() => (name ?? "").trim() !== "");
+  return {
+    [NAME]: "embedded-child",
+    isJoined,
+    [UI]: (
+      <div>
+        {isJoined
+          ? <div>Child joined as {name}</div>
+          : <div>Child join visible</div>}
+      </div>
+    ),
+  };
+});
+
+interface ParentInput {
+  name?: PerUser<string | Default<"">>;
+}
+
+export default pattern<ParentInput>(({ name }) => {
+  const child = Child({ name });
+  return {
+    [NAME]: "parent-with-embedded-child",
+    [UI]: (
+      <div>
+        <div>Parent static visible</div>
+        {child[UI]}
+      </div>
+    ),
+  };
+});`;
+
+      const embeddedChildProgram: Program = {
+        main: "/main.tsx",
+        files: [{
+          name: "/main.tsx",
+          contents: embeddedChildPattern,
+        }],
+      };
+
+      const creatorSession = await createTestSession();
+      await using creator = await createRuntimeClient(creatorSession, {
+        cfcEnforcementMode: "enforce-explicit",
+        trustSnapshot: {
+          id: `principal:${creatorSession.as.did()}`,
+          actingPrincipal: creatorSession.as.did(),
+        },
+      });
+      const page = await creator.createPage(
+        embeddedChildProgram,
+        creatorSession.space,
+        { run: true },
+      );
+
+      const readerIdentity = await Identity.fromPassphrase(
+        `embedded-child-reader-${globalThis.crypto.randomUUID()}`,
+        keyConfig,
+      );
+      const readerSession = {
+        ...creatorSession,
+        as: readerIdentity,
+      } as Session;
+      await using reader = await createRuntimeClient(readerSession, {
+        cfcEnforcementMode: "enforce-explicit",
+        trustSnapshot: {
+          id: `principal:${readerSession.as.did()}`,
+          actingPrincipal: readerSession.as.did(),
+        },
+      });
+      const pageForReader = await reader.getPage(
+        page.id(),
+        creatorSession.space,
+        true,
+      );
+      assertExists(pageForReader);
+
+      const mock = new MockDoc(
+        `<!DOCTYPE html><html><body><div id="root"></div></body></html>`,
+      );
+      const { document, renderOptions } = mock;
+      const root = document.getElementById("root")!;
+      const cancel = render(
+        root,
+        pageForReader.cell() as CellHandle<VNode>,
+        renderOptions,
+      );
+
+      try {
+        await waitFor(
+          () => {
+            const html = root.innerHTML;
+            return Promise.resolve(
+              html.includes("Parent static visible") &&
+                html.includes("Child join visible"),
+            );
+          },
+          { timeout: 5000 },
+        );
+      } finally {
+        cancel();
+      }
+    });
+
     it("dispatches click events through rendered page handlers", async () => {
       const clickPattern =
         `import { action, Default, NAME, pattern, UI, Writable } from "commonfabric";


### PR DESCRIPTION
## What Changed

- Changes the real lunch poll, `packages/patterns/lunch-poll/main.tsx`, so live votes are stored under each participant row (`users[n].votes`) instead of a global hot `votes` array.
- Projects the public `votes` output from participant child-vote state, so the existing output contract and UI can keep working.
- Updates `ParticipantIdentityCard` to store a PerUser append-only participant index, which lets vote handlers write directly to the current viewer's row.
- Runtime/protocol: preserves `nonRecursive` read semantics through memory-v2 commits and lets unrelated object sibling add/remove validation stay independent, while keeping array index edits conservative.
- Keeps `reference-shape-experiment.tsx` as supporting mechanism evidence for a more idiomatic future option-reference shape.
- Updates the investigation and Bernie handover docs with the real-pattern evidence, render smoke result, and remaining browser interaction gap.

## Performance / Correctness Gain

This is measured on the real lunch poll source, not just the fixture.

Same workload, same runtime patch, deterministic setup:

```bash
deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
  --program=main.tsx \
  --cases=3x10 --rounds=3 --skip-refresh \
  --event-mode=id --join-mode=serial
```

| Shape | Final users | Final votes | Conflicts/reverts | Elapsed | Vote round 3 graph | Workset | Trace |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Original `main.tsx` array votes | `10/10` | `18/30` | `1923` | `36.0s` | `467 nodes / 1361 edges` | `24` | `1680` |
| Real `main.tsx` child votes | `10/10` | `30/30` | `1309` | `28.1s` | `479 nodes / 1380 edges` | `16` | `915` |

What this proves:

- The real lunch poll preserves all expected votes in this 10-client workload.
- Conflict/revert churn drops about `1.47x`.
- End-to-end diagnostic time improves about `1.28x`.
- Final vote-round scheduler workset drops `24 -> 16`.
- Final vote-round trace entries drop `1680 -> 915`.

What this does not prove:

- The full real UI graph is not fixed; nodes/edges are slightly higher after the refactor because we still render and derive through the production surface.
- The existing `Option.id` / `Vote.optionId` contract remains. This PR improves the real hot write path without finishing the no-string-ID cleanup.
- Browser join/add/vote interaction durability is not yet validated manually.

## Browser Smoke

Local render URL:

`http://localhost:9000/lunch-poll-perf-a587/lunch-poll-reference-runtime-a587`

The local URL is repointed to the real `packages/patterns/lunch-poll/main.tsx` piece:

`fid1:48HeF0KAyJ0uP14LVRaJMvO6jnYUq4dyCC0CPEOyPDw`

Render smoke is verified only after controlling browser identity:

- A fresh anonymous `agent-browser` session showed only `Untitled`.
- After importing `cf.key`, the same URL rendered `Cozy lunch poll`, `Where should we eat?`, `Berkeley, CA`, `Join the poll`, `No options yet`, and `Waiting for a host to join.`
- CLI reads and a runtime-client web-worker probe both show the same `$UI/children/0/children/1/children` body through the target piece.
- Rendering the page cell with `@commonfabric/html/client` into `MockDoc` produced HTML containing `Join the poll` and `No options yet`.

Remaining browser gap: `agent-browser fill`/`click` changed the visible join input but did not successfully complete `joinAs`, likely because the driver did not update the `cf-input` backing cell. Treat browser event-path durability as unverified until a human/manual click-through, or a known-good driver sequence for `cf-input`, confirms join/add/vote.

## Supporting Fixture Evidence

The reference fixture remains useful as a lower-bound/mechanism experiment:

- `packages/patterns/lunch-poll/reference-shape-experiment.tsx`
- Option identity is the option cell/reference.
- Vote writes go under the participant child cell.
- Vote matching uses `equals()`.
- No generated app IDs, `optionId`, or string-keyed mutation maps in the fixture.

On the same 3x10x3 workload with `--event-mode=reference --join-mode=serial`, the fixture reaches `30/30` votes with `350` conflicts/reverts, `8.0s` elapsed, and final vote-round workset `4`. That explains the direction, but the merge proof is the real `main.tsx` result above.

## Validation

- `deno fmt --check packages/patterns/lunch-poll/main.tsx packages/patterns/lunch-poll/participant-identity-card.tsx packages/patterns/lunch-poll/participant-identity-card.test.tsx packages/patterns/lunch-poll/HANDOVER-PROPOSAL-2026-06-23.md packages/patterns/lunch-poll/PERF-INVESTIGATION-2026-06-23.md`
- `deno task cf check packages/patterns/lunch-poll/main.tsx --no-run --verbose-errors`
- `deno task cf test packages/patterns/lunch-poll/participant-identity-card.test.tsx`
- `deno task cf test packages/patterns/lunch-poll/main.test.tsx`
- `deno task cf test packages/patterns/lunch-poll/multi-user.test.tsx`
- `deno task cf test packages/patterns/lunch-poll/lunch-stats.test.tsx`
- `deno run -A packages/patterns/tools/lunch-poll-diagnose.ts --program=main.tsx --cases=3x10 --rounds=3 --skip-refresh --event-mode=id --join-mode=serial`
- `deno test --allow-env --allow-read --allow-ffi packages/lib-shell/test/runtime.test.ts`
- `deno test --allow-all packages/runtime-client/backends/runtime-processor.test.ts`
- `deno test --allow-env --allow-read --allow-ffi packages/html/test/worker-reconciler-cell-props.test.ts`
- `API_URL=http://localhost:9000 deno test --allow-all packages/runtime-client/integration/client.test.ts`
- `git diff --check`

## Handover

- `packages/patterns/lunch-poll/HANDOVER-PROPOSAL-2026-06-23.md`
- `packages/patterns/lunch-poll/PERF-INVESTIGATION-2026-06-23.md`
