### PR TITLE
fix(shell): defer the home-pattern favorites subscription off the log…

### DIFF
--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -521,6 +521,7 @@ export class XHeaderView extends BaseView {
   private accessor _localIsFavorite: boolean | undefined = undefined;
 
   private _unsubscribeFavorites: (() => void) | undefined;
+  private _favoritesSubscriptionRequested = false;
 
   /** Subscribe to the favorites list so the menu reflects current state. */
   private _setupFavoritesSubscription(): void {
@@ -533,6 +534,22 @@ export class XHeaderView extends BaseView {
         this._localIsFavorite = undefined;
         this.requestUpdate();
       });
+  }
+
+  /**
+   * Subscribe to favorites the first time a surface that shows them is opened.
+   * Reading favorites resolves the home space's default pattern, which on a
+   * fresh space the runtime has to create — a one-time cost that, run eagerly
+   * at login, lands in the same worker as the user's first write to a piece
+   * and delays it. Deferring the subscription to the first menu open keeps that
+   * work off the first-write path; the favorite toggle creates the pattern on
+   * demand when the user actually favorites something.
+   */
+  private _ensureFavoritesSubscription(): void {
+    if (this._favoritesSubscriptionRequested) return;
+    if (!this.rt) return;
+    this._favoritesSubscriptionRequested = true;
+    this._setupFavoritesSubscription();
   }
 
   /** Unsubscribe from favorites when component disconnects or runtime changes. */
