### PR TITLE
[codex] Emo chat reactions and grouping

### DIFF
--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -938,7 +938,9 @@ interface LobbyOutput {
 
 Minimal shared chat demo. Each user keeps their own display name, while the
 message log is shared across the space. The composer sends on Return and keeps
-the latest messages visible at the bottom of the message pane.
+the latest messages visible at the bottom of the message pane. Consecutive
+messages from the same user are grouped, and messages support simple emoji
+reactions.
 
 **Keywords:** chat, multiplayer, per-user, per-space, message-input
 
@@ -947,7 +949,15 @@ the latest messages visible at the bottom of the message pane.
 ```ts
 interface ChatMessage {
   from: string;
+  fromName?: Writable<string>;
   body: string;
+  reactions?: Reaction[] | Default<[]>;
+}
+
+interface Reaction {
+  emoji: string;
+  by: Writable<string>;
+  byName: string;
 }
 
 interface PicoChatInput {
@@ -962,7 +972,9 @@ interface PicoChatInput {
 interface PicoChatOutput {
   messages: PerSpace<ChatMessage[] | Default<[]>>;
   name: PerUser<string | Default<"">>;
+  groups: MessageGroup[];
   send: Stream<{ detail?: { message?: string } }>;
+  react: Stream<{ message: ChatMessage; emoji: string }>;
 }
 ```
 

--- a/packages/patterns/pico-chat/commonfabric-shim.test.ts
+++ b/packages/patterns/pico-chat/commonfabric-shim.test.ts
@@ -32,6 +32,10 @@ export class TestWritable<T> {
     this.#value.push(value);
   }
 
+  key<K extends keyof NonNullable<T>>(key: K): TestWritable<NonNullable<T>[K]> {
+    return new TestKeyWritable(this, key);
+  }
+
   get length(): number {
     return Array.isArray(this.#value) ? this.#value.length : 0;
   }
@@ -42,6 +46,31 @@ export class TestWritable<T> {
     }
 
     return this.#value[Symbol.iterator]();
+  }
+}
+
+class TestKeyWritable<T, K extends keyof NonNullable<T>>
+  extends TestWritable<NonNullable<T>[K]> {
+  #parent: TestWritable<T>;
+  #key: K;
+
+  constructor(parent: TestWritable<T>, key: K) {
+    super((parent.get() as NonNullable<T>)?.[key]);
+    this.#parent = parent;
+    this.#key = key;
+  }
+
+  override get(): NonNullable<T>[K] {
+    return (this.#parent.get() as NonNullable<T>)?.[this.#key];
+  }
+
+  override set(value: NonNullable<T>[K]): void {
+    const parentValue = this.#parent.get();
+    if (typeof parentValue !== "object" || parentValue === null) {
+      throw new TypeError("Cannot set a key on a non-object cell");
+    }
+
+    (parentValue as NonNullable<T>)[this.#key] = value;
   }
 }
 
@@ -75,6 +104,10 @@ function wrapInput<T extends Record<string, unknown>>(input: T): T {
 
 export function computed<T>(fn: () => T): T {
   return fn();
+}
+
+export function equals(left: unknown, right: unknown): boolean {
+  return left === right;
 }
 
 export function handler<Event, State>(

--- a/packages/patterns/pico-chat/coverage-deno.test.ts
+++ b/packages/patterns/pico-chat/coverage-deno.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { NAME, UI } from "commonfabric";
-import PicoChat, { groupMessages, reactionClick } from "./main.tsx";
+import PicoChat, { groupMessages } from "./main.tsx";
 
 Deno.test("pico chat sends trimmed messages from a named user", () => {
   const subject = PicoChat({
@@ -104,25 +104,6 @@ Deno.test("pico chat toggles emoji reactions by display name", () => {
 
   alex.react.send({ message, emoji: "👍" });
   assertEquals(message.reactions, []);
-});
-
-Deno.test("pico chat reaction helper sends the selected message and emoji", () => {
-  const subject = PicoChat({
-    messages: [],
-    name: "Alex",
-  });
-  subject.send.send({ detail: { message: "Click helper" } });
-  const [message] = subject.messages.get();
-
-  reactionClick(subject.react, message, "😂")();
-
-  assertEquals(
-    message.reactions?.map(({ emoji, byName }) => ({
-      emoji,
-      byName,
-    })),
-    [{ emoji: "😂", byName: "Alex" }],
-  );
 });
 
 Deno.test("pico chat ignores invalid reaction attempts", () => {

--- a/packages/patterns/pico-chat/coverage-deno.test.ts
+++ b/packages/patterns/pico-chat/coverage-deno.test.ts
@@ -2,13 +2,13 @@ import { assertEquals, assertExists } from "@std/assert";
 import { NAME, UI } from "commonfabric";
 import PicoChat, { groupMessages } from "./main.tsx";
 
-Deno.test("pico chat sends trimmed messages from a named user", () => {
+Deno.test("emo chat sends trimmed messages from a named user", () => {
   const subject = PicoChat({
     messages: [],
     name: " Alex ",
   });
 
-  assertEquals(subject[NAME], "Pico chat");
+  assertEquals(subject[NAME], "Emo chat");
   assertExists(subject[UI]);
   assertEquals(subject.messages.get(), []);
 
@@ -23,7 +23,7 @@ Deno.test("pico chat sends trimmed messages from a named user", () => {
   );
 });
 
-Deno.test("pico chat renders existing messages", () => {
+Deno.test("emo chat renders existing messages", () => {
   const subject = PicoChat({
     messages: [{ from: "Robin", body: "Already here" }],
     name: "Alex",
@@ -36,7 +36,7 @@ Deno.test("pico chat renders existing messages", () => {
   }]);
 });
 
-Deno.test("pico chat groups sequential messages from the same user", () => {
+Deno.test("emo chat groups sequential messages from the same user", () => {
   const subject = PicoChat({
     messages: [],
     name: "Alex",
@@ -53,7 +53,7 @@ Deno.test("pico chat groups sequential messages from the same user", () => {
   );
 });
 
-Deno.test("pico chat starts a new group when the sender changes", () => {
+Deno.test("emo chat starts a new group when the sender changes", () => {
   const alex = PicoChat({
     messages: [],
     name: "Alex",
@@ -72,7 +72,7 @@ Deno.test("pico chat starts a new group when the sender changes", () => {
   ]);
 });
 
-Deno.test("pico chat groups legacy same-name messages without cell links", () => {
+Deno.test("emo chat groups legacy same-name messages without cell links", () => {
   const groups = groupMessages([
     { from: "Robin", body: "First" },
     { from: "Robin", body: "Second" },
@@ -85,7 +85,7 @@ Deno.test("pico chat groups legacy same-name messages without cell links", () =>
   ]);
 });
 
-Deno.test("pico chat lets another named user toggle emoji reactions", () => {
+Deno.test("emo chat lets another named user toggle emoji reactions", () => {
   const author = PicoChat({
     messages: [],
     name: "Tony",
@@ -110,7 +110,7 @@ Deno.test("pico chat lets another named user toggle emoji reactions", () => {
   assertEquals(author.messages.get()[0].reactions, []);
 });
 
-Deno.test("pico chat ignores invalid reaction attempts", () => {
+Deno.test("emo chat ignores invalid reaction attempts", () => {
   const subject = PicoChat({
     messages: [],
     name: "Alex",
@@ -131,7 +131,7 @@ Deno.test("pico chat ignores invalid reaction attempts", () => {
   assertEquals(subject.messages.get()[0].reactions, []);
 });
 
-Deno.test("pico chat prevents reactions to own display-name messages", () => {
+Deno.test("emo chat prevents reactions to own display-name messages", () => {
   const firstAlex = PicoChat({
     messages: [],
     name: "Alex",
@@ -150,7 +150,7 @@ Deno.test("pico chat prevents reactions to own display-name messages", () => {
   assertEquals(message.reactions, []);
 });
 
-Deno.test("pico chat ignores blank names and messages", () => {
+Deno.test("emo chat ignores blank names and messages", () => {
   const emptyNameSubject = PicoChat({
     messages: [],
     name: " ",

--- a/packages/patterns/pico-chat/coverage-deno.test.ts
+++ b/packages/patterns/pico-chat/coverage-deno.test.ts
@@ -150,6 +150,23 @@ Deno.test("emo chat prevents reactions to own display-name messages", () => {
   assertEquals(message.reactions, []);
 });
 
+Deno.test("emo chat lets authors remove legacy own reactions", () => {
+  const subject = PicoChat({
+    messages: [{
+      from: "Alex",
+      body: "Old self reaction",
+      reactions: [{ emoji: "❤️", byName: "Alex" }],
+    }],
+    name: "Alex",
+  });
+
+  subject.react.send({ messageIndex: 0, emoji: "❤️" });
+  assertEquals(subject.messages.get()[0].reactions, []);
+
+  subject.react.send({ messageIndex: 0, emoji: "👍" });
+  assertEquals(subject.messages.get()[0].reactions, []);
+});
+
 Deno.test("emo chat ignores blank names and messages", () => {
   const emptyNameSubject = PicoChat({
     messages: [],

--- a/packages/patterns/pico-chat/coverage-deno.test.ts
+++ b/packages/patterns/pico-chat/coverage-deno.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { NAME, UI } from "commonfabric";
-import PicoChat from "./main.tsx";
+import PicoChat, { groupMessages, reactionClick } from "./main.tsx";
 
 Deno.test("pico chat sends trimmed messages from a named user", () => {
   const subject = PicoChat({
@@ -13,7 +13,14 @@ Deno.test("pico chat sends trimmed messages from a named user", () => {
   assertEquals(subject.messages.get(), []);
 
   subject.send.send({ detail: { message: " Hello " } });
-  assertEquals(subject.messages.get(), [{ from: "Alex", body: "Hello" }]);
+  assertEquals(
+    subject.messages.get().map(({ from, body, reactions }) => ({
+      from,
+      body,
+      reactions,
+    })),
+    [{ from: "Alex", body: "Hello", reactions: [] }],
+  );
 });
 
 Deno.test("pico chat renders existing messages", () => {
@@ -27,6 +34,139 @@ Deno.test("pico chat renders existing messages", () => {
     from: "Robin",
     body: "Already here",
   }]);
+});
+
+Deno.test("pico chat groups sequential messages from the same user", () => {
+  const subject = PicoChat({
+    messages: [],
+    name: "Alex",
+  });
+
+  subject.send.send({ detail: { message: "First" } });
+  subject.send.send({ detail: { message: "Second" } });
+
+  const groups = groupMessages(subject.messages.get());
+  assertEquals(groups.length, 1);
+  assertEquals(
+    groups[0].messages.map((message) => message.body),
+    ["First", "Second"],
+  );
+});
+
+Deno.test("pico chat starts a new group when the sender changes", () => {
+  const alex = PicoChat({
+    messages: [],
+    name: "Alex",
+  });
+  alex.send.send({ detail: { message: "Hello" } });
+
+  const mary = PicoChat({
+    messages: alex.messages,
+    name: "Mary",
+  });
+  mary.send.send({ detail: { message: "Hi" } });
+
+  assertEquals(groupMessages(alex.messages.get()).map((group) => group.from), [
+    "Alex",
+    "Mary",
+  ]);
+});
+
+Deno.test("pico chat groups legacy same-name messages without cell links", () => {
+  const groups = groupMessages([
+    { from: "Robin", body: "First" },
+    { from: "Robin", body: "Second" },
+  ]);
+
+  assertEquals(groups.length, 1);
+  assertEquals(groups[0].messages.map((message) => message.body), [
+    "First",
+    "Second",
+  ]);
+});
+
+Deno.test("pico chat toggles emoji reactions by user reference", () => {
+  const alex = PicoChat({
+    messages: [],
+    name: "Alex",
+  });
+  alex.send.send({ detail: { message: "Reactable" } });
+  const [message] = alex.messages.get();
+
+  alex.react.send({ message, emoji: "👍" });
+  assertEquals(
+    message.reactions?.map(({ emoji, byName }) => ({
+      emoji,
+      byName,
+    })),
+    [{ emoji: "👍", byName: "Alex" }],
+  );
+
+  alex.react.send({ message, emoji: "👍" });
+  assertEquals(message.reactions, []);
+});
+
+Deno.test("pico chat reaction helper sends the selected message and emoji", () => {
+  const subject = PicoChat({
+    messages: [],
+    name: "Alex",
+  });
+  subject.send.send({ detail: { message: "Click helper" } });
+  const [message] = subject.messages.get();
+
+  reactionClick(subject.react, message, "😂")();
+
+  assertEquals(
+    message.reactions?.map(({ emoji, byName }) => ({
+      emoji,
+      byName,
+    })),
+    [{ emoji: "😂", byName: "Alex" }],
+  );
+});
+
+Deno.test("pico chat ignores invalid reaction attempts", () => {
+  const subject = PicoChat({
+    messages: [],
+    name: "Alex",
+  });
+  subject.send.send({ detail: { message: "Valid" } });
+  const [message] = subject.messages.get();
+  const detached = { from: "Alex", body: "Detached" };
+
+  subject.react.send({ message, emoji: "   " });
+  subject.react.send({ message: detached, emoji: "👍" });
+
+  const emptyNameSubject = PicoChat({
+    messages: subject.messages,
+    name: " ",
+  });
+  emptyNameSubject.react.send({ message, emoji: "👍" });
+
+  assertEquals(message.reactions, []);
+});
+
+Deno.test("pico chat allows same display names to react independently", () => {
+  const firstAlex = PicoChat({
+    messages: [],
+    name: "Alex",
+  });
+  firstAlex.send.send({ detail: { message: "Same names" } });
+  const [message] = firstAlex.messages.get();
+
+  const secondAlex = PicoChat({
+    messages: firstAlex.messages,
+    name: "Alex",
+  });
+
+  firstAlex.react.send({ message, emoji: "❤️" });
+  secondAlex.react.send({ message, emoji: "❤️" });
+
+  assertEquals(message.reactions?.length, 2);
+  assertEquals(message.reactions?.map((reaction) => reaction.byName), [
+    "Alex",
+    "Alex",
+  ]);
 });
 
 Deno.test("pico chat ignores blank names and messages", () => {

--- a/packages/patterns/pico-chat/coverage-deno.test.ts
+++ b/packages/patterns/pico-chat/coverage-deno.test.ts
@@ -85,25 +85,29 @@ Deno.test("pico chat groups legacy same-name messages without cell links", () =>
   ]);
 });
 
-Deno.test("pico chat toggles emoji reactions by display name", () => {
-  const alex = PicoChat({
+Deno.test("pico chat lets another named user toggle emoji reactions", () => {
+  const author = PicoChat({
     messages: [],
+    name: "Tony",
+  });
+  author.send.send({ detail: { message: "Reactable" } });
+
+  const reactor = PicoChat({
+    messages: author.messages,
     name: "Alex",
   });
-  alex.send.send({ detail: { message: "Reactable" } });
-  const [message] = alex.messages.get();
 
-  alex.react.send({ message, emoji: "👍" });
+  reactor.react.send({ messageIndex: 0, emoji: "👍" });
   assertEquals(
-    message.reactions?.map(({ emoji, byName }) => ({
+    author.messages.get()[0].reactions?.map(({ emoji, byName }) => ({
       emoji,
       byName,
     })),
     [{ emoji: "👍", byName: "Alex" }],
   );
 
-  alex.react.send({ message, emoji: "👍" });
-  assertEquals(message.reactions, []);
+  reactor.react.send({ messageIndex: 0, emoji: "👍" });
+  assertEquals(author.messages.get()[0].reactions, []);
 });
 
 Deno.test("pico chat ignores invalid reaction attempts", () => {
@@ -112,22 +116,22 @@ Deno.test("pico chat ignores invalid reaction attempts", () => {
     name: "Alex",
   });
   subject.send.send({ detail: { message: "Valid" } });
-  const [message] = subject.messages.get();
-  const detached = { from: "Alex", body: "Detached" };
 
-  subject.react.send({ message, emoji: "   " });
-  subject.react.send({ message: detached, emoji: "👍" });
+  subject.react.send({ messageIndex: 0, emoji: "   " });
+  subject.react.send({ messageIndex: -1, emoji: "👍" });
+  subject.react.send({ messageIndex: 99, emoji: "👍" });
+  subject.react.send({ messageIndex: 0.5, emoji: "👍" });
 
   const emptyNameSubject = PicoChat({
     messages: subject.messages,
     name: " ",
   });
-  emptyNameSubject.react.send({ message, emoji: "👍" });
+  emptyNameSubject.react.send({ messageIndex: 0, emoji: "👍" });
 
-  assertEquals(message.reactions, []);
+  assertEquals(subject.messages.get()[0].reactions, []);
 });
 
-Deno.test("pico chat treats the same display name as the same reactor", () => {
+Deno.test("pico chat prevents reactions to own display-name messages", () => {
   const firstAlex = PicoChat({
     messages: [],
     name: "Alex",
@@ -140,8 +144,8 @@ Deno.test("pico chat treats the same display name as the same reactor", () => {
     name: "Alex",
   });
 
-  firstAlex.react.send({ message, emoji: "❤️" });
-  secondAlex.react.send({ message, emoji: "❤️" });
+  firstAlex.react.send({ messageIndex: 0, emoji: "❤️" });
+  secondAlex.react.send({ messageIndex: 0, emoji: "❤️" });
 
   assertEquals(message.reactions, []);
 });

--- a/packages/patterns/pico-chat/coverage-deno.test.ts
+++ b/packages/patterns/pico-chat/coverage-deno.test.ts
@@ -85,7 +85,7 @@ Deno.test("pico chat groups legacy same-name messages without cell links", () =>
   ]);
 });
 
-Deno.test("pico chat toggles emoji reactions by user reference", () => {
+Deno.test("pico chat toggles emoji reactions by display name", () => {
   const alex = PicoChat({
     messages: [],
     name: "Alex",
@@ -146,7 +146,7 @@ Deno.test("pico chat ignores invalid reaction attempts", () => {
   assertEquals(message.reactions, []);
 });
 
-Deno.test("pico chat allows same display names to react independently", () => {
+Deno.test("pico chat treats the same display name as the same reactor", () => {
   const firstAlex = PicoChat({
     messages: [],
     name: "Alex",
@@ -162,11 +162,7 @@ Deno.test("pico chat allows same display names to react independently", () => {
   firstAlex.react.send({ message, emoji: "❤️" });
   secondAlex.react.send({ message, emoji: "❤️" });
 
-  assertEquals(message.reactions?.length, 2);
-  assertEquals(message.reactions?.map((reaction) => reaction.byName), [
-    "Alex",
-    "Alex",
-  ]);
+  assertEquals(message.reactions, []);
 });
 
 Deno.test("pico chat ignores blank names and messages", () => {

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -1,6 +1,7 @@
 import {
   computed,
   Default,
+  equals,
   handler,
   NAME,
   pattern,
@@ -12,20 +13,41 @@ import {
   Writable,
 } from "commonfabric";
 
+export type NameCell = Writable<string>;
+
+export interface Reaction {
+  emoji: string;
+  by: NameCell;
+  byName: string;
+}
+
 export interface ChatMessage {
   from: string;
+  fromName?: NameCell;
   body: string;
+  reactions?: Reaction[] | Default<[]>;
 }
 
 const DEFAULT_MESSAGES: ChatMessage[] = [];
+const REACTION_EMOJIS = ["👍", "❤️", "😂"] as const;
 
 export type MessagesCell = Writable<ChatMessage[]>;
-export type NameCell = Writable<string>;
 
 export interface SendEvent {
   detail?: {
     message?: string;
   };
+}
+
+export interface ReactEvent {
+  message: ChatMessage;
+  emoji: string;
+}
+
+export interface MessageGroup {
+  from: string;
+  fromName?: NameCell;
+  messages: ChatMessage[];
 }
 
 export interface PicoChatInput {
@@ -38,7 +60,9 @@ export interface PicoChatOutput {
   [UI]: VNode;
   messages: PerSpace<Default<ChatMessage[], typeof DEFAULT_MESSAGES>>;
   name: PerUser<Default<string, "">>;
+  groups: MessageGroup[];
   send: Stream<SendEvent>;
+  react: Stream<ReactEvent>;
 }
 
 const sendMessage = handler<SendEvent, {
@@ -50,16 +74,127 @@ const sendMessage = handler<SendEvent, {
 
   if (!from || !body) return;
 
-  messages.push({ from, body });
+  messages.push({ from, fromName: name, body, reactions: [] });
 });
 
-const textStyle =
-  "unicode-bidi: plaintext; white-space: pre-wrap; overflow-wrap: anywhere;";
+const toggleReaction = handler<ReactEvent, {
+  messages: MessagesCell;
+  name: NameCell;
+}>(({ message, emoji }, { messages, name }) => {
+  const mark = emoji.trim();
+  const byName = name.get().trim();
+  if (!message || !mark || !byName) return;
+
+  const currentMessages = messages.get();
+  const index = currentMessages.findIndex((candidate) =>
+    equals(candidate, message)
+  );
+  if (index < 0) return;
+
+  const reactionsCell = messages.key(index).key("reactions");
+  const reactions = asReactions(reactionsCell.get());
+  const existingIndex = reactions.findIndex((reaction) =>
+    reaction.emoji === mark && reaction.by && equals(reaction.by, name)
+  );
+
+  reactionsCell.set(
+    existingIndex >= 0
+      ? reactions.toSpliced(existingIndex, 1)
+      : [...reactions, { emoji: mark, by: name, byName }],
+  );
+});
+
+function asReactions(
+  reactions: readonly Reaction[] | Default<[]> | undefined,
+): Reaction[] {
+  return Array.isArray(reactions) ? [...reactions] : [];
+}
+
+function sameAuthor(left: ChatMessage, right: ChatMessage) {
+  if (left.fromName && right.fromName) {
+    return equals(left.fromName, right.fromName);
+  }
+  return left.from === right.from;
+}
+
+export function groupMessages(
+  messages: readonly ChatMessage[],
+): MessageGroup[] {
+  const groups: MessageGroup[] = [];
+
+  for (const message of messages) {
+    const last = groups[groups.length - 1];
+    if (last && sameAuthor(last.messages[last.messages.length - 1], message)) {
+      last.from = message.from;
+      last.fromName = message.fromName;
+      last.messages.push(message);
+    } else {
+      groups.push({
+        from: message.from,
+        fromName: message.fromName,
+        messages: [message],
+      });
+    }
+  }
+
+  return groups;
+}
+
+function reactionCount(message: ChatMessage, emoji: string) {
+  return asReactions(message.reactions).filter((reaction) =>
+    reaction.emoji === emoji
+  ).length;
+}
+
+function reactionLabel(message: ChatMessage, emoji: string) {
+  const count = reactionCount(message, emoji);
+  return count > 0 ? `${emoji} ${count}` : emoji;
+}
+
+export function reactionClick(
+  react: Stream<ReactEvent>,
+  message: ChatMessage,
+  emoji: string,
+) {
+  return () => react.send({ message, emoji });
+}
+
+const textStyle = {
+  unicodeBidi: "plaintext",
+  whiteSpace: "pre-wrap",
+  overflowWrap: "anywhere",
+};
+
+const messagePaneStyle = {
+  height: "320px",
+  overflowY: "auto",
+  display: "flex",
+  flexDirection: "column-reverse",
+};
+
+const groupStyle = {
+  padding: "10px 0",
+  borderBottom: "1px solid var(--cf-colors-border, #e2e8f0)",
+};
+
+const messageStackStyle = {
+  display: "grid",
+  gap: "0.5rem",
+  marginTop: "0.25rem",
+};
+
+const reactionRowStyle = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "0.25rem",
+};
 
 export default pattern<PicoChatInput, PicoChatOutput>(
   ({ messages, name }) => {
     const send = sendMessage({ messages, name });
-    const displayMessages = computed(() => [...messages].reverse());
+    const react = toggleReaction({ messages, name });
+    const groups = computed(() => groupMessages([...messages]));
+    const displayGroups = computed(() => [...groups].reverse());
 
     return {
       [NAME]: "Pico chat",
@@ -82,17 +217,49 @@ export default pattern<PicoChatInput, PicoChatOutput>(
               <div
                 slot="content"
                 id="chat-messages"
-                style="height: 320px; overflow-y: auto; display: flex; flex-direction: column-reverse;"
+                style={messagePaneStyle}
               >
-                <div style="display: flex; flex-direction: column-reverse;">
-                  {displayMessages.length === 0
-                    ? <div style="color: #64748b;">No messages yet</div>
-                    : displayMessages.map((message) => (
-                      <div style="padding: 10px 0; border-bottom: 1px solid #e2e8f0;">
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "column-reverse",
+                  }}
+                >
+                  {displayGroups.length === 0
+                    ? (
+                      <div style={{ color: "var(--cf-colors-muted, #64748b)" }}>
+                        No messages yet
+                      </div>
+                    )
+                    : displayGroups.map((group) => (
+                      <div style={groupStyle}>
                         <strong dir="ltr" style={textStyle}>
-                          {message.from}
+                          {group.from}
                         </strong>
-                        <div dir="ltr" style={textStyle}>{message.body}</div>
+                        <div style={messageStackStyle}>
+                          {group.messages.map((message) => (
+                            <div>
+                              <div dir="ltr" style={textStyle}>
+                                {message.body}
+                              </div>
+                              <div style={reactionRowStyle}>
+                                {REACTION_EMOJIS.map((emoji) => (
+                                  <cf-button
+                                    size="sm"
+                                    variant="ghost"
+                                    onClick={reactionClick(
+                                      react,
+                                      message,
+                                      emoji,
+                                    )}
+                                  >
+                                    {reactionLabel(message, emoji)}
+                                  </cf-button>
+                                ))}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
                       </div>
                     ))}
                 </div>
@@ -110,7 +277,9 @@ export default pattern<PicoChatInput, PicoChatOutput>(
       ),
       messages,
       name,
+      groups,
       send,
+      react,
     };
   },
 );

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -180,6 +180,12 @@ function hasAnyReaction(message: ChatMessage) {
     hasReaction(message, "😂");
 }
 
+function reactionOptionClass(message: ChatMessage, emoji: string) {
+  return hasReaction(message, emoji)
+    ? "pico-reaction-option pico-reaction-option-active"
+    : "pico-reaction-option";
+}
+
 const textStyle = {
   unicodeBidi: "plaintext",
   whiteSpace: "pre-wrap",
@@ -227,10 +233,15 @@ export default pattern<PicoChatInput, PicoChatOutput>(
         <cf-screen>
           <style>
             {`
-              .pico-reactions {
+              .pico-reaction-option {
                 opacity: 0;
                 pointer-events: none;
                 transition: opacity 120ms ease;
+              }
+
+              .pico-reaction-option-active {
+                opacity: 1;
+                pointer-events: auto;
               }
 
               .pico-message-row {
@@ -246,8 +257,8 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                 border-bottom: 1px solid var(--cf-colors-border, #e2e8f0);
               }
 
-              .pico-message-row:hover .pico-reactions,
-              .pico-message-row:focus-within .pico-reactions {
+              .pico-message-row:hover .pico-reaction-option,
+              .pico-message-row:focus-within .pico-reaction-option {
                 opacity: 1;
                 pointer-events: auto;
               }
@@ -298,6 +309,10 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                               style={reactionRowStyle}
                             >
                               <cf-button
+                                className={reactionOptionClass(
+                                  row.message,
+                                  "👍",
+                                )}
                                 size="sm"
                                 variant="ghost"
                                 onClick={() =>
@@ -309,6 +324,10 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                 {reactionLabel(row.message, "👍")}
                               </cf-button>
                               <cf-button
+                                className={reactionOptionClass(
+                                  row.message,
+                                  "❤️",
+                                )}
                                 size="sm"
                                 variant="ghost"
                                 onClick={() =>
@@ -320,6 +339,10 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                 {reactionLabel(row.message, "❤️")}
                               </cf-button>
                               <cf-button
+                                className={reactionOptionClass(
+                                  row.message,
+                                  "😂",
+                                )}
                                 size="sm"
                                 variant="ghost"
                                 onClick={() =>

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -293,14 +293,13 @@ const textStyle = {
 const messagePaneStyle = {
   height: "320px",
   overflowY: "auto",
-  display: "flex",
-  flexDirection: "column-reverse",
 };
 
 const messageListStyle = {
   minHeight: "100%",
   display: "flex",
-  flexDirection: "column-reverse",
+  flexDirection: "column",
+  justifyContent: "flex-end",
 };
 
 const reactionSummaryStyle = {
@@ -324,7 +323,6 @@ export default pattern<PicoChatInput, PicoChatOutput>(
     const rows = computed(() =>
       displayMessages([...messages], currentViewerName(name))
     );
-    const visibleRows = computed(() => [...rows].reverse());
 
     return {
       [NAME]: "Emo chat",
@@ -405,6 +403,7 @@ export default pattern<PicoChatInput, PicoChatOutput>(
               .pico-message-row {
                 border-radius: 6px;
                 margin: 0 -0.5rem;
+                overflow-anchor: none;
                 padding: 0.375rem 2.5rem 0.375rem 0.5rem;
                 position: relative;
                 transition: background-color 120ms ease;
@@ -441,6 +440,21 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                 opacity: 1;
                 pointer-events: auto;
               }
+
+              .pico-scroll-anchor {
+                appearance: none;
+                align-self: flex-end;
+                background: transparent;
+                border: 0;
+                height: 1px;
+                opacity: 0;
+                outline: 0;
+                overflow-anchor: auto;
+                overflow: hidden;
+                padding: 0;
+                pointer-events: none;
+                width: 1px;
+              }
             `}
           </style>
           <cf-vstack gap="4" padding="6" style="max-width: 720px;">
@@ -463,13 +477,13 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                 style={messagePaneStyle}
               >
                 <div style={messageListStyle}>
-                  {visibleRows.length === 0
+                  {rows.length === 0
                     ? (
                       <div style={{ color: "var(--cf-colors-muted, #64748b)" }}>
                         No messages yet
                       </div>
                     )
-                    : visibleRows.map((row) => (
+                    : rows.map((row) => (
                       <div className={row.className}>
                         {row.showAuthor
                           ? (
@@ -615,6 +629,14 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                           : null}
                       </div>
                     ))}
+                  <button
+                    id="chat-latest"
+                    type="button"
+                    className="pico-scroll-anchor"
+                    aria-hidden="true"
+                    tabIndex={-1}
+                    autoFocus
+                  />
                 </div>
               </div>
             </cf-card>

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -49,10 +49,16 @@ interface DisplayMessage {
   index: number;
   from: string;
   body: string;
-  message: ChatMessage;
   showAuthor: boolean;
   className: string;
   canReact: boolean;
+  thumbsActive: boolean;
+  thumbsLabel: string;
+  heartActive: boolean;
+  heartLabel: string;
+  laughActive: boolean;
+  laughLabel: string;
+  hasAnyReaction: boolean;
 }
 
 export interface PicoChatInput {
@@ -147,9 +153,15 @@ function displayMessages(
       index,
       from: message.from,
       body: message.body,
-      message,
       showAuthor,
       canReact: viewerName !== "" && message.from !== viewerName,
+      thumbsActive: hasReaction(message, "👍"),
+      thumbsLabel: reactionLabel(message, "👍"),
+      heartActive: hasReaction(message, "❤️"),
+      heartLabel: reactionLabel(message, "❤️"),
+      laughActive: hasReaction(message, "😂"),
+      laughLabel: reactionLabel(message, "😂"),
+      hasAnyReaction: hasAnyReaction(message),
       className: [
         "pico-message-row",
         showAuthor ? "pico-message-row-start" : "",
@@ -180,8 +192,8 @@ function hasAnyReaction(message: ChatMessage) {
     hasReaction(message, "😂");
 }
 
-function reactionOptionClass(message: ChatMessage, emoji: string) {
-  return hasReaction(message, emoji)
+function reactionOptionClass(active: boolean) {
+  return active
     ? "pico-reaction-option pico-reaction-option-active"
     : "pico-reaction-option";
 }
@@ -310,8 +322,7 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                             >
                               <cf-button
                                 className={reactionOptionClass(
-                                  row.message,
-                                  "👍",
+                                  row.thumbsActive,
                                 )}
                                 size="sm"
                                 variant="ghost"
@@ -321,13 +332,10 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                     emoji: "👍",
                                   })}
                               >
-                                {reactionLabel(row.message, "👍")}
+                                {row.thumbsLabel}
                               </cf-button>
                               <cf-button
-                                className={reactionOptionClass(
-                                  row.message,
-                                  "❤️",
-                                )}
+                                className={reactionOptionClass(row.heartActive)}
                                 size="sm"
                                 variant="ghost"
                                 onClick={() =>
@@ -336,13 +344,10 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                     emoji: "❤️",
                                   })}
                               >
-                                {reactionLabel(row.message, "❤️")}
+                                {row.heartLabel}
                               </cf-button>
                               <cf-button
-                                className={reactionOptionClass(
-                                  row.message,
-                                  "😂",
-                                )}
+                                className={reactionOptionClass(row.laughActive)}
                                 size="sm"
                                 variant="ghost"
                                 onClick={() =>
@@ -351,31 +356,31 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                     emoji: "😂",
                                   })}
                               >
-                                {reactionLabel(row.message, "😂")}
+                                {row.laughLabel}
                               </cf-button>
                             </div>
                           )
-                          : hasAnyReaction(row.message)
+                          : row.hasAnyReaction
                           ? (
                             <div style={reactionRowStyle}>
-                              {hasReaction(row.message, "👍")
+                              {row.thumbsActive
                                 ? (
                                   <span style={reactionBadgeStyle}>
-                                    {reactionLabel(row.message, "👍")}
+                                    {row.thumbsLabel}
                                   </span>
                                 )
                                 : null}
-                              {hasReaction(row.message, "❤️")
+                              {row.heartActive
                                 ? (
                                   <span style={reactionBadgeStyle}>
-                                    {reactionLabel(row.message, "❤️")}
+                                    {row.heartLabel}
                                   </span>
                                 )
                                 : null}
-                              {hasReaction(row.message, "😂")
+                              {row.laughActive
                                 ? (
                                   <span style={reactionBadgeStyle}>
-                                    {reactionLabel(row.message, "😂")}
+                                    {row.laughLabel}
                                   </span>
                                 )
                                 : null}

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -59,7 +59,6 @@ interface DisplayMessage {
   body: string;
   showAuthor: boolean;
   className: string;
-  canReact: boolean;
   thumbsCount: number;
   thumbsPicked: boolean;
   thumbsChoiceClass: string;
@@ -195,7 +194,6 @@ function displayMessages(
       from: message.from,
       body: message.body,
       showAuthor,
-      canReact: viewerName !== "" && message.from !== viewerName,
       thumbsCount,
       thumbsPicked,
       thumbsChoiceClass: reactionChoiceClass(thumbsPicked),
@@ -590,54 +588,50 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                             </div>
                           )
                           : null}
-                        {row.canReact
-                          ? (
-                            <div
-                              className="pico-reaction-picker"
-                              style={reactionPickerStyle}
-                            >
-                              <button
-                                type="button"
-                                className={row.thumbsChoiceClass}
-                                aria-label="React with thumbs up"
-                                title={row.thumbsPickerTitle}
-                                onClick={() =>
-                                  react.send({
-                                    messageIndex: row.index,
-                                    emoji: "👍",
-                                  })}
-                              >
-                                👍
-                              </button>
-                              <button
-                                type="button"
-                                className={row.heartChoiceClass}
-                                aria-label="React with heart"
-                                title={row.heartPickerTitle}
-                                onClick={() =>
-                                  react.send({
-                                    messageIndex: row.index,
-                                    emoji: "❤️",
-                                  })}
-                              >
-                                ❤️
-                              </button>
-                              <button
-                                type="button"
-                                className={row.laughChoiceClass}
-                                aria-label="React with laughing face"
-                                title={row.laughPickerTitle}
-                                onClick={() =>
-                                  react.send({
-                                    messageIndex: row.index,
-                                    emoji: "😂",
-                                  })}
-                              >
-                                😂
-                              </button>
-                            </div>
-                          )
-                          : null}
+                        <div
+                          className="pico-reaction-picker"
+                          style={reactionPickerStyle}
+                        >
+                          <button
+                            type="button"
+                            className={row.thumbsChoiceClass}
+                            aria-label="React with thumbs up"
+                            title={row.thumbsPickerTitle}
+                            onClick={() =>
+                              react.send({
+                                messageIndex: row.index,
+                                emoji: "👍",
+                              })}
+                          >
+                            👍
+                          </button>
+                          <button
+                            type="button"
+                            className={row.heartChoiceClass}
+                            aria-label="React with heart"
+                            title={row.heartPickerTitle}
+                            onClick={() =>
+                              react.send({
+                                messageIndex: row.index,
+                                emoji: "❤️",
+                              })}
+                          >
+                            ❤️
+                          </button>
+                          <button
+                            type="button"
+                            className={row.laughChoiceClass}
+                            aria-label="React with laughing face"
+                            title={row.laughPickerTitle}
+                            onClick={() =>
+                              react.send({
+                                messageIndex: row.index,
+                                emoji: "😂",
+                              })}
+                          >
+                            😂
+                          </button>
+                        </div>
                       </div>
                     ))}
                   <button

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -60,15 +60,15 @@ interface DisplayMessage {
   showAuthor: boolean;
   className: string;
   canReact: boolean;
-  thumbsActive: boolean;
-  thumbsLabel: string;
-  thumbsClassName: string;
-  heartActive: boolean;
-  heartLabel: string;
-  heartClassName: string;
-  laughActive: boolean;
-  laughLabel: string;
-  laughClassName: string;
+  thumbsCount: number;
+  thumbsPicked: boolean;
+  thumbsSummaryLabel: string;
+  heartCount: number;
+  heartPicked: boolean;
+  heartSummaryLabel: string;
+  laughCount: number;
+  laughPicked: boolean;
+  laughSummaryLabel: string;
   hasAnyReaction: boolean;
 }
 
@@ -159,9 +159,9 @@ function displayMessages(
     const showAuthor = index === 0 || messages[index - 1].from !== message.from;
     const endGroup = index === messages.length - 1 ||
       messages[index + 1].from !== message.from;
-    const thumbsActive = hasReaction(message, "👍");
-    const heartActive = hasReaction(message, "❤️");
-    const laughActive = hasReaction(message, "😂");
+    const thumbsCount = reactionCount(message, "👍");
+    const heartCount = reactionCount(message, "❤️");
+    const laughCount = reactionCount(message, "😂");
 
     return {
       index,
@@ -169,16 +169,16 @@ function displayMessages(
       body: message.body,
       showAuthor,
       canReact: viewerName !== "" && message.from !== viewerName,
-      thumbsActive,
-      thumbsLabel: reactionLabel(message, "👍"),
-      thumbsClassName: reactionOptionClass(thumbsActive),
-      heartActive,
-      heartLabel: reactionLabel(message, "❤️"),
-      heartClassName: reactionOptionClass(heartActive),
-      laughActive,
-      laughLabel: reactionLabel(message, "😂"),
-      laughClassName: reactionOptionClass(laughActive),
-      hasAnyReaction: hasAnyReaction(message),
+      thumbsCount,
+      thumbsPicked: hasViewerReaction(message, "👍", viewerName),
+      thumbsSummaryLabel: reactionSummaryLabel("👍", thumbsCount),
+      heartCount,
+      heartPicked: hasViewerReaction(message, "❤️", viewerName),
+      heartSummaryLabel: reactionSummaryLabel("❤️", heartCount),
+      laughCount,
+      laughPicked: hasViewerReaction(message, "😂", viewerName),
+      laughSummaryLabel: reactionSummaryLabel("😂", laughCount),
+      hasAnyReaction: thumbsCount > 0 || heartCount > 0 || laughCount > 0,
       className: [
         "pico-message-row",
         showAuthor ? "pico-message-row-start" : "",
@@ -194,25 +194,25 @@ function reactionCount(message: ChatMessage, emoji: string) {
   ).length;
 }
 
-function reactionLabel(message: ChatMessage, emoji: string) {
-  const count = reactionCount(message, emoji);
+function reactionSummaryLabel(emoji: string, count: number) {
   return count > 0 ? `${emoji} ${count}` : emoji;
 }
 
-function hasReaction(message: ChatMessage, emoji: string) {
-  return reactionCount(message, emoji) > 0;
+function hasViewerReaction(
+  message: ChatMessage,
+  emoji: string,
+  viewerName: string,
+) {
+  return viewerName !== "" &&
+    asReactions(message.reactions).some((reaction) =>
+      reaction.emoji === emoji && reaction.byName === viewerName
+    );
 }
 
-function hasAnyReaction(message: ChatMessage) {
-  return hasReaction(message, "👍") ||
-    hasReaction(message, "❤️") ||
-    hasReaction(message, "😂");
-}
-
-function reactionOptionClass(active: boolean) {
-  return active
-    ? "pico-reaction-option pico-reaction-option-active"
-    : "pico-reaction-option";
+function reactionChoiceClass(picked: boolean) {
+  return picked
+    ? "pico-reaction-choice pico-reaction-choice-picked"
+    : "pico-reaction-choice";
 }
 
 const textStyle = {
@@ -234,8 +234,14 @@ const messageListStyle = {
   flexDirection: "column-reverse",
 };
 
-const reactionRowStyle = {
+const reactionSummaryStyle = {
   display: "flex",
+  flexWrap: "wrap",
+  gap: "0.25rem",
+  minHeight: "1.5rem",
+};
+
+const reactionPickerStyle = {
   flexWrap: "wrap",
   gap: "0.25rem",
   minHeight: "1.75rem",
@@ -264,15 +270,15 @@ export default pattern<PicoChatInput, PicoChatOutput>(
         <cf-screen>
           <style>
             {`
-              .pico-reaction-option {
+              .pico-reaction-picker {
+                display: none;
                 opacity: 0;
                 pointer-events: none;
                 transition: opacity 120ms ease;
               }
 
-              .pico-reaction-option-active {
-                opacity: 1;
-                pointer-events: auto;
+              .pico-reaction-choice-picked {
+                background: var(--cf-colors-muted, #e2e8f0);
               }
 
               .pico-message-row {
@@ -288,8 +294,9 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                 border-bottom: 1px solid var(--cf-colors-border, #e2e8f0);
               }
 
-              .pico-message-row:hover .pico-reaction-option,
-              .pico-message-row:has(.pico-reaction-option:focus-visible) .pico-reaction-option {
+              .pico-message-row:hover .pico-reaction-picker,
+              .pico-message-row:has(.pico-reaction-choice:focus-visible) .pico-reaction-picker {
+                display: flex;
                 opacity: 1;
                 pointer-events: auto;
               }
@@ -333,14 +340,43 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                         <div dir="ltr" style={textStyle}>
                           {row.body}
                         </div>
+                        {row.hasAnyReaction
+                          ? (
+                            <div style={reactionSummaryStyle}>
+                              {row.thumbsCount > 0
+                                ? (
+                                  <span style={reactionBadgeStyle}>
+                                    {row.thumbsSummaryLabel}
+                                  </span>
+                                )
+                                : null}
+                              {row.heartCount > 0
+                                ? (
+                                  <span style={reactionBadgeStyle}>
+                                    {row.heartSummaryLabel}
+                                  </span>
+                                )
+                                : null}
+                              {row.laughCount > 0
+                                ? (
+                                  <span style={reactionBadgeStyle}>
+                                    {row.laughSummaryLabel}
+                                  </span>
+                                )
+                                : null}
+                            </div>
+                          )
+                          : null}
                         {row.canReact
                           ? (
                             <div
-                              className="pico-reactions"
-                              style={reactionRowStyle}
+                              className="pico-reaction-picker"
+                              style={reactionPickerStyle}
                             >
                               <cf-button
-                                className={row.thumbsClassName}
+                                className={reactionChoiceClass(
+                                  row.thumbsPicked,
+                                )}
                                 size="sm"
                                 variant="ghost"
                                 onClick={() =>
@@ -349,10 +385,12 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                     emoji: "👍",
                                   })}
                               >
-                                {row.thumbsLabel}
+                                👍
                               </cf-button>
                               <cf-button
-                                className={row.heartClassName}
+                                className={reactionChoiceClass(
+                                  row.heartPicked,
+                                )}
                                 size="sm"
                                 variant="ghost"
                                 onClick={() =>
@@ -361,10 +399,12 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                     emoji: "❤️",
                                   })}
                               >
-                                {row.heartLabel}
+                                ❤️
                               </cf-button>
                               <cf-button
-                                className={row.laughClassName}
+                                className={reactionChoiceClass(
+                                  row.laughPicked,
+                                )}
                                 size="sm"
                                 variant="ghost"
                                 onClick={() =>
@@ -373,34 +413,8 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                     emoji: "😂",
                                   })}
                               >
-                                {row.laughLabel}
+                                😂
                               </cf-button>
-                            </div>
-                          )
-                          : row.hasAnyReaction
-                          ? (
-                            <div style={reactionRowStyle}>
-                              {row.thumbsActive
-                                ? (
-                                  <span style={reactionBadgeStyle}>
-                                    {row.thumbsLabel}
-                                  </span>
-                                )
-                                : null}
-                              {row.heartActive
-                                ? (
-                                  <span style={reactionBadgeStyle}>
-                                    {row.heartLabel}
-                                  </span>
-                                )
-                                : null}
-                              {row.laughActive
-                                ? (
-                                  <span style={reactionBadgeStyle}>
-                                    {row.laughLabel}
-                                  </span>
-                                )
-                                : null}
                             </div>
                           )
                           : null}

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -292,6 +292,7 @@ const textStyle = {
 
 const messagePaneStyle = {
   height: "320px",
+  overflowX: "hidden",
   overflowY: "auto",
 };
 
@@ -441,6 +442,15 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                 pointer-events: auto;
               }
 
+              .pico-message-pane {
+                -ms-overflow-style: none;
+                scrollbar-width: none;
+              }
+
+              .pico-message-pane::-webkit-scrollbar {
+                display: none;
+              }
+
               .pico-scroll-anchor {
                 appearance: none;
                 align-self: flex-end;
@@ -474,6 +484,7 @@ export default pattern<PicoChatInput, PicoChatOutput>(
               <div
                 slot="content"
                 id="chat-messages"
+                className="pico-message-pane"
                 style={messagePaneStyle}
               >
                 <div style={messageListStyle}>

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -130,6 +130,14 @@ function asReactions(
   return Array.isArray(reactions) ? [...reactions] : [];
 }
 
+function currentViewerName(value: unknown): string {
+  const maybeWritable = value as { get?: () => unknown };
+  const current = typeof maybeWritable?.get === "function"
+    ? maybeWritable.get()
+    : value;
+  return typeof current === "string" ? current.trim() : "";
+}
+
 export function groupMessages(
   messages: readonly ChatMessage[],
 ): MessageGroup[] {
@@ -260,7 +268,7 @@ export default pattern<PicoChatInput, PicoChatOutput>(
     const react = toggleReaction({ messages, name });
     const groups = computed(() => groupMessages([...messages]));
     const rows = computed(() =>
-      displayMessages([...messages], String(name).trim())
+      displayMessages([...messages], currentViewerName(name))
     );
     const visibleRows = computed(() => [...rows].reverse());
 
@@ -277,8 +285,36 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                 transition: opacity 120ms ease;
               }
 
+              .pico-reaction-choice {
+                appearance: none;
+                align-items: center;
+                background: transparent;
+                border: 0;
+                border-radius: 4px;
+                color: inherit;
+                cursor: pointer;
+                display: inline-flex;
+                font: inherit;
+                height: 1.75rem;
+                justify-content: center;
+                line-height: 1;
+                padding: 0;
+                transition: filter 120ms ease, transform 120ms ease;
+                width: 1.75rem;
+              }
+
+              .pico-reaction-choice:hover,
+              .pico-reaction-choice:focus-visible {
+                transform: translateY(-1px) scale(1.08);
+              }
+
+              .pico-reaction-choice:focus-visible {
+                outline: 2px solid currentColor;
+                outline-offset: 2px;
+              }
+
               .pico-reaction-choice-picked {
-                background: var(--cf-colors-muted, #e2e8f0);
+                filter: drop-shadow(0 0 4px rgba(96, 165, 250, 0.75));
               }
 
               .pico-message-row {
@@ -373,12 +409,12 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                               className="pico-reaction-picker"
                               style={reactionPickerStyle}
                             >
-                              <cf-button
+                              <button
+                                type="button"
                                 className={reactionChoiceClass(
                                   row.thumbsPicked,
                                 )}
-                                size="sm"
-                                variant="ghost"
+                                aria-label="React with thumbs up"
                                 onClick={() =>
                                   react.send({
                                     messageIndex: row.index,
@@ -386,13 +422,13 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                   })}
                               >
                                 👍
-                              </cf-button>
-                              <cf-button
+                              </button>
+                              <button
+                                type="button"
                                 className={reactionChoiceClass(
                                   row.heartPicked,
                                 )}
-                                size="sm"
-                                variant="ghost"
+                                aria-label="React with heart"
                                 onClick={() =>
                                   react.send({
                                     messageIndex: row.index,
@@ -400,13 +436,13 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                   })}
                               >
                                 ❤️
-                              </cf-button>
-                              <cf-button
+                              </button>
+                              <button
+                                type="button"
                                 className={reactionChoiceClass(
                                   row.laughPicked,
                                 )}
-                                size="sm"
-                                variant="ghost"
+                                aria-label="React with laughing face"
                                 onClick={() =>
                                   react.send({
                                     messageIndex: row.index,
@@ -414,7 +450,7 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                   })}
                               >
                                 😂
-                              </cf-button>
+                              </button>
                             </div>
                           )
                           : null}

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -139,14 +139,6 @@ function reactionLabel(message: ChatMessage, emoji: string) {
   return count > 0 ? `${emoji} ${count}` : emoji;
 }
 
-export function reactionClick(
-  react: Stream<ReactEvent>,
-  message: ChatMessage,
-  emoji: string,
-) {
-  return () => react.send({ message, emoji });
-}
-
 const textStyle = {
   unicodeBidi: "plaintext",
   whiteSpace: "pre-wrap",
@@ -234,11 +226,8 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                   <cf-button
                                     size="sm"
                                     variant="ghost"
-                                    onClick={reactionClick(
-                                      react,
-                                      message,
-                                      emoji,
-                                    )}
+                                    onClick={() =>
+                                      react.send({ message, emoji })}
                                   >
                                     {reactionLabel(message, emoji)}
                                   </cf-button>

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -54,10 +54,13 @@ interface DisplayMessage {
   canReact: boolean;
   thumbsActive: boolean;
   thumbsLabel: string;
+  thumbsClassName: string;
   heartActive: boolean;
   heartLabel: string;
+  heartClassName: string;
   laughActive: boolean;
   laughLabel: string;
+  laughClassName: string;
   hasAnyReaction: boolean;
 }
 
@@ -148,6 +151,9 @@ function displayMessages(
     const showAuthor = index === 0 || messages[index - 1].from !== message.from;
     const endGroup = index === messages.length - 1 ||
       messages[index + 1].from !== message.from;
+    const thumbsActive = hasReaction(message, "👍");
+    const heartActive = hasReaction(message, "❤️");
+    const laughActive = hasReaction(message, "😂");
 
     return {
       index,
@@ -155,12 +161,15 @@ function displayMessages(
       body: message.body,
       showAuthor,
       canReact: viewerName !== "" && message.from !== viewerName,
-      thumbsActive: hasReaction(message, "👍"),
+      thumbsActive,
       thumbsLabel: reactionLabel(message, "👍"),
-      heartActive: hasReaction(message, "❤️"),
+      thumbsClassName: reactionOptionClass(thumbsActive),
+      heartActive,
       heartLabel: reactionLabel(message, "❤️"),
-      laughActive: hasReaction(message, "😂"),
+      heartClassName: reactionOptionClass(heartActive),
+      laughActive,
       laughLabel: reactionLabel(message, "😂"),
+      laughClassName: reactionOptionClass(laughActive),
       hasAnyReaction: hasAnyReaction(message),
       className: [
         "pico-message-row",
@@ -321,9 +330,7 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                               style={reactionRowStyle}
                             >
                               <cf-button
-                                className={reactionOptionClass(
-                                  row.thumbsActive,
-                                )}
+                                className={row.thumbsClassName}
                                 size="sm"
                                 variant="ghost"
                                 onClick={() =>
@@ -335,7 +342,7 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                 {row.thumbsLabel}
                               </cf-button>
                               <cf-button
-                                className={reactionOptionClass(row.heartActive)}
+                                className={row.heartClassName}
                                 size="sm"
                                 variant="ghost"
                                 onClick={() =>
@@ -347,7 +354,7 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                 {row.heartLabel}
                               </cf-button>
                               <cf-button
-                                className={reactionOptionClass(row.laughActive)}
+                                className={row.laughClassName}
                                 size="sm"
                                 variant="ghost"
                                 onClick={() =>

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -63,12 +63,15 @@ interface DisplayMessage {
   thumbsCount: number;
   thumbsPicked: boolean;
   thumbsSummaryLabel: string;
+  thumbsTitle: string;
   heartCount: number;
   heartPicked: boolean;
   heartSummaryLabel: string;
+  heartTitle: string;
   laughCount: number;
   laughPicked: boolean;
   laughSummaryLabel: string;
+  laughTitle: string;
   hasAnyReaction: boolean;
 }
 
@@ -180,12 +183,15 @@ function displayMessages(
       thumbsCount,
       thumbsPicked: hasViewerReaction(message, "👍", viewerName),
       thumbsSummaryLabel: reactionSummaryLabel("👍", thumbsCount),
+      thumbsTitle: reactionTitle(message, "👍"),
       heartCount,
       heartPicked: hasViewerReaction(message, "❤️", viewerName),
       heartSummaryLabel: reactionSummaryLabel("❤️", heartCount),
+      heartTitle: reactionTitle(message, "❤️"),
       laughCount,
       laughPicked: hasViewerReaction(message, "😂", viewerName),
       laughSummaryLabel: reactionSummaryLabel("😂", laughCount),
+      laughTitle: reactionTitle(message, "😂"),
       hasAnyReaction: thumbsCount > 0 || heartCount > 0 || laughCount > 0,
       className: [
         "pico-message-row",
@@ -204,6 +210,16 @@ function reactionCount(message: ChatMessage, emoji: string) {
 
 function reactionSummaryLabel(emoji: string, count: number) {
   return count > 0 ? `${emoji} ${count}` : emoji;
+}
+
+function reactionTitle(message: ChatMessage, emoji: string) {
+  const names = asReactions(message.reactions)
+    .filter((reaction) => reaction.emoji === emoji)
+    .map((reaction) => reaction.byName.trim())
+    .filter(Boolean);
+  return names.length > 0
+    ? `${emoji} by ${Array.from(new Set(names)).join(", ")}`
+    : "";
 }
 
 function hasViewerReaction(
@@ -282,6 +298,9 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                 display: none;
                 opacity: 0;
                 pointer-events: none;
+                position: absolute;
+                right: 0.5rem;
+                top: 0.5rem;
                 transition: opacity 120ms ease;
               }
 
@@ -318,16 +337,25 @@ export default pattern<PicoChatInput, PicoChatOutput>(
               }
 
               .pico-message-row {
-                padding: 4px 0;
+                border-radius: 6px;
+                margin: 0 -0.5rem;
+                padding: 0.375rem 2.5rem 0.375rem 0.5rem;
+                position: relative;
+                transition: background-color 120ms ease;
               }
 
               .pico-message-row-start {
-                padding-top: 10px;
+                padding-top: 0.625rem;
               }
 
               .pico-message-row-end {
-                padding-bottom: 10px;
+                padding-bottom: 0.625rem;
                 border-bottom: 1px solid var(--cf-colors-border, #e2e8f0);
+              }
+
+              .pico-message-row:hover,
+              .pico-message-row:focus-within {
+                background: rgba(148, 163, 184, 0.14);
               }
 
               .pico-message-row:hover .pico-reaction-picker,
@@ -381,21 +409,30 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                             <div style={reactionSummaryStyle}>
                               {row.thumbsCount > 0
                                 ? (
-                                  <span style={reactionBadgeStyle}>
+                                  <span
+                                    style={reactionBadgeStyle}
+                                    title={row.thumbsTitle}
+                                  >
                                     {row.thumbsSummaryLabel}
                                   </span>
                                 )
                                 : null}
                               {row.heartCount > 0
                                 ? (
-                                  <span style={reactionBadgeStyle}>
+                                  <span
+                                    style={reactionBadgeStyle}
+                                    title={row.heartTitle}
+                                  >
                                     {row.heartSummaryLabel}
                                   </span>
                                 )
                                 : null}
                               {row.laughCount > 0
                                 ? (
-                                  <span style={reactionBadgeStyle}>
+                                  <span
+                                    style={reactionBadgeStyle}
+                                    title={row.laughTitle}
+                                  >
                                     {row.laughSummaryLabel}
                                   </span>
                                 )
@@ -415,6 +452,9 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                   row.thumbsPicked,
                                 )}
                                 aria-label="React with thumbs up"
+                                title={row.thumbsPicked
+                                  ? "Remove your thumbs up"
+                                  : "React with thumbs up"}
                                 onClick={() =>
                                   react.send({
                                     messageIndex: row.index,
@@ -429,6 +469,9 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                   row.heartPicked,
                                 )}
                                 aria-label="React with heart"
+                                title={row.heartPicked
+                                  ? "Remove your heart"
+                                  : "React with heart"}
                                 onClick={() =>
                                   react.send({
                                     messageIndex: row.index,
@@ -443,6 +486,9 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                                   row.laughPicked,
                                 )}
                                 aria-label="React with laughing face"
+                                title={row.laughPicked
+                                  ? "Remove your laughing face"
+                                  : "React with laughing face"}
                                 onClick={() =>
                                   react.send({
                                     messageIndex: row.index,

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -168,8 +168,13 @@ const textStyle = {
 const messagePaneStyle = {
   height: "320px",
   overflowY: "auto",
+};
+
+const messageListStyle = {
+  minHeight: "100%",
   display: "flex",
-  flexDirection: "column-reverse",
+  flexDirection: "column",
+  justifyContent: "flex-end",
 };
 
 const groupStyle = {
@@ -194,7 +199,6 @@ export default pattern<PicoChatInput, PicoChatOutput>(
     const send = sendMessage({ messages, name });
     const react = toggleReaction({ messages, name });
     const groups = computed(() => groupMessages([...messages]));
-    const displayGroups = computed(() => [...groups].reverse());
 
     return {
       [NAME]: "Pico chat",
@@ -219,19 +223,14 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                 id="chat-messages"
                 style={messagePaneStyle}
               >
-                <div
-                  style={{
-                    display: "flex",
-                    flexDirection: "column-reverse",
-                  }}
-                >
-                  {displayGroups.length === 0
+                <div style={messageListStyle}>
+                  {groups.length === 0
                     ? (
                       <div style={{ color: "var(--cf-colors-muted, #64748b)" }}>
                         No messages yet
                       </div>
                     )
-                    : displayGroups.map((group) => (
+                    : groups.map((group) => (
                       <div style={groupStyle}>
                         <strong dir="ltr" style={textStyle}>
                           {group.from}

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -251,7 +251,7 @@ export default pattern<PicoChatInput, PicoChatOutput>(
     const visibleRows = computed(() => [...rows].reverse());
 
     return {
-      [NAME]: "Pico chat",
+      [NAME]: "Emo chat",
       [UI]: (
         <cf-screen>
           <style>
@@ -288,7 +288,7 @@ export default pattern<PicoChatInput, PicoChatOutput>(
             `}
           </style>
           <cf-vstack gap="4" padding="6" style="max-width: 720px;">
-            <cf-heading level={2}>Pico chat</cf-heading>
+            <cf-heading level={2}>Emo chat</cf-heading>
 
             <cf-vstack gap="2">
               <cf-label>Your name</cf-label>

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -279,7 +279,7 @@ export default pattern<PicoChatInput, PicoChatOutput>(
               }
 
               .pico-message-row:hover .pico-reaction-option,
-              .pico-message-row:focus-within .pico-reaction-option {
+              .pico-message-row:has(.pico-reaction-option:focus-visible) .pico-reaction-option {
                 opacity: 1;
                 pointer-events: auto;
               }

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -51,6 +51,7 @@ interface DisplayMessage {
   body: string;
   message: ChatMessage;
   showAuthor: boolean;
+  endGroup: boolean;
 }
 
 export interface PicoChatInput {
@@ -140,6 +141,8 @@ function displayMessages(messages: readonly ChatMessage[]): DisplayMessage[] {
     body: message.body,
     message,
     showAuthor: index === 0 || messages[index - 1].from !== message.from,
+    endGroup: index === messages.length - 1 ||
+      messages[index + 1].from !== message.from,
   }));
 }
 
@@ -172,21 +175,32 @@ const messageListStyle = {
   justifyContent: "flex-end",
 };
 
-const groupStyle = {
-  padding: "10px 0",
+const groupStartStyle = {
+  padding: "10px 0 4px",
+};
+
+const groupEndStyle = {
+  padding: "4px 0 10px",
   borderBottom: "1px solid var(--cf-colors-border, #e2e8f0)",
 };
 
 const continuationStyle = {
-  padding: "4px 0 10px",
-  borderBottom: "1px solid var(--cf-colors-border, #e2e8f0)",
+  padding: "4px 0",
 };
 
 const reactionRowStyle = {
   display: "flex",
   flexWrap: "wrap",
   gap: "0.25rem",
+  minHeight: "1.75rem",
 };
+
+function rowStyle(row: DisplayMessage) {
+  if (row.showAuthor && row.endGroup) return groupEndStyle;
+  if (row.showAuthor) return groupStartStyle;
+  if (row.endGroup) return groupEndStyle;
+  return continuationStyle;
+}
 
 export default pattern<PicoChatInput, PicoChatOutput>(
   ({ messages, name }) => {
@@ -199,6 +213,21 @@ export default pattern<PicoChatInput, PicoChatOutput>(
       [NAME]: "Pico chat",
       [UI]: (
         <cf-screen>
+          <style>
+            {`
+              .pico-reactions {
+                opacity: 0;
+                pointer-events: none;
+                transition: opacity 120ms ease;
+              }
+
+              .pico-message-row:hover .pico-reactions,
+              .pico-message-row:focus-within .pico-reactions {
+                opacity: 1;
+                pointer-events: auto;
+              }
+            `}
+          </style>
           <cf-vstack gap="4" padding="6" style="max-width: 720px;">
             <cf-heading level={2}>Pico chat</cf-heading>
 
@@ -227,7 +256,8 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                     )
                     : rows.map((row) => (
                       <div
-                        style={row.showAuthor ? groupStyle : continuationStyle}
+                        className="pico-message-row"
+                        style={rowStyle(row)}
                       >
                         {row.showAuthor
                           ? (
@@ -239,7 +269,10 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                         <div dir="ltr" style={textStyle}>
                           {row.body}
                         </div>
-                        <div style={reactionRowStyle}>
+                        <div
+                          className="pico-reactions"
+                          style={reactionRowStyle}
+                        >
                           <cf-button
                             size="sm"
                             variant="ghost"

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -17,13 +17,11 @@ export type NameCell = Writable<string>;
 
 export interface Reaction {
   emoji: string;
-  by: NameCell;
   byName: string;
 }
 
 export interface ChatMessage {
   from: string;
-  fromName?: NameCell;
   body: string;
   reactions?: Reaction[] | Default<[]>;
 }
@@ -46,7 +44,6 @@ export interface ReactEvent {
 
 export interface MessageGroup {
   from: string;
-  fromName?: NameCell;
   messages: ChatMessage[];
 }
 
@@ -74,7 +71,7 @@ const sendMessage = handler<SendEvent, {
 
   if (!from || !body) return;
 
-  messages.push({ from, fromName: name, body, reactions: [] });
+  messages.push({ from, body, reactions: [] });
 });
 
 const toggleReaction = handler<ReactEvent, {
@@ -94,13 +91,13 @@ const toggleReaction = handler<ReactEvent, {
   const reactionsCell = messages.key(index).key("reactions");
   const reactions = asReactions(reactionsCell.get());
   const existingIndex = reactions.findIndex((reaction) =>
-    reaction.emoji === mark && reaction.by && equals(reaction.by, name)
+    reaction.emoji === mark && reaction.byName === byName
   );
 
   reactionsCell.set(
     existingIndex >= 0
-      ? reactions.toSpliced(existingIndex, 1)
-      : [...reactions, { emoji: mark, by: name, byName }],
+      ? reactions.filter((_, index) => index !== existingIndex)
+      : [...reactions, { emoji: mark, byName }],
   );
 });
 
@@ -110,13 +107,6 @@ function asReactions(
   return Array.isArray(reactions) ? [...reactions] : [];
 }
 
-function sameAuthor(left: ChatMessage, right: ChatMessage) {
-  if (left.fromName && right.fromName) {
-    return equals(left.fromName, right.fromName);
-  }
-  return left.from === right.from;
-}
-
 export function groupMessages(
   messages: readonly ChatMessage[],
 ): MessageGroup[] {
@@ -124,14 +114,12 @@ export function groupMessages(
 
   for (const message of messages) {
     const last = groups[groups.length - 1];
-    if (last && sameAuthor(last.messages[last.messages.length - 1], message)) {
+    if (last && last.messages[last.messages.length - 1].from === message.from) {
       last.from = message.from;
-      last.fromName = message.fromName;
       last.messages.push(message);
     } else {
       groups.push({
         from: message.from,
-        fromName: message.fromName,
         messages: [message],
       });
     }

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -51,7 +51,7 @@ interface DisplayMessage {
   body: string;
   message: ChatMessage;
   showAuthor: boolean;
-  endGroup: boolean;
+  className: string;
 }
 
 export interface PicoChatInput {
@@ -136,14 +136,23 @@ export function groupMessages(
 }
 
 function displayMessages(messages: readonly ChatMessage[]): DisplayMessage[] {
-  return messages.map((message, index) => ({
-    from: message.from,
-    body: message.body,
-    message,
-    showAuthor: index === 0 || messages[index - 1].from !== message.from,
-    endGroup: index === messages.length - 1 ||
-      messages[index + 1].from !== message.from,
-  }));
+  return messages.map((message, index) => {
+    const showAuthor = index === 0 || messages[index - 1].from !== message.from;
+    const endGroup = index === messages.length - 1 ||
+      messages[index + 1].from !== message.from;
+
+    return {
+      from: message.from,
+      body: message.body,
+      message,
+      showAuthor,
+      className: [
+        "pico-message-row",
+        showAuthor ? "pico-message-row-start" : "",
+        endGroup ? "pico-message-row-end" : "",
+      ].filter(Boolean).join(" "),
+    };
+  });
 }
 
 function reactionCount(message: ChatMessage, emoji: string) {
@@ -175,32 +184,12 @@ const messageListStyle = {
   justifyContent: "flex-end",
 };
 
-const groupStartStyle = {
-  padding: "10px 0 4px",
-};
-
-const groupEndStyle = {
-  padding: "4px 0 10px",
-  borderBottom: "1px solid var(--cf-colors-border, #e2e8f0)",
-};
-
-const continuationStyle = {
-  padding: "4px 0",
-};
-
 const reactionRowStyle = {
   display: "flex",
   flexWrap: "wrap",
   gap: "0.25rem",
   minHeight: "1.75rem",
 };
-
-function rowStyle(row: DisplayMessage) {
-  if (row.showAuthor && row.endGroup) return groupEndStyle;
-  if (row.showAuthor) return groupStartStyle;
-  if (row.endGroup) return groupEndStyle;
-  return continuationStyle;
-}
 
 export default pattern<PicoChatInput, PicoChatOutput>(
   ({ messages, name }) => {
@@ -219,6 +208,19 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                 opacity: 0;
                 pointer-events: none;
                 transition: opacity 120ms ease;
+              }
+
+              .pico-message-row {
+                padding: 4px 0;
+              }
+
+              .pico-message-row-start {
+                padding-top: 10px;
+              }
+
+              .pico-message-row-end {
+                padding-bottom: 10px;
+                border-bottom: 1px solid var(--cf-colors-border, #e2e8f0);
               }
 
               .pico-message-row:hover .pico-reactions,
@@ -255,10 +257,7 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                       </div>
                     )
                     : rows.map((row) => (
-                      <div
-                        className="pico-message-row"
-                        style={rowStyle(row)}
-                      >
+                      <div className={row.className}>
                         {row.showAuthor
                           ? (
                             <strong dir="ltr" style={textStyle}>

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -1,7 +1,6 @@
 import {
   computed,
   Default,
-  equals,
   handler,
   NAME,
   pattern,
@@ -37,7 +36,7 @@ export interface SendEvent {
 }
 
 export interface ReactEvent {
-  message: ChatMessage;
+  messageIndex: number;
   emoji: string;
 }
 
@@ -47,11 +46,13 @@ export interface MessageGroup {
 }
 
 interface DisplayMessage {
+  index: number;
   from: string;
   body: string;
   message: ChatMessage;
   showAuthor: boolean;
   className: string;
+  canReact: boolean;
 }
 
 export interface PicoChatInput {
@@ -84,18 +85,16 @@ const sendMessage = handler<SendEvent, {
 const toggleReaction = handler<ReactEvent, {
   messages: MessagesCell;
   name: NameCell;
-}>(({ message, emoji }, { messages, name }) => {
+}>(({ messageIndex, emoji }, { messages, name }) => {
   const mark = emoji.trim();
   const byName = name.get().trim();
-  if (!message || !mark || !byName) return;
+  if (!mark || !byName || !Number.isInteger(messageIndex)) return;
 
   const currentMessages = messages.get();
-  const index = currentMessages.findIndex((candidate) =>
-    equals(candidate, message)
-  );
-  if (index < 0) return;
+  const message = currentMessages[messageIndex];
+  if (!message || message.from === byName) return;
 
-  const reactionsCell = messages.key(index).key("reactions");
+  const reactionsCell = messages.key(messageIndex).key("reactions");
   const reactions = asReactions(reactionsCell.get());
   const existingIndex = reactions.findIndex((reaction) =>
     reaction.emoji === mark && reaction.byName === byName
@@ -135,17 +134,22 @@ export function groupMessages(
   return groups;
 }
 
-function displayMessages(messages: readonly ChatMessage[]): DisplayMessage[] {
+function displayMessages(
+  messages: readonly ChatMessage[],
+  viewerName: string,
+): DisplayMessage[] {
   return messages.map((message, index) => {
     const showAuthor = index === 0 || messages[index - 1].from !== message.from;
     const endGroup = index === messages.length - 1 ||
       messages[index + 1].from !== message.from;
 
     return {
+      index,
       from: message.from,
       body: message.body,
       message,
       showAuthor,
+      canReact: viewerName !== "" && message.from !== viewerName,
       className: [
         "pico-message-row",
         showAuthor ? "pico-message-row-start" : "",
@@ -164,6 +168,16 @@ function reactionCount(message: ChatMessage, emoji: string) {
 function reactionLabel(message: ChatMessage, emoji: string) {
   const count = reactionCount(message, emoji);
   return count > 0 ? `${emoji} ${count}` : emoji;
+}
+
+function hasReaction(message: ChatMessage, emoji: string) {
+  return reactionCount(message, emoji) > 0;
+}
+
+function hasAnyReaction(message: ChatMessage) {
+  return hasReaction(message, "👍") ||
+    hasReaction(message, "❤️") ||
+    hasReaction(message, "😂");
 }
 
 const textStyle = {
@@ -191,12 +205,21 @@ const reactionRowStyle = {
   minHeight: "1.75rem",
 };
 
+const reactionBadgeStyle = {
+  display: "inline-flex",
+  alignItems: "center",
+  minHeight: "1.75rem",
+  padding: "0 0.35rem",
+};
+
 export default pattern<PicoChatInput, PicoChatOutput>(
   ({ messages, name }) => {
     const send = sendMessage({ messages, name });
     const react = toggleReaction({ messages, name });
     const groups = computed(() => groupMessages([...messages]));
-    const rows = computed(() => displayMessages([...messages]));
+    const rows = computed(() =>
+      displayMessages([...messages], String(name).trim())
+    );
 
     return {
       [NAME]: "Pico chat",
@@ -268,44 +291,74 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                         <div dir="ltr" style={textStyle}>
                           {row.body}
                         </div>
-                        <div
-                          className="pico-reactions"
-                          style={reactionRowStyle}
-                        >
-                          <cf-button
-                            size="sm"
-                            variant="ghost"
-                            onClick={() =>
-                              react.send({
-                                message: row.message,
-                                emoji: "👍",
-                              })}
-                          >
-                            {reactionLabel(row.message, "👍")}
-                          </cf-button>
-                          <cf-button
-                            size="sm"
-                            variant="ghost"
-                            onClick={() =>
-                              react.send({
-                                message: row.message,
-                                emoji: "❤️",
-                              })}
-                          >
-                            {reactionLabel(row.message, "❤️")}
-                          </cf-button>
-                          <cf-button
-                            size="sm"
-                            variant="ghost"
-                            onClick={() =>
-                              react.send({
-                                message: row.message,
-                                emoji: "😂",
-                              })}
-                          >
-                            {reactionLabel(row.message, "😂")}
-                          </cf-button>
-                        </div>
+                        {row.canReact
+                          ? (
+                            <div
+                              className="pico-reactions"
+                              style={reactionRowStyle}
+                            >
+                              <cf-button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() =>
+                                  react.send({
+                                    messageIndex: row.index,
+                                    emoji: "👍",
+                                  })}
+                              >
+                                {reactionLabel(row.message, "👍")}
+                              </cf-button>
+                              <cf-button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() =>
+                                  react.send({
+                                    messageIndex: row.index,
+                                    emoji: "❤️",
+                                  })}
+                              >
+                                {reactionLabel(row.message, "❤️")}
+                              </cf-button>
+                              <cf-button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() =>
+                                  react.send({
+                                    messageIndex: row.index,
+                                    emoji: "😂",
+                                  })}
+                              >
+                                {reactionLabel(row.message, "😂")}
+                              </cf-button>
+                            </div>
+                          )
+                          : hasAnyReaction(row.message)
+                          ? (
+                            <div style={reactionRowStyle}>
+                              {hasReaction(row.message, "👍")
+                                ? (
+                                  <span style={reactionBadgeStyle}>
+                                    {reactionLabel(row.message, "👍")}
+                                  </span>
+                                )
+                                : null}
+                              {hasReaction(row.message, "❤️")
+                                ? (
+                                  <span style={reactionBadgeStyle}>
+                                    {reactionLabel(row.message, "❤️")}
+                                  </span>
+                                )
+                                : null}
+                              {hasReaction(row.message, "😂")
+                                ? (
+                                  <span style={reactionBadgeStyle}>
+                                    {reactionLabel(row.message, "😂")}
+                                  </span>
+                                )
+                                : null}
+                            </div>
+                          )
+                          : null}
                       </div>
                     ))}
                 </div>

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -62,14 +62,23 @@ interface DisplayMessage {
   canReact: boolean;
   thumbsCount: number;
   thumbsPicked: boolean;
+  thumbsChoiceClass: string;
+  thumbsPickerTitle: string;
+  thumbsRemoveTitle: string;
   thumbsSummaryLabel: string;
   thumbsTitle: string;
   heartCount: number;
   heartPicked: boolean;
+  heartChoiceClass: string;
+  heartPickerTitle: string;
+  heartRemoveTitle: string;
   heartSummaryLabel: string;
   heartTitle: string;
   laughCount: number;
   laughPicked: boolean;
+  laughChoiceClass: string;
+  laughPickerTitle: string;
+  laughRemoveTitle: string;
   laughSummaryLabel: string;
   laughTitle: string;
   hasAnyReaction: boolean;
@@ -112,13 +121,14 @@ const toggleReaction = handler<ReactEvent, {
 
   const currentMessages = messages.get();
   const message = currentMessages[messageIndex];
-  if (!message || message.from === byName) return;
+  if (!message) return;
 
   const reactionsCell = messages.key(messageIndex).key("reactions");
   const reactions = asReactions(reactionsCell.get());
   const existingIndex = reactions.findIndex((reaction) =>
     reaction.emoji === mark && reaction.byName === byName
   );
+  if (message.from === byName && existingIndex < 0) return;
 
   reactionsCell.set(
     existingIndex >= 0
@@ -173,6 +183,12 @@ function displayMessages(
     const thumbsCount = reactionCount(message, "👍");
     const heartCount = reactionCount(message, "❤️");
     const laughCount = reactionCount(message, "😂");
+    const thumbsPicked = hasViewerReaction(message, "👍", viewerName);
+    const heartPicked = hasViewerReaction(message, "❤️", viewerName);
+    const laughPicked = hasViewerReaction(message, "😂", viewerName);
+    const thumbsTitle = reactionTitle(message, "👍");
+    const heartTitle = reactionTitle(message, "❤️");
+    const laughTitle = reactionTitle(message, "😂");
 
     return {
       index,
@@ -181,17 +197,38 @@ function displayMessages(
       showAuthor,
       canReact: viewerName !== "" && message.from !== viewerName,
       thumbsCount,
-      thumbsPicked: hasViewerReaction(message, "👍", viewerName),
+      thumbsPicked,
+      thumbsChoiceClass: reactionChoiceClass(thumbsPicked),
+      thumbsPickerTitle: reactionPickerTitle(
+        "React with thumbs up",
+        thumbsPicked,
+      ),
+      thumbsRemoveTitle: reactionBadgeTitle(
+        "Remove your thumbs up",
+        thumbsTitle,
+      ),
       thumbsSummaryLabel: reactionSummaryLabel("👍", thumbsCount),
-      thumbsTitle: reactionTitle(message, "👍"),
+      thumbsTitle,
       heartCount,
-      heartPicked: hasViewerReaction(message, "❤️", viewerName),
+      heartPicked,
+      heartChoiceClass: reactionChoiceClass(heartPicked),
+      heartPickerTitle: reactionPickerTitle("React with heart", heartPicked),
+      heartRemoveTitle: reactionBadgeTitle("Remove your heart", heartTitle),
       heartSummaryLabel: reactionSummaryLabel("❤️", heartCount),
-      heartTitle: reactionTitle(message, "❤️"),
+      heartTitle,
       laughCount,
-      laughPicked: hasViewerReaction(message, "😂", viewerName),
+      laughPicked,
+      laughChoiceClass: reactionChoiceClass(laughPicked),
+      laughPickerTitle: reactionPickerTitle(
+        "React with laughing face",
+        laughPicked,
+      ),
+      laughRemoveTitle: reactionBadgeTitle(
+        "Remove your laughing face",
+        laughTitle,
+      ),
       laughSummaryLabel: reactionSummaryLabel("😂", laughCount),
-      laughTitle: reactionTitle(message, "😂"),
+      laughTitle,
       hasAnyReaction: thumbsCount > 0 || heartCount > 0 || laughCount > 0,
       className: [
         "pico-message-row",
@@ -239,6 +276,14 @@ function reactionChoiceClass(picked: boolean) {
     : "pico-reaction-choice";
 }
 
+function reactionPickerTitle(action: string, picked: boolean) {
+  return picked ? action.replace("React with", "Remove your") : action;
+}
+
+function reactionBadgeTitle(action: string, title: string) {
+  return title ? `${action}. ${title}` : action;
+}
+
 const textStyle = {
   unicodeBidi: "plaintext",
   whiteSpace: "pre-wrap",
@@ -269,13 +314,6 @@ const reactionPickerStyle = {
   flexWrap: "wrap",
   gap: "0.25rem",
   minHeight: "1.75rem",
-};
-
-const reactionBadgeStyle = {
-  display: "inline-flex",
-  alignItems: "center",
-  minHeight: "1.75rem",
-  padding: "0 0.35rem",
 };
 
 export default pattern<PicoChatInput, PicoChatOutput>(
@@ -336,6 +374,34 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                 filter: drop-shadow(0 0 4px rgba(96, 165, 250, 0.75));
               }
 
+              .pico-reaction-badge {
+                align-items: center;
+                display: inline-flex;
+                min-height: 1.75rem;
+                padding: 0 0.35rem;
+              }
+
+              .pico-reaction-badge-action {
+                appearance: none;
+                background: transparent;
+                border: 0;
+                border-radius: 4px;
+                color: inherit;
+                cursor: pointer;
+                font: inherit;
+                line-height: inherit;
+              }
+
+              .pico-reaction-badge-action:hover,
+              .pico-reaction-badge-action:focus-visible {
+                background: rgba(148, 163, 184, 0.18);
+              }
+
+              .pico-reaction-badge-action:focus-visible {
+                outline: 2px solid currentColor;
+                outline-offset: 2px;
+              }
+
               .pico-message-row {
                 border-radius: 6px;
                 margin: 0 -0.5rem;
@@ -350,7 +416,18 @@ export default pattern<PicoChatInput, PicoChatOutput>(
 
               .pico-message-row-end {
                 padding-bottom: 0.625rem;
-                border-bottom: 1px solid var(--cf-colors-border, #e2e8f0);
+              }
+
+              .pico-message-row-end::after {
+                background: rgba(148, 163, 184, 0.28);
+                bottom: 0;
+                content: "";
+                height: 1px;
+                left: 0.5rem;
+                position: absolute;
+                right: 0.5rem;
+                transform: scaleY(0.5);
+                transform-origin: bottom;
               }
 
               .pico-message-row:hover,
@@ -408,34 +485,82 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                           ? (
                             <div style={reactionSummaryStyle}>
                               {row.thumbsCount > 0
-                                ? (
-                                  <span
-                                    style={reactionBadgeStyle}
-                                    title={row.thumbsTitle}
-                                  >
-                                    {row.thumbsSummaryLabel}
-                                  </span>
-                                )
+                                ? row.thumbsPicked
+                                  ? (
+                                    <button
+                                      type="button"
+                                      className="pico-reaction-badge pico-reaction-badge-action"
+                                      aria-label="Remove your thumbs up"
+                                      title={row.thumbsRemoveTitle}
+                                      onClick={() =>
+                                        react.send({
+                                          messageIndex: row.index,
+                                          emoji: "👍",
+                                        })}
+                                    >
+                                      {row.thumbsSummaryLabel}
+                                    </button>
+                                  )
+                                  : (
+                                    <span
+                                      className="pico-reaction-badge"
+                                      title={row.thumbsTitle}
+                                    >
+                                      {row.thumbsSummaryLabel}
+                                    </span>
+                                  )
                                 : null}
                               {row.heartCount > 0
-                                ? (
-                                  <span
-                                    style={reactionBadgeStyle}
-                                    title={row.heartTitle}
-                                  >
-                                    {row.heartSummaryLabel}
-                                  </span>
-                                )
+                                ? row.heartPicked
+                                  ? (
+                                    <button
+                                      type="button"
+                                      className="pico-reaction-badge pico-reaction-badge-action"
+                                      aria-label="Remove your heart"
+                                      title={row.heartRemoveTitle}
+                                      onClick={() =>
+                                        react.send({
+                                          messageIndex: row.index,
+                                          emoji: "❤️",
+                                        })}
+                                    >
+                                      {row.heartSummaryLabel}
+                                    </button>
+                                  )
+                                  : (
+                                    <span
+                                      className="pico-reaction-badge"
+                                      title={row.heartTitle}
+                                    >
+                                      {row.heartSummaryLabel}
+                                    </span>
+                                  )
                                 : null}
                               {row.laughCount > 0
-                                ? (
-                                  <span
-                                    style={reactionBadgeStyle}
-                                    title={row.laughTitle}
-                                  >
-                                    {row.laughSummaryLabel}
-                                  </span>
-                                )
+                                ? row.laughPicked
+                                  ? (
+                                    <button
+                                      type="button"
+                                      className="pico-reaction-badge pico-reaction-badge-action"
+                                      aria-label="Remove your laughing face"
+                                      title={row.laughRemoveTitle}
+                                      onClick={() =>
+                                        react.send({
+                                          messageIndex: row.index,
+                                          emoji: "😂",
+                                        })}
+                                    >
+                                      {row.laughSummaryLabel}
+                                    </button>
+                                  )
+                                  : (
+                                    <span
+                                      className="pico-reaction-badge"
+                                      title={row.laughTitle}
+                                    >
+                                      {row.laughSummaryLabel}
+                                    </span>
+                                  )
                                 : null}
                             </div>
                           )
@@ -448,13 +573,9 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                             >
                               <button
                                 type="button"
-                                className={reactionChoiceClass(
-                                  row.thumbsPicked,
-                                )}
+                                className={row.thumbsChoiceClass}
                                 aria-label="React with thumbs up"
-                                title={row.thumbsPicked
-                                  ? "Remove your thumbs up"
-                                  : "React with thumbs up"}
+                                title={row.thumbsPickerTitle}
                                 onClick={() =>
                                   react.send({
                                     messageIndex: row.index,
@@ -465,13 +586,9 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                               </button>
                               <button
                                 type="button"
-                                className={reactionChoiceClass(
-                                  row.heartPicked,
-                                )}
+                                className={row.heartChoiceClass}
                                 aria-label="React with heart"
-                                title={row.heartPicked
-                                  ? "Remove your heart"
-                                  : "React with heart"}
+                                title={row.heartPickerTitle}
                                 onClick={() =>
                                   react.send({
                                     messageIndex: row.index,
@@ -482,13 +599,9 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                               </button>
                               <button
                                 type="button"
-                                className={reactionChoiceClass(
-                                  row.laughPicked,
-                                )}
+                                className={row.laughChoiceClass}
                                 aria-label="React with laughing face"
-                                title={row.laughPicked
-                                  ? "Remove your laughing face"
-                                  : "React with laughing face"}
+                                title={row.laughPickerTitle}
                                 onClick={() =>
                                   react.send({
                                     messageIndex: row.index,

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -27,7 +27,6 @@ export interface ChatMessage {
 }
 
 const DEFAULT_MESSAGES: ChatMessage[] = [];
-const REACTION_EMOJIS = ["👍", "❤️", "😂"] as const;
 
 export type MessagesCell = Writable<ChatMessage[]>;
 
@@ -45,6 +44,13 @@ export interface ReactEvent {
 export interface MessageGroup {
   from: string;
   messages: ChatMessage[];
+}
+
+interface DisplayMessage {
+  from: string;
+  body: string;
+  message: ChatMessage;
+  showAuthor: boolean;
 }
 
 export interface PicoChatInput {
@@ -128,6 +134,15 @@ export function groupMessages(
   return groups;
 }
 
+function displayMessages(messages: readonly ChatMessage[]): DisplayMessage[] {
+  return messages.map((message, index) => ({
+    from: message.from,
+    body: message.body,
+    message,
+    showAuthor: index === 0 || messages[index - 1].from !== message.from,
+  }));
+}
+
 function reactionCount(message: ChatMessage, emoji: string) {
   return asReactions(message.reactions).filter((reaction) =>
     reaction.emoji === emoji
@@ -162,10 +177,9 @@ const groupStyle = {
   borderBottom: "1px solid var(--cf-colors-border, #e2e8f0)",
 };
 
-const messageStackStyle = {
-  display: "grid",
-  gap: "0.5rem",
-  marginTop: "0.25rem",
+const continuationStyle = {
+  padding: "4px 0 10px",
+  borderBottom: "1px solid var(--cf-colors-border, #e2e8f0)",
 };
 
 const reactionRowStyle = {
@@ -179,6 +193,7 @@ export default pattern<PicoChatInput, PicoChatOutput>(
     const send = sendMessage({ messages, name });
     const react = toggleReaction({ messages, name });
     const groups = computed(() => groupMessages([...messages]));
+    const rows = computed(() => displayMessages([...messages]));
 
     return {
       [NAME]: "Pico chat",
@@ -204,37 +219,60 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                 style={messagePaneStyle}
               >
                 <div style={messageListStyle}>
-                  {groups.length === 0
+                  {rows.length === 0
                     ? (
                       <div style={{ color: "var(--cf-colors-muted, #64748b)" }}>
                         No messages yet
                       </div>
                     )
-                    : groups.map((group) => (
-                      <div style={groupStyle}>
-                        <strong dir="ltr" style={textStyle}>
-                          {group.from}
-                        </strong>
-                        <div style={messageStackStyle}>
-                          {group.messages.map((message) => (
-                            <div>
-                              <div dir="ltr" style={textStyle}>
-                                {message.body}
-                              </div>
-                              <div style={reactionRowStyle}>
-                                {REACTION_EMOJIS.map((emoji) => (
-                                  <cf-button
-                                    size="sm"
-                                    variant="ghost"
-                                    onClick={() =>
-                                      react.send({ message, emoji })}
-                                  >
-                                    {reactionLabel(message, emoji)}
-                                  </cf-button>
-                                ))}
-                              </div>
-                            </div>
-                          ))}
+                    : rows.map((row) => (
+                      <div
+                        style={row.showAuthor ? groupStyle : continuationStyle}
+                      >
+                        {row.showAuthor
+                          ? (
+                            <strong dir="ltr" style={textStyle}>
+                              {row.from}
+                            </strong>
+                          )
+                          : null}
+                        <div dir="ltr" style={textStyle}>
+                          {row.body}
+                        </div>
+                        <div style={reactionRowStyle}>
+                          <cf-button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() =>
+                              react.send({
+                                message: row.message,
+                                emoji: "👍",
+                              })}
+                          >
+                            {reactionLabel(row.message, "👍")}
+                          </cf-button>
+                          <cf-button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() =>
+                              react.send({
+                                message: row.message,
+                                emoji: "❤️",
+                              })}
+                          >
+                            {reactionLabel(row.message, "❤️")}
+                          </cf-button>
+                          <cf-button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() =>
+                              react.send({
+                                message: row.message,
+                                emoji: "😂",
+                              })}
+                          >
+                            {reactionLabel(row.message, "😂")}
+                          </cf-button>
                         </div>
                       </div>
                     ))}

--- a/packages/patterns/pico-chat/main.tsx
+++ b/packages/patterns/pico-chat/main.tsx
@@ -216,13 +216,14 @@ const textStyle = {
 const messagePaneStyle = {
   height: "320px",
   overflowY: "auto",
+  display: "flex",
+  flexDirection: "column-reverse",
 };
 
 const messageListStyle = {
   minHeight: "100%",
   display: "flex",
-  flexDirection: "column",
-  justifyContent: "flex-end",
+  flexDirection: "column-reverse",
 };
 
 const reactionRowStyle = {
@@ -247,6 +248,7 @@ export default pattern<PicoChatInput, PicoChatOutput>(
     const rows = computed(() =>
       displayMessages([...messages], String(name).trim())
     );
+    const visibleRows = computed(() => [...rows].reverse());
 
     return {
       [NAME]: "Pico chat",
@@ -305,13 +307,13 @@ export default pattern<PicoChatInput, PicoChatOutput>(
                 style={messagePaneStyle}
               >
                 <div style={messageListStyle}>
-                  {rows.length === 0
+                  {visibleRows.length === 0
                     ? (
                       <div style={{ color: "var(--cf-colors-muted, #64748b)" }}>
                         No messages yet
                       </div>
                     )
-                    : rows.map((row) => (
+                    : visibleRows.map((row) => (
                       <div className={row.className}>
                         {row.showAuthor
                           ? (


### PR DESCRIPTION
## What changed

Optimistic follow-up stacked on #4362.

- groups consecutive messages from the same user into a single visual block
- adds emoji reactions with per-user toggle/count behavior
- uses the user's name cell as identity where available, with legacy same-name fallback for old messages
- keeps app-generated message IDs out of the pattern
- extends the focused coverage tests for grouping, reaction toggling, invalid reactions, and same-display-name users

## Validation

- `deno fmt --check packages/patterns/pico-chat/main.tsx packages/patterns/pico-chat/coverage-deno.test.ts`
- `deno task cf test packages/patterns/pico-chat/main.test.tsx --root packages/patterns`
- `deno task test` from `packages/patterns`
- GitHub Actions passed before this work was split from #4362

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds grouped messages and emoji reactions to Emo Chat with tooltips and a subtle hover frame. Counts stay visible while controls appear on hover/focus, the pane uses normal scrollback with hidden scrollbars, and the reaction picker now renders eagerly for smoother interaction.

- **New Features**
  - Group consecutive messages by `from`; expose `groups` and `groupMessages`.
  - Emoji reactions (👍 ❤️ 😂): per-name toggle with counts, highlight selected, separate picker from summary, tooltips list who reacted, no self-reactions, and you can remove expressed reactions (authors can clear legacy self-reactions). Expose `react` as `{ messageIndex, emoji }`. Shared data stays plain (`from`, `byName`).

- **Bug Fixes**
  - Avoid sticky hover: show controls on row hover or control focus only.
  - Flatten message rendering and precompute reaction visibility; use normal scrollback and keep the pane bottom-pinned without scroll jumps.
  - Use CSS class-based group separators for consistent spacing and borders.
  - Eagerly render the reaction picker on each row to avoid first-hover jank.
  - Hide chat scrollbars for a cleaner view.

<sup>Written for commit cfda9e5c886450f08882b1071495b1822267731f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

