### PR TITLE
Perf/shared compile byte cache

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -515,6 +515,24 @@ jobs:
       - name: 🔍 Verify lock file & install dependencies
         uses: ./.github/actions/deno-install
 
+      # Cross-run compile cache: persist the per-shard compiled-module-byte cache
+      # so unchanged patterns reuse last run's emitted bytes (skip the
+      # type-check + transform + emit). The key folds in a hash of everything
+      # that shapes the emitted bytes — the js-compiler, the CF transformer, the
+      # schema-generator it bakes schemas from, the root deno.json compiler
+      # options (jsx/jsxImportSource), and the lockfile — so any change to what
+      # emits the bytes invalidates the whole file even when it leaves module
+      # identity and the manual runtime-version tag untouched. The pattern-source
+      # hash rolls the key while `restore-keys` still seeds from the most recent
+      # prior cache.
+      - name: ♻️ Restore/save compile byte cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json
+          key: cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/schema-generator/**', 'deno.json', 'deno.lock') }}-${{ matrix.shard }}-${{ hashFiles('packages/patterns/**/*.tsx') }}
+          restore-keys: |
+            cc-${{ hashFiles('packages/ts-transformers/**', 'packages/js-compiler/**', 'packages/schema-generator/**', 'deno.json', 'deno.lock') }}-${{ matrix.shard }}-
+
       - name: 📥 Download built binaries
         uses: actions/download-artifact@v8
         with:
@@ -548,6 +566,7 @@ jobs:
           HEADLESS=1 \
           API_URL=http://localhost:8000/ \
           PATTERN_INTEGRATION_SHARD="${{ matrix.shard }}/${{ matrix.total }}" \
+          CF_COMPILE_CACHE_FILE="${{ github.workspace }}/.compile-cache/pattern-integration-${{ matrix.shard }}.json" \
           DENO_COVERAGE_DIR=../../coverage/raw/pattern-integration-${{ matrix.shard }} \
           deno test --v8-flags=--max-old-space-size=4096 --trace-leaks -A \
             --junit-path=../../test-results/patterns-${{ matrix.shard }}.xml \

--- a/packages/patterns/integration/all.test.ts
+++ b/packages/patterns/integration/all.test.ts
@@ -5,8 +5,15 @@ import { join } from "@std/path";
 import { assert } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { createCompileByteCache } from "./compile-byte-cache.ts";
 
 const { API_URL } = env;
+
+// Share compiled module bytes across this suite's fresh-per-pattern runtimes.
+// In-memory within the process; also persisted to disk when CF_COMPILE_CACHE_FILE
+// is set (CI), so a shard reuses bytes it compiled last run. The cache lives
+// entirely in test code; the runtime only consults the injected interface.
+const moduleByteCache = createCompileByteCache();
 
 // Optional sharding for CI fan-out: PATTERN_INTEGRATION_SHARD="i/n" (1-based)
 // runs only the patterns where (sorted index % n) == (i - 1), so the pattern
