### PR TITLE
Localize lunch poll vote writes

### DIFF
--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -196,9 +196,12 @@ export default pattern(() => {
 
   const assert_green_vote_recorded = computed(() => {
     const v = poll.votes[0];
+    const stored = poll.users[0]?.votes?.[0];
     return poll.votes.length === 1 &&
       v?.voteType === "green" &&
-      v?.voterName === "Alex";
+      v?.voterName === "Alex" &&
+      stored?.optionId === v?.optionId &&
+      stored?.voteType === "green";
   });
 
   // The "All options" overview renders one swatch per voter, sourced from a

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -32,9 +32,10 @@
  * denormalized, so the snapshot survives the option being removed. The
  * "📊 Lunch stats" card derives per-place visit + green/yellow/red tallies from
  * those embedded snapshots via a plain `computed` (the `tallyOptions` idiom).
- * Live voting stays on the in-cell `votes` array. Each entry — and each embedded
- * vote — carries a frozen name snapshot plus a live `Cell<User>` profile link
- * (the shared-profile-roster live-link idiom).
+ * Live voting is stored on each user's roster row and projected back to the
+ * public `votes` output. Each embedded history vote carries a frozen name
+ * snapshot plus a live `Cell<User>` profile link (the shared-profile-roster
+ * live-link idiom).
  *
  * History was briefly backed by the SQLite builtin (#4144/#4145, to dogfood it),
  * but that brought a deployed-piece "invalid database handle" failure plus a
@@ -62,11 +63,15 @@ import PollOptionCard from "./poll-option-card.tsx";
 import ParticipantIdentityCard from "./participant-identity-card.tsx";
 
 export interface User {
+  /** Stable participant id; keeps row-local child state anchored. */
+  id?: string;
   name: string;
   /** Avatar URL or glyph, snapshotted from the joiner's shared profile. */
   avatar?: string;
   color: string;
   joinedAt: number;
+  /** Row-local votes for this participant. */
+  votes?: UserVote[];
 }
 
 export interface Option {
@@ -76,6 +81,11 @@ export interface Option {
 }
 
 export type VoteColor = "green" | "yellow" | "red";
+
+export interface UserVote {
+  optionId: string;
+  voteType: VoteColor;
+}
 
 export interface Vote {
   voterName: string;
@@ -166,9 +176,9 @@ export type ClearHistoryEvent = Record<PropertyKey, never>;
 
 type QuestionCell = Writable<string | Default<"Where should we eat?">>;
 type OptionsCell = Writable<Option[] | Default<[]>>;
-type VotesCell = Writable<Vote[] | Default<[]>>;
 type UsersCell = Writable<User[] | Default<[]>>;
 type NameCell = Writable<string | Default<"">>;
+type UserIndexCell = Writable<number | Default<-1>>;
 type HistoryCell = Writable<HistoryEntry[] | Default<[]>>;
 
 const POLL_THEME = {
@@ -284,10 +294,10 @@ const addOption = handler<AddOptionEvent, {
 
 const removeOption = handler<RemoveOptionEvent, {
   options: OptionsCell;
-  votes: VotesCell;
+  users: UsersCell;
   myName: NameCell;
   adminName: NameCell;
-}>(({ optionId }, { options, votes, myName, adminName }) => {
+}>(({ optionId }, { options, users, myName, adminName }) => {
   const me = trimmedName(myName.get());
   const admin = trimmedName(adminName.get());
   if (!me || me !== admin) return;
@@ -295,40 +305,82 @@ const removeOption = handler<RemoveOptionEvent, {
   const target = current.find((o) => o.id === optionId);
   if (!target) return;
   options.remove(target);
-  votes.set(votes.get().filter((v) => v.optionId !== optionId));
+  users.get().forEach((user, index) => {
+    const currentVotes: readonly UserVote[] = Array.isArray(user.votes)
+      ? user.votes
+      : [];
+    if (currentVotes.length === 0) return;
+    users.key(index).key("votes").set(
+      currentVotes.filter((v) => v.optionId !== optionId),
+    );
+  });
 });
 
-const castVote = handler<CastVoteEvent, {
-  votes: VotesCell;
-  myName: NameCell;
-}>(({ optionId, voteType }, { votes, myName }) => {
+const currentUserIndex = (
+  users: UsersCell,
+  myName: NameCell,
+  myUserIndex: UserIndexCell,
+): number => {
   const me = trimmedName(myName.get());
-  if (!me) return;
-  const current = votes.get();
+  if (!me) return -1;
+
+  const storedIndex = myUserIndex.get();
+  if (Number.isInteger(storedIndex) && storedIndex >= 0) {
+    const storedUser = users.key(storedIndex).get();
+    if (storedUser?.name === me) return storedIndex;
+  }
+
+  const foundIndex = users.get().findIndex((user) => user.name === me);
+  if (foundIndex >= 0) {
+    myUserIndex.set(foundIndex);
+    return foundIndex;
+  }
+  return -1;
+};
+
+const castVote = handler<CastVoteEvent, {
+  users: UsersCell;
+  myName: NameCell;
+  myUserIndex: UserIndexCell;
+}>(({ optionId, voteType }, { users, myName, myUserIndex }) => {
+  const userIndex = currentUserIndex(users, myName, myUserIndex);
+  if (userIndex < 0) return;
+
+  const userVotes = users.key(userIndex).key("votes");
+  const rawVotes = userVotes.get();
+  const current: readonly UserVote[] = Array.isArray(rawVotes)
+    ? rawVotes as readonly UserVote[]
+    : [];
+  if (!Array.isArray(rawVotes)) {
+    userVotes.set([]);
+  }
+
   const existingIdx = current.findIndex(
-    (v) => v.voterName === me && v.optionId === optionId,
+    (v) => v.optionId === optionId,
   );
   if (existingIdx >= 0) {
     const existing = current[existingIdx];
     if (existing.voteType === voteType) {
-      votes.remove(existing);
+      userVotes.remove(existing);
       return;
     }
-    votes.key(existingIdx).key("voteType").set(voteType);
+    userVotes.key(existingIdx).key("voteType").set(voteType);
     return;
   }
-  votes.push({ voterName: me, optionId, voteType });
+  userVotes.push({ optionId, voteType });
 });
 
 const resetVotes = handler<ResetVotesEvent, {
-  votes: VotesCell;
+  users: UsersCell;
   myName: NameCell;
   adminName: NameCell;
-}>((_, { votes, myName, adminName }) => {
+}>((_, { users, myName, adminName }) => {
   const me = trimmedName(myName.get());
   const admin = trimmedName(adminName.get());
   if (!me || me !== admin) return;
-  votes.set([]);
+  users.get().forEach((_user, index) => {
+    users.key(index).key("votes").set([]);
+  });
 });
 
 export interface ClearVoteEvent {
@@ -336,17 +388,32 @@ export interface ClearVoteEvent {
 }
 
 const clearMyVote = handler<ClearVoteEvent, {
-  votes: VotesCell;
+  users: UsersCell;
   myName: NameCell;
-}>(({ optionId }, { votes, myName }) => {
-  const me = trimmedName(myName.get());
-  if (!me) return;
-  votes.set(
-    votes.get().filter(
-      (v) => !(v.voterName === me && v.optionId === optionId),
-    ),
-  );
+  myUserIndex: UserIndexCell;
+}>(({ optionId }, { users, myName, myUserIndex }) => {
+  const userIndex = currentUserIndex(users, myName, myUserIndex);
+  if (userIndex < 0) return;
+
+  const userVotes = users.key(userIndex).key("votes");
+  const rawVotes = userVotes.get();
+  const currentVotes: readonly UserVote[] = Array.isArray(rawVotes)
+    ? rawVotes as readonly UserVote[]
+    : [];
+  if (currentVotes.length === 0) return;
+  userVotes.set(currentVotes.filter((v) => v.optionId !== optionId));
 });
+
+const votesForUsers = (
+  users: readonly User[],
+): Vote[] =>
+  users.flatMap((user) =>
+    (user.votes ?? []).map((vote) => ({
+      voterName: user.name,
+      optionId: vote.optionId,
+      voteType: vote.voteType,
+    }))
+  );
 
 // Host-only, same gate as the other mutating admin actions. Logs where the
 // group actually ate — by option id (resolved to its title) or a free title —
@@ -355,7 +422,6 @@ const clearMyVote = handler<ClearVoteEvent, {
 const logVisit = handler<LogVisitEvent, {
   visits: HistoryCell;
   options: OptionsCell;
-  votes: VotesCell;
   users: UsersCell;
   myName: NameCell;
   adminName: NameCell;
@@ -363,7 +429,7 @@ const logVisit = handler<LogVisitEvent, {
 }>(
   (
     { optionId, title, wentAt },
-    { visits, options, votes, users, myName, adminName, visitDate },
+    { visits, options, users, myName, adminName, visitDate },
   ) => {
     const me = trimmedName(myName.get());
     const admin = trimmedName(adminName.get());
@@ -391,7 +457,7 @@ const logVisit = handler<LogVisitEvent, {
     // option title (options can be removed later; the title is the record).
     const titleById = new Map(options.get().map((o) => [o.id, o.title]));
     const voteSnapshot: VoteSnapshot[] = [];
-    for (const v of votes.get()) {
+    for (const v of votesForUsers(users.get())) {
       const optTitle = trimmedName(titleById.get(v.optionId));
       if (!optTitle) continue; // vote for an already-removed option → skip
       voteSnapshot.push({
@@ -513,10 +579,13 @@ const summarizePlaces = (visits: readonly HistoryEntry[]): PlaceStat[] => {
 export interface CozyPollInput {
   question?: PerSpace<string | Default<"Where should we eat?">>;
   options?: PerSpace<Option[] | Default<[]>>;
+  // Deprecated storage slot retained for older callers. New live votes are
+  // stored on `users[].votes` and projected to the `votes` output.
   votes?: PerSpace<Vote[] | Default<[]>>;
   users?: PerSpace<User[] | Default<[]>>;
   adminName?: PerSpace<string | Default<"">>;
   myName?: PerUser<string | Default<"">>;
+  myUserIndex?: PerUser<number | Default<-1>>;
   // Durable "we went here" log; each entry embeds its own vote snapshot. Capped
   // at MAX_HISTORY most-recent entries in `logVisit`. optionDraft etc. are
   // internal form drafts, declared as local per-session cells in the pattern
@@ -565,7 +634,6 @@ export interface CozyPollOutput {
 // Stable empty fallbacks for the output snapshots below — fresh `[]` per
 // recompute would make the computed results non-idempotent.
 const EMPTY_OPTIONS: Option[] = [];
-const EMPTY_VOTES: Vote[] = [];
 const EMPTY_USERS: User[] = [];
 
 export default pattern<CozyPollInput, CozyPollOutput>(
@@ -573,10 +641,10 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     {
       question,
       options,
-      votes,
       users,
       adminName,
       myName,
+      myUserIndex,
       visits,
     },
   ) => {
@@ -596,6 +664,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     const participantIdentity = ParticipantIdentityCard({
       users,
       myName,
+      myUserIndex,
       adminName,
     });
     const boundAddOption = addOption({
@@ -606,17 +675,24 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     });
     const boundRemoveOption = removeOption({
       options,
-      votes,
+      users,
       myName,
       adminName,
     });
-    const boundCastVote = castVote({ votes, myName });
-    const boundClearMyVote = clearMyVote({ votes, myName });
-    const boundResetVotes = resetVotes({ votes, myName, adminName });
+    const boundCastVote = castVote({
+      users,
+      myName,
+      myUserIndex,
+    });
+    const boundClearMyVote = clearMyVote({
+      users,
+      myName,
+      myUserIndex,
+    });
+    const boundResetVotes = resetVotes({ users, myName, adminName });
     const boundLogVisit = logVisit({
       visits,
       options,
-      votes,
       users,
       myName,
       adminName,
@@ -634,7 +710,8 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     });
     const userCount = users.length;
     const optionCount = options.length;
-    const voteCount = votes.length;
+    const liveVotes = computed(() => votesForUsers(users));
+    const voteCount = liveVotes.length;
     // The "Recently eaten" card: the 8 most-recent visits (newest first),
     // derived straight from the `visits` array. An array-shaped computed (not a
     // lift-returned VNode) is what lets the card keep its plain-JSX `.map(...)`
@@ -672,7 +749,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     const isClearHistoryConfirm = computed(() =>
       clearHistoryConfirmPending.get()
     );
-    const ranked = tallyOptions(options, votes, users);
+    const ranked = tallyOptions(options, liveVotes, users);
 
     const topChoice = voteCount > 0 && ranked.length > 0 ? ranked[0] : null;
 
@@ -939,32 +1016,33 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                                   justifyContent: "flex-end",
                                 }}
                               >
-                                {votes.filter((vote) => vote.optionId === oid)
-                                  .map((vote) => (
-                                    <span
-                                      title={vote.voterName}
-                                      data-vote-swatch-name={vote.voterName}
-                                      style={{
-                                        display: "inline-flex",
-                                        alignItems: "center",
-                                        justifyContent: "center",
-                                        minWidth: "22px",
-                                        height: "22px",
-                                        padding: "0 6px",
-                                        borderRadius: "9999px",
-                                        backgroundColor:
-                                          VOTE_SWATCH[vote.voteType],
-                                        color: "white",
-                                        fontSize: "11px",
-                                        fontWeight: 700,
-                                        boxShadow: vote.voterName === me
-                                          ? "0 0 0 2px white, 0 0 0 3px #111827"
-                                          : "none",
-                                      }}
-                                    >
-                                      {getInitials(vote.voterName)}
-                                    </span>
-                                  ))}
+                                {liveVotes.filter((vote) =>
+                                  vote.optionId === oid
+                                ).map((vote) => (
+                                  <span
+                                    title={vote.voterName}
+                                    data-vote-swatch-name={vote.voterName}
+                                    style={{
+                                      display: "inline-flex",
+                                      alignItems: "center",
+                                      justifyContent: "center",
+                                      minWidth: "22px",
+                                      height: "22px",
+                                      padding: "0 6px",
+                                      borderRadius: "9999px",
+                                      backgroundColor:
+                                        VOTE_SWATCH[vote.voteType],
+                                      color: "white",
+                                      fontSize: "11px",
+                                      fontWeight: 700,
+                                      boxShadow: vote.voterName === me
+                                        ? "0 0 0 2px white, 0 0 0 3px #111827"
+                                        : "none",
+                                    }}
+                                  >
+                                    {getInitials(vote.voterName)}
+                                  </span>
+                                ))}
                               </div>
                             </div>
                           );
@@ -1034,7 +1112,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                       me={me}
                       isJoined={isJoined}
                       isAdmin={isAdmin}
-                      votes={votes}
+                      votes={liveVotes}
                       removeConfirmTarget={removeConfirmTarget}
                       castVote={boundCastVote}
                       removeOption={boundRemoveOption}
@@ -1374,10 +1452,9 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       // indistinguishable from "not yet computed" for cross-runtime readers —
       // so every snapshot yields a real, stable value (the shared EMPTY
       // constants keep the fallback idempotent across recomputes). The visit
-      // history is no longer a PerSpace input — it lives in SQLite now and is
-      // surfaced via `recentVisits`/`mostRecentTitle` below.
+      // history is surfaced via `recentVisits`/`mostRecentTitle` below.
       options: computed(() => options ?? EMPTY_OPTIONS),
-      votes: computed(() => votes ?? EMPTY_VOTES),
+      votes: liveVotes,
       users: computed(() => users ?? EMPTY_USERS),
       adminName: computed(() => trimmedName(adminName)),
       myName: participantIdentity.me,

--- a/packages/patterns/lunch-poll/multi-user.test.tsx
+++ b/packages/patterns/lunch-poll/multi-user.test.tsx
@@ -70,6 +70,13 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
     (poll.options ?? []).length === 1 &&
     poll.myName === "Alice"
   );
+  const assert_bob_changed_without_clobbering_alice = computed(() =>
+    (poll.votes ?? []).length === 2 &&
+    poll.votes?.[0]?.voterName === "Alice" &&
+    poll.votes?.[0]?.voteType === "green" &&
+    poll.votes?.[1]?.voterName === "Bob" &&
+    poll.votes?.[1]?.voteType === "yellow"
+  );
   // Host takeover observed from the deposed host's runtime.
   const assert_deposed = computed(() =>
     poll.adminName === "Bob" && poll.isAdmin === false
@@ -86,6 +93,8 @@ export const alice = pattern<{ setup: Setup }>(({ setup }) => {
       { label: "alice-set-up" },
       { await: "bob-voted" },
       { assertion: assert_sees_bob },
+      { await: "bob-changed-vote" },
+      { assertion: assert_bob_changed_without_clobbering_alice },
       { await: "bob-claimed-host" },
       { assertion: assert_deposed },
     ],
@@ -107,6 +116,10 @@ export const bob = pattern<{ setup: Setup }>(({ setup }) => {
   const action_vote_green = action(() => {
     const first = poll.options?.[0];
     if (first) poll.castVote.send({ optionId: first.id, voteType: "green" });
+  });
+  const action_vote_yellow = action(() => {
+    const first = poll.options?.[0];
+    if (first) poll.castVote.send({ optionId: first.id, voteType: "yellow" });
   });
   const action_claim_host = action(() => {
     poll.claimHost.send({});
@@ -138,7 +151,16 @@ export const bob = pattern<{ setup: Setup }>(({ setup }) => {
   const assert_both_votes = computed(() =>
     (poll.votes ?? []).length === 2 &&
     poll.votes?.[0]?.voterName === "Alice" &&
-    poll.votes?.[1]?.voterName === "Bob"
+    poll.votes?.[0]?.voteType === "green" &&
+    poll.votes?.[1]?.voterName === "Bob" &&
+    poll.votes?.[1]?.voteType === "green"
+  );
+  const assert_bob_changed_vote = computed(() =>
+    (poll.votes ?? []).length === 2 &&
+    poll.votes?.[0]?.voterName === "Alice" &&
+    poll.votes?.[0]?.voteType === "green" &&
+    poll.votes?.[1]?.voterName === "Bob" &&
+    poll.votes?.[1]?.voteType === "yellow"
   );
   const assert_is_host_now = computed(() =>
     poll.adminName === "Bob" && poll.isAdmin === true
@@ -157,6 +179,9 @@ export const bob = pattern<{ setup: Setup }>(({ setup }) => {
       { action: action_vote_green },
       { assertion: assert_both_votes },
       { label: "bob-voted" },
+      { action: action_vote_yellow },
+      { assertion: assert_bob_changed_vote },
+      { label: "bob-changed-vote" },
       { action: action_claim_host },
       { assertion: assert_is_host_now },
       { label: "bob-claimed-host" },

--- a/packages/patterns/lunch-poll/participant-identity-card.test.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.test.tsx
@@ -5,10 +5,12 @@ import type { User } from "./main.tsx";
 export default pattern(() => {
   const users = new Writable<User[] | Default<[]>>([]);
   const myName = new Writable<string | Default<"">>("");
+  const myUserIndex = new Writable<number | Default<-1>>(-1);
   const adminName = new Writable<string | Default<"">>("");
   const participantIdentity = ParticipantIdentityCard({
     users,
     myName,
+    myUserIndex,
     adminName,
   });
 
@@ -22,12 +24,15 @@ export default pattern(() => {
 
   const action_switch_to_blair = action(() => {
     users.push({
+      id: "u_blair",
       name: "Blair",
       avatar: "",
       color: "#c2573a",
       joinedAt: 1,
+      votes: [],
     });
     myName.set("Blair");
+    myUserIndex.set(1);
   });
 
   const action_claim_host_as_blair = action(() => {
@@ -43,9 +48,14 @@ export default pattern(() => {
 
   const assert_joined_as_alex = computed(() => {
     const currentUsers = users.get();
+    const userId = currentUsers[0]?.id ?? "";
     return currentUsers.length === 1 &&
+      typeof currentUsers[0]?.id === "string" &&
+      userId !== "" &&
       currentUsers[0]?.name === "Alex" &&
+      currentUsers[0]?.votes?.length === 0 &&
       myName.get() === "Alex" &&
+      myUserIndex.get() === 0 &&
       adminName.get() === "Alex" &&
       participantIdentity.me === "Alex" &&
       participantIdentity.isJoined === true &&

--- a/packages/patterns/lunch-poll/participant-identity-card.tsx
+++ b/packages/patterns/lunch-poll/participant-identity-card.tsx
@@ -3,6 +3,7 @@ import {
   Default,
   handler,
   NAME,
+  nonPrivateRandom,
   pattern,
   safeDateNow,
   type Stream,
@@ -19,6 +20,9 @@ export type ParticipantIdentityUsersCell = Writable<User[] | Default<[]>>;
 /** Parent-owned viewer/admin name cell. */
 export type ParticipantIdentityNameCell = Writable<string | Default<"">>;
 
+/** Parent-owned per-user pointer into the append-only participant roster. */
+export type ParticipantIdentityUserIndexCell = Writable<number | Default<-1>>;
+
 const PLAYER_COLORS = [
   "#2f8a64",
   "#c2573a",
@@ -30,10 +34,15 @@ const PLAYER_COLORS = [
 
 const trimmedName = (n: string | undefined) => (n ?? "").trim();
 const colorForIndex = (i: number) => PLAYER_COLORS[i % PLAYER_COLORS.length];
+const newUserId = () =>
+  `u_${safeDateNow().toString(36)}_${
+    Math.floor(nonPrivateRandom() * 1e6).toString(36)
+  }`;
 
 const joinAs = handler<JoinEvent, {
   users: ParticipantIdentityUsersCell;
   myName: ParticipantIdentityNameCell;
+  myUserIndex: ParticipantIdentityUserIndexCell;
   adminName: ParticipantIdentityNameCell;
   joinName: ParticipantIdentityNameCell;
   profileName: string;
@@ -41,7 +50,15 @@ const joinAs = handler<JoinEvent, {
 }>(
   (
     { name },
-    { users, myName, adminName, joinName, profileName, profileAvatar },
+    {
+      users,
+      myName,
+      myUserIndex,
+      adminName,
+      joinName,
+      profileName,
+      profileAvatar,
+    },
   ) => {
     const override = trimmedName(name) || trimmedName(joinName.get());
     const trimmed = override || trimmedName(profileName);
@@ -50,14 +67,19 @@ const joinAs = handler<JoinEvent, {
     if (current) return;
     const existing = users.get();
     if (existing.some((u) => u.name === trimmed)) return;
+    const userIndex = existing.length;
+    const userId = newUserId();
     const user: User = {
+      id: userId,
       name: trimmed,
       avatar: override ? "" : (profileAvatar ?? "").trim(),
-      color: colorForIndex(existing.length),
+      color: colorForIndex(userIndex),
       joinedAt: safeDateNow(),
+      votes: [],
     };
     users.push(user);
     myName.set(trimmed);
+    myUserIndex.set(userIndex);
     if (trimmedName(adminName.get()) === "") {
       adminName.set(trimmed);
     }
@@ -99,6 +121,9 @@ export interface ParticipantIdentityCardInput {
   /** Per-user current viewer name cell. */
   myName: ParticipantIdentityNameCell;
 
+  /** Per-user append-only index of the current viewer's participant row. */
+  myUserIndex: ParticipantIdentityUserIndexCell;
+
   /** Shared admin name cell. */
   adminName: ParticipantIdentityNameCell;
 }
@@ -137,7 +162,7 @@ export default pattern<
   ParticipantIdentityCardInput,
   ParticipantIdentityCardOutput
 >(
-  ({ users, myName, adminName }) => {
+  ({ users, myName, myUserIndex, adminName }) => {
     const joinName = Writable.perSession.of<string>("");
     const profileNameWish = wish<string>({ query: "#profileName" });
     const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
@@ -147,6 +172,7 @@ export default pattern<
     const boundJoin = joinAs({
       users,
       myName,
+      myUserIndex,
       adminName,
       joinName,
       profileName,

--- a/packages/patterns/tools/lunch-poll-diagnose.ts
+++ b/packages/patterns/tools/lunch-poll-diagnose.ts
@@ -75,13 +75,17 @@ interface MatrixConfig {
   optionCounts: readonly number[];
   userCounts: readonly number[];
   voteRounds: number;
+  joinMode: JoinMode;
 }
 
 interface CaseConfig {
   optionCount: number;
   userCount: number;
   voteRounds: number;
+  joinMode: JoinMode;
 }
+
+type JoinMode = "concurrent" | "serial";
 
 interface CompactSessionSample {
   label: string;
@@ -151,6 +155,7 @@ interface CaseResult {
     users: number;
     options: number;
     voteRounds: number;
+    joinMode: JoinMode;
   };
   churn: ChurnTotals;
   convergence: ConvergenceResult;
@@ -196,7 +201,7 @@ async function collectConvergence(
   sessions: readonly MultiRuntimeSession[],
 ): Promise<ConvergenceResult> {
   const states = await Promise.all(sessions.map(async (session) => {
-    const poll = pollSummary(await session.read());
+    const poll = await readPollSummary(session);
     const fingerprint = poll.votes
       .map((vote) =>
         `${vote.voterName ?? "?"}|${vote.optionId ?? "?"}|${
@@ -274,6 +279,56 @@ function pollSummary(value: unknown): PollOutputSummary {
     isJoined: asBoolean(value.isJoined),
     isAdmin: asBoolean(value.isAdmin),
   };
+}
+
+async function readPollSummary(
+  session: MultiRuntimeSession,
+): Promise<PollOutputSummary> {
+  const root = await session.read();
+  if (isRecord(root)) return pollSummary(root);
+
+  const [
+    users,
+    options,
+    votes,
+    history,
+    adminName,
+    myName,
+    userCount,
+    optionCount,
+    voteCount,
+    historyCount,
+    isJoined,
+    isAdmin,
+  ] = await Promise.all([
+    session.read(["users"]),
+    session.read(["options"]),
+    session.read(["votes"]),
+    session.read(["recentVisits"]),
+    session.read(["adminName"]),
+    session.read(["myName"]),
+    session.read(["userCount"]),
+    session.read(["optionCount"]),
+    session.read(["voteCount"]),
+    session.read(["historyCount"]),
+    session.read(["isJoined"]),
+    session.read(["isAdmin"]),
+  ]);
+
+  return pollSummary({
+    users,
+    options,
+    votes,
+    history,
+    adminName,
+    myName,
+    userCount,
+    optionCount,
+    voteCount,
+    historyCount,
+    isJoined,
+    isAdmin,
+  });
 }
 
 function pathKey(address: TraceAddressSummary): string {
@@ -546,7 +601,7 @@ async function samplePhase(
   await runActions();
   await harness.settle(3);
   const sessions = await Promise.all(harness.sessions.map(async (session) => {
-    const poll = pollSummary(await session.read());
+    const poll = await readPollSummary(session);
     const diagnostics = diagnosticsSummary(
       session.label,
       await session.diagnostics(),
@@ -569,7 +624,7 @@ async function samplePhase(
 }
 
 async function optionIds(session: MultiRuntimeSession): Promise<string[]> {
-  const poll = pollSummary(await session.read());
+  const poll = await readPollSummary(session);
   return poll.options.map((option) => option.id).filter((id): id is string =>
     typeof id === "string" && id !== ""
   );
@@ -607,11 +662,17 @@ async function runCase(config: CaseConfig): Promise<CaseResult> {
     phases.push(
       await samplePhase("all-users-join", harness, async () => {
         await host.send("joinAs", { name: "User 1" });
-        await Promise.all(
-          sessions.slice(1).map((session, index) =>
-            session.send("joinAs", { name: `User ${index + 2}` })
-          ),
-        );
+        if (config.joinMode === "serial") {
+          for (let index = 1; index < sessions.length; index++) {
+            await sessions[index].send("joinAs", { name: `User ${index + 1}` });
+          }
+        } else {
+          await Promise.all(
+            sessions.slice(1).map((session, index) =>
+              session.send("joinAs", { name: `User ${index + 2}` })
+            ),
+          );
+        }
       }),
     );
 
@@ -674,6 +735,7 @@ async function runCase(config: CaseConfig): Promise<CaseResult> {
         users: config.userCount,
         options: config.optionCount,
         voteRounds: config.voteRounds,
+        joinMode: config.joinMode,
       },
       churn,
       convergence,
@@ -719,6 +781,18 @@ function stringArg(name: string, fallback: string): string {
   return arg ? arg.slice(prefix.length) : fallback;
 }
 
+function choiceArg<T extends string>(
+  name: string,
+  fallback: T,
+  choices: readonly T[],
+): T {
+  const value = stringArg(name, fallback);
+  if ((choices as readonly string[]).includes(value)) return value as T;
+  throw new Error(
+    `--${name} must be one of ${choices.join(",")}; got ${value}`,
+  );
+}
+
 function explicitCasesArg(
   config: MatrixConfig,
 ): CaseConfig[] | undefined {
@@ -735,6 +809,7 @@ function explicitCasesArg(
       optionCount,
       userCount,
       voteRounds: config.voteRounds,
+      joinMode: config.joinMode,
     }];
   });
   return cases.length > 0 ? cases : undefined;
@@ -756,6 +831,10 @@ function matrixConfigFromArgs(): MatrixConfig {
     optionCounts: numberListArg("options", quick ? [1, 3] : [1, 3, 10]),
     userCounts: numberListArg("users", quick ? [2] : [2, 5], 1),
     voteRounds: numberArg("rounds", quick ? 1 : 3),
+    joinMode: choiceArg<JoinMode>("join-mode", "concurrent", [
+      "concurrent",
+      "serial",
+    ]),
   };
 }
 
@@ -770,6 +849,7 @@ function casesFromConfig(config: MatrixConfig): CaseConfig[] {
         optionCount,
         userCount,
         voteRounds: config.voteRounds,
+        joinMode: config.joinMode,
       });
     }
   }
@@ -790,7 +870,8 @@ async function run(): Promise<void> {
   for (const caseConfig of cases) {
     console.error(
       `[lunch-poll diagnose] case ${caseConfig.optionCount} options x ` +
-        `${caseConfig.userCount} users, rounds=${caseConfig.voteRounds}`,
+        `${caseConfig.userCount} users, rounds=${caseConfig.voteRounds} ` +
+        `joinMode=${caseConfig.joinMode}`,
     );
     try {
       results.push({ ok: true, result: await runCase(caseConfig) });


### PR DESCRIPTION
Draft for Gideon. This is the narrowed replacement shape for the useful lunch-poll part of #4307, without runtime changes or the exploratory reference-shape/docs churn.

## Summary
- Store live votes on each participant row as `users[].votes`, then project that row-local state back to the existing public `votes` output.
- Add a per-user `myUserIndex` pointer plus stable participant ids so each voter writes to their own roster row instead of the shared votes array.
- Keep the old `votes` input slot as deprecated compatibility state, but stop using it for live vote writes.
- Extend lunch-poll diagnostics with `--join-mode=serial` and a field-by-field read fallback for the newer output shape.

## Performance profile
Workload: `3x10`, 3 vote rounds, serial joins, same diagnostic harness on both sides.

Baseline was latest `origin/main` at `76bf4f8f63`, with only the diagnostic harness copied in for fair measurement:

```bash
deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
  --cases=3x10 --rounds=3 --join-mode=serial \
  > /private/tmp/lunch-baseline-pr.json
```

Current was this PR branch:

```bash
deno run -A packages/patterns/tools/lunch-poll-diagnose.ts \
  --cases=3x10 --rounds=3 --join-mode=serial \
  > /private/tmp/lunch-current-pr-clean.json
```

| metric | baseline | this PR | delta |
| --- | ---: | ---: | ---: |
| elapsed | 102.3s | 46.3s | -54.8% |
| commit conflicts | 10,671 | 8,020 | -24.8% |
| commit reverts | 10,671 | 8,020 | -24.8% |
| rejected commits | 0 | 0 | no change |
| convergence | 10/10 sessions at 30 votes | 10/10 sessions at 30 votes | same |

Tradeoff: this is a conflict and elapsed-time win, not a graph-size win. The final vote round graph was larger on this PR branch: `maxNodes` 937 vs 781, `maxEdges` 1934 vs 1826, `totalNewTraceEntries` 4977 vs 2909.

## Verification
Run in the clean PR worktree. `mise` refused the temporary worktree config as untrusted, so these used the same Deno binary selected by `mise` in the main checkout, Deno 2.8.1.

```bash
deno fmt --check packages/patterns/lunch-poll/main.tsx packages/patterns/lunch-poll/participant-identity-card.tsx packages/patterns/lunch-poll/main.test.tsx packages/patterns/lunch-poll/participant-identity-card.test.tsx packages/patterns/lunch-poll/multi-user.test.tsx packages/patterns/tools/lunch-poll-diagnose.ts
deno task cf check packages/patterns/lunch-poll/main.tsx --no-run
deno check packages/patterns/tools/lunch-poll-diagnose.ts
deno task cf test packages/patterns/lunch-poll/participant-identity-card.test.tsx
deno task cf test packages/patterns/lunch-poll/main.test.tsx
deno task cf test packages/patterns/lunch-poll/multi-user.test.tsx
```

Results: participant identity 5/5, main 19/19, multi-user 13/13.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store live lunch-poll votes on each participant row (`users[].votes`) and project them to the existing `votes` output. This reduces write conflicts and speeds up multi-user sessions.

- **Refactors**
  - Add stable participant `id` and per-user `myUserIndex`; join sets both and initializes `votes: []`.
  - Write votes row-locally in `castVote`, `clearMyVote`, `resetVotes`, and `removeOption`.
  - Compute `liveVotes` from `users[].votes` and use it across UI, tallies, and `logVisit`.
  - Keep legacy `votes` input for compatibility, but stop using it for live writes.
  - Diagnostics: add `--join-mode=serial` and a field-by-field read fallback for the newer output shape.

- **Performance**
  - 3x10 users/options, 3 rounds, serial joins: elapsed time -54.8% (102.3s → 46.3s).
  - Commit conflicts -24.8%; convergence unchanged. Final round graph slightly larger.

<sup>Written for commit 3854f764c243fd9ab5564b7fa5f3b80c8c159256. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

