### PR TITLE
fix: converge fresh-vs-resume cell identity (awaitSync out-of-band + canonical schema interning)

### DIFF
--- a/packages/data-model/src/schema-hash.ts
+++ b/packages/data-model/src/schema-hash.ts
@@ -136,7 +136,8 @@ function canonicalizeSchemaKeyOrder(value: unknown): unknown {
   // Never silently drop owned non-string (symbol) keys, even though schemas are
   // normally string-keyed and symbol keys do not affect JSON serialization.
   for (const sym of Object.getOwnPropertySymbols(obj)) {
-    (out as Record<symbol, unknown>)[sym] = (obj as Record<symbol, unknown>)[sym];
+    (out as Record<symbol, unknown>)[sym] =
+      (obj as Record<symbol, unknown>)[sym];
   }
   return out;
 }
@@ -216,9 +217,10 @@ function internSchemaReturningSchemaAndHash(
   // is key-order-insensitive, so it is unchanged and stays consistent with the
   // stored object. (See `canonicalizeSchemaKeyOrder`.)
   const canonicalized = canonicalizeSchemaKeyOrder(frozen);
-  const canonical = (canonicalized === frozen
-    ? frozen
-    : deepFreeze(canonicalized)) as JSONSchemaObj;
+  const canonical =
+    (canonicalized === frozen
+      ? frozen
+      : deepFreeze(canonicalized)) as JSONSchemaObj;
 
   const sah = new SchemaAndHash(canonical, hash);
   schemaToSah.set(frozen, sah);

--- a/packages/data-model/src/schema-hash.ts
+++ b/packages/data-model/src/schema-hash.ts
@@ -5,8 +5,11 @@
 
 import type { JSONSchema, JSONSchemaObj } from "@commonfabric/api";
 
+import { utf8SortedKeysOf } from "@commonfabric/utils/utf8";
+
 import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
 import { SchemaAndHash } from "./SchemaAndHash.ts";
+import { deepFreeze } from "./deep-freeze.ts";
 import { toDeepFrozenSchema } from "./schema-utils.ts";
 import { hashOf, hashStringOf } from "./value-hash.ts";
 
@@ -81,6 +84,64 @@ hashToRef.set(primInterns.true.taggedHashString, true);
 hashToRef.set(primInterns.undefined.taggedHashString, undefined);
 
 /**
+ * Recursively rebuild a (deep-frozen) schema so its object keys are in the same
+ * UTF-8 byte order the schema hash already uses (`utf8SortedKeysOf`).
+ *
+ * The schema hash is key-order-insensitive (see `value-hash`'s `feedPlainObject`,
+ * which sorts keys), but the *interned object* previously kept the key order of
+ * whichever code path first interned it. Schemas are serialized directly from
+ * the interned object — most consequentially into content-addressed `data:`
+ * cell ids via `JSON.stringify` — so two runtimes that first interned the same
+ * schema via different paths (a fresh deployer serializing links vs. a resumed
+ * browser standardizing query selectors, whose `getStandardSchema` sorts keys)
+ * minted *different* ids for the *same* schema. For space-scoped (shared) cells
+ * that produced a non-terminating cross-runtime overwrite storm. Canonicalizing
+ * the stored key order makes the interned object's serialization deterministic,
+ * matching its already-canonical hash, so every path/runtime converges.
+ *
+ * - Array order is preserved (arrays are ordered).
+ * - Already-interned sub-schemas are returned by reference: they are already
+ *   canonical and shared, so the freshly-spread owned top is the only part
+ *   rebuilt (see `traverse.ts`'s `schemaAtPathCanonical`).
+ * - An object already in canonical order with unchanged children is returned
+ *   unchanged, preserving identity (and `internSchema`'s same-reference contract)
+ *   for the common already-canonical case.
+ */
+function canonicalizeSchemaKeyOrder(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  // Already-interned sub-schemas are canonical (and shared); keep them as-is.
+  if (isInternedSchema(value as JSONSchema)) return value;
+  if (Array.isArray(value)) {
+    let changed = false;
+    const mapped = value.map((element) => {
+      const canon = canonicalizeSchemaKeyOrder(element);
+      if (canon !== element) changed = true;
+      return canon;
+    });
+    return changed ? mapped : value;
+  }
+  const obj = value as Record<string, unknown>;
+  const sortedKeys = utf8SortedKeysOf(obj);
+  const currentKeys = Object.keys(obj);
+  let changed = false;
+  const out: Record<string, unknown> = {};
+  for (let i = 0; i < sortedKeys.length; i++) {
+    const key = sortedKeys[i];
+    if (key !== currentKeys[i]) changed = true;
+    const canon = canonicalizeSchemaKeyOrder(obj[key]);
+    if (canon !== obj[key]) changed = true;
+    out[key] = canon;
+  }
+  if (!changed) return value;
+  // Never silently drop owned non-string (symbol) keys, even though schemas are
+  // normally string-keyed and symbol keys do not affect JSON serialization.
+  for (const sym of Object.getOwnPropertySymbols(obj)) {
+    (out as Record<symbol, unknown>)[sym] = (obj as Record<symbol, unknown>)[sym];
+  }
+  return out;
+}
+
+/**
  * Helper for `internSchema()` and friends, which always returns a
  * `SchemaAndHash` and takes configurable sharing-or-not.
  */
@@ -150,10 +211,20 @@ function internSchemaReturningSchemaAndHash(
 
   // Not interned yet (or interned but later collected).
 
-  const sah = new SchemaAndHash(frozen, hash);
+  // Store the canonical (key-sorted) form so the interned object serializes
+  // deterministically regardless of which code path first interned it. The hash
+  // is key-order-insensitive, so it is unchanged and stays consistent with the
+  // stored object. (See `canonicalizeSchemaKeyOrder`.)
+  const canonicalized = canonicalizeSchemaKeyOrder(frozen);
+  const canonical = (canonicalized === frozen
+    ? frozen
+    : deepFreeze(canonicalized)) as JSONSchemaObj;
+
+  const sah = new SchemaAndHash(canonical, hash);
   schemaToSah.set(frozen, sah);
-  hashToRef.set(hashStr, new WeakRef(frozen));
-  schemaFinalizer.register(frozen, hashStr);
+  if (canonical !== frozen) schemaToSah.set(canonical, sah);
+  hashToRef.set(hashStr, new WeakRef(canonical));
+  schemaFinalizer.register(canonical, hashStr);
 
   return sah;
 }

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -497,5 +497,51 @@ describe("schema-hash", () => {
       });
       assert(isDeepFrozen(interned));
     });
