### PR TITLE
docs: default dev identity to `id new`; scope `implicit trust` to local-server operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ dist/
 .cf-harness-artifacts/
 claude-research.key
 *.key
+# Exported PKCS8/PEM identity keys (e.g. cf.pem) — never commit private keys
+*.pem
 .passphrase
 *passphrase*
 .page-agent-config.json

--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -143,14 +143,18 @@ process you're configuring.
 | CF CLI | `CF_IDENTITY` env or `--identity <path>` | _(none)_ | _(none — error if remote)_ |
 
 For local dev, all three default to the implicit-trust passphrase so they
-share an identity automatically. To match the CLI to the local server:
+share an identity automatically. To match the CLI to the local server (only
+needed for operator/admin tasks on your own localhost):
 
 ```bash
 deno run -A packages/cli/mod.ts id derive "implicit trust" > claude.key
 export CF_IDENTITY=./claude.key
 ```
 
-See [`docs/development/SHARED_IDENTITY.md`](./SHARED_IDENTITY.md) for the
+`"implicit trust"` is a shared, publicly-derivable identity — never use it
+against a shared or remote server (everyone who derives it becomes the same
+principal). For a personal or unique identity, use `id new`. See
+[`docs/development/SHARED_IDENTITY.md`](./SHARED_IDENTITY.md) for the
 browser-import flow.
 
 ---

--- a/docs/development/LOCAL_DEV_SERVERS.md
+++ b/docs/development/LOCAL_DEV_SERVERS.md
@@ -56,11 +56,16 @@ server. See `docs/development/EXPERIMENTAL_OPTIONS.md` for all available flags.
 - `packages/toolshed/local-dev-toolshed.log`
 
 **CLI identity for local dev:** The local toolshed uses an identity derived from
-the passphrase `"implicit trust"`. To create a matching key for CLI operations:
+the passphrase `"implicit trust"`. To create a key matching the local server (so
+the CLI can act as its operator/admin):
 ```bash
 deno run -A packages/cli/mod.ts id derive "implicit trust" > claude.key
 export CF_IDENTITY=./claude.key
 ```
+This is a shared, publicly-derivable key — every developer who derives it gets
+the same DID. Use it only against your own localhost. For a personal identity, or
+any shared/remote server, use `id new` instead (see
+[`SHARED_IDENTITY.md`](./SHARED_IDENTITY.md)).
 
 For workflows that touch `PerUser`, `PerSession`, favorites, or home-space
 state, use one shared identity in both browser and CLI. The browser login screen

--- a/docs/development/SHARED_IDENTITY.md
+++ b/docs/development/SHARED_IDENTITY.md
@@ -5,6 +5,24 @@ when testing identity-sensitive behavior. Scoped cells make this important:
 `PerUser<T>` and `PerSession<T>` data is keyed by the active user DID, not only
 by the space DID.
 
