### PR TITLE
fix(utils): remove dangling ./integration subpath export

### DIFF
--- a/packages/utils/deno.json
+++ b/packages/utils/deno.json
@@ -19,7 +19,6 @@
     "./encoding": "./src/encoding.ts",
     "./env": "./src/env.ts",
     "./equal-ignoring-symbols": "./src/equal-ignoring-symbols.ts",
-    "./integration": "./src/integration.ts",
     "./logger": "./src/logger.ts",
     "./path-key-map": "./src/path-key-map.ts",
     "./sandbox-contract": "./src/sandbox-contract.ts",


### PR DESCRIPTION
The @commonfabric/utils package declared a subpath export "./integration" -> "./src/integration.ts", but that source file no longer exists. The file was removed when the browser-orchestration utilities it contained were extracted into the standalone packages/integration package; that move deleted src/integration.ts but left the export entry behind in packages/utils/deno.json.

Nothing imports @commonfabric/utils/integration (nor the older @commontools/utils/integration name) anywhere in the repository, so the export served only to point consumers at a missing file. Remove the entry so the exports map matches what is actually on disk.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the dead `./integration` subpath export from `@commonfabric/utils` so the exports map matches files on disk. This avoids pointing consumers to the deleted `./src/integration.ts`; no in-repo imports used it.

<sup>Written for commit df5d5d9c884755e3517c4532f3ce1ff14c730893. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

