### PR TITLE
Key Cell.get cache by stable view

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -12,6 +12,7 @@ import {
   shallowFabricFromNativeValue,
   valueEqual,
 } from "@commonfabric/data-model/fabric-value";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { codecOf } from "@commonfabric/data-model/codec-common";
 import {
   type EntityRef,
@@ -628,6 +629,11 @@ export class CellImpl<T extends FabricValue>
 
   // Self-reference for pattern SELF symbol support
   private _selfRef?: OpaqueRef<any>;
+  private viewRefHashCache?: {
+    link: NormalizedFullLink;
+    cfcLabelView: CfcLabelView | undefined;
+    hash: string;
+  };
 
   constructor(
     public readonly runtime: Runtime,
@@ -693,6 +699,18 @@ export class CellImpl<T extends FabricValue>
       link: this.link,
       cfcLabelView: this._cfcLabelView,
     };
+  }
+
+  private viewRefHash(): string {
+    const link = this.link;
+    const cfcLabelView = this._cfcLabelView;
+    const cached = this.viewRefHashCache;
+    if (cached?.link === link && cached.cfcLabelView === cfcLabelView) {
+      return cached.hash;
+    }
+    const hash = hashStringOf({ link, cfcLabelView } satisfies CellViewRef);
+    this.viewRefHashCache = { link, cfcLabelView, hash };
+    return hash;
   }
 
   /**
@@ -882,8 +900,10 @@ export class CellImpl<T extends FabricValue>
     // tx, and the same CFC state. Reuse the prior result when the tx supports
     // caching (the non-reactive sample() wrapper does not) and is still open.
     // The tx clears this cache on any write, so a hit only happens when nothing
-    // has changed since the last read. Keyed on the cell's link identity, which
-    // is stable per cell; `variant` separates reads that differ in options.
+    // has changed since the last read. Key by the stable value of the view ref
+    // (link + CFC label view), not link object identity, so equivalent CellImpl
+    // wrappers in the same tx can share the cached traversal result. `variant`
+    // separates reads that differ in options or synced state.
     const tx = this.tx;
     const cacheable = tx !== undefined &&
       tx.getCachedReadResult !== undefined &&
@@ -893,8 +913,9 @@ export class CellImpl<T extends FabricValue>
       // still goes through readOrThrow() and invalidates the prepared digest.
       tx.getCfcState().prepare.status !== "prepared";
     const variant = `${options?.traverseCells ?? false}|${this.synced}`;
+    const cacheKey = cacheable ? this.viewRefHash() : undefined;
     if (cacheable) {
-      const cached = tx.getCachedReadResult!(this._link, variant);
+      const cached = tx.getCachedReadResult!(cacheKey!, variant);
       if (cached !== undefined) {
         return cached.value as Readonly<StripDefaultBrand<T>>;
       }
@@ -919,8 +940,8 @@ export class CellImpl<T extends FabricValue>
     if (cacheable) {
       // Re-read this._link: validateAndTransform (via viewRef -> link) may have
       // run ensureLink() and replaced it with the completed link object, which
-      // is the identity subsequent get()s will key on.
-      tx.setCachedReadResult!(this._link, variant, value);
+      // is the identity subsequent get()s will hash.
+      tx.setCachedReadResult!(this.viewRefHash(), variant, value);
     }
     return value;
   }

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -143,13 +143,15 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   // ECMAScript-private (#) so handler code reaching cell.tx cannot enter the
   // scope via `(cell.tx as any)` — `as any` cannot touch a `#private` member.
   #privilegedSystemWriteDepth = 0;
-  // Per-transaction cache of `Cell.get()` results, keyed by cell link identity.
+  // Per-transaction cache of `Cell.get()` results, keyed by stable cell view.
   // Replaced wholesale on any write (see `invalidateReadResultCache`), so a hit
   // is only ever served when nothing has been written since the cached read.
-  private readResultCache = new WeakMap<
-    object,
-    Map<string, { value: unknown }>
-  >();
+  // This is a Map rather than a WeakMap, but the transaction owns it and writes
+  // drop it wholesale, bounding retention to reads-without-writes in one tx.
+  private readResultCache = new Map<string, Map<string, { value: unknown }>>();
+  private readResultCacheHits = 0;
+  private readResultCacheMisses = 0;
+  private readResultCacheSets = 0;
 
   constructor(
     public tx: IStorageTransaction,
@@ -380,31 +382,56 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   }
 
   getCachedReadResult(
-    keyObject: object,
+    key: string,
     variant: string,
   ): { value: unknown } | undefined {
-    return this.readResultCache.get(keyObject)?.get(variant);
+    const cached = this.readResultCache.get(key)?.get(variant);
+    if (cached === undefined) {
+      this.readResultCacheMisses++;
+    } else {
+      this.readResultCacheHits++;
+    }
+    return cached;
   }
 
   setCachedReadResult(
-    keyObject: object,
+    key: string,
     variant: string,
     value: unknown,
   ): void {
-    let byVariant = this.readResultCache.get(keyObject);
+    let byVariant = this.readResultCache.get(key);
     if (byVariant === undefined) {
       byVariant = new Map();
-      this.readResultCache.set(keyObject, byVariant);
+      this.readResultCache.set(key, byVariant);
     }
     byVariant.set(variant, { value });
+    this.readResultCacheSets++;
+  }
+
+  getReadResultCacheStats(): {
+    hits: number;
+    misses: number;
+    sets: number;
+    entries: number;
+  } {
+    let entries = 0;
+    for (const byVariant of this.readResultCache.values()) {
+      entries += byVariant.size;
+    }
+    return {
+      hits: this.readResultCacheHits,
+      misses: this.readResultCacheMisses,
+      sets: this.readResultCacheSets,
+      entries,
+    };
   }
 
   private invalidateReadResultCache(): void {
     // A write may have changed any value a cached read depends on. Drop the
-    // whole cache by replacing the map (WeakMap has no clear()); this enforces
+    // whole cache by replacing the map; this enforces
     // the "no writes between the last read and this one" invariant the cache
     // relies on.
-    this.readResultCache = new WeakMap();
+    this.readResultCache = new Map();
   }
 
   recordCfcDereferenceTrace(trace: CfcDereferenceTrace): void {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -1026,26 +1026,41 @@ export interface IExtendedStorageTransaction
    * When no write has occurred since the last read, that work is redundant: the
    * value, the reactive reads it registers, and the CFC state it produces are all
    * identical. These two methods let `Cell.get()` cache its result keyed by the
-   * cell's link identity; the implementation clears the entire cache on any
-   * write, so a cached entry is only ever returned when no write has intervened.
+   * stable value of the cell view; the implementation clears the entire cache
+   * on any write, so a cached entry is only ever returned when no write has
+   * intervened.
    *
    * Optional: transactions that must not cache (e.g. the non-reactive `sample()`
    * wrapper) leave these undefined and callers fall back to recomputing.
-   * `keyObject` must be a stable per-cell object identity (the cell's normalized
-   * link); `variant` distinguishes reads that differ in options. A returned
-   * `{ value }` wrapper signals a hit, so a cached `undefined` value is
-   * distinguishable from a miss.
+   * `key` must be a stable value key for the cell view (normalized link,
+   * including schema, plus any CFC label view); `variant` distinguishes reads
+   * that differ in options. A returned `{ value }` wrapper signals a hit, so a
+   * cached `undefined` value is distinguishable from a miss.
    */
   getCachedReadResult?(
-    keyObject: object,
+    key: string,
     variant: string,
   ): { value: unknown } | undefined;
 
   setCachedReadResult?(
-    keyObject: object,
+    key: string,
     variant: string,
     value: unknown,
   ): void;
