### PR TITLE
Revert "ci: bump GitHub Actions to Node 24 runtimes"

### DIFF
--- a/.github/actions/apt-install/action.yml
+++ b/.github/actions/apt-install/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: 💾 Cache apt packages
       id: cache
-      uses: actions/cache@v6
+      uses: actions/cache@v4
       with:
         path: ~/.cache/apt-deb/${{ inputs.cache-key }}
         key: apt-deb-${{ inputs.cache-key }}-${{ runner.os }}-${{ steps.norm.outputs.image }}-${{ steps.norm.outputs.id }}

--- a/.github/actions/deno-setup/action.yml
+++ b/.github/actions/deno-setup/action.yml
@@ -22,7 +22,7 @@ runs:
     # Cache version: bump the `deno-bin-v1` token to invalidate all toolchain caches.
     - name: 💾 Restore Deno toolchain ${{ inputs.deno-version }}
       id: deno-toolchain-cache
-      uses: actions/cache@v6
+      uses: actions/cache@v4
       with:
         path: ${{ runner.tool_cache }}/deno/${{ inputs.deno-version }}
         key: deno-bin-v1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.deno-version }}
@@ -59,7 +59,7 @@ runs:
     # Cache version: bump to invalidate all caches (e.g., v2 -> v3)
     - name: 📦 Cache Deno dependencies
       if: inputs.cache == 'true'
-      uses: actions/cache@v6
+      uses: actions/cache@v4
       with:
         path: |
           ~/.deno

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -13,7 +13,7 @@ jobs:
       group: labs
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -36,7 +36,7 @@ jobs:
 
       - name: 📤 Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: bench-results
           path: bench-results/

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.target_sha }}
 
@@ -25,7 +25,7 @@ jobs:
         uses: ./.github/actions/deno-setup
 
       - name: 📦 Cache Deno dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@v3
         with:
           # TODO these are not the paths used in macos
           path: |
@@ -42,7 +42,7 @@ jobs:
           ./dist/cf --help
 
       - name: 📤 Upload CLI
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: macos-cli
           path: |

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -42,7 +42,7 @@ jobs:
 
       - name: 📥 Download coverage comment artifact
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: coverage-comment
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -63,7 +63,7 @@ jobs:
         total: [4]
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -82,7 +82,7 @@ jobs:
       group: labs
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -116,7 +116,7 @@ jobs:
 
       - name: 📤 Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-profile-workspace
           path: coverage/lcov/workspace.lcov
@@ -133,7 +133,7 @@ jobs:
         total: [4]
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -170,7 +170,7 @@ jobs:
 
       - name: 📤 Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-profile-runner-${{ matrix.shard }}
           path: coverage/lcov/runner-${{ matrix.shard }}.lcov
@@ -183,7 +183,7 @@ jobs:
       group: labs
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -198,7 +198,7 @@ jobs:
 
       # Upload binaries as artifacts for the integration tests
       - name: 📤 Upload binaries for integration tests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: common-binaries
           path: |
@@ -216,7 +216,7 @@ jobs:
         total: [4]
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -250,7 +250,7 @@ jobs:
 
       - name: 📤 Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-profile-generated-patterns-${{ matrix.shard }}
           path: coverage/lcov/generated-patterns-${{ matrix.shard }}.lcov
@@ -259,7 +259,7 @@ jobs:
 
       - name: 📤 Upload test timing data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: test-timing-generated-patterns-${{ matrix.shard }}
           path: test-results/
@@ -295,7 +295,7 @@ jobs:
             headless: true
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -304,7 +304,7 @@ jobs:
         uses: ./.github/actions/deno-install
 
       - name: 📥 Download built binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
 
       - name: 🚀 Start Toolshed server for testing
         env:
@@ -342,7 +342,7 @@ jobs:
 
       - name: 📤 Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-profile-package-${{ matrix.suite_name }}
           path: coverage/lcov/package-${{ matrix.suite_name }}.lcov
@@ -351,7 +351,7 @@ jobs:
 
       - name: 📤 Upload test timing data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: test-timing-package-integration-${{ matrix.suite_name }}
           path: test-results/${{ matrix.junit_name }}.xml
@@ -393,7 +393,7 @@ jobs:
             timeout_minutes: 15
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -402,7 +402,7 @@ jobs:
         uses: ./.github/actions/deno-install
 
       - name: 📥 Download built binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
 
       - name: 🚀 Start Toolshed server for testing
         env:
