### PR TITLE
feat(runner): skip redundant ifElse writes via setRawUntyped onlyIfDifferent

### DIFF
--- a/packages/runner/src/builtins/if-else.ts
+++ b/packages/runner/src/builtins/if-else.ts
@@ -49,8 +49,11 @@ export function ifElse(
       base: result,
     });
 
-    // When writing links, we need to use setRawUntyped (link doesn't match T)
-    resultWithLog.setRawUntyped(serializedRef);
+    // When writing links, we need to use setRawUntyped (link doesn't match T).
+    // Pass `onlyIfDifferent` so re-running with the same selected branch (e.g.
+    // the condition changed between two truthy values) does not write the
+    // identical reference again and needlessly re-trigger downstream work.
+    resultWithLog.setRawUntyped(serializedRef, true);
   };
 
   // Only depend on the condition for initial scheduling.

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -10,6 +10,7 @@ import {
   FabricSpecialObject,
   type FabricValue,
   shallowFabricFromNativeValue,
+  valueEqual,
 } from "@commonfabric/data-model/fabric-value";
 import { codecOf } from "@commonfabric/data-model/codec-common";
 import {
@@ -18,7 +19,6 @@ import {
   linkRefFrom,
 } from "@commonfabric/data-model/cell-rep";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
-import { deepEqual } from "@commonfabric/utils/deep-equal";
 import {
   deepFrozenCloneAndInternSchema,
   internSchema,
@@ -1809,21 +1809,22 @@ export class CellImpl<T extends FabricValue>
     const inlined = findAndInlineDataURILinks(value);
 
     // When asked to write only on change, read the current raw value and bail
-    // out if it already deep-equals what we'd write. `readValueOrThrow` mirrors
-    // the `writeValueOrThrow` below (same transaction and address, no link
-    // resolution). The read is purely an internal write-elision decision, so
-    // it is marked `ignoreReadForScheduling` (it must not register a
-    // self-dependency that would re-trigger the writer) and `internalVerifierRead`
-    // (it must not taint the transaction's CFC labels with this cell's own
-    // value). Note `deepEqual` is not `Fabric`-aware (same-class
-    // `FabricPrimitive`s compare equal regardless of value), matching the
-    // existing no-op write gate in `setValueAtPath`; current callers write
-    // links / plain objects, for which it is exact.
+    // out if it already equals what we'd write. `readValueOrThrow` mirrors the
+    // `writeValueOrThrow` below (same transaction and address, no link
+    // resolution). The read is purely an internal write-elision decision, so it
+    // is marked `ignoreReadForScheduling` (it must not register a
+    // self-dependency that would re-trigger the writer) and
+    // `internalVerifierRead` (it must not taint the transaction's CFC labels
+    // with this cell's own value). Comparison uses `valueEqual`, the
+    // `Fabric`-aware content equality the storage no-op gates rely on:
+    // `deepEqual` walks enumerable own-props and so conflates distinct
+    // same-class `FabricSpecialObject`s (e.g. `FabricBytes`/`FabricHash`),
+    // which would drop a real change.
     if (onlyIfDifferent) {
       const current = this.tx.readValueOrThrow(this.link, {
         meta: { ...ignoreReadForScheduling, ...internalVerifierRead },
       });
-      if (deepEqual(current, inlined)) return;
+      if (valueEqual(current, inlined)) return;
     }
 
     // Raw writes bypass diff-based attempted-target capture. Same-value direct

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1811,11 +1811,17 @@ export class CellImpl<T extends FabricValue>
     // When asked to write only on change, read the current raw value and bail
     // out if it already deep-equals what we'd write. `readValueOrThrow` mirrors
     // the `writeValueOrThrow` below (same transaction and address, no link
-    // resolution), and `ignoreReadForScheduling` keeps the read from
-    // registering a self-dependency that would re-trigger the writer.
+    // resolution). The read is purely an internal write-elision decision, so
+    // it is marked `ignoreReadForScheduling` (it must not register a
+    // self-dependency that would re-trigger the writer) and `internalVerifierRead`
+    // (it must not taint the transaction's CFC labels with this cell's own
+    // value). Note `deepEqual` is not `Fabric`-aware (same-class
+    // `FabricPrimitive`s compare equal regardless of value), matching the
+    // existing no-op write gate in `setValueAtPath`; current callers write
+    // links / plain objects, for which it is exact.
     if (onlyIfDifferent) {
       const current = this.tx.readValueOrThrow(this.link, {
-        meta: ignoreReadForScheduling,
+        meta: { ...ignoreReadForScheduling, ...internalVerifierRead },
       });
       if (deepEqual(current, inlined)) return;
     }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -18,6 +18,7 @@ import {
   linkRefFrom,
 } from "@commonfabric/data-model/cell-rep";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
 import {
   deepFrozenCloneAndInternSchema,
   internSchema,
@@ -368,8 +369,13 @@ declare module "@commonfabric/api" {
      * storage layer but does not conform to the cell's schema type.
      *
      * Prefer `setRaw()` when the value matches `T`.
+     *
+     * When `onlyIfDifferent` is `true`, the current raw value is read first and
+     * the write is skipped entirely if it deep-equals the value that would be
+     * written. The read is marked `ignoreReadForScheduling`, so it does not
+     * register a dependency that could re-trigger the writing computation.
      */
-    setRawUntyped(value: FabricValue): void;
+    setRawUntyped(value: FabricValue, onlyIfDifferent?: boolean): void;
     freeze(reason: string): void;
     isFrozen(): boolean;
     setSchema(newSchema: JSONSchema): void;
@@ -1793,12 +1799,26 @@ export class CellImpl<T extends FabricValue>
     this.setRawUntyped(value);
   }
 
-  setRawUntyped(value: FabricValue): void {
+  setRawUntyped(value: FabricValue, onlyIfDifferent = false): void {
     if (!this.tx) throw new Error("Transaction required for setRaw");
 
     // No await for the sync, just kicking this off, so we have the data to
     // retry on conflict.
     if (!this.synced) this.sync();
+
+    const inlined = findAndInlineDataURILinks(value);
+
+    // When asked to write only on change, read the current raw value and bail
+    // out if it already deep-equals what we'd write. `readValueOrThrow` mirrors
+    // the `writeValueOrThrow` below (same transaction and address, no link
+    // resolution), and `ignoreReadForScheduling` keeps the read from
+    // registering a self-dependency that would re-trigger the writer.
+    if (onlyIfDifferent) {
+      const current = this.tx.readValueOrThrow(this.link, {
+        meta: ignoreReadForScheduling,
+      });
+      if (deepEqual(current, inlined)) return;
+    }
 
     // Raw writes bypass diff-based attempted-target capture. Same-value direct
     // writes through this internal path are therefore outside phase-1 CFC
@@ -1808,7 +1828,7 @@ export class CellImpl<T extends FabricValue>
       this.link,
       this.link.schema ?? this.schema,
     );
-    this.tx.writeValueOrThrow(this.link, findAndInlineDataURILinks(value));
+    this.tx.writeValueOrThrow(this.link, inlined);
   }
 
   getArgumentCell<U>(schema?: JSONSchema): Cell<U> | undefined {

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -1,6 +1,9 @@
 import { isRecord } from "@commonfabric/utils/types";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
-import type { FabricValue } from "@commonfabric/data-model/fabric-value";
+import {
+  type FabricValue,
+  valueEqual,
+} from "@commonfabric/data-model/fabric-value";
 import { isPattern, type JSONSchema, type JSONValue } from "./builder/types.ts";
 import { noteDerivedCopy } from "./builder/pattern-metadata.ts";
 import { type AnyCell } from "./cell.ts";
@@ -19,6 +22,7 @@ import {
 } from "./link-utils.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import { ignoreReadForScheduling } from "./scheduler.ts";
+import { internalVerifierRead } from "./storage/reactivity-log.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import type {
   Cell,
@@ -267,10 +271,22 @@ export function sendValueToBinding<T>(
         valueLink !== undefined &&
         !areNormalizedLinksSame(valueLink, bindingLink)
       ) {
-        tx.writeValueOrThrow(
-          bindingLink,
-          createSigilLinkFromParsedLink(valueLink) as FabricValue,
-        );
+        const newValue = createSigilLinkFromParsedLink(
+          valueLink,
+        ) as FabricValue;
+        // Skip the write when the redirect already holds this exact link. Raw
+        // builtins (ifElse/when/unless/map/...) re-run and re-send their result
+        // whenever their inputs change, but the output binding points at a
+        // cause-stable result cell, so the link is usually unchanged. The read
+        // is an internal write-elision decision: kept out of scheduling
+        // (`ignoreReadForScheduling`) and CFC taint (`internalVerifierRead`),
+        // and compared with the `Fabric`-aware `valueEqual`.
+        const current = tx.readValueOrThrow(bindingLink, {
+          meta: { ...ignoreReadForScheduling, ...internalVerifierRead },
+        });
+        if (!valueEqual(current, newValue)) {
+          tx.writeValueOrThrow(bindingLink, newValue);
+        }
         return;
       }
     }

--- a/packages/runner/test/patterns-ifelse.test.ts
+++ b/packages/runner/test/patterns-ifelse.test.ts
@@ -398,25 +398,30 @@ describe("Pattern Runner - ifElse", () => {
       await piece.pull();
       expect(piece.key("text").get()).toEqual("A");
 
-      // ifElse writes a redirect into its own result doc that points at the
-      // selected branch input. The other redirect written when wiring the result
-      // (the output binding) points at the result doc itself, so the ifElse
-      // result doc is the link-write whose target is NOT itself a link-write doc.
+      // On each run the ifElse action makes two link-writes:
+      //  - its result doc, holding a redirect to the selected branch input, and
+      //  - the output binding, holding a redirect to that result doc.
+      // The result doc is therefore the link-write whose target is NOT itself a
+      // link-write doc; the binding is the one that targets the result doc.
       const firstWrites = writesByPhase["first"] ?? [];
       const writtenIds = new Set(firstWrites.map((w) => w.id));
-      const resultDocs = new Set(
-        firstWrites
-          .filter((w) => w.target !== undefined && !writtenIds.has(w.target))
-          .map((w) => w.id),
-      );
-      expect(resultDocs.size).toEqual(1);
-      const ifElseResultId = [...resultDocs][0];
-      // It was written exactly once on the first trigger.
+      const resultDocs = firstWrites
+        .filter((w) => w.target !== undefined && !writtenIds.has(w.target))
+        .map((w) => w.id);
+      expect(resultDocs.length).toEqual(1);
+      const ifElseResultId = resultDocs[0];
+      const bindingDocs = firstWrites
+        .filter((w) => w.target === ifElseResultId)
+        .map((w) => w.id);
+      expect(bindingDocs.length).toEqual(1);
+      const bindingId = bindingDocs[0];
+      // Each was written exactly once on the first trigger.
       expect(firstWrites.filter((w) => w.id === ifElseResultId).length)
         .toEqual(1);
+      expect(firstWrites.filter((w) => w.id === bindingId).length).toEqual(1);
 
       // Re-trigger with a different-but-still-truthy condition. ifElse re-runs and
-      // selects the same branch, so the reference it would write is unchanged.
+      // selects the same branch, so neither reference it would write changes.
       phase = "second";
       tx = runtime.edit();
       piece.withTx(tx).key("n").set(2);
@@ -424,12 +429,13 @@ describe("Pattern Runner - ifElse", () => {
       await piece.pull();
       expect(piece.key("text").get()).toEqual("A");
 
-      // The selected branch is unchanged, so ifElse must not write its result
-      // again — the redundant write is what `onlyIfDifferent` suppresses.
-      expect(
-        (writesByPhase["second"] ?? []).filter((w) => w.id === ifElseResultId)
-          .length,
-      ).toEqual(0);
+      // The selection is unchanged, so the re-run must rewrite neither the
+      // result doc (`setRawUntyped` onlyIfDifferent) nor the output binding
+      // (`sendValueToBinding` no-op).
+      const secondWrites = writesByPhase["second"] ?? [];
+      expect(secondWrites.filter((w) => w.id === ifElseResultId).length)
+        .toEqual(0);
+      expect(secondWrites.filter((w) => w.id === bindingId).length).toEqual(0);
     },
   );
 });

--- a/packages/runner/test/patterns-ifelse.test.ts
+++ b/packages/runner/test/patterns-ifelse.test.ts
@@ -325,4 +325,107 @@ describe("Pattern Runner - ifElse", () => {
       ]),
     );
   });
