### PR TITLE
Add scoped name handoff pattern

### DIFF
--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -66,9 +66,9 @@ App and integration directories: `activity-log/`, `agent/`, `airtable/`,
 `contacts/`, `cozy-poll/`, `examples/`, `experimental/` (explicitly unhardened
 explorations), `github-activity/`, `google/` (the `core/` tree; `google/WIP/` is
 legacy), `habit-tracker/`, `lunch-poll/`, `profile-group-chat/`,
-`project-list/`, `router/`, `scoped-group-chat/`, `scoped-user-directory/`,
-`scrabble/`, `shared-profile-demo/`, `shared-profile-roster/`, `suggestable/`,
-`weekly-calendar/`.
+`project-list/`, `router/`, `scoped-group-chat/`, `scoped-name-handoff/`,
+`scoped-user-directory/`, `scrabble/`, `shared-profile-demo/`,
+`shared-profile-roster/`, `suggestable/`, `weekly-calendar/`.
 
 CFC spec demos (intentionally verbose wiring): `cfc/`,
 `cfc-agent-prompt-injection-demo/`, `cfc-authorized-save/`,
@@ -811,6 +811,34 @@ interface Output {
   balances: Balance[];
   settlements: Settlement[];
   total: number;
+}
+```
+
+## `scoped-name-handoff/main.tsx`
+
+Minimal scoped-cell demo. Each viewer edits their own durable `PerUser` name,
+then clicks a button to copy that value into the shared `PerSpace` name visible
+to everyone in the space.
+
+**Keywords:** scopes, per-space, per-user, shared cell, personal cell, name,
+multi-user
+
+### Input Schema
+
+```ts
+interface ScopedNameHandoffInput {
+  sharedName?: PerSpace<Writable<string | Default<"">>>;
+  myName?: PerUser<Writable<string | Default<"">>>;
+}
+```
+
+### Output Schema
+
+```ts
+interface ScopedNameHandoffOutput {
+  sharedName: PerSpace<string | Default<"">>;
+  myName: PerUser<string | Default<"">>;
+  publishName: Stream<void>;
 }
 ```
 

--- a/packages/patterns/scoped-name-handoff/main.tsx
+++ b/packages/patterns/scoped-name-handoff/main.tsx
@@ -1,0 +1,68 @@
+import {
+  action,
+  Default,
+  NAME,
+  pattern,
+  type PerSpace,
+  type PerUser,
+  Stream,
+  UI,
+  type VNode,
+  Writable,
+} from "commonfabric";
+
+type NameCell = Writable<string | Default<"">>;
+
+export interface ScopedNameHandoffInput {
+  sharedName?: PerSpace<NameCell>;
+  myName?: PerUser<NameCell>;
+}
+
+export interface ScopedNameHandoffOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  sharedName: PerSpace<string | Default<"">>;
+  myName: PerUser<string | Default<"">>;
+  publishName: Stream<void>;
+}
+
+export default pattern<ScopedNameHandoffInput, ScopedNameHandoffOutput>(
+  ({ sharedName, myName }) => {
+    const publishName = action(() => {
+      sharedName.set(myName.get());
+    });
+
+    return {
+      [NAME]: "Scoped name handoff",
+      [UI]: (
+        <cf-screen>
+          <cf-vstack slot="header" gap="1">
+            <cf-heading level={4}>Scoped name handoff</cf-heading>
+          </cf-vstack>
+
+          <cf-vstack gap="3" style="padding: 1rem; max-width: 420px;">
+            <cf-vstack gap="1">
+              <cf-label>Your name</cf-label>
+              <cf-input
+                $value={myName}
+                placeholder="Ada Lovelace"
+                aria-label="Your name"
+                timing-strategy="immediate"
+              />
+            </cf-vstack>
+
+            <cf-vstack gap="1">
+              <cf-label>Shared name</cf-label>
+              <div>{sharedName}</div>
+            </cf-vstack>
+
+            <cf-button onClick={publishName}>Use my name</cf-button>
+          </cf-vstack>
+        </cf-screen>
+      ),
+      sharedName,
+      myName,
+      publishName,
+    };
+  },
+);


### PR DESCRIPTION
## Summary

- Adds `packages/patterns/scoped-name-handoff/main.tsx`, a minimal scoped-cell pattern with one shared `PerSpace` name cell and one durable `PerUser` name cell.
- Adds a `publishName` action/button that copies the active user's `myName` value into the shared `sharedName` cell.
- Adds the pattern to `packages/patterns/index.md` with input/output schema notes.

## Validation

- `DENO_DIR=/private/tmp/deno-cache deno fmt --check packages/patterns/scoped-name-handoff/main.tsx`
- `DENO_DIR=/private/tmp/deno-cache deno task cf check packages/patterns/scoped-name-handoff/main.tsx`
- `DENO_DIR=/private/tmp/deno-cache deno task cf check packages/patterns/scoped-name-handoff/main.tsx --show-transformed --no-run`
  - Confirmed `sharedName` lowers with `scope: "space"`.
  - Confirmed `myName` lowers with `scope: "user"`.
- Local deploy smoke:
  - `las deploy` was requested, but this checkout has no `.commands/` directory, so `las` could not run a project deploy command.
  - Used repo-supported CF deploy path instead:
    `deno task cf piece new packages/patterns/scoped-name-handoff/main.tsx --identity ./claude.key --api-url http://localhost:8000 --space scoped-name-handoff`
  - Local piece: `fid1:IcNR8ZmB1AUfMoD4KgGhKLh8VzUAjlVKGWe-PLzB-VM`
  - Local URL returned HTTP 200:
    `http://localhost:8000/scoped-name-handoff/fid1:IcNR8ZmB1AUfMoD4KgGhKLh8VzUAjlVKGWe-PLzB-VM`
  - CLI behavior smoke passed: set `myName` to `"Codex"`, called `publishName`, stepped, and read `sharedName` as `"Codex"`.

