### PR TITLE
refactor(lunch-poll): remove web-search homepage enrichment

### DIFF
--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -96,16 +96,6 @@ export default pattern(() => {
     poll.addOption.send({ title: "Chipotle" });
   });
 
-  const action_set_chipotle_link = action(() => {
-    const first = poll.options[0];
-    if (first) {
-      poll.setOptionUrl.send({
-        optionId: first.id,
-        url: "https://example.com/chipotle",
-      });
-    }
-  });
-
   const action_add_thai = action(() => {
     poll.addOption.send({ title: "Thai Kitchen" });
   });
@@ -199,14 +189,7 @@ export default pattern(() => {
   const assert_chipotle_added = computed(() =>
     poll.options.length === 1 &&
     poll.options[0]?.title === "Chipotle" &&
-    poll.options[0]?.addedByName === "Alex" &&
-    poll.options[0]?.homePageUrl === "" &&
-    poll.options[0]?.homePageUrlOverride === ""
-  );
-
-  const assert_chipotle_link_updated = computed(() =>
-    poll.options.length === 1 &&
-    poll.options[0]?.homePageUrlOverride === "https://example.com/chipotle"
+    poll.options[0]?.addedByName === "Alex"
   );
 
   const assert_two_options = computed(() => poll.options.length === 2);
@@ -342,8 +325,6 @@ export default pattern(() => {
       // Admin adds options
       { action: action_add_chipotle },
       { assertion: assert_chipotle_added },
-      { action: action_set_chipotle_link },
-      { assertion: assert_chipotle_link_updated },
       { action: action_add_thai },
       { assertion: assert_two_options },
 

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -73,14 +73,7 @@ export interface Option {
   id: string;
   title: string;
   addedByName: string;
-  // Homepage link enrichment, persisted so we don't re-run the grounded web
-  // search on every load. `homePageUrl` is the auto-found official site; a host
-  // can refresh it. `homePageUrlOverride` is a human-supplied link that wins.
-  homePageUrl?: string;
-  homePageUrlOverride?: string;
 }
-
-const WEB_SEARCH_URL = "/api/agent-tools/web-search";
 
 export type VoteColor = "green" | "yellow" | "red";
 
@@ -172,13 +165,10 @@ export interface RemoveHistoryEntryEvent {
 export type ClearHistoryEvent = Record<PropertyKey, never>;
 
 type QuestionCell = Writable<string | Default<"Where should we eat?">>;
-type CityCell = Writable<string | Default<"Berkeley, CA">>;
-type LinkTargetCell = Writable<string | null>;
 type OptionsCell = Writable<Option[] | Default<[]>>;
 type VotesCell = Writable<Vote[] | Default<[]>>;
 type UsersCell = Writable<User[] | Default<[]>>;
 type NameCell = Writable<string | Default<"">>;
-type HomePageRefreshCell = Writable<number>;
 type HistoryCell = Writable<HistoryEntry[] | Default<[]>>;
 
 const POLL_THEME = {
@@ -217,39 +207,6 @@ const VOTE_SWATCH: Record<VoteColor, string> = {
 };
 
 const trimmedName = (n: string | undefined) => (n ?? "").trim();
-
-// Normalize a human-entered link to a safe http(s) URL. Returns "" for anything
-// that isn't http/https — this is what keeps a pasted `javascript:`/`data:`
-// override from ever reaching an `href`. We parse the value as-is first (so a
-// real `http(s)://` URL is honored), and only on failure retry with an
-// `https://` prefix — so a scheme-less `host:port` like `example.com:8080`
-// isn't mistaken for a `scheme:` and rejected. Also used defensively at render.
-const httpsOrNull = (candidate: string): string | null => {
-  try {
-    const u = new URL(candidate);
-    return (u.protocol === "http:" || u.protocol === "https:")
-      ? u.toString()
-      : null;
-  } catch {
-    return null;
-  }
-};
-const safeHttpUrl = (raw: string | undefined): string => {
-  const s = (raw ?? "").trim();
-  if (!s) return "";
-  return httpsOrNull(s) ?? httpsOrNull(`https://${s}`) ?? "";
-};
-
-const homePageLookupUrlFor = (
-  isAdmin: boolean,
-  _refresh: number,
-  storedUrl: string | undefined,
-  overrideUrl: string | undefined,
-  endpoint: string,
-): string =>
-  isAdmin && !trimmedName(storedUrl) && !trimmedName(overrideUrl)
-    ? endpoint
-    : "";
 
 const newOptionId = () =>
   `o_${safeDateNow().toString(36)}_${
@@ -321,92 +278,8 @@ const addOption = handler<AddOptionEvent, {
     id: newOptionId(),
     title: trimmed,
     addedByName: me,
-    homePageUrl: "",
-    homePageUrlOverride: "",
   });
   optionDraft.set("");
-});
-
-export interface SetCityEvent {
-  city?: string;
-}
-
-// Host sets the city the poll is happening in. This scopes the menu-link web
-// search to local restaurants. Gate: host only.
-const setCity = handler<SetCityEvent, {
-  city: CityCell;
-  myName: NameCell;
-  adminName: NameCell;
-  cityDraft: NameCell;
-}>(({ city: cityArg }, { city, myName, adminName, cityDraft }) => {
-  const me = trimmedName(myName.get());
-  const admin = trimmedName(adminName.get());
-  if (!me || me !== admin) return;
-  const next = trimmedName(cityArg ?? cityDraft.get());
-  if (!next) return;
-  city.set(next);
-  cityDraft.set("");
-});
-
-export type EnrichHomePagesEvent = Record<PropertyKey, never>;
-
-// Host-only: bump the shared refresh marker. The actual homepage lookup is a
-// reactive fetchData node per option, so the handler never waits on network I/O.
-const enrichHomePages = handler<EnrichHomePagesEvent, {
-  myName: NameCell;
-  adminName: NameCell;
-  homePageRefresh: HomePageRefreshCell;
-}>((_evt, { myName, adminName, homePageRefresh }) => {
-  const me = trimmedName(myName.get());
-  const admin = trimmedName(adminName.get());
-  if (!me || me !== admin) return;
-  homePageRefresh.set(Number(homePageRefresh.get() ?? 0) + 1);
-});
-
-export interface SetOptionUrlEvent {
-  optionId: string;
-  url?: string;
-}
-
-const setOptionHomePageUrl = handler<SetOptionUrlEvent, {
-  options: OptionsCell;
-  myName: NameCell;
-  adminName: NameCell;
-}>(({ optionId, url }, { options, myName, adminName }) => {
-  const me = trimmedName(myName.get());
-  const admin = trimmedName(adminName.get());
-  if (!me || me !== admin) return;
-  const cur = options.get();
-  const idx = cur.findIndex((o) => o.id === optionId);
-  if (idx < 0) return;
-  const safe = safeHttpUrl(url ?? "");
-  if (!safe || trimmedName(cur[idx]?.homePageUrl) === safe) return;
-  options.key(idx).key("homePageUrl").set(safe);
-});
-
-// Any joined user supplies/overrides the homepage link for an option. An empty
-// value clears the override (reverting to the auto-enriched value). The
-// override always wins over the auto-found URL.
-const setOptionUrl = handler<SetOptionUrlEvent, {
-  options: OptionsCell;
-  myName: NameCell;
-  linkDraft: NameCell;
-  linkEditTarget: LinkTargetCell;
-}>(({ optionId, url }, { options, myName, linkDraft, linkEditTarget }) => {
-  const me = trimmedName(myName.get());
-  if (!me) return;
-  const cur = options.get();
-  const idx = cur.findIndex((o) => o.id === optionId);
-  if (idx < 0) return;
-  const raw = trimmedName(url ?? linkDraft.get());
-  // Empty clears the override; otherwise only accept a safe http(s) URL. A
-  // non-empty value that isn't http(s) (e.g. `javascript:`) is rejected — leave
-  // the existing override and the edit field open so it can be corrected.
-  const safe = raw === "" ? "" : safeHttpUrl(raw);
-  if (raw !== "" && safe === "") return;
-  options.key(idx).key("homePageUrlOverride").set(safe);
-  linkDraft.set("");
-  linkEditTarget.set(null);
 });
 
 const removeOption = handler<RemoveOptionEvent, {
@@ -639,15 +512,11 @@ const summarizePlaces = (visits: readonly HistoryEntry[]): PlaceStat[] => {
 
 export interface CozyPollInput {
   question?: PerSpace<string | Default<"Where should we eat?">>;
-  // City the poll is happening in — scopes the menu-link web search so it
-  // finds the right local restaurants. Defaults to Berkeley, CA.
-  city?: PerSpace<string | Default<"Berkeley, CA">>;
   options?: PerSpace<Option[] | Default<[]>>;
   votes?: PerSpace<Vote[] | Default<[]>>;
   users?: PerSpace<User[] | Default<[]>>;
   adminName?: PerSpace<string | Default<"">>;
   myName?: PerUser<string | Default<"">>;
-  webSearchUrl?: PerSpace<string | Default<typeof WEB_SEARCH_URL>>;
   // Durable "we went here" log; each entry embeds its own vote snapshot. Capped
   // at MAX_HISTORY most-recent entries in `logVisit`. optionDraft etc. are
   // internal form drafts, declared as local per-session cells in the pattern
@@ -659,7 +528,6 @@ export interface CozyPollOutput {
   [NAME]: string;
   [UI]: VNode;
   question: string;
-  city: string;
   options: readonly Option[];
   votes: readonly Vote[];
   users: readonly User[];
@@ -682,7 +550,6 @@ export interface CozyPollOutput {
   placeStats: readonly PlaceStat[];
   isJoined: boolean;
   isAdmin: boolean;
-  homePageLookupUrls: readonly string[];
   joinAs: Stream<JoinEvent>;
   claimHost: Stream<ClaimHostEvent>;
   addOption: Stream<AddOptionEvent>;
@@ -693,9 +560,6 @@ export interface CozyPollOutput {
   logVisit: Stream<LogVisitEvent>;
   removeHistoryEntry: Stream<RemoveHistoryEntryEvent>;
   clearHistory: Stream<ClearHistoryEvent>;
-  setCity: Stream<SetCityEvent>;
-  enrichHomePages: Stream<EnrichHomePagesEvent>;
-  setOptionUrl: Stream<SetOptionUrlEvent>;
 }
 
 // Stable empty fallbacks for the output snapshots below — fresh `[]` per
@@ -708,13 +572,11 @@ export default pattern<CozyPollInput, CozyPollOutput>(
   (
     {
       question,
-      city,
       options,
       votes,
       users,
       adminName,
       myName,
-      webSearchUrl,
       visits,
     },
   ) => {
@@ -722,12 +584,6 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     // not exposed as pattern inputs. Uses the scoped-constructor idiom
     // introduced by parking-coordinator (PR #3610).
     const optionDraft = Writable.perSession.of<string>("");
-    // Host's draft for the poll's city (scopes the menu web search).
-    const cityDraft = Writable.perSession.of<string>("");
-    // Which option's homepage link is being edited (null = none), plus the
-    // in-progress URL text. Per-session, like the other form drafts.
-    const linkEditTarget = Writable.perSession.of<string | null>(null);
-    const linkDraft = Writable.perSession.of<string>("");
     // Host's backdate field for "we went here" — a "YYYY-MM-DD" draft, blank
     // means today. Per-session like the other form drafts.
     const visitDate = Writable.perSession.of<string>("");
@@ -737,9 +593,6 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     const removeConfirmTarget = Writable.perSession.of<string | null>(null);
     const resetConfirmPending = Writable.perSession.of<boolean>(false);
     const clearHistoryConfirmPending = Writable.perSession.of<boolean>(false);
-    // Shared marker that retriggers the host's reactive homepage lookup nodes.
-    // Missing homepage links are also looked up on first host load.
-    const homePageRefresh = Writable.perSpace.of<number>(0);
     const participantIdentity = ParticipantIdentityCard({
       users,
       myName,
@@ -779,23 +632,6 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       myName,
       adminName,
     });
-    const boundSetCity = setCity({ city, myName, adminName, cityDraft });
-    const boundEnrichHomePages = enrichHomePages({
-      myName,
-      adminName,
-      homePageRefresh,
-    });
-    const boundSetOptionUrl = setOptionUrl({
-      options,
-      myName,
-      linkDraft,
-      linkEditTarget,
-    });
-    const boundSetOptionHomePageUrl = setOptionHomePageUrl({
-      options,
-      myName,
-      adminName,
-    });
     const userCount = users.length;
     const optionCount = options.length;
     const voteCount = votes.length;
@@ -827,11 +663,6 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     // per-option `options.map(...)` lift; passing this resolved value down
     // avoids that.
     const me = participantIdentity.me;
-    // Resolve the poll's city ONCE here (same reason as `me`): the raw ref
-    // doesn't resolve inside the per-option `options.map` lift where the menu
-    // search query is built. Blank → Berkeley, CA.
-    const cityLabel = trimmedName(city) || "Berkeley, CA";
-    const searchEndpoint = trimmedName(webSearchUrl) || WEB_SEARCH_URL;
     const isJoined = participantIdentity.isJoined;
     const isAdmin = participantIdentity.isAdmin;
     // Hoist a boolean cell for the reset-confirm JSX ternary so TS doesn't
@@ -842,15 +673,6 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       clearHistoryConfirmPending.get()
     );
     const ranked = tallyOptions(options, votes, users);
-    const homePageLookupUrls = options.map((option) =>
-      homePageLookupUrlFor(
-        isAdmin,
-        Number(homePageRefresh.get() ?? 0),
-        option.homePageUrl,
-        option.homePageUrlOverride,
-        searchEndpoint,
-      )
-    );
 
     const topChoice = voteCount > 0 && ranked.length > 0 ? ranked[0] : null;
 
@@ -887,15 +709,6 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                   >
                     {question}
                   </h2>
-                  <div
-                    style={{
-                      fontSize: "12px",
-                      color: "#6b7280",
-                      marginTop: "2px",
-                    }}
-                  >
-                    📍 {cityLabel}
-                  </div>
                   {computed(() => {
                     const u = userCount ?? 0;
                     const o = optionCount ?? 0;
@@ -1207,8 +1020,6 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                     id: option.id,
                     title: option.title,
                     addedByName: option.addedByName,
-                    homePageUrl: option.homePageUrl,
-                    homePageUrlOverride: option.homePageUrlOverride,
                   };
                   const rank = computed(() => {
                     const idx = ranked.findIndex(
@@ -1224,17 +1035,10 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                       isJoined={isJoined}
                       isAdmin={isAdmin}
                       votes={votes}
-                      cityLabel={cityLabel}
-                      searchEndpoint={searchEndpoint}
-                      homePageRefresh={homePageRefresh}
-                      linkEditTarget={linkEditTarget}
-                      linkDraft={linkDraft}
                       removeConfirmTarget={removeConfirmTarget}
                       castVote={boundCastVote}
                       removeOption={boundRemoveOption}
                       logVisit={boundLogVisit}
-                      setOptionUrl={boundSetOptionUrl}
-                      setOptionHomePageUrl={boundSetOptionHomePageUrl}
                     />
                   );
                 })}
@@ -1491,30 +1295,6 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                           display: "flex",
                           gap: "8px",
                           alignItems: "center",
-                          marginBottom: "8px",
-                        }}
-                      >
-                        <cf-input
-                          $value={cityDraft}
-                          placeholder={`City for menu search (now: ${cityLabel})`}
-                          aria-label="Poll city"
-                          timing-strategy="immediate"
-                          style="flex:1"
-                        />
-                        <cf-button onClick={boundSetCity}>Set city</cf-button>
-                        <cf-button
-                          variant="secondary"
-                          onClick={boundEnrichHomePages}
-                          title="Look up each option's official homepage and store it"
-                        >
-                          🔄 Refresh homepage links
-                        </cf-button>
-                      </div>
-                      <div
-                        style={{
-                          display: "flex",
-                          gap: "8px",
-                          alignItems: "center",
                         }}
                       >
                         <cf-input
@@ -1588,7 +1368,6 @@ export default pattern<CozyPollInput, CozyPollOutput>(
         </cf-theme>
       ),
       question,
-      city: cityLabel,
       // Output snapshots readable from OTHER runtimes (multi-user tests,
       // remote viewers): raw scoped values read as undefined in runtimes that
       // didn't write them, and a computed that RETURNS undefined is
@@ -1612,7 +1391,6 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       placeStats,
       isJoined: participantIdentity.isJoined,
       isAdmin: participantIdentity.isAdmin,
-      homePageLookupUrls,
       joinAs: participantIdentity.joinAs,
       claimHost: participantIdentity.claimHost,
       addOption: boundAddOption,
@@ -1623,9 +1401,6 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       logVisit: boundLogVisit,
       removeHistoryEntry: boundRemoveHistoryEntry,
       clearHistory: boundClearHistory,
-      setCity: boundSetCity,
-      enrichHomePages: boundEnrichHomePages,
-      setOptionUrl: boundSetOptionUrl,
     };
   },
 );

--- a/packages/patterns/lunch-poll/multi-user.test.tsx
+++ b/packages/patterns/lunch-poll/multi-user.test.tsx
@@ -21,15 +21,12 @@
 import { action, computed, multiUserTest, pattern } from "commonfabric";
 import LunchPoll, { type CozyPollOutput } from "./main.tsx";
 
-const TEST_WEB_SEARCH_URL =
-  "data:application/json,%7B%22results%22%3A%5B%5D%7D";
-
 interface Setup {
   poll: CozyPollOutput;
 }
 
 export const setup = pattern(() => ({
-  poll: LunchPoll({ webSearchUrl: TEST_WEB_SEARCH_URL }),
+  poll: LunchPoll({}),
 }));
 
 export const alice = pattern<{ setup: Setup }>(({ setup }) => {
@@ -45,9 +42,6 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
     const first = poll.options?.[0];
     if (first) poll.castVote.send({ optionId: first.id, voteType: "green" });
   });
-  const action_refresh_homepages = action(() => {
-    poll.enrichHomePages.send({});
-  });
 
   // First joiner becomes the host.
   const assert_joined_as_host = computed(() =>
@@ -60,9 +54,7 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
   );
   const assert_option_added = computed(() =>
     (poll.options ?? []).length === 1 &&
-    poll.options?.[0]?.title === "Sushi" &&
-    poll.options?.[0]?.homePageUrl === "" &&
-    poll.options?.[0]?.homePageUrlOverride === ""
+    poll.options?.[0]?.title === "Sushi"
   );
   const assert_own_vote = computed(() =>
     (poll.votes ?? []).length === 1 &&
@@ -77,10 +69,6 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
     poll.votes?.[1]?.voterName === "Bob" &&
     (poll.options ?? []).length === 1 &&
     poll.myName === "Alice"
-  );
-  const assert_host_lookup_active = computed(() =>
-    (poll.homePageLookupUrls ?? []).length === 1 &&
-    poll.homePageLookupUrls?.[0] === TEST_WEB_SEARCH_URL
   );
   // Host takeover observed from the deposed host's runtime.
   const assert_deposed = computed(() =>
@@ -98,9 +86,6 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
       { label: "alice-set-up" },
       { await: "bob-voted" },
       { assertion: assert_sees_bob },
-      { action: action_refresh_homepages },
-      { assertion: assert_host_lookup_active },
-      { label: "alice-refreshed-homepages" },
       { await: "bob-claimed-host" },
       { assertion: assert_deposed },
     ],
@@ -155,12 +140,6 @@ export const bob = pattern<{ setup: Setup }>(({ setup }) => {
     poll.votes?.[0]?.voterName === "Alice" &&
     poll.votes?.[1]?.voterName === "Bob"
   );
-  const assert_non_host_lookup_inactive = computed(() =>
-    poll.myName === "Bob" &&
-    poll.isAdmin === false &&
-    (poll.homePageLookupUrls ?? []).length === 1 &&
-    poll.homePageLookupUrls?.[0] === ""
-  );
   const assert_is_host_now = computed(() =>
     poll.adminName === "Bob" && poll.isAdmin === true
   );
@@ -178,8 +157,6 @@ export const bob = pattern<{ setup: Setup }>(({ setup }) => {
       { action: action_vote_green },
       { assertion: assert_both_votes },
       { label: "bob-voted" },
-      { await: "alice-refreshed-homepages" },
-      { assertion: assert_non_host_lookup_inactive },
       { action: action_claim_host },
       { assertion: assert_is_host_now },
       { label: "bob-claimed-host" },

--- a/packages/patterns/lunch-poll/poll-option-card.test.tsx
+++ b/packages/patterns/lunch-poll/poll-option-card.test.tsx
@@ -1,6 +1,5 @@
 import {
   computed,
-  Default,
   handler,
   pattern,
   type Stream,
@@ -13,7 +12,6 @@ import type {
   LogVisitEvent,
   Option,
   RemoveOptionEvent,
-  SetOptionUrlEvent,
   Vote,
 } from "./main.tsx";
 
@@ -76,14 +74,11 @@ const propValue = (node: unknown, prop: string): unknown => {
 const noopCastVote = handler<CastVoteEvent, EmptyState>(() => {});
 const noopRemoveOption = handler<RemoveOptionEvent, EmptyState>(() => {});
 const noopLogVisit = handler<LogVisitEvent, EmptyState>(() => {});
-const noopSetOptionUrl = handler<SetOptionUrlEvent, EmptyState>(() => {});
 
 const STORED_OPTION: Option = {
   id: "opt-sushi",
   title: "Sushi Place",
   addedByName: "Alex",
-  homePageUrl: "https://sushi.example/menu",
-  homePageUrlOverride: "",
 };
 
 const votes: Vote[] = [
@@ -95,16 +90,11 @@ const votes: Vote[] = [
 ];
 
 export default pattern(() => {
-  const linkEditTarget = new Writable<string | null>(null);
-  const linkDraft = new Writable<string | Default<"">>("");
   const removeConfirmTarget = new Writable<string | null>(null);
-  const homePageRefresh = new Writable<number>(0);
 
   const castVote: Stream<CastVoteEvent> = noopCastVote({});
   const removeOption: Stream<RemoveOptionEvent> = noopRemoveOption({});
   const logVisit: Stream<LogVisitEvent> = noopLogVisit({});
-  const setOptionUrl: Stream<SetOptionUrlEvent> = noopSetOptionUrl({});
-  const setOptionHomePageUrl: Stream<SetOptionUrlEvent> = noopSetOptionUrl({});
 
   const card = PollOptionCard({
     option: STORED_OPTION,
@@ -113,17 +103,10 @@ export default pattern(() => {
     isJoined: true,
     isAdmin: true,
     votes,
-    cityLabel: "Berkeley, CA",
-    searchEndpoint: "",
-    homePageRefresh,
-    linkEditTarget,
-    linkDraft,
     removeConfirmTarget,
     castVote,
     removeOption,
     logVisit,
-    setOptionUrl,
-    setOptionHomePageUrl,
   });
 
   const assert_my_green_vote_label_renders = computed(() =>
@@ -152,14 +135,6 @@ export default pattern(() => {
       propValue(red, "style") === "opacity: 0.4;";
   });
 
-  const assert_host_homepage_link_renders = computed(() =>
-    findNodeByProp(
-      card[UI],
-      "href",
-      "https://sushi.example/menu",
-    ) !== undefined
-  );
-
   const assert_host_controls_render = computed(() => {
     const remove = findNodeByProp(
       card[UI],
@@ -178,7 +153,6 @@ export default pattern(() => {
     tests: [
       { assertion: assert_my_green_vote_label_renders },
       { assertion: assert_my_green_vote_styles_buttons },
-      { assertion: assert_host_homepage_link_renders },
       { assertion: assert_host_controls_render },
     ],
     card,

--- a/packages/patterns/lunch-poll/poll-option-card.tsx
+++ b/packages/patterns/lunch-poll/poll-option-card.tsx
@@ -1,8 +1,5 @@
 import {
   computed,
-  Default,
-  fetchData,
-  generateText,
   NAME,
   pattern,
   type Stream,
@@ -15,74 +12,12 @@ import type {
   LogVisitEvent,
   Option,
   RemoveOptionEvent,
-  SetOptionUrlEvent,
   Vote,
   VoteColor,
 } from "./main.tsx";
 
 /** Shared per-session target cell used for one open option editor at a time. */
 export type PollOptionLinkTargetCell = Writable<string | null>;
-
-/** Shared per-session draft text cell used by the option link editor. */
-export type PollOptionNameCell = Writable<string | Default<"">>;
-
-/** Parent-owned counter cell that retriggers admin homepage lookup. */
-export type PollOptionHomePageRefreshCell = Writable<number>;
-
-interface WebSearchResponse {
-  results?: Array<{ title?: string; url?: string; description?: string }>;
-}
-
-const trimmedName = (n: string | undefined) => (n ?? "").trim();
-
-const homePageLookupUrlFor = (
-  isAdmin: boolean,
-  _refresh: number,
-  storedUrl: string | undefined,
-  overrideUrl: string | undefined,
-  endpoint: string,
-): string =>
-  isAdmin && !trimmedName(storedUrl) && !trimmedName(overrideUrl)
-    ? endpoint
-    : "";
-
-const homePageVerifierSystem =
-  "You verify restaurant website search results. Choose the restaurant's own " +
-  "official website only when it is clear from the candidate URL, title, and " +
-  "description. Reject directories, review sites, delivery apps, reservation " +
-  "sites, social media, maps, unrelated restaurants, and similarly named " +
-  "businesses. Answer with exactly one candidate number, or NONE.";
-
-const homePageVerifierPrompt = (
-  title: string,
-  city: string,
-  refresh: number,
-  candidates: WebSearchResponse["results"],
-): string => {
-  const rows = (candidates ?? [])
-    .map((candidate, index) =>
-      typeof candidate?.url === "string" && candidate.url.length > 0
-        ? (
-          `${index + 1}. URL: ${candidate.url}\n` +
-          `   Title: ${candidate.title ?? ""}\n` +
-          `   Description: ${(candidate.description ?? "").slice(0, 300)}`
-        )
-        : ""
-    )
-    .filter((row) => row !== "");
-  if (rows.length === 0) return "";
-  return `Restaurant: ${title}\nCity: ${city}\nRefresh: ${refresh}\n\nCandidates:\n${
-    rows.join("\n")
-  }\n\nReturn only the candidate number, or NONE.`;
-};
-
-function toHomepage(url: string): string {
-  try {
-    return new URL(url).origin + "/";
-  } catch {
-    return url;
-  }
-}
 
 const myVoteFor = (
   votes: readonly Vote[],
@@ -99,9 +34,9 @@ const myVoteFor = (
  * PollOptionCard renders one complete ranked restaurant option row.
  *
  * Use it when a parent pattern already owns option, vote, viewer, and admin
- * state and wants composed UI for voting, homepage display/edit/lookup, and
- * admin-only remove/history actions. This is not a standalone vote engine;
- * durable mutations happen through the input streams supplied by the parent.
+ * state and wants composed UI for voting and admin-only remove/history actions.
+ * This is not a standalone vote engine; durable mutations happen through the
+ * input streams supplied by the parent.
  */
 
 /**
@@ -114,7 +49,7 @@ const myVoteFor = (
  * cell.
  */
 export interface PollOptionCardInput {
-  /** Option record to render and enrich. */
+  /** Option record to render. */
   option: Option;
 
   /** One-based display rank supplied by the parent's ranking computation. */
@@ -123,7 +58,7 @@ export interface PollOptionCardInput {
   /** Resolved current viewer name; required for per-option vote styling. */
   me: string;
 
-  /** Whether the current viewer is allowed to vote and edit links. */
+  /** Whether the current viewer is allowed to vote. */
   isJoined: boolean;
 
   /** Whether the current viewer owns admin-only actions. */
@@ -131,21 +66,6 @@ export interface PollOptionCardInput {
 
   /** Shared vote list used to compute this viewer's selected vote. */
   votes: readonly Vote[];
-
-  /** Human-readable city label used for homepage lookup and map fallback. */
-  cityLabel: string;
-
-  /** Endpoint used by admins to search for official restaurant homepages. */
-  searchEndpoint: string;
-
-  /** Parent-owned counter cell; increments force homepage lookup to rerun. */
-  homePageRefresh: PollOptionHomePageRefreshCell;
-
-  /** Per-session option id whose homepage editor is open. */
-  linkEditTarget: PollOptionLinkTargetCell;
-
-  /** Per-session homepage URL draft shared across option editors. */
-  linkDraft: PollOptionNameCell;
 
   /** Per-session option id awaiting admin remove confirmation. */
   removeConfirmTarget: PollOptionLinkTargetCell;
@@ -158,19 +78,12 @@ export interface PollOptionCardInput {
 
   /** Parent-owned admin stream that records this option in visit history. */
   logVisit: Stream<LogVisitEvent>;
-
-  /** Parent-owned stream that saves a viewer-edited homepage override. */
-  setOptionUrl: Stream<SetOptionUrlEvent>;
-
-  /** Parent-owned admin stream that persists an auto-discovered homepage. */
-  setOptionHomePageUrl: Stream<SetOptionUrlEvent>;
 }
 
 /**
  * Outputs for one rendered ranked option row.
  *
- * Parents normally embed this sub-pattern with JSX. Use function-call
- * instantiation only when reading `homePageUrl`.
+ * Parents normally embed this sub-pattern with JSX.
  */
 export interface PollOptionCardOutput {
   /** Human-readable pattern name, matching the option title. */
@@ -178,9 +91,6 @@ export interface PollOptionCardOutput {
 
   /** Static VNode rendering the complete option row. */
   [UI]: VNode;
-
-  /** Display homepage URL after stored, edited, or verified lookup resolution. */
-  homePageUrl: string;
 }
 
 export default pattern<PollOptionCardInput, PollOptionCardOutput>(
@@ -192,124 +102,16 @@ export default pattern<PollOptionCardInput, PollOptionCardOutput>(
       isJoined,
       isAdmin,
       votes,
-      cityLabel,
-      searchEndpoint,
-      homePageRefresh,
-      linkEditTarget,
-      linkDraft,
       removeConfirmTarget,
       castVote,
       removeOption,
       logVisit,
-      setOptionUrl,
-      setOptionHomePageUrl,
     },
   ) => {
     const oid = option.id;
     const optionTitle = option.title;
     const myVote = computed(() => myVoteFor(votes, me, oid));
     const isRemoveConfirm = computed(() => removeConfirmTarget.get() === oid);
-    const refresh = computed(() => Number(homePageRefresh.get() ?? 0));
-
-    const homePageSearch = fetchData<WebSearchResponse>({
-      url: computed(() =>
-        homePageLookupUrlFor(
-          isAdmin,
-          refresh,
-          option.homePageUrl,
-          option.homePageUrlOverride,
-          searchEndpoint,
-        )
-      ),
-      mode: "json",
-      options: {
-        method: "POST",
-        mutexTimeoutMs: 30_000,
-        headers: computed(() => ({
-          "Content-Type": "application/json",
-          "X-Lunch-Poll-Refresh": String(refresh),
-        })),
-        body: computed(() => ({
-          query:
-            `official website of the restaurant "${option.title}" in ${cityLabel}`,
-          max_results: 4,
-        })),
-      },
-    });
-
-    const homePageVerifier = generateText({
-      system: homePageVerifierSystem,
-      prompt: computed(() => {
-        if (
-          !homePageLookupUrlFor(
-            isAdmin,
-            refresh,
-            option.homePageUrl,
-            option.homePageUrlOverride,
-            searchEndpoint,
-          )
-        ) return "";
-        if (homePageSearch.pending) return "";
-        return homePageVerifierPrompt(
-          option.title,
-          cityLabel,
-          refresh,
-          homePageSearch.result?.results,
-        );
-      }),
-    });
-
-    const fetchedHomePageUrl = computed(() => {
-      if (
-        !homePageLookupUrlFor(
-          isAdmin,
-          refresh,
-          option.homePageUrl,
-          option.homePageUrlOverride,
-          searchEndpoint,
-        )
-      ) return "";
-      if (homePageSearch.pending || homePageVerifier.pending) {
-        return "";
-      }
-      const choice = Number(trimmedName(homePageVerifier.result));
-      const url = Number.isInteger(choice) && choice > 0
-        ? homePageSearch.result?.results?.[choice - 1]?.url
-        : "";
-      return typeof url === "string" && url ? toHomepage(url) : "";
-    });
-
-    const displayHomePageUrl = computed(() => {
-      const stored = trimmedName(option.homePageUrl);
-      if (stored) return stored;
-      const fetched = fetchedHomePageUrl;
-      if (fetched) {
-        setOptionHomePageUrl.send({
-          optionId: oid,
-          url: fetched,
-        });
-        return fetched;
-      }
-      return "";
-    });
-
-    const homeUrl = computed(() => {
-      const o = trimmedName(option.homePageUrlOverride);
-      if (o) return o;
-      const stored = trimmedName(option.homePageUrl);
-      if (stored) return stored;
-      return `https://www.google.com/maps/search/?api=1&query=${
-        encodeURIComponent(`${option.title} ${cityLabel}`)
-      }`;
-    });
-
-    const isEditingLink = computed(() => linkEditTarget.get() === option.id);
-    const homeLabel = computed(() => {
-      if (trimmedName(option.homePageUrlOverride)) {
-        return "🔗 Website (edited)";
-      }
-      return trimmedName(option.homePageUrl) ? "🔗 Website" : "🔎 Find on Maps";
-    });
 
     return {
       [NAME]: optionTitle,
@@ -325,7 +127,6 @@ export default pattern<PollOptionCardInput, PollOptionCardOutput>(
             alignItems: "center",
             gap: "10px",
           }}
-          data-homepage-sync={displayHomePageUrl}
         >
           <span
             style={{
@@ -353,97 +154,6 @@ export default pattern<PollOptionCardInput, PollOptionCardOutput>(
             >
               {optionTitle}
             </div>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "baseline",
-                gap: "8px",
-                marginTop: "2px",
-                flexWrap: "wrap",
-              }}
-            >
-              <a
-                href={homeUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{
-                  fontSize: "11px",
-                  color: "#2f6f4e",
-                  textDecoration: "underline",
-                }}
-              >
-                {homeLabel}
-              </a>
-              {isJoined
-                ? (
-                  <button
-                    type="button"
-                    aria-label="Edit homepage link"
-                    title="Edit link"
-                    style={{
-                      border: "none",
-                      background: "transparent",
-                      color: "#9ca3af",
-                      cursor: "pointer",
-                      fontSize: "11px",
-                      padding: 0,
-                    }}
-                    onClick={() => linkEditTarget.set(option.id)}
-                  >
-                    ✎ edit
-                  </button>
-                )
-                : null}
-            </div>
-            {isEditingLink
-              ? (
-                <div
-                  style={{
-                    display: "flex",
-                    gap: "6px",
-                    alignItems: "center",
-                    marginTop: "4px",
-                    flexWrap: "wrap",
-                  }}
-                >
-                  <cf-input
-                    $value={linkDraft}
-                    placeholder="Paste a homepage URL…"
-                    aria-label="Homepage URL"
-                    timing-strategy="immediate"
-                    style="flex:1; min-width:160px;"
-                  />
-                  <cf-button
-                    size="sm"
-                    variant="primary"
-                    onClick={() =>
-                      setOptionUrl.send({
-                        optionId: option.id,
-                      })}
-                  >
-                    Save
-                  </cf-button>
-                  <cf-button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() =>
-                      setOptionUrl.send({
-                        optionId: option.id,
-                        url: "",
-                      })}
-                  >
-                    Clear
-                  </cf-button>
-                  <cf-button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => linkEditTarget.set(null)}
-                  >
-                    Cancel
-                  </cf-button>
-                </div>
-              )
-              : null}
             <div
               style={{
                 fontSize: "11px",
@@ -600,7 +310,6 @@ export default pattern<PollOptionCardInput, PollOptionCardOutput>(
             : null}
         </div>
       ),
-      homePageUrl: displayHomePageUrl,
     };
   },
 );

--- a/packages/patterns/tools/lunch-poll-diagnose.ts
+++ b/packages/patterns/tools/lunch-poll-diagnose.ts
@@ -21,7 +21,6 @@ interface PollOutputSummary {
   historyCount: number;
   isJoined: boolean;
   isAdmin: boolean;
-  homePageLookupUrls: readonly string[];
 }
 
 interface TraceAddressSummary {
@@ -76,14 +75,12 @@ interface MatrixConfig {
   optionCounts: readonly number[];
   userCounts: readonly number[];
   voteRounds: number;
-  includeHomepageRefresh: boolean;
 }
 
 interface CaseConfig {
   optionCount: number;
   userCount: number;
   voteRounds: number;
-  includeHomepageRefresh: boolean;
 }
 
 interface CompactSessionSample {
@@ -94,7 +91,6 @@ interface CompactSessionSample {
     users: number;
     options: number;
     votes: number;
-    activeLookupUrls: number;
   };
   graph: {
     nodes: number;
@@ -155,7 +151,6 @@ interface CaseResult {
     users: number;
     options: number;
     voteRounds: number;
-    includeHomepageRefresh: boolean;
   };
   churn: ChurnTotals;
   convergence: ConvergenceResult;
@@ -234,8 +229,6 @@ async function collectConvergence(
 }
 
 const traceCursors = new Map<string, number>();
-const TEST_WEB_SEARCH_URL =
-  "data:application/json,%7B%22results%22%3A%5B%5D%7D";
 const VOTE_COLORS = ["green", "yellow", "red"] as const;
 let matrixProgram = "main.tsx";
 const ROOT_PATH = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
@@ -280,7 +273,6 @@ function pollSummary(value: unknown): PollOutputSummary {
     historyCount: asNumber(value.historyCount),
     isJoined: asBoolean(value.isJoined),
     isAdmin: asBoolean(value.isAdmin),
-    homePageLookupUrls: asStringArray(value.homePageLookupUrls),
   };
 }
 
@@ -470,8 +462,6 @@ function compactSessionSample(
       users: poll.userCount,
       options: poll.optionCount,
       votes: poll.voteCount,
-      activeLookupUrls: poll.homePageLookupUrls.filter((url) => url !== "")
-        .length,
     },
     graph: {
       nodes: diagnostics.graph.nodes,
@@ -590,9 +580,6 @@ async function createHarness(config: CaseConfig): Promise<MultiRuntimeHarness> {
     programPath: `${LUNCH_POLL_DIR}/${matrixProgram}`,
     rootPath: ROOT_PATH,
     diagnostics: true,
-    input: {
-      webSearchUrl: TEST_WEB_SEARCH_URL,
-    },
     sessions: Array.from(
       { length: config.userCount },
       (_entry, index) => `user-${index + 1}`,
@@ -657,18 +644,6 @@ async function runCase(config: CaseConfig): Promise<CaseResult> {
       );
     }
 
-    if (config.includeHomepageRefresh) {
-      phases.push(
-        await samplePhase(
-          "host-refreshes-homepage-lookups",
-          harness,
-          async () => {
-            await host.send("enrichHomePages", {});
-          },
-        ),
-      );
-    }
-
     const churn = await collectChurn(sessions);
     console.error(
       `[lunch-poll diagnose] churn ${config.optionCount}x${config.userCount} ` +
@@ -699,7 +674,6 @@ async function runCase(config: CaseConfig): Promise<CaseResult> {
         users: config.userCount,
         options: config.optionCount,
         voteRounds: config.voteRounds,
-        includeHomepageRefresh: config.includeHomepageRefresh,
       },
       churn,
       convergence,
@@ -761,7 +735,6 @@ function explicitCasesArg(
       optionCount,
       userCount,
       voteRounds: config.voteRounds,
-      includeHomepageRefresh: config.includeHomepageRefresh,
     }];
   });
   return cases.length > 0 ? cases : undefined;
@@ -783,7 +756,6 @@ function matrixConfigFromArgs(): MatrixConfig {
     optionCounts: numberListArg("options", quick ? [1, 3] : [1, 3, 10]),
     userCounts: numberListArg("users", quick ? [2] : [2, 5], 1),
     voteRounds: numberArg("rounds", quick ? 1 : 3),
-    includeHomepageRefresh: !Deno.args.includes("--skip-refresh"),
   };
 }
 
@@ -798,7 +770,6 @@ function casesFromConfig(config: MatrixConfig): CaseConfig[] {
         optionCount,
         userCount,
         voteRounds: config.voteRounds,
-        includeHomepageRefresh: config.includeHomepageRefresh,
       });
     }
   }


### PR DESCRIPTION
## Why

Per-option homepage enrichment (a grounded web search + a `generateText`
verifier, both behind a 30s mutex) and the city control are heavy, non-essential
load on the lunch poll. Per Gideon, we're removing the two enrichment features as
**separate** PRs so each can be toggled on/off (land/revert) independently while
testing concurrency. The generated-image removal is the sibling PR (#4325).

Applies to the array-vote `main` (#4303); orthogonal to the runtime
conflict-granularity fix (#4220).

## What changed

- `main.tsx`: drop `homePageUrl`/`homePageUrlOverride` from `Option` + inits,
  `WEB_SEARCH_URL`, the `setCity`/`enrichHomePages`/`setOptionUrl`/
  `setOptionHomePageUrl` handlers, `homePageLookupUrlFor`, the `city`/
  `webSearchUrl` I/O, the city header badge, and the city/refresh host controls.
- `poll-option-card.tsx`: drop the homepage link + inline editor and the
  `homePageSearch`/`homePageVerifier`/`displayHomePageUrl`/`homeUrl` computeds.
- `lunch-poll-diagnose.ts`: drop the `host-refreshes-homepage-lookups` phase
  (it dispatched the removed `enrichHomePages`) plus the `homePageLookupUrls`/
  `activeLookupUrls`/`includeHomepageRefresh`/`--skip-refresh` plumbing, so the
  harness still drives the stripped poll.
- Trim web-search assertions from the tests.
- **Kept** the shared `httpsOrNull`/`safeHttpUrl` URL helpers — generated-art's
  `safeImageUrl` uses them.

## Test plan

`cf check` clean; `cf test`: main 19/0, multi-user 11/0, poll-option-card 7/0,
lunch-stats 1/0; diagnose smoke run converges with no `enrichHomePages` dispatch.

## Note for the reviewer

Independent of the sibling generated-art PR (#4325), but they touch a few of
the same lines — a mechanical merge. If **both** land, `httpsOrNull`/
`safeHttpUrl` go unused (~10-line follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed per-option web-search homepage enrichment and the city control from the lunch poll to simplify the experience and cut runtime load. Also removed now-unused URL helpers after generated-art was already deleted.

- **Refactors**
  - Dropped `homePageUrl`/`homePageUrlOverride` from `Option`; removed homepage link UI and editor from the option card.
  - Removed `setCity`, `enrichHomePages`, `setOptionUrl`, and `setOptionHomePageUrl` handlers, plus the city badge and host controls.
  - Deleted web-search and verifier logic from the option card; removed `WEB_SEARCH_URL` and per-option lookup plumbing.
  - Removed `httpsOrNull`/`safeHttpUrl` helpers (no longer used after generated-art removal).
  - Trimmed tests and synced `lunch-poll-diagnose` by removing the homepage refresh phase and related fields/flags; dropped the `webSearchUrl` harness input.

- **Migration**
  - Removed inputs: `city`, `webSearchUrl`.
  - Removed outputs: `city`, `homePageLookupUrls`; in `PollOptionCard`, removed `homePageUrl`.
  - Removed streams: `setCity`, `enrichHomePages`, `setOptionUrl`, `setOptionHomePageUrl`.
  - Remove any usages of homepage links or city UI; no replacement is provided.

<sup>Written for commit 7f83a8eddf700b05cdd721b6bb5db0fbe01b451a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