+
+    it("shares already-interned sub-schemas by reference (no needless rebuild)", () => {
+      // Pre-intern a child, then intern a parent that holds it. Canonicalizing
+      // the parent keeps the already-interned (already-canonical) child by
+      // reference instead of cloning it, preserving structural sharing.
+      const child = internSchema({
+        title: `canon-child-${Date.now()}-${Math.random()}`,
+        type: "string",
+      }) as JSONSchemaObj;
+      const parent = internSchema({
+        type: "object",
+        title: `canon-parent-${Date.now()}-${Math.random()}`,
+        properties: { x: child },
+      }) as JSONSchemaObj;
+      expect((parent.properties as Record<string, unknown>).x).toBe(child);
+    });
+
+    it("rebuilds non-canonical array elements while preserving array order", () => {
+      // An array element that is itself a non-canonical object gets its keys
+      // sorted, but the array's element order is preserved (arrays are ordered).
+      const interned = internSchema({
+        title: `canon-arr-${Date.now()}-${Math.random()}`,
+        anyOf: [
+          { type: "object", $defs: { X: { type: "null" } } }, // non-canonical
+          { type: "string" },
+        ],
+      }) as JSONSchemaObj;
+      const anyOf = interned.anyOf as JSONSchemaObj[];
+      expect(Object.keys(anyOf[0])).toEqual(["$defs", "type"]); // element sorted
+      expect((anyOf[1] as JSONSchemaObj).type).toBe("string"); // order preserved
+      expect(anyOf.length).toBe(2);
+    });
+
+    it("preserves owned symbol-keyed properties when it rebuilds for sorting", () => {
+      // Schemas are normally string-keyed, but canonicalization must never
+      // silently drop an owned (symbol) property when it rebuilds to sort keys.
+      const marker = Symbol("schemaMarker");
+      const schema = {
+        type: "object",
+        title: `canon-sym-${Date.now()}-${Math.random()}`,
+        [marker]: "kept",
+      } as unknown as JSONSchemaObj;
+      const interned = internSchema(schema) as JSONSchemaObj;
+      expect(Object.keys(interned)).toEqual(["title", "type"]); // string keys sorted
+      expect((interned as Record<symbol, unknown>)[marker]).toBe("kept");
+    });
   });
 });

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -108,27 +108,43 @@ describe("schema-hash", () => {
           expect(isDeepFrozen(schema)).toBe(true);
         });
 
