### PR TITLE
Authenticate privileged toolshed routes with request proofs

### DIFF
--- a/docs/specs/toolshed-access-control.md
+++ b/docs/specs/toolshed-access-control.md
@@ -1,0 +1,124 @@
+# Toolshed Access Control
+
+## Current Model
+
+Toolshed has public routes, browser shell routes, storage routes, external
+callback routes, and local privileged HTTP routes.
+
+This document covers local privileged HTTP routes. These routes let a caller use
+server-held authority. That authority may be provider API keys, local runtime
+authority, toolshed service storage, or a sandbox command runner.
+
+First-party local callers authenticate with the same user DID key that the shell
+and runtime use for the logged-in user. The caller attaches a request proof. The
+server verifies the proof before it starts privileged work. The verified DID is
+stored on the Hono context as `verifiedUserDid` so handlers can log it and use it
+for later moderation and audit work.
+
+## Protected Now
+
+These routes require a first-party HTTP request proof:
+
+- `POST /api/agent-tools/web-search`
+- `POST /api/agent-tools/web-read`
+- `POST /api/sandbox/exec`
+
+They were selected first because first-party code calls them through
+`fetchData`, and each route spends server-held or local runtime authority.
+`web-search` uses the AI gateway. `web-read` uses the Jina key. `sandbox/exec`
+uses the sandbox service to run commands.
+
+The protected routes do not expose wildcard CORS. Same-origin shell calls do not
+need CORS. Cross-origin callers must not get a credentialed wildcard surface for
+these routes.
+
+## Request Proof Format
+
+The implementation uses a CommonTools-specific first-party request proof. It
+does not use the RFC 9421 header names or vocabulary. This keeps the local
+format separate from a future RFC 9421 implementation.
+
+The custom headers are:
+
+- `CF-Request-Auth`
+- `CF-Request-Proof`
+- `CF-Request-Body-SHA256`, when the request has a body
+- `CF-User-DID`
+
+The request proof covers:
+
+- HTTP method
+- HTTP authority
+- Path, including the query string
+- `CF-Request-Body-SHA256`, when the request has a body
+- `CF-User-DID`
+- Issue time, valid-until time, proof DID, and proof kind
+
+The `CF-Request-Auth` header includes `issued-at`, `valid-until`, `proof-did`,
+and `proof-kind`. The `proof-did` value is the verified DID key. The
+`CF-User-DID` header must match that key and is covered by the proof.
+`CF-Request-Proof` and `CF-Request-Body-SHA256` use unpadded base64url values.
+
+Requests expire quickly. The verifier rejects expired proofs, proofs issued too
+far in the future, and proofs with an excessive lifetime.
+
+## First-Party Caller Behavior
+
+The runtime adds request proofs only to narrow `fetchData` requests:
+
+- the resolved URL must target the runtime API origin
+- the route path must be one of the protected local routes
+- the method must be `POST`
+
+The runtime replaces caller-supplied proof headers for protected routes. It does
+not add user request proofs to arbitrary external requests, even when the path
+looks like a toolshed route.
+
+## Deferred Routes
+
+These routes are privileged but are not changed in this pass:
+
+- AI routes under `/api/ai/*`. They use provider keys or gateway authority.
+  They have broader caller shapes than the three local `fetchData` tools. They
+  should get the same kind of caller authentication once their browser and
+  service caller model is written down.
+- Webhook admin routes such as create, list, and delete. They write toolshed
+  service storage. External webhook ingest is separate because it authenticates
+  with a webhook bearer secret and has a different caller model.
+- Integration admin routes that create, exchange, refresh, or remove tokens.
+  OAuth callbacks are separate because the identity provider calls them. Login,
+  refresh, logout, and token exchange routes need a focused design that binds
+  the user DID to the target auth cell.
+- Memory WebSocket `session.open`. It already has its own DID-key verification
+  path. This change intentionally does not modify that protocol.
+
+## Remaining Gaps
+
+- There is no replay cache. The request proof is not trying to prevent replay
+  of captured HTTP messages. Toolshed expects TLS to keep an attacker from
+  observing and replaying a request on the wire. If a complete valid request is
+  obtained some other way, it can be replayed until the proof expires. Short
+  expiration and method, authority, path, query, DID, and body binding limit
+  where that captured request can be used.
+- A verified proof proves control of the DID key. It does not prove that the
+  caller is code shipped by the shell. Toolshed does not yet have a server-side
+  logged-in user registry or DID allowlist for these local HTTP routes.
+- The deferred privileged routes remain unauthenticated unless they already have
+  a route-specific mechanism.
+- Authentication identifies the caller. It does not yet authorize which user DID
+  may operate on which sandbox, auth cell, or service record.
+- This does not add new URL allowlists or destination filtering. Existing SSRF
+  defenses stay in their current route handlers.
+
+## Attack Vectors Covered
+
+- A caller without a valid proof cannot start protected privileged work.
+- A proof cannot be reused across another protected route because the path is
+  covered by the proof.
+- A proof cannot be reused across another host because the authority is covered
+  by the proof.
+- A body cannot be changed after the proof is attached because
+  `CF-Request-Body-SHA256` is verified and covered by the proof when a body is
+  present.
+- A caller-supplied user DID header is not trusted unless it is covered by a
+  valid proof from the same DID key.

--- a/packages/runner/deno.json
+++ b/packages/runner/deno.json
@@ -23,6 +23,7 @@
     "./traverse": "./src/traverse.ts",
     "./storage/cache": "./src/storage/cache.ts",
     "./storage/cache.deno": "./src/storage/cache.deno.ts",
+    "./toolshed-http-auth": "./src/toolshed-http-auth.ts",
     "./cfc": "./src/cfc/mod.ts",
     "./cfc/label-view-core": "./src/cfc/label-view-core.ts"
   }

--- a/packages/runner/src/builtins/fetch-data.ts
+++ b/packages/runner/src/builtins/fetch-data.ts
@@ -9,6 +9,11 @@ import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { createFrozenRequestSnapshot } from "../cfc/request-snapshot.ts";
 import { enqueueSinkRequestPostCommitEffect } from "../cfc/sink-request.ts";
 import {
+  isProtectedToolshedFirstPartyRoute,
+  isToolshedApiOrigin,
+  signFirstPartyHttpRequest,
+} from "../toolshed-http-auth.ts";
+import {
   computeInputHashFromValue,
   internalSchema,
   tryClaimMutex,
@@ -386,6 +391,39 @@ export function fetchData(
   };
 }
 
