### PR TITLE
Fix/profile clear on submit

### DIFF
--- a/docs/common/components/COMPONENTS.md
+++ b/docs/common/components/COMPONENTS.md
@@ -135,7 +135,7 @@ cell means none confirmed — check the component source before assuming.
 | `cf-map` | Interactive Leaflet/OpenStreetMap map (see [cf-map](#cf-map)) | `$value`, `$center`, `$zoom`, `$bounds` |
 | `cf-markdown` | Renders markdown with syntax highlighting and copy buttons | `$content` |
 | `cf-message-beads` | Compact bead visualization of a message history | `$messages` |
-| `cf-message-input` | Input + send button combo for chat-style item entry | |
+| `cf-message-input` | Input + send button combo for chat-style item entry; emits a synthetic (untrusted) `cf-send` event, so use `cf-submit-input` when the submit must authorize an owner-protected write | |
 | `cf-modal` | Accessible modal dialog with bottom-sheet presentation mode | `$open` |
 | `cf-modal-provider` | Modal stack manager | |
 | `cf-oauth` | Generic OAuth authentication | `$auth` |
@@ -161,6 +161,7 @@ cell means none confirmed — check the component source before assuming.
 | `cf-skeleton` | Animated loading placeholder | |
 | `cf-slider` | Range input slider | |
 | `cf-space-link` | Renders a space as a clickable navigation pill | |
+| `cf-submit-input` | Text field + submit button whose real (trusted) click carries the typed text as `event.target.value` with the surface's UI integrity, so it can authorize an owner-protected runtime write; prefer over `cf-message-input` when the submit gesture must be trusted | |
 | `cf-svg` | Renders SVG content from a string | |
 | `cf-switch` | Toggle switch for binary on/off state | `$checked` |
 | `cf-tab` | Individual tab button used within `cf-tab-list` | |

--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -2922,6 +2922,7 @@ interface CFQuestionElement extends CFHTMLElement {}
 interface CFAlertElement extends CFHTMLElement {}
 interface CFVStackElement extends CFHTMLElement {}
 interface CFMessageInputElement extends CFHTMLElement {}
+interface CFSubmitInputElement extends CFHTMLElement {}
 interface CFToolbarElement extends CFHTMLElement {}
 interface CFKbdElement extends CFHTMLElement {}
 interface CFKeybindElement extends CFHTMLElement {}
@@ -3346,6 +3347,17 @@ interface CFMessageInputAttributes<T> extends CFHTMLAttributes<T> {
   "size"?: "xs" | "sm" | "md" | "lg" | "xl" | CellLike<string>;
   "appearance"?: "rounded";
   "oncf-send"?: EventHandler<{ message: string }>;
+}
+
+interface CFSubmitInputAttributes<T> extends CFHTMLAttributes<T> {
+  "placeholder"?: string;
+  "buttonText"?: string;
+  "inputId"?: string;
+  "disabled"?: boolean | CellLike<boolean>;
+  // Optional initial text. The field is otherwise uncontrolled: it mirrors the
+  // typed text into its own `value` (read on the host as event.target.value on
+  // submit) and is not meant for two-way cell binding.
+  "initialValue"?: string;
 }
 
 interface CTSendMessageAttributes<T> extends CFHTMLAttributes<T> {
@@ -5045,6 +5057,10 @@ declare global {
       "cf-message-input": CFDOM.DetailedHTMLProps<
         CFMessageInputAttributes<CFMessageInputElement>,
         CFMessageInputElement
+      >;
+      "cf-submit-input": CFDOM.DetailedHTMLProps<
+        CFSubmitInputAttributes<CFSubmitInputElement>,
+        CFSubmitInputElement
       >;
       "cf-chat-message": CFDOM.DetailedHTMLProps<
         CFChatMessageAttributes<CFChatMessageElement>,

--- a/packages/patterns/catalog/catalog.tsx
+++ b/packages/patterns/catalog/catalog.tsx
@@ -50,6 +50,7 @@ interface CatalogInput {
           { id: "toggle"; label: "Toggle" },
           { id: "toggle-group"; label: "Toggle Group" },
           { id: "message-input"; label: "Message Input" },
+          { id: "submit-input"; label: "Submit Input" },
           { id: "calendar"; label: "Calendar" },
           { id: "radio"; label: "Radio" },
           { id: "autocomplete"; label: "Autocomplete" },

--- a/packages/patterns/catalog/stories/cf-submit-input-story.test.tsx
+++ b/packages/patterns/catalog/stories/cf-submit-input-story.test.tsx
@@ -1,0 +1,16 @@
+import { computed, NAME, pattern, UI } from "commonfabric";
+import SubmitInputStory from "./cf-submit-input-story.tsx";
+
+// Lane-2 pattern test (run by `cf test`): instantiating the story runs its body
+// — the [UI] and controls JSX — so the story's authored lines are recorded as
+// covered, and the assertion checks the story builds the shape the catalog
+// renderer expects.
+export default pattern(() => {
+  const story = SubmitInputStory({});
+  const assert_story_built = computed(() =>
+    story[NAME] === "cf-submit-input Story" &&
+    story[UI] != null &&
+    story.controls != null
+  );
+  return { tests: [{ assertion: assert_story_built }] };
+});

--- a/packages/patterns/catalog/stories/cf-submit-input-story.tsx
+++ b/packages/patterns/catalog/stories/cf-submit-input-story.tsx
@@ -1,0 +1,41 @@
+import { NAME, pattern, UI, type VNode } from "commonfabric";
+
+// deno-lint-ignore no-empty-interface
+interface SubmitInputStoryInput {}
+export interface SubmitInputStoryOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  controls: VNode;
+}
+
+export default pattern<SubmitInputStoryInput, SubmitInputStoryOutput>(() => {
+  return {
+    [NAME]: "cf-submit-input Story",
+    [UI]: (
+      <div
+        style={{
+          padding: "1rem",
+          display: "flex",
+          flexDirection: "column",
+          gap: "16px",
+          maxWidth: "400px",
+        }}
+      >
+        <cf-submit-input
+          inputId="story-submit-input"
+          placeholder="Your name..."
+          buttonText="Create profile"
+        />
+      </div>
+    ),
+    controls: (
+      <div style={{ color: "#6b7280", fontSize: "13px", padding: "8px 12px" }}>
+        No interactive controls. The submit button's real (trusted) click
+        bubbles to the host carrying the typed text as event.target.value, so a
+        pattern reads it off the trusted gesture — unlike cf-message-input's
+        synthetic cf-send event. Use it when the submit must authorize an
+        owner-protected write (e.g. creating a profile).
+      </div>
+    ),
+  };
+});

--- a/packages/patterns/catalog/ui/story-renderer.tsx
+++ b/packages/patterns/catalog/ui/story-renderer.tsx
@@ -22,6 +22,7 @@ import VScrollStory from "../stories/cf-vscroll-story.tsx";
 import HScrollStory from "../stories/cf-hscroll-story.tsx";
 import TextareaStory from "../stories/cf-textarea-story.tsx";
 import MessageInputStory from "../stories/cf-message-input-story.tsx";
+import SubmitInputStory from "../stories/cf-submit-input-story.tsx";
 import ToolbarStory from "../stories/cf-toolbar-story.tsx";
 import HeadingStory from "../stories/cf-heading-story.tsx";
 import TextStory from "../stories/cf-text-story.tsx";
@@ -126,6 +127,8 @@ export default pattern<StoryRendererInput, StoryRendererOutput>(
           return TextareaStory({});
         case "message-input":
           return MessageInputStory({});
+        case "submit-input":
+          return SubmitInputStory({});
         case "toolbar":
           return ToolbarStory({});
         case "heading":

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -96,18 +96,15 @@ const fillAndVerify = async (
 
   const root = input.getRootNode();
   const host = root instanceof ShadowRoot ? root.host : element;
-  const hostWithCell = host as Element & {
-    value?: {
-      get?: () => unknown;
-      set?: (value: string) => Promise<void>;
-      sync?: () => Promise<unknown>;
-    };
+  // The host component owns durably committing a typed edit. A cf-input two-way
+  // bound to a Cell flushes the value into the cell and awaits the runtime
+  // round-trip via commit(); a field with no cell (cf-submit-input) exposes no
+  // commit() and its DOM value is authoritative. Drive the DOM like a user and
+  // then ask the host to commit, rather than reaching into the cell.
+  const hostElement = host as Element & {
+    commit?: () => Promise<void>;
     requestUpdate?: () => void | Promise<void>;
   };
-  const readCellValue = () =>
-    typeof hostWithCell.value?.get === "function"
-      ? hostWithCell.value.get()
-      : undefined;
 
   input.focus();
   const valueSetter = Object.getOwnPropertyDescriptor(
@@ -120,22 +117,16 @@ const fillAndVerify = async (
   input.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
   input.blur();
 
-  if (typeof hostWithCell.value?.set === "function") {
-    await hostWithCell.value.set(nextValue);
-  }
-  const cellValue = typeof hostWithCell.value?.sync === "function"
-    ? await hostWithCell.value.sync()
-    : readCellValue();
-  if (typeof hostWithCell.requestUpdate === "function") {
-    await hostWithCell.requestUpdate.call(hostWithCell);
-  }
+  // Ask the host to flush and durably commit the typed value (a no-op for
+  // fields not bound to a cell), then re-render so the inner input reflects the
+  // committed value before we read it back.
+  await hostElement.commit?.();
+  await hostElement.requestUpdate?.();
   await new Promise((resolve) =>
     requestAnimationFrame(() => requestAnimationFrame(resolve))
   );
 
-  return hostWithCell.value !== undefined
-    ? cellValue === nextValue
-    : input.value === nextValue;
+  return input.value === nextValue;
 };
 
 // Scroll the cf-button behind `selector` into view and tag its inner click
@@ -1159,8 +1150,6 @@ type CfInputProbe = {
   selector: string;
   found: boolean;
   value: string;
-  cellValue: unknown;
-  hasCell: boolean;
   disabled: boolean;
   readOnly: boolean;
   visible: boolean;
@@ -1191,8 +1180,6 @@ async function readCfInputProbe(
         selector: targetSelector,
         found: false,
         value: "",
-        cellValue: undefined,
-        hasCell: false,
         disabled: false,
         readOnly: false,
         visible: false,
@@ -1207,8 +1194,6 @@ async function readCfInputProbe(
         selector: element.tagName.toLowerCase(),
         found: false,
         value: "",
-        cellValue: undefined,
-        hasCell: false,
         disabled: false,
         readOnly: false,
         visible: false,
@@ -1224,22 +1209,14 @@ async function readCfInputProbe(
       style.visibility !== "hidden" && style.display !== "none";
     const root = input.getRootNode();
     const host = root instanceof ShadowRoot ? root.host : element;
-    const hostWithCell = host as Element & {
-      value?: { get?: () => unknown };
-    };
-    const cellValue = typeof hostWithCell.value?.get === "function"
-      ? hostWithCell.value.get()
-      : undefined;
     return {
       selector: input.tagName.toLowerCase(),
       found: true,
       value: input.value,
-      cellValue,
-      hasCell: hostWithCell.value !== undefined,
       disabled: input.disabled,
       readOnly: input.readOnly,
       visible,
-      hostTagName: hostWithCell.tagName.toLowerCase(),
+      hostTagName: host.tagName.toLowerCase(),
     };
   }, { args: [selector] });
 }

--- a/packages/patterns/integration/shared-profile.test.ts
+++ b/packages/patterns/integration/shared-profile.test.ts
@@ -7,6 +7,7 @@ import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import {
   clickTrustedAction,
+  fillCfInput,
   waitForRuntimeIdle,
   waitForText,
 } from "./cfc-browser-helpers.ts";
@@ -74,7 +75,7 @@ describe("shared profile integration test", () => {
 
     await submitProfileCreate(
       page,
-      "cf-input",
+      "#wish-profile-name-input",
       "Ada Lovelace",
     );
     await waitForText(page, "#shared-profile-name", "Ada Lovelace");
@@ -89,7 +90,7 @@ describe("shared profile integration test", () => {
 
     await submitProfileCreate(
       page,
-      "cf-input",
+      "#wish-profile-name-input",
       "Grace Hopper",
     );
     await waitForText(page, "#shared-profile-name", "Grace Hopper");
@@ -121,110 +122,16 @@ async function submitProfileCreate(
   inputSelector: string,
   message: string,
 ) {
-  await fillAllProfileCreateInputs(page, inputSelector, message);
+  // The create surface is a `cf-submit-input` whose inner input carries the id
+  // passed as `inputId` by the #profile create launch (see runner wish.ts:
+  // `inputId: "wish-profile-name-input"`). `fillCfInput` drives the DOM like a
+  // user and calls the host's `commit()` (a no-op for a cell-less submit input),
+  // then the trusted submit click carries the typed text as event.target.value.
+  await fillCfInput(page, inputSelector, message, {
+    timeout: SHARED_PROFILE_TIMEOUT,
+  });
   await clickTrustedAction(page, TRUSTED_PROFILE_CREATE_ACTION);
   await waitForRuntimeIdle(page);
-}
-
-async function fillAllProfileCreateInputs(
-  page: Page,
-  inputSelector: string,
-  message: string,
-) {
-  try {
-    await page.waitForSelector(inputSelector, {
-      strategy: "pierce",
-      timeout: SHARED_PROFILE_TIMEOUT,
-    });
-  } catch (cause) {
-    const snapshot = await readProfileCreateProbe(page).catch(() => undefined);
-    throw new Error(
-      `Unable to find profile create input "${inputSelector}". Probe: ${
-        JSON.stringify(snapshot)
-      }`,
-      { cause },
-    );
-  }
-  const filled = await page.evaluate(
-    async (selector, value): Promise<number> => {
-      function collect(root: Document | ShadowRoot, result: Element[]): void {
-        for (const element of root.querySelectorAll("*")) {
-          try {
-            if (element.matches(selector)) {
-              result.push(element);
-            }
-          } catch {
-            // Invalid selectors are reported through the zero filled count.
-          }
-          if (element.shadowRoot) {
-            collect(element.shadowRoot, result);
-          }
-        }
-      }
-
-      function isVisible(element: HTMLElement): boolean {
-        const rect = element.getBoundingClientRect();
-        const style = globalThis.getComputedStyle(element);
-        return rect.width > 0 && rect.height > 0 &&
-          rect.bottom >= 0 && rect.right >= 0 &&
-          rect.top <= globalThis.innerHeight &&
-          rect.left <= globalThis.innerWidth &&
-          style.visibility !== "hidden" &&
-          style.display !== "none";
-      }
-
-      const matches: Element[] = [];
-      collect(document, matches);
-      let count = 0;
-      for (const element of matches) {
-        const host = element as HTMLElement & {
-          value?: {
-            set?: (value: string) => Promise<void>;
-            sync?: () => Promise<unknown>;
-          };
-          requestUpdate?: () => void | Promise<void>;
-        };
-        const input = element instanceof HTMLInputElement
-          ? element
-          : element.shadowRoot?.querySelector("input");
-        if (!(input instanceof HTMLInputElement) || !isVisible(input)) {
-          continue;
-        }
-        input.focus();
-        const valueSetter = Object.getOwnPropertyDescriptor(
-          HTMLInputElement.prototype,
-          "value",
-        )?.set;
-        if (valueSetter) {
-          valueSetter.call(input, value);
-        } else {
-          input.value = value;
-        }
-        input.dispatchEvent(
-          new Event("input", { bubbles: true, composed: true }),
-        );
-        input.dispatchEvent(
-          new Event("change", { bubbles: true, composed: true }),
-        );
-        if (typeof host.value?.set === "function") {
-          await host.value.set(value);
-        }
-        if (typeof host.value?.sync === "function") {
-          await host.value.sync();
-        }
-        if (typeof host.requestUpdate === "function") {
-          await host.requestUpdate();
-        }
-        input.blur();
-        count++;
-      }
-      return count;
-    },
-    { args: [inputSelector, message] },
-  );
-  if (filled === 0) {
-    throw new Error(`Profile create input not filled: ${inputSelector}`);
-  }
 }
 
 async function readProfileCreateProbe(page: Page) {

--- a/packages/patterns/system/profile-create.tsx
+++ b/packages/patterns/system/profile-create.tsx
@@ -71,21 +71,28 @@ export type CreateProfileEvent = {
 export const submitProfileCreation = handler<
   CreateProfileEvent,
   {
-    draftName?: Writable<string>;
     profiles: Writable<ProfileHomeOutput[]>;
   }
->((event, { draftName, profiles }) => {
+>((event, { profiles }) => {
+  // The submitted name rides the event: the create surface is a
+  // `cf-submit-input`, whose submit-button click carries the typed text as
+  // `event.target.value` (and the trusted surface's UI integrity). The handler
+  // keeps no draft cell. This is what makes clear-on-submit safe: the push
+  // materializes the profile in its own `inSpace` space, so the create is a
+  // cross-space (multi-space) commit the runner drives through a pending →
+  // resolve → retry cycle plus optimistic-conflict retries. Re-reading a
+  // mutable draft on those retries — or clearing one — would race a back-to-back
+  // second create; the event payload is fixed per creation, so the name stays
+  // stable across retries and nothing is cleared late. The field clears itself
+  // in the DOM after submit, with no durable write to clobber.
   const name = (event.name ?? event.detail?.message ?? event.target?.value ??
-    draftName?.get() ?? "").trim();
+    "").trim();
   if (name) {
     profiles.push(
       ProfileHome.inSpace()({
         initialName: name,
       }) as ProfileHomeOutput,
     );
-    // Clear the draft name input after a successful create (mirrors the form
-    // handlers in self.tsx / home's space input).
-    draftName?.set("");
   }
 });
 
@@ -204,7 +211,6 @@ export type TrustedProfileMru = Cfc<
 export type ProfileCreateInput = {
   profiles: Writable<ProfileHomeOutput[]>;
   inputId?: string;
-  buttonId?: string;
 };
 
 export type ProfileCreateOutput = {
@@ -214,10 +220,8 @@ export type ProfileCreateOutput = {
 };
 
 export default pattern<ProfileCreateInput, ProfileCreateOutput>(
-  ({ profiles, inputId, buttonId }) => {
-    const draftName = new Writable("").for("draftName");
+  ({ profiles, inputId }) => {
     const createProfile = submitProfileCreation({
-      draftName,
       profiles: profiles as any,
     });
     return {
@@ -230,19 +234,18 @@ export default pattern<ProfileCreateInput, ProfileCreateOutput>(
           data-ui-event-integrity={TRUSTED_PROFILE_CREATE_SURFACE}
           gap="1"
         >
-          <cf-input
-            id={inputId ?? "profile-name-input"}
-            $value={draftName}
-            placeholder="Your name..."
-            timingStrategy="immediate"
-          />
-          <cf-button
-            id={buttonId ?? "profile-create-button"}
+          {
+            /* The submit-button click carries the typed name as
+              event.target.value with this surface's trusted UI integrity, so
+              the create needs no draft cell and the field self-clears. */
+          }
+          <cf-submit-input
+            inputId={inputId ?? "profile-name-input"}
             data-ui-action={TRUSTED_PROFILE_CREATE_ACTION}
+            placeholder="Your name..."
+            buttonText="Create profile"
             onClick={createProfile}
-          >
-            Create profile
-          </cf-button>
+          />
         </cf-vstack>
       ),
     };

--- a/packages/patterns/system/profile-picker.tsx
+++ b/packages/patterns/system/profile-picker.tsx
@@ -76,7 +76,6 @@ export default pattern<
   const profileCreate = ProfileCreate({
     profiles: profiles as any,
     inputId: "wish-profile-picker-name-input",
-    buttonId: "wish-profile-picker-create-button",
   });
 
   return {

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -135,7 +135,8 @@ Useful references:
 | Element           | Element           | Element            | Element            |
 | ----------------- | ----------------- | ------------------ | ------------------ |
 | `cf-chat`         | `cf-chat-message` | `cf-message-beads` | `cf-message-input` |
-| `cf-prompt-input` | `cf-question`     | `cf-tool-call`     | `cf-tools-chip`    |
+| `cf-prompt-input` | `cf-question`     | `cf-submit-input`  | `cf-tool-call`     |
+| `cf-tools-chip`   |                   |                    |                    |
 
 ### Identity And Integrations
 

--- a/packages/ui/src/v2/components/cf-input/cf-input.test.ts
+++ b/packages/ui/src/v2/components/cf-input/cf-input.test.ts
@@ -184,6 +184,16 @@ describe("CFInput", () => {
     el.timingDelay = 500;
     expect(el.timingDelay).toBe(500);
   });
+
+  it("commit() returns a promise and resolves", async () => {
+    const el = new CFInput();
+    // No cell is bound (binding happens in firstUpdated, not run here), so
+    // commit() flushes and falls back to the cell controller's setValue (a
+    // no-op for an unbound value), then resolves.
+    const result = el.commit();
+    expect(result).toBeInstanceOf(Promise);
+    await result;
+  });
 });
 
 describe("CFInput — INPUT_PATTERNS", () => {

--- a/packages/ui/src/v2/components/cf-input/cf-input.ts
+++ b/packages/ui/src/v2/components/cf-input/cf-input.ts
@@ -503,6 +503,17 @@ export class CFInput extends BaseElement {
     this._formField.setValue(newValue);
   }
 
+  /**
+   * Flush any pending edit and await its commit to the bound cell, so callers
+   * can rely on the typed value having been applied and the set() round-trip
+   * completed before continuing. Does not surface a remote-commit rejection (the
+   * underlying set() logs and swallows that). When the field is not bound to a
+   * Cell, it falls back to the cell controller's setValue.
+   */
+  commit(): Promise<void> {
+    return this._formField.commit();
+  }
+
   private getPattern(): string {
     // Use custom pattern if provided
     if (this.pattern) {

--- a/packages/ui/src/v2/components/cf-submit-input/cf-submit-input.test.ts
+++ b/packages/ui/src/v2/components/cf-submit-input/cf-submit-input.test.ts
@@ -1,0 +1,179 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { CFSubmitInput } from "./index.ts";
+
+// The unit runner uses Lit's SSR DOM shim: instances and direct method/lifecycle
+// calls work, but there is no real shadow-DOM rendering. These tests exercise
+// the component's logic by constructing an instance and driving its handlers
+// with realistic mock events, asserting the observable value / clear behavior.
+// Full rendered-DOM interaction is covered by the browser integration tests
+// (home-profile / shared-profile).
+
+type Internals = {
+  _onInput(event: Event): void;
+  _onContainerClick(event: Event): void;
+  _onSubmit(event: Event): void;
+  _submitting: boolean;
+  _seeded: boolean;
+  willUpdate(changed: Map<string, unknown>): void;
+  render(): unknown;
+};
+
+function internals(el: CFSubmitInput): Internals {
+  return el as unknown as Internals;
+}
+
+// A click event whose composed path optionally runs through a CF-BUTTON, with a
+// stopPropagation spy.
+function clickEvent(throughButton: boolean): Event & { stopped: boolean } {
+  const path = throughButton
+    ? [{ tagName: "INPUT" }, { tagName: "CF-BUTTON" }]
+    : [{ tagName: "INPUT" }, { tagName: "DIV" }];
+  const event = {
+    stopped: false,
+    composedPath: () => path,
+    stopPropagation() {
+      (this as { stopped: boolean }).stopped = true;
+    },
+  };
+  return event as unknown as Event & { stopped: boolean };
+}
+
+// Lets a pending setTimeout(0) callback run.
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe("CFSubmitInput", () => {
+  it("is defined and registered", () => {
+    expect(CFSubmitInput).toBeDefined();
+    expect(customElements.get("cf-submit-input")).toBe(CFSubmitInput);
+  });
+
+  it("has the expected property defaults", () => {
+    const el = new CFSubmitInput();
+    expect(el.placeholder).toBe("");
+    expect(el.buttonText).toBe("Submit");
+    expect(el.inputId).toBe("");
+    expect(el.disabled).toBe(false);
+    expect(el.initialValue).toBe("");
+    expect(el.value).toBe("");
+  });
+
+  describe("willUpdate / initialValue seeding", () => {
+    it("seeds value from initialValue once on first update", () => {
+      const el = new CFSubmitInput();
+      el.initialValue = "Ada";
+      internals(el).willUpdate(new Map());
+      expect(el.value).toBe("Ada");
+      expect(internals(el)._seeded).toBe(true);
+    });
+
+    it("does not re-seed after the first time", () => {
+      const el = new CFSubmitInput();
+      el.initialValue = "Ada";
+      internals(el).willUpdate(new Map());
+      // A later initialValue change is ignored; the field is uncontrolled.
+      el.initialValue = "Bob";
+      internals(el).willUpdate(new Map());
+      expect(el.value).toBe("Ada");
+    });
+
+    it("does not seed when initialValue is empty", () => {
+      const el = new CFSubmitInput();
+      internals(el).willUpdate(new Map());
+      expect(el.value).toBe("");
+      expect(internals(el)._seeded).toBe(false);
+    });
+  });
+
+  it("_onInput mirrors the inner input value into `value`", () => {
+    const el = new CFSubmitInput();
+    internals(el)._onInput({ target: { value: "typed" } } as unknown as Event);
+    expect(el.value).toBe("typed");
+  });
+
+  describe("_onContainerClick", () => {
+    it("stops a click that does not run through the submit button", () => {
+      const el = new CFSubmitInput();
+      const event = clickEvent(false);
+      internals(el)._onContainerClick(event);
+      expect(event.stopped).toBe(true);
+    });
+
+    it("lets a click through the submit button reach the host", () => {
+      const el = new CFSubmitInput();
+      const event = clickEvent(true);
+      internals(el)._onContainerClick(event);
+      expect(event.stopped).toBe(false);
+    });
+  });
+
+  describe("_onSubmit", () => {
+    it("ignores an empty submit", async () => {
+      const el = new CFSubmitInput();
+      el.value = "   ";
+      internals(el)._onSubmit(clickEvent(true));
+      expect(internals(el)._submitting).toBe(false);
+      await tick();
+      expect(el.value).toBe("   ");
+    });
+
+    it("clears the field after the submit click is handled", async () => {
+      const el = new CFSubmitInput();
+      el.value = "Ada";
+      internals(el)._onSubmit(clickEvent(true));
+      // In-flight immediately after the click, before the deferred clear.
+      expect(internals(el)._submitting).toBe(true);
+      expect(el.value).toBe("Ada");
+      await tick();
+      expect(el.value).toBe("");
+      expect(internals(el)._submitting).toBe(false);
+    });
+
+    it("stops a re-entrant click and does not schedule a second clear", async () => {
+      const el = new CFSubmitInput();
+      el.value = "Ada";
+      internals(el)._onSubmit(clickEvent(true));
+      const second = clickEvent(true);
+      internals(el)._onSubmit(second);
+      expect(second.stopped).toBe(true);
+      await tick();
+      // The first submit's clear still runs.
+      expect(el.value).toBe("");
+    });
+
+    it("does not wipe a value the user retyped before the clear runs", async () => {
+      const el = new CFSubmitInput();
+      el.value = "Ada";
+      internals(el)._onSubmit(clickEvent(true));
+      // A new name typed before the deferred clear fires must survive.
+      el.value = "Alan";
+      await tick();
+      expect(el.value).toBe("Alan");
+      // The in-flight flag still resets, so a later submit is not blocked.
+      expect(internals(el)._submitting).toBe(false);
+    });
+
+    it("clears the inner input element when present", async () => {
+      const el = new CFSubmitInput();
+      const fakeInput = { value: "Ada" } as HTMLInputElement;
+      Object.defineProperty(el, "_input", {
+        configurable: true,
+        get: () => fakeInput,
+      });
+      el.value = "Ada";
+      internals(el)._onSubmit(clickEvent(true));
+      await tick();
+      expect(el.value).toBe("");
+      expect(fakeInput.value).toBe("");
+    });
+  });
+
+  it("render() produces a template", () => {
+    const el = new CFSubmitInput();
+    el.inputId = "name";
+    el.value = "Ada";
+    el.placeholder = "Your name...";
+    el.buttonText = "Create profile";
+    expect(internals(el).render()).toBeDefined();
+  });
+});

--- a/packages/ui/src/v2/components/cf-submit-input/cf-submit-input.ts
+++ b/packages/ui/src/v2/components/cf-submit-input/cf-submit-input.ts
@@ -1,0 +1,206 @@
+import { css, html, type PropertyValues } from "lit";
+import { BaseElement } from "../../core/base-element.ts";
+import "../cf-button/cf-button.ts";
+
+/**
+ * CFSubmitInput - A text field with a submit button whose click carries the
+ * typed text on the event itself.
+ *
+ * The submit button click is a real (trusted) DOM gesture that bubbles to this
+ * host. A pattern wires `onClick` on the host and reads `event.target.value`:
+ * the host mirrors the field's text in its `value` property, so the submitted
+ * text rides the trusted click — together with the surrounding surface's UI
+ * integrity (data-ui-action / data-ui-event-integrity on the host and an
+ * ancestor). Because the text travels in the event, the consuming handler needs
+ * no durable draft cell, and the field clears itself in the DOM after submit —
+ * deferred past the click's handling so the value is read first, and guarded so
+ * a back-to-back submit's freshly typed name is never wiped. This
+ * keeps a cross-space create handler stable across retries — the event payload
+ * is fixed — with nothing to clobber.
+ *
+ * Unlike cf-message-input (which emits a `cf-send` CustomEvent — isTrusted is
+ * false for those, so they cannot carry UI integrity to a worker handler), the
+ * create here flows from the raw, trusted button click.
+ *
+ * @element cf-submit-input
+ *
+ * @attr {string} placeholder - Placeholder text for the field
+ * @attr {string} button-text - Text for the submit button (default: "Submit")
+ * @attr {string} input-id - id forwarded to the inner <input> so callers/tests
+ *   can target the field directly
+ * @attr {boolean} disabled - Whether the field and button are disabled
+ * @attr {string} initial-value - Optional one-time seed copied into `value` on
+ *   first render; the field is uncontrolled after that
+ * @attr {string} value - Live field text; read on the host as
+ *   event.target.value when the submit button is clicked
+ */
+export class CFSubmitInput extends BaseElement {
+  static override styles = [
+    BaseElement.baseStyles,
+    css`
+      :host {
+        display: block;
+        width: 100%;
+      }
+
+      .container {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: var(--cf-submit-input-gap, var(--cf-spacing-2, 0.5rem));
+        align-items: stretch;
+      }
+
+      input {
+        width: 100%;
+        box-sizing: border-box;
+        font: inherit;
+        padding: var(--cf-spacing-2, 0.5rem) var(--cf-spacing-3, 0.75rem);
+        border: 1px solid var(--cf-theme-color-border, #e5e5e7);
+        border-radius: var(--cf-radius-md, 8px);
+        background: var(--cf-theme-color-surface, #fff);
+        color: var(--cf-theme-color-text, inherit);
+      }
+
+      input:focus {
+        outline: 2px solid var(--cf-theme-color-accent, #0a7);
+        outline-offset: -1px;
+      }
+
+      cf-button {
+        white-space: nowrap;
+      }
+    `,
+  ];
+
+  static override properties = {
+    placeholder: { type: String },
+    buttonText: { type: String, attribute: "button-text" },
+    inputId: { type: String, attribute: "input-id" },
+    disabled: { type: Boolean, reflect: true },
+    initialValue: { type: String, attribute: "initial-value" },
+    value: { type: String },
+  };
+
+  declare placeholder: string;
+  declare buttonText: string;
+  declare inputId: string;
+  declare disabled: boolean;
+  // Optional one-time seed for the field text, copied into `value` on first
+  // render. The field is uncontrolled after that.
+  declare initialValue: string;
+  // Mirrors the field text. Read on the host as event.target.value when the
+  // submit button is clicked.
+  declare value: string;
+
+  constructor() {
+    super();
+    this.placeholder = "";
+    this.buttonText = "Submit";
+    this.inputId = "";
+    this.disabled = false;
+    this.initialValue = "";
+    this.value = "";
+  }
+
+  private _seeded = false;
+
+  // Set while a submit click is in flight, between the click and the deferred
+  // field-clear. A second click that arrives in that window is a duplicate
+  // (the field still holds the submitted text), so its propagation to the host
+  // is stopped to suppress a second create. The flag is reset when the clear
+  // runs, including the case where the clear is skipped because the value
+  // changed, so a later submit is never blocked.
+  private _submitting = false;
+
+  // Copy `initialValue` into the editable `value` once, the first time it is
+  // present. Later `initialValue` changes and the user's own typing are left
+  // alone, so the field stays uncontrolled.
+  override willUpdate(changed: PropertyValues) {
+    super.willUpdate(changed);
+    if (!this._seeded && this.initialValue) {
+      this._seeded = true;
+      this.value = this.initialValue;
+    }
+  }
+
+  private get _input(): HTMLInputElement | null | undefined {
+    return this.shadowRoot?.querySelector("input");
+  }
+
+  private _onInput(event: Event) {
+    this.value = (event.target as HTMLInputElement).value;
+  }
+
+  // Only the submit button click should reach a host-level onClick (the create
+  // gesture). Clicks on the field (to focus/edit) or the surrounding gap compose
+  // out of the shadow root and would otherwise bubble to the host and fire a
+  // spurious create. Let only a click whose path runs through the submit button
+  // continue; stop the rest here.
+  private _onContainerClick(event: Event) {
+    const fromButton = event.composedPath().some(
+      (node) => (node as Element)?.tagName === "CF-BUTTON",
+    );
+    if (!fromButton) event.stopPropagation();
+  }
+
+  private _onSubmit(event: Event) {
+    // A second click arriving before the deferred clear runs is a duplicate:
+    // the field still holds the submitted text, so the host would fire a second
+    // create. Stop this click at the shadow boundary so it never reaches the
+    // host.
+    if (this._submitting) {
+      event.stopPropagation();
+      return;
+    }
+    const submitted = this.value;
+    if (!submitted.trim()) return;
+    this._submitting = true;
+    // Clear the field only after the submit click has been handled — the
+    // framework's host-level click listener reads `event.target.value` while
+    // handling the click. A `setTimeout` runs after that dispatch (a microtask
+    // defer proved too early in practice), so the submitted text is captured
+    // first. Clear only if the field still holds the submitted text: a
+    // back-to-back create may have already typed the next name, which must not
+    // be wiped. The value is local component state, so this guard is synchronous
+    // and race-free — and no durable cell is written, so there is nothing to
+    // clobber across the cross-space commit. The in-flight flag is reset here
+    // whether or not the clear runs, so a later submit is never blocked.
+    setTimeout(() => {
+      this._submitting = false;
+      if (this.value !== submitted) return;
+      this.value = "";
+      const input = this._input;
+      if (input) input.value = "";
+    }, 0);
+  }
+
+  override render() {
+    return html`
+      <div class="container" @click="${this._onContainerClick}">
+        <input
+          id="${this.inputId}"
+          type="text"
+          .value="${this.value}"
+          placeholder="${this.placeholder}"
+          ?disabled="${this.disabled}"
+          @input="${this._onInput}"
+          part="input"
+        />
+        <cf-button
+          data-cf-button
+          ?disabled="${this.disabled}"
+          @click="${this._onSubmit}"
+          part="button"
+        >
+          ${this.buttonText}
+        </cf-button>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "cf-submit-input": CFSubmitInput;
+  }
+}

--- a/packages/ui/src/v2/components/cf-submit-input/index.ts
+++ b/packages/ui/src/v2/components/cf-submit-input/index.ts
@@ -1,0 +1,9 @@
+import { CFSubmitInput } from "./cf-submit-input.ts";
+
+if (!customElements.get("cf-submit-input")) {
+  customElements.define("cf-submit-input", CFSubmitInput);
+}
+
+export type { CFSubmitInput as CFSubmitInputElement } from "./cf-submit-input.ts";
+
+export { CFSubmitInput };

--- a/packages/ui/src/v2/core/cell-controller.test.ts
+++ b/packages/ui/src/v2/core/cell-controller.test.ts
@@ -364,6 +364,36 @@ describe("CellController", () => {
 });
 
 // ---------------------------------------------------------------------------
+// CellController.flush()
+// ---------------------------------------------------------------------------
+
+describe("CellController — flush", () => {
+  it("runs a pending debounced write immediately", () => {
+    const cell = createMockCellHandle("initial");
+    const ctrl = new CellController<string>(createMockHost(), {
+      timing: { strategy: "debounce", delay: 300 },
+    });
+    ctrl.bind(cell);
+    ctrl.setValue("updated");
+    // Debounced: the write has not landed yet.
+    expect(cell.get()).toBe("initial");
+    ctrl.flush();
+    // flush() drains the pending write to the cell.
+    expect(cell.get()).toBe("updated");
+  });
+
+  it("is a no-op when nothing is pending", () => {
+    const cell = createMockCellHandle("x");
+    const ctrl = new CellController<string>(createMockHost(), {
+      timing: { strategy: "debounce", delay: 300 },
+    });
+    ctrl.bind(cell);
+    ctrl.flush();
+    expect(cell.get()).toBe("x");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // StringCellController
 // ---------------------------------------------------------------------------
 

--- a/packages/ui/src/v2/core/cell-controller.ts
+++ b/packages/ui/src/v2/core/cell-controller.ts
@@ -236,6 +236,14 @@ export class CellController<T> implements ReactiveController {
   }
 
   /**
+   * Run any pending (debounced or throttled) write immediately, so a following
+   * read or commit sees the latest value.
+   */
+  flush(): void {
+    this._inputTiming?.flush();
+  }
+
+  /**
    * Check if current value is a Cell
    */
   hasCell(): boolean {

--- a/packages/ui/src/v2/core/form-field-controller.test.ts
+++ b/packages/ui/src/v2/core/form-field-controller.test.ts
@@ -435,3 +435,75 @@ describe("captureOriginalValue", () => {
     expect(formField.isDirty()).toBe(false);
   });
 });
+
+describe("FormFieldController commit", () => {
+  it("flushes the cell controller and writes through the cell", async () => {
+    const host = new MockHost() as unknown as MockHost & HTMLElement;
+    let flushed = false;
+    let cellSet: string | undefined;
+    const cellController: CellControllerLike<string> = {
+      getValue: () => "current",
+      setValue: () => {},
+      flush: () => {
+        flushed = true;
+      },
+      getCell: () => ({
+        set: (v: string) => {
+          cellSet = v;
+          return Promise.resolve();
+        },
+      }),
+    };
+
+    const formField = new FormFieldController(host, { cellController });
+    await formField.commit();
+
+    expect(flushed).toBe(true);
+    expect(cellSet).toBe("current");
+  });
+
+  it("falls back to setValue when no cell is bound", async () => {
+    const host = new MockHost() as unknown as MockHost & HTMLElement;
+    let setArg: string | undefined;
+    const cellController: CellControllerLike<string> = {
+      getValue: () => "current",
+      setValue: (v: string) => {
+        setArg = v;
+      },
+      getCell: () => null,
+    };
+
+    const formField = new FormFieldController(host, { cellController });
+    await formField.commit();
+
+    expect(setArg).toBe("current");
+  });
+
+  it("commits the buffered value when one is present", async () => {
+    const host = new MockHost() as unknown as MockHost & HTMLElement;
+    let cellSet: string | undefined;
+    const cellController: CellControllerLike<string> = {
+      getValue: () => "cell-value",
+      setValue: () => {},
+      getCell: () => ({
+        set: (v: string) => {
+          cellSet = v;
+          return Promise.resolve();
+        },
+      }),
+    };
+
+    const formField = new FormFieldController(host, { cellController });
+    // Simulate a buffered edit, as a form context would produce.
+    const buffered = formField as unknown as {
+      _buffer: string;
+      _hasBuffer: boolean;
+    };
+    buffered._buffer = "buffered";
+    buffered._hasBuffer = true;
+
+    await formField.commit();
+
+    expect(cellSet).toBe("buffered");
+  });
+});

--- a/packages/ui/src/v2/core/form-field-controller.ts
+++ b/packages/ui/src/v2/core/form-field-controller.ts
@@ -53,6 +53,11 @@ export interface CellControllerLike<T> {
   getValue(): T;
   setValue(value: T): void;
   /**
+   * Optional: run any pending (debounced) write immediately, so a following
+   * read or commit sees the latest value.
+   */
+  flush?(): void;
+  /**
    * Optional method to get the underlying CellHandle for direct async operations.
    * Used by FormFieldController to await cell.set() during flush.
    * Returns null if no Cell is bound, or the CellHandle with async set().
@@ -160,6 +165,33 @@ export class FormFieldController<T> implements ReactiveController {
     } else {
       this._cellController.setValue(value);
     }
+  }
+
+  /**
+   * Flush the field's current value to the bound cell and await the set()
+   * round-trip. Uses the buffered value in a form context, otherwise the cell
+   * controller's value, draining any pending debounced/throttled write first.
+   * In a form context this commits the field immediately rather than waiting for
+   * the form's atomic submit, and rebaselines dirty/reset tracking to the
+   * committed value. Resolves once the local apply and the set() round-trip
+   * complete; it does not surface a remote-commit rejection (the underlying
+   * set() logs and swallows that). When no Cell is bound, it falls back to the
+   * cell controller's setValue, mirroring the form's flush.
+   */
+  async commit(): Promise<void> {
+    this._cellController.flush?.();
+    const valueToFlush = this._hasBuffer
+      ? this._buffer as T
+      : this._cellController.getValue();
+    const cell = this._cellController.getCell?.();
+    if (cell) {
+      await cell.set(valueToFlush);
+    } else {
+      this._cellController.setValue(valueToFlush);
+    }
+    // Rebaseline dirty/reset tracking so a later isDirty()/reset() stays
+    // coherent with what was committed (mirrors the form-registered flush).
+    this._originalValue = valueToFlush;
   }
 
   /**

--- a/packages/ui/src/v2/core/input-timing-controller.test.ts
+++ b/packages/ui/src/v2/core/input-timing-controller.test.ts
@@ -243,6 +243,97 @@ describe("InputTimingController — blur", () => {
 });
 
 // ---------------------------------------------------------------------------
+// flush()
+// ---------------------------------------------------------------------------
+
+describe("InputTimingController — flush", () => {
+  let time: FakeTime;
+
+  beforeEach(() => {
+    time = new FakeTime();
+  });
+  afterEach(() => {
+    time.restore();
+  });
+
+  it("runs a pending debounced callback immediately and cancels the timer", () => {
+    const ctrl = new InputTimingController(createMockHost(), {
+      strategy: "debounce",
+      delay: 500,
+    });
+    const calls: string[] = [];
+    ctrl.schedule(() => calls.push("v"));
+
+    expect(calls).toEqual([]);
+    ctrl.flush();
+    expect(calls).toEqual(["v"]);
+
+    // The scheduled timer must not fire again after a manual flush.
+    time.tick(500);
+    expect(calls).toEqual(["v"]);
+  });
+
+  it("flushes only the latest debounced callback", () => {
+    const ctrl = new InputTimingController(createMockHost(), {
+      strategy: "debounce",
+      delay: 200,
+    });
+    const calls: string[] = [];
+    ctrl.schedule(() => calls.push("first"));
+    ctrl.schedule(() => calls.push("second"));
+    ctrl.flush();
+    expect(calls).toEqual(["second"]);
+  });
+
+  it("runs a pending throttle trailing edge instead of dropping it", () => {
+    const ctrl = new InputTimingController(createMockHost(), {
+      strategy: "throttle",
+      delay: 100,
+    });
+    const calls: string[] = [];
+
+    // Leading edge fires immediately.
+    ctrl.schedule(() => calls.push("leading"));
+    expect(calls).toEqual(["leading"]);
+
+    // A second call within the window queues a trailing-edge write.
+    ctrl.schedule(() => calls.push("trailing"));
+    expect(calls).toEqual(["leading"]);
+
+    // flush() must run the trailing write now, not cancel it.
+    ctrl.flush();
+    expect(calls).toEqual(["leading", "trailing"]);
+
+    // And the scheduled trailing timer must not fire a second time.
+    time.tick(100);
+    expect(calls).toEqual(["leading", "trailing"]);
+  });
+
+  it("runs a pending blur-strategy callback immediately", () => {
+    const ctrl = new InputTimingController(createMockHost(), {
+      strategy: "blur",
+    });
+    let fired = false;
+    ctrl.schedule(() => {
+      fired = true;
+    });
+    ctrl.flush();
+    expect(fired).toBe(true);
+  });
+
+  it("is a no-op when nothing is pending", () => {
+    const ctrl = new InputTimingController(createMockHost(), {
+      strategy: "debounce",
+      delay: 100,
+    });
+    ctrl.flush();
+    time.tick(100);
+    // No callback was scheduled, so nothing fires and flush() does not throw.
+    expect(true).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Lifecycle and configuration
 // ---------------------------------------------------------------------------
 

--- a/packages/ui/src/v2/core/input-timing-controller.ts
+++ b/packages/ui/src/v2/core/input-timing-controller.ts
@@ -97,6 +97,16 @@ export class InputTimingController implements ReactiveController {
   }
 
   /**
+   * Run any pending callback immediately and cancel the scheduled timer.
+   * No-op when nothing is pending.
+   */
+  flush(): void {
+    const callback = this.pendingCallback;
+    this.cancel();
+    callback?.();
+  }
+
+  /**
    * Notify the controller that the input has gained focus
    */
   onFocus(): void {
@@ -166,13 +176,17 @@ export class InputTimingController implements ReactiveController {
 
     // Leading edge execution
     if (timeSinceLastCall >= this.options.delay && this.options.leading) {
+      this.pendingCallback = null;
       this.lastCallTime = now;
       callback();
     } else if (this.options.trailing) {
-      // Schedule trailing edge execution
+      // Schedule trailing edge execution. Mirror the callback into
+      // pendingCallback so flush() (and onBlur) can run it immediately.
       const remainingTime = this.options.delay - timeSinceLastCall;
+      this.pendingCallback = callback;
       this.timeoutId = setTimeout(() => {
         this.timeoutId = null;
+        this.pendingCallback = null;
         this.lastCallTime = Date.now();
         callback();
       }, remainingTime);

--- a/packages/ui/src/v2/index.ts
+++ b/packages/ui/src/v2/index.ts
@@ -111,6 +111,7 @@ export * from "./components/cf-vscroll/index.ts";
 export * from "./components/cf-vstack/index.ts";
 export * from "./components/cf-select/index.ts";
 export * from "./components/cf-message-input/index.ts";
+export * from "./components/cf-submit-input/index.ts";
 export * from "./components/cf-prompt-input/index.ts";
 export * from "./components/cf-keybind/index.ts";
 export * from "./components/cf-tools-chip/index.ts";


### PR DESCRIPTION
Creating a second profile from the home picker rendered it with the first profile's name. The create handler cleared the name field by writing an empty string back into a durable draft cell, and because profile creation is a cross-space (multi-space) commit, that clear rode the home-space half that lands *after* the child-space half — so on a back-to-back create it overwrote the second profile's freshly typed name before the second create could read it. This branch drops the draft cell entirely: the create surface is now a new `cf-submit-input` whose trusted submit click carries the typed name on the event itself (as `event.target.value`, together with the surface's UI integrity), so the handler reads a payload that is fixed per creation and stable across the commit's retries, and the field clears itself in the DOM with nothing durable left to race. Supporting that, `cf-input` gains a `commit()` method that flushes a debounced field and awaits its durable write to the bound cell, which in turn lets the CFC integration helper stop reaching into cell internals (structural get/set/sync probing across the test-to-browser boundary) and instead drive the field like a user and ask the host to commit. Anonymous `inSpace()` is retained so two same-named profiles still get distinct spaces, with the typed name flowing only into the profile's editable `initialName`. The change is covered by UI unit tests — including the new flush paths — and by the CFC integration suites for both a cell-bound `cf-input` and a plain `cf-submit-input`, and it went through an adversarial multi-reviewer pass whose single must-fix (a dropped throttle-flush edge) is addressed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the profile-name clear-on-submit race by replacing the draft cell with a trusted `cf-submit-input`, and adds a durable commit path for inputs. Updates docs/tests and blocks duplicate submits.

- **New Features**
  - Added `cf-submit-input`: trusted text field + submit button; click carries `event.target.value`; self-clears; blocks double-clicks; optional `initialValue`; `inputId` for targeting; registered/exported from `v2`, JSX typings, catalog story + test, and docs entry with a `cf-message-input` cross‑ref.
  - Added `cf-input.commit()`: flushes debounced/throttled edits and awaits the cell `set()` via `InputTimingController.flush()`, `CellController.flush()`, and `FormFieldController.commit()`; exported from `v2`.

- **Bug Fixes**
  - Profile creation reads the name from the trusted submit event and no longer writes/clears a draft cell, preventing late clears across spaces; keeps anonymous `inSpace()` and applies the name to `initialName` only.
  - Blocks re-entrant submits and defers/guards the clear so newly typed text is never wiped.
  - Integration helper drives the DOM and calls `commit()`; shared-profile test targets `#wish-profile-name-input`; docs updated to note `cf-message-input` emits an untrusted event.

<sup>Written for commit 8066eb2d63dd84914ae5cda2791e29a129fabb3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

