### PR TITLE
Fix slug reloads for patternIdentity pieces

### DIFF
--- a/packages/piece/test/pull-materialization.test.ts
+++ b/packages/piece/test/pull-materialization.test.ts
@@ -1,11 +1,18 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createSession, Identity } from "@commonfabric/identity";
-import { NAME, Pattern, Runtime } from "@commonfabric/runner";
+import {
+  getPatternIdentityRef,
+  NAME,
+  Pattern,
+  Runtime,
+  type RuntimeProgram,
+} from "@commonfabric/runner";
 import { entityRefToString } from "@commonfabric/data-model/cell-rep";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { PieceManager } from "../src/manager.ts";
 import { PieceController } from "../src/ops/piece-controller.ts";
+import { PiecesController } from "../src/ops/pieces-controller.ts";
 
 const signer = await Identity.fromPassphrase("piece pull materialization");
 
@@ -105,6 +112,28 @@ function namedPattern(name: string, multiplier: number): Pattern {
   };
 }
 
+function compiledMultiplierProgram(
+  version: string,
+  multiplier: number,
+): RuntimeProgram {
+  return {
+    main: "/main.tsx",
+    files: [
+      {
+        name: "/main.tsx",
+        contents: [
+          "import { pattern, lift } from 'commonfabric';",
+          `const multiply = lift((input: number) => input * ${multiplier});`,
+          "export default pattern<{ input: number }>(({ input }) => ({",
+          `  version: ${JSON.stringify(version)},`,
+          "  output: multiply(input),",
+          "}));",
+        ].join("\n"),
+      },
+    ],
+  };
+}
+
 async function waitFor(
   predicate: () => boolean,
   timeoutMs: number = 1_000,
@@ -199,6 +228,70 @@ describe("piece pull materialization", () => {
     );
 
     expect(manager.getResult(piece).get()).toEqual({ output: 50 });
+  });
+
+  it("persists setPattern replacement by identity for fresh runtime reloads", async () => {
+    const firstPattern = await runtime.patternManager.compilePattern(
+      compiledMultiplierProgram("v1", 2),
+      { space: manager.getSpace() },
+    );
+    const piece = await manager.runPersistent(
+      firstPattern,
+      { input: 5 },
+      "compiled-set-pattern-" + crypto.randomUUID(),
+      { start: true },
+    );
+    const id = entityRefToString(piece.entityId);
+    const controller = new PieceController(manager, piece);
+    const firstRef = getPatternIdentityRef(piece);
+
+    expect(firstRef).toBeDefined();
+    expect(manager.getResult(piece).get()).toEqual({
+      version: "v1",
+      output: 10,
+    });
+
+    await controller.setPattern(compiledMultiplierProgram("v2", 10));
+    await manager.runtime.idle();
+    await manager.synced();
+
+    const secondRef = getPatternIdentityRef(piece);
+    expect(secondRef).toBeDefined();
+    expect(secondRef!.identity).not.toEqual(firstRef!.identity);
+    expect(manager.getResult(piece).get()).toEqual({
+      version: "v2",
+      output: 50,
+    });
+
+    const session = await createSession({
+      identity: signer,
+      spaceName: manager.getSpaceName()!,
+    });
+    const freshRuntime = new Runtime({
+      apiUrl: new URL("http://localhost:9999"),
+      storageManager,
+    });
+    const freshManager = new PieceManager(session, freshRuntime);
+    const freshPieces = new PiecesController(freshManager);
+
+    try {
+      await freshManager.synced();
+      const freshPiece = await freshPieces.get(id, true);
+      const freshCell = freshPiece.getCell();
+      const freshRef = getPatternIdentityRef(freshCell);
+
+      expect(freshRef).toEqual(secondRef);
+      expect(await freshPiece.result.get()).toEqual({
+        version: "v2",
+        output: 50,
+      });
+      const source = await freshPiece.getPatternSourceProgram();
+      expect(source?.files.some((file) => file.contents.includes("v2"))).toBe(
+        true,
+      );
+    } finally {
+      await freshRuntime.dispose();
+    }
   });
 
   it("waits for setup to settle before setupPersistent syncs pattern metadata", async () => {

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -144,6 +144,7 @@ describe("page slug redirects", () => {
     schemaCell?: unknown;
     onPull?: () => void;
     patternLink?: unknown;
+    patternIdentity?: unknown;
     onSync?: () => void;
   } = {}) {
     return {
@@ -157,7 +158,11 @@ describe("page slug redirects", () => {
       },
       getRaw: () => options.raw,
       getMetaRaw: (metaField: string) =>
-        metaField === "pattern" ? options.patternLink : undefined,
+        metaField === "patternIdentity"
+          ? options.patternIdentity
+          : metaField === "pattern"
+          ? options.patternLink
+          : undefined,
       getAsLink: () => cellRefToSigilLink(ref),
       getAsNormalizedFullLink: () => ref,
       asSchemaFromLinks: () => options.schemaCell,
@@ -245,14 +250,9 @@ describe("page slug redirects", () => {
         required: ["$NAME", "$UI"],
       },
     };
-    // if we don't have a pattern link, the processor won't pull the cell and
-    // thus won't pull the schema, so we have to include a pattern link
-    const patternRef: CellRef = {
-      id: "of:fid1-pattern-doc" as CellRef["id"],
-      space,
-      scope: "space",
-      path: [],
-    };
+    // If we don't have a pattern identity, the processor won't pull the cell and
+    // thus won't pull the schema, so include the current piece marker.
+    const patternIdentity = { identity: "pattern-identity", symbol: "default" };
     let schemaPulled = false;
     const schemaCell = mockCell(schemaRef, {
       onPull: () => {
@@ -262,7 +262,7 @@ describe("page slug redirects", () => {
     let targetSynced = false;
     const targetCell = mockCell(targetRef, {
       schemaCell,
-      patternLink: redirectRaw(patternRef),
+      patternIdentity,
       onSync: () => {
         targetSynced = true;
       },
@@ -316,14 +316,11 @@ describe("page slug redirects", () => {
       scope: "space",
       path: [],
     };
-    const patternRef: CellRef = {
-      id: "of:fid1-pattern-doc" as CellRef["id"],
-      space,
-      scope: "space",
-      path: [],
-    };
     const pieceCell = mockCell(pieceRef, {
-      patternLink: redirectRaw(patternRef),
+      patternIdentity: {
+        identity: "piece-pattern-identity",
+        symbol: "default",
+      },
     });
     const resultCell = mockCell(resultRef);
     const slugCell = mockCell(slugRef, { raw: redirectRaw(pieceRef) });

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -19,6 +19,7 @@ import {
   convertCellsToLinks,
   entityIdFrom,
   getCellOrThrow,
+  getPatternIdentityRef,
   isCell,
   isCellResult,
   Runtime,
@@ -946,7 +947,8 @@ export class RuntimeProcessor {
       });
       await target.sync();
       const targetLink = target.getAsNormalizedFullLink();
-      const hasPattern = target.getMetaRaw("pattern") !== undefined;
+      const hasPattern = getPatternIdentityRef(target) !== undefined ||
+        target.getMetaRaw("pattern") !== undefined;
       if (!hasPattern || targetLink.path.length > 0) {
         const pageCell = hasPattern && targetLink.path.length > 0
           ? target.asSchemaFromLinks()


### PR DESCRIPTION
## Summary
- Treat `patternIdentity` as the current piece marker when resolving slug redirects, keeping legacy `meta("pattern")` as a fallback.
- Update runtime-processor slug redirect tests to exercise current pattern identity metadata.
- Add a piece regression proving in-place source replacement persists by identity and reloads correctly in a fresh runtime.

## Root cause
Slug redirect navigation followed the slug target, then decided whether the target was a piece by checking the deleted legacy `pattern` metadata. Current pieces updated by `setsrc` carry `patternIdentity`, so a slug reload could treat a real piece as a plain cell and skip `PieceManager.get(..., runIt=true)`. That made the page render stored state without starting the latest pattern source.

## Tests
- `DENO_DIR=/private/tmp/deno-cache deno test --allow-env --allow-ffi --allow-read --allow-write --allow-net packages/runtime-client/backends/runtime-processor.test.ts`
- `DENO_DIR=/private/tmp/deno-cache deno test --allow-env --allow-ffi --allow-read --allow-write --allow-net packages/piece/test/pull-materialization.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix slug reloads by recognizing `patternIdentity` as the piece marker during redirect resolution, so pieces start correctly instead of rendering stale state. This prevents slug navigations from downgrading pieces to plain cells.

- **Bug Fixes**
  - Treat `patternIdentity` as the current piece flag; keep legacy `meta("pattern")` as fallback in `packages/runtime-client/backends/runtime-processor.ts`.
  - Update slug redirect tests to use `patternIdentity` and verify schema pulling.
  - Add regression test in `packages/piece` to confirm `setPattern` replacements persist by identity and reload correctly in a fresh runtime.

<sup>Written for commit b56a6fb5fef2bd1b9174bcf25f20cc2291dd39cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