+function headersToRecord(headers: Headers): Record<string, string> {
+  return Object.fromEntries(headers.entries());
+}
+
+async function signedToolshedFetchOptions(
+  runtime: Runtime,
+  url: URL,
+  apiBase: URL,
+  options: FetchRequestOptions | undefined,
+): Promise<FetchRequestOptions | undefined> {
+  const method = options?.method ?? "GET";
+  if (
+    !isToolshedApiOrigin(url, apiBase) ||
+    !isProtectedToolshedFirstPartyRoute(url, method)
+  ) {
+    return options;
+  }
+
+  const headers = await signFirstPartyHttpRequest({
+    url,
+    method,
+    headers: options?.headers,
+    body: options?.body as BodyInit | null | undefined,
+    signer: runtime.storageManager.as,
+  });
+
+  return {
+    ...options,
+    method,
+    headers: headersToRecord(headers),
+  };
+}
+
 async function startFetch(
   runtime: Runtime,
   inputsCell: Cell<FetchDataInputs>,
@@ -427,11 +465,19 @@ async function startFetch(
     // some deployments (toolshed) deliberately differs from the runtime's
     // default memory host, so hostForSpace's fallback is NOT used here.
     const mappedHost = runtime.mappedHostFor(inputsCell.space);
+    const apiBase = new URL(mappedHost ?? getPatternEnvironment().apiUrl);
+    const resolvedUrl = new URL(url, apiBase);
+    const requestOptions = await signedToolshedFetchOptions(
+      runtime,
+      resolvedUrl,
+      apiBase,
+      options,
+    );
     const response = await fetch(
-      new URL(url, mappedHost ?? getPatternEnvironment().apiUrl),
+      resolvedUrl,
       {
         signal: abortSignal,
-        ...options,
+        ...requestOptions,
       },
     );
 

--- a/packages/runner/src/toolshed-http-auth.ts
+++ b/packages/runner/src/toolshed-http-auth.ts
@@ -1,0 +1,409 @@
+import {
+  type AsBytes,
+  type DIDKey,
+  VerifierIdentity,
+} from "@commonfabric/identity";
+import { sha256 } from "@commonfabric/content-hash";
+import {
+  fromBase64url,
+  toUnpaddedBase64url,
+} from "@commonfabric/utils/base64url";
+
+const textEncoder = new TextEncoder();
+
+export type FirstPartyHttpSigner = {
+  did(): string;
+  sign<T>(
+    payload: AsBytes<T>,
+  ):
+    | PromiseLike<
+      { ok: Uint8Array; error?: undefined } | { error: Error; ok?: undefined }
+    >
+    | { ok: Uint8Array; error?: undefined }
+    | { error: Error; ok?: undefined };
+};
+
+export const FIRST_PARTY_HTTP_AUTH_VERSION = "CF1";
+export const FIRST_PARTY_HTTP_PROOF_DOMAIN =
+  "common-toolshed-first-party-request-v1";
+export const FIRST_PARTY_USER_DID_HEADER = "CF-User-DID";
+export const FIRST_PARTY_HTTP_AUTH_HEADERS = {
+  auth: "CF-Request-Auth",
+  proof: "CF-Request-Proof",
+  bodySha256: "CF-Request-Body-SHA256",
+  userDid: FIRST_PARTY_USER_DID_HEADER,
+} as const;
+
+export const PROTECTED_TOOLSHED_FIRST_PARTY_ROUTES = [
+  "/api/agent-tools/web-read",
+  "/api/agent-tools/web-search",
+  "/api/sandbox/exec",
+] as const;
+
+const protectedRouteSet = new Set<string>(
+  PROTECTED_TOOLSHED_FIRST_PARTY_ROUTES,
+);
+
+const DEFAULT_VALID_FOR_SECONDS = 60;
+const DEFAULT_MAX_PROOF_AGE_SECONDS = 300;
+const DEFAULT_FUTURE_SKEW_SECONDS = 60;
+const PROOF_ALGORITHM = "ed25519";
+const AUTH_FIELD_ISSUED_AT = "issued-at";
+const AUTH_FIELD_VALID_UNTIL = "valid-until";
+const AUTH_FIELD_PROOF_DID = "proof-did";
+const AUTH_FIELD_PROOF_KIND = "proof-kind";
+
+export class FirstPartyHttpAuthError extends Error {
+  override name = "AuthorizationError";
+}
+
+function authError(message: string): FirstPartyHttpAuthError {
+  return new FirstPartyHttpAuthError(message);
+}
+
+export function isProtectedToolshedFirstPartyRoute(
+  url: URL,
+  method: string,
+): boolean {
+  return method.toUpperCase() === "POST" &&
+    protectedRouteSet.has(normalizeProtectedPath(url.pathname));
+}
+
+export function isToolshedApiOrigin(url: URL, apiBase: URL): boolean {
+  return url.origin === apiBase.origin;
+}
+
+function normalizeProtectedPath(pathname: string): string {
+  return pathname.length > 1 && pathname.endsWith("/")
+    ? pathname.slice(0, -1)
+    : pathname;
+}
+
+function requestPath(url: URL): string {
+  return `${url.pathname}${url.search}`;
+}
+
+function authority(url: URL): string {
+  return url.host.toLowerCase();
+}
+
+function isUnpaddedBase64url(encoded: string): boolean {
+  return /^[A-Za-z0-9_-]*$/.test(encoded);
+}
+
+function sha256Base64url(bytes: Uint8Array): string {
+  return toUnpaddedBase64url(sha256(bytes));
+}
+
+async function bodyBytesFromInit(
+  body: BodyInit | null | undefined,
+): Promise<Uint8Array | undefined> {
+  if (body === undefined || body === null) return undefined;
+  if (typeof body === "string") return textEncoder.encode(body);
+  if (body instanceof Uint8Array) return body;
+  if (body instanceof ArrayBuffer) return new Uint8Array(body);
+  if (ArrayBuffer.isView(body)) {
+    return new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+  }
+  if (body instanceof URLSearchParams) {
+    return textEncoder.encode(body.toString());
+  }
+  if (body instanceof Blob) {
+    return new Uint8Array(await body.arrayBuffer());
+  }
+
+  throw authError("unsupported authenticated request body type");
+}
+
+async function bodyBytesFromRequest(request: Request): Promise<Uint8Array> {
+  try {
+    return new Uint8Array(await request.clone().arrayBuffer());
+  } catch {
+    throw authError("could not read request body for authentication");
+  }
+}
+
+function removeAuthHeaders(headers: Headers): void {
+  headers.delete(FIRST_PARTY_HTTP_AUTH_HEADERS.auth);
+  headers.delete(FIRST_PARTY_HTTP_AUTH_HEADERS.proof);
+  headers.delete(FIRST_PARTY_HTTP_AUTH_HEADERS.bodySha256);
+  headers.delete(FIRST_PARTY_HTTP_AUTH_HEADERS.userDid);
+  headers.delete("Signature");
+  headers.delete("Signature-Input");
+  headers.delete("Content-Digest");
+}
+
+function encodeHeaderParam(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function decodeHeaderParam(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    throw authError("request auth metadata has invalid encoding");
+  }
+}
+
+function authHeaderValue(params: {
+  issuedAt: number;
+  validUntil: number;
+  did: string;
+}): string {
+  return `${FIRST_PARTY_HTTP_AUTH_VERSION} ${AUTH_FIELD_ISSUED_AT}=${params.issuedAt}; ${AUTH_FIELD_VALID_UNTIL}=${params.validUntil}; ${AUTH_FIELD_PROOF_DID}=${
+    encodeHeaderParam(params.did)
+  }; ${AUTH_FIELD_PROOF_KIND}=${PROOF_ALGORITHM}`;
+}
+
+function parseAuthHeader(headerValue: string): {
+  issuedAt: number;
+  validUntil: number;
+  did: string;
+  proofKind: string;
+} {
+  const prefix = `${FIRST_PARTY_HTTP_AUTH_VERSION} `;
+  if (!headerValue.startsWith(prefix)) {
+    throw authError("request auth metadata has an unknown version");
+  }
+
+  const rawParams = headerValue.slice(prefix.length);
+  const params = new Map<string, string>();
+  for (const rawPart of rawParams.split(";")) {
+    const part = rawPart.trim();
+    const separator = part.indexOf("=");
+    if (separator <= 0 || separator === part.length - 1) {
+      throw authError("request auth metadata is malformed");
+    }
+
+    const key = part.slice(0, separator);
+    const value = part.slice(separator + 1);
+    if (
+      ![
+        AUTH_FIELD_ISSUED_AT,
+        AUTH_FIELD_VALID_UNTIL,
+        AUTH_FIELD_PROOF_DID,
+        AUTH_FIELD_PROOF_KIND,
+      ].includes(key)
+    ) {
+      throw authError("request auth metadata has an unknown field");
+    }
+    if (params.has(key)) {
+      throw authError("request auth metadata has a duplicate field");
+    }
+    params.set(key, value);
+  }
+
+  const issuedAt = Number(params.get(AUTH_FIELD_ISSUED_AT));
+  const validUntil = Number(params.get(AUTH_FIELD_VALID_UNTIL));
+  const didValue = params.get(AUTH_FIELD_PROOF_DID);
+  const proofKind = params.get(AUTH_FIELD_PROOF_KIND);
+
+  if (!Number.isInteger(issuedAt) || !Number.isInteger(validUntil)) {
+    throw authError("request auth freshness fields must be integers");
+  }
+  if (!didValue || !proofKind) {
+    throw authError("request auth metadata is missing required fields");
+  }
+
+  return {
+    issuedAt,
+    validUntil,
+    did: decodeHeaderParam(didValue),
+    proofKind,
+  };
+}
+
+function requestProofBase(params: {
+  method: string;
+  url: URL;
+  headers: Headers;
+  userDid: string;
+  issuedAt: number;
+  validUntil: number;
+  proofKind: string;
+}): string {
+  const lines = [
+    FIRST_PARTY_HTTP_PROOF_DOMAIN,
+    `method: ${params.method.toUpperCase()}`,
+    `authority: ${authority(params.url)}`,
+    `path: ${requestPath(params.url)}`,
+    `user-did: ${params.userDid}`,
+    `issued-at: ${params.issuedAt}`,
+    `valid-until: ${params.validUntil}`,
+    `proof-kind: ${params.proofKind}`,
+  ];
+
+  const bodySha256 = params.headers.get(
+    FIRST_PARTY_HTTP_AUTH_HEADERS.bodySha256,
+  );
+  if (bodySha256 !== null) {
+    lines.push(`body-sha256: ${bodySha256}`);
+  }
+
+  return lines.join("\n");
+}
+
+function parseProofHeader(headerValue: string): Uint8Array {
+  if (!isUnpaddedBase64url(headerValue)) {
+    throw authError("request proof is not valid unpadded base64url");
+  }
+
+  try {
+    return fromBase64url(headerValue);
+  } catch {
+    throw authError("request proof is not valid unpadded base64url");
+  }
+}
+
+function assertFresh(params: {
+  issuedAt: number;
+  validUntil: number;
+  nowSeconds: number;
+  maxProofAgeSeconds: number;
+  futureSkewSeconds: number;
+}) {
+  if (params.validUntil <= params.issuedAt) {
+    throw authError("request auth validUntil must be after issuedAt");
+  }
+  if (params.validUntil - params.issuedAt > params.maxProofAgeSeconds) {
+    throw authError("request auth lifetime is too long");
+  }
+  if (params.issuedAt > params.nowSeconds + params.futureSkewSeconds) {
+    throw authError("request auth issuedAt is too far in the future");
+  }
+  if (params.validUntil < params.nowSeconds) {
+    throw authError("request auth has expired");
+  }
+}
+
+function assertBodySha256(
+  headers: Headers,
+  bodyBytes: Uint8Array,
+) {
+  const bodySha256 = headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.bodySha256);
+  if (!bodySha256 && bodyBytes.length > 0) {
+    throw authError("request body must have a body SHA-256 header");
+  }
+  if (!bodySha256) return;
+
+  const expected = sha256Base64url(bodyBytes);
+  if (bodySha256 !== expected) {
+    throw authError("body SHA-256 does not match request body");
+  }
+}
+
+export async function signFirstPartyHttpRequest(params: {
+  url: URL;
+  method: string;
+  headers?: HeadersInit;
+  body?: BodyInit | null;
+  signer: FirstPartyHttpSigner;
+  nowSeconds?: number;
+  validForSeconds?: number;
+}): Promise<Headers> {
+  const headers = new Headers(params.headers);
+  removeAuthHeaders(headers);
+
+  const userDid = params.signer.did();
+  if (!userDid.startsWith("did:key:")) {
+    throw authError("first-party HTTP authentication requires did:key signers");
+  }
+
+  headers.set(FIRST_PARTY_HTTP_AUTH_HEADERS.userDid, userDid);
+
+  const bodyBytes = await bodyBytesFromInit(params.body);
+  if (bodyBytes !== undefined) {
+    headers.set(
+      FIRST_PARTY_HTTP_AUTH_HEADERS.bodySha256,
+      sha256Base64url(bodyBytes),
+    );
+  }
+
+  const issuedAt = params.nowSeconds ?? Math.floor(Date.now() / 1000);
+  const validUntil = issuedAt +
+    (params.validForSeconds ?? DEFAULT_VALID_FOR_SECONDS);
+  headers.set(
+    FIRST_PARTY_HTTP_AUTH_HEADERS.auth,
+    authHeaderValue({ issuedAt, validUntil, did: userDid }),
+  );
+
+  const base = requestProofBase({
+    method: params.method,
+    url: params.url,
+    headers,
+    userDid,
+    issuedAt,
+    validUntil,
+    proofKind: PROOF_ALGORITHM,
+  });
+  const payload = textEncoder.encode(base) as unknown as AsBytes<string>;
+  const signed = await params.signer.sign(payload);
+  if (signed.error) throw signed.error;
+
+  headers.set(
+    FIRST_PARTY_HTTP_AUTH_HEADERS.proof,
+    toUnpaddedBase64url(signed.ok),
+  );
+  return headers;
+}
+
+export async function verifyFirstPartyHttpRequest(params: {
+  request: Request;
+  nowSeconds?: number;
+  maxProofAgeSeconds?: number;
+  futureSkewSeconds?: number;
+}): Promise<{ userDid: DIDKey }> {
+  const { request } = params;
+  const authHeader = request.headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.auth);
+  const proofHeader = request.headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.proof);
+  if (!authHeader || !proofHeader) {
+    throw authError("request is missing first-party auth headers");
+  }
+
+  const parsedAuth = parseAuthHeader(authHeader);
+  if (parsedAuth.proofKind !== PROOF_ALGORITHM) {
+    throw authError("unsupported first-party proof algorithm");
+  }
+  if (!parsedAuth.did.startsWith("did:key:")) {
+    throw authError("first-party auth DID must be a did:key");
+  }
+
+  const userDid = request.headers.get(FIRST_PARTY_USER_DID_HEADER);
+  if (!userDid || userDid !== parsedAuth.did) {
+    throw authError("proof user DID does not match request auth DID");
+  }
+
+  const nowSeconds = params.nowSeconds ?? Math.floor(Date.now() / 1000);
+  assertFresh({
+    issuedAt: parsedAuth.issuedAt,
+    validUntil: parsedAuth.validUntil,
+    nowSeconds,
+    maxProofAgeSeconds: params.maxProofAgeSeconds ??
+      DEFAULT_MAX_PROOF_AGE_SECONDS,
+    futureSkewSeconds: params.futureSkewSeconds ??
+      DEFAULT_FUTURE_SKEW_SECONDS,
+  });
+
+  const bodyBytes = await bodyBytesFromRequest(request);
+  assertBodySha256(request.headers, bodyBytes);
+
+  const base = requestProofBase({
+    method: request.method,
+    url: new URL(request.url),
+    headers: request.headers,
+    userDid,
+    issuedAt: parsedAuth.issuedAt,
+    validUntil: parsedAuth.validUntil,
+    proofKind: parsedAuth.proofKind,
+  });
+
+  const verifier = await VerifierIdentity.fromDid(parsedAuth.did as DIDKey);
+  const proof = parseProofHeader(proofHeader);
+  const verified = await verifier.verify({
+    payload: textEncoder.encode(base),
+    signature: proof,
+  });
+  if (verified.error) throw verified.error;
+
+  return { userDid: userDid as DIDKey };
+}

--- a/packages/runner/test/cfc-schema-merge.test.ts
+++ b/packages/runner/test/cfc-schema-merge.test.ts
@@ -86,6 +86,190 @@ describe("mergeCfcSchemaEnvelopes", () => {
     ).toThrow(/maxConfidentiality/i);
   });
 
