### PR TITLE
refactor(runner): remove dead legacy `{ cell, path }` link detection

### DIFF
--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -203,12 +203,7 @@ export function resolveLink(
 
         if (lastValid.length === link.path.length) {
           // full path candidate, only check legacy-at full path
-          const legacy = checkLegacyAt(
-            tx,
-            link,
-            lastValid,
-            lastNode === "writeRedirect",
-          );
+          const legacy = checkLegacyAt(tx, link, lastValid);
           if (legacy) {
             nextHop = {
               link: legacy,
@@ -241,7 +236,7 @@ export function resolveLink(
               kind: hopKindForLink(nextLink),
             };
           } else {
-            const legacy = checkLegacyAt(tx, link, lastValid, false);
+            const legacy = checkLegacyAt(tx, link, lastValid);
             if (legacy) {
               nextHop = {
                 link: legacy,
@@ -367,7 +362,6 @@ function checkLegacyAt(
   tx: IExtendedStorageTransaction,
   link: NormalizedFullLink,
   atPath: readonly string[],
-  onlyRedirects: boolean,
 ): NormalizedFullLink | undefined {
   const aliasPath = tx.read(
     toMemorySpaceAddress({
@@ -377,20 +371,6 @@ function checkLegacyAt(
     { meta: linkResolutionProbe },
   );
   if (Array.isArray(aliasPath.ok?.value)) {
-    return parseLink(
-      tx.readValueOrThrow({ ...link, path: atPath }) as CellLink,
-      { ...link, path: atPath },
-    );
-  }
-  if (onlyRedirects) return undefined;
-  const legacyCell = tx.read(
-    toMemorySpaceAddress({
-      ...link,
-      path: [...atPath, "cell", "/"],
-    }),
-    { meta: linkResolutionProbe },
-  );
-  if (typeof legacyCell.ok?.value === "string") {
     return parseLink(
       tx.readValueOrThrow({ ...link, path: atPath }) as CellLink,
       { ...link, path: atPath },
@@ -426,9 +406,6 @@ export function readMaybeLink(
     (maybeSigilPayload !== undefined &&
       (!onlyWriteRedirects ||
         (maybeSigilPayload as CellLinkRefPayload).overwrite === "redirect")) ||
-    // Legacy cell link: { cell: {"/": <id> }, path: [] }
-    (!onlyWriteRedirects && typeof readSubPath(["cell", "/"]) === "string" &&
-      Array.isArray(readSubPath(["path"]))) ||
     // Legacy alias: { $alias: { path: [] } }
     Array.isArray(readSubPath(["$alias", "path"]))
   ) {


### PR DESCRIPTION
## What

Removes the link-resolution probes that recognized the old
`{ cell: { "/": string }, path: [...] }` link shape, at the two sites in
`packages/runner/src/link-resolution.ts`:

- the `["cell", "/"]` branch in `checkLegacyAt`
- the matching clause in `readMaybeLink`

Also drops `checkLegacyAt`'s now-vestigial `onlyRedirects` parameter.

## Why it's safe

**Nothing produces this shape.** Modern links are emitted only as the sigil
form `{ "/": { "link@1": ... } }` or as a legacy `$alias`. A repo-wide sweep
finds no non-test code constructing a top-level `{ cell, path }` link.

**The detection was already non-functional.** Both sites finish by calling
`parseLink`, whose gate is
`isPrimitiveCellLink = isSigilLink(value) || isLegacyAlias(value)`. A bare
`{ cell, path }` object matches neither, so `parseLink` returns `undefined` —
the branches could fire but never yield a link.

**`onlyRedirects` becomes vestigial.** With the `cell` branch gone, the only
form `checkLegacyAt` still handles is `$alias`, which always parses with
`overwrite: "redirect"`. The parameter existed solely to suppress the
non-redirect `cell` branch, so it's dropped too.

**Not touched:** `cell: { "/": ... }` still appears nested *inside* `$alias`
objects in some test fixtures (e.g. `cfc-ui-contract.test.ts`,
`json-encoding.test.ts`). That is a different, still-live shape — left as-is.

## Testing

- `deno check` / `deno lint` / `deno fmt --check` clean on the changed file.
- Full workspace test suite (`deno task test`) passes, including the runner
  link suite (`link-resolution`, `link-utils`, `cell-links`, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqKYyzitpYXQyywipkfDCg


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dead detection of legacy `{ cell: { "/": string }, path: [...] }` links in `packages/runner` and dropped the unused `onlyRedirects` parameter. No behavior change: only sigil links and legacy `$alias` remain supported, and the removed path was unreachable.

- **Refactors**
  - Removed the `["cell","/"]` probe in `checkLegacyAt` and the matching clause in `readMaybeLink` in `packages/runner/src/link-resolution.ts`.
  - Deleted `onlyRedirects` from `checkLegacyAt` and updated call sites.

<sup>Written for commit ad137f5e390c12dafe904978008b7b2fb62332c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

