### PR TITLE
ci: cache the Deno toolchain binary to insulate CI from deno.com outages

### DIFF
--- a/.github/actions/deno-setup/action.yml
+++ b/.github/actions/deno-setup/action.yml
@@ -6,15 +6,55 @@ inputs:
     default: true
   deno-version:
     description: "Deno version to install"
+    # Keep in sync with `./tasks/check.sh` version
     default: "2.8.1"
 runs:
   using: "composite"
   steps:
-    # Keep in sync with `./tasks/check.sh` version
-    - name: 🦕 Setup Deno ${{ inputs.deno-version }}
+    # Cache the Deno toolchain binary. denoland/setup-deno resolves the version
+    # against deno.com/versions.json and downloads the binary at job time, so a
+    # deno.com outage breaks every job. A cache hit installs the binary from disk
+    # instead, with no deno.com contact. setup-deno installs into
+    # <tool_cache>/deno/<version>/<arch>/, so caching that directory and re-adding
+    # it to PATH is enough to run Deno. This is independent of the `cache` input
+    # below (which gates the module/dependency cache) so jobs that pass
+    # `cache: false` are covered too.
+    # Cache version: bump the `deno-bin-v1` token to invalidate all toolchain caches.
+    - name: 💾 Restore Deno toolchain ${{ inputs.deno-version }}
+      id: deno-toolchain-cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.tool_cache }}/deno/${{ inputs.deno-version }}
+        key: deno-bin-v1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.deno-version }}
+
+    - name: 🦕 Download Deno ${{ inputs.deno-version }}
+      # Cache miss: download the toolchain from upstream. setup-deno installs it
+      # into the cached path above, so actions/cache saves it at job end and
+      # later runs hit.
+      if: steps.deno-toolchain-cache.outputs.cache-hit != 'true'
       uses: denoland/setup-deno@v2
       with:
         deno-version: ${{ inputs.deno-version }}
+
+    - name: 🦕 Use cached Deno ${{ inputs.deno-version }}
+      # Cache hit: add the restored binary to PATH and verify, with no deno.com
+      # contact.
+      if: steps.deno-toolchain-cache.outputs.cache-hit == 'true'
+      shell: bash
+      env:
+        TOOLCHAIN_DIR: ${{ runner.tool_cache }}/deno/${{ inputs.deno-version }}
+      run: |
+        # setup-deno extracts the binary into <tool_cache>/deno/<version>/<arch>/.
+        # The arch subdir name comes from the runner's node arch, so find the
+        # binary instead of assuming the directory name.
+        bin="$(find "$TOOLCHAIN_DIR" -type f -name deno -print -quit 2>/dev/null || true)"
+        if [ -z "$bin" ]; then
+          echo "::error::Cached Deno toolchain not found under $TOOLCHAIN_DIR"
+          exit 1
+        fi
+        chmod +x "$bin"
+        dirname "$bin" >> "$GITHUB_PATH"
+        "$bin" --version
 
     # Cache version: bump to invalidate all caches (e.g., v2 -> v3)
     - name: 📦 Cache Deno dependencies


### PR DESCRIPTION
CI installs Deno through the composite action
`.github/actions/deno-setup/action.yml`, which runs `denoland/setup-deno@v2`. That action resolves the requested version by fetching `deno.com/versions.json` and then downloads the toolchain, both at job time. When deno.com is briefly unreachable from the runners, the install step fails, `deno` never reaches PATH, and every later step in the job dies with `deno: command not found` (exit 127). A short window of deno.com unavailability took down many jobs at once, because nothing in the build insulated it from upstream Deno availability.

The action already caches Deno's module/dependency cache, but not the toolchain binary itself, which was the unprotected upstream dependency.

This adds a cache for the toolchain binary, mirroring the hit/miss structure of the existing `.github/actions/apt-install/action.yml`. setup-deno installs the binary into the runner tool cache at `<tool_cache>/deno/<version>/<arch>/`, so the change caches that directory keyed by the pinned Deno version plus the runner OS and architecture:

- On a cache hit, the toolchain is already on disk. The hit branch finds the binary under the restored directory, adds its directory to PATH, and runs `deno --version` to confirm it works, with no contact to deno.com. It locates the binary by searching rather than constructing the path, because the arch subdirectory name comes from Node's `os.arch()` (`x64`/`arm64`) and differs from the GitHub `runner.arch` value (`X64`/`ARM64`) used in the cache key.
- On a cache miss (for example the first run after a version bump), the action falls back to `denoland/setup-deno@v2`, which downloads the toolchain into the same tool-cache directory. actions/cache then saves that directory at job end, so subsequent runs hit and stay offline from deno.com.

The toolchain cache is intentionally independent of the existing `cache` input (which gates only the module/dependency cache), so jobs that pass `cache: false` are insulated too. The dependency cache step is left unchanged. The cache key carries a `deno-bin-v1` token so the toolchain cache can be invalidated later, and uses an exact match with no restore-keys so a different pinned version is never restored under this version's key.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches the Deno toolchain binary in CI to avoid failures during deno.com outages and speed up repeated runs. Falls back to `denoland/setup-deno@v2` on cache miss; uses the restored binary on hit with no network calls.

- **Bug Fixes**
  - Cache `<tool_cache>/deno/<version>` via `actions/cache@v4` with key `deno-bin-v1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.deno-version }}`.
  - Cache hit: find the binary, add its dir to PATH, and run `deno --version` to verify.
  - Cache miss: run `denoland/setup-deno@v2`, then save the toolchain for future runs.
  - Toolchain cache is separate from the module/dependency cache (`cache` input), so all jobs are protected.

<sup>Written for commit 8e8775704644a7b1b3f89a87e51d84f43225d2bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