## Conversation Context

The full user-facing transcript is attached below. Hidden system/developer instructions and raw tool internals are not included in this public PR context.

<details>
<summary>Transcript</summary>

```text
User:
# AGENTS.md instructions for /Users/ben/.codex/worktrees/35b2/labs

<INSTRUCTIONS>
## Tooling Preferences

- Prefer `uv` over direct `python` / `python3` invocations when running
  Python tools, validators, one-off scripts, or commands that need Python
  dependencies. Use direct Python only when the project explicitly requires it
  or `uv` is unavailable.
- Be aware that `mise` may manage runtime versions in projects, including
  `deno`. Check and respect project-local `mise` configuration before assuming
  a globally installed runtime is the intended one.
- When probing local HTTP servers, run the probing command outside the sandbox;
  sandboxed commands may not be able to reach local services reliably.

--- project-doc ---

# Repository Guidelines for AI Agents

This repository represents the Common Fabric runtime: a fully integrated,
reactive runtime and execution environment for user-created programs. These
programs are known as patterns and somewhat similar to Solid.js components. Each
pattern is comprised of reactive `Cell`s stored in `Space`s (defined by a DID).
These cells enable durable communication between patterns. The reactivity is
enabled by subscribing to the result of a query, defined by the schemas/type
signatures.

## Pace Layers

This repository contains many packages that compose and stack to create the
Common Fabric product.

1. Foundation: api, runtime, identity, memory
2. System: schema-generator, iframe-sandbox, ts-transformers, js-compiler
3. Capabilities: piece, html, llm
4. Operation: background-piece-service, cli
5. Deployed Product: toolshed, shell
6. User Interface: ui
7. End-User Programs: home-schemas, patterns

## Pattern Development

If you are developing patterns, use the repo-local `pattern-dev` skill at
`skills/pattern-dev/SKILL.md`. `skills/` is the canonical authored source. Codex
discovers the repo-local skill mirror through `.agents/skills/`, and Claude
compatibility continues to use `.claude/skills/`.

When authoring or reviewing a skill itself, read
`docs/development/skill-authoring.md` -- what belongs in a skill (non-derivable
map & values) versus what just constrains the agent (procedure a capable model
already does).

### Useful Pattern documentation

**Start here:**

- `docs/common/README.md` - Overview of the pattern system and index of all
  pattern documentation
- `packages/patterns/catalog/catalog.tsx` - Authoritative, type-checked
  component catalog; story files in `packages/patterns/catalog/stories/` show
  live usage for each component
- `docs/common/components/COMPONENTS.md` - UI component narrative reference with
  bidirectional binding and event handling

**Core concepts:**

- `docs/common/concepts/reactivity.md` - Cell system, reactivity mental models
- `docs/common/concepts/computed/` - computed(), lift(), derived values
- `docs/common/concepts/types-and-schemas/` - Type system, Writable<>, Default<>
- `docs/common/patterns/` - Common patterns (conditionals, composition, binding)

**Workflow:**

- `docs/development/debugging/` - Error reference, debugging workflows,
  troubleshooting
- `docs/common/capabilities/llm.md` - Using generateText and generateObject for
  LLM integration
- `docs/common/conventions/adding-pieces.md` - How to add pieces (use addPiece
  handler, not allPieces.push)

**Reference:**

- `packages/patterns/index.md` - Catalog of all pattern examples with summaries,
  data types, and keywords. Check its "Status tiers" section before imitating
  any pattern -- only `exemplar` entries are style references.

**Important:** Ignore the top level `deprecated-patterns` folder - it is
defunct.

## Runtime Development

If you are developing runtime code, read the following documentation:

- `docs/development/DEVELOPMENT.md` - Coding style, design principles, and best
  practices
- `docs/development/LOCAL_DEV_SERVERS.md` - **CRITICAL**: How to start local dev
  servers correctly (use `dev-local` for shell, not `dev`)
- `docs/development/CI_PERFORMANCE.md` - When to stop or revisit CI wall-time
  splitting/rebalancing work
- `docs/development/UI_TESTING.md` - How to work with shadow dom in our
  integration tests
- `docs/development/debugging/` - Runtime errors, type errors, and
  troubleshooting

When investigating transformer behavior, inspect the emitted output directly
before inferring from source code alone:

```bash
deno task cf check <pattern-or-fixture>.tsx --show-transformed --no-run
```

### Adding New Packages

When adding a new workspace package:

1. Add the package path (e.g., `./packages/my-package`) to the root `deno.json`
   `"workspace"` array.
2. The package's `deno.json` **must** include a `"tasks"` object with a `"test"`
   entry. Use `"deno test"` if the package has tests, or
   `"echo 'No tests defined.'"` as a stub for packages without tests yet.

This is required because the root test runner (`tasks/test.ts`) iterates all
workspace packages and runs `deno task test` in each. If a package has no test
task, Deno falls back to the root workspace's test task, which re-runs the
entire suite recursively -- causing exponential process spawning and CI timeouts.

See `packages/utils/deno.json` for an example of a correctly configured package.

</INSTRUCTIONS>

Environment context:
- cwd: `/Users/ben/.codex/worktrees/35b2/labs`
- shell: `zsh`
- current date: `2026-06-25`
- timezone: `Australia/Brisbane`

User:
use pattern-dev skill to make a basic pattern using scopes

I want a shared cell and a per user cell and each user should set their 'name' and then there is a button to set the shared cell to the value of their user cell

super simple

Assistant:
I’ll use the repo-local `pattern-dev` skill, then inspect the existing pattern conventions so the new example lands in the right place and uses current scope APIs.

Assistant:
The skill points at the canonical pattern guide plus the reactivity and new-cells references. I’m reading those before touching code, because scope wrappers are exactly the part that can look type-correct while producing the wrong durable state.

Assistant:
The base docs confirm this should stay a one-file pattern: `PerSpace` for the shared durable value and `PerUser` for each person’s name. I’m pulling the multi-user notes now because the requested behavior is identity-sensitive even though the UI is tiny.

Assistant:
This is small enough for the simple pattern path: one `main.tsx`, writable scoped inputs, one action that copies `myName` into `sharedName`. I’m checking nearby scoped examples and the pattern catalog/index so I don’t copy an older broken idiom.

Assistant:
I’m going to add this as a new small pattern under `packages/patterns/scoped-name-handoff/main.tsx`. It will use writable scoped inputs because the button needs `.get()` on the per-user name and `.set()` on the shared cell.

Assistant:
`scoped-group-chat` and `scoped-user-directory` are marked exemplar, so I’m using their scoped input/output shape as the model but keeping the UI intentionally bare.

Assistant:
I’m creating the new pattern file now, scoped narrowly to the requested behavior. The exported output will expose plain scoped values plus the `publishName` action stream, so it is easy to inspect or test later.

Assistant:
The first implementation is in place. I’m checking the repo runtime configuration before running `cf check`, then I’ll validate both type/schema lowering and the transformed scope output if needed.

Assistant:
The local `mise.toml` pins Deno 2.8.1 and the active `deno` matches it. I’m running the focused pattern check with a tmp Deno cache to avoid sandbox cache-write noise.

Assistant:
`cf check` reached dependency resolution and hit blocked JSR/npm downloads, not a pattern error. I’m rerunning the same focused check outside the sandbox so Deno can fetch the missing cached dependencies.

Assistant:
The focused `cf check --no-run` passes. I’m doing a quick format check and one transformed-output pass so the scoped input annotations are validated by the transformer, not just by TypeScript surface types.

Assistant:
The transformed output shows `sharedName` lowering with `scope: "space"` and `myName` with `scope: "user"` in both input and output schemas. I’m running the normal `cf check` now as the final pattern-level validation.

Assistant:
The normal `cf check` passes too. I’m adding a short catalog entry so the new pattern is discoverable alongside the other scoped demos.

Assistant:
The index layout is not strictly alphabetic, so I’m locating the existing scoped entries before patching rather than guessing a spot.

Assistant:
I’m adding a compact index section: this pattern is a demo rather than an exemplar, and the schema note calls out the `PerSpace`/`PerUser` split directly.

Assistant:
The first patch missed the exact nearby text in `index.md`, so I’m reading the local sections and applying a tighter patch.

Assistant:
The index entry is patched. I’m doing the final diff and whitespace checks now, then I’ll summarize the exact files and validation results.

Assistant:
`git diff --check` is clean. Since the new pattern file is still untracked, I’m reading it directly once more and rerunning the focused validation after the index edit.

Assistant:
Validation is still clean after the doc update. The only worktree changes are the new scoped pattern directory and the index entry.

Assistant:
Implemented the scoped pattern in `packages/patterns/scoped-name-handoff/main.tsx`. It has `sharedName?: PerSpace<Writable<string | Default<"">>>`, `myName?: PerUser<Writable<string | Default<"">>>`, a bound input for each user’s name, and a `publishName` button/action that copies `myName.get()` into the shared cell.

I also added it to the patterns index at `packages/patterns/index.md`.

Validation passed:
- `deno fmt --check packages/patterns/scoped-name-handoff/main.tsx`
- `deno task cf check packages/patterns/scoped-name-handoff/main.tsx`
- `deno task cf check ... --show-transformed --no-run` confirmed `scope: "space"` for `sharedName` and `scope: "user"` for `myName`
- `git diff --check` is clean

User:
please deploy it with las deploy

Assistant:
I’ll use the repo deployment guidance and first confirm what `las deploy` maps to in this checkout, then run the deploy command with network approval if it needs the hosted service.

Assistant:
I don’t see `las deploy` in the repo docs, so I’m checking whether `las` exists as a local wrapper or shell tool. In parallel I’m checking the current CF identity/API settings because the repo deploy path needs those.

Assistant:
`las` is installed, but this worktree has no `.commands` directory, so `las` currently has no project commands to run from here. I’m checking whether there’s a global `deploy` command or documented wrapper before falling back to the repo’s `cf piece new` deploy path.

Assistant:
`las deploy` cannot run in this checkout as-is: `las` exits because there is no `.commands/` directory. I’m reading the repo’s local deploy docs now so I can still deploy the pattern through the supported CF CLI if there’s enough local configuration.

Assistant:
The deploy target isn’t configured in env and there’s no key file in this worktree. I’m checking whether the local Common Fabric servers are already up; if not, I’ll start them and deploy to a local space with the standard local-dev identity.

Assistant:
Local Toolshed and Shell are down, so I’m starting the repo-local dev servers on the default ports. After they report healthy I’ll create/use the local dev identity and deploy the new piece.

Assistant:
The local servers are healthy and being kept attached for this thread. I’m creating the standard local-dev CLI key (`implicit trust`) because this worktree did not have an identity key yet.

Assistant:
The local key is in place. I’m deploying the new pattern as a fresh piece in a local `scoped-name-handoff` space, then I’ll inspect it to confirm the piece exists and has the expected scoped fields.

Assistant:
The deploy succeeded and returned a piece ID. I’m inspecting the deployed piece and probing the browser URL so the handoff includes a verified runnable link, not just a created ID.

Assistant:
The piece inspects cleanly and the URL returns HTTP 200. I’m doing one CLI smoke test of the actual behavior now: set this CLI user’s `myName`, call `publishName`, step the piece, then read `sharedName`.

Assistant:
The CLI confirms `piece set` reads JSON from stdin. I’ll use `"Codex"` as the smoke-test name, then call the stream and step the piece so the shared result updates.

Assistant:
The CLI user’s `myName` is set. Next I’m invoking the `publishName` stream and stepping the piece, which is the important part of the requested button behavior.

Assistant:
The stream call succeeded. I’m stepping now and then reading `sharedName` to verify the handler copied the per-user value into shared space state.

Assistant:
The smoke test passed: `sharedName` now reads `"Codex"` after setting `myName` and invoking `publishName`. I’m doing a final status check so I can separate code changes from deploy artifacts.

Assistant:
The deploy is complete. One caveat for the final note: `las deploy` itself could not run here because `las` found no `.commands/` directory in this worktree, so I used the repo-supported CF deploy path and verified the resulting local piece.

Assistant:
`las deploy` itself is not runnable in this worktree: `las` reports there is no `.commands/` directory. I deployed it with the repo-supported CF deploy path instead.

Deployed local piece:

http://localhost:8000/scoped-name-handoff/fid1:IcNR8ZmB1AUfMoD4KgGhKLh8VzUAjlVKGWe-PLzB-VM

Piece ID: `fid1:IcNR8ZmB1AUfMoD4KgGhKLh8VzUAjlVKGWe-PLzB-VM`

Verified:
- Local Toolshed/Shell are healthy.
- URL returns HTTP 200.
- `piece inspect` shows `myName` and `sharedName`.
- Smoke test passed: set `myName` to `"Codex"`, called `publishName`, stepped, then `sharedName` read back `"Codex"`.

The local dev server is still running for that URL.

User:
can you assemble a draft PR with this pattern and the ENTIRE TRANSCRIPT OF THIS CONVERSATION attached as context?

Assistant:
I’ll turn the local change into a draft PR. I’ll include a transcript artifact in the repo/PR context, but I will not include hidden system/developer instructions; I can include the full user-facing conversation plus the command evidence relevant to the implementation/deploy.

Assistant:
First I’m checking branch/remotes and the exact worktree state so I only stage the pattern/index changes, not the local deployment key or any unrelated artifacts.

Assistant:
The worktree is detached HEAD with only the intended index edit plus the untracked pattern directory. I’m going to create a branch for the PR, then stage only those two paths.

Assistant:
Before committing, I’m re-running the narrow checks one last time on the staged scope: format, `cf check`, and whitespace.

Assistant:
Checks are clean. I’m creating the PR branch now and staging only `packages/patterns/index.md` plus `packages/patterns/scoped-name-handoff/main.tsx`.

Assistant:
Branch created. I’m staging the two intended paths and checking the staged diff before committing.

Assistant:
The intended files are staged. I’m reviewing staged names/stat now, then I’ll commit.

Assistant:
The staged set is exactly the new pattern and catalog entry. I’m committing it now.

Assistant:
The commit is created. I’m drafting the PR body now with a normal summary/tests section and a collapsible transcript section that includes the full user-facing conversation context; hidden system/developer/tool internals are intentionally not included in a public PR.
```

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimal scoped pattern that lets each user set their own name and publish it to a shared space-wide name. Demonstrates `PerUser` and `PerSpace` cells with a simple publish action.

- **New Features**
  - Added `packages/patterns/scoped-name-handoff/main.tsx` with `myName` (`PerUser<Writable<string | Default<"">>>`) and `sharedName` (`PerSpace<Writable<string | Default<"">>>`).
  - Added `publishName` action/button to copy `myName` into `sharedName`.
  - Updated `packages/patterns/index.md` with input/output schema notes.

<sup>Written for commit eb428de3f6eaa08dc8bcb46581aad8130ae12f4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

