### PR TITLE
refactor(runner): route link-resolution's storage probe through cell-rep

### DIFF
--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -163,6 +163,38 @@ export function linkRefPayload<Payload extends FabricObject>(
   throw new Error("Not a link reference.");
 }
 
+/**
+ * The storage sub-path, relative to a value's position in the document tree, at
+ * which a link rooted there exposes its recognizable form. This encodes the
+ * link layout for consumers that navigate _into_ the document tree (notably link
+ * resolution), so they need not hardcode the layout — or the link tag —
+ * themselves.
+ *
+ * A link is a decomposed plain-object envelope (`{ "/": { "link@1": … } }`), so
+ * the recognizable payload sits two segments down at `["/", "link@1"]`. Pair
+ * with {@link linkPayloadAtProbe} to interpret whatever is read at
+ * `position + linkProbeSubPath()`. This is gathered here alongside the rest of
+ * the link chokepoint so that the modern cell representation can later dispatch
+ * the layout (an atomic value → an empty sub-path) from a single seam.
+ */
+export function linkProbeSubPath(): readonly string[] {
+  return ["/", LINK_V1_TAG];
+}
+
+/**
+ * Interprets the value read at `position + ` {@link linkProbeSubPath}: returns
+ * the link payload if that value denotes a link rooted at `position`, or
+ * `undefined` otherwise.
+ *
+ * The probed value already _is_ the inner payload (the tree walk descended into
+ * the envelope), so any record there is the payload.
+ */
+export function linkPayloadAtProbe(
+  probeValue: unknown,
+): FabricObject | undefined {
+  return isRecord(probeValue) ? probeValue as FabricObject : undefined;
+}
+
 //
 // Wire serialization of a (plain) link payload
 //

--- a/packages/data-model/test/cell-rep.test.ts
+++ b/packages/data-model/test/cell-rep.test.ts
@@ -10,6 +10,8 @@ import {
   isEntityRef,
   isLinkRef,
   LINK_V1_TAG,
+  linkPayloadAtProbe,
+  linkProbeSubPath,
   linkRefFrom,
   linkRefPayload,
   linkRefPayloadFromString,
@@ -132,6 +134,37 @@ describe("cell-rep link-ref envelope", () => {
       "Not a link reference",
     );
     expect(() => linkRefPayload({} as never)).toThrow("Not a link reference");
+  });
+});
+
+describe("cell-rep link storage-tree probe", () => {
+  const PAYLOAD = { id: "of:abc", path: ["x", "y"] };
+
+  it('probes two segments down at ["/", "link@1"]', () => {
+    expect(linkProbeSubPath()).toEqual(["/", LINK_V1_TAG]);
+  });
+
+  it("reads the payload back from the value at the probe sub-path", () => {
+    // The envelope is decomposed in the tree, so walking the probe sub-path
+    // lands directly on the payload record.
+    const envelope = linkRefFrom(PAYLOAD);
+    const atProbe = linkProbeSubPath().reduce<unknown>(
+      (node, key) => (node as Record<string, unknown>)[key],
+      envelope,
+    );
+    expect(linkPayloadAtProbe(atProbe)).toEqual(PAYLOAD);
+  });
+
+  it("treats any record at the probe as the payload", () => {
+    expect(linkPayloadAtProbe(PAYLOAD)).toBe(PAYLOAD);
+    expect(linkPayloadAtProbe({})).toEqual({});
+  });
+
+  it("returns undefined when the probed value is not a record", () => {
+    expect(linkPayloadAtProbe(undefined)).toBeUndefined();
+    expect(linkPayloadAtProbe(null)).toBeUndefined();
+    expect(linkPayloadAtProbe("redirect")).toBeUndefined();
+    expect(linkPayloadAtProbe(42)).toBeUndefined();
   });
 });
 

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -1,8 +1,11 @@
-import { isRecord } from "@commonfabric/utils/types";
 import { getLogger } from "@commonfabric/utils/logger";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
