### PR TITLE
fix(runner): preserve resumed list results while children sync

### DIFF
--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -115,7 +115,6 @@ export function filter(
         tx,
       );
       result = scopedCell(runtime, tx, baseResult, outputScope);
-      result.send([]);
       // Link this cell to the parent cell
       setResultCell(result, parentCell);
       // Link the new result cells to the pattern cell too
@@ -137,7 +136,11 @@ export function filter(
       ...(argumentUsage.usesParams ? { params: inputsCell.key("params") } : {}),
     });
 
-    if (resultWithLog.get() === undefined) {
+    const existingResult = resultWithLog.get();
+    const preserveResumeResult = elementAwaitSync &&
+      Array.isArray(existingResult) &&
+      existingResult.length > 0;
+    if (existingResult === undefined) {
       resultWithLog.set([]);
     }
     if (list === undefined) {
@@ -153,10 +156,9 @@ export function filter(
       throw new Error("filter currently only supports arrays");
     }
 
-    if (list.length > 0) resumeBatchAwaitSync = false;
-
     const keyCounts = new Map<string, number>();
     const newArrayValue: any[] = [];
+    let hasPendingPredicate = false;
     for (let i = 0; i < list.length; i++) {
       // Skip sparse holes — don't create predicate runs for them
       if (!(i in list)) continue;
@@ -210,10 +212,15 @@ export function filter(
       // Read predicate result — creates subscription for reactivity.
       // Truthy/falsy coercion, not strict boolean.
       const included = elementRuns.get(elementKey)!.resultCell.withTx(tx).get();
+      if (included === undefined) {
+        hasPendingPredicate = true;
+      }
       if (included) {
         newArrayValue.push(list[i]); // Original element cell reference
       }
     }
+    if (preserveResumeResult && hasPendingPredicate) return;
+    resumeBatchAwaitSync = false;
     resultWithLog.set(newArrayValue);
 
     // NOTE: Same as map — elementRuns is not pruned. See map.ts for rationale.

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -117,7 +117,6 @@ export function flatMap(
         tx,
       );
       result = scopedCell(runtime, tx, baseResult, outputScope);
-      result.send([]);
       // Link this cell to the parent cell
       setResultCell(result, parentCell);
       // Link the new result cells to the pattern cell too
@@ -139,7 +138,11 @@ export function flatMap(
       ...(argumentUsage.usesParams ? { params: inputsCell.key("params") } : {}),
     });
 
-    if (resultWithLog.get() === undefined) {
+    const existingResult = resultWithLog.get();
+    const preserveResumeResult = elementAwaitSync &&
+      Array.isArray(existingResult) &&
+      existingResult.length > 0;
+    if (existingResult === undefined) {
       resultWithLog.set([]);
     }
     if (list === undefined) {
@@ -155,10 +158,9 @@ export function flatMap(
       throw new Error("flatMap currently only supports arrays");
     }
 
-    if (list.length > 0) resumeBatchAwaitSync = false;
-
     const keyCounts = new Map<string, number>();
     const newArrayValue: any[] = [];
+    let hasPendingElementResult = false;
     for (let i = 0; i < list.length; i++) {
       // Skip sparse holes — don't create pattern runs for them
       if (!(i in list)) continue;
@@ -219,8 +221,12 @@ export function flatMap(
         });
       } else if (elemResult !== undefined) {
         newArrayValue.push(elemResult);
+      } else {
+        hasPendingElementResult = true;
       }
     }
+    if (preserveResumeResult && hasPendingElementResult) return;
+    resumeBatchAwaitSync = false;
     resultWithLog.set(newArrayValue);
 
     // NOTE: Same as map — elementRuns is not pruned. See map.ts for rationale.

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -172,7 +172,6 @@ export function map(
         tx,
       );
       result = scopedCell(runtime, tx, baseResult, listScope);
-      result.send([]);
       setResultCell(result, parentCell);
       // Link the new result cells to the pattern cell too
       setPatternCell(result, parentCell.key("pattern"));


### PR DESCRIPTION
## Summary
- preserve existing resumed map/filter/flatMap result cells while child runs are still syncing
- avoid refresh-time transient empty/partial list outputs without changing converged list semantics

## Verification
- deno fmt --check packages/runner/src/builtins/filter.ts packages/runner/src/builtins/flatmap.ts packages/runner/src/builtins/map.ts
- deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp packages/runner/test/map-op-by-identity.test.ts packages/runner/test/patterns-dynamic.test.ts
- LSP diagnostics clean for packages/runner/src/builtins/{map,filter,flatmap}.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves resumed `map`/`filter`/`flatMap` results while child runs sync to avoid transient empty or partial list outputs. Final list semantics are unchanged; this removes refresh-time flicker.

- **Bug Fixes**
  - Keep existing array results on resume when child predicates/elements are still pending; only update once available.
  - Remove eager `result.send([])` in `map`, `filter`, and `flatMap` scoped result cells.
  - Delay `resumeBatchAwaitSync` reset until after aggregation (and skip when preserving), so batches end only when children are accounted for.

<sup>Written for commit c21dcff9886b804d8b362f538e12524512a4cd48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

