### PR TITLE
perf(patterns): stop compiling .test.tsx files in all.test.ts

### DIFF
--- a/packages/patterns/integration/all.test.ts
+++ b/packages/patterns/integration/all.test.ts
@@ -39,6 +39,13 @@ describe("Compile all patterns", () => {
   const patterns = [...Deno.readDirSync(join(import.meta.dirname!, ".."))]
     .filter((file) => file.name.endsWith(".tsx"))
     .map((file) => file.name)
+    // `.test.tsx` files are pattern tests, not authored patterns: they wrap a
+    // pattern in a test harness and are compiled and executed by the separate
+    // pattern unit-test job (`cf test`). Compiling them here too repeats that
+    // work — and recompiles the real pattern they import — on the pattern
+    // integration critical path. Match the pattern-source definition in
+    // tasks/cfcheck.ts, which already excludes `.test.tsx`/`.test.ts`.
+    .filter((name) => !name.endsWith(".test.tsx") && !name.endsWith(".test.ts"))
     .filter((name) => !skippedPatterns.includes(name))
     .sort();
 


### PR DESCRIPTION
The "Compile all patterns" smoke test globbed every top-level *.tsx file, which pulled in pattern test files (shopping-list.test.tsx, store-mapper.test.tsx, self-improving-classifier.test.tsx, self.test.tsx). Those are not authored patterns — they wrap a pattern in a test harness and are already compiled and executed by the separate pattern unit-test job (cf test). Compiling them here repeated that work, and recompiled the real pattern each one imports, on the pattern-integration critical path: on the slowest shard the two .test.tsx files alone cost ~30s of the ~90s compile block.

Exclude .test.tsx/.test.ts to match the pattern-source definition in tasks/cfcheck.ts (the other "compile every pattern" job), which already excludes them. Compile-failure and instantiation coverage for these files is preserved by the pattern unit-test job.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop compiling `.test.tsx`/`.test.ts` in the "Compile all patterns" smoke test so only authored patterns are compiled. This removes duplicate work handled by `cf test`, matches `tasks/cfcheck.ts`, preserves test coverage, and cuts slow-shard compile time by ~30s.

<sup>Written for commit c77826884f12302fc786e951d54b7bfd7cf6169e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

