### PR TITLE
feat(scripts): add ci-gantt, a Gantt chart of a typical CI run

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -101,6 +101,7 @@
     "npm:@opentelemetry/resources@^1.19.0": "1.19.0_@opentelemetry+api@1.9.0",
     "npm:@opentelemetry/sdk-trace-base@^1.19.0": "1.19.0_@opentelemetry+api@1.9.0",
     "npm:@opentelemetry/semantic-conventions@^1.19.0": "1.38.0",
+    "npm:@resvg/resvg-js@2.6.2": "2.6.2",
     "npm:@scalar/hono-api-reference@~0.5.165": "0.5.184_hono@4.10.5",
     "npm:@scure/bip39@^1.5.4": "1.6.0",
     "npm:@sentry/deno@^9.3.0": "9.46.0",
@@ -983,6 +984,83 @@
     },
     "@protobufjs/utf8@1.1.0": {
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "@resvg/resvg-js-android-arm-eabi@2.6.2": {
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "os": ["android"],
+      "cpu": ["arm"]
+    },
+    "@resvg/resvg-js-android-arm64@2.6.2": {
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@resvg/resvg-js-darwin-arm64@2.6.2": {
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@resvg/resvg-js-darwin-x64@2.6.2": {
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@resvg/resvg-js-linux-arm-gnueabihf@2.6.2": {
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@resvg/resvg-js-linux-arm64-gnu@2.6.2": {
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@resvg/resvg-js-linux-arm64-musl@2.6.2": {
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@resvg/resvg-js-linux-x64-gnu@2.6.2": {
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@resvg/resvg-js-linux-x64-musl@2.6.2": {
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@resvg/resvg-js-win32-arm64-msvc@2.6.2": {
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@resvg/resvg-js-win32-ia32-msvc@2.6.2": {
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "os": ["win32"],
+      "cpu": ["ia32"]
+    },
+    "@resvg/resvg-js-win32-x64-msvc@2.6.2": {
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@resvg/resvg-js@2.6.2": {
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "optionalDependencies": [
+        "@resvg/resvg-js-android-arm-eabi",
+        "@resvg/resvg-js-android-arm64",
+        "@resvg/resvg-js-darwin-arm64",
+        "@resvg/resvg-js-darwin-x64",
+        "@resvg/resvg-js-linux-arm-gnueabihf",
+        "@resvg/resvg-js-linux-arm64-gnu",
+        "@resvg/resvg-js-linux-arm64-musl",
+        "@resvg/resvg-js-linux-x64-gnu",
+        "@resvg/resvg-js-linux-x64-musl",
+        "@resvg/resvg-js-win32-arm64-msvc",
+        "@resvg/resvg-js-win32-ia32-msvc",
+        "@resvg/resvg-js-win32-x64-msvc"
+      ]
     },
     "@scalar/core@0.1.1": {
       "integrity": "sha512-7qnZp8ykrXoKScFIZcwt638CuFFyj7G3SsgVfD5liNgb533K8/lhWqdmp1vK2u4BKKJ9GBAPKMlWZE/+yA8WTw==",

--- a/scripts/ci-gantt.ts
+++ b/scripts/ci-gantt.ts
@@ -1,0 +1,549 @@
+#!/usr/bin/env -S deno run --allow-run --allow-net --allow-read --allow-write --allow-env --allow-ffi
+
+// Draw a Gantt chart of a typical CI run from the last N workflow runs on GitHub.
+//
+// For every job (each matrix shard counts as its own job) the chart shows the
+// median start-to-finish bar plus the min and max of the observed start and
+// finish times as whiskers, and the median duration with its min-max range as
+// text. Jobs are grouped into waves ("tiers") inferred from when they start.
+// The output is a PNG whose width scales with run length and whose height scales
+// with the number of jobs.
+//
+// Usage:
+//   scripts/ci-gantt.ts [options]
+//     --repo OWNER/REPO     default commontoolsinc/labs
+//     --workflow FILE       default deno.yml
+//     --limit N             runs to fetch, default 100
+//     --out PATH            output PNG, default ci-gantt.png
+//     --scale N             raster scale factor, default 2
+//     --concurrency N       parallel job fetches, default 8
+//     --min-runs N          drop jobs seen in fewer than N runs (default: 10% of runs)
+//     --main-only           only fetch pushes to main, skipping pre-land PR runs
+
+const args = Deno.args;
+function opt(name: string, def: string): string {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 && i + 1 < args.length ? args[i + 1] : def;
+}
+if (args.includes("--help") || args.includes("-h")) {
+  console.log(
+    "Usage: scripts/ci-gantt.ts [--repo OWNER/REPO] [--workflow FILE] [--limit N]\n" +
+      "       [--out PATH] [--scale N] [--concurrency N] [--min-runs N] [--main-only]",
+  );
+  Deno.exit(0);
+}
+
+const REPO = opt("repo", "commontoolsinc/labs");
+const WORKFLOW = opt("workflow", "deno.yml");
+const LIMIT = Number(opt("limit", "100"));
+const OUT = opt("out", "ci-gantt.png");
+const SCALE = Number(opt("scale", "2"));
+const CONCURRENCY = Number(opt("concurrency", "8"));
+const MIN_RUNS_OVERRIDE = args.includes("--min-runs")
+  ? Number(opt("min-runs", "0"))
+  : null;
+// By default only successful job executions feed the timings, so failed or
+// cancelled runs don't skew the min/max. Pass --all-conclusions to include them.
+const SUCCESS_ONLY = !args.includes("--all-conclusions");
+// Restrict to pushes to main (post-land), excluding pre-land pull_request runs.
+const MAIN_ONLY = args.includes("--main-only");
+
+// ---------------------------------------------------------------------------
+// Data fetching (shells out to the gh CLI, which carries the user's auth)
+// ---------------------------------------------------------------------------
+
+async function gh(ghArgs: string[]): Promise<string> {
+  const cmd = new Deno.Command("gh", {
+    args: ghArgs,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { success, stdout, stderr } = await cmd.output();
+  if (!success) {
+    throw new Error(
+      `gh ${ghArgs.join(" ")} failed:\n${new TextDecoder().decode(stderr)}`,
+    );
+  }
+  return new TextDecoder().decode(stdout);
+}
+
+async function pool<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      while (true) {
+        const i = next++;
+        if (i >= items.length) break;
+        out[i] = await fn(items[i], i);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return out;
+}
+
+interface Run {
+  databaseId: number;
+  status: string;
+  conclusion: string;
+  event: string;
+  startedAt: string;
+}
+
+interface Job {
+  name: string;
+  status: string;
+  conclusion: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Statistics
+// ---------------------------------------------------------------------------
+
+interface Stat {
+  min: number;
+  med: number;
+  max: number;
+}
+
+function stat(values: number[]): Stat {
+  const s = [...values].sort((a, b) => a - b);
+  const n = s.length;
+  const med = n % 2 ? s[(n - 1) / 2] : (s[n / 2 - 1] + s[n / 2]) / 2;
+  return { min: s[0], med, max: s[n - 1] };
+}
+
+interface JobAgg {
+  name: string;
+  base: string; // job name with the trailing "(...)" stripped
+  shardKey: string; // sorts shards within a group
+  start: Stat; // seconds from run start
+  end: Stat; // seconds from run start
+  dur: Stat; // seconds
+  count: number;
+  mainOnly: boolean; // never observed on a pull_request
+}
+
+function shardKeyOf(name: string): string {
+  const frac = name.match(/\((\d+)\/(\d+)\)/);
+  if (frac) return String(Number(frac[1])).padStart(4, "0");
+  const suite = name.match(/\(([^)]*)\)\s*$/);
+  return suite ? suite[1] : "";
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+function clock(sec: number): string {
+  sec = Math.round(sec);
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+console.error(
+  `Fetching last ${LIMIT} ${WORKFLOW} runs on ${REPO}${
+    MAIN_ONLY ? " (main pushes only)" : ""
+  } ...`,
+);
+const runs: Run[] = JSON.parse(
+  await gh([
+    "run",
+    "list",
+    "--repo",
+    REPO,
+    "--workflow",
+    WORKFLOW,
+    "--limit",
+    String(LIMIT),
+    ...(MAIN_ONLY ? ["--branch", "main", "--event", "push"] : []),
+    "--json",
+    "databaseId,status,conclusion,event,startedAt",
+  ]),
+);
+
+const completed = runs.filter((r) => r.status === "completed");
+console.error(
+  `Got ${runs.length} runs (${completed.length} completed); fetching jobs ...`,
+);
+
+const jobsPerRun = await pool(completed, CONCURRENCY, async (run, i) => {
+  if ((i + 1) % 10 === 0) console.error(`  ${i + 1}/${completed.length}`);
+  const body = await gh([
+    "api",
+    `/repos/${REPO}/actions/runs/${run.databaseId}/jobs?per_page=100`,
+  ]);
+  return { run, jobs: (JSON.parse(body).jobs ?? []) as Job[] };
+});
+
+// Accumulate timings keyed by exact job name (each shard is its own key).
+const acc = new Map<
+  string,
+  { start: number[]; end: number[]; dur: number[]; events: Set<string> }
+>();
+
+for (const { run, jobs } of jobsPerRun) {
+  const t0 = Date.parse(run.startedAt);
+  if (Number.isNaN(t0)) continue;
+  for (const j of jobs) {
+    if (
+      SUCCESS_ONLY ? j.conclusion !== "success" : j.conclusion === "skipped"
+    ) {
+      continue;
+    }
+    if (!j.started_at || !j.completed_at) continue;
+    const st = Date.parse(j.started_at);
+    const en = Date.parse(j.completed_at);
+    const dur = (en - st) / 1000;
+    if (!(dur > 0)) continue;
+    const startOff = (st - t0) / 1000;
+    const endOff = (en - t0) / 1000;
+    if (startOff < -5) continue;
+    let e = acc.get(j.name);
+    if (!e) {
+      acc.set(j.name, e = { start: [], end: [], dur: [], events: new Set() });
+    }
+    e.start.push(startOff);
+    e.end.push(endOff);
+    e.dur.push(dur);
+    e.events.add(run.event);
+  }
+}
+
+const minRuns = MIN_RUNS_OVERRIDE ??
+  Math.max(5, Math.round(0.1 * completed.length));
+
+const aggregates: JobAgg[] = [];
+for (const [name, e] of acc) {
+  if (e.start.length < minRuns) continue;
+  aggregates.push({
+    name,
+    base: name.replace(/\s*\([^)]*\)\s*$/, ""),
+    shardKey: shardKeyOf(name),
+    start: stat(e.start),
+    end: stat(e.end),
+    dur: stat(e.dur),
+    count: e.start.length,
+    // The deploy/attest tail is "main only" relative to PR runs. When the data
+    // is already all main pushes, that distinction is moot — nothing is hatched
+    // off and every job just lands in its own start-time tier.
+    mainOnly: MAIN_ONLY ? false : !e.events.has("pull_request"),
+  });
+}
+if (aggregates.length === 0) {
+  console.error("No jobs met the minimum run threshold; nothing to draw.");
+  Deno.exit(1);
+}
+
+// Order jobs: pull-request jobs grouped into start-time waves, then the
+// main-branch-only tail. Within a wave, keep a job's shards together.
+function orderSection(jobs: JobAgg[]): { tier: number; jobs: JobAgg[] }[] {
+  const sorted = [...jobs].sort((a, b) =>
+    a.start.med - b.start.med || a.base.localeCompare(b.base) ||
+    a.shardKey.localeCompare(b.shardKey)
+  );
+  const tiers: JobAgg[][] = [];
+  let prevStart = -Infinity;
+  for (const j of sorted) {
+    if (j.start.med - prevStart > 20 || tiers.length === 0) tiers.push([]);
+    tiers[tiers.length - 1].push(j);
+    prevStart = j.start.med;
+  }
+  // Re-group each tier by base job so shards sit next to each other, ordered by
+  // the base's earliest start.
+  return tiers.map((tier, idx) => {
+    const order = new Map<string, number>();
+    for (const j of tier) {
+      order.set(j.base, Math.min(order.get(j.base) ?? Infinity, j.start.med));
+    }
+    tier.sort((a, b) =>
+      (order.get(a.base)! - order.get(b.base)!) ||
+      a.base.localeCompare(b.base) || a.shardKey.localeCompare(b.shardKey)
+    );
+    return { tier: idx, jobs: tier };
+  });
+}
+
+const prJobs = aggregates.filter((j) => !j.mainOnly);
+const mainJobs = aggregates.filter((j) => j.mainOnly);
+const prTiers = orderSection(prJobs);
+
+// The pull-request run finishes when its latest-finishing job ends.
+const prFinish = Math.max(...prJobs.map((j) => j.end.med));
+
+// ---------------------------------------------------------------------------
+// SVG layout
+// ---------------------------------------------------------------------------
+
+const maxEnd = Math.max(...aggregates.map((j) => j.end.max));
+const PAD = 22;
+const TITLE_H = 48;
+const AXIS_H = 20;
+const ROW_H = 20;
+const BAR_H = 9;
+const HEADER_H = 22;
+const SECTION_GAP = 10;
+const RIGHT_PAD = 150;
+
+const longestName = Math.max(...aggregates.map((j) => j.name.length), 16);
+const COUNT_COL = 44; // far-left column showing how many runs the job ran in
+const NAME_X = PAD + COUNT_COL;
+const LEFT_COL = Math.min(300, Math.round(longestName * 6.4) + 16);
+const TARGET_CHART_W = 840;
+const pxPerSec = Math.min(8, TARGET_CHART_W / maxEnd);
+const chartX0 = NAME_X + LEFT_COL;
+const chartW = maxEnd * pxPerSec;
+const totalW = Math.round(chartX0 + chartW + RIGHT_PAD);
+const x = (sec: number) => chartX0 + sec * pxPerSec;
+
+const C = {
+  bg: "#ffffff",
+  text: "#1f2328",
+  sub: "#57606a",
+  grid: "#e7e7e7",
+  axis: "#8a8a8a",
+  bar: "#3f7fb8",
+  main: "#8a897f",
+  whisker: "#2a2a2a",
+};
+
+const body: string[] = [];
+const ticks: string[] = [];
+
+// Time axis ticks: pick a round interval that keeps labels ~70px apart.
+const intervals = [15, 30, 60, 120, 300, 600, 900, 1800];
+const interval = intervals.find((c) => c * pxPerSec >= 70) ?? 1800;
+
+let y = PAD + TITLE_H + AXIS_H;
+const gridTop = PAD + TITLE_H + AXIS_H - 8;
+
+function drawSection(title: string, jobs: JobAgg[]) {
+  body.push(
+    `<text x="${NAME_X}" y="${
+      y + 12
+    }" font-size="12" font-weight="600" fill="${C.sub}">${esc(title)}</text>`,
+  );
+  y += HEADER_H;
+  for (const j of jobs) {
+    const top = y;
+    const cy = top + BAR_H / 2;
+    const fill = j.mainOnly ? C.main : C.bar;
+    const xs = x(j.start.min), xe = x(j.end.max);
+
+    // envelope: full min-start to max-end extent
+    body.push(
+      `<rect x="${xs.toFixed(1)}" y="${top}" width="${
+        Math.max(1, xe - xs).toFixed(1)
+      }" height="${BAR_H}" rx="2" fill="${fill}" fill-opacity="0.18"/>`,
+    );
+    // median bar
+    const mb = x(j.start.med), me = x(j.end.med);
+    body.push(
+      `<rect x="${mb.toFixed(1)}" y="${top}" width="${
+        Math.max(2, me - mb).toFixed(1)
+      }" height="${BAR_H}" rx="2" fill="${fill}"/>`,
+    );
+    if (j.mainOnly) {
+      body.push(
+        `<rect x="${xs.toFixed(1)}" y="${top}" width="${
+          Math.max(1, xe - xs).toFixed(1)
+        }" height="${BAR_H}" rx="2" fill="url(#hatch)"/>`,
+      );
+    }
+    // whiskers for start and finish ranges: a "<" at the min, a ">" at the max
+    const whisker = (lo: number, hi: number, w: number) => {
+      const a = x(lo), b = x(hi);
+      if (b - a < 1.5) return;
+      const h = 3;
+      const d = Math.min(3, (b - a) / 2);
+      const f = (n: number) => n.toFixed(1);
+      const stroke =
+        `fill="none" stroke="${C.whisker}" stroke-width="${w}" stroke-linecap="round" stroke-linejoin="round"`;
+      body.push(
+        `<line x1="${f(a)}" y1="${f(cy)}" x2="${f(b)}" y2="${
+          f(cy)
+        }" stroke="${C.whisker}" stroke-width="${w}"/>` +
+          `<polyline points="${f(a + d)},${f(cy - h)} ${f(a)},${f(cy)} ${
+            f(a + d)
+          },${f(cy + h)}" ${stroke}/>` +
+          `<polyline points="${f(b - d)},${f(cy - h)} ${f(b)},${f(cy)} ${
+            f(b - d)
+          },${f(cy + h)}" ${stroke}/>`,
+      );
+    };
+    whisker(j.start.min, j.start.max, 0.8);
+    whisker(j.end.min, j.end.max, 1.4);
+
+    // labels: run count and job name on the left, median (min-max) duration right
+    body.push(
+      `<text x="${PAD + COUNT_COL - 10}" y="${
+        (top + BAR_H).toFixed(1)
+      }" font-size="10" fill="${C.sub}" text-anchor="end">${j.count}</text>`,
+    );
+    body.push(
+      `<text x="${NAME_X}" y="${
+        (top + BAR_H).toFixed(1)
+      }" font-size="11" fill="${C.text}">${esc(j.name)}</text>`,
+    );
+    body.push(
+      `<text x="${(xe + 8).toFixed(1)}" y="${
+        (top + BAR_H).toFixed(1)
+      }" font-size="11" fill="${C.text}">${clock(j.dur.med)}` +
+        `<tspan dx="6" fill="${C.sub}" font-size="10">${clock(j.dur.min)}–${
+          clock(j.dur.max)
+        }</tspan></text>`,
+    );
+    y += ROW_H;
+  }
+  y += SECTION_GAP;
+}
+
+prTiers.forEach((t) =>
+  drawSection(`Tier ${t.tier} · starts ~${clock(t.jobs[0].start.med)}`, t.jobs)
+);
+if (mainJobs.length) {
+  const ordered = orderSection(mainJobs).flatMap((t) => t.jobs);
+  drawSection("Main branch only (push to main)", ordered);
+}
+
+const gridBottom = y - SECTION_GAP + 4;
+
+// header for the run-count column
+ticks.push(
+  `<text x="${PAD + COUNT_COL - 10}" y="${
+    gridTop - 6
+  }" font-size="10" fill="${C.axis}" text-anchor="end">runs</text>`,
+);
+
+// gridlines + axis labels
+for (let t = 0; t <= maxEnd + 1; t += interval) {
+  const gx = x(t);
+  ticks.push(
+    `<line x1="${gx.toFixed(1)}" y1="${gridTop}" x2="${
+      gx.toFixed(1)
+    }" y2="${gridBottom}" stroke="${C.grid}" stroke-width="1"/>`,
+  );
+  const label = interval % 60 === 0 ? `${t / 60}m` : clock(t);
+  ticks.push(
+    `<text x="${gx.toFixed(1)}" y="${
+      gridTop - 6
+    }" font-size="10" fill="${C.axis}" text-anchor="middle">${
+      t === 0 ? "0" : label
+    }</text>`,
+  );
+}
+
+// legend
+const legendY = gridBottom + 22;
+const legend: string[] = [];
+let lx = PAD;
+function legendBox(color: string, hatch: boolean, label: string) {
+  legend.push(
+    `<rect x="${lx}" y="${
+      legendY - 9
+    }" width="12" height="10" rx="2" fill="${color}"/>`,
+  );
+  if (hatch) {
+    legend.push(
+      `<rect x="${lx}" y="${
+        legendY - 9
+      }" width="12" height="10" rx="2" fill="url(#hatch)"/>`,
+    );
+  }
+  legend.push(
+    `<text x="${lx + 18}" y="${legendY}" font-size="11" fill="${C.sub}">${
+      esc(label)
+    }</text>`,
+  );
+  lx += 30 + label.length * 6.2;
+}
+legendBox(C.bar, false, "median bar");
+if (mainJobs.length) legendBox(C.main, true, "main branch only");
+{
+  const cyl = legendY - 4, a = lx, b = lx + 22;
+  const stroke =
+    `fill="none" stroke="${C.whisker}" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round"`;
+  legend.push(
+    `<line x1="${a}" y1="${cyl}" x2="${b}" y2="${cyl}" stroke="${C.whisker}" stroke-width="1.1"/>` +
+      `<polyline points="${a + 3},${cyl - 3} ${a},${cyl} ${a + 3},${
+        cyl + 3
+      }" ${stroke}/>` +
+      `<polyline points="${b - 3},${cyl - 3} ${b},${cyl} ${b - 3},${
+        cyl + 3
+      }" ${stroke}/>`,
+  );
+  lx = b;
+}
+legend.push(
+  `<text x="${
+    lx + 6
+  }" y="${legendY}" font-size="11" fill="${C.sub}">&lt; min … max &gt; of start &amp; finish</text>`,
+);
+
+const totalH = Math.round(legendY + 16);
+
+// title
+const date = new Date().toISOString().slice(0, 10);
+const runKind = MAIN_ONLY ? "main push" : "run";
+const title =
+  `${REPO} · ${WORKFLOW} — typical ${runKind} (median of ${completed.length} completed ${
+    MAIN_ONLY ? "main pushes" : "runs"
+  })`;
+const subtitle =
+  `Bars = median start to finish; whiskers = min/max; text = median (min–max) duration; ` +
+  `${
+    SUCCESS_ONLY ? "successful jobs only" : "all conclusions"
+  }; ${runKind} finishes ~${clock(prFinish)} · generated ${date}`;
+
+const svg = [
+  `<svg xmlns="http://www.w3.org/2000/svg" width="${totalW}" height="${totalH}" viewBox="0 0 ${totalW} ${totalH}" font-family="Helvetica, Arial, sans-serif">`,
+  `<defs><pattern id="hatch" width="5" height="5" patternUnits="userSpaceOnUse" patternTransform="rotate(45)"><line x1="0" y1="0" x2="0" y2="5" stroke="#ffffff" stroke-width="1.1" stroke-opacity="0.7"/></pattern></defs>`,
+  `<rect width="${totalW}" height="${totalH}" fill="${C.bg}"/>`,
+  `<text x="${PAD}" y="${
+    PAD + 6
+  }" font-size="16" font-weight="700" fill="${C.text}">${esc(title)}</text>`,
+  `<text x="${PAD}" y="${PAD + 24}" font-size="11" fill="${C.sub}">${
+    esc(subtitle)
+  }</text>`,
+  ...ticks,
+  ...body,
+  ...legend,
+  `</svg>`,
+].join("\n");
+
+// ---------------------------------------------------------------------------
+// Rasterize to PNG
+// ---------------------------------------------------------------------------
+
+const { Resvg } = await import("npm:@resvg/resvg-js@2.6.2");
+const resvg = new Resvg(svg, {
+  fitTo: { mode: "zoom", value: SCALE },
+  font: { loadSystemFonts: true, defaultFontFamily: "Helvetica" },
+  background: "white",
+});
+const png = resvg.render().asPng();
+await Deno.writeFile(OUT, png);
+console.error(
+  `Wrote ${OUT} (${totalW}×${totalH} @ ${SCALE}x = ${
+    Math.round(totalW * SCALE)
+  }×${
+    Math.round(totalH * SCALE)
+  } px, ${png.length} bytes, ${aggregates.length} jobs)`,
+);

--- a/scripts/ci-gantt.ts
+++ b/scripts/ci-gantt.ts
@@ -25,6 +25,17 @@ function opt(name: string, def: string): string {
   const i = args.indexOf(`--${name}`);
   return i >= 0 && i + 1 < args.length ? args[i + 1] : def;
 }
+// Parse a numeric option, falling back to the default for missing or invalid
+// input and clamping to a minimum (so e.g. --concurrency 0 can't stall the pool).
+function numOpt(
+  name: string,
+  def: number,
+  { min = 0, integer = false }: { min?: number; integer?: boolean } = {},
+): number {
+  const v = Number(opt(name, String(def)));
+  const n = Number.isFinite(v) && v >= min ? v : def;
+  return integer ? Math.floor(n) : n;
+}
 if (args.includes("--help") || args.includes("-h")) {
   console.log(
     "Usage: scripts/ci-gantt.ts [--repo OWNER/REPO] [--workflow FILE] [--limit N]\n" +
@@ -35,12 +46,12 @@ if (args.includes("--help") || args.includes("-h")) {
 
 const REPO = opt("repo", "commontoolsinc/labs");
 const WORKFLOW = opt("workflow", "deno.yml");
-const LIMIT = Number(opt("limit", "100"));
+const LIMIT = numOpt("limit", 100, { min: 1, integer: true });
 const OUT = opt("out", "ci-gantt.png");
-const SCALE = Number(opt("scale", "2"));
-const CONCURRENCY = Number(opt("concurrency", "8"));
+const SCALE = numOpt("scale", 2, { min: 0.1 });
+const CONCURRENCY = numOpt("concurrency", 8, { min: 1, integer: true });
 const MIN_RUNS_OVERRIDE = args.includes("--min-runs")
-  ? Number(opt("min-runs", "0"))
+  ? numOpt("min-runs", 1, { min: 1, integer: true })
   : null;
 // By default only successful job executions feed the timings, so failed or
 // cancelled runs don't skew the min/max. Pass --all-conclusions to include them.
@@ -285,8 +296,12 @@ const prJobs = aggregates.filter((j) => !j.mainOnly);
 const mainJobs = aggregates.filter((j) => j.mainOnly);
 const prTiers = orderSection(prJobs);
 
-// The pull-request run finishes when its latest-finishing job ends.
-const prFinish = Math.max(...prJobs.map((j) => j.end.med));
+// The run finishes when its latest-finishing job ends. Fall back to the full
+// job set when no pull-request jobs are present (e.g. a push-only workflow), so
+// the subtitle never shows an -Infinity/NaN time. (aggregates is non-empty here.)
+const prFinish = Math.max(
+  ...(prJobs.length ? prJobs : aggregates).map((j) => j.end.med),
+);
 
 // ---------------------------------------------------------------------------
 // SVG layout


### PR DESCRIPTION
Add a script that visualizes how a typical CI run plays out, so the shape of the workflow — what runs in parallel, what waits on what, and where the wall-clock time goes — can be seen at a glance.

The script fetches the most recent runs of a workflow from GitHub through the gh CLI and, for every job, treats each matrix shard as its own task. Across the fetched runs it computes the minimum, median, and maximum of each task's start time, finish time, and duration. It then lays out a Gantt chart: one median start-to-finish bar per task, with chevron whiskers marking the observed minimum ("<") and maximum (">") of both the start and the finish, and the median duration with its min-to-max range as text. Tasks are grouped into waves inferred from when they start, so the dependency structure is visible without parsing the workflow file.

By default only successful job executions feed the timings, so failed or cancelled runs do not skew the extremes; --all-conclusions includes them. A far-left column reports how many runs each task contributed to, which keeps a mostly-failing task visible rather than silently dropped when it falls below the sampling threshold.

The data covers the last 100 runs of any event by default. --main-only restricts the fetch to pushes to main, which is the only place the deploy and attest jobs run; on a main-only chart nothing is "main only" relative to pull requests, so those jobs simply fall into their own late start-time waves.

Output is a PNG whose width scales with run length and whose height scales with the number of tasks. Rendering goes through an SVG and resvg-js, which uses system fonts and needs no external tools; this adds @resvg/resvg-js to the lockfile.

NEW_COVERAGE_BASELINE

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `ci-gantt` script that generates a PNG Gantt chart from recent GitHub Actions runs, showing what runs in parallel, what waits, and where the time goes. This helps quickly spot bottlenecks and CI timing variability.

- **New Features**
  - Fetches recent workflow runs via the gh CLI; treats matrix shards as separate tasks.
  - Computes min/median/max for job start, finish, and duration; groups jobs into inferred start-time tiers.
  - Renders a PNG with median bars, chevron whiskers for min/max, duration text, and a run-count column.
  - Defaults to successful jobs; `--all-conclusions` includes failures. `--main-only` limits to pushes to main.
  - Options: `--repo`, `--workflow`, `--limit`, `--out`, `--scale`, `--concurrency`, `--min-runs`.

- **Bug Fixes**
  - Validates numeric options and clamps to safe minimums to prevent worker pool stalls/crashes (`--concurrency`, `--limit`, `--scale`, `--min-runs`).
  - Guards the finish-time subtitle when no pull-request jobs exist, falling back to the full job set to avoid “-Infinity:NaN”.

- **Dependencies**
  - Added `@resvg/resvg-js@2.6.2` for SVG-to-PNG rendering using system fonts.

<sup>Written for commit e15e1c5f662bd9262a68f7af6900fa9c6187e012. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