+
+  /**
+   * Optional diagnostics for the transaction-local `Cell.get()` cache.
+   *
+   * `entries` reports the currently retained cache entries, which drops to zero
+   * after any write because writes replace the transaction-local cache map.
+   * Hit/miss/set counts are cumulative for the transaction.
+   */
+  getReadResultCacheStats?(): {
+    hits: number;
+    misses: number;
+    sets: number;
+    entries: number;
+  };
 }
 
 export interface ITransactionReader {

--- a/packages/runner/test/cell-get-cache.test.ts
+++ b/packages/runner/test/cell-get-cache.test.ts
@@ -9,6 +9,7 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import type { JSONSchema } from "../src/builder/types.ts";
+import type { CfcLabelView } from "../src/cfc/label-view.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("cell-get-cache test");
@@ -17,12 +18,25 @@ const space = signer.did();
 const OBJECT_SCHEMA = {
   type: "object",
   properties: { x: { type: "number" } },
+  additionalProperties: false,
+} as const satisfies JSONSchema;
+
+const Y_ONLY_SCHEMA = {
+  type: "object",
+  properties: { y: { type: "number" } },
+  additionalProperties: false,
 } as const satisfies JSONSchema;
 
 describe("Cell.get() per-transaction cache", () => {
   let runtime: Runtime;
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let tx: IExtendedStorageTransaction;
+
+  const cacheStats = () => {
+    const stats = tx.getReadResultCacheStats?.();
+    expect(stats).toBeDefined();
+    return stats!;
+  };
 
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
@@ -50,6 +64,114 @@ describe("Cell.get() per-transaction cache", () => {
     // reference identity is the observable signal that the cache served it.
     expect(second).toBe(first);
     expect(first).toEqual({ x: 1 });
+    expect(cacheStats()).toEqual({
+      hits: 1,
+      misses: 1,
+      sets: 1,
+      entries: 1,
+    });
+  });
+
+  it("shares a cached read across equivalent wrappers for the same view", () => {
+    const firstWrapper = runtime.getCell(
+      space,
+      "equivalent-wrapper",
+      OBJECT_SCHEMA,
+      tx,
+    );
+    const secondWrapper = runtime.getCell(
+      space,
+      "equivalent-wrapper",
+      OBJECT_SCHEMA,
+      tx,
+    );
+    firstWrapper.set({ x: 1 });
+
+    const first = firstWrapper.get();
+    const second = secondWrapper.get();
+
+    expect(second).toBe(first);
+    expect(second).toEqual({ x: 1 });
+    expect(cacheStats()).toEqual({
+      hits: 1,
+      misses: 1,
+      sets: 1,
+      entries: 1,
+    });
+  });
+
+  it("does not collide equivalent wrappers with different schemas", () => {
+    const c = runtime.getCell<{ x: number; y: number }>(
+      space,
+      "schema-split",
+      { type: "object", additionalProperties: true },
+      tx,
+    );
+    c.set({ x: 1, y: 2 });
+
+    const xOnly = c.asSchema(OBJECT_SCHEMA);
+    const yOnly = c.asSchema(Y_ONLY_SCHEMA);
+    const x = xOnly.get();
+    const y = yOnly.get();
+
+    expect(x).not.toBe(y);
+    expect(x).toEqual({ x: 1 });
+    expect(y).toEqual({ y: 2 });
+    expect(xOnly.get()).toBe(x);
+    expect(yOnly.get()).toBe(y);
+    expect(cacheStats()).toEqual({
+      hits: 2,
+      misses: 2,
+      sets: 2,
+      entries: 2,
+    });
+  });
+
+  it("does not collide equivalent wrappers with different CFC label views", () => {
+    const c = runtime.getCell(space, "cfc-label-split", OBJECT_SCHEMA, tx);
+    c.set({ x: 1 });
+    const link = c.getAsNormalizedFullLink();
+    const labelViewA: CfcLabelView = {
+      version: 1,
+      entries: [{
+        path: [],
+        label: { confidentiality: ["a"] },
+      }],
+    };
+    const labelViewB: CfcLabelView = {
+      version: 1,
+      entries: [{
+        path: [],
+        label: { confidentiality: ["b"] },
+      }],
+    };
+    const viewA = runtime.getCellFromLink(
+      link,
+      OBJECT_SCHEMA,
+      tx,
+      labelViewA,
+    );
+    const viewB = runtime.getCellFromLink(
+      link,
+      OBJECT_SCHEMA,
+      tx,
+      labelViewB,
+    );
+
+    const a = viewA.get();
+    const b = viewB.get();
+
+    expect(a).not.toBe(b);
+    expect(a).toEqual({ x: 1 });
+    expect(b).toEqual({ x: 1 });
+    expect(viewA.get()).toBe(a);
+    expect(viewB.get()).toBe(b);
+    expect(cacheStats()).toEqual({
+      hits: 2,
+      misses: 2,
+      sets: 2,
+      entries: 2,
+    });
   });
 
   it("recomputes after an intervening write to the same cell", () => {
@@ -60,6 +182,7 @@ describe("Cell.get() per-transaction cache", () => {
     expect(first).toEqual({ x: 1 });
 
     c.set({ x: 2 });
+    expect(cacheStats().entries).toBe(0);
     const second = c.get();
 
     expect(second).not.toBe(first);
@@ -74,6 +197,7 @@ describe("Cell.get() per-transaction cache", () => {
 
     const first = a.get();
     b.set({ x: 10 }); // unrelated write clears the whole per-tx cache
+    expect(cacheStats().entries).toBe(0);
 
     const second = a.get();
     expect(second).not.toBe(first); // recomputed
@@ -89,10 +213,17 @@ describe("Cell.get() per-transaction cache", () => {
 
     // Different option variants are cached separately; each is internally
     // stable.
+    expect(traversed).not.toBe(plain);
     expect(c.get()).toBe(plain);
     expect(c.get({ traverseCells: true })).toBe(traversed);
     expect(plain).toEqual({ x: 1 });
     expect(traversed).toEqual({ x: 1 });
+    expect(cacheStats()).toEqual({
+      hits: 2,
+      misses: 2,
+      sets: 2,
+      entries: 2,
+    });
   });
 
   it("does not let the non-reactive sample() path pollute the get() cache", () => {
@@ -102,11 +233,51 @@ describe("Cell.get() per-transaction cache", () => {
     // sample() runs through a non-reactive wrapper tx that exposes no cache, so
     // it neither reads from nor writes to the get() cache.
     const sampled = c.sample();
+    const sampledAgain = c.sample();
     expect(sampled).toEqual({ x: 7 });
+    expect(sampledAgain).toEqual({ x: 7 });
+    expect(sampledAgain).not.toBe(sampled);
+    expect(cacheStats()).toEqual({
+      hits: 0,
+      misses: 0,
+      sets: 0,
+      entries: 0,
+    });
 
     const got = c.get();
     expect(got).toEqual({ x: 7 });
     expect(c.get()).toBe(got); // get() still caches normally
+    expect(cacheStats()).toEqual({
+      hits: 1,
+      misses: 1,
+      sets: 1,
+      entries: 1,
+    });
+  });
+
+  it("distinguishes a cached undefined value from a cache miss", () => {
+    const c = runtime.getCell<undefined>(
+      space,
+      "undefined-value",
+      undefined,
+      tx,
+    );
+    c.set(undefined);
+
+    expect(c.get()).toBeUndefined();
+    expect(cacheStats()).toEqual({
+      hits: 0,
+      misses: 1,
+      sets: 1,
+      entries: 1,
+    });
+    expect(c.get()).toBeUndefined();
+    expect(cacheStats()).toEqual({
+      hits: 1,
+      misses: 1,
+      sets: 1,
+      entries: 1,
+    });
   });
 
   it("keeps reactive reads stable across a cached get()", () => {


### PR DESCRIPTION
## Why

`Cell.get()` already has a transaction-local read-result cache, but it was keyed
by the normalized link object's identity. Two `CellImpl` wrappers for the same
logical cell view can carry equivalent link values with different object
identities, so they miss the cache and repeat the same schema traversal inside
one transaction.

Within a transaction with no intervening write, two reads of the same link
including schema, the same CFC label view, and the same read variant
(`traverseCells|synced`) produce the same value, the same registered reactive
reads, and the same CFC state. The stable view hash captures those
read-affecting inputs: `NormalizedLink` includes `schema`, `viewRef` adds
`cfcLabelView`, and the existing variant separates `traverseCells`/`synced`.
The transaction drops the whole read cache on any write, so a hit is only served
when nothing changed.

This preserves the original cache contract while allowing equivalent wrappers
to share the cached traversal result. The new `Map` retention is bounded by
reads-without-writes in one transaction, and writes replace the map wholesale.

## What Changed

- Key the transaction-local `Cell.get()` cache by a stable hash of the cell view
  instead of link object identity.
- Memoize that view hash on each `CellImpl` wrapper and recompute only when the
  link or CFC label view identity changes. The set side recomputes after
  traversal because `ensureLink()` can complete/replace the link during a read.
- Change the transaction cache from `WeakMap<object, ...>` to
  `Map<string, ...>`, while preserving whole-cache invalidation on any write.
- Add transaction-local cache diagnostics for hits, misses, sets, and retained
  entries so tests can assert hit/miss behavior.
- Broaden `cell-get-cache` coverage for equivalent wrappers, schema and CFC
  label separation, read variants, write invalidation, non-cacheable `sample()`,
  and cached `undefined` values.

## Test plan

- `mise exec -- deno fmt packages/runner/src/cell.ts packages/runner/src/storage/extended-storage-transaction.ts packages/runner/src/storage/interface.ts packages/runner/test/cell-get-cache.test.ts`
- `git diff --check`
- `mise exec -- deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git packages/runner/test/cell-get-cache.test.ts`
- `cd packages/runner && mise exec -- deno task test`
  - `ok | 669 passed (3434 steps) | 0 failed | 0 ignored (11 steps)`
- `mise exec -- deno task integration runner`
  - `ok | 13 passed | 0 failed`
- `mise exec -- deno task test`
  - `All tests passing!`

Perf validation from the proposal's worker-aware CDP capture harness on the same
`/ben-loom-dev-6` route, keeping raw JSONL out of git:

- Baseline `baseline-clean2.jsonl`: 26 slow traversals, 4,682ms total,
  p50/p90/max 159/231/281ms, dominant root 3,990ms across 22 traversals.
- P1 candidate `after.jsonl`: 11 slow traversals, 2,345ms total,
  p50/p90/max 226/236/279ms, dominant root 1,639ms across 7 traversals.
- Delta: -49.9% slow-traverse ms and -57.7% slow-traverse count.
- Route-level cache-effect proxy: 15 avoided slow traversals out of 26 baseline
  slow traversals, 57.7%. The saved capture predates the committed hit/miss
  diagnostics, so direct transaction hit/miss rates are covered by
  `cell-get-cache.test.ts` assertions instead.

I also attempted a fresh CDP rerun against cloned local memory stores from both
the main labs checkout and the live Loom vendor checkout. Those cloned stores
loaded only the sparse shell (`Untitled`) and produced 0 slow traversals, so I
did not use that non-representative sample for the aggregate comparison.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keys the `Cell.get()` transaction cache by a stable view hash (link + schema + CFC label view) instead of object identity. This avoids duplicate traversals within a transaction and improves read performance.

- **Bug Fixes**
  - Cache hits now work across equivalent `CellImpl` wrappers for the same view.
  - No cache collisions between different schemas, CFC label views, or read variants.
  - Correctly caches `undefined` values (distinct from a miss).

- **Refactors**
  - Use `Map<string, ...>` keyed by the stable view hash; drop the whole map on any write.
  - Memoize the view hash per wrapper; recompute when link or CFC label view changes.
  - Add per-transaction cache stats (hits, misses, sets, entries) for tests.
  - Import hash helper from `@commonfabric/data-model/value-hash`.

<sup>Written for commit c89907e57e68205abf94f45d1cc495ddf6c9731c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

