### PR TITLE
perf(schema-generator): memoize getCellBrand per type

### DIFF
--- a/packages/schema-generator/src/typescript/cell-brand.ts
+++ b/packages/schema-generator/src/typescript/cell-brand.ts
@@ -82,7 +82,19 @@ function findCellBrandSymbol(
   }, seen);
 }
 
-export function getCellBrand(
+// A type's cell brand is invariant: it depends only on the type's own shape,
+// which is fixed within the checker that owns the type. The transformer and
+// schema-generation pipelines query the same types tens of thousands of times,
+// so the hierarchy walk and `getPropertiesOfType` lookups below are cached per
+// type. Keyed first by checker so a type identity is never read against a
+// foreign checker; the inner WeakMap lets per-program types be collected once
+// their checker is gone.
+const cellBrandCache = new WeakMap<
+  ts.TypeChecker,
+  WeakMap<ts.Type, CellBrand | undefined>
+>();
+
+function computeCellBrand(
   type: ts.Type,
   checker: ts.TypeChecker,
 ): CellBrand | undefined {
@@ -99,6 +111,22 @@ export function getCellBrand(
   }
 
   return undefined;
+}
+
+export function getCellBrand(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+): CellBrand | undefined {
+  let byType = cellBrandCache.get(checker);
+  if (byType === undefined) {
+    byType = new WeakMap();
+    cellBrandCache.set(checker, byType);
+  } else if (byType.has(type)) {
+    return byType.get(type);
+  }
+  const brand = computeCellBrand(type, checker);
+  byType.set(type, brand);
+  return brand;
 }
 
 export function isCellType(type: ts.Type, checker: ts.TypeChecker): boolean {


### PR DESCRIPTION
getCellBrand walks a type's hierarchy and calls getPropertiesOfType on every type it visits to find the cell-brand marker. The transformer and schema-generation pipelines call it (and getCellKind / isCellType / isCellBrand / getCellWrapperInfo, which all funnel through it) once per type they touch — measured at ~150k calls over ~2.9k distinct types when compiling record.tsx, a 52x redundancy.

A type's brand is invariant: it depends only on the type's own shape, which is fixed within the owning checker. Cache the result in a per-checker WeakMap keyed by type. Compiled output is byte-identical (verified by hashing the emitted module bodies of seven patterns with and without the cache); warm compile time drops ~4-5% on complex patterns (record.tsx 2028ms -> 1922ms, store-mapper.tsx 1064ms -> 1019ms). This shared compile path is exercised by every pattern compile in CI (pattern integration, pattern unit, cfcheck, generated-patterns) and the runner tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoized `getCellBrand` in `packages/schema-generator` using a per-checker cache (`WeakMap<ts.TypeChecker, WeakMap<ts.Type, CellBrand | undefined>>`) to avoid repeated hierarchy walks. This removes ~52× redundant lookups, keeps output byte-identical, and speeds up warm compiles by ~4–5% on complex patterns; all callers (`getCellKind`, `isCellType`, `isCellBrand`, `getCellWrapperInfo`) benefit.

<sup>Written for commit 570e1f0b5320894279b70e1a3b1819911ffbbc4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