+
+  it("only writes the branch reference once when re-triggered with the " +
+    "same value", async () => {
+    // Record every reactive link-write, grouped by trigger phase, by
+    // instrumenting the transactions the scheduler creates via
+    // `runtime.edit()`. For each write we capture both the doc written and, for
+    // link writes, the doc the link points at.
+    const linkTarget = (value: unknown): string | undefined => {
+      if (!value || typeof value !== "object") return undefined;
+      const sigil = (value as Record<string, unknown>)["/"];
+      if (!sigil || typeof sigil !== "object") return undefined;
+      const inner = Object.values(sigil as Record<string, unknown>)[0] as
+        | { id?: string }
+        | undefined;
+      return inner?.id;
+    };
+    const writesByPhase: Record<
+      string,
+      Array<{ id: string; target?: string }>
+    > = {};
+    let phase = "init";
+    const origEdit = runtime.edit.bind(runtime);
+    (runtime as unknown as { edit: typeof origEdit }).edit = ((opts?: any) => {
+      const t = origEdit(opts);
+      const origWrite = t.writeValueOrThrow.bind(t);
+      (t as unknown as { writeValueOrThrow: typeof origWrite })
+        .writeValueOrThrow = ((address: any, value: any, options?: any) => {
+          (writesByPhase[phase] ??= []).push({
+            id: String(address.id),
+            target: linkTarget(value),
+          });
+          return origWrite(address, value, options);
+        }) as typeof origWrite;
+      return t;
+    }) as typeof origEdit;
+
+    // `n` is a truthy number rather than a boolean: changing it from 1 to 2
+    // re-triggers ifElse while still selecting the same (`ifTrue`) branch. The
+    // branches are stable input cells (not inline literals, which would be
+    // re-materialized with new ids when `n` changes), so the branch reference
+    // ifElse would write is identical to what is already stored.
+    const ifElsePattern = pattern<{ n: number; a: string; b: string }>(
+      ({ n, a, b }) => ({
+        n,
+        a,
+        b,
+        text: ifElse(n, a, b),
+      }),
+    );
+
+    const pieceCell = runtime.getCell<
+      { n: number; a: string; b: string; text: string }
+    >(
+      space,
+      "ifElse only writes once for same value",
+      ifElsePattern.resultSchema,
+      tx,
+    );
+    const piece = runtime.run(
+      tx,
+      ifElsePattern,
+      { n: 1, a: "A", b: "B" },
+      pieceCell,
+    );
+    tx.commit();
+
+    phase = "first";
+    await piece.pull();
+    expect(piece.key("text").get()).toEqual("A");
+
+    // ifElse writes a redirect into its own result doc that points at the
+    // selected branch input. The other redirect written when wiring the result
+    // (the output binding) points at the result doc itself, so the ifElse
+    // result doc is the link-write whose target is NOT itself a link-write doc.
+    const firstWrites = writesByPhase["first"] ?? [];
+    const writtenIds = new Set(firstWrites.map((w) => w.id));
+    const resultDocs = new Set(
+      firstWrites
+        .filter((w) => w.target !== undefined && !writtenIds.has(w.target))
+        .map((w) => w.id),
+    );
+    expect(resultDocs.size).toEqual(1);
+    const ifElseResultId = [...resultDocs][0];
+    // It was written exactly once on the first trigger.
+    expect(firstWrites.filter((w) => w.id === ifElseResultId).length)
+      .toEqual(1);
+
+    // Re-trigger with a different-but-still-truthy condition. ifElse re-runs and
+    // selects the same branch, so the reference it would write is unchanged.
+    phase = "second";
+    tx = runtime.edit();
+    piece.withTx(tx).key("n").set(2);
+    tx.commit();
+    await piece.pull();
+    expect(piece.key("text").get()).toEqual("A");
+
+    // The selected branch is unchanged, so ifElse must not write its result
+    // again — the redundant write is what `onlyIfDifferent` suppresses.
+    expect(
+      (writesByPhase["second"] ?? []).filter((w) => w.id === ifElseResultId)
+        .length,
+    ).toEqual(0);
+  });
 });

