### PR TITLE
feat(runtime-client): opt-in bridge to forward worker console to the …

### DIFF
--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -58,6 +58,12 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
   experimental?: ExperimentalRuntimeFlags;
   cfcEnforcementMode?: RuntimeCfcEnforcementMode;
   trustSnapshot?: RuntimeTrustSnapshot | null;
+  /**
+   * When true, forward the worker runtime's console output to the main
+   * thread so it reaches devtools and integration-test console capture.
+   * Off by default.
+   */
+  forwardWorkerConsole?: boolean;
   getBuildHash?: () => Promise<string | undefined>;
   workerUrl?: URL;
 };
@@ -111,6 +117,7 @@ export function createRuntimeClientOptions({
   experimental,
   cfcEnforcementMode = "enforce-explicit",
   trustSnapshot,
+  forwardWorkerConsole,
 }: {
   session: Session;
   apiUrl: URL;
@@ -118,6 +125,7 @@ export function createRuntimeClientOptions({
   experimental?: ExperimentalRuntimeFlags;
   cfcEnforcementMode?: RuntimeCfcEnforcementMode;
   trustSnapshot?: RuntimeTrustSnapshot | null;
+  forwardWorkerConsole?: boolean;
 }) {
   const resolvedTrustSnapshot = trustSnapshot === undefined
     ? {
@@ -136,6 +144,7 @@ export function createRuntimeClientOptions({
     experimental,
     cfcEnforcementMode,
     trustSnapshot: resolvedTrustSnapshot,
+    forwardWorkerConsole,
   };
 }
 
@@ -462,6 +471,7 @@ export class RuntimeInternals extends EventTarget {
     experimental,
     cfcEnforcementMode,
     trustSnapshot,
+    forwardWorkerConsole,
     getBuildHash = fetchBuildHash,
     workerUrl,
     navigate,
@@ -502,6 +512,7 @@ export class RuntimeInternals extends EventTarget {
         experimental,
         cfcEnforcementMode,
         trustSnapshot,
+        forwardWorkerConsole,
       }),
     );
 

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -343,6 +343,94 @@ describe("RuntimeInternals", () => {
     expect(withoutTrust.trustSnapshot).toBeUndefined();
   });
 
+  it("carries the worker-console flag onto the client options", async () => {
+    const { createRuntimeClientOptions } = await import(
+      "@commonfabric/lib-shell"
+    );
+    const { createSession, Identity } = await import("@commonfabric/identity");
+    const identity = await Identity.generate({ implementation: "noble" });
+    const session = await createSession({
+      identity,
+      spaceName: "lib-shell-forward-worker-console",
+    });
+
+    expect(
+      createRuntimeClientOptions({
+        session,
+        apiUrl: new URL("http://shell.test/"),
+        forwardWorkerConsole: true,
+      }).forwardWorkerConsole,
+    ).toBe(true);
+    expect(
+      createRuntimeClientOptions({
+        session,
+        apiUrl: new URL("http://shell.test/"),
+      }).forwardWorkerConsole,
+    ).toBeUndefined();
+  });
+
+  // create() builds the client options and sends the Initialize request; this
+  // covers that path end to end and asserts the worker-console flag reaches the
+  // worker. A stub worker completes the READY handshake, then fails Initialize
+  // so create() aborts without a real runtime.
+  describe("create() forwards the worker-console flag to the worker", () => {
+    it("includes forwardWorkerConsole in the Initialize request", async () => {
+      const { RuntimeInternals } = await import("@commonfabric/lib-shell");
+      const { Identity } = await import("@commonfabric/identity");
+      const identity = await Identity.generate({ implementation: "noble" });
+
+      const initRequests: Array<{ data: { forwardWorkerConsole?: boolean } }> =
+        [];
+      class StubWorker extends EventTarget {
+        constructor(_url: URL | string) {
+          super();
+          queueMicrotask(() =>
+            this.dispatchEvent(new MessageEvent("message", { data: "READY" }))
+          );
+        }
+        postMessage(message: unknown): void {
+          const msg = message as {
+            msgId?: number;
+            data?: { type?: string; data?: { forwardWorkerConsole?: boolean } };
+          };
+          if (typeof msg?.msgId !== "number") return;
+          if (msg.data?.type === "initialize") {
+            initRequests.push(
+              msg.data as { data: { forwardWorkerConsole?: boolean } },
+            );
+          }
+          queueMicrotask(() =>
+            this.dispatchEvent(
+              new MessageEvent("message", {
+                data: { msgId: msg.msgId, error: "stub init failure" },
+              }),
+            )
+          );
+        }
+        terminate(): void {}
+      }
+
+      const OriginalWorker = (globalThis as { Worker: unknown }).Worker;
+      (globalThis as { Worker: unknown }).Worker = StubWorker;
+      try {
+        await expect(
+          RuntimeInternals.create({
+            identity,
+            apiUrl: new URL("http://shell.test/"),
+            workerUrl: new URL("http://shell.test/scripts/worker-runtime.js"),
+            getBuildHash: () => Promise.resolve(undefined),
+            forwardWorkerConsole: true,
+          }),
+        ).rejects.toThrow("stub init failure");
+      } finally {
+        (globalThis as { Worker: unknown }).Worker = OriginalWorker;
+      }
+
+      expect(initRequests).toHaveLength(1);
+      expect(initRequests[0].data.forwardWorkerConsole).toBe(true);
+    });
+  });
+
   // A deploy must always load the fresh worker bundle: the worker URL is
   // cache-busted with `?v=<buildHash>` whenever the build manifest provides
   // a hash (no feature gate).

--- a/packages/runtime-client/backends/web-worker-console-bridge.test.ts
+++ b/packages/runtime-client/backends/web-worker-console-bridge.test.ts
@@ -1,0 +1,166 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { ClientNotificationType, RequestType } from "../protocol/mod.ts";
+
+// The worker entry (`backends/web-worker/index.ts`) installs a `message`
+// listener on `self` (which is `globalThis` under Deno) and reads
+// `self.postMessage` at call time. We capture posted messages, import the
+// module so its listener registers, then drive the handler by dispatching
+// `MessageEvent`s — exercising the opt-in console bridge and the request
+// branches without spawning a real worker or initializing the runtime.
+
+type Posted = Record<string, unknown> | string;
+
+function dispatch(data: unknown): Promise<void> {
+  globalThis.dispatchEvent(new MessageEvent("message", { data }));
+  // The handler is async; let its microtasks settle before asserting.
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("web worker console bridge", () => {
+  it("forwards console output only while enabled and restores native console", async () => {
+    const posted: Posted[] = [];
+    const realConsole = {
+      log: console.log,
+      warn: console.warn,
+      error: console.error,
+    };
+    const originalPostMessage =
+      (globalThis as { postMessage?: unknown }).postMessage;
+    (globalThis as { postMessage: (m: Posted) => void }).postMessage = (
+      m: Posted,
+    ) => {
+      posted.push(m);
+    };
+
+    try {
+      // Importing registers the message listener and posts "READY".
+      await import("./web-worker/index.ts");
+      expect(posted).toContain("READY");
+
+      const consoleMessages = () =>
+        posted.filter(
+          (m): m is { __workerConsole: { level: string; text: string } } =>
+            typeof m === "object" && m !== null && "__workerConsole" in m,
+        ).map((m) => m.__workerConsole);
+
+      // A request before initialization is rejected (not patched yet, so no
+      // forwarded copy reaches `posted`).
+      posted.length = 0;
+      await dispatch({ msgId: 1, data: { type: RequestType.Idle } });
+      expect(posted).toEqual([
+        { msgId: 1, error: "WorkerRuntime not initialized." },
+      ]);
+      expect(consoleMessages()).toHaveLength(0);
+
+      // A one-way notification carries no msgId; with no worker it is dropped
+      // silently (no response, no error).
+      posted.length = 0;
+      await dispatch({ type: ClientNotificationType.VDomBatchApplied });
+      expect(posted).toEqual([]);
+
+      // Disabling while forwarding is already off is a no-op that still acks
+      // and leaves the native console untouched.
+      posted.length = 0;
+      await dispatch({
+        msgId: 9,
+        data: { type: RequestType.SetForwardWorkerConsole, enabled: false },
+      });
+      expect(posted).toEqual([{ msgId: 9 }]);
+      expect(console.log).toBe(realConsole.log);
+
+      // Enable forwarding: the worker patches its console and acks.
+      posted.length = 0;
+      await dispatch({
+        msgId: 2,
+        data: { type: RequestType.SetForwardWorkerConsole, enabled: true },
+      });
+      expect(posted).toContainEqual({ msgId: 2 });
+
+      // A second enable is a no-op that still acks; the bridge stays installed.
+      posted.length = 0;
+      await dispatch({
+        msgId: 21,
+        data: { type: RequestType.SetForwardWorkerConsole, enabled: true },
+      });
+      expect(posted).toContainEqual({ msgId: 21 });
+
+      // Now console output is mirrored. Cover each formatting branch.
+      posted.length = 0;
+      console.log("plain string");
+      expect(consoleMessages()).toContainEqual({
+        level: "log",
+        text: "plain string",
+      });
+
+      posted.length = 0;
+      console.warn({ a: 1 });
+      expect(consoleMessages()).toContainEqual({
+        level: "warn",
+        text: '{"a":1}',
+      });
+
+      posted.length = 0;
+      console.error(new Error("boom"));
+      const errMsg = consoleMessages().find((m) => m.level === "error");
+      expect(errMsg?.text).toContain("boom");
+
+      // A circular value cannot be JSON.stringified; the bridge falls back to
+      // String(...) rather than throwing.
+      posted.length = 0;
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      console.log(circular);
+      expect(consoleMessages()).toContainEqual({
+        level: "log",
+        text: "[object Object]",
+      });
+
+      // A postMessage failure inside the patched method must not throw out of
+      // the logging call.
+      (globalThis as { postMessage: (m: Posted) => void }).postMessage = () => {
+        throw new Error("channel closed");
+      };
+      expect(() => console.log("survives")).not.toThrow();
+      (globalThis as { postMessage: (m: Posted) => void }).postMessage = (
+        m: Posted,
+      ) => {
+        posted.push(m);
+      };
+
+      // Disable forwarding: native console is restored, so a subsequent log is
+      // not forwarded.
+      posted.length = 0;
+      await dispatch({
+        msgId: 3,
+        data: { type: RequestType.SetForwardWorkerConsole, enabled: false },
+      });
+      expect(posted).toContainEqual({ msgId: 3 });
+      expect(console.log).toBe(realConsole.log);
+
+      posted.length = 0;
+      console.log("after disable");
+      expect(consoleMessages()).toHaveLength(0);
+
+      // A structurally invalid IPC message is rejected with an error response.
+      posted.length = 0;
+      await dispatch({ msgId: 4, data: { type: "not-a-real-type" } });
+      const errorResponse = posted.find(
+        (m): m is { msgId: number; error: string } =>
+          typeof m === "object" && m !== null && "error" in m,
+      );
+      expect(errorResponse?.msgId).toBe(4);
+      expect(typeof errorResponse?.error).toBe("string");
+    } finally {
+      console.log = realConsole.log;
+      console.warn = realConsole.warn;
+      console.error = realConsole.error;
+      if (originalPostMessage === undefined) {
+        delete (globalThis as { postMessage?: unknown }).postMessage;
+      } else {
+        (globalThis as { postMessage?: unknown }).postMessage =
+          originalPostMessage;
+      }
+    }
+  });
+});

--- a/packages/runtime-client/backends/web-worker/index.ts
+++ b/packages/runtime-client/backends/web-worker/index.ts
@@ -18,6 +18,78 @@ import { RuntimeProcessor } from "../mod.ts";
 let worker: RuntimeProcessor | undefined;
 let workerInitialization: Promise<RuntimeProcessor> | undefined;
 
+const CONSOLE_LEVELS = ["log", "warn", "error"] as const;
+type ConsoleLevel = (typeof CONSOLE_LEVELS)[number];
+type ConsoleMethod = (...args: unknown[]) => void;
+
+// The worker's original console methods, saved while the bridge is installed.
+// `undefined` means the bridge is off and `console` is untouched, so disabled
+// forwarding adds no per-log cost.
+let savedConsole: Record<ConsoleLevel, ConsoleMethod> | undefined;
+
+function formatConsoleArg(arg: unknown): string {
+  if (typeof arg === "string") return arg;
+  // Errors serialize to `{}` under JSON.stringify (message/stack are
+  // non-enumerable), which would drop exactly the detail this bridge exists
+  // to surface, so forward the stack (or name/message) instead.
+  if (arg instanceof Error) return arg.stack ?? `${arg.name}: ${arg.message}`;
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+/**
+ * Patch the worker's `console.log`/`warn`/`error` so each call also posts a
+ * structured `{ __workerConsole: { level, text } }` message that the web-worker
+ * transport re-emits on the page console. The original method is called first,
+ * so nothing is lost in the worker's own console. No-op if already installed.
+ */
+function installWorkerConsoleBridge(): void {
+  if (savedConsole) return;
+  const saved: Record<ConsoleLevel, ConsoleMethod> = {
+    log: console.log,
+    warn: console.warn,
+    error: console.error,
+  };
+  savedConsole = saved;
+
+  for (const level of CONSOLE_LEVELS) {
+    console[level] = (...args: unknown[]) => {
+      saved[level].apply(console, args);
+      try {
+        self.postMessage({
+          __workerConsole: {
+            level,
+            text: args.map(formatConsoleArg).join(" "),
+          },
+        });
+      } catch {
+        // A non-cloneable payload or a closed channel must not break the
+        // logging call itself.
+      }
+    };
+  }
+}
+
+/**
+ * Restore the worker's native console methods, returning `console` to a state
+ * with no forwarding overhead. No-op if the bridge is not installed.
+ */
+function uninstallWorkerConsoleBridge(): void {
+  if (!savedConsole) return;
+  for (const level of CONSOLE_LEVELS) {
+    console[level] = savedConsole[level];
+  }
+  savedConsole = undefined;
+}
+
+function setWorkerConsoleBridge(enabled: boolean): void {
+  if (enabled) installWorkerConsoleBridge();
+  else uninstallWorkerConsoleBridge();
+}
+
 self.addEventListener("message", async (event: MessageEvent) => {
   const message = event.data;
 
@@ -45,11 +117,21 @@ self.addEventListener("message", async (event: MessageEvent) => {
       if (workerInitialization) {
         throw new Error("Initialization of WorkerRuntime already attempted.");
       }
+      setWorkerConsoleBridge(request.data.forwardWorkerConsole === true);
       workerInitialization = RuntimeProcessor.initialize(
         request.data,
       );
       worker = await workerInitialization;
       self.postMessage({ msgId: message.msgId });
+      return;
+    }
+
+    // Toggling console forwarding is handled here, not in the RuntimeProcessor,
+    // because the console patch lives in this worker entry. It is independent
+    // of runtime initialization, so it is answered before the init check.
+    if (request.type === RequestType.SetForwardWorkerConsole) {
+      setWorkerConsoleBridge(request.enabled);
+      self.postMessage({ msgId });
       return;
     }
 

--- a/packages/runtime-client/client/transport-web-worker.test.ts
+++ b/packages/runtime-client/client/transport-web-worker.test.ts
@@ -1,0 +1,95 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { WebWorkerRuntimeTransport } from "./transports/web-worker/transport-web-worker.ts";
+
+// Exercises the transport's handling of `{ __workerConsole }` messages without
+// a real worker: a fake Worker class lets us construct the transport, then we
+// drive its private message handler directly.
+class FakeWorker extends EventTarget {
+  posted: unknown[] = [];
+  terminated = false;
+  postMessage(message: unknown): void {
+    this.posted.push(message);
+  }
+  terminate(): void {
+    this.terminated = true;
+  }
+}
+
+function makeTransport(): WebWorkerRuntimeTransport {
+  const OriginalWorker = (globalThis as { Worker: unknown }).Worker;
+  (globalThis as { Worker: unknown }).Worker = FakeWorker;
+  try {
+    return new WebWorkerRuntimeTransport({
+      workerUrl: new URL("http://localhost/worker.js"),
+    });
+  } finally {
+    (globalThis as { Worker: unknown }).Worker = OriginalWorker;
+  }
+}
+
+function handlerOf(
+  transport: WebWorkerRuntimeTransport,
+): (event: MessageEvent) => void {
+  return (transport as unknown as {
+    _handleMessage: (event: MessageEvent) => void;
+  })._handleMessage;
+}
+
+describe("WebWorkerRuntimeTransport worker-console re-emit", () => {
+  it("re-emits forwarded worker console at the matching level and stops", async () => {
+    const transport = makeTransport();
+    const emitted: unknown[] = [];
+    transport.on("message", (m) => emitted.push(m));
+
+    const calls: Array<[string, string]> = [];
+    const realConsole = {
+      log: console.log,
+      warn: console.warn,
+      error: console.error,
+    };
+    console.log = (m: string) => calls.push(["log", m]);
+    console.warn = (m: string) => calls.push(["warn", m]);
+    console.error = (m: string) => calls.push(["error", m]);
+
+    try {
+      const handle = handlerOf(transport);
+
+      handle(
+        new MessageEvent("message", {
+          data: { __workerConsole: { level: "error", text: "kaboom" } },
+        }),
+      );
+      handle(
+        new MessageEvent("message", {
+          data: { __workerConsole: { level: "warn", text: "careful" } },
+        }),
+      );
+      // A level with no matching console method falls back to console.log.
+      handle(
+        new MessageEvent("message", {
+          data: { __workerConsole: { level: "fatal", text: "fallback" } },
+        }),
+      );
+
+      expect(calls).toEqual([
+        ["error", "[worker] kaboom"],
+        ["warn", "[worker] careful"],
+        ["log", "[worker] fallback"],
+      ]);
+      // None of these were treated as IPC messages.
+      expect(emitted).toEqual([]);
+    } finally {
+      console.log = realConsole.log;
+      console.warn = realConsole.warn;
+      console.error = realConsole.error;
+    }
+
+    // A non-console message still flows through as an emitted IPC message.
+    const ipc = { msgId: 7, data: { value: true } };
+    handlerOf(transport)(new MessageEvent("message", { data: ipc }));
+    expect(emitted).toContainEqual(ipc);
+
+    await transport.dispose();
+  });
+});

--- a/packages/runtime-client/client/transports/web-worker/transport-web-worker.ts
+++ b/packages/runtime-client/client/transports/web-worker/transport-web-worker.ts
@@ -70,6 +70,25 @@ export class WebWorkerRuntimeTransport
   private _handleMessage = (event: MessageEvent): void => {
     const data = event.data;
 
+    // Worker-side console output forwarded by the bridge in
+    // `backends/web-worker/index.ts` (opt-in). Re-emit it on the page
+    // console so it reaches devtools and integration-test console capture,
+    // then stop: it is not an IPC response and carries no `msgId`.
+    if (
+      data && typeof data === "object" &&
+      (data as { __workerConsole?: unknown }).__workerConsole
+    ) {
+      const { level, text } = (data as {
+        __workerConsole: { level: string; text: string };
+      }).__workerConsole;
+      const sink = (console as unknown as Record<
+        string,
+        (message: string) => void
+      >)[level] ?? console.log;
+      sink(`[worker] ${text}`);
+      return;
+    }
+
     if (!this._ready && data === "READY") {
       this._ready = true;
       this._readyPromise.resolve();

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -58,6 +58,7 @@ export enum RequestType {
   SetLoggerLevel = "runtime:setLoggerLevel",
   SetLoggerEnabled = "runtime:setLoggerEnabled",
   SetTelemetryEnabled = "runtime:setTelemetryEnabled",
+  SetForwardWorkerConsole = "runtime:setForwardWorkerConsole",
   ResetLoggerBaselines = "runtime:resetLoggerBaselines",
   GetSettleStats = "runtime:getSettleStats",
   GetSettleStatsHistory = "runtime:getSettleStatsHistory",
@@ -177,6 +178,12 @@ export interface InitializationData {
     actingPrincipal?: string;
     revision?: string;
   };
+  // When true, the worker mirrors its own console output (log/warn/error)
+  // to the main thread, which re-emits it on the page console prefixed
+  // with `[worker]`, so runtime-internal logs reach devtools and
+  // integration-test console capture. Off by default: each forwarded call
+  // costs one postMessage, so it is enabled only for diagnostic runs.
+  forwardWorkerConsole?: boolean;
 }
 
 export interface InitializeRequest extends BaseRequest {
@@ -320,6 +327,11 @@ export interface SetLoggerEnabledRequest extends BaseRequest {
 
 export interface SetTelemetryEnabledRequest extends BaseRequest {
   type: RequestType.SetTelemetryEnabled;
+  enabled: boolean;
+}
+
+export interface SetForwardWorkerConsoleRequest extends BaseRequest {
+  type: RequestType.SetForwardWorkerConsole;
   enabled: boolean;
 }
 
@@ -686,6 +698,7 @@ export type IPCClientRequest =
   | SetLoggerLevelRequest
   | SetLoggerEnabledRequest
   | SetTelemetryEnabledRequest
+  | SetForwardWorkerConsoleRequest
   | ResetLoggerBaselinesRequest
   | GetSettleStatsRequest
   | GetSettleStatsHistoryRequest
@@ -918,6 +931,10 @@ export type Commands = {
   };
   [RequestType.SetTelemetryEnabled]: {
     request: SetTelemetryEnabledRequest;
+    response: EmptyResponse;
+  };
+  [RequestType.SetForwardWorkerConsole]: {
+    request: SetForwardWorkerConsoleRequest;
     response: EmptyResponse;
   };
   [RequestType.ResetLoggerBaselines]: {

--- a/packages/runtime-client/runtime-client.test.ts
+++ b/packages/runtime-client/runtime-client.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { RuntimeClient } from "./runtime-client.ts";
+import { RequestType } from "./protocol/mod.ts";
 import type { RuntimeTransport } from "./client/transport.ts";
 
 describe("RuntimeClient.initialize option validation", () => {
@@ -43,5 +44,43 @@ describe("RuntimeClient.signal", () => {
       new (conn: never, options: unknown): RuntimeClient;
     })(conn, {});
     expect(client.signal).toBe(signal);
+  });
+});
+
+describe("RuntimeClient.setForwardWorkerConsole", () => {
+  // The constructor only wires `on()` listeners and stores the connection, so a
+  // stub that records requests is enough to assert the IPC the method sends.
+  function clientWithRequestStub(): {
+    client: RuntimeClient;
+    requests: unknown[];
+  } {
+    const requests: unknown[] = [];
+    const conn = {
+      on: () => {},
+      request: (message: unknown) => {
+        requests.push(message);
+        return Promise.resolve(undefined);
+      },
+    } as unknown as never;
+    const client = new (RuntimeClient as unknown as {
+      new (conn: never, options: unknown): RuntimeClient;
+    })(conn, {});
+    return { client, requests };
+  }
+
+  it("sends a SetForwardWorkerConsole request to enable forwarding", async () => {
+    const { client, requests } = clientWithRequestStub();
+    await client.setForwardWorkerConsole(true);
+    expect(requests).toEqual([
+      { type: RequestType.SetForwardWorkerConsole, enabled: true },
+    ]);
+  });
+
+  it("sends a SetForwardWorkerConsole request to disable forwarding", async () => {
+    const { client, requests } = clientWithRequestStub();
+    await client.setForwardWorkerConsole(false);
+    expect(requests).toEqual([
+      { type: RequestType.SetForwardWorkerConsole, enabled: false },
+    ]);
   });
 });

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -122,6 +122,7 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
       renderDeclassificationPolicy: options.renderDeclassificationPolicy,
       renderConfidentialityCeiling: options.renderConfidentialityCeiling,
       trustSnapshot: options.trustSnapshot,
+      forwardWorkerConsole: options.forwardWorkerConsole,
     });
     return new RuntimeClient(initialized, options);
   }
@@ -402,6 +403,19 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
   async setTelemetryEnabled(enabled: boolean): Promise<void> {
     await this.#conn.request<RequestType.SetTelemetryEnabled>({
       type: RequestType.SetTelemetryEnabled,
+      enabled,
+    });
+  }
+
+  /**
+   * Enable or disable forwarding of the worker runtime's console output to the
+   * main thread for the running worker. Takes effect immediately, without a
+   * reload. When disabled the worker restores its native console methods, so
+   * there is no per-log cost while off.
+   */
+  async setForwardWorkerConsole(enabled: boolean): Promise<void> {
+    await this.#conn.request<RequestType.SetForwardWorkerConsole>({
+      type: RequestType.SetForwardWorkerConsole,
       enabled,
     });
   }

--- a/packages/shell/src/globals.ts
+++ b/packages/shell/src/globals.ts
@@ -30,6 +30,7 @@ declare global {
       rootOnly?: boolean;
       includeCurrentValue?: boolean;
     }) => Promise<unknown>;
+    forwardWorkerConsole?: (enabled?: boolean) => void;
     [key: string]: unknown;
   };
 }

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -2,6 +2,7 @@ import "core-js/proposals/explicit-resource-management";
 import "core-js/proposals/async-explicit-resource-management";
 import "@commonfabric/ui";
 import { API_URL, COMMIT_SHA, ENVIRONMENT } from "./lib/env.ts";
+import { setupWorkerConsoleToggle } from "./lib/worker-console.ts";
 import "./components/index.ts";
 import "./views/index.ts";
 import { App, AppElement, AppUpdateEvent, Navigation } from "../shared/mod.ts";
@@ -14,6 +15,7 @@ if ("serviceWorker" in navigator) {
 console.log(`ENVIRONMENT=${ENVIRONMENT}`);
 console.log(`API_URL=${API_URL}`);
 console.log(`COMMIT_SHA=${COMMIT_SHA}`);
+setupWorkerConsoleToggle();
 
 const root = document.querySelector("x-root-view");
 if (!root) throw new Error("No root view found.");

--- a/packages/shell/src/lib/worker-console.ts
+++ b/packages/shell/src/lib/worker-console.ts
@@ -1,0 +1,85 @@
+/**
+ * Runtime toggle for forwarding the web-worker runtime's console output to the
+ * main thread (the page console). The flag is read here on the main thread and
+ * passed to the worker, which patches its console only while enabled: the
+ * worker is a browser context with no access to localStorage, so it cannot
+ * read the setting itself.
+ *
+ * The setting is persisted in localStorage, which seeds the worker when a
+ * runtime is created (covering startup logging and fresh page loads).
+ * `commonfabric.forwardWorkerConsole(enabled?)` also applies it to the running
+ * worker immediately, so flipping it needs no reload. A hint is printed at
+ * boot.
+ */
+
+import type { RuntimeClient } from "@commonfabric/runtime-client";
+
+const STORAGE_KEY = "forwardWorkerConsole";
+
+type CommonfabricGlobal = typeof globalThis & {
+  commonfabric?:
+    & {
+      rt?: RuntimeClient;
+      forwardWorkerConsole?: (enabled?: boolean) => void;
+    }
+    & Record<string, unknown>;
+};
+
+/** Whether worker console forwarding is enabled for this session. */
+export function isWorkerConsoleForwardingEnabled(): boolean {
+  try {
+    return globalThis.localStorage?.getItem(STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function setWorkerConsoleForwarding(enabled: boolean): void {
+  try {
+    if (enabled) {
+      globalThis.localStorage.setItem(STORAGE_KEY, "true");
+    } else {
+      globalThis.localStorage.removeItem(STORAGE_KEY);
+    }
+  } catch (error) {
+    console.error("[worker-console] Could not persist the setting:", error);
+    return;
+  }
+  // Apply to the running worker now; the persisted value seeds the next one.
+  const rt = (globalThis as CommonfabricGlobal).commonfabric?.rt;
+  void rt?.setForwardWorkerConsole(enabled).catch((error: unknown) => {
+    console.error(
+      "[worker-console] Could not update the running runtime:",
+      error,
+    );
+  });
+  console.info(
+    `[worker-console] Worker console forwarding ${
+      enabled ? "enabled" : "disabled"
+    }.`,
+  );
+}
+
+/**
+ * Install `commonfabric.forwardWorkerConsole(enabled?)` and print a one-line
+ * hint describing the current state and how to flip it. Run once at boot,
+ * before any runtime exists, so the command is available while logged out.
+ */
+export function setupWorkerConsoleToggle(): void {
+  const global = globalThis as CommonfabricGlobal;
+  const cf = (global.commonfabric ??= {});
+  cf.forwardWorkerConsole = (enabled = true) =>
+    setWorkerConsoleForwarding(enabled);
+
+  if (isWorkerConsoleForwardingEnabled()) {
+    console.info(
+      "[worker-console] Worker runtime console forwarding is ON. Disable with " +
+        "commonfabric.forwardWorkerConsole(false).",
+    );
+  } else {
+    console.info(
+      "[worker-console] Worker runtime console forwarding is OFF. Enable with " +
+        "commonfabric.forwardWorkerConsole().",
+    );
+  }
+}

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -29,6 +29,7 @@ import {
   type ThemePreference,
 } from "../lib/theme-preference.ts";
 import { EXPERIMENTAL } from "../lib/env.ts";
+import { isWorkerConsoleForwardingEnabled } from "../lib/worker-console.ts";
 
 function getCommonfabricGlobal(): typeof globalThis & {
   commonfabric?: CommonfabricDebugState;
@@ -107,6 +108,7 @@ export class XRootView extends BaseView {
           identity: app.identity,
           apiUrl: app.apiUrl,
           experimental: EXPERIMENTAL,
+          forwardWorkerConsole: isWorkerConsoleForwardingEnabled(),
           // lib-shell emits address-shaped targets ({spaceDid, pieceId});
           // mapNavigationView (shared/navigate.ts) maps a DID back to the
           // human-readable spaceName URL at the Navigation layer.

--- a/packages/shell/test/root-view.test.ts
+++ b/packages/shell/test/root-view.test.ts
@@ -1,0 +1,87 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+// XRootView is a Lit element; load and exercise it under a minimal browser
+// shim, mirroring login-view.test.ts. Constructing it runs its field
+// initializers (including the runtime Task that reads
+// isWorkerConsoleForwardingEnabled), and its pure methods render and report
+// state without needing the reactive update lifecycle.
+function installBrowserGlobals(): () => void {
+  const originals = new Map<string, PropertyDescriptor | undefined>();
+  function setGlobal(name: string, value: unknown): void {
+    originals.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value,
+    });
+  }
+  class TestHTMLElement extends EventTarget {}
+  setGlobal("window", globalThis);
+  setGlobal("HTMLElement", TestHTMLElement);
+  setGlobal("customElements", {
+    define() {},
+    get() {},
+    whenDefined: () => Promise.resolve(),
+  });
+  setGlobal("document", {
+    documentElement: { style: {} },
+    addEventListener() {},
+    removeEventListener() {},
+    createElement: () => ({
+      style: {},
+      setAttribute() {},
+      append() {},
+      appendChild() {},
+    }),
+    createTreeWalker: () => ({}),
+  });
+  setGlobal("devicePixelRatio", 1);
+  setGlobal("screen", { deviceXDPI: 1, logicalXDPI: 1 });
+  setGlobal("navigator", { platform: "", userAgent: "deno" });
+  setGlobal("location", {
+    protocol: "http:",
+    host: "localhost:8000",
+    hostname: "localhost",
+    href: "http://localhost:8000/common-knowledge",
+  });
+
+  return () => {
+    for (const [name, descriptor] of originals) {
+      if (descriptor) {
+        Object.defineProperty(globalThis, name, descriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, name);
+      }
+    }
+  };
+}
+
+function templateStrings(value: unknown): string {
+  const result = value as { strings?: readonly string[] };
+  return (result?.strings ?? []).join("");
+}
+
+describe("XRootView", () => {
+  it("constructs with default app state and renders the app view", async () => {
+    const restore = installBrowserGlobals();
+    try {
+      const { XRootView } = await import("../src/views/RootView.ts");
+      const view = new XRootView();
+
+      // A fresh root has no resolved space yet, and state() clones out the
+      // default app state.
+      expect(view.getRuntimeSpaceDID()).toBeUndefined();
+      const state = view.state();
+      expect(state).toBeDefined();
+      expect(state).not.toBe(view.app);
+
+      // render() builds the themed app-view template without a live DOM.
+      const markup = templateStrings(view.render());
+      expect(markup).toContain("cf-theme");
+      expect(markup).toContain("x-app-view");
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/shell/test/worker-console.test.ts
+++ b/packages/shell/test/worker-console.test.ts
@@ -1,0 +1,247 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  isWorkerConsoleForwardingEnabled,
+  setupWorkerConsoleToggle,
+} from "../src/lib/worker-console.ts";
+// Load the ambient-globals module so its declaration of
+// `commonfabric.forwardWorkerConsole` is exercised alongside the toggle.
+import "../src/globals.ts";
+
+const STORAGE_KEY = "forwardWorkerConsole";
+
+class FakeStorage {
+  map = new Map<string, string>();
+  throwOnRead = false;
+  throwOnWrite = false;
+  getItem(key: string): string | null {
+    if (this.throwOnRead) throw new Error("read blocked");
+    return this.map.has(key) ? this.map.get(key)! : null;
+  }
+  setItem(key: string, value: string): void {
+    if (this.throwOnWrite) throw new Error("write blocked");
+    this.map.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+}
+
+interface FakeRuntime {
+  calls: boolean[];
+  setForwardWorkerConsole: (enabled: boolean) => Promise<void>;
+}
+
+function makeRuntime(reject = false): FakeRuntime {
+  const calls: boolean[] = [];
+  return {
+    calls,
+    setForwardWorkerConsole: (enabled: boolean) => {
+      calls.push(enabled);
+      return reject
+        ? Promise.reject(new Error("runtime gone"))
+        : Promise.resolve();
+    },
+  };
+}
+
+interface Harness {
+  storage: FakeStorage;
+  info: string[];
+  errors: string[];
+  setRuntime: (rt: FakeRuntime | undefined) => void;
+  restore: () => void;
+}
+
+function setup(): Harness {
+  const storage = new FakeStorage();
+  const info: string[] = [];
+  const errors: string[] = [];
+
+  const storageDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "localStorage",
+  );
+  Object.defineProperty(globalThis, "localStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+
+  const cfGlobal = globalThis as {
+    commonfabric?: { rt?: unknown; forwardWorkerConsole?: unknown };
+  };
+  const originalCommonfabric = cfGlobal.commonfabric;
+  cfGlobal.commonfabric = {};
+
+  const realInfo = console.info;
+  const realError = console.error;
+  console.info = (...args: unknown[]) => info.push(args.join(" "));
+  console.error = (...args: unknown[]) => errors.push(args.join(" "));
+
+  return {
+    storage,
+    info,
+    errors,
+    setRuntime: (rt) => {
+      // Mutate `.rt` in place so the installed `forwardWorkerConsole` command
+      // survives — replacing the object would drop it.
+      const cf = (cfGlobal.commonfabric ??= {});
+      cf.rt = rt;
+    },
+    restore: () => {
+      console.info = realInfo;
+      console.error = realError;
+      if (storageDescriptor) {
+        Object.defineProperty(globalThis, "localStorage", storageDescriptor);
+      } else {
+        delete (globalThis as { localStorage?: unknown }).localStorage;
+      }
+      if (originalCommonfabric === undefined) {
+        delete (globalThis as { commonfabric?: unknown }).commonfabric;
+      } else {
+        cfGlobal.commonfabric = originalCommonfabric;
+      }
+    },
+  };
+}
+
+function command(): (enabled?: boolean) => void {
+  const cf = (globalThis as {
+    commonfabric?: { forwardWorkerConsole?: (enabled?: boolean) => void };
+  }).commonfabric;
+  if (!cf?.forwardWorkerConsole) {
+    throw new Error("forwardWorkerConsole was not installed");
+  }
+  return cf.forwardWorkerConsole;
+}
+
+describe("isWorkerConsoleForwardingEnabled", () => {
+  it('is false when the key is absent and true when set to "true"', () => {
+    const h = setup();
+    try {
+      expect(isWorkerConsoleForwardingEnabled()).toBe(false);
+      h.storage.map.set(STORAGE_KEY, "true");
+      expect(isWorkerConsoleForwardingEnabled()).toBe(true);
+      h.storage.map.set(STORAGE_KEY, "yes");
+      expect(isWorkerConsoleForwardingEnabled()).toBe(false);
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("is false when reading localStorage throws", () => {
+    const h = setup();
+    try {
+      h.storage.throwOnRead = true;
+      expect(isWorkerConsoleForwardingEnabled()).toBe(false);
+    } finally {
+      h.restore();
+    }
+  });
+});
+
+describe("setupWorkerConsoleToggle", () => {
+  it("prints the OFF hint and installs the command when disabled", () => {
+    const h = setup();
+    try {
+      setupWorkerConsoleToggle();
+      expect(h.info.join("\n")).toContain("is OFF");
+      expect(typeof command()).toBe("function");
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("prints the ON hint when already enabled", () => {
+    const h = setup();
+    try {
+      h.storage.map.set(STORAGE_KEY, "true");
+      setupWorkerConsoleToggle();
+      expect(h.info.join("\n")).toContain("is ON");
+    } finally {
+      h.restore();
+    }
+  });
+});
+
+describe("commonfabric.forwardWorkerConsole", () => {
+  it("persists, applies to the running runtime, and logs when enabling", async () => {
+    const h = setup();
+    const rt = makeRuntime();
+    try {
+      setupWorkerConsoleToggle();
+      h.setRuntime(rt);
+      command()(); // default argument enables
+      await Promise.resolve();
+      expect(h.storage.map.get(STORAGE_KEY)).toBe("true");
+      expect(rt.calls).toEqual([true]);
+      expect(h.info.join("\n")).toContain("enabled");
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("clears the key, applies to the running runtime, and logs when disabling", async () => {
+    const h = setup();
+    const rt = makeRuntime();
+    try {
+      h.storage.map.set(STORAGE_KEY, "true");
+      setupWorkerConsoleToggle();
+      h.setRuntime(rt);
+      command()(false);
+      await Promise.resolve();
+      expect(h.storage.map.has(STORAGE_KEY)).toBe(false);
+      expect(rt.calls).toEqual([false]);
+      expect(h.info.join("\n")).toContain("disabled");
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("persists without a runtime when none is running", () => {
+    const h = setup();
+    try {
+      setupWorkerConsoleToggle();
+      h.setRuntime(undefined);
+      command()(true);
+      expect(h.storage.map.get(STORAGE_KEY)).toBe("true");
+      expect(h.info.join("\n")).toContain("enabled");
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("logs and bails out when persistence fails, without touching the runtime", () => {
+    const h = setup();
+    const rt = makeRuntime();
+    try {
+      setupWorkerConsoleToggle();
+      h.setRuntime(rt);
+      h.storage.throwOnWrite = true;
+      command()(true);
+      expect(h.errors.join("\n")).toContain("Could not persist");
+      expect(rt.calls).toEqual([]);
+      // The "enabled"/"disabled" confirmation is not logged on failure.
+      expect(h.info.join("\n")).not.toContain("enabled");
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("reports a runtime that rejects the live update", async () => {
+    const h = setup();
+    const rt = makeRuntime(true);
+    try {
+      setupWorkerConsoleToggle();
+      h.setRuntime(rt);
+      command()(true);
+      // Let the rejected live-update promise settle so its catch runs.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(rt.calls).toEqual([true]);
+      expect(h.errors.join("\n")).toContain("Could not update the running");
+    } finally {
+      h.restore();
+    }
+  });
+});


### PR DESCRIPTION
…main thread

In shell and browser deployments, the Common Fabric runtime runs inside a Web Worker (the RuntimeProcessor backend). Every console.log, console.warn, and console.error made by runtime code — the scheduler, the storage commit path, pattern handlers running in the worker — goes to the worker's own console, which is a separate context from the main page's console.

Two tools that developers rely on only ever see the page console, never the worker's. The integration test harness captures the page console (via PIPE_CONSOLE and the page "console" event in packages/integration), so worker console output never reaches the test output. Browser devtools show the page console by default, and the worker console is a separate target that is easy to overlook.

The practical consequence is that when something goes wrong inside the runtime during an integration test, you can observe the pattern's effects on the DOM but not the runtime's own logs about what it actually did. Runtime-internal logs — from the scheduler, the multi-space commit path, and in-worker handlers — never reach the headless test output. This has made a real regression much harder to diagnose: the commit-path logs that would have pinpointed it never left the worker.

This adds a lightweight, opt-in bridge that closes the gap. When enabled, the worker patches console.log/warn/error so each call also posts a structured { __workerConsole: { level, text } } message to the main thread, after calling the original console method first so nothing is lost in the worker's own console. The main-thread web-worker transport recognizes these messages in its message handler and re-emits them on the page console at the matching level, prefixed with "[worker]" so they are distinguishable, then returns early so the message is never treated as an IPC response. Error arguments are forwarded by their stack (or name and message) rather than JSON.stringify, which serializes an Error to "{}" and would drop exactly the detail this bridge exists to surface.

The bridge is off by default. Forwarding every console call adds a postMessage per log, and the runtime logs frequently, so leaving it always on would flood the worker-to-main channel and measurably perturb timing during a diagnostic run. The worker patches console only when enabled. The worker is a browser context with no access to Deno.env or localStorage, so it cannot read the setting itself; the main thread reads it and passes it to the worker.

In the shell the setting is a runtime toggle persisted in localStorage, not a build-time flag, so it can be turned on without rebuilding and an integration run can flip it per page. On every boot the shell prints a one-line hint stating whether forwarding is on or off and the command to change it. The command, commonfabric.forwardWorkerConsole(enabled?), is installed alongside the other commonfabric debug helpers and is available before login.

Flipping the toggle takes effect immediately, without a reload. A SetForwardWorkerConsole IPC request tells the running worker to install or uninstall the console patch, and the command sends it right after persisting the setting. The persisted localStorage value also seeds the worker when a runtime is created, which covers startup logging and fresh page loads. Disabling restores the worker's exact native console methods rather than leaving a wrapper that checks a flag, so there is no per-log cost while forwarding is off. The worker entry answers SetForwardWorkerConsole itself, before the initialization check, because the console patch lives there rather than in the RuntimeProcessor.

One consequence to expect when forwarding is on: worker console.error calls surface on the page console as real errors, so a diagnostic run can trip the integration harness's fail-on-console-error check. That is the intended cost of making worker errors visible, and forwarding stays off for normal runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt‑in bridge that forwards the runtime Web Worker’s console output to the page console so logs show in devtools and integration test output. Off by default; can be toggled at runtime without a reload.

- **New Features**
  - Worker mirrors `console.log`/`warn`/`error`; the main-thread `WebWorkerRuntimeTransport` re-emits at the same level with “[worker]” and ignores these as IPC; `Error` args forward by stack/name+message.
  - `forwardWorkerConsole` option flows from `lib-shell` into `InitializationData`; `RootView` seeds it from localStorage.
  - Toggle live with `RuntimeClient#setForwardWorkerConsole(enabled)`; new IPC `runtime:setForwardWorkerConsole` handled in the worker entry even before init; disabling restores native console for zero overhead while off.
  - Shell prints a boot hint and exposes `commonfabric.forwardWorkerConsole(enabled?)` (available before login) which persists the setting and applies it to the running runtime.

- **Migration**
  - Enable: `commonfabric.forwardWorkerConsole()`. Disable: `commonfabric.forwardWorkerConsole(false)`. Persists per page and seeds new runtimes.
  - Heads-up: forwarded worker `console.error` shows as page errors and can trip fail-on-console-error checks in tests.

<sup>Written for commit 66adf9583532292f5f8eab8bccfa4abdd68d33c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