+> **Use a unique key (`id new`) for your own identity.** `cf id derive "implicit
+> trust"` produces a *fixed, publicly-derivable* DID — the one the local toolshed
+> runs as in dev mode — so every developer who derives it shares the exact same
+> identity. That is fine on your own single-tenant localhost (it lets the CLI,
+> browser, and server act as one admin identity), but against a **shared or remote
+> server** (a teammate's box, staging, anything on a tailnet) it collapses
+> everyone into one principal: you see and overwrite each other's `PerUser` data
+> and act as each other. **Never derive or browser-import `implicit trust` against
+> a server other people use.** Reserve it for the one case below.
+
+## When To Derive `implicit trust`
+
+Only to deliberately act *as the local dev server's own identity* — i.e. for
+operator/admin tasks on your own localhost where the caller must match toolshed's
+dev identity (e.g. `add-admin-charm`, the background-charm-service operator,
+deploying system home patterns). For everything else — your personal identity,
+normal pattern dev, and any shared or remote server — use `id new`.
+
 ## Recommended Local Workflow
 
 Create one repo-local key and use it everywhere:

--- a/docs/tutorial/06-workflow.md
+++ b/docs/tutorial/06-workflow.md
@@ -28,9 +28,11 @@ runs Toolshed on `localhost:8000`; use `dev-local` for the shell, not
 `dev`). Then:
 
 ```bash
-# Derive a deterministic dev key. Use `id derive`, NOT `id new > file` —
-# the latter pollutes the key file with ANSI output.
-deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
+# Create a unique dev key. Redirect from `deno run -A packages/cli/mod.ts`,
+# never `deno task cf` — the task wrapper prints ANSI preamble that corrupts
+# the key file. (Chapter 10 covers the shared `implicit trust` dev identity
+# and the narrow case where you'd derive it instead.)
+deno run -A packages/cli/mod.ts id new > cf.key
 
 export CF_IDENTITY=./cf.key
 export CF_API_URL=http://localhost:8000

--- a/docs/tutorial/10-identity-and-security.md
+++ b/docs/tutorial/10-identity-and-security.md
@@ -24,10 +24,18 @@ Two derivation tricks give the system its shape:
 
 A **space DID** is just `someIdentity.derive(spaceName).did()`. No
 registration step, no central registry: knowing the derivation inputs *is*
-knowing the space. (Dev environments lean on this hard — the CLI's
-`id derive "implicit trust"` from Chapter 6 reproduces the standard dev
-identity, and named dev spaces derive from a well-known passphrase, which
-is why two local setups agree on what `did:key:...` a space name means.)
+knowing the space. Dev environments lean on this hard: named dev spaces
+derive from a well-known passphrase, which is why two local setups agree on
+what `did:key:...` a space name means. The same trick defines the **shared
+dev identity** `id derive "implicit trust"` — the DID the local toolshed
+itself runs as in dev mode. Because it comes from a public string, *everyone*
+who derives it gets the identical keypair. That is a convenience on your own
+localhost (CLI, browser, and server can all act as one admin identity) and a
+footgun anywhere shared: derive or browser-import it against a server other
+people use and you all become the *same* principal — seeing and overwriting
+each other's `PerUser` data. Use a unique `id new` key for your own identity;
+reserve `implicit trust` for deliberately acting as a local dev server's
+operator. See `docs/development/SHARED_IDENTITY.md`.
 
 ## Passkeys: the browser login
 

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -28,20 +28,16 @@ ls -la cf.key                  # Check for existing
 # Never overwrite an existing key file — existing identity-scoped data
 # becomes invisible under a new identity.
 
-# Default: a fresh, UNIQUE key. Use this for normal pattern dev and for ANY
-# shared or remote server (staging, a teammate's box, anything on a tailnet).
+# Default: a fresh, UNIQUE key. Use this for normal pattern dev and for any
+# server (local, shared, or remote).
 deno run -A packages/cli/mod.ts id new > cf.key
 
 # To match a browser identity registered with a recovery phrase:
 deno run -A packages/cli/mod.ts id from-mnemonic -- phrase.txt > cf.key
 
-# ONLY to act as a LOCAL dev server's operator/admin (localhost, single-tenant):
-# derive the well-known "implicit trust" identity that toolshed itself runs as in
-# dev. This DID is PUBLIC and SHARED — every developer who derives it gets the
-# identical key. Never use it against a shared/remote server, and never import it
-# into a browser pointed at one, or you collide into one principal with everyone
-# else who did (see docs/development/SHARED_IDENTITY.md).
-deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
+# To reproduce a key from your OWN secret passphrase (unique to you; pass via
+# file or stdin to keep it out of shell history):
+deno run -A packages/cli/mod.ts id derive -- passphrase.txt > cf.key
 ```
 
 Both `id derive` and `id from-mnemonic` accept the secret three ways: as a file
@@ -70,10 +66,9 @@ export CF_IDENTITY=./cf.key
 **Identity visibility footgun:** If CLI and browser use different DIDs, the same
 piece should still load and unscoped/`PerSpace` data should remain visible, but
 `PerUser`, `PerSession`, favorites, drafts, and home-space state may look empty