+  it("merges compatible set-like ifc labels", () => {
+    const merged = mergeCfcSchemaEnvelopes({
+      type: "object",
+      properties: {
+        secret: {
+          type: "string",
+          ifc: {
+            confidentiality: ["secret"],
+            addIntegrity: ["reviewed"],
+            requiredIntegrity: ["trusted"],
+            integrity: ["trusted", "narrow"],
+            maxConfidentiality: ["internal", "public"],
+          },
+        },
+      },
+    }, {
+      type: "object",
+      properties: {
+        secret: {
+          type: "string",
+          ifc: {
+            confidentiality: ["secret", "internal"],
+            addIntegrity: ["reviewed", "audited"],
+            requiredIntegrity: ["trusted", "operator"],
+            integrity: ["trusted"],
+            maxConfidentiality: ["internal"],
+          },
+        },
+      },
+    });
+
+    const ifc = (
+      (merged as JSONSchemaObj).properties?.secret as JSONSchemaObj
+    ).ifc;
+    expect(ifc?.confidentiality).toEqual(["secret", "internal"]);
+    expect(ifc?.addIntegrity).toEqual(["reviewed", "audited"]);
+    expect(ifc?.requiredIntegrity).toEqual(["trusted", "operator"]);
+    expect(ifc?.integrity).toEqual(["trusted"]);
+    expect(ifc?.maxConfidentiality).toEqual(["internal"]);
+  });
+
+  it("rejects unstable scalar ifc labels", () => {
+    expect(() =>
+      mergeCfcSchemaEnvelopes({
+        ifc: { ownerPrincipal: "did:key:one" },
+      }, {
+        ifc: { ownerPrincipal: "did:key:two" },
+      })
+    ).toThrow(/ownerPrincipal must remain stable/);
+
+    expect(() =>
+      mergeCfcSchemaEnvelopes({
+        ifc: { confidentiality: "secret" } as any,
+      }, {
+        ifc: { confidentiality: "internal" } as any,
+      })
+    ).toThrow(/confidentiality must remain stable/);
+
+    expect(() =>
+      mergeCfcSchemaEnvelopes({
+        ifc: { writeAuthorizedBy: { notAClaim: true } } as any,
+      }, {
+        ifc: { writeAuthorizedBy: { notAClaim: false } } as any,
+      })
+    ).toThrow(/writeAuthorizedBy must remain stable/);
+  });
+
+  it("preserves stable copy and projection ifc metadata", () => {
+    const stableIfc = {
+      exactCopyOf: { source: "of:source" },
+      projection: { path: ["value"] },
+      collection: { id: "collection" },
+      ownerPrincipal: "did:key:owner",
+      flowPrecisionClaim: { path: ["legacy"] },
+    };
+
+    const merged = mergeCfcSchemaEnvelopes({
+      ifc: stableIfc as any,
+    }, {
+      ifc: stableIfc as any,
+    });
+
+    expect((merged as JSONSchemaObj).ifc).toMatchObject(stableIfc);
+  });
+
+  it("preserves equal scalar ifc labels", () => {
+    const claim = {
+      __ctWriterIdentityOf: {
+        file: "/system/profile-home.tsx",
+        path: ["save"],
+      },
+    };
+
+    const merged = mergeCfcSchemaEnvelopes({
+      ifc: {
+        confidentiality: "secret",
+        writeAuthorizedBy: claim,
+      } as any,
+    }, {
+      ifc: {
+        confidentiality: "secret",
+        writeAuthorizedBy: claim,
+      } as any,
+    });
+
+    expect((merged as JSONSchemaObj).ifc?.confidentiality).toBe("secret");
+    expect((merged as JSONSchemaObj).ifc?.writeAuthorizedBy).toEqual(claim);
+  });
+
+  it("preserves existing ifc when the candidate has none", () => {
+    const merged = mergeCfcSchemaEnvelopes({
+      ifc: { confidentiality: ["secret"] },
+    }, {
+      type: "object",
+    });
+
+    expect((merged as JSONSchemaObj).ifc?.confidentiality).toEqual(["secret"]);
+  });
+
+  it("rejects incompatible schema forms and types", () => {
+    expect(() => mergeCfcSchemaEnvelopes(false, {})).toThrow(
+      /unsupported schema form/,
+    );
+
+    expect(() =>
+      mergeCfcSchemaEnvelopes({
+        type: "string",
+      }, {
+        type: "number",
+      })
+    ).toThrow(/type changed incompatibly/);
+
+    expect(() =>
+      mergeCfcSchemaEnvelopes({
+        type: ["string", "number"],
+      }, {
+        type: ["string", "boolean"],
+      })
+    ).toThrow(/type changed incompatibly/);
+  });
+
+  it("merges item schemas and object defaults", () => {
+    const merged = mergeCfcSchemaEnvelopes({
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+        },
+        default: { title: "Untitled" },
+      },
+    }, {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          done: { type: "boolean" },
+        },
+        default: { done: false },
+      },
+    });
+
+    const items = (merged as JSONSchemaObj).items as JSONSchemaObj;
+    expect(items.properties).toMatchObject({
+      title: { type: "string" },
+      done: { type: "boolean" },
+    });
+    expect(items.default).toEqual({
+      title: "Untitled",
+      done: false,
+    });
+  });
+
+  it("keeps candidate items when only the candidate declares them", () => {
+    const merged = mergeCfcSchemaEnvelopes({
+      type: "array",
+    }, {
+      type: "array",
+      items: { type: "string" },
+    });
+
+    expect((merged as JSONSchemaObj).items).toEqual({ type: "string" });
+  });
+
   it("preserves uiContract metadata when merging schema envelopes", () => {
     const uiContract = {
       helper: "UiAction",
@@ -167,6 +351,47 @@ describe("mergeCfcSchemaEnvelopes", () => {
     });
 
     expect((merged as JSONSchemaObj).ifc?.confidentiality).toEqual(["secret"]);
+  });
+
+  it("rejects nested divergent branches with local ifc labels", () => {
+    expect(() =>
+      mergeCfcSchemaEnvelopes({
+        type: "array",
+        items: {
+          oneOf: [
+            {
+              type: "string",
+              ifc: { confidentiality: ["secret"] },
+            },
+            { type: "number" },
+          ],
+        },
+      }, {
+        type: "array",
+        items: {
+          oneOf: [
+            {
+              type: "string",
+              ifc: { confidentiality: ["secret"] },
+            },
+            { type: "number" },
+          ],
+        },
+      })
+    ).toThrow(/divergent oneOf branches/);
+  });
+
+  it("allows non-object divergent branches without ifc labels", () => {
+    const merged = mergeCfcSchemaEnvelopes({
+      anyOf: [true, { type: "string" }],
+    }, {
+      anyOf: [true, { type: "string" }],
+    });
+
+    expect((merged as JSONSchemaObj).anyOf).toEqual([
+      true,
+      { type: "string" },
+    ]);
   });
 
   it("merges writeAuthorizedBy claims that differ only by the identity stamp", () => {
@@ -337,6 +562,31 @@ describe("mergeCfcSchemaEnvelopes", () => {
             },
           },
         },
+      })
+    ).toThrow(/writeAuthorizedBy must remain stable/);
+  });
+
+  it("rejects stamped writeAuthorizedBy claims with different bindings", () => {
+    expect(() =>
+      mergeCfcSchemaEnvelopes({
+        ifc: {
+          writeAuthorizedBy: {
+            __ctWriterIdentityOf: {
+              file: "/system/profile-home.tsx",
+              path: ["save"],
+              moduleIdentity: "module-identity-hash",
+            },
+          },
+        } as any,
+      }, {
+        ifc: {
+          writeAuthorizedBy: {
+            __ctWriterIdentityOf: {
+              file: "/system/profile-home.tsx",
+              path: ["delete"],
+            },
+          },
+        } as any,
       })
     ).toThrow(/writeAuthorizedBy must remain stable/);
   });

