### PR TITLE
Ianh/reload churn read mostly resume

### DIFF
--- a/packages/patterns/integration/home-rehydration-churn.test.ts
+++ b/packages/patterns/integration/home-rehydration-churn.test.ts
@@ -4,6 +4,7 @@ import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { beforeAll, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
+  type ChurnCounters,
   clickCfButton,
   clickTrustedAction,
   collectBrowserLoadSummary,
@@ -16,6 +17,41 @@ import {
 
 const { FRONTEND_URL } = env;
 const TRUSTED_PROFILE_CREATE_ACTION = "CreateProfile";
+
+// One stable, machine-parseable line per churn measurement, logged before the
+// assertions so a run that exceeds a bound still records its value rather than
+// hiding it behind the failure. The reload bounds below are timing- and
+// hardware-sensitive, so the right value can only be read from the real
+// distribution across CI runs and runners. The `CHURN_METRIC` tag and
+// `key=value` shape are the stable contract — keep them greppable.
+//
+// To pull the distribution from the most recent 100 CI runs (this test runs in
+// the "Deno Workflow" / deno.yml `package-integration-test` job; PRs land on
+// commontoolsinc/labs — adjust -R for a fork). Requires the `gh` CLI:
+//
+//   gh run list -R commontoolsinc/labs --workflow deno.yml --limit 100 \
+//     --json databaseId --jq '.[].databaseId' \
+//     | xargs -P4 -I{} gh run view -R commontoolsinc/labs {} --log 2>/dev/null \
+//     | grep 'CHURN_METRIC label=reload' > /tmp/churn.txt
+//
+//   for k in commitConflicts commitReverts scheduleRunErrors; do
+//     printf '%s:\n' "$k"
+//     grep -oE "$k=[0-9]+" /tmp/churn.txt | cut -d= -f2 | sort -n | uniq -c
+//   done
+//
+// The `uniq -c` columns are "occurrences value", so the largest value with a
+// non-trivial count is the floor the bound should clear.
+function logChurnMetric(label: string, churn: ChurnCounters): void {
+  console.log(
+    `CHURN_METRIC label=${label}` +
+      ` commitConflicts=${churn.commitConflicts}` +
+      ` commitReverts=${churn.commitReverts}` +
+      ` scheduleRunErrors=${churn.scheduleRunErrors}` +
+      ` commitRejected=${churn.commitRejected}` +
+      ` actionRuns=${churn.actionRuns}` +
+      ` eventLostRaces=${churn.eventLostRaces}`,
+  );
+}
 
 // deno-lint-ignore no-explicit-any
 async function profileTabHidden(page: any): Promise<boolean> {
@@ -110,6 +146,7 @@ describe("home rehydration", () => {
     // counters reflect real activity in this measurement).
     const afterCreate = await collectBrowserLoadSummary(page, "after-create");
     logBrowserLoadSummary(afterCreate);
+    logChurnMetric("after-create", afterCreate.churn);
     expect(afterCreate.churn.actionRuns).toBeGreaterThan(0);
 
     // RELOAD: re-instantiate the runtime against the populated, durable space.
@@ -121,15 +158,22 @@ describe("home rehydration", () => {
 
     const reload = await collectBrowserLoadSummary(page, "reload");
     logBrowserLoadSummary(reload);
+    logChurnMetric("reload", reload.churn);
 
     const c = reload.churn;
-    // Read-mostly reload: re-commits stay bounded rather than scaling into a
-    // storm. The exact count is timing- and hardware-sensitive (it is logged
-    // above for observability), so the bound is generous; the durability test
-    // below is the precise correctness gate.
-    expect(c.commitConflicts).toBeLessThanOrEqual(20);
-    expect(c.commitReverts).toBeLessThanOrEqual(20);
-    expect(c.scheduleRunErrors).toBeLessThanOrEqual(20);
+    // Read-mostly reload: re-commits stay near zero rather than scaling into a
+    // storm. Resuming reads confirmed-loaded state before re-deriving — owned
+    // cells are pre-synced, the manifest probe no longer reads not-yet-loaded
+    // derived cells, and the list builtins defer their reconcile until the
+    // durable container lands instead of overwriting it with []. The residual
+    // is a small, bounded number of optimistic re-commits that lose a stale
+    // basis once and settle. The exact count is timing- and hardware-sensitive,
+    // so this bound is a regression sentinel with margin, not the measured
+    // floor — the values logged above are the basis for narrowing it. The
+    // durability test below is the precise correctness gate.
+    expect(c.commitConflicts).toBeLessThanOrEqual(12);
+    expect(c.commitReverts).toBeLessThanOrEqual(12);
+    expect(c.scheduleRunErrors).toBeLessThanOrEqual(12);
   });
 
   it("a profile created in the post-reload window is durable", async () => {

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -176,12 +176,6 @@ export function filter(
         tx,
       );
       result = scopedCell(runtime, tx, baseResult, outputScope);
-      // On a resume reconcile the container is durable (a filter that has run
-      // always persisted at least []); seeding [] here would write a stale
-      // basis that loses to the durable value on commit. Leave it for the
-      // defer-until-loaded guard below; a genuinely new filter (not resumed)
-      // still seeds [] so its first render has a value.
-      if (!elementAwaitSync) result.send([]);
       // Link this cell to the parent cell
       setResultCell(result, parentCell);
       // Link the new result cells to the pattern cell too
@@ -266,6 +260,10 @@ export function filter(
       return;
     }
 
+    // A fresh (non-resume) reconcile has no container yet; seed [] so the first
+    // render has a value. On resume this is unreachable — the defer guard above
+    // either holds for the still-loading container or sees the durable value, so
+    // priorSlots is never undefined here.
     if (priorSlots === undefined) {
       resultWithLog.set([]);
     }

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -209,9 +209,7 @@ export function filter(
       // syncCell is async, so the container pull is always a Promise; the union
       // on Cell.sync() is a vestigial synchronous fast path the storage manager
       // no longer takes. Assert it to narrow before awaiting.
-      if (!(pending instanceof Promise)) {
-        throw new Error("filter: result.sync() returned a non-Promise");
-      }
+      if (!(pending instanceof Promise)) throw new Error("result.sync()");
       // The container's durable value is still streaming in; its arrival
       // re-triggers this reconcile (the read above is journaled). If the
       // container was never persisted — so nothing will ever stream in to

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -37,6 +37,10 @@ import {
   scopedCell,
 } from "./scope-policy.ts";
 import { resolveOpPattern } from "./op-pattern-ref.ts";
+import { createResumeRepublisher } from "./resume-republish.ts";
+import { getLogger } from "@commonfabric/utils/logger";
+
+const logger = getLogger("runner.filter", { enabled: true, level: "warn" });
 
 /**
  * Implementation of built-in filter module. Like map, this is called once at
@@ -84,6 +88,63 @@ export function filter(
   // and must not wait. Cleared once a non-empty resume batch is processed.
   let resumeBatchAwaitSync = !!awaitSync;
 
+  // Rebuild the filtered list from the per-element predicate results: keep an
+  // input element when its predicate settled truthy, exclude it when the
+  // predicate settled a defined falsy value, and treat an undefined predicate as
+  // still streaming in. See resume-republish.ts for the convergence machinery.
+  const { awaitPendingThenRepublish } = createResumeRepublisher({
+    runtime,
+    logger,
+    getResult: () => result,
+    inputsCell,
+    inputSchema: FILTER_INPUT_SCHEMA,
+    resultSchema: RESULT_PRESENCE_SCHEMA,
+    elementRuns,
+    aggregateNoun: "filtered list",
+    elementNoun: "predicate",
+    contribute: (included, inputElement, out) => {
+      if (included) out.push(inputElement);
+      else if (included === undefined) return "pending";
+    },
+  });
+
+  // Hold the durable list while the input list itself confirms. On a resume
+  // reconcile the input can be undefined or a transient empty default standing in
+  // while the real list streams in; setting [] then would clobber the durable
+  // aggregate. Await the resolved input and, once it confirms, clear the result
+  // only if the input is genuinely empty — a non-empty input re-triggers the
+  // normal reconcile via its journaled read, so it converges either way.
+  const awaitInputThenSettle = (
+    inputListCell: Cell<any>,
+  ): void => {
+    runtime.storageManager.trackUntilSettled(
+      Promise.resolve(inputListCell.sync())
+        .then(() =>
+          runtime.editWithRetry((settleTx) => {
+            if (!result) return;
+            const { list } = inputsCell.asSchema(FILTER_INPUT_SCHEMA)
+              .withTx(settleTx).get();
+            if (
+              list === undefined || (Array.isArray(list) && list.length === 0)
+            ) {
+              result.asSchema(RESULT_PRESENCE_SCHEMA).withTx(settleTx).set([]);
+            }
+          }).then(({ error }) => {
+            if (error) {
+              logger.warn("resume-input", "settling the resumed input failed", {
+                error,
+              });
+            }
+          })
+        )
+        .catch((error) =>
+          logger.warn("resume-input", "the resumed input list sync rejected", {
+            error,
+          })
+        ),
+    );
+  };
+
   return (tx: IExtendedStorageTransaction) => {
     const elementAwaitSync = resumeBatchAwaitSync;
     const { list, op } = inputsCell.asSchema(FILTER_INPUT_SCHEMA)
@@ -115,7 +176,12 @@ export function filter(
         tx,
       );
       result = scopedCell(runtime, tx, baseResult, outputScope);
-      result.send([]);
+      // On a resume reconcile the container is durable (a filter that has run
+      // always persisted at least []); seeding [] here would write a stale
+      // basis that loses to the durable value on commit. Leave it for the
+      // defer-until-loaded guard below; a genuinely new filter (not resumed)
+      // still seeds [] so its first render has a value.
+      if (!elementAwaitSync) result.send([]);
       // Link this cell to the parent cell
       setResultCell(result, parentCell);
       // Link the new result cells to the pattern cell too
@@ -137,7 +203,70 @@ export function filter(
       ...(argumentUsage.usesParams ? { params: inputsCell.key("params") } : {}),
     });
 
-    if (resultWithLog.get() === undefined) {
+    // Resume against confirmed state, not the not-yet-loaded value: on the
+    // resume reconcile an undefined container is its durable value still
+    // streaming in (a filter that has run persisted at least []). Reconciling
+    // now would write a stale-basis result that conflicts on commit and re-runs
+    // against the same absent value until it happens to sync. Pull the
+    // container and defer; its arrival re-triggers this reconcile, which then
+    // no-ops against the durable value.
+    if (elementAwaitSync && resultWithLog.get() === undefined) {
+      const pending = result.sync();
+      // syncCell is async, so the container pull is always a Promise; the union
+      // on Cell.sync() is a vestigial synchronous fast path the storage manager
+      // no longer takes. Assert it to narrow before awaiting.
+      if (!(pending instanceof Promise)) {
+        throw new Error("filter: result.sync() returned a non-Promise");
+      }
+      // The container's durable value is still streaming in; its arrival
+      // re-triggers this reconcile (the read above is journaled). If the
+      // container was never persisted — so nothing will ever stream in to
+      // re-trigger — seed [] once the pull settles, so the coordinator is not
+      // left wedged waiting for a value that never arrives.
+      const seedIfStillAbsent = () =>
+        runtime.editWithRetry((seedTx) => {
+          const container = result!.withTx(seedTx);
+          if (container.getRaw() === undefined) container.set([]);
+        }).then(({ error }) => {
+          if (error) {
+            logger.warn(
+              "resume-seed",
+              "seeding the empty result container failed",
+              { error },
+            );
+          }
+        });
+      // Run on either outcome (resolve or reject); the seed recovers from the
+      // pull's own rejection, so log it rather than dropping it silently.
+      pending.finally(seedIfStillAbsent).catch((error) => {
+        logger.warn("resume-pull", "resume container pull rejected", {
+          error,
+        });
+      });
+      return;
+    }
+    // The durable aggregate currently in the container, read links-only
+    // (presence schema), so this is a length comparison rather than a content
+    // read of every element.
+    const priorSlots = resultWithLog.get();
+    const priorLen = Array.isArray(priorSlots) ? priorSlots.length : 0;
+
+    // Resume preservation: on a resume reconcile the input list itself may not be
+    // confirmed yet — undefined, or a transient empty default while the real list
+    // streams in. Setting [] now would clobber the durable aggregate the
+    // container already holds. Hold it and await the input; a non-empty input
+    // then re-triggers this reconcile via its journaled read, and a confirmed
+    // empty input clears the result. Outside resume the flag is clear, so a list
+    // set undefined at runtime still runs the cleanup below.
+    if (
+      elementAwaitSync && priorLen > 0 &&
+      (list === undefined || (Array.isArray(list) && list.length === 0))
+    ) {
+      awaitInputThenSettle(inputsCell.key("list").withTx(tx).resolveAsCell());
+      return;
+    }
+
+    if (priorSlots === undefined) {
       resultWithLog.set([]);
     }
     if (list === undefined) {
@@ -157,6 +286,11 @@ export function filter(
 
     const keyCounts = new Map<string, number>();
     const newArrayValue: any[] = [];
+    // Collected when an element is excluded only because its predicate result is
+    // still streaming in (reads undefined). Their docs are awaited below so the
+    // list can be republished once they confirm — distinct from a predicate that
+    // has settled falsy, which reads false and is excluded immediately.
+    const pendingCells: Cell<any>[] = [];
     for (let i = 0; i < list.length; i++) {
       // Skip sparse holes — don't create predicate runs for them
       if (!(i in list)) continue;
@@ -209,10 +343,28 @@ export function filter(
 
       // Read predicate result — creates subscription for reactivity.
       // Truthy/falsy coercion, not strict boolean.
-      const included = elementRuns.get(elementKey)!.resultCell.withTx(tx).get();
+      const childCell = elementRuns.get(elementKey)!.resultCell;
+      const included = childCell.withTx(tx).get();
       if (included) {
         newArrayValue.push(list[i]); // Original element cell reference
+      } else if (included === undefined) {
+        pendingCells.push(childCell);
       }
+    }
+
+    // Resume preservation: a predicate whose result is still streaming in reads
+    // undefined and would exclude its element, shrinking the aggregate below the
+    // durable value the container already holds. Republishing that shrink is the
+    // reload flicker — a populated list blinks to empty and refills. Hold the
+    // durable value and wait for the pending predicates to confirm their docs,
+    // then republish against the confirmed values. A predicate whose value
+    // arrived is included; one confirmed undefined is excluded — so a genuine
+    // shrink still converges instead of freezing.
+    if (
+      priorLen > 0 && newArrayValue.length < priorLen && pendingCells.length > 0
+    ) {
+      awaitPendingThenRepublish(pendingCells);
+      return;
     }
     resultWithLog.set(newArrayValue);
 

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -37,6 +37,10 @@ import {
   scopedCell,
 } from "./scope-policy.ts";
 import { resolveOpPattern } from "./op-pattern-ref.ts";
+import { createResumeRepublisher } from "./resume-republish.ts";
+import { getLogger } from "@commonfabric/utils/logger";
+
+const logger = getLogger("runner.flatmap", { enabled: true, level: "warn" });
 
 /**
  * Implementation of built-in flatMap module. Like map, this is called once at
@@ -86,6 +90,63 @@ export function flatMap(
   // and must not wait. Cleared once a non-empty resume batch is processed.
   let resumeBatchAwaitSync = !!awaitSync;
 
+  // Rebuild the flattened list from the per-element results: spread an array
+  // result one level deep, push a defined scalar directly, and treat an undefined
+  // result as still streaming in. forEach over the array skips holes, so sparse
+  // per-element results densify here. See resume-republish.ts for the convergence
+  // machinery.
+  const { awaitPendingThenRepublish } = createResumeRepublisher({
+    runtime,
+    logger,
+    getResult: () => result,
+    inputsCell,
+    inputSchema: FLATMAP_INPUT_SCHEMA,
+    resultSchema: RESULT_PRESENCE_SCHEMA,
+    elementRuns,
+    aggregateNoun: "flatMap result",
+    elementNoun: "result",
+    contribute: (elemResult, _inputElement, out) => {
+      if (Array.isArray(elemResult)) elemResult.forEach((v) => out.push(v));
+      else if (elemResult !== undefined) out.push(elemResult);
+      else return "pending";
+    },
+  });
+
+  // Hold the durable list while the input list itself confirms. On a resume
+  // reconcile the input can be undefined or a transient empty default standing in
+  // while the real list streams in; setting [] then would clobber the durable
+  // aggregate. Await the resolved input and, once it confirms, clear the result
+  // only if the input is genuinely empty — a non-empty input re-triggers the
+  // normal reconcile via its journaled read, so it converges either way.
+  const awaitInputThenSettle = (inputListCell: Cell<any>): void => {
+    runtime.storageManager.trackUntilSettled(
+      Promise.resolve(inputListCell.sync())
+        .then(() =>
+          runtime.editWithRetry((settleTx) => {
+            if (!result) return;
+            const { list } = inputsCell.asSchema(FLATMAP_INPUT_SCHEMA)
+              .withTx(settleTx).get();
+            if (
+              list === undefined || (Array.isArray(list) && list.length === 0)
+            ) {
+              result.asSchema(RESULT_PRESENCE_SCHEMA).withTx(settleTx).set([]);
+            }
+          }).then(({ error }) => {
+            if (error) {
+              logger.warn("resume-input", "settling the resumed input failed", {
+                error,
+              });
+            }
+          })
+        )
+        .catch((error) =>
+          logger.warn("resume-input", "the resumed input list sync rejected", {
+            error,
+          })
+        ),
+    );
+  };
+
   return (tx: IExtendedStorageTransaction) => {
     const elementAwaitSync = resumeBatchAwaitSync;
     const { list, op } = inputsCell.asSchema(FLATMAP_INPUT_SCHEMA)
@@ -117,7 +178,12 @@ export function flatMap(
         tx,
       );
       result = scopedCell(runtime, tx, baseResult, outputScope);
-      result.send([]);
+      // On a resume reconcile the container is durable (a flatMap that has run
+      // always persisted at least []); seeding [] here would write a stale
+      // basis that loses to the durable value on commit. Leave it for the
+      // defer-until-loaded guard below; a genuinely new flatMap (not resumed)
+      // still seeds [] so its first render has a value.
+      if (!elementAwaitSync) result.send([]);
       // Link this cell to the parent cell
       setResultCell(result, parentCell);
       // Link the new result cells to the pattern cell too
@@ -139,7 +205,70 @@ export function flatMap(
       ...(argumentUsage.usesParams ? { params: inputsCell.key("params") } : {}),
     });
 
-    if (resultWithLog.get() === undefined) {
+    // Resume against confirmed state, not the not-yet-loaded value: on the
+    // resume reconcile an undefined container is its durable value still
+    // streaming in (a flatMap that has run persisted at least []). Reconciling
+    // now would write a stale-basis result that conflicts on commit and re-runs
+    // against the same absent value until it happens to sync. Pull the
+    // container and defer; its arrival re-triggers this reconcile, which then
+    // no-ops against the durable value.
+    if (elementAwaitSync && resultWithLog.get() === undefined) {
+      const pending = result.sync();
+      // syncCell is async, so the container pull is always a Promise; the union
+      // on Cell.sync() is a vestigial synchronous fast path the storage manager
+      // no longer takes. Assert it to narrow before awaiting.
+      if (!(pending instanceof Promise)) {
+        throw new Error("flatMap: result.sync() returned a non-Promise");
+      }
+      // The container's durable value is still streaming in; its arrival
+      // re-triggers this reconcile (the read above is journaled). If the
+      // container was never persisted — so nothing will ever stream in to
+      // re-trigger — seed [] once the pull settles, so the coordinator is not
+      // left wedged waiting for a value that never arrives.
+      const seedIfStillAbsent = () =>
+        runtime.editWithRetry((seedTx) => {
+          const container = result!.withTx(seedTx);
+          if (container.getRaw() === undefined) container.set([]);
+        }).then(({ error }) => {
+          if (error) {
+            logger.warn(
+              "resume-seed",
+              "seeding the empty result container failed",
+              { error },
+            );
+          }
+        });
+      // Run on either outcome (resolve or reject); the seed recovers from the
+      // pull's own rejection, so log it rather than dropping it silently.
+      pending.finally(seedIfStillAbsent).catch((error) => {
+        logger.warn("resume-pull", "resume container pull rejected", {
+          error,
+        });
+      });
+      return;
+    }
+    // The durable aggregate currently in the container, read links-only
+    // (presence schema), so this is a length comparison rather than a content
+    // read of every element.
+    const priorSlots = resultWithLog.get();
+    const priorLen = Array.isArray(priorSlots) ? priorSlots.length : 0;
+
+    // Resume preservation: on a resume reconcile the input list itself may not be
+    // confirmed yet — undefined, or a transient empty default while the real list
+    // streams in. Setting [] now would clobber the durable aggregate the
+    // container already holds. Hold it and await the input; a non-empty input
+    // then re-triggers this reconcile via its journaled read, and a confirmed
+    // empty input clears the result. Outside resume the flag is clear, so a list
+    // set undefined at runtime still runs the cleanup below.
+    if (
+      elementAwaitSync && priorLen > 0 &&
+      (list === undefined || (Array.isArray(list) && list.length === 0))
+    ) {
+      awaitInputThenSettle(inputsCell.key("list").withTx(tx).resolveAsCell());
+      return;
+    }
+
+    if (priorSlots === undefined) {
       resultWithLog.set([]);
     }
     if (list === undefined) {
@@ -159,6 +288,11 @@ export function flatMap(
 
     const keyCounts = new Map<string, number>();
     const newArrayValue: any[] = [];
+    // Collected when an element contributes nothing only because its result is
+    // still streaming in (reads undefined). Their docs are awaited below so the
+    // list can be republished once they confirm — distinct from an op that has
+    // settled undefined (a real skip), which converges immediately.
+    const pendingCells: Cell<any>[] = [];
     for (let i = 0; i < list.length; i++) {
       // Skip sparse holes — don't create pattern runs for them
       if (!(i in list)) continue;
@@ -210,8 +344,8 @@ export function flatMap(
       // Matches JS flatMap semantics: arrays are spread, scalars are included
       // directly. undefined is skipped (two-pass convergence: new elements
       // have undefined result cells on the first pass before the pattern runs).
-      const elemResult = elementRuns.get(elementKey)!.resultCell.withTx(tx)
-        .get();
+      const childCell = elementRuns.get(elementKey)!.resultCell;
+      const elemResult = childCell.withTx(tx).get();
       if (Array.isArray(elemResult)) {
         // forEach skips holes in sub-arrays (sparse-safe)
         elemResult.forEach((v) => {
@@ -219,7 +353,24 @@ export function flatMap(
         });
       } else if (elemResult !== undefined) {
         newArrayValue.push(elemResult);
+      } else {
+        pendingCells.push(childCell);
       }
+    }
+
+    // Resume preservation: an element whose result is still streaming in reads
+    // undefined and contributes nothing, shrinking the aggregate below the
+    // durable value the container already holds. Republishing that shrink is the
+    // reload flicker — a populated list blinks to empty and refills. Hold the
+    // durable value and wait for the pending elements to confirm their docs, then
+    // republish against the confirmed results. An element whose result arrived is
+    // contributed; one confirmed undefined is skipped — so a genuine shrink still
+    // converges instead of freezing.
+    if (
+      priorLen > 0 && newArrayValue.length < priorLen && pendingCells.length > 0
+    ) {
+      awaitPendingThenRepublish(pendingCells);
+      return;
     }
     resultWithLog.set(newArrayValue);
 

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -178,12 +178,6 @@ export function flatMap(
         tx,
       );
       result = scopedCell(runtime, tx, baseResult, outputScope);
-      // On a resume reconcile the container is durable (a flatMap that has run
-      // always persisted at least []); seeding [] here would write a stale
-      // basis that loses to the durable value on commit. Leave it for the
-      // defer-until-loaded guard below; a genuinely new flatMap (not resumed)
-      // still seeds [] so its first render has a value.
-      if (!elementAwaitSync) result.send([]);
       // Link this cell to the parent cell
       setResultCell(result, parentCell);
       // Link the new result cells to the pattern cell too
@@ -268,6 +262,10 @@ export function flatMap(
       return;
     }
 
+    // A fresh (non-resume) reconcile has no container yet; seed [] so the first
+    // render has a value. On resume this is unreachable — the defer guard above
+    // either holds for the still-loading container or sees the durable value, so
+    // priorSlots is never undefined here.
     if (priorSlots === undefined) {
       resultWithLog.set([]);
     }

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -211,9 +211,7 @@ export function flatMap(
       // syncCell is async, so the container pull is always a Promise; the union
       // on Cell.sync() is a vestigial synchronous fast path the storage manager
       // no longer takes. Assert it to narrow before awaiting.
-      if (!(pending instanceof Promise)) {
-        throw new Error("flatMap: result.sync() returned a non-Promise");
-      }
+      if (!(pending instanceof Promise)) throw new Error("result.sync()");
       // The container's durable value is still streaming in; its arrival
       // re-triggers this reconcile (the read above is journaled). If the
       // container was never persisted — so nothing will ever stream in to

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -42,6 +42,9 @@ import { resolveLink } from "../link-resolution.ts";
 import { isPrimitiveCellLink, parseLink } from "../link-utils.ts";
 import { linkResolutionProbe } from "../storage/reactivity-log.ts";
 import { resolveOpPattern } from "./op-pattern-ref.ts";
+import { getLogger } from "@commonfabric/utils/logger";
+
+const logger = getLogger("runner.map", { enabled: true, level: "warn" });
 
 /**
  * Implementation of built-in map module. Unlike regular modules, this will be
@@ -97,6 +100,46 @@ export function map(
   // resumed, so its first reconcile already runs against synced data; elements
   // added by later (post-resume) reconciles are fresh and must not wait.
   let resumeBatchAwaitSync = !!awaitSync;
+
+  // Hold the durable container while the input list itself confirms. On a resume
+  // reconcile the input can be undefined or a transient empty default standing in
+  // while the real list streams in; setting [] then would clobber the durable
+  // container the resume loaded. Await the resolved input and, once it confirms,
+  // clear the container only if the input is genuinely empty — a non-empty input
+  // re-triggers the normal reconcile via its journaled read, so it converges
+  // either way.
+  const awaitInputThenSettle = (inputListCell: Cell<any>): void => {
+    runtime.storageManager.trackUntilSettled(
+      Promise.resolve(inputListCell.sync())
+        .then(() =>
+          runtime.editWithRetry((settleTx) => {
+            if (!result) return;
+            const raw = inputsCell.key("list").withTx(settleTx).resolveAsCell()
+              .withTx(settleTx).getRaw();
+            if (raw === undefined || (Array.isArray(raw) && raw.length === 0)) {
+              settleTx.runWithAmbientReadMeta(
+                linkResolutionProbe,
+                () =>
+                  result!.asSchema(RESULT_PRESENCE_SCHEMA).withTx(settleTx).set(
+                    [],
+                  ),
+              );
+            }
+          }).then(({ error }) => {
+            if (error) {
+              logger.warn("resume-input", "settling the resumed input failed", {
+                error,
+              });
+            }
+          })
+        )
+        .catch((error) =>
+          logger.warn("resume-input", "the resumed input list sync rejected", {
+            error,
+          })
+        ),
+    );
+  };
 
   return (tx: IExtendedStorageTransaction) => {
     // Captured before the loop consumes it: this reconcile's element runs use
@@ -172,7 +215,12 @@ export function map(
         tx,
       );
       result = scopedCell(runtime, tx, baseResult, listScope);
-      result.send([]);
+      // On a resume reconcile the container is durable (a map that has run
+      // always persisted at least []); seeding [] here would write a stale
+      // basis that loses to the durable value on commit. Leave it for the
+      // defer-until-loaded guard below; a genuinely new map (not resumed)
+      // still seeds [] so its first render has a value.
+      if (!elementAwaitSync) result.send([]);
       setResultCell(result, parentCell);
       // Link the new result cells to the pattern cell too
       setPatternCell(result, parentCell.key("pattern"));
@@ -205,7 +253,71 @@ export function map(
     // smearing it onto fresh elements' scaffolding (S16 pointwise).
     const probeScoped = <T>(fn: () => T): T =>
       tx.runWithAmbientReadMeta(linkResolutionProbe, fn);
-    if (probeScoped(() => resultWithLog.get()) === undefined) {
+    // Resume against confirmed state, not the not-yet-loaded value: on the
+    // resume reconcile an undefined container is its durable value still
+    // streaming in (a map that has run persisted at least []). Reconciling now
+    // would write a stale-basis result that conflicts on commit and re-runs
+    // against the same absent value until it happens to sync — the reload
+    // commit storm. Pull the container and defer; its arrival re-triggers this
+    // reconcile, which then no-ops against the durable value.
+    if (
+      elementAwaitSync &&
+      probeScoped(() => resultWithLog.get()) === undefined
+    ) {
+      const pending = result.sync();
+      // syncCell is async, so the container pull is always a Promise; the union
+      // on Cell.sync() is a vestigial synchronous fast path the storage manager
+      // no longer takes. Assert it to narrow before awaiting.
+      if (!(pending instanceof Promise)) {
+        throw new Error("map: result.sync() returned a non-Promise");
+      }
+      // The container's durable value is still streaming in; its arrival
+      // re-triggers this reconcile (the probe read above is journaled). If the
+      // container was never persisted — so nothing will ever stream in to
+      // re-trigger — seed [] once the pull settles, so the coordinator is not
+      // left wedged waiting for a value that will never arrive.
+      const seedIfStillAbsent = () =>
+        runtime.editWithRetry((seedTx) => {
+          const container = result!.withTx(seedTx);
+          if (container.getRaw() === undefined) container.set([]);
+        }).then(({ error }) => {
+          if (error) {
+            logger.warn(
+              "resume-seed",
+              "seeding the empty result container failed",
+              { error },
+            );
+          }
+        });
+      // Run on either outcome (resolve or reject); the seed recovers from the
+      // pull's own rejection, so log it rather than dropping it silently.
+      pending.finally(seedIfStillAbsent).catch((error) => {
+        logger.warn("resume-pull", "resume container pull rejected", {
+          error,
+        });
+      });
+      return;
+    }
+    // Resume preservation: on a resume reconcile the input list itself may not be
+    // confirmed yet — undefined, or a transient empty default while the real list
+    // streams in. Setting [] now would clobber the durable container the resume
+    // loaded (map's output is link-shaped, so its slots survive a pending element,
+    // but a pending input would still blank the whole container). Hold it and
+    // await the input; a non-empty input then re-triggers this reconcile via its
+    // journaled read, and a confirmed empty input clears the container. Outside
+    // resume the flag is clear, so a list set undefined at runtime still runs the
+    // cleanup below.
+    const priorSlots = probeScoped(() => resultWithLog.get());
+    const priorLen = Array.isArray(priorSlots) ? priorSlots.length : 0;
+    if (
+      elementAwaitSync && priorLen > 0 &&
+      (list === undefined || (Array.isArray(list) && list.length === 0))
+    ) {
+      awaitInputThenSettle(listCell);
+      return;
+    }
+
+    if (priorSlots === undefined) {
       probeScoped(() => resultWithLog.set([]));
     }
     // If the list is undefined it means the input isn't available yet.

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -215,12 +215,6 @@ export function map(
         tx,
       );
       result = scopedCell(runtime, tx, baseResult, listScope);
-      // On a resume reconcile the container is durable (a map that has run
-      // always persisted at least []); seeding [] here would write a stale
-      // basis that loses to the durable value on commit. Leave it for the
-      // defer-until-loaded guard below; a genuinely new map (not resumed)
-      // still seeds [] so its first render has a value.
-      if (!elementAwaitSync) result.send([]);
       setResultCell(result, parentCell);
       // Link the new result cells to the pattern cell too
       setPatternCell(result, parentCell.key("pattern"));
@@ -317,6 +311,10 @@ export function map(
       return;
     }
 
+    // A fresh (non-resume) reconcile has no container yet; seed [] so the first
+    // render has a value. On resume this is unreachable — the defer guard above
+    // either holds for the still-loading container or sees the durable value, so
+    // priorSlots is never undefined here.
     if (priorSlots === undefined) {
       probeScoped(() => resultWithLog.set([]));
     }

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -262,9 +262,7 @@ export function map(
       // syncCell is async, so the container pull is always a Promise; the union
       // on Cell.sync() is a vestigial synchronous fast path the storage manager
       // no longer takes. Assert it to narrow before awaiting.
-      if (!(pending instanceof Promise)) {
-        throw new Error("map: result.sync() returned a non-Promise");
-      }
+      if (!(pending instanceof Promise)) throw new Error("result.sync()");
       // The container's durable value is still streaming in; its arrival
       // re-triggers this reconcile (the probe read above is journaled). If the
       // container was never persisted — so nothing will ever stream in to

--- a/packages/runner/src/builtins/resume-republish.ts
+++ b/packages/runner/src/builtins/resume-republish.ts
@@ -1,0 +1,158 @@
+import type { Cell } from "../cell.ts";
+import type { Runtime } from "../runtime.ts";
+import type { Logger } from "@commonfabric/utils/logger";
+import type { JSONSchema } from "../builder/types.ts";
+import { cellIdentityKey } from "./scope-policy.ts";
+
+type ElementRuns = Map<
+  string,
+  { resultCell: Cell<any>; lastIndex: number }
+>;
+
+/**
+ * Decide what one element contributes to the rebuilt aggregate. `value` is the
+ * element's per-element result (a predicate boolean for filter, a result value
+ * or array for flatMap); `inputElement` is the corresponding input list entry.
+ * Append the contribution to `out`, or return "pending" if the element's result
+ * has not arrived yet. A present-but-undefined value that the builtin treats as
+ * a settled exclusion contributes nothing and is not pending.
+ */
+export type ElementContribution = (
+  value: unknown,
+  inputElement: unknown,
+  out: any[],
+) => "pending" | void;
+
+export interface ResumeRepublisher {
+  /**
+   * Hold the durable aggregate while the given still-pending element result
+   * cells confirm their docs, then rebuild and write it. The entry point; the
+   * republish it schedules re-defers any straggler and calls back in.
+   */
+  awaitPendingThenRepublish(cells: Cell<any>[], awaited?: Set<string>): void;
+}
+
+export interface ResumeRepublisherOptions {
+  runtime: Runtime;
+  logger: Logger;
+  /**
+   * The result container is bound after the builtin's setup, so it is read
+   * lazily on each republish rather than captured once.
+   */
+  getResult: () => Cell<any[]> | undefined;
+  inputsCell: Cell<any>;
+  inputSchema: JSONSchema;
+  resultSchema: JSONSchema;
+  elementRuns: ElementRuns;
+  contribute: ElementContribution;
+  /** The aggregate's noun for logs, e.g. "filtered list" / "flatMap result". */
+  aggregateNoun: string;
+  /** The per-element noun for logs, e.g. "predicate" / "result". */
+  elementNoun: string;
+}
+
+/**
+ * Shared resume-preservation machinery for the list builtins that rebuild an
+ * aggregate from per-element results (filter, flatMap). map does not use it: its
+ * output is link-shaped and never holds element values to reconcile.
+ *
+ * On a resume reconcile the durable aggregate is held while the per-element
+ * results stream in. Once their docs confirm, the aggregate is rebuilt from the
+ * settled results and written. The only per-builtin variation is how each
+ * element maps to its contribution, supplied as `contribute`; everything else —
+ * the element-identity keying, the straggler re-defer, and the convergence
+ * bookkeeping — is the same.
+ *
+ * `awaited` holds the ids of result cells whose sync has already resolved in
+ * this republish chain. An undefined result in that set has settled (the builtin
+ * excludes or skips it — convergence), while an undefined result not in it is
+ * still streaming in, for example a child mid-revert that read a value at defer
+ * time and so was never in the pending set. Rather than write a partial shrink,
+ * those stragglers are returned to be re-awaited before republishing.
+ */
+export function createResumeRepublisher(
+  opts: ResumeRepublisherOptions,
+): ResumeRepublisher {
+  const {
+    runtime,
+    logger,
+    getResult,
+    inputsCell,
+    inputSchema,
+    resultSchema,
+    elementRuns,
+    contribute,
+    aggregateNoun,
+    elementNoun,
+  } = opts;
+
+  const republishFromConfirmed = (awaited: Set<string>): Promise<void> =>
+    runtime.editWithRetry((tx): Cell<any>[] => {
+      const result = getResult();
+      if (!result) return [];
+      const inputs = inputsCell.asSchema(inputSchema).withTx(tx).get() as {
+        list?: unknown;
+      };
+      const list = inputs?.list;
+      if (!Array.isArray(list)) return [];
+      const keyCounts = new Map<string, number>();
+      const out: any[] = [];
+      const stillPending: Cell<any>[] = [];
+      for (let i = 0; i < list.length; i++) {
+        if (!(i in list)) continue;
+        const { dedupKey, linkKey } = cellIdentityKey(list[i]);
+        const occurrence = keyCounts.get(dedupKey) ?? 0;
+        keyCounts.set(dedupKey, occurrence + 1);
+        const elementKey = JSON.stringify([...linkKey, occurrence]);
+        const entry = elementRuns.get(elementKey);
+        if (!entry) continue;
+        const value = entry.resultCell.withTx(tx).get();
+        if (
+          contribute(value, list[i], out) === "pending" &&
+          !awaited.has(entry.resultCell.getAsNormalizedFullLink().id)
+        ) {
+          stillPending.push(entry.resultCell);
+        }
+      }
+      if (stillPending.length > 0) return stillPending;
+      result.asSchema(resultSchema).withTx(tx).set(out);
+      return [];
+    }).then(({ ok, error }) => {
+      if (error) {
+        logger.warn(
+          "resume-republish",
+          `republishing the ${aggregateNoun} failed`,
+          { error },
+        );
+        return;
+      }
+      if (ok && ok.length > 0) awaitPendingThenRepublish(ok, awaited);
+    });
+
+  // Hold the durable aggregate while the still-pending elements confirm their
+  // docs, then republish. Each element's sync resolves whether its value arrives
+  // or its doc is confirmed absent, so the republish runs against settled state.
+  // Using sync as an async confirmation, not a read-time guess, is the
+  // load-bearing distinction here. `awaited` accumulates the confirmed ids across
+  // a chain of re-awaits, so a straggler found at republish time is awaited too
+  // and a settled-undefined element is honored once rather than awaited forever.
+  const awaitPendingThenRepublish = (
+    cells: Cell<any>[],
+    awaited: Set<string> = new Set<string>(),
+  ): void => {
+    for (const c of cells) awaited.add(c.getAsNormalizedFullLink().id);
+    runtime.storageManager.trackUntilSettled(
+      Promise.all(cells.map((c) => c.sync()))
+        .then(() => republishFromConfirmed(awaited))
+        .catch((error) =>
+          logger.warn(
+            "resume-republish",
+            `a pending ${elementNoun} sync rejected`,
+            { error },
+          )
+        ),
+    );
+  };
+
+  return { awaitPendingThenRepublish };
+}

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -895,25 +895,28 @@ export class Runner {
           link: derivedSigilLink,
         });
         setResultCell(derivedCell, resultCell.asSchema(pattern.resultSchema));
+
+        // Seed the build-time default for the freshly created cell. The
+        // manifest entry and this default are written together in one
+        // transaction, so a manifest-referenced cell is already durable; on a
+        // cold-cache resume its value may simply be unsynced. Reading and
+        // seeding only when there is no manifest entry keeps resume read-mostly:
+        // a probe read of the not-yet-loaded value would otherwise enter the
+        // commit's conflict set and lose to the durable value when it streams
+        // in, reverting the whole instantiation commit.
+        const schemaDefault = isRecord(descriptor.schema)
+          ? descriptor.schema.default as JSONValue | undefined
+          : undefined;
+        if (schemaDefault !== undefined) {
+          const currentValue = derivedCell.getRawUntyped({
+            meta: ignoreReadForScheduling,
+          });
+          if (currentValue === undefined) {
+            derivedCell.setRawUntyped(fabricFromNativeValue(schemaDefault));
+          }
+        }
       } else {
         manifest.push(existingManifest[manifestMatch]);
-      }
-
-      const currentValue = derivedCell.getRawUntyped({
-        meta: ignoreReadForScheduling,
-      });
-      const schemaDefault = isRecord(descriptor.schema)
-        ? descriptor.schema.default as JSONValue | undefined
-        : undefined;
-      if (currentValue === undefined && schemaDefault !== undefined) {
-        // A manifest entry means this cell's doc is durable: the manifest entry
-        // and the build-time default are written together in one transaction.
-        // So for a manifest-referenced cell an undefined read means the doc is
-        // not loaded yet on a cold-cache resume, not that it is absent; seed the
-        // default only when there is no manifest entry yet.
-        if (manifestMatch === -1) {
-          derivedCell.setRawUntyped(fabricFromNativeValue(schemaDefault));
-        }
       }
     }
 
@@ -1850,6 +1853,28 @@ export class Runner {
       });
     }
 
+    // Sync the owned (derived internal) cells of this pattern and every nested
+    // sub-pattern, to any depth, before instantiating. The setup re-derivation
+    // and the sub-patterns' argument writes read these owned cells by value
+    // (e.g. a child bound to the parent's list). On a cold-cache resume an
+    // unsynced owned cell reads as absent and its read enters the instantiation
+    // commit's conflict set, so when the durable value streams in the whole
+    // batched instantiation commit loses and reverts — stranding the optimistic
+    // writes that the resumed actions then depend on. Pulling them here keeps
+    // that commit read-mostly.
+    // Resolving each sub-pattern node's output redirect chain needs a
+    // transaction (resolveLink reads link metadata). The walk only reads, so the
+    // transaction is discarded afterward.
+    const resolveTx = this.runtime.edit();
+    this.collectResumeOwnedCells(
+      pattern,
+      resultCell,
+      cells,
+      new Set(),
+      resolveTx,
+    );
+    resolveTx.abort("collectResumeOwnedCells: read-only resolution");
+
     // Sync all the previously computed results.
     if (pattern.resultSchema !== undefined) {
       cells.push(resultCell.asSchema(pattern.resultSchema));
@@ -1871,6 +1896,103 @@ export class Runner {
     await Promise.all(cells.map((c) => c.sync()));
 
     return true;
+  }
+
+  // Walk the pattern tree — this pattern and every nested sub-pattern — and
+  // collect each one's owned (derived internal) cells into `out`, so the resume
+  // pre-sync pulls them before instantiation reads them. A sub-pattern node's
+  // result cell is the cell reserved by the node's resolved output spot, the
+  // same `resultFor` identity instantiatePatternNode mints; deriving owned cells
+  // from it matches what the child's setup will use. The `seen` set keys on the
+  // result cell to bound the walk against a cyclic reference. This only pulls
+  // cells, so a node shape it cannot resolve contributes nothing rather than
+  // misbehaving.
+  private collectResumeOwnedCells(
+    pattern: Pattern,
+    resultCell: Cell<any>,
+    out: Cell<any>[],
+    seen: Set<string>,
+    tx: IExtendedStorageTransaction,
+  ): void {
+    const link = resultCell.getAsNormalizedFullLink();
+    const key = `${link.space}\0${link.id}\0${link.scope ?? "space"}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+
+    for (const descriptor of pattern.derivedInternalCells ?? []) {
+      out.push(getDerivedInternalCell(resultCell, descriptor));
+    }
+
+    for (const node of pattern.nodes) {
+      const module = node.module;
+      if (module.type !== "pattern" || !isPattern(module.implementation)) {
+        continue;
+      }
+      const childPattern = module.implementation;
+      const targetSpace = module.targetSpace ?? resultCell.space;
+      const childScope = patternDefaultScope(childPattern) ??
+        module.defaultScope;
+      // Resolve the node's reserved output spot the way instantiatePatternNode
+      // does: unwrap one level (so a deferred-alias output is decremented and
+      // followed) and follow the write-redirect chain to its resolved end (a
+      // pattern node reserves one result cell). The minting path keys the child
+      // result cell on the fully resolved redirect, so deriving from the same
+      // resolved spot yields the same `resultFor` identity the child's setup
+      // mints; the unresolved head of a multi-hop binding would be a different
+      // cell, pre-syncing the wrong owned-cell subtree.
+      const argumentLink = getMetaLink(resultCell, "argument") ??
+        resultCell.getAsNormalizedFullLink();
+      const unwrappedOutputs = unwrapOneLevelAndBindtoDoc(
+        this.runtime.cfc,
+        node.outputs,
+        argumentLink,
+        resultCell,
+      );
+      let spotLink: NormalizedFullLink | undefined;
+      try {
+        spotLink = firstResolvedOutputRedirect(
+          this.runtime,
+          tx,
+          unwrappedOutputs,
+          resultCell,
+        );
+      } catch (error) {
+        // A node shape that cannot be resolved contributes nothing rather than
+        // breaking the resume walk; log it so a resume that silently skips its
+        // owned-cell pre-sync is diagnosable.
+        logger.warn("resume-owned-cells", () => [
+          "skipping a sub-pattern node whose output redirect did not resolve",
+          error,
+        ]);
+        continue;
+      }
+      if (spotLink === undefined) continue;
+      let childResultCell = this.runtime.getCell(
+        targetSpace,
+        {
+          resultFor: {
+            space: spotLink.space,
+            id: spotLink.id,
+            path: [...spotLink.path],
+          },
+        },
+        childPattern.resultSchema,
+      );
+      if (childScope !== undefined && childScope !== "space") {
+        const childLink = childResultCell.getAsNormalizedFullLink();
+        childResultCell = this.runtime.getCellFromLink({
+          ...childLink,
+          scope: childScope,
+        });
+      }
+      this.collectResumeOwnedCells(
+        childPattern,
+        childResultCell,
+        out,
+        seen,
+        tx,
+      );
+    }
   }
 
   /**

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -750,13 +750,12 @@ export class Runtime {
     this.missingDocLoadKicks.add(key);
     const maybePromise = this.getCellFromLink(link).sync();
     if (maybePromise instanceof Promise) {
-      const promise = maybePromise.catch(() => {
-        // Allow a retry on failure (e.g. transient disconnect).
-        this.missingDocLoadKicks.delete(key);
-      }).finally(() => {
-        this.storageManager.removeCrossSpacePromise(promise);
-      }) as unknown as Promise<void>;
-      this.storageManager.addCrossSpacePromise(promise);
+      this.storageManager.trackUntilSettled(
+        maybePromise.catch(() => {
+          // Allow a retry on failure (e.g. transient disconnect).
+          this.missingDocLoadKicks.delete(key);
+        }),
+      );
     }
   }
 

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -167,6 +167,17 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
   removeCrossSpacePromise(promise: Promise<void>): void;
 
   /**
+   * Register a deferred async chain in the cross-space promise set so
+   * `Cell.pull()` and the scheduler's `idle()` await it, then drop it from the
+   * set once it settles. Until a chain is registered it is invisible to the
+   * convergence waiters: a pull can return before the chain has settled and
+   * observe held, not-yet-loaded state. This is the safe composition of
+   * `addCrossSpacePromise` and `removeCrossSpacePromise` — prefer it over
+   * wiring the self-removing `finally` by hand at each call site.
+   */
+  trackUntilSettled(work: Promise<unknown>): void;
+
+  /**
    * Number of cross-space promises currently pending (async loads of link
    * targets in other spaces, kicked during link resolution or read
    * traversal). Zero in steady state — `Cell.pull()` uses this to decide

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -743,6 +743,13 @@ export class StorageManager implements IStorageManager {
     this.#crossSpacePromises.delete(promise);
   }
 
+  trackUntilSettled(work: Promise<unknown>): void {
+    const tracked = work.finally(() =>
+      this.#crossSpacePromises.delete(tracked)
+    ) as Promise<void>;
+    this.#crossSpacePromises.add(tracked);
+  }
+
   pendingCrossSpacePromiseCount(): number {
     return this.#crossSpacePromises.size;
   }

--- a/packages/runner/test/list-builtin-edge-paths.test.ts
+++ b/packages/runner/test/list-builtin-edge-paths.test.ts
@@ -1,0 +1,630 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { OpaqueCell } from "@commonfabric/api";
+import { Identity } from "@commonfabric/identity";
+import type { Signer } from "@commonfabric/memory/interface";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { EmulatedStorageManager } from "../src/storage/v2-emulate.ts";
+import {
+  type Options,
+  type SessionFactory,
+  StorageManager as StorageManagerV2,
+} from "../src/storage/v2.ts";
+import { createBuilder } from "../src/builder/factory.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { Runtime } from "../src/runtime.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("list builtin edge paths");
+const space = signer.did();
+
+// These tests exercise edge paths in the three list builtins (map/filter/
+// flatMap) that the resume-preservation tests do not reach:
+//
+//   - The usesIndex re-run branch: a reused per-element run whose element keeps
+//     its identity (a cell link) but lands at a new index re-executes its op so
+//     the index argument it observes is current.
+//   - The non-array guard: a list input that resolves to a non-array value makes
+//     the reconcile throw.
+//
+// Both are driven against a live runtime (no resume needed): cell-link elements
+// give stable identity across a reorder, and a direct set() of a scalar list
+// drives the non-array path.
+
+describe("list builtin edge paths", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+  let lift: ReturnType<typeof createBuilder>["commonfabric"]["lift"];
+  let pattern: ReturnType<typeof createBuilder>["commonfabric"]["pattern"];
+
+  // An op pattern with no explicit argument schema runs in legacy mode, where
+  // inferListOpArgumentUsage reports every argument (element, index, array,
+  // params) as used. That makes usesIndex true, so a reused element that shifts
+  // position re-runs its op.
+  function indexUsingOp(
+    // deno-lint-ignore no-explicit-any
+    fn: (element: any, index: any) => any,
+  ) {
+    // deno-lint-ignore no-explicit-any
+    return pattern(({ element, index }: any) => fn(element, index));
+  }
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+    const { commonfabric } = createTrustedBuilder(runtime);
+    ({ lift, pattern } = commonfabric);
+  });
+
+  async function commitTx() {
+    if (tx.status().status !== "ready") {
+      return { ok: undefined, error: undefined };
+    }
+    runtime.prepareTxForCommit(tx);
+    return await tx.commit();
+  }
+
+  afterEach(async () => {
+    await commitTx();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("re-runs a reused map element when its index changes (usesIndex)", async () => {
+    // The op tags each element with the index it observed, so a reorder that
+    // keeps an element's identity but moves it must re-run that element to
+    // refresh the observed index.
+    const tagIndex = lift(
+      (input: { element: number; index: number }) =>
+        input.element * 100 + input.index,
+    );
+    const op = indexUsingOp((element, index) => tagIndex({ element, index }));
+
+    const cellA = runtime.getCell<number>(space, "m-a", undefined, tx);
+    cellA.withTx(tx).set(1);
+    const cellB = runtime.getCell<number>(space, "m-b", undefined, tx);
+    cellB.withTx(tx).set(2);
+    const cellC = runtime.getCell<number>(space, "m-c", undefined, tx);
+    cellC.withTx(tx).set(3);
+
+    const mapPattern = pattern<{ values: number[] }>(({ values }) => ({
+      values,
+      tagged: (values as unknown as OpaqueCell<number[]>).mapWithPattern(
+        // deno-lint-ignore no-explicit-any
+        op as any,
+        {},
+      ),
+    }));
+
+    const resultCell = runtime.getCell<
+      { values: number[]; tagged: number[] }
+    >(space, "map-index-rerun", undefined, tx);
+    const result = runtime.run(tx, mapPattern, {
+      values: [cellA, cellB, cellC],
+    }, resultCell);
+    await commitTx();
+    tx = runtime.edit();
+
+    await result.pull();
+    // element*100 + index: [1*100+0, 2*100+1, 3*100+2]
+    expect(result.key("tagged").get()).toEqual([100, 201, 302]);
+
+    // Reverse the list: [C, B, A]. Identity is stable (cell links), so each run
+    // is reused, but every element's index changed, forcing a re-run.
+    result.withTx(tx).key("values").set([cellC, cellB, cellA]);
+    await commitTx();
+    tx = runtime.edit();
+
+    await result.pull();
+    // [3*100+0, 2*100+1, 1*100+2]
+    expect(result.key("tagged").get()).toEqual([300, 201, 102]);
+  });
+
+  it("re-runs a reused filter element when its index changes (usesIndex)", async () => {
+    // Keep elements at even observed indices. A reorder changes which elements
+    // sit at even indices, so reused runs must re-evaluate their predicate.
+    const keepEven = lift(
+      (input: { element: number; index: number }) => input.index % 2 === 0,
+    );
+    const op = indexUsingOp((element, index) => keepEven({ element, index }));
+
+    const cellA = runtime.getCell<number>(space, "f-a", undefined, tx);
+    cellA.withTx(tx).set(10);
+    const cellB = runtime.getCell<number>(space, "f-b", undefined, tx);
+    cellB.withTx(tx).set(20);
+    const cellC = runtime.getCell<number>(space, "f-c", undefined, tx);
+    cellC.withTx(tx).set(30);
+
+    const filterPattern = pattern<{ values: number[] }>(({ values }) => ({
+      values,
+      evens: (values as unknown as OpaqueCell<number[]>).filterWithPattern(
+        // deno-lint-ignore no-explicit-any
+        op as any,
+        {},
+      ),
+    }));
+
+    const resultCell = runtime.getCell<
+      { values: number[]; evens: number[] }
+    >(space, "filter-index-rerun", undefined, tx);
+    const result = runtime.run(tx, filterPattern, {
+      values: [cellA, cellB, cellC],
+    }, resultCell);
+    await commitTx();
+    tx = runtime.edit();
+
+    await result.pull();
+    // indices 0,2 kept: A(10), C(30)
+    expect(result.key("evens").get()).toEqual([10, 30]);
+
+    // [C, A, B]: now C at 0 (kept), A at 1 (dropped), B at 2 (kept).
+    result.withTx(tx).key("values").set([cellC, cellA, cellB]);
+    await commitTx();
+    tx = runtime.edit();
+
+    await result.pull();
+    expect(result.key("evens").get()).toEqual([30, 20]);
+  });
+
+  it("re-runs a reused flatMap element when its index changes (usesIndex)", async () => {
+    // Each element contributes its index, so a reorder must re-run reused
+    // elements to refresh the contributed value.
+    const emitIndex = lift(
+      (input: { element: number; index: number }) => input.index,
+    );
+    const op = indexUsingOp((element, index) => emitIndex({ element, index }));
+
+    const cellA = runtime.getCell<number>(space, "fm-a", undefined, tx);
+    cellA.withTx(tx).set(7);
+    const cellB = runtime.getCell<number>(space, "fm-b", undefined, tx);
+    cellB.withTx(tx).set(8);
+    const cellC = runtime.getCell<number>(space, "fm-c", undefined, tx);
+    cellC.withTx(tx).set(9);
+
+    const flatMapPattern = pattern<{ values: number[] }>(({ values }) => ({
+      values,
+      indices: (values as unknown as OpaqueCell<number[]>).flatMapWithPattern(
+        // deno-lint-ignore no-explicit-any
+        op as any,
+        {},
+      ),
+    }));
+
+    const resultCell = runtime.getCell<
+      { values: number[]; indices: number[] }
+    >(space, "flatmap-index-rerun", undefined, tx);
+    const result = runtime.run(tx, flatMapPattern, {
+      values: [cellA, cellB, cellC],
+    }, resultCell);
+    await commitTx();
+    tx = runtime.edit();
+
+    await result.pull();
+    expect(result.key("indices").get()).toEqual([0, 1, 2]);
+
+    // Rotate: [B, C, A]. Identity stable, indices shift, so each reused run
+    // re-emits its new index.
+    result.withTx(tx).key("values").set([cellB, cellC, cellA]);
+    await commitTx();
+    tx = runtime.edit();
+
+    await result.pull();
+    expect(result.key("indices").get()).toEqual([0, 1, 2]);
+  });
+
+  it("spreads a flatMap element whose op returns an array", async () => {
+    // flatMap flattens one level: an op returning an array has its entries
+    // pushed individually into the aggregate.
+    const expand = lift((x: number) => [x, x + 1]);
+    const op = pattern(
+      // deno-lint-ignore no-explicit-any
+      ({ element }: any) => expand(element),
+    );
+
+    const flatMapPattern = pattern<{ values: number[] }>(({ values }) => ({
+      out: (values as unknown as OpaqueCell<number[]>).flatMapWithPattern(
+        // deno-lint-ignore no-explicit-any
+        op as any,
+        {},
+      ),
+    }));
+
+    const resultCell = runtime.getCell<{ out: number[] }>(
+      space,
+      "flatmap-spread",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, flatMapPattern, {
+      values: [1, 5],
+    }, resultCell);
+    await commitTx();
+    tx = runtime.edit();
+
+    await result.pull();
+    expect(result.key("out").get()).toEqual([1, 2, 5, 6]);
+  });
+
+  // The non-array guard fires inside the builtin's scheduler action, so the
+  // error surfaces through the scheduler's error handler rather than the
+  // pull() promise. Each variant seeds the list input as a scalar.
+  async function expectNonArrayThrow(
+    name: string,
+    build: (
+      values: OpaqueCell<number[]>,
+      // deno-lint-ignore no-explicit-any
+      op: any,
+      // deno-lint-ignore no-explicit-any
+    ) => any,
+    messageRe: RegExp,
+  ): Promise<void> {
+    const op = pattern(
+      // deno-lint-ignore no-explicit-any
+      ({ element }: any) => lift((x: number) => x)(element),
+    );
+    const opPattern = pattern<{ values: number[] }>(({ values }) => ({
+      // deno-lint-ignore no-explicit-any
+      out: build(values as unknown as OpaqueCell<number[]>, op as any),
+    }));
+    const resultCell = runtime.getCell<{ out: number[] }>(
+      space,
+      name,
+      undefined,
+      tx,
+    );
+    const errors: string[] = [];
+    runtime.scheduler.onError((e) => errors.push(String(e?.message ?? e)));
+    // Seed the input as a scalar, not an array.
+    const result = runtime.run(tx, opPattern, {
+      // deno-lint-ignore no-explicit-any
+      values: 42 as any,
+    }, resultCell);
+    await commitTx();
+    tx = runtime.edit();
+
+    try {
+      await result.pull();
+    } catch (_e) {
+      // The throw may also surface here depending on scheduling; either path is
+      // acceptable as long as the guard fired.
+      errors.push(String(_e));
+    }
+    await runtime.idle();
+
+    expect(errors.some((m) => messageRe.test(m))).toBe(true);
+  }
+
+  it("throws when a map list input is not an array", async () => {
+    // map reads the list with getRaw(), so a non-array input value survives to
+    // the guard. (filter/flatMap read through an array-typed schema that
+    // coerces a non-array to undefined, taking the empty-result path instead, so
+    // their guard is not reachable from a non-array input value.)
+    await expectNonArrayThrow(
+      "map-non-array",
+      (values, op) => values.mapWithPattern(op, {}),
+      /map currently only supports arrays/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resume harness for the owned-cell walk's nested-node branches.
+//
+// The walk (Runner.collectResumeOwnedCells) recurses through nested sub-pattern
+// nodes. A sub-pattern whose result cell carries a non-"space" cell scope makes
+// the walk re-scope the child result cell before recursing, the branch the
+// single-space resume tests do not reach. A cold resume drives the walk.
+// ---------------------------------------------------------------------------
+
+function plainLoopback(
+  server: MemoryV2Server.Server,
+): MemoryV2Client.Transport {
+  return MemoryV2Client.loopback(server);
+}
+
+class LoopbackSessionFactory implements SessionFactory {
+  constructor(private readonly getServer: () => MemoryV2Server.Server) {}
+  async create(spaceId: string, sgnr?: Signer) {
+    const client = await MemoryV2Client.connect({
+      transport: plainLoopback(this.getServer()),
+    });
+    const session = await client.mount(spaceId, {}, () => ({
+      invocation: {},
+      authorization: { principal: sgnr?.did() },
+    }));
+    return { client, session };
+  }
+}
+
+class LoopbackStorageManager extends StorageManagerV2 {
+  static make(
+    as: Identity,
+    server: MemoryV2Server.Server,
+  ): LoopbackStorageManager {
+    return new LoopbackStorageManager(
+      { as, memoryHost: new URL("memory://") } as Options,
+      server,
+    );
+  }
+  private constructor(options: Options, server: MemoryV2Server.Server) {
+    super(options, new LoopbackSessionFactory(() => server));
+  }
+  override registerSpaceHost(): boolean {
+    return false;
+  }
+}
+
+// An outer pattern that composes an inner sub-pattern scoped to "user" (via
+// `.asScope("user")`). The inner pattern keeps a derived internal cell (the
+// lifted scaled value), so the resume walk both re-scopes the child result cell
+// to "user" and has an owned cell to pre-sync for the nested node.
+const SCOPED_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { lift, pattern, UI } from 'commonfabric';",
+      "const scale = lift((n: number) => n * 10);",
+      "const inner = pattern<{ n: number }>(({ n }) => {",
+      "  return { scaled: scale(n) };",
+      "});",
+      // The explicit Output type omits UI, so the inferred result schema has no
+      // $UI property even though the result object carries one. That makes the
+      // resume walk's UI-presence branch sync the UI cell separately.
+      "export default pattern<{ seed: number }, { value: number }>(({ seed }) => {",
+      "  const child = inner.asScope('user')({ n: seed });",
+      "  return {",
+      "    value: child.scaled,",
+      "    [UI]: <div>{child.scaled}</div>,",
+      "  };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+describe("resume owned-cell walk: scoped sub-pattern", () => {
+  let server: MemoryV2Server.Server;
+  let sm1: LoopbackStorageManager;
+  let sm2: LoopbackStorageManager;
+
+  beforeEach(() => {
+    server = new MemoryV2Server.Server({
+      authorizeSessionOpen(message) {
+        const principal = (message.authorization as { principal?: unknown })
+          ?.principal;
+        return typeof principal === "string" ? principal : undefined;
+      },
+    });
+    sm1 = LoopbackStorageManager.make(signer, server);
+    sm2 = LoopbackStorageManager.make(signer, server);
+  });
+  afterEach(async () => {
+    await sm1?.close();
+    await sm2?.close();
+    await server?.close();
+  });
+
+  it("re-scopes a user-scoped nested sub-pattern across a cold resume", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm1,
+    });
+    const compiled1 = await rt1.patternManager.compilePattern(SCOPED_PROGRAM, {
+      space,
+    });
+    const tx0 = rt1.edit();
+    const rc1 = rt1.getCell<{ value: number }>(
+      space,
+      "scoped-owned-result",
+      compiled1.resultSchema,
+      tx0,
+    );
+    const h1 = rt1.run(tx0, compiled1, { seed: 4 }, rc1);
+    await tx0.commit();
+    for (let k = 0; k < 10; k++) {
+      await h1.pull();
+      await rt1.idle();
+    }
+    await rt1.patternManager.flushCompileCacheWrites();
+    await sm1.synced();
+    expect(rc1.key("value").get()).toBe(40);
+    rt1.scheduler.dispose();
+
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm2,
+    });
+    try {
+      await rt2.patternManager.compilePattern(SCOPED_PROGRAM, { space });
+      const tx = rt2.edit();
+      const rc2 = rt2.getCell<{ value: number }>(
+        space,
+        "scoped-owned-result",
+        compiled1.resultSchema,
+        tx,
+      );
+      await tx.commit();
+
+      const started = await rt2.start(rc2);
+      expect(started).toBe(true);
+
+      for (let k = 0; k < 10; k++) {
+        await rc2.pull();
+        await rt2.idle();
+      }
+      expect(rc2.key("value").get()).toBe(40);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-space link load kick (Runtime.ensureLinkedDocLoaded).
+//
+// A value read that follows a link to a target in ANOTHER space, whose doc is
+// absent from this session's replica, kicks an async load and registers it as a
+// cross-space promise so pull()'s convergence loop awaits it. Per-space server
+// queries cannot follow links across space boundaries, so the client fetches
+// the target itself. A reader session that never created the target drives the
+// kick.
+// ---------------------------------------------------------------------------
+
+const spaceH = signer.did(); // "home" — holds the link
+const spaceP = (await Identity.fromPassphrase("edge paths target P")).did();
+
+class SharedServerStorageManager extends EmulatedStorageManager {
+  static connectTo(
+    server: MemoryV2Server.Server,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
+  ): SharedServerStorageManager {
+    const manager = new SharedServerStorageManager(
+      { ...options, memoryHost: new URL("memory://") },
+      () => server,
+    );
+    manager.sharedServer = server;
+    return manager;
+  }
+  private sharedServer!: MemoryV2Server.Server;
+  protected override server(): MemoryV2Server.Server {
+    return this.sharedServer;
+  }
+}
+
+const CROSS_SPACE_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { handler, pattern, Writable } from 'commonfabric';",
+      "export const child = pattern<{ name: string }>(({ name }) => ({",
+      "  name,",
+      "  greeting: 'hello',",
+      "}));",
+      "type ChildOutput = { name: string; greeting: string };",
+      "const create = handler<",
+      "  { name?: string },",
+      "  { items: Writable<ChildOutput[]> }",
+      ">((event, { items }) => {",
+      `  items.push(child.inSpace("${spaceP}")({`,
+      "    name: event.name ?? 'Ada',",
+      "  }) as ChildOutput);",
+      "});",
+      "export default pattern(() => {",
+      "  const items = new Writable<ChildOutput[]>([]).for('items');",
+      "  return { items, create: create({ items }) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+const crossSpaceLinkListSchema = {
+  type: "array",
+  items: { type: "unknown", asCell: ["cell"] },
+  // deno-lint-ignore no-explicit-any
+} as any;
+
+describe("cross-space link load kick", () => {
+  let server: MemoryV2Server.Server;
+  let writerStorage: SharedServerStorageManager;
+  let readerStorage: SharedServerStorageManager;
+
+  beforeEach(() => {
+    server = new MemoryV2Server.Server({
+      authorizeSessionOpen(message) {
+        const principal = (message.authorization as { principal?: unknown })
+          ?.principal;
+        return typeof principal === "string" ? principal : undefined;
+      },
+    });
+    writerStorage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+    readerStorage = SharedServerStorageManager.connectTo(server, {
+      as: signer,
+    });
+  });
+  afterEach(async () => {
+    await writerStorage?.close();
+    await readerStorage?.close();
+    await server?.close();
+  });
+
+  it("kicks an async load for a cross-space link target and converges", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: writerStorage,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: readerStorage,
+    });
+    try {
+      // Writer: create the parent in H and the child in P, fully synced.
+      const tx1 = rt1.edit();
+      const parent = await rt1.patternManager.compilePattern(
+        CROSS_SPACE_PROGRAM,
+        { space: spaceH, tx: tx1 },
+      );
+      const resultCell1 = rt1.getCell<Record<string, unknown>>(
+        spaceH,
+        "edge-paths-cross-space-parent",
+        undefined,
+        tx1,
+      );
+      // deno-lint-ignore no-explicit-any
+      const r1 = rt1.run(tx1, parent as any, {}, resultCell1);
+      await tx1.commit();
+      await r1.pull();
+      r1.key("create").send({ name: "Ada" });
+      await r1.pull();
+      await rt1.idle();
+      // deno-lint-ignore no-explicit-any
+      const links = r1.key("items").asSchema(crossSpaceLinkListSchema)
+        .get() as any[];
+      expect(links.length).toBe(1);
+      expect(links[0].getAsNormalizedFullLink().space).toBe(spaceP);
+      await rt1.patternManager.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+      const parentLink = r1.getAsNormalizedFullLink();
+
+      // Reader: a fresh session whose replica never fetched space P. A deep
+      // whole-value pull of the linking parent's items goes through traverse's
+      // followPointer, which finds the cross-space child doc absent and kicks
+      // the async load via ensureLinkedDocLoaded; the convergence loop awaits
+      // it.
+      const parentCell = rt2.getCellFromLink(parentLink);
+      await parentCell.sync();
+      const itemsCell = parentCell.key("items");
+      await itemsCell.pull();
+      // deno-lint-ignore no-explicit-any
+      const items = itemsCell.get() as any[];
+      expect(Array.isArray(items)).toBe(true);
+      expect(items.length).toBe(1);
+      expect(items[0]?.name).toBe("Ada");
+
+      // Also read through the link by key path, and drain any kicked async load
+      // so the kick is observed within this test rather than leaking into the
+      // next one.
+      const childField = parentCell.key("items").key(0).key("name");
+      const pulled = await childField.pull();
+      expect(pulled).toBe("Ada");
+      await rt2.idle();
+      await rt2.storageManager.synced();
+      await rt2.idle();
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});

--- a/packages/runner/test/list-fresh-init.test.ts
+++ b/packages/runner/test/list-fresh-init.test.ts
@@ -1,0 +1,278 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import {
+  type Options,
+  type SessionFactory,
+  StorageManager,
+} from "../src/storage/v2.ts";
+import type { Signer } from "@commonfabric/memory/interface";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// Fresh-init seeding guard for the list builtins (filter/flatMap/map).
+//
+// The builtins no longer seed the result container with an explicit early
+// send([]) at container creation. A fresh (non-resume) reconcile instead seeds
+// the container via the `priorSlots === undefined` path and the reconcile's own
+// final write. This test pins that a brand-new builtin always produces a dense
+// array on its first run — never a stuck-undefined container — across an empty
+// input, an input where nothing matches, and one where some elements match. It
+// records every emission through a sink, so a container that regressed to
+// undefined after first becoming an array would be caught too.
+
+const signer = await Identity.fromPassphrase("list fresh init");
+const space = signer.did();
+
+function lb(s: MemoryV2Server.Server) {
+  return MemoryV2Client.loopback(s);
+}
+class F implements SessionFactory {
+  constructor(private gs: () => MemoryV2Server.Server) {}
+  async create(spaceId: string, sgnr?: Signer) {
+    const client = await MemoryV2Client.connect({ transport: lb(this.gs()) });
+    const session = await client.mount(spaceId, {}, () => ({
+      invocation: {},
+      authorization: { principal: sgnr?.did() },
+    }));
+    return { client, session };
+  }
+}
+class SM extends StorageManager {
+  static make(as: Identity, s: MemoryV2Server.Server) {
+    return new SM({ as, memoryHost: new URL("memory://") } as Options, s);
+  }
+  private constructor(o: Options, s: MemoryV2Server.Server) {
+    super(o, new F(() => s));
+  }
+  override registerSpaceHost(): boolean {
+    return false;
+  }
+}
+
+// Each call builds an isolated runtime over a fresh in-memory server, so every
+// run is genuinely a first run (no durable carryover to resume against).
+function runtime() {
+  const server = new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+  });
+  const sm = SM.make(signer, server);
+  const rt = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: sm,
+  });
+  return { rt, server };
+}
+
+const FILTER_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: { keep: boolean; label: string }[] }>(({ items }) => {",
+      "  return { out: items.filter((item) => item.keep) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+const FLATMAP_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: { keep: boolean; n: number }[] }>(({ items }) => {",
+      "  return { out: items.flatMap((item) => item.keep ? item.n : undefined) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+const MAP_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: { n: number }[] }>(({ items }) => {",
+      "  return { out: items.map((item) => item.n) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+type Row = { keep?: boolean; n?: number; label?: string };
+
+// Materialize one `out` snapshot to plain, comparable values while the runtime
+// is still live. `project` pulls a primitive out of each element — the identity
+// for flatMap/map (numbers), the label for filter (element cell references) — so
+// the result never leaves the runtime as a live query-result proxy (those break
+// structural equality and die after dispose). null marks an absent (undefined)
+// container, distinct from a seeded empty array.
+type Project = (x: unknown) => unknown;
+const snapshotWith = (project: Project) => (v: unknown): unknown[] | null =>
+  Array.isArray(v) ? (v as unknown[]).map(project) : v == null ? null : [NaN];
+
+// Run a fresh pattern, record every `out` emission projected to plain values,
+// and return the final value plus the full trajectory.
+async function runFresh(
+  program: RuntimeProgram,
+  id: string,
+  items: Row[],
+  project: Project,
+): Promise<{ final: unknown[] | null; trajectory: (unknown[] | null)[] }> {
+  const { rt, server } = runtime();
+  const snapshot = snapshotWith(project);
+  try {
+    const compiled = await rt.patternManager.compilePattern(program, { space });
+    const tx0 = rt.edit();
+    const rc = rt.getCell<{ out: unknown[] }>(
+      space,
+      id,
+      compiled.resultSchema,
+      tx0,
+    );
+    rt.run(tx0, compiled, { items }, rc);
+    await tx0.commit();
+
+    const trajectory: (unknown[] | null)[] = [];
+    const cancel = rc.key("out").sink((v) => {
+      trajectory.push(snapshot(v));
+    });
+
+    for (let k = 0; k < 10; k++) {
+      await rc.pull();
+      await rt.idle();
+      trajectory.push(snapshot(rc.key("out").get()));
+    }
+    cancel();
+    const final = snapshot(rc.key("out").get());
+    return { final, trajectory };
+  } finally {
+    await rt.dispose();
+    await server.close();
+  }
+}
+
+const IDENTITY: Project = (x) => x;
+const LABEL: Project = (x) => (x as { label?: string }).label;
+
+// Once `out` has been observed as an array, it must never be observed as
+// undefined again — a fresh container that blinked back to absent would be a
+// seeding regression.
+function assertNoUndefinedAfterArray(trajectory: (unknown[] | null)[]): void {
+  let sawArray = false;
+  for (const t of trajectory) {
+    if (Array.isArray(t)) sawArray = true;
+    else if (sawArray && t === null) {
+      throw new Error(
+        `container regressed to undefined after being an array: ${
+          JSON.stringify(trajectory)
+        }`,
+      );
+    }
+  }
+}
+
+describe("list builtin fresh-init seeding", () => {
+  it("filter seeds [] on a fresh run over an empty input", async () => {
+    const { final, trajectory } = await runFresh(
+      FILTER_PROGRAM,
+      "fi-filter-empty",
+      [],
+      LABEL,
+    );
+    expect(final).toEqual([]);
+    assertNoUndefinedAfterArray(trajectory);
+  });
+
+  it("filter seeds [] on a fresh run where nothing matches", async () => {
+    const items = [
+      { keep: false, label: "a" },
+      { keep: false, label: "b" },
+      { keep: false, label: "c" },
+    ];
+    const { final, trajectory } = await runFresh(
+      FILTER_PROGRAM,
+      "fi-filter-none",
+      items,
+      LABEL,
+    );
+    expect(final).toEqual([]);
+    assertNoUndefinedAfterArray(trajectory);
+  });
+
+  it("filter produces the matching subset on a fresh run", async () => {
+    const items = [
+      { keep: true, label: "a" },
+      { keep: false, label: "b" },
+      { keep: true, label: "c" },
+    ];
+    const { final, trajectory } = await runFresh(
+      FILTER_PROGRAM,
+      "fi-filter-some",
+      items,
+      LABEL,
+    );
+    expect(final).toEqual(["a", "c"]);
+    assertNoUndefinedAfterArray(trajectory);
+  });
+
+  it("flatMap seeds [] on a fresh run over an empty input", async () => {
+    const { final, trajectory } = await runFresh(
+      FLATMAP_PROGRAM,
+      "fi-flatmap-empty",
+      [],
+      IDENTITY,
+    );
+    expect(final).toEqual([]);
+    assertNoUndefinedAfterArray(trajectory);
+  });
+
+  it("flatMap produces the kept values on a fresh run", async () => {
+    const items = [
+      { keep: true, n: 1 },
+      { keep: false, n: 2 },
+      { keep: true, n: 3 },
+    ];
+    const { final, trajectory } = await runFresh(
+      FLATMAP_PROGRAM,
+      "fi-flatmap-some",
+      items,
+      IDENTITY,
+    );
+    expect(final).toEqual([1, 3]);
+    assertNoUndefinedAfterArray(trajectory);
+  });
+
+  it("map seeds [] on a fresh run over an empty input", async () => {
+    const { final, trajectory } = await runFresh(
+      MAP_PROGRAM,
+      "fi-map-empty",
+      [],
+      IDENTITY,
+    );
+    expect(final).toEqual([]);
+    assertNoUndefinedAfterArray(trajectory);
+  });
+
+  it("map produces the mapped values on a fresh run", async () => {
+    const items = [{ n: 1 }, { n: 2 }, { n: 3 }];
+    const { final, trajectory } = await runFresh(
+      MAP_PROGRAM,
+      "fi-map-some",
+      items,
+      IDENTITY,
+    );
+    expect(final).toEqual([1, 2, 3]);
+    assertNoUndefinedAfterArray(trajectory);
+  });
+});

--- a/packages/runner/test/list-resume-container-defer.test.ts
+++ b/packages/runner/test/list-resume-container-defer.test.ts
@@ -1,0 +1,348 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import type { Signer } from "@commonfabric/memory/interface";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import {
+  type Options,
+  type SessionFactory,
+  StorageManager,
+} from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { Cell } from "../src/cell.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// Container-defer guard for the list builtins (filter / flatMap / map).
+//
+// On a cold resume the coordinator reconcile for one of these builtins reads its
+// result container. The reconcile runs after the resume pre-sync settles, so a
+// container that was persisted in a prior runtime is loaded before the reconcile
+// reads it. The defer guard handles the other case: a container that has no
+// durable document at all. Reading it returns undefined, and rather than
+// reconcile against that absent value (which would write a stale-basis result
+// that conflicts on commit and re-runs in a loop), the builtin pulls the
+// container and defers. Once the pull settles and the container is still absent,
+// the builtin seeds an empty array so the coordinator is not wedged waiting for
+// a value that will never arrive. The per-element results then re-trigger the
+// reconcile, which rebuilds the aggregate against the confirmed per-element
+// values.
+//
+// This drives that path deterministically. A first runtime builds and persists
+// the durable aggregate, and its result container's document id is resolved from
+// the result cell. A second (resuming) runtime uses a loopback transport that
+// removes that one document from every resume sync, modeling a container that was
+// never persisted. Everything else — the input list and the per-element result
+// docs — still loads, so the builtin recovers the aggregate from the per-element
+// values after seeding the empty container. The test asserts convergence to the
+// correct aggregate.
+
+const signer = await Identity.fromPassphrase("list resume container defer");
+const space = signer.did();
+
+// Doc ids withheld from the resuming runtime's syncs. Populated from runtime A
+// once the container cell is resolved.
+const droppedDocIds = new Set<string>();
+
+// Rewrite a sync payload, removing any upsert for a withheld doc id. Payloads
+// are `<prefix>:<json>`; anything that does not parse or carries no matching
+// upsert passes through untouched.
+function stripDroppedUpserts(payload: string): {
+  payload: string;
+  removed: number;
+} {
+  if (!payload.includes('"upserts"')) return { payload, removed: 0 };
+  let matches = false;
+  for (const id of droppedDocIds) {
+    if (payload.includes(id)) {
+      matches = true;
+      break;
+    }
+  }
+  if (!matches) return { payload, removed: 0 };
+  const colon = payload.indexOf(":");
+  if (colon < 0) return { payload, removed: 0 };
+  const prefix = payload.slice(0, colon + 1);
+  let obj: any;
+  try {
+    obj = JSON.parse(payload.slice(colon + 1));
+  } catch {
+    return { payload, removed: 0 };
+  }
+  const sync = obj?.ok?.sync ?? obj?.effect;
+  if (!sync || !Array.isArray(sync.upserts)) return { payload, removed: 0 };
+  const before = sync.upserts.length;
+  sync.upserts = sync.upserts.filter(
+    (u: any) => !droppedDocIds.has(String(u?.id)),
+  );
+  const removed = before - sync.upserts.length;
+  if (removed === 0) return { payload, removed: 0 };
+  return { payload: prefix + JSON.stringify(obj), removed };
+}
+
+function droppingLoopback(
+  server: MemoryV2Server.Server,
+  active: () => boolean,
+  onRemove: (n: number) => void,
+): MemoryV2Client.Transport {
+  const inner = MemoryV2Client.loopback(server);
+  return {
+    send: (p: string) => inner.send(p),
+    close: () => inner.close(),
+    setReceiver: (r: (p: string) => void) => {
+      inner.setReceiver((payload: string) => {
+        if (active()) {
+          const { payload: rewritten, removed } = stripDroppedUpserts(payload);
+          if (removed > 0) {
+            onRemove(removed);
+            r(rewritten);
+            return;
+          }
+        }
+        r(payload);
+      });
+    },
+    setCloseReceiver: (r: (e?: Error) => void) => inner.setCloseReceiver?.(r),
+  };
+}
+
+class DroppingSessionFactory implements SessionFactory {
+  constructor(
+    private readonly getServer: () => MemoryV2Server.Server,
+    private readonly active: () => boolean,
+    private readonly onRemove: (n: number) => void,
+  ) {}
+  async create(spaceId: string, sgnr?: Signer) {
+    const client = await MemoryV2Client.connect({
+      transport: droppingLoopback(this.getServer(), this.active, this.onRemove),
+    });
+    const session = await client.mount(spaceId, {}, () => ({
+      invocation: {},
+      authorization: { principal: sgnr?.did() },
+    }));
+    return { client, session };
+  }
+}
+
+class DroppingStorageManager extends StorageManager {
+  static make(
+    as: Identity,
+    server: MemoryV2Server.Server,
+    active: () => boolean,
+    onRemove: (n: number) => void = () => {},
+  ): DroppingStorageManager {
+    return new DroppingStorageManager(
+      { as, memoryHost: new URL("memory://") } as Options,
+      server,
+      active,
+      onRemove,
+    );
+  }
+  private constructor(
+    options: Options,
+    server: MemoryV2Server.Server,
+    active: () => boolean,
+    onRemove: (n: number) => void,
+  ) {
+    super(
+      options,
+      new DroppingSessionFactory(() => server, active, onRemove),
+    );
+  }
+  override registerSpaceHost(): boolean {
+    return false;
+  }
+}
+
+const FILTER_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: { keep: boolean; label: string }[] }>(({ items }) => {",
+      "  return { kept: items.filter((item) => item.keep) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+const FLATMAP_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: { keep: boolean; n: number }[] }>(({ items }) => {",
+      "  return { values: items.flatMap((item) => item.keep ? item.n : undefined) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+const MAP_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: { n: number }[] }>(({ items }) => {",
+      "  return { doubled: items.map((item) => item.n * 2) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+const FILTER_ITEMS = [
+  { keep: true, label: "a" },
+  { keep: true, label: "b" },
+  { keep: false, label: "c" },
+  { keep: true, label: "d" },
+];
+const FLATMAP_ITEMS = [
+  { keep: true, n: 1 },
+  { keep: false, n: 2 },
+  { keep: true, n: 3 },
+  { keep: true, n: 4 },
+];
+const MAP_ITEMS = [{ n: 1 }, { n: 2 }, { n: 3 }];
+
+describe("list builtin resume container defer", () => {
+  let server: MemoryV2Server.Server;
+  let sm1: DroppingStorageManager;
+  let sm2: DroppingStorageManager;
+  let dropActive: boolean;
+  let removed: number;
+
+  beforeEach(() => {
+    dropActive = false;
+    removed = 0;
+    droppedDocIds.clear();
+    server = new MemoryV2Server.Server({
+      authorizeSessionOpen(message) {
+        const principal = (message.authorization as { principal?: unknown })
+          ?.principal;
+        return typeof principal === "string" ? principal : undefined;
+      },
+    });
+    sm1 = DroppingStorageManager.make(signer, server, () => false);
+    sm2 = DroppingStorageManager.make(
+      signer,
+      server,
+      () => dropActive,
+      (n) => removed += n,
+    );
+  });
+  afterEach(async () => {
+    await sm1?.close();
+    await sm2?.close();
+    await server?.close();
+  });
+
+  async function runResumeWithMissingContainer<T>(
+    program: RuntimeProgram,
+    items: unknown,
+    resultKey: string,
+    resultField: string,
+    read: (rc: Cell<any>) => T,
+    expected: T,
+  ): Promise<void> {
+    // CREATE (runtime A): build and persist the durable aggregate, then resolve
+    // the result container's own document id so the resume can withhold it.
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm1,
+    });
+    const compiled1 = await rt1.patternManager.compilePattern(program, {
+      space,
+    });
+    const tx0 = rt1.edit();
+    const rc1 = rt1.getCell(space, resultKey, compiled1.resultSchema, tx0);
+    const h1 = rt1.run(tx0, compiled1, { items }, rc1);
+    await tx0.commit();
+    for (let k = 0; k < 10; k++) {
+      await h1.pull();
+      await rt1.idle();
+    }
+    await rt1.patternManager.flushCompileCacheWrites();
+    await sm1.synced();
+    expect(read(rc1)).toEqual(expected);
+
+    // The result field's cell write-redirects to the builtin's container; the
+    // resolved cell is the container document to withhold on resume.
+    const resolveTx = rt1.edit();
+    const container = rc1.key(resultField).withTx(resolveTx).resolveAsCell();
+    droppedDocIds.add(String(container.getAsNormalizedFullLink().id));
+    resolveTx.abort("resolve container id");
+    expect(droppedDocIds.size).toBe(1);
+    rt1.scheduler.dispose();
+
+    // RESUME (runtime B): the transport removes the container document from every
+    // sync, so the coordinator reconcile reads it undefined and takes the
+    // defer-then-seed recovery path.
+    dropActive = true;
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm2,
+    });
+    try {
+      await rt2.patternManager.compilePattern(program, { space });
+      const tx = rt2.edit();
+      const rc2 = rt2.getCell(space, resultKey, compiled1.resultSchema, tx);
+      await tx.commit();
+
+      const started = await rt2.start(rc2);
+      expect(started).toBe(true);
+
+      for (let k = 0; k < 25; k++) {
+        await rc2.pull();
+        await rt2.idle();
+      }
+
+      // The container document was actually withheld; otherwise the defer path
+      // is not exercised and the assertion below would pass vacuously.
+      expect(removed).toBeGreaterThan(0);
+      // Converges to the durable aggregate despite the missing container.
+      expect(read(rc2)).toEqual(expected);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  }
+
+  it("recovers a filter result whose container is missing on resume", async () => {
+    await runResumeWithMissingContainer(
+      FILTER_PROGRAM,
+      FILTER_ITEMS,
+      "cd-filter",
+      "kept",
+      (rc) =>
+        (rc.key("kept").getAsQueryResult() ?? []).map(
+          (x: { label: string }) => x.label,
+        ),
+      ["a", "b", "d"],
+    );
+  });
+
+  it("recovers a flatMap result whose container is missing on resume", async () => {
+    await runResumeWithMissingContainer(
+      FLATMAP_PROGRAM,
+      FLATMAP_ITEMS,
+      "cd-flatmap",
+      "values",
+      (rc) => rc.key("values").getAsQueryResult() ?? [],
+      [1, 3, 4],
+    );
+  });
+
+  it("recovers a map result whose container is missing on resume", async () => {
+    await runResumeWithMissingContainer(
+      MAP_PROGRAM,
+      MAP_ITEMS,
+      "cd-map",
+      "doubled",
+      (rc) => rc.key("doubled").getAsQueryResult() ?? [],
+      [2, 4, 6],
+    );
+  });
+});

--- a/packages/runner/test/list-resume-deferred-settle.test.ts
+++ b/packages/runner/test/list-resume-deferred-settle.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("list-resume-deferred-settle");
+const space = signer.did();
+
+// Resume-time deferral path in the map/filter/flatMap builtins.
+//
+// When a builtin's per-element runs are sync-gated on resume (awaitSync), the
+// first reconcile after a cold start defers those runs until storage sync
+// completes. The hard case to reach is when the durable result container is
+// already loaded (so the builtin keeps its prior identity) while the input list
+// reads empty on that first reconcile, because the list lives deep inside a
+// larger persisted document that hydrates only after the first reconcile.
+//
+// This mirrors the home-favorites shape: a Default empty-list nested several
+// levels down in the pattern's state, populated by handler calls in the first
+// runtime rather than by the run() argument. On resume in a fresh runtime the
+// container is present but the nested list arrives late, so the builtin runs its
+// deferred per-element settle path and must still converge to the right
+// aggregate.
+const RESULT_CAUSE = "list-resume-deferred-settle result cell";
+
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        "import { Cell, Default, handler, pattern } from 'commonfabric';",
+        "",
+        "interface Entry { value: number }",
+        "",
+        "interface Bucket {",
+        "  items: Entry[] | Default<[]>;",
+        "  opt?: Entry[];",
+        "}",
+        "interface Level2 { bucket: Bucket }",
+        "interface Level1 { inner: Level2 }",
+        "",
+        "interface Input {",
+        "  store:",
+        "    | Level1",
+        "    | Default<{ inner: { bucket: { items: []; opt?: Entry[] } } }>;",
+        "}",
+        "",
+        "const addEntry = handler<{ value: number }, { items: Cell<Entry[]> }>(",
+        "  ({ value }, { items }) => {",
+        "    items.set([...items.get(), { value }]);",
+        "  },",
+        ");",
+        "",
+        "const reverseEntries = handler<unknown, { items: Cell<Entry[]> }>(",
+        "  (_event, { items }) => {",
+        "    items.set([...items.get()].reverse());",
+        "  },",
+        ");",
+        "",
+        "const seedOpt = handler<unknown, { opt: Cell<Entry[] | undefined> }>(",
+        "  (_event, { opt }) => {",
+        "    opt.set([{ value: 6 }, { value: 7 }]);",
+        "  },",
+        ");",
+        "",
+        "const clearOpt = handler<unknown, { opt: Cell<Entry[] | undefined> }>(",
+        "  (_event, { opt }) => {",
+        "    opt.set(undefined);",
+        "  },",
+        ");",
+        "",
+        "export default pattern<Input, any>(({ store }) => {",
+        "  const items = store.inner.bucket.items;",
+        "  const optRef = store.inner.bucket.opt;",
+        "  const opt = optRef as Entry[];",
+        "  const doubled = items.map((e) => ({ value: e.value * 2 }));",
+        "  const positioned = items.map((e, i) => ({ value: e.value, at: i }));",
+        "  const evens = items.filter((e) => e.value % 2 === 0);",
+        "  const spread = items.flatMap((e) => [e.value, e.value]);",
+        "  const optDoubled = opt.map((e) => ({ value: e.value * 2 }));",
+        "  const optEvens = opt.filter((e) => e.value % 2 === 0);",
+        "  const optSpread = opt.flatMap((e) => [e.value, e.value]);",
+        "  return {",
+        "    add: addEntry({ items }),",
+        "    reverse: reverseEntries({ items }),",
+        "    seed: seedOpt({ opt: optRef }),",
+        "    clear: clearOpt({ opt: optRef }),",
+        "    doubled,",
+        "    positioned,",
+        "    evens,",
+        "    spread,",
+        "    optDoubled,",
+        "    optEvens,",
+        "    optSpread,",
+        "  };",
+        "});",
+      ].join("\n"),
+    },
+  ],
+};
+
+describe("list builtins defer-settle when their input hydrates after resume", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  const newRuntime = () =>
+    new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+  });
+  afterEach(async () => {
+    await storageManager?.close();
+  });
+
+  it("converges the deep-nested aggregate after a cold resume", async () => {
+    const rt1 = newRuntime();
+    // Session 1: compile + run, then populate the nested list via the handler
+    // (not via the run() argument), so the list is durable but lives deep
+    // inside the pattern's own state document.
+    const tx1 = rt1.edit();
+    const pm1 = rt1.patternManager;
+    const cold = await pm1.compilePattern(PROGRAM, { space, tx: tx1 });
+    const resultCell1 = rt1.getCell<Record<string, unknown>>(
+      space,
+      RESULT_CAUSE,
+      undefined,
+      tx1,
+    );
+    const r1 = rt1.run(tx1, cold, {}, resultCell1);
+    await tx1.commit();
+    await r1.pull();
+
+    for (const value of [1, 2, 3, 4]) {
+      r1.key("add").send({ value });
+      await r1.pull();
+      await rt1.idle();
+    }
+
+    // Reorder the existing elements: this drives the index-changed re-run branch
+    // in map (the same element cell reappears at a new position), and leaves a
+    // durable reversed order for the resume to converge to.
+    r1.key("reverse").send({});
+    await r1.pull();
+    await rt1.idle();
+
+    // Drive the optional list through populated -> undefined: seeding creates
+    // per-element runs, clearing back to undefined exercises the builtins'
+    // undefined-input branch (which stops those runs and resets the result to
+    // []). The durable end state leaves opt undefined.
+    r1.key("seed").send({});
+    await r1.pull();
+    await rt1.idle();
+    r1.key("clear").send({});
+    await r1.pull();
+    await rt1.idle();
+
+    const live = r1.getAsQueryResult() as {
+      doubled: { value: number }[];
+      positioned: { value: number; at: number }[];
+      evens: { value: number }[];
+      spread: number[];
+      optDoubled: { value: number }[];
+      optEvens: { value: number }[];
+      optSpread: number[];
+    };
+    expect(live.doubled.map((e) => e.value)).toEqual([8, 6, 4, 2]);
+    expect(live.positioned).toEqual([
+      { value: 4, at: 0 },
+      { value: 3, at: 1 },
+      { value: 2, at: 2 },
+      { value: 1, at: 3 },
+    ]);
+    expect(live.evens.map((e) => e.value)).toEqual([4, 2]);
+    expect(live.spread).toEqual([4, 4, 3, 3, 2, 2, 1, 1]);
+    expect(live.optDoubled).toEqual([]);
+    expect(live.optEvens).toEqual([]);
+    expect(live.optSpread).toEqual([]);
+
+    await pm1.flushCompileCacheWrites();
+    await rt1.storageManager.synced();
+
+    // Session 2: a fresh runtime cold-resumes the same result cell. The result
+    // container persists, but the nested list hydrates only after the first
+    // reconcile, exercising the builtins' deferred per-element settle path.
+    const rt2 = newRuntime();
+    try {
+      const tx2 = rt2.edit();
+      const resultCell2 = rt2.getCell<Record<string, unknown>>(
+        space,
+        RESULT_CAUSE,
+        undefined,
+        tx2,
+      );
+      await tx2.commit();
+
+      await resultCell2.sync();
+      const started = await rt2.start(resultCell2);
+      expect(started).toBe(true);
+
+      for (let k = 0; k < 8; k++) {
+        await resultCell2.pull();
+        await rt2.idle();
+      }
+
+      const resumed = resultCell2.getAsQueryResult() as {
+        doubled: { value: number }[];
+        positioned: { value: number; at: number }[];
+        evens: { value: number }[];
+        spread: number[];
+        optDoubled: { value: number }[];
+        optEvens: { value: number }[];
+        optSpread: number[];
+      };
+      expect(resumed.doubled.map((e) => e.value)).toEqual([8, 6, 4, 2]);
+      expect(resumed.positioned).toEqual([
+        { value: 4, at: 0 },
+        { value: 3, at: 1 },
+        { value: 2, at: 2 },
+        { value: 1, at: 3 },
+      ]);
+      expect(resumed.evens.map((e) => e.value)).toEqual([4, 2]);
+      expect(resumed.spread).toEqual([4, 4, 3, 3, 2, 2, 1, 1]);
+      expect(resumed.optDoubled).toEqual([]);
+      expect(resumed.optEvens).toEqual([]);
+      expect(resumed.optSpread).toEqual([]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});

--- a/packages/runner/test/list-resume-input-settle.test.ts
+++ b/packages/runner/test/list-resume-input-settle.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import type { Signer } from "@commonfabric/memory/interface";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import {
+  type Options,
+  type SessionFactory,
+  StorageManager,
+} from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// awaitInputThenSettle path in the list builtins (filter/flatMap/map).
+//
+// On a resume reconcile the builtin can find its durable result container
+// already loaded and non-empty (priorLen > 0) while the input list reads empty
+// or undefined. Writing [] then would clobber the durable aggregate before the
+// input is confirmed, so the builtin holds the durable value and awaits the
+// input, clearing the result only once the input confirms genuinely empty
+// (otherwise re-reconciling and converging).
+//
+// This drives that path with a durable state that is inconsistent the way a
+// stale container is: the first runtime builds a non-empty result, then — with
+// the builtin's action stopped so it cannot react — sets the input list to []
+// and persists that. On resume the reconcile reads priorLen > 0 with an empty
+// input, takes awaitInputThenSettle, and settles the result to [].
+
+const signer = await Identity.fromPassphrase("list resume input settle");
+const space = signer.did();
+
+function loopback(s: MemoryV2Server.Server) {
+  return MemoryV2Client.loopback(s);
+}
+class F implements SessionFactory {
+  constructor(private gs: () => MemoryV2Server.Server) {}
+  async create(id: string, s?: Signer) {
+    const client = await MemoryV2Client.connect({
+      transport: loopback(this.gs()),
+    });
+    const session = await client.mount(id, {}, () => ({
+      invocation: {},
+      authorization: { principal: s?.did() },
+    }));
+    return { client, session };
+  }
+}
+class SM extends StorageManager {
+  static make(as: Identity, s: MemoryV2Server.Server) {
+    return new SM({ as, memoryHost: new URL("memory://") } as Options, s);
+  }
+  private constructor(o: Options, s: MemoryV2Server.Server) {
+    super(o, new F(() => s));
+  }
+  override registerSpaceHost(): boolean {
+    return false;
+  }
+}
+
+// Each pattern returns `items` too, so the test can overwrite the input list
+// through the result cell after the builtin's action is stopped.
+const FILTER_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: { keep: boolean; label: string }[] }>(({ items }) => {",
+      "  return { items, kept: items.filter((item) => item.keep) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+const FLATMAP_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: { keep: boolean; n: number }[] }>(({ items }) => {",
+      "  return { items, values: items.flatMap((item) => item.keep ? item.n : undefined) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+const MAP_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: { n: number }[] }>(({ items }) => {",
+      "  return { items, doubled: items.map((item) => item.n * 2) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+describe("list builtin resume input-settle", () => {
+  let server: MemoryV2Server.Server;
+
+  beforeEach(() => {
+    server = new MemoryV2Server.Server({
+      authorizeSessionOpen(message) {
+        const principal = (message.authorization as { principal?: unknown })
+          ?.principal;
+        return typeof principal === "string" ? principal : undefined;
+      },
+    });
+  });
+  afterEach(async () => {
+    await server.close();
+  });
+
+  async function run(
+    program: RuntimeProgram,
+    id: string,
+    field: string,
+    items: unknown[],
+    builtValue: unknown[],
+  ): Promise<void> {
+    const sm1 = SM.make(signer, server);
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm1,
+    });
+    const compiled = await rt1.patternManager.compilePattern(program, {
+      space,
+    });
+    const tx0 = rt1.edit();
+    const rc1 = rt1.getCell<Record<string, unknown[]>>(
+      space,
+      id,
+      compiled.resultSchema,
+      tx0,
+    );
+    rt1.run(tx0, compiled, { items }, rc1);
+    await tx0.commit();
+    for (let k = 0; k < 10; k++) {
+      await rc1.pull();
+      await rt1.idle();
+    }
+    expect(rc1.key(field).getAsQueryResult() ?? []).toEqual(builtValue);
+
+    // Stop the builtin's action, then overwrite the input list with [] so the
+    // durable container stays non-empty while the input is empty.
+    rt1.scheduler.dispose();
+    const tx1 = rt1.edit();
+    rc1.withTx(tx1).key("items").set([]);
+    await tx1.commit();
+    await rt1.patternManager.flushCompileCacheWrites();
+    await sm1.synced();
+    await rt1.dispose();
+
+    const sm2 = SM.make(signer, server);
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm2,
+    });
+    try {
+      await rt2.patternManager.compilePattern(program, { space });
+      const tx = rt2.edit();
+      const rc2 = rt2.getCell<Record<string, unknown[]>>(
+        space,
+        id,
+        compiled.resultSchema,
+        tx,
+      );
+      await tx.commit();
+      const started = await rt2.start(rc2);
+      expect(started).toBe(true);
+      for (let k = 0; k < 20; k++) {
+        await rc2.pull();
+        await rt2.idle();
+      }
+      // The container is held while the input confirms, then settled to [] —
+      // converging on the confirmed empty input rather than the stale value.
+      expect(rc2.key(field).getAsQueryResult() ?? []).toEqual([]);
+    } finally {
+      await rt2.dispose();
+    }
+  }
+
+  it("filter settles its stale container against a confirmed-empty input", async () => {
+    await run(
+      FILTER_PROGRAM,
+      "is-filter",
+      "kept",
+      [{ keep: true, label: "a" }, { keep: true, label: "b" }],
+      [{ keep: true, label: "a" }, { keep: true, label: "b" }],
+    );
+  });
+
+  it("flatMap settles its stale container against a confirmed-empty input", async () => {
+    await run(
+      FLATMAP_PROGRAM,
+      "is-flatmap",
+      "values",
+      [{ keep: true, n: 1 }, { keep: true, n: 2 }],
+      [1, 2],
+    );
+  });
+
+  it("map settles its stale container against a confirmed-empty input", async () => {
+    await run(
+      MAP_PROGRAM,
+      "is-map",
+      "doubled",
+      [{ n: 1 }, { n: 2 }, { n: 3 }],
+      [2, 4, 6],
+    );
+  });
+});

--- a/packages/runner/test/list-resume-preserve.test.ts
+++ b/packages/runner/test/list-resume-preserve.test.ts
@@ -337,6 +337,40 @@ const FLATMAP_SKIP_PROGRAM: RuntimeProgram = {
 };
 const FLATMAP_SKIP_EXPECTED = [1, 2, 4, 5, 7, 8]; // omits 3 and 6 (non-keep)
 
+// As above but the op returns an array, which flatMap flattens one level into
+// the aggregate. This drives the array-spread branch of the flatMap
+// contribution that the scalar cases above do not reach.
+const FLATMAP_SPREAD_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: { keep: boolean; n: number; label: string }[] }>(({ items }) => {",
+      "  return { values: items.flatMap((item) => [item.n, item.n + 100]) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+const FLATMAP_SPREAD_EXPECTED = [
+  1,
+  101,
+  2,
+  102,
+  3,
+  103,
+  4,
+  104,
+  5,
+  105,
+  6,
+  106,
+  7,
+  107,
+  8,
+  108,
+];
+
 const numbersOf = (v: unknown): number[] | null =>
   Array.isArray(v) ? (v as number[]) : v == null ? null : [NaN];
 
@@ -466,6 +500,14 @@ describe("flatMap builtin resume preservation", () => {
       FLATMAP_SKIP_PROGRAM,
       FLATMAP_ITEMS,
       FLATMAP_SKIP_EXPECTED,
+    );
+  });
+
+  it("spreads a flatMap element whose op returns an array across a resume", async () => {
+    await runFlatMapResume(
+      FLATMAP_SPREAD_PROGRAM,
+      FLATMAP_ITEMS,
+      FLATMAP_SPREAD_EXPECTED,
     );
   });
 });

--- a/packages/runner/test/list-resume-preserve.test.ts
+++ b/packages/runner/test/list-resume-preserve.test.ts
@@ -1,0 +1,471 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import type { Signer } from "@commonfabric/memory/interface";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import {
+  type Options,
+  type SessionFactory,
+  StorageManager,
+} from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// Resume preservation guard for the list builtins (filter/flatMap).
+//
+// On a reload the result container of a `filter` can already hold its durable
+// non-empty value while the per-element predicate result cells are still
+// streaming in from storage. While a predicate cell reads `undefined` (its
+// value not yet arrived), the coordinator's reconcile treats the element as
+// excluded and republishes a shrunk aggregate, overwriting the durable list
+// with a partial/empty array — the user-visible reload flicker where a
+// populated list blinks to empty and refills (e.g. the Lunch Poll vote swatches
+// going 35 -> 0 -> refill). The correct behavior: do not let a per-element run
+// whose result is still pending clobber a known durable aggregate; preserve the
+// prior value until the children settle, then reconcile normally (so a child
+// that genuinely settles falsy/undefined is still excluded — convergence, not
+// freeze).
+//
+// The window is timing-dependent, so this test forces it deterministically: a
+// loopback transport delays delivery of the per-element predicate documents
+// (boolean-valued) relative to everything else, modeling a real reload where the
+// per-element results rehydrate after the aggregate container has loaded. The
+// container's `kept` entries are `{ keep, label }` objects, so the boolean
+// predicate documents are cleanly separable from the container document. The
+// test asserts that the `kept` list is never observed as empty or a strict
+// shrink during the resume window.
+
+const signer = await Identity.fromPassphrase("list resume preserve");
+const space = signer.did();
+
+// Per-element result docs are separated from the aggregate container by the
+// schema type their query carries. A `filter` predicate result is a boolean and
+// its sync carries `"type":"boolean"`; a `flatMap` op result here is a number
+// (the container's own query carries no scalar item type, only `asCell` slots),
+// so the two builtins pass distinct matchers below.
+const FILTER_CHILD_DOC = /"type":"boolean"/;
+const FLATMAP_CHILD_DOC = /"type":"number"/;
+
+function delayingLoopback(
+  server: MemoryV2Server.Server,
+  childDelayMs: number,
+  childDoc: RegExp,
+  onDelay: () => void,
+): MemoryV2Client.Transport {
+  const inner = MemoryV2Client.loopback(server);
+  return {
+    send: (p: string) => inner.send(p),
+    close: () => inner.close(),
+    setReceiver: (r: (p: string) => void) => {
+      inner.setReceiver((payload: string) => {
+        if (childDelayMs > 0 && childDoc.test(payload)) {
+          onDelay();
+          setTimeout(() => r(payload), childDelayMs);
+        } else {
+          r(payload);
+        }
+      });
+    },
+    setCloseReceiver: (r: (e?: Error) => void) => inner.setCloseReceiver?.(r),
+  };
+}
+
+class DelayingSessionFactory implements SessionFactory {
+  constructor(
+    private readonly getServer: () => MemoryV2Server.Server,
+    private readonly childDelayMs: number,
+    private readonly childDoc: RegExp,
+    private readonly onDelay: () => void,
+  ) {}
+  async create(spaceId: string, sgnr?: Signer) {
+    const client = await MemoryV2Client.connect({
+      transport: delayingLoopback(
+        this.getServer(),
+        this.childDelayMs,
+        this.childDoc,
+        this.onDelay,
+      ),
+    });
+    const session = await client.mount(spaceId, {}, () => ({
+      invocation: {},
+      authorization: { principal: sgnr?.did() },
+    }));
+    return { client, session };
+  }
+}
+
+class DelayingStorageManager extends StorageManager {
+  static make(
+    as: Identity,
+    server: MemoryV2Server.Server,
+    childDelayMs: number,
+    childDoc: RegExp,
+    onDelay: () => void = () => {},
+  ): DelayingStorageManager {
+    return new DelayingStorageManager(
+      { as, memoryHost: new URL("memory://") } as Options,
+      server,
+      childDelayMs,
+      childDoc,
+      onDelay,
+    );
+  }
+  private constructor(
+    options: Options,
+    server: MemoryV2Server.Server,
+    childDelayMs: number,
+    childDoc: RegExp,
+    onDelay: () => void,
+  ) {
+    super(
+      options,
+      new DelayingSessionFactory(
+        () => server,
+        childDelayMs,
+        childDoc,
+        onDelay,
+      ),
+    );
+  }
+  override registerSpaceHost(): boolean {
+    return false;
+  }
+}
+
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: { keep: boolean; label: string }[] }>(({ items }) => {",
+      "  return { kept: items.filter((item) => item.keep) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+const ITEMS = [
+  { keep: true, label: "a" },
+  { keep: true, label: "b" },
+  { keep: false, label: "c" },
+  { keep: true, label: "d" },
+  { keep: true, label: "e" },
+  { keep: false, label: "f" },
+  { keep: true, label: "g" },
+  { keep: true, label: "h" },
+];
+const EXPECTED = ["a", "b", "d", "e", "g", "h"];
+
+const labelsOf = (v: unknown): string[] | null =>
+  Array.isArray(v)
+    ? (v as { label?: string }[]).map((x) => x?.label as string)
+    : v == null
+    ? null
+    : ["<non-array>"];
+
+describe("list builtin resume preservation", () => {
+  let server: MemoryV2Server.Server;
+  let sm1: DelayingStorageManager;
+  let sm2: DelayingStorageManager;
+  let delayed: number;
+
+  beforeEach(() => {
+    delayed = 0;
+    server = new MemoryV2Server.Server({
+      authorizeSessionOpen(message) {
+        const principal = (message.authorization as { principal?: unknown })
+          ?.principal;
+        return typeof principal === "string" ? principal : undefined;
+      },
+    });
+    sm1 = DelayingStorageManager.make(signer, server, 0, FILTER_CHILD_DOC);
+    sm2 = DelayingStorageManager.make(
+      signer,
+      server,
+      80,
+      FILTER_CHILD_DOC,
+      () => delayed++,
+    );
+  });
+  afterEach(async () => {
+    await sm1?.close();
+    await sm2?.close();
+    await server?.close();
+  });
+
+  it("preserves a durable filter result while per-element children resync", async () => {
+    // CREATE (runtime A): build the durable, non-empty filtered list.
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm1,
+    });
+    const compiled1 = await rt1.patternManager.compilePattern(PROGRAM, {
+      space,
+    });
+    const tx0 = rt1.edit();
+    const rc1 = rt1.getCell<{ kept: { label: string }[] }>(
+      space,
+      "lr-result",
+      compiled1.resultSchema,
+      tx0,
+    );
+    const h1 = rt1.run(tx0, compiled1, { items: ITEMS }, rc1);
+    await tx0.commit();
+    for (let k = 0; k < 10; k++) {
+      await h1.pull();
+      await rt1.idle();
+    }
+    await rt1.patternManager.flushCompileCacheWrites();
+    await sm1.synced();
+    expect(
+      (rc1.key("kept").getAsQueryResult() ?? []).map((x: { label: string }) =>
+        x.label
+      ),
+    ).toEqual(EXPECTED);
+    rt1.scheduler.dispose();
+
+    // RELOAD (runtime B): cold cache, with per-element predicate documents
+    // delivered late so the container loads before the children.
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm2,
+    });
+    const trajectory: (string[] | null)[] = [];
+    try {
+      await rt2.patternManager.compilePattern(PROGRAM, { space });
+      const tx = rt2.edit();
+      const rc2 = rt2.getCell<{ kept: { label: string }[] }>(
+        space,
+        "lr-result",
+        compiled1.resultSchema,
+        tx,
+      );
+      await tx.commit();
+
+      const cancel = rc2.key("kept").sink((v) => {
+        trajectory.push(labelsOf(v));
+      });
+
+      const started = await rt2.start(rc2);
+      expect(started).toBe(true);
+
+      for (let k = 0; k < 24; k++) {
+        await rc2.pull();
+        await rt2.idle();
+        trajectory.push(labelsOf(rc2.key("kept").get()));
+      }
+      cancel();
+
+      // Self-check: the harness only exercises the bug if it actually deferred
+      // some per-element documents. If the storage payload shape changes so the
+      // matcher no longer fires, fail loudly rather than pass vacuously.
+      expect(delayed).toBeGreaterThan(0);
+
+      const finalLabels = (rc2.key("kept").getAsQueryResult() ?? []).map(
+        (x: { label: string }) => x.label,
+      );
+      // Converges to the durable value.
+      expect(finalLabels).toEqual(EXPECTED);
+
+      // Never transiently emptied or shrunk during the resume window. On
+      // failure the offending values (the empty/partial snapshots) are shown;
+      // the full trajectory is logged for context.
+      const shrank = trajectory.filter(
+        (t) => t !== null && t.length > 0 && t.length < EXPECTED.length,
+      );
+      const empties = trajectory.filter((t) => t !== null && t.length === 0);
+      if (shrank.length > 0 || empties.length > 0) {
+        console.log("kept trajectory:", JSON.stringify(trajectory));
+      }
+      expect(empties).toEqual([]);
+      expect(shrank).toEqual([]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});
+
+// The flatMap mirror. The op result is a number, so each per-element result
+// doc's sync carries `"type":"number"`, which the aggregate container's own
+// slot-link query does not — that is the matcher the reload uses to deliver the
+// per-element results late. Each element carries a distinct `n` so the skip test
+// can assert exactly which element is omitted; the per-test self-check on the
+// delayed count guards against the matcher drifting if the payload shape moves.
+const FLATMAP_ITEMS = [
+  { keep: true, n: 1, label: "a" },
+  { keep: true, n: 2, label: "b" },
+  { keep: false, n: 3, label: "c" },
+  { keep: true, n: 4, label: "d" },
+  { keep: true, n: 5, label: "e" },
+  { keep: false, n: 6, label: "f" },
+  { keep: true, n: 7, label: "g" },
+  { keep: true, n: 8, label: "h" },
+];
+
+const FLATMAP_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: { keep: boolean; n: number; label: string }[] }>(({ items }) => {",
+      "  return { values: items.flatMap((item) => item.n) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+const FLATMAP_EXPECTED = [1, 2, 3, 4, 5, 6, 7, 8];
+
+// As above but the op returns undefined for non-`keep` elements, which flatMap
+// treats as a skip. The aggregate omits exactly those elements, and must do so
+// by convergence (settled undefined is honored) rather than by ever republishing
+// a transient shrink while the kept elements' results are still resyncing.
+const FLATMAP_SKIP_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: { keep: boolean; n: number; label: string }[] }>(({ items }) => {",
+      "  return { values: items.flatMap((item) => item.keep ? item.n : undefined) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+const FLATMAP_SKIP_EXPECTED = [1, 2, 4, 5, 7, 8]; // omits 3 and 6 (non-keep)
+
+const numbersOf = (v: unknown): number[] | null =>
+  Array.isArray(v) ? (v as number[]) : v == null ? null : [NaN];
+
+describe("flatMap builtin resume preservation", () => {
+  let server: MemoryV2Server.Server;
+  let sm1: DelayingStorageManager;
+  let sm2: DelayingStorageManager;
+  let delayed: number;
+
+  beforeEach(() => {
+    delayed = 0;
+    server = new MemoryV2Server.Server({
+      authorizeSessionOpen(message) {
+        const principal = (message.authorization as { principal?: unknown })
+          ?.principal;
+        return typeof principal === "string" ? principal : undefined;
+      },
+    });
+    sm1 = DelayingStorageManager.make(signer, server, 0, FLATMAP_CHILD_DOC);
+    sm2 = DelayingStorageManager.make(
+      signer,
+      server,
+      80,
+      FLATMAP_CHILD_DOC,
+      () => delayed++,
+    );
+  });
+  afterEach(async () => {
+    await sm1?.close();
+    await sm2?.close();
+    await server?.close();
+  });
+
+  async function runFlatMapResume(
+    program: RuntimeProgram,
+    items: typeof FLATMAP_ITEMS,
+    expected: number[],
+  ): Promise<void> {
+    // CREATE (runtime A): build the durable, non-empty flattened list.
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm1,
+    });
+    const compiled1 = await rt1.patternManager.compilePattern(program, {
+      space,
+    });
+    const tx0 = rt1.edit();
+    const rc1 = rt1.getCell<{ values: number[] }>(
+      space,
+      "fm-result",
+      compiled1.resultSchema,
+      tx0,
+    );
+    const h1 = rt1.run(tx0, compiled1, { items }, rc1);
+    await tx0.commit();
+    for (let k = 0; k < 10; k++) {
+      await h1.pull();
+      await rt1.idle();
+    }
+    await rt1.patternManager.flushCompileCacheWrites();
+    await sm1.synced();
+    expect(rc1.key("values").getAsQueryResult() ?? []).toEqual(expected);
+    rt1.scheduler.dispose();
+
+    // RELOAD (runtime B): cold cache, per-element result docs delivered late so
+    // the container loads before the children.
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm2,
+    });
+    const trajectory: (number[] | null)[] = [];
+    try {
+      await rt2.patternManager.compilePattern(program, { space });
+      const tx = rt2.edit();
+      const rc2 = rt2.getCell<{ values: number[] }>(
+        space,
+        "fm-result",
+        compiled1.resultSchema,
+        tx,
+      );
+      await tx.commit();
+
+      const cancel = rc2.key("values").sink((v) => {
+        trajectory.push(numbersOf(v));
+      });
+
+      const started = await rt2.start(rc2);
+      expect(started).toBe(true);
+
+      for (let k = 0; k < 24; k++) {
+        await rc2.pull();
+        await rt2.idle();
+        trajectory.push(numbersOf(rc2.key("values").get()));
+      }
+      cancel();
+
+      // Self-check: fail loudly if the matcher stopped firing, rather than pass
+      // vacuously.
+      expect(delayed).toBeGreaterThan(0);
+
+      const finalValues = rc2.key("values").getAsQueryResult() ?? [];
+      // Converges to the durable value.
+      expect(finalValues).toEqual(expected);
+
+      // Never transiently emptied or shrunk during the resume window.
+      const shrank = trajectory.filter(
+        (t) => t !== null && t.length > 0 && t.length < expected.length,
+      );
+      const empties = trajectory.filter((t) => t !== null && t.length === 0);
+      if (shrank.length > 0 || empties.length > 0) {
+        console.log("values trajectory:", JSON.stringify(trajectory));
+      }
+      expect(empties).toEqual([]);
+      expect(shrank).toEqual([]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  }
+
+  it("preserves a durable flatMap result while per-element children resync", async () => {
+    await runFlatMapResume(FLATMAP_PROGRAM, FLATMAP_ITEMS, FLATMAP_EXPECTED);
+  });
+
+  it("skips a flatMap element that settles undefined without dropping the list", async () => {
+    await runFlatMapResume(
+      FLATMAP_SKIP_PROGRAM,
+      FLATMAP_ITEMS,
+      FLATMAP_SKIP_EXPECTED,
+    );
+  });
+});

--- a/packages/runner/test/list-shrink-converge.test.ts
+++ b/packages/runner/test/list-shrink-converge.test.ts
@@ -1,0 +1,190 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import {
+  type Options,
+  type SessionFactory,
+  StorageManager,
+} from "../src/storage/v2.ts";
+import type { Signer } from "@commonfabric/memory/interface";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// Convergence guard for the list-builtin resume preservation.
+//
+// The reload preservation holds the durable aggregate while a per-element result
+// is still streaming in, so the list doesn't flicker to empty. The risk is that
+// it cannot tell "still loading" from "settled undefined" and so freezes a
+// genuine shrink. These tests exercise a steady-state (non-resume) shrink: an
+// element's per-element result legitimately settles undefined, so the aggregate
+// should get shorter, and the builtin must publish that shrink rather than pin
+// the longer prior value.
+
+const signer = await Identity.fromPassphrase("list shrink converge");
+const space = signer.did();
+
+function lb(s: MemoryV2Server.Server) {
+  return MemoryV2Client.loopback(s);
+}
+class F implements SessionFactory {
+  constructor(private gs: () => MemoryV2Server.Server) {}
+  async create(spaceId: string, sgnr?: Signer) {
+    const client = await MemoryV2Client.connect({ transport: lb(this.gs()) });
+    const session = await client.mount(spaceId, {}, () => ({
+      invocation: {},
+      authorization: { principal: sgnr?.did() },
+    }));
+    return { client, session };
+  }
+}
+class SM extends StorageManager {
+  static make(as: Identity, s: MemoryV2Server.Server) {
+    return new SM({ as, memoryHost: new URL("memory://") } as Options, s);
+  }
+  private constructor(o: Options, s: MemoryV2Server.Server) {
+    super(o, new F(() => s));
+  }
+  override registerSpaceHost(): boolean {
+    return false;
+  }
+}
+
+function runtime() {
+  const server = new MemoryV2Server.Server({
+    authorizeSessionOpen(message) {
+      const principal = (message.authorization as { principal?: unknown })
+        ?.principal;
+      return typeof principal === "string" ? principal : undefined;
+    },
+  });
+  const sm = SM.make(signer, server);
+  const rt = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: sm,
+  });
+  return { rt, server };
+}
+
+// The pattern returns `items` too, so the test can mutate an element through the
+// result cell and have the predicate/op re-evaluate.
+const FILTER_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: { keep?: boolean; label: string }[] }>(({ items }) => {",
+      "  return { items, kept: items.filter((item) => item.keep) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+const FLATMAP_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern } from 'commonfabric';",
+      "export default pattern<{ items: { keep?: boolean; n: number }[] }>(({ items }) => {",
+      "  return { items, values: items.flatMap((item) => item.keep ? item.n : undefined) };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+describe("list builtin steady-state shrink convergence", () => {
+  it("filter: a predicate that settles undefined drops its element", async () => {
+    const { rt, server } = runtime();
+    try {
+      const compiled = await rt.patternManager.compilePattern(FILTER_PROGRAM, {
+        space,
+      });
+      const tx0 = rt.edit();
+      const rc = rt.getCell<{ kept: { label: string }[] }>(
+        space,
+        "shrink-filter",
+        compiled.resultSchema,
+        tx0,
+      );
+      rt.run(tx0, compiled, {
+        items: [
+          { keep: true, label: "a" },
+          { keep: true, label: "b" },
+          { keep: true, label: "c" },
+        ],
+      }, rc);
+      await tx0.commit();
+      for (let k = 0; k < 10; k++) {
+        await rc.pull();
+        await rt.idle();
+      }
+      expect(
+        (rc.key("kept").getAsQueryResult() ?? []).map((x: { label: string }) =>
+          x.label
+        ),
+      ).toEqual(["a", "b", "c"]);
+
+      // b's predicate settles undefined -> b drops.
+      const tx1 = rt.edit();
+      rc.withTx(tx1).key("items").key(1).key("keep").set(undefined as never);
+      await tx1.commit();
+      for (let k = 0; k < 10; k++) {
+        await rc.pull();
+        await rt.idle();
+      }
+      expect(
+        (rc.key("kept").getAsQueryResult() ?? []).map((x: { label: string }) =>
+          x.label
+        ),
+      ).toEqual(["a", "c"]);
+    } finally {
+      await rt.dispose();
+      await server.close();
+    }
+  });
+
+  it("flatMap: an op that settles undefined drops its element", async () => {
+    const { rt, server } = runtime();
+    try {
+      const compiled = await rt.patternManager.compilePattern(FLATMAP_PROGRAM, {
+        space,
+      });
+      const tx0 = rt.edit();
+      const rc = rt.getCell<{ values: number[] }>(
+        space,
+        "shrink-flatmap",
+        compiled.resultSchema,
+        tx0,
+      );
+      rt.run(tx0, compiled, {
+        items: [
+          { keep: true, n: 1 },
+          { keep: true, n: 2 },
+          { keep: true, n: 3 },
+        ],
+      }, rc);
+      await tx0.commit();
+      for (let k = 0; k < 10; k++) {
+        await rc.pull();
+        await rt.idle();
+      }
+      expect(rc.key("values").getAsQueryResult() ?? []).toEqual([1, 2, 3]);
+
+      // The middle element's op settles undefined (skip) -> [1,3].
+      const tx1 = rt.edit();
+      rc.withTx(tx1).key("items").key(1).key("keep").set(false as never);
+      await tx1.commit();
+      for (let k = 0; k < 10; k++) {
+        await rc.pull();
+        await rt.idle();
+      }
+      expect(rc.key("values").getAsQueryResult() ?? []).toEqual([1, 3]);
+    } finally {
+      await rt.dispose();
+      await server.close();
+    }
+  });
+});

--- a/packages/runner/test/resume-owned-cells.test.ts
+++ b/packages/runner/test/resume-owned-cells.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import type { Signer } from "@commonfabric/memory/interface";
+import * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import {
+  type Options,
+  type SessionFactory,
+  StorageManager,
+} from "../src/storage/v2.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// Resume owned-cell pre-sync for a pattern with a static nested sub-pattern node.
+//
+// On a cold resume, the runner walks the pattern tree and pre-syncs each
+// sub-pattern's owned (derived internal) cells before instantiation, so the
+// resume instantiation commit reads confirmed-loaded state and stays
+// read-mostly. The walk derives each child node's result cell from its output
+// redirect, resolved the same way the minting path resolves it.
+//
+// This is a coverage-and-smoke test: it drives the owned-cell walk and its
+// redirect resolution and asserts the nested value survives a cold reload. It
+// does not by itself distinguish resolving the redirect to its end from taking
+// the unresolved head, because this single-hop binding makes those the same
+// cell — the multi-hop case where they differ is exercised by the home
+// rehydration churn integration test (nested profile patterns), which would
+// regress to commit churn if the walk pre-synced the wrong subtree.
+
+const signer = await Identity.fromPassphrase("resume owned cells");
+const space = signer.did();
+
+function plainLoopback(
+  server: MemoryV2Server.Server,
+): MemoryV2Client.Transport {
+  return MemoryV2Client.loopback(server);
+}
+
+class LoopbackSessionFactory implements SessionFactory {
+  constructor(private readonly getServer: () => MemoryV2Server.Server) {}
+  async create(spaceId: string, sgnr?: Signer) {
+    const client = await MemoryV2Client.connect({
+      transport: plainLoopback(this.getServer()),
+    });
+    const session = await client.mount(spaceId, {}, () => ({
+      invocation: {},
+      authorization: { principal: sgnr?.did() },
+    }));
+    return { client, session };
+  }
+}
+
+class LoopbackStorageManager extends StorageManager {
+  static make(
+    as: Identity,
+    server: MemoryV2Server.Server,
+  ): LoopbackStorageManager {
+    return new LoopbackStorageManager(
+      { as, memoryHost: new URL("memory://") } as Options,
+      server,
+    );
+  }
+  private constructor(options: Options, server: MemoryV2Server.Server) {
+    super(options, new LoopbackSessionFactory(() => server));
+  }
+  override registerSpaceHost(): boolean {
+    return false;
+  }
+}
+
+// An outer pattern that statically composes an inner sub-pattern; the inner
+// pattern keeps a derived internal cell (the lifted scaled value), so the resume
+// walk has an owned cell to pre-sync for the nested node.
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { lift, pattern } from 'commonfabric';",
+      "const scale = lift((n: number) => n * 10);",
+      "const inner = pattern<{ n: number }>(({ n }) => {",
+      "  return { scaled: scale(n) };",
+      "});",
+      "export default pattern<{ seed: number }>(({ seed }) => {",
+      "  const child = inner({ n: seed });",
+      "  return { value: child.scaled };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+describe("resume owned-cell pre-sync", () => {
+  let server: MemoryV2Server.Server;
+  let sm1: LoopbackStorageManager;
+  let sm2: LoopbackStorageManager;
+
+  beforeEach(() => {
+    server = new MemoryV2Server.Server({
+      authorizeSessionOpen(message) {
+        const principal = (message.authorization as { principal?: unknown })
+          ?.principal;
+        return typeof principal === "string" ? principal : undefined;
+      },
+    });
+    sm1 = LoopbackStorageManager.make(signer, server);
+    sm2 = LoopbackStorageManager.make(signer, server);
+  });
+  afterEach(async () => {
+    await sm1?.close();
+    await sm2?.close();
+    await server?.close();
+  });
+
+  it("resumes a nested sub-pattern's value from durable state", async () => {
+    // CREATE (runtime A): run the composed pattern and persist its value.
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm1,
+    });
+    const compiled1 = await rt1.patternManager.compilePattern(PROGRAM, {
+      space,
+    });
+    const tx0 = rt1.edit();
+    const rc1 = rt1.getCell<{ value: number }>(
+      space,
+      "owned-result",
+      compiled1.resultSchema,
+      tx0,
+    );
+    const h1 = rt1.run(tx0, compiled1, { seed: 7 }, rc1);
+    await tx0.commit();
+    for (let k = 0; k < 10; k++) {
+      await h1.pull();
+      await rt1.idle();
+    }
+    await rt1.patternManager.flushCompileCacheWrites();
+    await sm1.synced();
+    expect(rc1.key("value").get()).toBe(70);
+    rt1.scheduler.dispose();
+
+    // RESUME (runtime B): cold cache. start() walks the pattern tree and
+    // pre-syncs the nested node's owned cells before instantiating.
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm2,
+    });
+    try {
+      await rt2.patternManager.compilePattern(PROGRAM, { space });
+      const tx = rt2.edit();
+      const rc2 = rt2.getCell<{ value: number }>(
+        space,
+        "owned-result",
+        compiled1.resultSchema,
+        tx,
+      );
+      await tx.commit();
+
+      const started = await rt2.start(rc2);
+      expect(started).toBe(true);
+
+      for (let k = 0; k < 10; k++) {
+        await rc2.pull();
+        await rt2.idle();
+      }
+      expect(rc2.key("value").get()).toBe(70);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});

--- a/packages/runner/test/resume-owned-cells.test.ts
+++ b/packages/runner/test/resume-owned-cells.test.ts
@@ -10,6 +10,7 @@ import {
   StorageManager,
 } from "../src/storage/v2.ts";
 import { Runtime } from "../src/runtime.ts";
+import type { Cell } from "../src/cell.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 
 // Resume owned-cell pre-sync for a pattern with a static nested sub-pattern node.
@@ -85,6 +86,31 @@ const PROGRAM: RuntimeProgram = {
       "export default pattern<{ seed: number }>(({ seed }) => {",
       "  const child = inner({ n: seed });",
       "  return { value: child.scaled };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+// Three sibling sub-pattern nodes of the SAME inner pattern type. Their result
+// cells are minted from distinct reserved output spots (x/y/z), the structure
+// most likely to collide if the walk's cycle key were not identity-safe. Each
+// child owns its own derived `scaled` cell, so a skipped sibling would drop that
+// cell from the resume pre-sync set.
+const SIBLINGS_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { lift, pattern } from 'commonfabric';",
+      "const scale = lift((n: number) => n * 10);",
+      "const inner = pattern<{ n: number }>(({ n }) => {",
+      "  return { scaled: scale(n) };",
+      "});",
+      "export default pattern<{ a: number; b: number; c: number }>(({ a, b, c }) => {",
+      "  const x = inner({ n: a });",
+      "  const y = inner({ n: b });",
+      "  const z = inner({ n: c });",
+      "  return { x: x.scaled, y: y.scaled, z: z.scaled };",
       "});",
     ].join("\n"),
   }],
@@ -168,5 +194,197 @@ describe("resume owned-cell pre-sync", () => {
       await rt2.dispose();
       await rt1.dispose();
     }
+  });
+
+  it("pre-syncs every same-type sibling sub-pattern across a cold resume", async () => {
+    // Drives the real owned-cell walk over three sibling nodes of the same inner
+    // pattern. If the cycle key collided across siblings, the walk would skip a
+    // sibling's subtree; here every sibling's owned `scaled` cell must survive
+    // the cold resume with its own value.
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm1,
+    });
+    const compiled1 = await rt1.patternManager.compilePattern(
+      SIBLINGS_PROGRAM,
+      {
+        space,
+      },
+    );
+    const tx0 = rt1.edit();
+    const rc1 = rt1.getCell<{ x: number; y: number; z: number }>(
+      space,
+      "siblings-result",
+      compiled1.resultSchema,
+      tx0,
+    );
+    const h1 = rt1.run(tx0, compiled1, { a: 1, b: 2, c: 3 }, rc1);
+    await tx0.commit();
+    for (let k = 0; k < 10; k++) {
+      await h1.pull();
+      await rt1.idle();
+    }
+    await rt1.patternManager.flushCompileCacheWrites();
+    await sm1.synced();
+    expect([
+      rc1.key("x").get(),
+      rc1.key("y").get(),
+      rc1.key("z").get(),
+    ]).toEqual([10, 20, 30]);
+    rt1.scheduler.dispose();
+
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm2,
+    });
+    try {
+      await rt2.patternManager.compilePattern(SIBLINGS_PROGRAM, { space });
+      const tx = rt2.edit();
+      const rc2 = rt2.getCell<{ x: number; y: number; z: number }>(
+        space,
+        "siblings-result",
+        compiled1.resultSchema,
+        tx,
+      );
+      await tx.commit();
+
+      const started = await rt2.start(rc2);
+      expect(started).toBe(true);
+
+      for (let k = 0; k < 10; k++) {
+        await rc2.pull();
+        await rt2.idle();
+      }
+      // All three siblings resumed with their own distinct values — no sibling
+      // was conflated or dropped by the cycle key.
+      expect([
+        rc2.key("x").get(),
+        rc2.key("y").get(),
+        rc2.key("z").get(),
+      ]).toEqual([10, 20, 30]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});
+
+// Direct refutation of the review note:
+//   "Cycle-detection key is not identity-safe; collisions can skip sub-pattern
+//    traversal and miss required pre-sync cells on resume."
+//
+// collectResumeOwnedCells dedups sub-pattern nodes on `${space}\0${id}\0${scope}`
+// (runner.ts). The id is the content-addressed entity id createRef() mints from
+// the child node's resultFor cause {space, id, path}, so the output-spot path
+// that distinguishes sibling nodes is already folded into the id. These tests
+// mint child result cells exactly the way the walk does and show the key is
+// injective over distinct nodes: distinct nodes get distinct keys, the \0
+// delimiter is unambiguous because every component is null-free, and only a
+// genuinely identical node collapses.
+describe("resume owned-cell walk cycle-detection key", () => {
+  let keyServer: MemoryV2Server.Server;
+  let keySm: LoopbackStorageManager;
+  let rt: Runtime;
+
+  beforeEach(() => {
+    keyServer = new MemoryV2Server.Server({
+      authorizeSessionOpen(message) {
+        const principal = (message.authorization as { principal?: unknown })
+          ?.principal;
+        return typeof principal === "string" ? principal : undefined;
+      },
+    });
+    keySm = LoopbackStorageManager.make(signer, keyServer);
+    rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: keySm,
+    });
+  });
+  afterEach(async () => {
+    await rt.dispose();
+    await keySm.close();
+    await keyServer.close();
+  });
+
+  // Mirror of the walk's cycle key (collectResumeOwnedCells in runner.ts).
+  const cycleKey = (cell: Cell<any>): string => {
+    const l = cell.getAsNormalizedFullLink();
+    return `${l.space}\0${l.id}\0${l.scope ?? "space"}`;
+  };
+
+  // Mint a child result cell the way the walk does: from a resultFor cause over
+  // the resolved output spot {space, id, path}, with an optional cell scope.
+  const mint = (
+    causeId: string,
+    path: string[],
+    scope: "space" | "user" | "session" = "space",
+  ): Cell<any> =>
+    rt.getCell(
+      space,
+      { resultFor: { space, id: causeId, path } },
+      undefined,
+      undefined,
+      scope,
+    );
+
+  it("gives distinct sub-pattern nodes distinct keys", () => {
+    const cells = [
+      mint("of:spot-a", ["value"]),
+      mint("of:spot-b", ["value"]), // sibling: different output spot
+      mint("of:spot-a", ["other"]), // same spot id, different path
+      mint("of:spot-a", ["a", "b"]), // multi-component path
+      mint("of:spot-a", ["ab"]), // would join-collide with ["a","b"] under a delimiter
+      mint("of:spot-a", ["a b"]), // a path component that itself contains the delimiter
+    ];
+    const keys = cells.map(cycleKey);
+    expect(new Set(keys).size).toBe(cells.length); // injective: no collisions
+
+    // The \0 delimiter is unambiguous because no component can carry a null byte:
+    // space is a DID, id is an `of:` content hash, scope is one of three literals.
+    for (const c of cells) {
+      const l = c.getAsNormalizedFullLink();
+      expect(l.space).not.toContain("\0");
+      expect(String(l.id)).not.toContain("\0");
+      expect(String(l.scope ?? "space")).not.toContain("\0");
+    }
+  });
+
+  it("captures scope, so the three cell scopes do not collide", () => {
+    const keys = [
+      mint("of:spot", ["value"], "space"),
+      mint("of:spot", ["value"], "user"),
+      mint("of:spot", ["value"], "session"),
+    ].map(cycleKey);
+    expect(new Set(keys).size).toBe(3);
+  });
+
+  it("collapses only a genuinely identical node", () => {
+    // Same cause and scope -> same cell -> same key. The dedup fires for a real
+    // cycle, never for a distinct sibling.
+    expect(cycleKey(mint("of:spot", ["value"]))).toBe(
+      cycleKey(mint("of:spot", ["value"])),
+    );
+  });
+
+  it("separates siblings by the entity id, which the omitted path folds into", () => {
+    const siblings = [
+      mint("of:spot", ["x"]),
+      mint("of:spot", ["y"]),
+      mint("of:spot", ["z"]),
+    ];
+    // A key that dropped the id (the reviewer's feared shape) WOULD collide for
+    // these sibling spots...
+    const naiveKey = (cell: Cell<any>): string => {
+      const l = cell.getAsNormalizedFullLink();
+      return `${l.space}\0${l.scope ?? "space"}`;
+    };
+    expect(new Set(siblings.map(naiveKey)).size).toBe(1);
+    // ...but the real key does not, because the path is folded into the id, so
+    // the id alone already differs across the siblings.
+    expect(new Set(siblings.map(cycleKey)).size).toBe(3);
+    expect(
+      new Set(siblings.map((c) => String(c.getAsNormalizedFullLink().id))).size,
+    )
+      .toBe(3);
   });
 });

--- a/packages/runner/test/resume-republish-unit.test.ts
+++ b/packages/runner/test/resume-republish-unit.test.ts
@@ -1,0 +1,350 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { getLogger } from "@commonfabric/utils/logger";
+import type { Cell } from "../src/cell.ts";
+import type { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import {
+  createResumeRepublisher,
+  type ElementContribution,
+} from "../src/builtins/resume-republish.ts";
+
+// Focused coverage for the shared resume-republish machinery
+// (src/builtins/resume-republish.ts), driving the straggler and guard arms that
+// the end-to-end resume tests (list-resume-preserve.test.ts and friends) cannot
+// reach deterministically: the still-pending re-defer, the input/result guards,
+// the editWithRetry error arm, and the rejected-sync catch.
+//
+// The republisher's only real collaborators are the cells it reads and writes,
+// the runtime's editWithRetry, and the storage manager's trackUntilSettled. Each
+// is mocked so the test controls exactly what the rebuild loop sees: which
+// elements are present, what each per-element result reads, whether a commit
+// fails, and whether a child sync rejects. The republisher code under test is
+// the real module; nothing about its logic is stubbed.
+
+const logger = getLogger("runner.resume-republish-unit", {
+  enabled: false,
+  level: "warn",
+});
+
+interface FakeLink {
+  space: string;
+  id: string;
+  path: readonly unknown[];
+  scope: string;
+}
+
+// A minimal cell stand-in. `value` is what get() returns; `syncResult` is the
+// promise its sync() hands back. Only the methods the republisher calls are
+// implemented.
+class FakeCell {
+  setValues: unknown[] = [];
+  constructor(
+    readonly id: string,
+    public value: unknown,
+    private readonly syncResult: () => Promise<unknown> = () =>
+      Promise.resolve(),
+  ) {}
+  getAsNormalizedFullLink(): FakeLink {
+    return { space: "space", id: this.id, path: [], scope: "space" };
+  }
+  withTx(): this {
+    return this;
+  }
+  asSchema(): this {
+    return this;
+  }
+  get(): unknown {
+    return this.value;
+  }
+  set(v: unknown): void {
+    this.setValues.push(v);
+  }
+  sync(): Promise<unknown> {
+    return this.syncResult();
+  }
+  asCell(): this {
+    return this;
+  }
+}
+
+// An input-list cell: get() returns `{ list }`. The list is whatever the test
+// supplies (a real array, a sparse array, or a non-array to drive the guard).
+class FakeInputsCell {
+  constructor(private readonly listValue: unknown) {}
+  asSchema(): this {
+    return this;
+  }
+  withTx(): this {
+    return this;
+  }
+  get(): { list?: unknown } {
+    return { list: this.listValue };
+  }
+}
+
+// editWithRetry stand-in. By default it runs the action and reports {ok}. In
+// error mode it skips the action and reports a commit error, driving the
+// republisher's failure arm.
+interface FakeEditOptions {
+  failCommit?: boolean;
+}
+
+function makeRuntime(options: FakeEditOptions = {}): {
+  runtime: Runtime;
+  tracked: Promise<unknown>[];
+} {
+  const tracked: Promise<unknown>[] = [];
+  const runtime = {
+    editWithRetry<T>(fn: (tx: unknown) => T) {
+      if (options.failCommit) {
+        return Promise.resolve({
+          error: {
+            name: "StorageTransactionAborted" as const,
+            message: "forced commit failure",
+          },
+        });
+      }
+      const ok = fn({});
+      return Promise.resolve({ ok });
+    },
+    storageManager: {
+      trackUntilSettled(work: Promise<unknown>) {
+        tracked.push(work);
+      },
+    },
+  } as unknown as Runtime;
+  return { runtime, tracked };
+}
+
+const SCHEMA = {} as JSONSchema;
+
+// The filter contribution: include a truthy element, exclude a defined falsy
+// one, and report an undefined predicate as still pending.
+const filterContribution: ElementContribution = (value, inputElement, out) => {
+  if (value) out.push(inputElement);
+  else if (value === undefined) return "pending";
+};
+
+function makeRepublisher(opts: {
+  result: FakeCell | undefined;
+  inputsList: unknown;
+  elementRuns: Map<string, { resultCell: Cell<any>; lastIndex: number }>;
+  runtime: Runtime;
+  contribute?: ElementContribution;
+}) {
+  return createResumeRepublisher({
+    runtime: opts.runtime,
+    logger,
+    getResult: () => opts.result as unknown as Cell<any[]> | undefined,
+    inputsCell: new FakeInputsCell(opts.inputsList) as unknown as Cell<any>,
+    inputSchema: SCHEMA,
+    resultSchema: SCHEMA,
+    elementRuns: opts.elementRuns,
+    contribute: opts.contribute ?? filterContribution,
+    aggregateNoun: "filtered list",
+    elementNoun: "predicate",
+  });
+}
+
+// Build an element-runs map keyed exactly as the republisher keys them, from a
+// list of input-element cells and their corresponding result cells.
+function runsFor(
+  inputCells: FakeCell[],
+  resultCells: FakeCell[],
+): Map<string, { resultCell: Cell<any>; lastIndex: number }> {
+  const runs = new Map<string, { resultCell: Cell<any>; lastIndex: number }>();
+  const keyCounts = new Map<string, number>();
+  for (let i = 0; i < inputCells.length; i++) {
+    if (inputCells[i] === undefined) continue;
+    const link = inputCells[i].getAsNormalizedFullLink();
+    const linkKey = [link.space, link.id, link.scope, link.path];
+    const dedupKey = JSON.stringify(linkKey);
+    const occurrence = keyCounts.get(dedupKey) ?? 0;
+    keyCounts.set(dedupKey, occurrence + 1);
+    const elementKey = JSON.stringify([...linkKey, occurrence]);
+    runs.set(elementKey, {
+      resultCell: resultCells[i] as unknown as Cell<any>,
+      lastIndex: i,
+    });
+  }
+  return runs;
+}
+
+describe("resume-republish unit", () => {
+  it("rebuilds the aggregate from confirmed per-element results", async () => {
+    const inputs = [new FakeCell("e0", null), new FakeCell("e1", null)];
+    // Both predicates settled truthy, so both elements are included.
+    const results = [new FakeCell("r0", true), new FakeCell("r1", true)];
+    const result = new FakeCell("container", [0]);
+    const { runtime, tracked } = makeRuntime();
+    const rr = makeRepublisher({
+      result,
+      inputsList: inputs,
+      elementRuns: runsFor(inputs, results),
+      runtime,
+    });
+
+    rr.awaitPendingThenRepublish(results as unknown as Cell<any>[]);
+    await Promise.all(tracked);
+
+    // The container was written exactly once, with both input elements.
+    expect(result.setValues.length).toBe(1);
+    expect(result.setValues[0]).toEqual(inputs);
+  });
+
+  it("re-defers a still-pending element outside the awaited set", async () => {
+    const inputs = [new FakeCell("e0", null), new FakeCell("e1", null)];
+    // Element 0 settled truthy. Element 1's predicate reads undefined at first.
+    // Its sync confirms the doc and the value arrives truthy, modeling a child
+    // whose result streamed in only after the first republish was scheduled.
+    const r0 = new FakeCell("r0", true);
+    let r1Synced = 0;
+    const r1 = new FakeCell("r1", undefined, () => {
+      r1Synced++;
+      r1.value = true;
+      return Promise.resolve();
+    });
+    const result = new FakeCell("container", [0, 1]);
+    const { runtime, tracked } = makeRuntime();
+    const rr = makeRepublisher({
+      result,
+      inputsList: inputs,
+      elementRuns: runsFor(inputs, [r0, r1]),
+      runtime,
+    });
+
+    // Await only element 0. The republish rebuild then finds element 1
+    // undefined and not awaited, so it returns it as still-pending and
+    // re-awaits it. The re-await syncs element 1, whose value arrives truthy,
+    // so the next republish includes it.
+    rr.awaitPendingThenRepublish([r0] as unknown as Cell<any>[]);
+    await drain(tracked);
+
+    // The re-defer actually happened: the straggler was re-awaited (its sync
+    // ran) rather than written out as a partial shrink.
+    expect(r1Synced).toBeGreaterThan(0);
+    // The first republish held the shrink (it returned the straggler instead of
+    // writing); only the converged rebuild reached the container, with both
+    // elements.
+    expect(result.setValues.length).toBe(1);
+    expect(result.setValues[0]).toEqual(inputs);
+  });
+
+  it("returns early when the result container is unbound", async () => {
+    const inputs = [new FakeCell("e0", null)];
+    const results = [new FakeCell("r0", true)];
+    const { runtime, tracked } = makeRuntime();
+    const rr = makeRepublisher({
+      result: undefined, // getResult() yields undefined
+      inputsList: inputs,
+      elementRuns: runsFor(inputs, results),
+      runtime,
+    });
+
+    rr.awaitPendingThenRepublish(results as unknown as Cell<any>[]);
+    await drain(tracked);
+    // Nothing to assert on a write; the guard simply returns without throwing.
+    expect(true).toBe(true);
+  });
+
+  it("returns early when the resumed input is not yet an array", async () => {
+    const result = new FakeCell("container", [0]);
+    const r0 = new FakeCell("r0", undefined);
+    const { runtime, tracked } = makeRuntime();
+    const rr = makeRepublisher({
+      result,
+      inputsList: undefined, // input list not confirmed yet
+      elementRuns: new Map(),
+      runtime,
+    });
+
+    rr.awaitPendingThenRepublish([r0] as unknown as Cell<any>[]);
+    await drain(tracked);
+    // The guard returns [] without writing the container.
+    expect(result.setValues.length).toBe(0);
+  });
+
+  it("steps over a sparse hole and a list entry with no element run", async () => {
+    // index 1 is a hole; index 2 is present in the list but has no entry in
+    // elementRuns (its run has not been created), exercising both continues.
+    const inputs: FakeCell[] = [];
+    inputs[0] = new FakeCell("e0", null);
+    inputs[2] = new FakeCell("e2", null);
+    const result = new FakeCell("container", [0]);
+    const r0 = new FakeCell("r0", true);
+    // elementRuns holds only element 0; element 2 is intentionally absent.
+    const runs = runsFor([inputs[0]], [r0]);
+    const { runtime, tracked } = makeRuntime();
+    const rr = makeRepublisher({
+      result,
+      inputsList: inputs,
+      elementRuns: runs,
+      runtime,
+    });
+
+    rr.awaitPendingThenRepublish([r0] as unknown as Cell<any>[]);
+    await drain(tracked);
+
+    // Only element 0 is rebuilt; the hole and the entry-less index contribute
+    // nothing.
+    expect(result.setValues.at(-1)).toEqual([inputs[0]]);
+  });
+
+  it("logs and stops when the republish commit fails", async () => {
+    const inputs = [new FakeCell("e0", null)];
+    const results = [new FakeCell("r0", true)];
+    const result = new FakeCell("container", [0]);
+    const { runtime, tracked } = makeRuntime({ failCommit: true });
+    const rr = makeRepublisher({
+      result,
+      inputsList: inputs,
+      elementRuns: runsFor(inputs, results),
+      runtime,
+    });
+
+    rr.awaitPendingThenRepublish(results as unknown as Cell<any>[]);
+    await drain(tracked);
+    // The failed commit means no successful write; the error arm just logs.
+    expect(result.setValues.length).toBe(0);
+  });
+
+  it("logs when a pending element sync rejects", async () => {
+    const inputs = [new FakeCell("e0", null)];
+    const result = new FakeCell("container", [0]);
+    // This element's sync rejects, driving the catch arm.
+    const r0 = new FakeCell(
+      "r0",
+      undefined,
+      () => Promise.reject(new Error("sync rejected")),
+    );
+    const { runtime, tracked } = makeRuntime();
+    const rr = makeRepublisher({
+      result,
+      inputsList: inputs,
+      elementRuns: runsFor(inputs, [r0]),
+      runtime,
+    });
+
+    rr.awaitPendingThenRepublish([r0] as unknown as Cell<any>[]);
+    await drain(tracked);
+    // The rejected sync skips the rebuild entirely; the container is untouched.
+    expect(result.setValues.length).toBe(0);
+  });
+});
+
+// trackUntilSettled receives a fresh promise per re-await, so draining once is
+// not enough: await the current batch, then await any promises the rebuild
+// scheduled while settling, until the queue stops growing.
+async function drain(tracked: Promise<unknown>[]): Promise<void> {
+  let seen = 0;
+  // A bounded number of passes; the re-defer chain here is at most a few deep.
+  for (let pass = 0; pass < 10; pass++) {
+    if (tracked.length === seen) break;
+    const batch = tracked.slice(seen);
+    seen = tracked.length;
+    await Promise.allSettled(batch);
+    // Let any microtasks the settled batch queued run before the next pass.
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}

--- a/packages/runner/test/transaction-notfound.test.ts
+++ b/packages/runner/test/transaction-notfound.test.ts
@@ -66,6 +66,8 @@ class MockStorageManager implements IStorageManager {
 
   removeCrossSpacePromise() {}
 
+  trackUntilSettled() {}
+
   syncCell<T>(cell: Cell<T>): Promise<Cell<T>> {
     return Promise.resolve(cell);
   }


### PR DESCRIPTION
Split into 3 commits for ease of review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make reloads read‑mostly and stop list flicker. We pre‑sync owned cells and defer/await list reconciles until inputs and child results confirm; reads now wait on these deferred chains.

- **New Features — Read‑mostly resume**
  - Pre‑sync owned `resultFor` cells across the pattern tree before instantiation, resolving output write‑redirects to final targets and skipping unresolved nodes.
  - Seed build‑time defaults only when no manifest entry exists.
  - Add `trackUntilSettled` to `IStorageManager`/`StorageManager` and use it for missing‑doc kicks so `Cell.pull()`/scheduler `idle()` await deferred work.

- **Bug Fixes — List builtins on resume**
  - `filter`/`flatMap`: preserve the prior aggregate while children load; await pending children and republish via shared `createResumeRepublisher`, re‑deferring stragglers.
  - `map`/`filter`/`flatMap`: await input confirmation before clearing the container on resume; remove redundant fresh‑init seeding.
  - Tighten home rehydration churn bounds to 12 and emit `CHURN_METRIC` key=value logs for CI.
  - Collapse the resume‑defer sync assert in `map`/`filter`/`flatMap` to a single‑line narrowing; behavior unchanged.
  - `flatMap`: add a resume test for array‑spread results to cover the republish contribution path; preservation holds without transient shrink.

<sup>Written for commit 0b96eba45827a506bc917a2f65d2b568fd954b35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

