### PR TITLE
Bind memory session opens to challenge and audience

### DIFF
--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -19,11 +19,11 @@ rewrite. In particular:
   declaration
 - request messages are plain JSON envelopes; transport-level UCAN framing
   remains deferred for this pass
-- the toolshed v2 websocket route currently requires a signed `session.open`
-  payload whose invocation issuer / subject match the requested space DID and
-  requested session descriptor
-- broader route-level ACL / `Origin` enforcement remains deferred, so the
-  endpoint should still be treated as trusted-only
+- the toolshed v2 websocket route requires a signed `session.open`
+  invocation whose subject, challenge, audience, and session descriptor match
+  the current request
+- the server ACL policy gates session opens and commands when enabled
+- route-level `Origin` enforcement remains deferred
 - session resume remains keyed by caller-supplied `(space, sessionId)` rather
   than a server-issued, principal-bound identifier
 - the public one-shot read surface is currently `graph.query`
@@ -62,6 +62,13 @@ If the server accepts the protocol, it returns:
   "flags": {
     "modernCellRep": true,
     "persistentSchedulerState": true
+  },
+  "sessionOpen": {
+    "audience": "did:key:z6Mk...",
+    "challenge": {
+      "value": "64 hex characters",
+      "expiresAt": 1760000000
+    }
   }
 }
 ```
@@ -69,6 +76,21 @@ If the server accepts the protocol, it returns:
 If the server does not support the requested version or the required data-model
 flags do not match what it implements, it returns a typed error response and
 does not mark the connection ready.
+
+Memory hosts include `sessionOpen.audience` and `sessionOpen.challenge` in
+`hello.ok`. The audience is the server DID the client must sign for. Toolshed
+uses its service identity DID. The standalone memory host uses a stable
+deterministic DID. The public memory client rejects a server that omits either
+field.
+
+The challenge is scoped to this WebSocket connection. The current
+implementation generates 32 cryptographically random bytes and encodes them as
+64 hexadecimal characters. The challenge expires at `expiresAt`, in unix
+seconds. The client signs the challenge and audience into the next
+`session.open` invocation. The server accepts the current challenge only once.
+After a successful `session.open`, the response includes a new
+`sessionOpen.challenge`. The client uses that new challenge for the next
+`session.open` on the same connection.
 
 `persistentSchedulerState` advertises whether the runner and memory server are
 allowed to write and serve internal scheduler observations. It defaults to
@@ -88,6 +110,7 @@ logical session per space rather than to one TCP connection.
 ```typescript
 // Shown at module scope.
 type SessionId = string;
+type SignatureBytes = Uint8Array;
 
 interface SessionOpenRequest {
   type: "session.open";
@@ -98,6 +121,28 @@ interface SessionOpenRequest {
     seenSeq?: number;
     sessionToken?: string;
   };
+  invocation?: SessionOpenInvocation;
+  authorization?: {
+    signature: SignatureBytes;
+  };
+}
+
+interface SessionOpenInvocation {
+  iss: DID;
+  cmd: "session.open";
+  sub: SpaceId;
+  aud: DID;
+  args: {
+    protocol: "memory/v2";
+    session: {
+      sessionId?: SessionId;
+      seenSeq?: number;
+      sessionToken?: string;
+    };
+  };
+  challenge: string;
+  iat: number;
+  exp: number;
 }
 
 interface SessionOpenResult {
@@ -106,6 +151,13 @@ interface SessionOpenResult {
   serverSeq: number;
   resumed?: boolean;
   sync?: SessionSync;
+  sessionOpen: {
+    challenge: {
+      value: string;
+      expiresAt: number;
+    };
+    audience: string;
+  };
 }
 ```
 
@@ -127,6 +179,8 @@ Rules:
 - a successful resume transfers ownership to the new connection, invalidates the
   old owner for that session, and MAY emit `session/revoked` to the previous
   owner with reason `"taken-over"`
+- a successful `session.open` rotates the one-time connection challenge and
+  returns the next challenge in `sessionOpen`
 - a stale `sessionToken` MUST fail with `SessionRevokedError`
 - when a resumed session already has watches installed, `sync` carries the
   catch-up delta the client missed while offline
@@ -429,21 +483,48 @@ Write-class requests may carry `invocation` / `authorization` payloads so they
 can be persisted alongside accepted commits, but the current wire protocol
 still uses plain JSON envelopes rather than full UCAN message framing.
 
-On the current toolshed websocket route, `session.open` itself is
-authenticated:
+On memory WebSocket routes, `session.open` itself is authenticated:
 
 - the request must carry `invocation` and `authorization`
 - `invocation.cmd` must be `"session.open"`
-- `invocation.iss` and `invocation.sub` must match the requested `space`
+- `invocation.iss` must be a DID whose signature verifies
+- `invocation.sub` must match the requested `space`
 - `invocation.args.session` must match the requested session descriptor
-- the signature must verify against the requested space DID
+- `invocation.args.protocol` must be the memory protocol
+- `invocation.challenge` must match the current connection challenge
+- the challenge must still be live
+- the challenge must not have been used already on this connection
+- `invocation.aud` must match the server audience from `hello.ok`
+- `invocation.iat` and `invocation.exp` are signed into the invocation
+- `invocation.exp` must not be expired beyond the server clock-skew grace
+- the signature must verify against `invocation.iss` for the hash of
+  `invocation`
 
 Opening a previously unused space may initialize empty backing storage, but
 `session.open` is not itself a logical write or claim.
 
-Broader ACL-based read opens, non-owner session opens, and `Origin` checks are
-still future work on the v2 websocket route, so the endpoint remains
-trusted-only for now.
+The challenge protects against replay of a captured signed `session.open` after
+the original WebSocket handshake has moved on.
+It also limits a captured open to the connection that received the challenge.
+Audience binding protects against replaying an open signed for one memory host
+to another memory host.
+
+This does not prevent every relay attack.
+A fully interactive relay can still forward the server challenge to a signer
+and forward the signed result back to the same server.
+The user or calling code still needs to intend the operation it signs.
+Transport security, origin checks, and product-level signing prompts remain
+part of the complete security boundary.
+
+The memory protocol does not add encryption above WebSocket.
+Remote deployments must expose the route over `wss` or another TLS-protected
+transport.
+Plain `ws` is only appropriate for local development or a trusted private
+transport.
+
+Broader ACL-based read opens and non-owner session opens are implemented by the
+server ACL policy when enabled.
+Route-level `Origin` checks remain future work on the v2 websocket route.
 
 ### 4.5.2 Future Target
 

--- a/packages/memory/test/session-open-auth-test.ts
+++ b/packages/memory/test/session-open-auth-test.ts
@@ -6,13 +6,39 @@ import { hashOf } from "@commonfabric/data-model/value-hash";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { verifySessionOpenAuthorization } from "../v2/session-open-auth.ts";
 
+const now = 1_000_000;
+const audience = bob.did();
+const challenge = {
+  value: "challenge:one",
+  expiresAt: now + 60,
+};
+
+const signedFields = (
+  extra: { aud?: string; challenge?: string; iat?: number; exp?: number } = {},
+) => ({
+  aud: audience,
+  challenge: challenge.value,
+  iat: now,
+  exp: now + 300,
+  ...extra,
+});
+
+const verifyOptions = (
+  extra: Partial<Parameters<typeof verifySessionOpenAuthorization>[1]> = {},
+) => ({
+  audience,
+  challenge,
+  nowSeconds: now,
+  ...extra,
+});
+
 // Build a signed session.open authorization the same way the production client
-// (v2-remote-session.ts) does, with optional aud/iat/exp for the PR5 checks.
+// does.
 const buildOpen = async (
-  extra: { aud?: string; iat?: number; exp?: number } = {},
+  extra: { aud?: string; challenge?: string; iat?: number; exp?: number } = {},
   identity = alice,
+  session: { sessionId?: string; seenSeq?: number; sessionToken?: string } = {},
 ) => {
-  const session = {};
   const sub = space.did();
   const invocation: Record<string, unknown> = {
     iss: identity.did(),
@@ -25,7 +51,7 @@ const buildOpen = async (
   if (signature.error) throw signature.error;
   return {
     space: sub,
-    session,
+    session: { ...session },
     invocation,
     authorization: { signature: new FabricBytes(signature.ok) },
   };
@@ -34,83 +60,194 @@ const buildOpen = async (
 describe("verifySessionOpenAuthorization", () => {
   it("accepts a valid signed open and returns the issuer principal", async () => {
     assertEquals(
-      await verifySessionOpenAuthorization(await buildOpen()),
+      await verifySessionOpenAuthorization(
+        await buildOpen(signedFields()),
+        verifyOptions(),
+      ),
       alice.did(),
     );
   });
 
   it("rejects a malformed/unauthorized open", async () => {
-    const msg = await buildOpen();
-    // Tamper with the issuer after signing — the signature no longer verifies.
+    const msg = await buildOpen(signedFields());
+    // Tamper with the issuer after signing.
     msg.invocation.iss = bob.did();
-    await assertRejects(() => verifySessionOpenAuthorization(msg));
+    await assertRejects(() =>
+      verifySessionOpenAuthorization(msg, verifyOptions())
+    );
   });
 
-  // --- expiry (no audience identity needed) ---
+  it("rejects a resume token changed outside the signed invocation", async () => {
+    const msg = await buildOpen(signedFields(), alice, {
+      sessionId: "session:resume",
+      seenSeq: 7,
+      sessionToken: "token:signed",
+    });
+    msg.session = {
+      sessionId: "session:resume",
+      seenSeq: 7,
+      sessionToken: "token:tampered",
+    };
+    await assertRejects(
+      () => verifySessionOpenAuthorization(msg, verifyOptions()),
+      Error,
+      "authorization mismatch",
+    );
+  });
+
+  // --- expiry ---
 
   it("accepts an unexpired open", async () => {
-    const now = 1_000_000;
-    const msg = await buildOpen({ iat: now, exp: now + 300 });
+    const msg = await buildOpen(signedFields({ iat: now, exp: now + 300 }));
     assertEquals(
-      await verifySessionOpenAuthorization(msg, { nowSeconds: now + 10 }),
+      await verifySessionOpenAuthorization(
+        msg,
+        verifyOptions({
+          nowSeconds: now + 10,
+        }),
+      ),
       alice.did(),
     );
   });
 
   it("rejects an expired open (beyond the skew grace)", async () => {
-    const now = 1_000_000;
-    const msg = await buildOpen({ iat: now - 1000, exp: now - 500 });
+    const msg = await buildOpen(
+      signedFields({ iat: now - 1000, exp: now - 500 }),
+    );
     await assertRejects(
       () =>
-        verifySessionOpenAuthorization(msg, {
-          nowSeconds: now,
-          clockSkewSeconds: 120,
-        }),
+        verifySessionOpenAuthorization(
+          msg,
+          verifyOptions({
+            nowSeconds: now,
+            clockSkewSeconds: 120,
+          }),
+        ),
       Error,
       "expired",
     );
   });
 
   it("tolerates clock skew within the grace window", async () => {
-    const now = 1_000_000;
-    const msg = await buildOpen({ iat: now, exp: now - 30 }); // just expired
+    const msg = await buildOpen(signedFields({ iat: now, exp: now - 30 }));
     assertEquals(
-      await verifySessionOpenAuthorization(msg, {
-        nowSeconds: now,
-        clockSkewSeconds: 120,
-      }),
+      await verifySessionOpenAuthorization(
+        msg,
+        verifyOptions({
+          nowSeconds: now,
+          clockSkewSeconds: 120,
+        }),
+      ),
       alice.did(),
     );
   });
 
-  // --- audience binding (the cross-host replay fix) ---
+  it("rejects a missing issued-at timestamp", async () => {
+    const msg = await buildOpen({
+      aud: audience,
+      challenge: challenge.value,
+      exp: now + 300,
+    });
+    await assertRejects(
+      () => verifySessionOpenAuthorization(msg, verifyOptions()),
+      Error,
+      "requires iat",
+    );
+  });
+
+  it("rejects a missing expiry timestamp", async () => {
+    const msg = await buildOpen({
+      aud: audience,
+      challenge: challenge.value,
+      iat: now,
+    });
+    await assertRejects(
+      () => verifySessionOpenAuthorization(msg, verifyOptions()),
+      Error,
+      "requires exp",
+    );
+  });
+
+  // --- challenge binding ---
+
+  it("accepts a challenged open with the matching challenge", async () => {
+    const msg = await buildOpen(signedFields());
+    assertEquals(
+      await verifySessionOpenAuthorization(msg, verifyOptions()),
+      alice.did(),
+    );
+  });
+
+  it("rejects a missing challenge when one was issued", async () => {
+    const msg = await buildOpen({ aud: audience });
+    await assertRejects(
+      () => verifySessionOpenAuthorization(msg, verifyOptions()),
+      Error,
+      "requires challenge",
+    );
+  });
+
+  it("rejects the wrong challenge", async () => {
+    const msg = await buildOpen(signedFields({ challenge: "challenge:other" }));
+    await assertRejects(
+      () => verifySessionOpenAuthorization(msg, verifyOptions()),
+      Error,
+      "challenge mismatch",
+    );
+  });
+
+  it("rejects an expired challenge", async () => {
+    const msg = await buildOpen(signedFields());
+    await assertRejects(
+      () =>
+        verifySessionOpenAuthorization(
+          msg,
+          verifyOptions({
+            challenge: {
+              value: challenge.value,
+              expiresAt: now,
+            },
+            nowSeconds: now,
+          }),
+        ),
+      Error,
+      "challenge expired",
+    );
+  });
+
+  // --- audience binding ---
 
   it("accepts an audience-bound open at the matching host", async () => {
-    const aud = bob.did(); // stand-in for the host's audience identity
     assertEquals(
-      await verifySessionOpenAuthorization(await buildOpen({ aud }), {
-        audience: aud,
-      }),
+      await verifySessionOpenAuthorization(
+        await buildOpen(signedFields()),
+        verifyOptions(),
+      ),
       alice.did(),
+    );
+  });
+
+  it("rejects a missing audience when the server configures one", async () => {
+    const msg = await buildOpen({ challenge: challenge.value });
+    await assertRejects(
+      () => verifySessionOpenAuthorization(msg, verifyOptions()),
+      Error,
+      "requires audience",
     );
   });
 
   it("rejects an audience-bound open replayed to a different host", async () => {
-    const msg = await buildOpen({ aud: bob.did() });
+    const msg = await buildOpen(signedFields());
     await assertRejects(
-      () => verifySessionOpenAuthorization(msg, { audience: mallory.did() }),
+      () =>
+        verifySessionOpenAuthorization(
+          msg,
+          verifyOptions({
+            audience: mallory.did(),
+          }),
+        ),
       Error,
       "audience mismatch",
-    );
-  });
-
-  it("ignores aud when the server configures no audience (opt-in rollout)", async () => {
-    // Until the memory server has an audience identity, an aud-bearing open is
-    // still accepted (no audience option passed) — so the client change can
-    // land before the server one.
-    assertEquals(
-      await verifySessionOpenAuthorization(await buildOpen({ aud: bob.did() })),
-      alice.did(),
     );
   });
 });

--- a/packages/memory/test/v2-auth-test-helpers.ts
+++ b/packages/memory/test/v2-auth-test-helpers.ts
@@ -1,0 +1,31 @@
+import type { SessionOpenAuthFactory } from "../v2/client.ts";
+
+export const TEST_SESSION_OPEN_AUDIENCE =
+  "did:key:z6Mk-memory-v2-test-audience";
+export const TEST_SESSION_OPEN_PRINCIPAL =
+  "did:key:z6Mk-memory-v2-test-principal";
+
+export const testSessionOpenAuth = {
+  audience: TEST_SESSION_OPEN_AUDIENCE,
+} as const;
+
+export const testAuthorizeSessionOpen = () => TEST_SESSION_OPEN_PRINCIPAL;
+
+export const testSessionOpenServerOptions = {
+  authorizeSessionOpen: testAuthorizeSessionOpen,
+  sessionOpenAuth: testSessionOpenAuth,
+} as const;
+
+export const testSessionOpenAuthFactory: SessionOpenAuthFactory = (
+  _space,
+  _session,
+  context,
+) => {
+  return {
+    invocation: {
+      aud: context.audience,
+      challenge: context.challenge.value,
+    },
+    authorization: {},
+  };
+};

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -87,6 +87,117 @@ const handshakeTransport = (
   };
 };
 
+const asyncHandshakeTransport = (helloOk: FabricValue): Transport => {
+  let receiver = (_payload: string) => {};
+  return {
+    send(payload: string): Promise<void> {
+      const message = decodeMemoryBoundary(payload) as {
+        type?: string;
+      };
+      if (message.type === "hello") {
+        queueMicrotask(() => receiver(encodeMemoryBoundary(helloOk)));
+      }
+      return Promise.resolve();
+    },
+    close() {
+      return Promise.resolve();
+    },
+    setReceiver(next) {
+      receiver = next;
+    },
+    setCloseReceiver() {},
+  };
+};
+
+Deno.test("memory v2 client rejects malformed async hello session.open metadata", async () => {
+  await assertRejects(
+    () =>
+      connect({
+        transport: asyncHandshakeTransport({
+          ...HELLO_OK,
+          sessionOpen: {
+            audience: TEST_SESSION_OPEN_AUDIENCE,
+          },
+        }),
+      }),
+    Error,
+    "challenge",
+  );
+});
+
+Deno.test("memory v2 client rejects malformed hello session.open metadata", async () => {
+  const cases: {
+    name: string;
+    helloOk: FabricValue;
+    message: string;
+  }[] = [
+    {
+      name: "missing metadata",
+      helloOk: {
+        type: "hello.ok",
+        protocol: MEMORY_PROTOCOL,
+        flags: getMemoryProtocolFlags(),
+      },
+      message: "authentication metadata",
+    },
+    {
+      name: "non-object metadata",
+      helloOk: {
+        ...HELLO_OK,
+        sessionOpen: "bad",
+      },
+      message: "malformed",
+    },
+    {
+      name: "non-string audience",
+      helloOk: {
+        ...HELLO_OK,
+        sessionOpen: {
+          audience: 123,
+          challenge: sessionOpenChallenge,
+        },
+      },
+      message: "malformed",
+    },
+    {
+      name: "non-object challenge",
+      helloOk: {
+        ...HELLO_OK,
+        sessionOpen: {
+          audience: TEST_SESSION_OPEN_AUDIENCE,
+          challenge: "bad",
+        },
+      },
+      message: "malformed",
+    },
+    {
+      name: "malformed challenge fields",
+      helloOk: {
+        ...HELLO_OK,
+        sessionOpen: {
+          audience: TEST_SESSION_OPEN_AUDIENCE,
+          challenge: {
+            value: 123,
+            expiresAt: "soon",
+          },
+        },
+      },
+      message: "malformed",
+    },
+  ];
+
+  for (const testCase of cases) {
+    await assertRejects(
+      () =>
+        connect({
+          transport: handshakeTransport(testCase.helloOk),
+        }),
+      Error,
+      testCase.message,
+    );
+  }
+});
+
 Deno.test("memory v2 client rejects a missing session.open challenge", async () => {
   await assertRejects(
     () =>

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -11,17 +11,237 @@ import {
   type SessionSync,
   toDocumentPath,
 } from "../v2.ts";
-import { connect, loopback, type Transport, WatchView } from "../v2/client.ts";
+import {
+  connect,
+  loopback,
+  type SessionOpenAuthContext,
+  type Transport,
+  WatchView,
+} from "../v2/client.ts";
+import {
+  TEST_SESSION_OPEN_AUDIENCE,
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "./v2-auth-test-helpers.ts";
 import { createGraphFixture } from "./v2-graph.fixture.ts";
+
+const sessionOpenChallenge = {
+  value: "challenge:memory-v2-client",
+  expiresAt: 1_000_000,
+} as const;
 
 const HELLO_OK = {
   type: "hello.ok",
   protocol: MEMORY_PROTOCOL,
   flags: getMemoryProtocolFlags(),
+  sessionOpen: {
+    audience: TEST_SESSION_OPEN_AUDIENCE,
+    challenge: sessionOpenChallenge,
+  },
 } as const;
+
+const sessionOpenFor = (id: string) => ({
+  audience: TEST_SESSION_OPEN_AUDIENCE,
+  challenge: {
+    value: `challenge:memory-v2-client:${id}`,
+    expiresAt: 1_000_000,
+  },
+});
+
+const handshakeTransport = (
+  helloOk: FabricValue,
+  sessionOpen: unknown = undefined,
+): Transport => {
+  let receiver = (_payload: string) => {};
+  return {
+    send(payload: string): Promise<void> {
+      const message = decodeMemoryBoundary(payload) as {
+        type?: string;
+        requestId?: string;
+      };
+      if (message.type === "hello") {
+        receiver(encodeMemoryBoundary(helloOk));
+        return Promise.resolve();
+      }
+      if (message.type === "session.open") {
+        receiver(encodeMemoryBoundary({
+          type: "response",
+          requestId: message.requestId!,
+          ok: {
+            sessionId: "session:handshake-context",
+            sessionToken: "token:handshake-context",
+            serverSeq: 0,
+            sessionOpen: sessionOpen ?? sessionOpenFor(message.requestId!),
+          },
+        }));
+      }
+      return Promise.resolve();
+    },
+    close() {
+      return Promise.resolve();
+    },
+    setReceiver(next) {
+      receiver = next;
+    },
+    setCloseReceiver() {},
+  };
+};
+
+Deno.test("memory v2 client rejects a missing session.open challenge", async () => {
+  await assertRejects(
+    () =>
+      connect({
+        transport: handshakeTransport({
+          ...HELLO_OK,
+          sessionOpen: {
+            audience: "did:key:z6Mk-memory-v2-client-audience",
+          },
+        }),
+      }),
+    Error,
+    "challenge",
+  );
+});
+
+Deno.test("memory v2 client rejects a missing session.open audience", async () => {
+  await assertRejects(
+    () =>
+      connect({
+        transport: handshakeTransport({
+          ...HELLO_OK,
+          sessionOpen: {
+            challenge: sessionOpenChallenge,
+          },
+        }),
+      }),
+    Error,
+    "audience",
+  );
+});
+
+Deno.test("memory v2 client rejects a missing rotated session.open challenge", async () => {
+  const client = await connect({
+    transport: handshakeTransport(HELLO_OK, {
+      audience: TEST_SESSION_OPEN_AUDIENCE,
+    }),
+  });
+  try {
+    await assertRejects(
+      () =>
+        client.mount(
+          "did:key:z6Mk-memory-v2-client-missing-rotated-challenge",
+          {},
+          testSessionOpenAuthFactory,
+        ),
+      Error,
+      "challenge",
+    );
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client rejects a missing rotated session.open audience", async () => {
+  const client = await connect({
+    transport: handshakeTransport(HELLO_OK, {
+      challenge: sessionOpenChallenge,
+    }),
+  });
+  try {
+    await assertRejects(
+      () =>
+        client.mount(
+          "did:key:z6Mk-memory-v2-client-missing-rotated-audience",
+          {},
+          testSessionOpenAuthFactory,
+        ),
+      Error,
+      "audience",
+    );
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client passes session.open handshake context to the auth factory", async () => {
+  const sessionOpen = {
+    audience: "did:key:z6Mk-memory-v2-client-audience",
+    challenge: sessionOpenChallenge,
+  };
+  const client = await connect({
+    transport: handshakeTransport({
+      ...HELLO_OK,
+      sessionOpen,
+    }),
+  });
+  try {
+    let captured: unknown;
+    await client.mount(
+      "did:key:z6Mk-memory-v2-client-handshake-context",
+      {},
+      (_space, _session, context) => {
+        captured = context;
+        return undefined;
+      },
+    );
+    assertEquals(captured, sessionOpen);
+  } finally {
+    await client.close();
+  }
+});
+
+Deno.test("memory v2 client rotates session.open challenges between protected mounts", async () => {
+  const audience = "did:key:z6Mk-memory-v2-client-rotate-audience";
+  const server = new Server({
+    store: new URL("memory://memory-v2-client-rotate-challenges"),
+    authorizeSessionOpen: () => "did:key:z6Mk-memory-v2-client-principal",
+    sessionOpenAuth: {
+      audience,
+    },
+  });
+  const client = await connect({
+    transport: loopback(server),
+  });
+  const challenges: string[] = [];
+  try {
+    const authFactory = (
+      _space: string,
+      _session: unknown,
+      context: SessionOpenAuthContext,
+    ) => {
+      challenges.push(context.challenge.value);
+      return {
+        invocation: {
+          aud: context.audience,
+          challenge: context.challenge.value,
+        },
+        authorization: {},
+      };
+    };
+    const first = await client.mount(
+      "did:key:z6Mk-memory-v2-client-rotate-one",
+      {},
+      authFactory,
+    );
+    const second = await client.mount(
+      "did:key:z6Mk-memory-v2-client-rotate-two",
+      {},
+      authFactory,
+    );
+
+    assertEquals(first.serverSeq, 0);
+    assertEquals(second.serverSeq, 0);
+    assertEquals(challenges.length, 2);
+    assertEquals(challenges[0] === challenges[1], false);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
 
 Deno.test("memory v2 client watch sets expand to previously hidden graph nodes", async () => {
   const server = new Server({
+    ...testSessionOpenServerOptions,
     store: new URL("memory://memory-v2-client-graph-expansion"),
   });
   const writerClient = await connect({
@@ -32,9 +252,13 @@ Deno.test("memory v2 client watch sets expand to previously hidden graph nodes",
   });
   const writer = await writerClient.mount(
     "did:key:z6Mk-memory-v2-client-graph",
+    {},
+    testSessionOpenAuthFactory,
   );
   const observer = await observerClient.mount(
     "did:key:z6Mk-memory-v2-client-graph",
+    {},
+    testSessionOpenAuthFactory,
   );
   const fixture = createGraphFixture(writer.space);
 
@@ -95,6 +319,7 @@ Deno.test("memory v2 client watch sets expand to previously hidden graph nodes",
 
 Deno.test("memory v2 client can bootstrap watches with watchAdd", async () => {
   const server = new Server({
+    ...testSessionOpenServerOptions,
     store: new URL("memory://memory-v2-client-watch-add-bootstrap"),
   });
   const writerClient = await connect({
@@ -105,9 +330,13 @@ Deno.test("memory v2 client can bootstrap watches with watchAdd", async () => {
   });
   const writer = await writerClient.mount(
     "did:key:z6Mk-memory-v2-client-watch-add-bootstrap",
+    {},
+    testSessionOpenAuthFactory,
   );
   const observer = await observerClient.mount(
     "did:key:z6Mk-memory-v2-client-watch-add-bootstrap",
+    {},
+    testSessionOpenAuthFactory,
   );
 
   try {
@@ -164,6 +393,7 @@ Deno.test("memory v2 client can bootstrap watches with watchAdd", async () => {
 
 Deno.test("memory v2 client watch views expose incremental sync effects", async () => {
   const server = new Server({
+    ...testSessionOpenServerOptions,
     store: new URL("memory://memory-v2-client-watch-sync-effects"),
   });
   const writerClient = await connect({
@@ -174,9 +404,13 @@ Deno.test("memory v2 client watch views expose incremental sync effects", async 
   });
   const writer = await writerClient.mount(
     "did:key:z6Mk-memory-v2-client-watch-sync-effects",
+    {},
+    testSessionOpenAuthFactory,
   );
   const observer = await observerClient.mount(
     "did:key:z6Mk-memory-v2-client-watch-sync-effects",
+    {},
+    testSessionOpenAuthFactory,
   );
 
   try {
@@ -250,6 +484,7 @@ Deno.test("memory v2 client watch views expose incremental sync effects", async 
 
 Deno.test("memory v2 client conflict errors expose readiness after caught-up sync", async () => {
   const server = new Server({
+    ...testSessionOpenServerOptions,
     store: new URL("memory://memory-v2-client-conflict-ready-to-retry"),
     subscriptionRefreshDelayMs: 20,
   });
@@ -258,6 +493,8 @@ Deno.test("memory v2 client conflict errors expose readiness after caught-up syn
   });
   const session = await client.mount(
     "did:key:z6Mk-memory-v2-client-conflict-ready-to-retry",
+    {},
+    testSessionOpenAuthFactory,
   );
 
   try {
@@ -858,6 +1095,7 @@ class ScriptedReconnectTransport implements Transport {
           ok: {
             sessionId: "session:scripted",
             serverSeq: 0,
+            sessionOpen: sessionOpenFor(message.requestId!),
           },
         });
         return Promise.resolve();
@@ -946,6 +1184,7 @@ class DelayedTransactTransport implements Transport {
             sessionId: "session:delayed-transact",
             sessionToken: "token:delayed-transact",
             serverSeq: 0,
+            sessionOpen: sessionOpenFor(message.requestId!),
           },
         });
         return Promise.resolve();
@@ -1033,6 +1272,7 @@ class ConflictReadyTransport implements Transport {
             sessionId: this.#sessionId,
             sessionToken: "token:conflict-ready",
             serverSeq: 0,
+            sessionOpen: sessionOpenFor(message.requestId!),
           },
         });
         return Promise.resolve();
@@ -1114,6 +1354,7 @@ class ConflictReadySessionChangingTransport implements Transport {
             sessionId,
             sessionToken: `token:${sessionId}`,
             serverSeq: 0,
+            sessionOpen: sessionOpenFor(message.requestId!),
           },
         });
         return Promise.resolve();
@@ -1172,6 +1413,7 @@ class ConflictReadyFreshSameSessionTransport implements Transport {
             sessionId: "session:fresh-same-session",
             sessionToken: "token:fresh-same-session",
             serverSeq: 0,
+            sessionOpen: sessionOpenFor(message.requestId!),
           },
         });
         return Promise.resolve();
@@ -1233,6 +1475,7 @@ class AckCountingTransport implements Transport {
           ok: {
             sessionId: "session:ack-count",
             serverSeq: 0,
+            sessionOpen: sessionOpenFor(message.requestId!),
           },
         });
         return Promise.resolve();
@@ -1309,6 +1552,7 @@ class HangingAckTransport implements Transport {
           ok: {
             sessionId: "session:hanging-ack",
             serverSeq: 0,
+            sessionOpen: sessionOpenFor(message.requestId!),
           },
         });
         return Promise.resolve();
@@ -1395,6 +1639,7 @@ class ControlledReconnectTransport implements Transport {
           ok: {
             sessionId: "session:controlled",
             serverSeq: 0,
+            sessionOpen: sessionOpenFor(message.requestId!),
           },
         }));
         return Promise.resolve();
@@ -1479,6 +1724,7 @@ class CloseOnAppliedCommitTransport implements Transport {
           ok: {
             sessionId: "session:close-on-applied-commit",
             serverSeq: 0,
+            sessionOpen: sessionOpenFor(message.requestId!),
           },
         }));
         return Promise.resolve();
@@ -1553,6 +1799,7 @@ Deno.test(
   "memory v2 client reconnects without reinstalling watch sets when the session resumes",
   async () => {
     const server = new Server({
+      ...testSessionOpenServerOptions,
       store: new URL("memory://memory-v2-client-reconnect"),
     });
     const transport = new ReconnectableLoopbackTransport(server);
@@ -1560,9 +1807,15 @@ Deno.test(
     const writerClient = await connect({
       transport: loopback(server),
     });
-    const space = await client.mount("did:key:z6Mk-memory-v2-client-reconnect");
+    const space = await client.mount(
+      "did:key:z6Mk-memory-v2-client-reconnect",
+      {},
+      testSessionOpenAuthFactory,
+    );
     const writer = await writerClient.mount(
       "did:key:z6Mk-memory-v2-client-reconnect",
+      {},
+      testSessionOpenAuthFactory,
     );
     const originalSessionId = space.sessionId;
 
@@ -1780,6 +2033,7 @@ class TopLevelCaughtUpResumeTransport implements Transport {
             // Resume carries the caught-up marker ONLY at the top level — no
             // sync — exactly the case that previously stranded the runner.
             ...(resumed ? { resumed: true, caughtUpLocalSeq: 4 } : {}),
+            sessionOpen: sessionOpenFor(message.requestId!),
           },
         }));
         return Promise.resolve();
@@ -1879,6 +2133,7 @@ class EmptyCaughtUpResumeTransport implements Transport {
                 },
               }
               : {}),
+            sessionOpen: sessionOpenFor(message.requestId!),
           },
         }));
         return Promise.resolve();
@@ -1929,6 +2184,7 @@ Deno.test(
   "memory v2 client does not restore a closed session after reconnect",
   async () => {
     const server = new Server({
+      ...testSessionOpenServerOptions,
       store: new URL("memory://memory-v2-client-closed-session-reconnect"),
       sessions: new SessionRegistry({ ttlMs: 0 }),
     });
@@ -1936,6 +2192,8 @@ Deno.test(
     const client = await connect({ transport });
     const space = await client.mount(
       "did:key:z6Mk-memory-v2-client-closed-session-reconnect",
+      {},
+      testSessionOpenAuthFactory,
     );
 
     try {
@@ -1971,6 +2229,7 @@ Deno.test(
   "memory v2 client reinstalls watch sets when reconnect opens a fresh session",
   async () => {
     const server = new Server({
+      ...testSessionOpenServerOptions,
       store: new URL("memory://memory-v2-client-reconnect-expired"),
       sessions: new SessionRegistry({ ttlMs: 0 }),
     });
@@ -1981,9 +2240,13 @@ Deno.test(
     });
     const space = await client.mount(
       "did:key:z6Mk-memory-v2-client-reconnect-expired",
+      {},
+      testSessionOpenAuthFactory,
     );
     const writer = await writerClient.mount(
       "did:key:z6Mk-memory-v2-client-reconnect-expired",
+      {},
+      testSessionOpenAuthFactory,
     );
 
     try {
@@ -2209,6 +2472,7 @@ Deno.test("memory v2 client sends later transacts before earlier responses settl
 
 Deno.test("memory v2 client closes a revoked session after takeover and rejects stale resume tokens", async () => {
   const server = new Server({
+    ...testSessionOpenServerOptions,
     store: new URL("memory://memory-v2-client-session-takeover"),
   });
   const firstClient = await connect({
@@ -2225,14 +2489,14 @@ Deno.test("memory v2 client closes a revoked session after takeover and rejects 
   try {
     const first = await firstClient.mount(space, {
       sessionId: "session:shared",
-    });
+    }, testSessionOpenAuthFactory);
     const initialToken = first.sessionToken;
     assertExists(initialToken);
 
     const second = await secondClient.mount(space, {
       sessionId: first.sessionId,
       sessionToken: initialToken,
-    });
+    }, testSessionOpenAuthFactory);
     assertEquals(second.sessionId, first.sessionId);
     assertExists(second.sessionToken);
     assertEquals(second.sessionToken === initialToken, false);
@@ -2263,7 +2527,7 @@ Deno.test("memory v2 client closes a revoked session after takeover and rejects 
         staleClient.mount(space, {
           sessionId: first.sessionId,
           sessionToken: initialToken,
-        }),
+        }, testSessionOpenAuthFactory),
       Error,
       "resume token is no longer valid",
     );
@@ -2485,6 +2749,7 @@ class DisconnectableAckTransport implements Transport {
           ok: {
             sessionId: `session:ack-disconnect-${this.#sessionOpenCount}`,
             serverSeq: this.#watchSeq,
+            sessionOpen: sessionOpenFor(message.requestId!),
           },
         });
         return Promise.resolve();
