### PR TITLE
test(runner): route link tests through the cell-rep chokepoint

### DIFF
--- a/packages/runner/test/cell-links.test.ts
+++ b/packages/runner/test/cell-links.test.ts
@@ -6,7 +6,9 @@ import "@commonfabric/utils/equal-ignoring-symbols";
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { LINK_V1_TAG } from "../src/sigil-types.ts";
+import { linkRefPayload } from "@commonfabric/data-model/cell-rep";
+import { isSigilLink } from "../src/link-utils.ts";
+import { type SigilLink } from "../src/sigil-types.ts";
 import { JSONSchema } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
@@ -51,19 +53,19 @@ describe("getAsLink method", () => {
     const link = cell.getAsLink();
 
     // Verify structure
-    expect(link["/"]).toBeDefined();
-    expect(link["/"][LINK_V1_TAG]).toBeDefined();
-    expect(link["/"][LINK_V1_TAG].id).toBeDefined();
-    expect(link["/"][LINK_V1_TAG].path).toBeDefined();
+    expect(isSigilLink(link)).toBe(true);
+    expect(linkRefPayload(link)).toBeDefined();
+    expect(linkRefPayload(link).id).toBeDefined();
+    expect(linkRefPayload(link).path).toBeDefined();
 
     // Verify id has of: prefix
-    expect(link["/"][LINK_V1_TAG].id).toMatch(/^of:/);
+    expect(linkRefPayload(link).id).toMatch(/^of:/);
 
     // Verify path is empty array
-    expect(link["/"][LINK_V1_TAG].path).toEqual([]);
+    expect(linkRefPayload(link).path).toEqual([]);
 
     // Verify space is included if present
-    expect(link["/"][LINK_V1_TAG].space).toBe(space);
+    expect(linkRefPayload(link).space).toBe(space);
   });
 
   it("should return correct path for nested cells", () => {
@@ -78,7 +80,7 @@ describe("getAsLink method", () => {
 
     const link = nestedCell.getAsLink();
 
-    expect(link["/"][LINK_V1_TAG].path).toEqual(["nested", "value"]);
+    expect(linkRefPayload(link).path).toEqual(["nested", "value"]);
   });
 
   it("should return sigil format for both getAsLink and toJSON", () => {
@@ -95,15 +97,15 @@ describe("getAsLink method", () => {
 
     // getAsLink returns sigil format
     expect(link).toHaveProperty("/");
-    expect(link["/"][LINK_V1_TAG]).toBeDefined();
+    expect(linkRefPayload(link)).toBeDefined();
 
     // toJSON now also returns sigil format (includes space for cross-space references)
-    expect(json).toHaveProperty("/");
-    expect((json as any)["/"][LINK_V1_TAG]).toBeDefined();
-    expect((json as any)["/"][LINK_V1_TAG].id).toBeDefined();
-    expect((json as any)["/"][LINK_V1_TAG].path).toEqual([]);
+    expect(json).not.toBeNull();
+    const jsonPayload = linkRefPayload(json as SigilLink);
+    expect(jsonPayload.id).toBeDefined();
+    expect(jsonPayload.path).toEqual([]);
     // Verify space is included for cross-space resolution
-    expect((json as any)["/"][LINK_V1_TAG].space).toEqual(space);
+    expect(jsonPayload.space).toEqual(space);
   });
 
   it("should create relative links with base parameter - same document", () => {
@@ -120,9 +122,9 @@ describe("getAsLink method", () => {
     const link = cell.getAsLink({ base: c });
 
     // Should omit id and space since they're the same
-    expect(link["/"][LINK_V1_TAG].id).toBeUndefined();
-    expect(link["/"][LINK_V1_TAG].space).toBeUndefined();
-    expect(link["/"][LINK_V1_TAG].path).toEqual(["value"]);
+    expect(linkRefPayload(link).id).toBeUndefined();
+    expect(linkRefPayload(link).space).toBeUndefined();
+    expect(linkRefPayload(link).path).toEqual(["value"]);
   });
 
   it("should create relative links with base parameter - different document", () => {
@@ -146,10 +148,10 @@ describe("getAsLink method", () => {
     const link = cell.getAsLink({ base: c2 });
 
     // Should include id but not space since space is the same
-    expect(link["/"][LINK_V1_TAG].id).toBeDefined();
-    expect(link["/"][LINK_V1_TAG].id).toMatch(/^of:/);
-    expect(link["/"][LINK_V1_TAG].space).toBeUndefined();
-    expect(link["/"][LINK_V1_TAG].path).toEqual(["value"]);
+    expect(linkRefPayload(link).id).toBeDefined();
+    expect(linkRefPayload(link).id).toMatch(/^of:/);
+    expect(linkRefPayload(link).space).toBeUndefined();
+    expect(linkRefPayload(link).path).toEqual(["value"]);
   });
 
   it("should create relative links with base parameter - different space", () => {
@@ -175,10 +177,10 @@ describe("getAsLink method", () => {
     const link = cell.getAsLink({ base: c2 });
 
     // Should include both id and space since they're different
-    expect(link["/"][LINK_V1_TAG].id).toBeDefined();
-    expect(link["/"][LINK_V1_TAG].id).toMatch(/^of:/);
-    expect(link["/"][LINK_V1_TAG].space).toBe(space);
-    expect(link["/"][LINK_V1_TAG].path).toEqual(["value"]);
+    expect(linkRefPayload(link).id).toBeDefined();
+    expect(linkRefPayload(link).id).toMatch(/^of:/);
+    expect(linkRefPayload(link).space).toBe(space);
+    expect(linkRefPayload(link).path).toEqual(["value"]);
   });
 
   it("should include schema when includeSchema is true", () => {
@@ -195,9 +197,9 @@ describe("getAsLink method", () => {
     // Link with schema included
     const link = cell.getAsLink({ includeSchema: true });
 
-    expect(link["/"][LINK_V1_TAG].schema).toEqual(schema);
-    expect(link["/"][LINK_V1_TAG].id).toBeDefined();
-    expect(link["/"][LINK_V1_TAG].path).toEqual(["value"]);
+    expect(linkRefPayload(link).schema).toEqual(schema);
+    expect(linkRefPayload(link).id).toBeDefined();
+    expect(linkRefPayload(link).path).toEqual(["value"]);
   });
 
   it("should not include schema when includeSchema is false", () => {
@@ -214,7 +216,7 @@ describe("getAsLink method", () => {
     // Link without schema
     const link = cell.getAsLink({ includeSchema: false });
 
-    expect(link["/"][LINK_V1_TAG].schema).toBeUndefined();
+    expect(linkRefPayload(link).schema).toBeUndefined();
   });
 
   it("should not include schema when includeSchema is undefined", () => {
@@ -230,7 +232,7 @@ describe("getAsLink method", () => {
     // Link with default options (no schema)
     const link = cell.getAsLink();
 
-    expect(link["/"][LINK_V1_TAG].schema).toBeUndefined();
+    expect(linkRefPayload(link).schema).toBeUndefined();
   });
 
   it("should handle both base and includeSchema options together", () => {
@@ -254,10 +256,10 @@ describe("getAsLink method", () => {
     const link = cell.getAsLink({ base: c2, includeSchema: true });
 
     // Should include id (different docs) but not space (same space)
-    expect(link["/"][LINK_V1_TAG].id).toBeDefined();
-    expect(link["/"][LINK_V1_TAG].space).toBeUndefined();
-    expect(link["/"][LINK_V1_TAG].path).toEqual(["value"]);
-    expect(link["/"][LINK_V1_TAG].schema).toEqual(schema);
+    expect(linkRefPayload(link).id).toBeDefined();
+    expect(linkRefPayload(link).space).toBeUndefined();
+    expect(linkRefPayload(link).path).toEqual(["value"]);
+    expect(linkRefPayload(link).schema).toEqual(schema);
   });
 
   it("should handle cell without schema when includeSchema is true", () => {
@@ -273,7 +275,7 @@ describe("getAsLink method", () => {
     // Link with includeSchema but cell has no schema
     const link = cell.getAsLink({ includeSchema: true });
 
-    expect(link["/"][LINK_V1_TAG].schema).toBeUndefined();
+    expect(linkRefPayload(link).schema).toBeUndefined();
   });
 });
 
@@ -312,20 +314,20 @@ describe("getAsWriteRedirectLink method", () => {
     const alias = cell.getAsWriteRedirectLink();
 
     // Verify structure
-    expect(alias["/"]).toBeDefined();
-    expect(alias["/"][LINK_V1_TAG]).toBeDefined();
-    expect(alias["/"][LINK_V1_TAG].id).toBeDefined();
-    expect(alias["/"][LINK_V1_TAG].path).toBeDefined();
-    expect(alias["/"][LINK_V1_TAG].overwrite).toBe("redirect");
+    expect(isSigilLink(alias)).toBe(true);
+    expect(linkRefPayload(alias)).toBeDefined();
+    expect(linkRefPayload(alias).id).toBeDefined();
+    expect(linkRefPayload(alias).path).toBeDefined();
+    expect(linkRefPayload(alias).overwrite).toBe("redirect");
 
     // Verify id has of: prefix
-    expect(alias["/"][LINK_V1_TAG].id).toMatch(/^of:/);
+    expect(linkRefPayload(alias).id).toMatch(/^of:/);
 
     // Verify path is empty array
-    expect(alias["/"][LINK_V1_TAG].path).toEqual([]);
+    expect(linkRefPayload(alias).path).toEqual([]);
 
     // Verify space is included if present
-    expect(alias["/"][LINK_V1_TAG].space).toBe(space);
+    expect(linkRefPayload(alias).space).toBe(space);
   });
 
   it("should return correct path for nested cells", () => {
@@ -340,7 +342,7 @@ describe("getAsWriteRedirectLink method", () => {
 
     const alias = nestedCell.getAsWriteRedirectLink();
 
-    expect(alias["/"][LINK_V1_TAG].path).toEqual(["nested", "value"]);
+    expect(linkRefPayload(alias).path).toEqual(["nested", "value"]);
   });
 
   it("should omit space when baseSpace matches", () => {
@@ -355,7 +357,7 @@ describe("getAsWriteRedirectLink method", () => {
     const alias = cell.getAsWriteRedirectLink({ baseSpace: space });
 
     // Should omit space
-    expect(alias["/"][LINK_V1_TAG].space).toBeUndefined();
+    expect(linkRefPayload(alias).space).toBeUndefined();
   });
 });
 

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -7,6 +7,7 @@ import {
 import type { CfcMetadata } from "../src/cfc/types.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import { Runtime } from "../src/runtime.ts";
 import { parseLink } from "../src/link-utils.ts";
 import { toCell } from "../src/back-to-cell.ts";
@@ -312,7 +313,7 @@ describe("CFC label view helpers", () => {
 
       const recovered = runtime.getCellFromLink(link);
       expect(cfcLabelViewForCell(recovered)).toEqual(view);
-      expect(recovered.getAsLink()["/"][LINK_V1_TAG]).not.toHaveProperty(
+      expect(linkRefPayload(recovered.getAsLink())).not.toHaveProperty(
         "cfcLabelView",
       );
     } finally {

--- a/packages/runner/test/link-resolution.test.ts
+++ b/packages/runner/test/link-resolution.test.ts
@@ -3,10 +3,11 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 
+import { linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import { type JSONSchema } from "../src/builder/types.ts";
 import { resolveLink } from "../src/link-resolution.ts";
 import { Runtime } from "../src/runtime.ts";
-import { areNormalizedLinksSame } from "../src/link-utils.ts";
+import { areNormalizedLinksSame, isSigilLink } from "../src/link-utils.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import { parseLink } from "../src/link-utils.ts";
 
@@ -342,8 +343,8 @@ describe("link-resolution", () => {
       );
       const linkData = targetCell.getAsLink();
       // Manually set schema on the link
-      if (linkData["/"] && linkData["/"]["link@1"]) {
-        linkData["/"]["link@1"].schema = schema;
+      if (isSigilLink(linkData)) {
+        linkRefPayload(linkData).schema = schema;
       }
       sourceCell.setRaw({ link: linkData });
       tx.commit();

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -22,6 +22,7 @@ import {
 import { getJSONFromDataURI } from "../src/uri-utils.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { linkRefPayload } from "@commonfabric/data-model/cell-rep";
 import type { JSONSchema } from "../src/builder/types.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -507,7 +508,7 @@ describe("link-utils", () => {
       };
 
       const result = createSigilLinkFromParsedLink(normalizedLink);
-      expect(result["/"][LINK_V1_TAG].scope).toBe("session");
+      expect(linkRefPayload(result).scope).toBe("session");
 
       expect(parseLink(result, {
         id: "of:base",
@@ -571,7 +572,7 @@ describe("link-utils", () => {
         base: baseCell,
       });
 
-      expect(result["/"][LINK_V1_TAG].space).toBeUndefined();
+      expect(linkRefPayload(result).space).toBeUndefined();
     });
 
     it("should omit id when same as base", () => {
@@ -586,7 +587,7 @@ describe("link-utils", () => {
         base: baseCell,
       });
 
-      expect(result["/"][LINK_V1_TAG].id).toBe(`of:${baseId}`);
+      expect(linkRefPayload(result).id).toBe(`of:${baseId}`);
     });
 
     it("should include overwrite field when present", () => {
@@ -598,7 +599,7 @@ describe("link-utils", () => {
 
       const result = createSigilLinkFromParsedLink(normalizedLink);
 
-      expect(result["/"][LINK_V1_TAG].overwrite).toBe("redirect");
+      expect(linkRefPayload(result).overwrite).toBe("redirect");
     });
 
     it("should preserve stream cell schemas by default when including schema", () => {
@@ -625,7 +626,7 @@ describe("link-utils", () => {
         schema,
       }, { includeSchema: true });
 
-      expect(result["/"][LINK_V1_TAG].schema).toEqual(schema);
+      expect(linkRefPayload(result).schema).toEqual(schema);
     });
 
     it("should strip stream cell schemas from links when requested", () => {
@@ -652,7 +653,7 @@ describe("link-utils", () => {
         schema,
       }, { includeSchema: true, keepStreams: false });
 
-      expect(result["/"][LINK_V1_TAG].schema).toEqual({
+      expect(linkRefPayload(result).schema).toEqual({
         type: "object",
         properties: {
           title: { type: "string" },


### PR DESCRIPTION
## What

Four runner test suites reached into the legacy `{ "/": { "link@1": … } }` envelope **structurally** — reading payload fields (`link["/"][LINK_V1_TAG].id`), asserting envelope existence (`link["/"]`), and mutating payloads for setup (`["/"]["link@1"].schema = …`). This routes those through the link chokepoint instead:

- `linkRefPayload(link)` for payload field access (and payload mutation in legacy setup).
- `isSigilLink(link)` for "is this a link" existence checks.

Files: `cell-links.test.ts`, `link-utils.test.ts`, `link-resolution.test.ts`, `cfc-label-view.test.ts`.

## Why

This is the prep step that makes these tests **shape-agnostic in advance**, so the upcoming `FabricLink` flip — which turns `LinkRef` from the envelope-only type into a `FabricLink | { "/": { "link@1": … } }` union — is a localized cell-rep edit rather than a tree-wide change (the same prep→flip rhythm as #4328).

## Scope

**No-op on `main`.** The production runtime already routes all link handling through the chokepoint, so only these tests still named the envelope shape. They pass unchanged in legacy mode. Construction of legacy-envelope literals as test *inputs* is deliberately left as-is — those are legacy-specific parsing/negative tests, exercised with the flag off.

## Testing

- The 4 suites type-check clean and pass (182 steps, 0 failed).
- `deno fmt` / `deno lint` clean.
- Verified sufficient: with the (not-yet-landed) `LinkRef`-union flip applied locally, these files produce **zero** type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes runner link tests through the cell-rep chokepoint to stop touching the legacy `{ "/": { "link@1": … } }` envelope directly and make tests shape-agnostic ahead of the `FabricLink` flip. No behavior change on `main`; tests still pass in legacy mode.

- **Refactors**
  - Replaced direct envelope reads/mutations with `linkRefPayload()` and existence checks with `isSigilLink()`.
  - Updated `cell-links.test.ts`, `link-utils.test.ts`, `link-resolution.test.ts`, `cfc-label-view.test.ts`.
  - Kept legacy-envelope literals only where tests intentionally cover legacy parsing/negative cases.

<sup>Written for commit 3920c6ca6ebc24e4270375dcb5101d9e528e6a15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