@@ -561,7 +578,6 @@ export class XHeaderView extends BaseView {
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this._setupFavoritesSubscription();
     this.addEventListener("keydown", this._handleKeyDown);
     globalThis.addEventListener("resize", this._handleResize);
     globalThis.addEventListener("click", this._closeHeaderPieceDropdown);
@@ -612,7 +628,11 @@ export class XHeaderView extends BaseView {
       this._serverFavorites = [];
       this._localIsFavorite = undefined;
       this._piecesCache = undefined;
-      this._setupFavoritesSubscription();
+      this._cleanupFavoritesSubscription();
+      this._favoritesSubscriptionRequested = false;
+      // If the menu is already open when a runtime arrives, the favorites
+      // surface is showing, so subscribe now; otherwise wait for the first open.
+      if (this.menuOpen) this._ensureFavoritesSubscription();
     }
     // One runtime serves every space, so a space switch no longer
     // replaces rt — the per-space pieces cache must invalidate on the
@@ -730,6 +750,7 @@ export class XHeaderView extends BaseView {
     e.preventDefault();
     e.stopPropagation();
     this.menuOpen = true;
+    this._ensureFavoritesSubscription();
     this.updateComplete.then(() => {
       this.renderRoot.querySelector<HTMLElement>(".menu-close")?.focus();
     });
@@ -871,6 +892,9 @@ export class XHeaderView extends BaseView {
     const currentlyFavorite = this._isFavorite();
     this._localIsFavorite = !currentlyFavorite;
     this._isFavoriteLoading = true;
+    // Favoriting touches the home pattern anyway; start reflecting server
+    // state from here on if the menu was never opened.
+    this._ensureFavoritesSubscription();
 
     try {
       if (currentlyFavorite) {

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -521,7 +521,6 @@ export class XHeaderView extends BaseView {
   private accessor _localIsFavorite: boolean | undefined = undefined;
 
   private _unsubscribeFavorites: (() => void) | undefined;
-  private _favoritesSubscriptionRequested = false;
 
   /** Subscribe to the favorites list so the menu reflects current state. */
   private _setupFavoritesSubscription(): void {
@@ -544,11 +543,13 @@ export class XHeaderView extends BaseView {
    * and delays it. Deferring the subscription to the first menu open keeps that
    * work off the first-write path; the favorite toggle creates the pattern on
    * demand when the user actually favorites something.
+   *
+   * Idempotent while a subscription is live. After teardown — a disconnect or
+   * a runtime swap clears `_unsubscribeFavorites` — the next call re-subscribes,
+   * so a reconnected header is not left without favorites.
    */
   private _ensureFavoritesSubscription(): void {
-    if (this._favoritesSubscriptionRequested) return;
-    if (!this.rt) return;
-    this._favoritesSubscriptionRequested = true;
+    if (this._unsubscribeFavorites) return;
     this._setupFavoritesSubscription();
   }
 
@@ -629,7 +630,6 @@ export class XHeaderView extends BaseView {
       this._localIsFavorite = undefined;
       this._piecesCache = undefined;
       this._cleanupFavoritesSubscription();
-      this._favoritesSubscriptionRequested = false;
       // If the menu is already open when a runtime arrives, the favorites
       // surface is showing, so subscribe now; otherwise wait for the first open.
       if (this.menuOpen) this._ensureFavoritesSubscription();

--- a/packages/shell/test/header-view-favorites.test.ts
+++ b/packages/shell/test/header-view-favorites.test.ts
@@ -1,0 +1,207 @@
+import { assert, assertEquals, assertFalse } from "@std/assert";
+
+// Exercises the lazy favorites-subscription paths in HeaderView. The header
+// resolves the home space's default pattern only when its favorites surface is
+// first opened (menu open or favorite toggle), not at login, so the home
+// pattern's one-time creation does not contend with the user's first write.
+
+// The members the tests drive, typed loosely so fakes can stand in for the
+// runtime and the private methods/state are reachable without leaking `any`.
+interface HeaderViewLike {
+  rt: unknown;
+  space: unknown;
+  pieceId: unknown;
+  menuOpen: boolean;
+  _favoritesSubscriptionRequested: boolean;
+  _isFavoriteLoading: boolean;
+  _ensureFavoritesSubscription(): void;
+  willUpdate(changed: Map<string, unknown>): void;
+  handleLogoClick(e: Event): void;
+  handleToggleFavorite(e: Event): Promise<void>;
+}
+
+function installBrowserGlobals(): () => void {
+  const originals = new Map<string, PropertyDescriptor | undefined>();
+
+  function setGlobal(name: string, value: unknown): void {
+    originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    });
+  }
+
+  class TestHTMLElement extends EventTarget {}
+
+  setGlobal("window", globalThis);
+  setGlobal("HTMLElement", TestHTMLElement);
+  setGlobal("customElements", {
+    define() {},
+    get() {},
+    whenDefined: () => Promise.resolve(),
+  });
+  setGlobal("document", {
+    documentElement: { style: {} },
+    createElement: () => ({
+      style: {},
+      setAttribute() {},
+      append() {},
+      appendChild() {},
+    }),
+    createTreeWalker: () => ({}),
+  });
+  setGlobal("devicePixelRatio", 1);
+  setGlobal("navigator", { platform: "", userAgent: "deno" });
+  setGlobal("location", {
+    protocol: "http:",
+    host: "localhost:8000",
+    hostname: "localhost",
+    href: "http://localhost:8000/common-knowledge",
+  });
+
+  return () => {
+    for (const [name, descriptor] of originals) {
+      if (descriptor) {
+        Object.defineProperty(globalThis, name, descriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, name);
+      }
+    }
+  };
+}
+
+/**
+ * A stand-in for the runtime's favorites surface. Counts subscriptions so a
+ * test can assert when (and how often) the header asks for favorites, and can
+ * reject writes to simulate a disposed runtime.
+ */
+function makeRuntime(opts: { aborted?: boolean; failWrite?: boolean } = {}) {
+  let subscribeCount = 0;
+  const favorites = {
+    subscribeFavorites(cb: (favorites: readonly unknown[]) => void) {
+      subscribeCount++;
+      cb([]);
+      return () => {};
+    },
+    addFavorite: () =>
+      opts.failWrite
+        ? Promise.reject(new Error("write cancelled"))
+        : Promise.resolve(),
+    removeFavorite: () =>
+      opts.failWrite
+        ? Promise.reject(new Error("write cancelled"))
+        : Promise.resolve(),
+  };
+  return {
+    favorites: () => favorites,
+    signal: { aborted: opts.aborted ?? false },
+    get subscribeCount() {
+      return subscribeCount;
+    },
+  };
+}
+
+const fakeEvent = () =>
+  ({ preventDefault() {}, stopPropagation() {} }) as unknown as Event;
+
+Deno.test("favorites stay unsubscribed until a runtime exists and a surface opens", async () => {
+  const restore = installBrowserGlobals();
+  try {
+    const { XHeaderView } = await import("../src/views/HeaderView.ts");
+    const view = new XHeaderView() as unknown as HeaderViewLike;
+    const rt = makeRuntime();
+
+    // No runtime yet: requesting the subscription is a no-op.
+    view._ensureFavoritesSubscription();
+    assertEquals(rt.subscribeCount, 0);
+    assertFalse(view._favoritesSubscriptionRequested);
+
+    // Runtime present: the first request subscribes exactly once.
+    view.rt = rt;
+    view._ensureFavoritesSubscription();
+    assertEquals(rt.subscribeCount, 1);
+    assert(view._favoritesSubscriptionRequested);
+
+    // Idempotent: a repeat request does not subscribe again.
+    view._ensureFavoritesSubscription();
+    assertEquals(rt.subscribeCount, 1);
+  } finally {
+    restore();
+  }
+});
+
+Deno.test("a new runtime re-arms the lazy subscription", async () => {
+  const restore = installBrowserGlobals();
+  try {
+    const { XHeaderView } = await import("../src/views/HeaderView.ts");
+
+    // Menu closed when the runtime arrives: stay unsubscribed until it opens.
+    const closed = new XHeaderView() as unknown as HeaderViewLike;
+    const first = makeRuntime();
+    closed.rt = first;
+    closed._ensureFavoritesSubscription();
+    assertEquals(first.subscribeCount, 1);
+
+    closed.willUpdate(new Map([["rt", undefined]]));
+    assertFalse(closed._favoritesSubscriptionRequested);
+    closed._ensureFavoritesSubscription();
+    assertEquals(first.subscribeCount, 2);
+
+    // Menu already open when the runtime arrives: subscribe immediately.
+    const open = new XHeaderView() as unknown as HeaderViewLike;
+    const second = makeRuntime();
+    open.menuOpen = true;
+    open.rt = second;
+    open.willUpdate(new Map([["rt", undefined]]));
+    assert(open._favoritesSubscriptionRequested);
+    assertEquals(second.subscribeCount, 1);
+  } finally {
+    restore();
+  }
+});
+
+Deno.test("opening the header menu requests the favorites subscription", async () => {
+  const restore = installBrowserGlobals();
+  try {
+    const { XHeaderView } = await import("../src/views/HeaderView.ts");
+    const view = new XHeaderView() as unknown as HeaderViewLike;
+    const rt = makeRuntime();
+    view.rt = rt;
+
+    view.handleLogoClick(fakeEvent());
+    assert(view.menuOpen);
+    assertEquals(rt.subscribeCount, 1);
+  } finally {
+    restore();
+  }
+});
+
+Deno.test("toggling a favorite requests the subscription and swallows a disposal race", async () => {
+  const restore = installBrowserGlobals();
+  try {
+    const { XHeaderView } = await import("../src/views/HeaderView.ts");
+
+    // A successful toggle subscribes and clears the in-flight flag.
+    const ok = new XHeaderView() as unknown as HeaderViewLike;
+    const okRt = makeRuntime();
+    ok.rt = okRt;
+    ok.space = "did:key:test";
+    ok.pieceId = "piece-1";
+    await ok.handleToggleFavorite(fakeEvent());
+    assertEquals(okRt.subscribeCount, 1);
+    assert(ok._favoritesSubscriptionRequested);
+    assertFalse(ok._isFavoriteLoading);
+
+    // A write cancelled by a disposed runtime is swallowed, not surfaced.
+    const racing = new XHeaderView() as unknown as HeaderViewLike;
+    const racingRt = makeRuntime({ failWrite: true, aborted: true });
+    racing.rt = racingRt;
+    racing.space = "did:key:test";
+    racing.pieceId = "piece-2";
+    await racing.handleToggleFavorite(fakeEvent());
+    assertFalse(racing._isFavoriteLoading);
+  } finally {
+    restore();
+  }
+});

--- a/packages/shell/test/header-view-favorites.test.ts
+++ b/packages/shell/test/header-view-favorites.test.ts
@@ -12,12 +12,12 @@ interface HeaderViewLike {
   space: unknown;
   pieceId: unknown;
   menuOpen: boolean;
-  _favoritesSubscriptionRequested: boolean;
   _isFavoriteLoading: boolean;
   _ensureFavoritesSubscription(): void;
   willUpdate(changed: Map<string, unknown>): void;
   handleLogoClick(e: Event): void;
   handleToggleFavorite(e: Event): Promise<void>;
+  disconnectedCallback(): void;
 }
 
 function installBrowserGlobals(): () => void {
@@ -78,11 +78,14 @@ function installBrowserGlobals(): () => void {
  */
 function makeRuntime(opts: { aborted?: boolean; failWrite?: boolean } = {}) {
   let subscribeCount = 0;
+  let unsubscribeCount = 0;
   const favorites = {
     subscribeFavorites(cb: (favorites: readonly unknown[]) => void) {
       subscribeCount++;
       cb([]);
-      return () => {};
+      return () => {
+        unsubscribeCount++;
+      };
     },
     addFavorite: () =>
       opts.failWrite
@@ -98,6 +101,9 @@ function makeRuntime(opts: { aborted?: boolean; failWrite?: boolean } = {}) {
     signal: { aborted: opts.aborted ?? false },
     get subscribeCount() {
       return subscribeCount;
+    },
+    get unsubscribeCount() {
+      return unsubscribeCount;
     },
   };
 }
@@ -115,13 +121,11 @@ Deno.test("favorites stay unsubscribed until a runtime exists and a surface open
     // No runtime yet: requesting the subscription is a no-op.
     view._ensureFavoritesSubscription();
     assertEquals(rt.subscribeCount, 0);
-    assertFalse(view._favoritesSubscriptionRequested);
 
     // Runtime present: the first request subscribes exactly once.
     view.rt = rt;
     view._ensureFavoritesSubscription();
     assertEquals(rt.subscribeCount, 1);
-    assert(view._favoritesSubscriptionRequested);
 
     // Idempotent: a repeat request does not subscribe again.
     view._ensureFavoritesSubscription();
@@ -143,8 +147,10 @@ Deno.test("a new runtime re-arms the lazy subscription", async () => {
     closed._ensureFavoritesSubscription();
     assertEquals(first.subscribeCount, 1);
 
+    // Swapping the runtime tears down the old subscription; with the menu
+    // closed nothing resubscribes yet, but the next open does.
     closed.willUpdate(new Map([["rt", undefined]]));
-    assertFalse(closed._favoritesSubscriptionRequested);
+    assertEquals(first.unsubscribeCount, 1);
     closed._ensureFavoritesSubscription();
     assertEquals(first.subscribeCount, 2);
 
@@ -154,7 +160,6 @@ Deno.test("a new runtime re-arms the lazy subscription", async () => {
     open.menuOpen = true;
     open.rt = second;
     open.willUpdate(new Map([["rt", undefined]]));
-    assert(open._favoritesSubscriptionRequested);
     assertEquals(second.subscribeCount, 1);
   } finally {
     restore();
@@ -190,7 +195,6 @@ Deno.test("toggling a favorite requests the subscription and swallows a disposal
     ok.pieceId = "piece-1";
     await ok.handleToggleFavorite(fakeEvent());
     assertEquals(okRt.subscribeCount, 1);
-    assert(ok._favoritesSubscriptionRequested);
     assertFalse(ok._isFavoriteLoading);
 
     // A write cancelled by a disposed runtime is swallowed, not surfaced.
@@ -201,6 +205,30 @@ Deno.test("toggling a favorite requests the subscription and swallows a disposal
     racing.pieceId = "piece-2";
     await racing.handleToggleFavorite(fakeEvent());
     assertFalse(racing._isFavoriteLoading);
+  } finally {
+    restore();
+  }
+});
+
+Deno.test("favorites re-subscribe after the header disconnects and reopens", async () => {
+  const restore = installBrowserGlobals();
+  try {
+    const { XHeaderView } = await import("../src/views/HeaderView.ts");
+    const view = new XHeaderView() as unknown as HeaderViewLike;
+    const rt = makeRuntime();
+    view.rt = rt;
+
+    // Opening the menu subscribes.
+    view._ensureFavoritesSubscription();
+    assertEquals(rt.subscribeCount, 1);
+
+    // Disconnecting tears the subscription down.
+    view.disconnectedCallback();
+    assertEquals(rt.unsubscribeCount, 1);
+
+    // Reopening after reconnect must subscribe again, not skip on stale state.
+    view._ensureFavoritesSubscription();
+    assertEquals(rt.subscribeCount, 2);
   } finally {
     restore();
   }


### PR DESCRIPTION
…in path

Problem. When you log into the shell and open a piece, the header quietly loads your "favorites" list so its menu can show whether the current piece is starred. Loading favorites requires the home space's default pattern to exist, and for a brand-new account that pattern has to be created first — compiled, started, and written to storage. That creation runs in the same worker that handles your first action on the piece you just opened. Worse, login waits for the runtime to go quiet, and the in-progress creation keeps it busy. So under any real load — several browsers sharing one backend, or a slow machine — login could stall for tens of seconds, and our headless browser integration tests would time out before doing anything.

Change. The header now loads favorites lazily — the first time you open the header menu, rather than at login. Favorites are only ever shown inside that menu, and a new account has none to show, so nothing is lost by waiting. The "add to favorites" button still creates the pattern on demand when you actually star something.

Impact. Measured with six browser copies of the parking-coordinator integration test running against one backend: before the change, login blocked and zero of six runs passed; after it, login dropped to about two seconds and five of six passed, with the home-pattern creation no longer running during the test. A single run, the way CI runs these (one file per shard), went from failing under load to passing in about thirteen seconds.

What this does not fix. A separate, smaller cost remains — the very first write into a freshly created space is intrinsically slow under backend contention (storage round-trips to a busy server). That is real backend work the client cannot skip; under CI's one-file-per-shard execution it stays well within the default step budget.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers the header’s favorites subscription until the first menu open or star to keep login fast and avoid blocking the first write. Also fixes missed re-subscribe after disconnects by guarding on the live subscription handle.

- **Bug Fixes**
  - Added `_ensureFavoritesSubscription()`; idempotent while a subscription is live; subscribe on first menu open and on favorite toggle.
  - Reset on runtime changes; auto-subscribe if the menu is already open when a runtime arrives; re-subscribe after disconnect/reconnect.
  - Removed eager subscription from `connectedCallback`; observed ~2s logins and stable CI; added unit tests for lazy subscription, runtime swap, disconnect/reopen, and disposal races.

<sup>Written for commit 6f4c4b3ce845e8e657d1138435ac4752ff563485. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

