### PR TITLE
Add runtime pattern coverage LCOV collection

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -673,8 +673,11 @@ jobs:
       - name: 🧪 Run pattern unit tests
         run: |
           chmod +x ./common-binaries/cf
-          mkdir -p test-results
-          DENO_COVERAGE_DIR=coverage/raw/pattern-unit-${{ matrix.chunk }} CF_BINARY=./common-binaries/cf deno task integration --junit-dir=test-results pattern-tests ${{ matrix.chunk }}/${{ matrix.total }}
+          mkdir -p test-results coverage/lcov/pattern-runtime/pattern-unit-${{ matrix.chunk }}
+          DENO_COVERAGE_DIR=coverage/raw/pattern-unit-${{ matrix.chunk }} \
+          CF_PATTERN_COVERAGE_DIR=coverage/lcov/pattern-runtime/pattern-unit-${{ matrix.chunk }} \
+          CF_BINARY=./common-binaries/cf \
+          deno task integration --junit-dir=test-results pattern-tests ${{ matrix.chunk }}/${{ matrix.total }}
 
       - name: 🧾 Write coverage report
         if: always()
@@ -685,7 +688,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: coverage-profile-pattern-unit-${{ matrix.chunk }}
-          path: coverage/lcov/pattern-unit-${{ matrix.chunk }}.lcov
+          path: coverage/lcov/
           retention-days: 90
           if-no-files-found: error
 

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -92,7 +92,7 @@ pipeline from `CFC_TRANSFORMER_STAGE_SPECS`. Every stage shares:
 
 The authoritative ordering lives in `CFC_TRANSFORMER_STAGE_SPECS` /
 `CFC_TRANSFORMER_STAGE_NAMES` in `src/cf-pipeline.ts`. Transformers always run
-in this order (18 stages):
+in this order (19 stages):
 
 1. `CastValidationTransformer`
 2. `EmptyArrayOfValidationTransformer`
@@ -111,7 +111,8 @@ in this order (18 stages):
 15. `ReactiveVariableForTransformer`
 16. `ModuleScopeShadowingTransformer`
 17. `ModuleScopeCfDataTransformer`
-18. `ModuleScopeFunctionHardeningTransformer`
+18. `PatternCoverageTransformer`
+19. `ModuleScopeFunctionHardeningTransformer`
 
 The order is behaviorally significant (invariant C-002). Two ordering facts
 worth calling out:
@@ -124,8 +125,12 @@ worth calling out:
   former separate `LiftHoistingTransformer` (which hoisted only `lift`); the
   even-older `BuilderCallbackHoistingTransformer` was deleted (#3864). Earlier
   spec revisions listing those two as distinct stages are obsolete.
-- The four module-scope stages (15–18) run last so they operate on fully lowered
-  and schema-injected output.
+- The final five stages (15–19) run last so they operate on fully lowered and
+  schema-injected output.
+- `PatternCoverageTransformer` (stage 18) does no work unless pattern runtime
+  coverage is enabled. When enabled, it runs before
+  `ModuleScopeFunctionHardeningTransformer` so coverage counters are added to
+  authored bodies before hardening helpers are emitted.
 
 ## 4. Global Modes
 

--- a/packages/cli/commands/test.ts
+++ b/packages/cli/commands/test.ts
@@ -65,6 +65,10 @@ export const test = new Command()
     "Maximum number of storage timing/count entries to print with --storage-stats.",
     { default: 16 },
   )
+  .option(
+    "--pattern-coverage-dir <dir:string>",
+    "Write pattern runtime coverage LCOV artifacts to this directory.",
+  )
   .arguments("<paths...:string>")
   .action(async (options, ...paths) => {
     const testFiles: string[] = [];
@@ -123,6 +127,11 @@ export const test = new Command()
 
     // Resolve root path if provided
     const root = options.root ? resolve(Deno.cwd(), options.root) : undefined;
+    const patternCoverageDir = options.patternCoverageDir
+      ? resolve(Deno.cwd(), options.patternCoverageDir)
+      : Deno.env.get("CF_PATTERN_COVERAGE_DIR")
+      ? resolve(Deno.cwd(), Deno.env.get("CF_PATTERN_COVERAGE_DIR")!)
+      : undefined;
     const statsInclude = options.statsInclude
       ? String(options.statsInclude)
         .split(",")
@@ -140,6 +149,7 @@ export const test = new Command()
       statsActionLimit: options.statsActionLimit,
       storageStats: options.storageStats,
       storageStatsLimit: options.storageStatsLimit,
+      patternCoverageDir,
     });
 
     // Exit with error code if any tests failed

--- a/packages/cli/lib/multi-user-test-runner.ts
+++ b/packages/cli/lib/multi-user-test-runner.ts
@@ -228,6 +228,7 @@ export async function runMultiUserTestPattern(
           apiUrl: server.url.href,
           testPath,
           root: options.root,
+          patternCoverageDir: options.patternCoverageDir,
           participant: spec.name,
           seedDefaults: index === 0,
         }) as ParticipantInitResult;
@@ -439,11 +440,26 @@ export async function runMultiUserTestPattern(
     };
   } finally {
     for (const participant of participants) {
+      if (options.patternCoverageDir) {
+        await participant.worker.call("writeCoverage").catch((error) => {
+          console.error(
+            `[cf test] failed to write pattern coverage for ${participant.spec.name}: ${
+              formatError(error)
+            }`,
+          );
+        });
+      }
       await participant.worker.call("dispose").catch(() => {});
       participant.worker.terminate();
     }
     await server.close().catch(() => {});
   }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error
+    ? error.stack || error.message || String(error)
+    : String(error);
 }
 
 function recordSkip(

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -21,7 +21,10 @@ import {
   ConsoleMethod,
   type Engine,
   type Pattern,
+  PatternCoverageCollector,
+  patternCoverageOutputPath,
   Runtime,
+  writePatternCoverageLcov,
 } from "@commonfabric/runner";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { buildActionEvent } from "./trusted-test-event.ts";
@@ -72,6 +75,9 @@ let storageManager:
   | undefined;
 let engine: Engine | undefined;
 let stepCells: Cell<unknown>[] = [];
+let patternCoverage: PatternCoverageCollector | undefined;
+let patternCoveragePath: string | undefined;
+let patternCoverageRoot: string | undefined;
 const runtimeErrors: string[] = [];
 /** Channel 1: console.error/warn captured via the harness console event. */
 const consoleErrors: string[] = [];
@@ -198,6 +204,17 @@ const handlers: Record<
     // splits verified-load/source-map state and breaks CFC verified-binding
     // identities under enforcement.
     engine = runtime.harness;
+    patternCoverage = typeof args.patternCoverageDir === "string"
+      ? new PatternCoverageCollector()
+      : undefined;
+    patternCoveragePath = typeof args.patternCoverageDir === "string"
+      ? patternCoverageOutputPath(
+        args.patternCoverageDir,
+        args.testPath as string,
+        args.participant as string,
+      )
+      : undefined;
+    patternCoverageRoot = typeof args.root === "string" ? args.root : undefined;
 
     const program = await engine.resolve(
       new FileSystemProgramResolver(
@@ -205,7 +222,9 @@ const handlers: Record<
         args.root as string | undefined,
       ),
     );
-    const { main } = await engine.compileAndEvaluateModules(program);
+    const { main } = await engine.compileAndEvaluateModules(program, {
+      patternCoverage,
+    });
     // Channel 2: snapshot logger counts AFTER compile, before the run phase.
     loggerCountsBeforeRun = snapshotLoggerErrorWarnCounts();
     consoleCaptureActive = true;
@@ -370,6 +389,17 @@ const handlers: Record<
     });
   },
 
+  async writeCoverage() {
+    if (patternCoverage && patternCoveragePath) {
+      await writePatternCoverageLcov(
+        patternCoverage,
+        patternCoveragePath,
+        { root: patternCoverageRoot },
+      );
+    }
+    return {};
+  },
+
   async dispose() {
     stepCells = [];
     // `engine` is the runtime's own harness; runtime.dispose() disposes it.
@@ -378,6 +408,9 @@ const handlers: Record<
     runtime = undefined;
     storageManager = undefined;
     engine = undefined;
+    patternCoverage = undefined;
+    patternCoveragePath = undefined;
+    patternCoverageRoot = undefined;
     return {};
   },
 };
@@ -393,12 +426,12 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
   }
   handler(args).then(
     (ok) => respond({ id, ok }),
-    (error: unknown) =>
-      respond({
-        id,
-        error: error instanceof Error
-          ? `${error.message}\n${error.stack ?? ""}`
-          : String(error),
-      }),
+    (error: unknown) => respond({ id, error: formatError(error) }),
   );
 };
+
+function formatError(error: unknown): string {
+  return error instanceof Error
+    ? error.stack || error.message || String(error)
+    : String(error);
+}

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -26,7 +26,13 @@
  */
 
 import { Identity } from "@commonfabric/identity";
-import { ConsoleMethod, Runtime } from "@commonfabric/runner";
+import {
+  ConsoleMethod,
+  PatternCoverageCollector,
+  patternCoverageOutputPath,
+  Runtime,
+  writePatternCoverageLcov,
+} from "@commonfabric/runner";
 import type {
   Cell,
   ConsoleHandler,
@@ -98,6 +104,12 @@ async function withPhase<T>(
     phaseLogger.timeEnd(...keys);
     performance.measure(`${label}#${phaseMarkSequence}`, startMark, endMark);
   }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error
+    ? error.stack || error.message || String(error)
+    : String(error);
 }
 
 /**
@@ -252,6 +264,8 @@ export interface TestRunnerOptions {
   storageStats?: boolean;
   /** Limit for storage timing/count tables when storageStats is enabled. */
   storageStatsLimit?: number;
