### PR TITLE
docs(development): explain that the require-await fix is going synchr…

### DIFF
--- a/docs/development/DEVELOPMENT.md
+++ b/docs/development/DEVELOPMENT.md
@@ -38,6 +38,33 @@ This guide covers coding standards, design principles, and build/test workflows 
 - Prefer strong typing with interfaces or types instead of `any`.
 - Update package-level README.md files.
 
+### Async only when you await
+
+The `require-await` lint flags any `async` function whose body has no `await`,
+`for await`, or `await using`. The fix is almost always to make the function
+synchronous, not to keep it asynchronous:
+
+- Remove the `async` keyword and drop the `Promise<...>` from the return type.
+- Update callers to invoke it directly and delete the now-redundant `await`.
+
+> **❌ Avoid**
+
+- Reaching for `.then()`, `Promise.resolve()`, or `new Promise(...)` to keep the
+  `Promise` return type only so the lint passes. That dresses a synchronous
+  operation up as an asynchronous one, which forces every caller to keep
+  awaiting it for no reason.
+
+> **✅ Prefer**
+
+- A synchronous signature when the work is synchronous. Add `async` back only
+  when you introduce a real `await`.
+
+Keep `async` and suppress the lint with `// deno-lint-ignore require-await` only
+when the asynchronous signature is fixed by a contract the body does not yet
+exercise. An interface method whose other implementations await, or an
+overridable hook that callers already await, are the usual cases. Write that
+reason in a comment next to the suppression.
+
 ### Keep the Module Graph clean
 
 We execute our JavaScript modules in many different environments:


### PR DESCRIPTION
…onous

The `require-await` deno lint flags an async function whose body has no await, for-await, or await-using. The built-in diagnostic only suggests removing the `async` keyword or adding an await; it never points out that removing `async` also means dropping the `Promise<...>` return type and making callers synchronous. Contributors, LLM-assisted ones in particular, therefore work around the lint by wrapping the synchronous body in the Promise API (`.then()`, `Promise.resolve()`, `new Promise(...)`), which keeps a synchronous operation wearing an asynchronous interface and forces every caller to keep awaiting it for no reason.

Add an "Async only when you await" subsection to the Code Design & Principles section of the development guide. It names the lint, states that the usual fix is to make the function synchronous (drop `async` and the `Promise<...>` return type, then remove the redundant awaits in callers), calls out the Promise-API workaround as something to avoid, and describes the narrow case where keeping `async` plus a `deno-lint-ignore` suppression is warranted (a signature fixed by a contract the body does not yet exercise).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add “Async only when you await” guidance to DEVELOPMENT.md to clarify the correct fix for `require-await` lint findings and reduce unnecessary async code.

Explains that the fix is to make the function synchronous (drop `async` and `Promise<...>`) and remove redundant awaits in callers, avoid wrapping sync work in `.then()`/`Promise.resolve()`/`new Promise(...)`, and only keep `async` with `// deno-lint-ignore require-await` when an async signature is required by a contract.

<sup>Written for commit 899b1fd94a8b60a33c71a4a97eaf1c5ee2782793. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

