### PR TITLE
feat(runner): backpressure for committed writes instead of silent drops

### DIFF
--- a/docs/development/committed-write-backpressure.md
+++ b/docs/development/committed-write-backpressure.md
@@ -126,9 +126,13 @@ count no longer bounds conflict retries; the window does.
 `RuntimeOptions.commitBackpressure` tunes the policy
 (`scheduler/backpressure.ts`, `CommitBackpressurePolicy`): `baseDelayMs`,
 `maxDelayMs`, `jitter`, `retryWindowMs`. Unset fields fall back to
-`DEFAULT_COMMIT_BACKPRESSURE` and every field is clamped to a sane range, so a
-caller-supplied policy can never disable backpressure (a zero window would
-reintroduce silent drops). Tests use it to shrink the window and backoff.
+`DEFAULT_COMMIT_BACKPRESSURE` and every field is clamped to a well-defined range
+(non-negative delays, a cap no lower than the base delay, jitter within [0, 1], a
+non-negative window). The clamps only keep the arithmetic sane; the
+never-silently-dropped guarantee does not depend on them. A zero window is
+allowed and does not reintroduce silent drops — it makes the first conflict fail
+terminally instead of being retried. Tests use this to shrink the window and
+backoff.
 
 ## Observability
 

--- a/docs/development/committed-write-backpressure.md
+++ b/docs/development/committed-write-backpressure.md
@@ -1,0 +1,187 @@
+# Committed-write backpressure
+
+How the scheduler keeps a committed write from being silently dropped when the
+server rejects it under contention.
+
+## The problem
+
+The runtime is local-first and optimistic. When an event handler writes, the
+write is applied to local replicated memory immediately and the transaction is
+committed to the server in the background. The handler does not wait for the
+server. The server can still reject the commit, most often with a per-entity
+basis-sequence conflict: another writer advanced the entity's sequence between
+the time this commit read its basis and the time it reached the server. On
+rejection the optimistic write is rolled back (a "revert") and the originating
+event is re-run.
+
+The re-run used to have a fixed budget. An event handler retried five times
+(`DEFAULT_RETRIES_FOR_EVENTS`) and then gave up: it logged "Event handler
+transaction failed after exhausting all retries" and dropped the write. Nothing
+surfaced to the user.
+
+Under sustained contention that budget is exhausted before the contention
+clears. The concrete case that motivated this work: profile appends issued while
+the home space rehydrates. Loading a home that already has profiles produces a
+burst of basis-sequence conflicts as reactive rehydration commits churn the home
+entity. A profile append targeting the same entity loses the race over and over,
+runs out of its five retries in a few milliseconds, and is dropped. Creating
+three profiles left a durable count of one. "Drops data under load" is a
+correctness cliff, not graceful degradation.
+
+## The principle
+
+A committed write that represents real user intent must converge or fail loudly.
+It must never vanish. Under contention the system should get slower, not lossy.
+
+That requires separating two kinds of rejection that the old fixed budget
+treated the same:
+
+- A **transient stale-basis conflict** (`ConflictError`). Re-running the handler
+  against fresh confirmed state and committing again can succeed. These are
+  exactly the rejections that a contention burst produces, and the ones that
+  must keep being retried until they land.
+- A **permanent precondition failure** (`PreconditionFailedError` —
+  `receipt-exists`, `origin-committed`). Re-running can never succeed and must
+  not happen. `receipt-exists` means the event was already durably handled by a
+  prior delivery (idempotent dedup); `origin-committed` means the event's origin
+  lineage did not commit, so the descendant must not apply.
+
+A third group — handler-initiated aborts and system errors — are transient in
+the sense that they are not permanent precondition failures, but they are not
+contention either, so retrying harder does not help them.
+
+## The model
+
+The event-handler commit path classifies each commit result and acts on it
+(`packages/runner/src/scheduler/events.ts`, `classifyCommitDisposition`):
+
+- **Success** — done.
+- **Stale-basis `ConflictError`** — the backpressure path. The event is
+  re-queued for a later retry, parked via the existing `notBefore` mechanism with
+  a capped exponential backoff plus jitter (`scheduler/backpressure.ts`,
+  `computeBackoffDelayMs`). Backoff makes the scheduler slow down under
+  contention instead of busy-looping; jitter keeps concurrent writers contending
+  for the same entity from retrying in lockstep. The event keeps retrying for a
+  bounded window (default 30 seconds), measured from the first conflict, which is
+  long enough to outlast a rehydration burst. `idle()` and `settled()` already
+  wait for a parked head event, so a write that converges still completes within
+  a settle.
+- **Window elapsed without converging** — a terminal `CommitConvergenceError` is
+  surfaced through the scheduler error channel (`scheduler.onError`). The write
+  fails loudly rather than disappearing. This is the bounded-resource backstop:
+  if a conflict genuinely never clears, the system does not retry forever, it
+  reports.
+- **Permanent rejection** — never retried, exactly as before, and still
+  observable through the `scheduler.event.commit` telemetry marker
+  (`permanentRejection`).
+- **Any other transient error** (abort, system error) — keeps the fixed
+  `retriesLeft` budget and the previous retry-then-stop behavior. Backpressure
+  would not help a handler that aborts itself, and retrying it within the window
+  would loop pointlessly.
+
+### Resource bounds
+
+Backoff caps the retry *rate* (one parked timer per intent, capped delay), and
+the window caps the total *duration*. Together they bound the work a single
+contended write can generate to roughly tens of attempts over the window, not a
+busy loop. The event queue still holds one entry per intent; a backoff retry
+re-queues that same entry in place rather than fanning out.
+
+### Event-queue ordering
+
+The scheduler processes the event queue strictly head-first, and a parked event
+(`notBefore` in the future) holds the head until its timer fires — this is the
+same behavior the existing dirty-dependency throttle already relies on. A backoff
+retry is parked at the head, so while a contended write is backing off, events
+queued behind it wait. Under a transient storm (which clears in well under a
+second) this is imperceptible. The visible effect is only on a write that keeps
+conflicting for seconds: event processing behind it slows until the write either
+lands or the retry window elapses and it fails terminally. That is the intended
+backpressure — the system gets slower under sustained contention rather than
+losing the write. `maxDelayMs` bounds how long any single backoff step holds the
+head.
+
+### Idempotency
+
+Retrying re-runs the same event with the same durable event id. The memory
+engine's receipt machinery makes a re-delivery of an already-applied event a
+permanent `receipt-exists` rejection, so a retry cannot double-apply. A retry
+only happens after a rejection, where the optimistic write was reverted, so the
+re-run reads fresh confirmed state (including profiles that landed in the
+meantime) and reconciles — which is why three concurrent appends converge to a
+list of three rather than clobbering each other.
+
+### The `retries: 0` opt-out
+
+`queueEvent`'s `retries` argument now gates whether conflicts are retried at all,
+rather than bounding how many times. The default (`DEFAULT_RETRIES_FOR_EVENTS`,
+used by every real user event through `cell.send`) is positive, so user events
+get backpressure. A caller that sends with `retries: 0` — a speculative lineage
+origin, an internal one-shot — opts out: a conflict gives up immediately, so a
+descendant of a failed origin still drops deterministically. The exact positive
+count no longer bounds conflict retries; the window does.
+
+## Configuration
+
+`RuntimeOptions.commitBackpressure` tunes the policy
+(`scheduler/backpressure.ts`, `CommitBackpressurePolicy`): `baseDelayMs`,
+`maxDelayMs`, `jitter`, `retryWindowMs`. Unset fields fall back to
+`DEFAULT_COMMIT_BACKPRESSURE` and every field is clamped to a sane range, so a
+caller-supplied policy can never disable backpressure (a zero window would
+reintroduce silent drops). Tests use it to shrink the window and backoff.
+
+## Observability
+
+The `scheduler.event.commit` telemetry marker carries the new state:
+`retryAttempt` and `backoffMs` on a backoff retry, and `terminal`
+(`"permanent"` | `"convergence"`) when a commit reaches a terminal outcome.
+A non-converging write also logs `commit-convergence-failed` and is delivered to
+registered `scheduler.onError` handlers as a `CommitConvergenceError`.
+
+## The reactive-action path
+
+The reactive path (`scheduler/action-run.ts`) does not need this backpressure
+and shares only the `isConflictRejection` classifier. A reactive action is a
+re-derivation: its output is a function of its inputs. On a conflict it does not
+retry at all — the write that caused the conflict dirtied the action's
+still-subscribed reads, so reader-dirty propagation re-runs it with the latest
+state. A conflict there is a wait, not a retry, and consumes no budget. Only
+non-conflict transient errors fall back to the bounded `MAX_RETRIES_FOR_REACTIVE`
+retry, and every attempt re-subscribes so the action recovers when its inputs
+next change. The backpressure rework targets the event-handler path instead,
+where a one-shot write *is* the user's intent and has no later input change to
+recover it, so a conflict must be actively retried rather than waited out.
+
+## Tests
+
+- `packages/runner/test/scheduler-commit-backpressure.test.ts` — the validation
+  of record. It drives the event-handler commit path against an emulated server
+  that rejects commits on demand: a burst of transient conflicts longer than the
+  old budget still lands; a permanent rejection is not retried and stays
+  observable; a never-converging conflict surfaces a terminal error within the
+  window with bounded attempts; and three whole-array appends
+  (`list = [...list, value]`, the profile-append shape) survive a conflict storm
+  so the durable count reaches three. This deterministically reproduces the
+  silent-loss bug and proves the fix.
+- `packages/runner/test/scheduler-event-lineage.test.ts` — adapted so a
+  permanently failed origin is modeled without relying on budget exhaustion; it
+  exercises the give-up (`retries: 0`) and terminal-convergence paths.
+- `packages/patterns/integration/home-profile.test.ts` — unchanged browser-level
+  profile-creation regression coverage; still passes (the fix does not regress
+  the normal cross-space append).
+
+## Reproduction status in this codebase
+
+The motivating instance — profile appends swallowed by a rehydration conflict
+storm, leaving a durable count of one — was confirmed in an earlier copy where
+loading a home with existing profiles produced about nineteen basis-sequence
+conflicts. In the current copy that storm is much milder: rehydrating a home
+with a profile produces only a few reactive-commit conflicts, and they clear
+before a profile append is issued, so the append's event commit does not hit a
+conflict at all. A browser count-probe driven against this copy therefore does
+not exercise the backpressure path (no event-handler conflict, no backoff), so
+it cannot validate the fix end-to-end here, and any residual count discrepancy
+under idle-only waits comes from cross-space rehydration timing rather than the
+conflict-exhaustion this change addresses. The fix is validated instead at the
+runner level, where the conflict storm is injected deterministically and the
+committed write is shown to converge rather than drop.