@@ -480,7 +480,7 @@ jobs:
 
       - name: 📤 Upload CLI integration timing data
         if: ${{ always() && startsWith(matrix.suite_name, 'core-') }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: test-timing-cli-${{ matrix.suite_name }}
           path: test-results/cli-${{ matrix.suite_name }}-cf-timings.log
@@ -498,7 +498,7 @@ jobs:
         total: [4]
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -507,7 +507,7 @@ jobs:
         uses: ./.github/actions/deno-install
 
       - name: 📥 Download built binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
 
       - name: 🚀 Start Toolshed server for testing
         run: |
@@ -547,7 +547,7 @@ jobs:
 
       - name: 📤 Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-profile-pattern-integration-${{ matrix.shard }}
           path: coverage/lcov/pattern-integration-${{ matrix.shard }}.lcov
@@ -556,7 +556,7 @@ jobs:
 
       - name: 📤 Upload test timing data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: test-timing-pattern-integration-${{ matrix.shard }}
           path: test-results/
@@ -568,7 +568,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -596,7 +596,7 @@ jobs:
 
       - name: 📤 Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-profile-pattern-reload
           path: coverage/lcov/pattern-reload.lcov
@@ -605,7 +605,7 @@ jobs:
 
       - name: 📤 Upload test timing data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: test-timing-pattern-reload-integration
           path: test-results/
@@ -622,7 +622,7 @@ jobs:
         total: [5]
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -634,7 +634,7 @@ jobs:
         run: deno task initialize-db
 
       - name: 📥 Download built binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
 
       - name: 🧪 Run pattern unit tests
         run: |
@@ -648,7 +648,7 @@ jobs:
 
       - name: 📤 Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-profile-pattern-unit-${{ matrix.chunk }}
           path: coverage/lcov/pattern-unit-${{ matrix.chunk }}.lcov
@@ -657,7 +657,7 @@ jobs:
 
       - name: 📤 Upload test timing data
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: test-timing-pattern-unit-${{ matrix.chunk }}
           path: test-results/
@@ -692,7 +692,7 @@ jobs:
       pull-requests: read
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -709,7 +709,7 @@ jobs:
 
       - name: 📤 Upload coverage regression comment
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-comment
           path: coverage-comment.json
@@ -718,7 +718,7 @@ jobs:
 
       - name: 📤 Upload performance metrics
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: perf-metrics
           path: perf-metrics.json
@@ -727,7 +727,7 @@ jobs:
 
       - name: 📤 Upload performance metrics backfill
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: perf-metrics-backfill
           path: perf-metrics-backfill.json
@@ -758,10 +758,10 @@ jobs:
       attestations: write
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 📥 Download built binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
 
       - name: 🔐 Process & sign binaries
         run: |
@@ -851,7 +851,7 @@ jobs:
           subject-digest: sha256:${{ steps.binary_processing.outputs.tarball_hash }}
 
       - name: 📤 Upload attestations as artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: binary_attestations
           if-no-files-found: error
@@ -937,7 +937,7 @@ jobs:
     environment: toolshed
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -961,7 +961,7 @@ jobs:
     environment: toolshed
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -994,7 +994,7 @@ jobs:
     environment: ci
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup
@@ -1085,7 +1085,7 @@ jobs:
 
       - name: 📤 Upload test logs as artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: patterns-test-logs-${{ github.sha }}
           path: patterns-test-${{ github.sha }}.log

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout specific ref
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
 

--- a/.github/workflows/deploy-shell-production.yml
+++ b/.github/workflows/deploy-shell-production.yml
@@ -15,7 +15,7 @@ jobs:
     environment: production
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.sha || github.sha }}
 

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -51,7 +51,7 @@ jobs:
       # TODO Upload `seeder` as a deno executable to avoid
       # running from source.
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.target_sha }}
 
@@ -59,7 +59,7 @@ jobs:
         uses: ./.github/actions/deno-setup
 
       - name: 📦 Cache Deno dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@v3
         with:
           path: |
             ~/.deno
@@ -98,7 +98,7 @@ jobs:
       # https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
       - name: 📦 Load LLM Cache
         id: load-llm-cache
-        uses: actions/cache@v6
+        uses: actions/cache@v4
         with:
           path: ./llm_cache_dir
           key: llm-cache-${{ github.run_id }}
@@ -165,7 +165,7 @@ jobs:
           fi
 
       - name: 📤 Upload reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: seeder-results
           path: |

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -15,7 +15,7 @@ jobs:
       actions: read
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: 🦕 Setup Deno
         uses: ./.github/actions/deno-setup


### PR DESCRIPTION
Reverts commontoolsinc/labs#4315

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the Node 24 GitHub Actions upgrade and restores Node 20–compatible action versions to unblock CI.

- **Dependencies**
  - Set `actions/checkout` to `v4` across all workflows.
  - Set `actions/upload-artifact` and `actions/download-artifact` to `v4`.
  - Set `actions/cache` to `v4` (and `v3` where needed); updated in workflows and composite actions.
  - Set `actions/setup-node` to `v4` in docs deploy.
  - Aligned internal actions (`.github/actions/deno-setup`, `apt-install`) with these versions.

<sup>Written for commit 69dbd41aabdd61f57898a274d9d99caeabdec629. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

