### PR TITLE
feat(data-model): dispatch links to FabricLink under modern-cell-rep

### DIFF
--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -10,6 +10,7 @@ import {
   isUnsafeObjectKey,
 } from "@commonfabric/utils/types";
 import { FabricHash } from "@/fabric-primitives/index.ts";
+import { FabricLink } from "@/fabric-instances/FabricLink.ts";
 import type { FabricObject } from "@/interface.ts";
 
 //
@@ -112,40 +113,45 @@ export function entityRefToString(value: EntityRef): string {
 export const LINK_V1_TAG = "link@1" as const;
 
 /**
- * A link reference: today the `{ "/": { "link@1": … } }` envelope wrapping a
- * link payload.
+ * A link reference, wrapping a link payload. Its concrete shape is
+ * flag-dispatched: with the modern cell representation _off_ it is the plain
+ * `{ "/": { "link@1": … } }` envelope; with it _on_ it is a {@link FabricLink}
+ * instance. This is the link analog of {@link EntityRef}'s `{ "/": string }` →
+ * {@link FabricHash}.
  *
  * Construction ({@link linkRefFrom}), recognition ({@link isLinkRef}) and
- * extraction ({@link linkRefPayload}) are gathered here so that this chokepoint
- * can later become the seam at which the modern cell representation dispatches
- * the envelope to a Fabric primitive (provisionally `FabricLink`) — the link
- * analog of {@link EntityRef}'s `{ "/": string }` → {@link FabricHash}. That
- * dispatch is intentionally NOT wired up yet: this pass only collapses the
- * scattered envelope sites onto these functions, so the eventual flag flip is a
- * localized edit here rather than a tree-wide change.
+ * extraction ({@link linkRefPayload}) are gathered here so this chokepoint is
+ * the sole seam that dispatches the representation; everything else stays
+ * shape-agnostic. As with {@link EntityRef}, recognition is strict — it accepts
+ * only the form for the _currently active_ regime, never both.
  *
- * When that dispatch lands, this type becomes a union (`FabricLink | { "/": …
- * }`) mirroring {@link EntityRef}. `Payload` is bounded by {@link FabricObject}
- * (the payload is always a stored/serialized fabric record) but otherwise open,
- * so this layer needn't know the exact field types (URI / MemorySpace /
- * JSONSchema — those stay in `runner`).
+ * `Payload` is bounded by {@link FabricObject} (the payload is always a
+ * stored/serialized fabric record) but otherwise open, so this layer needn't
+ * know the exact field types (URI / MemorySpace / JSONSchema — those stay in
+ * `runner`). In modern mode the payload type is erased: a {@link FabricLink}
+ * holds an unparameterized {@link FabricObject}, just as {@link FabricHash} is
+ * unparameterized on the modern arm of {@link EntityRef}.
  */
-export type LinkRef<Payload extends FabricObject> = {
-  "/": { [LINK_V1_TAG]: Payload };
-};
+export type LinkRef<Payload extends FabricObject> =
+  | FabricLink
+  | { "/": { [LINK_V1_TAG]: Payload } };
 
-/** Wraps a link payload in the link-ref envelope. */
+/** Produces a {@link LinkRef} wrapping `payload` for the active regime. */
 export function linkRefFrom<Payload extends FabricObject>(
   payload: Payload,
 ): LinkRef<Payload> {
-  return { "/": { [LINK_V1_TAG]: payload } };
+  return modernCellRepEnabled
+    ? new FabricLink(payload)
+    : { "/": { [LINK_V1_TAG]: payload } };
 }
 
 /**
- * Recognizes a {@link LinkRef}: the `{ "/": { "link@1": … } }` envelope, no
- * other props.
+ * Recognizes the legacy `{ "/": { "link@1": … } }` envelope (no other props).
+ * Regime-independent: names only the structural form, not the active flag.
  */
-export function isLinkRef(value: unknown): value is LinkRef<FabricObject> {
+function isLegacyLinkEnvelope(
+  value: unknown,
+): value is { "/": { [LINK_V1_TAG]: FabricObject } } {
   return isRecord(value) &&
     Object.keys(value).length === 1 &&
     isRecord(value["/"]) &&
@@ -153,13 +159,28 @@ export function isLinkRef(value: unknown): value is LinkRef<FabricObject> {
 }
 
 /**
+ * Recognizes a {@link LinkRef} for the currently active regime: a
+ * {@link FabricLink} in modern mode, or the `{ "/": { "link@1": … } }` envelope
+ * (no other props) in legacy mode.
+ */
+export function isLinkRef(value: unknown): value is LinkRef<FabricObject> {
+  return modernCellRepEnabled
+    ? value instanceof FabricLink
+    : isLegacyLinkEnvelope(value);
+}
+
+/**
  * Extracts the link payload from a {@link LinkRef}. Throws if the value is not
- * a link reference.
+ * a link reference for the currently active regime.
  */
 export function linkRefPayload<Payload extends FabricObject>(
   value: LinkRef<Payload>,
 ): Payload {
-  if (isLinkRef(value)) return value["/"][LINK_V1_TAG] as Payload;
+  if (modernCellRepEnabled) {
+    if (value instanceof FabricLink) return value.payload as Payload;
+  } else if (isLegacyLinkEnvelope(value)) {
+    return value["/"][LINK_V1_TAG] as Payload;
+  }
   throw new Error("Not a link reference.");
 }
 
@@ -170,15 +191,16 @@ export function linkRefPayload<Payload extends FabricObject>(
  * resolution), so they need not hardcode the layout — or the link tag —
  * themselves.
  *
- * A link is a decomposed plain-object envelope (`{ "/": { "link@1": … } }`), so
- * the recognizable payload sits two segments down at `["/", "link@1"]`. Pair
- * with {@link linkPayloadAtProbe} to interpret whatever is read at
- * `position + linkProbeSubPath()`. This is gathered here alongside the rest of
- * the link chokepoint so that the modern cell representation can later dispatch
- * the layout (an atomic value → an empty sub-path) from a single seam.
+ * The sub-path is flag-dispatched to match the regime's storage layout. In
+ * legacy mode a link is a decomposed plain-object envelope
+ * (`{ "/": { "link@1": … } }`), so the recognizable payload sits two segments
+ * down at `["/", "link@1"]`. In modern mode a link is an atomic {@link FabricLink}
+ * value at the position itself, so the sub-path is empty. Pair with
+ * {@link linkPayloadAtProbe} to interpret whatever is read at
+ * `position + linkProbeSubPath()`.
  */
 export function linkProbeSubPath(): readonly string[] {
-  return ["/", LINK_V1_TAG];
+  return modernCellRepEnabled ? [] : ["/", LINK_V1_TAG];
 }
 
 /**
@@ -186,12 +208,17 @@ export function linkProbeSubPath(): readonly string[] {
  * the link payload if that value denotes a link rooted at `position`, or
  * `undefined` otherwise.
  *
- * The probed value already _is_ the inner payload (the tree walk descended into
- * the envelope), so any record there is the payload.
+ * In legacy mode the probed value already _is_ the inner payload (the tree walk
+ * descended into the envelope), so any record there is the payload. In modern
+ * mode the probed value is the whole {@link FabricLink}, whose payload is
+ * unwrapped via {@link linkRefPayload}.
  */
 export function linkPayloadAtProbe(
   probeValue: unknown,
 ): FabricObject | undefined {
+  if (modernCellRepEnabled) {
+    return isLinkRef(probeValue) ? linkRefPayload(probeValue) : undefined;
+  }
   return isRecord(probeValue) ? probeValue as FabricObject : undefined;
 }
 

--- a/packages/data-model/test/cell-rep.test.ts
+++ b/packages/data-model/test/cell-rep.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
+import { FabricLink } from "@/fabric-instances/FabricLink.ts";
 import {
   type EntityRef,
   entityRefFrom,
@@ -100,7 +101,7 @@ describe("cell-rep entity-id reference", () => {
   });
 });
 
-describe("cell-rep link-ref envelope", () => {
+describe("cell-rep link-ref (legacy envelope form)", () => {
   const PAYLOAD = { id: "of:abc", path: ["x", "y"] };
 
   it('wraps a payload in the `{ "/": { "link@1": … } }` envelope', () => {
@@ -137,7 +138,42 @@ describe("cell-rep link-ref envelope", () => {
   });
 });
 
-describe("cell-rep link storage-tree probe", () => {
+describe("cell-rep link-ref (modern FabricLink form)", () => {
+  const PAYLOAD = { id: "of:abc", path: ["x", "y"] };
+
+  afterEach(() => {
+    resetModernCellRepConfig();
+  });
+
+  it("produces a FabricLink wrapping the payload", () => {
+    setModernCellRepConfig(true);
+    const link = linkRefFrom(PAYLOAD);
+    expect(link).toBeInstanceOf(FabricLink);
+    expect((link as FabricLink).payload).toEqual(PAYLOAD);
+  });
+
+  it("recognizes a FabricLink, not the legacy envelope", () => {
+    setModernCellRepConfig(true);
+    expect(isLinkRef(linkRefFrom(PAYLOAD))).toBe(true);
+    expect(isLinkRef(new FabricLink(PAYLOAD))).toBe(true);
+    // The legacy envelope is the wrong regime's form, so it is NOT recognized.
+    expect(isLinkRef({ "/": { [LINK_V1_TAG]: PAYLOAD } })).toBe(false);
+  });
+
+  it("extracts the payload from a FabricLink", () => {
+    setModernCellRepConfig(true);
+    expect(linkRefPayload(linkRefFrom(PAYLOAD))).toEqual(PAYLOAD);
+    expect(linkRefPayload(new FabricLink(PAYLOAD))).toEqual(PAYLOAD);
+  });
+
+  it("throws extracting from the legacy envelope (wrong regime)", () => {
+    setModernCellRepConfig(true);
+    expect(() => linkRefPayload({ "/": { [LINK_V1_TAG]: PAYLOAD } } as never))
+      .toThrow("Not a link reference");
+  });
+});
+
+describe("cell-rep link storage-tree probe (legacy)", () => {
   const PAYLOAD = { id: "of:abc", path: ["x", "y"] };
 
   it('probes two segments down at ["/", "link@1"]', () => {
@@ -165,6 +201,36 @@ describe("cell-rep link storage-tree probe", () => {
     expect(linkPayloadAtProbe(null)).toBeUndefined();
     expect(linkPayloadAtProbe("redirect")).toBeUndefined();
     expect(linkPayloadAtProbe(42)).toBeUndefined();
+  });
+});
+
+describe("cell-rep link storage-tree probe (modern)", () => {
+  const PAYLOAD = { id: "of:abc", path: ["x", "y"] };
+
+  afterEach(() => {
+    resetModernCellRepConfig();
+  });
+
+  it("probes at the position itself (empty sub-path)", () => {
+    setModernCellRepConfig(true);
+    // A modern link is an atomic value at its position, not a decomposed
+    // envelope, so there is nothing to descend into.
+    expect(linkProbeSubPath()).toEqual([]);
+  });
+
+  it("unwraps a FabricLink read at the probe position", () => {
+    setModernCellRepConfig(true);
+    expect(linkPayloadAtProbe(linkRefFrom(PAYLOAD))).toEqual(PAYLOAD);
+  });
+
+  it("returns undefined for a non-link value at the probe", () => {
+    setModernCellRepConfig(true);
+    // A bare record is the payload in legacy mode, but in modern mode only a
+    // FabricLink denotes a link — plain data and the legacy envelope do not.
+    expect(linkPayloadAtProbe(PAYLOAD)).toBeUndefined();
+    expect(linkPayloadAtProbe({ "/": { [LINK_V1_TAG]: PAYLOAD } }))
+      .toBeUndefined();
+    expect(linkPayloadAtProbe(undefined)).toBeUndefined();
   });
 });
 

--- a/packages/runner/test/link-rep-wedge.test.ts
+++ b/packages/runner/test/link-rep-wedge.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { FabricLink } from "@commonfabric/data-model/fabric-instances";
+import {
+  isLinkRef,
+  linkRefPayload,
+  resetModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
+import { Runtime } from "../src/runtime.ts";
+
+const signer = await Identity.fromPassphrase("link-rep wedge");
+const space = signer.did();
+
+/**
+ * Exercises the modern-cell-rep flag end to end at the link boundary: the
+ * representation a `Cell` hands out for `getAsLink`, and — crucially — that a
+ * link written into storage round-trips and still resolves. In modern mode a
+ * link is a {@link FabricLink} instance stored as one atomic leaf, so the
+ * storage path-walk that link resolution relies on must find it without the
+ * legacy `{ "/": { "link@1": … } }` sub-tree to descend into.
+ */
+describe("modern-cell-rep link wedge", () => {
+  afterEach(() => {
+    // Runtime.dispose already resets, but guard against an early failure that
+    // skips disposal from leaking the flag into the next test.
+    resetModernCellRepConfig();
+  });
+
+  /** Runs `fn` against a runtime built in the requested regime. */
+  async function withRuntime(
+    modernCellRep: boolean,
+    fn: (runtime: Runtime) => Promise<void>,
+  ): Promise<void> {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { modernCellRep },
+    });
+    try {
+      await fn(runtime);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  }
+
+  it("flag ON: getAsLink() produces a FabricLink", async () => {
+    await withRuntime(true, async (runtime) => {
+      const tx = runtime.edit();
+      const cell = runtime.getCell<{ value: number }>(
+        space,
+        "wedge-shape",
+        undefined,
+        tx,
+      );
+      cell.set({ value: 42 });
+
+      const link = cell.getAsLink();
+      expect(link).toBeInstanceOf(FabricLink);
+      expect(isLinkRef(link)).toBe(true);
+      expect(linkRefPayload(link).id).toMatch(/^of:/);
+
+      await tx.commit();
+    });
+  });
+
+  it("flag OFF: getAsLink() produces the legacy envelope", async () => {
+    await withRuntime(false, async (runtime) => {
+      const tx = runtime.edit();
+      const cell = runtime.getCell<{ value: number }>(
+        space,
+        "wedge-shape",
+        undefined,
+        tx,
+      );
+      cell.set({ value: 42 });
+
+      const link = cell.getAsLink();
+      expect(link).not.toBeInstanceOf(FabricLink);
+      expect(isLinkRef(link)).toBe(true);
+      expect(linkRefPayload(link).id).toMatch(/^of:/);
+
+      await tx.commit();
+    });
+  });
+
+  it("flag ON: a stored FabricLink round-trips and resolves through storage", async () => {
+    await withRuntime(true, async (runtime) => {
+      const tx = runtime.edit();
+      const target = runtime.getCell<string>(
+        space,
+        "wedge-target",
+        undefined,
+        tx,
+      );
+      target.set("linked content");
+      const source = runtime.getCell<string>(
+        space,
+        "wedge-source",
+        undefined,
+        tx,
+      );
+      // The source cell's value is a link to the target.
+      source.set(target);
+      await tx.commit();
+
+      const readTx = runtime.edit();
+      const sourceRead = runtime.getCell<string>(
+        space,
+        "wedge-source",
+        undefined,
+        readTx,
+      );
+      // The stored value decodes back to a FabricLink (an atomic leaf), not a
+      // decomposed envelope.
+      expect(sourceRead.getRawUntyped()).toBeInstanceOf(FabricLink);
+      // Reading through follows the link — proving link resolution finds and
+      // dereferences a modern FabricLink in the storage tree.
+      expect(sourceRead.get()).toBe("linked content");
+      readTx.abort();
+    });
+  });
+});


### PR DESCRIPTION
## What

Flips the link chokepoint to dispatch on the modern-cell-rep flag, mirroring the `EntityRef → FabricHash` wiring exactly:

- `LinkRef<Payload>` becomes a `FabricLink | { "/": { "link@1": … } }` union.
- `linkRefFrom` / `isLinkRef` / `linkRefPayload` + the two probe helpers (`linkProbeSubPath` / `linkPayloadAtProbe`) all dispatch on `modernCellRepEnabled` — modern mode produces/recognizes a `FabricLink` instance; legacy keeps the plain-object envelope.
- A private `isLegacyLinkEnvelope` keeps `isLinkRef`'s and `linkRefPayload`'s legacy arms from drifting.

This is the payoff of the two prep PRs (#4328 link-resolution → chokepoint, #4331 link tests → chokepoint): the flip is a localized data-model edit.

## Flag OFF — no-op, CI-green

- **Whole workspace type-checks clean.** The runtime already routes every link through the chokepoint, so making `LinkRef` a union surfaces zero production changes.
- **Runner unit suite: 666 passed, 0 failed.**
- `deno fmt` / `deno lint` clean.

## Flag ON — in-process works; real transport is a known gap

- **In-process (`emulate`): works end to end.** New `link-rep-wedge.test.ts` stores a `FabricLink`, reads it back as a `FabricLink` atomic leaf, and resolves through it. `cell-rep.test.ts` gains modern-mode coverage for the four dispatched functions.
- **Real memory-server transport: not yet.** `array_push` passes on baseline but fails with the flag on ("Pattern result did not materialize expected arrays"). The delta is the **wire**: `emulate` keeps values as live instances, whereas the real transport JSON-serializes them, and a modern `FabricLink` doesn't yet survive that round-trip as a recognizable link. This is the next follow-on (under investigation).

Flag-OFF CI is unaffected — the integration test reads `EXPERIMENTAL_MODERN_CELL_REP` and runs legacy by default.

## Scope note

Per the agreed plan, this lands the basic structure for the flip with flag-off green; full flag-on parity (wire serialization across the memory transport) is explicitly deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Coverage Baseline

We blithely accept the 2 additional uncovered lines.

NEW_COVERAGE_BASELINE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dispatches link references to `FabricLink` under the `modern-cell-rep` flag, mirroring the `EntityRef` → `FabricHash` path. Flag off remains unchanged.

- **New Features**
  - `LinkRef<Payload>` is now `FabricLink | { "/": { "link@1": … } }`, selected by `modernCellRepEnabled`.
  - `linkRefFrom`, `isLinkRef`, `linkRefPayload`, `linkProbeSubPath`, and `linkPayloadAtProbe` all dispatch on the flag; modern treats links as atomic `FabricLink` values (empty probe sub-path), legacy keeps the envelope with `["/", "link@1"]`.
  - Adds a private `isLegacyLinkEnvelope` to keep legacy detection consistent.
  - Tests: new runner wedge test verifies end-to-end `FabricLink` storage/resolve in-process; modern-mode coverage added to `cell-rep.test.ts`.

- **Migration**
  - No changes needed with the flag off; CI stays green.
  - To try modern mode, enable `EXPERIMENTAL_MODERN_CELL_REP` (or pass the runtime’s `experimental.modernCellRep` option).
  - Known gap: memory-server transport does not yet round-trip `FabricLink` via JSON; in-process (`emulate`) works.

<sup>Written for commit ac45925f90136220791bb72f3619cdb6f21abdd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

