### PR TITLE
Fix compile-cache writeback durability

### DIFF
--- a/packages/piece/test/ensure-default-pattern.test.ts
+++ b/packages/piece/test/ensure-default-pattern.test.ts
@@ -300,15 +300,25 @@ describe("PiecesController.recreateDefaultPattern", () => {
   });
 
   it("should explain storage transaction errors when updating defaultPattern fails", async () => {
+    const originalEditWithRetry = runtime.editWithRetry.bind(runtime);
     const storageError = {
       name: "StorageTransactionAborted" as const,
       message: "commit rejected for test",
       reason: new Error("storage reason"),
     };
-    runtime.editWithRetry = (() =>
-      Promise.resolve({
+    let editWithRetryCalls = 0;
+    runtime.editWithRetry = ((fn, maxRetries) => {
+      editWithRetryCalls++;
+      // recreateDefaultPattern first unlinks any existing default, then cold
+      // compile writes its cache. This test targets the following transaction:
+      // linking the newly-created piece as defaultPattern.
+      if (editWithRetryCalls < 3) {
+        return originalEditWithRetry(fn, maxRetries);
+      }
+      return Promise.resolve({
         error: storageError,
-      })) as typeof runtime.editWithRetry;
+      });
+    }) as typeof runtime.editWithRetry;
 
     try {
       await controller.recreateDefaultPattern({
@@ -324,6 +334,8 @@ describe("PiecesController.recreateDefaultPattern", () => {
         "StorageTransactionAborted",
       );
       expect((error as Error).cause).toBe(storageError);
+    } finally {
+      runtime.editWithRetry = originalEditWithRetry;
     }
   });
 });

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -352,11 +352,12 @@ export function writeSourceDocs(
       undefined,
       tx,
     );
-    // Preserve any product annotations already on this entry doc — a recompile
-    // of identical source (idempotent, content-addressed) must not clobber them.
-    // Annotations are not part of the content identity, so they ride along
-    // verbatim and never perturb verification.
-    const existingAnnotations = cell.get()?.annotations;
+    // Preserve product annotations on the entry doc only. Annotations are only
+    // written there; reading every dependency doc here turns unrelated stale
+    // cache cells into writeback conflict preconditions.
+    const existingAnnotations = identity === entryIdentity
+      ? cell.get()?.annotations
+      : undefined;
     cell.set({
       kind: "source",
       identity,

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -25,9 +25,13 @@ import type {
 } from "./harness/types.ts";
 import { RuntimeProgram } from "./harness/types.ts";
 import type { CachedCompiledModule } from "./sandbox/module-record-compiler.ts";
-import type { IExtendedStorageTransaction } from "./storage/interface.ts";
+import type {
+  CommitError,
+  IExtendedStorageTransaction,
+} from "./storage/interface.ts";
 import {
   COMPILE_CACHE_RUNTIME_VERSION,
+  compiledDocKey,
   loadCompiledClosure,
   loadVerifiedSourceClosure,
   ROOT_LINK_SPECIFIER,
@@ -52,6 +56,14 @@ const logger = getLogger("pattern-manager");
 // namespace).
 const MAX_EVALUATED_MODULE_CACHE_SIZE = 1000;
 const FABRIC_IMPORT_SCAN_TARGET = ts.ScriptTarget.ES2023;
+
+function throwableStorageError(error: CommitError): Error {
+  if (error instanceof Error) return error;
+  return Object.assign(new Error(error.message), {
+    name: error.name,
+    cause: error,
+  });
+}
 
 /**
  * Re-derive a stored module's fabric edges from its SOURCE text (source docs
@@ -146,8 +158,10 @@ export class PatternManager {
   // re-evaluating it in SES. Content-addressed, so a hit is always the same
   // bytes — never stale. Bounded (FIFO) to cap memory.
   private modulesByIdentity = new Map<string, { exports: Exports }>();
-  // In-flight compiled-cache write-backs (fire-and-forget); awaited by
-  // flushCompileCacheWrites() for graceful shutdown / deterministic tests.
+  // In-flight compiled-cache write-backs; awaited by flushCompileCacheWrites()
+  // for graceful shutdown / deterministic tests. Cold compile write-backs are
+  // awaited by compilePattern; recovery/replication paths may still run in the
+  // background.
   private compileCacheWrites = new Set<Promise<unknown>>();
   // The subset of `compileCacheWrites` that are cold-compile closure
   // write-backs. Tracked separately so `replicateClosures` can await them
@@ -455,7 +469,7 @@ export class PatternManager {
    * `cacheCtx.space`. On a warm full hit the per-module compiled bodies are
    * reused (no TypeScript compile / transformer pipeline / SES re-verify); on a
    * miss the program is compiled and its modules are written back (source +
-   * integrity-stamped compiled docs) on a fresh transaction, fire-and-forget.
+   * integrity-stamped compiled docs) on a fresh transaction before returning.
    */
   private async compileViaCellCache(
     program: RuntimeProgram,
@@ -495,8 +509,8 @@ export class PatternManager {
     // Read the cache on a dedicated, owned transaction (used read-only — the
     // load path only reads, and it is aborted below, never committed) so
     // cache-cell reads never enter the caller's transaction (whose commit must
-    // not gain dependencies on, or race, the fire-and-forget write-back), and
-    // so repeated compiles don't accumulate open transactions.
+    // not gain dependencies on the write-back), and so repeated compiles don't
+    // accumulate open transactions.
     const readTx = this.runtime.edit();
 
     let warmHit = false;
@@ -570,9 +584,8 @@ export class PatternManager {
       // guarantees every persisted ref has a durable closure behind it (no
       // race against session end). Cold compiles only; a warm hit means the
       // closure was just READ from storage, i.e. it is already durable. A
-      // failed cache write logs and does not fail the compile: the pattern
-      // works in-session regardless, and the next cold compile of the same
-      // content retries the write.
+      // failed cache write fails the compile: persisted refs-only pattern JSON
+      // would otherwise point at a closure that is not durable in `space`.
       const writeBack = this.writeBackCompileCache(
         space,
         modules,
@@ -583,11 +596,6 @@ export class PatternManager {
       this.pendingCacheWriteBacks.add(writeBack);
       try {
         await writeBack;
-      } catch (error) {
-        logger.warn("compile-cache-write-back-failed", () => [
-          `entry=${entryIdentity}`,
-          String(error),
-        ]);
       } finally {
         this.compileCacheWrites.delete(writeBack);
         this.pendingCacheWriteBacks.delete(writeBack);
@@ -840,7 +848,13 @@ export class PatternManager {
         compiled.modules,
         entryIdentity,
         cacheOpts,
-      );
+      ).catch((error) => {
+        logger.warn("load-pattern-by-identity-writeback-failed", () => [
+          `entry=${entryIdentity}`,
+          `symbol=${symbol}`,
+          String(error),
+        ]);
+      });
       this.compileCacheWrites.add(writeBack);
       this.pendingCacheWriteBacks.add(writeBack);
       writeBack.finally(() => {
@@ -1063,8 +1077,8 @@ export class PatternManager {
    * `space`, on its own transaction, independent of the caller's. Uses
    * `editWithRetry` so a commit conflict (e.g. the cache write racing the
    * pattern's own space writes) retries rather than silently dropping the
-   * entry; a final failure is logged (not thrown) since the cache is an
-   * optimization, never on the correctness path.
+   * entry. A final failure throws because persisted refs-only pattern JSON
+   * requires a durable closure behind every `$patternRef`.
    */
   private async writeBackCompileCache(
     space: MemorySpace,
@@ -1073,6 +1087,7 @@ export class PatternManager {
     opts: { runtimeVersion: string },
   ): Promise<void> {
     const writebackStart = performance.now();
+    await this.syncCompileCacheWriteTargets(space, modules, opts);
     const { error } = await this.runtime.editWithRetry((tx) => {
       writeSourceDocs(this.runtime, space, modules, entryIdentity, tx);
       writeCompiledDocs(this.runtime, space, modules, entryIdentity, opts, tx);
@@ -1083,7 +1098,24 @@ export class PatternManager {
         `entry=${entryIdentity}`,
         error.message,
       ]);
+      throw throwableStorageError(error);
     }
+  }
+
+  private async syncCompileCacheWriteTargets(
+    space: MemorySpace,
+    modules: readonly CacheableModule[],
+    opts: { runtimeVersion: string },
+  ): Promise<void> {
+    await Promise.all(
+      modules.flatMap((module) => [
+        this.runtime.getCell(space, sourceDocKey(module.identity)).sync(),
+        this.runtime.getCell(
+          space,
+          compiledDocKey(opts.runtimeVersion, module.identity),
+        ).sync(),
+      ]),
+    );
   }
 
   // Resolve a Pattern from an evaluate result.

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -93,7 +93,7 @@ const PROGRAM = {
 
 /** Synthesize the engine's `CacheableModule[]` from an authored program. */
 function toModules(
-  program: typeof PROGRAM,
+  program: RuntimeProgram,
 ): { modules: CacheableModule[]; entryIdentity: string } {
   const ids = computeModuleHashes(program);
   const edges = resolveModuleImports(program);
@@ -879,5 +879,61 @@ describe("cell-cache: two-identity shared-space compile cache (e2e)", () => {
     wtxB2.prepareCfc();
     const result = await wtxB2.commit();
     expect(result.error).toBe(undefined);
+  });
+
+  it("cold writeback recovers from a partial source cache already committed by another replica", async () => {
+    const { modules, entryIdentity } = toModules(E2E_PROGRAM);
+    const utilModule = modules.find((module) => module.filename === "/util.ts");
+    expect(utilModule).toBeDefined();
+
+    // A partially committed cache graph: only an imported source doc is present
+    // in the shared space. Runtime B has not pulled it yet, so its local replica
+    // would otherwise build the writeback transaction from a stale seq-0 view.
+    const partialTx = rtA.edit();
+    writeSourceDocs(
+      rtA,
+      sharedSpace,
+      [utilModule!],
+      utilModule!.identity,
+      partialTx,
+    );
+    rtA.prepareTxForCommit(partialTx);
+    const partialResult = await partialTx.commit();
+    expect(partialResult.error).toBe(undefined);
+    await smA.synced();
+
+    const txB = rtB.edit();
+    const compiled = await rtB.patternManager.compilePattern(E2E_PROGRAM, {
+      space: sharedSpace,
+      tx: txB,
+    });
+    await txB.commit();
+    expect(typeof compiled).toBe("function");
+    expect(rtB.patternManager.getCompileCacheStats()).toEqual({
+      hits: 0,
+      misses: 1,
+      byIdentityHits: 0,
+    });
+
+    const readTx = rtB.edit();
+    const source = await loadVerifiedSourceClosure(
+      rtB,
+      sharedSpace,
+      entryIdentity,
+      readTx,
+    );
+    const compiledClosure = await loadCompiledClosure(
+      rtB,
+      sharedSpace,
+      entryIdentity,
+      { runtimeVersion: RTVER },
+      readTx,
+    );
+    readTx.abort?.();
+
+    expect(source?.has(entryIdentity)).toBe(true);
+    expect(source?.has(utilModule!.identity)).toBe(true);
+    expect(compiledClosure.has(entryIdentity)).toBe(true);
+    expect(compiledClosure.has(utilModule!.identity)).toBe(true);
   });
 });

--- a/packages/runner/test/esm-cell-cache-integration.test.ts
+++ b/packages/runner/test/esm-cell-cache-integration.test.ts
@@ -6,11 +6,15 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import type { Engine } from "../src/harness/engine.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
-import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import type {
+  CommitError,
+  IExtendedStorageTransaction,
+} from "../src/storage/interface.ts";
 import {
   COMPILE_CACHE_RUNTIME_VERSION,
   loadCompiledClosure,
   loadVerifiedSourceClosure,
+  writeSourceDocs,
 } from "../src/compilation-cache/cell-cache.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
@@ -79,7 +83,8 @@ describe("ESM compile via content-addressed cell cache", () => {
   it("cold compile writes back, warm compile is a hit, both run correctly", async () => {
     const pm = runtime.patternManager;
 
-    // Cold compile (miss): evaluates correctly and triggers write-back.
+    // Cold compile (miss): evaluates correctly and durably writes back before
+    // returning.
     const cold = await pm.compilePattern(PROGRAM, { space, tx });
     expect(await run(cold, 3)).toEqual({ result: 6 });
     expect(pm.getCompileCacheStats()).toEqual({
@@ -88,7 +93,8 @@ describe("ESM compile via content-addressed cell cache", () => {
       byIdentityHits: 0,
     });
 
-    // Wait for the fire-and-forget write-back to commit.
+    // The write-back is awaited by compilePattern; flushing remains harmless and
+    // keeps the test aligned with other cache paths.
     await pm.flushCompileCacheWrites();
 
     // Warm compile (hit): served from the cache, still evaluates correctly.
@@ -119,6 +125,75 @@ describe("ESM compile via content-addressed cell cache", () => {
     expect(stats.byIdentityHits).toBe(1);
     expect(stats.misses).toBe(1); // only the initial cold compile
     expect(await run(warm, 6)).toEqual({ result: 12 });
+  });
+
+  it("surfaces cold writeback failure instead of returning an unloadable pattern", async () => {
+    const originalEditWithRetry = runtime.editWithRetry.bind(runtime);
+    const failure = {
+      name: "StorageTransactionAborted" as const,
+      message: "forced compile cache writeback failure",
+      reason: "synthetic writeback failure",
+    } satisfies CommitError;
+
+    runtime.editWithRetry =
+      (() =>
+        Promise.resolve({ error: failure })) as typeof runtime.editWithRetry;
+
+    try {
+      let thrown: unknown;
+      try {
+        await runtime.patternManager.compilePattern(PROGRAM, { space, tx });
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as Error).message).toContain(
+        "forced compile cache writeback failure",
+      );
+      expect((thrown as Error & { cause?: unknown }).cause).toBe(failure);
+    } finally {
+      runtime.editWithRetry = originalEditWithRetry;
+    }
+  });
+
+  it("keeps source-free identity recovery best-effort when writeback fails", async () => {
+    const compiled = await (runtime.harness as Engine).compileToRecordGraph(
+      PROGRAM,
+    );
+    const sourceTx = runtime.edit();
+    writeSourceDocs(
+      runtime,
+      space,
+      compiled.modules,
+      compiled.entryIdentity,
+      sourceTx,
+    );
+    runtime.prepareTxForCommit(sourceTx);
+    expect((await sourceTx.commit()).error).toBeUndefined();
+
+    const runtime2 = newRuntime();
+    const originalEditWithRetry = runtime2.editWithRetry.bind(runtime2);
+    const failure = {
+      name: "StorageTransactionAborted" as const,
+      message: "forced identity recovery writeback failure",
+      reason: "synthetic background writeback failure",
+    } satisfies CommitError;
+    runtime2.editWithRetry =
+      (() =>
+        Promise.resolve({ error: failure })) as typeof runtime2.editWithRetry;
+
+    try {
+      const loaded = await runtime2.patternManager.loadPatternByIdentity(
+        compiled.entryIdentity,
+        "default",
+        space,
+      );
+      expect(typeof loaded).toBe("function");
+      await runtime2.patternManager.flushCompileCacheWrites();
+    } finally {
+      runtime2.editWithRetry = originalEditWithRetry;
+      await runtime2.dispose();
+    }
   });
 
   it("warm hit reuses the cached body across a fresh runtime (cross-session)", async () => {


### PR DESCRIPTION
## Why

A cold compile can persist a `$patternRef`, so the compile-cache source and compiled closure must be durably written before returning. If writeback conflicts are swallowed, piece creation can succeed with refs that a fresh runtime cannot load. Spaces with a partial cache graph also need the next writeback to refresh stale cache cells instead of retrying the same stale read until failure.

## What changed

- Propagate final compile-cache writeback errors on the cold compile path.
- Wrap storage result errors as real `Error` instances at the throw site, preserving the storage object as `cause`.
- Refresh source and compiled cache target cells before building the writeback transaction so stale partial cache state can converge.
- Keep background identity-recovery writebacks best-effort by logging failures.
- Avoid dependency-doc annotation reads during source-doc writes; annotations are preserved on the entry doc only.
- Add regression coverage for fatal writeback errors, stale partial-cache recovery, and the affected piece default-pattern error path.

## Tests

- `ENV=test deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git packages/runner/test/esm-cell-cache-integration.test.ts packages/runner/test/cell-cache.test.ts`
- `ENV=test deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git packages/piece/test/ensure-default-pattern.test.ts`
- `cd packages/piece && deno task test`
- `cd packages/runner && deno task test`
- `deno lint packages/runner/src/pattern-manager.ts packages/runner/src/compilation-cache/cell-cache.ts packages/runner/test/cell-cache.test.ts packages/runner/test/esm-cell-cache-integration.test.ts packages/piece/test/ensure-default-pattern.test.ts`
