### PR TITLE
refactor(utils): extract TwoLevelWeakCache; consolidate per-checker memo caches

### DIFF
--- a/packages/schema-generator/src/typescript/cell-brand.ts
+++ b/packages/schema-generator/src/typescript/cell-brand.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { TwoLevelWeakCache } from "@commonfabric/utils/cache";
 import { traverseTypeHierarchy } from "./type-traversal.ts";
 
 export type CellBrand =
@@ -89,9 +90,10 @@ function findCellBrandSymbol(
 // type. Keyed first by checker so a type identity is never read against a
 // foreign checker; the inner WeakMap lets per-program types be collected once
 // their checker is gone.
-const cellBrandCache = new WeakMap<
+const cellBrandCache = new TwoLevelWeakCache<
   ts.TypeChecker,
-  WeakMap<ts.Type, CellBrand | undefined>
+  ts.Type,
+  CellBrand | undefined
 >();
 
 function computeCellBrand(
@@ -117,16 +119,11 @@ export function getCellBrand(
   type: ts.Type,
   checker: ts.TypeChecker,
 ): CellBrand | undefined {
-  let byType = cellBrandCache.get(checker);
-  if (byType === undefined) {
-    byType = new WeakMap();
-    cellBrandCache.set(checker, byType);
-  } else if (byType.has(type)) {
-    return byType.get(type);
-  }
-  const brand = computeCellBrand(type, checker);
-  byType.set(type, brand);
-  return brand;
+  return cellBrandCache.getOrCompute(
+    checker,
+    type,
+    () => computeCellBrand(type, checker),
+  );
 }
 
 export function isCellType(type: ts.Type, checker: ts.TypeChecker): boolean {

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -31,6 +31,7 @@
  */
 import ts from "typescript";
 
+import { TwoLevelWeakCache } from "@commonfabric/utils/cache";
 import { spellingsWhere } from "@commonfabric/schema-generator/wrapper-names";
 import { CF_HELPERS_IDENTIFIER } from "../core/cf-helpers.ts";
 import { isCommonFabricSymbol } from "../core/common-fabric-symbols.ts";
@@ -223,42 +224,21 @@ export type WildcardTraversalCallKind =
   | "object-wildcard-traversal"
   | "json-stringify";
 
-type ExpressionCache<T> = WeakMap<ts.TypeChecker, WeakMap<ts.Expression, T>>;
+// Per-checker memo of expression-level analyses. Keyed first by checker so an
+// expression is never read against a foreign checker; the inner WeakMap lets
+// per-program nodes be collected once their checker is gone. See
+// `TwoLevelWeakCache`.
+type ExpressionCache<T> = TwoLevelWeakCache<ts.TypeChecker, ts.Expression, T>;
 
-const callKindCacheByChecker: ExpressionCache<CallKind | null> = new WeakMap();
+const callKindCacheByChecker: ExpressionCache<CallKind | null> =
+  new TwoLevelWeakCache();
 const directBuilderKindCacheByChecker: ExpressionCache<
   Extract<CallKind, { kind: "builder" }> | null
-> = new WeakMap();
-const reactiveValueCacheByChecker: ExpressionCache<boolean> = new WeakMap();
+> = new TwoLevelWeakCache();
+const reactiveValueCacheByChecker: ExpressionCache<boolean> =
+  new TwoLevelWeakCache();
 const reactiveCollectionProvenanceCacheByChecker: ExpressionCache<boolean> =
-  new WeakMap();
-
-function getCheckerExpressionCache<T>(
-  cacheByChecker: ExpressionCache<T>,
-  checker: ts.TypeChecker,
-): WeakMap<ts.Expression, T> {
-  let cache = cacheByChecker.get(checker);
-  if (!cache) {
-    cache = new WeakMap<ts.Expression, T>();
-    cacheByChecker.set(checker, cache);
-  }
-  return cache;
-}
-
-function getCachedExpressionValue<T>(
-  cacheByChecker: ExpressionCache<T>,
-  checker: ts.TypeChecker,
-  expression: ts.Expression,
-  compute: () => T,
-): T {
-  const cache = getCheckerExpressionCache(cacheByChecker, checker);
-  if (cache.has(expression)) {
-    return cache.get(expression)!;
-  }
-  const value = compute();
-  cache.set(expression, value);
-  return value;
-}
+  new TwoLevelWeakCache();
 
 function usesDefaultReactiveCollectionProvenanceOptions(
   options: ReactiveCollectionProvenanceOptions,
@@ -965,8 +945,7 @@ export function isReactiveValueExpression(
   expression: ts.Expression,
   checker: ts.TypeChecker,
 ): boolean {
-  return getCachedExpressionValue(
-    reactiveValueCacheByChecker,
+  return reactiveValueCacheByChecker.getOrCompute(
     checker,
     expression,
     () => {
@@ -1020,8 +999,7 @@ export function hasReactiveCollectionProvenance(
   options: ReactiveCollectionProvenanceOptions = {},
 ): boolean {
   if (usesDefaultReactiveCollectionProvenanceOptions(options)) {
-    return getCachedExpressionValue(
-      reactiveCollectionProvenanceCacheByChecker,
+    return reactiveCollectionProvenanceCacheByChecker.getOrCompute(
       checker,
       expression,
       () =>
@@ -1296,7 +1274,7 @@ function resolveExpressionKind(
   checker: ts.TypeChecker,
   seen: Set<ts.Symbol>,
 ): CallKind | undefined {
-  const cache = getCheckerExpressionCache(callKindCacheByChecker, checker);
+  const cache = callKindCacheByChecker.innerFor(checker);
   if (cache.has(expression)) {
     return cache.get(expression) ?? undefined;
   }
@@ -1671,7 +1649,7 @@ function resolveBuilderExpressionKind(
 ): Extract<CallKind, { kind: "builder" }> | undefined {
   const cache = options.followFactoryResults
     ? undefined
-    : getCheckerExpressionCache(directBuilderKindCacheByChecker, checker);
+    : directBuilderKindCacheByChecker.innerFor(checker);
   if (cache?.has(expression)) {
     return cache.get(expression) ?? undefined;
   }

--- a/packages/utils/src/cache.ts
+++ b/packages/utils/src/cache.ts
@@ -170,3 +170,55 @@ export class LRUCache<K, V> implements Cache<K, V> {
     this.#removeNode(node);
   }
 }
+
+/**
+ * A memo keyed by a pair of garbage-collectable keys, `(outer, inner)`, with a
+ * `WeakMap` at each level. An entry is reclaimed as soon as either key becomes
+ * unreachable, so the cache never keeps its keys (or the values hanging off
+ * them) alive.
+ *
+ * The canonical use is memoizing a pure function of `(ts.TypeChecker, ts.Type)`
+ * or `(ts.TypeChecker, ts.Expression)` across a compile. Keying by the checker
+ * first means a key minted by one checker is never read against another, and
+ * lets a whole program's entries fall away once its checker is gone — while the
+ * inner `WeakMap` collects individual types/nodes as they themselves die.
+ * Several hot transformer/schema-generation paths share this shape; this is its
+ * one implementation.
+ */
+export class TwoLevelWeakCache<
+  Outer extends object,
+  Inner extends object,
+  V,
+> {
+  readonly #buckets = new WeakMap<Outer, WeakMap<Inner, V>>();
+
+  /**
+   * The inner cache for `outer`, created on first access. Use this when a
+   * single logical entry is read or written from several branches and a single
+   * `getOrCompute` call doesn't fit; operate on the returned map's
+   * `has`/`get`/`set` directly. Both levels stay weak.
+   */
+  innerFor(outer: Outer): WeakMap<Inner, V> {
+    let bucket = this.#buckets.get(outer);
+    if (bucket === undefined) {
+      bucket = new WeakMap<Inner, V>();
+      this.#buckets.set(outer, bucket);
+    }
+    return bucket;
+  }
+
+  /**
+   * Return the cached value for `(outer, inner)`, computing it with `compute`
+   * on the first miss. A stored `undefined` is a real cached result and is not
+   * recomputed — the `has` check distinguishes "cached undefined" from "absent".
+   */
+  getOrCompute(outer: Outer, inner: Inner, compute: () => V): V {
+    const bucket = this.innerFor(outer);
+    if (bucket.has(inner)) {
+      return bucket.get(inner) as V;
+    }
+    const value = compute();
+    bucket.set(inner, value);
+    return value;
+  }
+}

--- a/packages/utils/test/cache.test.ts
+++ b/packages/utils/test/cache.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { LRUCache } from "@commonfabric/utils/cache";
+import { LRUCache, TwoLevelWeakCache } from "@commonfabric/utils/cache";
 
 describe("LRUCache", () => {
   describe("basic operations", () => {
@@ -169,6 +169,85 @@ describe("LRUCache", () => {
       expect(cache.has("b")).toBe(true);
       expect(cache.has("c")).toBe(true);
       expect(cache.has("d")).toBe(true);
+    });
+  });
+});
+
+describe("TwoLevelWeakCache", () => {
+  describe("getOrCompute", () => {
+    it("computes once per (outer, inner) and reuses the result", () => {
+      const cache = new TwoLevelWeakCache<object, object, number>();
+      const outer = {};
+      const inner = {};
+      let calls = 0;
+      const compute = () => {
+        calls++;
+        return 42;
+      };
+
+      expect(cache.getOrCompute(outer, inner, compute)).toBe(42);
+      expect(cache.getOrCompute(outer, inner, compute)).toBe(42);
+      expect(calls).toBe(1);
+    });
+
+    it("caches an undefined result without recomputing", () => {
+      const cache = new TwoLevelWeakCache<object, object, number | undefined>();
+      const outer = {};
+      const inner = {};
+      let calls = 0;
+      const compute = () => {
+        calls++;
+        return undefined;
+      };
+
+      expect(cache.getOrCompute(outer, inner, compute)).toBe(undefined);
+      expect(cache.getOrCompute(outer, inner, compute)).toBe(undefined);
+      expect(calls).toBe(1);
+    });
+
+    it("keys independently on the inner key under one outer", () => {
+      const cache = new TwoLevelWeakCache<object, object, string>();
+      const outer = {};
+      const a = {};
+      const b = {};
+
+      expect(cache.getOrCompute(outer, a, () => "a")).toBe("a");
+      expect(cache.getOrCompute(outer, b, () => "b")).toBe("b");
+      // Re-reading does not collapse to a shared entry.
+      expect(cache.getOrCompute(outer, a, () => "recompute")).toBe("a");
+    });
+
+    it("isolates entries across outer keys for the same inner key", () => {
+      const cache = new TwoLevelWeakCache<object, object, string>();
+      const outerA = {};
+      const outerB = {};
+      const inner = {};
+
+      expect(cache.getOrCompute(outerA, inner, () => "from-a")).toBe("from-a");
+      // Same inner object, different outer: a separate compute, no bleed.
+      expect(cache.getOrCompute(outerB, inner, () => "from-b")).toBe("from-b");
+      expect(cache.getOrCompute(outerA, inner, () => "ignored")).toBe("from-a");
+    });
+  });
+
+  describe("innerFor", () => {
+    it("returns a stable inner map per outer key", () => {
+      const cache = new TwoLevelWeakCache<object, object, number>();
+      const outer = {};
+      expect(cache.innerFor(outer)).toBe(cache.innerFor(outer));
+    });
+
+    it("returns distinct inner maps for distinct outer keys", () => {
+      const cache = new TwoLevelWeakCache<object, object, number>();
+      expect(cache.innerFor({})).not.toBe(cache.innerFor({}));
+    });
+
+    it("shares state with getOrCompute under the same outer key", () => {
+      const cache = new TwoLevelWeakCache<object, object, number>();
+      const outer = {};
+      const inner = {};
+      cache.innerFor(outer).set(inner, 7);
+      expect(cache.getOrCompute(outer, inner, () => 99)).toBe(7);
     });
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #4321. That PR added a per-checker `WeakMap<TypeChecker, WeakMap<Type, Brand>>` memo for `getCellBrand` — correct and self-contained, but it hand-inlined the same two-level checker-keyed cache idiom already implemented **four times** in `ts-transformers`' `ast/call-kind.ts` (`ExpressionCache<T>` + `getCheckerExpressionCache` / `getCachedExpressionValue`). Five copies, two slightly different inline implementations.

This extracts one generic helper and migrates all five onto it:

- **New `TwoLevelWeakCache<Outer extends object, Inner extends object, V>`** in `@commonfabric/utils/cache` — `getOrCompute(outer, inner, compute)` for the memoize sites and `innerFor(outer)` for sites that read/write the inner map across several branches. No `typescript` dependency (generic over object keys), so it lives cleanly in `utils` (dep direction stays `ts-transformers → schema-generator → utils`).
- **`schema-generator/cell-brand.ts`** — `getCellBrand`'s `cellBrandCache` now delegates to the helper.
- **`ts-transformers/ast/call-kind.ts`** — the 4 `*ByChecker` caches use the helper; the inline `getCheckerExpressionCache` / `getCachedExpressionValue` are removed.
- Unit tests for the helper (memoization, `undefined`-caching, inner-key independence, outer-key isolation, stable `innerFor`).

### Notes
- The **two-level checker-keyed** shape is kept deliberately — a single `WeakMap<ts.Type, …>` would be correct (a `ts.Type` is unique to its owning checker), but matching the established `ExpressionCache` idiom and making the choice once is the win.
- Pure refactor: **behavior is unchanged.**

## Test plan
- `deno check` (src) + `deno fmt --check` + `deno lint` on the three packages — clean
- `ts-transformers` unit suite — 299 passed
- `schema-generator` unit suite — 27 passed
- `deno task integration pattern-tests` — 67 passed
- `deno task integration generated-patterns` — 147 passed

Resolves CT-1782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a generic `TwoLevelWeakCache` and migrated five per-checker memo caches to it to remove duplication and keep GC-safe caching; behavior is unchanged. Fulfills CT-1782 by consolidating checker-keyed `WeakMap` memos across `schema-generator` and `ts-transformers`.

- **Refactors**
  - Added `TwoLevelWeakCache<Outer, Inner, V>` to `@commonfabric/utils/cache` with `getOrCompute` and `innerFor`.
  - Replaced per-checker caches in:
    - `schema-generator/src/typescript/cell-brand.ts` (`getCellBrand`).
    - `ts-transformers/src/ast/call-kind.ts` (call kind, direct builder kind, reactive value, reactive collection provenance); removed `getCheckerExpressionCache` and `getCachedExpressionValue`.
  - Added tests for memoization, caching of `undefined`, key isolation, and stable `innerFor`.
  - Kept the two-level checker-keyed shape for consistency; no behavioral changes.

<sup>Written for commit 95658943a3348bb2220ed41a9b53ce11907b0a0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