--- a/packages/runner/test/cfc-schema-sanitization.test.ts
+++ b/packages/runner/test/cfc-schema-sanitization.test.ts
@@ -1,9 +1,13 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
 import type { JSONSchema } from "../src/builder/types.ts";
 import {
+  cfcObjectSchemaIsClosed,
   INJECTION_SAFE_ATOM,
+  isPrimitiveJsonValue,
   isPromptInjectionMaterialRiskAtom,
+  resolveSchemaForValidation,
   schemaWithInjectionSafeAnnotations,
   validateAgainstSchema,
   validateAndSanitizeSchemaValueWithOpaqueLinks,
@@ -21,7 +25,233 @@ const promptInfluence = {
   source: "of:hostile",
 } as const;
 
-describe("schema-based prompt injection sanitization", () => {
+describe("cfc schema sanitization", () => {
+  it("classifies primitive values and prompt-injection risk atoms", () => {
+    expect(isPrimitiveJsonValue(null)).toBe(true);
+    expect(isPrimitiveJsonValue("text")).toBe(true);
+    expect(isPrimitiveJsonValue(1)).toBe(true);
+    expect(isPrimitiveJsonValue(false)).toBe(true);
+    expect(isPrimitiveJsonValue({})).toBe(false);
+
+    expect(isPromptInjectionMaterialRiskAtom("prompt-injection-risk"))
+      .toBe(true);
+    expect(isPromptInjectionMaterialRiskAtom({
+      type: CFC_ATOM_TYPE.Caveat,
+      kind: "prompt-injection-risk-value-screened",
+    })).toBe(true);
+    expect(isPromptInjectionMaterialRiskAtom({
+      type: CFC_ATOM_TYPE.Caveat,
+      kind: "prompt-influence",
+    })).toBe(false);
+  });
+
+  it("detects closed object schemas", () => {
+    expect(cfcObjectSchemaIsClosed({ type: "object" })).toBe(true);
+    expect(cfcObjectSchemaIsClosed({ properties: {} })).toBe(true);
+    expect(cfcObjectSchemaIsClosed({ required: ["title"] })).toBe(true);
+    expect(cfcObjectSchemaIsClosed({ additionalProperties: false })).toBe(
+      true,
+    );
+    expect(cfcObjectSchemaIsClosed({ additionalProperties: true })).toBe(
+      false,
+    );
+    expect(cfcObjectSchemaIsClosed({
+      additionalProperties: { type: "string" },
+    })).toBe(false);
+  });
+
+  it("resolves refs for validation and falls back on unresolved refs", () => {
+    const fullSchema = {
+      $defs: {
+        Count: { type: "integer" },
+      },
+    } as const;
+
+    expect(resolveSchemaForValidation({ $ref: "#/$defs/Count" }, fullSchema))
+      .toEqual({ type: "integer" });
+    expect(resolveSchemaForValidation({ $ref: "#/$defs/Missing" }, fullSchema))
+      .toBe(false);
+    expect(resolveSchemaForValidation({ type: "string" }, fullSchema))
+      .toEqual({ type: "string" });
+  });
+
+  it("annotates injection-safe primitive schema shapes", () => {
+    const risk = {
+      type: CFC_ATOM_TYPE.Caveat,
+      kind: "prompt-injection-risk-unscreened",
+    } as const;
+    const retained = {
+      type: CFC_ATOM_TYPE.Caveat,
+      kind: "prompt-influence",
+    } as const;
+
+    const annotated = schemaWithInjectionSafeAnnotations({
+      type: "object",
+      properties: {
+        approved: { type: "boolean" },
+        status: { enum: ["open", "closed"] },
+        note: { type: "string" },
+      },
+      required: ["approved", "status", "note"],
+      additionalProperties: false,
+    }, [risk, retained]) as any;
+
+    expect(annotated.required).toBeUndefined();
+    expect(annotated.properties.approved.ifc.addIntegrity).toContainEqual(
+      INJECTION_SAFE_ATOM,
+    );
+    expect(annotated.properties.approved.ifc.confidentiality).toEqual([
+      retained,
+    ]);
+    expect(annotated.properties.status.ifc.addIntegrity).toContainEqual(
+      INJECTION_SAFE_ATOM,
+    );
+    expect(annotated.properties.note.ifc.confidentiality).toContainEqual(risk);
+    expect(annotated.properties.note.ifc.confidentiality).toContainEqual(
+      retained,
+    );
+  });
+
+  it("leaves boolean schemas unchanged while annotating", () => {
+    expect(schemaWithInjectionSafeAnnotations(true, ["secret"])).toBe(true);
+  });
+
+  it("breaks ref cycles during annotation", () => {
+    const annotated = schemaWithInjectionSafeAnnotations({
+      $defs: {
+        Node: { $ref: "#/$defs/Node" },
+      },
+      $ref: "#/$defs/Node",
+    }, ["secret"]) as any;
+
+    expect(annotated.ifc.confidentiality).toEqual(["secret"]);
+  });
+
+  it("annotates refs, branches, arrays, and open objects", () => {
+    const observed = ["secret"];
+    const annotated = schemaWithInjectionSafeAnnotations({
+      $defs: {
+        Choice: {
+          anyOf: [
+            { type: "boolean" },
+            { type: "string" },
+          ],
+        },
+      },
+      type: "object",
+      properties: {
+        child: { $ref: "#/$defs/Choice" },
+        list: {
+          type: "array",
+          items: { type: "integer" },
+        },
+      },
+      additionalProperties: true,
+    }, observed) as any;
+
+    expect(annotated.ifc.confidentiality).toEqual(observed);
+    expect(annotated.properties.child.ifc.confidentiality).toEqual(observed);
+    expect(annotated.properties.list.ifc.addIntegrity).toContainEqual(
+      INJECTION_SAFE_ATOM,
+    );
+    expect(annotated.properties.list.items.ifc.addIntegrity).toContainEqual(
+      INJECTION_SAFE_ATOM,
+    );
+  });
+
+  it("annotates oneOf, allOf, empty objects, and not schemas", () => {
+    const annotated = schemaWithInjectionSafeAnnotations({
+      type: "object",
+      properties: {
+        choice: {
+          oneOf: [
+            { type: "boolean" },
+            { type: "null" },
+          ],
+        },
+        combined: {
+          allOf: [
+            { type: "integer" },
+            { const: 1 },
+          ],
+        },
+      },
+      required: ["choice", "combined"],
+      additionalProperties: false,
+      not: {
+        required: ["blocked"],
+      },
+    }, ["secret"]) as any;
+
+    expect(annotated.required).toBeUndefined();
+    expect(annotated.properties.choice.oneOf[0].ifc.addIntegrity)
+      .toContainEqual(INJECTION_SAFE_ATOM);
+    expect(annotated.properties.combined.allOf[1].ifc.addIntegrity)
+      .toContainEqual(INJECTION_SAFE_ATOM);
+    expect(annotated.not.required).toBeUndefined();
+
+    const emptyObject = schemaWithInjectionSafeAnnotations({
+      type: "object",
+      additionalProperties: false,
+    }, ["secret"]) as any;
+    expect(emptyObject.ifc.addIntegrity).toContainEqual(INJECTION_SAFE_ATOM);
+  });
+
+  it("validates values against schema features", () => {
+    expect(validateAgainstSchema(true, "anything")).toBeUndefined();
+    expect(validateAgainstSchema(false, "anything")).toBe(
+      "schema rejects all values",
+    );
+    expect(validateAgainstSchema({
+      $defs: { Count: { type: "integer" } },
+      $ref: "#/$defs/Count",
+    }, 2)).toBeUndefined();
+    expect(validateAgainstSchema({
+      allOf: [
+        { type: "object" },
+        { required: ["name"] },
+      ],
+    }, {})).toBe("missing required property name");
+    expect(validateAgainstSchema({
+      anyOf: [{ type: "string" }, { type: "number" }],
+    }, false)).toBe("value does not match anyOf");
+    expect(validateAgainstSchema({
+      oneOf: [{ type: "number" }, { type: "integer" }],
+    }, 1)).toBe("value does not match exactly one oneOf branch");
+    expect(validateAgainstSchema({ enum: ["a", "b"] }, "c")).toBe(
+      "value is not in enum",
+    );
+    expect(validateAgainstSchema({ const: "ready" }, "waiting")).toBe(
+      "value does not match const",
+    );
+    expect(validateAgainstSchema({ type: ["string", "number"] }, false)).toBe(
+      "value does not match type string|number",
+    );
+    expect(validateAgainstSchema({ type: "unknown" }, Symbol("value")))
+      .toBeUndefined();
+    expect(validateAgainstSchema({ type: "null" }, null)).toBeUndefined();
+    expect(validateAgainstSchema({ type: "custom" } as any, "value"))
+      .toBeUndefined();
+    expect(validateAgainstSchema({
+      type: "object",
+      properties: { count: { type: "number" } },
+      additionalProperties: false,
+    }, { count: 1, extra: true })).toBe("additional property extra");
+    expect(validateAgainstSchema({
+      type: "object",
+      properties: { title: { type: "string" } },
+      additionalProperties: { type: "number" },
+    }, { title: "ok", extra: "bad" })).toBe(
+      "extra: value does not match type number",
+    );
+    expect(validateAgainstSchema({
+      type: "array",
+      items: { type: "string" },
+    }, ["ok", 2])).toBe("1: value does not match type string");
+  });
+});
+
+describe("schema-based prompt injection sanitization compatibility", () => {
   it("adds InjectionSafe to closed enum, number, and boolean fields but not free strings", () => {
     const schema = {
       type: "object",
@@ -133,9 +363,7 @@ describe("schema-based prompt injection sanitization", () => {
     expect(isPromptInjectionMaterialRiskAtom(promptInfluence)).toBe(false);
   });
 
-  it("terminates on self-referential $ref schemas", () => {
-    // Cyclic schema: a tree node whose `children` is an array of the same
-    // node. The sanitizer must not infinite-loop walking the cycle.
+  it("terminates on self-referential ref schemas", () => {
     const schema = {
       $defs: {
         Node: {
@@ -154,17 +382,11 @@ describe("schema-based prompt injection sanitization", () => {
       $ref: "#/$defs/Node",
     } as const satisfies JSONSchema;
 
-    // Should resolve, terminate, and produce a sanitized schema; the inner
-    // `label` field is a free string so it carries the prompt-influence
-    // confidentiality but no InjectionSafe integrity.
     const sanitized = schemaWithInjectionSafeAnnotations(schema, [
       promptInfluence,
     ]) as any;
 
     expect(sanitized).toBeDefined();
-    // The cycle in `children` must not have produced an exception or a
-    // structurally infinite tree. We don't assert deep shape here — only
-    // that termination + sanitization happened.
     expect(typeof sanitized).toBe("object");
   });
 
@@ -185,12 +407,7 @@ describe("schema-based prompt injection sanitization", () => {
     expect(JSON.stringify(schema)).toBe(before);
   });
 
-  it("validates nested $refs by preserving root $defs across recursion", () => {
-    // Top-level $ref → $defs/Outer → contains property whose type is
-    // $defs/Inner. If validateAgainstSchema dropped root $defs when
-    // recursing through the top-level $ref, the nested $ref to Inner
-    // would resolve to false and the validation would reject valid
-    // values. This guards against that regression.
+  it("validates nested refs by preserving root defs across recursion", () => {
     const schema = {
       $defs: {
         Outer: {

--- a/packages/runner/test/fetch-data-mutex.test.ts
+++ b/packages/runner/test/fetch-data-mutex.test.ts
@@ -16,6 +16,10 @@ import {
   internalSchema,
   tryClaimMutex,
 } from "../src/builtins/fetch-utils.ts";
+import {
+  FIRST_PARTY_HTTP_AUTH_HEADERS,
+  verifyFirstPartyHttpRequest,
+} from "../src/toolshed-http-auth.ts";
 import type { Schema } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("test fetch-data mutex");
@@ -684,5 +688,196 @@ describe("fetch-data mutex mechanism", () => {
         (call.init?.headers as Record<string, string>)?.["Accept"],
       ).toBe("application/vnd.github.v3.star+json");
     }
+  });
+
+  it("adds custom auth headers to protected toolshed fetchData requests", async () => {
+    const fetchData = byRef("fetchData");
+    const testRecipe = pattern<{ query: string }>(
+      ({ query }) =>
+        fetchData({
+          url: "/api/agent-tools/web-search",
+          mode: "json",
+          options: {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: { query },
+          },
+        }),
+    );
+
+    const resultCell = runtime.getCell(
+      space,
+      "signed-toolshed-fetch",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(
+      tx,
+      testRecipe,
+      { query: "signed request" },
+      resultCell,
+    );
+    tx.commit();
+
+    await result.pull();
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    await result.pull();
+
+    const call = fetchCalls.find((call) =>
+      call.url === "http://mock-test-server.local/api/agent-tools/web-search"
+    );
+    expect(call).toBeDefined();
+
+    const headers = new Headers(call!.init?.headers);
+    expect(
+      headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.proof),
+    ).toBeTruthy();
+    expect(
+      headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.auth),
+    ).toBeTruthy();
+    expect(
+      headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.bodySha256),
+    ).toBeTruthy();
+    expect(headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.userDid)).toBe(
+      signer.did(),
+    );
+    expect(headers.get("Signature")).toBe(null);
+    expect(headers.get("Signature-Input")).toBe(null);
+    expect(headers.get("Content-Digest")).toBe(null);
+
+    const verified = await verifyFirstPartyHttpRequest({
+      request: new Request(call!.url, {
+        method: call!.init?.method,
+        headers,
+        body: call!.init?.body as BodyInit,
+      }),
+    });
+    expect(verified.userDid).toBe(signer.did());
+  });
+
+  it("replaces caller-supplied auth headers on protected fetchData requests", async () => {
+    const fetchData = byRef("fetchData");
+    const testRecipe = pattern<{ query: string }>(
+      ({ query }) =>
+        fetchData({
+          url: "/api/agent-tools/web-search",
+          mode: "json",
+          options: {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              [FIRST_PARTY_HTTP_AUTH_HEADERS.proof]: "bogus",
+              [FIRST_PARTY_HTTP_AUTH_HEADERS.auth]: "bogus",
+              [FIRST_PARTY_HTTP_AUTH_HEADERS.bodySha256]: "bogus",
+              [FIRST_PARTY_HTTP_AUTH_HEADERS.userDid]: "did:key:bogus",
+              "Signature": "bogus",
+              "Signature-Input": "bogus",
+              "Content-Digest": "bogus",
+            },
+            body: { query },
+          },
+        }),
+    );
+
+    const resultCell = runtime.getCell(
+      space,
+      "replace-auth-headers",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(
+      tx,
+      testRecipe,
+      { query: "replace request" },
+      resultCell,
+    );
+    tx.commit();
+
+    await result.pull();
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    await result.pull();
+
+    const call = fetchCalls.find((call) =>
+      call.url === "http://mock-test-server.local/api/agent-tools/web-search"
+    );
+    expect(call).toBeDefined();
+
+    const headers = new Headers(call!.init?.headers);
+    expect(headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.proof)).not.toBe(
+      "bogus",
+    );
+    expect(
+      headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.auth),
+    ).not.toBe("bogus");
+    expect(
+      headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.bodySha256),
+    ).not.toBe("bogus");
+    expect(headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.userDid)).toBe(
+      signer.did(),
+    );
+    expect(headers.get("Signature")).toBe(null);
+    expect(headers.get("Signature-Input")).toBe(null);
+    expect(headers.get("Content-Digest")).toBe(null);
+
+    const verified = await verifyFirstPartyHttpRequest({
+      request: new Request(call!.url, {
+        method: call!.init?.method,
+        headers,
+        body: call!.init?.body as BodyInit,
+      }),
+    });
+    expect(verified.userDid).toBe(signer.did());
+  });
+
+  it("does not add auth headers to protected-looking external requests", async () => {
+    const fetchData = byRef("fetchData");
+    const testRecipe = pattern<{ query: string }>(
+      ({ query }) =>
+        fetchData({
+          url: "http://external.test/api/agent-tools/web-search",
+          mode: "json",
+          options: {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: { query },
+          },
+        }),
+    );
+
+    const resultCell = runtime.getCell(
+      space,
+      "external-toolshed-looking-fetch",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(
+      tx,
+      testRecipe,
+      { query: "external request" },
+      resultCell,
+    );
+    tx.commit();
+
+    await result.pull();
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    await result.pull();
+
+    const call = fetchCalls.find((call) =>
+      call.url === "http://external.test/api/agent-tools/web-search"
+    );
+    expect(call).toBeDefined();
+
+    const headers = new Headers(call!.init?.headers);
+    expect(headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.proof)).toBe(
+      null,
+    );
+    expect(headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.auth)).toBe(
+      null,
+    );
+    expect(headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.userDid)).toBe(null);
   });
 });

--- a/packages/runner/test/plain-data.test.ts
+++ b/packages/runner/test/plain-data.test.ts
@@ -79,6 +79,100 @@ describe("plain-data sandbox helper", () => {
     expect(value.nested).not.toBeInstanceOf(FrozenMap);
   });
 
+  it("assertPlainData accepts already verified frozen data", () => {
+    const value = freezeVerifiedPlainData({ nested: { ok: true } });
+
+    assertPlainData(value);
+
+    expect(value.nested).toEqual({ ok: true });
+  });
+
+  it("assertPlainData accepts primitives, arrays, and sets", () => {
+    assertPlainData(undefined);
+    assertPlainData(true);
+    assertPlainData(null);
+    assertPlainData([1, "two"]);
+    assertPlainData(new Set([1, { ok: true }]));
+  });
+
+  it("rejects unsupported primitive values", () => {
+    expect(() => assertPlainData(() => "nope")).toThrow(
+      "Unsupported value type 'function'",
+    );
+    expect(() => freezeVerifiedPlainData(Symbol("nope"))).toThrow(
+      "Unsupported value type 'symbol'",
+    );
+  });
+
+  it("rejects unsupported object prototypes during validation", () => {
+    expect(() => assertPlainData(new Date())).toThrow(
+      "Unsupported object prototype 'Date'",
+    );
+  });
+
+  it("rejects values whose own property descriptors disappear", () => {
+    const source = new Proxy({}, {
+      ownKeys: () => ["ghost"],
+      getOwnPropertyDescriptor: () => undefined,
+    });
+
+    expect(() => assertPlainData(source)).toThrow(
+      "Own property descriptor is missing",
+    );
+    expect(() => freezeVerifiedPlainData(source)).toThrow(
+      "Own property descriptor is missing",
+    );
+  });
+
+  it("rejects Map and Set values when prototype iteration is unavailable", () => {
+    const originalEntriesDescriptor = Object.getOwnPropertyDescriptor(
+      Map.prototype,
+      "entries",
+    );
+    const originalValuesDescriptor = Object.getOwnPropertyDescriptor(
+      Set.prototype,
+      "values",
+    );
+    try {
+      Object.defineProperty(Map.prototype, "entries", {
+        value: undefined,
+        configurable: true,
+      });
+      expect(() => freezeVerifiedPlainData(new Map())).toThrow(
+        "Map-like value has no entries method on its prototype",
+      );
+
+      Object.defineProperty(Set.prototype, "values", {
+        value: undefined,
+        configurable: true,
+      });
+      expect(() => freezeVerifiedPlainData(new Set())).toThrow(
+        "Set-like value has no values method on its prototype",
+      );
+    } finally {
+      if (originalEntriesDescriptor) {
+        Object.defineProperty(
+          Map.prototype,
+          "entries",
+          originalEntriesDescriptor,
+        );
+      }
+      if (originalValuesDescriptor) {
+        Object.defineProperty(
+          Set.prototype,
+          "values",
+          originalValuesDescriptor,
+        );
+      }
+    }
+  });
+
+  it("returns primitive values unchanged when freezing", () => {
+    expect(freezeVerifiedPlainData(undefined)).toBeUndefined();
+    expect(freezeVerifiedPlainData(null)).toBeNull();
+    expect(freezeVerifiedPlainData(true)).toBe(true);
+  });
+
   it("materializes accessor properties once into data properties", () => {
     let reads = 0;
     const value = Object.defineProperty({}, "secret", {
@@ -259,11 +353,37 @@ describe("plain-data sandbox helper", () => {
     expect(Object.isFrozen(result[secret] as object)).toBe(true);
   });
 
+  it("preserves stateless RegExp values and own properties", () => {
+    const value = /hello/i;
+    Object.defineProperty(value, "label", {
+      value: { kind: "greeting" },
+      enumerable: true,
+      configurable: true,
+    });
+
+    const result = freezeVerifiedPlainData(
+      value,
+    ) as RegExp & { readonly label?: { readonly kind: string } };
+
+    expect(result).not.toBe(value);
+    expect(result.source).toBe("hello");
+    expect(result.flags).toBe("i");
+    expect(result.label).toEqual({ kind: "greeting" });
+    expect(Object.isFrozen(result.label as object)).toBe(true);
+    expect(Object.isFrozen(result)).toBe(true);
+  });
+
   it("rejects intrinsic stateful RegExp instances", () => {
     const value = /hello/gi;
     value.lastIndex = 2;
 
     expect(() => freezeVerifiedPlainData(value)).toThrow(
+      "Stateful RegExp values are not allowed in verified plain data",
+    );
+  });
+
+  it("assertPlainData rejects intrinsic stateful RegExp instances", () => {
+    expect(() => assertPlainData(/hello/y)).toThrow(
       "Stateful RegExp values are not allowed in verified plain data",
     );
   });

--- a/packages/runner/test/toolshed-http-auth.test.ts
+++ b/packages/runner/test/toolshed-http-auth.test.ts
@@ -1,0 +1,313 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { sha256 } from "@commonfabric/content-hash";
+import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
+import {
+  FIRST_PARTY_HTTP_AUTH_HEADERS,
+  signFirstPartyHttpRequest,
+  verifyFirstPartyHttpRequest,
+} from "../src/toolshed-http-auth.ts";
+
+const NOW_SECONDS = 1_800_000_000;
+const signer = await Identity.fromPassphrase("toolshed http auth test");
+const textEncoder = new TextEncoder();
+
+async function signedRequest(
+  url: string,
+  init: RequestInit = {},
+  options: { nowSeconds?: number; validForSeconds?: number } = {},
+): Promise<Request> {
+  const method = init.method ?? "POST";
+  const headers = await signFirstPartyHttpRequest({
+    url: new URL(url),
+    method,
+    headers: init.headers,
+    body: init.body,
+    signer,
+    nowSeconds: options.nowSeconds ?? NOW_SECONDS,
+    validForSeconds: options.validForSeconds,
+  });
+  return new Request(url, { ...init, method, headers });
+}
+
+async function expectAuthReject(request: Request): Promise<void> {
+  let rejected = false;
+  try {
+    await verifyFirstPartyHttpRequest({
+      request,
+      nowSeconds: NOW_SECONDS,
+    });
+  } catch {
+    rejected = true;
+  }
+  expect(rejected).toBe(true);
+}
+
+function expectUnpaddedBase64url(value: string | null): void {
+  expect(value).toBeTruthy();
+  expect(/^[A-Za-z0-9_-]+$/.test(value!)).toBe(true);
+  expect(value).not.toContain("=");
+}
+
+describe("first-party toolshed HTTP request proofs", () => {
+  it("accepts a POST with a covered body hash", async () => {
+    const body = JSON.stringify({ query: "hello" });
+    const request = await signedRequest(
+      "http://toolshed.test/api/agent-tools/web-search?q=1",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Signature": "bogus",
+          "Signature-Input": "bogus",
+          "Content-Digest": "bogus",
+        },
+        body,
+      },
+    );
+
+    const verified = await verifyFirstPartyHttpRequest({
+      request,
+      nowSeconds: NOW_SECONDS,
+    });
+
+    expect(verified.userDid).toBe(signer.did());
+    expect(request.headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.auth))
+      .toBeTruthy();
+    expectUnpaddedBase64url(
+      request.headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.proof),
+    );
+    expectUnpaddedBase64url(
+      request.headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.bodySha256),
+    );
+    expect(
+      request.headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.bodySha256),
+    ).toBe(toUnpaddedBase64url(sha256(textEncoder.encode(body))));
+    expect(request.headers.get("Signature")).toBe(null);
+    expect(request.headers.get("Signature-Input")).toBe(null);
+    expect(request.headers.get("Content-Digest")).toBe(null);
+    expect(
+      request.headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.auth),
+    ).toContain("issued-at=");
+    expect(
+      request.headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.auth),
+    ).toContain("valid-until=");
+    expect(
+      request.headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.auth),
+    ).toContain("proof-did=");
+    expect(
+      request.headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.auth),
+    ).toContain("proof-kind=");
+    expect(
+      request.headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.auth),
+    ).not.toContain("created=");
+    expect(
+      request.headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.auth),
+    ).not.toContain("expires=");
+    expect(
+      request.headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.auth),
+    ).not.toContain("alg=");
+  });
+
+  it("rejects requests without a proof", async () => {
+    await expectAuthReject(
+      new Request("http://toolshed.test/api/agent-tools/web-search", {
+        method: "POST",
+        body: "{}",
+      }),
+    );
+  });
+
+  it("rejects a tampered method", async () => {
+    const request = await signedRequest(
+      "http://toolshed.test/api/agent-tools/web-search",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      },
+    );
+
+    await expectAuthReject(
+      new Request(request.url, {
+        method: "PUT",
+        headers: request.headers,
+        body: "{}",
+      }),
+    );
+  });
+
+  it("rejects a tampered authority", async () => {
+    const request = await signedRequest(
+      "http://toolshed.test/api/agent-tools/web-search",
+      {
+        method: "POST",
+        body: "{}",
+      },
+    );
+
+    await expectAuthReject(
+      new Request("http://other.test/api/agent-tools/web-search", {
+        method: "POST",
+        headers: request.headers,
+        body: "{}",
+      }),
+    );
+  });
+
+  it("rejects a tampered path", async () => {
+    const request = await signedRequest(
+      "http://toolshed.test/api/agent-tools/web-search",
+      {
+        method: "POST",
+        body: "{}",
+      },
+    );
+
+    await expectAuthReject(
+      new Request("http://toolshed.test/api/agent-tools/web-read", {
+        method: "POST",
+        headers: request.headers,
+        body: "{}",
+      }),
+    );
+  });
+
+  it("rejects a tampered query string", async () => {
+    const request = await signedRequest(
+      "http://toolshed.test/api/agent-tools/web-search?x=1",
+      {
+        method: "POST",
+        body: "{}",
+      },
+    );
+
+    await expectAuthReject(
+      new Request("http://toolshed.test/api/agent-tools/web-search?x=2", {
+        method: "POST",
+        headers: request.headers,
+        body: "{}",
+      }),
+    );
+  });
+
+  it("rejects a tampered body hash", async () => {
+    const request = await signedRequest(
+      "http://toolshed.test/api/agent-tools/web-search",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: "original" }),
+      },
+    );
+
+    await expectAuthReject(
+      new Request(request.url, {
+        method: "POST",
+        headers: request.headers,
+        body: JSON.stringify({ query: "changed" }),
+      }),
+    );
+  });
+
+  it("rejects a body when the body hash header is missing", async () => {
+    const request = await signedRequest(
+      "http://toolshed.test/api/agent-tools/web-search",
+      {
+        method: "POST",
+        body: "{}",
+      },
+    );
+    const headers = new Headers(request.headers);
+    headers.delete(FIRST_PARTY_HTTP_AUTH_HEADERS.bodySha256);
+
+    await expectAuthReject(
+      new Request(request.url, {
+        method: "POST",
+        headers,
+        body: "{}",
+      }),
+    );
+  });
+
+  it("rejects padded proof values", async () => {
+    const request = await signedRequest(
+      "http://toolshed.test/api/agent-tools/web-search",
+      {
+        method: "POST",
+        body: "{}",
+      },
+    );
+    const headers = new Headers(request.headers);
+    headers.set(
+      FIRST_PARTY_HTTP_AUTH_HEADERS.proof,
+      `${headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.proof)}=`,
+    );
+
+    await expectAuthReject(
+      new Request(request.url, {
+        method: "POST",
+        headers,
+        body: "{}",
+      }),
+    );
+  });
+
+  it("rejects expired proofs", async () => {
+    const request = await signedRequest(
+      "http://toolshed.test/api/agent-tools/web-search",
+      {
+        method: "POST",
+        body: "{}",
+      },
+      { nowSeconds: NOW_SECONDS - 120 },
+    );
+
+    await expectAuthReject(request);
+  });
+
+  it("rejects proofs issued too far in the future", async () => {
+    const request = await signedRequest(
+      "http://toolshed.test/api/agent-tools/web-search",
+      {
+        method: "POST",
+        body: "{}",
+      },
+      { nowSeconds: NOW_SECONDS + 120 },
+    );
+
+    await expectAuthReject(request);
+  });
+
+  it("rejects a replay across a different protected route", async () => {
+    const request = await signedRequest(
+      "http://toolshed.test/api/sandbox/exec",
+      {
+        method: "POST",
+        body: "{}",
+      },
+    );
+
+    await expectAuthReject(
+      new Request("http://toolshed.test/api/agent-tools/web-search", {
+        method: "POST",
+        headers: request.headers,
+        body: "{}",
+      }),
+    );
+  });
+
+  it("rejects proofs with excessive lifetime", async () => {
+    const request = await signedRequest(
+      "http://toolshed.test/api/agent-tools/web-search",
+      {
+        method: "POST",
+        body: "{}",
+      },
+      { validForSeconds: 600 },
+    );
+
+    await expectAuthReject(request);
+  });
+});

