### PR TITLE
refactor(runner): drop producer-less EntityRef `cell` scoping from $ctx contracts

### DIFF
--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -1,5 +1,4 @@
 import { isRecord } from "@commonfabric/utils/types";
-import { isEntityRef } from "@commonfabric/data-model/cell-rep";
 import type { CellScope, JSONSchema } from "../builder/types.ts";
 import {
   findAndInlineDataURILinks,
@@ -7,7 +6,7 @@ import {
   parseLink,
 } from "../link-utils.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
-import { getJSONFromDataURI, toURI } from "../uri-utils.ts";
+import { getJSONFromDataURI } from "../uri-utils.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import type { CfcAddress } from "./types.ts";
 
@@ -546,9 +545,6 @@ const eventEnvelopePayloads = (
   return payloads;
 };
 
-const aliasCellId = (cell: unknown): string | undefined =>
-  isEntityRef(cell) ? toURI(cell) : undefined;
-
 const contractCandidatesFromEventContext = (
   event: unknown,
   write: NormalizedFullLink,
@@ -567,10 +563,6 @@ const contractCandidatesFromEventContext = (
         !Array.isArray(alias.path) ||
         !pathHasPrefix(write.path, alias.path)
       ) {
-        continue;
-      }
-      const id = aliasCellId(alias.cell);
-      if (id !== undefined && id !== write.id) {
         continue;
       }
       const aliasSpace = typeof alias.space === "string"

--- a/packages/runner/test/cfc-ui-contract.test.ts
+++ b/packages/runner/test/cfc-ui-contract.test.ts
@@ -692,7 +692,6 @@ describe("CFC trusted UI event enforcement", () => {
                 $ctx: {
                   savedTitle: {
                     $alias: {
-                      cell: { "/": "cfc-ui-contract-context-document" },
                       path: ["argument", "savedTitle"],
                       schema: {
                         $ref: "#/$defs/TrustedAction",
@@ -772,7 +771,6 @@ describe("CFC trusted UI event enforcement", () => {
                 $ctx: {
                   messages: {
                     $alias: {
-                      cell: { "/": "cfc-ui-contract-context-array-document" },
                       path: ["argument", "messages"],
                       schema: {
                         type: "array",


### PR DESCRIPTION
## What

Removes the EntityRef-`cell` document-scoping path from CFC trusted-event
contract matching, and the `{ "/": ... }` shape it required from the two `$ctx`
fixtures.

In `packages/runner/src/cfc/ui-contract.ts`, `contractCandidatesFromEventContext`
scoped a `$ctx` alias to a document via:

```ts
const id = aliasCellId(alias.cell);          // non-undefined only if cell is { "/": <id> }
if (id !== undefined && id !== write.id) continue;
```

- Delete `aliasCellId` and the guard (the remaining `path` / `space` / schema
  checks still scope the contract).
- Drop the now-unused `isEntityRef` / `toURI` imports.
- Strip the `cell: { "/": ... }` line from the two `$ctx` fixtures in
  `cfc-ui-contract.test.ts`; they keep exercising the `$ctx`-schema-hint path.

## Why it's safe

`alias.cell` is **never** an EntityRef in practice:

- A real `$ctx` alias's `cell` is the named-cell form (`"argument"` / `"result"`),
  type-pinned by `LegacyAliasNamedCell` (`cell?: "result" | "argument"`).
- Handler-prop cell references resolve to **sigil links** before any event
  fires; the `$ctx` envelope (`builder/module.ts`'s `{ $ctx: props, $event }`)
  never carries an EntityRef-`cell` `$alias`.

So `aliasCellId(alias.cell)` always returned `undefined` and the guard never
fired. The EntityRef branch was reachable only by the hand-built fixtures that
fed it. I confirmed this with a throwaway probe driving the real exported
`recordTrustedEventPolicyInputs`: a renderer-trusted event carries no `$ctx`,
authorizes via the schema path, and only a synthetic `data:`-URI `$ctx` payload
reaches the branch.

**Untouched:** the live named-cell `alias.cell` handling
(`"argument"`/`"result"`) in `pattern-binding.ts` / `builder/json-utils.ts` —
that is core binding machinery, a different concern from this EntityRef form.

This is CFC security-contract code, so the scoping change is worth a careful
look. The doc-id dimension being removed only ever depended on the EntityRef
`cell` that never exists; `path` + `space` + schema-path scoping remain.
The branch (and its fixtures) date to #3263 — @seefeldb a good reviewer.

## Testing

- `deno check` / `deno fmt --check` / `deno lint` clean on both files.
- Full workspace `deno task test` passes (incl. the `cfc-ui-contract` suite,
  25 steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqKYyzitpYXQyywipkfDCg


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the unused EntityRef `cell` path from `$ctx` contract matching in CFC trusted UI events. Simplifies scoping logic with no behavior change; real events never set `alias.cell` to an EntityRef.

- **Refactors**
  - Removed the `aliasCellId` guard in `contractCandidatesFromEventContext`.
  - Deleted unused `isEntityRef` and `toURI` imports in `packages/runner/src/cfc/ui-contract.ts`.
  - Updated `$ctx` test fixtures to remove `cell: { "/": ... }` in `packages/runner/test/cfc-ui-contract.test.ts`.

<sup>Written for commit 9801976d501a86cd853f8c16bae1047d30e86162. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->