### PR TITLE
feat(toolshed): gated per-connection memory-write trace

### DIFF
--- a/docs/development/debugging/README.md
+++ b/docs/development/debugging/README.md
@@ -88,9 +88,11 @@ inside computed(); Stream subscribe doesn't exist; binding the whole item to
   - Reference tail covers logger counts/timing/baselines/flags and worker traces
 - **Server-side write trace** — set `CF_DEBUG_MEMORY_WRITES=1` on the toolshed to
   log every memory write as `[memwrite] c=<conn> op=… id=… scope=… vhash=…`,
-  per-connection-tagged (`c=`) so a cross-client write storm can be attributed to
+  per-connection-tagged (`c=`) so cross-client write churn can be attributed to
   specific clients. Add `CF_DEBUG_MEMORY_WRITE_VALUES=1` to also dump raw values
-  (avoid on real data — they can hold PII/secrets). See
+  (avoid on real data — they can hold PII/secrets). Output goes to the toolshed's
+  stderr — `packages/toolshed/local-dev-toolshed.log` under the local-dev scripts.
+  See
   [`memwrite-trace.ts`](../../../packages/toolshed/routes/storage/memory/memwrite-trace.ts).
 - [VDOM Debug Helpers](vdom-debug.md) - `commonfabric.vdom.*` VDOM tree inspection
 - [Logger Internals](../logger-internals.md) - Creating loggers in runtime code (`getLogger`, timing, flags)

--- a/docs/development/debugging/README.md
+++ b/docs/development/debugging/README.md
@@ -86,6 +86,12 @@ inside computed(); Stream subscribe doesn't exist; binding the whole item to
   - Starts with common tasks: read piece data, dump the rendered VDOM, diagnose
     churn, find dead handlers, watch values, agent-browser recipes
   - Reference tail covers logger counts/timing/baselines/flags and worker traces
+- **Server-side write trace** — set `CF_DEBUG_MEMORY_WRITES=1` on the toolshed to
+  log every memory write as `[memwrite] c=<conn> op=… id=… scope=… vhash=…`,
+  per-connection-tagged (`c=`) so a cross-client write storm can be attributed to
+  specific clients. Add `CF_DEBUG_MEMORY_WRITE_VALUES=1` to also dump raw values
+  (avoid on real data — they can hold PII/secrets). See
+  [`memwrite-trace.ts`](../../../packages/toolshed/routes/storage/memory/memwrite-trace.ts).
 - [VDOM Debug Helpers](vdom-debug.md) - `commonfabric.vdom.*` VDOM tree inspection
 - [Logger Internals](../logger-internals.md) - Creating loggers in runtime code (`getLogger`, timing, flags)
 

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -4,6 +4,7 @@ import * as MemoryServer from "@commonfabric/memory/v2/server";
 import type * as Routes from "./memory.routes.ts";
 import { memoryServer } from "../memory.ts";
 import { createSpan } from "@/middlewares/opentelemetry.ts";
+import { formatMemWriteTrace, type MemWriteOp } from "./memwrite-trace.ts";
 
 type NegotiatedSocketHandlers = {
   onMessage: (message: string) => void;
@@ -133,6 +134,12 @@ export const bufferTextMessagesUntilNegotiated = (
   };
 };
 
