### PR TITLE
refactor(runner): one exponential backoff curve, no immediate-retry c…

### DIFF
--- a/docs/development/committed-write-backpressure.md
+++ b/docs/development/committed-write-backpressure.md
@@ -56,22 +56,23 @@ The event-handler commit path classifies each commit result and acts on it
 (`packages/runner/src/scheduler/events.ts`, `classifyCommitDisposition`):
 
 - **Success** — done.
-- **Stale-basis `ConflictError`** — the backpressure path. A stale-basis conflict
-  usually clears the instant the fresh confirmed state arrives, so the first
-  `immediateRetries` retries (default 5) fire with no delay — the fast path the
-  runtime had before backoff existed, where a transient conflict converges within
-  a few rapid retries. This matters: the harness and the UI settle by waiting for
-  the event queue to drain, so spacing out a retry that would have cleared
-  immediately can keep a write from converging within a settle. Only once the
-  immediate retries are exhausted (sustained contention) does the event re-queue
-  parked via the existing `notBefore` mechanism with a capped exponential backoff
-  plus jitter (`scheduler/backpressure.ts`, `computeBackoffDelayMs`). Backoff
-  makes the scheduler slow down under contention instead of busy-looping; jitter
-  keeps concurrent writers contending for the same entity from retrying in
-  lockstep. The event keeps retrying for a bounded window (default 30 seconds),
-  measured from the first conflict, which is long enough to outlast a rehydration
-  burst. `idle()` and `settled()` already wait for a parked head event, so a write
-  that converges still completes within a settle.
+- **Stale-basis `ConflictError`** — the backpressure path. The event is re-queued
+  parked via the existing `notBefore` mechanism with a single capped exponential
+  backoff plus jitter (`scheduler/backpressure.ts`, `computeBackoffDelayMs`). The
+  curve is deliberately near-immediate at the start: the default `baseDelayMs` is
+  25/32 ms, so the first few delays are 0.78, 1.56, 3.125 ms — effectively
+  immediate. A stale-basis conflict usually clears the instant the fresh confirmed
+  state arrives, and these sub-5ms delays let it converge within a settle (the
+  harness and the UI settle by waiting for the event queue to drain, so a retry
+  that would have cleared immediately must not be spaced out). The delay only
+  grows into real spacing once a conflict persists: it reaches 25ms before the
+  seventh attempt and doubles to a 1-second cap. Backoff makes the scheduler slow
+  down under sustained contention instead of busy-looping; jitter keeps concurrent
+  writers contending for the same entity from retrying in lockstep. The event
+  keeps retrying for a bounded window (default 30 seconds), measured from the
+  first conflict, which is long enough to outlast a rehydration burst. `idle()`
+  and `settled()` already wait for a parked head event, so a write that converges
+  still completes within a settle.
 - **Window elapsed without converging** — a terminal `CommitConvergenceError` is
   surfaced through the scheduler error channel (`scheduler.onError`). The write
   fails loudly rather than disappearing. This is the bounded-resource backstop:
@@ -131,8 +132,7 @@ count no longer bounds conflict retries; the window does.
 
 `RuntimeOptions.commitBackpressure` tunes the policy
 (`scheduler/backpressure.ts`, `CommitBackpressurePolicy`): `baseDelayMs`,
-`maxDelayMs`, `jitter`, `retryWindowMs`, `immediateRetries`. Unset fields fall
-back to
+`maxDelayMs`, `jitter`, `retryWindowMs`. Unset fields fall back to
 `DEFAULT_COMMIT_BACKPRESSURE` and every field is clamped to a well-defined range
 (non-negative delays, a cap no lower than the base delay, jitter within [0, 1], a
 non-negative window). The clamps only keep the arithmetic sane; the

