### PR TITLE
Rename FabricValue type FabricObject -> FabricPlainObject

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -117,17 +117,17 @@ export declare const FabricHash: FabricHashConstructor;
 
 /**
  * The modern, object-shaped form of a link reference, wrapping the link's
- * addressing payload (a `FabricObject`: its addressing fields plus an optional
+ * addressing payload (a `FabricPlainObject`: its addressing fields plus an optional
  * `schema`). Extends `FabricInstance` (not `FabricPrimitive`): the payload is an
  * outgoing reference (it may carry an arbitrary-`FabricValue` `schema`), so a
  * link is a small object graph, not a leaf.
  */
 export interface FabricLink extends FabricInstance {
-  readonly payload: FabricObject;
+  readonly payload: FabricPlainObject;
 }
 
 export interface FabricLinkConstructor {
-  new (payload: FabricObject): FabricLink;
+  new (payload: FabricPlainObject): FabricLink;
   prototype: FabricLink;
 }
 
@@ -144,14 +144,14 @@ export type FabricValue =
   | bigint
   | FabricSpecialObject
   | FabricArray
-  | FabricObject
+  | FabricPlainObject
   | undefined;
 
 /** An array of fabric values. */
 export interface FabricArray extends ArrayLike<FabricValue> {}
 
 /** An object/record of fabric values. */
-export interface FabricObject extends Record<string, FabricValue> {}
+export interface FabricPlainObject extends Record<string, FabricValue> {}
 
 // ============================================================================
 // Runtime Constants

--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -11,7 +11,7 @@ import {
 } from "@commonfabric/utils/types";
 import { FabricHash } from "@/fabric-primitives/index.ts";
 import { FabricLink } from "@/fabric-instances/FabricLink.ts";
-import type { FabricObject } from "@/interface.ts";
+import type { FabricPlainObject } from "@/interface.ts";
 
 //
 // Configuration flags
@@ -125,19 +125,19 @@ export const LINK_V1_TAG = "link@1" as const;
  * shape-agnostic. As with {@link EntityRef}, recognition is strict — it accepts
  * only the form for the _currently active_ regime, never both.
  *