-        it("uses an already-deep-frozen schema by reference", () => {
-          // Content-unique key guarantees no prior interning has seen this
-          // exact schema.
+        it("uses an already-deep-frozen, already-canonical schema by reference", () => {
+          // Content-unique key guarantees no prior interning has seen this exact
+          // schema. Its keys are already in canonical (UTF-8 byte) order, so
+          // interning returns the input by reference — no canonicalizing clone.
           const schema = toDeepFrozenSchema({
-            type: "object",
             title: `schemaHashTestAt${Date.now()}-${Math.random()}`,
+            type: "object",
           }) as JSONSchemaObj;
           expect(isDeepFrozen(schema)).toBe(true);
           const result = callIntern(schema);
           expect(result).toBe(schema);
         });
 
-        it("uses a never-before-encountered mutable schema by reference", () => {
-          // Content-unique key guarantees no prior interning has seen this
-          // exact schema.
+        it("uses a never-before-encountered, already-canonical mutable schema by reference", () => {
+          // As above: content-unique, with keys already in canonical order, so
+          // it is frozen in place and returned by reference.
           const schema: JSONSchemaObj = {
-            type: "number",
             title: `schemaHashTestAt${Date.now()}-${Math.random()}`,
+            type: "number",
           };
           const result = callIntern(schema);
           expect(result).toBe(schema);
+        });
+
+        it("returns a sorted clone (not by reference) for a non-canonical schema", () => {
+          // Keys NOT in canonical order: interning returns a structurally-equal
+          // clone with keys sorted, so the interned form serializes the same way
+          // regardless of the input's key order (the convergence property).
+          const schema: JSONSchemaObj = {
+            type: "object",
+            title: `schemaHashTestAt${Date.now()}-${Math.random()}`,
+          };
+          const result = callIntern(schema) as JSONSchemaObj;
+          expect(result).not.toBe(schema);
+          expect(result).toEqual(schema); // structurally equal
+          expect(Object.keys(result)).toEqual(["title", "type"]); // sorted
+          expect(isDeepFrozen(result)).toBe(true);
         });
 
         it("handles boolean schema `true`", () => {
@@ -395,5 +411,83 @@ describe("schema-hash", () => {
   it("returns base64url strings from `hashSchema()` (no algorithm prefix)", () => {
     const result = hashSchema({ type: "number" });
     expect(result).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  // The schema hash is key-order-insensitive (value-hash sorts keys), but the
+  // interned object previously kept the key order of whichever code path first
+  // interned it. Schemas are serialized directly from the interned object (e.g.
+  // into content-addressed `data:` cell ids), so divergent stored key order let
+  // two runtimes mint different ids for the same schema. The interned form is
+  // now key-order-canonical so serialization is deterministic across paths.
+  describe("key-order canonicalization", () => {
+    it("interns object keys in UTF-8 sorted order regardless of input order", () => {
+      // "$defs" (0x24) < "items" (0x69) < "type" (0x74)
+      const interned = internSchema({
+        type: "array",
+        items: { type: "string" },
+        $defs: { X: { type: "null" } },
+      }) as JSONSchemaObj;
+      expect(Object.keys(interned)).toEqual(["$defs", "items", "type"]);
+    });
+
+    it("sorts keys deeply (nested objects too)", () => {
+      const interned = internSchema({
+        type: "object",
+        properties: { b: { type: "number" }, a: { type: "string" } },
+      }) as JSONSchemaObj;
+      expect(Object.keys(interned)).toEqual(["properties", "type"]);
+      expect(Object.keys(interned.properties as JSONSchemaObj)).toEqual([
+        "a",
+        "b",
+      ]);
+    });
+
+    it("preserves array order (arrays are ordered, not sorted)", () => {
+      const interned = internSchema({
+        type: "object",
+        required: ["b", "a", "c"],
+      }) as JSONSchemaObj;
+      expect(interned.required).toEqual(["b", "a", "c"]);
+    });
+
+    it("converges: equal schemas in opposite key orders intern to one object and serialize identically", () => {
+      // A unique `title` keeps this test's structural hash to itself.
+      const tag = "canon-converge-test";
+      const unsorted: JSONSchema = {
+        type: "array",
+        title: tag,
+        items: { type: "string" },
+        $defs: { X: { type: "null" } },
+      };
+      const sorted: JSONSchema = {
+        $defs: { X: { type: "null" } },
+        items: { type: "string" },
+        title: tag,
+        type: "array",
+      };
+      const a = internSchema(unsorted);
+      const b = internSchema(sorted);
+      expect(a).toBe(b); // same canonical object, regardless of which interned first
+      expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+      // ...and the canonical serialization is the sorted one.
+      expect(JSON.stringify(a)).toBe(JSON.stringify(sorted));
+    });
+
+    it("leaves the schema hash unchanged (it was already key-order-insensitive)", () => {
+      const tag = "canon-hash-test";
+      const unsorted: JSONSchema = { type: "number", title: tag, description: "d" };
+      const sorted: JSONSchema = { description: "d", title: tag, type: "number" };
+      expect(hashSchema(unsorted)).toBe(hashSchema(sorted));
+      expect(hashSchema(internSchema(unsorted))).toBe(hashSchema(unsorted));
+    });
+
+    it("interns to a deep-frozen object", () => {
+      const interned = internSchema({
+        type: "array",
+        items: { type: "string" },
+        $defs: { X: { type: "null" } },
+      });
+      assert(isDeepFrozen(interned));
+    });
   });
 });

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -475,8 +475,16 @@ describe("schema-hash", () => {
 
     it("leaves the schema hash unchanged (it was already key-order-insensitive)", () => {
       const tag = "canon-hash-test";
-      const unsorted: JSONSchema = { type: "number", title: tag, description: "d" };
-      const sorted: JSONSchema = { description: "d", title: tag, type: "number" };
+      const unsorted: JSONSchema = {
+        type: "number",
+        title: tag,
+        description: "d",
+      };
+      const sorted: JSONSchema = {
+        description: "d",
+        title: tag,
+        type: "number",
+      };
       expect(hashSchema(unsorted)).toBe(hashSchema(sorted));
       expect(hashSchema(internSchema(unsorted))).toBe(hashSchema(unsorted));
     });

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -64,10 +64,11 @@ export function filter(
   }>,
   sendResult: (tx: IExtendedStorageTransaction, result: any) => void,
   addCancel: AddCancel,
-  cause: any,
+  _cause: any,
   parentCell: Cell<any>,
   runtime: Runtime,
   outputBinding?: NormalizedFullLink,
+  awaitSync?: boolean,
 ): Action {
   let result: Cell<any[]> | undefined;
 
@@ -81,8 +82,7 @@ export function filter(
   // Only the initial (resume) reconcile defers its per-element sub-pattern runs
   // until sync completes; elements from later (post-resume) reconciles are fresh
   // and must not wait. Cleared once a non-empty resume batch is processed.
-  let resumeBatchAwaitSync = !!(cause as { awaitSync?: boolean } | undefined)
-    ?.awaitSync;
+  let resumeBatchAwaitSync = !!awaitSync;
 
   return (tx: IExtendedStorageTransaction) => {
     const elementAwaitSync = resumeBatchAwaitSync;

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -66,10 +66,11 @@ export function flatMap(
   }>,
   sendResult: (tx: IExtendedStorageTransaction, result: any) => void,
   addCancel: AddCancel,
-  cause: any,
+  _cause: any,
   parentCell: Cell<any>,
   runtime: Runtime,
   outputBinding?: NormalizedFullLink,
+  awaitSync?: boolean,
 ): Action {
   let result: Cell<any[]> | undefined;
 
@@ -83,8 +84,7 @@ export function flatMap(
   // Only the initial (resume) reconcile defers its per-element sub-pattern runs
   // until sync completes; elements from later (post-resume) reconciles are fresh
   // and must not wait. Cleared once a non-empty resume batch is processed.
-  let resumeBatchAwaitSync = !!(cause as { awaitSync?: boolean } | undefined)
-    ?.awaitSync;
+  let resumeBatchAwaitSync = !!awaitSync;
 
   return (tx: IExtendedStorageTransaction) => {
     const elementAwaitSync = resumeBatchAwaitSync;

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -76,10 +76,11 @@ export function map(
   }>,
   sendResult: (tx: IExtendedStorageTransaction, result: any) => void,
   addCancel: AddCancel,
-  cause: any,
+  _cause: any,
   parentCell: Cell<any>,
   runtime: Runtime, // Runtime will be injected by the registration function
   outputBinding?: NormalizedFullLink,
+  awaitSync?: boolean,
 ): Action {
   let result: Cell<any[]> | undefined;
 
@@ -95,8 +96,7 @@ export function map(
   // runs until storage sync completes. This map action is itself sync-gated when
   // resumed, so its first reconcile already runs against synced data; elements
   // added by later (post-resume) reconciles are fresh and must not wait.
-  let resumeBatchAwaitSync = !!(cause as { awaitSync?: boolean } | undefined)
-    ?.awaitSync;
+  let resumeBatchAwaitSync = !!awaitSync;
 
   return (tx: IExtendedStorageTransaction) => {
     // Captured before the loop consumes it: this reconcile's element runs use

--- a/packages/runner/src/module.ts
+++ b/packages/runner/src/module.ts
@@ -124,6 +124,14 @@ export function raw<T, R>(
     // `cause.outputSpot` for scope-aware builtins; `cause.outputSpot` stays for
     // identity (it is hashed into result-cell causes and must not churn).
     outputBinding?: NormalizedFullLink,
+    // Whether this node is resuming from synced storage and should defer its
+    // initial run until sync completes. Passed out-of-band (like `outputBinding`
+    // above) rather than folded into `cause`: it is transient (present only on
+    // resume), so hashing it into the result-cell id would diverge a fresh
+    // runtime from a resumed one for the same logical node. Container-minting
+    // builtins (map/filter/flatMap) read it to defer their per-element
+    // sub-pattern runs until sync completes too.
+    awaitSync?: boolean,
   ) => RawBuiltinReturnType,
   options?: RawModuleOptions,
 ): ModuleFactory<T, R> {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3788,16 +3788,18 @@ export class Runner {
               },
             }
             : {}),
-          // Propagate the resumed-from-synced-state flag so container-minting
-          // builtins (map/filter/flatmap) defer their per-element sub-pattern
-          // runs until sync completes too.
-          ...(defersInitialRunUntilSynced(schedulerRehydration)
-            ? { awaitSync: true }
-            : {}),
         },
         processCell,
         this.runtime,
         outputBinding,
+        // The resumed-from-synced-state flag is passed out-of-band (a behavioral
+        // param, like `outputBinding`) instead of folded into the identity
+        // `cause` above. It is transient (present only on resume), so hashing it
+        // into the result-cell id would diverge a fresh runtime from a resumed
+        // one for the same logical node — the root of the cross-runtime write
+        // storm. Container-minting builtins (map/filter/flatMap) read it to
+        // defer their per-element sub-pattern runs until sync completes too.
+        defersInitialRunUntilSynced(schedulerRehydration),
       );
     } finally {
       popFrame(builtinFrame);


### PR DESCRIPTION
## Why

Multi-user patterns whose conditionals branch on **shared** state (lunch-poll's `ifElse`/`when` over `options`/`votes`) hit a **non-terminating cross-runtime write storm** — ~27.8k writes for a *static* 3-user poll — degrading load and pinning CPU. Root cause: the **deployer** (creates the pattern fresh) and the **browsers** (resume from synced storage) mint **different ids for the same shared result cell**, so their writes are genuinely different bytes, defeat the value-equal short-circuit, and overwrite each other forever. This PR converges those ids so the writes become value-equal and terminate.

## What — two independent identity channels, both fixed (separate commits)

### 1. `awaitSync` in the identity cause — `fix(runner)`
`awaitSync` is a transient resume flag that was folded into the raw-builtin `cause`, which `createRef` deep-hashes into the result-cell id — present on resume, absent on fresh. Lifted out-of-band into a behavioral param, mirroring the existing `outputBinding` precedent (which moved scope out of `cause.outputSpot` for the same "must not churn in identity" reason). Covers all ~11 identity-hashing builtins.

### 2. Non-canonical schema key order — `fix(data-model)`
`internSchema`'s hash is key-order-insensitive (value-hash sorts keys), but the *interned object* kept first-seen key order. Schemas serialize directly from the interned object into content-addressed `data:` cell ids, so a fresh deployer (interns the link schema unsorted) and a resumed browser (interns it sorted via `getStandardSchema` selector standardization) produced different bytes → different ids. The interned object is now stored key-order-canonical (the same `utf8SortedKeysOf` the hash already uses), so serialization is deterministic regardless of intern order.

## Verification

| metric | before | after |
|---|---|---|
| memwrites (3-user poll) | 27,806 | **2,148** (−92%) |
| `ifElse` runs | ~22k | 102 |
| host-add storm test | 12m46s FAIL | **2s PASS** |

- `data-model` suite green, incl. a new `key-order canonicalization` suite proving convergence + the narrowed by-reference contract.
- `runner` suite: **669/669**, zero regressions; no unit test's asserted id shifted.

## Scope — what this does *not* change

The storm needs **both** (a) divergent ids **and** (b) these `ifElse` results being `space`-scoped (shared) and written back by every client. This PR fixes (a). Whether ephemeral shared-condition `ifElse` results should be written to shared storage at all (computed-once / per-client-local) is the separate architectural question in `MULTI-USER-CONTENTION-HANDOFF.md` §9 — orthogonal to this fix.

Caveat from **local** two-browser validation (the untracked `lunch-poll-two-browsers` matrix harness — **not part of CI**, lives on `test/lunch-poll-browser-matrix`): the host-add storm test now passes in 2s, but a separate `keeps header summary… in sync` step still times out. That is the **separate `#4210`/`#4343` reactive-strand** (commit-conflict stranding under async load: low writes, correct summary state, asymmetric per-browser), not this storm — which is why this PR's CI is fully green without exercising it.

## Migration / review note

Channel 2 changes the content-address of schema-bearing cells — a deliberate, one-time shift toward the canonical sorted form browsers already produced. It touches the schema-interning subsystem, so flagging explicitly for owner review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## CI — coverage ratchet note (runner)

The runner coverage-debt ratchet reports +2 uncovered lines, but this is a coverage-diff line-shift artifact, not new untested logic. Verified line-by-line: §5.1's runner change adds no genuinely-uncovered executable lines (the new 8th-arg call `defersInitialRunUntilSynced(...)` and the `!!awaitSync` readers in map/filter/flatMap are all covered), and it actually *removes* a resume-only sub-expression (`{ awaitSync: true }`). The +2 is re-attribution of pre-existing uncovered error/resume paths after the param addition shifted line numbers. The *novel* logic (`canonicalizeSchemaKeyOrder`) is covered by the new `key-order canonicalization` tests. Accepting the runner metric narrowly:

NEW_PERF_BASELINE: coverage-debt: packages/runner uncovered lines = 8189 lines

