### PR TITLE
fix(html): stabilize VDOM list child settling

### DIFF
--- a/packages/html/src/main/applicator.ts
+++ b/packages/html/src/main/applicator.ts
@@ -456,6 +456,13 @@ export class DomApplicator {
     const child = this.nodes.get(childId);
     if (!parent || !child) return false;
 
+    const beforeNode = beforeId === null ? null : this.nodes.get(beforeId);
+    if (
+      beforeId !== null && (!beforeNode || beforeNode.parentNode !== parent)
+    ) {
+      return false;
+    }
+
     this.discardPendingForChild(childId);
 
     // Update parent/children tracking
@@ -473,15 +480,9 @@ export class DomApplicator {
     }
     children.add(childId);
 
-    const beforeNode = beforeId !== null
-      ? this.nodes.get(beforeId) ?? null
-      : null;
-
-    if (beforeNode && beforeNode.parentNode === parent) {
-      // Only use insertBefore if the beforeNode is actually a child of parent
+    if (beforeNode) {
       parent.insertBefore(child, beforeNode);
     } else {
-      // Either no beforeNode, or it's not a child of this parent - just append
       parent.appendChild(child);
     }
     return true;

--- a/packages/html/src/main/applicator.ts
+++ b/packages/html/src/main/applicator.ts
@@ -513,10 +513,19 @@ export class DomApplicator {
   }
 
   private discardPendingForNodeIds(nodeIds: ReadonlySet<number>): void {
-    this.pendingChildInserts = this.pendingChildInserts.filter((pending) =>
-      !nodeIds.has(pending.parentId) && !nodeIds.has(pending.childId) &&
-      (pending.beforeId === null || !nodeIds.has(pending.beforeId))
-    );
+    const remaining: PendingChildInsert[] = [];
+    for (const pending of this.pendingChildInserts) {
+      if (nodeIds.has(pending.parentId) || nodeIds.has(pending.childId)) {
+        continue;
+      }
+
+      remaining.push(
+        pending.beforeId !== null && nodeIds.has(pending.beforeId)
+          ? { ...pending, beforeId: null }
+          : pending,
+      );
+    }
+    this.pendingChildInserts = remaining;
   }
 
   private replayPendingChildInserts(): void {

--- a/packages/html/src/main/applicator.ts
+++ b/packages/html/src/main/applicator.ts
@@ -20,6 +20,12 @@ const logger = getLogger("vdom-applicator", { enabled: false, level: "debug" });
 const ELEMENT_NODE = 1;
 const TEXT_NODE = 3;
 
+interface PendingChildInsert {
+  parentId: number;
+  childId: number;
+  beforeId: number | null;
+}
+
 function hasNodeType(node: unknown, nodeType: number): boolean {
   return typeof node === "object" && node !== null &&
     (node as { nodeType?: unknown }).nodeType === nodeType;
@@ -77,6 +83,7 @@ export class DomApplicator {
   private readonly runtimeClient: RuntimeClient;
   private readonly onError?: (error: Error) => void;
   private readonly setPropHandler: SetPropHandler;
+  private pendingChildInserts: PendingChildInsert[] = [];
 
   private rootNodeId: number | null = null;
 
@@ -98,12 +105,14 @@ export class DomApplicator {
     for (const op of batch.ops) {
       try {
         this.applyOp(op);
+        this.replayPendingChildInserts();
       } catch (error) {
         this.onError?.(
           error instanceof Error ? error : new Error(String(error)),
         );
       }
     }
+    this.replayPendingChildInserts();
 
     if (batch.rootId !== undefined) {
       this.rootNodeId = batch.rootId;
@@ -156,11 +165,15 @@ export class DomApplicator {
         break;
 
       case "insert-child":
-        this.insertChild(op.parentId, op.childId, op.beforeId);
+        if (!this.insertChild(op.parentId, op.childId, op.beforeId)) {
+          this.deferChildInsert(op.parentId, op.childId, op.beforeId);
+        }
         break;
 
       case "move-child":
-        this.moveChild(op.parentId, op.childId, op.beforeId);
+        if (!this.moveChild(op.parentId, op.childId, op.beforeId)) {
+          this.deferChildInsert(op.parentId, op.childId, op.beforeId);
+        }
         break;
 
       case "remove-node":
@@ -243,6 +256,7 @@ export class DomApplicator {
     this.nodes.clear();
     this.nodeParents.clear();
     this.nodeChildren.clear();
+    this.pendingChildInserts = [];
     this.rootNodeId = null;
 
     const elapsed = logger.timeEnd("dispose");
@@ -437,10 +451,12 @@ export class DomApplicator {
     parentId: number,
     childId: number,
     beforeId: number | null,
-  ): void {
+  ): boolean {
     const parent = this.nodes.get(parentId);
     const child = this.nodes.get(childId);
-    if (!parent || !child) return;
+    if (!parent || !child) return false;
+
+    this.discardPendingForChild(childId);
 
     // Update parent/children tracking
     // Remove from old parent if any
@@ -468,19 +484,63 @@ export class DomApplicator {
       // Either no beforeNode, or it's not a child of this parent - just append
       parent.appendChild(child);
     }
+    return true;
   }
 
   private moveChild(
     parentId: number,
     childId: number,
     beforeId: number | null,
-  ): void {
+  ): boolean {
     // Move is the same as insert - insertBefore handles it
-    this.insertChild(parentId, childId, beforeId);
+    return this.insertChild(parentId, childId, beforeId);
+  }
+
+  private deferChildInsert(
+    parentId: number,
+    childId: number,
+    beforeId: number | null,
+  ): void {
+    this.discardPendingForChild(childId);
+    this.pendingChildInserts.push({ parentId, childId, beforeId });
+  }
+
+  private discardPendingForChild(childId: number): void {
+    this.pendingChildInserts = this.pendingChildInserts.filter((pending) =>
+      pending.childId !== childId
+    );
+  }
+
+  private discardPendingForNodeIds(nodeIds: ReadonlySet<number>): void {
+    this.pendingChildInserts = this.pendingChildInserts.filter((pending) =>
+      !nodeIds.has(pending.parentId) && !nodeIds.has(pending.childId) &&
+      (pending.beforeId === null || !nodeIds.has(pending.beforeId))
+    );
+  }
+
+  private replayPendingChildInserts(): void {
+    if (this.pendingChildInserts.length === 0) return;
+
+    const remaining: PendingChildInsert[] = [];
+    for (const pending of this.pendingChildInserts) {
+      if (
+        !this.insertChild(
+          pending.parentId,
+          pending.childId,
+          pending.beforeId,
+        )
+      ) {
+        remaining.push(pending);
+      }
+    }
+    this.pendingChildInserts = remaining;
   }
 
   private removeNode(nodeId: number): void {
     const node = this.nodes.get(nodeId);
+    const removedNodeIds = new Set([nodeId]);
+    this.collectDescendantNodeIds(nodeId, removedNodeIds);
+    this.discardPendingForNodeIds(removedNodeIds);
     if (!node) return;
 
     logger.timeStart("remove-node", String(nodeId));
@@ -558,6 +618,16 @@ export class DomApplicator {
     }
 
     return count;
+  }
+
+  private collectDescendantNodeIds(nodeId: number, into: Set<number>): void {
+    const children = this.nodeChildren.get(nodeId);
+    if (!children || children.size === 0) return;
+
+    for (const childId of children) {
+      into.add(childId);
+      this.collectDescendantNodeIds(childId, into);
+    }
   }
 
   private setAttrs(nodeId: number, attrs: Record<string, unknown>): void {

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -1072,10 +1072,15 @@ export class WorkerReconciler {
     if (state.tagName !== CFC_AUTHORSHIP_TAG) {
       return;
     }
-    if (policy.textIntegrity?.boundaryNodeId !== state.nodeId) {
+    if (
+      policy.textIntegrity !== undefined &&
+      policy.textIntegrity.boundaryNodeId !== state.nodeId
+    ) {
       return;
     }
-    const value = this.hasTextIntegrityBlockForBoundary(state, state.nodeId)
+    const value = policy.textIntegrity === undefined
+      ? "ok"
+      : this.hasTextIntegrityBlockForBoundary(state, state.nodeId)
       ? "blocked"
       : "ok";
     this.queueOps([{

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -1065,31 +1065,60 @@ export class WorkerReconciler {
     }]);
   }
 
-  private resetTextIntegrityBoundary(
+  private refreshTextIntegrityBoundaryState(
     state: NodeState,
     policy: RenderPolicy,
   ): void {
     if (state.tagName !== CFC_AUTHORSHIP_TAG) {
       return;
     }
-    if (
-      policy.textIntegrity !== undefined &&
-      policy.textIntegrity.boundaryNodeId !== state.nodeId
-    ) {
+    if (policy.textIntegrity?.boundaryNodeId !== state.nodeId) {
       return;
     }
+    const value = this.hasTextIntegrityBlockForBoundary(state, state.nodeId)
+      ? "blocked"
+      : "ok";
     this.queueOps([{
       op: "set-prop",
       nodeId: state.nodeId,
       key: "textIntegrityState",
-      value: "ok",
+      value,
     }]);
   }
 
-  private markTextIntegrityBlocked(policy: RenderPolicy): void {
+  private hasTextIntegrityBlockForBoundary(
+    state: NodeState,
+    boundaryNodeId: number,
+  ): boolean {
+    if (state.textIntegrityBlockedFor === boundaryNodeId) {
+      return true;
+    }
+    if (
+      state.textIntegrityBlockedProps !== undefined &&
+      [...state.textIntegrityBlockedProps.values()].some((id) =>
+        id === boundaryNodeId
+      )
+    ) {
+      return true;
+    }
+    for (const child of state.children.values()) {
+      if (
+        child.elementState &&
+        this.hasTextIntegrityBlockForBoundary(
+          child.elementState,
+          boundaryNodeId,
+        )
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private markTextIntegrityBlocked(policy: RenderPolicy): number | undefined {
     const boundaryNodeId = policy.textIntegrity?.boundaryNodeId;
     if (boundaryNodeId === undefined) {
-      return;
+      return undefined;
     }
     this.queueOps([{
       op: "set-prop",
@@ -1097,6 +1126,7 @@ export class WorkerReconciler {
       key: "textIntegrityState",
       value: "blocked",
     }]);
+    return boundaryNodeId;
   }
 
   private canRenderCellTextUnderPolicy(
@@ -1234,13 +1264,21 @@ export class WorkerReconciler {
     sourceCell?: Cell<unknown>,
     // deno-lint-ignore no-explicit-any
   ): any {
-    if (
-      this.isTextIntegrityProp(state, key) &&
-      (sourceCell
+    if (this.isTextIntegrityProp(state, key)) {
+      const shouldBlock = sourceCell
         ? this.shouldBlockTextFromCell(value, sourceCell, state.renderPolicy)
-        : this.shouldBlockLiteralText(value, state.renderPolicy))
-    ) {
-      this.markTextIntegrityBlocked(state.renderPolicy);
+        : this.shouldBlockLiteralText(value, state.renderPolicy);
+      if (!shouldBlock) {
+        state.textIntegrityBlockedProps?.delete(key);
+        return this.transformPropValue(key, value);
+      }
+      const boundaryNodeId = this.markTextIntegrityBlocked(state.renderPolicy);
+      if (boundaryNodeId !== undefined) {
+        if (state.textIntegrityBlockedProps === undefined) {
+          state.textIntegrityBlockedProps = new Map();
+        }
+        state.textIntegrityBlockedProps.set(key, boundaryNodeId);
+      }
       this.queueOps([{
         op: "set-prop",
         nodeId: state.nodeId,
@@ -1362,9 +1400,6 @@ export class WorkerReconciler {
             oldState,
             policyChildren.children,
           );
-          if (!childrenSame || policyChanged) {
-            this.resetTextIntegrityBoundary(oldState, childPolicy);
-          }
           this.updateChildrenInPlace(
             ctx,
             oldState,
@@ -1373,6 +1408,9 @@ export class WorkerReconciler {
             childPolicy,
             policyChanged,
           );
+          if (!childrenSame || policyChanged) {
+            this.refreshTextIntegrityBoundaryState(oldState, childPolicy);
+          }
         }
         return;
       }
@@ -1541,6 +1579,7 @@ export class WorkerReconciler {
       this.removeSingleProp(state, key);
     }
     state.propSubscriptions.clear();
+    state.textIntegrityBlockedProps?.clear();
   }
 
   /**
@@ -1997,7 +2036,6 @@ export class WorkerReconciler {
 
     const childrenSame = this.areChildrenSame(state, policyChildren.children);
     if (!childrenSame || policyChanged) {
-      this.resetTextIntegrityBoundary(state, childPolicy);
       this.updateChildrenInPlace(
         ctx,
         state,
@@ -2006,6 +2044,7 @@ export class WorkerReconciler {
         childPolicy,
         policyChanged,
       );
+      this.refreshTextIntegrityBoundaryState(state, childPolicy);
     }
   }
 
@@ -2115,6 +2154,7 @@ export class WorkerReconciler {
    * Remove a single prop from a node (DOM side + handler cleanup).
    */
   private removeSingleProp(state: NodeState, key: string): void {
+    state.textIntegrityBlockedProps?.delete(key);
     if (isEventProp(key)) {
       const eventType = getEventType(key);
       this.retireEventHandler(state, eventType);
@@ -2450,6 +2490,9 @@ export class WorkerReconciler {
       renderPolicy: policy,
       childRenderPolicy: policy,
       childrenBlockedByPolicy: false,
+      textIntegrityBlockedFor: integrityBlocked
+        ? policy.textIntegrity?.boundaryNodeId
+        : undefined,
     };
   }
 
@@ -3069,9 +3112,6 @@ export class WorkerReconciler {
         childState.elementState,
         policyChildren.children,
       );
-      if (!childrenSame || policyChanged) {
-        this.resetTextIntegrityBoundary(childState.elementState, childPolicy);
-      }
       this.updateChildrenInPlace(
         ctx,
         childState.elementState,
@@ -3080,6 +3120,12 @@ export class WorkerReconciler {
         childPolicy,
         policyChanged,
       );
+      if (!childrenSame || policyChanged) {
+        this.refreshTextIntegrityBoundaryState(
+          childState.elementState,
+          childPolicy,
+        );
+      }
     }
     return true;
   }
@@ -3293,12 +3339,6 @@ export class WorkerReconciler {
                     childState.elementState,
                     policyChildren.children,
                   );
-                  if (!childrenSame || policyChanged) {
-                    this.resetTextIntegrityBoundary(
-                      childState.elementState,
-                      childPolicy,
-                    );
-                  }
                   this.updateChildrenInPlace(
                     ctx,
                     childState.elementState,
@@ -3307,6 +3347,12 @@ export class WorkerReconciler {
                     childPolicy,
                     policyChanged,
                   );
+                  if (!childrenSame || policyChanged) {
+                    this.refreshTextIntegrityBoundaryState(
+                      childState.elementState,
+                      childPolicy,
+                    );
+                  }
                 }
                 return;
               }

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -1272,7 +1272,7 @@ export class WorkerReconciler {
    * Follows [UI] chains and returns the VNode, or null if not a VNode.
    * Includes cycle detection to prevent infinite loops.
    */
-  private extractVNode(node: WorkerRenderNode): WorkerVNode | null {
+  private extractVNode(node: unknown): WorkerVNode | null {
     if (isWorkerVNode(node)) return node;
 
     // Follow [UI] chain with cycle detection
@@ -2898,11 +2898,33 @@ export class WorkerReconciler {
       if (!forceReplace && state.children.has(key)) {
         // Reuse existing child
         const existingState = state.children.get(key)!;
-        newMapping.set(key, existingState);
+        const canReuse = this.reconcileReusedChild(
+          ctx,
+          existingState,
+          child,
+          visited,
+          policy,
+        );
         state.children.delete(key);
-
-        // Update if it's an element with new data
-        // (For now, we trust the key - updates happen through Cell subscriptions)
+        if (canReuse) {
+          newMapping.set(key, existingState);
+        } else {
+          existingState.cancel();
+          this.cleanupNodeHandlers(existingState);
+          this.queueOps([{ op: "remove-node", nodeId: existingState.nodeId }]);
+          hasNewChildren = true;
+          const childState = this.renderChild(
+            ctx,
+            child,
+            visited,
+            state,
+            key,
+            policy,
+          );
+          if (childState) {
+            newMapping.set(key, childState);
+          }
+        }
       } else {
         // Create new child, passing parent state and key for position tracking
         hasNewChildren = true;
@@ -2974,6 +2996,98 @@ export class WorkerReconciler {
   }
 
   /**
+   * Reconcile a reused keyed child. A stable key preserves DOM identity and
+   * ordering, but the VNode payload may still have fresh captured values from a
+   * parent recomputation, so same-key reuse cannot blindly skip descendants.
+   */
+  private reconcileReusedChild(
+    ctx: ReconcileContext,
+    childState: ChildNodeState,
+    child: unknown,
+    visited: Set<object>,
+    policy: RenderPolicy,
+  ): boolean {
+    if (isCell(child)) {
+      return childState.cell !== undefined &&
+        this.sameCellForReuse(childState.cell, child);
+    }
+
+    if (
+      childState.isText &&
+      (typeof child === "string" || typeof child === "number" ||
+        typeof child === "boolean" || child === null || child === undefined)
+    ) {
+      const text = this.stringifyText(child);
+      if (text !== childState.currentValue) {
+        childState.currentValue = text;
+        this.queueOps([{
+          op: "update-text",
+          nodeId: childState.nodeId,
+          text,
+        }]);
+      }
+      return true;
+    }
+
+    if (!childState.elementState) return false;
+
+    const newVNode = this.extractVNode(child);
+    if (!newVNode) return false;
+
+    const sanitized = this.sanitizeNode(newVNode);
+    if (!sanitized || sanitized.name !== childState.elementState.tagName) {
+      return false;
+    }
+
+    const childPolicy = this.childRenderPolicyForNode(
+      sanitized,
+      policy,
+      childState.elementState.nodeId,
+    );
+    const policyChildren = this.childrenForRenderPolicy(
+      sanitized,
+      childPolicy,
+    );
+    const policyChanged = !this.renderPolicyEquals(
+      childState.elementState.childRenderPolicy,
+      childPolicy,
+    ) || childState.elementState.childrenBlockedByPolicy !==
+        policyChildren.blocked;
+
+    childState.currentValue = child;
+    childState.elementState.renderPolicy = policy;
+    childState.elementState.childRenderPolicy = childPolicy;
+    childState.elementState.childrenBlockedByPolicy = policyChildren.blocked;
+    childState.elementState.sourceChildren = sanitized.children;
+    childState.elementState.sourceProps = sanitized.props;
+
+    this.updatePropsInPlace(ctx, childState.elementState, sanitized.props);
+
+    if (policyChildren.children !== undefined) {
+      if (policyChanged) {
+        this.resetTextIntegrityBoundary(childState.elementState, childPolicy);
+      }
+      this.updateChildrenInPlace(
+        ctx,
+        childState.elementState,
+        policyChildren.children,
+        new Set(visited),
+        childPolicy,
+        policyChanged,
+      );
+    }
+    return true;
+  }
+
+  private sameCellForReuse(left: Cell<unknown>, right: Cell<unknown>): boolean {
+    try {
+      return areLinksSame(left, right);
+    } catch {
+      return left === right;
+    }
+  }
+
+  /**
    * Render a child node (which may be a VNode, text, or Cell).
    * For Cell children, uses position-aware insertion instead of wrapper elements.
    */
@@ -3026,6 +3140,7 @@ export class WorkerReconciler {
       nodeId: -1,
       isText: false,
       cancel,
+      cell,
     };
 
     let currentCancel: Cancel | undefined;
@@ -3168,27 +3283,21 @@ export class WorkerReconciler {
                   sanitized.props,
                 );
 
-                // Check children: if same, do nothing (sinks active);
-                // if different, tear down and rebuild
                 if (policyChildren.children !== undefined) {
-                  const childrenSame = this.areChildrenSame(
-                    childState.elementState,
-                    policyChildren.children,
-                  );
-                  if (!childrenSame || policyChanged) {
+                  if (policyChanged) {
                     this.resetTextIntegrityBoundary(
                       childState.elementState,
                       childPolicy,
                     );
-                    this.updateChildrenInPlace(
-                      ctx,
-                      childState.elementState,
-                      policyChildren.children,
-                      new Set(),
-                      childPolicy,
-                      policyChanged,
-                    );
                   }
+                  this.updateChildrenInPlace(
+                    ctx,
+                    childState.elementState,
+                    policyChildren.children,
+                    new Set(),
+                    childPolicy,
+                    policyChanged,
+                  );
                 }
                 return;
               }

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -3064,7 +3064,11 @@ export class WorkerReconciler {
     this.updatePropsInPlace(ctx, childState.elementState, sanitized.props);
 
     if (policyChildren.children !== undefined) {
-      if (policyChanged) {
+      const childrenSame = this.areChildrenSame(
+        childState.elementState,
+        policyChildren.children,
+      );
+      if (!childrenSame || policyChanged) {
         this.resetTextIntegrityBoundary(childState.elementState, childPolicy);
       }
       this.updateChildrenInPlace(
@@ -3284,7 +3288,11 @@ export class WorkerReconciler {
                 );
 
                 if (policyChildren.children !== undefined) {
-                  if (policyChanged) {
+                  const childrenSame = this.areChildrenSame(
+                    childState.elementState,
+                    policyChildren.children,
+                  );
+                  if (!childrenSame || policyChanged) {
                     this.resetTextIntegrityBoundary(
                       childState.elementState,
                       childPolicy,

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -3014,6 +3014,7 @@ export class WorkerReconciler {
 
     if (
       childState.isText &&
+      childState.cell === undefined &&
       (typeof child === "string" || typeof child === "number" ||
         typeof child === "boolean" || child === null || child === undefined)
     ) {

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -188,6 +188,9 @@ export interface ChildNodeState {
 
   /** Track current value for deduping updates */
   currentValue?: unknown;
+
+  /** Source cell for reactive child nodes; used to decide same-key reuse. */
+  cell?: Cell<unknown>;
 }
 
 /**

--- a/packages/html/src/worker/types.ts
+++ b/packages/html/src/worker/types.ts
@@ -168,6 +168,12 @@ export interface NodeState {
 
   /** Original authored props, used to recompute child render policy. */
   sourceProps?: WorkerVNode["props"];
+
+  /** Text-integrity boundary that blocked this whole rendered node. */
+  textIntegrityBlockedFor?: number;
+
+  /** Text-integrity boundary that blocked each visible prop on this node. */
+  textIntegrityBlockedProps?: Map<string, number>;
 }
 
 /**

--- a/packages/html/test/main-applicator.test.ts
+++ b/packages/html/test/main-applicator.test.ts
@@ -359,6 +359,63 @@ Deno.test("DomApplicator - child operations", async (t) => {
   );
 
   await t.step(
+    "waits for beforeId to attach before replaying placement",
+    () => {
+      const doc = createMockDocument();
+      const applicator = createDomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "div" },
+          { op: "create-element", nodeId: 4, tagName: "c" },
+          { op: "insert-child", parentId: 1, childId: 4, beforeId: null },
+          { op: "create-element", nodeId: 2, tagName: "a" },
+          { op: "insert-child", parentId: 1, childId: 2, beforeId: 3 },
+          { op: "create-element", nodeId: 3, tagName: "b" },
+          { op: "insert-child", parentId: 1, childId: 3, beforeId: 4 },
+        ],
+      });
+
+      const parent = applicator.getNode(1) as unknown as {
+        childNodes: Array<{ tagName: string }>;
+      };
+      assertEquals(parent.childNodes.map((child) => child.tagName), [
+        "A",
+        "B",
+        "C",
+      ]);
+    },
+  );
+
+  await t.step("replays deferred move-child when nodes appear", () => {
+    const doc = createMockDocument();
+    const applicator = createDomApplicator({
+      document: doc,
+      runtimeClient: createMockRuntimeClient(),
+      onEvent: () => {},
+    });
+
+    applicator.applyBatch({
+      batchId: 1,
+      ops: [
+        { op: "move-child", parentId: 1, childId: 2, beforeId: null },
+        { op: "create-element", nodeId: 1, tagName: "div" },
+        { op: "create-element", nodeId: 2, tagName: "span" },
+      ],
+    });
+
+    const parent = applicator.getNode(1) as unknown as {
+      childNodes: Array<{ tagName: string }>;
+    };
+    assertEquals(parent.childNodes.map((child) => child.tagName), ["SPAN"]);
+  });
+
+  await t.step(
     "does not replay insert after child is removed before creation",
     () => {
       const doc = createMockDocument();
@@ -388,6 +445,40 @@ Deno.test("DomApplicator - child operations", async (t) => {
       );
     },
   );
+
+  await t.step("drops pending inserts that target removed descendants", () => {
+    const doc = createMockDocument();
+    const applicator = createDomApplicator({
+      document: doc,
+      runtimeClient: createMockRuntimeClient(),
+      onEvent: () => {},
+    });
+
+    applicator.applyBatch({
+      batchId: 1,
+      ops: [
+        { op: "create-element", nodeId: 1, tagName: "section" },
+        { op: "create-element", nodeId: 2, tagName: "div" },
+        { op: "create-element", nodeId: 3, tagName: "b" },
+        { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
+        { op: "insert-child", parentId: 2, childId: 3, beforeId: null },
+        { op: "create-element", nodeId: 4, tagName: "a" },
+        { op: "insert-child", parentId: 1, childId: 4, beforeId: 3 },
+        { op: "remove-node", nodeId: 1 },
+        { op: "create-element", nodeId: 5, tagName: "footer" },
+      ],
+    });
+
+    assertEquals(applicator.getNode(1), undefined);
+    assertEquals(applicator.getNode(2), undefined);
+    assertEquals(applicator.getNode(3), undefined);
+    const pendingChild = applicator.getNode(4) as unknown as {
+      parentNode: unknown;
+      tagName: string;
+    };
+    assertEquals(pendingChild.tagName, "A");
+    assertEquals(pendingChild.parentNode, null);
+  });
 
   await t.step("moves child to new position", () => {
     const doc = createMockDocument();
@@ -447,6 +538,62 @@ Deno.test("DomApplicator - child operations", async (t) => {
 
     const parent = applicator.getNode(1) as any;
     assertEquals(parent.childNodes.length, 0);
+    assertEquals(applicator.getNode(2), undefined);
+  });
+
+  await t.step("removes listeners from removed descendants", () => {
+    const doc = createMockDocument();
+    const events: DomEventMessage[] = [];
+    const applicator = createDomApplicator({
+      document: doc,
+      runtimeClient: createMockRuntimeClient(),
+      onEvent: (msg) => events.push(msg),
+    });
+
+    applicator.applyBatch({
+      batchId: 1,
+      ops: [
+        { op: "create-element", nodeId: 1, tagName: "section" },
+        { op: "create-element", nodeId: 2, tagName: "button" },
+        { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
+        { op: "set-event", nodeId: 1, eventType: "click", handlerId: 11 },
+        { op: "set-event", nodeId: 2, eventType: "click", handlerId: 22 },
+      ],
+    });
+
+    const parentNode = applicator.getNode(1) as unknown as {
+      dispatchEvent(event: {
+        type: string;
+        target: unknown;
+        isTrusted: boolean;
+      }): void;
+    };
+    const childNode = applicator.getNode(2) as unknown as {
+      dispatchEvent(event: {
+        type: string;
+        target: unknown;
+        isTrusted: boolean;
+      }): void;
+    };
+
+    applicator.applyBatch({
+      batchId: 2,
+      ops: [{ op: "remove-node", nodeId: 1 }],
+    });
+
+    parentNode.dispatchEvent({
+      type: "click",
+      target: parentNode,
+      isTrusted: true,
+    });
+    childNode.dispatchEvent({
+      type: "click",
+      target: childNode,
+      isTrusted: true,
+    });
+
+    assertEquals(events, []);
+    assertEquals(applicator.getNode(1), undefined);
     assertEquals(applicator.getNode(2), undefined);
   });
 });

--- a/packages/html/test/main-applicator.test.ts
+++ b/packages/html/test/main-applicator.test.ts
@@ -297,6 +297,98 @@ Deno.test("DomApplicator - child operations", async (t) => {
     assertEquals(parent.childNodes[1].tagName, "SPAN");
   });
 
+  await t.step(
+    "replays insert when child is created later in the batch",
+    () => {
+      const doc = createMockDocument();
+      const applicator = createDomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
+          { op: "create-element", nodeId: 1, tagName: "div" },
+          { op: "create-element", nodeId: 2, tagName: "span" },
+        ],
+      });
+
+      const parent = applicator.getNode(1) as unknown as {
+        childNodes: Array<{ tagName: string }>;
+      };
+      assertEquals(parent.childNodes.length, 1);
+      assertEquals(parent.childNodes[0].tagName, "SPAN");
+    },
+  );
+
+  await t.step(
+    "does not replay stale placement after child moves elsewhere",
+    () => {
+      const doc = createMockDocument();
+      const applicator = createDomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "section" },
+          { op: "insert-child", parentId: 2, childId: 3, beforeId: null },
+          { op: "create-element", nodeId: 3, tagName: "span" },
+          { op: "insert-child", parentId: 1, childId: 3, beforeId: null },
+          { op: "create-element", nodeId: 2, tagName: "div" },
+        ],
+      });
+
+      const laterParent = applicator.getNode(1) as unknown as {
+        childNodes: Array<{ tagName: string }>;
+      };
+      const staleParent = applicator.getNode(2) as unknown as {
+        childNodes: Array<{ tagName: string }>;
+      };
+      assertEquals(laterParent.childNodes.map((child) => child.tagName), [
+        "SPAN",
+      ]);
+      assertEquals(staleParent.childNodes, []);
+    },
+  );
+
+  await t.step(
+    "does not replay insert after child is removed before creation",
+    () => {
+      const doc = createMockDocument();
+      const applicator = createDomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "div" },
+          { op: "insert-child", parentId: 1, childId: 2, beforeId: null },
+          { op: "remove-node", nodeId: 2 },
+          { op: "create-element", nodeId: 2, tagName: "span" },
+        ],
+      });
+
+      const parent = applicator.getNode(1) as unknown as {
+        childNodes: Array<{ tagName: string }>;
+      };
+      assertEquals(parent.childNodes, []);
+      assertEquals(
+        (applicator.getNode(2) as unknown as { tagName: string }).tagName,
+        "SPAN",
+      );
+    },
+  );
+
   await t.step("moves child to new position", () => {
     const doc = createMockDocument();
     const applicator = createDomApplicator({

--- a/packages/html/test/main-applicator.test.ts
+++ b/packages/html/test/main-applicator.test.ts
@@ -480,6 +480,46 @@ Deno.test("DomApplicator - child operations", async (t) => {
     assertEquals(pendingChild.parentNode, null);
   });
 
+  await t.step(
+    "appends pending insert when only beforeId anchor is removed",
+    () => {
+      const doc = createMockDocument();
+      const applicator = createDomApplicator({
+        document: doc,
+        runtimeClient: createMockRuntimeClient(),
+        onEvent: () => {},
+      });
+
+      applicator.applyBatch({
+        batchId: 1,
+        ops: [
+          { op: "create-element", nodeId: 1, tagName: "section" },
+          { op: "create-element", nodeId: 2, tagName: "a" },
+          { op: "create-element", nodeId: 3, tagName: "b" },
+          { op: "insert-child", parentId: 1, childId: 2, beforeId: 3 },
+        ],
+      });
+
+      const parent = applicator.getNode(1) as unknown as {
+        childNodes: Array<{ tagName: string }>;
+      };
+      const pendingChild = applicator.getNode(2) as unknown as {
+        parentNode: unknown;
+        tagName: string;
+      };
+      assertEquals(parent.childNodes, []);
+      assertEquals(pendingChild.parentNode, null);
+
+      applicator.applyBatch({
+        batchId: 2,
+        ops: [{ op: "remove-node", nodeId: 3 }],
+      });
+
+      assertEquals(parent.childNodes.map((child) => child.tagName), ["A"]);
+      assertEquals(pendingChild.parentNode, parent);
+    },
+  );
+
   await t.step("moves child to new position", () => {
     const doc = createMockDocument();
     const applicator = createDomApplicator({

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -200,6 +200,63 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
   );
 
   await t.step(
+    "replaces same-key text Cell when parent supplies a literal child",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const oldChild = new MockCell("cell text");
+      const rootCell = new MockCell(
+        {
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: [oldChild as unknown as WorkerRenderNode],
+        } satisfies WorkerVNode,
+      );
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      collector.clear();
+
+      rootCell.set(
+        {
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: ["literal text"],
+        } satisfies WorkerVNode,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      assertEquals(
+        collector.getOpsOfType("remove-node").length > 0,
+        true,
+        "old cell-backed text child should be removed",
+      );
+      assertEquals(
+        collector.getOpsOfType("create-text").some((op) =>
+          "text" in op && op.text === "literal text"
+        ),
+        true,
+        "literal replacement should render as a new static text node",
+      );
+
+      collector.clear();
+      oldChild.set("stale cell update");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      assertEquals(
+        collector.getOps().length,
+        0,
+        "old cell subscription should be cancelled after literal replacement",
+      );
+    },
+  );
+
+  await t.step(
     "updates cell-backed conditional row children at first middle and last positions",
     async () => {
       const collector = createOpsCollector();

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -1,11 +1,12 @@
 import { assertEquals } from "@std/assert";
 import { WorkerReconciler } from "../src/worker/reconciler.ts";
-import type { WorkerVNode } from "../src/worker/types.ts";
+import type { WorkerRenderNode, WorkerVNode } from "../src/worker/types.ts";
 
 import type { VDomOp } from "../src/vdom-ops.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "@commonfabric/runner";
+import { Runtime, UI } from "@commonfabric/runner";
+import type { Cell } from "@commonfabric/runner";
 
 /**
  * Helper to collect ops emitted by the reconciler.
@@ -154,6 +155,50 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
     },
   );
 
+  await t.step(
+    "replaces same-key child Cell when parent supplies a different cell",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const firstChild = new MockCell("first");
+      const secondChild = new MockCell("second");
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "div",
+        props: {},
+        children: [firstChild as unknown as Cell<WorkerRenderNode>],
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      collector.clear();
+
+      rootCell.set({
+        type: "vnode",
+        name: "div",
+        props: {},
+        children: [secondChild as unknown as Cell<WorkerRenderNode>],
+      } as WorkerVNode);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      assertEquals(
+        collector.getOpsOfType("remove-node").length > 0,
+        true,
+        "old cell child should be removed when the parent supplies a new cell",
+      );
+      assertEquals(
+        collector.getOpsOfType("create-text").some((op) =>
+          "text" in op && op.text === "second"
+        ),
+        true,
+        "new cell child should render its current value",
+      );
+    },
+  );
+
   await t.step("replaces child Cell when tag changes", async () => {
     const collector = createOpsCollector();
     const reconciler = new WorkerReconciler({
@@ -234,6 +279,229 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
     assertEquals(updateTextOps.length, 1, "Should emit update-text");
     assertEquals((updateTextOps[0] as any).text, "World");
   });
+
+  await t.step(
+    "updates same-shape slotted header cell VNode children",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const header = new MockCell(
+        {
+          type: "vnode",
+          name: "div",
+          props: { slot: "header" },
+          children: [{
+            type: "vnode",
+            name: "span",
+            props: { "data-poll-summary": "true" },
+            children: ["4 joined · 0 options · 0 votes · hosted by Alice"],
+          }],
+        } satisfies WorkerVNode,
+      );
+
+      const rootCell = new MockCell(
+        {
+          type: "vnode",
+          name: "cf-screen",
+          props: {},
+          children: [header as unknown as WorkerRenderNode],
+        } satisfies WorkerVNode,
+      );
+
+      reconciler.mount(rootCell as unknown as Cell<unknown>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      const screenCreate = collector.getOpsOfType("create-element").find(
+        (op) => "tagName" in op && op.tagName === "cf-screen",
+      );
+      if (!screenCreate || !("nodeId" in screenCreate)) {
+        throw new Error("Expected cf-screen to be created");
+      }
+      const screenNodeId = screenCreate.nodeId;
+      collector.clear();
+
+      header.set(
+        {
+          type: "vnode",
+          name: "div",
+          props: { slot: "header" },
+          children: [{
+            type: "vnode",
+            name: "span",
+            props: { "data-poll-summary": "true" },
+            children: ["4 joined · 1 options · 0 votes · hosted by Alice"],
+          }],
+        } satisfies WorkerVNode,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const textOps = collector.getOps().filter((op) =>
+        (op.op === "update-text" || op.op === "create-text") &&
+        "text" in op
+      );
+      assertEquals(
+        textOps.some((op) =>
+          "text" in op &&
+          op.text === "4 joined · 1 options · 0 votes · hosted by Alice"
+        ),
+        true,
+        "slotted header summary text should update",
+      );
+
+      assertEquals(
+        collector.getOpsOfType("remove-node").some((op) =>
+          "nodeId" in op && op.nodeId === screenNodeId
+        ),
+        false,
+        "slotted header summary update should not remount cf-screen",
+      );
+    },
+  );
+
+  await t.step(
+    "updates same-shape split text children from a Cell VNode",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const summary = new MockCell(
+        {
+          type: "vnode",
+          name: "div",
+          props: { "data-poll-summary": "true" },
+          children: [
+            4,
+            " joined · ",
+            4,
+            " options · ",
+            1,
+            " votes · hosted by Dave",
+          ],
+        } satisfies WorkerVNode,
+      );
+      const rootCell = new MockCell(
+        {
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: [summary as unknown as WorkerRenderNode],
+        } satisfies WorkerVNode,
+      );
+
+      reconciler.mount(rootCell as unknown as Cell<unknown>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      collector.clear();
+
+      summary.set(
+        {
+          type: "vnode",
+          name: "div",
+          props: { "data-poll-summary": "true" },
+          children: [
+            4,
+            " joined · ",
+            4,
+            " options · ",
+            4,
+            " votes · hosted by Dave",
+          ],
+        } satisfies WorkerVNode,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const textOps = collector.getOpsOfType("update-text");
+      assertEquals(
+        textOps.some((op) => "text" in op && op.text === "4"),
+        true,
+        "same-shape split vote-count text should update",
+      );
+      assertEquals(
+        collector.getOps().some((op) =>
+          (op.op === "update-text" || op.op === "create-text") &&
+          "text" in op && op.text === "4"
+        ),
+        true,
+        "same-shape split vote-count text should be represented",
+      );
+    },
+  );
+
+  await t.step(
+    "replaces same-key UI child when rendered root tag changes",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const beforeChild = {
+        [UI]: {
+          type: "vnode",
+          name: "span",
+          props: {},
+          children: ["Before"],
+        } satisfies WorkerVNode,
+      } as unknown as WorkerRenderNode;
+      const afterChild = {
+        [UI]: {
+          type: "vnode",
+          name: "button",
+          props: {},
+          children: ["After"],
+        } satisfies WorkerVNode,
+      } as unknown as WorkerRenderNode;
+
+      const rootCell = new MockCell(
+        {
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: [beforeChild],
+        } satisfies WorkerVNode,
+      );
+
+      reconciler.mount(rootCell as unknown as Cell<unknown>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const spanCreate = collector.getOpsOfType("create-element").find(
+        (op) => "tagName" in op && op.tagName === "span",
+      );
+      if (!spanCreate || !("nodeId" in spanCreate)) {
+        throw new Error("Expected span to be created");
+      }
+      const spanNodeId = spanCreate.nodeId;
+      collector.clear();
+
+      rootCell.set(
+        {
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: [afterChild],
+        } satisfies WorkerVNode,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      assertEquals(
+        collector.getOpsOfType("remove-node").some((op) =>
+          "nodeId" in op && op.nodeId === spanNodeId
+        ),
+        true,
+        "same-key UI payload should remove the stale root element",
+      );
+      assertEquals(
+        collector.getOpsOfType("create-element").some((op) =>
+          "tagName" in op && op.tagName === "button"
+        ),
+        true,
+        "same-key UI payload should create the replacement root element",
+      );
+    },
+  );
 
   await t.step(
     "avoids re-emitting set-event when handler is identical (VNode path)",
@@ -613,6 +881,96 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       // With implementation "insert from end", it likely emits inserts.
       // At least 1 insert is expected (to move).
       assertEquals(swapInserts.length > 0, true, "Should insert to re-order");
+    },
+  );
+
+  await t.step(
+    "updates same-key subpattern UI payloads without reinserting",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+      const subpatternOutput = (node: WorkerVNode): WorkerRenderNode => ({
+        [UI]: node,
+        toJSON: () => "stable-subpattern-output",
+      } as unknown as WorkerRenderNode);
+
+      const rootCell = new MockCell(
+        {
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: [
+            subpatternOutput({
+              type: "vnode",
+              name: "span",
+              props: { "data-row": "same", "data-count": "1" },
+              children: ["one"],
+            }),
+          ],
+        } satisfies WorkerVNode,
+      );
+
+      reconciler.mount(rootCell as unknown as Cell<unknown>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      const spanCreate = collector.getOps().find((op) =>
+        op.op === "create-element" && "tagName" in op &&
+        op.tagName === "span"
+      );
+      if (!spanCreate || !("nodeId" in spanCreate)) {
+        throw new Error("Expected initial span to be created");
+      }
+      const spanNodeId = spanCreate.nodeId;
+      collector.clear();
+
+      rootCell.set(
+        {
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: [
+            subpatternOutput({
+              type: "vnode",
+              name: "span",
+              props: { "data-row": "same", "data-count": "2" },
+              children: ["two"],
+            }),
+          ],
+        } satisfies WorkerVNode,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      assertEquals(
+        collector.getOpsOfType("create-element").some((op) =>
+          "tagName" in op && op.tagName === "span"
+        ),
+        false,
+        "same-key child update should not recreate the element",
+      );
+      assertEquals(
+        collector.getOpsOfType("remove-node").some((op) =>
+          "nodeId" in op && op.nodeId === spanNodeId
+        ),
+        false,
+        "same-key child update should not remove the element",
+      );
+      assertEquals(
+        collector.getOpsOfType("set-prop").some((op) =>
+          "key" in op && op.key === "data-count" &&
+          "value" in op && op.value === "2"
+        ),
+        true,
+        "same-key child prop should update",
+      );
+      assertEquals(
+        collector.getOps().some((op) =>
+          (op.op === "update-text" || op.op === "create-text") &&
+          "text" in op && op.text === "two"
+        ),
+        true,
+        "same-key child text should update",
+      );
     },
   );
 });

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -101,7 +101,7 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       const rootCell = new MockCell(rootVNode);
 
       // Mount
-      reconciler.mount(rootCell as any);
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       const createOps = collector.getOpsOfType("create-element");
@@ -195,6 +195,150 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         ),
         true,
         "new cell child should render its current value",
+      );
+    },
+  );
+
+  await t.step(
+    "updates cell-backed conditional row children at first middle and last positions",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const voteSpan = (id: string): WorkerVNode => ({
+        type: "vnode",
+        name: "span",
+        props: { "data-vote-swatch-name": id },
+        children: [id],
+      });
+
+      const firstChildren = new MockCell([]);
+      const middleChildren = new MockCell([]);
+      const lastChildren = new MockCell([]);
+
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "div",
+        props: {},
+        children: [
+          {
+            type: "vnode",
+            name: "div",
+            props: { "data-option-id": "first" },
+            children: firstChildren,
+          },
+          {
+            type: "vnode",
+            name: "div",
+            props: { "data-option-id": "middle" },
+            children: middleChildren,
+          },
+          {
+            type: "vnode",
+            name: "div",
+            props: { "data-option-id": "last" },
+            children: lastChildren,
+          },
+        ],
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      collector.clear();
+
+      firstChildren.set([voteSpan("Alice")]);
+      middleChildren.set([null, voteSpan("Alice")]);
+      lastChildren.set([null, null, voteSpan("Alice")]);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const spanCreates = collector.getOpsOfType("create-element").filter(
+        (op) => "tagName" in op && op.tagName === "span",
+      );
+      assertEquals(
+        spanCreates.length,
+        3,
+        "should create one swatch span for each cell-backed row",
+      );
+
+      const swatchPropOps = collector.getOpsOfType("set-prop").filter(
+        (op) =>
+          op.op === "set-prop" && op.key === "data-vote-swatch-name" &&
+          op.value === "Alice",
+      );
+      assertEquals(
+        swatchPropOps.length,
+        3,
+        "each cell-backed swatch span should receive the voter data attribute",
+      );
+    },
+  );
+
+  await t.step(
+    "inserts pending mapped child cells when they resolve after parent array update",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const voteSpan = (id: string): WorkerVNode => ({
+        type: "vnode",
+        name: "span",
+        props: { "data-vote-swatch-name": id },
+        children: [id],
+      });
+
+      const firstMappedResult = new MockCell(undefined);
+      const middleMappedResult = new MockCell(undefined);
+      const lastMappedResult = new MockCell(undefined);
+
+      const mappedChildren = new MockCell([]);
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "div",
+        props: { "data-option-id": "mapped" },
+        children: mappedChildren,
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      collector.clear();
+
+      mappedChildren.set([
+        firstMappedResult,
+        middleMappedResult,
+        lastMappedResult,
+      ]);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      collector.clear();
+
+      firstMappedResult.set(voteSpan("Alice"));
+      middleMappedResult.set(voteSpan("Alice"));
+      lastMappedResult.set(voteSpan("Alice"));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const spanCreates = collector.getOpsOfType("create-element").filter(
+        (op) => "tagName" in op && op.tagName === "span",
+      );
+      assertEquals(
+        spanCreates.length,
+        3,
+        "should create one swatch span for each late-resolving mapped child cell",
+      );
+
+      const spanInserts = collector.getOpsOfType("insert-child").filter(
+        (op) =>
+          op.op === "insert-child" &&
+          spanCreates.some((createOp) =>
+            "nodeId" in createOp && createOp.nodeId === op.childId
+          ),
+      );
+      assertEquals(
+        spanInserts.length,
+        3,
+        "each late-resolving swatch span should be inserted into the parent row",
       );
     },
   );

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -1117,4 +1117,66 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       );
     },
   );
+
+  await t.step("replaces same-key child when tag changes", async () => {
+    const collector = createOpsCollector();
+    const reconciler = new WorkerReconciler({
+      onOps: collector.onOps,
+    });
+
+    const rootCell = new MockCell(
+      {
+        type: "vnode",
+        name: "div",
+        props: {},
+        children: [{
+          type: "vnode",
+          name: "span",
+          props: { key: "stable" },
+          children: ["old"],
+        }],
+      } satisfies WorkerVNode,
+    );
+
+    reconciler.mount(rootCell as unknown as Cell<unknown>);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const spanCreate = collector.getOpsOfType("create-element").find((op) =>
+      "tagName" in op && op.tagName === "span"
+    );
+    if (!spanCreate || !("nodeId" in spanCreate)) {
+      throw new Error("Expected initial keyed span");
+    }
+    const spanNodeId = spanCreate.nodeId;
+    collector.clear();
+
+    rootCell.set(
+      {
+        type: "vnode",
+        name: "div",
+        props: {},
+        children: [{
+          type: "vnode",
+          name: "button",
+          props: { key: "stable" },
+          children: ["new"],
+        }],
+      } satisfies WorkerVNode,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    assertEquals(
+      collector.getOpsOfType("remove-node").some((op) =>
+        "nodeId" in op && op.nodeId === spanNodeId
+      ),
+      true,
+      "same-key tag change should remove the old child",
+    );
+    assertEquals(
+      collector.getOpsOfType("create-element").some((op) =>
+        "tagName" in op && op.tagName === "button"
+      ),
+      true,
+      "same-key tag change should create the replacement child",
+    );
+  });
 });

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -2136,6 +2136,57 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
     );
 
     await t.step(
+      "strict text integrity resets when policy is removed",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+        });
+        const rootCell = new MockCell({
+          type: "vnode",
+          name: "cf-cfc-authorship",
+          props: {
+            verifyTextIntegrity: true,
+            requiredTextIntegrity: otherReleaseAtom,
+          },
+          children: [verifiedText as never],
+        });
+
+        const cancel = reconciler.mount(rootCell as never);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          assertEquals(
+            collector.getOpsOfType("set-prop").some((op) =>
+              op.key === "textIntegrityState" && op.value === "blocked"
+            ),
+            true,
+          );
+          collector.clear();
+
+          rootCell.set({
+            type: "vnode",
+            name: "cf-cfc-authorship",
+            props: {},
+            children: [verifiedText as never],
+          });
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          const renderedText = collector.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(renderedText.includes("Verified release note"), true);
+          assertEquals(
+            collector.getOpsOfType("set-prop").some((op) =>
+              op.key === "textIntegrityState" && op.value === "ok"
+            ),
+            true,
+          );
+        } finally {
+          cancel();
+        }
+      },
+    );
+
+    await t.step(
       "strict text integrity resets same-key child when content becomes clean",
       async () => {
         const collector = createOpsCollector();

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -2079,6 +2079,72 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
     );
 
     await t.step(
+      "strict text integrity resets same-key child when content becomes clean",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+        });
+        const rootCell = new MockCell({
+          type: "vnode",
+          name: "div",
+          props: {},
+          children: [{
+            type: "vnode",
+            name: "cf-cfc-authorship",
+            props: {
+              key: "stable-authorship",
+              verifyTextIntegrity: true,
+              requiredTextIntegrity: signedReleaseAtom,
+            },
+            children: [unsignedReleaseText as never],
+          }],
+        });
+
+        const cancel = reconciler.mount(rootCell as never);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          assertEquals(
+            collector.getOpsOfType("set-prop").some((op) =>
+              op.key === "textIntegrityState" && op.value === "blocked"
+            ),
+            true,
+          );
+          collector.clear();
+
+          rootCell.set({
+            type: "vnode",
+            name: "div",
+            props: {},
+            children: [{
+              type: "vnode",
+              name: "cf-cfc-authorship",
+              props: {
+                key: "stable-authorship",
+                verifyTextIntegrity: true,
+                requiredTextIntegrity: signedReleaseAtom,
+              },
+              children: [verifiedText as never],
+            }],
+          });
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          assertEquals(
+            collector.getOpsOfType("set-prop").some((op) =>
+              op.key === "textIntegrityState" && op.value === "ok"
+            ),
+            true,
+          );
+          const renderedText = collector.getOpsOfType("create-text")
+            .map((op) => op.text);
+          assertEquals(renderedText.includes("Verified release note"), true);
+        } finally {
+          cancel();
+        }
+      },
+    );
+
+    await t.step(
       "strict text integrity blocks mismatched visible name props",
       async () => {
         const collector = createOpsCollector();

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -2079,6 +2079,63 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
     );
 
     await t.step(
+      "strict text integrity stays blocked when sibling changes beside blocked child",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+        });
+        const rootCell = new MockCell({
+          type: "vnode",
+          name: "cf-cfc-authorship",
+          props: {
+            verifyTextIntegrity: true,
+            requiredTextIntegrity: otherReleaseAtom,
+          },
+          children: [verifiedText as never, "sibling-before"],
+        });
+
+        const cancel = reconciler.mount(rootCell as never);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          assertEquals(
+            collector.getOpsOfType("set-prop").some((op) =>
+              op.key === "textIntegrityState" && op.value === "blocked"
+            ),
+            true,
+          );
+          collector.clear();
+
+          rootCell.set({
+            type: "vnode",
+            name: "cf-cfc-authorship",
+            props: {
+              verifyTextIntegrity: true,
+              requiredTextIntegrity: otherReleaseAtom,
+            },
+            children: [verifiedText as never, "sibling-after"],
+          });
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          assertEquals(
+            collector.getOpsOfType("set-prop").some((op) =>
+              op.key === "textIntegrityState" && op.value === "ok"
+            ),
+            false,
+          );
+          assertEquals(
+            collector.getOpsOfType("set-prop").some((op) =>
+              op.key === "textIntegrityState" && op.value === "blocked"
+            ),
+            true,
+          );
+        } finally {
+          cancel();
+        }
+      },
+    );
+
+    await t.step(
       "strict text integrity resets same-key child when content becomes clean",
       async () => {
         const collector = createOpsCollector();

--- a/packages/html/test/worker-reconciler-diffing.test.ts
+++ b/packages/html/test/worker-reconciler-diffing.test.ts
@@ -12,7 +12,7 @@
 import { assertEquals } from "@std/assert";
 import { WorkerReconciler } from "../src/worker/reconciler.ts";
 import type { VDomOp } from "../src/vdom-ops.ts";
-import type { WorkerVNode } from "../src/worker/types.ts";
+import type { WorkerRenderNode, WorkerVNode } from "../src/worker/types.ts";
 
 // Import the actual Cell implementation to create test cells
 import { Identity } from "@commonfabric/identity";
@@ -290,6 +290,97 @@ Deno.test("worker reconciler diffing - same tag updates in place", async (t) => 
 
       cancel();
     });
+
+    await t.step(
+      "conditional mapped children insert spans at first middle and last positions",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+        });
+
+        const vnodeCell = runtime.getCell<WorkerVNode>(
+          space,
+          "test-conditional-mapped-children",
+          undefined,
+          tx,
+        );
+
+        const voteSpan = (id: string): WorkerVNode => ({
+          type: "vnode",
+          name: "span",
+          props: { "data-vote-swatch-name": id },
+          children: [id],
+        });
+
+        const row = (
+          id: string,
+          children: WorkerRenderNode[],
+        ): WorkerVNode => ({
+          type: "vnode",
+          name: "div",
+          props: { "data-option-id": id },
+          children,
+        });
+
+        vnodeCell.set({
+          type: "vnode",
+          name: "div",
+          props: { id: "root" },
+          children: [
+            row("first", []),
+            row("middle", []),
+            row("last", []),
+          ],
+        } as WorkerVNode);
+        await tx.commit();
+        tx = runtime.edit();
+
+        const cancel = reconciler.mount(vnodeCell as Cell<WorkerVNode>);
+        await runtime.idle();
+        collector.clear();
+
+        vnodeCell.withTx(tx).set({
+          type: "vnode",
+          name: "div",
+          props: { id: "root" },
+          children: [
+            row("first", [voteSpan("Alice")]),
+            row("middle", [null, voteSpan("Alice")]),
+            row("last", [
+              null,
+              null,
+              voteSpan("Alice"),
+            ]),
+          ],
+        } as WorkerVNode);
+        await tx.commit();
+        tx = runtime.edit();
+        await runtime.idle();
+
+        const spanCreates = collector.getOpsOfType("create-element").filter(
+          (op) => "tagName" in op && op.tagName === "span",
+        );
+        assertEquals(
+          spanCreates.length,
+          3,
+          "should create one swatch span for each conditional child position",
+        );
+
+        const swatchPropOps = collector.getOpsOfType("set-prop").filter(
+          (op) =>
+            op.op === "set-prop" && op.key === "data-vote-swatch-name" &&
+            op.value === "Alice",
+        );
+        assertEquals(
+          swatchPropOps.length,
+          3,
+          "each created swatch span should receive the voter data attribute",
+        );
+
+        cancel();
+      },
+    );
 
     await t.step("clears root when Cell emits undefined", async () => {
       const collector = createOpsCollector();


### PR DESCRIPTION
## Summary

This PR fixes two HTML/VDOM settling bugs that can make the rendered DOM temporarily disagree with the worker VDOM even when the underlying Fabric state is correct.

It is split out from the mixed DOM + runner PR. The separate runner resume fix is #4365.

## Problems fixed

### 1. Reused keyed children could keep stale payloads

The worker reconciler reused an existing child whenever the generated/stable key matched. That preserved DOM identity, but it also skipped reconciling the child payload supplied by the parent recomputation.

Concrete example:

```tsx
<div>
  {rows.map((row) => (
    <span key={row.id} data-vote-swatch-name={row.voter}>
      {row.voter}
    </span>
  ))}
</div>
```

If the parent recomputed a same-key child with fresh props or children, the worker could keep the old child state and not push the updated props/text/descendants. In Lunch Poll terms, an "All Options" row could preserve the right keyed slot but fail to reconcile the swatch/text payload that belongs in that slot.

User impact:

- rows or swatches can look stale after a reactive recompute;
- a refresh/resume can briefly show DOM that does not match the current worker VDOM;
- keyed identity is preserved, but content inside that identity may be wrong until another update happens to touch it.

Fix:

- same-key reuse now reconciles the payload in place when it is compatible;
- text children update through `update-text`;
- same-tag VNodes update props and descendants in place;
- incompatible same-key replacements, such as `span` -> `button`, remove and recreate the child instead of incorrectly reusing it.

### 2. Child placement ops could arrive before the referenced DOM position was attachable

The main-thread DOM applicator previously treated `insert-child`/`move-child` as effectively best-effort. If the child, parent, or `beforeId` reference was not ready at the exact moment the op arrived, placement could be dropped or applied as an append.

Concrete example:

```ts
insert-child(parent=1, child=2, beforeId=3)
create-element(3)
insert-child(parent=1, child=3, beforeId=4)
```

In that sequence, child `2` must wait until `3` exists **and** is attached under parent `1`; otherwise `2` can append early and produce the wrong visual order. This matters for mapped children and conditional children because the worker and main thread can receive/create nested nodes in multiple batches.

User impact:

- a list can appear in the wrong order during refresh;
- child UI can disappear and then refill row-by-row as later ops repair the tree;
- late-resolving mapped children, such as Lunch Poll vote swatches, can be skipped or placed after the wrong sibling;
- stale deferred placements must be discarded when a child or ancestor is removed, otherwise removed subtrees can influence future replay.

Fix:

- unresolved `insert-child`/`move-child` operations are deferred and replayed after later ops;
- placement waits for `beforeId` to be attached to the same parent instead of appending early;
- pending placements are discarded when the target child, parent, `beforeId`, or removed descendant subtree goes away;
- node/event cleanup still runs for removed descendants.

## Multi-browser / multi-session implications

This is not a browser-specific API compatibility issue; it is an ordering/timing issue between worker VDOM output and main-thread DOM application. Different browsers, tabs, reload timing, and machine speeds can interleave those batches differently.

That means two clients looking at the same durable state can temporarily see different UI:

- one browser may attach the reference node quickly enough and render the right order;
- another may receive/apply the placement before the reference is attached and briefly append or omit the child;
- after refresh/resume, one tab may show a full list while another shows a blank/refilling list even though both are reading the same cells.

The fix makes DOM convergence less timing-dependent: the applicator waits until a placement is actually valid, and the worker reconciles same-key payloads instead of relying on a later incidental update.

## Verification

- `deno fmt --check packages/html/src/main/applicator.ts packages/html/src/worker/reconciler.ts packages/html/src/worker/types.ts packages/html/test/main-applicator.test.ts packages/html/test/worker-reconciler-cell-child.test.ts packages/html/test/worker-reconciler-diffing.test.ts`
- `deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp packages/html/test/worker-reconciler-cell-child.test.ts packages/html/test/worker-reconciler-diffing.test.ts packages/html/test/main-applicator.test.ts`
- Full workspace test/coverage run with `DENO_COVERAGE_DIR=/tmp/opencode/coverage-4366-vdom deno task test`
- `deno run --allow-read --allow-write --allow-run tasks/coverage-metrics.ts --profile-dir=/tmp/opencode/coverage-4366-vdom --root=$(pwd)` reported `coverage-debt: packages/html uncovered lines = 1456`, below the previous gate baseline of `1460`
- LSP diagnostics clean for the touched HTML source and test files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes VDOM list settling and authorship boundaries. Keyed children update in place, child placements wait for valid anchors, and text‑integrity state derives correctly and resets when disabled so clean content renders without remounts.

- **Bug Fixes**
  - Keyed reuse updates in place: texts via `update-text`; same-tag props/children diff; tag or UI-root changes replace; cell-backed children reuse only for the same cell (cell→literal replaces and cancels); UI-wrapped outputs update without reinserting.
  - `insert-child`/`move-child` defer until `beforeId` exists and is attached under the same parent; pending placements replay when valid, are dropped if the parent/child is removed or stale, and append if only the `beforeId` anchor is removed; pending state clears on dispose; removed subtrees still clean nodes and events.
  - Strict text-integrity/authorship: boundary state is derived from the subtree and stays blocked when only siblings change; it unblocks when content becomes clean; state clears when the policy is removed; per‑prop blocks are tracked and cleared on prop removal; slotted headers and split text update in place without remounting.

<sup>Written for commit 16065cc4c1c0da2c59e2b7e88f8ee356b968ebe9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