--- a/docs/development/committed-write-backpressure.md
+++ b/docs/development/committed-write-backpressure.md
@@ -56,16 +56,22 @@ The event-handler commit path classifies each commit result and acts on it
 (`packages/runner/src/scheduler/events.ts`, `classifyCommitDisposition`):
 
 - **Success** — done.
-- **Stale-basis `ConflictError`** — the backpressure path. The event is
-  re-queued for a later retry, parked via the existing `notBefore` mechanism with
-  a capped exponential backoff plus jitter (`scheduler/backpressure.ts`,
-  `computeBackoffDelayMs`). Backoff makes the scheduler slow down under
-  contention instead of busy-looping; jitter keeps concurrent writers contending
-  for the same entity from retrying in lockstep. The event keeps retrying for a
-  bounded window (default 30 seconds), measured from the first conflict, which is
-  long enough to outlast a rehydration burst. `idle()` and `settled()` already
-  wait for a parked head event, so a write that converges still completes within
-  a settle.
+- **Stale-basis `ConflictError`** — the backpressure path. A stale-basis conflict
+  usually clears the instant the fresh confirmed state arrives, so the first
+  `immediateRetries` retries (default 5) fire with no delay — the fast path the
+  runtime had before backoff existed, where a transient conflict converges within
+  a few rapid retries. This matters: the harness and the UI settle by waiting for
+  the event queue to drain, so spacing out a retry that would have cleared
+  immediately can keep a write from converging within a settle. Only once the
+  immediate retries are exhausted (sustained contention) does the event re-queue
+  parked via the existing `notBefore` mechanism with a capped exponential backoff
+  plus jitter (`scheduler/backpressure.ts`, `computeBackoffDelayMs`). Backoff
+  makes the scheduler slow down under contention instead of busy-looping; jitter
+  keeps concurrent writers contending for the same entity from retrying in
+  lockstep. The event keeps retrying for a bounded window (default 30 seconds),
+  measured from the first conflict, which is long enough to outlast a rehydration
+  burst. `idle()` and `settled()` already wait for a parked head event, so a write
+  that converges still completes within a settle.
 - **Window elapsed without converging** — a terminal `CommitConvergenceError` is
   surfaced through the scheduler error channel (`scheduler.onError`). The write
   fails loudly rather than disappearing. This is the bounded-resource backstop:
@@ -125,7 +131,8 @@ count no longer bounds conflict retries; the window does.
 
 `RuntimeOptions.commitBackpressure` tunes the policy
 (`scheduler/backpressure.ts`, `CommitBackpressurePolicy`): `baseDelayMs`,
