### PR TITLE
refactor(utils): extract a shared two-level per-checker memo cache

### DIFF
--- a/packages/schema-generator/src/typescript/cell-brand.ts
+++ b/packages/schema-generator/src/typescript/cell-brand.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { TwoLevelWeakCache } from "@commonfabric/utils/two-level-weak-cache";
 import { traverseTypeHierarchy } from "./type-traversal.ts";
 
 export type CellBrand =
@@ -85,13 +86,12 @@ function findCellBrandSymbol(
 // A type's cell brand is invariant: it depends only on the type's own shape,
 // which is fixed within the checker that owns the type. The transformer and
 // schema-generation pipelines query the same types tens of thousands of times,
-// so the hierarchy walk and `getPropertiesOfType` lookups below are cached per
-// type. Keyed first by checker so a type identity is never read against a
-// foreign checker; the inner WeakMap lets per-program types be collected once
-// their checker is gone.
-const cellBrandCache = new WeakMap<
+// so the hierarchy walk and `getPropertiesOfType` lookups below are memoized per
+// (checker, type).
+const cellBrandCache = new TwoLevelWeakCache<
   ts.TypeChecker,
-  WeakMap<ts.Type, CellBrand | undefined>
+  ts.Type,
+  CellBrand | undefined
 >();
 
 function computeCellBrand(
@@ -117,16 +117,11 @@ export function getCellBrand(
   type: ts.Type,
   checker: ts.TypeChecker,
 ): CellBrand | undefined {
-  let byType = cellBrandCache.get(checker);
-  if (byType === undefined) {
-    byType = new WeakMap();
-    cellBrandCache.set(checker, byType);
-  } else if (byType.has(type)) {
-    return byType.get(type);
-  }
-  const brand = computeCellBrand(type, checker);
-  byType.set(type, brand);
-  return brand;
+  return cellBrandCache.memoize(
+    checker,
+    type,
+    () => computeCellBrand(type, checker),
+  );
 }
 
 export function isCellType(type: ts.Type, checker: ts.TypeChecker): boolean {

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -32,6 +32,7 @@
 import ts from "typescript";
 
 import { spellingsWhere } from "@commonfabric/schema-generator/wrapper-names";
+import { TwoLevelWeakCache } from "@commonfabric/utils/two-level-weak-cache";
 import { CF_HELPERS_IDENTIFIER } from "../core/cf-helpers.ts";
 import { isCommonFabricSymbol } from "../core/common-fabric-symbols.ts";
 import { getEnclosingFunctionLikeDeclaration } from "./function-predicates.ts";
@@ -223,42 +224,15 @@ export type WildcardTraversalCallKind =
   | "object-wildcard-traversal"
   | "json-stringify";
 
-type ExpressionCache<T> = WeakMap<ts.TypeChecker, WeakMap<ts.Expression, T>>;
+type ExpressionCache<T> = TwoLevelWeakCache<ts.TypeChecker, ts.Expression, T>;
 
-const callKindCacheByChecker: ExpressionCache<CallKind | null> = new WeakMap();
-const directBuilderKindCacheByChecker: ExpressionCache<
+const callKindCache: ExpressionCache<CallKind | null> = new TwoLevelWeakCache();
+const directBuilderKindCache: ExpressionCache<
   Extract<CallKind, { kind: "builder" }> | null
-> = new WeakMap();
-const reactiveValueCacheByChecker: ExpressionCache<boolean> = new WeakMap();
-const reactiveCollectionProvenanceCacheByChecker: ExpressionCache<boolean> =
-  new WeakMap();
-
-function getCheckerExpressionCache<T>(
-  cacheByChecker: ExpressionCache<T>,
-  checker: ts.TypeChecker,
-): WeakMap<ts.Expression, T> {
-  let cache = cacheByChecker.get(checker);
-  if (!cache) {
-    cache = new WeakMap<ts.Expression, T>();
-    cacheByChecker.set(checker, cache);
-  }
-  return cache;
-}
-
-function getCachedExpressionValue<T>(
-  cacheByChecker: ExpressionCache<T>,
-  checker: ts.TypeChecker,
-  expression: ts.Expression,
-  compute: () => T,
-): T {
-  const cache = getCheckerExpressionCache(cacheByChecker, checker);
-  if (cache.has(expression)) {
-    return cache.get(expression)!;
-  }
-  const value = compute();
-  cache.set(expression, value);
-  return value;
-}
+> = new TwoLevelWeakCache();
+const reactiveValueCache: ExpressionCache<boolean> = new TwoLevelWeakCache();
+const reactiveCollectionProvenanceCache: ExpressionCache<boolean> =
+  new TwoLevelWeakCache();
 
 function usesDefaultReactiveCollectionProvenanceOptions(
   options: ReactiveCollectionProvenanceOptions,
@@ -965,8 +939,7 @@ export function isReactiveValueExpression(
   expression: ts.Expression,
   checker: ts.TypeChecker,
 ): boolean {
-  return getCachedExpressionValue(
-    reactiveValueCacheByChecker,
+  return reactiveValueCache.memoize(
     checker,
     expression,
     () => {
@@ -1020,8 +993,7 @@ export function hasReactiveCollectionProvenance(
   options: ReactiveCollectionProvenanceOptions = {},
 ): boolean {
   if (usesDefaultReactiveCollectionProvenanceOptions(options)) {
-    return getCachedExpressionValue(
-      reactiveCollectionProvenanceCacheByChecker,
+    return reactiveCollectionProvenanceCache.memoize(
       checker,
       expression,
       () =>
@@ -1296,7 +1268,7 @@ function resolveExpressionKind(
   checker: ts.TypeChecker,
   seen: Set<ts.Symbol>,
 ): CallKind | undefined {
-  const cache = getCheckerExpressionCache(callKindCacheByChecker, checker);
+  const cache = callKindCache.groupFor(checker);
   if (cache.has(expression)) {
     return cache.get(expression) ?? undefined;
   }
@@ -1671,7 +1643,7 @@ function resolveBuilderExpressionKind(
 ): Extract<CallKind, { kind: "builder" }> | undefined {
   const cache = options.followFactoryResults
     ? undefined
-    : getCheckerExpressionCache(directBuilderKindCacheByChecker, checker);
+    : directBuilderKindCache.groupFor(checker);
   if (cache?.has(expression)) {
     return cache.get(expression) ?? undefined;
   }

--- a/packages/utils/deno.json
+++ b/packages/utils/deno.json
@@ -25,6 +25,7 @@
     "./sandbox-contract": "./src/sandbox-contract.ts",
     "./sleep": "./src/sleep.ts",
     "./strip-undefined-props": "./src/strip-undefined-props.ts",
+    "./two-level-weak-cache": "./src/two-level-weak-cache.ts",
     "./types": "./src/types.ts",
     "./utf8": "./src/utf8.ts",
     "./zod-utils": "./src/zod-utils.ts"

--- a/packages/utils/src/two-level-weak-cache.ts
+++ b/packages/utils/src/two-level-weak-cache.ts
@@ -1,0 +1,49 @@
+/**
+ * A memo cache keyed in two levels, with both levels held weakly.
+ *
+ * The outer key groups entries; the inner key identifies a value within that
+ * group. Both levels are WeakMaps, so a whole group is collected once its outer
+ * key is unreachable, and an individual entry is collected once its inner key is
+ * unreachable while the group is still alive.
+ *
+ * The TypeScript pipelines use this to memoize a fact derived from a `ts.Type`
+ * or AST node — a type's cell brand, a call's kind — against the
+ * `ts.TypeChecker` that owns it. The fact depends only on the inner key's shape
+ * within its checker, so keying by the checker first keeps a value from ever
+ * being read against a foreign checker.
+ *
+ * Stored values may be `undefined`. Presence is tracked with `WeakMap.has`, so a
+ * computed `undefined` is cached and not recomputed.
+ */
+export class TwoLevelWeakCache<
+  Outer extends WeakKey,
+  Key extends WeakKey,
+  Value,
+> {
+  readonly #groups = new WeakMap<Outer, WeakMap<Key, Value>>();
+
+  /** The inner map for `outer`, created empty on first access. */
+  groupFor(outer: Outer): WeakMap<Key, Value> {
+    let group = this.#groups.get(outer);
+    if (group === undefined) {
+      group = new WeakMap<Key, Value>();
+      this.#groups.set(outer, group);
+    }
+    return group;
+  }
+
+  /**
+   * The value stored for (`outer`, `key`), computing and storing it on the first
+   * request. `compute` runs at most once per distinct (`outer`, `key`) pair; a
+   * computed `undefined` is cached like any other value.
+   */
+  memoize(outer: Outer, key: Key, compute: () => Value): Value {
+    const group = this.groupFor(outer);
+    if (group.has(key)) {
+      return group.get(key) as Value;
+    }
+    const value = compute();
+    group.set(key, value);
+    return value;
+  }
+}

--- a/packages/utils/test/two-level-weak-cache.test.ts
+++ b/packages/utils/test/two-level-weak-cache.test.ts
@@ -1,0 +1,93 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { TwoLevelWeakCache } from "@commonfabric/utils/two-level-weak-cache";
+
+describe("TwoLevelWeakCache", () => {
+  describe("memoize", () => {
+    it("computes once per (outer, key) pair", () => {
+      const cache = new TwoLevelWeakCache<object, object, number>();
+      const outer = {};
+      const key = {};
+      let calls = 0;
+      const compute = () => {
+        calls++;
+        return 42;
+      };
+
+      expect(cache.memoize(outer, key, compute)).toBe(42);
+      expect(cache.memoize(outer, key, compute)).toBe(42);
+      expect(calls).toBe(1);
+    });
+
+    it("returns the same reference on a cache hit", () => {
+      const cache = new TwoLevelWeakCache<object, object, object>();
+      const outer = {};
+      const key = {};
+      const value = {};
+
+      const first = cache.memoize(outer, key, () => value);
+      const second = cache.memoize(outer, key, () => ({}));
+      expect(first).toBe(value);
+      expect(second).toBe(value);
+    });
+
+    it("caches a computed undefined and does not recompute", () => {
+      const cache = new TwoLevelWeakCache<object, object, number | undefined>();
+      const outer = {};
+      const key = {};
+      let calls = 0;
+      const compute = () => {
+        calls++;
+        return undefined;
+      };
+
+      expect(cache.memoize(outer, key, compute)).toBe(undefined);
+      expect(cache.memoize(outer, key, compute)).toBe(undefined);
+      expect(calls).toBe(1);
+    });
+
+    it("keeps entries separate per outer key", () => {
+      const cache = new TwoLevelWeakCache<object, object, string>();
+      const outerA = {};
+      const outerB = {};
+      const key = {};
+
+      expect(cache.memoize(outerA, key, () => "a")).toBe("a");
+      // Same inner key, different outer key: a distinct entry, not the cached "a".
+      expect(cache.memoize(outerB, key, () => "b")).toBe("b");
+      expect(cache.memoize(outerA, key, () => "ignored")).toBe("a");
+    });
+
+    it("keeps entries separate per inner key within an outer", () => {
+      const cache = new TwoLevelWeakCache<object, object, string>();
+      const outer = {};
+      const keyA = {};
+      const keyB = {};
+
+      expect(cache.memoize(outer, keyA, () => "a")).toBe("a");
+      expect(cache.memoize(outer, keyB, () => "b")).toBe("b");
+      expect(cache.memoize(outer, keyA, () => "ignored")).toBe("a");
+    });
+  });
+
+  describe("groupFor", () => {
+    it("returns the same inner map across calls for one outer key", () => {
+      const cache = new TwoLevelWeakCache<object, object, number>();
+      const outer = {};
+      expect(cache.groupFor(outer)).toBe(cache.groupFor(outer));
+    });
+
+    it("returns distinct inner maps for distinct outer keys", () => {
+      const cache = new TwoLevelWeakCache<object, object, number>();
+      expect(cache.groupFor({})).not.toBe(cache.groupFor({}));
+    });
+
+    it("shares storage with memoize", () => {
+      const cache = new TwoLevelWeakCache<object, object, number>();
+      const outer = {};
+      const key = {};
+      cache.groupFor(outer).set(key, 7);
+      expect(cache.memoize(outer, key, () => 99)).toBe(7);
+    });
+  });
+});


### PR DESCRIPTION
The TypeScript pipelines memoize facts derived from a type or AST node against the TypeChecker that owns them. A fact depends only on the key's shape within its checker, so it is safe to cache per (checker, key). Five caches had each hand-rolled the same two-level `WeakMap<TypeChecker, WeakMap<Key, Value>>`: four in the transformer's call-kind detection (call kind, direct builder kind, reactive value, and reactive-collection provenance) and one in the schema generator's cell brand lookup. Each repeated the get-or-create of the inner map and the has/get/set memoization, and the call-kind copies additionally shared a local `ExpressionCache` type plus two helper functions.

Introduce a generic `TwoLevelWeakCache<Outer, Key, Value>` in @commonfabric/utils that owns the two-level structure. It exposes `memoize(outer, key, compute)` for the common compute-once case and `groupFor(outer)` for callers that cache at several interleaved return points — the two recursive call-kind resolvers, which also cache conditionally and so need the raw inner map. Both levels stay weak, so a whole group is collected once its checker is gone and individual entries are collected with their keys. Presence is tracked with `has`, so a memoized `undefined` is cached and not recomputed.

The helper is generic over both key levels rather than typed to `ts.TypeChecker`, which keeps @commonfabric/utils free of a typescript dependency; the consumers pin the concrete types at construction. Both key levels are constrained to `WeakKey`, matching `WeakMap`'s own bound. Behavior at all five sites is unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared two-level weak memo cache and replaced five hand-rolled per-checker caches in the TypeScript pipelines. Behavior is unchanged, with less duplication and the same memory safety.

- **Refactors**
  - Added `@commonfabric/utils/two-level-weak-cache` providing `TwoLevelWeakCache<Outer, Key, Value>` with `memoize` and `groupFor`.
  - Swapped in the utility for caches in call-kind detection and cell-brand lookup.
  - Exported the module in `@commonfabric/utils` and added unit tests.
  - Both levels are weak; `undefined` is cached; grouping by checker prevents cross-checker reads.

<sup>Written for commit f00f80f25e49623af52533677cf5f53adedae4ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