+// Per-connection ordinal for the gated `CF_DEBUG_MEMORY_WRITES` trace. Each
+// WebSocket connection is one client, so tagging every `[memwrite]` line with
+// this `c=<n>` attributes a write storm to specific clients. See
+// `memwrite-trace.ts`.
+let memwriteConnSeq = 0;
+
 const attachMemorySocketPipeline = (
   socket: WebSocket,
   negotiation: ReturnType<typeof bufferTextMessagesUntilNegotiated>,
@@ -164,11 +171,39 @@ const attachMemorySocketPipeline = (
   const closeConnection = () => {
     connection.close();
   };
+
+  // Gated diagnostic write trace (off by default). `CF_DEBUG_MEMORY_WRITES=1`
+  // logs one `[memwrite]` line per committed op, tagged with this connection's
+  // `c=<n>` so a write storm can be attributed to specific clients;
+  // `CF_DEBUG_MEMORY_WRITE_VALUES=1` additionally dumps raw values (avoid on
+  // real data — see memwrite-trace.ts).
+  const debugMemWrites = Deno.env.get("CF_DEBUG_MEMORY_WRITES") === "1";
+  const debugMemWriteValues =
+    Deno.env.get("CF_DEBUG_MEMORY_WRITE_VALUES") === "1";
+  const memConnId = debugMemWrites ? ++memwriteConnSeq : 0;
+  const logMemWrites = (payload: string): void => {
+    if (!debugMemWrites) return;
+    try {
+      const parsed = MemoryServer.parseClientMessage(payload) as unknown as {
+        commit?: { operations?: Array<Record<string, unknown>> };
+      };
+      for (const op of parsed?.commit?.operations ?? []) {
+        console.error(
+          formatMemWriteTrace(op as MemWriteOp, memConnId, debugMemWriteValues),
+        );
+      }
+    } catch {
+      // Logging only.
+    }
+  };
+
   void (async () => {
     try {
+      logMemWrites(firstMessage);
       await connection.receive(firstMessage);
       negotiation.handoff({
         onMessage(message) {
+          logMemWrites(message);
           void connection.receive(message).catch(() => {
             safeSocketClose(1011, "Memory websocket receive failure");
             closeConnection();

--- a/packages/toolshed/routes/storage/memory/memory.handlers.ts
+++ b/packages/toolshed/routes/storage/memory/memory.handlers.ts
@@ -199,15 +199,19 @@ const attachMemorySocketPipeline = (
 
   void (async () => {
     try {
-      logMemWrites(firstMessage);
       await connection.receive(firstMessage);
+      logMemWrites(firstMessage);
       negotiation.handoff({
         onMessage(message) {
-          logMemWrites(message);
-          void connection.receive(message).catch(() => {
-            safeSocketClose(1011, "Memory websocket receive failure");
-            closeConnection();
-          });
+          // Trace only after the receive resolves, so a message whose receive
+          // fails (the fatal-error path below) is not logged as a write.
+          void connection.receive(message).then(
+            () => logMemWrites(message),
+            () => {
+              safeSocketClose(1011, "Memory websocket receive failure");
+              closeConnection();
+            },
+          );
         },
         onClose: closeConnection,
         onError(error) {

--- a/packages/toolshed/routes/storage/memory/memwrite-trace.test.ts
+++ b/packages/toolshed/routes/storage/memory/memwrite-trace.test.ts
@@ -22,6 +22,11 @@ describe("memwrite-trace", () => {
       cyclic.self = cyclic;
       expect(stableStringify(cyclic)).toContain("[circular]");
     });
+
+    it("falls back to String(value) when a value is not JSON-serializable", () => {
+      // BigInt can't be JSON.stringify'd, so the catch fallback runs.
+      expect(stableStringify(1n)).toBe("1");
+    });
   });
 
   describe("memwriteHash", () => {

--- a/packages/toolshed/routes/storage/memory/memwrite-trace.test.ts
+++ b/packages/toolshed/routes/storage/memory/memwrite-trace.test.ts
@@ -1,42 +1,11 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import {
-  formatMemWriteTrace,
-  memwriteHash,
-  stableStringify,
-} from "./memwrite-trace.ts";
+import { formatMemWriteTrace } from "./memwrite-trace.ts";
+
+const vhashOf = (line: string) => line.match(/vhash=(\S+)/)?.[1];
 
 describe("memwrite-trace", () => {
-  describe("stableStringify", () => {
-    it("sorts object keys, so equal content renders identically", () => {
-      expect(stableStringify({ b: 1, a: 2 })).toBe(
-        stableStringify({ a: 2, b: 1 }),
-      );
-      expect(stableStringify({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
-    });
-
-    it("preserves array order and tolerates cycles", () => {
-      expect(stableStringify([3, 1, 2])).toBe("[3,1,2]");
-      const cyclic: Record<string, unknown> = {};
-      cyclic.self = cyclic;
-      expect(stableStringify(cyclic)).toContain("[circular]");
-    });
-
-    it("falls back to String(value) when a value is not JSON-serializable", () => {
-      // BigInt can't be JSON.stringify'd, so the catch fallback runs.
-      expect(stableStringify(1n)).toBe("1");
-    });
-  });
-
-  describe("memwriteHash", () => {
-    it("is deterministic and distinguishes different content", () => {
-      expect(memwriteHash("abc")).toBe(memwriteHash("abc"));
-      expect(memwriteHash("abc")).not.toBe(memwriteHash("abd"));
-      expect(memwriteHash("")).toMatch(/^[0-9a-f]{8}$/);
-    });
-  });
-
   describe("formatMemWriteTrace", () => {
     it("tags the connection and includes op/id/scope/vhash/paths", () => {
       const line = formatMemWriteTrace(
@@ -48,6 +17,17 @@ describe("memwrite-trace", () => {
       expect(line).toContain("op=set");
       expect(line).toContain("vhash=");
       expect(line).toContain("paths=[]");
+    });
+
+    it("renders vhash as a fixed-length base64url prefix of the canonical hash", () => {
+      const line = formatMemWriteTrace(
+        { op: "set", id: "i", scope: "space", value: { x: 1 } },
+        1,
+        false,
+      );
+      // 12-char base64url display form; the full canonical hash is the source
+      // of truth, this is only its truncation.
+      expect(vhashOf(line)).toMatch(/^[A-Za-z0-9_-]{12}$/);
     });
 
     it("omits raw values by default and includes them only when asked", () => {
@@ -87,10 +67,9 @@ describe("memwrite-trace", () => {
     });
 
     it("hashes equal content equally regardless of key order", () => {
-      // This is the property the storm investigation leans on: two writes with
-      // the same content get the same vhash, so a *different* vhash means a
-      // genuinely divergent value, not just reordered keys.
-      const vhashOf = (s: string) => s.match(/vhash=(\S+)/)?.[1];
+      // The property the storm investigation leans on: two writes with the same
+      // content get the same vhash, so a *different* vhash means a genuinely
+      // divergent value, not just reordered keys.
       const a = formatMemWriteTrace(
         { op: "set", id: "i", scope: "space", value: { x: 1, y: 2 } },
         1,
@@ -102,6 +81,53 @@ describe("memwrite-trace", () => {
         false,
       );
       expect(vhashOf(a)).toBe(vhashOf(b));
+    });
+
+    // The reason for using the canonical Fabric hash over a JSON round-trip: a
+    // JSON-derived hash collapses values that the runtime treats as distinct, so
+    // the trace would report a false "same value" and hide a real divergence.
+    it("distinguishes values a JSON round-trip would collapse (undefined fields)", () => {
+      // `JSON.stringify` drops `undefined`-valued keys, so both would serialize
+      // to `{}`; the canonical hash keys on the present `a` field.
+      const withUndef = formatMemWriteTrace(
+        { op: "set", id: "i", scope: "space", value: { a: undefined } },
+        1,
+        false,
+      );
+      const empty = formatMemWriteTrace(
+        { op: "set", id: "i", scope: "space", value: {} },
+        1,
+        false,
+      );
+      expect(vhashOf(withUndef)).not.toBe(vhashOf(empty));
+    });
+
+    it("distinguishes values a JSON round-trip would collapse (non-finite numbers)", () => {
+      // `JSON.stringify(Infinity)` is `null`, so a JSON hash can't tell these
+      // apart; the canonical number encoding can.
+      const inf = formatMemWriteTrace(
+        { op: "set", id: "i", scope: "space", value: { n: Infinity } },
+        1,
+        false,
+      );
+      const nul = formatMemWriteTrace(
+        { op: "set", id: "i", scope: "space", value: { n: null } },
+        1,
+        false,
+      );
+      expect(vhashOf(inf)).not.toBe(vhashOf(nul));
+    });
+
+    it("never throws on a value the canonical hasher rejects", () => {
+      // Not expected for a real FabricValue, but the trace must stay alive: a
+      // value the hasher can't encode (here, a function) yields a sentinel
+      // rather than an exception that would abort the rest of the commit's ops.
+      const line = formatMemWriteTrace(
+        { op: "set", id: "i", scope: "space", value: { fn: () => {} } },
+        1,
+        false,
+      );
+      expect(line).toContain("vhash=<unhashable>");
     });
   });
 });

--- a/packages/toolshed/routes/storage/memory/memwrite-trace.test.ts
+++ b/packages/toolshed/routes/storage/memory/memwrite-trace.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  formatMemWriteTrace,
+  memwriteHash,
+  stableStringify,
+} from "./memwrite-trace.ts";
+
+describe("memwrite-trace", () => {
+  describe("stableStringify", () => {
+    it("sorts object keys, so equal content renders identically", () => {
+      expect(stableStringify({ b: 1, a: 2 })).toBe(
+        stableStringify({ a: 2, b: 1 }),
+      );
+      expect(stableStringify({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+    });
+
+    it("preserves array order and tolerates cycles", () => {
+      expect(stableStringify([3, 1, 2])).toBe("[3,1,2]");
+      const cyclic: Record<string, unknown> = {};
+      cyclic.self = cyclic;
+      expect(stableStringify(cyclic)).toContain("[circular]");
+    });
+  });
+
+  describe("memwriteHash", () => {
+    it("is deterministic and distinguishes different content", () => {
+      expect(memwriteHash("abc")).toBe(memwriteHash("abc"));
+      expect(memwriteHash("abc")).not.toBe(memwriteHash("abd"));
+      expect(memwriteHash("")).toMatch(/^[0-9a-f]{8}$/);
+    });
+  });
+
+  describe("formatMemWriteTrace", () => {
+    it("tags the connection and includes op/id/scope/vhash/paths", () => {
+      const line = formatMemWriteTrace(
+        { op: "set", id: "of:fid1:abc", scope: "space", value: { x: 1 } },
+        3,
+        false,
+      );
+      expect(line).toContain("c=3");
+      expect(line).toContain("op=set");
+      expect(line).toContain("vhash=");
+      expect(line).toContain("paths=[]");
+    });
+
+    it("omits raw values by default and includes them only when asked", () => {
+      const op = {
+        op: "set",
+        id: "i",
+        scope: "space",
+        value: { secret: "shh" },
+      };
+      const hashed = formatMemWriteTrace(op, 1, false);
+      expect(hashed).not.toContain("val=");
+      expect(hashed).not.toContain("shh"); // raw value never leaks by default
+      const withValues = formatMemWriteTrace(op, 1, true);
+      expect(withValues).toContain("val=");
+      expect(withValues).toContain("shh");
+    });
+
+    it("hashes patch values (where op.value is absent) and extracts paths", () => {
+      const op = {
+        op: "patch",
+        id: "i",
+        scope: "space",
+        patches: [{ path: "/a", value: 1 }, { path: "/b", value: 2 }],
+      };
+      const line = formatMemWriteTrace(op, 2, false);
+      expect(line).toContain("paths=[/a,/b]");
+      expect(line).not.toContain("vhash=--------"); // a value is present
+    });
+
+    it("marks a value-less op (e.g. delete) with the empty-hash sentinel", () => {
+      const line = formatMemWriteTrace(
+        { op: "delete", id: "i", scope: "space" },
+        1,
+        false,
+      );
+      expect(line).toContain("vhash=--------");
+    });
+
+    it("hashes equal content equally regardless of key order", () => {
+      // This is the property the storm investigation leans on: two writes with
+      // the same content get the same vhash, so a *different* vhash means a
+      // genuinely divergent value, not just reordered keys.
+      const vhashOf = (s: string) => s.match(/vhash=(\S+)/)?.[1];
+      const a = formatMemWriteTrace(
+        { op: "set", id: "i", scope: "space", value: { x: 1, y: 2 } },
+        1,
+        false,
+      );
+      const b = formatMemWriteTrace(
+        { op: "set", id: "i", scope: "space", value: { y: 2, x: 1 } },
+        1,
+        false,
+      );
+      expect(vhashOf(a)).toBe(vhashOf(b));
+    });
+  });
+});

--- a/packages/toolshed/routes/storage/memory/memwrite-trace.ts
+++ b/packages/toolshed/routes/storage/memory/memwrite-trace.ts
@@ -7,15 +7,25 @@
  * link targets for the same shared cell come from two distinct clients each
  * minting a different id, vs. one client alternating between branches).
  *
- * Values are summarized as a stable content hash (`vhash`) only. To additionally
- * dump raw values (`val=`), set `CF_DEBUG_MEMORY_WRITE_VALUES=1` — AVOID on real
- * data: cell values can contain user content, PII, or secrets. The hash alone is
- * enough to tell "same value" from "different value", which is all a divergence
- * investigation needs.
+ * Values are summarized as a content hash (`vhash`). The hash is the **canonical
+ * Fabric value hash** (`@commonfabric/data-model/value-hash`) — the same
+ * identity the runtime uses for `valueEqual` — so "same vhash" means "same value
+ * by the runtime's own semantics". The parsed memory operations carry hydrated
+ * `FabricValue`s (`parseClientMessage` → `decodeMemoryBoundary`), so a JSON
+ * round-trip would silently collapse distinct values (Fabric primitives /
+ * instances with no enumerable fields, `undefined` object fields, non-finite
+ * numbers) into a false match — exactly what would make a write-storm diagnostic
+ * lie. To additionally dump raw values (`val=`), set
+ * `CF_DEBUG_MEMORY_WRITE_VALUES=1` — AVOID on real data: cell values can contain
+ * user content, PII, or secrets. The hash alone tells "same value" from
+ * "different value", which is all a divergence investigation needs.
  *
  * This module holds the pure formatting so it is unit-testable; the impure parts
  * (env reads, per-connection counter, message parsing) live in the route.
  */
+
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
+import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 
 /** A single operation from a parsed memory commit. */
 export interface MemWriteOp {
@@ -28,44 +38,37 @@ export interface MemWriteOp {
   patches?: unknown;
 }
 
-/**
- * Deterministic JSON with object keys sorted, so equal content always renders
- * the same regardless of key insertion order (the very thing that diverged in
- * the fresh-vs-resume storm). Stable across runs and processes. Cycles render as
- * `"[circular]"`; anything unserializable falls back to `String(value)`.
- */
-export function stableStringify(value: unknown): string {
-  const seen = new WeakSet<object>();
-  const walk = (x: unknown): unknown => {
-    if (x === null || typeof x !== "object") return x;
-    if (seen.has(x as object)) return "[circular]";
-    seen.add(x as object);
-    if (Array.isArray(x)) return x.map(walk);
-    const out: Record<string, unknown> = {};
-    for (const k of Object.keys(x as Record<string, unknown>).sort()) {
-      out[k] = walk((x as Record<string, unknown>)[k]);
-    }
-    return out;
-  };
-  try {
-    return JSON.stringify(walk(value)) ?? "undefined";
-  } catch {
-    return String(value);
-  }
-}
-
-/** FNV-1a/32 of a string as 8 hex chars. Stable across runs and processes. */
-export function memwriteHash(s: string): string {
-  let h = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) {
-    h ^= s.charCodeAt(i);
-    h = Math.imul(h, 0x01000193);
-  }
-  return (h >>> 0).toString(16).padStart(8, "0");
-}
-
 /** Sentinel `vhash` for an operation that carries no value (e.g. `delete`). */
 const NO_VALUE_HASH = "--------";
+
+/**
+ * Sentinel `vhash` for a value the canonical hasher rejects. Not expected for a
+ * well-formed `FabricValue`, but a diagnostic must never throw and abort the
+ * trace (or, via the route's catch, the rest of a commit's ops).
+ */
+const UNHASHABLE = "<unhashable>";
+
+/**
+ * Length of the base64url hash prefix shown per line. 12 chars (~72 bits) is far
+ * more than enough to tell writes apart by eye without bloating the log; the
+ * full canonical hash is the source of truth, this is only its display form.
+ */
+const VHASH_DISPLAY_LEN = 12;
+
+/** Max characters of raw value rendered after `val=`. */
+const VALUE_DISPLAY_LEN = 600;
+
+/**
+ * Canonical Fabric value hash, truncated for display. Returns a sentinel rather
+ * than throwing so a single odd op can never abort the trace.
+ */
+function displayVhash(value: unknown): string {
+  try {
+    return hashStringOf(value).slice(0, VHASH_DISPLAY_LEN);
+  } catch {
+    return UNHASHABLE;
+  }
+}
 
 /**
  * Format one memory-commit operation as a single `[memwrite]` trace line.
@@ -85,8 +88,7 @@ export function formatMemWriteTrace(
   // present so a patch's value isn't silently dropped.
   const valueSource = op.patches !== undefined ? op.patches : op.value;
   const hasValue = valueSource !== undefined;
-  const canon = hasValue ? stableStringify(valueSource) : "";
-  const vhash = hasValue ? memwriteHash(canon) : NO_VALUE_HASH;
+  const vhash = hasValue ? displayVhash(valueSource) : NO_VALUE_HASH;
   const paths = Array.isArray(op.patches)
     ? op.patches
       .map((p) => (p as { path?: unknown } | null)?.path)
@@ -97,5 +99,11 @@ export function formatMemWriteTrace(
   const base = `[memwrite] c=${connId} op=${op.op} id=${
     String(op.id).slice(0, 28)
   } scope=${op.scope ?? "(space)"} vhash=${vhash} paths=[${paths}]`;
-  return includeValues ? `${base} val=${canon.slice(0, 600)}` : base;
+  if (!includeValues) return base;
+  // Render via the canonical Fabric debug formatter (handles special
+  // primitives/instances, bigints, non-finite numbers; never throws).
+  const rendered = hasValue
+    ? toCompactDebugString(valueSource, VALUE_DISPLAY_LEN)
+    : "";
+  return `${base} val=${rendered}`;
 }

--- a/packages/toolshed/routes/storage/memory/memwrite-trace.ts
+++ b/packages/toolshed/routes/storage/memory/memwrite-trace.ts
@@ -1,0 +1,101 @@
+/**
+ * Gated diagnostic trace for writes hitting the v2 memory route.
+ *
+ * Off by default. Enable with `CF_DEBUG_MEMORY_WRITES=1`. Each emitted line
+ * attributes one write to a specific client connection via `c=<n>` — the lever
+ * that makes cross-client write storms diagnosable (e.g. whether two divergent
+ * link targets for the same shared cell come from two distinct clients each
+ * minting a different id, vs. one client alternating between branches).
+ *
+ * Values are summarized as a stable content hash (`vhash`) only. To additionally
+ * dump raw values (`val=`), set `CF_DEBUG_MEMORY_WRITE_VALUES=1` — AVOID on real
+ * data: cell values can contain user content, PII, or secrets. The hash alone is
+ * enough to tell "same value" from "different value", which is all a divergence
+ * investigation needs.
+ *
+ * This module holds the pure formatting so it is unit-testable; the impure parts
+ * (env reads, per-connection counter, message parsing) live in the route.
+ */
+
+/** A single operation from a parsed memory commit. */
+export interface MemWriteOp {
+  op?: string;
+  id?: unknown;
+  scope?: unknown;
+  /** Present for `set`/`delete`; absent for `patch` (value lives in `patches`). */
+  value?: unknown;
+  /** JSON-patch entries for `patch` ops, each `{ path, value, ... }`. */
+  patches?: unknown;
+}
+
+/**
+ * Deterministic JSON with object keys sorted, so equal content always renders
+ * the same regardless of key insertion order (the very thing that diverged in
+ * the fresh-vs-resume storm). Stable across runs and processes. Cycles render as
+ * `"[circular]"`; anything unserializable falls back to `String(value)`.
+ */
+export function stableStringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+  const walk = (x: unknown): unknown => {
+    if (x === null || typeof x !== "object") return x;
+    if (seen.has(x as object)) return "[circular]";
+    seen.add(x as object);
+    if (Array.isArray(x)) return x.map(walk);
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(x as Record<string, unknown>).sort()) {
+      out[k] = walk((x as Record<string, unknown>)[k]);
+    }
+    return out;
+  };
+  try {
+    return JSON.stringify(walk(value)) ?? "undefined";
+  } catch {
+    return String(value);
+  }
+}
+
+/** FNV-1a/32 of a string as 8 hex chars. Stable across runs and processes. */
+export function memwriteHash(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+/** Sentinel `vhash` for an operation that carries no value (e.g. `delete`). */
+const NO_VALUE_HASH = "--------";
+
+/**
+ * Format one memory-commit operation as a single `[memwrite]` trace line.
+ *
+ * @param connId per-connection ordinal (`c=`), so a storm's writes can be
+ *   attributed to specific clients.
+ * @param includeValues when true, append the raw value (`val=`, truncated).
+ *   Off by default — see the module-level privacy note.
+ */
+export function formatMemWriteTrace(
+  op: MemWriteOp,
+  connId: number,
+  includeValues: boolean,
+): string {
+  // For `set`/`delete` the written value is `op.value`; for `patch` it lives in
+  // the JSON-patch entries and `op.value` is absent. Summarize whichever is
+  // present so a patch's value isn't silently dropped.
+  const valueSource = op.patches !== undefined ? op.patches : op.value;
+  const hasValue = valueSource !== undefined;
+  const canon = hasValue ? stableStringify(valueSource) : "";
+  const vhash = hasValue ? memwriteHash(canon) : NO_VALUE_HASH;
+  const paths = Array.isArray(op.patches)
+    ? op.patches
+      .map((p) => (p as { path?: unknown } | null)?.path)
+      .filter((p) => p !== undefined)
+      .slice(0, 4)
+      .join(",")
+    : "";
+  const base = `[memwrite] c=${connId} op=${op.op} id=${
+    String(op.id).slice(0, 28)
+  } scope=${op.scope ?? "(space)"} vhash=${vhash} paths=[${paths}]`;
+  return includeValues ? `${base} val=${canon.slice(0, 600)}` : base;
+}


### PR DESCRIPTION
## Why

Diagnosing write storms / conflict cascades — e.g. the lunch-poll fresh-vs-resume cell-identity storm fixed in #4360 — needs a server-side view of *which client* writes *what* to *which cell*. This upstreams the gated trace that made that diagnosis possible, cleaned up for general reuse (these contention investigations recur).

## What

`CF_DEBUG_MEMORY_WRITES=1` on the toolshed logs one `[memwrite]` line per committed memory op:

```
[memwrite] c=1 op=set id=of:fid1:… scope=space vhash=109967bf paths=[]
```

- **`c=<n>`** — per-connection ordinal. Each WebSocket is one client, so this attributes a storm's writes to specific clients (the key lever: is a divergent link target two clients each minting a different id, or one client alternating between branches?).
- **`vhash`** — stable, cross-process content hash of the written value (FNV-1a over key-sorted JSON). Equal content → equal hash, so a *different* vhash means a genuinely divergent value.
- **`paths`** — first few JSON-patch paths for `patch` ops.

Off by default; the gate is a cheap boolean check.

## Privacy

Raw values are **not** logged by default — only `vhash`. `CF_DEBUG_MEMORY_WRITE_VALUES=1` additionally appends `val=…`; avoid on real data, as cell values can hold user content, PII, or secrets. The hash alone distinguishes "same value" from "different value", which is all a divergence investigation needs.

## Design notes

- The pure formatting (`stableStringify` / `memwriteHash` / `formatMemWriteTrace`) is extracted into `memwrite-trace.ts` and unit-tested; the route keeps only env reads + the per-connection counter + message parsing.
- Kept as a gated `console.error` trace (greppable for ad-hoc debugging) rather than structured/pino output. The memory route already runs under `--unstable-otel`, so promoting this to otel events/metrics is a reasonable future enhancement — intentionally out of scope here.
- Documented under `docs/development/debugging/README.md` → Runtime Inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a gated, per-connection memory-write trace in the Toolshed v2 memory route to diagnose cross-client write churn. Off by default; logs one line per committed write with the connection id and a canonical Fabric value hash.

- New Features
  - Enable with `CF_DEBUG_MEMORY_WRITES=1`; add `CF_DEBUG_MEMORY_WRITE_VALUES=1` to append `val=…`.
  - Each line includes `c=<n>` (per WebSocket), `op`, `id`, `scope`, `vhash` (12-char prefix from `@commonfabric/data-model/value-hash`), and first JSON-patch `paths`; values (when enabled) render via `@commonfabric/data-model/value-debug`.
  - Output goes to toolshed stderr (local dev: `packages/toolshed/local-dev-toolshed.log`). Pure formatting lives in `memwrite-trace.ts` with unit tests; the route handles env checks, per-connection counter, and message parsing.

- Bug Fixes
  - Emit the memwrite trace only after `connection.receive()` resolves, so failed receives aren’t logged as writes.

<sup>Written for commit 52b17cf7a158f7456f966b5176f0c321a002ed2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## CI — coverage ratchet note (toolshed)

This PR adds **gated debug instrumentation** (`CF_DEBUG_MEMORY_WRITES`, off by default), so the `logMemWrites` route wrapper's body only runs when the flag is set — it is *inherently* never exercised in CI, and the toolshed coverage-debt ratchet flags it. The pure logic (`stableStringify` / `memwriteHash` / `formatMemWriteTrace`) is **fully unit-tested** in `memwrite-trace.test.ts` (100% line coverage); only the env-gated route wrapper is uncovered. Accepting the toolshed metric narrowly:

NEW_PERF_BASELINE: coverage-debt: packages/toolshed uncovered lines = 4919 lines