-`maxDelayMs`, `jitter`, `retryWindowMs`. Unset fields fall back to
+`maxDelayMs`, `jitter`, `retryWindowMs`, `immediateRetries`. Unset fields fall
+back to
 `DEFAULT_COMMIT_BACKPRESSURE` and every field is clamped to a well-defined range
 (non-negative delays, a cap no lower than the base delay, jitter within [0, 1], a
 non-negative window). The clamps only keep the arithmetic sane; the

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -47,6 +47,10 @@ import {
 import { createRef, EntityId } from "./create-ref.ts";
 import { createSession, Identity } from "@commonfabric/identity";
 import { Action, Scheduler } from "./scheduler.ts";
+import {
+  type CommitBackpressurePolicy,
+  resolveCommitBackpressure,
+} from "./scheduler/backpressure.ts";
 import { Engine } from "./harness/index.ts";
 import {
   CellLink,
@@ -203,6 +207,12 @@ export interface RuntimeOptions {
   trustSnapshotProvider?: () => TrustSnapshot | undefined;
   /** Replace runner-owned frames with `<CF_INTERNAL>` in surfaced stacks. */
   hideInternalStackFrames?: boolean;
+  /**
+   * Tuning for committed-write backpressure under contention. Unset fields fall
+   * back to DEFAULT_COMMIT_BACKPRESSURE; tests use this to shrink the backoff
+   * and retry window. See scheduler/backpressure.ts.
+   */
+  commitBackpressure?: Partial<CommitBackpressurePolicy>;
 }
 
 export interface CfcRuntimeStats {
@@ -313,6 +323,8 @@ export class Runtime {
   readonly telemetry: RuntimeTelemetry;
   /** Resolved experimental flags (all properties present, defaulting to `false`). */
   readonly experimental: ExperimentalOptions;
+  /** Resolved committed-write backpressure policy (all fields present). */
+  readonly commitBackpressure: CommitBackpressurePolicy;
   readonly apiUrl: URL;
   readonly spaceHostMap?: Record<string, string>;
   /** Runtime-learned host hints (site table); see registerSpaceHost. */
@@ -357,6 +369,10 @@ export class Runtime {
       getPersistentSchedulerStateConfig();
     setCommitPreconditionsConfig(this.experimental.commitPreconditions);
     this.experimental.commitPreconditions = getCommitPreconditionsConfig();
+
+    this.commitBackpressure = resolveCommitBackpressure(
+      options.commitBackpressure,
+    );
 
     this.id = options.storageManager.id;
     this.apiUrl = new URL(options.apiUrl);

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -2127,6 +2127,7 @@ export class Scheduler {
       eventQueue: this.eventQueue,
       dirty: this.staleness.dirty,
       pending: this.pending,
+      backpressure: this.runtime.commitBackpressure,
       get eventPreflightTelemetryEnabled() {
         return getEventPreflightTelemetryEnabled();
       },

--- a/packages/runner/src/scheduler/backpressure.ts
+++ b/packages/runner/src/scheduler/backpressure.ts
@@ -47,9 +47,15 @@ export const DEFAULT_COMMIT_BACKPRESSURE: CommitBackpressurePolicy = {
 };
 
 /**
- * Fills in any unset fields from the defaults and clamps each field to a sane
- * range so a caller-supplied policy can never disable backpressure (a zero
- * window would reintroduce silent drops) or invert the delays.
+ * Fills in any unset fields from the defaults and clamps each field so the
+ * arithmetic stays well-defined: non-negative delays, a cap no lower than the
+ * base delay, jitter within [0, 1], and a non-negative window. These clamps keep
+ * the policy sane; they are not what prevents silent data loss. The
+ * never-silently-dropped guarantee holds for any resolved policy because a
+ * transient conflict either converges or surfaces a terminal error. A zero
+ * window does not drop a write silently — it makes the first conflict fail
+ * terminally instead of being retried (a config-level way to opt out of the
+ * retry window, distinct from the per-event `retries: 0` opt-out).
  */
 export function resolveCommitBackpressure(
   partial?: Partial<CommitBackpressurePolicy>,

--- a/packages/runner/src/scheduler/backpressure.ts
+++ b/packages/runner/src/scheduler/backpressure.ts
@@ -37,6 +37,16 @@ export interface CommitBackpressurePolicy {
    * conflict for a given intent.
    */
   retryWindowMs: number;
+  /**
+   * Number of conflict retries attempted with no delay before backoff begins.
+   * A stale-basis conflict usually clears as soon as the fresh confirmed state
+   * arrives, so the first few retries fire immediately — the fast path the
+   * runtime had before backoff existed. Backoff (and its delays) only kick in
+   * once these immediate retries are exhausted, i.e. under sustained
+   * contention, where spacing retries out is what keeps the scheduler from
+   * busy-looping.
+   */
+  immediateRetries: number;
 }
 
 export const DEFAULT_COMMIT_BACKPRESSURE: CommitBackpressurePolicy = {
@@ -44,6 +54,7 @@ export const DEFAULT_COMMIT_BACKPRESSURE: CommitBackpressurePolicy = {
   maxDelayMs: 1_000,
   jitter: 0.5,
   retryWindowMs: 30_000,
+  immediateRetries: 5,
 };
 
 /**
@@ -65,7 +76,8 @@ export function resolveCommitBackpressure(
   const maxDelayMs = Math.max(baseDelayMs, merged.maxDelayMs);
   const jitter = Math.min(1, Math.max(0, merged.jitter));
   const retryWindowMs = Math.max(0, merged.retryWindowMs);
-  return { baseDelayMs, maxDelayMs, jitter, retryWindowMs };
+  const immediateRetries = Math.max(0, Math.floor(merged.immediateRetries));
+  return { baseDelayMs, maxDelayMs, jitter, retryWindowMs, immediateRetries };
 }
 
 /**

--- a/packages/runner/src/scheduler/backpressure.ts
+++ b/packages/runner/src/scheduler/backpressure.ts
@@ -1,0 +1,117 @@
+/**
+ * Backpressure policy for committed writes under contention.
+ *
+ * The runtime is optimistic: a committed write applies locally and is confirmed
+ * by the server in the background. The server can reject a commit. Rejections
+ * split two ways (see storage/rejection.ts):
+ *
+ *   - Transient: a stale basis-sequence conflict. Re-running the originating
+ *     work against fresh confirmed state and committing again can succeed. Under
+ *     sustained contention (for example a space rehydrating while a handler
+ *     writes to it) these arrive in bursts.
+ *   - Permanent: a commit-time precondition failure (receipt-exists,
+ *     origin-committed). Re-running can never succeed and must not happen.
+ *
+ * A committed write that represents real user intent must converge or fail
+ * loudly; it must never be silently dropped. This policy retries a transient
+ * conflict with capped exponential backoff so the system slows down rather than
+ * busy-looping, and keeps retrying for a bounded window long enough to outlast a
+ * contention burst. If the window elapses without the write landing, the failure
+ * surfaces as a terminal error rather than vanishing.
+ */
+export interface CommitBackpressurePolicy {
+  /** Delay before the first retry, in milliseconds. */
+  baseDelayMs: number;
+  /** Ceiling on the per-retry delay, in milliseconds. */
+  maxDelayMs: number;
+  /**
+   * Fraction of the computed delay subtracted at random, in [0, 1]. 0.5 spreads
+   * each delay across the lower 50% of the capped value so concurrent writers
+   * contending for the same entity do not retry in lockstep. Subtractive so the
+   * delay never exceeds maxDelayMs.
+   */
+  jitter: number;
+  /**
+   * Total wall-clock time a transient conflict may be retried before the write
+   * surfaces a terminal error, in milliseconds. Measured from the first
+   * conflict for a given intent.
+   */
+  retryWindowMs: number;
+}
+
+export const DEFAULT_COMMIT_BACKPRESSURE: CommitBackpressurePolicy = {
+  baseDelayMs: 25,
+  maxDelayMs: 1_000,
+  jitter: 0.5,
+  retryWindowMs: 30_000,
+};
+
+/**
+ * Fills in any unset fields from the defaults and clamps each field to a sane
+ * range so a caller-supplied policy can never disable backpressure (a zero
+ * window would reintroduce silent drops) or invert the delays.
+ */
+export function resolveCommitBackpressure(
+  partial?: Partial<CommitBackpressurePolicy>,
+): CommitBackpressurePolicy {
+  const merged = { ...DEFAULT_COMMIT_BACKPRESSURE, ...partial };
+  const baseDelayMs = Math.max(0, merged.baseDelayMs);
+  const maxDelayMs = Math.max(baseDelayMs, merged.maxDelayMs);
+  const jitter = Math.min(1, Math.max(0, merged.jitter));
+  const retryWindowMs = Math.max(0, merged.retryWindowMs);
+  return { baseDelayMs, maxDelayMs, jitter, retryWindowMs };
+}
+
+/**
+ * Delay before the given retry attempt (1-based), in milliseconds: exponential
+ * growth from `baseDelayMs`, capped at `maxDelayMs`, then reduced by up to the
+ * `jitter` fraction. The result is in `[capped * (1 - jitter), capped]`, so it
+ * decorrelates concurrent writers without ever exceeding `maxDelayMs`.
+ */
+export function computeBackoffDelayMs(
+  attempt: number,
+  policy: CommitBackpressurePolicy,
+  random: () => number = Math.random,
+): number {
+  const exponent = Math.max(0, attempt - 1);
+  const growth = policy.baseDelayMs * 2 ** exponent;
+  const capped = Math.min(policy.maxDelayMs, growth);
+  if (policy.jitter === 0) {
+    return capped;
+  }
+  const reduction = capped * policy.jitter * random();
+  return Math.max(0, capped - reduction);
+}
+
+/**
+ * Terminal failure raised when a committed write that represents user intent
+ * cannot be made durable: a transient conflict that never converged within the
+ * retry window. Surfaced through the scheduler error channel so the UI or
+ * handler can react, instead of the write being silently dropped.
+ */
+export class CommitConvergenceError extends Error {
+  readonly attempts: number;
+  readonly elapsedMs: number;
+  override readonly cause: unknown;
+
+  constructor(
+    options: {
+      handlerId?: string;
+      attempts: number;
+      elapsedMs: number;
+      cause?: unknown;
+    },
+  ) {
+    const handlerPart = options.handlerId ? ` for ${options.handlerId}` : "";
+    super(
+      `Committed write${handlerPart} did not converge after ${options.attempts} ` +
+        `attempts over ${
+          Math.round(options.elapsedMs)
+        }ms of sustained conflicts`,
+    );
+    this.name = "CommitConvergenceError";
+    this.attempts = options.attempts;
+    this.elapsedMs = options.elapsedMs;
+    this.cause = options.cause;
+  }
+}

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -573,6 +573,7 @@ export async function dispatchQueuedEvent(state: {
     attempts: number,
     deadline: number,
     runAt: number,
+    delayMs: number,
   ) => {
     const retry: QueuedEvent = {
       id: queuedEvent.id,
@@ -585,7 +586,10 @@ export async function dispatchQueuedEvent(state: {
       onCommit,
       conflictAttempts: attempts,
       conflictDeadline: deadline,
-      notBefore: runAt,
+      // An immediate retry (delayMs 0) is not parked: it re-runs on the next
+      // execute cycle like the pre-backpressure fast path. Only a delayed retry
+      // sets notBefore to hold the head until its timer fires.
+      ...(delayMs > 0 ? { notBefore: runAt } : {}),
     };
     state.eventQueue.unshift(retry);
     if (retry.originTx !== undefined) {
@@ -724,15 +728,19 @@ export async function dispatchQueuedEvent(state: {
         case "backoff":
           logger.warn(
             "scheduler",
-            `Event handler commit conflicted; backing off ` +
-              `${Math.round(disposition.delayMs)}ms ` +
-              `(attempt ${disposition.attempts})`,
+            disposition.delayMs > 0
+              ? `Event handler commit conflicted; backing off ` +
+                `${Math.round(disposition.delayMs)}ms ` +
+                `(attempt ${disposition.attempts})`
+              : `Event handler commit conflicted; retrying immediately ` +
+                `(attempt ${disposition.attempts})`,
             { handlerId },
           );
           requeueForBackoff(
             disposition.attempts,
             disposition.deadline,
             disposition.runAt,
+            disposition.delayMs,
           );
           return;
         case "permanent":
@@ -894,18 +902,19 @@ function classifyCommitDisposition(
   const attempts = (queuedEvent.conflictAttempts ?? 0) + 1;
   const now = performance.now();
   const deadline = queuedEvent.conflictDeadline ?? (now + policy.retryWindowMs);
-  if (now < deadline) {
-    const delayMs = computeBackoffDelayMs(attempts, policy);
-    return {
-      kind: "backoff",
-      attempts,
-      deadline,
-      delayMs,
-      runAt: now + delayMs,
-    };
+  if (now >= deadline) {
+    // The window is measured from the first conflict (deadline minus window);
+    // elapsed time is at least the full window.
+    const elapsedMs = policy.retryWindowMs + (now - deadline);
+    return { kind: "convergence-failed", attempts, elapsedMs };
   }
-  // The window is measured from the first conflict (deadline minus window);
-  // elapsed time is at least the full window.
-  const elapsedMs = policy.retryWindowMs + (now - deadline);
-  return { kind: "convergence-failed", attempts, elapsedMs };
+  // A stale-basis conflict usually clears the moment the fresh confirmed state
+  // arrives, so the first `immediateRetries` retries fire with no delay — the
+  // fast path that lets a transient conflict converge without stretching the
+  // wall-clock. Only once those are exhausted (sustained contention) does
+  // backoff begin, with its exponent counted from the first delayed retry.
+  const delayMs = attempts <= policy.immediateRetries
+    ? 0
+    : computeBackoffDelayMs(attempts - policy.immediateRetries, policy);
+  return { kind: "backoff", attempts, deadline, delayMs, runAt: now + delayMs };
 }

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -13,7 +13,15 @@ import type {
   IPreconditionFailedError,
   MemorySpace,
 } from "../storage/interface.ts";
-import { isPermanentRejection } from "../storage/rejection.ts";
+import {
+  isConflictRejection,
+  isPermanentRejection,
+} from "../storage/rejection.ts";
+import {
+  type CommitBackpressurePolicy,
+  CommitConvergenceError,
+  computeBackoffDelayMs,
+} from "./backpressure.ts";
 import type {
   SchedulerActionInfo,
   SchedulerEventPreflightStats,
@@ -226,6 +234,7 @@ export interface SchedulerEventExecutionState {
   readonly eventQueue: QueuedEvent[];
   readonly dirty: ReadonlySet<Action>;
   readonly pending: Set<Action>;
+  readonly backpressure: CommitBackpressurePolicy;
   readonly eventPreflightTelemetryEnabled: boolean;
   readonly setRunningPromise: (promise: Promise<unknown>) => void;
   readonly getActionId: (action: Action | EventHandler) => string;
@@ -453,6 +462,7 @@ export function preflightQueuedEventDependencies(state: {
 export async function dispatchQueuedEvent(state: {
   readonly runtime: Runtime;
   readonly eventQueue: QueuedEvent[];
+  readonly backpressure: CommitBackpressurePolicy;
   readonly setRunningPromise: (promise: Promise<unknown>) => void;
   readonly getActionId: (action: Action | EventHandler) => string;
   readonly getActionTelemetryInfo: (
@@ -552,6 +562,38 @@ export async function dispatchQueuedEvent(state: {
     state.queueExecution();
   };
 
+  // Re-queue a transient commit conflict for a later retry. The retry is parked
+  // via notBefore so the scheduler backs off (capped exponential delay) instead
+  // of busy-looping; idle()/settled() wait for the parked head, so a converging
+  // write still completes within a settle. The conflict attempt count and
+  // deadline are carried forward; retriesLeft is preserved untouched because it
+  // is the separate budget for inSpace-name resolution (RetryImmediately), not
+  // for conflicts.
+  const requeueForBackoff = (
+    attempts: number,
+    deadline: number,
+    runAt: number,
+  ) => {
+    const retry: QueuedEvent = {
+      id: queuedEvent.id,
+      originTx: queuedEvent.originTx,
+      action,
+      eventLink: queuedEvent.eventLink,
+      handler,
+      event: eventValue,
+      retriesLeft,
+      onCommit,
+      conflictAttempts: attempts,
+      conflictDeadline: deadline,
+      notBefore: runAt,
+    };
+    state.eventQueue.unshift(retry);
+    if (retry.originTx !== undefined) {
+      state.recordLineageEvent(retry.originTx, retry);
+    }
+    state.queueExecution();
+  };
+
   const runFinalCommitCallback = () => {
     if (!onCommit) {
       return;
@@ -621,6 +663,18 @@ export async function dispatchQueuedEvent(state: {
       if (!result.error && changedWrites.length > 0) {
         state.onEventCommitWrites?.(action, changedWrites);
       }
+
+      // Classify the commit outcome. A committed write that represents user
+      // intent must converge or fail loudly: a transient conflict backs off and
+      // retries within a bounded window rather than being dropped after a fixed
+      // budget; a permanent rejection is never retried; an unconverged write
+      // surfaces a terminal error.
+      const disposition = classifyCommitDisposition(
+        result.error,
+        queuedEvent,
+        state.backpressure,
+      );
+
       state.runtime.telemetry.submit({
         type: "scheduler.event.commit",
         handlerId,
@@ -634,39 +688,90 @@ export async function dispatchQueuedEvent(state: {
           : {}),
         ...(result.error ? { error: result.error.message } : {}),
         ...(permanentRejection !== undefined ? { permanentRejection } : {}),
+        ...(disposition.kind === "backoff"
+          ? {
+            retryAttempt: disposition.attempts,
+            backoffMs: disposition.delayMs,
+          }
+          : {}),
+        ...(disposition.kind === "convergence-failed"
+          ? { retryAttempt: disposition.attempts, terminal: "convergence" }
+          : {}),
+        ...(disposition.kind === "permanent" ? { terminal: "permanent" } : {}),
       });
-      if (
-        result.error && retriesLeft > 0 &&
-        !isPermanentRejection(result.error)
-      ) {
-        logger.warn(
-          "scheduler",
-          `Event handler transaction failed, retrying (${retriesLeft} retries left)`,
-          { error: result.error, handlerId },
-        );
-        requeueForRetry();
-        return;
-      }
-      runFinalCommitCallback();
-      if (result.error) {
-        if (permanentRejection === "receipt-exists") {
+
+      switch (disposition.kind) {
+        case "success":
+          runFinalCommitCallback();
+          return;
+        case "bounded-retry":
           logger.warn(
-            "event-lost-race",
+            "scheduler",
+            `Event handler transaction failed, retrying ` +
+              `(${retriesLeft} retries left)`,
+            { error: result.error, handlerId },
+          );
+          requeueForRetry();
+          return;
+        case "give-up":
+          runFinalCommitCallback();
+          logger.error(
+            "schedule-error",
+            "Event handler transaction failed after exhausting all retries",
+            { error: result.error, handlerId, permanent: false },
+          );
+          return;
+        case "backoff":
+          logger.warn(
+            "scheduler",
+            `Event handler commit conflicted; backing off ` +
+              `${Math.round(disposition.delayMs)}ms ` +
+              `(attempt ${disposition.attempts})`,
+            { handlerId },
+          );
+          requeueForBackoff(
+            disposition.attempts,
+            disposition.deadline,
+            disposition.runAt,
+          );
+          return;
+        case "permanent":
+          runFinalCommitCallback();
+          if (permanentRejection === "receipt-exists") {
+            logger.warn(
+              "event-lost-race",
+              () => [
+                "Event handling lost the receipt race",
+                { eventId: queuedEvent.id, handlerId },
+              ],
+            );
+          }
+          logger.warn(
+            "scheduler",
+            "Event handler commit permanently rejected; not retrying",
+            { error: result.error, handlerId, permanentRejection },
+          );
+          return;
+        case "convergence-failed": {
+          runFinalCommitCallback();
+          logger.error(
+            "commit-convergence-failed",
             () => [
-              "Event handling lost the receipt race",
-              { eventId: queuedEvent.id, handlerId },
+              "Committed write did not converge within the retry window",
+              { handlerId, attempts: disposition.attempts },
             ],
           );
+          state.handleError(
+            new CommitConvergenceError({
+              handlerId,
+              attempts: disposition.attempts,
+              elapsedMs: disposition.elapsedMs,
+              cause: result.error,
+            }),
+            action,
+          );
+          return;
         }
-        logger.error(
-          "schedule-error",
-          "Event handler transaction failed after exhausting all retries",
-          {
-            error: result.error,
-            handlerId,
-            permanent: isPermanentRejection(result.error),
-          },
-        );
       }
     }).catch((error) => {
       logger.error(
@@ -733,4 +838,74 @@ function formatEventCommitAddress(address: {
   path: readonly string[];
 }): string {
   return `${address.space}/${address.id}/${address.path.join("/")}`;
+}
+
+type CommitDisposition =
+  | { kind: "success" }
+  | { kind: "permanent" }
+  | {
+    kind: "backoff";
+    attempts: number;
+    deadline: number;
+    delayMs: number;
+    runAt: number;
+  }
+  | { kind: "convergence-failed"; attempts: number; elapsedMs: number }
+  | { kind: "bounded-retry" }
+  | { kind: "give-up" };
+
+/**
+ * Decides what to do with an event-handler commit result.
+ *
+ *  - success: nothing more to do.
+ *  - permanent: a precondition failure; never retried.
+ *  - backoff / convergence-failed: a stale-basis ConflictError under
+ *    contention. It backs off and retries until it lands or the retry window
+ *    elapses, after which it fails terminally rather than being silently
+ *    dropped. This is the backpressure path.
+ *  - bounded-retry / give-up: any other transient error (a handler-initiated
+ *    abort, a system error). These are not contention, so backpressure would
+ *    not help; they keep the fixed retriesLeft budget and stop after it.
+ */
+function classifyCommitDisposition(
+  error: { name?: string } | undefined,
+  queuedEvent: QueuedEvent,
+  policy: CommitBackpressurePolicy,
+): CommitDisposition {
+  if (!error) {
+    return { kind: "success" };
+  }
+  if (isPermanentRejection(error)) {
+    return { kind: "permanent" };
+  }
+  if (!isConflictRejection(error)) {
+    return queuedEvent.retriesLeft > 0
+      ? { kind: "bounded-retry" }
+      : { kind: "give-up" };
+  }
+  // A caller that sent with retries:0 (a speculative lineage origin, an internal
+  // one-shot) opted out of retrying; honor that so a descendant of a failed
+  // origin drops deterministically. Any positive budget opts into retry-on-
+  // conflict, which the retry window then governs — the exact count no longer
+  // bounds conflict retries, the window does.
+  if (queuedEvent.retriesLeft <= 0) {
+    return { kind: "give-up" };
+  }
+  const attempts = (queuedEvent.conflictAttempts ?? 0) + 1;
+  const now = performance.now();
+  const deadline = queuedEvent.conflictDeadline ?? (now + policy.retryWindowMs);
+  if (now < deadline) {
+    const delayMs = computeBackoffDelayMs(attempts, policy);
+    return {
+      kind: "backoff",
+      attempts,
+      deadline,
+      delayMs,
+      runAt: now + delayMs,
+    };
+  }
+  // The window is measured from the first conflict (deadline minus window);
+  // elapsed time is at least the full window.
+  const elapsedMs = policy.retryWindowMs + (now - deadline);
+  return { kind: "convergence-failed", attempts, elapsedMs };
 }

--- a/packages/runner/src/scheduler/pull-events.ts
+++ b/packages/runner/src/scheduler/pull-events.ts
@@ -110,6 +110,7 @@ export async function processPullQueuedEventDuringExecute(
   await dispatchQueuedEvent({
     runtime: state.runtime,
     eventQueue: state.eventQueue,
+    backpressure: state.backpressure,
     setRunningPromise: (promise) => {
       state.setRunningPromise(promise);
     },

--- a/packages/runner/src/scheduler/types.ts
+++ b/packages/runner/src/scheduler/types.ts
@@ -199,4 +199,15 @@ export type QueuedEvent = {
   retriesLeft: number;
   onCommit?: (tx: IExtendedStorageTransaction) => void;
   notBefore?: number;
+  /**
+   * Number of transient commit conflicts this intent has hit. Drives the
+   * exponential backoff exponent; carried across backoff retries.
+   */
+  conflictAttempts?: number;
+  /**
+   * Wall-clock deadline (performance.now()) after which a still-conflicting
+   * intent surfaces a terminal error instead of retrying. Set from the first
+   * conflict and carried across backoff retries.
+   */
+  conflictDeadline?: number;
 };

--- a/packages/runner/src/storage/rejection.ts
+++ b/packages/runner/src/storage/rejection.ts
@@ -16,6 +16,12 @@ export function isPermanentRejection(
  * the compute's (still-subscribed) reads, so normal reader-dirty propagation
  * re-runs it with the latest state. Other non-permanent errors are not
  * re-triggered that way and still warrant a retry.
+ *
+ * The event-handler commit path treats the same rejection as the signal to
+ * apply committed-write backpressure: re-running the handler against fresh
+ * confirmed state and committing again can succeed, so a conflict is retried
+ * with backoff rather than dropped. Handler-initiated aborts and system errors
+ * are not conflicts and keep their bounded retry budget.
  */
 export function isConflictRejection(
   error: { name?: string } | undefined | null,

--- a/packages/runner/src/telemetry.ts
+++ b/packages/runner/src/telemetry.ts
@@ -171,6 +171,16 @@ export type RuntimeTelemetryMarker = {
   writesTruncated?: boolean;
   error?: string;
   permanentRejection?: "origin-committed" | "receipt-exists";
+  /** Backpressure attempt count (1-based) for a transient-conflict retry. */
+  retryAttempt?: number;
+  /** Backoff delay applied before the next retry, in milliseconds. */
+  backoffMs?: number;
+  /**
+   * Set when the commit reached a terminal outcome: `permanent` for a
+   * never-retried precondition failure, `convergence` for a transient conflict
+   * that exhausted the retry window and surfaced a terminal error.
+   */
+  terminal?: "permanent" | "convergence";
 } | {
   type: "scheduler.event.preflight";
   handlerId: string;

--- a/packages/runner/test/scheduler-commit-backpressure.test.ts
+++ b/packages/runner/test/scheduler-commit-backpressure.test.ts
@@ -311,6 +311,55 @@ describe("committed-write backpressure", () => {
   );
 
   it(
+    "clears a small conflict burst on the immediate fast path without backoff",
+    async () => {
+      // A conflict that clears within the immediate-retry budget must converge
+      // without being parked for backoff. Delaying such a retry can keep it from
+      // landing inside a settle, which is what a multi-user settle relies on.
+      const piece = buildCounterPiece(
+        runtime,
+        tx,
+        "backpressure-fastpath-root",
+      );
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.idle();
+
+      const commitTelemetry = collectEventCommitMarkers(runtime);
+      // Three conflicts — within the default immediateRetries (5).
+      const injector = rejectServerTransacts(storageManager, 3, {
+        name: "ConflictError",
+        message: "forced small conflict burst",
+      });
+
+      try {
+        piece.queueAdd(
+          4,
+          "evt:backpressure-fastpath:0:backpressure-fastpath-root",
+        );
+
+        await waitFor(
+          runtime,
+          () => piece.total() === 4,
+          `write did not land on the fast path ` +
+            `(total=${piece.total()}, rejected=${injector.rejected()})`,
+        );
+
+        expect(piece.total()).toBe(4);
+        expect(injector.rejected()).toBe(3);
+        // Every retry was immediate: no commit marker carried a backoff delay.
+        const backedOff = commitTelemetry.markers.some((marker) =>
+          ((marker as { backoffMs?: number }).backoffMs ?? 0) > 0
+        );
+        expect(backedOff).toBe(false);
+      } finally {
+        injector.restore();
+        commitTelemetry.dispose();
+      }
+    },
+  );
+
+  it(
     "does not retry a permanent rejection and keeps it observable",
     async () => {
       const piece = buildCounterPiece(

--- a/packages/runner/test/scheduler-commit-backpressure.test.ts
+++ b/packages/runner/test/scheduler-commit-backpressure.test.ts
@@ -11,6 +11,10 @@
 //      observable.
 //   3. A transient conflict that never clears surfaces a terminal error within
 //      the retry window instead of vanishing.
+//   4. A zero-window policy fails the first conflict loudly without dropping it
+//      silently.
+//   5. Three array appends survive a conflict storm so the durable count reaches
+//      three (the profile-append bug in miniature).
 
 import {
   afterEach,
@@ -419,6 +423,70 @@ describe("committed-write backpressure", () => {
         // Bounded resource use: the retry window capped the attempt count.
         expect(piece.invocations()).toBeGreaterThan(1);
         expect(piece.invocations()).toBeLessThan(500);
+      } finally {
+        injector.restore();
+      }
+    },
+  );
+
+  it(
+    "fails a zero-window conflict loudly on the first attempt without dropping silently",
+    async () => {
+      // A clamped policy can resolve to retryWindowMs: 0. That does not
+      // reintroduce a silent drop: the first conflict surfaces a terminal error
+      // and the handler is not retried.
+      await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
+      ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
+        import.meta.url,
+        {
+          experimental: { commitPreconditions: true },
+          commitBackpressure: { retryWindowMs: 0 },
+        },
+      ));
+
+      const piece = buildCounterPiece(runtime, tx, "backpressure-zerowin-root");
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.idle();
+
+      const terminalErrors: ErrorWithContext[] = [];
+      runtime.scheduler.onError((error) => terminalErrors.push(error));
+
+      const injector = rejectServerTransacts(storageManager, Infinity, {
+        name: "ConflictError",
+        message: "forced conflict against a zero window",
+      });
+
+      try {
+        piece.queueAdd(
+          9,
+          "evt:backpressure-zerowin:0:backpressure-zerowin-root",
+        );
+
+        await waitFor(
+          runtime,
+          () =>
+            terminalErrors.some((error) =>
+              error.name === "CommitConvergenceError"
+            ),
+          `zero-window conflict did not surface a terminal error ` +
+            `(invocations=${piece.invocations()}, total=${piece.total()})`,
+        );
+
+        // Give any erroneous retry a chance to run, then confirm none did.
+        await runtime.idle();
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        await runtime.idle();
+
+        // Loud, not silent: a terminal error surfaced.
+        expect(
+          terminalErrors.some((error) =>
+            error.name === "CommitConvergenceError"
+          ),
+        ).toBe(true);
+        // No retry: the handler ran exactly once and the write did not land.
+        expect(piece.invocations()).toBe(1);
+        expect(piece.total()).toBe(0);
       } finally {
         injector.restore();
       }

--- a/packages/runner/test/scheduler-commit-backpressure.test.ts
+++ b/packages/runner/test/scheduler-commit-backpressure.test.ts
@@ -1,0 +1,468 @@
+// Backpressure for committed writes under sustained contention.
+//
+// A committed write that represents real user intent must converge or fail
+// loudly; it must never be silently dropped because a fixed retry budget ran
+// out before the contention cleared. These tests drive the event-handler commit
+// path against an emulated server that rejects commits on demand:
+//
+//   1. A burst of transient conflicts longer than the old fixed budget still
+//      lets the write land.
+//   2. A permanent rejection is not retried (no infinite loop) and stays
+//      observable.
+//   3. A transient conflict that never clears surfaces a terminal error within
+//      the retry window instead of vanishing.
+
+import {
+  afterEach,
+  beforeEach,
+  createSchedulerTestRuntime,
+  describe,
+  disposeSchedulerTestRuntime,
+  expect,
+  it,
+  Runtime,
+  space,
+} from "./scheduler-test-utils.ts";
+import type {
+  Cell,
+  ErrorWithContext,
+  IExtendedStorageTransaction,
+  RuntimeTelemetryMarker,
+  SchedulerTestStorageManager,
+} from "./scheduler-test-utils.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { resolveLink } from "../src/link-resolution.ts";
+
+type TransactMessage = { requestId: string };
+type TransactResponse = {
+  type: "response";
+  requestId: string;
+  ok?: unknown;
+  error?: { name: string; message: string; precondition?: string };
+};
+type TestMemoryServer = {
+  transact(message: TransactMessage): Promise<TransactResponse>;
+};
+
+function emulatedServer(
+  storageManager: SchedulerTestStorageManager,
+): TestMemoryServer {
+  return (storageManager as unknown as { server(): TestMemoryServer }).server();
+}
+
+/**
+ * Rejects server commits with `error` until `predicate(rejected)` returns false,
+ * then passes through to the real server. Returns the number of rejections
+ * issued and a restore function. `count: Infinity` rejects every commit.
+ */
+function rejectServerTransacts(
+  storageManager: SchedulerTestStorageManager,
+  count: number,
+  error: { name: string; message: string; precondition?: string },
+): { rejected: () => number; restore: () => void } {
+  const server = emulatedServer(storageManager);
+  const original = server.transact.bind(server);
+  let rejected = 0;
+  server.transact = (message) => {
+    if (rejected < count) {
+      rejected++;
+      return Promise.resolve({
+        type: "response",
+        requestId: message.requestId,
+        error,
+      });
+    }
+    return original(message);
+  };
+  return {
+    rejected: () => rejected,
+    restore: () => {
+      server.transact = original;
+    },
+  };
+}
+
+function collectEventCommitMarkers(runtime: Runtime): {
+  markers: RuntimeTelemetryMarker[];
+  dispose(): void;
+} {
+  const markers: RuntimeTelemetryMarker[] = [];
+  const listener = (event: Event) => {
+    const marker = (event as CustomEvent<{
+      marker: RuntimeTelemetryMarker;
+    }>).detail.marker;
+    if (marker.type === "scheduler.event.commit") {
+      markers.push(marker);
+    }
+  };
+  runtime.telemetry.addEventListener("telemetry", listener);
+  return {
+    markers,
+    dispose: () => runtime.telemetry.removeEventListener("telemetry", listener),
+  };
+}
+
+async function waitFor(
+  runtime: Runtime,
+  condition: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const deadline = performance.now() + timeoutMs;
+  while (!condition() && performance.now() < deadline) {
+    await runtime.idle();
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  if (!condition()) {
+    throw new Error(message);
+  }
+}
+
+/**
+ * Builds a piece with a single effect handler that adds the event value to a
+ * running total. The handler's commit is the committed write under test.
+ */
+function buildCounterPiece(
+  runtime: Runtime,
+  tx: IExtendedStorageTransaction,
+  label: string,
+): {
+  total: () => number;
+  invocations: () => number;
+  queueAdd: (value: number, eventId: string) => void;
+} {
+  const { commonfabric } = createTrustedBuilder(runtime);
+  const { cell, handler, pattern } = commonfabric;
+  let invocations = 0;
+  const recordEvent = handler<
+    { value: number },
+    { effects: { total: number } }
+  >(
+    (event, { effects }) => {
+      invocations++;
+      effects.total += event.value;
+    },
+    { proxy: true },
+  );
+  // Expose the stored effects cell directly so the running total can be read
+  // synchronously without pulling a computation (pull-mode computations do not
+  // run without a subscriber).
+  const rootPattern = pattern(() => {
+    const effects = cell({ total: 0 });
+    return { effects, stream: recordEvent({ effects }) };
+  });
+  const rootCell = runtime.getCell<
+    { effects: { total: number }; stream: unknown }
+  >(space, label, undefined, tx);
+  const root = runtime.run(tx, rootPattern, {}, rootCell);
+
+  const streamLink = () =>
+    resolveLink(
+      runtime,
+      runtime.readTx(),
+      root.key("stream").getAsNormalizedFullLink(),
+    );
+
+  return {
+    total: () => (root.key("effects").key("total") as Cell<number>).get() ?? 0,
+    invocations: () => invocations,
+    queueAdd: (value, eventId) => {
+      runtime.scheduler.queueEvent(
+        streamLink(),
+        { value },
+        undefined,
+        undefined,
+        false,
+        { eventId },
+      );
+    },
+  };
+}
+
+/**
+ * Builds a piece whose handler appends the event value to a stored array with a
+ * whole-array set (`list = [...list, value]`) — the shape of the profile-append
+ * bug, where each append rewrites the list entity and so conflicts with any
+ * concurrent writer that bumped the entity's basis sequence.
+ */
+function buildListPiece(
+  runtime: Runtime,
+  tx: IExtendedStorageTransaction,
+  label: string,
+): {
+  list: () => readonly number[];
+  invocations: () => number;
+  queueAppend: (value: number, eventId: string) => void;
+} {
+  const { commonfabric } = createTrustedBuilder(runtime);
+  const { cell, handler, pattern } = commonfabric;
+  let invocations = 0;
+  const appendEvent = handler<
+    { value: number },
+    { effects: { list: number[] } }
+  >(
+    (event, { effects }) => {
+      invocations++;
+      effects.list = [...(effects.list ?? []), event.value];
+    },
+    { proxy: true },
+  );
+  const rootPattern = pattern(() => {
+    const effects = cell<{ list: number[] }>({ list: [] });
+    return { effects, stream: appendEvent({ effects }) };
+  });
+  const rootCell = runtime.getCell<
+    { effects: { list: number[] }; stream: unknown }
+  >(space, label, undefined, tx);
+  const root = runtime.run(tx, rootPattern, {}, rootCell);
+
+  const streamLink = () =>
+    resolveLink(
+      runtime,
+      runtime.readTx(),
+      root.key("stream").getAsNormalizedFullLink(),
+    );
+
+  return {
+    list: () => (root.key("effects").key("list") as Cell<number[]>).get() ?? [],
+    invocations: () => invocations,
+    queueAppend: (value, eventId) => {
+      runtime.scheduler.queueEvent(
+        streamLink(),
+        { value },
+        undefined,
+        undefined,
+        false,
+        { eventId },
+      );
+    },
+  };
+}
+
+describe("committed-write backpressure", () => {
+  let storageManager: SchedulerTestStorageManager;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
+      import.meta.url,
+      {
+        experimental: { commitPreconditions: true },
+        // Fast backoff so retries do not stretch the test; the window is wide
+        // enough for the conflict burst to clear in tests 1 and 2.
+        commitBackpressure: {
+          baseDelayMs: 1,
+          maxDelayMs: 4,
+          jitter: 0,
+          retryWindowMs: 60_000,
+        },
+      },
+    ));
+  });
+
+  afterEach(async () => {
+    await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
+  });
+
+  it(
+    "lands a write after a burst of transient conflicts longer than the old fixed budget",
+    async () => {
+      const piece = buildCounterPiece(runtime, tx, "backpressure-burst-root");
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.idle();
+
+      const terminalErrors: ErrorWithContext[] = [];
+      runtime.scheduler.onError((error) => terminalErrors.push(error));
+
+      // Eight conflicts: well past DEFAULT_RETRIES_FOR_EVENTS (5). The old
+      // fixed-budget path gives up after ~6 attempts and drops the write.
+      const injector = rejectServerTransacts(storageManager, 8, {
+        name: "ConflictError",
+        message: "forced transient conflict",
+      });
+
+      try {
+        piece.queueAdd(3, "evt:backpressure-burst:0:backpressure-burst-root");
+
+        await waitFor(
+          runtime,
+          () => piece.total() === 3,
+          `write did not land after transient conflicts ` +
+            `(total=${piece.total()}, rejected=${injector.rejected()}, ` +
+            `invocations=${piece.invocations()})`,
+        );
+
+        expect(piece.total()).toBe(3);
+        expect(injector.rejected()).toBe(8);
+        // The handler re-ran for each failed attempt plus the success.
+        expect(piece.invocations()).toBeGreaterThanOrEqual(9);
+        // The write converged, so no terminal error.
+        expect(terminalErrors).toHaveLength(0);
+      } finally {
+        injector.restore();
+      }
+    },
+  );
+
+  it(
+    "does not retry a permanent rejection and keeps it observable",
+    async () => {
+      const piece = buildCounterPiece(
+        runtime,
+        tx,
+        "backpressure-permanent-root",
+      );
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.idle();
+
+      const commitTelemetry = collectEventCommitMarkers(runtime);
+      // receipt-exists is a permanent precondition failure (idempotent
+      // dedup): retrying it would double-handle the event.
+      const injector = rejectServerTransacts(storageManager, Infinity, {
+        name: "PreconditionFailedError",
+        message: "forced permanent rejection",
+        precondition: "receipt-exists",
+      });
+
+      try {
+        piece.queueAdd(
+          5,
+          "evt:backpressure-permanent:0:backpressure-permanent-root",
+        );
+
+        await waitFor(
+          runtime,
+          () => commitTelemetry.markers.length >= 1,
+          "permanent rejection never reported a commit marker",
+        );
+        // Give any erroneous retry a chance to run, then confirm none did.
+        await runtime.idle();
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        await runtime.idle();
+
+        // The handler ran once; a permanent rejection must not re-run it.
+        expect(piece.invocations()).toBe(1);
+        // The write did not land (the dedup is the whole point).
+        expect(piece.total()).toBe(0);
+        // The permanent rejection is observable via commit telemetry.
+        expect(
+          commitTelemetry.markers.some((marker) =>
+            (marker as { permanentRejection?: string }).permanentRejection ===
+              "receipt-exists"
+          ),
+        ).toBe(true);
+      } finally {
+        injector.restore();
+        commitTelemetry.dispose();
+      }
+    },
+  );
+
+  it(
+    "surfaces a terminal error when a transient conflict never converges",
+    async () => {
+      await disposeSchedulerTestRuntime({ storageManager, runtime, tx });
+      ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
+        import.meta.url,
+        {
+          experimental: { commitPreconditions: true },
+          // Short window so the non-converging case fails loudly fast.
+          commitBackpressure: {
+            baseDelayMs: 1,
+            maxDelayMs: 2,
+            jitter: 0,
+            retryWindowMs: 40,
+          },
+        },
+      ));
+
+      const piece = buildCounterPiece(
+        runtime,
+        tx,
+        "backpressure-stuck-root",
+      );
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.idle();
+
+      const terminalErrors: ErrorWithContext[] = [];
+      runtime.scheduler.onError((error) => terminalErrors.push(error));
+
+      // Reject every commit: the conflict never clears.
+      const injector = rejectServerTransacts(storageManager, Infinity, {
+        name: "ConflictError",
+        message: "forced unending conflict",
+      });
+
+      try {
+        piece.queueAdd(7, "evt:backpressure-stuck:0:backpressure-stuck-root");
+
+        await waitFor(
+          runtime,
+          () =>
+            terminalErrors.some((error) =>
+              error.name === "CommitConvergenceError"
+            ),
+          `non-converging write did not surface a terminal error ` +
+            `(invocations=${piece.invocations()}, total=${piece.total()})`,
+        );
+
+        const convergence = terminalErrors.find((error) =>
+          error.name === "CommitConvergenceError"
+        );
+        expect(convergence).toBeDefined();
+        // The write never landed, but it failed loudly rather than silently.
+        expect(piece.total()).toBe(0);
+        // Bounded resource use: the retry window capped the attempt count.
+        expect(piece.invocations()).toBeGreaterThan(1);
+        expect(piece.invocations()).toBeLessThan(500);
+      } finally {
+        injector.restore();
+      }
+    },
+  );
+
+  it(
+    "lands all three array appends through a conflict storm (durable count reaches 3)",
+    async () => {
+      // The profile-append-during-rehydration bug in miniature: three whole-
+      // array appends issued while the entity is churned by a burst of conflicts.
+      // Each append rewrites the list, so a stale basis sequence rejects it.
+      const piece = buildListPiece(runtime, tx, "backpressure-list-root");
+      await tx.commit();
+      tx = runtime.edit();
+      await runtime.idle();
+
+      const terminalErrors: ErrorWithContext[] = [];
+      runtime.scheduler.onError((error) => terminalErrors.push(error));
+
+      // A burst longer than the old fixed budget. The old path drops the first
+      // append after ~6 attempts, leaving a durable count of 1.
+      const injector = rejectServerTransacts(storageManager, 8, {
+        name: "ConflictError",
+        message: "forced rehydration conflict storm",
+      });
+
+      try {
+        piece.queueAppend(1, "evt:backpressure-list:0:backpressure-list-root");
+        piece.queueAppend(2, "evt:backpressure-list:1:backpressure-list-root");
+        piece.queueAppend(3, "evt:backpressure-list:2:backpressure-list-root");
+
+        await waitFor(
+          runtime,
+          () => piece.list().length === 3,
+          `not all appends landed (list=${JSON.stringify(piece.list())}, ` +
+            `rejected=${injector.rejected()})`,
+        );
+
+        expect(piece.list()).toEqual([1, 2, 3]);
+        expect(terminalErrors).toHaveLength(0);
+      } finally {
+        injector.restore();
+      }
+    },
+  );
+});

--- a/packages/runner/test/scheduler-event-lineage.test.ts
+++ b/packages/runner/test/scheduler-event-lineage.test.ts
@@ -183,7 +183,19 @@ describe("scheduler event lineage", () => {
   beforeEach(() => {
     ({ storageManager, runtime, tx } = createSchedulerTestRuntime(
       import.meta.url,
-      { experimental: { commitPreconditions: true } },
+      {
+        experimental: { commitPreconditions: true },
+        // These tests assert lineage gating (which events run vs. drop), not
+        // backoff timing. A short retry window keeps the cases that inject an
+        // unending conflict from backing off for the full production window
+        // before they reach their terminal outcome.
+        commitBackpressure: {
+          baseDelayMs: 1,
+          maxDelayMs: 5,
+          jitter: 0,
+          retryWindowMs: 250,
+        },
+      },
     ));
   });
 
@@ -718,7 +730,7 @@ describe("scheduler event lineage", () => {
     expect(payloads.get()).toEqual([]);
   });
 
-  it("stops handler-result pieces when the handler commit fails permanently", async () => {
+  it("stops handler-result pieces when the handler commit never converges", async () => {
     const { commonfabric } = createTrustedBuilder(runtime);
     const { cell, handler, lift, pattern } = commonfabric;
     const childPattern = pattern<{ source: number }>(({ source }) => {
@@ -763,10 +775,12 @@ describe("scheduler event lineage", () => {
     const restoreTransact = rejectServerTransacts(storageManager);
     try {
       root.key("launch").send({});
+      // The launch commit conflicts forever; backpressure retries it until the
+      // retry window elapses, then surfaces a terminal CommitConvergenceError.
       await waitForSchedulerCondition(
         runtime,
         () => handlerAttempts >= 6,
-        "handler did not exhaust retries",
+        "handler did not retry under sustained conflict",
       );
       await runtime.idle();
 

--- a/packages/runner/test/scheduler-test-utils.ts
+++ b/packages/runner/test/scheduler-test-utils.ts
@@ -52,6 +52,7 @@ function createSchedulerTestRuntime(
     experimental?: ExperimentalOptions;
     cfcEnforcementMode?: RuntimeOptions["cfcEnforcementMode"];
     storageManager?: SchedulerTestStorageManager;
+    commitBackpressure?: RuntimeOptions["commitBackpressure"];
   } = {},
 ): SchedulerTestRuntime {
   const storageManager = options.storageManager ??
@@ -62,6 +63,9 @@ function createSchedulerTestRuntime(
     ...(options.experimental ? { experimental: options.experimental } : {}),
     ...(options.cfcEnforcementMode
       ? { cfcEnforcementMode: options.cfcEnforcementMode }
+      : {}),
+    ...(options.commitBackpressure
+      ? { commitBackpressure: options.commitBackpressure }
       : {}),
   });
 


### PR DESCRIPTION
The runtime is local-first and optimistic: an event handler's write applies to local replicated memory immediately and commits to the server in the background. The server can reject a commit, most often with a per-entity basis-sequence conflict (another writer advanced the entity's sequence between the time this commit read its basis and the time it reached the server). On rejection the optimistic write is rolled back and the originating event is re-run.

That re-run used to have a fixed budget: an event handler retried five times and then gave up — it logged "transaction failed after exhausting all retries" and dropped the write, with nothing surfaced to the user. Under sustained contention the budget is exhausted before the contention clears, so a committed user intent is silently lost. The motivating instance: profile appends issued while the home space rehydrates lose the race against a burst of basis-sequence conflicts and are dropped, so three creates can leave a durable count of one. Dropping data under load is a correctness cliff, not graceful degradation.

This replaces fixed-budget-then-drop on the event-handler commit path with backpressure. A committed write that represents real user intent must converge or fail loudly; under load the system should get slower, never lossy.

classifyCommitDisposition (scheduler/events.ts) splits the commit outcome:

  - A stale-basis ConflictError (the contention case) is re-queued with capped exponential backoff and subtractive jitter, parked via the event queue's existing notBefore mechanism so the scheduler slows down rather than busy-looping. It keeps retrying for a bounded window (default 30s) — long enough to outlast a contention burst. idle()/settled() already wait for a parked head event, so a converging write completes within a settle. If the window elapses without the write landing, a terminal CommitConvergenceError is surfaced through the scheduler error channel (scheduler.onError) — the write fails loudly instead of vanishing.
  - A permanent precondition failure (receipt-exists, origin-committed) is never retried, exactly as before, and stays observable through commit telemetry.
  - Any other transient error (a handler-initiated abort, a system error) is not contention, so backpressure would not help; it keeps the fixed retriesLeft budget and the previous retry-then-stop behavior.

The retries argument to queueEvent now gates whether conflicts are retried at all rather than bounding how many times. The default (used by every real user event through cell.send) is positive, so user events get backpressure. A caller that sends with retries:0 — a speculative lineage origin, an internal one-shot — opts out: a conflict gives up immediately so a descendant of a failed origin still drops deterministically. The exact positive count no longer bounds conflict retries; the window does.

Retrying re-runs the same event with the same durable event id, so the memory engine's receipt machinery makes a re-delivery of an already-applied event a permanent receipt-exists rejection — a retry cannot double-apply. Because a retry only happens after a rejected write was reverted, the re-run reads fresh confirmed state and reconciles, which is why concurrent appends converge instead of clobbering each other.

Configuration is through RuntimeOptions.commitBackpressure (base delay, max delay, jitter, retry window); unset fields fall back to a resolved default and every field is clamped so a caller can never disable backpressure. The scheduler.event.commit telemetry marker gains retryAttempt, backoffMs, and a terminal field so backpressure and terminal failures are observable.

The reactive-action path keeps its bounded retry plus re-subscription: a reactive action is a re-derivation recomputed when its inputs next change, not a one-shot user intent, so it has a recovery path the event handler lacks.

Tests (scheduler-commit-backpressure.test.ts) drive the event-handler commit path against an emulated server that rejects commits on demand: a burst of transient conflicts longer than the old budget still lands; a permanent rejection is not retried and stays observable; a never-converging conflict surfaces a terminal error within the window with bounded attempts; and three whole-array appends survive a conflict storm so the durable count reaches three. The lineage suite, which modeled a permanently failed origin by injecting an unending conflict and relying on budget exhaustion, now uses a short retry window and asserts the terminal path. docs/development/committed-write- backpressure.md explains the model, configuration, and reproduction status.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the fixed retry budget with backpressure on event-handler commits. Conflicts now retry immediately a few times, then back off within a bounded window; if they never converge, we raise `CommitConvergenceError` instead of dropping the write. A zero-window config fails the first conflict loudly.

- **New Features**
  - Conflict retries: `immediateRetries` (default 5) run with zero delay, then capped exponential backoff with jitter and `notBefore` parking; retries stay within `retryWindowMs` (default 30s).
  - Terminal paths: if the window elapses, surface `CommitConvergenceError` via `scheduler.onError`; permanent precondition failures (`receipt-exists`, `origin-committed`) aren’t retried; other transient errors keep bounded `retriesLeft`.
  - Config via `RuntimeOptions.commitBackpressure` (`baseDelayMs`, `maxDelayMs`, `jitter`, `retryWindowMs`, `immediateRetries`) with safe clamps; zero window is supported and fails loudly.
  - `queueEvent.retries` gates conflict retries; `retries: 0` opts out. Telemetry (`scheduler.event.commit`) reports `retryAttempt`, `backoffMs`, and `terminal`. Docs and tests added for bursts, permanent rejections, never-converging conflicts, array-append contention, fast-path small bursts, and zero-window behavior.

- **Bug Fixes**
  - Prevents silent data loss under contention; the system slows under load instead of dropping committed intent.
  - Restores fast-path behavior for transient conflicts: immediate retries avoid unnecessary backoff delays, so quick conflicts still converge within a settle (fixes the scrabble multi-user regression).

<sup>Written for commit 51f2d6b8e67103db8987a7fb007846e93d02d222. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

