### PR TITLE
Raise minimum regression margin from 15% to 50%

### DIFF
--- a/docs/development/PERFORMANCE_PROGRAM.md
+++ b/docs/development/PERFORMANCE_PROGRAM.md
@@ -56,7 +56,7 @@ step, and we'll ratchet targets down as we improve.
 - 14 micro-benchmark files across runner, memory, utils
 - CI benchmarks on every push to main (64-core runner), JSON artifacts with
   90-day retention
-- Regression detector every 4 hours (median + 3σ or +15%, auto-creates GitHub issues)
+- Regression detector every 4 hours (median + 3σ or +50%, auto-creates GitHub issues)
 - Recent wins: compilation cache (~100-500ms saved), schema freeze caching,
   LLM queue batching, scheduler debouncing, scheduler writer-index cleanup
   (`writersByEntity` is Set-backed), refer() caching (~2x)

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -616,15 +616,15 @@ Deno.test("computeCiWallTimeRevisitSignals flags long required wall time", () =>
   );
 });
 
-Deno.test("computeBaseline enforces the 15 percent floor for low-variance samples", () => {
+Deno.test("computeBaseline enforces the 50 percent floor for low-variance samples", () => {
   const baseline = computeBaseline([100, 100, 100, 100, 100]);
 
   assertEquals(baseline?.median, 100);
   assertEquals(baseline?.stddev, 0);
-  assertAlmostEquals(baseline?.threshold ?? 0, 115, 1e-9);
+  assertAlmostEquals(baseline?.threshold ?? 0, 150, 1e-9);
 });
 
-Deno.test("computeBaseline uses the 3 sigma threshold when it exceeds 15 percent", () => {
+Deno.test("computeBaseline uses the 3 sigma threshold when it exceeds 50 percent", () => {
   const baseline = computeBaseline([100, 100, 100, 100, 150]);
 
   assertEquals(baseline?.median, 100);

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -89,7 +89,7 @@ export const RECENT_THRESHOLD = 2;
 export const STDDEV_FACTOR = 3;
 
 /** Minimum percentage increase over median to flag a regression. */
-export const MIN_REGRESSION_PCT = 0.15;
+export const MIN_REGRESSION_PCT = 0.50;
 
 /** Minimum absolute increase (in seconds) over median for non-bench metrics. */
 export const MIN_ABSOLUTE_DELTA = 2;


### PR DESCRIPTION
The performance regression detector flags a metric when a recent run exceeds the historical median by both a standard-deviation factor and a minimum percentage margin. The minimum margin (MIN_REGRESSION_PCT) was 15%, which produced regression issues for swings that were within normal run-to-run noise for many metrics.

Raise the minimum percentage increase over median required to flag a regression to 50%, so only larger, more clearly meaningful slowdowns are reported. The constant feeds the threshold computation in perf-lib, perf-check, and perf-regression, so all three pick up the new value. Update the performance-program documentation, which quoted the old "+15%" figure, to match.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the minimum regression margin from 15% to 50% so the detector only reports clear, meaningful slowdowns. Updates `MIN_REGRESSION_PCT` in `tasks/perf-lib.ts`, adjusts unit tests in `tasks/perf-lib.test.ts` for the new floor, and aligns `docs/development/PERFORMANCE_PROGRAM.md` to +50%.

<sup>Written for commit 29802326e03ec71ed02c1b61f82c68a27dda5d95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