- * `Payload` is bounded by {@link FabricObject} (the payload is always a
+ * `Payload` is bounded by {@link FabricPlainObject} (the payload is always a
  * stored/serialized fabric record) but otherwise open, so this layer needn't
  * know the exact field types (URI / MemorySpace / JSONSchema — those stay in
  * `runner`). In modern mode the payload type is erased: a {@link FabricLink}
- * holds an unparameterized {@link FabricObject}, just as {@link FabricHash} is
+ * holds an unparameterized {@link FabricPlainObject}, just as {@link FabricHash} is
  * unparameterized on the modern arm of {@link EntityRef}.
  */
-export type LinkRef<Payload extends FabricObject> =
+export type LinkRef<Payload extends FabricPlainObject> =
   | FabricLink
   | { "/": { [LINK_V1_TAG]: Payload } };
 
 /** Produces a {@link LinkRef} wrapping `payload` for the active regime. */
-export function linkRefFrom<Payload extends FabricObject>(
+export function linkRefFrom<Payload extends FabricPlainObject>(
   payload: Payload,
 ): LinkRef<Payload> {
   return modernCellRepEnabled
@@ -151,7 +151,7 @@ export function linkRefFrom<Payload extends FabricObject>(
  */
 function isLegacyLinkEnvelope(
   value: unknown,
-): value is { "/": { [LINK_V1_TAG]: FabricObject } } {
+): value is { "/": { [LINK_V1_TAG]: FabricPlainObject } } {
   return isRecord(value) &&
     Object.keys(value).length === 1 &&
     isRecord(value["/"]) &&
@@ -163,7 +163,7 @@ function isLegacyLinkEnvelope(
  * {@link FabricLink} in modern mode, or the `{ "/": { "link@1": … } }` envelope
  * (no other props) in legacy mode.
  */
-export function isLinkRef(value: unknown): value is LinkRef<FabricObject> {
+export function isLinkRef(value: unknown): value is LinkRef<FabricPlainObject> {
   return modernCellRepEnabled
     ? value instanceof FabricLink
     : isLegacyLinkEnvelope(value);
@@ -173,7 +173,7 @@ export function isLinkRef(value: unknown): value is LinkRef<FabricObject> {
  * Extracts the link payload from a {@link LinkRef}. Throws if the value is not
  * a link reference for the currently active regime.
  */
-export function linkRefPayload<Payload extends FabricObject>(
+export function linkRefPayload<Payload extends FabricPlainObject>(
   value: LinkRef<Payload>,
 ): Payload {
   if (modernCellRepEnabled) {
@@ -215,11 +215,11 @@ export function linkProbeSubPath(): readonly string[] {
  */
 export function linkPayloadAtProbe(
   probeValue: unknown,
-): FabricObject | undefined {
+): FabricPlainObject | undefined {
   if (modernCellRepEnabled) {
     return isLinkRef(probeValue) ? linkRefPayload(probeValue) : undefined;
   }
-  return isRecord(probeValue) ? probeValue as FabricObject : undefined;
+  return isRecord(probeValue) ? probeValue as FabricPlainObject : undefined;
 }
 
 //

--- a/packages/data-model/src/fabric-instances/FabricLink.ts
+++ b/packages/data-model/src/fabric-instances/FabricLink.ts
@@ -6,7 +6,7 @@ import { isPlainObject, isUnsafeObjectKey } from "@commonfabric/utils/types";
 
 import {
   DEEP_FREEZE,
-  type FabricObject,
+  type FabricPlainObject,
   type FabricValue,
   IS_DEEP_FROZEN,
 } from "@/interface.ts";
@@ -25,7 +25,7 @@ import { ProblematicValue } from "./ProblematicValue.ts";
 /**
  * A link value in the fabric type system: the modern, object-shaped form of a
  * `{ "/": { "link@1": … } }` link reference. It wraps the link's payload — a
- * {@link FabricObject} of addressing fields (`id`, `space`, `scope`, `path`,
+ * {@link FabricPlainObject} of addressing fields (`id`, `space`, `scope`, `path`,
  * `overwrite`) plus an optional `schema` — as its sole nested value. The
  * data-model layer does not constrain the field set; that is a consumer concern
  * (e.g. runner's `CellLinkRefPayload`).
@@ -39,7 +39,7 @@ import { ProblematicValue } from "./ProblematicValue.ts";
  */
 export class FabricLink extends BaseFabricInstance implements ApiFabricLink {
   /** The wrapped addressing payload (this link's sole outgoing reference). */
-  #payload: FabricObject;
+  #payload: FabricPlainObject;
 
   /**
    * Constructs a `FabricLink` wrapping `payload`. The payload must be a plain
@@ -50,7 +50,7 @@ export class FabricLink extends BaseFabricInstance implements ApiFabricLink {
    *
    * @param payload - The addressing payload to wrap.
    */
-  constructor(payload: FabricObject) {
+  constructor(payload: FabricPlainObject) {
     super();
     assertValidPayload(payload);
     this.#payload = payload;
@@ -61,7 +61,7 @@ export class FabricLink extends BaseFabricInstance implements ApiFabricLink {
   //
 
   /** The wrapped addressing payload. */
-  get payload(): FabricObject {
+  get payload(): FabricPlainObject {
     return this.#payload;
   }
 
@@ -99,7 +99,7 @@ export class FabricLink extends BaseFabricInstance implements ApiFabricLink {
     // structure with the original; already-deep-frozen subtrees are shared).
     const payload = cloneIfNecessary(this.#payload, {
       frozen,
-    }) as FabricObject;
+    }) as FabricPlainObject;
     const result = new FabricLink(payload);
     return frozen ? deepFreeze(result) as FabricLink : result;
   }
@@ -130,7 +130,7 @@ export class FabricLink extends BaseFabricInstance implements ApiFabricLink {
         // The constructor validates the shape and throws on any violation, so
         // bad state falls into the `catch`.
         try {
-          const result = new FabricLink(state as FabricObject);
+          const result = new FabricLink(state as FabricPlainObject);
           return context.shouldDeepFreeze ? deepFreeze(result) : result;
         } catch (e) {
           return new ProblematicValue(
@@ -150,13 +150,13 @@ export class FabricLink extends BaseFabricInstance implements ApiFabricLink {
 }
 
 /**
- * Validates that `payload` is a well-formed {@link FabricObject}: a plain
+ * Validates that `payload` is a well-formed {@link FabricPlainObject}: a plain
  * object with no prototype-pollution keys. Throws otherwise. (Values are
  * arbitrary `FabricValue`s and are not constrained here.)
  */
 function assertValidPayload(
-  payload: FabricObject,
-): asserts payload is FabricObject {
+  payload: FabricPlainObject,
+): asserts payload is FabricPlainObject {
   if (!isPlainObject(payload)) {
     throw new Error("Link payload must be a plain object.");
   }

--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -5,7 +5,7 @@ export {
   type FabricArray,
   FabricInstance,
   type FabricNativeObject,
-  type FabricObject,
+  type FabricPlainObject,
   FabricPrimitive,
   FabricSpecialObject,
   type FabricValue,

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -197,7 +197,7 @@ export type FabricValue =
   | FabricSpecialObject
   // -- Containers --
   | FabricArray
-  | FabricObject
+  | FabricPlainObject
   // -- undefined --
   | undefined;
 
@@ -212,7 +212,7 @@ export interface FabricArray extends ArrayLike<FabricValue> {}
  * If prototype pollution becomes a concern, add boundary validation where
  * values enter the fabric system (e.g., `fabricFromNativeValue()`).
  */
-export interface FabricObject extends Record<string, FabricValue> {}
+export interface FabricPlainObject extends Record<string, FabricValue> {}
 
 /**
  * Single "layer" of fabric conversion -- the result of shallow conversion

--- a/packages/data-model/src/type-check.ts
+++ b/packages/data-model/src/type-check.ts
@@ -2,7 +2,7 @@ import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
 import { type Immutable, isPlainObject } from "@commonfabric/utils/types";
 
 import {
-  type FabricObject,
+  type FabricPlainObject,
   FabricSpecialObject,
   type FabricValue,
   type FabricValueLayer,
@@ -60,19 +60,19 @@ export function isFabricValueLayer(
 }
 
 /**
- * Narrows to the plain-record arm of `FabricValue` (`FabricObject`): an object
+ * Narrows to the plain-record arm of `FabricValue` (`FabricPlainObject`): an object
  * whose prototype is `Object.prototype` or `null`. This rejects arrays,
  * `FabricSpecialObject`s, and other class instances (`Date`, `Map`, …), none of
- * which are representable as a `FabricObject`. Unlike a bare `isRecord()` check,
- * it preserves the value type — `FabricObject`'s string index of `FabricValue`
+ * which are representable as a `FabricPlainObject`. Unlike a bare `isRecord()` check,
+ * it preserves the value type — `FabricPlainObject`'s string index of `FabricValue`
  * keeps an indexed value typed as a `FabricValue`.
  */
 export function isFabricPlainObject(
   value: FabricValue,
-): value is FabricObject;
+): value is FabricPlainObject;
 export function isFabricPlainObject(
   value: Immutable<FabricValue>,
-): value is Immutable<FabricObject>;
+): value is Immutable<FabricPlainObject>;
 export function isFabricPlainObject(value: unknown): boolean {
   return isPlainObject(value);
 }

--- a/packages/data-model/src/valueEqual.ts
+++ b/packages/data-model/src/valueEqual.ts
@@ -2,7 +2,7 @@ import { isPlainObject } from "@commonfabric/utils/types";
 import { isDeepFrozen } from "./deep-freeze.ts";
 import {
   type FabricArray,
-  type FabricObject,
+  type FabricPlainObject,
   FabricSpecialObject,
   type FabricValue,
 } from "./interface.ts";
@@ -107,8 +107,8 @@ export function valueEqual(a: FabricValue, b: FabricValue): boolean {
     case "plain": {
       // Alas, casts are required because TS doesn't know the correspondence
       // between subtype names and type restrictions.
-      const aObject = a as FabricObject;
-      const bObject = b as FabricObject;
+      const aObject = a as FabricPlainObject;
+      const bObject = b as FabricPlainObject;
       if (Object.keys(aObject).length !== Object.keys(bObject).length) {
         // Plain objects can't possibly be equal if they have different numbers
         // of properties.
@@ -136,7 +136,7 @@ export function valueEqual(a: FabricValue, b: FabricValue): boolean {
  * `throw`s given an object that shouldn't have been passed as a `FabricValue`.
  */
 function objectSubtypeOf(
-  value: FabricObject | FabricArray | FabricSpecialObject,
+  value: FabricPlainObject | FabricArray | FabricSpecialObject,
 ): "array" | "plain" | "special" {
   if (value instanceof FabricSpecialObject) {
     return "special";

--- a/packages/data-model/test/type-check.test.ts
+++ b/packages/data-model/test/type-check.test.ts
@@ -181,7 +181,7 @@ describe("type-check", () => {
       });
 
       it("rejects non-plain class instances (`Date`, `Map`, …)", () => {
-        // Not representable as a `FabricObject`; reachable only via an unsound
+        // Not representable as a `FabricPlainObject`; reachable only via an unsound
         // cast, so the guard is fed them as `unknown`.
         expect(isFabricPlainObject(new Date() as unknown as FabricValue))
           .toBe(false);

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -1,7 +1,7 @@
 import { isObject, isRecord } from "@commonfabric/utils/types";
 import {
   fabricFromNativeValue,
-  type FabricObject,
+  type FabricPlainObject,
   FabricSpecialObject,
   type FabricValue,
   shallowFabricFromNativeValue,
@@ -462,7 +462,7 @@ export function normalizeAndDiff(
     );
     const { [ID_FIELD]: fieldName, ...rest } = newValue as
       & { [ID_FIELD]: string }
-      & FabricObject;
+      & FabricPlainObject;
     const id = newValue[fieldName as PropertyKey];
     if (link.path.length > 1) {
       const parent = tx.readValueOrThrow({
@@ -833,7 +833,7 @@ export function normalizeAndDiff(
     );
     const { [ID]: id, ...rest } = newValue as
       & { [ID]: string }
-      & FabricObject;
+      & FabricPlainObject;
     let path = link.path;
 
     // If we're setting an array element, make the array the context for the

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -2,7 +2,7 @@ import { Immutable, isRecord } from "@commonfabric/utils/types";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { getLogger } from "@commonfabric/utils/logger";
 import {
-  type FabricObject,
+  type FabricPlainObject,
   type FabricValue,
   shallowMutableClone,
 } from "@commonfabric/data-model/fabric-value";
@@ -761,7 +761,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
       // just start with {}. But if errorPath has content (e.g., ["foo"]), the
       // document exists and we need to read from lastExistingPath to preserve
       // existing fields.
-      let valueObj: FabricObject;
+      let valueObj: FabricPlainObject;
       if (errorPath.length === 0) {
         valueObj = {};
       } else {
@@ -783,7 +783,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
         // the shared input.
         valueObj = shallowMutableClone(
           currentValue as FabricValue,
-        ) as FabricObject;
+        ) as FabricPlainObject;
       }
       const remainingPath = address.path.slice(lastExistingPath.length);
       if (remainingPath.length === 0) {
@@ -792,7 +792,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
         );
       }
       const lastKey = remainingPath.pop()!;
-      let nextValue: FabricObject = valueObj;
+      let nextValue: FabricPlainObject = valueObj;
       // Create intermediate containers. The container type depends on whether
       // the NEXT key (the one that will access this container) is a valid array
       // index.
@@ -802,7 +802,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
         const isNextKeyArrayIndex = isArrayIndexPropertyName(nextKey);
         nextValue =
           nextValue[key] =
-            (isNextKeyArrayIndex ? [] : {}) as FabricObject;
+            (isNextKeyArrayIndex ? [] : {}) as FabricPlainObject;
       }
       nextValue[lastKey] = value as FabricValue;
       const parentAddress = { ...address, path: lastExistingPath };

--- a/packages/runner/src/storage/transaction/attestation.ts
+++ b/packages/runner/src/storage/transaction/attestation.ts
@@ -1,7 +1,7 @@
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isRecord } from "@commonfabric/utils/types";
 import {
-  type FabricObject,
+  type FabricPlainObject,
   type FabricValue,
 } from "@commonfabric/data-model/fabric-value";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
@@ -198,7 +198,7 @@ export const resolve = (
   while (++at < path.length) {
     const key = path[at];
     if (isRecord(value)) {
-      value = (value as FabricObject)[key];
+      value = (value as FabricPlainObject)[key];
     } else {
       // If the value is undefined, the path doesn't exist, but we can still
       // write onto it. Return error with last valid path component.


### PR DESCRIPTION
Pure type rename, no runtime behavior change.

The plain-record arm of `FabricValue` was named `FabricObject`. This renames it to `FabricPlainObject`, which:

- Reads consistently with its type guard `isFabricPlainObject()` (added in #4310 at `type-check.ts:70`) — `is` + `FabricPlainObject`.
- Distinguishes the plain-record case from the FabricInstance-shaped "objects" elsewhere in the value model.

Mechanical word-boundary rename across the 11 files that referenced the type (api, data-model, runner). Every occurrence was standalone, so no longer identifiers (including `isFabricPlainObject`) were touched.

Verification: `deno fmt --check`, `deno lint`, and `deno task check` clean for api / data-model / runner; data-model test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed FabricValue’s plain-record type from FabricObject to FabricPlainObject to match the isFabricPlainObject() guard and distinguish it from instance-shaped objects. Pure refactor with no runtime changes.

- **Migration**
  - Replace FabricObject with FabricPlainObject in type annotations, generics, and imports (e.g., from `@commonfabric/data-model/fabric-value`).
  - No other changes needed; behavior is unchanged.

<sup>Written for commit f82bf9ed1a8c068e1e7703650b0f5c9f5f22d1d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