@@ -2621,6 +2886,7 @@ class SessionChangingTransport implements Transport {
           ok: {
             sessionId,
             serverSeq: 0,
+            sessionOpen: sessionOpenFor(message.requestId!),
           },
         }));
         return Promise.resolve();

--- a/packages/memory/test/v2-client-watch-test.ts
+++ b/packages/memory/test/v2-client-watch-test.ts
@@ -2,6 +2,10 @@ import { assertEquals } from "@std/assert";
 import { Server } from "../v2/server.ts";
 import { connect, loopback, WatchView } from "../v2/client.ts";
 import type { EntitySnapshot } from "../v2.ts";
+import {
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "./v2-auth-test-helpers.ts";
 
 Deno.test("memory v2 watch view keeps same id snapshots in different scopes", () => {
   const view = WatchView.fromSync({
@@ -49,6 +53,7 @@ Deno.test("memory v2 watch view keeps same id snapshots in different scopes", ()
 
 Deno.test("memory v2 client installs a watch set and receives live updates", async () => {
   const server = new Server({
+    ...testSessionOpenServerOptions,
     store: new URL("memory://memory-v2-client-watch"),
     subscriptionRefreshDelayMs: 0,
   });
@@ -59,8 +64,16 @@ Deno.test("memory v2 client installs a watch set and receives live updates", asy
     transport: loopback(server),
   });
   const space = "did:key:z6Mk-memory-v2-client-watch";
-  const writer = await writerClient.mount(space);
-  const watcher = await watcherClient.mount(space);
+  const writer = await writerClient.mount(
+    space,
+    {},
+    testSessionOpenAuthFactory,
+  );
+  const watcher = await watcherClient.mount(
+    space,
+    {},
+    testSessionOpenAuthFactory,
+  );
 
   try {
     await writer.transact({

--- a/packages/memory/test/v2-commit-preconditions.test.ts
+++ b/packages/memory/test/v2-commit-preconditions.test.ts
@@ -14,6 +14,10 @@ import { Server } from "../v2/server.ts";
 import { connect, loopback } from "../v2/client.ts";
 import { type EntityDocument, toDocumentPath } from "../v2.ts";
 import type { FabricValue } from "@commonfabric/api";
+import {
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "./v2-auth-test-helpers.ts";
 
 const createEngine = async (): Promise<{
   engine: Engine;
@@ -613,11 +617,14 @@ Deno.test("malformed preconditions are rejected with ProtocolError", async () =>
 
 Deno.test("precondition failures keep name and precondition through client round trip", async () => {
   const server = new Server({
+    ...testSessionOpenServerOptions,
     store: new URL("memory://memory-v2-commit-preconditions-client"),
   });
   const client = await connect({ transport: loopback(server) });
   const session = await client.mount(
     "did:key:z6Mk-memory-v2-commit-preconditions-client",
+    {},
+    testSessionOpenAuthFactory,
   );
 
   try {
@@ -653,11 +660,14 @@ Deno.test("precondition failures keep name and precondition through client round
 
 Deno.test("entity-absent failures keep receipt-exists through client round trip", async () => {
   const server = new Server({
+    ...testSessionOpenServerOptions,
     store: new URL("memory://memory-v2-entity-absent-client"),
   });
   const client = await connect({ transport: loopback(server) });
   const session = await client.mount(
     "did:key:z6Mk-memory-v2-entity-absent-client",
+    {},
+    testSessionOpenAuthFactory,
   );
 
   try {

--- a/packages/memory/test/v2-restore-flush-test.ts
+++ b/packages/memory/test/v2-restore-flush-test.ts
@@ -2,6 +2,10 @@ import { assert, assertEquals } from "@std/assert";
 import { Server } from "../v2/server.ts";
 import { connect, type Transport } from "../v2/client.ts";
 import { decodeMemoryBoundary, encodeMemoryBoundary } from "../v2.ts";
+import {
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "./v2-auth-test-helpers.ts";
 
 const SPACE = "did:key:z6Mk-restore-flush-test";
 
@@ -143,12 +147,17 @@ Deno.test(
   "commits enqueued during restore are eventually flushed",
   async () => {
     const server = new Server({
+      ...testSessionOpenServerOptions,
       store: new URL("memory://restore-flush-test"),
     });
 
     const transport = new ReconnectableTransport(server);
     const client = await connect({ transport });
-    const session = await client.mount(SPACE);
+    const session = await client.mount(
+      SPACE,
+      {},
+      testSessionOpenAuthFactory,
+    );
     const suppressDisconnectRejection = (event: PromiseRejectionEvent) => {
       if (
         event.reason instanceof Error &&
@@ -274,12 +283,17 @@ Deno.test(
   "closing a session during restore does not replay queued commits after close begins",
   async () => {
     const server = new Server({
+      ...testSessionOpenServerOptions,
       store: new URL("memory://restore-flush-close-test"),
     });
 
     const transport = new ReconnectableTransport(server);
     const client = await connect({ transport });
-    const session = await client.mount(SPACE);
+    const session = await client.mount(
+      SPACE,
+      {},
+      testSessionOpenAuthFactory,
+    );
     const suppressDisconnectRejection = (event: PromiseRejectionEvent) => {
       if (
         event.reason instanceof Error &&

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -23,6 +23,11 @@ import {
   setPersistentSchedulerStateConfig,
   toDocumentPath,
 } from "../v2.ts";
+import {
+  testSessionOpenAuth,
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "./v2-auth-test-helpers.ts";
 
 const createEngine = async (): Promise<{
   engine: Engine;
@@ -883,12 +888,13 @@ Deno.test("memory v2 server mirrors scheduler read indexes into read spaces", as
   const server = new Server({
     store,
     authorizeSessionOpen: () => "did:key:test-principal",
+    sessionOpenAuth: testSessionOpenAuth,
   });
   const client = await connect({ transport: loopback(server) });
   const ownerSpace = "did:key:scheduler-owner-space";
   const readSpace = "did:key:scheduler-read-space";
-  const owner = await client.mount(ownerSpace);
-  const reader = await client.mount(readSpace);
+  const owner = await client.mount(ownerSpace, {}, testSessionOpenAuthFactory);
+  const reader = await client.mount(readSpace, {}, testSessionOpenAuthFactory);
   const mirroredRead = {
     ...sourceRead,
     space: readSpace,
@@ -965,9 +971,14 @@ Deno.test("memory v2 server does not serve scheduler snapshots while persistent 
   const setupServer = new Server({
     store,
     authorizeSessionOpen: () => "did:key:test-principal",
+    sessionOpenAuth: testSessionOpenAuth,
   });
   const setupClient = await connect({ transport: loopback(setupServer) });
-  const setupOwner = await setupClient.mount(ownerSpace);
+  const setupOwner = await setupClient.mount(
+    ownerSpace,
+    {},
+    testSessionOpenAuthFactory,
+  );
   try {
     await setupOwner.transact({
       localSeq: 1,
@@ -984,9 +995,10 @@ Deno.test("memory v2 server does not serve scheduler snapshots while persistent 
   const server = new Server({
     store,
     authorizeSessionOpen: () => "did:key:test-principal",
+    sessionOpenAuth: testSessionOpenAuth,
   });
   const client = await connect({ transport: loopback(server) });
-  const owner = await client.mount(ownerSpace);
+  const owner = await client.mount(ownerSpace, {}, testSessionOpenAuthFactory);
 
   try {
     const listed = await owner.listSchedulerActionSnapshots({
@@ -1009,12 +1021,13 @@ Deno.test("memory v2 server mirrors batched scheduler observations into read spa
   const server = new Server({
     store,
     authorizeSessionOpen: () => "did:key:test-principal",
+    sessionOpenAuth: testSessionOpenAuth,
   });
   const client = await connect({ transport: loopback(server) });
   const ownerSpace = "did:key:scheduler-batch-owner-space";
   const readSpace = "did:key:scheduler-batch-read-space";
-  const owner = await client.mount(ownerSpace);
-  const reader = await client.mount(readSpace);
+  const owner = await client.mount(ownerSpace, {}, testSessionOpenAuthFactory);
+  const reader = await client.mount(readSpace, {}, testSessionOpenAuthFactory);
   const mirroredRead = {
     ...sourceRead,
     space: readSpace,
@@ -1075,11 +1088,12 @@ Deno.test("memory v2 server skips scheduler mirrors for unmounted read spaces", 
   const server = new Server({
     store,
     authorizeSessionOpen: () => "did:key:test-principal",
+    sessionOpenAuth: testSessionOpenAuth,
   });
   const client = await connect({ transport: loopback(server) });
   const ownerSpace = "did:key:scheduler-owner-authorized-space";
   const readSpace = "did:key:scheduler-unmounted-read-space";
-  const owner = await client.mount(ownerSpace);
+  const owner = await client.mount(ownerSpace, {}, testSessionOpenAuthFactory);
   const mirroredRead = {
     ...sourceRead,
     space: readSpace,
@@ -1124,12 +1138,12 @@ Deno.test("memory v2 server propagates cross-space dirty state back to the owner
   setPersistentSchedulerStateConfig(true);
   const storePath = await Deno.makeTempDir();
   const store = toFileUrl(`${storePath}/`);
-  const server = new Server({ store });
+  const server = new Server({ ...testSessionOpenServerOptions, store });
   const client = await connect({ transport: loopback(server) });
   const ownerSpace = "did:key:scheduler-owner-dirty-space";
   const readSpace = "did:key:scheduler-owner-read-space";
-  const owner = await client.mount(ownerSpace);
-  const reader = await client.mount(readSpace);
+  const owner = await client.mount(ownerSpace, {}, testSessionOpenAuthFactory);
+  const reader = await client.mount(readSpace, {}, testSessionOpenAuthFactory);
   const mirroredRead = {
     ...sourceRead,
     space: readSpace,

--- a/packages/memory/test/v2-server-acl-test.ts
+++ b/packages/memory/test/v2-server-acl-test.ts
@@ -4,9 +4,11 @@ import {
   encodeMemoryBoundary,
   getMemoryProtocolFlags,
   type GraphQueryResult,
+  type HelloOkMessage,
   MEMORY_PROTOCOL,
   type ResponseMessage,
   type ServerMessage,
+  type SessionOpenAuthMetadata,
 } from "../v2.ts";
 
 const HELLO_FLAGS = getMemoryProtocolFlags();
@@ -20,6 +22,7 @@ const ALICE = "did:key:z6Mk-acl-alice";
 const BOB = "did:key:z6Mk-acl-bob";
 const CAROL = "did:key:z6Mk-acl-carol";
 const SERVICE = "did:key:z6Mk-acl-service";
+const TEST_AUDIENCE = "did:key:z6Mk-acl-test-audience";
 
 const shiftMessage = (messages: ServerMessage[]): ServerMessage => {
   const message = messages.shift();
@@ -50,36 +53,46 @@ const createAclServer = (
       const iss = message.invocation?.iss;
       return typeof iss === "string" ? iss : undefined;
     },
+    sessionOpenAuth: {
+      audience: TEST_AUDIENCE,
+    },
     acl,
   });
 
 type Harness = {
   messages: ServerMessage[];
   connection: ReturnType<Server["connect"]>;
+  sessionOpen: SessionOpenAuthMetadata;
 };
 
 const connect = async (server: Server): Promise<Harness> => {
   const messages: ServerMessage[] = [];
   const connection = server.connect((message) => messages.push(message));
   await connection.receive(encodeMemoryBoundary(HELLO));
-  shiftMessage(messages); // hello.ok
-  return { messages, connection };
+  const hello = shiftMessage(messages) as HelloOkMessage;
+  assertEquals(hello.type, "hello.ok");
+  assertExists(hello.sessionOpen);
+  return { messages, connection, sessionOpen: hello.sessionOpen };
 };
 
 let requestCounter = 0;
 const nextRequestId = (label: string): string => `${label}-${++requestCounter}`;
 
 const openSession = async (
-  { connection, messages }: Harness,
+  { connection, messages, sessionOpen }: Harness,
   space: string,
-  principal?: string,
+  principal: string,
 ): Promise<ResponseMessage<{ sessionId: string; serverSeq: number }>> => {
   await connection.receive(encodeMemoryBoundary({
     type: "session.open",
     requestId: nextRequestId("open"),
     space,
     session: {},
-    ...(principal === undefined ? {} : { invocation: { iss: principal } }),
+    invocation: {
+      iss: principal,
+      aud: sessionOpen.audience,
+      challenge: sessionOpen.challenge.value,
+    },
   }));
   return assertResponse<{ sessionId: string; serverSeq: number }>(
     shiftMessage(messages),

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -269,6 +269,157 @@ Deno.test("memory v2 server rejects an expired session open challenge", async ()
   }
 });
 
+Deno.test("memory v2 server rejects invalid session open auth metadata", async () => {
+  const server = createServer(
+    "memory://memory-v2-server-invalid-session-open-auth",
+  );
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    const sessionOpen = expectHelloOk(messages);
+    const cases = [
+      {
+        requestId: "missing-audience",
+        invocation: {
+          challenge: sessionOpen.challenge.value,
+        },
+        message: "memory session.open requires audience",
+      },
+      {
+        requestId: "wrong-audience",
+        invocation: {
+          aud: "did:key:z6Mk-memory-v2-server-wrong-audience",
+          challenge: sessionOpen.challenge.value,
+        },
+        message: "memory session.open audience mismatch",
+      },
+      {
+        requestId: "missing-challenge",
+        invocation: {
+          aud: sessionOpen.audience,
+        },
+        message: "memory session.open requires challenge",
+      },
+      {
+        requestId: "wrong-challenge",
+        invocation: {
+          aud: sessionOpen.audience,
+          challenge: "challenge:wrong",
+        },
+        message: "memory session.open challenge mismatch",
+      },
+    ];
+
+    for (const testCase of cases) {
+      await connection.receive(encodeMemoryBoundary({
+        type: "session.open",
+        requestId: testCase.requestId,
+        space: "did:key:z6Mk-memory-v2-server-invalid-auth-space",
+        session: {},
+        invocation: testCase.invocation,
+      }));
+      assertEquals(shiftMessage(messages), {
+        type: "response",
+        requestId: testCase.requestId,
+        error: {
+          name: "AuthorizationError",
+          message: testCase.message,
+        },
+      });
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 server rejects session open before issuing challenge", async () => {
+  const server = createServer(
+    "memory://memory-v2-server-session-open-before-challenge",
+  );
+  const connection = server.connect(() => {});
+
+  try {
+    const response = await server.openSession({
+      type: "session.open",
+      requestId: "open-1",
+      space: "did:key:z6Mk-memory-v2-server-before-challenge-space",
+      session: {},
+      invocation: {
+        aud: TEST_AUDIENCE,
+        challenge: "challenge:missing",
+      },
+    }, connection);
+    assertEquals(response, {
+      type: "response",
+      requestId: "open-1",
+      error: {
+        name: "AuthorizationError",
+        message: "memory session.open challenge unavailable",
+      },
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 server consumes challenge before denied session open", async () => {
+  const audience = "did:key:z6Mk-memory-v2-server-denied-audience";
+  const space = "did:key:z6Mk-memory-v2-server-denied-space";
+  const server = new Server({
+    store: new URL("memory://memory-v2-server-denied-consumes-challenge"),
+    authorizeSessionOpen: () => undefined,
+    sessionOpenAuth: {
+      audience,
+    },
+    acl: {
+      mode: "enforce",
+    },
+  });
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    const sessionOpen = expectHelloOk(messages);
+
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-1",
+      space,
+      session: {},
+      invocation: authInvocation(sessionOpen),
+    }));
+    assertEquals(shiftMessage(messages), {
+      type: "response",
+      requestId: "open-1",
+      error: {
+        name: "AuthorizationError",
+        message: `Principal <anonymous> lacks READ on space ${space}`,
+      },
+    });
+
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-2",
+      space,
+      session: {},
+      invocation: authInvocation(sessionOpen),
+    }));
+    assertEquals(shiftMessage(messages), {
+      type: "response",
+      requestId: "open-2",
+      error: {
+        name: "AuthorizationError",
+        message: "memory session.open challenge already used",
+      },
+    });
+  } finally {
+    await server.close();
+  }
+});
+
 Deno.test("memory v2 server allows the same session id in different spaces", async () => {
   const server = createServer("memory://memory-v2-server-session-scope");
   const messages: ServerMessage[] = [];

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -3,13 +3,16 @@ import { FakeTime } from "@std/testing/time";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { parseClientMessage, Server, SessionRegistry } from "../v2/server.ts";
 import {
+  decodeMemoryBoundary,
   encodeMemoryBoundary,
   getMemoryProtocolFlags,
   type GraphQueryResult,
+  type HelloOkMessage,
   MEMORY_PROTOCOL,
   type ResponseMessage,
   type ServerMessage,
   type SessionEffectMessage,
+  type SessionOpenAuthMetadata,
   type SessionSync,
 } from "../v2.ts";
 import { createGraphFixture } from "./v2-graph.fixture.ts";
@@ -20,11 +23,7 @@ const HELLO = {
   protocol: MEMORY_PROTOCOL,
   flags: HELLO_FLAGS,
 } as const;
-const HELLO_OK = {
-  type: "hello.ok",
-  protocol: MEMORY_PROTOCOL,
-  flags: HELLO_FLAGS,
-} as const;
+const TEST_AUDIENCE = "did:key:z6Mk-memory-v2-server-test-audience";
 
 const tick = async () => {
   await new Promise((resolve) => setTimeout(resolve, 0));
@@ -35,6 +34,21 @@ const shiftMessage = (messages: ServerMessage[]): ServerMessage => {
   assertExists(message, "expected a server message");
   return message;
 };
+
+const assertHelloOk = (message: ServerMessage): HelloOkMessage => {
+  assertEquals(message.type, "hello.ok");
+  const hello = message as HelloOkMessage;
+  assertExists(hello.sessionOpen);
+  return hello;
+};
+
+const expectHelloOk = (messages: ServerMessage[]): SessionOpenAuthMetadata =>
+  assertHelloOk(shiftMessage(messages)).sessionOpen!;
+
+const authInvocation = (sessionOpen: SessionOpenAuthMetadata) => ({
+  aud: sessionOpen.audience,
+  challenge: sessionOpen.challenge.value,
+});
 
 const assertResponse = <Result>(
   message: ServerMessage,
@@ -54,7 +68,32 @@ const createServer = (store: string, refreshDelayMs = 0) =>
   new Server({
     store: new URL(store),
     subscriptionRefreshDelayMs: refreshDelayMs,
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string"
+        ? principal
+        : "did:key:z6Mk-memory-v2-server-principal";
+    },
+    sessionOpenAuth: {
+      audience: TEST_AUDIENCE,
+    },
   });
+
+Deno.test("memory v2 server stateless respond does not issue hello.ok", async () => {
+  const server = createServer("memory://memory-v2-server-stateless-respond");
+  try {
+    const payload = await server.respond(encodeMemoryBoundary(HELLO));
+    assertExists(payload);
+    const response = assertResponse<unknown>(
+      decodeMemoryBoundary(payload) as ServerMessage,
+    );
+    assertEquals(response.requestId, "handshake");
+    assertEquals(response.error?.name, "ProtocolError");
+  } finally {
+    await server.close();
+  }
+});
 
 Deno.test("memory v2 server parser ignores transact invocation and authorization payloads", () => {
   assertEquals(
@@ -114,6 +153,122 @@ Deno.test("memory v2 session registry scopes session ids by space", () => {
   assertExists(second.sessionToken);
 });
 
+Deno.test("memory v2 server consumes a challenged session open", async () => {
+  const audience = "did:key:z6Mk-memory-v2-server-audience";
+  let now = 1_000_000;
+  const server = new Server({
+    store: new URL("memory://memory-v2-server-challenge-reuse"),
+    authorizeSessionOpen: () => "did:key:z6Mk-memory-v2-server-principal",
+    sessionOpenAuth: {
+      audience,
+      challengeTtlSeconds: 60,
+      nowSeconds: () => now,
+    },
+  });
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    const hello = shiftMessage(messages) as HelloOkMessage;
+    assertEquals(hello.type, "hello.ok");
+    assertEquals(hello.sessionOpen?.audience, audience);
+    const challenge = hello.sessionOpen?.challenge;
+    assertExists(challenge);
+    assertEquals(challenge.expiresAt, now + 60);
+
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-1",
+      space: "did:key:z6Mk-memory-v2-server-challenge-space",
+      session: {},
+      invocation: {
+        aud: audience,
+        challenge: challenge.value,
+      },
+    }));
+    const opened = assertResponse<{
+      sessionId: string;
+      sessionOpen?: { challenge?: { value: string; expiresAt: number } };
+    }>(
+      shiftMessage(messages),
+    );
+    assertEquals(opened.requestId, "open-1");
+    assertExists(opened.ok?.sessionId);
+    const nextChallenge = opened.ok?.sessionOpen?.challenge;
+    assertExists(nextChallenge);
+    assertEquals(nextChallenge.expiresAt, now + 60);
+
+    now += 1;
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-2",
+      space: "did:key:z6Mk-memory-v2-server-challenge-space",
+      session: {},
+      invocation: {
+        aud: audience,
+        challenge: challenge.value,
+      },
+    }));
+    assertEquals(shiftMessage(messages), {
+      type: "response",
+      requestId: "open-2",
+      error: {
+        name: "AuthorizationError",
+        message: "memory session.open challenge mismatch",
+      },
+    });
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("memory v2 server rejects an expired session open challenge", async () => {
+  const audience = "did:key:z6Mk-memory-v2-server-expired-audience";
+  let now = 1_000_000;
+  const server = new Server({
+    store: new URL("memory://memory-v2-server-challenge-expired"),
+    authorizeSessionOpen: () => "did:key:z6Mk-memory-v2-server-principal",
+    sessionOpenAuth: {
+      audience,
+      challengeTtlSeconds: 60,
+      nowSeconds: () => now,
+    },
+  });
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+
+  try {
+    await connection.receive(encodeMemoryBoundary(HELLO));
+    const hello = shiftMessage(messages) as HelloOkMessage;
+    assertEquals(hello.type, "hello.ok");
+    const challenge = hello.sessionOpen?.challenge;
+    assertExists(challenge);
+
+    now = challenge.expiresAt;
+    await connection.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-1",
+      space: "did:key:z6Mk-memory-v2-server-expired-space",
+      session: {},
+      invocation: {
+        aud: audience,
+        challenge: challenge.value,
+      },
+    }));
+    assertEquals(shiftMessage(messages), {
+      type: "response",
+      requestId: "open-1",
+      error: {
+        name: "AuthorizationError",
+        message: "memory session.open challenge expired",
+      },
+    });
+  } finally {
+    await server.close();
+  }
+});
+
 Deno.test("memory v2 server allows the same session id in different spaces", async () => {
   const server = createServer("memory://memory-v2-server-session-scope");
   const messages: ServerMessage[] = [];
@@ -121,29 +276,34 @@ Deno.test("memory v2 server allows the same session id in different spaces", asy
 
   try {
     await connection.receive(encodeMemoryBoundary(HELLO));
-    assertEquals(shiftMessage(messages), HELLO_OK);
+    let sessionOpen = expectHelloOk(messages);
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
       space: "did:key:z6Mk-space-one",
       session: { sessionId: "session:fixed" },
+      invocation: authInvocation(sessionOpen),
     }));
     const openedOne = assertResponse<{
       sessionId: string;
       sessionToken: string;
       serverSeq: number;
+      sessionOpen: SessionOpenAuthMetadata;
     }>(shiftMessage(messages));
     assertEquals(openedOne.requestId, "open-1");
     assertEquals(openedOne.ok?.sessionId, "session:fixed");
     assertEquals(openedOne.ok?.serverSeq, 0);
     assertExists(openedOne.ok?.sessionToken);
+    assertExists(openedOne.ok?.sessionOpen);
+    sessionOpen = openedOne.ok.sessionOpen;
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-2",
       space: "did:key:z6Mk-space-two",
       session: { sessionId: "session:fixed" },
+      invocation: authInvocation(sessionOpen),
     }));
     const openedTwo = assertResponse<{
       sessionId: string;
@@ -236,6 +396,9 @@ Deno.test("memory v2 server binds resumed sessions to the original principal", a
         ? (message.authorization as { principal: string }).principal
         : undefined;
     },
+    sessionOpenAuth: {
+      audience: TEST_AUDIENCE,
+    },
   });
   const firstMessages: ServerMessage[] = [];
   const secondMessages: ServerMessage[] = [];
@@ -248,13 +411,14 @@ Deno.test("memory v2 server binds resumed sessions to the original principal", a
 
   try {
     await firstConnection.receive(encodeMemoryBoundary(HELLO));
-    assertEquals(shiftMessage(firstMessages), HELLO_OK);
+    const firstSessionOpen = expectHelloOk(firstMessages);
 
     await firstConnection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
       space: "did:key:z6Mk-space-one",
       session: { sessionId: "session:fixed" },
+      invocation: authInvocation(firstSessionOpen),
       authorization: { principal: "did:key:z6Mk-alice" },
     }));
     const opened = assertResponse<{
@@ -268,13 +432,14 @@ Deno.test("memory v2 server binds resumed sessions to the original principal", a
     assertExists(opened.ok?.sessionToken);
 
     await secondConnection.receive(encodeMemoryBoundary(HELLO));
-    assertEquals(shiftMessage(secondMessages), HELLO_OK);
+    const secondSessionOpen = expectHelloOk(secondMessages);
 
     await secondConnection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-2",
       space: "did:key:z6Mk-space-one",
       session: { sessionId: "session:fixed" },
+      invocation: authInvocation(secondSessionOpen),
       authorization: { principal: "did:key:z6Mk-bob" },
     }));
     assertEquals(shiftMessage(secondMessages), {
@@ -304,13 +469,14 @@ Deno.test("memory v2 server requires sessions to be opened on the current connec
 
   try {
     await firstConnection.receive(encodeMemoryBoundary(HELLO));
-    assertEquals(shiftMessage(firstMessages), HELLO_OK);
+    const firstSessionOpen = expectHelloOk(firstMessages);
 
     await firstConnection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
       space,
       session: { sessionId: "session:fixed" },
+      invocation: authInvocation(firstSessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string }>(
       shiftMessage(firstMessages),
@@ -318,7 +484,7 @@ Deno.test("memory v2 server requires sessions to be opened on the current connec
     const sessionId = opened.ok!.sessionId;
 
     await secondConnection.receive(encodeMemoryBoundary(HELLO));
-    assertEquals(shiftMessage(secondMessages), HELLO_OK);
+    expectHelloOk(secondMessages);
 
     await secondConnection.receive(encodeMemoryBoundary({
       type: "graph.query",
@@ -427,24 +593,28 @@ Deno.test("memory v2 server transfers session ownership and rejects stale resume
   try {
     await firstConnection.receive(encodeMemoryBoundary(HELLO));
     await secondConnection.receive(encodeMemoryBoundary(HELLO));
-    assertEquals(shiftMessage(firstMessages), HELLO_OK);
-    assertEquals(shiftMessage(secondMessages), HELLO_OK);
+    let firstSessionOpen = expectHelloOk(firstMessages);
+    const secondSessionOpen = expectHelloOk(secondMessages);
 
     await firstConnection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
       space,
       session: { sessionId: "session:fixed" },
+      invocation: authInvocation(firstSessionOpen),
     }));
     const openedFirst = assertResponse<{
       sessionId: string;
       sessionToken: string;
       serverSeq: number;
+      sessionOpen: SessionOpenAuthMetadata;
     }>(shiftMessage(firstMessages));
     const initialToken = openedFirst.ok?.sessionToken;
     assertEquals(openedFirst.ok?.sessionId, "session:fixed");
     assertEquals(openedFirst.ok?.serverSeq, 0);
     assertExists(initialToken);
+    assertExists(openedFirst.ok?.sessionOpen);
+    firstSessionOpen = openedFirst.ok.sessionOpen;
 
     await secondConnection.receive(encodeMemoryBoundary({
       type: "session.open",
@@ -454,6 +624,7 @@ Deno.test("memory v2 server transfers session ownership and rejects stale resume
         sessionId: "session:fixed",
         sessionToken: initialToken,
       },
+      invocation: authInvocation(secondSessionOpen),
     }));
 
     assertEquals(shiftMessage(firstMessages), {
@@ -499,6 +670,7 @@ Deno.test("memory v2 server transfers session ownership and rejects stale resume
         sessionId: "session:fixed",
         sessionToken: initialToken,
       },
+      invocation: authInvocation(firstSessionOpen),
     }));
     assertEquals(shiftMessage(firstMessages), {
       type: "response",
@@ -561,7 +733,7 @@ Deno.test("memory v2 server accepts scheduler-state flag mismatch", async () => 
       },
     }));
 
-    assertEquals(shiftMessage(messages), HELLO_OK);
+    expectHelloOk(messages);
   } finally {
     await server.close();
   }
@@ -574,13 +746,14 @@ Deno.test("memory v2 server rejects unsafe spaces before opening a store", async
 
   try {
     await connection.receive(encodeMemoryBoundary(HELLO));
-    assertEquals(shiftMessage(messages), HELLO_OK);
+    const sessionOpen = expectHelloOk(messages);
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-unsafe",
       space: "../../evil",
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     assertEquals(shiftMessage(messages), {
       type: "response",
@@ -603,13 +776,14 @@ Deno.test("memory v2 server opens sessions, commits documents, and answers graph
 
   try {
     await connection.receive(encodeMemoryBoundary(HELLO));
-    assertEquals(shiftMessage(messages), HELLO_OK);
+    const sessionOpen = expectHelloOk(messages);
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string; serverSeq: number }>(
       shiftMessage(messages),
@@ -697,13 +871,14 @@ Deno.test("memory v2 server rejects legacy live graph.query subscriptions", asyn
 
   try {
     await connection.receive(encodeMemoryBoundary(HELLO));
-    shiftMessage(messages);
+    const sessionOpen = expectHelloOk(messages);
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string }>(
       shiftMessage(messages),
@@ -753,14 +928,15 @@ Deno.test("memory v2 server watch sets expand to previously hidden nodes after r
     for (const client of [connection, writer]) {
       await client.receive(encodeMemoryBoundary(HELLO));
     }
-    shiftMessage(messages);
-    shiftMessage(writerMessages);
+    const sessionOpen = expectHelloOk(messages);
+    const writerSessionOpen = expectHelloOk(writerMessages);
 
     await writer.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "writer-open",
       space,
       session: {},
+      invocation: authInvocation(writerSessionOpen),
     }));
     const writerSessionId = assertResponse<{ sessionId: string }>(
       shiftMessage(writerMessages),
@@ -771,6 +947,7 @@ Deno.test("memory v2 server watch sets expand to previously hidden nodes after r
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string }>(
       shiftMessage(messages),
@@ -884,14 +1061,15 @@ Deno.test("memory v2 server does not emit delayed exact-reconcile removes after 
     for (const client of [connection, writer]) {
       await client.receive(encodeMemoryBoundary(HELLO));
     }
-    shiftMessage(messages);
-    shiftMessage(writerMessages);
+    const sessionOpen = expectHelloOk(messages);
+    const writerSessionOpen = expectHelloOk(writerMessages);
 
     await writer.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "writer-open",
       space,
       session: {},
+      invocation: authInvocation(writerSessionOpen),
     }));
     const writerSessionId = assertResponse<{ sessionId: string }>(
       shiftMessage(writerMessages),
@@ -902,6 +1080,7 @@ Deno.test("memory v2 server does not emit delayed exact-reconcile removes after 
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string }>(
       shiftMessage(messages),
@@ -1001,13 +1180,14 @@ Deno.test("memory v2 server does not send watch effects after a connection close
 
   try {
     await connection.receive(encodeMemoryBoundary(HELLO));
-    shiftMessage(messages);
+    const sessionOpen = expectHelloOk(messages);
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     sessionId = assertResponse<{ sessionId: string }>(
       shiftMessage(messages),
@@ -1054,14 +1234,15 @@ Deno.test("memory v2 server refreshes watched docs by syncing only the touched e
     for (const client of [connection, writer]) {
       await client.receive(encodeMemoryBoundary(HELLO));
     }
-    shiftMessage(messages);
-    shiftMessage(writerMessages);
+    const sessionOpen = expectHelloOk(messages);
+    const writerSessionOpen = expectHelloOk(writerMessages);
 
     await writer.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "writer-open",
       space,
       session: {},
+      invocation: authInvocation(writerSessionOpen),
     }));
     const writerSessionId = assertResponse<{ sessionId: string }>(
       shiftMessage(writerMessages),
@@ -1072,6 +1253,7 @@ Deno.test("memory v2 server refreshes watched docs by syncing only the touched e
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string }>(
       shiftMessage(messages),
@@ -1175,13 +1357,14 @@ Deno.test("memory v2 server watch.add bootstraps only the newly added watch", as
 
   try {
     await connection.receive(encodeMemoryBoundary(HELLO));
-    shiftMessage(messages);
+    const sessionOpen = expectHelloOk(messages);
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string }>(
       shiftMessage(messages),
@@ -1276,13 +1459,14 @@ Deno.test("memory v2 server can bootstrap watches with session.watch.add", async
 
   try {
     await connection.receive(encodeMemoryBoundary(HELLO));
-    shiftMessage(messages);
+    const sessionOpen = expectHelloOk(messages);
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string }>(
       shiftMessage(messages),
@@ -1344,13 +1528,14 @@ Deno.test("memory v2 server treats duplicate watch ids in session.watch.add as n
 
   try {
     await connection.receive(encodeMemoryBoundary(HELLO));
-    shiftMessage(messages);
+    const sessionOpen = expectHelloOk(messages);
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string }>(
       shiftMessage(messages),
@@ -1549,13 +1734,14 @@ Deno.test("memory v2 server rolls back failed watch.add mutations", async () => 
 
   try {
     await connection.receive(encodeMemoryBoundary(HELLO));
-    assertEquals(shiftMessage(messages), HELLO_OK);
+    const sessionOpen = expectHelloOk(messages);
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string }>(
       shiftMessage(messages),
@@ -1676,13 +1862,14 @@ Deno.test("memory v2 server watch set replacement emits removes for entities tha
 
   try {
     await connection.receive(encodeMemoryBoundary(HELLO));
-    shiftMessage(messages);
+    const sessionOpen = expectHelloOk(messages);
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string }>(
       shiftMessage(messages),
@@ -1786,14 +1973,15 @@ Deno.test("memory v2 server does not echo same-session operation docs through wa
     for (const connection of [writer, observer]) {
       await connection.receive(encodeMemoryBoundary(HELLO));
     }
-    shiftMessage(writerMessages);
-    shiftMessage(observerMessages);
+    const writerSessionOpen = expectHelloOk(writerMessages);
+    const observerSessionOpen = expectHelloOk(observerMessages);
 
     await writer.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "writer-open",
       space,
       session: {},
+      invocation: authInvocation(writerSessionOpen),
     }));
     const writerSessionId = assertResponse<{ sessionId: string }>(
       shiftMessage(writerMessages),
@@ -1804,6 +1992,7 @@ Deno.test("memory v2 server does not echo same-session operation docs through wa
       requestId: "observer-open",
       space,
       session: {},
+      invocation: authInvocation(observerSessionOpen),
     }));
     const observerSessionId = assertResponse<{ sessionId: string }>(
       shiftMessage(observerMessages),
@@ -1884,13 +2073,14 @@ Deno.test("memory v2 server returns conflicts before deferred caught-up session 
 
   try {
     await connection.receive(encodeMemoryBoundary(HELLO));
-    shiftMessage(messages);
+    const sessionOpen = expectHelloOk(messages);
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string }>(
       shiftMessage(messages),
@@ -2027,13 +2217,14 @@ Deno.test("memory v2 server empty caught-up sync preserves previous fromSeq", as
 
   try {
     await connection.receive(encodeMemoryBoundary(HELLO));
-    shiftMessage(messages);
+    const sessionOpen = expectHelloOk(messages);
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string }>(
       shiftMessage(messages),
@@ -2124,13 +2315,14 @@ Deno.test("memory v2 server processes back-to-back websocket messages in receive
 
   try {
     await connection.receive(encodeMemoryBoundary(HELLO));
-    shiftMessage(messages);
+    const sessionOpen = expectHelloOk(messages);
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string }>(
       shiftMessage(messages),
@@ -2293,14 +2485,15 @@ Deno.test("memory v2 server waits for queued receives before rerunning scheduled
     for (const client of [connection, writer]) {
       await client.receive(encodeMemoryBoundary(HELLO));
     }
-    shiftMessage(messages);
-    shiftMessage(writerMessages);
+    const sessionOpen = expectHelloOk(messages);
+    const writerSessionOpen = expectHelloOk(writerMessages);
 
     await writer.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "writer-open",
       space,
       session: {},
+      invocation: authInvocation(writerSessionOpen),
     }));
     const writerSessionId = assertResponse<{ sessionId: string }>(
       shiftMessage(writerMessages),
@@ -2311,6 +2504,7 @@ Deno.test("memory v2 server waits for queued receives before rerunning scheduled
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string }>(
       shiftMessage(messages),
@@ -2507,14 +2701,15 @@ Deno.test("memory v2 server reruns scheduled watch refresh after max deferral", 
     for (const client of [connection, writer]) {
       await client.receive(encodeMemoryBoundary(HELLO));
     }
-    shiftMessage(messages);
-    shiftMessage(writerMessages);
+    const sessionOpen = expectHelloOk(messages);
+    const writerSessionOpen = expectHelloOk(writerMessages);
 
     await writer.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "writer-open",
       space,
       session: {},
+      invocation: authInvocation(writerSessionOpen),
     }));
     const writerSessionId = assertResponse<{ sessionId: string }>(
       shiftMessage(writerMessages),
@@ -2525,6 +2720,7 @@ Deno.test("memory v2 server reruns scheduled watch refresh after max deferral", 
       requestId: "open-1",
       space,
       session: {},
+      invocation: authInvocation(sessionOpen),
     }));
     const opened = assertResponse<{ sessionId: string }>(
       shiftMessage(messages),

--- a/packages/memory/test/v2-sqlite-disk-source-test.ts
+++ b/packages/memory/test/v2-sqlite-disk-source-test.ts
@@ -19,6 +19,10 @@ import { DiskSourceRegistry } from "../v2/sqlite/disk-source.ts";
 import { Server } from "../v2/server.ts";
 import { connect, loopback } from "../v2/client.ts";
 import type { SqliteDbRef } from "../v2.ts";
+import {
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "./v2-auth-test-helpers.ts";
 
 function seedDiskDb(path: string): void {
   const seed = new Database(path);
@@ -111,9 +115,12 @@ describe("server attaches a registered on-disk source (read-only v1)", () => {
     diskPath = Deno.makeTempFileSync({ suffix: ".sqlite" });
     seedDiskDb(diskPath);
     handleId = `of:disk-${crypto.randomUUID()}`;
-    server = new Server({ store: new URL("memory://sqlite-disk-source-test") });
+    server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://sqlite-disk-source-test"),
+    });
     client = await connect({ transport: loopback(server) });
-    session = await client.mount(SPACE);
+    session = await client.mount(SPACE, {}, testSessionOpenAuthFactory);
   });
 
   afterEach(async () => {
@@ -179,6 +186,8 @@ describe("server attaches a registered on-disk source (read-only v1)", () => {
   it("does not leak a registration across spaces (C2)", async () => {
     const session2 = await client.mount(
       "did:key:z6Mk-sqlite-disk-source-test-2",
+      {},
+      testSessionOpenAuthFactory,
     );
     // Register the on-disk source under SPACE (session), NOT the second space.
     await session.registerSqliteDiskSource(handleId, diskPath);

--- a/packages/memory/test/v2-sqlite-protocol-test.ts
+++ b/packages/memory/test/v2-sqlite-protocol-test.ts
@@ -9,6 +9,10 @@ import { Server } from "../v2/server.ts";
 import { connect, loopback } from "../v2/client.ts";
 import { cfLink, table } from "../v2/sqlite/schema.ts";
 import type { SqliteDbRef } from "../v2.ts";
+import {
+  testSessionOpenAuthFactory,
+  testSessionOpenServerOptions,
+} from "./v2-auth-test-helpers.ts";
 
 const SPACE = "did:key:z6Mk-sqlite-protocol-test";
 
@@ -34,9 +38,12 @@ describe("sqlite protocol verbs (loopback)", () => {
 
   beforeEach(async () => {
     dbId = `of:test-db-${crypto.randomUUID()}`;
-    server = new Server({ store: new URL("memory://sqlite-protocol-test") });
+    server = new Server({
+      ...testSessionOpenServerOptions,
+      store: new URL("memory://sqlite-protocol-test"),
+    });
     client = await connect({ transport: loopback(server) });
-    session = await client.mount(SPACE);
+    session = await client.mount(SPACE, {}, testSessionOpenAuthFactory);
   });
 
   afterEach(async () => {
@@ -130,7 +137,11 @@ describe("sqlite protocol verbs (loopback)", () => {
     // space). The fix detaches each cell-db before the post-commit await, so the
     // ≤1-attached invariant holds and neither write leaks into the other db.
     const client2 = await connect({ transport: loopback(server) });
-    const session2 = await client2.mount(SPACE);
+    const session2 = await client2.mount(
+      SPACE,
+      {},
+      testSessionOpenAuthFactory,
+    );
     try {
       const dbA: SqliteDbRef = {
         id: `of:b1-a-${crypto.randomUUID()}`,

--- a/packages/memory/test/v2-sqlite-scope-test.ts
+++ b/packages/memory/test/v2-sqlite-scope-test.ts
@@ -13,6 +13,7 @@ import { Server } from "../v2/server.ts";
 import { connect, loopback } from "../v2/client.ts";
 import { table } from "../v2/sqlite/schema.ts";
 import type { CellScope, SqliteDbRef } from "../v2.ts";
+import { testSessionOpenAuth } from "./v2-auth-test-helpers.ts";
 
 const SPACE = "did:key:z6Mk-sqlite-scope-test";
 const ALICE = "did:key:z6Mk-alice";
@@ -35,6 +36,7 @@ describe("sqlite cell-db scope (per-user / per-session files)", () => {
             ?.principal;
         return typeof principal === "string" ? principal : undefined;
       },
+      sessionOpenAuth: testSessionOpenAuth,
     });
   });
 
@@ -48,7 +50,13 @@ describe("sqlite cell-db scope (per-user / per-session files)", () => {
     const session = await client.mount(
       SPACE,
       { sessionId },
-      () => ({ invocation: {}, authorization: { principal } }),
+      (_space, _session, context) => ({
+        invocation: {
+          aud: context.audience,
+          challenge: context.challenge.value,
+        },
+        authorization: { principal },
+      }),
     );
     return { client, session };
   };

--- a/packages/memory/test/v2-sync-schema-table-test.ts
+++ b/packages/memory/test/v2-sync-schema-table-test.ts
@@ -11,10 +11,12 @@ import type { JSONSchema } from "@commonfabric/api";
 import {
   encodeMemoryBoundary,
   getMemoryProtocolFlags,
+  type HelloOkMessage,
   MEMORY_PROTOCOL,
   type ResponseMessage,
   type ServerMessage,
   type SessionEffectMessage,
+  type SessionOpenAuthMetadata,
   type SessionOpenResult,
   type SessionSync,
   type WatchAddResult,
@@ -27,6 +29,7 @@ import {
   expandSessionSyncSchemas,
   type SchemaTableSessionSync,
 } from "../v2/sync-schema-table.ts";
+import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
 
 const textEncoder = new TextEncoder();
 
@@ -111,6 +114,18 @@ const assertResponse = <Result>(
   assertEquals(message.type, "response");
   return message as ResponseMessage<Result>;
 };
+
+const expectHelloOk = (messages: ServerMessage[]): SessionOpenAuthMetadata => {
+  const hello = shiftMessage(messages) as HelloOkMessage;
+  assertEquals(hello.type, "hello.ok");
+  assertExists(hello.sessionOpen);
+  return hello.sessionOpen;
+};
+
+const authInvocation = (sessionOpen: SessionOpenAuthMetadata) => ({
+  aud: sessionOpen.audience,
+  challenge: sessionOpen.challenge.value,
+});
 
 Deno.test("sync schema table experiment captures repeated schema savings", () => {
   const sync = repeatedSchemaSync();
@@ -508,6 +523,7 @@ Deno.test("memory server negotiates schema-table v2 sync frames per connection",
     mode: "v2" | "legacy" | "off",
   ) => {
     const server = new Server({
+      ...testSessionOpenServerOptions,
       store: new URL(
         `memory://sync-schema-table-negotiation-${mode}`,
       ),
@@ -528,13 +544,14 @@ Deno.test("memory server negotiates schema-table v2 sync frames per connection",
         protocol: MEMORY_PROTOCOL,
         flags: clientFlags,
       }));
-      shiftMessage(messages);
+      const sessionOpen = expectHelloOk(messages);
 
       await connection.receive(encodeMemoryBoundary({
         type: "session.open",
         requestId: "open",
         space,
         session: {},
+        invocation: authInvocation(sessionOpen),
       }));
       const opened = assertResponse<SessionOpenResult>(
         shiftMessage(messages),

--- a/packages/memory/test/v2-watch-sync-test.ts
+++ b/packages/memory/test/v2-watch-sync-test.ts
@@ -3,11 +3,14 @@ import { Server } from "../v2/server.ts";
 import {
   encodeMemoryBoundary,
   getMemoryProtocolFlags,
+  type HelloOkMessage,
   MEMORY_PROTOCOL,
   type ResponseMessage,
   type ServerMessage,
   type SessionEffectMessage,
+  type SessionOpenAuthMetadata,
 } from "../v2.ts";
+import { testSessionOpenServerOptions } from "./v2-auth-test-helpers.ts";
 
 const HELLO = {
   type: "hello",
@@ -33,8 +36,21 @@ const assertEffect = (message: ServerMessage): SessionEffectMessage => {
   return message as SessionEffectMessage;
 };
 
+const expectHelloOk = (messages: ServerMessage[]): SessionOpenAuthMetadata => {
+  const hello = shiftMessage(messages) as HelloOkMessage;
+  assertEquals(hello.type, "hello.ok");
+  assertExists(hello.sessionOpen);
+  return hello.sessionOpen;
+};
+
+const authInvocation = (sessionOpen: SessionOpenAuthMetadata) => ({
+  aud: sessionOpen.audience,
+  challenge: sessionOpen.challenge.value,
+});
+
 Deno.test("memory v2 server replaces watch sets and emits session sync effects", async () => {
   const server = new Server({
+    ...testSessionOpenServerOptions,
     store: new URL("memory://memory-v2-watch-sync"),
     subscriptionRefreshDelayMs: 0,
   });
@@ -48,14 +64,15 @@ Deno.test("memory v2 server replaces watch sets and emits session sync effects",
     for (const connection of [writer, watcher]) {
       await connection.receive(encodeMemoryBoundary(HELLO));
     }
-    shiftMessage(writerMessages);
-    shiftMessage(watcherMessages);
+    const writerSessionOpen = expectHelloOk(writerMessages);
+    const watcherSessionOpen = expectHelloOk(watcherMessages);
 
     await writer.receive(encodeMemoryBoundary({
       type: "session.open",
       requestId: "writer-open",
       space,
       session: {},
+      invocation: authInvocation(writerSessionOpen),
     }));
     const writerOpen = assertResponse<{ sessionId: string; serverSeq: number }>(
       shiftMessage(writerMessages),
@@ -66,6 +83,7 @@ Deno.test("memory v2 server replaces watch sets and emits session sync effects",
       requestId: "watcher-open",
       space,
       session: {},
+      invocation: authInvocation(watcherSessionOpen),
     }));
     const watcherOpen = assertResponse<{
       sessionId: string;

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -217,6 +217,7 @@ export interface SessionOpenResult {
   caughtUpLocalSeq?: number;
   resumed?: boolean;
   sync?: SessionSync;
+  sessionOpen: SessionOpenAuthMetadata;
 }
 
 export interface MemoryProtocolFlags {
@@ -250,6 +251,17 @@ export interface HelloOkMessage {
   type: "hello.ok";
   protocol: typeof MEMORY_PROTOCOL;
   flags: WireMemoryProtocolFlags;
+  sessionOpen?: SessionOpenAuthMetadata;
+}
+
+export interface SessionOpenChallenge {
+  value: string;
+  expiresAt: number;
+}
+
+export interface SessionOpenAuthMetadata {
+  challenge: SessionOpenChallenge;
+  audience: string;
 }
 
 export interface SessionDescriptor {

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -15,6 +15,8 @@ import {
   type SchedulerActionSnapshotQuery,
   type SchedulerSnapshotListResult,
   type SessionEffectMessage,
+  type SessionOpenAuthMetadata,
+  type SessionOpenChallenge,
   type SessionOpenResult,
   type SessionRevokedMessage,
   type SessionSync,
@@ -53,9 +55,15 @@ export interface SessionOpenAuth {
   authorization: unknown;
 }
 
+export interface SessionOpenAuthContext {
+  challenge: SessionOpenChallenge;
+  audience: string;
+}
+
 export type SessionOpenAuthFactory = (
   space: string,
   session: MountOptions,
+  context: SessionOpenAuthContext,
 ) => Promise<SessionOpenAuth | undefined> | SessionOpenAuth | undefined;
 
 export interface WatchMutationResult {
@@ -99,11 +107,14 @@ export class Client {
   #spaces = new Set<SpaceSession>();
   #nextRequest = 1;
   #helloPending: PromiseWithResolvers<void> | null = null;
+  #sessionOpenAuthContext: SessionOpenAuthContext | null = null;
   #reconnecting: Promise<void> | null = null;
   #connected = false;
   #closed = false;
 
-  private constructor(private readonly transport: Transport) {
+  private constructor(
+    private readonly transport: Transport,
+  ) {
     this.transport.setReceiver((payload) => this.onMessage(payload));
     this.transport.setCloseReceiver?.((error) => this.onClose(error));
   }
@@ -129,7 +140,11 @@ export class Client {
     options: MountOptions = {},
     openAuthFactory?: SessionOpenAuthFactory,
   ): Promise<SpaceSession> {
-    const auth = await openAuthFactory?.(space, options);
+    const auth = await openAuthFactory?.(
+      space,
+      options,
+      this.sessionOpenAuthContext(),
+    );
     const result = await this.openSession(space, options, auth);
     const session = new SpaceSession(
       this,
@@ -175,17 +190,34 @@ export class Client {
     session: MountOptions,
     auth?: SessionOpenAuth,
   ): Promise<SessionOpenResult> {
-    return await this.request<SessionOpenResult>({
+    const result = await this.request<SessionOpenResult>({
       type: "session.open",
       requestId: this.nextRequestId(),
       space,
       session,
       ...(auth ? auth : {}),
     });
+    this.updateSessionOpenAuthContext(result.sessionOpen);
+    return result;
   }
 
   isConnected(): boolean {
     return this.#connected;
+  }
+
+  sessionOpenAuthContext(): SessionOpenAuthContext {
+    if (this.#sessionOpenAuthContext === null) {
+      const error = new Error(
+        "memory server did not provide session.open authentication metadata",
+      );
+      error.name = "ProtocolError";
+      throw error;
+    }
+    return this.#sessionOpenAuthContext;
+  }
+
+  private updateSessionOpenAuthContext(sessionOpen: unknown): void {
+    this.#sessionOpenAuthContext = requireSessionOpenAuthMetadata(sessionOpen);
   }
 
   async restoreConnection(): Promise<void> {
@@ -240,6 +272,9 @@ export class Client {
           this.#helloPending.reject(error);
           return;
         }
+        this.#sessionOpenAuthContext = requireSessionOpenAuthMetadata(
+          helloOk.sessionOpen,
+        );
         this.#helloPending.resolve();
         return;
       }
@@ -918,7 +953,11 @@ export class SpaceSession {
       seenSeq: this.#serverSeq,
       sessionToken: this.#sessionToken,
     };
-    const auth = await this.openAuthFactory?.(this.space, session);
+    const auth = await this.openAuthFactory?.(
+      this.space,
+      session,
+      this.client.sessionOpenAuthContext(),
+    );
     const restored = await this.client.openSession(this.space, {
       sessionId: this.#sessionId,
       seenSeq: this.#serverSeq,
@@ -1285,9 +1324,81 @@ const isConnectionError = (error: unknown): boolean =>
     error.message.includes("transport closed") ||
     error.message.includes("disconnect"));
 
+const protocolError = (message: string): Error => {
+  const error = new Error(message);
+  error.name = "ProtocolError";
+  return error;
+};
+
+const requireSessionOpenAuthMetadata = (
+  value: unknown,
+): SessionOpenAuthMetadata => {
+  if (value === undefined) {
+    throw protocolError(
+      "memory server did not provide session.open authentication metadata",
+    );
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw protocolError(
+      "memory server sent malformed session.open authentication metadata",
+    );
+  }
+
+  const sessionOpen = value as {
+    audience?: unknown;
+    challenge?: unknown;
+  };
+  if (sessionOpen.challenge === undefined) {
+    throw protocolError(
+      "memory server did not provide a session.open challenge",
+    );
+  }
+  if (sessionOpen.audience === undefined) {
+    throw protocolError(
+      "memory server did not provide a session.open audience",
+    );
+  }
+  if (typeof sessionOpen.audience !== "string") {
+    throw protocolError(
+      "memory server sent malformed session.open authentication metadata",
+    );
+  }
+  if (
+    typeof sessionOpen.challenge !== "object" ||
+    sessionOpen.challenge === null ||
+    Array.isArray(sessionOpen.challenge)
+  ) {
+    throw protocolError(
+      "memory server sent malformed session.open authentication metadata",
+    );
+  }
+  const challenge = sessionOpen.challenge as {
+    value?: unknown;
+    expiresAt?: unknown;
+  };
+  if (
+    typeof challenge.value !== "string" ||
+    typeof challenge.expiresAt !== "number"
+  ) {
+    throw protocolError(
+      "memory server sent malformed session.open authentication metadata",
+    );
+  }
+  return {
+    audience: sessionOpen.audience,
+    challenge: {
+      value: challenge.value,
+      expiresAt: challenge.expiresAt,
+    },
+  };
+};
+
 const parseHelloOk = (
   message: unknown,
-): { flags: MemoryProtocolFlags } | null => {
+): {
+  flags: MemoryProtocolFlags;
+  sessionOpen?: unknown;
+} | null => {
   if (typeof message !== "object" || message === null) {
     return null;
   }
@@ -1295,6 +1406,7 @@ const parseHelloOk = (
     type?: unknown;
     protocol?: unknown;
     flags?: unknown;
+    sessionOpen?: unknown;
   };
   if (obj.type !== "hello.ok" || obj.protocol !== MEMORY_PROTOCOL) {
     return null;
@@ -1303,7 +1415,7 @@ const parseHelloOk = (
   if (parsed === null) {
     return null;
   }
-  return { flags: parsed };
+  return { flags: parsed, sessionOpen: obj.sessionOpen };
 };
 
 const isSessionEffect = (

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -272,9 +272,16 @@ export class Client {
           this.#helloPending.reject(error);
           return;
         }
-        this.#sessionOpenAuthContext = requireSessionOpenAuthMetadata(
-          helloOk.sessionOpen,
-        );
+        try {
+          this.#sessionOpenAuthContext = requireSessionOpenAuthMetadata(
+            helloOk.sessionOpen,
+          );
+        } catch (error) {
+          this.#helloPending.reject(
+            error instanceof Error ? error : protocolError(String(error)),
+          );
+          return;
+        }
         this.#helloPending.resolve();
         return;
       }

--- a/packages/memory/v2/handshake.ts
+++ b/packages/memory/v2/handshake.ts
@@ -2,6 +2,7 @@ import {
   compatibleMemoryProtocolFlags,
   getMemoryProtocolFlags,
   type HelloMessage,
+  type HelloOkMessage,
   MEMORY_PROTOCOL,
   parseMemoryProtocolFlags,
   type ServerMessage,
@@ -48,9 +49,10 @@ export const respondToHello = (message: HelloMessage): ServerMessage => {
     };
   }
 
-  return {
+  const response: HelloOkMessage = {
     type: "hello.ok",
     protocol: MEMORY_PROTOCOL,
     flags: wireMemoryProtocolFlags(expectedFlags),
   };
+  return response;
 };

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -23,6 +23,8 @@ import {
   type SessionAckRequest,
   type SessionAckResult,
   type SessionEffectMessage,
+  type SessionOpenAuthMetadata,
+  type SessionOpenChallenge,
   type SessionOpenRequest,
   type SessionOpenResult,
   type SessionRevokedMessage,
@@ -83,6 +85,7 @@ import {
   trackedIdsFromEntries,
 } from "./server-sync.ts";
 import { SessionRegistry, type SessionState } from "./session-registry.ts";
+import { authorizationError } from "./session-open-auth.ts";
 
 export { SessionRegistry } from "./session-registry.ts";
 
@@ -90,6 +93,8 @@ const SUBSCRIPTION_REFRESH_DELAY_MS = 5;
 const MIN_REFRESH_QUEUE_DRAIN_WAIT_MS = 500;
 const SLOW_QUERY_THRESHOLD_MS = 100;
 const SLOW_QUERY_BUFFER_SIZE = 100;
+const DEFAULT_SESSION_OPEN_CHALLENGE_TTL_SECONDS = 300;
+const SESSION_OPEN_CHALLENGE_BYTES = 32;
 
 // SQLite resource caps (mirror the `sqlite.query` wire-parse caps; also applied
 // to the folded-write path, which is parsed loosely as part of a `transact`).
@@ -144,6 +149,11 @@ export const getSlowQueries = (): readonly SlowQuery[] => slowQueries;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
+
+const randomHex = (bytes: number): string => {
+  const data = crypto.getRandomValues(new Uint8Array(bytes));
+  return [...data].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+};
 
 const schedulerObservationFromValue = (
   observation: unknown,
@@ -296,6 +306,15 @@ const sessionKey = (space: string, sessionId: string): string =>
 
 type Send = (message: ServerMessage) => void;
 
+type SessionOpenAuthContext = {
+  audience: string;
+  challenge: SessionOpenChallenge;
+};
+
+type SessionOpenChallengeState = SessionOpenChallenge & {
+  consumed: boolean;
+};
+
 type SessionHandle = {
   space: string;
   sessionId: string;
@@ -311,6 +330,7 @@ class Connection {
   #closed = false;
   #syncSchemaTable = false;
   #sessions = new Map<string, SessionHandle>();
+  #sessionOpenChallenge: SessionOpenChallengeState | null = null;
   #receiving: Promise<void> = Promise.resolve();
   #pendingReceives = 0;
   #receiveIdle: PromiseWithResolvers<void> | null = null;
@@ -354,6 +374,60 @@ class Connection {
       sessionId,
       reason,
     });
+  }
+
+  issueSessionOpenAuth(): SessionOpenAuthMetadata {
+    const sessionOpen = this.server.sessionOpenHandshake();
+    this.#sessionOpenChallenge = {
+      ...sessionOpen.challenge,
+      consumed: false,
+    };
+    return sessionOpen;
+  }
+
+  sessionOpenAuthContext(message: SessionOpenRequest): SessionOpenAuthContext {
+    const audience = this.server.sessionOpenAudience();
+    const invocation = isRecord(message.invocation) ? message.invocation : null;
+    if (invocation === null || typeof invocation.aud !== "string") {
+      throw authorizationError("memory session.open requires audience");
+    }
+    if (invocation.aud !== audience) {
+      throw authorizationError("memory session.open audience mismatch");
+    }
+
+    const challenge = this.#sessionOpenChallenge;
+    if (challenge === null) {
+      throw authorizationError("memory session.open challenge unavailable");
+    }
+    if (challenge.consumed) {
+      throw authorizationError("memory session.open challenge already used");
+    }
+    if (challenge.expiresAt <= this.server.nowSeconds()) {
+      throw authorizationError("memory session.open challenge expired");
+    }
+    if (typeof invocation.challenge !== "string") {
+      throw authorizationError("memory session.open requires challenge");
+    }
+    if (invocation.challenge !== challenge.value) {
+      throw authorizationError("memory session.open challenge mismatch");
+    }
+
+    return {
+      audience,
+      challenge: {
+        value: challenge.value,
+        expiresAt: challenge.expiresAt,
+      },
+    };
+  }
+
+  consumeSessionOpenChallenge(challenge: SessionOpenChallenge): void {
+    if (this.#sessionOpenChallenge === null) {
+      return;
+    }
+    if (this.#sessionOpenChallenge.value === challenge.value) {
+      this.#sessionOpenChallenge.consumed = true;
+    }
   }
 
   async receive(payload: string): Promise<void> {
@@ -450,6 +524,9 @@ class Connection {
         return;
       }
       const response = respondToHello(parsed);
+      if (response.type === "hello.ok") {
+        response.sessionOpen = this.issueSessionOpenAuth();
+      }
       this.send(response);
       if (response.type !== "hello.ok") {
         return;
@@ -656,9 +733,22 @@ export class Server {
       sessions?: SessionRegistry;
       store?: URL;
       subscriptionRefreshDelayMs?: number;
-      authorizeSessionOpen?: (
+      authorizeSessionOpen: (
         message: SessionOpenRequest,
+        context: SessionOpenAuthContext,
       ) => Promise<string | undefined> | string | undefined;
+      /**
+       * Authentication data advertised in `hello.ok` and enforced for
+       * `session.open` on this server.
+       */
+      sessionOpenAuth: {
+        /** Audience value clients must sign into `session.open` as `aud`. */
+        audience: string;
+        /** How long a connection challenge may be used, in seconds. */
+        challengeTtlSeconds?: number;
+        /** Current unix time in seconds. Tests may inject this. */
+        nowSeconds?: () => number;
+      };
       /**
        * Space access control. `off` (default) preserves the historical
        * any-authenticated-session-may-do-anything behavior. `observe`
@@ -684,10 +774,31 @@ export class Server {
         mode: MemoryAclMode;
         serviceDids?: readonly string[];
       };
-    } = {},
+    },
   ) {
     this.#sessions = options.sessions ?? new SessionRegistry();
     this.#store = options.store;
+  }
+
+  nowSeconds(): number {
+    return this.options.sessionOpenAuth.nowSeconds?.() ??
+      Math.floor(Date.now() / 1000);
+  }
+
+  sessionOpenAudience(): string {
+    return this.options.sessionOpenAuth.audience;
+  }
+
+  sessionOpenHandshake(): SessionOpenAuthMetadata {
+    const ttl = this.options.sessionOpenAuth.challengeTtlSeconds ??
+      DEFAULT_SESSION_OPEN_CHALLENGE_TTL_SECONDS;
+    return {
+      audience: this.sessionOpenAudience(),
+      challenge: {
+        value: randomHex(SESSION_OPEN_CHALLENGE_BYTES),
+        expiresAt: this.nowSeconds() + ttl,
+      },
+    };
   }
 
   /** Counters for ACL decisions; `wouldDeny` is the observe-mode rollout
@@ -1354,8 +1465,13 @@ export class Server {
     connection: Connection,
   ): Promise<ResponseMessage<SessionOpenResult>> {
     try {
+      const authContext = connection.sessionOpenAuthContext(message);
+      const principal = await this.options.authorizeSessionOpen(
+        message,
+        authContext,
+      );
+      connection.consumeSessionOpenChallenge(authContext.challenge);
       const engine = await this.openEngine(message.space);
-      const principal = await this.options.authorizeSessionOpen?.(message);
       this.#ensureCreatorSeeded(engine, message.space, principal);
       const deny = await this.#authorizeMessage(
         message.space,
@@ -1385,6 +1501,7 @@ export class Server {
           opened.sessionId,
         )
         : null;
+      const nextSessionOpen = connection.issueSessionOpenAuth();
       return {
         type: "response",
         requestId: message.requestId,
@@ -1395,6 +1512,7 @@ export class Server {
           caughtUpLocalSeq: opened.caughtUpLocalSeq,
           ...(opened.resumed === true ? { resumed: true } : {}),
           ...(catchup ? { sync: catchup.effect } : {}),
+          sessionOpen: nextSessionOpen,
         },
       };
     } catch (error) {
@@ -2389,7 +2507,18 @@ export class Server {
   respond(payload: string): Promise<string | null> {
     const parsed = parseClientMessage(payload);
     if (parsed?.type === "hello") {
-      return Promise.resolve(encodeMemoryBoundary(respondToHello(parsed)));
+      const response = respondToHello(parsed);
+      if (response.type !== "hello.ok") {
+        return Promise.resolve(encodeMemoryBoundary(response));
+      }
+      return Promise.resolve(encodeMemoryBoundary({
+        type: "response",
+        requestId: "handshake",
+        error: toError(
+          "ProtocolError",
+          "memory Server.respond cannot issue session.open authentication metadata",
+        ),
+      }));
     }
     return Promise.resolve(null);
   }

--- a/packages/memory/v2/session-open-auth.ts
+++ b/packages/memory/v2/session-open-auth.ts
@@ -4,34 +4,26 @@
  * The memory server authenticates a client by verifying the signature on its
  * `session.open` invocation; the verified issuer becomes the session principal
  * that storage partitioning keys off. Toolshed's `/api/storage/memory` route
- * and the standalone test server both performed this verification with
- * byte-identical copies — this is the single source of truth they now share.
+ * and the standalone test server use this shared verifier.
  *
- * Federation §14 PR5 adds two anti-replay checks on top of the signature:
+ * The handshake adds three anti-replay checks on top of the signature:
  *
  *  - **expiry** (`exp`): a `session.open` is a live handshake, not a durable
  *    grant. When the invocation carries an `exp` (the client now stamps one),
  *    reject it once expired (with a clock-skew grace). Bounds how long a
  *    captured open can be replayed.
  *
- *  - **audience** (`aud`): when the invocation is bound to an audience AND this
- *    server is configured with its own `audience` identity, require they match
- *    — so an open signed for host A cannot be replayed to host B. This is the
- *    cross-host replay fix that lets the site table's host hints become
- *    trustable. Both halves are opt-in (absent `aud` or unconfigured server →
- *    skip) so the check rolls out without a flag day. NOTE: the `Invocation`
- *    `aud` field is typed `DID`, so a *proper* audience is the server's own
- *    identity DID — which the memory server does not have today. Provisioning
- *    that identity (and letting the client discover it, e.g. via the site
- *    table) is the open architectural decision tracked in
- *    docs/development/federation-pr5-design.md; until it lands no client sets
- *    `aud` and this stays inert. The mechanism + tests are here so that
- *    decision is a wiring change, not a protocol change.
+ *  - **challenge** (`challenge`): the server advertises a fresh, connection
+ *    scoped challenge in `hello.ok`; the client signs that value into
+ *    `session.open`, and the server accepts it once.
+ *
+ *  - **audience** (`aud`): the invocation must carry this server's audience
+ *    identity. An open signed for host A cannot be replayed to host B.
  */
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { fromDID } from "../util.ts";
-import { MEMORY_PROTOCOL } from "../v2.ts";
+import { MEMORY_PROTOCOL, type SessionOpenChallenge } from "../v2.ts";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
@@ -41,24 +33,27 @@ export const authorizationError = (message: string): Error =>
 
 const sameSessionDescriptor = (
   left: Record<string, unknown>,
-  right: { sessionId?: string; seenSeq?: number },
+  right: { sessionId?: string; seenSeq?: number; sessionToken?: string },
 ): boolean =>
   (typeof left.sessionId === "string" ? left.sessionId : undefined) ===
     right.sessionId &&
   (typeof left.seenSeq === "number" ? left.seenSeq : undefined) ===
-    right.seenSeq;
+    right.seenSeq &&
+  (typeof left.sessionToken === "string" ? left.sessionToken : undefined) ===
+    right.sessionToken;
 
 export type SessionOpenMessage = {
   space: string;
-  session: { sessionId?: string; seenSeq?: number };
+  session: { sessionId?: string; seenSeq?: number; sessionToken?: string };
   invocation?: Record<string, unknown>;
   authorization?: unknown;
 };
 
 export type VerifySessionOpenOptions = {
-  /** This server's own audience identity (a DID). When set, an invocation that
-   * carries an `aud` must match it. Unset → audience is not enforced. */
-  audience?: string;
+  /** This server's own audience identity. */
+  audience: string;
+  /** The challenge issued to this connection. */
+  challenge: SessionOpenChallenge;
   /** Current unix time in seconds (defaults to now). Injectable for tests. */
   nowSeconds?: number;
   /** Grace window for `exp` to tolerate client/server clock skew. */
@@ -68,13 +63,12 @@ export type VerifySessionOpenOptions = {
 const DEFAULT_CLOCK_SKEW_SECONDS = 120;
 
 /**
- * Verify a `session.open` authorization. Returns the verified issuer DID (the
- * session principal) or throws an AuthorizationError. Behaviour matches the
- * prior inline copies exactly, plus the opt-in expiry/audience checks above.
+ * Verify a `session.open` authorization. Returns the verified issuer DID or
+ * throws an AuthorizationError.
  */
 export const verifySessionOpenAuthorization = async (
   message: SessionOpenMessage,
-  options: VerifySessionOpenOptions = {},
+  options: VerifySessionOpenOptions,
 ): Promise<string> => {
   const rawSignature = isRecord(message.authorization)
     ? message.authorization.signature
@@ -99,28 +93,34 @@ export const verifySessionOpenAuthorization = async (
     throw authorizationError("memory session.open authorization mismatch");
   }
 
-  // Audience binding: an open bound to a *different* audience must not be
-  // accepted here (replay across hosts). Opt-in on both sides.
-  if (
-    options.audience !== undefined &&
-    invocation.aud !== undefined &&
-    invocation.aud !== options.audience
-  ) {
-    throw authorizationError(
-      "memory session.open audience mismatch (replayed to the wrong host)",
-    );
+  if (typeof invocation.aud !== "string") {
+    throw authorizationError("memory session.open requires audience");
+  }
+  if (invocation.aud !== options.audience) {
+    throw authorizationError("memory session.open audience mismatch");
   }
 
-  // Expiry: a captured open must not be replayable forever.
-  if (invocation.exp !== undefined) {
-    if (typeof invocation.exp !== "number") {
-      throw authorizationError("memory session.open has a malformed exp");
-    }
-    const now = options.nowSeconds ?? Math.floor(Date.now() / 1000);
-    const skew = options.clockSkewSeconds ?? DEFAULT_CLOCK_SKEW_SECONDS;
-    if (invocation.exp < now - skew) {
-      throw authorizationError("memory session.open authorization expired");
-    }
+  if (typeof invocation.challenge !== "string") {
+    throw authorizationError("memory session.open requires challenge");
+  }
+  if (invocation.challenge !== options.challenge.value) {
+    throw authorizationError("memory session.open challenge mismatch");
+  }
+  const challengeNow = options.nowSeconds ?? Math.floor(Date.now() / 1000);
+  if (options.challenge.expiresAt <= challengeNow) {
+    throw authorizationError("memory session.open challenge expired");
+  }
+
+  if (typeof invocation.iat !== "number" || !Number.isFinite(invocation.iat)) {
+    throw authorizationError("memory session.open requires iat");
+  }
+  if (typeof invocation.exp !== "number" || !Number.isFinite(invocation.exp)) {
+    throw authorizationError("memory session.open requires exp");
+  }
+  const now = options.nowSeconds ?? Math.floor(Date.now() / 1000);
+  const skew = options.clockSkewSeconds ?? DEFAULT_CLOCK_SKEW_SECONDS;
+  if (invocation.exp < now - skew) {
+    throw authorizationError("memory session.open authorization expired");
   }
 
   const issuer = await fromDID(invocation.iss);

--- a/packages/memory/v2/session-registry.ts
+++ b/packages/memory/v2/session-registry.ts
@@ -1,9 +1,4 @@
-import type {
-  SessionDescriptor,
-  SessionOpenResult,
-  SessionToken,
-  WatchSpec,
-} from "../v2.ts";
+import type { SessionDescriptor, SessionToken, WatchSpec } from "../v2.ts";
 import type { TrackedGraphState } from "./query.ts";
 import type { SessionCacheEntry } from "./server-sync.ts";
 import { trackedIdsFromEntries } from "./server-sync.ts";
@@ -25,7 +20,12 @@ export type SessionState = {
   principal?: string;
 };
 
-type OpenSessionState = SessionOpenResult & {
+type OpenSessionState = {
+  sessionId: string;
+  sessionToken: SessionToken;
+  serverSeq: number;
+  caughtUpLocalSeq?: number;
+  resumed?: boolean;
   revokedConnectionId?: string;
 };
 

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -15,13 +15,19 @@
 import { encodeMemoryBoundary } from "../v2.ts";
 import * as MemoryServer from "./server.ts";
 import { verifySessionOpenAuthorization } from "./session-open-auth.ts";
+import { Identity } from "@commonfabric/identity";
 
-// Session.open verification is shared with toolshed's memory route — see
-// session-open-auth.ts. The standalone test server does not configure an
-// audience (audience binding is opt-in), so this enforces signature + expiry.
+const standaloneMemoryAudience = (await Identity.fromPassphrase(
+  "common tools standalone memory audience",
+)).did();
+
+// Session.open verification is shared with toolshed's memory route. The
+// standalone server advertises a stable audience DID and requires the
+// connection challenge issued in `hello.ok`.
 const authorizeSessionOpen = (
   message: Parameters<typeof verifySessionOpenAuthorization>[0],
-): Promise<string> => verifySessionOpenAuthorization(message);
+  context: Parameters<typeof verifySessionOpenAuthorization>[1],
+): Promise<string> => verifySessionOpenAuthorization(message, context);
 
 let nextConnectionTag = 0;
 
@@ -49,6 +55,9 @@ export class StandaloneMemoryServer {
   ): StandaloneMemoryServer {
     const memory = new MemoryServer.Server({
       authorizeSessionOpen,
+      sessionOpenAuth: {
+        audience: standaloneMemoryAudience,
+      },
       acl: options.acl,
     });
     const http = Deno.serve({

--- a/packages/runner/src/storage/v2-emulate.ts
+++ b/packages/runner/src/storage/v2-emulate.ts
@@ -3,6 +3,8 @@ import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { type Options, type SessionFactory, StorageManager } from "./v2.ts";
 
+const emulatedMemoryAudience = "did:key:z6Mk-runner-emulated-memory";
+
 class EmulatedSessionFactory implements SessionFactory {
   constructor(private readonly getServer: () => MemoryV2Server.Server) {}
 
@@ -10,12 +12,19 @@ class EmulatedSessionFactory implements SessionFactory {
     const client = await MemoryV2Client.connect({
       transport: MemoryV2Client.loopback(this.getServer()),
     });
-    const session = await client.mount(space, {}, () => ({
-      invocation: {},
-      authorization: {
-        principal: signer?.did(),
-      },
-    }));
+    const session = await client.mount(
+      space,
+      {},
+      (_space, _session, context) => ({
+        invocation: {
+          aud: context.audience,
+          challenge: context.challenge.value,
+        },
+        authorization: {
+          principal: signer?.did(),
+        },
+      }),
+    );
     return { client, session };
   }
 }
@@ -40,6 +49,9 @@ export class EmulatedStorageManager extends StorageManager {
             const principal = (message.authorization as { principal?: unknown })
               ?.principal;
             return typeof principal === "string" ? principal : undefined;
+          },
+          sessionOpenAuth: {
+            audience: emulatedMemoryAudience,
           },
         }),
     );

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -34,11 +34,9 @@ export const toSpaceWebSocketAddress = (
 export const MEMORY_STORAGE_PATH = "/api/storage/memory";
 
 /**
- * Validity window stamped onto each signed `session.open` (federation PR5).
- * `session.open` is a live handshake sent the instant a connection opens, so a
- * few minutes is ample for clock skew and round-trip while bounding how long a
- * captured open stays replayable (the server adds its own skew grace). Was
- * effectively infinite before this — the open carried no `exp` at all.
+ * Validity window stamped onto each signed `session.open`.
+ * `session.open` is a live handshake sent when a connection opens, so a few
+ * minutes covers clock skew and round-trip time while bounding replay.
  */
 export const SESSION_OPEN_TTL_SECONDS = 300;
 
@@ -189,20 +187,19 @@ export class RemoteSessionFactory implements SessionFactory {
     signer: Signer,
     space: MemorySpace,
     session: MemoryClient.MountOptions,
+    context: MemoryClient.SessionOpenAuthContext,
   ): Promise<MemoryClient.SessionOpenAuth> {
-    // Stamp a short validity window so a captured session.open can't be
-    // replayed forever (federation PR5). `exp` rides inside the signed
-    // invocation hash and is enforced server-side in session-open-auth.ts;
-    // servers that don't yet check it simply ignore the extra fields.
     const iat = Math.floor(Date.now() / 1000);
     const invocation = {
       iss: signer.did(),
       cmd: "session.open",
       sub: space,
+      aud: context.audience,
       args: {
         protocol: MEMORY_PROTOCOL,
         session,
       },
+      challenge: context.challenge.value,
       iat,
       exp: iat + SESSION_OPEN_TTL_SECONDS,
     };
@@ -231,11 +228,16 @@ export class RemoteSessionFactory implements SessionFactory {
     const session = await client.mount(
       space,
       {},
-      (targetSpace: string, descriptor: MemoryClient.MountOptions) =>
+      (
+        targetSpace: string,
+        descriptor: MemoryClient.MountOptions,
+        context: MemoryClient.SessionOpenAuthContext,
+      ) =>
         this.#createSessionOpenAuth(
           signer,
           targetSpace as MemorySpace,
           descriptor,
+          context,
         ),
     );
     return { client, session };

--- a/packages/runner/test/array-push-mergeable.test.ts
+++ b/packages/runner/test/array-push-mergeable.test.ts
@@ -7,6 +7,7 @@ import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import { TransactionWrapper } from "../src/storage/extended-storage-transaction.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 // A storage manager with its OWN per-space client replicas, loopback-connected
 // to a SHARED in-process memory server (mirrors cross-space-value-read.test.ts).
@@ -40,6 +41,7 @@ const newSharedServer = () =>
         ?.principal;
       return typeof principal === "string" ? principal : undefined;
     },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
   });
 
 const signer = await Identity.fromPassphrase("array-push-mergeable");

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -26,6 +26,7 @@ import {
   writeCompiledDocs,
   writeSourceDocs,
 } from "../src/compilation-cache/cell-cache.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 // ---------------------------------------------------------------------------
 // Shared-server helper: two managers with DIFFERENT signers over ONE in-process
@@ -63,6 +64,7 @@ const newSharedServer = () =>
         ?.principal;
       return typeof principal === "string" ? principal : undefined;
     },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
   });
 
 const signer = await Identity.fromPassphrase("cell-cache test");

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -35,6 +35,10 @@ import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { ignoreReadForScheduling } from "../src/scheduler.ts";
 import { internalVerifierRead } from "../src/storage/reactivity-log.ts";
 import { setResultCell } from "../src/result-utils.ts";
+import {
+  TEST_MEMORY_SERVER_AUTH,
+  testSessionOpenAuthFactory,
+} from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-boundary-tests");
 
@@ -70,7 +74,7 @@ class SharedV2SessionFactory implements V2Storage.SessionFactory {
     const client = await MemoryV2Client.connect({
       transport: MemoryV2Client.loopback(this.server),
     });
-    const session = await client.mount(space);
+    const session = await client.mount(space, {}, testSessionOpenAuthFactory);
     return { client, session };
   }
 }
@@ -1929,7 +1933,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
   });
 
   it("does not conflict when another transaction already wrote the same schema document", async () => {
-    const server = new MemoryV2Server.Server();
+    const server = new MemoryV2Server.Server(TEST_MEMORY_SERVER_AUTH);
     const storageManagerA = new SharedV2StorageManager({
       as: signer,
       memoryHost: new URL("memory://"),
@@ -3963,7 +3967,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
   });
 
   it("syncs cfc schema documents into separate v2 runtime caches", async () => {
-    const server = new MemoryV2Server.Server();
+    const server = new MemoryV2Server.Server(TEST_MEMORY_SERVER_AUTH);
     const createStorageManager = () =>
       new SharedV2StorageManager({
         as: signer,
@@ -4043,6 +4047,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
 
   it("syncs cfc schema documents for scoped v2 documents", async () => {
     const server = new MemoryV2Server.Server({
+      ...TEST_MEMORY_SERVER_AUTH,
       authorizeSessionOpen: () => signer.did(),
     });
     const createStorageManager = () =>

--- a/packages/runner/test/commit-conflict-reconcile.test.ts
+++ b/packages/runner/test/commit-conflict-reconcile.test.ts
@@ -19,6 +19,7 @@ import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("read-repair-strand");
 const space = signer.did();
@@ -51,6 +52,7 @@ const newSharedServer = () =>
         ?.principal;
       return typeof principal === "string" ? principal : undefined;
     },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
   });
 
 describe("read-repair: stale read after cross-replica conflict", () => {

--- a/packages/runner/test/cross-space-value-read.test.ts
+++ b/packages/runner/test/cross-space-value-read.test.ts
@@ -7,6 +7,7 @@ import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("cross-space-value-read");
 const spaceH = signer.did(); // "home" — holds the link
@@ -50,6 +51,7 @@ const newSharedServer = () =>
         ?.principal;
       return typeof principal === "string" ? principal : undefined;
     },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
   });
 
 // CT-1667: a value READ through a cross-space link never materializes the

--- a/packages/runner/test/effect-conflict-recovery.test.ts
+++ b/packages/runner/test/effect-conflict-recovery.test.ts
@@ -32,6 +32,7 @@ import { type StorageNotification } from "../src/storage/interface.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { Action } from "../src/scheduler.ts";
 import { toMemorySpaceAddress } from "../src/link-utils.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("effect-conflict-recovery");
 const space = signer.did();
@@ -61,6 +62,7 @@ const newSharedServer = () =>
         ?.principal;
       return typeof principal === "string" ? principal : undefined;
     },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
   });
 
 const waitFor = async (

--- a/packages/runner/test/inspace-child-owner-seed.test.ts
+++ b/packages/runner/test/inspace-child-owner-seed.test.ts
@@ -7,6 +7,7 @@ import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("inspace-child-owner-seed");
 const spaceA = signer.did(); // "home" — runs the parent, holds the list
@@ -44,6 +45,7 @@ const newSharedServer = () =>
         ?.principal;
       return typeof principal === "string" ? principal : undefined;
     },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
   });
 
 // The profile-create flow in miniature: a handler pushes an `inSpace` child

--- a/packages/runner/test/inspace-child-owner-write.test.ts
+++ b/packages/runner/test/inspace-child-owner-write.test.ts
@@ -7,6 +7,7 @@ import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 // SCOPE (CT-1754): this guards the verified-binding regression only — an
 // inSpace child's owner-protected list, written by a NON-exported mode-bound
@@ -53,6 +54,7 @@ const newSharedServer = () =>
         ?.principal;
       return typeof principal === "string" ? principal : undefined;
     },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
   });
 
 // The profile-create flow in miniature, exercising the OWNER-PROTECTED WRITE

--- a/packages/runner/test/linked-stale-read-conflict.test.ts
+++ b/packages/runner/test/linked-stale-read-conflict.test.ts
@@ -23,6 +23,7 @@ import * as MemoryV2Server from "@commonfabric/memory/v2/server";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("linked-stale-read-strand");
 const space = signer.did();
@@ -55,6 +56,7 @@ const newSharedServer = () =>
         ?.principal;
       return typeof principal === "string" ? principal : undefined;
     },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
   });
 
 describe("stale linked read across two clients", () => {

--- a/packages/runner/test/list-builtin-edge-paths.test.ts
+++ b/packages/runner/test/list-builtin-edge-paths.test.ts
@@ -18,6 +18,10 @@ import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import {
+  TEST_MEMORY_SERVER_AUTH,
+  testPrincipalSessionOpenAuthFactory,
+} from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("list builtin edge paths");
 const space = signer.did();
@@ -337,10 +341,11 @@ class LoopbackSessionFactory implements SessionFactory {
     const client = await MemoryV2Client.connect({
       transport: plainLoopback(this.getServer()),
     });
-    const session = await client.mount(spaceId, {}, () => ({
-      invocation: {},
-      authorization: { principal: sgnr?.did() },
-    }));
+    const session = await client.mount(
+      spaceId,
+      {},
+      testPrincipalSessionOpenAuthFactory(sgnr),
+    );
     return { client, session };
   }
 }
@@ -403,6 +408,7 @@ describe("resume owned-cell walk: scoped sub-pattern", () => {
           ?.principal;
         return typeof principal === "string" ? principal : undefined;
       },
+      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
     });
     sm1 = LoopbackStorageManager.make(signer, server);
     sm2 = LoopbackStorageManager.make(signer, server);
@@ -546,6 +552,7 @@ describe("cross-space link load kick", () => {
           ?.principal;
         return typeof principal === "string" ? principal : undefined;
       },
+      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
     });
     writerStorage = SharedServerStorageManager.connectTo(server, {
       as: signer,

--- a/packages/runner/test/list-fresh-init.test.ts
+++ b/packages/runner/test/list-fresh-init.test.ts
@@ -11,6 +11,10 @@ import {
 import type { Signer } from "@commonfabric/memory/interface";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import {
+  TEST_MEMORY_SERVER_AUTH,
+  testPrincipalSessionOpenAuthFactory,
+} from "./memory-v2-test-utils.ts";
 
 // Fresh-init seeding guard for the list builtins (filter/flatMap/map).
 //
@@ -33,10 +37,11 @@ class F implements SessionFactory {
   constructor(private gs: () => MemoryV2Server.Server) {}
   async create(spaceId: string, sgnr?: Signer) {
     const client = await MemoryV2Client.connect({ transport: lb(this.gs()) });
-    const session = await client.mount(spaceId, {}, () => ({
-      invocation: {},
-      authorization: { principal: sgnr?.did() },
-    }));
+    const session = await client.mount(
+      spaceId,
+      {},
+      testPrincipalSessionOpenAuthFactory(sgnr),
+    );
     return { client, session };
   }
 }
@@ -61,6 +66,7 @@ function runtime() {
         ?.principal;
       return typeof principal === "string" ? principal : undefined;
     },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
   });
   const sm = SM.make(signer, server);
   const rt = new Runtime({

--- a/packages/runner/test/list-resume-container-defer.test.ts
+++ b/packages/runner/test/list-resume-container-defer.test.ts
@@ -12,6 +12,10 @@ import {
 import { Runtime } from "../src/runtime.ts";
 import type { Cell } from "../src/cell.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import {
+  TEST_MEMORY_SERVER_AUTH,
+  testPrincipalSessionOpenAuthFactory,
+} from "./memory-v2-test-utils.ts";
 
 // Container-defer guard for the list builtins (filter / flatMap / map).
 //
@@ -116,10 +120,11 @@ class DroppingSessionFactory implements SessionFactory {
     const client = await MemoryV2Client.connect({
       transport: droppingLoopback(this.getServer(), this.active, this.onRemove),
     });
-    const session = await client.mount(spaceId, {}, () => ({
-      invocation: {},
-      authorization: { principal: sgnr?.did() },
-    }));
+    const session = await client.mount(
+      spaceId,
+      {},
+      testPrincipalSessionOpenAuthFactory(sgnr),
+    );
     return { client, session };
   }
 }
@@ -224,6 +229,7 @@ describe("list builtin resume container defer", () => {
           ?.principal;
         return typeof principal === "string" ? principal : undefined;
       },
+      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
     });
     sm1 = DroppingStorageManager.make(signer, server, () => false);
     sm2 = DroppingStorageManager.make(

--- a/packages/runner/test/list-resume-input-settle.test.ts
+++ b/packages/runner/test/list-resume-input-settle.test.ts
@@ -11,6 +11,10 @@ import {
 } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import {
+  TEST_MEMORY_SERVER_AUTH,
+  testPrincipalSessionOpenAuthFactory,
+} from "./memory-v2-test-utils.ts";
 
 // awaitInputThenSettle path in the list builtins (filter/flatMap/map).
 //
@@ -39,10 +43,11 @@ class F implements SessionFactory {
     const client = await MemoryV2Client.connect({
       transport: loopback(this.gs()),
     });
-    const session = await client.mount(id, {}, () => ({
-      invocation: {},
-      authorization: { principal: s?.did() },
-    }));
+    const session = await client.mount(
+      id,
+      {},
+      testPrincipalSessionOpenAuthFactory(s),
+    );
     return { client, session };
   }
 }
@@ -107,6 +112,7 @@ describe("list builtin resume input-settle", () => {
           ?.principal;
         return typeof principal === "string" ? principal : undefined;
       },
+      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
     });
   });
   afterEach(async () => {

--- a/packages/runner/test/list-resume-preserve.test.ts
+++ b/packages/runner/test/list-resume-preserve.test.ts
@@ -11,6 +11,10 @@ import {
 } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import {
+  TEST_MEMORY_SERVER_AUTH,
+  testPrincipalSessionOpenAuthFactory,
+} from "./memory-v2-test-utils.ts";
 
 // Resume preservation guard for the list builtins (filter/flatMap).
 //
@@ -87,10 +91,11 @@ class DelayingSessionFactory implements SessionFactory {
         this.onDelay,
       ),
     });
-    const session = await client.mount(spaceId, {}, () => ({
-      invocation: {},
-      authorization: { principal: sgnr?.did() },
-    }));
+    const session = await client.mount(
+      spaceId,
+      {},
+      testPrincipalSessionOpenAuthFactory(sgnr),
+    );
     return { client, session };
   }
 }
@@ -179,6 +184,7 @@ describe("list builtin resume preservation", () => {
           ?.principal;
         return typeof principal === "string" ? principal : undefined;
       },
+      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
     });
     sm1 = DelayingStorageManager.make(signer, server, 0, FILTER_CHILD_DOC);
     sm2 = DelayingStorageManager.make(
@@ -388,6 +394,7 @@ describe("flatMap builtin resume preservation", () => {
           ?.principal;
         return typeof principal === "string" ? principal : undefined;
       },
+      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
     });
     sm1 = DelayingStorageManager.make(signer, server, 0, FLATMAP_CHILD_DOC);
     sm2 = DelayingStorageManager.make(

--- a/packages/runner/test/list-shrink-converge.test.ts
+++ b/packages/runner/test/list-shrink-converge.test.ts
@@ -11,6 +11,10 @@ import {
 import type { Signer } from "@commonfabric/memory/interface";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import {
+  TEST_MEMORY_SERVER_AUTH,
+  testPrincipalSessionOpenAuthFactory,
+} from "./memory-v2-test-utils.ts";
 
 // Convergence guard for the list-builtin resume preservation.
 //
@@ -32,10 +36,11 @@ class F implements SessionFactory {
   constructor(private gs: () => MemoryV2Server.Server) {}
   async create(spaceId: string, sgnr?: Signer) {
     const client = await MemoryV2Client.connect({ transport: lb(this.gs()) });
-    const session = await client.mount(spaceId, {}, () => ({
-      invocation: {},
-      authorization: { principal: sgnr?.did() },
-    }));
+    const session = await client.mount(
+      spaceId,
+      {},
+      testPrincipalSessionOpenAuthFactory(sgnr),
+    );
     return { client, session };
   }
 }
@@ -58,6 +63,7 @@ function runtime() {
         ?.principal;
       return typeof principal === "string" ? principal : undefined;
     },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
   });
   const sm = SM.make(signer, server);
   const rt = new Runtime({

--- a/packages/runner/test/memory-v2-lazy-session.test.ts
+++ b/packages/runner/test/memory-v2-lazy-session.test.ts
@@ -6,7 +6,10 @@ import type { AppliedCommit } from "@commonfabric/memory/v2/engine";
 import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 import { type Options as V2StorageOptions } from "../src/storage/v2.ts";
 import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
-import { TestStorageManager } from "./memory-v2-test-utils.ts";
+import {
+  TEST_MEMORY_SERVER_AUTH,
+  TestStorageManager,
+} from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("memory-v2-lazy-session");
 const space = signer.did();
@@ -211,7 +214,7 @@ describe("Memory v2 lazy emulated server creation", () => {
       { as: signer },
       () => {
         serverCreates += 1;
-        return new MemoryV2Server.Server();
+        return new MemoryV2Server.Server(TEST_MEMORY_SERVER_AUTH);
       },
     );
 
@@ -248,7 +251,7 @@ describe("Memory v2 lazy emulated server creation", () => {
       { as: signer },
       () => {
         serverCreates += 1;
-        return new MemoryV2Server.Server();
+        return new MemoryV2Server.Server(TEST_MEMORY_SERVER_AUTH);
       },
     );
 

--- a/packages/runner/test/memory-v2-pull-reactivity.test.ts
+++ b/packages/runner/test/memory-v2-pull-reactivity.test.ts
@@ -10,6 +10,7 @@ import type { Action } from "../src/scheduler.ts";
 import type { URI } from "@commonfabric/memory/interface";
 import { createGraphFixture } from "./memory-v2-graph.fixture.ts";
 import { toMemorySpaceAddress } from "../src/link-utils.ts";
+import { testSessionOpenAuthFactory } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("memory-v2-pull-reactivity");
 const space = signer.did();
@@ -59,7 +60,11 @@ describe("Memory v2 pull reactivity", () => {
     remoteClient = await MemoryV2Client.connect({
       transport: MemoryV2Client.loopback(candidate.server()),
     });
-    remoteSession = await remoteClient.mount(space);
+    remoteSession = await remoteClient.mount(
+      space,
+      {},
+      testSessionOpenAuthFactory,
+    );
     remoteLocalSeq = 1;
   });
 

--- a/packages/runner/test/memory-v2-reconnect-race.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-race.test.ts
@@ -18,6 +18,10 @@ import type {
 import {
   NotificationRecorder,
   SingleSessionFactory,
+  TEST_HELLO_SESSION_OPEN,
+  TEST_MEMORY_SERVER_AUTH,
+  testSessionOpenAuthFactory,
+  testSessionOpenAuthMetadata,
   TestStorageManager,
 } from "./memory-v2-test-utils.ts";
 import { createGraphFixture } from "./memory-v2-graph.fixture.ts";
@@ -29,6 +33,7 @@ const HELLO_OK = {
   type: "hello.ok",
   protocol: "memory",
   flags: getMemoryProtocolFlags(),
+  sessionOpen: TEST_HELLO_SESSION_OPEN,
 } as const;
 
 type TestProvider = IStorageProviderWithReplica & {
@@ -124,6 +129,8 @@ class SabotagedReconnectTransport implements MemoryV2Client.Transport {
 class RejectThenSucceedTransport implements MemoryV2Client.Transport {
   #receiver: (payload: string) => void = () => {};
   #closeReceiver: (error?: Error) => void = () => {};
+  #sessionOpen = TEST_HELLO_SESSION_OPEN;
+  #sessionOpenCount = 0;
 
   setReceiver(receiver: (payload: string) => void): void {
     this.#receiver = receiver;
@@ -138,19 +145,35 @@ class RejectThenSucceedTransport implements MemoryV2Client.Transport {
       type: string;
       requestId?: string;
       commit?: { localSeq?: number };
+      invocation?: { aud?: unknown; challenge?: unknown };
     };
 
     switch (message.type) {
       case "hello":
-        this.#respond(HELLO_OK);
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          "reject-then-succeed-hello",
+        );
+        this.#respond({
+          ...HELLO_OK,
+          sessionOpen: this.#sessionOpen,
+        });
         return;
       case "session.open":
+        assertEquals(message.invocation?.aud, this.#sessionOpen.audience);
+        assertEquals(
+          message.invocation?.challenge,
+          this.#sessionOpen.challenge.value,
+        );
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          `reject-then-succeed-open-${++this.#sessionOpenCount}`,
+        );
         this.#respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
             sessionId: "session:reject-then-succeed",
             serverSeq: 0,
+            sessionOpen: this.#sessionOpen,
           },
         });
         return;
@@ -266,6 +289,7 @@ const visibleIds = (
 
 Deno.test("memory v2 runner does not integrate its own replayed commit after reconnect", async () => {
   const server = new MemoryV2Server.Server({
+    ...TEST_MEMORY_SERVER_AUTH,
     store: new URL(`memory://runner-v2-own-replay-${crypto.randomUUID()}`),
   });
   const transport = new SabotagedReconnectTransport(server, [1]);
@@ -278,7 +302,11 @@ Deno.test("memory v2 runner does not integrate its own replayed commit after rec
   const writerClient = await MemoryV2Client.connect({
     transport: MemoryV2Client.loopback(server),
   });
-  const writer = await writerClient.mount(space);
+  const writer = await writerClient.mount(
+    space,
+    {},
+    testSessionOpenAuthFactory,
+  );
   const provider = storageManager.open(space) as TestProvider;
   const localUri = `of:memory-v2-local-${crypto.randomUUID()}` as URI;
   const remoteUri = `of:memory-v2-remote-${crypto.randomUUID()}` as URI;
@@ -351,6 +379,7 @@ Deno.test("memory v2 runner does not integrate its own replayed commit after rec
 
 Deno.test("memory v2 runner deduplicates replayed stacked commits while integrating remote updates", async () => {
   const server = new MemoryV2Server.Server({
+    ...TEST_MEMORY_SERVER_AUTH,
     store: new URL(`memory://runner-v2-stacked-replay-${crypto.randomUUID()}`),
   });
   const transport = new SabotagedReconnectTransport(server, [1]);
@@ -363,7 +392,11 @@ Deno.test("memory v2 runner deduplicates replayed stacked commits while integrat
   const writerClient = await MemoryV2Client.connect({
     transport: MemoryV2Client.loopback(server),
   });
-  const writer = await writerClient.mount(space);
+  const writer = await writerClient.mount(
+    space,
+    {},
+    testSessionOpenAuthFactory,
+  );
   const provider = storageManager.open(space) as TestProvider;
   const localUri = `of:memory-v2-stacked-local-${crypto.randomUUID()}` as URI;
   const remoteUri = `of:memory-v2-stacked-remote-${crypto.randomUUID()}` as URI;
@@ -438,6 +471,7 @@ Deno.test("memory v2 runner deduplicates replayed stacked commits while integrat
 
 Deno.test("memory v2 runner restores watched graph state after reconnect and keeps retarget updates flowing", async () => {
   const server = new MemoryV2Server.Server({
+    ...TEST_MEMORY_SERVER_AUTH,
     store: new URL(`memory://runner-v2-watch-reconnect-${crypto.randomUUID()}`),
   });
   const transport = new SabotagedReconnectTransport(server);
@@ -450,7 +484,11 @@ Deno.test("memory v2 runner restores watched graph state after reconnect and kee
   const writerClient = await MemoryV2Client.connect({
     transport: MemoryV2Client.loopback(server),
   });
-  const writer = await writerClient.mount(space);
+  const writer = await writerClient.mount(
+    space,
+    {},
+    testSessionOpenAuthFactory,
+  );
   const provider = storageManager.open(space) as TestProvider;
   const fixture = createGraphFixture(space);
 
@@ -612,7 +650,11 @@ Deno.test("memory v2 runner can retry immediately after a conflict revert", asyn
     remoteClient = await MemoryV2Client.connect({
       transport: MemoryV2Client.loopback(candidate.server()),
     });
-    const remoteSession = await remoteClient.mount(space);
+    const remoteSession = await remoteClient.mount(
+      space,
+      {},
+      testSessionOpenAuthFactory,
+    );
     let remoteLocalSeq = 1;
 
     await provider.sync(uri);

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -41,6 +41,9 @@ import type {
 import {
   NotificationRecorder,
   SingleSessionFactory,
+  TEST_HELLO_SESSION_OPEN,
+  testSessionOpenAuthFactory,
+  testSessionOpenAuthMetadata,
   TestStorageManager,
 } from "./memory-v2-test-utils.ts";
 
@@ -51,6 +54,7 @@ const helloOk = () => ({
   type: "hello.ok",
   protocol: "memory",
   flags: getMemoryProtocolFlags(),
+  sessionOpen: TEST_HELLO_SESSION_OPEN,
 } as const);
 const testReconstructionContext = new EmptyReconstructionContext(
   true,
@@ -323,6 +327,8 @@ class ScriptedServerModel {
 class ScriptedModelTransport implements MemoryV2Client.Transport {
   #receiver: (payload: string) => void = () => {};
   #closeReceiver: (error?: Error) => void = () => {};
+  #sessionOpen = TEST_HELLO_SESSION_OPEN;
+  #sessionOpenCount = 0;
 
   constructor(readonly model: ScriptedServerModel) {}
 
@@ -342,21 +348,37 @@ class ScriptedModelTransport implements MemoryV2Client.Transport {
       type: string;
       requestId?: string;
       session?: { sessionId?: string };
+      invocation?: { aud?: unknown; challenge?: unknown };
       commit?: ClientCommit;
     };
 
     switch (message.type) {
       case "hello":
         this.model.connectionCount += 1;
-        this.respond(helloOk());
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          `stacked-hello-${this.model.connectionCount}`,
+        );
+        this.respond({
+          ...helloOk(),
+          sessionOpen: this.#sessionOpen,
+        });
         break;
       case "session.open":
+        assertEquals(message.invocation?.aud, this.#sessionOpen.audience);
+        assertEquals(
+          message.invocation?.challenge,
+          this.#sessionOpen.challenge.value,
+        );
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          `stacked-open-${++this.#sessionOpenCount}`,
+        );
         this.respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
             sessionId: message.session?.sessionId ?? this.model.sessionId,
             serverSeq: this.model.serverSeq,
+            sessionOpen: this.#sessionOpen,
           },
         });
         break;
@@ -1621,7 +1643,11 @@ Deno.test("memory v2 stacked commits: duplicate localSeq returns the same promis
   const transport = new ScriptedModelTransport(model);
   const client = await MemoryV2Client.connect({ transport });
   try {
-    const session = await client.mount(space);
+    const session = await client.mount(
+      space,
+      {},
+      testSessionOpenAuthFactory,
+    );
     model.setOutcome(1, { kind: "accept" });
     const commit: ClientCommit = {
       localSeq: 1,

--- a/packages/runner/test/memory-v2-subscription.test.ts
+++ b/packages/runner/test/memory-v2-subscription.test.ts
@@ -22,6 +22,7 @@ import type {
 import type { MIME, URI } from "@commonfabric/memory/interface";
 import type { SessionSync } from "@commonfabric/memory/v2";
 import { createGraphFixture } from "./memory-v2-graph.fixture.ts";
+import { testSessionOpenAuthFactory } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("memory-v2-storage-subscription");
 const space = signer.did();
@@ -162,7 +163,11 @@ describe("Memory v2 storage notifications", () => {
     remoteClient = await MemoryV2Client.connect({
       transport: MemoryV2Client.loopback(candidate.server()),
     });
-    remoteSession = await remoteClient.mount(space);
+    remoteSession = await remoteClient.mount(
+      space,
+      {},
+      testSessionOpenAuthFactory,
+    );
     remoteLocalSeq = 1;
   });
 

--- a/packages/runner/test/memory-v2-test-utils.ts
+++ b/packages/runner/test/memory-v2-test-utils.ts
@@ -1,4 +1,5 @@
-import type { MemorySpace } from "@commonfabric/memory/interface";
+import type { MemorySpace, Signer } from "@commonfabric/memory/interface";
+import type { SessionOpenAuthMetadata } from "@commonfabric/memory/v2";
 import * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import type {
   IStorageNotification,
@@ -9,6 +10,65 @@ import {
   type SessionFactory,
   StorageManager as V2StorageManager,
 } from "../src/storage/v2.ts";
+
+export const TEST_SESSION_OPEN_AUDIENCE =
+  "did:key:z6Mk-runner-memory-v2-test-audience";
+export const TEST_SESSION_OPEN_PRINCIPAL =
+  "did:key:z6Mk-runner-memory-v2-test-principal";
+export const TEST_SESSION_OPEN_CHALLENGE = {
+  value: "challenge:runner-memory-v2-test",
+  expiresAt: 1_000_000,
+} as const;
+export const testSessionOpenAuthMetadata = (
+  challengeId: string,
+): SessionOpenAuthMetadata => ({
+  audience: TEST_SESSION_OPEN_AUDIENCE,
+  challenge: {
+    value: `challenge:runner-memory-v2-test:${challengeId}`,
+    expiresAt: 1_000_000,
+  },
+});
+export const TEST_HELLO_SESSION_OPEN: SessionOpenAuthMetadata = {
+  audience: TEST_SESSION_OPEN_AUDIENCE,
+  challenge: TEST_SESSION_OPEN_CHALLENGE,
+};
+export const TEST_MEMORY_SERVER_AUTH = {
+  authorizeSessionOpen: () => TEST_SESSION_OPEN_PRINCIPAL,
+  sessionOpenAuth: {
+    audience: TEST_SESSION_OPEN_AUDIENCE,
+  },
+} as const;
+
+export const testSessionOpenAuthFactory: MemoryV2Client.SessionOpenAuthFactory =
+  (
+    _space,
+    _session,
+    context,
+  ) => ({
+    invocation: {
+      aud: context.audience,
+      challenge: context.challenge.value,
+    },
+    authorization: {},
+  });
+
+export function testPrincipalSessionOpenAuthFactory(
+  signer?: Signer,
+): MemoryV2Client.SessionOpenAuthFactory {
+  return (
+    _space,
+    _session,
+    context,
+  ) => ({
+    invocation: {
+      aud: context.audience,
+      challenge: context.challenge.value,
+    },
+    authorization: {
+      principal: signer?.did(),
+    },
+  });
+}
 
 export class NotificationRecorder implements IStorageNotification {
   notifications: StorageNotification[] = [];
@@ -35,7 +95,7 @@ export class SingleSessionFactory implements SessionFactory {
     const client = await MemoryV2Client.connect({
       transport: this.transport,
     });
-    const session = await client.mount(space);
+    const session = await client.mount(space, {}, testSessionOpenAuthFactory);
     this.client = client;
     return { client, session };
   }

--- a/packages/runner/test/memory-v2-watch-refresh-race.test.ts
+++ b/packages/runner/test/memory-v2-watch-refresh-race.test.ts
@@ -15,6 +15,8 @@ import {
 import type { IStorageProviderWithReplica } from "../src/storage/interface.ts";
 import {
   SingleSessionFactory,
+  TEST_HELLO_SESSION_OPEN,
+  testSessionOpenAuthMetadata,
   TestStorageManager,
 } from "./memory-v2-test-utils.ts";
 
@@ -24,6 +26,7 @@ const HELLO_OK = {
   type: "hello.ok",
   protocol: "memory",
   flags: getMemoryProtocolFlags(),
+  sessionOpen: TEST_HELLO_SESSION_OPEN,
 } as const;
 
 type TestProvider = IStorageProviderWithReplica & {
@@ -40,6 +43,8 @@ class CountingWatchSetTransport implements MemoryV2Client.Transport {
   watchSetCount = 0;
   watchAddCount = 0;
   rootCounts: number[] = [];
+  #sessionOpen = TEST_HELLO_SESSION_OPEN;
+  #sessionOpenCount = 0;
 
   setReceiver(receiver: (payload: string) => void): void {
     this.#receiver = receiver;
@@ -53,6 +58,7 @@ class CountingWatchSetTransport implements MemoryV2Client.Transport {
     const message = decodeMemoryBoundary(payload) as {
       type: string;
       requestId?: string;
+      invocation?: { aud?: unknown; challenge?: unknown };
       watches?: Array<{
         query?: { roots?: Array<{ id: string }> };
       }>;
@@ -60,15 +66,30 @@ class CountingWatchSetTransport implements MemoryV2Client.Transport {
 
     switch (message.type) {
       case "hello":
-        this.#respond(HELLO_OK);
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          "watch-refresh-batch-hello",
+        );
+        this.#respond({
+          ...HELLO_OK,
+          sessionOpen: this.#sessionOpen,
+        });
         return Promise.resolve();
       case "session.open":
+        assertEquals(message.invocation?.aud, this.#sessionOpen.audience);
+        assertEquals(
+          message.invocation?.challenge,
+          this.#sessionOpen.challenge.value,
+        );
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          `watch-refresh-batch-open-${++this.#sessionOpenCount}`,
+        );
         this.#respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
             sessionId: "session:watch-refresh-batch",
             serverSeq: 0,
+            sessionOpen: this.#sessionOpen,
           },
         });
         return Promise.resolve();
@@ -134,6 +155,8 @@ class DelayedWatchAddTransport implements MemoryV2Client.Transport {
   >();
   watchAddCount = 0;
   rootCounts: number[] = [];
+  #sessionOpen = TEST_HELLO_SESSION_OPEN;
+  #sessionOpenCount = 0;
 
   setReceiver(receiver: (payload: string) => void): void {
     this.#receiver = receiver;
@@ -147,6 +170,7 @@ class DelayedWatchAddTransport implements MemoryV2Client.Transport {
     const message = decodeMemoryBoundary(payload) as {
       type: string;
       requestId?: string;
+      invocation?: { aud?: unknown; challenge?: unknown };
       watches?: Array<{
         query?: { roots?: Array<{ id: string }> };
       }>;
@@ -154,15 +178,30 @@ class DelayedWatchAddTransport implements MemoryV2Client.Transport {
 
     switch (message.type) {
       case "hello":
-        this.#respond(HELLO_OK);
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          "delayed-watch-add-hello",
+        );
+        this.#respond({
+          ...HELLO_OK,
+          sessionOpen: this.#sessionOpen,
+        });
         return Promise.resolve();
       case "session.open":
+        assertEquals(message.invocation?.aud, this.#sessionOpen.audience);
+        assertEquals(
+          message.invocation?.challenge,
+          this.#sessionOpen.challenge.value,
+        );
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          `delayed-watch-add-open-${++this.#sessionOpenCount}`,
+        );
         this.#respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
             sessionId: "session:delayed-watch-add",
             serverSeq: 0,
+            sessionOpen: this.#sessionOpen,
           },
         });
         return Promise.resolve();
@@ -233,6 +272,8 @@ class IncrementalEffectTransport implements MemoryV2Client.Transport {
   #closeReceiver: (error?: Error) => void = () => {};
   readonly #sessionId = "session:incremental-effect";
   readonly #space = space;
+  #sessionOpen = TEST_HELLO_SESSION_OPEN;
+  #sessionOpenCount = 0;
 
   constructor(
     private readonly docs: Map<URI, SessionSyncUpsert["doc"]>,
@@ -250,6 +291,7 @@ class IncrementalEffectTransport implements MemoryV2Client.Transport {
     const message = decodeMemoryBoundary(payload) as {
       type: string;
       requestId?: string;
+      invocation?: { aud?: unknown; challenge?: unknown };
       watches?: Array<{
         query?: { roots?: Array<{ id: string }> };
       }>;
@@ -257,15 +299,30 @@ class IncrementalEffectTransport implements MemoryV2Client.Transport {
 
     switch (message.type) {
       case "hello":
-        this.#respond(HELLO_OK);
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          "incremental-effect-hello",
+        );
+        this.#respond({
+          ...HELLO_OK,
+          sessionOpen: this.#sessionOpen,
+        });
         return Promise.resolve();
       case "session.open":
+        assertEquals(message.invocation?.aud, this.#sessionOpen.audience);
+        assertEquals(
+          message.invocation?.challenge,
+          this.#sessionOpen.challenge.value,
+        );
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          `incremental-effect-open-${++this.#sessionOpenCount}`,
+        );
         this.#respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
             sessionId: this.#sessionId,
             serverSeq: 0,
+            sessionOpen: this.#sessionOpen,
           },
         });
         return Promise.resolve();

--- a/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
+++ b/packages/runner/test/memory-v2-watch-remove-coverage.test.ts
@@ -21,6 +21,8 @@ import {
 import type { IStorageProviderWithReplica } from "../src/storage/interface.ts";
 import {
   SingleSessionFactory,
+  TEST_HELLO_SESSION_OPEN,
+  testSessionOpenAuthMetadata,
   TestStorageManager,
 } from "./memory-v2-test-utils.ts";
 
@@ -30,6 +32,7 @@ const HELLO_OK = {
   type: "hello.ok",
   protocol: "memory",
   flags: getMemoryProtocolFlags(),
+  sessionOpen: TEST_HELLO_SESSION_OPEN,
 } as const;
 
 type TestProvider = IStorageProviderWithReplica & {
@@ -67,6 +70,8 @@ const getObjectValue = (
 class WatchAddRemoveTransport implements MemoryV2Client.Transport {
   #receiver: (payload: string) => void = () => {};
   #closeReceiver: (error?: Error) => void = () => {};
+  #sessionOpen = TEST_HELLO_SESSION_OPEN;
+  #sessionOpenCount = 0;
 
   constructor(private readonly removedId: URI) {}
 
@@ -82,6 +87,7 @@ class WatchAddRemoveTransport implements MemoryV2Client.Transport {
     const message = decodeMemoryBoundary(payload) as {
       type: string;
       requestId?: string;
+      invocation?: { aud?: unknown; challenge?: unknown };
       watches?: Array<{
         query?: { roots?: Array<{ id: string }> };
       }>;
@@ -89,15 +95,30 @@ class WatchAddRemoveTransport implements MemoryV2Client.Transport {
 
     switch (message.type) {
       case "hello":
-        this.#respond(HELLO_OK);
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          "watch-remove-coverage-hello",
+        );
+        this.#respond({
+          ...HELLO_OK,
+          sessionOpen: this.#sessionOpen,
+        });
         return Promise.resolve();
       case "session.open":
+        assertEquals(message.invocation?.aud, this.#sessionOpen.audience);
+        assertEquals(
+          message.invocation?.challenge,
+          this.#sessionOpen.challenge.value,
+        );
+        this.#sessionOpen = testSessionOpenAuthMetadata(
+          `watch-remove-coverage-open-${++this.#sessionOpenCount}`,
+        );
         this.#respond({
           type: "response",
           requestId: message.requestId!,
           ok: {
             sessionId: "session:watch-remove-coverage",
             serverSeq: 0,
+            sessionOpen: this.#sessionOpen,
           },
         });
         return Promise.resolve();

--- a/packages/runner/test/profile-create-real-card-add.test.ts
+++ b/packages/runner/test/profile-create-real-card-add.test.ts
@@ -8,6 +8,7 @@ import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
 import type { Options } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 // GOLD-STANDARD end-to-end repro of the profile card-add flow using the REAL
 // shipped patterns (profile-create.tsx + profile-home.tsx) — no synthetic
@@ -50,6 +51,7 @@ const newSharedServer = () =>
         ?.principal;
       return typeof principal === "string" ? principal : undefined;
     },
+    sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
   });
 
 const sysDir = fromFileUrl(

--- a/packages/runner/test/rehydrate-internal-default.test.ts
+++ b/packages/runner/test/rehydrate-internal-default.test.ts
@@ -10,6 +10,7 @@ import { trustExecutable } from "./support/trusted-builder.ts";
 import { JSONValue } from "@commonfabric/runner/shared";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { isPrimitiveCellLink } from "../src/link-types.ts";
+import { TEST_MEMORY_SERVER_AUTH } from "./memory-v2-test-utils.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -116,6 +117,7 @@ describe("rehydrate internal default (CT-1666)", () => {
           ?.principal;
         return typeof principal === "string" ? principal : undefined;
       },
+      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
     });
     sm1 = new SharedServerStorageManager(signer, server);
     sm2 = new SharedServerStorageManager(signer, server);

--- a/packages/runner/test/resume-owned-cells.test.ts
+++ b/packages/runner/test/resume-owned-cells.test.ts
@@ -12,6 +12,10 @@ import {
 import { Runtime } from "../src/runtime.ts";
 import type { Cell } from "../src/cell.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import {
+  TEST_MEMORY_SERVER_AUTH,
+  testPrincipalSessionOpenAuthFactory,
+} from "./memory-v2-test-utils.ts";
 
 // Resume owned-cell pre-sync for a pattern with a static nested sub-pattern node.
 //
@@ -44,10 +48,11 @@ class LoopbackSessionFactory implements SessionFactory {
     const client = await MemoryV2Client.connect({
       transport: plainLoopback(this.getServer()),
     });
-    const session = await client.mount(spaceId, {}, () => ({
-      invocation: {},
-      authorization: { principal: sgnr?.did() },
-    }));
+    const session = await client.mount(
+      spaceId,
+      {},
+      testPrincipalSessionOpenAuthFactory(sgnr),
+    );
     return { client, session };
   }
 }
@@ -128,6 +133,7 @@ describe("resume owned-cell pre-sync", () => {
           ?.principal;
         return typeof principal === "string" ? principal : undefined;
       },
+      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
     });
     sm1 = LoopbackStorageManager.make(signer, server);
     sm2 = LoopbackStorageManager.make(signer, server);
@@ -293,6 +299,7 @@ describe("resume owned-cell walk cycle-detection key", () => {
           ?.principal;
         return typeof principal === "string" ? principal : undefined;
       },
+      sessionOpenAuth: TEST_MEMORY_SERVER_AUTH.sessionOpenAuth,
     });
     keySm = LoopbackStorageManager.make(signer, keyServer);
     rt = new Runtime({

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -27,6 +27,7 @@ import { parseLink } from "../../runner/src/link-utils.ts";
 const cfcSigner = await Identity.fromPassphrase(
   "runtime-processor-cfc-label-tests",
 );
+const testSessionOpenAudience = "did:key:z6Mk-runtime-processor-test-audience";
 
 class SharedV2SessionFactory implements V2Storage.SessionFactory {
   constructor(private readonly server: MemoryV2Server.Server) {}
@@ -35,7 +36,19 @@ class SharedV2SessionFactory implements V2Storage.SessionFactory {
     const client = await MemoryV2Client.connect({
       transport: MemoryV2Client.loopback(this.server),
     });
-    const session = await client.mount(space);
+    const session = await client.mount(
+      space,
+      {},
+      (_space, _session, context) => ({
+        invocation: {
+          aud: context.audience,
+          challenge: context.challenge.value,
+        },
+        authorization: {
+          principal: cfcSigner.did(),
+        },
+      }),
+    );
     return { client, session };
   }
 }
@@ -47,7 +60,16 @@ class SharedV2StorageManager extends V2Storage.StorageManager {
 }
 
 const createRuntime = () => {
-  const server = new MemoryV2Server.Server();
+  const server = new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+    sessionOpenAuth: {
+      audience: testSessionOpenAudience,
+    },
+  });
   const storageManager = new SharedV2StorageManager({
     as: cfcSigner,
     memoryHost: new URL("memory://"),

--- a/packages/toolshed/routes/storage/memory.ts
+++ b/packages/toolshed/routes/storage/memory.ts
@@ -4,14 +4,17 @@ import * as FS from "@std/fs";
 import * as Path from "@std/path";
 import env from "@/env.ts";
 import { resolveMemoryEngineStoreRootUrl } from "./memory-path.ts";
+import { identity } from "@/lib/identity.ts";
 
-// Session.open verification is shared with the standalone server — see
-// @commonfabric/memory/v2/session-open-auth. Audience binding is opt-in; the
-// toolshed does not yet configure an audience identity (federation PR5 design
-// doc), so this enforces signature + expiry today.
+const memoryAudience = identity.did();
+
+// Session.open verification is shared with the standalone server. Toolshed
+// requires the signed invocation to carry its audience DID and the challenge
+// issued to this WebSocket connection.
 const authorizeSessionOpen = (
   message: Parameters<typeof verifySessionOpenAuthorization>[0],
-): Promise<string> => verifySessionOpenAuthorization(message);
+  context: Parameters<typeof verifySessionOpenAuthorization>[1],
+): Promise<string> => verifySessionOpenAuthorization(message, context);
 
 // Determine store URL: DB_PATH (single-file mode) or MEMORY_DIR (directory mode)
 let storeUrl: URL;
@@ -34,6 +37,9 @@ await FS.ensureDir(memoryEngineStoreUrl);
 export const memoryServer = new MemoryServer.Server({
   store: memoryEngineStoreUrl,
   authorizeSessionOpen,
+  sessionOpenAuth: {
+    audience: memoryAudience,
+  },
   acl: {
     mode: env.MEMORY_ACL_MODE,
     serviceDids: env.MEMORY_SERVICE_DIDS

--- a/packages/toolshed/routes/storage/memory/memory.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.test.ts
@@ -7,6 +7,7 @@ import {
   encodeMemoryBoundary,
   getMemoryProtocolFlags,
   MEMORY_PROTOCOL,
+  type SessionOpenChallenge,
 } from "@commonfabric/memory/v2";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
@@ -19,6 +20,16 @@ const HELLO = {
   protocol: MEMORY_PROTOCOL,
   flags: getMemoryProtocolFlags(),
 } as const;
+
+type HelloOkWithSessionOpen = {
+  type: "hello.ok";
+  protocol: string;
+  flags: ReturnType<typeof getMemoryProtocolFlags>;
+  sessionOpen: {
+    audience: string;
+    challenge: SessionOpenChallenge;
+  };
+};
 
 const openSocket = async (url: URL): Promise<WebSocket> => {
   const socket = new WebSocket(url);
@@ -33,15 +44,34 @@ const createSessionOpenAuth = async (
   identity: Identity,
   space: string,
   session: { sessionId?: string; seenSeq?: number } = {},
+  sessionOpen: {
+    audience?: string;
+    challenge?: SessionOpenChallenge;
+  },
+  overrides: {
+    audience?: string | null;
+    challenge?: string | null;
+  } = {},
 ) => {
+  const iat = Math.floor(Date.now() / 1000);
+  const audience = overrides.audience ?? sessionOpen.audience;
+  const challenge = overrides.challenge ?? sessionOpen.challenge?.value;
   const invocation = {
     iss: identity.did(),
     cmd: "session.open",
     sub: space,
+    ...(overrides.audience === null || audience === undefined ? {} : {
+      aud: audience,
+    }),
     args: {
       protocol: MEMORY_PROTOCOL,
       session,
     },
+    ...(overrides.challenge === null || challenge === undefined ? {} : {
+      challenge,
+    }),
+    iat,
+    exp: iat + 300,
   };
   const signature = await identity.sign(hashOf(invocation).bytes);
   if (signature.error) {
@@ -291,17 +321,20 @@ serialTest("memory websocket negotiates a session", async () => {
     const socket = await openSocket(address);
     socket.send(encodeMemoryBoundary(HELLO));
 
-    const message = await readJsonMessage<{
-      type: "hello.ok";
-      protocol: string;
-      flags: ReturnType<typeof getMemoryProtocolFlags>;
-    }>(socket);
+    const message = await readJsonMessage<HelloOkWithSessionOpen>(socket);
 
     assertEquals(message.type, "hello.ok");
     assertEquals(message.protocol, MEMORY_PROTOCOL);
     assertEquals(message.flags, getMemoryProtocolFlags());
+    assert(message.sessionOpen.audience.length > 0);
+    assert(message.sessionOpen.challenge.value.length > 0);
 
-    const auth = await createSessionOpenAuth(identity, space);
+    const auth = await createSessionOpenAuth(
+      identity,
+      space,
+      {},
+      message.sessionOpen,
+    );
     socket.send(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",
@@ -362,6 +395,235 @@ serialTest("memory websocket rejects an unsigned session open", async () => {
   }
 });
 
+serialTest("memory websocket rejects a missing challenge", async () => {
+  const identity = await Identity.fromPassphrase(
+    "memory-route-missing-challenge",
+  );
+  const server = Deno.serve({ port: 0 }, app.fetch);
+  const address = new URL(
+    `ws://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
+  );
+  let socket: WebSocket | undefined;
+
+  try {
+    socket = await openSocket(address);
+    socket.send(encodeMemoryBoundary(HELLO));
+    const hello = await readJsonMessage<HelloOkWithSessionOpen>(socket);
+    const auth = await createSessionOpenAuth(
+      identity,
+      identity.did(),
+      {},
+      hello.sessionOpen,
+      { challenge: null },
+    );
+
+    socket.send(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-1",
+      space: identity.did(),
+      session: {},
+      ...auth,
+    }));
+
+    const message = await readJsonMessage<{
+      type: "response";
+      requestId: string;
+      error: { name: string; message: string };
+    }>(socket);
+    assertEquals(message.requestId, "open-1");
+    assertEquals(message.error.name, "AuthorizationError");
+    assert(message.error.message.includes("challenge"));
+  } finally {
+    socket?.close();
+    await server.shutdown();
+  }
+});
+
+serialTest("memory websocket rejects a mismatched challenge", async () => {
+  const identity = await Identity.fromPassphrase(
+    "memory-route-wrong-challenge",
+  );
+  const server = Deno.serve({ port: 0 }, app.fetch);
+  const address = new URL(
+    `ws://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
+  );
+  let socket: WebSocket | undefined;
+
+  try {
+    socket = await openSocket(address);
+    socket.send(encodeMemoryBoundary(HELLO));
+    const hello = await readJsonMessage<HelloOkWithSessionOpen>(socket);
+    const auth = await createSessionOpenAuth(
+      identity,
+      identity.did(),
+      {},
+      hello.sessionOpen,
+      { challenge: "challenge:wrong" },
+    );
+
+    socket.send(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-1",
+      space: identity.did(),
+      session: {},
+      ...auth,
+    }));
+
+    const message = await readJsonMessage<{
+      type: "response";
+      requestId: string;
+      error: { name: string; message: string };
+    }>(socket);
+    assertEquals(message.requestId, "open-1");
+    assertEquals(message.error.name, "AuthorizationError");
+    assert(message.error.message.includes("challenge"));
+  } finally {
+    socket?.close();
+    await server.shutdown();
+  }
+});
+
+serialTest("memory websocket rejects a missing audience", async () => {
+  const identity = await Identity.fromPassphrase(
+    "memory-route-missing-audience",
+  );
+  const server = Deno.serve({ port: 0 }, app.fetch);
+  const address = new URL(
+    `ws://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
+  );
+  let socket: WebSocket | undefined;
+
+  try {
+    socket = await openSocket(address);
+    socket.send(encodeMemoryBoundary(HELLO));
+    const hello = await readJsonMessage<HelloOkWithSessionOpen>(socket);
+    const auth = await createSessionOpenAuth(
+      identity,
+      identity.did(),
+      {},
+      hello.sessionOpen,
+      { audience: null },
+    );
+
+    socket.send(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-1",
+      space: identity.did(),
+      session: {},
+      ...auth,
+    }));
+
+    const message = await readJsonMessage<{
+      type: "response";
+      requestId: string;
+      error: { name: string; message: string };
+    }>(socket);
+    assertEquals(message.requestId, "open-1");
+    assertEquals(message.error.name, "AuthorizationError");
+    assert(message.error.message.includes("audience"));
+  } finally {
+    socket?.close();
+    await server.shutdown();
+  }
+});
+
+serialTest("memory websocket rejects a mismatched audience", async () => {
+  const identity = await Identity.fromPassphrase("memory-route-wrong-audience");
+  const server = Deno.serve({ port: 0 }, app.fetch);
+  const address = new URL(
+    `ws://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
+  );
+  let socket: WebSocket | undefined;
+
+  try {
+    socket = await openSocket(address);
+    socket.send(encodeMemoryBoundary(HELLO));
+    const hello = await readJsonMessage<HelloOkWithSessionOpen>(socket);
+    const auth = await createSessionOpenAuth(
+      identity,
+      identity.did(),
+      {},
+      hello.sessionOpen,
+      { audience: "did:key:z6Mk-memory-route-wrong-audience" },
+    );
+
+    socket.send(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-1",
+      space: identity.did(),
+      session: {},
+      ...auth,
+    }));
+
+    const message = await readJsonMessage<{
+      type: "response";
+      requestId: string;
+      error: { name: string; message: string };
+    }>(socket);
+    assertEquals(message.requestId, "open-1");
+    assertEquals(message.error.name, "AuthorizationError");
+    assert(message.error.message.includes("audience"));
+  } finally {
+    socket?.close();
+    await server.shutdown();
+  }
+});
+
+serialTest("memory websocket rejects a reused challenge", async () => {
+  const identity = await Identity.fromPassphrase("memory-route-reused");
+  const server = Deno.serve({ port: 0 }, app.fetch);
+  const address = new URL(
+    `ws://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
+  );
+  let socket: WebSocket | undefined;
+
+  try {
+    socket = await openSocket(address);
+    socket.send(encodeMemoryBoundary(HELLO));
+    const hello = await readJsonMessage<HelloOkWithSessionOpen>(socket);
+    const auth = await createSessionOpenAuth(
+      identity,
+      identity.did(),
+      {},
+      hello.sessionOpen,
+    );
+
+    socket.send(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-1",
+      space: identity.did(),
+      session: {},
+      ...auth,
+    }));
+    const opened = await readJsonMessage<{
+      type: "response";
+      requestId: string;
+      ok: { sessionId: string; serverSeq: number };
+    }>(socket);
+    assertEquals(opened.requestId, "open-1");
+    assert(opened.ok.sessionId.length > 0);
+
+    socket.send(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "open-2",
+      space: identity.did(),
+      session: {},
+      ...auth,
+    }));
+    const replay = await readJsonMessage<{
+      type: "response";
+      requestId: string;
+      error: { name: string; message: string };
+    }>(socket);
+    assertEquals(replay.requestId, "open-2");
+    assertEquals(replay.error.name, "AuthorizationError");
+    assert(replay.error.message.includes("challenge"));
+  } finally {
+    socket?.close();
+    await server.shutdown();
+  }
+});
+
 serialTest("memory websocket resumes a requested session id", async () => {
   const identity = await Identity.fromPassphrase("memory-route-resume-auth");
   const server = Deno.serve({ port: 0 }, app.fetch);
@@ -374,12 +636,12 @@ serialTest("memory websocket resumes a requested session id", async () => {
     const socket = await openSocket(address);
     socket.send(encodeMemoryBoundary(HELLO));
 
-    await readJsonMessage(socket);
+    const hello = await readJsonMessage<HelloOkWithSessionOpen>(socket);
 
     const auth = await createSessionOpenAuth(identity, space, {
       sessionId: "session:test-resume",
       seenSeq: 7,
-    });
+    }, hello.sessionOpen);
     socket.send(encodeMemoryBoundary({
       type: "session.open",
       requestId: "open-1",


### PR DESCRIPTION
A signed memory session.open previously proved the signer, but it did not prove that the signed open was fresh or intended for the specific memory host that received it. That left the protected WebSocket path relying on expiry alone for replay resistance, and audience checks could be skipped when a server did not advertise an identity.

This change adds sessionOpen metadata to the WebSocket hello.ok response. Protected memory hosts advertise an audience DID and a connection-scoped challenge. The challenge is generated from 32 cryptographically random bytes, encoded as hex, and given a short expiry. Clients require both fields, sign the audience and challenge into session.open, and use the rotated challenge returned after each successful open. Servers reject missing, mismatched, expired, or already used challenges, and reject missing or mismatched audiences when an audience is configured.

Toolshed uses its service identity DID as the memory audience. The standalone memory host uses a stable deterministic audience DID. The runner remote and emulated memory clients include the advertised audience and challenge in the signed invocation. Tests cover valid opens, missing and wrong challenge values, expired and reused challenges, missing and wrong audiences, valid audiences, and existing session behavior after authentication. The memory-v2 protocol spec now documents the current handshake, what the challenge and audience protect against, the TLS assumption for remote deployments, and the remaining relay-attack risk.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make challenged, audience-bound session.open required for all memory v2 connections. Harden the hello handshake so the client rejects malformed sessionOpen metadata instead of hanging.

- **New Features**
  - `hello.ok` always includes `sessionOpen: { audience, challenge: { value, expiresAt } }`; challenge is single‑use with ~5‑minute TTL and rotates on hello and after each successful open. Clients reject missing/malformed metadata; `SessionOpenResult.sessionOpen` echoes it.
  - Client: `SessionOpenAuthFactory(space, session, context)` now receives `{ audience, challenge }` and must sign `aud`, `challenge`, `iat`, `exp`.
  - Server: `sessionOpenAuth` (with `audience`) and `authorizeSessionOpen` are required. The verifier enforces audience and challenge binding, expiry, freshness, and single‑use.
  - `toolshed` uses its service DID as the audience; the standalone host advertises a stable deterministic audience. `@commonfabric/runner` remote/emulated clients sign the advertised fields.
  - Client fix: validate `hello.ok` sessionOpen metadata and fail the handshake on errors to avoid unresolved connects.

- **Migration**
  - Servers: configure `sessionOpenAuth: { audience }` and `authorizeSessionOpen` (challenge is required).
  - Clients: update `SessionOpenAuthFactory` to accept the `context` argument and sign `aud`, `challenge`, `iat`, and `exp` (e.g., 5‑minute TTL).

<sup>Written for commit a4af08f16bd511613400b8e6813ce4daabe73b9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