@@ -65,6 +72,7 @@ describe("Compile all patterns", () => {
         spaceName: `${name}-${crypto.randomUUID()}`,
         apiUrl: new URL(API_URL),
         identity: identity,
+        moduleByteCache,
       });
 
       try {

--- a/packages/patterns/integration/compile-byte-cache.test.ts
+++ b/packages/patterns/integration/compile-byte-cache.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { ProcessModuleByteCache } from "./compile-byte-cache.ts";
+
+describe("ProcessModuleByteCache", () => {
+  const RT = "rtv";
+
+  it("returns stored bytes by identity and reports a full set", () => {
+    const cache = new ProcessModuleByteCache();
+    cache.put(RT, "a", { js: "JS_A" });
+    cache.put(RT, "b", { js: "JS_B", sourceMap: "MAP_B" });
+
+    expect(cache.get(RT, "a")).toEqual({ js: "JS_A" });
+    expect(cache.get(RT, "b")).toEqual({ js: "JS_B", sourceMap: "MAP_B" });
+    expect(cache.get(RT, "missing")).toBeUndefined();
+
+    expect(cache.getCompleteSet(RT, ["a", "b"])?.size).toBe(2);
+    expect(cache.getCompleteSet(RT, ["a", "missing"])).toBeUndefined();
+  });
+
+  it("scopes by runtimeVersion (a version bump misses)", () => {
+    const cache = new ProcessModuleByteCache();
+    cache.put("v1", "id", { js: "JS" });
+    expect(cache.get("v1", "id")).toEqual({ js: "JS" });
+    expect(cache.get("v2", "id")).toBeUndefined();
+  });
+
+  it("putAll loads a module set; clear empties it", () => {
+    const cache = new ProcessModuleByteCache();
+    cache.putAll(RT, [
+      { identity: "a", js: "JS_A" },
+      { identity: "b", js: "JS_B", sourceMap: "MAP_B" },
+    ]);
+    expect(cache.getCompleteSet(RT, ["a", "b"])?.size).toBe(2);
+    cache.clear();
+    expect(cache.getCompleteSet(RT, ["a", "b"])).toBeUndefined();
+    expect(cache.stats().entries).toBe(0);
+  });
+
+  it("evicts oldest entries past the byte cap", () => {
+    const cache = new ProcessModuleByteCache(10); // 10 chars
+    cache.put(RT, "a", { js: "12345" }); // 5
+    cache.put(RT, "b", { js: "67890" }); // 5 -> total 10
+    cache.put(RT, "c", { js: "ABCDE" }); // 5 -> evicts "a"
+    expect(cache.get(RT, "a")).toBeUndefined();
+    expect(cache.get(RT, "b")).toEqual({ js: "67890" });
+    expect(cache.get(RT, "c")).toEqual({ js: "ABCDE" });
+  });
+
+  it("round-trips through snapshot/restore into a fresh cache", () => {
+    const a = new ProcessModuleByteCache();
+    a.put(RT, "x", { js: "JS_X" });
+    a.put(RT, "y", { js: "JS_Y", sourceMap: "MAP_Y" });
+    a.put("v2", "z", { js: "JS_Z" });
+
+    const serialized = JSON.parse(JSON.stringify(a.snapshot())); // survives JSON
+    const b = new ProcessModuleByteCache();
+    b.restore(serialized);
+
+    expect(b.get(RT, "x")).toEqual({ js: "JS_X" });
+    expect(b.get(RT, "y")).toEqual({ js: "JS_Y", sourceMap: "MAP_Y" });
+    expect(b.get("v2", "z")).toEqual({ js: "JS_Z" });
+    expect(b.getCompleteSet(RT, ["x", "y"])?.size).toBe(2);
+  });
+
+  it("restore skips malformed entries and tolerates junk", () => {
+    const cache = new ProcessModuleByteCache();
+    cache.restore([
+      { key: `${RT}\0ok`, js: "GOOD" },
+      { key: 42, js: "no" }, // bad key
+      { key: `${RT}\0nojs` }, // missing js
+      null,
+      "garbage",
+    ] as unknown[]);
+    expect(cache.get(RT, "ok")).toEqual({ js: "GOOD" });
+    expect(cache.stats().entries).toBe(1);
+  });
+});

--- a/packages/patterns/integration/compile-byte-cache.ts
+++ b/packages/patterns/integration/compile-byte-cache.ts
@@ -1,0 +1,225 @@
+import type {
+  CompiledModuleArtifact,
+  ModuleByteCache,
+} from "@commonfabric/runner";
+import { dirname } from "@std/path";
+
+// The compiled-module-byte cache, in full. The runtime defines only the
+// `ModuleByteCache` interface it consults during a compile; this test-side
+// module owns the implementation and its disk persistence, and is the only
+// place an instance is created. So the cache is, by construction, a single
+// feature that exists only when tests install it — never in production.
+//
+// `createCompileByteCache` returns the instance to inject into the runtimes a
+// test builds. The in-memory cache is always created (cross-runtime reuse within
+// the process). Disk persistence is added only when `CF_COMPILE_CACHE_FILE` is
+// set — which only the CI workflow sets — so a run reuses bytes it compiled on a
+// previous run. Cross-run correctness rests on the CI cache key (see the
+// workflow): the persisted bytes are a function of the compiler / transformer
+// build, which a module's content identity does not cover, so the key folds in a
+// hash of the compiler sources + lockfile and invalidates the whole file when
+// the code that emits the bytes changes.
+
+/** A serialized {@link ProcessModuleByteCache} entry (for disk persistence). */
+export interface SerializedModuleBytes {
+  key: string;
+  js: string;
+  sourceMap?: unknown;
+}
+
+/**
+ * Process-level, content-addressed cache of compiled module bytes. An entry is
+ * the emitted JavaScript for one module (plus its optional source map), keyed by
+ * the module's content identity scoped by the compiled-set `runtimeVersion`. The
+ * emitted bytes are a deterministic function of that key, so a hit always returns
+ * the bytes the identity addresses. Holds emitted JS only, never live pattern
+ * instances. A byte cap bounds the total retained JS and evicts oldest-first.
+ */
+export class ProcessModuleByteCache implements ModuleByteCache {
+  // Keyed by `${runtimeVersion}\0${identity}`. Map insertion order gives FIFO
+  // eviction (recency-refreshed on read, so eviction is ~LRU).
+  private readonly entries = new Map<
+    string,
+    { artifact: CompiledModuleArtifact; size: number }
+  >();
+  private totalBytes = 0;
+  private readonly maxBytes: number;
+
+  constructor(maxBytes = 256 * 1024 * 1024) {
+    this.maxBytes = maxBytes;
+  }
+
+  private static key(runtimeVersion: string, identity: string): string {
+    return `${runtimeVersion}\0${identity}`;
+  }
+
+  private static sizeOf(artifact: CompiledModuleArtifact): number {
+    let size = artifact.js.length;
+    if (typeof artifact.sourceMap === "string") {
+      size += artifact.sourceMap.length;
+    }
+    return size;
+  }
+
+  get(
+    runtimeVersion: string,
+    identity: string,
+  ): CompiledModuleArtifact | undefined {
+    const key = ProcessModuleByteCache.key(runtimeVersion, identity);
+    const entry = this.entries.get(key);
+    if (entry === undefined) return undefined;
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return entry.artifact;
+  }
+
+  getCompleteSet(
+    runtimeVersion: string,
+    identities: readonly string[],
+  ): Map<string, CompiledModuleArtifact> | undefined {
+    const bodies = new Map<string, CompiledModuleArtifact>();
+    for (const identity of identities) {
+      const artifact = this.get(runtimeVersion, identity);
+      if (artifact === undefined) return undefined;
+      bodies.set(identity, artifact);
+    }
+    return bodies;
+  }
+
+  put(
+    runtimeVersion: string,
+    identity: string,
+    artifact: CompiledModuleArtifact,
+  ): void {
+    this.insert(ProcessModuleByteCache.key(runtimeVersion, identity), artifact);
+  }
+
+  private insert(key: string, artifact: CompiledModuleArtifact): void {
+    const existing = this.entries.get(key);
+    if (existing !== undefined) {
+      this.entries.delete(key);
+      this.entries.set(key, existing);
+      return;
+    }
+    const size = ProcessModuleByteCache.sizeOf(artifact);
+    this.entries.set(key, { artifact, size });
+    this.totalBytes += size;
+    this.evictToCap();
+  }
+
+  putAll(
+    runtimeVersion: string,
+    modules: readonly { identity: string; js: string; sourceMap?: unknown }[],
+  ): void {
+    for (const module of modules) {
+      this.put(
+        runtimeVersion,
+        module.identity,
+        module.sourceMap === undefined
+          ? { js: module.js }
+          : { js: module.js, sourceMap: module.sourceMap },
+      );
+    }
+  }
+
+  private evictToCap(): void {
+    while (this.totalBytes > this.maxBytes) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      const entry = this.entries.get(oldest);
+      this.entries.delete(oldest);
+      if (entry !== undefined) this.totalBytes -= entry.size;
+    }
+  }
+
+  /** A serializable dump of every cached module. Pairs with {@link restore}. */
+  snapshot(): SerializedModuleBytes[] {
+    const out: SerializedModuleBytes[] = [];
+    for (const [key, { artifact }] of this.entries) {
+      out.push(
+        artifact.sourceMap === undefined
+          ? { key, js: artifact.js }
+          : { key, js: artifact.js, sourceMap: artifact.sourceMap },
+      );
+    }
+    return out;
+  }
+
+  /**
+   * Merge a {@link snapshot} back in (idempotent; content-addressed, so a key
+   * collision is the same bytes). Malformed entries are skipped.
+   */
+  restore(entries: readonly unknown[]): void {
+    for (const entry of entries) {
+      if (entry === null || typeof entry !== "object") continue;
+      const e = entry as Partial<SerializedModuleBytes>;
+      if (typeof e.key !== "string" || typeof e.js !== "string") continue;
+      this.insert(
+        e.key,
+        e.sourceMap === undefined
+          ? { js: e.js }
+          : { js: e.js, sourceMap: e.sourceMap },
+      );
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+    this.totalBytes = 0;
+  }
+
+  stats(): { entries: number; bytes: number } {
+    return { entries: this.entries.size, bytes: this.totalBytes };
+  }
+}
+
+/**
+ * Create the compiled-module-byte cache and return it for injection into the
+ * runtimes a test builds (via `PiecesController.initialize`'s `moduleByteCache`).
+ * When `CF_COMPILE_CACHE_FILE` is set, the cache is also seeded from that file
+ * now and written back at process exit. Unset everywhere but CI, so locally the
+ * cache is in-memory only.
+ */
+export function createCompileByteCache(): ModuleByteCache {
+  const cache = new ProcessModuleByteCache();
+  const cacheFile = Deno.env.get("CF_COMPILE_CACHE_FILE");
+  if (!cacheFile) return cache;
+
+  let text: string | undefined;
+  try {
+    text = Deno.readTextFileSync(cacheFile);
+  } catch (error) {
+    // A missing file is the expected cold start. Any other read failure
+    // (permissions, I/O) is real — let it surface rather than masking it.
+    if (!(error instanceof Deno.errors.NotFound)) throw error;
+  }
+  if (text !== undefined) {
+    // A malformed cache file is a real fault, not a cold start: let the parse
+    // error surface. `restore` itself tolerates individual malformed entries.
+    const parsed = JSON.parse(text);
+    if (Array.isArray(parsed)) {
+      cache.restore(parsed);
+      console.log(
+        `[compile-byte-cache] restored ${parsed.length} modules from ${cacheFile}`,
+      );
+    }
+  }
+
+  globalThis.addEventListener("unload", () => {
+    try {
+      Deno.mkdirSync(dirname(cacheFile), { recursive: true });
+      const snapshot = cache.snapshot();
+      Deno.writeTextFileSync(cacheFile, JSON.stringify(snapshot));
+      console.log(
+        `[compile-byte-cache] wrote ${snapshot.length} modules to ${cacheFile}`,
+      );
+    } catch (error) {
+      console.error(
+        `[compile-byte-cache] failed to write ${cacheFile}:`,
+        error,
+      );
+    }
+  });
+
+  return cache;
+}

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -2,6 +2,7 @@ import {
   type Cell,
   entityIdFrom,
   type JSONSchema,
+  type ModuleByteCache,
   Runtime,
   RuntimeProgram,
   type Schema,
@@ -145,10 +146,14 @@ export class PiecesController<T = unknown> {
     }
   }
 
-  static async initialize({ apiUrl, identity, spaceName }: {
+  static async initialize({ apiUrl, identity, spaceName, moduleByteCache }: {
     apiUrl: URL;
     identity: Identity;
     spaceName: string;
+    // Optional compiled-module-byte cache to share across controllers. Supplied
+    // only by test code (see the integration suite's compile-byte-cache helper);
+    // unset in production, so no cache is installed.
+    moduleByteCache?: ModuleByteCache;
   }): Promise<PiecesController> {
     const session = await createSession({ identity, spaceName });
     const runtime = new Runtime({
@@ -159,6 +164,7 @@ export class PiecesController<T = unknown> {
         spaceIdentity: session.spaceIdentity,
       }),
       cfcEnforcementMode: "enforce-explicit",
+      moduleByteCache,
       trustSnapshotProvider: () => ({
         id: `principal:${session.as.did()}`,
         actingPrincipal: session.as.did(),

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -174,6 +174,8 @@ export {
   parseCellPath,
   resolveCellPath,
 } from "./piece-helpers.ts";
+export type { ModuleByteCache } from "./runtime.ts";
+export type { CompiledModuleArtifact } from "./harness/types.ts";
 export {
   isSlugAddress,
   slugCause,

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -513,19 +513,47 @@ export class PatternManager {
     // accumulate open transactions.
     const readTx = this.runtime.edit();
 
+    const byteCache = this.runtime.moduleByteCache;
+    // The per-space storage closure served the full module set (already durable
+    // in this space, so no write-back needed).
     let warmHit = false;
+    // The process-level byte cache served the full module set, skipping the
+    // transform-and-emit step (the TypeScript program build, type-check, the
+    // type-driven CF transformer, and the emit — `compileToModules`). The bytes
+    // are durable in the byte cache but NOT necessarily in this space's persisted
+    // cache, so this still triggers a write-back.
+    let processServed = false;
     let compiled;
     try {
       compiled = await harness.compileToRecordGraph(program, {
         fabricImports: { space },
-        // The bodies returned below come from `loadCompiledClosure`, an
-        // integrity-gated (`requiredIntegrity`, fail-closed) read of the
-        // compiled set. On a full hit the CFC integrity label is the security
-        // boundary, so skip the redundant per-module SES re-verification (threat
-        // model: docs/specs/module-loading.md). A partial/miss returns undefined
-        // below → fresh compile → bodies are SES-verified as usual.
+        // The bodies returned below come either from the process byte cache or
+        // from `loadCompiledClosure`, an integrity-gated (`requiredIntegrity`,
+        // fail-closed) read of the compiled set. On a full hit the byte cache's
+        // provenance (see the channel below) / the CFC integrity label is the
+        // security boundary, so skip the redundant per-module SES re-verification
+        // (threat model: docs/specs/module-loading.md). A partial/miss returns
+        // undefined below → fresh compile → bodies are SES-verified as usual.
         trustedBodies: true,
         precompiledModulesFor: async ({ entryIdentity, identities }) => {
+          // Process byte cache first (cross-runtime, cross-space): a full hit
+          // skips BOTH the transform-and-emit step (`compileToModules`: TS
+          // program build, type-check, CF transform, emit) and the per-space
+          // storage read. Trust by provenance: bytes this process compiled were
+          // SES-verified then; bytes a test seeded from a CI disk file were not —
+          // those are trusted via the workflow's cache key, which fingerprints
+          // every compile input. Either path is test/CI-only: nothing in
+          // production installs a byte cache.
+          if (byteCache) {
+            const bodies = byteCache.getCompleteSet(
+              cacheOpts.runtimeVersion,
+              identities,
+            );
+            if (bodies) {
+              processServed = true;
+              return bodies;
+            }
+          }
           // Concurrency-safe timing: explicit start (no shared timer key, which
           // parallel compiles would clobber). Same for the others below.
           const readStart = performance.now();
@@ -564,6 +592,12 @@ export class PatternManager {
     const { id, graph, mainSpecifier, entryIdentity, modules } = compiled;
     cacheCtx.onEntryIdentity?.(entryIdentity);
 
+    // Populate the process byte cache with this program's module bytes (freshly
+    // compiled, or reused from storage). Idempotent and content-addressed, so a
+    // redundant put is harmless. A later runtime or space then reuses these
+    // modules instead of re-transforming them.
+    byteCache?.putAll(cacheOpts.runtimeVersion, modules);
+
     const evalStart = performance.now();
     const result = harness.evaluateRecordGraph(
       id,
@@ -574,32 +608,28 @@ export class PatternManager {
     logger.time(evalStart, "compile-cache", "evaluate");
 
     if (warmHit) {
+      // The per-space storage closure was just READ from this space, i.e. it is
+      // already durable here — no write-back.
       this.esmCacheStats.hits++;
     } else {
-      this.esmCacheStats.misses++;
-      // Cold/partial: persist the freshly compiled module set. AWAITED
-      // (identity E4): refs-only pattern JSON makes artifact persistence part
-      // of the compilation contract — a cell can only carry a `$patternRef`
-      // after compilePattern returned, so completing the write here
-      // guarantees every persisted ref has a durable closure behind it (no
-      // race against session end). Cold compiles only; a warm hit means the
-      // closure was just READ from storage, i.e. it is already durable. A
-      // failed cache write fails the compile: persisted refs-only pattern JSON
-      // would otherwise point at a closure that is not durable in `space`.
-      const writeBack = this.writeBackCompileCache(
+      this.esmCacheStats[processServed ? "hits" : "misses"]++;
+      // Persist the module set into this space. AWAITED (identity E4): refs-only
+      // pattern JSON makes artifact persistence part of the compilation
+      // contract — a cell can only carry a `$patternRef` after compilePattern
+      // returned, so completing the write here guarantees every persisted ref
+      // has a durable closure behind it (no race against session end). This
+      // covers BOTH a cold compile AND a process-byte-cache hit: in the latter
+      // the transform-and-emit step was skipped, but this space's persisted
+      // cache may be empty (e.g. a fresh space), and the by-identity reload path
+      // needs the closure here. A failed write fails the compile: persisted
+      // refs-only pattern JSON would otherwise point at a closure that is not
+      // durable in `space`.
+      await this.persistCompileCacheTracked(
         space,
         modules,
         entryIdentity,
         cacheOpts,
       );
-      this.compileCacheWrites.add(writeBack);
-      this.pendingCacheWriteBacks.add(writeBack);
-      try {
-        await writeBack;
-      } finally {
-        this.compileCacheWrites.delete(writeBack);
-        this.pendingCacheWriteBacks.delete(writeBack);
-      }
     }
 
     return this.patternFromEvaluation(result, program, entryIdentity);
@@ -1070,6 +1100,35 @@ export class PatternManager {
     this.modulesByIdentity.set(entryIdentity, cached);
     setArtifactEntryRef(pattern, { identity: entryIdentity, symbol });
     return pattern;
+  }
+
+  /**
+   * Write the module set into `space` and AWAIT it, tracking the in-flight
+   * promise in `compileCacheWrites` + `pendingCacheWriteBacks` (so graceful
+   * shutdown and closure replication can observe it). A failure PROPAGATES and
+   * fails the compile: refs-only pattern JSON makes a durable closure in `space`
+   * part of the compilation contract.
+   */
+  private async persistCompileCacheTracked(
+    space: MemorySpace,
+    modules: CacheableModule[],
+    entryIdentity: string,
+    opts: { runtimeVersion: string },
+  ): Promise<void> {
+    const writeBack = this.writeBackCompileCache(
+      space,
+      modules,
+      entryIdentity,
+      opts,
+    );
+    this.compileCacheWrites.add(writeBack);
+    this.pendingCacheWriteBacks.add(writeBack);
+    try {
+      await writeBack;
+    } finally {
+      this.compileCacheWrites.delete(writeBack);
+      this.pendingCacheWriteBacks.delete(writeBack);
+    }
   }
 
   /**

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -74,6 +74,7 @@ import {
   type TrustSnapshot,
 } from "./cfc/mod.ts";
 import { PatternManager } from "./pattern-manager.ts";
+import type { CompiledModuleArtifact } from "./harness/types.ts";
 import { ModuleRegistry } from "./module.ts";
 import { Runner } from "./runner.ts";
 import { registerBuiltins } from "./builtins/index.ts";
@@ -170,6 +171,45 @@ export interface ExperimentalOptions {
   commitPreconditions?: boolean | undefined;
 }
 
+/**
+ * Content-addressed cache of compiled MODULE BYTES, injected via
+ * `RuntimeOptions.moduleByteCache`. The ESM cell-cache compile path consults it
+ * before the per-space storage read — a full hit skips both the storage read and
+ * the whole transform-and-emit step (`compileToModules`) — and populates it after
+ * a compile, so a module compiled in one runtime or space serves another
+ * compiling the same module.
+ *
+ * Entries are keyed by a module's content identity scoped by the compiled-set
+ * `runtimeVersion`; the emitted bytes are a deterministic function of that pair
+ * (the emitter strips the whole-program path prefix, so a module's bytes are the
+ * same in every program that contains it), so a hit always returns the bytes the
+ * identity addresses.
+ *
+ * The runtime defines only this interface. The implementation, and its
+ * persistence, live in test code, so the cache is instantiated only from tests
+ * and never in production.
+ */
+export interface ModuleByteCache {
+  /**
+   * The cached bodies for `identities` iff EVERY identity is present, else
+   * `undefined`. The transform-and-emit step is whole-program, so only a full
+   * set lets a compile skip it.
+   */
+  getCompleteSet(
+    runtimeVersion: string,
+    identities: readonly string[],
+  ): Map<string, CompiledModuleArtifact> | undefined;
+
+  /**
+   * Store a freshly compiled (or reused) module set, keyed by content identity
+   * scoped by `runtimeVersion`. Idempotent and content-addressed.
+   */
+  putAll(
+    runtimeVersion: string,
+    modules: readonly { identity: string; js: string; sourceMap?: unknown }[],
+  ): void;
+}
+
 export interface RuntimeOptions {
   apiUrl: URL;
   /**
@@ -213,6 +253,16 @@ export interface RuntimeOptions {
    * and retry window. See scheduler/backpressure.ts.
    */
   commitBackpressure?: Partial<CommitBackpressurePolicy>;
+  /**
+   * Process-level, content-addressed cache of compiled MODULE BYTES, shared
+   * across runtimes. When set, the ESM cell-cache compile path consults it before
+   * the per-space storage read and populates it after a compile, so a module
+   * compiled in one runtime or space serves another runtime or space compiling
+   * the same module. When unset, the byte cache is off and only the per-space
+   * cache applies. Holds emitted JS only, never live pattern instances. See
+   * {@link ModuleByteCache}.
+   */
+  moduleByteCache?: ModuleByteCache;
 }
 
 export interface CfcRuntimeStats {
@@ -319,6 +369,8 @@ export class Runtime {
   readonly cfcSinkMaxConfidentiality: SinkMaxConfidentiality;
   readonly staticCache: StaticCache;
   readonly storageManager: IStorageManager;
+  /** Optional process-level compiled-module-byte cache; see RuntimeOptions. */
+  readonly moduleByteCache?: ModuleByteCache;
   readonly trustSnapshotProvider: () => TrustSnapshot | undefined;
   readonly telemetry: RuntimeTelemetry;
   /** Resolved experimental flags (all properties present, defaulting to `false`). */
@@ -408,6 +460,7 @@ export class Runtime {
     });
 
     this.storageManager = options.storageManager;
+    this.moduleByteCache = options.moduleByteCache;
     const actingPrincipal = options.storageManager.as.did() as DID;
     this.trustSnapshotProvider = options.trustSnapshotProvider ?? (() => ({
       id: `principal:${actingPrincipal}`,

--- a/packages/runner/test/module-byte-cache.test.ts
+++ b/packages/runner/test/module-byte-cache.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { ModuleByteCache } from "../src/runtime.ts";
+import type {
+  CompiledModuleArtifact,
+  RuntimeProgram,
+} from "../src/harness/types.ts";
+import {
+  COMPILE_CACHE_RUNTIME_VERSION,
+  loadCompiledClosure,
+} from "../src/compilation-cache/cell-cache.ts";
+
+const signer = await Identity.fromPassphrase("module byte cache test");
+
+// Minimal in-memory cache implementing the injection interface — enough to
+// exercise the runtime's consult/populate behavior. The real implementation
+// (eviction, disk persistence) lives in test code outside the runtime and is
+// tested there.
+class FakeByteCache implements ModuleByteCache {
+  private readonly m = new Map<string, CompiledModuleArtifact>();
+  getCompleteSet(
+    rt: string,
+    ids: readonly string[],
+  ): Map<string, CompiledModuleArtifact> | undefined {
+    const out = new Map<string, CompiledModuleArtifact>();
+    for (const id of ids) {
+      const a = this.m.get(`${rt}\0${id}`);
+      if (a === undefined) return undefined;
+      out.set(id, a);
+    }
+    return out;
+  }
+  putAll(
+    rt: string,
+    mods: readonly { identity: string; js: string; sourceMap?: unknown }[],
+  ): void {
+    for (const x of mods) {
+      this.m.set(
+        `${rt}\0${x.identity}`,
+        x.sourceMap === undefined
+          ? { js: x.js }
+          : { js: x.js, sourceMap: x.sourceMap },
+      );
+    }
+  }
+}
+
+// A shared module-byte cache lets a fresh runtime compiling into a fresh space
+// reuse another runtime's compiled module bytes (cross-runtime, cross-space).
+describe("ModuleByteCache cross-runtime reuse", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  const PROGRAM: RuntimeProgram = {
+    main: "/main.tsx",
+    files: [
+      { name: "/util.ts", contents: "export const square=(x:number)=>x*x;" },
+      {
+        name: "/main.tsx",
+        contents: [
+          "import { pattern, lift } from 'commonfabric';",
+          "import { square } from './util.ts';",
+          "const sq = lift((x:number)=>square(x));",
+          "export default pattern<{ value: number }>(({ value }) => {",
+          "  return { result: sq(value) };",
+          "});",
+        ].join("\n"),
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+  });
+  afterEach(async () => {
+    await storageManager?.close();
+  });
+
+  const runtimeIn = (byteCache?: ModuleByteCache) =>
+    new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      moduleByteCache: byteCache,
+    });
+
+  it("a fresh runtime + fresh space process-hits and persists the closure", async () => {
+    const byteCache = new FakeByteCache();
+    const spaceA = (await Identity.fromPassphrase("byte-cache space A")).did();
+    const spaceB = (await Identity.fromPassphrase("byte-cache space B")).did();
+
+    // Runtime A compiles into space A: cold miss, populates the byte cache.
+    const rtA = runtimeIn(byteCache);
+    const txA = rtA.edit();
+    let entryIdentity: string;
+    try {
+      const cold = await rtA.patternManager.compilePattern(PROGRAM, {
+        space: spaceA,
+        tx: txA,
+      });
+      await rtA.patternManager.flushCompileCacheWrites();
+      expect(rtA.patternManager.getCompileCacheStats()).toEqual({
+        hits: 0,
+        misses: 1,
+        byIdentityHits: 0,
+      });
+      entryIdentity = rtA.patternManager.getArtifactEntryRef(cold)!.identity;
+      await txA.commit();
+    } finally {
+      await rtA.dispose();
+    }
+
+    // Runtime B (fresh runtime) compiles the SAME program into space B (fresh,
+    // empty space). The per-space cache in B is empty, but the shared byte cache
+    // serves every module → a hit, no TS recompile.
+    const rtB = runtimeIn(byteCache);
+    let txB = rtB.edit();
+    try {
+      const warm = await rtB.patternManager.compilePattern(PROGRAM, {
+        space: spaceB,
+        tx: txB,
+      });
+      await rtB.patternManager.flushCompileCacheWrites();
+      expect(rtB.patternManager.getCompileCacheStats()).toEqual({
+        hits: 1,
+        misses: 0,
+        byIdentityHits: 0,
+      });
+      await txB.commit();
+
+      // The closure was written back into space B, so a by-identity reload from
+      // B works (the byte-cache hit did not skip per-space persistence).
+      const readTx = rtB.edit();
+      const inB = await loadCompiledClosure(
+        rtB,
+        spaceB,
+        entryIdentity,
+        { runtimeVersion: COMPILE_CACHE_RUNTIME_VERSION },
+        readTx,
+      );
+      readTx.abort?.();
+      expect(inB.has(entryIdentity)).toBe(true);
+
+      // The byte-cache hit took the trusted-bytes path (SES re-verification
+      // skipped), so prove it yields a WORKING pattern, not just a durable
+      // closure: run the warm-compiled pattern and check it computes.
+      // PROGRAM returns `{ result: square(value) }`, so value 7 → 49.
+      txB = rtB.edit();
+      const resultCell = rtB.getCell<{ result: number }>(
+        spaceB,
+        "warm-run",
+        undefined,
+        txB,
+      );
+      const result = rtB.run(txB, warm, { value: 7 }, resultCell);
+      await txB.commit();
+      await result.pull();
+      expect(result.getAsQueryResult()).toEqual({ result: 49 });
+    } finally {
+      await rtB.dispose();
+    }
+  });
+
+  it("without a shared byte cache the fresh-space compile is a cold miss", async () => {
+    const spaceA = (await Identity.fromPassphrase("no-cache space A")).did();
+    const spaceB = (await Identity.fromPassphrase("no-cache space B")).did();
+
+    const rtA = runtimeIn(undefined);
+    const txA = rtA.edit();
+    try {
+      await rtA.patternManager.compilePattern(PROGRAM, {
+        space: spaceA,
+        tx: txA,
+      });
+      await rtA.patternManager.flushCompileCacheWrites();
+      await txA.commit();
+    } finally {
+      await rtA.dispose();
+    }
+
+    const rtB = runtimeIn(undefined);
+    const txB = rtB.edit();
+    try {
+      await rtB.patternManager.compilePattern(PROGRAM, {
+        space: spaceB,
+        tx: txB,
+      });
+      // Fresh runtime, fresh empty space, no shared bytes → cold compile.
+      expect(rtB.patternManager.getCompileCacheStats()).toEqual({
+        hits: 0,
+        misses: 1,
+        byIdentityHits: 0,
+      });
+      await txB.commit();
+    } finally {
+      await rtB.dispose();
+    }
+  });
+});


### PR DESCRIPTION
This is intended to improve the runtime of the "Run pattern unit tests" job. Eventually it can also be used in the "Pattern Integration Tests" job but I am currently trying to add coverage to that job and this would conflict significantly with that effort so I decided to do that later.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a process-wide compiled-module-byte cache to skip per-space reads and the TS transform/emit in pattern tests and CI shards, while still persisting closures per space for by-identity reloads.

- **New Features**
  - Introduced `ModuleByteCache` injection via `RuntimeOptions.moduleByteCache`; the compile path checks `getCompleteSet` before storage and populates via `putAll` after compile. Full hits still write the closure to the target space and skip per-module SES re-verification on the trusted path.
  - Added test-owned `ProcessModuleByteCache` and `createCompileByteCache` (content-addressed, byte-capped, snapshot/restore) with optional disk persistence via `CF_COMPILE_CACHE_FILE`; injected through `PiecesController.initialize`.
  - CI restores/saves a per-shard cache file with `actions/cache@v4`; the key includes `packages/ts-transformers/**`, `packages/js-compiler/**`, `packages/schema-generator/**`, `deno.json`, `deno.lock`, the shard, and the pattern source hash.
  - New tests cover cross-runtime reuse, snapshot/restore, eviction, and running a warm-compiled pattern to validate the trusted path.

- **Refactors**
  - Defined `ModuleByteCache` in `runtime.ts` and exported `ModuleByteCache` and `CompiledModuleArtifact` from `@commonfabric/runner`.

<sup>Written for commit 1f85ccb3b9f4cc4be43d79855356eb728012c282. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