--- a/packages/runner/test/patterns-ifelse.test.ts
+++ b/packages/runner/test/patterns-ifelse.test.ts
@@ -326,106 +326,110 @@ describe("Pattern Runner - ifElse", () => {
     );
   });
 
-  it("only writes the branch reference once when re-triggered with the " +
-    "same value", async () => {
-    // Record every reactive link-write, grouped by trigger phase, by
-    // instrumenting the transactions the scheduler creates via
-    // `runtime.edit()`. For each write we capture both the doc written and, for
-    // link writes, the doc the link points at.
-    const linkTarget = (value: unknown): string | undefined => {
-      if (!value || typeof value !== "object") return undefined;
-      const sigil = (value as Record<string, unknown>)["/"];
-      if (!sigil || typeof sigil !== "object") return undefined;
-      const inner = Object.values(sigil as Record<string, unknown>)[0] as
-        | { id?: string }
-        | undefined;
-      return inner?.id;
-    };
-    const writesByPhase: Record<
-      string,
-      Array<{ id: string; target?: string }>
-    > = {};
-    let phase = "init";
-    const origEdit = runtime.edit.bind(runtime);
-    (runtime as unknown as { edit: typeof origEdit }).edit = ((opts?: any) => {
-      const t = origEdit(opts);
-      const origWrite = t.writeValueOrThrow.bind(t);
-      (t as unknown as { writeValueOrThrow: typeof origWrite })
-        .writeValueOrThrow = ((address: any, value: any, options?: any) => {
-          (writesByPhase[phase] ??= []).push({
-            id: String(address.id),
-            target: linkTarget(value),
-          });
-          return origWrite(address, value, options);
-        }) as typeof origWrite;
-      return t;
-    }) as typeof origEdit;
+  it(
+    "only writes the branch reference once when re-triggered with the " +
+      "same value",
+    async () => {
+      // Record every reactive link-write, grouped by trigger phase, by
+      // instrumenting the transactions the scheduler creates via
+      // `runtime.edit()`. For each write we capture both the doc written and, for
+      // link writes, the doc the link points at.
+      const linkTarget = (value: unknown): string | undefined => {
+        if (!value || typeof value !== "object") return undefined;
+        const sigil = (value as Record<string, unknown>)["/"];
+        if (!sigil || typeof sigil !== "object") return undefined;
+        const inner = Object.values(sigil as Record<string, unknown>)[0] as
+          | { id?: string }
+          | undefined;
+        return inner?.id;
+      };
+      const writesByPhase: Record<
+        string,
+        Array<{ id: string; target?: string }>
+      > = {};
+      let phase = "init";
+      const origEdit = runtime.edit.bind(runtime);
+      (runtime as unknown as { edit: typeof origEdit }).edit =
+        ((opts?: any) => {
+          const t = origEdit(opts);
+          const origWrite = t.writeValueOrThrow.bind(t);
+          (t as unknown as { writeValueOrThrow: typeof origWrite })
+            .writeValueOrThrow = ((address: any, value: any, options?: any) => {
+              (writesByPhase[phase] ??= []).push({
+                id: String(address.id),
+                target: linkTarget(value),
+              });
+              return origWrite(address, value, options);
+            }) as typeof origWrite;
+          return t;
+        }) as typeof origEdit;
 
-    // `n` is a truthy number rather than a boolean: changing it from 1 to 2
-    // re-triggers ifElse while still selecting the same (`ifTrue`) branch. The
-    // branches are stable input cells (not inline literals, which would be
-    // re-materialized with new ids when `n` changes), so the branch reference
-    // ifElse would write is identical to what is already stored.
-    const ifElsePattern = pattern<{ n: number; a: string; b: string }>(
-      ({ n, a, b }) => ({
-        n,
-        a,
-        b,
-        text: ifElse(n, a, b),
-      }),
-    );
+      // `n` is a truthy number rather than a boolean: changing it from 1 to 2
+      // re-triggers ifElse while still selecting the same (`ifTrue`) branch. The
+      // branches are stable input cells (not inline literals, which would be
+      // re-materialized with new ids when `n` changes), so the branch reference
+      // ifElse would write is identical to what is already stored.
+      const ifElsePattern = pattern<{ n: number; a: string; b: string }>(
+        ({ n, a, b }) => ({
+          n,
+          a,
+          b,
+          text: ifElse(n, a, b),
+        }),
+      );
 
-    const pieceCell = runtime.getCell<
-      { n: number; a: string; b: string; text: string }
-    >(
-      space,
-      "ifElse only writes once for same value",
-      ifElsePattern.resultSchema,
-      tx,
-    );
-    const piece = runtime.run(
-      tx,
-      ifElsePattern,
-      { n: 1, a: "A", b: "B" },
-      pieceCell,
-    );
-    tx.commit();
+      const pieceCell = runtime.getCell<
+        { n: number; a: string; b: string; text: string }
+      >(
+        space,
+        "ifElse only writes once for same value",
+        ifElsePattern.resultSchema,
+        tx,
+      );
+      const piece = runtime.run(
+        tx,
+        ifElsePattern,
+        { n: 1, a: "A", b: "B" },
+        pieceCell,
+      );
+      tx.commit();
 
-    phase = "first";
-    await piece.pull();
-    expect(piece.key("text").get()).toEqual("A");
+      phase = "first";
+      await piece.pull();
+      expect(piece.key("text").get()).toEqual("A");
 
-    // ifElse writes a redirect into its own result doc that points at the
-    // selected branch input. The other redirect written when wiring the result
-    // (the output binding) points at the result doc itself, so the ifElse
-    // result doc is the link-write whose target is NOT itself a link-write doc.
-    const firstWrites = writesByPhase["first"] ?? [];
-    const writtenIds = new Set(firstWrites.map((w) => w.id));
-    const resultDocs = new Set(
-      firstWrites
-        .filter((w) => w.target !== undefined && !writtenIds.has(w.target))
-        .map((w) => w.id),
-    );
-    expect(resultDocs.size).toEqual(1);
-    const ifElseResultId = [...resultDocs][0];
-    // It was written exactly once on the first trigger.
-    expect(firstWrites.filter((w) => w.id === ifElseResultId).length)
-      .toEqual(1);
+      // ifElse writes a redirect into its own result doc that points at the
+      // selected branch input. The other redirect written when wiring the result
+      // (the output binding) points at the result doc itself, so the ifElse
+      // result doc is the link-write whose target is NOT itself a link-write doc.
+      const firstWrites = writesByPhase["first"] ?? [];
+      const writtenIds = new Set(firstWrites.map((w) => w.id));
+      const resultDocs = new Set(
+        firstWrites
+          .filter((w) => w.target !== undefined && !writtenIds.has(w.target))
+          .map((w) => w.id),
+      );
+      expect(resultDocs.size).toEqual(1);
+      const ifElseResultId = [...resultDocs][0];
+      // It was written exactly once on the first trigger.
+      expect(firstWrites.filter((w) => w.id === ifElseResultId).length)
+        .toEqual(1);
 
-    // Re-trigger with a different-but-still-truthy condition. ifElse re-runs and
-    // selects the same branch, so the reference it would write is unchanged.
-    phase = "second";
-    tx = runtime.edit();
-    piece.withTx(tx).key("n").set(2);
-    tx.commit();
-    await piece.pull();
-    expect(piece.key("text").get()).toEqual("A");
+      // Re-trigger with a different-but-still-truthy condition. ifElse re-runs and
+      // selects the same branch, so the reference it would write is unchanged.
+      phase = "second";
+      tx = runtime.edit();
+      piece.withTx(tx).key("n").set(2);
+      tx.commit();
+      await piece.pull();
+      expect(piece.key("text").get()).toEqual("A");
 
-    // The selected branch is unchanged, so ifElse must not write its result
-    // again — the redundant write is what `onlyIfDifferent` suppresses.
-    expect(
-      (writesByPhase["second"] ?? []).filter((w) => w.id === ifElseResultId)
-        .length,
-    ).toEqual(0);
-  });
+      // The selected branch is unchanged, so ifElse must not write its result
+      // again — the redundant write is what `onlyIfDifferent` suppresses.
+      expect(
+        (writesByPhase["second"] ?? []).filter((w) => w.id === ifElseResultId)
+          .length,
+      ).toEqual(0);
+    },
+  );
 });