--- a/packages/runner/test/toolshed-http-auth.test.ts
+++ b/packages/runner/test/toolshed-http-auth.test.ts
@@ -5,6 +5,8 @@ import { sha256 } from "@commonfabric/content-hash";
 import { toUnpaddedBase64url } from "@commonfabric/utils/base64url";
 import {
   FIRST_PARTY_HTTP_AUTH_HEADERS,
+  isProtectedToolshedFirstPartyRoute,
+  isToolshedApiOrigin,
   signFirstPartyHttpRequest,
   verifyFirstPartyHttpRequest,
 } from "../src/toolshed-http-auth.ts";
@@ -31,17 +33,43 @@ async function signedRequest(
   return new Request(url, { ...init, method, headers });
 }
 
-async function expectAuthReject(request: Request): Promise<void> {
-  let rejected = false;
+async function expectAuthReject(
+  request: Request,
+  expectedMessage?: string,
+): Promise<void> {
+  let error: unknown;
   try {
     await verifyFirstPartyHttpRequest({
       request,
       nowSeconds: NOW_SECONDS,
     });
-  } catch {
-    rejected = true;
+  } catch (caught) {
+    error = caught;
   }
-  expect(rejected).toBe(true);
+  if (!(error instanceof Error)) {
+    throw new Error("expected first-party auth rejection");
+  }
+  if (expectedMessage !== undefined) {
+    expect(error.message).toBe(expectedMessage);
+  }
+}
+
+async function expectSignReject(
+  params: Parameters<typeof signFirstPartyHttpRequest>[0],
+  expectedMessage?: string,
+): Promise<void> {
+  let error: unknown;
+  try {
+    await signFirstPartyHttpRequest(params);
+  } catch (caught) {
+    error = caught;
+  }
+  if (!(error instanceof Error)) {
+    throw new Error("expected first-party signing rejection");
+  }
+  if (expectedMessage !== undefined) {
+    expect(error.message).toBe(expectedMessage);
+  }
 }
 
 function expectUnpaddedBase64url(value: string | null): void {
@@ -50,7 +78,59 @@ function expectUnpaddedBase64url(value: string | null): void {
   expect(value).not.toContain("=");
 }
 
+function validAuthHeader(did: string = signer.did()): string {
+  return `CF1 issued-at=${NOW_SECONDS}; valid-until=${
+    NOW_SECONDS + 60
+  }; proof-did=${encodeURIComponent(did)}; proof-kind=ed25519`;
+}
+
+function requestWithAuth(
+  auth: string,
+  headers: HeadersInit = {},
+): Request {
+  return new Request("http://toolshed.test/api/agent-tools/web-search", {
+    method: "POST",
+    headers: {
+      [FIRST_PARTY_HTTP_AUTH_HEADERS.auth]: auth,
+      [FIRST_PARTY_HTTP_AUTH_HEADERS.proof]: "AA",
+      ...headers,
+    },
+  });
+}
+
 describe("first-party toolshed HTTP request proofs", () => {
+  it("identifies protected first-party toolshed routes", () => {
+    expect(isProtectedToolshedFirstPartyRoute(
+      new URL("http://toolshed.test/api/agent-tools/web-search"),
+      "POST",
+    )).toBe(true);
+    expect(isProtectedToolshedFirstPartyRoute(
+      new URL("http://toolshed.test/api/agent-tools/web-read/"),
+      "post",
+    )).toBe(true);
+    expect(isProtectedToolshedFirstPartyRoute(
+      new URL("http://toolshed.test/api/agent-tools/web-search"),
+      "GET",
+    )).toBe(false);
+    expect(isProtectedToolshedFirstPartyRoute(
+      new URL("http://toolshed.test/api/agent-tools/not-protected"),
+      "POST",
+    )).toBe(false);
+  });
+
+  it("identifies the toolshed API origin", () => {
+    const apiBase = new URL("https://toolshed.example/api/");
+
+    expect(isToolshedApiOrigin(
+      new URL("https://toolshed.example/api/agent-tools/web-search"),
+      apiBase,
+    )).toBe(true);
+    expect(isToolshedApiOrigin(
+      new URL("https://other.example/api/agent-tools/web-search"),
+      apiBase,
+    )).toBe(false);
+  });
+
   it("accepts a POST with a covered body hash", async () => {
     const body = JSON.stringify({ query: "hello" });
     const request = await signedRequest(
@@ -117,6 +197,83 @@ describe("first-party toolshed HTTP request proofs", () => {
         body: "{}",
       }),
     );
+  });
+
+  it("accepts requests without a body hash when the request has no body", async () => {
+    const request = await signedRequest(
+      "http://toolshed.test/api/agent-tools/web-search",
+      { method: "POST" },
+    );
+
+    const verified = await verifyFirstPartyHttpRequest({
+      request,
+      nowSeconds: NOW_SECONDS,
+    });
+
+    expect(verified.userDid).toBe(signer.did());
+    expect(request.headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.bodySha256))
+      .toBe(null);
+  });
+
+  it("accepts supported body input types", async () => {
+    const cases: BodyInit[] = [
+      new Uint8Array([1, 2, 3]),
+      new Uint8Array([4, 5, 6]).buffer,
+      new Uint16Array([0x0708, 0x090a]),
+      new URLSearchParams({ q: "hello", page: "1" }),
+      new Blob([new Uint8Array([10, 11, 12])]),
+    ];
+
+    for (const body of cases) {
+      const request = await signedRequest(
+        "http://toolshed.test/api/agent-tools/web-search",
+        { method: "POST", body },
+      );
+
+      const verified = await verifyFirstPartyHttpRequest({
+        request,
+        nowSeconds: NOW_SECONDS,
+      });
+
+      expect(verified.userDid).toBe(signer.did());
+      expect(request.headers.get(FIRST_PARTY_HTTP_AUTH_HEADERS.bodySha256))
+        .toBeTruthy();
+    }
+  });
+
+  it("rejects unsupported body input types before signing", async () => {
+    let signCalled = false;
+    await expectSignReject({
+      url: new URL("http://toolshed.test/api/agent-tools/web-search"),
+      method: "POST",
+      body: new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }) as BodyInit,
+      signer: {
+        did: () => signer.did(),
+        sign: () => {
+          signCalled = true;
+          return { ok: new Uint8Array() };
+        },
+      },
+      nowSeconds: NOW_SECONDS,
+    }, "unsupported authenticated request body type");
+    expect(signCalled).toBe(false);
+  });
+
+  it("rejects requests whose body cannot be read for verification", async () => {
+    const request = await signedRequest(
+      "http://toolshed.test/api/agent-tools/web-search",
+      {
+        method: "POST",
+        body: "{}",
+      },
+    );
+    await request.text();
+
+    await expectAuthReject(request);
   });
 
   it("rejects a tampered method", async () => {
@@ -254,6 +411,90 @@ describe("first-party toolshed HTTP request proofs", () => {
     );
   });
 
+  it("rejects proof values that are not decodable base64url", async () => {
+    await expectAuthReject(
+      requestWithAuth(validAuthHeader(), {
+        [FIRST_PARTY_HTTP_AUTH_HEADERS.userDid]: signer.did(),
+        [FIRST_PARTY_HTTP_AUTH_HEADERS.proof]: "A",
+      }),
+      "request proof is not valid unpadded base64url",
+    );
+  });
+
+  it("rejects malformed auth metadata", async () => {
+    const cases = [
+      {
+        auth: "CF2 issued-at=1",
+        message: "request auth metadata has an unknown version",
+      },
+      {
+        auth: "CF1 issued-at",
+        message: "request auth metadata is malformed",
+      },
+      {
+        auth: "CF1 issued-at=",
+        message: "request auth metadata is malformed",
+      },
+      {
+        auth: `${validAuthHeader()}; nonce=1`,
+        message: "request auth metadata has an unknown field",
+      },
+      {
+        auth:
+          `CF1 issued-at=${NOW_SECONDS}; issued-at=${NOW_SECONDS}; valid-until=${
+            NOW_SECONDS + 60
+          }; proof-did=${encodeURIComponent(signer.did())}; proof-kind=ed25519`,
+        message: "request auth metadata has a duplicate field",
+      },
+      {
+        auth: `CF1 issued-at=soon; valid-until=${NOW_SECONDS + 60}; proof-did=${
+          encodeURIComponent(signer.did())
+        }; proof-kind=ed25519`,
+        message: "request auth freshness fields must be integers",
+      },
+      {
+        auth: `CF1 issued-at=${NOW_SECONDS}; valid-until=${
+          NOW_SECONDS + 60
+        }; proof-did=${encodeURIComponent(signer.did())}`,
+        message: "request auth metadata is missing required fields",
+      },
+      {
+        auth: `CF1 issued-at=${NOW_SECONDS}; valid-until=${
+          NOW_SECONDS + 60
+        }; proof-did=%E0%A4%A; proof-kind=ed25519`,
+        message: "request auth metadata has invalid encoding",
+      },
+    ];
+
+    for (const { auth, message } of cases) {
+      await expectAuthReject(requestWithAuth(auth), message);
+    }
+  });
+
+  it("rejects invalid proof metadata after auth metadata parses", async () => {
+    await expectAuthReject(
+      requestWithAuth(
+        validAuthHeader().replace("proof-kind=ed25519", "proof-kind=rsa"),
+        { [FIRST_PARTY_HTTP_AUTH_HEADERS.userDid]: signer.did() },
+      ),
+      "unsupported first-party proof algorithm",
+    );
+
+    await expectAuthReject(
+      requestWithAuth(validAuthHeader("did:web:example"), {
+        [FIRST_PARTY_HTTP_AUTH_HEADERS.userDid]: "did:web:example",
+      }),
+      "first-party auth DID must be a did:key",
+    );
+
+    await expectAuthReject(
+      requestWithAuth(validAuthHeader(), {
+        [FIRST_PARTY_HTTP_AUTH_HEADERS.userDid]: "did:key:other",
+      }),
+      "proof user DID does not match request auth DID",
+    );
+  });
+
   it("rejects expired proofs", async () => {
     const request = await signedRequest(
       "http://toolshed.test/api/agent-tools/web-search",
@@ -275,6 +516,19 @@ describe("first-party toolshed HTTP request proofs", () => {
         body: "{}",
       },
       { nowSeconds: NOW_SECONDS + 120 },
+    );
+
+    await expectAuthReject(request);
+  });
+
+  it("rejects proofs whose valid-until is not after issued-at", async () => {
+    const request = await signedRequest(
+      "http://toolshed.test/api/agent-tools/web-search",
+      {
+        method: "POST",
+        body: "{}",
+      },
+      { validForSeconds: 0 },
     );
 
     await expectAuthReject(request);
@@ -309,5 +563,27 @@ describe("first-party toolshed HTTP request proofs", () => {
     );
 
     await expectAuthReject(request);
+  });
+
+  it("rejects invalid signers and signer failures", async () => {
+    await expectSignReject({
+      url: new URL("http://toolshed.test/api/agent-tools/web-search"),
+      method: "POST",
+      signer: {
+        did: () => "did:web:example",
+        sign: () => ({ ok: new Uint8Array() }),
+      },
+      nowSeconds: NOW_SECONDS,
+    }, "first-party HTTP authentication requires did:key signers");
+
+    await expectSignReject({
+      url: new URL("http://toolshed.test/api/agent-tools/web-search"),
+      method: "POST",
+      signer: {
+        did: () => signer.did(),
+        sign: () => ({ error: new Error("signing failed") }),
+      },
+      nowSeconds: NOW_SECONDS,
+    }, "signing failed");
   });
 });

--- a/packages/runner/test/transaction-summary.test.ts
+++ b/packages/runner/test/transaction-summary.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import {
+  debugTransactionWrites,
   formatTransactionSummary,
   summarizeTransaction,
 } from "../src/storage/transaction-summary.ts";
@@ -16,10 +17,11 @@ class TestJournal implements ITransactionJournal {
   constructor(
     private noveltyData: IAttestation[] = [],
     private historyData: IAttestation[] = [],
+    private activityData: any[] = [],
   ) {}
 
   activity(): Iterable<any> {
-    return [];
+    return this.activityData;
   }
 
   novelty(_space: any): Iterable<IAttestation> {
@@ -47,8 +49,9 @@ function attestation(id: string, path: string[], value?: any): IAttestation {
 function createTestTransaction(
   novelty: IAttestation[],
   history: IAttestation[] = [],
+  activity: any[] = [],
 ): IExtendedStorageTransaction {
-  const journal = new TestJournal(novelty, history);
+  const journal = new TestJournal(novelty, history, activity);
   return {
     journal,
     status: () => ({ status: "done" as const, journal }),
@@ -57,12 +60,24 @@ function createTestTransaction(
 
 function createInspectableTransaction(
   writes: TransactionWriteDetail[],
+  activity: any[] = [],
 ): IExtendedStorageTransaction {
-  const journal = new TestJournal();
+  const journal = new TestJournal([], [], activity);
   return {
     journal,
     getWriteDetails: () => writes,
     status: () => ({ status: "done" as const, journal }),
+  } as any;
+}
+
+function createStatusTransaction(
+  status: "done" | "error",
+  activity: any[] = [],
+): IExtendedStorageTransaction {
+  const journal = new TestJournal([], [], activity);
+  return {
+    journal,
+    status: () => ({ status, journal }),
   } as any;
 }
 
@@ -148,12 +163,25 @@ describe("transaction-summary", () => {
     const tx = createTestTransaction(
       [attestation("of:abc123", ["value", "old"], undefined)],
       [attestation("of:abc123", ["value", "old"], "previous")],
+      [{
+        write: {
+          space: "did:key:test" as any,
+          id: "of:abc123",
+          type: "application/json",
+          path: ["value", "old"],
+        },
+      }],
     );
 
     const summary = summarizeTransaction(tx, "did:key:test" as any);
 
     assertEquals(summary.writes.length, 1);
     assertEquals(summary.writes[0].isDeleted, true);
+    assertEquals(summary.summary, "Deleted value.old");
+    assertEquals(
+      formatTransactionSummary(tx, "did:key:test" as any),
+      "value.old: deleted",
+    );
   });
 
   it("should handle empty transaction", () => {
@@ -164,6 +192,41 @@ describe("transaction-summary", () => {
 
     const formatted = formatTransactionSummary(tx, "did:key:test" as any);
     assertEquals(formatted, "Empty transaction");
+  });
+
+  it("should summarize failed, read-only, and hidden-write transactions", () => {
+    assertEquals(
+      summarizeTransaction(createStatusTransaction("error")).summary,
+      "Transaction failed",
+    );
+
+    const readOnly = createStatusTransaction("done", [
+      { read: { id: "of:read", type: "application/json", path: [] } },
+    ]);
+    assertEquals(
+      summarizeTransaction(readOnly).summary,
+      "Read-only transaction",
+    );
+
+    const hiddenWrite = createStatusTransaction("done", [
+      { write: { id: "of:write", type: "application/json", path: [] } },
+    ]);
+    assertEquals(
+      formatTransactionSummary(hiddenWrite),
+      "(pass space parameter to see what was written)",
+    );
+  });
+
+  it("should include large read counts in formatted output", () => {
+    const activity = Array.from({ length: 11 }, (_, index) => ({
+      read: { id: `of:read-${index}`, type: "application/json", path: [] },
+    }));
+    const tx = createStatusTransaction("done", activity);
+
+    assertEquals(
+      formatTransactionSummary(tx),
+      "Read-only transaction\n(11 reads for context)",
+    );
   });
 
   it("should summarize direct write details without journal novelty/history", () => {
@@ -190,5 +253,199 @@ describe("transaction-summary", () => {
       previousValue: 10,
       isDeleted: false,
     }]);
+  });
+
+  it("should summarize direct reactivity activity", () => {
+    const tx = {
+      journal: new TestJournal(),
+      getReactivityLog: () => ({
+        reads: [
+          { id: "of:read", type: "application/json", path: [] },
+        ],
+        shallowReads: [
+          { id: "of:shallow", type: "application/json", path: [] },
+        ],
+        writes: [
+          { id: "of:write", type: "application/json", path: [] },
+        ],
+      }),
+      getWriteDetails: () => [],
+      status: () => ({
+        status: "done" as const,
+        journal: new TestJournal(),
+      }),
+    } as any;
+
+    const summary = summarizeTransaction(tx);
+
+    assertEquals(summary.activity, { reads: 2, writes: 1 });
+    assertEquals(
+      summary.summary,
+      "1 write(s) (details unavailable without space parameter)",
+    );
+  });
+
+  it("should debug direct reactivity write activity", () => {
+    const journal = new TestJournal([
+      attestation("of:direct123", ["value"], null),
+    ]);
+    const tx = {
+      journal,
+      getReactivityLog: () => ({
+        reads: [],
+        shallowReads: [],
+        writes: [
+          {
+            space: "did:key:test" as any,
+            id: "of:direct123",
+            type: "application/json",
+            path: ["value"],
+          },
+        ],
+      }),
+      status: () => ({
+        status: "done" as const,
+        journal,
+      }),
+    } as any;
+
+    const debug = debugTransactionWrites(tx);
+
+    assertEquals(debug.includes("Total writes in activity: 1"), true);
+    assertEquals(
+      debug.includes("Write to: of:direct123/value (space: did:key:test)"),
+      true,
+    );
+  });
+
+  it("should format null write values", () => {
+    const tx = createInspectableTransaction([{
+      address: {
+        space: "did:key:test" as any,
+        id: "short-id" as any,
+        type: "application/json",
+        path: ["nothing"],
+      },
+      value: null,
+    }], [{
+      write: {
+        space: "did:key:test" as any,
+        id: "short-id",
+        type: "application/json",
+        path: ["nothing"],
+      },
+    }]);
+
+    assertEquals(
+      formatTransactionSummary(tx, "did:key:test" as any),
+      "nothing = null",
+    );
+  });
+
+  it("should truncate verbose write values in summaries", () => {
+    const longText = "x".repeat(120);
+    const tx = createInspectableTransaction(
+      [
+        {
+          address: {
+            space: "did:key:test" as any,
+            id: "a-very-long-object-identifier" as any,
+            type: "application/json",
+            path: ["long"],
+          },
+          value: longText,
+        },
+        {
+          address: {
+            space: "did:key:test" as any,
+            id: "of:array123" as any,
+            type: "application/json",
+            path: ["items"],
+          },
+          value: [1, 2, 3],
+        },
+        {
+          address: {
+            space: "did:key:test" as any,
+            id: "of:object123" as any,
+            type: "application/json",
+            path: ["details"],
+          },
+          value: { nested: { count: 1 } },
+        },
+        {
+          address: {
+            space: "did:key:test" as any,
+            id: "of:boolean123" as any,
+            type: "application/json",
+            path: ["done"],
+          },
+          value: true,
+        },
+      ],
+      Array.from({ length: 4 }, (_, index) => ({
+        write: {
+          space: "did:key:test" as any,
+          id: `of:write-${index}`,
+          type: "application/json",
+          path: [],
+        },
+      })),
+    );
+
+    const summary = summarizeTransaction(tx, "did:key:test" as any);
+
+    assertEquals(summary.writes[0].objectId, "a-very-long-object-i...");
+    assertEquals(summary.writes[0].value, `${"x".repeat(100)}...`);
+    assertEquals(summary.writes[1].value, "[Array: 3 items]");
+    assertEquals(summary.writes[2].value, '{"nested":{"count":1}}');
+    assertEquals(
+      summarizeTransaction(
+        createInspectableTransaction([{
+          address: {
+            space: "did:key:test" as any,
+            id: "of:null123" as any,
+            type: "application/json",
+            path: ["nothing"],
+          },
+          value: null,
+        }]),
+        "did:key:test" as any,
+      ).writes[0].value,
+      null,
+    );
+    assertEquals(summary.summary.includes("... and 1 more"), true);
+    assertEquals(
+      formatTransactionSummary(tx, "did:key:test" as any).includes(
+        "Object a-very-long-object-i...",
+      ),
+      true,
+    );
+  });
+
+  it("should debug journal write activity", () => {
+    const tx = createTestTransaction(
+      [attestation("of:abc123", ["value"], 1)],
+      [],
+      [
+        {
+          write: {
+            space: "did:key:test" as any,
+            id: "of:abc123",
+            type: "application/json",
+            path: ["value"],
+          },
+        },
+      ],
+    );
+
+    const debug = debugTransactionWrites(tx);
+
+    assertEquals(debug.includes("Total writes in activity: 1"), true);
+    assertEquals(
+      debug.includes("Write to: of:abc123/value (space: did:key:test)"),
+      true,
+    );
+    assertEquals(debug.includes("did:key:test: 1 attestation(s)"), true);
   });
 });

--- a/packages/toolshed/lib/types.ts
+++ b/packages/toolshed/lib/types.ts
@@ -4,6 +4,7 @@ import type { Logger } from "pino";
 export interface AppBindings {
   Variables: {
     logger: Logger;
+    verifiedUserDid?: string;
   };
 }
 

--- a/packages/toolshed/middlewares/first-party-http-auth.ts
+++ b/packages/toolshed/middlewares/first-party-http-auth.ts
@@ -1,0 +1,29 @@
+import type { MiddlewareHandler } from "@hono/hono";
+import { verifyFirstPartyHttpRequest } from "@commonfabric/runner/toolshed-http-auth";
+import type { AppBindings } from "@/lib/types.ts";
+
+export function requireFirstPartyHttpAuth(): MiddlewareHandler<
+  AppBindings
+> {
+  return async (c, next) => {
+    try {
+      const { userDid } = await verifyFirstPartyHttpRequest({
+        request: c.req.raw,
+      });
+      c.set("verifiedUserDid", userDid);
+      // TODO(auth): Check that the verified DID is authorized for this privileged route before continuing.
+    } catch (error) {
+      const logger = c.get("logger");
+      logger.warn(
+        {
+          path: c.req.path,
+          method: c.req.method,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Rejected unauthenticated first-party HTTP request",
+      );
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    await next();
+  };
+}

--- a/packages/toolshed/routes/agent-tools/web-read/web-read.handlers.ts
+++ b/packages/toolshed/routes/agent-tools/web-read/web-read.handlers.ts
@@ -20,6 +20,7 @@ async function isValidCache(path: string): Promise<boolean> {
 
 export const webRead: AppRouteHandler<WebReadRoute> = async (c) => {
   const logger = c.get("logger");
+  const verifiedUserDid = c.get("verifiedUserDid");
   const payload = await c.req.json();
   const { url, ...options } = payload;
 
@@ -27,7 +28,7 @@ export const webRead: AppRouteHandler<WebReadRoute> = async (c) => {
   const cachePath = `${CACHE_DIR}/${promptSha}.json`;
 
   logger.info(
-    { url, promptSha, options },
+    { url, promptSha, options, verifiedUserDid },
     "Starting advanced web extraction",
   );
 

--- a/packages/toolshed/routes/agent-tools/web-read/web-read.index.ts
+++ b/packages/toolshed/routes/agent-tools/web-read/web-read.index.ts
@@ -1,21 +1,13 @@
 import { createRouter } from "@/lib/create-app.ts";
 import * as handlers from "./web-read.handlers.ts";
 import * as routes from "./web-read.routes.ts";
-import { cors } from "@hono/hono/cors";
+import { requireFirstPartyHttpAuth } from "@/middlewares/first-party-http-auth.ts";
 
 const router = createRouter();
+const requireAuth = requireFirstPartyHttpAuth();
 
-router.use(
-  "/api/agent-tools/web-read/*",
-  cors({
-    origin: "*",
-    allowMethods: ["POST", "OPTIONS"],
-    allowHeaders: ["Content-Type", "Authorization"],
-    exposeHeaders: ["Content-Length", "X-Disk-Cache"],
-    maxAge: 3600,
-    credentials: true,
-  }),
-);
+router.use("/api/agent-tools/web-read", requireAuth);
+router.use("/api/agent-tools/web-read/*", requireAuth);
 
 router.openapi(routes.webRead, handlers.webRead);
 

--- a/packages/toolshed/routes/agent-tools/web-search/web-search.handlers.ts
+++ b/packages/toolshed/routes/agent-tools/web-search/web-search.handlers.ts
@@ -279,6 +279,7 @@ async function isValidCache(path: string): Promise<boolean> {
 
 export const webSearch: AppRouteHandler<WebSearchRoute> = async (c) => {
   const logger = c.get("logger");
+  const verifiedUserDid = c.get("verifiedUserDid");
   const payload = await c.req.json();
   const { query, max_results = 5, include_content = false } = payload;
 
@@ -287,7 +288,7 @@ export const webSearch: AppRouteHandler<WebSearchRoute> = async (c) => {
   const cachePath = `${CACHE_DIR}/${promptSha}.json`;
 
   logger.info(
-    { query, max_results, include_content, promptSha },
+    { query, max_results, include_content, promptSha, verifiedUserDid },
     "Starting web search",
   );
 

--- a/packages/toolshed/routes/agent-tools/web-search/web-search.index.ts
+++ b/packages/toolshed/routes/agent-tools/web-search/web-search.index.ts
@@ -1,21 +1,13 @@
 import { createRouter } from "@/lib/create-app.ts";
 import * as handlers from "./web-search.handlers.ts";
 import * as routes from "./web-search.routes.ts";
-import { cors } from "@hono/hono/cors";
+import { requireFirstPartyHttpAuth } from "@/middlewares/first-party-http-auth.ts";
 
 const router = createRouter();
+const requireAuth = requireFirstPartyHttpAuth();
 
-router.use(
-  "/api/agent-tools/web-search/*",
-  cors({
-    origin: "*",
-    allowMethods: ["POST", "OPTIONS"],
-    allowHeaders: ["Content-Type", "Authorization"],
-    exposeHeaders: ["Content-Length", "X-Disk-Cache"],
-    maxAge: 3600,
-    credentials: true,
-  }),
-);
+router.use("/api/agent-tools/web-search", requireAuth);
+router.use("/api/agent-tools/web-search/*", requireAuth);
 
 router.openapi(routes.webSearch, handlers.webSearch);
 

--- a/packages/toolshed/routes/privileged-local-auth.test.ts
+++ b/packages/toolshed/routes/privileged-local-auth.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { signFirstPartyHttpRequest } from "@commonfabric/runner/toolshed-http-auth";
+import env from "@/env.ts";
+import { createTestApp } from "@/lib/create-app.ts";
+import webReadRouter from "@/routes/agent-tools/web-read/web-read.index.ts";
+import webSearchRouter from "@/routes/agent-tools/web-search/web-search.index.ts";
+import sandboxExecRouter from "@/routes/sandbox/exec/exec.index.ts";
+
+if (env.ENV !== "test") {
+  throw new Error("ENV must be 'test'");
+}
+
+const signer = await Identity.fromPassphrase("toolshed local route auth test");
+const originalFetch = globalThis.fetch;
+
+const webReadApp = createTestApp(webReadRouter);
+const webSearchApp = createTestApp(webSearchRouter);
+const sandboxExecApp = createTestApp(sandboxExecRouter);
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+async function signedHeaders(path: string, body: string): Promise<Headers> {
+  return await signFirstPartyHttpRequest({
+    url: new URL(path, "http://localhost"),
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+    signer,
+  });
+}
+
+describe("privileged local route authentication", () => {
+  const missingProofCases = [
+    {
+      name: "web-read",
+      app: webReadApp,
+      path: "/api/agent-tools/web-read",
+      body: JSON.stringify({ url: "https://example.com/read" }),
+    },
+    {
+      name: "web-search",
+      app: webSearchApp,
+      path: "/api/agent-tools/web-search",
+      body: JSON.stringify({ query: "example" }),
+    },
+    {
+      name: "sandbox exec",
+      app: sandboxExecApp,
+      path: "/api/sandbox/exec",
+      body: JSON.stringify({
+        sandboxId: "sandbox-auth-test",
+        command: "echo hello",
+      }),
+    },
+  ] as const;
+
+  for (const routeCase of missingProofCases) {
+    it(`rejects ${routeCase.name} calls without a proof before privileged work`, async () => {
+      let fetchCalled = false;
+      globalThis.fetch = () => {
+        fetchCalled = true;
+        return Promise.resolve(new Response("unexpected", { status: 500 }));
+      };
+
+      const response = await routeCase.app.request(routeCase.path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: routeCase.body,
+      });
+      await response.text();
+
+      expect(response.status).toBe(401);
+      expect(fetchCalled).toBe(false);
+    });
+  }
+
+  it("allows a web-read call with a proof through to the handler", async () => {
+    const url = `https://example.com/${crypto.randomUUID()}`;
+    const body = JSON.stringify({ url, max_tokens: 4000 });
+    const headers = await signedHeaders("/api/agent-tools/web-read", body);
+    let fetchCalled = false;
+
+    globalThis.fetch = () => {
+      fetchCalled = true;
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              content: "extracted content",
+              title: "Signed page",
+              publishedTime: "2026-06-22",
+              usage: { tokens: 12 },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+    };
+
+    const response = await webReadApp.request("/api/agent-tools/web-read", {
+      method: "POST",
+      headers,
+      body,
+    });
+    const result = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(fetchCalled).toBe(true);
+    expect(result.content).toBe("extracted content");
+  });
+});

--- a/packages/toolshed/routes/sandbox/exec/exec.handlers.ts
+++ b/packages/toolshed/routes/sandbox/exec/exec.handlers.ts
@@ -88,6 +88,7 @@ async function execInSandbox(
 
 export const sandboxExec: AppRouteHandler<SandboxExecRoute> = async (c) => {
   const logger = c.get("logger");
+  const verifiedUserDid = c.get("verifiedUserDid");
   const payload = await c.req.json();
   const {
     sandboxId,
@@ -97,7 +98,7 @@ export const sandboxExec: AppRouteHandler<SandboxExecRoute> = async (c) => {
     environment,
   } = payload;
 
-  logger.info({ sandboxId, command }, "Sandbox exec request");
+  logger.info({ sandboxId, command, verifiedUserDid }, "Sandbox exec request");
 
   // Inject CF_API_URL so `cf` inside sandboxes can reach the toolshed
   const sandboxToolshedUrl = env.SANDBOX_TOOLSHED_URL || env.API_URL;

--- a/packages/toolshed/routes/sandbox/exec/exec.index.ts
+++ b/packages/toolshed/routes/sandbox/exec/exec.index.ts
@@ -1,19 +1,13 @@
 import { createRouter } from "@/lib/create-app.ts";
 import * as handlers from "./exec.handlers.ts";
 import * as routes from "./exec.routes.ts";
-import { cors } from "@hono/hono/cors";
+import { requireFirstPartyHttpAuth } from "@/middlewares/first-party-http-auth.ts";
 
 const router = createRouter();
+const requireAuth = requireFirstPartyHttpAuth();
 
-router.use(
-  "/api/sandbox/exec/*",
-  cors({
-    origin: "*",
-    allowMethods: ["POST", "OPTIONS"],
-    allowHeaders: ["Content-Type", "Authorization"],
-    maxAge: 3600,
-  }),
-);
+router.use("/api/sandbox/exec", requireAuth);
+router.use("/api/sandbox/exec/*", requireAuth);
 
 router.openapi(routes.sandboxExec, handlers.sandboxExec);
 


### PR DESCRIPTION
Privileged local toolshed HTTP routes could be called without proving which logged-in user initiated the request. Routes such as web search, web read, and sandbox exec spend server-held provider budget or use local runtime authority, so an unauthenticated local HTTP call could start privileged work without leaving a verified user DID for logs or audit.

Add a shared first-party request proof helper that uses a CommonTools-specific wire format rather than RFC 9421 header names or vocabulary. Protected requests use CF-Request-Auth, CF-Request-Proof, CF-Request-Body-SHA256, and CF-User-DID. The proof binds the method, authority, path with query string, user DID, freshness fields, proof kind, and body hash when a body is present. The verifier rejects missing, expired, future-issued, or over-long proofs and verifies the DID key with the existing identity APIs.

Apply the verifier as Hono middleware to POST /api/agent-tools/web-search, POST /api/agent-tools/web-read, and POST /api/sandbox/exec. The middleware returns 401 before route handlers begin privileged work and stores the verified DID on the Hono context for handler logging. The middleware also records a TODO for the next layer that checks whether the verified DID is authorized for the privileged route.

Teach fetchData to add request proofs only for protected first-party toolshed routes when the resolved URL targets the runtime API origin. Protected requests use the runtime storage identity, generated auth headers replace caller-supplied proof headers, and caller-supplied Signature, Signature-Input, and Content-Digest headers are stripped. External requests are left unsigned, even if their path resembles a protected toolshed API path.

Remove the previous wildcard CORS exposure from the protected route modules. Add focused tests for proof verification, tamper rejection, protected-route 401 behavior, successful proofed route handling, and fetchData proof behavior. Document the current access-control model, the routes protected in this pass, intentionally deferred privileged routes, and remaining gaps such as lack of a replay cache and lack of a server-side DID authorization registry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authenticate privileged Toolshed routes using first‑party request proofs to block unauthenticated work and record the verified user DID on the request context for logs. `fetchData` now auto‑signs protected POSTs to the runtime API origin and never signs external hosts.

- **New Features**
  - Custom request proof with headers `CF-Request-Auth`, `CF-Request-Proof`, `CF-Request-Body-SHA256`, `CF-User-DID`; binds method, authority, path+query, user DID, freshness, and body hash; uses did:key, unpadded base64url via `@commonfabric/utils/base64url`, and SHA‑256 via `@commonfabric/content-hash`; padded proofs are rejected.
  - Hono middleware on `POST /api/agent-tools/web-search`, `POST /api/agent-tools/web-read`, and `POST /api/sandbox/exec` verifies proofs, sets `verifiedUserDid`, logs it, and returns 401 before privileged work on failure; removed wildcard CORS on these routes.
  - Updated `@commonfabric/runner` `fetchData` to sign only protected POSTs targeting the runtime API origin; replaces caller proof headers, strips `Signature`, `Signature-Input`, and `Content-Digest`, and never signs external hosts.
  - Added docs on the access‑control model, protected and deferred routes; expanded tests for body forms, parser failures, freshness bounds, cross‑route replay, padded‑value rejection, protected‑route 401/success paths, and `fetchData` signing/replacement; added nearby runner coverage for plain‑data validation, CFC schema merge/sanitization, and transaction summary formatting/debug.

- **Migration**
  - No change for first‑party callers using `fetchData`—requests are signed automatically.
  - Direct callers must attach valid proofs (unpadded base64url; include body hash when present) or receive 401.
  - Cross‑origin access to these routes is no longer allowed due to CORS removal.

<sup>Written for commit b1f778809dece34eabed557690676cca4138eee7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