+  /** Directory for pattern runtime coverage LCOV artifacts. */
+  patternCoverageDir?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -860,6 +874,10 @@ export async function runTestPattern(
 
   // Collect runtime errors via the scheduler's error handler
   const runtimeErrors: ErrorWithContext[] = [];
+  const patternCoverage = options.patternCoverageDir
+    ? new PatternCoverageCollector()
+    : undefined;
+  let writeLocalPatternCoverage = patternCoverage !== undefined;
 
   // Collect pattern-code console.error / console.warn calls (channel 1: harness
   // console event) and logger-level error/warn activity (channel 2: logger count
@@ -965,7 +983,7 @@ export async function runTestPattern(
     );
     const { main } = await withPhase(
       ["runTestPattern", "compile"],
-      () => engine.compileAndEvaluateModules(program),
+      () => engine.compileAndEvaluateModules(program, { patternCoverage }),
     );
 
     if (!main?.default) {
@@ -980,6 +998,7 @@ export async function runTestPattern(
     // runtime is only used for detection; the try/finally below disposes it).
     const multiUserMeta = multiUserDescriptorMeta(main.default);
     if (multiUserMeta) {
+      writeLocalPatternCoverage = false;
       return await withPhase(
         ["runTestPattern", "multiUser"],
         () => runMultiUserTestPattern(testPath, multiUserMeta, options),
@@ -1620,6 +1639,26 @@ export async function runTestPattern(
       consoleWarnings,
     };
   } finally {
+    if (
+      patternCoverage && options.patternCoverageDir &&
+      writeLocalPatternCoverage
+    ) {
+      await withPhase(
+        ["runTestPattern", "coverage", "write"],
+        () =>
+          writePatternCoverageLcov(
+            patternCoverage,
+            patternCoverageOutputPath(options.patternCoverageDir!, testPath),
+            { root: options.root },
+          ),
+      ).catch((error) => {
+        console.error(
+          `[cf test] failed to write pattern coverage for ${testPath}: ${
+            formatError(error)
+          }`,
+        );
+      });
+    }
     // 6. Cleanup
     await withPhase(["runTestPattern", "cleanup", "engineDispose"], () => {
       engine.dispose();

--- a/packages/cli/test/fixtures/pattern-coverage/multi-user.test.tsx
+++ b/packages/cli/test/fixtures/pattern-coverage/multi-user.test.tsx
@@ -1,0 +1,6 @@
+import { multiUserTest } from "commonfabric";
+import { alice, bob } from "./subject.tsx";
+
+export default multiUserTest({
+  participants: { alice, bob },
+});

--- a/packages/cli/test/fixtures/pattern-coverage/single.test.tsx
+++ b/packages/cli/test/fixtures/pattern-coverage/single.test.tsx
@@ -1,0 +1,3 @@
+import { singlePattern } from "./subject.tsx";
+
+export default singlePattern;

--- a/packages/cli/test/fixtures/pattern-coverage/subject.tsx
+++ b/packages/cli/test/fixtures/pattern-coverage/subject.tsx
@@ -1,0 +1,48 @@
+import { action, computed, pattern, Writable } from "commonfabric";
+
+function incrementCount(count: Writable<number>): void {
+  count.set(count.get() + 1);
+}
+
+function countIsOne(count: Writable<number>): boolean {
+  return count.get() === 1;
+}
+
+function isAliceName(name: Writable<string>): boolean {
+  return name.get() === "alice";
+}
+
+function isBobName(name: Writable<string>): boolean {
+  return name.get() === "bob";
+}
+
+export const singlePattern = pattern(() => {
+  const count = new Writable(0);
+  const increment = action(() => incrementCount(count));
+  const isOne = computed(() => countIsOne(count));
+
+  return {
+    tests: [
+      { action: increment },
+      { assertion: isOne },
+    ],
+  };
+});
+
+export const alice = pattern(() => {
+  const name = new Writable("alice");
+  const isAlice = computed(() => isAliceName(name));
+
+  return {
+    tests: [{ assertion: isAlice }],
+  };
+});
+
+export const bob = pattern(() => {
+  const name = new Writable("bob");
+  const isBob = computed(() => isBobName(name));
+
+  return {
+    tests: [{ assertion: isBob }],
+  };
+});

--- a/packages/cli/test/test-runner-pattern-coverage.test.ts
+++ b/packages/cli/test/test-runner-pattern-coverage.test.ts
@@ -1,0 +1,333 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join, resolve } from "@std/path";
+import { test as testCommand } from "../commands/test.ts";
+import { runTests } from "../lib/test-runner.ts";
+import { cf, checkStderr, withEnv } from "./utils.ts";
+
+const FIXTURES = resolve(import.meta.dirname!, "fixtures/pattern-coverage");
+const SUBJECT = join(FIXTURES, "subject.tsx").replaceAll("\\", "/");
+const SUBJECT_SOURCE = await Deno.readTextFile(SUBJECT);
+
+interface CoverageFile {
+  name: string;
+  text: string;
+}
+
+function fixture(name: string): string {
+  return resolve(FIXTURES, name);
+}
+
+async function readCoverageFiles(dir: string): Promise<CoverageFile[]> {
+  const out: CoverageFile[] = [];
+  for await (const entry of Deno.readDir(dir)) {
+    if (entry.isFile && entry.name.endsWith(".pattern-coverage.lcov")) {
+      out.push({
+        name: entry.name,
+        text: await Deno.readTextFile(join(dir, entry.name)),
+      });
+    }
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await Deno.makeTempDir();
+  try {
+    return await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+async function runTestCommand(args: string[]): Promise<void> {
+  const previousLog = console.log;
+  console.log = () => {};
+  try {
+    await testCommand.parse(args);
+  } finally {
+    console.log = previousLog;
+  }
+}
+
+function subjectLine(text: string): number {
+  const line = SUBJECT_SOURCE.split("\n").findIndex((entry) =>
+    entry.includes(text)
+  );
+  if (line < 0) {
+    throw new Error(`Could not find subject line containing ${text}`);
+  }
+  return line + 1;
+}
+
+function lineHitsForSource(
+  lcov: string,
+  sourcePath: string,
+): Map<number, number> {
+  const hits = new Map<number, number>();
+  let inSource = false;
+  for (const line of lcov.split("\n")) {
+    if (line.startsWith("SF:")) {
+      inSource = line === `SF:${sourcePath}`;
+      continue;
+    }
+    if (line === "end_of_record") {
+      inSource = false;
+      continue;
+    }
+    if (!inSource || !line.startsWith("DA:")) continue;
+
+    const [lineNumber, count] = line.slice(3).split(",").map(Number);
+    hits.set(lineNumber, count);
+  }
+  return hits;
+}
+
+function expectLineHit(
+  lcov: string,
+  sourceLineText: string,
+  expected: "hit" | "miss",
+): void {
+  const hits = lineHitsForSource(lcov, SUBJECT);
+  const line = subjectLine(sourceLineText);
+  const count = hits.get(line);
+  expect(typeof count).toBe("number");
+  if (expected === "hit") {
+    expect(count!).toBeGreaterThan(0);
+  } else {
+    expect(count).toBe(0);
+  }
+}
+
+describe(
+  "pattern coverage output",
+  { sanitizeOps: false, sanitizeResources: false },
+  () => {
+    it("writes local LCOV for imported pattern source", async () => {
+      await withTempDir(async (coverageDir) => {
+        const { passed, failed } = await runTests(
+          fixture("single.test.tsx"),
+          { root: FIXTURES, patternCoverageDir: coverageDir },
+        );
+
+        expect(passed).toBe(1);
+        expect(failed).toBe(0);
+
+        const coverageFiles = await readCoverageFiles(coverageDir);
+        expect(coverageFiles.length).toBe(1);
+        const coverage = coverageFiles[0]!.text;
+        expect(coverage).toContain(`SF:${SUBJECT}`);
+        expect(coverage).toContain("DA:");
+        expect(coverage).toContain("LH:");
+        expectLineHit(coverage, "count.set(count.get() + 1);", "hit");
+        expectLineHit(coverage, "return count.get() === 1;", "hit");
+        expectLineHit(coverage, 'return name.get() === "alice";', "miss");
+        expectLineHit(coverage, 'return name.get() === "bob";', "miss");
+      });
+    });
+
+    it("reports local coverage write failures without failing the test", async () => {
+      const coveragePath = await Deno.makeTempFile();
+      const errors: string[] = [];
+      const previousError = console.error;
+      console.error = (...args: unknown[]) => {
+        errors.push(args.map((arg) => String(arg)).join(" "));
+      };
+
+      try {
+        const { passed, failed } = await runTests(
+          fixture("single.test.tsx"),
+          { root: FIXTURES, patternCoverageDir: coveragePath },
+        );
+
+        expect(passed).toBe(1);
+        expect(failed).toBe(0);
+        expect(
+          errors.some((line) =>
+            line.includes("[cf test] failed to write pattern coverage for")
+          ),
+        ).toBe(true);
+      } finally {
+        console.error = previousError;
+        await Deno.remove(coveragePath).catch(() => {});
+      }
+    });
+
+    it("writes one LCOV artifact per multi-user participant", async () => {
+      await withTempDir(async (coverageDir) => {
+        const { passed, failed } = await runTests(
+          fixture("multi-user.test.tsx"),
+          { root: FIXTURES, patternCoverageDir: coverageDir },
+        );
+
+        expect(passed).toBe(2);
+        expect(failed).toBe(0);
+
+        const names: string[] = [];
+        for await (const entry of Deno.readDir(coverageDir)) {
+          if (entry.isFile) names.push(entry.name);
+        }
+        names.sort();
+
+        expect(names.length).toBe(2);
+        expect(names.some((name) => name.includes("--alice."))).toBe(true);
+        expect(names.some((name) => name.includes("--bob."))).toBe(true);
+
+        const coverageFiles = await readCoverageFiles(coverageDir);
+        expect(
+          coverageFiles.every(({ text }) => text.includes(`SF:${SUBJECT}`)),
+        )
+          .toBe(true);
+        const aliceCoverage = coverageFiles.find(({ name }) =>
+          name.includes("--alice.")
+        );
+        const bobCoverage = coverageFiles.find(({ name }) =>
+          name.includes("--bob.")
+        );
+        expect(aliceCoverage).toBeTruthy();
+        expect(bobCoverage).toBeTruthy();
+        expectLineHit(
+          aliceCoverage!.text,
+          'return name.get() === "alice";',
+          "hit",
+        );
+        expectLineHit(
+          aliceCoverage!.text,
+          'return name.get() === "bob";',
+          "miss",
+        );
+        expectLineHit(
+          bobCoverage!.text,
+          'return name.get() === "alice";',
+          "miss",
+        );
+        expectLineHit(
+          bobCoverage!.text,
+          'return name.get() === "bob";',
+          "hit",
+        );
+      });
+    });
+
+    it("reports multi-user coverage write failures", async () => {
+      const coveragePath = await Deno.makeTempFile();
+      const errors: string[] = [];
+      const previousError = console.error;
+      console.error = (...args: unknown[]) => {
+        errors.push(args.map((arg) => String(arg)).join(" "));
+      };
+
+      try {
+        const { passed, failed } = await runTests(
+          fixture("multi-user.test.tsx"),
+          { root: FIXTURES, patternCoverageDir: coveragePath },
+        );
+
+        expect(passed).toBe(2);
+        expect(failed).toBe(0);
+        expect(
+          errors.some((line) =>
+            line.includes(
+              "[cf test] failed to write pattern coverage for alice:",
+            )
+          ),
+        ).toBe(true);
+        expect(
+          errors.some((line) =>
+            line.includes(
+              "[cf test] failed to write pattern coverage for bob:",
+            )
+          ),
+        ).toBe(true);
+      } finally {
+        console.error = previousError;
+        await Deno.remove(coveragePath).catch(() => {});
+      }
+    });
+
+    it("passes the coverage directory from the cf test option", async () => {
+      await withTempDir(async (coverageDir) => {
+        const { code, stderr } = await cf(
+          `test "${
+            fixture("single.test.tsx")
+          }" --root "${FIXTURES}" --pattern-coverage-dir "${coverageDir}"`,
+        );
+
+        expect(code).toBe(0);
+        checkStderr(stderr);
+        const coverageFiles = await readCoverageFiles(coverageDir);
+        expect(coverageFiles.length).toBe(1);
+        expect(coverageFiles[0]!.text).toContain(`SF:${SUBJECT}`);
+        expectLineHit(
+          coverageFiles[0]!.text,
+          "count.set(count.get() + 1);",
+          "hit",
+        );
+      });
+    });
+
+    it("passes the coverage directory from CF_PATTERN_COVERAGE_DIR", async () => {
+      await withTempDir(async (coverageDir) => {
+        await withEnv("CF_PATTERN_COVERAGE_DIR", coverageDir, async () => {
+          const { code, stderr } = await cf(
+            `test "${fixture("single.test.tsx")}" --root "${FIXTURES}"`,
+          );
+
+          expect(code).toBe(0);
+          checkStderr(stderr);
+        });
+
+        const coverageFiles = await readCoverageFiles(coverageDir);
+        expect(coverageFiles.length).toBe(1);
+        expect(coverageFiles[0]!.text).toContain(`SF:${SUBJECT}`);
+        expectLineHit(
+          coverageFiles[0]!.text,
+          "count.set(count.get() + 1);",
+          "hit",
+        );
+      });
+    });
+
+    it("runs the command action with an explicit coverage option", async () => {
+      await withTempDir(async (coverageDir) => {
+        await runTestCommand([
+          fixture("single.test.tsx"),
+          "--root",
+          FIXTURES,
+          "--pattern-coverage-dir",
+          coverageDir,
+        ]);
+
+        const coverageFiles = await readCoverageFiles(coverageDir);
+        expect(coverageFiles.length).toBe(1);
+        expect(coverageFiles[0]!.text).toContain(`SF:${SUBJECT}`);
+        expectLineHit(
+          coverageFiles[0]!.text,
+          "count.set(count.get() + 1);",
+          "hit",
+        );
+      });
+    });
+
+    it("runs the command action with the coverage env fallback", async () => {
+      await withTempDir(async (coverageDir) => {
+        await withEnv("CF_PATTERN_COVERAGE_DIR", coverageDir, async () => {
+          await runTestCommand([
+            fixture("single.test.tsx"),
+            "--root",
+            FIXTURES,
+          ]);
+        });
+
+        const coverageFiles = await readCoverageFiles(coverageDir);
+        expect(coverageFiles.length).toBe(1);
+        expect(coverageFiles[0]!.text).toContain(`SF:${SUBJECT}`);
+        expectLineHit(
+          coverageFiles[0]!.text,
+          "count.set(count.get() + 1);",
+          "hit",
+        );
+      });
+    });
+  },
+);

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -23,6 +23,9 @@ import ts from "typescript";
 import {
   CommonFabricTransformerPipeline,
   OpaqueRefErrorTransformer,
+  PATTERN_COVERAGE_GLOBAL,
+  type PatternCoverageOptions,
+  sourceDisablesCfTransform,
 } from "@commonfabric/ts-transformers";
 import { getLogger } from "@commonfabric/utils/logger";
 import { type MemorySpace, Runtime } from "../runtime.ts";
@@ -61,6 +64,7 @@ import {
   verifyModuleGraph,
 } from "../sandbox/module-record-verifier.ts";
 import { popFrame, pushFrame } from "../builder/pattern.ts";
+import type { PatternCoverageCollector } from "../pattern-coverage.ts";
 import {
   ensureSESLockdown,
   getRuntimeModuleExports,
@@ -173,6 +177,10 @@ export class Engine extends EventTarget implements Harness {
   private canonicalSourceByPrefixed = new Map<string, string>();
   private readonly executableRegistry = new ExecutableRegistry();
   private readonly consoleShim = createSafeConsoleGlobal(new Console(this));
+  private readonly patternCoverageByGraph = new WeakMap<
+    CompiledModuleGraph,
+    PatternCoverageCollector
+  >();
 
   constructor(
     ctRuntime: Runtime,
@@ -281,6 +289,19 @@ export class Engine extends EventTarget implements Harness {
       const authoredByStoredName = new Map(
         program.files.map((f) => [f.name, f.contents]),
       );
+      const patternCoverage = patternCoverageOptionsForCompile(
+        options.patternCoverage,
+        {
+          id,
+          mounts,
+          sourceFiles: [
+            ...program.files,
+            ...resolvedFiles.filter((file) =>
+              file.name.startsWith(FABRIC_MOUNT_ROOT)
+            ),
+          ],
+        },
+      );
       const pristineModuleFiles = pristineModuleSources(
         moduleFiles,
         authoredByStoredName,
@@ -305,13 +326,17 @@ export class Engine extends EventTarget implements Harness {
       // transitively sensitive, so a partial set cannot be trusted — fall back
       // to a full recompile. The cache is queried by identity (directly, or
       // lazily once identities are known) without leaking the engine's prefix.
-      const cached = options.precompiledModules ??
-        (options.precompiledModulesFor
-          ? await options.precompiledModulesFor({
-            entryIdentity,
-            identities: [...new Set(identityByPath.values())],
-          })
-          : undefined);
+      // Coverage compiles need fresh emitted JavaScript because cached bodies do
+      // not include counters.
+      const cached = patternCoverage !== undefined
+        ? undefined
+        : options.precompiledModules ??
+          (options.precompiledModulesFor
+            ? await options.precompiledModulesFor({
+              entryIdentity,
+              identities: [...new Set(identityByPath.values())],
+            })
+            : undefined);
       const fullHit = cached !== undefined &&
         moduleFiles.every((f) => cached.has(identityByPath.get(f.name)!));
 
@@ -345,7 +370,9 @@ export class Engine extends EventTarget implements Harness {
             verbose: options.verboseErrors,
           }),
           beforeTransformers: (program) => {
-            const pipeline = new CommonFabricTransformerPipeline();
+            const pipeline = new CommonFabricTransformerPipeline({
+              patternCoverage,
+            });
             return {
               factories: pipeline.toFactories(program),
               getDiagnostics: () => pipeline.getDiagnostics(),
@@ -390,6 +417,9 @@ export class Engine extends EventTarget implements Harness {
         // a second hashing/import-resolution pass over the module set.
         identityByPath,
       });
+      if (options.patternCoverage) {
+        this.patternCoverageByGraph.set(graph, options.patternCoverage);
+      }
 
       // Register runtime-module records so cf:runtime/* imports resolve.
       const runtimeRecordExports: Record<string, Record<string, unknown>> = {};
@@ -812,8 +842,12 @@ export class Engine extends EventTarget implements Harness {
       // `action-fingerprint.test.ts` and `esm-source-location.test.ts`.
       ctx.registerHashes();
 
+      const patternCoverage = this.patternCoverageByGraph.get(graph);
       const globals = createModuleCompartmentGlobals({
         console: this.consoleShim,
+        ...(patternCoverage
+          ? { [PATTERN_COVERAGE_GLOBAL]: patternCoverage.sandboxGlobal() }
+          : {}),
       });
       // Concatenated module bodies give the source-location frame a `script`
       // for fn.src `indexOf` resolution. (Insertion order need not match the
@@ -1404,6 +1438,61 @@ function injectMountSources(files: readonly Source[]): Source[] {
     const next = injected.get(f.name);
     return next === undefined ? f : { ...f, contents: next };
   });
+}
+
+// Pattern coverage runs after helper injection. This maps spans back to the
+// authored file and skips spans from helper code added around the source.
+// The normal line offset depends on the one-line helper import from
+// packages/ts-transformers/src/core/cf-helpers.ts.
+function patternCoverageOptionsForCompile(
+  collector: PatternCoverageCollector | undefined,
+  params: {
+    id: string;
+    mounts: readonly FabricMount[];
+    sourceFiles: readonly Source[];
+  },
+): PatternCoverageOptions | undefined {
+  if (collector === undefined) return undefined;
+
+  const sourceInfo = new Map(
+    params.sourceFiles.map((file) => [
+      coverageFilenameFor(file.name, params.id, params.mounts),
+      {
+        lineOffset: sourceDisablesCfTransform(file.contents) ? 0 : -1,
+        lineCount: file.contents.split(/\r\n|\r|\n/).length,
+      },
+    ]),
+  );
+
+  return {
+    fileName: (sourceFileName) =>
+      coverageFilenameFor(sourceFileName, params.id, params.mounts),
+    mapSpan: (span) => {
+      const info = sourceInfo.get(span.fileName);
+      if (info === undefined) return span;
+
+      const startLine = span.startLine + info.lineOffset;
+      if (startLine < 1 || startLine > info.lineCount) return undefined;
+
+      return {
+        ...span,
+        startLine,
+        endLine: Math.min(span.endLine + info.lineOffset, info.lineCount),
+      };
+    },
+    registerSpan: (span) => collector.registerSpan(span),
+  };
+}
+
+function coverageFilenameFor(
+  name: string,
+  id: string,
+  mounts: readonly FabricMount[],
+): string {
+  // Mount paths carry the imported module identity. The coverage collector keys
+  // spans by file name and span id, and span ids restart for each source file.
+  if (name.startsWith(FABRIC_MOUNT_ROOT)) return name;
+  return storedFilenameFor(name, id, mounts);
 }
 
 function uniqueSourcesByName(files: readonly Source[]): Source[] {

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -1463,13 +1463,16 @@ function patternCoverageOptionsForCompile(
       },
     ]),
   );
+  const unknownSourceInfo = {
+    lineOffset: 0,
+    lineCount: Number.POSITIVE_INFINITY,
+  };
 
   return {
     fileName: (sourceFileName) =>
       coverageFilenameFor(sourceFileName, params.id, params.mounts),
     mapSpan: (span) => {
-      const info = sourceInfo.get(span.fileName);
-      if (info === undefined) return span;
+      const info = sourceInfo.get(span.fileName) ?? unknownSourceInfo;
 
       const startLine = span.startLine + info.lineOffset;
       if (startLine < 1 || startLine > info.lineCount) return undefined;

--- a/packages/runner/src/harness/pretransform.ts
+++ b/packages/runner/src/harness/pretransform.ts
@@ -107,10 +107,7 @@ function normalizeMixedModuleImports(source: string): string {
     }
 
     const { importClause } = statement;
-    const namedBindings = importClause.namedBindings;
-    if (!namedBindings || !ts.isNamedImports(namedBindings)) {
-      continue;
-    }
+    const namedBindings = importClause.namedBindings as ts.NamedImports;
 
     let rewrittenStatements: ts.ImportDeclaration[] | undefined;
     if (importClause.name) {
@@ -265,7 +262,10 @@ function cloneImportAttributeValue(value: ts.Expression): ts.Expression {
   return value;
 }
 
-function preserveLineCount(original: string, replacement: string): string {
+export function preserveLineCount(
+  original: string,
+  replacement: string,
+): string {
   const originalLineCount = original.split(/\r\n|\r|\n/).length;
   const replacementLineCount = replacement.split(/\r\n|\r|\n/).length;
   if (replacementLineCount > originalLineCount) {

--- a/packages/runner/src/harness/pretransform.ts
+++ b/packages/runner/src/harness/pretransform.ts
@@ -93,96 +93,186 @@ function normalizeMixedModuleImports(source: string): string {
     true,
     ts.ScriptKind.TSX,
   );
-  let changed = false;
-  const statements = sourceFile.statements.flatMap((statement) => {
+  const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+  const replacements: { start: number; end: number; text: string }[] = [];
+
+  for (const statement of sourceFile.statements) {
     if (
       !ts.isImportDeclaration(statement) ||
       !statement.importClause ||
       !statement.importClause.namedBindings ||
       !ts.isNamedImports(statement.importClause.namedBindings)
     ) {
-      return [statement];
+      continue;
     }
 
     const { importClause } = statement;
     const namedBindings = importClause.namedBindings;
     if (!namedBindings || !ts.isNamedImports(namedBindings)) {
-      return [statement];
+      continue;
     }
 
+    let rewrittenStatements: ts.ImportDeclaration[] | undefined;
     if (importClause.name) {
-      changed = true;
-      return [
+      rewrittenStatements = [
         ts.factory.createImportDeclaration(
           statement.modifiers,
           ts.factory.createImportClause(
             importClause.isTypeOnly,
-            importClause.name,
+            ts.factory.createIdentifier(importClause.name.text),
             undefined,
           ),
-          statement.moduleSpecifier,
-          statement.attributes,
+          cloneModuleSpecifier(statement.moduleSpecifier),
+          cloneImportAttributes(statement.attributes, sourceFile),
         ),
         ts.factory.createImportDeclaration(
           statement.modifiers,
           ts.factory.createImportClause(
             importClause.isTypeOnly,
             undefined,
-            namedBindings,
+            cloneNamedImports(namedBindings, sourceFile),
           ),
-          statement.moduleSpecifier,
-          statement.attributes,
+          cloneModuleSpecifier(statement.moduleSpecifier),
+          cloneImportAttributes(statement.attributes, sourceFile),
         ),
       ];
-    }
+    } else {
+      const defaultSpecifier = namedBindings.elements.find((
+        element,
+      ) => element.propertyName?.text === "default");
+      if (!defaultSpecifier) {
+        continue;
+      }
 
-    const defaultSpecifier = namedBindings.elements.find((
-      element,
-    ) => element.propertyName?.text === "default");
-    if (!defaultSpecifier) {
-      return [statement];
-    }
-
-    changed = true;
-    const remainingElements = namedBindings.elements.filter((
-      element,
-    ) => element !== defaultSpecifier);
-    const rewrittenStatements = [
-      ts.factory.createImportDeclaration(
-        statement.modifiers,
-        ts.factory.createImportClause(
-          importClause.isTypeOnly || defaultSpecifier.isTypeOnly,
-          defaultSpecifier.name,
-          undefined,
-        ),
-        statement.moduleSpecifier,
-        statement.attributes,
-      ),
-    ];
-
-    if (remainingElements.length > 0) {
-      rewrittenStatements.push(
+      const remainingElements = namedBindings.elements.filter((
+        element,
+      ) => element !== defaultSpecifier);
+      rewrittenStatements = [
         ts.factory.createImportDeclaration(
           statement.modifiers,
           ts.factory.createImportClause(
-            importClause.isTypeOnly,
+            importClause.isTypeOnly || defaultSpecifier.isTypeOnly,
+            ts.factory.createIdentifier(defaultSpecifier.name.text),
             undefined,
-            ts.factory.createNamedImports(remainingElements),
           ),
-          statement.moduleSpecifier,
-          statement.attributes,
+          cloneModuleSpecifier(statement.moduleSpecifier),
+          cloneImportAttributes(statement.attributes, sourceFile),
         ),
-      );
+      ];
+
+      if (remainingElements.length > 0) {
+        rewrittenStatements.push(
+          ts.factory.createImportDeclaration(
+            statement.modifiers,
+            ts.factory.createImportClause(
+              importClause.isTypeOnly,
+              undefined,
+              cloneNamedImportsFromElements(remainingElements, sourceFile),
+            ),
+            cloneModuleSpecifier(statement.moduleSpecifier),
+            cloneImportAttributes(statement.attributes, sourceFile),
+          ),
+        );
+      }
     }
 
-    return rewrittenStatements;
-  });
-
-  if (!changed) {
-    return source;
+    const start = statement.getStart(sourceFile);
+    const end = statement.getEnd();
+    replacements.push({
+      start,
+      end,
+      text: preserveLineCount(
+        source.slice(start, end),
+        rewrittenStatements.map((entry) =>
+          printer.printNode(ts.EmitHint.Unspecified, entry, sourceFile)
+        ).join(" "),
+      ),
+    });
   }
 
-  return ts.createPrinter({
-    newLine: ts.NewLineKind.LineFeed,
-  }).printFile(ts.factory.updateSourceFile(sourceFile, statements));
+  if (replacements.length === 0) return source;
+
+  let out = source;
+  for (const replacement of [...replacements].reverse()) {
+    out = out.slice(0, replacement.start) + replacement.text +
+      out.slice(replacement.end);
+  }
+  return out;
+}
+
+function cloneModuleSpecifier(moduleSpecifier: ts.Expression): ts.Expression {
+  return ts.isStringLiteral(moduleSpecifier)
+    ? ts.factory.createStringLiteral(moduleSpecifier.text)
+    : moduleSpecifier;
+}
+
+function cloneImportAttributes(
+  attributes: ts.ImportAttributes | undefined,
+  sourceFile: ts.SourceFile,
+): ts.ImportAttributes | undefined {
+  if (!attributes) return undefined;
+  const cloned = ts.factory.createImportAttributes(
+    ts.factory.createNodeArray(
+      attributes.elements.map((element) =>
+        ts.factory.createImportAttribute(
+          cloneModuleExportName(element.name, sourceFile),
+          cloneImportAttributeValue(element.value),
+        )
+      ),
+    ),
+    false,
+  );
+  return Object.assign(cloned, { token: attributes.token });
+}
+
+function cloneNamedImports(
+  namedImports: ts.NamedImports,
+  sourceFile: ts.SourceFile,
+): ts.NamedImports {
+  return cloneNamedImportsFromElements(namedImports.elements, sourceFile);
+}
+
+function cloneNamedImportsFromElements(
+  elements: readonly ts.ImportSpecifier[],
+  sourceFile: ts.SourceFile,
+): ts.NamedImports {
+  return ts.factory.createNamedImports(
+    elements.map((element) =>
+      ts.factory.createImportSpecifier(
+        element.isTypeOnly,
+        element.propertyName
+          ? cloneModuleExportName(element.propertyName, sourceFile)
+          : undefined,
+        ts.factory.createIdentifier(element.name.text),
+      )
+    ),
+  );
+}
+
+function cloneModuleExportName(
+  name: ts.ModuleExportName,
+  sourceFile: ts.SourceFile,
+): ts.ModuleExportName {
+  return ts.isIdentifier(name)
+    ? ts.factory.createIdentifier(name.text)
+    : ts.factory.createStringLiteral(name.text ?? name.getText(sourceFile));
+}
+
+function cloneImportAttributeValue(value: ts.Expression): ts.Expression {
+  if (ts.isStringLiteral(value)) {
+    return ts.factory.createStringLiteral(value.text);
+  }
+  return value;
+}
+
+function preserveLineCount(original: string, replacement: string): string {
+  const originalLineCount = original.split(/\r\n|\r|\n/).length;
+  const replacementLineCount = replacement.split(/\r\n|\r|\n/).length;
+  if (replacementLineCount > originalLineCount) {
+    throw new Error(
+      `Import rewrite expanded from ${originalLineCount} to ${replacementLineCount} lines`,
+    );
+  }
+  return replacement +
+    "\n".repeat(originalLineCount - replacementLineCount);
 }

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -4,7 +4,6 @@ import type {
   Source,
 } from "@commonfabric/js-compiler";
 import type { MemorySpace } from "../runtime.ts";
-import type { PatternCoverageCollector } from "../pattern-coverage.ts";
 import type {
   CachedCompiledModule,
   CompiledModuleGraph,
@@ -33,10 +32,6 @@ export interface TypeScriptHarnessProcessOptions {
   getTransformedProgram?: (program: Program) => void;
   // Show verbose TypeScript error messages instead of simplified hints.
   verboseErrors?: boolean;
-  // Collect statement-reach coverage for pattern source. It records authored
-  // statement ranges that ran; synthetic statements without source positions are
-  // not counted.
-  patternCoverage?: PatternCoverageCollector;
   // Cached per-module compiled bodies keyed by content-addressed module
   // identity (the prefix-free `cf:module/<hash>` minus the scheme). Used only on
   // the ESM record-graph path: when every emitted module is present,

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -4,6 +4,7 @@ import type {
   Source,
 } from "@commonfabric/js-compiler";
 import type { MemorySpace } from "../runtime.ts";
+import type { PatternCoverageCollector } from "../pattern-coverage.ts";
 import type {
   CachedCompiledModule,
   CompiledModuleGraph,
@@ -32,6 +33,10 @@ export interface TypeScriptHarnessProcessOptions {
   getTransformedProgram?: (program: Program) => void;
   // Show verbose TypeScript error messages instead of simplified hints.
   verboseErrors?: boolean;
+  // Collect statement-reach coverage for pattern source. It records authored
+  // statement ranges that ran; synthetic statements without source positions are
+  // not counted.
+  patternCoverage?: PatternCoverageCollector;
   // Cached per-module compiled bodies keyed by content-addressed module
   // identity (the prefix-free `cf:module/<hash>` minus the scheme). Used only on
   // the ESM record-graph path: when every emitted module is present,

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -58,6 +58,17 @@ export {
   type RuntimeProgram,
   type TypeScriptHarnessProcessOptions,
 } from "./harness/index.ts";
+export {
+  PatternCoverageCollector,
+  type PatternCoverageFileReport,
+  type PatternCoverageKind,
+  patternCoverageOutputPath,
+  type PatternCoverageReport,
+  type PatternCoverageReportOptions,
+  patternCoverageReportToLcov,
+  type PatternCoverageSpan,
+  writePatternCoverageLcov,
+} from "./pattern-coverage.ts";
 export { addCommonIDfromObjectID } from "./data-updating.ts";
 export { resolveLink } from "./link-resolution.ts";
 export {

--- a/packages/runner/src/pattern-coverage.ts
+++ b/packages/runner/src/pattern-coverage.ts
@@ -1,0 +1,264 @@
+import { dirname, fromFileUrl, join, relative, resolve } from "@std/path";
+import type {
+  PatternCoverageKind,
+  PatternCoverageSpan,
+} from "@commonfabric/ts-transformers";
+import { FABRIC_MOUNT_ROOT } from "./sandbox/module-record-compiler.ts";
+
+export type { PatternCoverageKind, PatternCoverageSpan };
+
+export interface PatternCoverageFileReport {
+  path: string;
+  spans: (PatternCoverageSpan & { count: number })[];
+  totals: {
+    runtimeLines: number;
+    coveredRuntimeLines: number;
+    uncoveredRuntimeLines: number;
+  };
+  lines: {
+    runtime: number[];
+    coveredRuntime: number[];
+    uncoveredRuntime: number[];
+  };
+}
+
+export interface PatternCoverageReport {
+  version: 1;
+  generatedAt: string;
+  files: PatternCoverageFileReport[];
+  totals: {
+    runtimeLines: number;
+    coveredRuntimeLines: number;
+    uncoveredRuntimeLines: number;
+  };
+}
+
+export interface PatternCoverageReportOptions {
+  root?: string;
+  includeTestFiles?: boolean;
+}
+
+export class PatternCoverageCollector {
+  #spans = new Map<string, PatternCoverageSpan>();
+  #hits = new Map<string, number>();
+
+  registerSpan(span: PatternCoverageSpan): void {
+    this.#spans.set(spanKey(span.fileName, span.id), span);
+  }
+
+  hit(fileName: string, id: number): void {
+    const key = spanKey(fileName, id);
+    this.#hits.set(key, (this.#hits.get(key) ?? 0) + 1);
+  }
+
+  sandboxGlobal(): { hit: (fileName: string, id: number) => void } {
+    return {
+      hit: (fileName: string, id: number) => this.hit(fileName, id),
+    };
+  }
+
+  report(options: PatternCoverageReportOptions = {}): PatternCoverageReport {
+    const files = new Map<
+      string,
+      (PatternCoverageSpan & { count: number })[]
+    >();
+    for (const span of this.#spans.values()) {
+      const path = normalizeReportPath(span.fileName, options.root);
+      if (options.includeTestFiles !== true && isTestFile(path)) continue;
+      const spans = files.get(path) ?? [];
+      spans.push({
+        ...span,
+        fileName: path,
+        count: this.#hits.get(spanKey(span.fileName, span.id)) ?? 0,
+      });
+      files.set(path, spans);
+    }
+
+    const fileReports = [...files.entries()]
+      .map(([path, spans]) => reportForFile(path, spans))
+      .sort((a, b) => a.path.localeCompare(b.path));
+
+    const totals = fileReports.reduce(
+      (acc, file) => {
+        acc.runtimeLines += file.totals.runtimeLines;
+        acc.coveredRuntimeLines += file.totals.coveredRuntimeLines;
+        acc.uncoveredRuntimeLines += file.totals.uncoveredRuntimeLines;
+        return acc;
+      },
+      {
+        runtimeLines: 0,
+        coveredRuntimeLines: 0,
+        uncoveredRuntimeLines: 0,
+      },
+    );
+
+    return {
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      files: fileReports,
+      totals,
+    };
+  }
+}
+
+export async function writePatternCoverageLcov(
+  collector: PatternCoverageCollector,
+  outputPath: string,
+  options: PatternCoverageReportOptions = {},
+): Promise<void> {
+  await Deno.mkdir(dirname(outputPath), { recursive: true });
+  await Deno.writeTextFile(
+    outputPath,
+    patternCoverageReportToLcov(collector.report(options)),
+  );
+}
+
+export function patternCoverageReportToLcov(
+  report: PatternCoverageReport,
+): string {
+  const lines: string[] = [];
+  for (const file of report.files) {
+    lines.push("TN:pattern-runtime");
+    lines.push(`SF:${normalizeLcovPath(file.path)}`);
+
+    const hitsByLine = hitsByRuntimeLine(file.spans);
+
+    let coveredLineCount = 0;
+    for (const line of file.lines.runtime) {
+      const hits = hitsByLine.get(line) ?? 0;
+      if (hits > 0) coveredLineCount++;
+      lines.push(`DA:${line},${hits}`);
+    }
+    lines.push(`LF:${file.lines.runtime.length}`);
+    lines.push(`LH:${coveredLineCount}`);
+    lines.push("end_of_record");
+  }
+
+  return lines.length === 0 ? "" : `${lines.join("\n")}\n`;
+}
+
+function reportForFile(
+  path: string,
+  spans: (PatternCoverageSpan & { count: number })[],
+): PatternCoverageFileReport {
+  spans.sort((a, b) => a.startLine - b.startLine || a.id - b.id);
+  const hitsByLine = hitsByRuntimeLine(spans);
+  const runtimeLines = sortedLines(new Set(hitsByLine.keys()));
+  const coveredRuntimeLines = runtimeLines.filter((line) =>
+    (hitsByLine.get(line) ?? 0) > 0
+  );
+  const uncoveredRuntimeLines = runtimeLines.filter((line) =>
+    (hitsByLine.get(line) ?? 0) === 0
+  );
+
+  return {
+    path,
+    spans,
+    totals: {
+      runtimeLines: runtimeLines.length,
+      coveredRuntimeLines: coveredRuntimeLines.length,
+      uncoveredRuntimeLines: uncoveredRuntimeLines.length,
+    },
+    lines: {
+      runtime: runtimeLines,
+      coveredRuntime: coveredRuntimeLines,
+      uncoveredRuntime: uncoveredRuntimeLines,
+    },
+  };
+}
+
+function hitsByRuntimeLine(
+  spans: (PatternCoverageSpan & { count: number })[],
+): Map<number, number> {
+  const hitsByLine = new Map<number, number>();
+  const widthsByLine = new Map<number, number>();
+  const boundaryHitsByLine = new Map<number, number>();
+
+  for (const span of spans) {
+    if (span.kind !== "runtime") continue;
+    const width = spanWidth(span);
+    for (let line = span.startLine; line <= span.endLine; line++) {
+      if (line === span.startLine || line === span.endLine) {
+        boundaryHitsByLine.set(
+          line,
+          Math.max(boundaryHitsByLine.get(line) ?? 0, span.count),
+        );
+      }
+      const existingWidth = widthsByLine.get(line);
+      if (existingWidth === undefined || width < existingWidth) {
+        widthsByLine.set(line, width);
+        hitsByLine.set(line, span.count);
+      } else if (width === existingWidth) {
+        hitsByLine.set(line, Math.max(hitsByLine.get(line) ?? 0, span.count));
+      }
+    }
+  }
+
+  for (const [line, hits] of boundaryHitsByLine) {
+    hitsByLine.set(line, Math.max(hitsByLine.get(line) ?? 0, hits));
+  }
+
+  return hitsByLine;
+}
+
+function spanWidth(span: PatternCoverageSpan): number {
+  return (span.endLine - span.startLine) * 100_000 +
+    Math.max(0, span.endColumn - span.startColumn);
+}
+
+function sortedLines(lines: Set<number>): number[] {
+  return [...lines].sort((a, b) => a - b);
+}
+
+function spanKey(fileName: string, id: number): string {
+  return `${fileName}\0${id}`;
+}
+
+function normalizeReportPath(fileName: string, root?: string): string {
+  if (fileName.startsWith("file://")) {
+    return fromFileUrl(fileName);
+  }
+  if (root && fileName.startsWith(FABRIC_MOUNT_ROOT)) {
+    return `cf-mount/${fileName.slice(FABRIC_MOUNT_ROOT.length)}`;
+  }
+  if (fileName.startsWith("/") && root) {
+    return resolve(root, fileName.slice(1));
+  }
+  if (fileName.startsWith("/")) {
+    return fileName;
+  }
+  if (root) return join(root, fileName);
+  return fileName;
+}
+
+function normalizeLcovPath(fileName: string): string {
+  if (fileName.startsWith(FABRIC_MOUNT_ROOT)) {
+    return `cf-mount/${fileName.slice(FABRIC_MOUNT_ROOT.length)}`;
+  }
+  return fileName;
+}
+
+function isTestFile(path: string): boolean {
+  return /\.test\.[cm]?[jt]sx?$/.test(path);
+}
+
+export function patternCoverageOutputPath(
+  coverageDir: string,
+  testPath: string,
+  suffix?: string,
+): string {
+  const relativePath = relative(Deno.cwd(), testPath).replaceAll("\\", "/");
+  const encodedPath = encodePathSegment(relativePath);
+  const encodedSuffix = suffix ? encodePathSegment(suffix) : undefined;
+  const label = encodedSuffix
+    ? `${encodedPath}--${encodedSuffix}`
+    : encodedPath;
+  return join(coverageDir, `${label}.pattern-coverage.lcov`);
+}
+
+function encodePathSegment(value: string): string {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}

--- a/packages/runner/src/pattern-coverage.ts
+++ b/packages/runner/src/pattern-coverage.ts
@@ -101,6 +101,12 @@ export class PatternCoverageCollector {
   }
 }
 
+declare module "./harness/types.ts" {
+  interface TypeScriptHarnessProcessOptions {
+    patternCoverage?: PatternCoverageCollector;
+  }
+}
+
 export async function writePatternCoverageLcov(
   collector: PatternCoverageCollector,
   outputPath: string,

--- a/packages/runner/src/sandbox/compiled-bundle-verifier.ts
+++ b/packages/runner/src/sandbox/compiled-bundle-verifier.ts
@@ -2,6 +2,7 @@ import {
   CompiledJsParseError,
   findTopLevelArrow,
   findTopLevelEquals,
+  isStringLiteralRange,
   locationFromOffset,
   type ParsedDefineCall,
   parseFunctionText,
@@ -223,7 +224,8 @@ export function classifyModuleItems(
 
       if (
         isAllowedFunctionHardeningStatementNormalized(normalized, env) ||
-        isAllowedBindingIdentityStatementNormalized(normalized, env)
+        isAllowedBindingIdentityStatementNormalized(normalized, env) ||
+        isPatternCoverageHitStatement(source, statement)
       ) {
         continue;
       }
@@ -1691,6 +1693,33 @@ function isIifeExpression(normalized: string): boolean {
     normalized,
   ) ||
     /^\(function.*\)\([^)]*\)$/.test(normalized);
+}
+
+function isPatternCoverageHitStatement(
+  source: string,
+  statement: StatementChunk,
+): boolean {
+  const call = tryParseCallExpression(source, statement.start, statement.end);
+  if (!call) return false;
+  const calleeRange = stripWholeParentheses(call.callee, 0, call.callee.length);
+  const callee = call.callee.slice(calleeRange.start, calleeRange.end);
+  if (callee !== "globalThis.__cfPatternCoverage?.hit") {
+    return false;
+  }
+  if (call.args.length !== 2) return false;
+
+  if (
+    !isStringLiteralRange(source, call.args[0].start, call.args[0].end)
+  ) {
+    return false;
+  }
+
+  const spanId = stripJsTrivia(
+    source,
+    call.args[1].start,
+    call.args[1].end,
+  );
+  return /^(?:0|[1-9]\d*)$/.test(spanId);
 }
 
 function isRawMutableExpression(normalized: string): boolean {

--- a/packages/runner/src/sandbox/compiled-js-parser.ts
+++ b/packages/runner/src/sandbox/compiled-js-parser.ts
@@ -840,11 +840,10 @@ export function parseStringLiteralValue(
   start: number,
   end: number,
 ): string {
-  const trimmed = trimRange(source, start, end);
-  const quote = source[trimmed.start];
-  if ((quote !== "'" && quote !== '"') || source[trimmed.end - 1] !== quote) {
+  const trimmed = exactStringLiteralRange(source, start, end);
+  if (!trimmed) {
     throw new CompiledJsParseError(
-      trimmed.start,
+      trimRange(source, start, end).start,
       "Expected a string literal",
     );
   }
@@ -868,6 +867,32 @@ export function parseStringLiteralValue(
     }
   }
   return source.slice(trimmed.start + 1, trimmed.end - 1);
+}
+
+export function isStringLiteralRange(
+  source: string,
+  start: number,
+  end: number,
+): boolean {
+  return exactStringLiteralRange(source, start, end) !== undefined;
+}
+
+function exactStringLiteralRange(
+  source: string,
+  start: number,
+  end: number,
+): SourceRange | undefined {
+  try {
+    const literalStart = skipTrivia(source, start, end);
+    const quoteCode = source.charCodeAt(literalStart);
+    if (quoteCode !== 34 && quoteCode !== 39) return undefined;
+    const literalEnd = scanStringLiteral(source, literalStart, quoteCode, end);
+    return skipTrivia(source, literalEnd, end) === end
+      ? { start: literalStart, end: literalEnd }
+      : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export function tryParseCallExpression(

--- a/packages/runner/test/compile-and-run.test.ts
+++ b/packages/runner/test/compile-and-run.test.ts
@@ -1,0 +1,76 @@
+import { assertEquals } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { compileAndRun } from "../src/builtins/compile-and-run.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+Deno.test("compileAndRun initializes outputs and handles invalid programs", async () => {
+  const identity = await Identity.fromPassphrase("compile and run coverage");
+  const storageManager = StorageManager.emulate({ as: identity });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const space = identity.did();
+  const tx: IExtendedStorageTransaction = runtime.edit();
+
+  try {
+    const inputs = runtime.getCell<any>(
+      space,
+      "compile-and-run-inputs",
+      undefined,
+      tx,
+    );
+    const parent = runtime.getCell(
+      space,
+      "compile-and-run-parent",
+      undefined,
+      tx,
+    );
+    const cancels: Array<() => void> = [];
+    let outputs: any;
+    let sendResultCount = 0;
+    const action = compileAndRun(
+      inputs,
+      (_tx, result) => {
+        sendResultCount++;
+        outputs = result;
+      },
+      (cancel) => cancels.push(cancel),
+      { test: "compile-and-run" },
+      parent,
+      runtime,
+    );
+
+    inputs.set({ files: [], main: "" });
+    action(tx);
+
+    assertEquals(cancels.length, 1);
+    assertEquals(sendResultCount, 1);
+    assertEquals(outputs.pending.withTx(tx).get(), false);
+    assertEquals(outputs.result.withTx(tx).get(), undefined);
+    assertEquals(outputs.error.withTx(tx).get(), undefined);
+    assertEquals(outputs.errors.withTx(tx).get(), undefined);
+
+    action(tx);
+    assertEquals(sendResultCount, 1);
+
+    inputs.set({
+      main: "/missing.tsx",
+      files: [{ name: "/other.tsx", contents: "export default 1;" }],
+    });
+    action(tx);
+
+    assertEquals(outputs.pending.withTx(tx).get(), false);
+    assertEquals(
+      outputs.error.withTx(tx).get(),
+      '"/missing.tsx" not found in files',
+    );
+
+    await tx.commit();
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});

--- a/packages/runner/test/compiled-js-parser.test.ts
+++ b/packages/runner/test/compiled-js-parser.test.ts
@@ -4,6 +4,7 @@ import {
   CompiledJsParseError,
   findTopLevelArrow,
   findTopLevelEquals,
+  isStringLiteralRange,
   locationFromOffset,
   parseCompiledBundleSource,
   parseFunctionText,
@@ -211,8 +212,74 @@ describe("scanner helpers", () => {
     expect(parseStringLiteralValue(source, 0, source.length)).toBe('a"b');
   });
 
+  it("recognizes exact string literal ranges", () => {
+    const literalWithTrivia = ` /* before */ "a\\\"b" /* after */ `;
+    expect(isStringLiteralRange(
+      literalWithTrivia,
+      0,
+      literalWithTrivia.length,
+    )).toBe(true);
+    const literalWithLineComment = ` /* before */ "a" // after`;
+    expect(isStringLiteralRange(
+      literalWithLineComment,
+      0,
+      literalWithLineComment.length,
+    )).toBe(true);
+    expect(isStringLiteralRange(`"a" + value`, 0, 11)).toBe(false);
+    expect(isStringLiteralRange(`"a\n"`, 0, 4)).toBe(false);
+    expect(isStringLiteralRange(`"a"b`, 0, 4)).toBe(false);
+  });
+
+  it("matches JavaScript string literal token boundaries", () => {
+    const escapedClosingQuote = '"' + 'a\\"b' + '"';
+    const loneBackslash = '"a\\';
+    const escapedBackslash = '"' + "a" + "\\\\" + '"';
+    const unicodeEscape = '"' + "\\u0061" + '"';
+    const adjacentStrings = '"a""b"';
+
+    expect(isStringLiteralRange(
+      escapedClosingQuote,
+      0,
+      escapedClosingQuote.length,
+    )).toBe(true);
+    expect(isStringLiteralRange(
+      loneBackslash,
+      0,
+      loneBackslash.length,
+    )).toBe(false);
+    expect(isStringLiteralRange(
+      escapedBackslash,
+      0,
+      escapedBackslash.length,
+    )).toBe(true);
+    expect(isStringLiteralRange(
+      unicodeEscape,
+      0,
+      unicodeEscape.length,
+    )).toBe(true);
+    expect(isStringLiteralRange(
+      adjacentStrings,
+      0,
+      adjacentStrings.length,
+    )).toBe(false);
+
+    expect(() => new Function(`return ${escapedClosingQuote};`)).not.toThrow();
+    expect(() => new Function(`return ${loneBackslash};`)).toThrow();
+    expect(() => new Function(`return ${escapedBackslash};`)).not.toThrow();
+    expect(() => new Function(`return ${unicodeEscape};`)).not.toThrow();
+    expect(() => new Function(`return ${adjacentStrings};`)).toThrow();
+  });
+
   it("rejects non-string literal values", () => {
     const source = `value`;
+
+    expect(() => parseStringLiteralValue(source, 0, source.length)).toThrow(
+      "Expected a string literal",
+    );
+  });
+
+  it("rejects malformed string literal ranges", () => {
+    const source = `"a\n"`;
 
     expect(() => parseStringLiteralValue(source, 0, source.length)).toThrow(
       "Expected a string literal",

--- a/packages/runner/test/compiled-module-verifier.test.ts
+++ b/packages/runner/test/compiled-module-verifier.test.ts
@@ -445,6 +445,125 @@ exports.default = build();
     expect(() => verify(body)).toThrow();
   });
 
+  it("accepts generated pattern coverage hits at module scope", () => {
+    const body = `
+(globalThis.__cfPatternCoverage?.hit)("/main.tsx", 1);
+exports.default = 42;
+`;
+
+    expect(() => verify(body)).not.toThrow();
+  });
+
+  it("accepts generated pattern coverage hits with unparenthesized callees", () => {
+    const body = `
+globalThis.__cfPatternCoverage?.hit("/main.tsx", 1);
+exports.default = 42;
+`;
+
+    expect(() => verify(body)).not.toThrow();
+  });
+
+  it("accepts generated pattern coverage hits with commas in filenames", () => {
+    const body = `
+globalThis.__cfPatternCoverage?.hit("/a,b.tsx", 1);
+exports.default = 42;
+`;
+
+    expect(() => verify(body)).not.toThrow();
+  });
+
+  it("rejects coverage-looking hits with executable filename arguments", () => {
+    const body = `
+(globalThis.__cfPatternCoverage?.hit)("/main.tsx" + (() => {
+  throw new Error("ran");
+})() + "", 1);
+exports.default = 42;
+`;
+
+    expect(() => verify(body)).toThrow(
+      "unsupported top-level executable code",
+    );
+  });
+
+  it("rejects coverage-looking hits with non-integer span ids", () => {
+    const body = `
+(globalThis.__cfPatternCoverage?.hit)("/main.tsx", 1 + 1);
+exports.default = 42;
+`;
+
+    expect(() => verify(body)).toThrow(
+      "unsupported top-level executable code",
+    );
+  });
+
+  it("rejects coverage-looking hits with the wrong callee", () => {
+    const body = `
+(globalThis.__cfPatternCoverage?.miss)("/main.tsx", 1);
+exports.default = 42;
+`;
+
+    expect(() => verify(body)).toThrow(
+      "unsupported top-level executable code",
+    );
+  });
+
+  it("rejects coverage-looking hits with the wrong argument count", () => {
+    const oneArg = `
+(globalThis.__cfPatternCoverage?.hit)("/main.tsx");
+exports.default = 42;
+`;
+    const threeArgs = `
+(globalThis.__cfPatternCoverage?.hit)("/main.tsx", 1, true);
+exports.default = 42;
+`;
+
+    expect(() => verify(oneArg)).toThrow(
+      "unsupported top-level executable code",
+    );
+    expect(() => verify(threeArgs)).toThrow(
+      "unsupported top-level executable code",
+    );
+  });
+
+  it("rejects coverage hits with trailing executable comma expressions", () => {
+    const body = `
+(globalThis.__cfPatternCoverage?.hit)("/main.tsx", 1), eval("x");
+exports.default = 42;
+`;
+
+    expect(() => verify(body)).toThrow(
+      "unsupported top-level executable code",
+    );
+  });
+
+  it("rejects executable statements after generated coverage hits", () => {
+    const body = `
+(globalThis.__cfPatternCoverage?.hit)("/main.tsx", 1);eval("x");
+exports.default = 42;
+`;
+
+    expect(() => verify(body)).toThrow(
+      "unsupported top-level executable code",
+    );
+  });
+
+  it("rejects a coverage callee split by Unicode whitespace", () => {
+    const nbsp = "\u00A0";
+    const body = `
+(globalThis.__cfPattern${nbsp}Coverage?.hit)("/main.tsx", 1);
+exports.default = 42;
+`;
+
+    expect(() => verify(body)).toThrow();
+    let v8Rejected = false;
+    try {
+      new Function(body);
+    } catch {
+      v8Rejected = true;
+    }
+    expect(v8Rejected).toBe(true);
+  });
+
   it("rejects compiled fragment mutation escape hatches at module scope", () => {
     const body = `
 function counter() {

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -5,6 +5,7 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import { Engine } from "../src/harness/engine.ts";
+import { PatternCoverageCollector } from "../src/pattern-coverage.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
@@ -234,6 +235,29 @@ describe("Engine.compileToRecordGraph", () => {
         precompiledModules: tagged,
       });
       expect((main as { total(): number }).total()).toBe(42);
+    });
+
+    it("ignores precompiled bodies when pattern coverage is enabled", async () => {
+      const first = await engine.compileToRecordGraph(MULTI);
+      const tagged = taggedFrom(first.modules);
+      const coverage = new PatternCoverageCollector();
+
+      const compiled = await engine.compileToRecordGraph(MULTI, {
+        patternCoverage: coverage,
+        precompiledModules: tagged,
+      });
+      for (const m of compiled.modules) {
+        expect(m.js).not.toContain("//cached");
+      }
+
+      const { main } = engine.evaluateRecordGraph(
+        compiled.id,
+        compiled.graph,
+        compiled.mainSpecifier,
+        MULTI.files,
+      );
+      expect((main as { total(): number }).total()).toBe(42);
+      expect(coverage.report().totals.coveredRuntimeLines).toBeGreaterThan(0);
     });
 
     it("security-verifies UNtrusted direct precompiled injection (no blind trust)", async () => {

--- a/packages/runner/test/fabric-imports-engine.test.ts
+++ b/packages/runner/test/fabric-imports-engine.test.ts
@@ -6,6 +6,7 @@ import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
 import { Engine } from "../src/harness/engine.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { PatternCoverageCollector } from "../src/pattern-coverage.ts";
 import { writeSourceDocs } from "../src/compilation-cache/cell-cache.ts";
 import { FABRIC_MOUNT_ROOT } from "../src/sandbox/module-record-compiler.ts";
 import { slugIdForSpace } from "../src/slugs.ts";
@@ -315,6 +316,69 @@ describe("Engine fabric imports", () => {
       program.files,
     );
     expect(evaluated.main?.total()).toBe(4);
+  });
+
+  it("keeps mounted pattern coverage keys separate for matching stored filenames", async () => {
+    const first = await publish({
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: [
+          `export const label = "first";`,
+          `export function value() {`,
+          `  return 10;`,
+          `}`,
+        ].join("\n"),
+      }],
+    });
+    const second = await publish({
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: [
+          `export const label = "second";`,
+          `export function value() {`,
+          `  return 20;`,
+          `}`,
+        ].join("\n"),
+      }],
+    });
+    const firstPath = `${FABRIC_MOUNT_ROOT}${first.entryIdentity}/main.tsx`;
+    const secondPath = `${FABRIC_MOUNT_ROOT}${second.entryIdentity}/main.tsx`;
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: [
+          `import { value as firstValue } from "cf:pattern:${first.entryIdentity}";`,
+          `import { value as secondValue } from "cf:pattern:${second.entryIdentity}";`,
+          `export function total() {`,
+          `  return firstValue() + secondValue();`,
+          `}`,
+        ].join("\n"),
+      }],
+    };
+    const coverage = new PatternCoverageCollector();
+
+    const compiled = await engine.compileToRecordGraph(program, {
+      fabricImports: { space },
+      patternCoverage: coverage,
+    });
+    const evaluated = engine.evaluateRecordGraph(
+      compiled.id,
+      compiled.graph,
+      compiled.mainSpecifier,
+      program.files,
+    );
+    expect(evaluated.main?.total()).toBe(30);
+
+    const filesByPath = new Map(
+      coverage.report().files.map((file) => [file.path, file]),
+    );
+    expect(filesByPath.has(firstPath)).toBe(true);
+    expect(filesByPath.has(secondPath)).toBe(true);
+    expect(filesByPath.get(firstPath)?.lines.runtime).toContain(3);
+    expect(filesByPath.get(secondPath)?.lines.runtime).toContain(3);
   });
 
   it("keeps old pins stable and changes importer identity when the pin text changes", async () => {

--- a/packages/runner/test/llm-dialog-helpers.test.ts
+++ b/packages/runner/test/llm-dialog-helpers.test.ts
@@ -1,9 +1,20 @@
 import { assert, assertEquals, assertThrows } from "@std/assert";
 import { expect } from "@std/expect";
 import type { BuiltInLLMMessage, BuiltInLLMToolCallPart } from "commonfabric";
-import { llmDialogTestHelpers } from "../src/builtins/llm-dialog.ts";
+import {
+  llmDialogTestHelpers,
+  llmToolExecutionHelpers,
+} from "../src/builtins/llm-dialog.ts";
 import { schemaWithInjectionSafeAnnotations } from "../src/cfc/schema-sanitization.ts";
 import type { NormalizedFullLink } from "../src/link-utils.ts";
+
+const {
+  buildAvailableCellsDocumentation,
+  buildAvailableCellsDocumentationWithObservation,
+  buildToolCatalog,
+  executeToolCalls,
+  PRESENT_RESULT_TOOL_NAME,
+} = llmToolExecutionHelpers;
 
 const {
   parseLLMFriendlyLink,
@@ -17,8 +28,44 @@ const {
   prepareSchemaForLLM,
   resolveRefsForLLM,
   serializeForLLMObservation,
+  traverseAndCellify,
   toolAllowsObservedConfidentiality,
 } = llmDialogTestHelpers;
+
+function makeDocumentationCell(params: {
+  id: string;
+  space: string;
+  path?: string[];
+  schema?: unknown;
+  value?: unknown;
+  rawValue?: unknown;
+  nested?: unknown;
+}) {
+  const link = {
+    id: params.id,
+    space: params.space,
+    scope: "space",
+    path: params.path ?? [],
+    schema: params.schema,
+  };
+  const cell: any = {
+    runtime: {},
+    schema: params.schema,
+    get: () => params.value,
+    getRaw: () => params.rawValue ?? params.value,
+    getMetaRaw: () => undefined,
+    getAsNormalizedFullLink: () => link,
+    resolveAsCell: () => cell,
+    asSchemaFromLinks: () => cell,
+    asSchema: () => cell,
+    key: () => ({ getRaw: () => undefined, get: () => undefined }),
+    pull: () => Promise.resolve(),
+  };
+  if (params.nested !== undefined) {
+    cell.get = () => params.nested;
+  }
+  return cell;
+}
 
 Deno.test("parseTargetString recognizes handle format", () => {
   const parsed = parseLLMFriendlyLink(
@@ -416,6 +463,429 @@ Deno.test("serializeForLLMObservation does not taint from redacted nested values
   assertEquals(result.observedConfidentiality, ["internal"]);
 });
 
+Deno.test("serializeForLLMObservation stops at the maximum depth", () => {
+  const result = serializeForLLMObservation({
+    value: { too: "deep" },
+    depth: 101,
+  });
+
+  assertEquals(result.value, "[Maximum depth reached]");
+  assertEquals(result.observedConfidentiality, []);
+});
+
+Deno.test("serializeForLLMObservation serializes arrays", () => {
+  const rootLink: NormalizedFullLink = {
+    id: "of:test-array",
+    space: "did:test:array",
+    scope: "space",
+    path: [],
+  };
+  const result = serializeForLLMObservation({
+    value: [{ title: "first" }, { title: "second" }],
+    schema: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+        },
+      },
+    },
+    contextSpace: "did:test:array",
+    rootLink,
+  });
+
+  assertEquals(result.value, [{ title: "first" }, { title: "second" }]);
+  assertEquals(result.observedConfidentiality, []);
+});
+
+Deno.test("traverseAndCellify converts LLM-friendly links inside strings and objects", () => {
+  const parsedLinks: unknown[] = [];
+  const runtime = {
+    getCellFromLink(link: unknown) {
+      parsedLinks.push(link);
+      return { kind: "cell", link };
+    },
+  };
+  const target =
+    "/of:bafyreihqwsfjfvsr6zbmwhk7fo4hcxqaihmqqzv3ohfyv5gfdjt5jnzqai/path";
+
+  const direct = traverseAndCellify(
+    runtime as any,
+    "did:test:cellify",
+    JSON.stringify({ "@link": target }),
+  ) as any;
+  const nested = traverseAndCellify(
+    runtime as any,
+    "did:test:cellify",
+    {
+      keep: "value",
+      list: [{ "@link": target }],
+      malformed: '{"@link":',
+    },
+  ) as any;
+
+  assertEquals(direct.kind, "cell");
+  assertEquals(nested.keep, "value");
+  assertEquals(nested.list[0].kind, "cell");
+  assertEquals(nested.malformed, '{"@link":');
+  assertEquals(parsedLinks.length, 2);
+});
+
+Deno.test("buildToolCatalog normalizes dynamic legacy tools", () => {
+  const childValues = new Map<string, unknown>([
+    [
+      "fromChildPattern",
+      {
+        pattern: {
+          get: () => ({
+            argumentSchema: {
+              type: "object",
+              properties: { prompt: { type: "string" } },
+            },
+          }),
+        },
+      },
+    ],
+  ]);
+  const childCells = new Map<string, unknown>();
+  const toolsCell = {
+    get: () => ({
+      fromInputSchema: {
+        description: "uses a parent schema",
+        inputSchema: {
+          type: "object",
+          properties: {
+            result: { type: "string" },
+            value: { type: "number" },
+          },
+          required: ["result", "value"],
+        },
+      },
+      fromChildPattern: {
+        description: "uses a child pattern schema",
+      },
+      booleanSchema: {
+        description: "uses a boolean schema",
+        inputSchema: true,
+      },
+      missingSchema: {
+        description: "skipped",
+      },
+      pieceTool: {
+        piece: {
+          get: () => ({ name: "piece" }),
+          getAsNormalizedFullLink: () => ({
+            id: "of:piece",
+            path: [],
+            space: "did:test:tools",
+            scope: "space",
+          }),
+        },
+      },
+    }),
+    key(name: string) {
+      const cell = {
+        get: () => childValues.get(name),
+      };
+      childCells.set(name, cell);
+      return cell;
+    },
+  };
+
+  const catalog = buildToolCatalog(toolsCell as any, false);
+
+  assertEquals(Object.keys(catalog.llmTools).sort(), [
+    "booleanSchema",
+    "fromChildPattern",
+    "fromInputSchema",
+  ]);
+  assertEquals(
+    catalog.llmTools.fromInputSchema.description,
+    "uses a parent schema",
+  );
+  assertEquals(
+    (catalog.llmTools.fromInputSchema.inputSchema as any).properties,
+    { value: { type: "number" } },
+  );
+  assertEquals(
+    (catalog.llmTools.fromInputSchema.inputSchema as any).required,
+    ["value"],
+  );
+  assertEquals(
+    (catalog.llmTools.fromChildPattern.inputSchema as any).properties.prompt
+      .type,
+    "string",
+  );
+  assertEquals(
+    (catalog.llmTools.booleanSchema.inputSchema as any).additionalProperties,
+    {},
+  );
+  assertEquals(
+    catalog.dynamicToolCells.get("fromChildPattern"),
+    childCells.get("fromChildPattern"),
+  );
+});
+
+Deno.test("buildToolCatalog adds built-in tools by default", () => {
+  const toolsCell = {
+    get: () => undefined,
+    key: () => ({ get: () => undefined }),
+  };
+
+  const catalog = buildToolCatalog(toolsCell as any);
+
+  assert("read" in catalog.llmTools);
+  assert("invoke" in catalog.llmTools);
+  assert("pin" in catalog.llmTools);
+  assert("unpin" in catalog.llmTools);
+  assert("updateArgument" in catalog.llmTools);
+  assert("schema" in catalog.llmTools);
+  assert(!(PRESENT_RESULT_TOOL_NAME in catalog.llmTools));
+  assertEquals(catalog.dynamicToolCells.size, 0);
+});
+
+Deno.test("buildAvailableCellsDocumentation documents context and pinned cells", () => {
+  const space = "did:test:docs";
+  const nestedCell = makeDocumentationCell({
+    id: "of:bafyreihqwsfjfvsr6zbmwhk7fo4hcxqaihmqqzv3ohfyv5gfdjt5jnzqai",
+    space,
+    path: ["project"],
+    schema: {
+      type: "object",
+      properties: { name: { type: "string" } },
+    },
+    value: { name: "Ada" },
+  });
+  const outerCell = makeDocumentationCell({
+    id: "of:bafyreiearlyouterouterouterouterouterouterouterouterouteroutera",
+    space,
+    nested: nestedCell,
+  });
+  const pinnedCell = makeDocumentationCell({
+    id: "of:bafyreibbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmmmmnnoo",
+    space,
+    path: ["tasks"],
+    value: { title: "Todo", $hidden: "skip" },
+  });
+  const runtime = {
+    getCellFromLink: () => pinnedCell,
+  };
+  const pinnedCells = {
+    get: () => [{
+      path:
+        "/of:bafyreibbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmmmmnnoo/tasks",
+      name: "Pinned",
+    }],
+  };
+
+  const docs = buildAvailableCellsDocumentation(
+    runtime as any,
+    space,
+    {
+      Project: outerCell,
+      NotACell: { title: "ignored" },
+    },
+    pinnedCells as any,
+  );
+
+  assert(docs.includes("# Available Cells"));
+  assert(docs.includes("## Project"));
+  assert(docs.includes("## Pinned"));
+  assert(docs.includes("Ada"));
+  assert(docs.includes("Todo"));
+  assert(docs.includes("- Schema:"));
+  assert(docs.includes("title"));
+
+  const empty = buildAvailableCellsDocumentationWithObservation(
+    runtime as any,
+    space,
+    undefined,
+    { get: () => [] } as any,
+  );
+  assertEquals(empty, { docs: "", observedConfidentiality: [] });
+});
+
+Deno.test("executeToolCalls wraps denied, present-result, pin, and error results", async () => {
+  const space = "did:test:tools";
+  const emptyToolsCell = {
+    get: () => undefined,
+    key: () => ({ get: () => undefined }),
+  };
+  const catalog = buildToolCatalog(emptyToolsCell as any);
+  catalog.llmTools.secretTool = {
+    description: "secret",
+    inputSchema: {
+      type: "object",
+      ifc: { maxConfidentiality: [] },
+    },
+  };
+
+  const pinnedState = [{ path: "/of:already", name: "Already" }];
+  const pinnedCells = {
+    get: () => pinnedState,
+    withTx: () => ({
+      get: () => pinnedState,
+      set: (next: typeof pinnedState) => {
+        pinnedState.splice(0, pinnedState.length, ...next);
+      },
+    }),
+  };
+  const targetCell = makeDocumentationCell({
+    id: "of:bafyreiqqqqrrrrssssttttuuuuvvvvwwwwxxxxyyyyzzzzaaaabbbbccccd",
+    space,
+    path: ["target"],
+    schema: {
+      type: "object",
+      properties: { value: { type: "number" } },
+    },
+    value: { value: 7 },
+  });
+  const runtime = {
+    editWithRetry: (fn: (tx: unknown) => void) => {
+      fn({});
+      return true;
+    },
+    getCellFromLink: () => targetCell,
+  };
+  const originalConsoleError = console.error;
+  const errors: unknown[][] = [];
+  console.error = (...args: unknown[]) => {
+    errors.push(args);
+  };
+  try {
+    const results = await executeToolCalls(
+      runtime as any,
+      space,
+      catalog as any,
+      [
+        {
+          type: "tool-call",
+          toolCallId: "denied",
+          toolName: "secretTool",
+          input: {},
+        },
+        {
+          type: "tool-call",
+          toolCallId: "present",
+          toolName: PRESENT_RESULT_TOOL_NAME,
+          input: { answer: 42 },
+        },
+        {
+          type: "tool-call",
+          toolCallId: "already",
+          toolName: "pin",
+          input: { path: "/of:already", name: "Already" },
+        },
+        {
+          type: "tool-call",
+          toolCallId: "new",
+          toolName: "pin",
+          input: { path: "/of:new", name: "New" },
+        },
+        {
+          type: "tool-call",
+          toolCallId: "missing",
+          toolName: "unpin",
+          input: { path: "/of:missing" },
+        },
+        {
+          type: "tool-call",
+          toolCallId: "remove",
+          toolName: "unpin",
+          input: { path: "/of:already" },
+        },
+        {
+          type: "tool-call",
+          toolCallId: "schema",
+          toolName: "schema",
+          input: {
+            path:
+              "/of:bafyreiqqqqrrrrssssttttuuuuvvvvwwwwxxxxyyyyzzzzaaaabbbbccccd/target",
+          },
+        },
+        {
+          type: "tool-call",
+          toolCallId: "bad-update",
+          toolName: "updateArgument",
+          input: {
+            path:
+              "/of:bafyreiqqqqrrrrssssttttuuuuvvvvwwwwxxxxyyyyzzzzaaaabbbbccccd/target",
+          },
+        },
+        {
+          type: "tool-call",
+          toolCallId: "bad-invoke",
+          toolName: "invoke",
+          input: {
+            path:
+              "/of:bafyreiqqqqrrrrssssttttuuuuvvvvwwwwxxxxyyyyzzzzaaaabbbbccccd/target",
+          },
+        },
+        {
+          type: "tool-call",
+          toolCallId: "unknown",
+          toolName: "unknownTool",
+          input: {},
+        },
+      ],
+      pinnedCells as any,
+      ["internal"],
+    );
+
+    assertEquals(
+      results.map((result) => result.id),
+      [
+        "denied",
+        "present",
+        "already",
+        "new",
+        "missing",
+        "remove",
+        "schema",
+        "bad-update",
+        "bad-invoke",
+        "unknown",
+      ],
+    );
+    assertEquals(
+      results[0].error,
+      "Tool call denied: observed confidentiality exceeds maxConfidentiality for secretTool",
+    );
+    assertEquals(results[1].result, {
+      type: "json",
+      value: { answer: 42 },
+    });
+    assertEquals(results[2].result?.value, {
+      success: false,
+      message: "Already pinned",
+    });
+    assertEquals(results[3].result?.value, { success: true });
+    assertEquals(results[4].result?.value, {
+      success: false,
+      message: "Not found",
+    });
+    assertEquals(results[5].result?.value, { success: true });
+    assertEquals(results[6].result?.value, {
+      type: "object",
+      properties: { value: { type: "number" } },
+    });
+    assertEquals(
+      results[7].error,
+      "updates must be an object with field names and values",
+    );
+    assertEquals(
+      results[8].error,
+      "target does not resolve to a handler stream or pattern.",
+    );
+    assertEquals(results[9].error, "Tool has neither pattern nor handler");
+    assertEquals(pinnedState, [{ path: "/of:new", name: "New" }]);
+    assertEquals(errors.length, 3);
+  } finally {
+    console.error = originalConsoleError;
+  }
+});
+
 Deno.test("toolAllowsObservedConfidentiality denies tools above maxConfidentiality", () => {
   const allowed = toolAllowsObservedConfidentiality(
     {
@@ -641,6 +1111,23 @@ Deno.test("simplifySchemaForContext handles Stream with nested detail structure"
   );
 });
 
+Deno.test("simplifySchemaForContext handles primitive and composed schemas", () => {
+  assertEquals(simplifySchemaForContext("plain" as any), "plain" as any);
+
+  const result = simplifySchemaForContext({
+    type: "object",
+    description: "choice",
+    anyOf: [{ type: "string" }, "literal" as any],
+    oneOf: [{ type: "number" }],
+    allOf: [{ type: "object", properties: { id: { type: "string" } } }],
+  } as any) as any;
+
+  assertEquals(result.description, "choice");
+  assertEquals(result.anyOf, [{ type: "string" }, "literal"]);
+  assertEquals(result.oneOf, [{ type: "number" }]);
+  assertEquals(result.allOf?.[0]?.properties?.id?.type, "string");
+});
+
 // Tests for resolveRefsForLLM
 
 Deno.test("resolveRefsForLLM converts boolean true schema to empty object", () => {
@@ -733,6 +1220,20 @@ Deno.test("resolveRefsForLLM truncates circular $ref", () => {
   assertEquals(result.$defs, undefined);
 });
 
+Deno.test("resolveRefsForLLM truncates unresolved $ref", () => {
+  const result = resolveRefsForLLM({
+    type: "object",
+    properties: {
+      missing: { $ref: "#/$defs/Missing" },
+    },
+  } as any) as any;
+
+  assertEquals(result.properties?.missing, {
+    type: "object",
+    additionalProperties: true,
+  });
+});
+
 Deno.test("resolveRefsForLLM passes through schema with no $ref unchanged", () => {
   const schema: any = {
     type: "object",
@@ -793,6 +1294,11 @@ Deno.test("resolveRefsForLLM handles mutually recursive types", () => {
 });
 
 // Tests for prepareSchemaForLLM
+
+Deno.test("prepareSchemaForLLM returns primitive schemas unchanged", () => {
+  assertEquals(prepareSchemaForLLM("plain" as any), "plain" as any);
+  assertEquals(prepareSchemaForLLM(null as any), null as any);
+});
 
 Deno.test("prepareSchemaForLLM strips internal markers and resolves $ref", () => {
   const schema: any = {

--- a/packages/runner/test/pattern-coverage.test.ts
+++ b/packages/runner/test/pattern-coverage.test.ts
@@ -1,0 +1,583 @@
+import { assert, assertEquals, assertObjectMatch } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import {
+  PatternCoverageCollector,
+  patternCoverageOutputPath,
+  patternCoverageReportToLcov,
+  Runtime,
+  type RuntimeProgram,
+} from "../src/index.ts";
+
+function lineContaining(source: string, text: string): number {
+  const line = source.split("\n").findIndex((entry) => entry.includes(text));
+  if (line < 0) throw new Error(`Could not find source line: ${text}`);
+  return line + 1;
+}
+
+function lineHits(lcov: string, sourcePath: string): Map<number, number> {
+  const hits = new Map<number, number>();
+  let inSource = false;
+  for (const line of lcov.split("\n")) {
+    if (line.startsWith("SF:")) {
+      inSource = line === `SF:${sourcePath}`;
+      continue;
+    }
+    if (line === "end_of_record") {
+      inSource = false;
+      continue;
+    }
+    if (!inSource || !line.startsWith("DA:")) continue;
+    const [lineNumber, count] = line.slice(3).split(",").map(Number);
+    hits.set(lineNumber, count);
+  }
+  return hits;
+}
+
+function assertLineHit(
+  source: string,
+  lcov: string,
+  sourcePath: string,
+  sourceLineText: string,
+): void {
+  const hits = lineHits(lcov, sourcePath);
+  assert((hits.get(lineContaining(source, sourceLineText)) ?? 0) > 0);
+}
+
+function assertLineMiss(
+  source: string,
+  lcov: string,
+  sourcePath: string,
+  sourceLineText: string,
+): void {
+  const hits = lineHits(lcov, sourcePath);
+  assertEquals(hits.get(lineContaining(source, sourceLineText)), 0);
+}
+
+Deno.test("pattern coverage records original runtime lines", async () => {
+  const { StorageManager } = await import("../src/storage/cache.deno.ts");
+  const identity = await Identity.fromPassphrase("pattern coverage test");
+  const storageManager = StorageManager.emulate({ as: identity });
+  const runtime = new Runtime({
+    storageManager,
+    apiUrl: new URL(import.meta.url),
+  });
+  try {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            "export function choose(value: number) {",
+            "  const next = value + 1;",
+            "  if (next > 1) {",
+            "    return next;",
+            "  }",
+            "  return 0;",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    };
+    const coverage = new PatternCoverageCollector();
+    const { main } = await runtime.harness.compileAndEvaluateModules(program, {
+      patternCoverage: coverage,
+    });
+
+    assert(main);
+    assertEquals(typeof main.choose, "function");
+    assertEquals(main.choose(1), 2);
+
+    const report = coverage.report();
+    assertObjectMatch(report.totals, {
+      coveredRuntimeLines: 4,
+      uncoveredRuntimeLines: 1,
+    });
+    assertEquals(report.files[0].path, "/main.tsx");
+    assertEquals(report.files[0].lines.coveredRuntime, [2, 3, 4, 5]);
+    assertEquals(report.files[0].lines.uncoveredRuntime, [6]);
+
+    assertEquals(
+      patternCoverageReportToLcov(report),
+      [
+        "TN:pattern-runtime",
+        "SF:/main.tsx",
+        "DA:2,1",
+        "DA:3,1",
+        "DA:4,1",
+        "DA:5,1",
+        "DA:6,0",
+        "LF:5",
+        "LH:4",
+        "end_of_record",
+        "",
+      ].join("\n"),
+    );
+    assertEquals(
+      patternCoverageOutputPath(
+        "/tmp/coverage",
+        `${Deno.cwd()}/pattern.test.tsx`,
+      ),
+      "/tmp/coverage/pattern.test.tsx.pattern-coverage.lcov",
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern coverage records top-level runtime lines", async () => {
+  const { StorageManager } = await import("../src/storage/cache.deno.ts");
+  const identity = await Identity.fromPassphrase("top-level coverage test");
+  const storageManager = StorageManager.emulate({ as: identity });
+  const runtime = new Runtime({
+    storageManager,
+    apiUrl: new URL(import.meta.url),
+  });
+  try {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            "export const first = 1;",
+            "export const result = 2;",
+          ].join("\n"),
+        },
+      ],
+    };
+    const coverage = new PatternCoverageCollector();
+    const { main } = await runtime.harness.compileAndEvaluateModules(program, {
+      patternCoverage: coverage,
+    });
+
+    assert(main);
+    assertEquals(main.result, 2);
+
+    const report = coverage.report();
+    assertObjectMatch(report.totals, {
+      coveredRuntimeLines: 2,
+      uncoveredRuntimeLines: 0,
+    });
+    assertEquals(report.files[0].lines.coveredRuntime, [1, 2]);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern coverage skips erased type-only namespaces", async () => {
+  const { StorageManager } = await import("../src/storage/cache.deno.ts");
+  const identity = await Identity.fromPassphrase(
+    "type namespace coverage test",
+  );
+  const storageManager = StorageManager.emulate({ as: identity });
+  const runtime = new Runtime({
+    storageManager,
+    apiUrl: new URL(import.meta.url),
+  });
+  try {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            "namespace Types {",
+            "  export interface Value { value: number }",
+            "}",
+            "export type Result = Types.Value;",
+            "export const result = 1;",
+          ].join("\n"),
+        },
+      ],
+    };
+    const coverage = new PatternCoverageCollector();
+    const { main } = await runtime.harness.compileAndEvaluateModules(program, {
+      patternCoverage: coverage,
+    });
+
+    assert(main);
+    assertEquals(main.result, 1);
+
+    const report = coverage.report();
+    assertObjectMatch(report.totals, {
+      coveredRuntimeLines: 1,
+      uncoveredRuntimeLines: 0,
+    });
+    assertEquals(report.files[0].lines.coveredRuntime, [5]);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern coverage does not let outer spans cover unrun callback bodies", async () => {
+  const { StorageManager } = await import("../src/storage/cache.deno.ts");
+  const identity = await Identity.fromPassphrase(
+    "unrun callback coverage test",
+  );
+  const storageManager = StorageManager.emulate({ as: identity });
+  const runtime = new Runtime({
+    storageManager,
+    apiUrl: new URL(import.meta.url),
+  });
+  try {
+    const source = [
+      'import { handler } from "commonfabric";',
+      "export const unused = handler(false, false, () => {",
+      "  const never = 1;",
+      "  return never;",
+      "});",
+      "export const loaded = 1;",
+    ].join("\n");
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: source }],
+    };
+    const coverage = new PatternCoverageCollector();
+    const { main } = await runtime.harness.compileAndEvaluateModules(program, {
+      patternCoverage: coverage,
+    });
+
+    assert(main);
+    assertEquals(main.loaded, 1);
+
+    const lcov = patternCoverageReportToLcov(coverage.report());
+    assertLineHit(source, lcov, "/main.tsx", "export const unused");
+    assertLineMiss(source, lcov, "/main.tsx", "const never = 1;");
+    assertLineMiss(source, lcov, "/main.tsx", "return never;");
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern coverage records taken and untaken control-flow branches", async () => {
+  const { StorageManager } = await import("../src/storage/cache.deno.ts");
+  const identity = await Identity.fromPassphrase("branch coverage test");
+  const storageManager = StorageManager.emulate({ as: identity });
+  const runtime = new Runtime({
+    storageManager,
+    apiUrl: new URL(import.meta.url),
+  });
+  try {
+    const source = [
+      "export function choose(flag: boolean) {",
+      "  let value = 0;",
+      "  if (flag) {",
+      "    value = 1;",
+      "  } else {",
+      "    value = 2;",
+      "  }",
+      "  return value;",
+      "}",
+    ].join("\n");
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: source }],
+    };
+    const coverage = new PatternCoverageCollector();
+    const { main } = await runtime.harness.compileAndEvaluateModules(program, {
+      patternCoverage: coverage,
+    });
+
+    assert(main);
+    assertEquals(main.choose(true), 1);
+
+    const lcov = patternCoverageReportToLcov(coverage.report());
+    assertLineHit(source, lcov, "/main.tsx", "value = 1;");
+    assertLineMiss(source, lcov, "/main.tsx", "value = 2;");
+    assertLineHit(source, lcov, "/main.tsx", "return value;");
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern coverage treats compact control flow as line coverage", async () => {
+  const { StorageManager } = await import("../src/storage/cache.deno.ts");
+  const identity = await Identity.fromPassphrase(
+    "compact branch coverage test",
+  );
+  const storageManager = StorageManager.emulate({ as: identity });
+  const runtime = new Runtime({
+    storageManager,
+    apiUrl: new URL(import.meta.url),
+  });
+  try {
+    const source = [
+      "export function choose(flag: boolean) {",
+      "  let value = 0;",
+      "  if (flag) value = 1;",
+      "  for (let i = 0; i < 2; i++) if (flag) value++;",
+      "  if (flag) { value = 2;",
+      "  }",
+      "  return value;",
+      "}",
+    ].join("\n");
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: source }],
+    };
+    const coverage = new PatternCoverageCollector();
+    const { main } = await runtime.harness.compileAndEvaluateModules(program, {
+      patternCoverage: coverage,
+    });
+
+    assert(main);
+    assertEquals(main.choose(false), 0);
+
+    const lcov = patternCoverageReportToLcov(coverage.report());
+    assertLineHit(source, lcov, "/main.tsx", "if (flag) value = 1;");
+    assertLineHit(source, lcov, "/main.tsx", "for (let i = 0;");
+    assertLineHit(source, lcov, "/main.tsx", "if (flag) { value = 2;");
+    assertLineHit(source, lcov, "/main.tsx", "return value;");
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern coverage keeps authored lines for mixed default and named imports", async () => {
+  const { StorageManager } = await import("../src/storage/cache.deno.ts");
+  const identity = await Identity.fromPassphrase("mixed import coverage test");
+  const storageManager = StorageManager.emulate({ as: identity });
+  const runtime = new Runtime({
+    storageManager,
+    apiUrl: new URL(import.meta.url),
+  });
+  try {
+    const source = [
+      'import base, { extra } from "./dep.ts";',
+      "export function run() {",
+      "  const value = base + extra;",
+      "  return value;",
+      "}",
+    ].join("\n");
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        { name: "/main.tsx", contents: source },
+        {
+          name: "/dep.ts",
+          contents: "export default 1;\nexport const extra = 2;",
+        },
+      ],
+    };
+    const coverage = new PatternCoverageCollector();
+    const { main } = await runtime.harness.compileAndEvaluateModules(program, {
+      patternCoverage: coverage,
+    });
+
+    assert(main);
+    assertEquals(main.run(), 3);
+
+    const lcov = patternCoverageReportToLcov(coverage.report());
+    assertLineHit(source, lcov, "/main.tsx", "const value = base + extra;");
+    assertLineHit(source, lcov, "/main.tsx", "return value;");
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern coverage keeps authored lines when Common Fabric transform is disabled", async () => {
+  const { StorageManager } = await import("../src/storage/cache.deno.ts");
+  const identity = await Identity.fromPassphrase(
+    "disabled transform coverage test",
+  );
+  const storageManager = StorageManager.emulate({ as: identity });
+  const runtime = new Runtime({
+    storageManager,
+    apiUrl: new URL(import.meta.url),
+  });
+  try {
+    const source = [
+      "/// <cf-disable-transform />",
+      "export function run() {",
+      "  const value = 1;",
+      "  return value;",
+      "}",
+    ].join("\n");
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: source }],
+    };
+    const coverage = new PatternCoverageCollector();
+    const { main } = await runtime.harness.compileAndEvaluateModules(program, {
+      patternCoverage: coverage,
+    });
+
+    assert(main);
+    assertEquals(main.run(), 1);
+
+    const lcov = patternCoverageReportToLcov(coverage.report());
+    assertLineHit(source, lcov, "/main.tsx", "const value = 1;");
+    assertLineHit(source, lcov, "/main.tsx", "return value;");
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern coverage records callback body lines after the full pipeline", async () => {
+  const { StorageManager } = await import("../src/storage/cache.deno.ts");
+  const identity = await Identity.fromPassphrase("callback coverage test");
+  const storageManager = StorageManager.emulate({ as: identity });
+  const runtime = new Runtime({
+    storageManager,
+    apiUrl: new URL(import.meta.url),
+  });
+  try {
+    const source = [
+      'import { action, computed, pattern, Writable } from "commonfabric";',
+      "export default pattern(() => {",
+      "  const count = new Writable(0);",
+      "  const inc = action(() => {",
+      "    count.set(count.get() + 1);",
+      "  });",
+      "  const isOne = computed(() => {",
+      "    const value = count.get();",
+      "    return value === 1;",
+      "  });",
+      "  return { inc, isOne };",
+      "});",
+    ].join("\n");
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: source }],
+    };
+    const coverage = new PatternCoverageCollector();
+    const { main } = await runtime.harness.compileAndEvaluateModules(program, {
+      patternCoverage: coverage,
+    });
+
+    assert(main);
+    const resultCell = runtime.getCell(identity.did(), "callback-coverage");
+    await runtime.setup(undefined, main.default, {}, resultCell);
+    runtime.start(resultCell);
+    await resultCell.pull();
+    resultCell.key("inc").send({});
+    await resultCell.pull();
+    await runtime.scheduler.idle();
+
+    const lcov = patternCoverageReportToLcov(coverage.report());
+    assertLineHit(source, lcov, "/main.tsx", "const count = new Writable");
+    assertLineHit(source, lcov, "/main.tsx", "count.set(count.get() + 1);");
+    assertLineHit(source, lcov, "/main.tsx", "const value = count.get();");
+    assertLineHit(source, lcov, "/main.tsx", "return value === 1;");
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern coverage reports fabric mount paths as virtual paths", () => {
+  const coverage = new PatternCoverageCollector();
+  coverage.registerSpan({
+    fileName: "/~cf/fid1abc/main.tsx",
+    id: 1,
+    kind: "runtime",
+    startLine: 1,
+    endLine: 1,
+    startColumn: 1,
+    endColumn: 10,
+  });
+  coverage.hit("/~cf/fid1abc/main.tsx", 1);
+
+  const report = coverage.report({ root: "/repo" });
+
+  assertEquals(report.files[0].path, "cf-mount/fid1abc/main.tsx");
+  assertEquals(
+    patternCoverageReportToLcov(report),
+    [
+      "TN:pattern-runtime",
+      "SF:cf-mount/fid1abc/main.tsx",
+      "DA:1,1",
+      "LF:1",
+      "LH:1",
+      "end_of_record",
+      "",
+    ].join("\n"),
+  );
+});
+
+Deno.test("pattern coverage keeps raw mount report keys before LCOV emission", () => {
+  const coverage = new PatternCoverageCollector();
+  coverage.registerSpan({
+    fileName: "/~cf/fid1abc/main.tsx",
+    id: 1,
+    kind: "runtime",
+    startLine: 1,
+    endLine: 1,
+    startColumn: 1,
+    endColumn: 10,
+  });
+  coverage.hit("/~cf/fid1abc/main.tsx", 1);
+
+  const report = coverage.report();
+
+  assertEquals(report.files[0].path, "/~cf/fid1abc/main.tsx");
+  assertEquals(
+    patternCoverageReportToLcov(report),
+    [
+      "TN:pattern-runtime",
+      "SF:cf-mount/fid1abc/main.tsx",
+      "DA:1,1",
+      "LF:1",
+      "LH:1",
+      "end_of_record",
+      "",
+    ].join("\n"),
+  );
+});
+
+Deno.test("pattern coverage excludes test files by default", () => {
+  const coverage = new PatternCoverageCollector();
+  coverage.registerSpan({
+    fileName: "/subject.tsx",
+    id: 1,
+    kind: "runtime",
+    startLine: 1,
+    endLine: 1,
+    startColumn: 1,
+    endColumn: 10,
+  });
+  coverage.registerSpan({
+    fileName: "/subject.test.tsx",
+    id: 1,
+    kind: "runtime",
+    startLine: 1,
+    endLine: 1,
+    startColumn: 1,
+    endColumn: 10,
+  });
+
+  assertEquals(
+    coverage.report().files.map((file) => file.path),
+    ["/subject.tsx"],
+  );
+  assertEquals(
+    coverage.report({ includeTestFiles: true }).files.map((file) => file.path),
+    ["/subject.test.tsx", "/subject.tsx"],
+  );
+});
+
+Deno.test("pattern coverage output paths distinguish separators from underscores", () => {
+  const coverageDir = "/tmp/coverage";
+  const cwd = Deno.cwd();
+  const withSeparator = patternCoverageOutputPath(
+    coverageDir,
+    `${cwd}/fixtures/a/b.test.tsx`,
+  );
+  const withUnderscores = patternCoverageOutputPath(
+    coverageDir,
+    `${cwd}/fixtures/a__b.test.tsx`,
+  );
+
+  assert(withSeparator.includes("fixtures%2Fa%2Fb.test.tsx"));
+  assert(withUnderscores.includes("fixtures%2Fa__b.test.tsx"));
+  assert(withSeparator !== withUnderscores);
+});

--- a/packages/runner/test/pattern-coverage.test.ts
+++ b/packages/runner/test/pattern-coverage.test.ts
@@ -534,6 +534,113 @@ Deno.test("pattern coverage keeps raw mount report keys before LCOV emission", (
   );
 });
 
+Deno.test("pattern coverage normalizes file URLs and relative paths", () => {
+  const fileUrlCoverage = new PatternCoverageCollector();
+  fileUrlCoverage.registerSpan({
+    fileName: "file:///tmp/pattern.tsx",
+    id: 1,
+    kind: "runtime",
+    startLine: 1,
+    endLine: 1,
+    startColumn: 1,
+    endColumn: 10,
+  });
+
+  assertEquals(fileUrlCoverage.report().files[0].path, "/tmp/pattern.tsx");
+
+  const absoluteCoverage = new PatternCoverageCollector();
+  absoluteCoverage.registerSpan({
+    fileName: "/absolute.tsx",
+    id: 1,
+    kind: "runtime",
+    startLine: 1,
+    endLine: 1,
+    startColumn: 1,
+    endColumn: 10,
+  });
+
+  assertEquals(
+    absoluteCoverage.report({ root: "/repo" }).files[0].path,
+    "/repo/absolute.tsx",
+  );
+
+  const relativeCoverage = new PatternCoverageCollector();
+  relativeCoverage.registerSpan({
+    fileName: "relative.tsx",
+    id: 1,
+    kind: "runtime",
+    startLine: 1,
+    endLine: 1,
+    startColumn: 1,
+    endColumn: 10,
+  });
+
+  assertEquals(
+    relativeCoverage.report({ root: "/repo" }).files[0].path,
+    "/repo/relative.tsx",
+  );
+  assertEquals(relativeCoverage.report().files[0].path, "relative.tsx");
+});
+
+Deno.test("pattern coverage ignores non-runtime spans", () => {
+  const coverage = new PatternCoverageCollector();
+  coverage.registerSpan({
+    fileName: "/subject.tsx",
+    id: 1,
+    kind: "non-runtime" as "runtime",
+    startLine: 1,
+    endLine: 1,
+    startColumn: 1,
+    endColumn: 10,
+  });
+
+  assertObjectMatch(coverage.report().files[0], {
+    totals: {
+      runtimeLines: 0,
+      coveredRuntimeLines: 0,
+      uncoveredRuntimeLines: 0,
+    },
+  });
+});
+
+Deno.test("pattern coverage uses the highest hit count for equal-width spans", () => {
+  const coverage = new PatternCoverageCollector();
+  coverage.registerSpan({
+    fileName: "/subject.tsx",
+    id: 1,
+    kind: "runtime",
+    startLine: 1,
+    endLine: 1,
+    startColumn: 1,
+    endColumn: 10,
+  });
+  coverage.registerSpan({
+    fileName: "/subject.tsx",
+    id: 2,
+    kind: "runtime",
+    startLine: 1,
+    endLine: 1,
+    startColumn: 1,
+    endColumn: 10,
+  });
+  coverage.hit("/subject.tsx", 1);
+  coverage.hit("/subject.tsx", 2);
+  coverage.hit("/subject.tsx", 2);
+
+  assertEquals(
+    patternCoverageReportToLcov(coverage.report()),
+    [
+      "TN:pattern-runtime",
+      "SF:/subject.tsx",
+      "DA:1,2",
+      "LF:1",
+      "LH:1",
+      "end_of_record",
+      "",
+    ].join("\n"),
+  );
+});
+
 Deno.test("pattern coverage excludes test files by default", () => {
   const coverage = new PatternCoverageCollector();
   coverage.registerSpan({

--- a/packages/runner/test/pretransform.test.ts
+++ b/packages/runner/test/pretransform.test.ts
@@ -1,5 +1,13 @@
-import { assertEquals, assertMatch, assertNotMatch } from "@std/assert";
-import { transformInjectHelperModule } from "../src/harness/pretransform.ts";
+import {
+  assertEquals,
+  assertMatch,
+  assertNotMatch,
+  assertThrows,
+} from "@std/assert";
+import {
+  preserveLineCount,
+  transformInjectHelperModule,
+} from "../src/harness/pretransform.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 
 Deno.test("transformInjectHelperModule transforms by default and respects cf-disable-transform", () => {
@@ -75,11 +83,13 @@ Deno.test("transformInjectHelperModule injects JS-syntax helpers into .js source
 // Coverage remapping assumes this pretransform only adds the one-line helper
 // prelude. Mixed import splitting must preserve the original line count.
 Deno.test("mixed import rewrite must not drift coverage line numbers", () => {
-  const markerOutputLine = (contents: string): number =>
+  const transformedContents = (contents: string): string =>
     transformInjectHelperModule({
       main: "/m.tsx",
       files: [{ name: "/m.tsx", contents }],
-    }).files[0]!.contents.split("\n").findIndex((line) =>
+    }).files[0]!.contents;
+  const markerOutputLine = (contents: string): number =>
+    transformedContents(contents).split("\n").findIndex((line) =>
       line.includes("MARKER")
     ) + 1;
 
@@ -100,4 +110,37 @@ Deno.test("mixed import rewrite must not drift coverage line numbers", () => {
   const multiLineNamedBindings =
     `import D, {\n  a,\n  b,\n} from "x";\nconst MARKER = 1;\n`;
   assertEquals(markerOutputLine(multiLineNamedBindings), 6);
+
+  const defaultInNamedBindings =
+    `import { default as D, a } from "x";\nconst MARKER = 1;\n`;
+  assertEquals(markerOutputLine(defaultInNamedBindings), 3);
+  assertMatch(
+    transformedContents(defaultInNamedBindings),
+    /import D from "x"; import \{ a \} from "x";/,
+  );
+
+  const onlyDefaultInNamedBindings =
+    `import { default as D } from "x";\nconst MARKER = 1;\n`;
+  assertEquals(markerOutputLine(onlyDefaultInNamedBindings), 3);
+  assertMatch(
+    transformedContents(onlyDefaultInNamedBindings),
+    /import D from "x";\nconst MARKER/,
+  );
+
+  const nonStringImportAttribute =
+    `import { default as D, a } from "x" with { type: json };\nconst MARKER = 1;\n`;
+  assertEquals(markerOutputLine(nonStringImportAttribute), 3);
+  assertMatch(
+    transformedContents(nonStringImportAttribute),
+    /with \{ type: json \}; import \{ a \} from "x" with \{ type: json \};/,
+  );
+});
+
+Deno.test("preserveLineCount rejects expanding rewrites", () => {
+  assertEquals(preserveLineCount("one\ntwo", "one"), "one\n");
+  assertThrows(
+    () => preserveLineCount("one", "one\ntwo"),
+    Error,
+    "Import rewrite expanded from 1 to 2 lines",
+  );
 });

--- a/packages/runner/test/pretransform.test.ts
+++ b/packages/runner/test/pretransform.test.ts
@@ -1,4 +1,4 @@
-import { assertMatch, assertNotMatch } from "@std/assert";
+import { assertEquals, assertMatch, assertNotMatch } from "@std/assert";
 import { transformInjectHelperModule } from "../src/harness/pretransform.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 
@@ -70,4 +70,34 @@ Deno.test("transformInjectHelperModule injects JS-syntax helpers into .js source
   assertMatch(main.contents, /function h\(\.\.\.args: any\[\]\)/);
   assertMatch(helper.contents, /function h\(\.\.\.args\)/);
   assertNotMatch(helper.contents, /any\[\]/);
+});
+
+// Coverage remapping assumes this pretransform only adds the one-line helper
+// prelude. Mixed import splitting must preserve the original line count.
+Deno.test("mixed import rewrite must not drift coverage line numbers", () => {
+  const markerOutputLine = (contents: string): number =>
+    transformInjectHelperModule({
+      main: "/m.tsx",
+      files: [{ name: "/m.tsx", contents }],
+    }).files[0]!.contents.split("\n").findIndex((line) =>
+      line.includes("MARKER")
+    ) + 1;
+
+  // Control: single-line attributes preserve the count. MARKER is authored line
+  // 2, so after the one-line helper prepend it lands on output line 3.
+  const singleLineAttributes =
+    `import D, { a } from "x" with { type: "json" };\nconst MARKER = 1;\n`;
+  assertEquals(markerOutputLine(singleLineAttributes), 3);
+
+  // MARKER is authored line 4, so after the one-line helper prepend it must land
+  // on output line 5. The rewrite must not add lines for multi-line attributes.
+  const multiLineAttributes =
+    `import D, { a } from "x" with {\n  type: "json"\n};\nconst MARKER = 1;\n`;
+  assertEquals(markerOutputLine(multiLineAttributes), 5);
+
+  // Multi-line named bindings must not drift either. MARKER is authored line 5,
+  // so after the helper prepend it lands on output line 6.
+  const multiLineNamedBindings =
+    `import D, {\n  a,\n  b,\n} from "x";\nconst MARKER = 1;\n`;
+  assertEquals(markerOutputLine(multiLineNamedBindings), 6);
 });

--- a/packages/ts-transformers/lint-plugins/no-node-get-text.ts
+++ b/packages/ts-transformers/lint-plugins/no-node-get-text.ts
@@ -1,3 +1,5 @@
+/// <reference lib="deno.unstable" />
+
 // Forbids bare `node.getText()` (called with no SourceFile argument) in the
 // transformer source.
 //
@@ -9,25 +11,45 @@
 //
 // Test files are exempt: they assert against source parsed in the test, whose
 // nodes always carry real positions, so `getText()` is safe and idiomatic there.
+interface LintContext {
+  readonly filename: string;
+  report(report: { node: unknown; message: string }): void;
+}
+
+interface LintCallExpression {
+  readonly callee: {
+    readonly type: string;
+    readonly computed?: boolean;
+    readonly property?: {
+      readonly type: string;
+      readonly name?: string;
+    };
+  };
+  readonly arguments: readonly unknown[];
+}
+
 export default {
   name: "cf-ts-transformers",
   rules: {
     "no-node-get-text": {
       create(context) {
-        if (context.filename.includes("/test/")) {
+        const localContext = context as unknown as LintContext;
+        if (localContext.filename.includes("/test/")) {
           return {};
         }
         return {
           CallExpression(node) {
-            const callee = node.callee;
+            const localNode = node as unknown as LintCallExpression;
+            const callee = localNode.callee;
             if (
               callee.type === "MemberExpression" &&
               !callee.computed &&
+              callee.property &&
               callee.property.type === "Identifier" &&
               callee.property.name === "getText" &&
-              node.arguments.length === 0
+              localNode.arguments.length === 0
             ) {
-              context.report({
+              localContext.report({
                 node,
                 message:
                   "Bare node.getText() throws on synthetic AST nodes. Use " +

--- a/packages/ts-transformers/src/cf-pipeline.ts
+++ b/packages/ts-transformers/src/cf-pipeline.ts
@@ -10,6 +10,7 @@ import {
   OpaqueGetValidationTransformer,
   PatternCallbackLoweringTransformer,
   PatternContextValidationTransformer,
+  PatternCoverageTransformer,
   PatternOwnedExpressionSiteLoweringTransformer,
   ReactiveVariableForTransformer,
   SchemaGeneratorTransformer,
@@ -101,6 +102,13 @@ const CFC_TRANSFORMER_STAGE_SPECS: readonly TransformerStageSpec[] = [
   {
     name: "ModuleScopeCfDataTransformer",
     create: (options) => new ModuleScopeCfDataTransformer(options),
+  },
+  // Coverage runs before function hardening. That keeps coverage counters out
+  // of the hardening helper output. The transformer does no work unless
+  // pattern coverage is enabled.
+  {
+    name: "PatternCoverageTransformer",
+    create: (options) => new PatternCoverageTransformer(options),
   },
   {
     name: "ModuleScopeFunctionHardeningTransformer",

--- a/packages/ts-transformers/src/core/cf-helpers.ts
+++ b/packages/ts-transformers/src/core/cf-helpers.ts
@@ -7,6 +7,9 @@ const CF_DATA_HELPER_KEEP_IDENTIFIER = "__cfDataHelperKeep";
 
 const CF_HELPERS_SPECIFIER = "commonfabric";
 
+// Runner pattern coverage line remapping treats this helper import as a
+// one-line prelude. Changes to its line count need a matching update in
+// patternCoverageOptionsForCompile.
 const HELPERS_STMT =
   `import { ${CF_HELPERS_IDENTIFIER} } from "${CF_HELPERS_SPECIFIER}";`;
 const CF_DATA_HELPER_STMT =

--- a/packages/ts-transformers/src/core/mod.ts
+++ b/packages/ts-transformers/src/core/mod.ts
@@ -206,6 +206,9 @@ export type {
   DiagnosticInput,
   DiagnosticSeverity,
   FunctionCapabilitySummary,
+  PatternCoverageKind,
+  PatternCoverageOptions,
+  PatternCoverageSpan,
   ReactiveCapability,
   SchemaHint,
   SchemaHints,
@@ -216,6 +219,7 @@ export type {
 } from "./transformers.ts";
 export {
   HelpersOnlyTransformer,
+  PATTERN_COVERAGE_GLOBAL,
   Pipeline,
   Transformer,
 } from "./transformers.ts";

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -58,6 +58,28 @@ export interface FunctionCapabilitySummary {
   readonly recursive?: boolean;
 }
 
+export type PatternCoverageKind = "runtime";
+
+export const PATTERN_COVERAGE_GLOBAL = "__cfPatternCoverage";
+
+export interface PatternCoverageSpan {
+  readonly fileName: string;
+  readonly id: number;
+  readonly kind: PatternCoverageKind;
+  readonly startLine: number;
+  readonly endLine: number;
+  readonly startColumn: number;
+  readonly endColumn: number;
+}
+
+export interface PatternCoverageOptions {
+  readonly fileName?: (sourceFileName: string) => string;
+  readonly mapSpan?: (
+    span: PatternCoverageSpan,
+  ) => PatternCoverageSpan | undefined;
+  readonly registerSpan: (span: PatternCoverageSpan) => void;
+}
+
 /**
  * Registry for passing schema hints between transformer stages.
  * Keyed by TypeNode (unique per usage) to avoid conflicts when the same
@@ -81,6 +103,7 @@ export interface TransformationOptions {
    * If provided, diagnostics are pushed to this array in addition to the local context.
    */
   readonly diagnosticsCollector?: TransformationDiagnostic[];
+  readonly patternCoverage?: PatternCoverageOptions;
 }
 
 export type DiagnosticSeverity = "error" | "warning";

--- a/packages/ts-transformers/src/mod.ts
+++ b/packages/ts-transformers/src/mod.ts
@@ -1,5 +1,8 @@
 export type {
   DiagnosticSeverity,
+  PatternCoverageKind,
+  PatternCoverageOptions,
+  PatternCoverageSpan,
   TransformationContext,
   TransformationDiagnostic,
   TransformationOptions,
@@ -9,6 +12,7 @@ export {
   CrossStageState,
   injectCfDataHelper,
   injectCfHelpers,
+  PATTERN_COVERAGE_GLOBAL,
   Pipeline,
   sourceDisablesCfTransform,
   transformCfDirective,

--- a/packages/ts-transformers/src/transformers/mod.ts
+++ b/packages/ts-transformers/src/transformers/mod.ts
@@ -8,6 +8,7 @@ export { ModuleScopeCfDataTransformer } from "./module-scope-cf-data.ts";
 export { ModuleScopeFunctionHardeningTransformer } from "./module-scope-function-hardening.ts";
 export { ModuleScopeShadowingTransformer } from "./module-scope-shadowing.ts";
 export { OpaqueGetValidationTransformer } from "./opaque-get-validation.ts";
+export { PatternCoverageTransformer } from "./pattern-coverage.ts";
 export { PatternContextValidationTransformer } from "./pattern-context-validation.ts";
 export { PatternOwnedExpressionSiteLoweringTransformer } from "./pattern-owned-expression-site-lowering.ts";
 export { ReactiveVariableForTransformer } from "./reactive-variable-for.ts";

--- a/packages/ts-transformers/src/transformers/pattern-coverage.ts
+++ b/packages/ts-transformers/src/transformers/pattern-coverage.ts
@@ -1,0 +1,430 @@
+import ts from "typescript";
+import {
+  PATTERN_COVERAGE_GLOBAL,
+  type PatternCoverageSpan,
+  TransformationContext,
+  Transformer,
+} from "../core/mod.ts";
+
+export class PatternCoverageTransformer extends Transformer {
+  override filter(context: TransformationContext): boolean {
+    return context.options.patternCoverage !== undefined &&
+      !context.sourceFile.isDeclarationFile;
+  }
+
+  transform(context: TransformationContext): ts.SourceFile {
+    const coverage = context.options.patternCoverage;
+    if (!coverage) return context.sourceFile;
+
+    let nextSpanId = 0;
+    const fileName = coverage.fileName?.(context.sourceFile.fileName) ??
+      context.sourceFile.fileName;
+
+    const coverageGlobal = () =>
+      context.factory.createPropertyAccessExpression(
+        context.factory.createIdentifier("globalThis"),
+        PATTERN_COVERAGE_GLOBAL,
+      );
+
+    const makeHitStatement = (spanId: number): ts.Statement => {
+      return context.factory.createExpressionStatement(
+        context.factory.createCallExpression(
+          context.factory.createPropertyAccessChain(
+            coverageGlobal(),
+            context.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+            "hit",
+          ),
+          undefined,
+          [
+            context.factory.createStringLiteral(fileName),
+            context.factory.createNumericLiteral(spanId),
+          ],
+        ),
+      );
+    };
+
+    const sourceRangeForSpan = (
+      node: ts.Node,
+    ): { start: number; end: number } | undefined => {
+      const original = ts.getOriginalNode(node);
+      const candidates = original === node ? [node] : [node, original];
+      for (const candidate of candidates) {
+        if (candidate.pos < 0 || candidate.end < 0) continue;
+        try {
+          const start = candidate.getStart(context.sourceFile);
+          const end = candidate.getEnd();
+          if (end > start) return { start, end };
+        } catch {
+          // Try the next source-linked candidate.
+        }
+      }
+
+      const sourceMapRange = ts.getSourceMapRange(node);
+      if (sourceMapRange.pos >= 0 && sourceMapRange.end > sourceMapRange.pos) {
+        return {
+          start: sourceMapRange.pos,
+          end: sourceMapRange.end,
+        };
+      }
+      return undefined;
+    };
+
+    const registerSpan = (node: ts.Node): number | undefined => {
+      const sourceRange = sourceRangeForSpan(node);
+      if (!sourceRange) return undefined;
+      const { start, end } = sourceRange;
+      if (end <= start) return undefined;
+      const startLoc = context.sourceFile.getLineAndCharacterOfPosition(start);
+      const endLoc = context.sourceFile.getLineAndCharacterOfPosition(end - 1);
+      const rawSpan: PatternCoverageSpan = {
+        fileName,
+        id: ++nextSpanId,
+        kind: "runtime",
+        startLine: startLoc.line + 1,
+        endLine: endLoc.line + 1,
+        startColumn: startLoc.character + 1,
+        endColumn: endLoc.character + 1,
+      };
+      const span = coverage.mapSpan ? coverage.mapSpan(rawSpan) : rawSpan;
+      if (span === undefined) return undefined;
+      coverage.registerSpan(span);
+      return span.id;
+    };
+
+    const hasModifier = (node: ts.Node, kind: ts.SyntaxKind): boolean => {
+      return ts.canHaveModifiers(node) &&
+        (ts.getModifiers(node)?.some((modifier) => modifier.kind === kind) ??
+          false);
+    };
+
+    const hasDeclareModifier = (node: ts.Node): boolean =>
+      hasModifier(node, ts.SyntaxKind.DeclareKeyword);
+
+    const isConstEnumDeclaration = (statement: ts.Statement): boolean =>
+      ts.isEnumDeclaration(statement) &&
+      hasModifier(statement, ts.SyntaxKind.ConstKeyword);
+
+    const isErasedNamespaceStatement = (statement: ts.Statement): boolean => {
+      return hasDeclareModifier(statement) ||
+        ts.isInterfaceDeclaration(statement) ||
+        ts.isTypeAliasDeclaration(statement) ||
+        ts.isImportDeclaration(statement) ||
+        ts.isExportDeclaration(statement) ||
+        isConstEnumDeclaration(statement) ||
+        (ts.isImportEqualsDeclaration(statement) && statement.isTypeOnly) ||
+        (ts.isModuleDeclaration(statement) &&
+          isErasedModuleDeclaration(statement));
+    };
+
+    const isErasedModuleDeclaration = (
+      statement: ts.ModuleDeclaration,
+    ): boolean => {
+      if (statement.body === undefined) return true;
+      if (ts.isModuleDeclaration(statement.body)) {
+        return isErasedModuleDeclaration(statement.body);
+      }
+      if (!ts.isModuleBlock(statement.body)) return true;
+      return statement.body.statements.every(isErasedNamespaceStatement);
+    };
+
+    const shouldInstrumentStatement = (statement: ts.Statement): boolean => {
+      return !hasDeclareModifier(statement) &&
+        !ts.isFunctionDeclaration(statement) &&
+        !ts.isClassDeclaration(statement) &&
+        !ts.isInterfaceDeclaration(statement) &&
+        !ts.isTypeAliasDeclaration(statement) &&
+        !isConstEnumDeclaration(statement) &&
+        !(ts.isModuleDeclaration(statement) &&
+          isErasedModuleDeclaration(statement)) &&
+        !ts.isImportDeclaration(statement) &&
+        !ts.isExportDeclaration(statement);
+    };
+
+    const isDirectiveStatement = (statement: ts.Statement): boolean =>
+      ts.isExpressionStatement(statement) &&
+      ts.isStringLiteral(statement.expression) &&
+      statement.expression.text === "use strict";
+
+    const instrumentStatements = (
+      statements: ts.NodeArray<ts.Statement>,
+      preserveDirectivePrologue = false,
+    ): ts.Statement[] => {
+      const out: ts.Statement[] = [];
+      let inDirectivePrologue = true;
+      for (const statement of statements) {
+        const visited = isErasedNamespaceStatement(statement)
+          ? statement
+          : ts.visitNode(statement, visit, ts.isStatement);
+        const isDirective = preserveDirectivePrologue &&
+          inDirectivePrologue &&
+          isDirectiveStatement(statement);
+        if (!isDirective && shouldInstrumentStatement(statement)) {
+          const spanId = registerSpan(statement);
+          if (spanId !== undefined) out.push(makeHitStatement(spanId));
+        }
+        out.push(visited);
+        if (!isDirective) inDirectivePrologue = false;
+      }
+      return out;
+    };
+
+    const instrumentBlock = (
+      body: ts.Block,
+      preserveDirectivePrologue = false,
+    ): ts.Block => {
+      return context.factory.updateBlock(
+        body,
+        instrumentStatements(body.statements, preserveDirectivePrologue),
+      );
+    };
+
+    const instrumentStatementBody = (statement: ts.Statement): ts.Statement => {
+      if (ts.isBlock(statement)) return instrumentBlock(statement);
+      const visited = ts.visitNode(statement, visit, ts.isStatement);
+      if (!shouldInstrumentStatement(statement)) return visited;
+      const spanId = registerSpan(statement);
+      return context.factory.createBlock(
+        spanId === undefined ? [visited] : [makeHitStatement(spanId), visited],
+        true,
+      );
+    };
+
+    const wrapVisitedStatementBody = (
+      statement: ts.Statement,
+    ): ts.Statement => {
+      if (ts.isBlock(statement)) return statement;
+      if (!shouldInstrumentStatement(statement)) return statement;
+      const spanId = registerSpan(statement);
+      return context.factory.createBlock(
+        spanId === undefined
+          ? [statement]
+          : [makeHitStatement(spanId), statement],
+        true,
+      );
+    };
+
+    const visitIfStatement = (node: ts.IfStatement): ts.IfStatement => {
+      return context.factory.updateIfStatement(
+        node,
+        ts.visitNode(node.expression, visit, ts.isExpression),
+        instrumentStatementBody(node.thenStatement),
+        node.elseStatement
+          ? instrumentStatementBody(node.elseStatement)
+          : undefined,
+      );
+    };
+
+    const visitIterationStatement = <
+      T extends ts.DoStatement | ts.WhileStatement | ts.ForStatement,
+    >(node: T): T => {
+      const visited = ts.visitEachChild(node, visit, context.tsContext) as T;
+      if (ts.isDoStatement(visited)) {
+        return context.factory.updateDoStatement(
+          visited,
+          wrapVisitedStatementBody(visited.statement),
+          visited.expression,
+        ) as T;
+      }
+      if (ts.isWhileStatement(visited)) {
+        return context.factory.updateWhileStatement(
+          visited,
+          visited.expression,
+          wrapVisitedStatementBody(visited.statement),
+        ) as T;
+      }
+      return context.factory.updateForStatement(
+        visited,
+        visited.initializer,
+        visited.condition,
+        visited.incrementor,
+        wrapVisitedStatementBody(visited.statement),
+      ) as T;
+    };
+
+    const visitForInOrOfStatement = (
+      node: ts.ForInStatement | ts.ForOfStatement,
+    ): ts.ForInStatement | ts.ForOfStatement => {
+      const visited = ts.visitEachChild(node, visit, context.tsContext);
+      if (ts.isForInStatement(visited)) {
+        return context.factory.updateForInStatement(
+          visited,
+          visited.initializer,
+          visited.expression,
+          wrapVisitedStatementBody(visited.statement),
+        );
+      }
+      return context.factory.updateForOfStatement(
+        visited,
+        visited.awaitModifier,
+        visited.initializer,
+        visited.expression,
+        wrapVisitedStatementBody(visited.statement),
+      );
+    };
+
+    const visitCaseOrDefaultClause = (
+      node: ts.CaseClause | ts.DefaultClause,
+    ): ts.CaseClause | ts.DefaultClause => {
+      const instrumentedStatements = node.statements.length === 0
+        ? (() => {
+          const spanId = registerSpan(node);
+          return spanId === undefined ? [] : [makeHitStatement(spanId)];
+        })()
+        : instrumentStatements(node.statements);
+      if (ts.isCaseClause(node)) {
+        return context.factory.updateCaseClause(
+          node,
+          ts.visitNode(node.expression, visit, ts.isExpression),
+          instrumentedStatements,
+        );
+      }
+      return context.factory.updateDefaultClause(
+        node,
+        instrumentedStatements,
+      );
+    };
+
+    const instrumentConciseBody = (
+      body: ts.ConciseBody,
+    ): ts.ConciseBody => {
+      if (ts.isBlock(body)) return instrumentBlock(body, true);
+
+      const visited = ts.visitNode(body, visit, ts.isExpression);
+      const spanId = registerSpan(body);
+      const statements: ts.Statement[] = [];
+      if (spanId !== undefined) statements.push(makeHitStatement(spanId));
+      statements.push(context.factory.createReturnStatement(visited));
+      return context.factory.createBlock(statements, true);
+    };
+
+    const visitFunctionLike = (node: ts.Node): ts.Node => {
+      if (ts.isArrowFunction(node)) {
+        return context.factory.updateArrowFunction(
+          node,
+          node.modifiers,
+          node.typeParameters,
+          node.parameters,
+          node.type,
+          node.equalsGreaterThanToken,
+          instrumentConciseBody(node.body),
+        );
+      }
+      if (ts.isFunctionDeclaration(node)) {
+        return context.factory.updateFunctionDeclaration(
+          node,
+          node.modifiers,
+          node.asteriskToken,
+          node.name,
+          node.typeParameters,
+          node.parameters,
+          node.type,
+          node.body ? instrumentBlock(node.body, true) : node.body,
+        );
+      }
+      if (ts.isFunctionExpression(node)) {
+        return context.factory.updateFunctionExpression(
+          node,
+          node.modifiers,
+          node.asteriskToken,
+          node.name,
+          node.typeParameters,
+          node.parameters,
+          node.type,
+          instrumentBlock(node.body, true),
+        );
+      }
+      if (ts.isMethodDeclaration(node)) {
+        return context.factory.updateMethodDeclaration(
+          node,
+          node.modifiers,
+          node.asteriskToken,
+          node.name,
+          node.questionToken,
+          node.typeParameters,
+          node.parameters,
+          node.type,
+          node.body ? instrumentBlock(node.body, true) : node.body,
+        );
+      }
+      if (ts.isConstructorDeclaration(node)) {
+        return context.factory.updateConstructorDeclaration(
+          node,
+          node.modifiers,
+          node.parameters,
+          node.body ? instrumentBlock(node.body, true) : node.body,
+        );
+      }
+      if (ts.isGetAccessorDeclaration(node)) {
+        return context.factory.updateGetAccessorDeclaration(
+          node,
+          node.modifiers,
+          node.name,
+          node.parameters,
+          node.type,
+          node.body ? instrumentBlock(node.body, true) : node.body,
+        );
+      }
+      if (ts.isSetAccessorDeclaration(node)) {
+        return context.factory.updateSetAccessorDeclaration(
+          node,
+          node.modifiers,
+          node.name,
+          node.parameters,
+          node.body ? instrumentBlock(node.body, true) : node.body,
+        );
+      }
+      return node;
+    };
+
+    const visit = (node: ts.Node): ts.Node => {
+      if (
+        ts.isArrowFunction(node) ||
+        ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isMethodDeclaration(node) ||
+        ts.isConstructorDeclaration(node) ||
+        ts.isGetAccessorDeclaration(node) ||
+        ts.isSetAccessorDeclaration(node)
+      ) {
+        return visitFunctionLike(node);
+      }
+      if (ts.isBlock(node)) {
+        return instrumentBlock(node);
+      }
+      if (ts.isIfStatement(node)) {
+        return visitIfStatement(node);
+      }
+      if (
+        ts.isDoStatement(node) ||
+        ts.isWhileStatement(node) ||
+        ts.isForStatement(node)
+      ) {
+        return visitIterationStatement(node);
+      }
+      if (ts.isForInStatement(node) || ts.isForOfStatement(node)) {
+        return visitForInOrOfStatement(node);
+      }
+      if (ts.isCaseClause(node) || ts.isDefaultClause(node)) {
+        return visitCaseOrDefaultClause(node);
+      }
+      if (ts.isModuleBlock(node)) {
+        return context.factory.updateModuleBlock(
+          node,
+          instrumentStatements(node.statements),
+        );
+      }
+      if (ts.isClassStaticBlockDeclaration(node)) {
+        return context.factory.updateClassStaticBlockDeclaration(
+          node,
+          instrumentBlock(node.body),
+        );
+      }
+      return ts.visitEachChild(node, visit, context.tsContext);
+    };
+
+    return context.factory.updateSourceFile(
+      context.sourceFile,
+      instrumentStatements(context.sourceFile.statements, true),
+    );
+  }
+}

--- a/packages/ts-transformers/test/ast/utils.test.ts
+++ b/packages/ts-transformers/test/ast/utils.test.ts
@@ -1,0 +1,298 @@
+import { assert, assertEquals } from "@std/assert";
+import ts from "typescript";
+
+import {
+  getExpressionText,
+  getMemberSymbol,
+  getMethodCallTarget,
+  getNodeText,
+  getTypeAtLocationWithFallback,
+  getVariableInitializer,
+  isFunctionParameter,
+  isMethodCall,
+  isOptionalMemberSymbol,
+  setParentPointers,
+} from "../../src/ast/utils.ts";
+
+function createProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const fileName = "/test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    skipLibCheck: true,
+  };
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const host = ts.createCompilerHost(compilerOptions, true);
+  const baseGetSourceFile = host.getSourceFile.bind(host);
+  const baseReadFile = host.readFile.bind(host);
+  const baseFileExists = host.fileExists.bind(host);
+
+  host.getSourceFile = (name, languageVersion, onError, shouldCreate) =>
+    name === fileName
+      ? sourceFile
+      : baseGetSourceFile(name, languageVersion, onError, shouldCreate);
+  host.readFile = (name) => name === fileName ? source : baseReadFile(name);
+  host.fileExists = (name) => name === fileName || baseFileExists(name);
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+function findIdentifier(
+  sourceFile: ts.SourceFile,
+  text: string,
+  predicate: (node: ts.Identifier) => boolean = () => true,
+): ts.Identifier {
+  let found: ts.Identifier | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      !found && ts.isIdentifier(node) && node.text === text && predicate(node)
+    ) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Missing identifier ${text}`);
+  return found;
+}
+
+function findInitializer(
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.Expression {
+  let found: ts.Expression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      !found &&
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name &&
+      node.initializer
+    ) {
+      found = node.initializer;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Missing initializer ${name}`);
+  return found;
+}
+
+function findPropertyAccess(
+  sourceFile: ts.SourceFile,
+  property: string,
+): ts.PropertyAccessExpression {
+  let found: ts.PropertyAccessExpression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      !found && ts.isPropertyAccessExpression(node) &&
+      node.name.text === property
+    ) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Missing property access ${property}`);
+  return found;
+}
+
+function findElementAccess(
+  sourceFile: ts.SourceFile,
+  property: string,
+): ts.ElementAccessExpression {
+  let found: ts.ElementAccessExpression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      !found &&
+      ts.isElementAccessExpression(node) &&
+      node.argumentExpression &&
+      ts.isStringLiteralLike(node.argumentExpression) &&
+      node.argumentExpression.text === property
+    ) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Missing element access ${property}`);
+  return found;
+}
+
+Deno.test("AST utils print source and synthetic nodes safely", () => {
+  const { sourceFile } = createProgram("const value = source.member;");
+  const access = findPropertyAccess(sourceFile, "member");
+  const synthetic = ts.factory.createPropertyAccessExpression(
+    ts.factory.createIdentifier("state"),
+    "count",
+  );
+
+  assertEquals(getNodeText(access), "source.member");
+  assertEquals(getNodeText(access), "source.member");
+  assertEquals(getExpressionText(synthetic), "state.count");
+});
+
+Deno.test("AST utils prefer registered synthetic initializer types", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare function unknownFactory(): any;
+    const value = unknownFactory();
+    const annotated: unknown = unknownFactory();
+  `);
+  const valueName = findIdentifier(
+    sourceFile,
+    "value",
+    (node) => ts.isVariableDeclaration(node.parent),
+  );
+  const annotatedName = findIdentifier(
+    sourceFile,
+    "annotated",
+    (node) => ts.isVariableDeclaration(node.parent),
+  );
+  const valueInitializer = findInitializer(sourceFile, "value");
+  const annotatedInitializer = findInitializer(sourceFile, "annotated");
+  const registry = new WeakMap<ts.Node, ts.Type>();
+  registry.set(valueInitializer, checker.getStringType());
+  registry.set(annotatedInitializer, checker.getNumberType());
+
+  assertEquals(
+    getTypeAtLocationWithFallback(valueName, checker, registry),
+    checker.getStringType(),
+  );
+  assertEquals(
+    checker.typeToString(
+      getTypeAtLocationWithFallback(annotatedName, checker, registry)!,
+    ),
+    "unknown",
+  );
+});
+
+Deno.test("AST utils resolve variable initializers through shorthand properties", () => {
+  const { sourceFile, checker } = createProgram(`
+    const source = { value: 1 };
+    const wrapper = { source };
+  `);
+  const shorthand = findIdentifier(
+    sourceFile,
+    "source",
+    (node) => ts.isShorthandPropertyAssignment(node.parent),
+  );
+
+  assertEquals(
+    getNodeText(getVariableInitializer(shorthand, checker)!),
+    "{ value: 1 }",
+  );
+  assertEquals(
+    getVariableInitializer(findInitializer(sourceFile, "wrapper"), checker),
+    undefined,
+  );
+});
+
+Deno.test("AST utils resolve member symbols and optional members", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface Item {
+      required: string;
+      optional?: number;
+    }
+    declare const item: Item;
+    declare const key: keyof Item;
+    const fromProperty = item.required;
+    const fromElement = item["optional"];
+    const fromDynamic = item[key];
+  `);
+  const required = findPropertyAccess(sourceFile, "required");
+  const optional = findElementAccess(sourceFile, "optional");
+  const dynamic = findInitializer(sourceFile, "fromDynamic");
+
+  assertEquals(getMemberSymbol(required, checker)?.getName(), "required");
+  assertEquals(getMemberSymbol(optional, checker)?.getName(), "optional");
+  assertEquals(
+    getMemberSymbol(dynamic as ts.ElementAccessExpression, checker)?.getName(),
+    undefined,
+  );
+  assertEquals(isOptionalMemberSymbol(required, checker), false);
+  assertEquals(isOptionalMemberSymbol(optional, checker), true);
+});
+
+Deno.test("AST utils classify function parameters outside builder callbacks", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare function lift<T, R>(callback: (value: T) => R): unknown;
+    declare function pattern<T, R>(callback: (value: T) => R): unknown;
+    function ordinary(param: string) {
+      return param;
+    }
+    const lifted = lift((value: string) => value);
+    const patterned = pattern((input: string) => input);
+    const local = "value";
+  `);
+  const ordinaryUse = findIdentifier(
+    sourceFile,
+    "param",
+    (node) => ts.isReturnStatement(node.parent),
+  );
+  const liftedUse = findIdentifier(
+    sourceFile,
+    "value",
+    (node) => ts.isArrowFunction(node.parent) && node.parent.body === node,
+  );
+  const patternedUse = findIdentifier(
+    sourceFile,
+    "input",
+    (node) => ts.isArrowFunction(node.parent) && node.parent.body === node,
+  );
+  const local = findIdentifier(
+    sourceFile,
+    "local",
+    (node) => ts.isVariableDeclaration(node.parent),
+  );
+
+  assertEquals(isFunctionParameter(ordinaryUse, checker), true);
+  assertEquals(isFunctionParameter(liftedUse, checker), false);
+  assertEquals(isFunctionParameter(patternedUse, checker), false);
+  assertEquals(isFunctionParameter(local, checker), false);
+});
+
+Deno.test("AST utils set synthetic parent pointers for method-call helpers", () => {
+  const call = ts.factory.createCallExpression(
+    ts.factory.createPropertyAccessExpression(
+      ts.factory.createPropertyAccessExpression(
+        ts.factory.createIdentifier("state"),
+        "counter",
+      ),
+      "set",
+    ),
+    undefined,
+    [],
+  );
+  setParentPointers(call);
+  const callee = call.expression;
+  assert(ts.isPropertyAccessExpression(callee));
+
+  assertEquals(isMethodCall(callee), true);
+  assertEquals(
+    getExpressionText(getMethodCallTarget(callee)!),
+    "state.counter",
+  );
+  assertEquals(
+    isMethodCall(callee.expression as ts.PropertyAccessExpression),
+    false,
+  );
+  assertEquals(
+    getMethodCallTarget(callee.expression as ts.PropertyAccessExpression),
+    undefined,
+  );
+});

--- a/packages/ts-transformers/test/destructuring-lowering.test.ts
+++ b/packages/ts-transformers/test/destructuring-lowering.test.ts
@@ -1,0 +1,306 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import ts from "typescript";
+
+import type { TransformationContext } from "../src/core/mod.ts";
+import {
+  collectDestructureBindings,
+  createKeyCall,
+  type DefaultDestructureBinding,
+  type DestructureBinding,
+  getStaticDefaultTypeNode,
+  toStringPath,
+} from "../src/transformers/destructuring-lowering.ts";
+
+function createProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const fileName = "/test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    skipLibCheck: true,
+  };
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+  );
+  const host = ts.createCompilerHost(compilerOptions, true);
+  const baseGetSourceFile = host.getSourceFile.bind(host);
+  const baseReadFile = host.readFile.bind(host);
+  const baseFileExists = host.fileExists.bind(host);
+
+  host.getSourceFile = (name, languageVersion, onError, shouldCreate) =>
+    name === fileName
+      ? sourceFile
+      : baseGetSourceFile(name, languageVersion, onError, shouldCreate);
+  host.readFile = (name) => name === fileName ? source : baseReadFile(name);
+  host.fileExists = (name) => name === fileName || baseFileExists(name);
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+function testContext(checker: ts.TypeChecker): TransformationContext {
+  return {
+    checker,
+    factory: ts.factory,
+    options: {
+      state: {
+        typeRegistry: new WeakMap<ts.Node, ts.Type>(),
+      },
+    },
+    cfHelpers: {
+      getHelperExpr: (name: string) => ts.factory.createIdentifier(name),
+    },
+  } as unknown as TransformationContext;
+}
+
+function findVariable(
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.VariableDeclaration {
+  let found: ts.VariableDeclaration | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      !found &&
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name
+    ) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Missing variable ${name}`);
+  return found;
+}
+
+function findBindingDeclaration(
+  sourceFile: ts.SourceFile,
+  predicate: (name: ts.BindingName) => boolean,
+): ts.VariableDeclaration {
+  let found: ts.VariableDeclaration | undefined;
+  const visit = (node: ts.Node): void => {
+    if (!found && ts.isVariableDeclaration(node) && predicate(node.name)) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error("Missing binding declaration");
+  return found;
+}
+
+function printType(node: ts.TypeNode, sourceFile: ts.SourceFile): string {
+  return ts.createPrinter({ newLine: ts.NewLineKind.LineFeed }).printNode(
+    ts.EmitHint.Unspecified,
+    node,
+    sourceFile,
+  );
+}
+
+Deno.test("destructuring lowering converts static defaults to type nodes", () => {
+  const { sourceFile, checker } = createProgram(`
+    const text = "hello";
+    const template = \`world\`;
+    const numberValue = -1;
+    const bigintValue = +2n;
+    const flag = false;
+    const empty = null;
+    const missing = undefined;
+    const tuple = ["x", 1, true];
+    const objectValue = { label: "Ada", "display-name": "A", 0: null };
+    const spreadArray = [...tuple];
+  `);
+  const context = testContext(checker);
+
+  assertEquals(
+    printType(
+      getStaticDefaultTypeNode(
+        findVariable(sourceFile, "text").initializer!,
+        context,
+      )!,
+      sourceFile,
+    ),
+    '"hello"',
+  );
+  assertEquals(
+    printType(
+      getStaticDefaultTypeNode(
+        findVariable(sourceFile, "template").initializer!,
+        context,
+      )!,
+      sourceFile,
+    ),
+    '"world"',
+  );
+  assertEquals(
+    printType(
+      getStaticDefaultTypeNode(
+        findVariable(sourceFile, "numberValue").initializer!,
+        context,
+      )!,
+      sourceFile,
+    ),
+    "-1",
+  );
+  assertEquals(
+    printType(
+      getStaticDefaultTypeNode(
+        findVariable(sourceFile, "bigintValue").initializer!,
+        context,
+      )!,
+      sourceFile,
+    ),
+    "+2n",
+  );
+  assertEquals(
+    printType(
+      getStaticDefaultTypeNode(
+        findVariable(sourceFile, "flag").initializer!,
+        context,
+      )!,
+      sourceFile,
+    ),
+    "false",
+  );
+  assertEquals(
+    printType(
+      getStaticDefaultTypeNode(
+        findVariable(sourceFile, "empty").initializer!,
+        context,
+      )!,
+      sourceFile,
+    ),
+    "null",
+  );
+  assertEquals(
+    printType(
+      getStaticDefaultTypeNode(
+        findVariable(sourceFile, "missing").initializer!,
+        context,
+      )!,
+      sourceFile,
+    ),
+    "undefined",
+  );
+  assertEquals(
+    printType(
+      getStaticDefaultTypeNode(
+        findVariable(sourceFile, "tuple").initializer!,
+        context,
+      )!,
+      sourceFile,
+    ).replace(/\s+/g, " "),
+    '[ "x", 1, true ]',
+  );
+  const objectType = printType(
+    getStaticDefaultTypeNode(
+      findVariable(sourceFile, "objectValue").initializer!,
+      context,
+    )!,
+    sourceFile,
+  );
+  assertStringIncludes(objectType, 'label: "Ada";');
+  assertStringIncludes(objectType, '"display-name": "A";');
+  assertStringIncludes(objectType, "0: null;");
+  assertEquals(
+    getStaticDefaultTypeNode(
+      findVariable(sourceFile, "spreadArray").initializer!,
+      context,
+    ),
+    undefined,
+  );
+});
+
+Deno.test("destructuring lowering collects array and object bindings", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare const input: unknown;
+    declare const dynamic: string;
+    const [first = "x", , { name }, ...rest] = input as any;
+    const { "title": title = 1, 0: zero, nested: { value }, [dynamic]: dyn } = input as any;
+  `);
+  const context = testContext(checker);
+  const bindings: DestructureBinding[] = [];
+  const defaults: DefaultDestructureBinding[] = [];
+  const unsupported: string[] = [];
+  const arrayBinding = findBindingDeclaration(
+    sourceFile,
+    ts.isArrayBindingPattern,
+  );
+  const objectBinding = findBindingDeclaration(
+    sourceFile,
+    ts.isObjectBindingPattern,
+  );
+
+  collectDestructureBindings(
+    arrayBinding.name,
+    ["root"],
+    bindings,
+    defaults,
+    unsupported,
+    context,
+  );
+  collectDestructureBindings(
+    objectBinding.name,
+    ["root"],
+    bindings,
+    defaults,
+    unsupported,
+    context,
+  );
+
+  assertEquals(bindings.map((binding) => binding.localName), [
+    "first",
+    "name",
+    "title",
+    "zero",
+    "value",
+    "dyn",
+  ]);
+  assertEquals(bindings.map((binding) => toStringPath(binding.path)), [
+    ["root", "0"],
+    ["root", "2", "name"],
+    ["root", "title"],
+    ["root", "0"],
+    ["root", "nested", "value"],
+    undefined,
+  ]);
+  assertEquals(defaults.map((entry) => entry.path), [
+    ["root", "0"],
+    ["root", "title"],
+  ]);
+  assertEquals(unsupported.length, 1);
+  assertStringIncludes(unsupported[0]!, "Rest destructuring");
+});
+
+Deno.test("destructuring lowering creates key calls for static and dynamic paths", () => {
+  const { sourceFile } = createProgram("const dynamic = keyName;");
+  const dynamic = findVariable(sourceFile, "dynamic").initializer!;
+  const call = createKeyCall(
+    ts.factory.createIdentifier("input"),
+    ["profile", dynamic],
+    ts.factory,
+  );
+
+  assertEquals(toStringPath(["profile", dynamic]), undefined);
+  assertEquals(
+    printType(ts.factory.createTypeReferenceNode("T"), sourceFile),
+    "T",
+  );
+  assertEquals(
+    ts.createPrinter({ newLine: ts.NewLineKind.LineFeed }).printNode(
+      ts.EmitHint.Expression,
+      call,
+      sourceFile,
+    ),
+    'input.key("profile", keyName)',
+  );
+});

--- a/packages/ts-transformers/test/expression-rewrite-bindings.test.ts
+++ b/packages/ts-transformers/test/expression-rewrite-bindings.test.ts
@@ -1,0 +1,61 @@
+import { assertEquals } from "@std/assert";
+import ts from "typescript";
+
+import { createBindingPlan } from "../src/transformers/expression-rewrite/bindings.ts";
+
+function parseExpressions(source: string): ts.Expression[] {
+  const sourceFile = ts.createSourceFile(
+    "/bindings.ts",
+    source,
+    ts.ScriptTarget.ES2020,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const expressions: ts.Expression[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isExpressionStatement(node)) {
+      expressions.push(node.expression);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return expressions;
+}
+
+Deno.test("createBindingPlan assigns stable unique binding names", () => {
+  const [first, second, third] = parseExpressions(`
+    user.profile.name;
+    user.profile.name;
+    $invalid["field-name"];
+  `);
+  const plan = createBindingPlan([
+    { expression: first! },
+    { expression: second! },
+    { expression: third! },
+  ] as never);
+
+  assertEquals(plan.usesObjectBinding, true);
+  assertEquals(
+    plan.entries.map((entry) => entry.propertyName),
+    ["user_profile_name", "user_profile_name_1", "$invalid__field_name__"],
+  );
+  assertEquals(
+    plan.entries.map((entry) => entry.paramName),
+    ["_v1", "_v2", "_v3"],
+  );
+  assertEquals(plan.entries.map((entry) => entry.dataFlow.expression), [
+    first,
+    second,
+    third,
+  ]);
+});
+
+Deno.test("createBindingPlan keeps single captures as direct bindings", () => {
+  const [expression] = parseExpressions("selected.id;");
+  const plan = createBindingPlan([{ expression: expression! }] as never);
+
+  assertEquals(plan.usesObjectBinding, false);
+  assertEquals(plan.entries[0]!.propertyName, "selected_id");
+  assertEquals(plan.entries[0]!.paramName, "_v1");
+});

--- a/packages/ts-transformers/test/no-node-get-text-lint-plugin.test.ts
+++ b/packages/ts-transformers/test/no-node-get-text-lint-plugin.test.ts
@@ -1,0 +1,85 @@
+import { assert, assertEquals } from "@std/assert";
+
+import plugin from "../lint-plugins/no-node-get-text.ts";
+
+interface Report {
+  node: unknown;
+  message: string;
+}
+
+function createRule(filename: string, reports: Report[]) {
+  return plugin.rules["no-node-get-text"].create({
+    filename,
+    report(report: Report) {
+      reports.push(report);
+    },
+  } as never);
+}
+
+Deno.test("no-node-get-text lint plugin reports bare getText calls", () => {
+  const reports: Report[] = [];
+  const rule = createRule("/src/transformer.ts", reports);
+  const visitCall = rule.CallExpression;
+  assert(visitCall);
+  const node = {
+    callee: {
+      type: "MemberExpression",
+      computed: false,
+      property: { type: "Identifier", name: "getText" },
+    },
+    arguments: [],
+  };
+
+  visitCall(node as never);
+
+  assertEquals(reports.length, 1);
+  assertEquals(reports[0]!.node, node);
+  assertEquals(
+    reports[0]!.message,
+    "Bare node.getText() throws on synthetic AST nodes. Use " +
+      "getNodeText()/getExpressionText() from ast/utils.ts, or pass " +
+      "a SourceFile.",
+  );
+});
+
+Deno.test("no-node-get-text lint plugin ignores allowed forms", () => {
+  const reports: Report[] = [];
+  const rule = createRule("/src/transformer.ts", reports);
+  const visitCall = rule.CallExpression;
+  assert(visitCall);
+
+  visitCall({
+    callee: {
+      type: "MemberExpression",
+      computed: false,
+      property: { type: "Identifier", name: "getText" },
+    },
+    arguments: [{}],
+  } as never);
+  visitCall({
+    callee: {
+      type: "MemberExpression",
+      computed: true,
+      property: { type: "Identifier", name: "getText" },
+    },
+    arguments: [],
+  } as never);
+  visitCall({
+    callee: {
+      type: "MemberExpression",
+      computed: false,
+      property: { type: "Identifier", name: "toString" },
+    },
+    arguments: [],
+  } as never);
+
+  assertEquals(reports, []);
+});
+
+Deno.test("no-node-get-text lint plugin skips test files", () => {
+  const reports: Report[] = [];
+  const rule = createRule("/src/test/transformer.test.ts", reports);
+
+  assertEquals(rule, {});
+  assertEquals(reports, []);
+});

--- a/packages/ts-transformers/test/pattern-coverage-transformer.test.ts
+++ b/packages/ts-transformers/test/pattern-coverage-transformer.test.ts
@@ -1,0 +1,490 @@
+import ts from "typescript";
+import { assertEquals, assertMatch, assertStringIncludes } from "@std/assert";
+import {
+  PatternCoverageTransformer,
+} from "../src/transformers/pattern-coverage.ts";
+import { CommonFabricTransformerPipeline } from "../src/cf-pipeline.ts";
+import {
+  type PatternCoverageOptions,
+  type PatternCoverageSpan,
+  TransformationContext,
+  type TransformationDiagnostic,
+} from "../src/core/mod.ts";
+
+interface TransformResult {
+  output: string;
+  spans: PatternCoverageSpan[];
+}
+
+function createProgramForSource(
+  fileName: string,
+  source: string,
+  scriptKind = ts.ScriptKind.TSX,
+): { program: ts.Program; sourceFile: ts.SourceFile } {
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.CommonJS,
+    jsx: ts.JsxEmit.React,
+  };
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.ES2020,
+    true,
+    scriptKind,
+  );
+  const host = ts.createCompilerHost(compilerOptions);
+  const baseGetSourceFile = host.getSourceFile.bind(host);
+  const baseReadFile = host.readFile.bind(host);
+  const baseFileExists = host.fileExists.bind(host);
+
+  host.getSourceFile = (name, languageVersion, onError, shouldCreate) =>
+    name === fileName
+      ? sourceFile
+      : baseGetSourceFile(name, languageVersion, onError, shouldCreate);
+  host.readFile = (name) => name === fileName ? source : baseReadFile(name);
+  host.fileExists = (name) => name === fileName || baseFileExists(name);
+
+  return {
+    program: ts.createProgram([fileName], compilerOptions, host),
+    sourceFile,
+  };
+}
+
+function printResult(result: ts.TransformationResult<ts.SourceFile>): string {
+  const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+  try {
+    return printer.printFile(result.transformed[0]);
+  } finally {
+    result.dispose();
+  }
+}
+
+function transformWithCoverage(
+  source: string,
+  options: Partial<PatternCoverageOptions> = {},
+): TransformResult {
+  const fileName = "/pattern.tsx";
+  const { program, sourceFile } = createProgramForSource(fileName, source);
+  const spans: PatternCoverageSpan[] = [];
+  const coverage: PatternCoverageOptions = {
+    ...options,
+    registerSpan: (span) => {
+      spans.push(span);
+      options.registerSpan?.(span);
+    },
+  };
+  const transformer = new PatternCoverageTransformer({
+    patternCoverage: coverage,
+  });
+  const result = ts.transform(sourceFile, [transformer.toFactory(program)]);
+
+  return {
+    output: printResult(result),
+    spans,
+  };
+}
+
+function transformWithDirectCall(source: string): string {
+  const fileName = "/pattern.tsx";
+  const { program, sourceFile } = createProgramForSource(fileName, source);
+  const transformer = new PatternCoverageTransformer({});
+  const result = ts.transform(sourceFile, [
+    (tsContext) => (file) => {
+      const context = new TransformationContext({
+        program,
+        sourceFile: file,
+        tsContext,
+        options: {},
+      });
+      return transformer.transform(context);
+    },
+  ]);
+
+  return printResult(result);
+}
+
+function sourceTextForSpan(source: string, span: PatternCoverageSpan): string {
+  return source.split("\n").slice(span.startLine - 1, span.endLine).join("\n");
+}
+
+function expectSpanContaining(
+  spans: PatternCoverageSpan[],
+  source: string,
+  text: string,
+): void {
+  assertEquals(
+    spans.some((span) => sourceTextForSpan(source, span).includes(text)),
+    true,
+  );
+}
+
+function expectNoSpanContaining(
+  spans: PatternCoverageSpan[],
+  source: string,
+  text: string,
+): void {
+  assertEquals(
+    spans.some((span) => sourceTextForSpan(source, span).includes(text)),
+    false,
+  );
+}
+
+Deno.test("PatternCoverageTransformer skips files when coverage is disabled", () => {
+  const source = "const value = 1;";
+  const { program, sourceFile } = createProgramForSource(
+    "/pattern.tsx",
+    source,
+  );
+  const transformer = new PatternCoverageTransformer({});
+  const result = ts.transform(sourceFile, [transformer.toFactory(program)]);
+
+  assertEquals(printResult(result), "const value = 1;\n");
+  assertEquals(transformWithDirectCall(source), "const value = 1;\n");
+});
+
+Deno.test("PatternCoverageTransformer skips declaration files", () => {
+  const source = "declare const value: string;";
+  const { program, sourceFile } = createProgramForSource(
+    "/types.d.ts",
+    source,
+    ts.ScriptKind.TS,
+  );
+  const spans: PatternCoverageSpan[] = [];
+  const transformer = new PatternCoverageTransformer({
+    patternCoverage: {
+      registerSpan: (span) => spans.push(span),
+    },
+  });
+  const result = ts.transform(sourceFile, [transformer.toFactory(program)]);
+
+  assertEquals(printResult(result), "declare const value: string;\n");
+  assertEquals(spans, []);
+});
+
+Deno.test("PatternCoverageTransformer instruments runtime statements", () => {
+  const source = `import "./dep.ts";
+export type ExportedType = string;
+interface Shape {
+  value: string;
+}
+type Alias = number;
+declare const declaredValue: string;
+declare namespace Ambient {
+  export const ambientValue: number;
+}
+const enum Hidden {
+  A,
+}
+namespace TypeOnly {
+  export interface Inner {
+    value: string;
+  }
+  export type Name = string;
+}
+namespace NestedTypeOnly {
+  export namespace Inner {
+    export interface Value {
+      value: string;
+    }
+  }
+}
+namespace DottedTypeOnly.Inner {
+  export interface Value {
+    value: string;
+  }
+}
+namespace RuntimeNamespace {
+  export const value = 1;
+}
+const skipMe = "not registered";
+const topLevel = 1;
+if (topLevel > 0) {
+  console.log(topLevel);
+}
+function declaredFunction(flag: boolean) {
+  const inside = flag ? 1 : 2;
+  return inside;
+}
+const expressionFunction = function () {
+  const local = declaredFunction(true);
+  return local;
+};
+const arrowBlock = () => {
+  const local = 1;
+  return local;
+};
+const arrowExpression = (value: number) => value + topLevel;
+class Demo {
+  static value = 0;
+  static {
+    Demo.value = 1;
+  }
+  value = 0;
+  constructor() {
+    this.value = 1;
+  }
+  get count() {
+    return this.value;
+  }
+  set count(value: number) {
+    this.value = value;
+  }
+  method() {
+    return arrowExpression(this.value);
+  }
+}
+export {};
+`;
+  const { output, spans } = transformWithCoverage(source, {
+    fileName: (sourceFileName) => `mapped:${sourceFileName}`,
+    mapSpan: (span) => {
+      const line = source.split("\n")[span.startLine - 1] ?? "";
+      if (line.includes("skipMe")) return undefined;
+      return { ...span, id: span.id + 1000 };
+    },
+  });
+
+  assertEquals(
+    spans.every((span) => span.fileName === "mapped:/pattern.tsx"),
+    true,
+  );
+  assertEquals(spans.every((span) => span.id > 1000), true);
+  assertEquals(
+    spans.some((span) => {
+      const line = source.split("\n")[span.startLine - 1] ?? "";
+      return line.includes("skipMe");
+    }),
+    false,
+  );
+  expectNoSpanContaining(spans, source, 'import "./dep.ts";');
+  expectNoSpanContaining(spans, source, "export type ExportedType = string;");
+  expectNoSpanContaining(spans, source, "interface Shape");
+  expectNoSpanContaining(spans, source, "type Alias = number;");
+  expectNoSpanContaining(spans, source, "declare const declaredValue");
+  expectNoSpanContaining(spans, source, "declare namespace Ambient");
+  expectNoSpanContaining(spans, source, "ambientValue");
+  expectNoSpanContaining(spans, source, "const enum Hidden");
+  expectNoSpanContaining(spans, source, "namespace TypeOnly");
+  expectNoSpanContaining(spans, source, "namespace NestedTypeOnly");
+  expectNoSpanContaining(spans, source, "namespace DottedTypeOnly");
+  expectSpanContaining(spans, source, "namespace RuntimeNamespace");
+  expectSpanContaining(spans, source, "const topLevel = 1;");
+  expectSpanContaining(spans, source, "if (topLevel > 0)");
+  expectSpanContaining(spans, source, "const inside = flag ? 1 : 2;");
+  expectSpanContaining(spans, source, "return inside;");
+  expectSpanContaining(spans, source, "const local = declaredFunction(true);");
+  expectSpanContaining(spans, source, "const local = 1;");
+  expectSpanContaining(spans, source, "value + topLevel");
+  expectSpanContaining(spans, source, "Demo.value = 1;");
+  expectSpanContaining(spans, source, "this.value = 1;");
+  expectSpanContaining(spans, source, "return this.value;");
+  expectSpanContaining(spans, source, "this.value = value;");
+  expectSpanContaining(spans, source, "return arrowExpression(this.value);");
+  assertStringIncludes(
+    output,
+    '(globalThis.__cfPatternCoverage?.hit)("mapped:/pattern.tsx", 1001);',
+  );
+  assertStringIncludes(output, "function declaredFunction(flag: boolean) {");
+  assertMatch(
+    output,
+    /function declaredFunction\(flag: boolean\) \{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)/,
+  );
+  assertMatch(
+    output,
+    /const arrowExpression = \(value: number\) => \{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)[\s\S]+return value \+ topLevel;/,
+  );
+  assertMatch(
+    output,
+    /constructor\(\) \{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)/,
+  );
+  assertMatch(
+    output,
+    /get count\(\) \{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)/,
+  );
+  assertMatch(
+    output,
+    /set count\(value: number\) \{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)/,
+  );
+  assertMatch(
+    output,
+    /method\(\) \{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)/,
+  );
+});
+
+Deno.test("PatternCoverageTransformer maps every registered span", () => {
+  const source = `const first = 1;
+function run() {
+  const second = 2;
+  return second;
+}
+`;
+  const { spans } = transformWithCoverage(source, {
+    fileName: () => "mapped:/pattern.tsx",
+    mapSpan: (span) => ({
+      ...span,
+      id: span.id + 10,
+      startLine: span.startLine + 100,
+      endLine: span.endLine + 100,
+    }),
+  });
+
+  assertEquals(spans, [
+    {
+      fileName: "mapped:/pattern.tsx",
+      id: 11,
+      kind: "runtime",
+      startLine: 101,
+      endLine: 101,
+      startColumn: 1,
+      endColumn: 16,
+    },
+    {
+      fileName: "mapped:/pattern.tsx",
+      id: 12,
+      kind: "runtime",
+      startLine: 103,
+      endLine: 103,
+      startColumn: 3,
+      endColumn: 19,
+    },
+    {
+      fileName: "mapped:/pattern.tsx",
+      id: 13,
+      kind: "runtime",
+      startLine: 104,
+      endLine: 104,
+      startColumn: 3,
+      endColumn: 16,
+    },
+  ]);
+});
+
+Deno.test("PatternCoverageTransformer leaves directive prologues first", () => {
+  const source = `"use strict";
+const top = 1;
+function run() {
+  "use strict";
+  const value = 1;
+  return value;
+}
+`;
+  const { output, spans } = transformWithCoverage(source);
+
+  expectSpanContaining(spans, source, "const top = 1;");
+  expectSpanContaining(spans, source, "const value = 1;");
+  assertMatch(
+    output,
+    /^"use strict";\s+\(globalThis\.__cfPatternCoverage\?\.hit\)[\s\S]+const top = 1;/,
+  );
+  assertMatch(
+    output,
+    /function run\(\) \{\s+"use strict";\s+\(globalThis\.__cfPatternCoverage\?\.hit\)/,
+  );
+});
+
+Deno.test("CommonFabricTransformerPipeline clears diagnostics", () => {
+  const pipeline = new CommonFabricTransformerPipeline();
+  const diagnostics = pipeline.getDiagnostics() as TransformationDiagnostic[];
+  diagnostics.push({
+    severity: "error",
+    type: "test",
+    message: "diagnostic for clear test",
+    fileName: "/test.ts",
+    line: 1,
+    column: 1,
+    start: 0,
+    length: 1,
+  });
+  assertEquals(pipeline.getDiagnostics().length, 1);
+  pipeline.clearDiagnostics();
+  assertEquals(pipeline.getDiagnostics(), []);
+});
+
+Deno.test("statements rebuilt as synthetic nodes still get coverage", () => {
+  const fileName = "/pattern.tsx";
+  const source = "const keep = 1;\nconst drop = 2;\n";
+  const { program, sourceFile } = createProgramForSource(fileName, source);
+  const spans: PatternCoverageSpan[] = [];
+
+  // Model an earlier pipeline stage that rebuilds `drop` as a fresh node (pos
+  // === end === -1) while keeping a link to the authored node via
+  // setOriginalNode, as factory updates and lowerings do.
+  const rebuildDropStatement: ts.TransformerFactory<ts.SourceFile> = (
+    tsContext,
+  ) =>
+  (file) => {
+    const statements = file.statements.map((statement) => {
+      if (
+        ts.isVariableStatement(statement) &&
+        ts.isIdentifier(statement.declarationList.declarations[0]!.name) &&
+        statement.declarationList.declarations[0]!.name.text === "drop"
+      ) {
+        const rebuilt = tsContext.factory.createVariableStatement(
+          undefined,
+          tsContext.factory.createVariableDeclarationList(
+            [tsContext.factory.createVariableDeclaration(
+              "drop",
+              undefined,
+              undefined,
+              tsContext.factory.createNumericLiteral(2),
+            )],
+            ts.NodeFlags.Const,
+          ),
+        );
+        return ts.setOriginalNode(rebuilt, statement);
+      }
+      return statement;
+    });
+    return tsContext.factory.updateSourceFile(file, statements);
+  };
+
+  const transformer = new PatternCoverageTransformer({
+    patternCoverage: { registerSpan: (span) => spans.push(span) },
+  });
+  ts.transform(sourceFile, [
+    rebuildDropStatement,
+    transformer.toFactory(program),
+  ]).dispose();
+
+  // Both authored statements must be instrumented; the rebuilt `drop` keeps its
+  // authored line (2) through its linked original node.
+  assertEquals(spans.length, 2);
+  assertEquals(spans.map((span) => span.startLine).sort((a, b) => a - b), [
+    1,
+    2,
+  ]);
+});
+
+Deno.test("leading non-directive string statement is instrumented", () => {
+  const source = `function f() {
+  "leading note";
+  doStuff();
+}
+`;
+  const { spans } = transformWithCoverage(source);
+
+  expectSpanContaining(spans, source, "doStuff();");
+  // The bare `"leading note";` statement is on authored line 2; a span must
+  // start there.
+  assertEquals(spans.some((span) => span.startLine === 2), true);
+});
+
+Deno.test("empty fall-through switch case is recorded", () => {
+  const source = `const x = 2;
+switch (x) {
+  case 1:
+  case 2:
+    doTwo();
+    break;
+}
+`;
+  const { spans } = transformWithCoverage(source);
+  const caseOneLine =
+    source.split("\n").findIndex((line) => line.includes("case 1:")) + 1;
+
+  expectSpanContaining(spans, source, "doTwo();");
+  // A span must start on the `case 1:` label line so reaching the case is
+  // recorded.
+  assertEquals(spans.some((span) => span.startLine === caseOneLine), true);
+});

--- a/packages/ts-transformers/test/pipeline-regressions.test.ts
+++ b/packages/ts-transformers/test/pipeline-regressions.test.ts
@@ -112,6 +112,7 @@ Deno.test(
       "ReactiveVariableForTransformer",
       "ModuleScopeShadowingTransformer",
       "ModuleScopeCfDataTransformer",
+      "PatternCoverageTransformer",
       "ModuleScopeFunctionHardeningTransformer",
     ]);
   },

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -402,6 +402,38 @@ Deno.test("Capability analysis tracks reassignment aliases", () => {
   assert(input.readPaths.includes("user.name"));
 });
 
+Deno.test("Capability analysis tracks object assignment pattern aliases", () => {
+  const fn = parseFirstCallback(
+    `const fn = (input) => {
+      let name;
+      let alias;
+      ({ user: { name }, profile: alias } = input);
+      return name + alias.title;
+    };`,
+  );
+  const summary = analyzeFunctionCapabilities(fn);
+  const input = getPaths(summary, "input");
+
+  assertEquals(input.capability, "readonly");
+  assert(input.readPaths.includes("user.name"));
+  assert(input.readPaths.includes("profile"));
+  assert(input.readPaths.includes("profile.title"));
+});
+
+Deno.test("Capability analysis treats array assignment patterns as wildcard", () => {
+  const fn = parseFirstCallback(
+    `const fn = (input) => {
+      let first;
+      [first] = input.items;
+      return first.name;
+    };`,
+  );
+  const summary = analyzeFunctionCapabilities(fn);
+  const input = getPaths(summary, "input");
+
+  assertEquals(input.wildcard, true);
+});
+
 Deno.test("Capability analysis treats dynamic alias keys as wildcard", () => {
   const fn = parseFirstCallback(
     `const fn = (input, key) => {
@@ -412,6 +444,54 @@ Deno.test("Capability analysis treats dynamic alias keys as wildcard", () => {
   const summary = analyzeFunctionCapabilities(fn);
   const input = getPaths(summary, "input");
 
+  assertEquals(input.wildcard, true);
+});
+
+Deno.test("Capability analysis tracks template literal and numeric key paths", () => {
+  const fn = parseFirstCallback(
+    "const fn = (input) => input.key(`profile`).key(0).get();",
+  );
+  const summary = analyzeFunctionCapabilities(fn);
+  const input = getPaths(summary, "input");
+
+  assertEquals(input.capability, "readonly");
+  assert(input.readPaths.includes("profile.0"));
+  assertEquals(input.wildcard, false);
+});
+
+Deno.test("Capability analysis tracks boolean wrapper conditions", () => {
+  const fn = parseFirstCallback(
+    `const fn = (input) => {
+      for (; (input.ready as boolean)!; ) {
+        break;
+      }
+      return input.done ? input.value : input.alt;
+    };`,
+  );
+  const summary = analyzeFunctionCapabilities(fn);
+  const input = getPaths(summary, "input");
+
+  assertEquals(input.capability, "readonly");
+  assert(input.readPaths.includes("ready"));
+  assert(input.readPaths.includes("done"));
+  assert(input.readPaths.includes("value"));
+  assert(input.readPaths.includes("alt"));
+});
+
+Deno.test("Capability analysis marks object assignment spreads as wildcard", () => {
+  const fn = parseFirstCallback(
+    `const fn = (input) => {
+      let value;
+      ({ ["profile"]: value, ...rest } = input);
+      return value.name;
+    };`,
+  );
+  const summary = analyzeFunctionCapabilities(fn);
+  const input = getPaths(summary, "input");
+
+  assertEquals(input.capability, "readonly");
+  assert(input.readPaths.includes("profile"));
+  assert(input.readPaths.includes("profile.name"));
   assertEquals(input.wildcard, true);
 });
 

--- a/packages/ts-transformers/test/type-inference.test.ts
+++ b/packages/ts-transformers/test/type-inference.test.ts
@@ -1,0 +1,463 @@
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import ts from "typescript";
+
+import {
+  ensureTypeNodeRegistered,
+  getTypeFromTypeNodeWithFallback,
+  hasArrayTypeArgument,
+  inferArrayElementType,
+  inferContextualType,
+  inferParameterType,
+  inferReturnType,
+  inferWidenedTypeFromExpression,
+  isAnyOrUnknownType,
+  isAnyType,
+  isCollectionType,
+  isUnknownType,
+  isUnresolvedSchemaType,
+  registerLiftAppliedCallType,
+  registerSyntheticCallType,
+  registerTypeForNode,
+  tryExplicitParameterType,
+  typeToSchemaTypeNode,
+  typeToTypeNode,
+  unwrapCellLikeType,
+  unwrapOpaqueLikeType,
+  widenLiteralType,
+} from "../src/ast/type-inference.ts";
+
+interface ProgramParts {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+}
+
+function createProgram(source: string): ProgramParts {
+  const fileName = "/test.ts";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    skipLibCheck: true,
+  };
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+  );
+  const host = ts.createCompilerHost(compilerOptions, true);
+  const baseGetSourceFile = host.getSourceFile.bind(host);
+  const baseReadFile = host.readFile.bind(host);
+  const baseFileExists = host.fileExists.bind(host);
+
+  host.getSourceFile = (name, languageVersion, onError, shouldCreate) =>
+    name === fileName
+      ? sourceFile
+      : baseGetSourceFile(name, languageVersion, onError, shouldCreate);
+  host.readFile = (name) => name === fileName ? source : baseReadFile(name);
+  host.fileExists = (name) => name === fileName || baseFileExists(name);
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+function findIdentifier(
+  sourceFile: ts.SourceFile,
+  text: string,
+): ts.Identifier {
+  let found: ts.Identifier | undefined;
+  const visit = (node: ts.Node): void => {
+    if (!found && ts.isIdentifier(node) && node.text === text) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Missing identifier ${text}`);
+  return found;
+}
+
+function findVariable(
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.VariableDeclaration {
+  let found: ts.VariableDeclaration | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      !found &&
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name
+    ) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Missing variable ${name}`);
+  return found;
+}
+
+function findTypeAlias(
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.TypeAliasDeclaration {
+  let found: ts.TypeAliasDeclaration | undefined;
+  const visit = (node: ts.Node): void => {
+    if (!found && ts.isTypeAliasDeclaration(node) && node.name.text === name) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Missing type alias ${name}`);
+  return found;
+}
+
+function findArrow(sourceFile: ts.SourceFile, variableName: string) {
+  const variable = findVariable(sourceFile, variableName);
+  if (!variable.initializer || !ts.isArrowFunction(variable.initializer)) {
+    throw new Error(`Missing arrow initializer for ${variableName}`);
+  }
+  return variable.initializer;
+}
+
+function typeText(
+  type: ts.Type | undefined,
+  checker: ts.TypeChecker,
+): string {
+  return type ? checker.typeToString(type) : "undefined";
+}
+
+Deno.test("type inference helpers classify special types and widen literals", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Generic<T> = T;
+    type AnyAlias = any;
+    type UnknownAlias = unknown;
+    const numberLiteral = 42 as const;
+    const stringLiteral = "title" as const;
+    const objectValue = { title: "kept" };
+  `);
+  const anyType = checker.getTypeFromTypeNode(
+    findTypeAlias(sourceFile, "AnyAlias").type,
+  );
+  const unknownType = checker.getTypeFromTypeNode(
+    findTypeAlias(sourceFile, "UnknownAlias").type,
+  );
+  const typeParameter = checker.getTypeAtLocation(
+    findTypeAlias(sourceFile, "Generic").typeParameters![0]!.name,
+  );
+  const numberType = checker.getTypeAtLocation(
+    findIdentifier(sourceFile, "numberLiteral"),
+  );
+  const stringType = checker.getTypeAtLocation(
+    findIdentifier(sourceFile, "stringLiteral"),
+  );
+  const objectType = checker.getTypeAtLocation(
+    findIdentifier(sourceFile, "objectValue"),
+  );
+  const booleanUnion = (checker as ts.TypeChecker & {
+    getUnionType: (types: readonly ts.Type[]) => ts.Type;
+  }).getUnionType([
+    checker.getTrueType(),
+    checker.getFalseType(),
+  ]);
+
+  assertEquals(isAnyType(undefined), false);
+  assertEquals(isAnyType(anyType), true);
+  assertEquals(isUnknownType(undefined), false);
+  assertEquals(isUnknownType(unknownType), true);
+  assertEquals(isAnyOrUnknownType(undefined), false);
+  assertEquals(isAnyOrUnknownType(anyType), true);
+  assertEquals(isUnresolvedSchemaType(undefined), false);
+  assertEquals(isUnresolvedSchemaType(typeParameter), true);
+  assertEquals(
+    typeText(widenLiteralType(numberType, checker), checker),
+    "number",
+  );
+  assertEquals(
+    typeText(widenLiteralType(stringType, checker), checker),
+    "string",
+  );
+  assertEquals(widenLiteralType(booleanUnion, checker), booleanUnion);
+  assertEquals(widenLiteralType(objectType, checker), objectType);
+});
+
+Deno.test("type inference helpers infer parameters, returns, and contextual types", () => {
+  const { sourceFile, checker } = createProgram(`
+    const typed = (value: { title: string }) => value.title;
+    const contextual: (value: { count: number }) => number = (value) => value.count;
+    type Fn = (item: { count: number }) => number;
+    declare const declared: Fn;
+    const literal = 1 as const;
+  `);
+  const typed = findArrow(sourceFile, "typed");
+  const contextual = findArrow(sourceFile, "contextual");
+  const declared = findVariable(sourceFile, "declared");
+  const typedSignature = checker.getSignatureFromDeclaration(typed)!;
+  const declaredSignature = checker.getSignaturesOfType(
+    checker.getTypeAtLocation(declared.name),
+    ts.SignatureKind.Call,
+  )[0]!;
+  const registry = new WeakMap<ts.Node, ts.Type>();
+
+  const explicit = tryExplicitParameterType(
+    typed.parameters[0],
+    checker,
+    registry,
+  );
+  assert(explicit);
+  assertEquals(
+    getTypeFromTypeNodeWithFallback(explicit.typeNode, checker, registry),
+    explicit.type,
+  );
+  assertStringIncludes(typeText(explicit.type, checker), "title");
+
+  const inferredFromSignature = inferParameterType(
+    undefined,
+    declaredSignature,
+    checker,
+  );
+  assertStringIncludes(typeText(inferredFromSignature, checker), "count");
+  assertEquals(
+    inferParameterType(typed.parameters[0], typedSignature, checker),
+    explicit.type,
+  );
+  assertEquals(
+    typeText(inferReturnType(typed, typedSignature, checker), checker),
+    "string",
+  );
+  assertStringIncludes(
+    typeText(inferContextualType(contextual, checker), checker),
+    "count",
+  );
+  assertEquals(
+    typeText(
+      inferWidenedTypeFromExpression(
+        findVariable(sourceFile, "literal").initializer!,
+        checker,
+      ),
+      checker,
+    ),
+    "number",
+  );
+});
+
+Deno.test("type inference helpers register synthetic type nodes", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Name = string;
+    type Count = number;
+    type Existing = { done: boolean };
+    declare function lift(): unknown;
+  `);
+  const nameNode = findTypeAlias(sourceFile, "Name").type;
+  const countNode = findTypeAlias(sourceFile, "Count").type;
+  const existingNode = findTypeAlias(sourceFile, "Existing").type;
+  const registry = new WeakMap<ts.Node, ts.Type>();
+  const typeLiteral = ts.factory.createTypeLiteralNode([
+    ts.factory.createPropertySignature(
+      undefined,
+      "name",
+      undefined,
+      nameNode,
+    ),
+    ts.factory.createPropertySignature(
+      undefined,
+      "count",
+      ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+      countNode,
+    ),
+  ]);
+  const arrayNode = ts.factory.createArrayTypeNode(nameNode);
+  const unionNode = ts.factory.createUnionTypeNode([nameNode, countNode]);
+  const parenthesizedNode = ts.factory.createParenthesizedType(nameNode);
+
+  assertEquals(
+    ensureTypeNodeRegistered(nameNode, checker),
+    checker.getStringType(),
+  );
+  assertEquals(
+    getTypeFromTypeNodeWithFallback(existingNode, checker, registry),
+    ensureTypeNodeRegistered(existingNode, checker, registry),
+  );
+  assertStringIncludes(
+    typeText(ensureTypeNodeRegistered(typeLiteral, checker, registry), checker),
+    "name",
+  );
+  assertStringIncludes(
+    typeText(ensureTypeNodeRegistered(arrayNode, checker, registry), checker),
+    "string[]",
+  );
+  assertStringIncludes(
+    typeText(ensureTypeNodeRegistered(unionNode, checker, registry), checker),
+    "string | number",
+  );
+  assertEquals(
+    ensureTypeNodeRegistered(parenthesizedNode, checker, registry),
+    checker.getStringType(),
+  );
+
+  const returnedNode = registerTypeForNode(
+    countNode,
+    checker.getNumberType(),
+    registry,
+  );
+  assertEquals(returnedNode, countNode);
+  assertEquals(registry.get(countNode), checker.getNumberType());
+
+  const call = ts.factory.createCallExpression(
+    findIdentifier(sourceFile, "lift"),
+    undefined,
+    [],
+  );
+  registerSyntheticCallType(call, checker.getBooleanType(), registry);
+  assertEquals(registry.get(call), checker.getBooleanType());
+  const secondCall = ts.factory.createCallExpression(
+    findIdentifier(sourceFile, "lift"),
+    undefined,
+    [],
+  );
+  registerLiftAppliedCallType(
+    secondCall,
+    nameNode,
+    undefined,
+    checker,
+    registry,
+  );
+  assertEquals(registry.get(secondCall), checker.getStringType());
+});
+
+Deno.test("type inference helpers detect collections and array element types", () => {
+  const { sourceFile, checker } = createProgram(`
+    type ArrayContainer = Array<string[]>;
+    type UnionContainer = Array<string[]> | Array<number>;
+    type IntersectionContainer = Array<string[]> & { tag: string };
+    const numbers = [1, 2, 3];
+    const tuple = ["name", 1] as const;
+    const unionArray = Math.random() > 0.5 ? ["a"] : [1];
+    const scalar = 1;
+    declare const arrayContainer: ArrayContainer;
+    declare const scalarContainer: Array<string>;
+  `);
+  const numbers = findIdentifier(sourceFile, "numbers");
+  const tuple = findIdentifier(sourceFile, "tuple");
+  const unionArray = findIdentifier(sourceFile, "unionArray");
+  const scalar = findIdentifier(sourceFile, "scalar");
+  const arrayContainer = findIdentifier(sourceFile, "arrayContainer");
+  const scalarContainer = findIdentifier(sourceFile, "scalarContainer");
+  const arrayContainerType = checker.getTypeFromTypeNode(
+    findTypeAlias(sourceFile, "ArrayContainer").type,
+  );
+  const unionContainerType = checker.getTypeFromTypeNode(
+    findTypeAlias(sourceFile, "UnionContainer").type,
+  );
+  const intersectionContainerType = checker.getTypeFromTypeNode(
+    findTypeAlias(sourceFile, "IntersectionContainer").type,
+  );
+
+  assertEquals(isCollectionType(undefined, checker), false);
+  assertEquals(
+    isCollectionType(checker.getTypeAtLocation(numbers), checker),
+    true,
+  );
+  assertEquals(
+    isCollectionType(checker.getTypeAtLocation(tuple), checker),
+    true,
+  );
+  assertEquals(
+    isCollectionType(checker.getTypeAtLocation(unionArray), checker),
+    true,
+  );
+  assertEquals(hasArrayTypeArgument(arrayContainerType, checker), true);
+  assertEquals(hasArrayTypeArgument(unionContainerType, checker), true);
+  assertEquals(hasArrayTypeArgument(intersectionContainerType, checker), true);
+  assertEquals(
+    hasArrayTypeArgument(checker.getTypeAtLocation(scalarContainer), checker),
+    false,
+  );
+
+  assertEquals(
+    typeText(
+      inferArrayElementType(numbers, {
+        checker,
+        factory: ts.factory,
+        sourceFile,
+      }).type,
+      checker,
+    ),
+    "number",
+  );
+  assertEquals(
+    typeText(
+      inferArrayElementType(arrayContainer, {
+        checker,
+        factory: ts.factory,
+        sourceFile,
+      }).type,
+      checker,
+    ),
+    "string",
+  );
+  assertEquals(
+    typeText(
+      inferArrayElementType(scalarContainer, {
+        checker,
+        factory: ts.factory,
+        sourceFile,
+      }).type,
+      checker,
+    ),
+    "string",
+  );
+  assertEquals(
+    inferArrayElementType(scalar, {
+      checker,
+      factory: ts.factory,
+      sourceFile,
+    }).typeNode.kind,
+    ts.SyntaxKind.UnknownKeyword,
+  );
+});
+
+Deno.test("type inference helpers convert and unwrap types conservatively", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Box<T> = { value: T };
+    type NameBox = Box<string>;
+    type NameOrCount = string | number;
+    const value: NameBox = { value: "Ada" };
+  `);
+  const boxType = checker.getTypeFromTypeNode(
+    findTypeAlias(sourceFile, "NameBox").type,
+  );
+  const unionType = checker.getTypeFromTypeNode(
+    findTypeAlias(sourceFile, "NameOrCount").type,
+  );
+  const value = findIdentifier(sourceFile, "value");
+
+  assertStringIncludes(
+    typeText(unwrapOpaqueLikeType(unionType, checker), checker),
+    "string | number",
+  );
+  assertEquals(unwrapCellLikeType(undefined, checker), undefined);
+  assertEquals(unwrapCellLikeType(boxType, checker), boxType);
+
+  const asTypeNode = typeToTypeNode(boxType, checker, sourceFile);
+  assert(asTypeNode);
+  assertStringIncludes(
+    ts.createPrinter().printNode(
+      ts.EmitHint.Unspecified,
+      asTypeNode,
+      sourceFile,
+    ),
+    "NameBox",
+  );
+  const schemaTypeNode = typeToSchemaTypeNode(
+    checker.getTypeAtLocation(value),
+    checker,
+    sourceFile,
+  );
+  assert(schemaTypeNode);
+});

--- a/packages/ts-transformers/test/type-shrinking.test.ts
+++ b/packages/ts-transformers/test/type-shrinking.test.ts
@@ -3,8 +3,15 @@ import ts from "typescript";
 
 import type { CapabilityParamSummary } from "../src/core/mod.ts";
 import {
+  applyCapabilityDefaultsToTypeNode,
   applyShrinkAndWrap,
+  containsAnyOrUnknownTypeNode,
+  isCellLikeTypeNode,
+  isSqliteTypeNode,
+  isStreamTypeNode,
+  preservedWrapperFor,
   printTypeNode,
+  wrapTypeNodeWithCapability,
 } from "../src/transformers/type-shrinking.ts";
 
 function createProgram(source: string): {
@@ -793,4 +800,90 @@ Deno.test("applyShrinkAndWrap preserves aliased fixed-symbol keys in node-driven
   assertStringIncludes(printed, "id: string;");
   assertEquals(printed.includes("title"), false);
   assertEquals(printed.includes("value"), false);
+});
+
+Deno.test("applyCapabilityDefaultsToTypeNode applies defaults through tuples and unions", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input =
+      | [{ name?: string; unused?: string }]
+      | { fallback?: string; unused?: string };
+    type NameDefault = "Anonymous";
+    type FallbackDefault = "Fallback";
+  `);
+  const input = findTypeAlias(sourceFile, "Input");
+  const nameDefault = findTypeAlias(sourceFile, "NameDefault");
+  const fallbackDefault = findTypeAlias(sourceFile, "FallbackDefault");
+  const baseType = checker.getTypeAtLocation(input.type);
+
+  const result = applyCapabilityDefaultsToTypeNode(
+    input.type,
+    [
+      { path: ["0", "name"], defaultType: nameDefault.type },
+      { path: ["fallback"], defaultType: fallbackDefault.type },
+    ],
+    baseType,
+    [["0", "name"], ["fallback"]],
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(
+    printed,
+    'name?: __cfHelpers.Default<string, "Anonymous">;',
+  );
+  assertStringIncludes(
+    printed,
+    'fallback?: __cfHelpers.Default<string, "Fallback">;',
+  );
+});
+
+Deno.test("type shrinking helper predicates detect wrapper type nodes", () => {
+  const { sourceFile, checker } = createProgram(`
+    type CellValue = Cell<string>;
+    type StreamValue = Stream<string>;
+    type SqliteValue = SqliteDb<{ id: string }>;
+    type PlainValue = string;
+    type AnyUnion = { value: any } | { fallback: unknown };
+  `);
+  const cellNode = findTypeAlias(sourceFile, "CellValue").type;
+  const streamNode = findTypeAlias(sourceFile, "StreamValue").type;
+  const sqliteNode = findTypeAlias(sourceFile, "SqliteValue").type;
+  const plainNode = findTypeAlias(sourceFile, "PlainValue").type;
+  const anyUnionNode = findTypeAlias(sourceFile, "AnyUnion").type;
+
+  assertEquals(containsAnyOrUnknownTypeNode(anyUnionNode), true);
+  assertEquals(containsAnyOrUnknownTypeNode(plainNode), false);
+  assertEquals(isCellLikeTypeNode(cellNode), true);
+  assertEquals(isCellLikeTypeNode(sqliteNode), false);
+  assertEquals(isStreamTypeNode(streamNode), true);
+  assertEquals(isStreamTypeNode(cellNode), false);
+  assertEquals(isSqliteTypeNode(sqliteNode), true);
+  assertEquals(isSqliteTypeNode(cellNode), false);
+  assertEquals(preservedWrapperFor(streamNode, undefined, checker), "Stream");
+  assertEquals(preservedWrapperFor(sqliteNode, undefined, checker), "SqliteDb");
+  assertEquals(preservedWrapperFor(plainNode, undefined, checker), undefined);
+});
+
+Deno.test("wrapTypeNodeWithCapability emits the expected cell wrappers", () => {
+  const { sourceFile } = createProgram(`type Value = string;`);
+  const valueNode = findTypeAlias(sourceFile, "Value").type;
+
+  const wrappers = [
+    ["readonly", "ReadonlyCell"],
+    ["comparable", "ComparableCell"],
+    ["writeonly", "WriteonlyCell"],
+    ["writable", "Writable"],
+    ["opaque", "OpaqueCell"],
+  ] as const;
+
+  for (const [capability, wrapperName] of wrappers) {
+    const printed = printTypeNode(
+      wrapTypeNodeWithCapability(valueNode, capability, ts.factory),
+      sourceFile,
+    );
+    assertStringIncludes(printed, `__cfHelpers.${wrapperName}<string>`);
+  }
 });


### PR DESCRIPTION
Pattern source files are transformed before execution, so Deno's normal coverage output cannot describe which pre-transformed pattern lines ran. This change adds a runtime coverage path that records the original pattern line ranges chosen by the transformer and counts hits while patterns execute.

The transformer is part of the normal Common Fabric transformer pipeline, but it only adds counters when pattern coverage is enabled. The runner exposes a collector, disables precompiled body reuse for covered runs, and writes LCOV records that use only instrumented runtime lines as their denominator.

The cf test runner and multi-user worker write those LCOV files when CF_PATTERN_COVERAGE_DIR is set. The pattern CI job stores them under the existing coverage-profile artifacts so the current coverage collection step can ingest them without a new artifact type.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime, statement-based pattern coverage mapped back to authored lines and writes LCOV for transformed pattern code. Integrated into `cf test` and CI with strict verifier/parser checks, stable line remapping, and a documented one‑line helper prelude contract.

- **New Features**
  - Added `PatternCoverageTransformer` to `@commonfabric/ts-transformers` (off by default; runs before function hardening). Records spans and injects hit calls at module scope and inside nested control flow; preserves directive prologues, skips erased ambient declarations, registers authored-line spans, and keeps mount identity in coverage keys.
  - Added `PatternCoverageCollector` and LCOV helpers to `@commonfabric/runner` (`writePatternCoverageLcov`, `patternCoverageOutputPath`, `patternCoverageReportToLcov`). The engine injects a sandbox global for hit counting, remaps helper‑prelude offsets back to authored lines, filters non‑runtime spans and excludes test files by default, merges equal‑width spans, ignores precompiled bodies when coverage is enabled, normalizes paths with collision‑resistant filenames, and accepts only generated top‑level hit calls with literal filename arguments; the parser shares string‑literal scanning with the verifier to reject malformed literals. Mixed‑import rewriting now preserves line counts for multiline import attributes. Docs describe statement‑reach semantics for multiline ranges and exclude synthetic statements from denominators.
  - `cf test` supports `--pattern-coverage-dir` and `CF_PATTERN_COVERAGE_DIR`. Single- and multi-user runs write `*.pattern-coverage.lcov` per test (and participant) during cleanup and log non‑fatal write errors. CI sets `CF_PATTERN_COVERAGE_DIR` and uploads `coverage/lcov/pattern-runtime/`.

- **Migration**
  - Local: run `cf test --pattern-coverage-dir <dir>` (or set `CF_PATTERN_COVERAGE_DIR`) to generate LCOV under that directory.
  - CI: no action needed; the pattern job emits and uploads runtime LCOV files under `coverage/lcov/pattern-runtime/`.

<sup>Written for commit 9b0d54b3115d7bb3c9ed9d78375440b8b1376060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