-import { type CellLinkRefPayload, LINK_V1_TAG } from "./sigil-types.ts";
+import {
+  linkPayloadAtProbe,
+  linkProbeSubPath,
+} from "@commonfabric/data-model/cell-rep";
+import { type CellLinkRefPayload } from "./sigil-types.ts";
 import {
   type CellLink,
   createDataCellURI,
@@ -164,16 +167,18 @@ export function resolveLink(
     const sigilProbe = tx.read(
       toMemorySpaceAddress({
         ...link,
-        path: [...link.path, "/", LINK_V1_TAG],
+        path: [...link.path, ...linkProbeSubPath()],
       }),
       { meta: linkResolutionProbe },
     );
+    const probePayload = sigilProbe.ok
+      ? linkPayloadAtProbe(sigilProbe.ok.value)
+      : undefined;
     if (
-      sigilProbe.ok &&
-      isRecord(sigilProbe.ok.value) &&
+      probePayload !== undefined &&
       lastNode !== "top" &&
       (lastNode !== "writeRedirect" ||
-        (sigilProbe.ok.value as CellLinkRefPayload).overwrite === "redirect")
+        (probePayload as CellLinkRefPayload).overwrite === "redirect")
     ) {
       // Read the full value at this path to ensure correct reactivity logging
       // (we need to be reactive to siblings that could invalidate the link)
@@ -216,11 +221,14 @@ export function resolveLink(
           const parentSigil = tx.read(
             toMemorySpaceAddress({
               ...link,
-              path: [...lastValid, "/", LINK_V1_TAG],
+              path: [...lastValid, ...linkProbeSubPath()],
             }),
             { meta: linkResolutionProbe },
           );
-          if (parentSigil.ok && isRecord(parentSigil.ok.value)) {
+          if (
+            parentSigil.ok &&
+            linkPayloadAtProbe(parentSigil.ok.value) !== undefined
+          ) {
             // Read the full value at the parent to ensure proper reactivity
             const whole = tx.readValueOrThrow({ ...link, path: lastValid });
             const nextLink = parseLink(whole as CellLink, {
@@ -409,16 +417,15 @@ export function readMaybeLink(
   link: NormalizedFullLink,
   onlyWriteRedirects = false,
 ): NormalizedFullLink | undefined {
-  const readSubPath = (extraPath: string[]) =>
+  const readSubPath = (extraPath: readonly string[]) =>
     tx.readValueOrThrow({ ...link, path: [...link.path, ...extraPath] });
 
-  const maybeSigilLink = readSubPath(["/", LINK_V1_TAG]);
+  const maybeSigilPayload = linkPayloadAtProbe(readSubPath(linkProbeSubPath()));
   if (
     // Sigil link: { "/": { "link@1": { id: <id>, ... } } }
-    (isRecord(maybeSigilLink) &&
+    (maybeSigilPayload !== undefined &&
       (!onlyWriteRedirects ||
-        ("overwrite" in maybeSigilLink &&
-          maybeSigilLink.overwrite === "redirect"))) ||
+        (maybeSigilPayload as CellLinkRefPayload).overwrite === "redirect")) ||
     // Legacy cell link: { cell: {"/": <id> }, path: [] }
     (!onlyWriteRedirects && typeof readSubPath(["cell", "/"]) === "string" &&
       Array.isArray(readSubPath(["path"]))) ||


### PR DESCRIPTION
## What

`link-resolution.ts` was the last structural holdout that hardcoded the link layout (`["/", LINK_V1_TAG]`) **outside** `cell-rep.ts` — splicing it into storage-tree paths to probe *into* the `{ "/": { "link@1": … } }` envelope (3 sites: the full-path sigil probe, the parent probe, and `readMaybeLink`). This was the blocker flagged when we deferred un-exporting `LINK_V1_TAG`.

This PR encapsulates that knowledge behind two pure helpers in `cell-rep.ts`:

- **`linkProbeSubPath()`** — the storage sub-path, relative to a value's position in the document tree, at which a link rooted there exposes its recognizable form (`["/", "link@1"]`).
- **`linkPayloadAtProbe(value)`** — interprets whatever is read at `position + linkProbeSubPath()`, returning the link payload or `undefined`.

The three probe sites in `resolveLink`/`readMaybeLink` now build their address from `linkProbeSubPath()` and interpret hits via `linkPayloadAtProbe()`, so the file no longer names the link tag (drops its `LINK_V1_TAG`/`isRecord` imports).

## Why

This is the prep step toward making `FabricLink` the modern in-memory link form. Unlike the `EntityRef → FabricHash` flip, links can't become a pure chokepoint dispatch, because a document is one in-memory tree and a "path" is a property-walk into it: a legacy link is plain-object-**decomposed** so the probe descends into it, whereas a modern `FabricLink` **instance** is stored as one atomic leaf — so `instance["/"]` is `undefined` and the old path-probe would find nothing. Moving the layout knowledge into cell-rep lets the modern representation dispatch it (an atomic value → an empty sub-path) from a single seam.

## Scope

**Behavior-identical refactor.** The helpers encapsulate only today's legacy layout — no `modernCellRepEnabled` branch yet. The actual `FabricLink` hookup (and the flag dispatch in these helpers) lands in a follow-on PR (the chokepoint flip of `linkRefFrom`/`isLinkRef`/`linkRefPayload`). The NotFound mid-path-link arithmetic is unchanged and suffix-length-independent: the suffix's first segment `"/"` only exists when there's a real link, in which case the probe is OK (not NotFound), so it never leaks into `error.path`.

## Testing

- data-model + runner type-check clean; `deno fmt`/`deno lint` clean.
- New helper coverage in `cell-rep.test.ts`.
- Runner unit suite: **664 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes link-resolution’s storage-tree probe through `@commonfabric/data-model/cell-rep` via new helpers, removing hardcoded link layout from the runner. Behavior is unchanged and this sets up the modern `FabricLink` representation.

- **Refactors**
  - Added `linkProbeSubPath()` and `linkPayloadAtProbe()` in `@commonfabric/data-model/cell-rep` to encode/interpret the link probe.
  - Updated `resolveLink` and `readMaybeLink` to use these helpers; removed direct `LINK_V1_TAG`/`isRecord` usage.
  - Added unit tests for the new helpers in `@commonfabric/data-model`.

<sup>Written for commit 874f69f1be15bc9c9a1a6829bbf537626998893a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