-or default. For identity-sensitive local work, use one key everywhere and import
-the CLI PKCS8/PEM key in the browser via `Import CLI Key` — make it a unique
-`id new` key, never the shared `implicit trust` identity on a server others use.
-See `docs/development/SHARED_IDENTITY.md`.
+or default. For identity-sensitive local work, use one key everywhere — generate
+it with `id new` and import the CLI PKCS8/PEM key in the browser via
+`Import CLI Key`. See `docs/development/SHARED_IDENTITY.md`.
 
 **Experimental flags** must be set as env vars on both servers AND CLI commands.
 See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -28,14 +28,20 @@ ls -la cf.key                  # Check for existing
 # Never overwrite an existing key file — existing identity-scoped data
 # becomes invisible under a new identity.
 
-# For local dev: derive key matching toolshed's "implicit trust" identity
-deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
-
-# For a fresh random key (e.g., against production):
+# Default: a fresh, UNIQUE key. Use this for normal pattern dev and for ANY
+# shared or remote server (staging, a teammate's box, anything on a tailnet).
 deno run -A packages/cli/mod.ts id new > cf.key
 
 # To match a browser identity registered with a recovery phrase:
 deno run -A packages/cli/mod.ts id from-mnemonic -- phrase.txt > cf.key
+
+# ONLY to act as a LOCAL dev server's operator/admin (localhost, single-tenant):
+# derive the well-known "implicit trust" identity that toolshed itself runs as in
+# dev. This DID is PUBLIC and SHARED — every developer who derives it gets the
+# identical key. Never use it against a shared/remote server, and never import it
+# into a browser pointed at one, or you collide into one principal with everyone
+# else who did (see docs/development/SHARED_IDENTITY.md).
+deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
 ```
 
 Both `id derive` and `id from-mnemonic` accept the secret three ways: as a file
@@ -65,8 +71,9 @@ export CF_IDENTITY=./cf.key
 piece should still load and unscoped/`PerSpace` data should remain visible, but
 `PerUser`, `PerSession`, favorites, drafts, and home-space state may look empty
 or default. For identity-sensitive local work, use one key everywhere and import
-the CLI PKCS8/PEM key in the browser via `Import CLI Key`. See
-`docs/development/SHARED_IDENTITY.md`.
+the CLI PKCS8/PEM key in the browser via `Import CLI Key` — make it a unique
+`id new` key, never the shared `implicit trust` identity on a server others use.
+See `docs/development/SHARED_IDENTITY.md`.
 
 **Experimental flags** must be set as env vars on both servers AND CLI commands.
 See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.

--- a/skills/fuse-workflow/SKILL.md
+++ b/skills/fuse-workflow/SKILL.md
@@ -28,8 +28,10 @@ change a cell in the browser, the file updates within ~1 second.
 # Prerequisites
 brew install --cask fuse-t          # macOS only, requires sudo
 
-# Identity (reuse existing or create one)
-ls cf.key || deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
+# Identity (reuse existing or create a unique one). Avoid `id derive "implicit
+# trust"` against any shared/remote server — it is a shared, publicly-derivable
+# DID that collides all such users into one identity (docs/development/SHARED_IDENTITY.md).
+ls cf.key || deno run -A packages/cli/mod.ts id new > cf.key
 
 # Environment
 export CF_API_URL=http://localhost:8000

--- a/skills/fuse-workflow/SKILL.md
+++ b/skills/fuse-workflow/SKILL.md
@@ -28,9 +28,7 @@ change a cell in the browser, the file updates within ~1 second.
 # Prerequisites
 brew install --cask fuse-t          # macOS only, requires sudo
 
-# Identity (reuse existing or create a unique one). Avoid `id derive "implicit
-# trust"` against any shared/remote server — it is a shared, publicly-derivable
-# DID that collides all such users into one identity (docs/development/SHARED_IDENTITY.md).
+# Identity (reuse existing, or create a unique one with `id new`)
 ls cf.key || deno run -A packages/cli/mod.ts id new > cf.key
 
 # Environment