--- a/packages/runner/src/scheduler/backpressure.ts
+++ b/packages/runner/src/scheduler/backpressure.ts
@@ -20,7 +20,12 @@
  * surfaces as a terminal error rather than vanishing.
  */
 export interface CommitBackpressurePolicy {
-  /** Delay before the first retry, in milliseconds. */
+  /**
+   * Delay before the first retry, in milliseconds. Small by default so the
+   * first few retries are near-immediate — a stale-basis conflict usually
+   * clears as soon as the fresh confirmed state arrives, and the exponential
+   * curve only grows into real spacing once a conflict persists.
+   */
   baseDelayMs: number;
   /** Ceiling on the per-retry delay, in milliseconds. */
   maxDelayMs: number;
@@ -37,24 +42,18 @@ export interface CommitBackpressurePolicy {
    * conflict for a given intent.
    */
   retryWindowMs: number;
-  /**
-   * Number of conflict retries attempted with no delay before backoff begins.
-   * A stale-basis conflict usually clears as soon as the fresh confirmed state
-   * arrives, so the first few retries fire immediately — the fast path the
-   * runtime had before backoff existed. Backoff (and its delays) only kick in
-   * once these immediate retries are exhausted, i.e. under sustained
-   * contention, where spacing retries out is what keeps the scheduler from
-   * busy-looping.
-   */
-  immediateRetries: number;
 }
 
+// baseDelayMs is 25/32: the exponential reaches 25ms at the sixth step (the
+// park before the seventh attempt) and then continues 50, 100, 200, 400, 800,
+// 1000 (capped). The first retries — 0.78, 1.56, 3.125ms — are sub-5ms and so
+// effectively immediate, which is what lets a transient conflict converge fast,
+// without a separate immediate-retry count.
 export const DEFAULT_COMMIT_BACKPRESSURE: CommitBackpressurePolicy = {
-  baseDelayMs: 25,
+  baseDelayMs: 25 / 32,
   maxDelayMs: 1_000,
   jitter: 0.5,
   retryWindowMs: 30_000,
-  immediateRetries: 5,
 };
 
 /**
@@ -76,8 +75,7 @@ export function resolveCommitBackpressure(
   const maxDelayMs = Math.max(baseDelayMs, merged.maxDelayMs);
   const jitter = Math.min(1, Math.max(0, merged.jitter));
   const retryWindowMs = Math.max(0, merged.retryWindowMs);
-  const immediateRetries = Math.max(0, Math.floor(merged.immediateRetries));
-  return { baseDelayMs, maxDelayMs, jitter, retryWindowMs, immediateRetries };
+  return { baseDelayMs, maxDelayMs, jitter, retryWindowMs };
 }
 
 /**

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -573,7 +573,6 @@ export async function dispatchQueuedEvent(state: {
     attempts: number,
     deadline: number,
     runAt: number,
-    delayMs: number,
   ) => {
     const retry: QueuedEvent = {
       id: queuedEvent.id,
@@ -586,10 +585,7 @@ export async function dispatchQueuedEvent(state: {
       onCommit,
       conflictAttempts: attempts,
       conflictDeadline: deadline,
-      // An immediate retry (delayMs 0) is not parked: it re-runs on the next
-      // execute cycle like the pre-backpressure fast path. Only a delayed retry
-      // sets notBefore to hold the head until its timer fires.
-      ...(delayMs > 0 ? { notBefore: runAt } : {}),
+      notBefore: runAt,
     };
     state.eventQueue.unshift(retry);
     if (retry.originTx !== undefined) {
@@ -728,19 +724,15 @@ export async function dispatchQueuedEvent(state: {
         case "backoff":
           logger.warn(
             "scheduler",
-            disposition.delayMs > 0
-              ? `Event handler commit conflicted; backing off ` +
-                `${Math.round(disposition.delayMs)}ms ` +
-                `(attempt ${disposition.attempts})`
-              : `Event handler commit conflicted; retrying immediately ` +
-                `(attempt ${disposition.attempts})`,
+            `Event handler commit conflicted; backing off ` +
+              `${Math.round(disposition.delayMs)}ms ` +
+              `(attempt ${disposition.attempts})`,
             { handlerId },
           );
           requeueForBackoff(
             disposition.attempts,
             disposition.deadline,
             disposition.runAt,
-            disposition.delayMs,
           );
           return;
         case "permanent":
@@ -908,13 +900,10 @@ function classifyCommitDisposition(
     const elapsedMs = policy.retryWindowMs + (now - deadline);
     return { kind: "convergence-failed", attempts, elapsedMs };
   }
-  // A stale-basis conflict usually clears the moment the fresh confirmed state
-  // arrives, so the first `immediateRetries` retries fire with no delay — the
-  // fast path that lets a transient conflict converge without stretching the
-  // wall-clock. Only once those are exhausted (sustained contention) does
-  // backoff begin, with its exponent counted from the first delayed retry.
-  const delayMs = attempts <= policy.immediateRetries
-    ? 0
-    : computeBackoffDelayMs(attempts - policy.immediateRetries, policy);
+  // Exponential backoff from the first conflict. The early steps are sub-5ms
+  // (near-immediate), so a transient conflict that clears once fresh state
+  // arrives converges fast; the delay only grows into real spacing once a
+  // conflict persists.
+  const delayMs = computeBackoffDelayMs(attempts, policy);
   return { kind: "backoff", attempts, deadline, delayMs, runAt: now + delayMs };
 }

--- a/packages/runner/test/scheduler-commit-backpressure.test.ts
+++ b/packages/runner/test/scheduler-commit-backpressure.test.ts
@@ -7,13 +7,15 @@
 //
 //   1. A burst of transient conflicts longer than the old fixed budget still
 //      lets the write land.
-//   2. A permanent rejection is not retried (no infinite loop) and stays
+//   2. The default backoff curve is near-immediate at first and reaches 25ms by
+//      the seventh attempt.
+//   3. A permanent rejection is not retried (no infinite loop) and stays
 //      observable.
-//   3. A transient conflict that never clears surfaces a terminal error within
+//   4. A transient conflict that never clears surfaces a terminal error within
 //      the retry window instead of vanishing.
-//   4. A zero-window policy fails the first conflict loudly without dropping it
+//   5. A zero-window policy fails the first conflict loudly without dropping it
 //      silently.
-//   5. Three array appends survive a conflict storm so the durable count reaches
+//   6. Three array appends survive a conflict storm so the durable count reaches
 //      three (the profile-append bug in miniature).
 
 import {
@@ -36,6 +38,10 @@ import type {
 } from "./scheduler-test-utils.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { resolveLink } from "../src/link-resolution.ts";
+import {
+  computeBackoffDelayMs,
+  resolveCommitBackpressure,
+} from "../src/scheduler/backpressure.ts";
 
 type TransactMessage = { requestId: string };
 type TransactResponse = {
@@ -311,51 +317,25 @@ describe("committed-write backpressure", () => {
   );
 
   it(
-    "clears a small conflict burst on the immediate fast path without backoff",
-    async () => {
-      // A conflict that clears within the immediate-retry budget must converge
-      // without being parked for backoff. Delaying such a retry can keep it from
-      // landing inside a settle, which is what a multi-user settle relies on.
-      const piece = buildCounterPiece(
-        runtime,
-        tx,
-        "backpressure-fastpath-root",
-      );
-      await tx.commit();
-      tx = runtime.edit();
-      await runtime.idle();
+    "default backoff curve: first retries are sub-5ms, reaching 25ms by the seventh attempt",
+    () => {
+      // One exponential curve, no immediate-retry special case: the early steps
+      // are near-immediate (sub-5ms) so a transient conflict converges fast, and
+      // the delay before the seventh attempt is 25ms, then doubles to the cap.
+      // random() === 0 removes the jitter reduction so we read the nominal curve.
+      const policy = resolveCommitBackpressure();
+      const step = (attempt: number) =>
+        computeBackoffDelayMs(attempt, policy, () => 0);
 
-      const commitTelemetry = collectEventCommitMarkers(runtime);
-      // Three conflicts — within the default immediateRetries (5).
-      const injector = rejectServerTransacts(storageManager, 3, {
-        name: "ConflictError",
-        message: "forced small conflict burst",
-      });
-
-      try {
-        piece.queueAdd(
-          4,
-          "evt:backpressure-fastpath:0:backpressure-fastpath-root",
-        );
-
-        await waitFor(
-          runtime,
-          () => piece.total() === 4,
-          `write did not land on the fast path ` +
-            `(total=${piece.total()}, rejected=${injector.rejected()})`,
-        );
-
-        expect(piece.total()).toBe(4);
-        expect(injector.rejected()).toBe(3);
-        // Every retry was immediate: no commit marker carried a backoff delay.
-        const backedOff = commitTelemetry.markers.some((marker) =>
-          ((marker as { backoffMs?: number }).backoffMs ?? 0) > 0
-        );
-        expect(backedOff).toBe(false);
-      } finally {
-        injector.restore();
-        commitTelemetry.dispose();
-      }
+      // The park before attempt N is step(N - 1).
+      expect(step(1)).toBeLessThan(5); // before attempt 2
+      expect(step(2)).toBeLessThan(5); // before attempt 3
+      expect(step(3)).toBeLessThan(5); // before attempt 4
+      expect(step(6)).toBe(25); // before the 7th attempt
+      expect(step(7)).toBe(50);
+      expect(step(8)).toBe(100);
+      // Capped at maxDelayMs.
+      expect(step(20)).toBe(policy.maxDelayMs);
     },
   );
 


### PR DESCRIPTION
…ount

The previous fix special-cased the first few conflict retries to fire with zero delay (an immediateRetries count) before exponential backoff began, so that a transient conflict converged within the test harness's / UI's settle. That dual path was avoidable: the same fast-convergence falls out of a single exponential curve whose early steps are simply small.

Drop immediateRetries and lower baseDelayMs to 25/32 ms. computeBackoffDelayMs now applies to every conflict from the first, and the curve is 0.78, 1.56, 3.125, 6.25, 12.5, then 25 ms before the seventh attempt, doubling to the 1-second cap — identical to the old curve from the seventh attempt on, but with the leading steps filled in instead of zeroed. The first few delays are sub-5ms, so a stale-basis conflict that clears as soon as fresh confirmed state arrives still converges near-immediately; the delay only grows into real spacing once a conflict persists. requeueForBackoff always parks via notBefore again (no zero-delay branch), and the disposition logic loses its immediate/backoff fork.

The CommitBackpressurePolicy loses its immediateRetries field. Behavior for sustained contention (capped backoff, bounded retry window, terminal CommitConvergenceError) is unchanged. The unit suite replaces the immediate-fast-path test with a direct check of the default curve (sub-5ms early, 25 ms before the seventh attempt, doubling to the cap).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified commit backpressure by removing the immediate-retry path and using one exponential backoff curve that starts with sub-5ms delays, keeping transient conflicts convergent while reducing scheduler complexity. `baseDelayMs` is set to 25/32 ms; behavior under sustained contention is unchanged.

- **Refactors**
  - Use `computeBackoffDelayMs` from the first conflict; early delays are ~0.78, 1.56, 3.125, 6.25, 12.5 ms, then 25 ms before the seventh attempt, doubling to the 1s cap.
  - Always park retries via `notBefore`; remove the zero-delay branch and immediate/backoff fork in `events.ts`.
  - Logging always reports a backoff delay; tests updated to verify the default curve; docs updated accordingly.

- **Migration**
  - Remove `immediateRetries` from `CommitBackpressurePolicy` options. Drop this field from any runtime config.

<sup>Written for commit 8c8013901359c988b797d8036c9412d23ea4daf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