### PR DESCRIPTION
## What

Elide **redundant writes when a raw builtin re-runs but produces the same result**, using `ifElse` as the driving case. Two complementary changes; together a same-selection `ifElse` re-run now writes **nothing**.

### 1. `Cell.setRawUntyped(value, onlyIfDifferent?)`
New optional flag. When `true`, the current raw value is read first and the write is **skipped** if it already equals what would be written. `ifElse` passes it: when the condition changes between two truthy values, ifElse re-runs but selects the same branch, so the branch reference it would write into its result doc is identical.

### 2. `sendValueToBinding` output-binding no-op gate
The raw-builtin result path (`sendResult`, `preserveLinkOutput`) wrote the output-binding redirect with a raw `writeValueOrThrow` on **every** run. For cause-stable builtins (ifElse/when/unless/map/…) the binding points at the same result cell each time, so the link is unchanged — yet the write still churned downstream. It's now skipped when the redirect already holds the same link. The other `sendValueToBinding` paths already diff via `normalizeAndDiff`, so only this fast-path needed gating; the change therefore benefits all cause-stable raw builtins, not just `ifElse`.

## Implementation notes

- **Symmetric read:** the current value is read with `tx.readValueOrThrow(link, …)` — same transaction/address, no link resolution — to mirror the `writeValueOrThrow` it guards.
- **Out of scheduling + CFC taint:** both reads are marked `ignoreReadForScheduling` (must not register a self-dependency that would re-trigger the writer) **and** `internalVerifierRead` (a purely internal write-elision decision must not taint the transaction's CFC labels with the cell's own value).
- **Fabric-aware equality:** comparison uses `valueEqual`, the content-hash comparator the runner's other change-detection gates already use (`reactive-dependencies`, `write-propagation`, `diagnosis`). `deepEqual` walks enumerable own-props and would conflate distinct same-class `FabricSpecialObject`s (`FabricBytes`/`FabricHash`/…), silently dropping a real change — addresses the Codex review comment.
- Both gates are opt-in / fast-path-scoped, so existing callers are otherwise unchanged.

## Test (red-green)

`packages/runner/test/patterns-ifelse.test.ts` — "only writes the branch reference once when re-triggered with the same value". It instruments the scheduler's transactions and asserts that re-triggering with the same selected branch rewrites **neither** the ifElse result doc **nor** the output binding. Verified red→green for each change independently by reverting just that change.

Scenario detail: the condition is a truthy *number* changed `1 → 2` (so ifElse genuinely re-runs while keeping the same branch), with **stable input** branches `a`/`b` rather than inline literals (which would be re-materialized with new ids when the condition changes).

## Verification

- `deno check` / `deno lint` / `deno fmt` clean on changed files.
- Broad local sweep green: `patterns-*` (core/dynamic/misc/regressions/ifelse/lift/handlers/self/reduce/findindex/schemas/async/materialization/per-path), `scheduler-pull*`, `cfc-*`, `when-unless`, `navigate-handler`, `pattern-scope`, `doc-map`, `map-op-by-identity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)