### PR TITLE
fix: stabilize HTML list child settling

### DIFF
--- a/packages/html/src/main/applicator.ts
+++ b/packages/html/src/main/applicator.ts
@@ -20,6 +20,12 @@ const logger = getLogger("vdom-applicator", { enabled: false, level: "debug" });
 const ELEMENT_NODE = 1;
 const TEXT_NODE = 3;
 
+interface PendingChildInsert {
+  parentId: number;
+  childId: number;
+  beforeId: number | null;
+}
+
 function hasNodeType(node: unknown, nodeType: number): boolean {
   return typeof node === "object" && node !== null &&
     (node as { nodeType?: unknown }).nodeType === nodeType;
@@ -77,6 +83,7 @@ export class DomApplicator {
   private readonly runtimeClient: RuntimeClient;
   private readonly onError?: (error: Error) => void;
   private readonly setPropHandler: SetPropHandler;
+  private pendingChildInserts: PendingChildInsert[] = [];
 
   private rootNodeId: number | null = null;
 
@@ -98,12 +105,14 @@ export class DomApplicator {
     for (const op of batch.ops) {
       try {
         this.applyOp(op);
+        this.replayPendingChildInserts();
       } catch (error) {
         this.onError?.(
           error instanceof Error ? error : new Error(String(error)),
         );
       }
     }
+    this.replayPendingChildInserts();
 
     if (batch.rootId !== undefined) {
       this.rootNodeId = batch.rootId;
@@ -156,11 +165,15 @@ export class DomApplicator {
         break;
 
       case "insert-child":
-        this.insertChild(op.parentId, op.childId, op.beforeId);
+        if (!this.insertChild(op.parentId, op.childId, op.beforeId)) {
+          this.deferChildInsert(op.parentId, op.childId, op.beforeId);
+        }
         break;
 
       case "move-child":
-        this.moveChild(op.parentId, op.childId, op.beforeId);
+        if (!this.moveChild(op.parentId, op.childId, op.beforeId)) {
+          this.deferChildInsert(op.parentId, op.childId, op.beforeId);
+        }
         break;
 
       case "remove-node":
@@ -243,6 +256,7 @@ export class DomApplicator {
     this.nodes.clear();
     this.nodeParents.clear();
     this.nodeChildren.clear();
+    this.pendingChildInserts = [];
     this.rootNodeId = null;
 
     const elapsed = logger.timeEnd("dispose");
@@ -437,10 +451,12 @@ export class DomApplicator {
     parentId: number,
     childId: number,
     beforeId: number | null,
-  ): void {
+  ): boolean {
     const parent = this.nodes.get(parentId);
     const child = this.nodes.get(childId);
-    if (!parent || !child) return;
+    if (!parent || !child) return false;
+
+    this.discardPendingForChild(childId);
 
     // Update parent/children tracking
     // Remove from old parent if any
@@ -468,19 +484,63 @@ export class DomApplicator {
       // Either no beforeNode, or it's not a child of this parent - just append
       parent.appendChild(child);
     }
+    return true;
   }
 
   private moveChild(
     parentId: number,
     childId: number,
     beforeId: number | null,
-  ): void {
+  ): boolean {
     // Move is the same as insert - insertBefore handles it
-    this.insertChild(parentId, childId, beforeId);
+    return this.insertChild(parentId, childId, beforeId);
+  }
+
+  private deferChildInsert(
+    parentId: number,
+    childId: number,
+    beforeId: number | null,
+  ): void {
+    this.discardPendingForChild(childId);
+    this.pendingChildInserts.push({ parentId, childId, beforeId });
+  }
+
+  private discardPendingForChild(childId: number): void {
+    this.pendingChildInserts = this.pendingChildInserts.filter((pending) =>
+      pending.childId !== childId
+    );
+  }
+
+  private discardPendingForNodeIds(nodeIds: ReadonlySet<number>): void {
+    this.pendingChildInserts = this.pendingChildInserts.filter((pending) =>
+      !nodeIds.has(pending.parentId) && !nodeIds.has(pending.childId) &&
+      (pending.beforeId === null || !nodeIds.has(pending.beforeId))
+    );
+  }
+
+  private replayPendingChildInserts(): void {
+    if (this.pendingChildInserts.length === 0) return;
+
+    const remaining: PendingChildInsert[] = [];
+    for (const pending of this.pendingChildInserts) {
+      if (
+        !this.insertChild(
+          pending.parentId,
+          pending.childId,
+          pending.beforeId,
+        )
+      ) {
+        remaining.push(pending);
+      }
+    }
+    this.pendingChildInserts = remaining;
   }
 
   private removeNode(nodeId: number): void {
     const node = this.nodes.get(nodeId);
+    const removedNodeIds = new Set([nodeId]);
+    this.collectDescendantNodeIds(nodeId, removedNodeIds);
+    this.discardPendingForNodeIds(removedNodeIds);
     if (!node) return;
 
     logger.timeStart("remove-node", String(nodeId));
@@ -558,6 +618,16 @@ export class DomApplicator {
     }
 
     return count;
+  }
+
+  private collectDescendantNodeIds(nodeId: number, into: Set<number>): void {
+    const children = this.nodeChildren.get(nodeId);
+    if (!children || children.size === 0) return;
+
+    for (const childId of children) {
+      into.add(childId);
+      this.collectDescendantNodeIds(childId, into);
+    }
   }
 
   private setAttrs(nodeId: number, attrs: Record<string, unknown>): void {

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -1272,7 +1272,7 @@ export class WorkerReconciler {
    * Follows [UI] chains and returns the VNode, or null if not a VNode.
    * Includes cycle detection to prevent infinite loops.
    */
-  private extractVNode(node: WorkerRenderNode): WorkerVNode | null {
+  private extractVNode(node: unknown): WorkerVNode | null {
     if (isWorkerVNode(node)) return node;
 
     // Follow [UI] chain with cycle detection
@@ -2898,11 +2898,33 @@ export class WorkerReconciler {
       if (!forceReplace && state.children.has(key)) {
         // Reuse existing child
         const existingState = state.children.get(key)!;
-        newMapping.set(key, existingState);
+        const canReuse = this.reconcileReusedChild(
+          ctx,
+          existingState,
+          child,
+          visited,
+          policy,
+        );
         state.children.delete(key);
-
-        // Update if it's an element with new data
-        // (For now, we trust the key - updates happen through Cell subscriptions)
+        if (canReuse) {
+          newMapping.set(key, existingState);
+        } else {
+          existingState.cancel();
+          this.cleanupNodeHandlers(existingState);
+          this.queueOps([{ op: "remove-node", nodeId: existingState.nodeId }]);
+          hasNewChildren = true;
+          const childState = this.renderChild(
+            ctx,
+            child,
+            visited,
+            state,
+            key,
+            policy,
+          );
+          if (childState) {
+            newMapping.set(key, childState);
+          }
+        }
       } else {
         // Create new child, passing parent state and key for position tracking
         hasNewChildren = true;
@@ -2974,6 +2996,98 @@ export class WorkerReconciler {
   }
 
   /**
+   * Reconcile a reused keyed child. A stable key preserves DOM identity and
+   * ordering, but the VNode payload may still have fresh captured values from a
+   * parent recomputation, so same-key reuse cannot blindly skip descendants.
+   */
+  private reconcileReusedChild(
+    ctx: ReconcileContext,
+    childState: ChildNodeState,
+    child: unknown,
+    visited: Set<object>,
+    policy: RenderPolicy,
+  ): boolean {
+    if (isCell(child)) {
+      return childState.cell !== undefined &&
+        this.sameCellForReuse(childState.cell, child);
+    }
+
+    if (
+      childState.isText &&
+      (typeof child === "string" || typeof child === "number" ||
+        typeof child === "boolean" || child === null || child === undefined)
+    ) {
+      const text = this.stringifyText(child);
+      if (text !== childState.currentValue) {
+        childState.currentValue = text;
+        this.queueOps([{
+          op: "update-text",
+          nodeId: childState.nodeId,
+          text,
+        }]);
+      }
+      return true;
+    }
+
+    if (!childState.elementState) return false;
+
+    const newVNode = this.extractVNode(child);
+    if (!newVNode) return false;
+
+    const sanitized = this.sanitizeNode(newVNode);
+    if (!sanitized || sanitized.name !== childState.elementState.tagName) {
+      return false;
+    }
+
+    const childPolicy = this.childRenderPolicyForNode(
+      sanitized,
+      policy,
+      childState.elementState.nodeId,
+    );
+    const policyChildren = this.childrenForRenderPolicy(
+      sanitized,
+      childPolicy,
+    );
+    const policyChanged = !this.renderPolicyEquals(
+      childState.elementState.childRenderPolicy,
+      childPolicy,
+    ) || childState.elementState.childrenBlockedByPolicy !==
+        policyChildren.blocked;
+
+    childState.currentValue = child;
+    childState.elementState.renderPolicy = policy;
+    childState.elementState.childRenderPolicy = childPolicy;
+    childState.elementState.childrenBlockedByPolicy = policyChildren.blocked;
+    childState.elementState.sourceChildren = sanitized.children;
+    childState.elementState.sourceProps = sanitized.props;
+
+    this.updatePropsInPlace(ctx, childState.elementState, sanitized.props);
+
+    if (policyChildren.children !== undefined) {
+      if (policyChanged) {
+        this.resetTextIntegrityBoundary(childState.elementState, childPolicy);
+      }
+      this.updateChildrenInPlace(
+        ctx,
+        childState.elementState,
+        policyChildren.children,
+        new Set(visited),
+        childPolicy,
+        policyChanged,
+      );
+    }
+    return true;
+  }
+
+  private sameCellForReuse(left: Cell<unknown>, right: Cell<unknown>): boolean {
+    try {
+      return areLinksSame(left, right);
+    } catch {
+      return left === right;
+    }
+  }
+
+  /**
    * Render a child node (which may be a VNode, text, or Cell).
    * For Cell children, uses position-aware insertion instead of wrapper elements.
    */
@@ -3026,6 +3140,7 @@ export class WorkerReconciler {
       nodeId: -1,
       isText: false,
       cancel,
+      cell,
     };
 
     let currentCancel: Cancel | undefined;
@@ -3168,27 +3283,21 @@ export class WorkerReconciler {
                   sanitized.props,
                 );
 
-                // Check children: if same, do nothing (sinks active);
-                // if different, tear down and rebuild
                 if (policyChildren.children !== undefined) {
-                  const childrenSame = this.areChildrenSame(
-                    childState.elementState,
-                    policyChildren.children,
-                  );
-                  if (!childrenSame || policyChanged) {
+                  if (policyChanged) {
                     this.resetTextIntegrityBoundary(
                       childState.elementState,
                       childPolicy,
                     );
-                    this.updateChildrenInPlace(
-                      ctx,
-                      childState.elementState,
-                      policyChildren.children,
-                      new Set(),
-                      childPolicy,
-                      policyChanged,
-                    );
                   }
+                  this.updateChildrenInPlace(
+                    ctx,
+                    childState.elementState,
+                    policyChildren.children,
+                    new Set(),
+                    childPolicy,
+                    policyChanged,
+                  );
                 }
                 return;
               }

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -188,6 +188,9 @@ export interface ChildNodeState {
 
   /** Track current value for deduping updates */
   currentValue?: unknown;
+
+  /** Source cell for reactive child nodes; used to decide same-key reuse. */
+  cell?: Cell<unknown>;
 }
 
 /**

--- a/packages/html/test/main-applicator.test.ts
+++ b/packages/html/test/main-applicator.test.ts
@@ -297,6 +297,98 @@ Deno.test("DomApplicator - child operations", async (t) => {
     assertEquals(parent.childNodes[1].tagName, "SPAN");
   });
 
+  await t.step(
+    "replays insert when child is created later in the batch",
+    () => {
+      const doc = createMockDocument();
+      const applicator = createDomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
+          { op: "create-element", nodeId: 1, tagName: "div" },
+          { op: "create-element", nodeId: 2, tagName: "span" },
+        ],
+      });
+
+      const parent = applicator.getNode(1) as unknown as {
+        childNodes: Array<{ tagName: string }>;
+      };
+      assertEquals(parent.childNodes.length, 1);
+      assertEquals(parent.childNodes[0].tagName, "SPAN");
+    },
+  );
+
+  await t.step(
+    "does not replay stale placement after child moves elsewhere",
+    () => {
+      const doc = createMockDocument();
+      const applicator = createDomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "section" },
+          { op: "insert-child", parentId: 2, childId: 3, beforeId: null },
+          { op: "create-element", nodeId: 3, tagName: "span" },
+          { op: "insert-child", parentId: 1, childId: 3, beforeId: null },
+          { op: "create-element", nodeId: 2, tagName: "div" },
+        ],
+      });
+
+      const laterParent = applicator.getNode(1) as unknown as {
+        childNodes: Array<{ tagName: string }>;
+      };
+      const staleParent = applicator.getNode(2) as unknown as {
+        childNodes: Array<{ tagName: string }>;
+      };
+      assertEquals(laterParent.childNodes.map((child) => child.tagName), [
+        "SPAN",
+      ]);
+      assertEquals(staleParent.childNodes, []);
+    },
+  );
+
+  await t.step(
+    "does not replay insert after child is removed before creation",
+    () => {
+      const doc = createMockDocument();
+      const applicator = createDomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "div" },
+          { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
+          { op: "remove-node", nodeId: 2 },
+          { op: "create-element", nodeId: 2, tagName: "span" },
+        ],
+      });
+
+      const parent = applicator.getNode(1) as unknown as {
+        childNodes: Array<{ tagName: string }>;
+      };
+      assertEquals(parent.childNodes, []);
+      assertEquals(
+        (applicator.getNode(2) as unknown as { tagName: string }).tagName,
+        "SPAN",
+      );
+    },
+  );
+
   await t.step("moves child to new position", () => {
     const doc = createMockDocument();
     const applicator = createDomApplicator({

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -1,11 +1,12 @@
 import { assertEquals } from "@std/assert";
 import { WorkerReconciler } from "../src/worker/reconciler.ts";
-import type { WorkerVNode } from "../src/worker/types.ts";
+import type { WorkerRenderNode, WorkerVNode } from "../src/worker/types.ts";
 
 import type { VDomOp } from "../src/vdom-ops.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "@commonfabric/runner";
+import { Runtime, UI } from "@commonfabric/runner";
+import type { Cell } from "@commonfabric/runner";
 
 /**
  * Helper to collect ops emitted by the reconciler.
@@ -154,6 +155,50 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
     },
   );
 
+  await t.step(
+    "replaces same-key child Cell when parent supplies a different cell",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const firstChild = new MockCell("first");
+      const secondChild = new MockCell("second");
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "div",
+        props: {},
+        children: [firstChild as unknown as Cell<WorkerRenderNode>],
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      collector.clear();
+
+      rootCell.set({
+        type: "vnode",
+        name: "div",
+        props: {},
+        children: [secondChild as unknown as Cell<WorkerRenderNode>],
+      } as WorkerVNode);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      assertEquals(
+        collector.getOpsOfType("remove-node").length > 0,
+        true,
+        "old cell child should be removed when the parent supplies a new cell",
+      );
+      assertEquals(
+        collector.getOpsOfType("create-text").some((op) =>
+          "text" in op && op.text === "second"
+        ),
+        true,
+        "new cell child should render its current value",
+      );
+    },
+  );
+
   await t.step("replaces child Cell when tag changes", async () => {
     const collector = createOpsCollector();
     const reconciler = new WorkerReconciler({
@@ -234,6 +279,229 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
     assertEquals(updateTextOps.length, 1, "Should emit update-text");
     assertEquals((updateTextOps[0] as any).text, "World");
   });
+
+  await t.step(
+    "updates same-shape slotted header cell VNode children",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const header = new MockCell(
+        {
+          type: "vnode",
+          name: "div",
+          props: { slot: "header" },
+          children: [{
+            type: "vnode",
+            name: "span",
+            props: { "data-poll-summary": "true" },
+            children: ["4 joined · 0 options · 0 votes · hosted by Alice"],
+          }],
+        } satisfies WorkerVNode,
+      );
+
+      const rootCell = new MockCell(
+        {
+          type: "vnode",
+          name: "cf-screen",
+          props: {},
+          children: [header as unknown as WorkerRenderNode],
+        } satisfies WorkerVNode,
+      );
+
+      reconciler.mount(rootCell as unknown as Cell<unknown>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      const screenCreate = collector.getOpsOfType("create-element").find(
+        (op) => "tagName" in op && op.tagName === "cf-screen",
+      );
+      if (!screenCreate || !("nodeId" in screenCreate)) {
+        throw new Error("Expected cf-screen to be created");
+      }
+      const screenNodeId = screenCreate.nodeId;
+      collector.clear();
+
+      header.set(
+        {
+          type: "vnode",
+          name: "div",
+          props: { slot: "header" },
+          children: [{
+            type: "vnode",
+            name: "span",
+            props: { "data-poll-summary": "true" },
+            children: ["4 joined · 1 options · 0 votes · hosted by Alice"],
+          }],
+        } satisfies WorkerVNode,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const textOps = collector.getOps().filter((op) =>
+        (op.op === "update-text" || op.op === "create-text") &&
+        "text" in op
+      );
+      assertEquals(
+        textOps.some((op) =>
+          "text" in op &&
+          op.text === "4 joined · 1 options · 0 votes · hosted by Alice"
+        ),
+        true,
+        "slotted header summary text should update",
+      );
+
+      assertEquals(
+        collector.getOpsOfType("remove-node").some((op) =>
+          "nodeId" in op && op.nodeId === screenNodeId
+        ),
+        false,
+        "slotted header summary update should not remount cf-screen",
+      );
+    },
+  );
+
+  await t.step(
+    "updates same-shape split text children from a Cell VNode",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const summary = new MockCell(
+        {
+          type: "vnode",
+          name: "div",
+          props: { "data-poll-summary": "true" },
+          children: [
+            4,
+            " joined · ",
+            4,
+            " options · ",
+            1,
+            " votes · hosted by Dave",
+          ],
+        } satisfies WorkerVNode,
+      );
+      const rootCell = new MockCell(
+        {
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: [summary as unknown as WorkerRenderNode],
+        } satisfies WorkerVNode,
+      );
+
+      reconciler.mount(rootCell as unknown as Cell<unknown>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      collector.clear();
+
+      summary.set(
+        {
+          type: "vnode",
+          name: "div",
+          props: { "data-poll-summary": "true" },
+          children: [
+            4,
+            " joined · ",
+            4,
+            " options · ",
+            4,
+            " votes · hosted by Dave",
+          ],
+        } satisfies WorkerVNode,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const textOps = collector.getOpsOfType("update-text");
+      assertEquals(
+        textOps.some((op) => "text" in op && op.text === "4"),
+        true,
+        "same-shape split vote-count text should update",
+      );
+      assertEquals(
+        collector.getOps().some((op) =>
+          (op.op === "update-text" || op.op === "create-text") &&
+          "text" in op && op.text === "4"
+        ),
+        true,
+        "same-shape split vote-count text should be represented",
+      );
+    },
+  );
+
+  await t.step(
+    "replaces same-key UI child when rendered root tag changes",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const beforeChild = {
+        [UI]: {
+          type: "vnode",
+          name: "span",
+          props: {},
+          children: ["Before"],
+        } satisfies WorkerVNode,
+      } as unknown as WorkerRenderNode;
+      const afterChild = {
+        [UI]: {
+          type: "vnode",
+          name: "button",
+          props: {},
+          children: ["After"],
+        } satisfies WorkerVNode,
+      } as unknown as WorkerRenderNode;
+
+      const rootCell = new MockCell(
+        {
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: [beforeChild],
+        } satisfies WorkerVNode,
+      );
+
+      reconciler.mount(rootCell as unknown as Cell<unknown>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const spanCreate = collector.getOpsOfType("create-element").find(
+        (op) => "tagName" in op && op.tagName === "span",
+      );
+      if (!spanCreate || !("nodeId" in spanCreate)) {
+        throw new Error("Expected span to be created");
+      }
+      const spanNodeId = spanCreate.nodeId;
+      collector.clear();
+
+      rootCell.set(
+        {
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: [afterChild],
+        } satisfies WorkerVNode,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      assertEquals(
+        collector.getOpsOfType("remove-node").some((op) =>
+          "nodeId" in op && op.nodeId === spanNodeId
+        ),
+        true,
+        "same-key UI payload should remove the stale root element",
+      );
+      assertEquals(
+        collector.getOpsOfType("create-element").some((op) =>
+          "tagName" in op && op.tagName === "button"
+        ),
+        true,
+        "same-key UI payload should create the replacement root element",
+      );
+    },
+  );
 
   await t.step(
     "avoids re-emitting set-event when handler is identical (VNode path)",
@@ -613,6 +881,96 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       // With implementation "insert from end", it likely emits inserts.
       // At least 1 insert is expected (to move).
       assertEquals(swapInserts.length > 0, true, "Should insert to re-order");
+    },
+  );
+
+  await t.step(
+    "updates same-key subpattern UI payloads without reinserting",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+      const subpatternOutput = (node: WorkerVNode): WorkerRenderNode => ({
+        [UI]: node,
+        toJSON: () => "stable-subpattern-output",
+      } as unknown as WorkerRenderNode);
+
+      const rootCell = new MockCell(
+        {
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: [
+            subpatternOutput({
+              type: "vnode",
+              name: "span",
+              props: { "data-row": "same", "data-count": "1" },
+              children: ["one"],
+            }),
+          ],
+        } satisfies WorkerVNode,
+      );
+
+      reconciler.mount(rootCell as unknown as Cell<unknown>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      const spanCreate = collector.getOps().find((op) =>
+        op.op === "create-element" && "tagName" in op &&
+        op.tagName === "span"
+      );
+      if (!spanCreate || !("nodeId" in spanCreate)) {
+        throw new Error("Expected initial span to be created");
+      }
+      const spanNodeId = spanCreate.nodeId;
+      collector.clear();
+
+      rootCell.set(
+        {
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: [
+            subpatternOutput({
+              type: "vnode",
+              name: "span",
+              props: { "data-row": "same", "data-count": "2" },
+              children: ["two"],
+            }),
+          ],
+        } satisfies WorkerVNode,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      assertEquals(
+        collector.getOpsOfType("create-element").some((op) =>
+          "tagName" in op && op.tagName === "span"
+        ),
+        false,
+        "same-key child update should not recreate the element",
+      );
+      assertEquals(
+        collector.getOpsOfType("remove-node").some((op) =>
+          "nodeId" in op && op.nodeId === spanNodeId
+        ),
+        false,
+        "same-key child update should not remove the element",
+      );
+      assertEquals(
+        collector.getOpsOfType("set-prop").some((op) =>
+          "key" in op && op.key === "data-count" &&
+          "value" in op && op.value === "2"
+        ),
+        true,
+        "same-key child prop should update",
+      );
+      assertEquals(
+        collector.getOps().some((op) =>
+          (op.op === "update-text" || op.op === "create-text") &&
+          "text" in op && op.text === "two"
+        ),
+        true,
+        "same-key child text should update",
+      );
     },
   );
 });

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -101,7 +101,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       const rootCell = new MockCell(rootVNode);
 
       // Mount
-      reconciler.mount(rootCell as any);
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       const createOps = collector.getOpsOfType("create-element");
@@ -195,6 +195,150 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         ),
         true,
         "new cell child should render its current value",
+      );
+    },
+  );
+
+  await t.step(
+    "updates cell-backed conditional row children at first middle and last positions",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const voteSpan = (id: string): WorkerVNode => ({
+        type: "vnode",
+        name: "span",
+        props: { "data-vote-swatch-name": id },
+        children: [id],
+      });
+
+      const firstChildren = new MockCell([]);
+      const middleChildren = new MockCell([]);
+      const lastChildren = new MockCell([]);
+
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "div",
+        props: {},
+        children: [
+          {
+            type: "vnode",
+            name: "div",
+            props: { "data-option-id": "first" },
+            children: firstChildren,
+          },
+          {
+            type: "vnode",
+            name: "div",
+            props: { "data-option-id": "middle" },
+            children: middleChildren,
+          },
+          {
+            type: "vnode",
+            name: "div",
+            props: { "data-option-id": "last" },
+            children: lastChildren,
+          },
+        ],
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      collector.clear();
+
+      firstChildren.set([voteSpan("Alice")]);
+      middleChildren.set([null, voteSpan("Alice")]);
+      lastChildren.set([null, null, voteSpan("Alice")]);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const spanCreates = collector.getOpsOfType("create-element").filter(
+        (op) => "tagName" in op && op.tagName === "span",
+      );
+      assertEquals(
+        spanCreates.length,
+        3,
+        "should create one swatch span for each cell-backed row",
+      );
+
+      const swatchPropOps = collector.getOpsOfType("set-prop").filter(
+        (op) =>
+          op.op === "set-prop" && op.key === "data-vote-swatch-name" &&
+          op.value === "Alice",
+      );
+      assertEquals(
+        swatchPropOps.length,
+        3,
+        "each cell-backed swatch span should receive the voter data attribute",
+      );
+    },
+  );
+
+  await t.step(
+    "inserts pending mapped child cells when they resolve after parent array update",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const voteSpan = (id: string): WorkerVNode => ({
+        type: "vnode",
+        name: "span",
+        props: { "data-vote-swatch-name": id },
+        children: [id],
+      });
+
+      const firstMappedResult = new MockCell(undefined);
+      const middleMappedResult = new MockCell(undefined);
+      const lastMappedResult = new MockCell(undefined);
+
+      const mappedChildren = new MockCell([]);
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "div",
+        props: { "data-option-id": "mapped" },
+        children: mappedChildren,
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      collector.clear();
+
+      mappedChildren.set([
+        firstMappedResult,
+        middleMappedResult,
+        lastMappedResult,
+      ]);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      collector.clear();
+
+      firstMappedResult.set(voteSpan("Alice"));
+      middleMappedResult.set(voteSpan("Alice"));
+      lastMappedResult.set(voteSpan("Alice"));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const spanCreates = collector.getOpsOfType("create-element").filter(
+        (op) => "tagName" in op && op.tagName === "span",
+      );
+      assertEquals(
+        spanCreates.length,
+        3,
+        "should create one swatch span for each late-resolving mapped child cell",
+      );
+
+      const spanInserts = collector.getOpsOfType("insert-child").filter(
+        (op) =>
+          op.op === "insert-child" &&
+          spanCreates.some((createOp) =>
+            "nodeId" in createOp && createOp.nodeId === op.childId
+          ),
+      );
+      assertEquals(
+        spanInserts.length,
+        3,
+        "each late-resolving swatch span should be inserted into the parent row",
       );
     },
   );

--- a/packages/html/test/worker-reconciler-diffing.test.ts
+++ b/packages/html/test/worker-reconciler-diffing.test.ts
@@ -12,7 +12,7 @@
 import { assertEquals } from "@std/assert";
 import { WorkerReconciler } from "../src/worker/reconciler.ts";
 import type { VDomOp } from "../src/vdom-ops.ts";
-import type { WorkerVNode } from "../src/worker/types.ts";
+import type { WorkerRenderNode, WorkerVNode } from "../src/worker/types.ts";
 
 // Import the actual Cell implementation to create test cells
 import { Identity } from "@commonfabric/identity";
@@ -290,6 +290,97 @@ Deno.test("worker reconciler diffing - same tag updates in place", async (t) => 
 
       cancel();
     });
+
+    await t.step(
+      "conditional mapped children insert spans at first middle and last positions",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+        });
+
+        const vnodeCell = runtime.getCell<WorkerVNode>(
+          space,
+          "test-conditional-mapped-children",
+          undefined,
+          tx,
+        );
+
+        const voteSpan = (id: string): WorkerVNode => ({
+          type: "vnode",
+          name: "span",
+          props: { "data-vote-swatch-name": id },
+          children: [id],
+        });
+
+        const row = (
+          id: string,
+          children: WorkerRenderNode[],
+        ): WorkerVNode => ({
+          type: "vnode",
+          name: "div",
+          props: { "data-option-id": id },
+          children,
+        });
+
+        vnodeCell.set({
+          type: "vnode",
+          name: "div",
+          props: { id: "root" },
+          children: [
+            row("first", []),
+            row("middle", []),
+            row("last", []),
+          ],
+        } as WorkerVNode);
+        await tx.commit();
+        tx = runtime.edit();
+
+        const cancel = reconciler.mount(vnodeCell as Cell<WorkerVNode>);
+        await runtime.idle();
+        collector.clear();
+
+        vnodeCell.withTx(tx).set({
+          type: "vnode",
+          name: "div",
+          props: { id: "root" },
+          children: [
+            row("first", [voteSpan("Alice")]),
+            row("middle", [null, voteSpan("Alice")]),
+            row("last", [
+              null,
+              null,
+              voteSpan("Alice"),
+            ]),
+          ],
+        } as WorkerVNode);
+        await tx.commit();
+        tx = runtime.edit();
+        await runtime.idle();
+
+        const spanCreates = collector.getOpsOfType("create-element").filter(
+          (op) => "tagName" in op && op.tagName === "span",
+        );
+        assertEquals(
+          spanCreates.length,
+          3,
+          "should create one swatch span for each conditional child position",
+        );
+
+        const swatchPropOps = collector.getOpsOfType("set-prop").filter(
+          (op) =>
+            op.op === "set-prop" && op.key === "data-vote-swatch-name" &&
+            op.value === "Alice",
+        );
+        assertEquals(
+          swatchPropOps.length,
+          3,
+          "each created swatch span should receive the voter data attribute",
+        );
+
+        cancel();
+      },
+    );
 
     await t.step("clears root when Cell emits undefined", async () => {
       const collector = createOpsCollector();

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -115,7 +115,6 @@ export function filter(
         tx,
       );
       result = scopedCell(runtime, tx, baseResult, outputScope);
-      result.send([]);
       // Link this cell to the parent cell
       setResultCell(result, parentCell);
       // Link the new result cells to the pattern cell too
@@ -137,7 +136,11 @@ export function filter(
       ...(argumentUsage.usesParams ? { params: inputsCell.key("params") } : {}),
     });
 
-    if (resultWithLog.get() === undefined) {
+    const existingResult = resultWithLog.get();
+    const preserveResumeResult = elementAwaitSync &&
+      Array.isArray(existingResult) &&
+      existingResult.length > 0;
+    if (existingResult === undefined) {
       resultWithLog.set([]);
     }
     if (list === undefined) {
@@ -153,10 +156,9 @@ export function filter(
       throw new Error("filter currently only supports arrays");
     }
 
-    if (list.length > 0) resumeBatchAwaitSync = false;
-
     const keyCounts = new Map<string, number>();
     const newArrayValue: any[] = [];
+    let hasPendingPredicate = false;
     for (let i = 0; i < list.length; i++) {
       // Skip sparse holes — don't create predicate runs for them
       if (!(i in list)) continue;
@@ -210,10 +212,15 @@ export function filter(
       // Read predicate result — creates subscription for reactivity.
       // Truthy/falsy coercion, not strict boolean.
       const included = elementRuns.get(elementKey)!.resultCell.withTx(tx).get();
+      if (included === undefined) {
+        hasPendingPredicate = true;
+      }
       if (included) {
         newArrayValue.push(list[i]); // Original element cell reference
       }
     }
+    if (preserveResumeResult && hasPendingPredicate) return;
+    resumeBatchAwaitSync = false;
     resultWithLog.set(newArrayValue);
 
     // NOTE: Same as map — elementRuns is not pruned. See map.ts for rationale.

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -117,7 +117,6 @@ export function flatMap(
         tx,
       );
       result = scopedCell(runtime, tx, baseResult, outputScope);
-      result.send([]);
       // Link this cell to the parent cell
       setResultCell(result, parentCell);
       // Link the new result cells to the pattern cell too
@@ -139,7 +138,11 @@ export function flatMap(
       ...(argumentUsage.usesParams ? { params: inputsCell.key("params") } : {}),
     });
 
-    if (resultWithLog.get() === undefined) {
+    const existingResult = resultWithLog.get();
+    const preserveResumeResult = elementAwaitSync &&
+      Array.isArray(existingResult) &&
+      existingResult.length > 0;
+    if (existingResult === undefined) {
       resultWithLog.set([]);
     }
     if (list === undefined) {
@@ -155,10 +158,9 @@ export function flatMap(
       throw new Error("flatMap currently only supports arrays");
     }
 
-    if (list.length > 0) resumeBatchAwaitSync = false;
-
     const keyCounts = new Map<string, number>();
     const newArrayValue: any[] = [];
+    let hasPendingElementResult = false;
     for (let i = 0; i < list.length; i++) {
       // Skip sparse holes — don't create pattern runs for them
       if (!(i in list)) continue;
@@ -219,8 +221,12 @@ export function flatMap(
         });
       } else if (elemResult !== undefined) {
         newArrayValue.push(elemResult);
+      } else {
+        hasPendingElementResult = true;
       }
     }
+    if (preserveResumeResult && hasPendingElementResult) return;
+    resumeBatchAwaitSync = false;
     resultWithLog.set(newArrayValue);
 
     // NOTE: Same as map — elementRuns is not pruned. See map.ts for rationale.

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -172,7 +172,6 @@ export function map(
         tx,
       );
       result = scopedCell(runtime, tx, baseResult, listScope);
-      result.send([]);
       setResultCell(result, parentCell);
       // Link the new result cells to the pattern cell too
       setPatternCell(result, parentCell.key("pattern"));


### PR DESCRIPTION
## Summary
- update the worker reconciler so reused keyed/cell child slots receive their new render payloads instead of retaining stale content
- replay deferred main-thread child insert/move operations once their nodes exist, while dropping stale placements
- preserve non-empty resumed map/filter/flatMap results while child result cells finish syncing, avoiding transient empty/partial list output

## Why
These are real DOM/VDOM discrepancies, not Lunch Poll-specific delays: the worker could reuse keyed child state without reconciling its replacement payload, and the main applicator could drop insert/move ops that arrived before their nodes. Separately, resumed list builtins could briefly overwrite synced list outputs with empty/partial arrays while child runs caught up. Together they explain the refresh-time All Options swatch disappearance/refill.

## Verification
- `deno fmt --check packages/html/src/worker/reconciler.ts packages/html/src/worker/types.ts packages/html/src/main/applicator.ts packages/html/test/worker-reconciler-cell-child.test.ts packages/html/test/worker-reconciler-diffing.test.ts packages/html/test/main-applicator.test.ts packages/runner/src/builtins/map.ts packages/runner/src/builtins/filter.ts packages/runner/src/builtins/flatmap.ts`
- `deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp packages/html/test/worker-reconciler-cell-child.test.ts packages/html/test/worker-reconciler-diffing.test.ts packages/html/test/main-applicator.test.ts`
- `deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp packages/runner/test/map-op-by-identity.test.ts packages/runner/test/patterns-dynamic.test.ts`
- browser probe on deployed minimal Lunch Poll: refresh goes shell/no poll -> 35 swatches, with no 35 -> 0 -> row-by-row refill transition


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes HTML list child settling by reconciling reused keyed/cell children, replaying deferred child placements, and preserving resumed list results to eliminate refresh-time swatch flicker/disappear/reappear.

- **Bug Fixes**
  - Worker reconciler now updates reused keyed/cell children with new VNode payloads in place; replaces on tag change; updates text/props and children without remounts.
  - Main applicator queues insert/move ops when nodes aren’t ready and replays them once created; drops stale placements and clears pending on remove/dispose.
  - `map`, `filter`, and `flatMap` keep non-empty resumed results while element runs resolve, avoiding transient empty/partial list outputs.

<sup>Written for commit 7da0d0a4f673f819d167251449a656d9987f22d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

