### PR TITLE
chore: fix stale references in repo config and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ signatures.
 This repository contains many packages that compose and stack to create the
 Common Fabric product.
 
-1. Foundation: api, runtime, identity, memory
+1. Foundation: api, runner, identity, memory
 2. System: schema-generator, iframe-sandbox, ts-transformers, js-compiler
 3. Capabilities: piece, html, llm
 4. Operation: background-piece-service, cli
@@ -67,8 +67,7 @@ already does).
   data types, and keywords. Check its "Status tiers" section before imitating
   any pattern — only `exemplar` entries are style references.
 
-**Important:** Ignore the top level `deprecated-patterns` folder - it is
-defunct.
+**Important:** Ignore the `packages/patterns/deprecated` folder - it is defunct.
 
 ## Runtime Development
 

--- a/deno.json
+++ b/deno.json
@@ -85,12 +85,8 @@
       ".beads/",
       "./packages/static/assets",
       "./packages/vendor-astral",
-      "./packages/patterns-saves-backup/",
       "./tmp/",
-      "./packages/patterns/default-array-push-test.tsx",
-      "./packages/patterns/notes-menu.tsx",
-      "./packages/patterns/record/",
-      "./packages/patterns/weight-tracker.tsx"
+      "./packages/patterns/record/"
     ],
     "rules": {
       "tags": [


### PR DESCRIPTION
Two onboarding/config references pointed at things that no longer exist. Neither caused a hard failure, but each misleads a reader (human or agent) about how the repository is laid out.

AGENTS.md "Pace Layers": the foundation layer named a "runtime" package. There is no such package; the runtime lives in "runner". Correct the name so the layer model matches the workspace. (The operation layer's "background-piece-service" is left as-is — that package exists under that name.)

AGENTS.md deprecated-patterns pointer: it told readers to ignore a top-level "deprecated-patterns" folder. There is no such folder; the defunct examples live at packages/patterns/deprecated. Point at the real path.

Root deno.json lint excludes: the list referenced three pattern files that have since been deleted (default-array-push-test.tsx, notes-menu.tsx, weight-tracker.tsx) and a packages/patterns-saves-backup directory that is not present. Remove those stale entries. The patterns/record/ exclude is kept because that directory still exists.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected stale references in AGENTS.md and root `deno.json` so docs and lint excludes match the current workspace. AGENTS.md now names the foundation package `runner` and points to `packages/patterns/deprecated`; `deno.json` drops deleted pattern files and the missing `packages/patterns-saves-backup/` from lint excludes.

<sup>Written for commit 667b932cafeef6adb8d5dfd3c5ec8b80492c040f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