--- a/skills/pattern-deploy/SKILL.md
+++ b/skills/pattern-deploy/SKILL.md
@@ -25,12 +25,15 @@ criteria.
 ls -la ./cf.key 2>/dev/null || ls -la *.key 2>/dev/null || find . -name "*.key" -maxdepth 2 2>/dev/null
 ```
 
-If no key exists, create one per the cf skill (local dev:
-`deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key` — note the
+If no key exists, create one per the cf skill
+(`deno run -A packages/cli/mod.ts id new > cf.key` for a unique key — note the
 cf skill's warning: never redirect `deno task cf` output into a key file, the
 wrapper pollutes it with ANSI preamble). Never overwrite an existing key file —
 identity-scoped data (PerUser state, favorites) becomes invisible under a new
-identity.
+identity. Do **not** use `id derive "implicit trust"` here: it is a shared,
+publicly-derivable identity, so deploying with it to a shared server collides
+you into one principal with every other developer who did the same (see the cf
+skill and `docs/development/SHARED_IDENTITY.md`).
 
 ## Commands
 

--- a/skills/pattern-deploy/SKILL.md
+++ b/skills/pattern-deploy/SKILL.md
@@ -30,10 +30,7 @@ If no key exists, create one per the cf skill
 cf skill's warning: never redirect `deno task cf` output into a key file, the
 wrapper pollutes it with ANSI preamble). Never overwrite an existing key file —
 identity-scoped data (PerUser state, favorites) becomes invisible under a new
-identity. Do **not** use `id derive "implicit trust"` here: it is a shared,
-publicly-derivable identity, so deploying with it to a shared server collides
-you into one principal with every other developer who did the same (see the cf
-skill and `docs/development/SHARED_IDENTITY.md`).
+identity.
 
 ## Commands
 


### PR DESCRIPTION
## Why

While voting in a poll on a shared toolshed, one developer showed up as a **different developer**. Root cause: both had logged into the shell by importing a CLI keyfile generated with the documented command:

```bash
deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
```

`id derive "implicit trust"` is deterministic and the passphrase is a **public string baked into the codebase** (`const ROOT = "implicit trust"` in `toolshed/lib/identity.ts`; the default `IDENTITY_PASSPHRASE` / `OPERATOR_PASS`). So *every* developer who follows the docs gets the **identical** DID (`did:key:z6MksHnZ…`). On a single-user localhost that's a harmless convenience. On a **shared** server (a teammate's box, staging, anything on a tailnet) it collapses everyone into one principal — they appear as each other and overwrite each other's `PerUser` data.

The skills (`cf`, `pattern-deploy`, `fuse-workflow`) and the tutorial all defaulted to deriving this shared identity for the user's *own* key, and `cf`/`SHARED_IDENTITY` even recommend importing that key into the browser — which is exactly the path that triggered the incident.

## When is `id derive "implicit trust"` actually legitimate?

Only one case: deliberately acting **as the local dev server's own identity** — operator/admin tasks on your own localhost where the caller must match toolshed's dev identity (`add-admin-charm`, the background-charm-service operator, deploying system home patterns). That's a "be the server" case, not a "be a user" case, and never applies to the browser or to a shared/remote server. It's niche enough that the **skills shouldn't mention it at all**; it lives in the docs.

## What this PR changes

- **Skills now use `id new` only.** `cf`, `pattern-deploy`, and `fuse-workflow` default to a unique key and no longer mention `implicit trust` at all — nothing in an agent-facing skill steers you toward the shared identity.
- **Docs keep the full picture.** `id derive "implicit trust"` is documented as the local-server operator identity only, with explicit "never against a shared/remote server, never browser-import it there" warnings, plus a new **"When To Derive `implicit trust`"** section and warning banner in `SHARED_IDENTITY.md` (also `CONFIGURATION.md`, `LOCAL_DEV_SERVERS.md`, `tutorial/10`).
- **Tutorial fix:** `docs/tutorial/06` now uses `id new`, and a wrong note that blamed `id new` (rather than the `deno task cf` wrapper) for ANSI key-file corruption is corrected — `deno run -A packages/cli/mod.ts id new > file` is clean.
- **`.gitignore` now ignores `*.pem`** so an exported identity key (e.g. `cf.pem`) can't be accidentally committed (only `*.key` was ignored before).

Docs/comments only — no runtime or behavioral change. The server-side `OPERATOR_PASS="implicit trust"` dev instructions (which *must* match the local toolshed) are intentionally left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
