### PR TITLE
Preserve asCell in node alias schemas

### DIFF
--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -422,7 +422,10 @@ function factoryFromPattern<T, R>(
     }
 
     const sanitizedSchema = cellReference.schema !== undefined
-      ? sanitizeSchemaForLinks(cellReference.schema, { keepStreams: true })
+      ? sanitizeSchemaForLinks(cellReference.schema, {
+        keepStreams: true,
+        keepAsCell: true,
+      })
       : undefined;
     const partialCause = derivedInternalPartialCausesByRoot.get(top);
     if (partialCause !== undefined) {

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -19,6 +19,7 @@ import {
   isWriteRedirectLink,
   type NormalizedFullLink,
   parseLink,
+  sanitizeSchemaForLinks,
 } from "./link-utils.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import { ignoreReadForScheduling } from "./scheduler.ts";
@@ -146,6 +147,12 @@ const scopedLinkForPath = (
     ...(finalSchema !== undefined && { schema: finalSchema }),
   };
 };
+
+const sanitizeAliasSchemaForBinding = (schema: JSONSchema): JSONSchema =>
+  // Compiled aliases retain asCell for schema fidelity. Live redirects still
+  // use link schemas without cell wrappers so scoped asCell entries do not
+  // stamp the redirect link's own scope and bypass stored argument links.
+  sanitizeSchemaForLinks(schema, { keepStreams: true });
 
 const descriptorForPartialCauseAlias = (
   partialCause: JSONValue,
@@ -417,7 +424,7 @@ export function unwrapOneLevelAndBindtoDoc<T, U>(
           });
         const path = alias.path;
         const sourceSchema = alias.schema !== undefined
-          ? alias.schema
+          ? sanitizeAliasSchemaForBinding(alias.schema)
           : link.schema !== undefined
           ? cfc.schemaAtPath(link.schema, path)
           : undefined;
@@ -439,7 +446,7 @@ export function unwrapOneLevelAndBindtoDoc<T, U>(
         // we might have a schema in the alias, but if not, we may have one
         // in the link (from the pattern)
         const sourceSchema = alias.schema !== undefined
-          ? alias.schema
+          ? sanitizeAliasSchemaForBinding(alias.schema)
           : link.schema !== undefined
           ? cfc.schemaAtPath(link.schema, path)
           : undefined;

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -129,14 +129,12 @@ const scopedLinkForPath = (
   }
 
   const finalSchema = schemaOverride ?? childSchema;
-  if (isRecord(finalSchema)) {
-    if (isCellScope(finalSchema.scope)) {
-      scope = finalSchema.scope;
-    }
-    const asCellEntry = ContextualFlowControl.getAsCellValues(finalSchema)[0];
-    const asCellScope = ContextualFlowControl.getAsCellScope(asCellEntry);
-    if (isCellScope(asCellScope)) {
-      scope = asCellScope;
+  const linkSchema = finalSchema === undefined
+    ? undefined
+    : sanitizeAliasSchemaForBinding(finalSchema);
+  if (isRecord(linkSchema)) {
+    if (isCellScope(linkSchema.scope)) {
+      scope = linkSchema.scope;
     }
   }
 
@@ -144,14 +142,14 @@ const scopedLinkForPath = (
     ...link,
     path: [...path],
     scope,
-    ...(finalSchema !== undefined && { schema: finalSchema }),
+    ...(linkSchema !== undefined && { schema: linkSchema }),
   };
 };
 
 const sanitizeAliasSchemaForBinding = (schema: JSONSchema): JSONSchema =>
-  // Compiled aliases retain asCell for schema fidelity. Live redirects still
-  // use link schemas without cell wrappers so scoped asCell entries do not
-  // stamp the redirect link's own scope and bypass stored argument links.
+  // Compiled aliases retain asCell for schema fidelity. Live redirects use link
+  // schemas without cell wrappers so scoped asCell entries do not stamp the
+  // redirect link's own scope and bypass stored argument links.
   sanitizeSchemaForLinks(schema, { keepStreams: true });
 
 const descriptorForPartialCauseAlias = (

--- a/packages/runner/test/pattern-binding.test.ts
+++ b/packages/runner/test/pattern-binding.test.ts
@@ -252,6 +252,44 @@ describe("pattern-binding", () => {
         ),
       ).toBe(true);
     });
+
+    it("does not stamp scoped asCell alias schemas onto write redirect links", () => {
+      const output = runtime.getCell<{ value: unknown }>(
+        space,
+        "scoped asCell alias write redirect output",
+        undefined,
+        tx,
+      );
+      output.set({ value: null });
+      const argumentCellLink = getMetaCell(output, "argument", tx)
+        .getAsNormalizedFullLink();
+
+      const userScopedValue = runtime.getCellFromLink(
+        { ...output.key("value").getAsNormalizedFullLink(), scope: "user" },
+        undefined,
+        tx,
+      );
+
+      sendValueToBinding(
+        tx,
+        output,
+        argumentCellLink,
+        {
+          $alias: {
+            cell: "result",
+            path: ["value"],
+            schema: {
+              type: "string",
+              asCell: [{ kind: "cell", scope: "user" }],
+            },
+          },
+        },
+        "secret",
+      );
+
+      expect(output.key("value").getRaw()).toBe("secret");
+      expect(userScopedValue.getRaw()).toBeUndefined();
+    });
   });
 
   describe("mapBindingToCell", () => {

--- a/packages/runner/test/pattern-node-alias-schema.test.ts
+++ b/packages/runner/test/pattern-node-alias-schema.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { isCell } from "../src/cell.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+const FLAT_LINKED_SOURCE = `
+  import { pattern, type Writable } from "commonfabric";
+
+  interface Child {
+    name: string;
+  }
+
+  interface Input {
+    items: Writable<Child>[];
+  }
+
+  const Sink = pattern((input: Input) => ({ input }));
+
+  export default pattern((input: Input) => ({
+    node: Sink(input),
+  }));
+`;
+
+const PURE_RECURSIVE_SOURCE = `
+  import { pattern, type Writable } from "commonfabric";
+
+  interface Folder {
+    title: string;
+    children?: Writable<Folder>[];
+  }
+
+  const Sink = pattern((folder: Writable<Folder>) => ({ folder }));
+
+  export default pattern((folder: Writable<Folder>) => ({
+    node: Sink(folder),
+  }));
+`;
+
+const UNION_SOURCE = `
+  import { pattern, type Writable } from "commonfabric";
+
+  interface InlineFolder {
+    title: string;
+    children?: InlineFolder[];
+  }
+
+  interface LinkedFolder {
+    title: string;
+    children?: Writable<LinkedFolder>[];
+  }
+
+  type Input = InlineFolder[] | LinkedFolder;
+
+  const Sink = pattern<Input>((input) => ({ input }));
+
+  export default pattern<Input>((input) => ({
+    node: Sink(input),
+  }));
+`;
+
+type CompiledPattern = {
+  argumentSchema: any;
+  resultSchema: any;
+  nodes: any[];
+};
+
+describe("compiled pattern node alias schemas", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  async function compileSource(source: string) {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: source }],
+    };
+    const { main } = await runtime.harness.compileAndEvaluateModules(program);
+    const live = main!.default;
+    const serialized = JSON.parse(JSON.stringify(live)) as CompiledPattern;
+    return { live, serialized };
+  }
+
+  function nodeAliasSchema(pattern: CompiledPattern) {
+    return pattern.nodes[0].inputs.$alias.schema;
+  }
+
+  function linkedFolderArrayItems(schema: any) {
+    return Object.values(schema.$defs).find((definition: any) =>
+      definition?.type === "array" &&
+      definition.items?.$ref === "#/$defs/LinkedFolder"
+    ) as any;
+  }
+
+  it("preserves asCell on flat, recursive, and union node aliases", async () => {
+    const flat = (await compileSource(FLAT_LINKED_SOURCE)).serialized;
+    expect(
+      flat.argumentSchema.properties.items.items.asCell,
+    ).toEqual(["cell"]);
+    expect(
+      nodeAliasSchema(flat).properties.items.items.asCell,
+    ).toEqual(["cell"]);
+
+    const recursive = (await compileSource(PURE_RECURSIVE_SOURCE)).serialized;
+    expect(
+      recursive.argumentSchema.$defs.Folder.properties.children.items.asCell,
+    ).toEqual(["cell"]);
+    expect(
+      nodeAliasSchema(recursive).$defs.Folder.properties.children.items.asCell,
+    ).toEqual(["cell"]);
+
+    const union = (await compileSource(UNION_SOURCE)).serialized;
+    expect(
+      linkedFolderArrayItems(union.argumentSchema).items.asCell,
+    ).toEqual(["cell"]);
+    expect(
+      linkedFolderArrayItems(nodeAliasSchema(union)).items.asCell,
+    ).toEqual(["cell"]);
+  });
+
+  it("reads recursive node arguments shallowly through the alias schema", async () => {
+    const { live, serialized } = await compileSource(PURE_RECURSIVE_SOURCE);
+    const aliasSchema = nodeAliasSchema(serialized);
+
+    const tx = runtime.edit();
+    const root = runtime.getCell<any>(
+      space,
+      "recursive-node-alias-root",
+      aliasSchema,
+      tx,
+    );
+    root.set({
+      title: "root",
+      children: [{ title: "child" }],
+    });
+
+    const directRoot = root.get();
+    expect(isCell(directRoot)).toBe(true);
+    expect(isCell(directRoot.get().children[0])).toBe(true);
+
+    const resultCell = runtime.getCell<any>(
+      space,
+      "recursive-node-alias-result",
+      (live as CompiledPattern).resultSchema,
+      tx,
+    );
+    const result = runtime.run(tx, live as any, root, resultCell);
+    await tx.commit();
+    await runtime.idle();
+
+    const childArgument = result.key("node").getArgumentCell(
+      serialized.nodes[0].module.implementation.argumentSchema,
+    )!;
+    const childRoot = childArgument.get();
+    expect(isCell(childRoot)).toBe(true);
+    expect(isCell(childRoot.get().children[0])).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Preserves `asCell` when serializing compiled pattern node alias schemas.
- Keeps live binding redirects on the historical sanitized link-schema path so scoped `asCell` metadata does not stamp the redirect link scope.
- Adds a runner regression test covering flat linked refs, pure recursive linked refs, union linked refs, and shallow runtime reads.

## Repro Verdict

- A flat linked: argument and node alias both keep `children/items.asCell: ["cell"]`.
- B pure recursive: argument and node alias both keep recursive `children.items.asCell: ["cell"]`.
- C union: linked branch keeps `asCell: ["cell"]`; inline branch remains bare.

This was not a recursion-specific bug and not a schema-generator union merge bug. The drop happened in runner pattern serialization: node aliases called `sanitizeSchemaForLinks(..., { keepStreams: true })`, which stripped non-stream `asCell`.

## Tests

- `deno test --allow-read --allow-env --allow-run --allow-ffi packages/runner/test/pattern-node-alias-schema.test.ts`
- `deno test --allow-read --allow-env --allow-run --allow-ffi packages/runner/test/pattern-scope.test.ts --filter "lift can read session-scoped cell passed from pattern input"`
- `deno task test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `asCell` in compiled pattern node alias schemas so linked cells keep their wrappers, while live redirect link schemas are sanitized to avoid scope stamping. Adds regression tests for flat, recursive, and union linked refs, shallow runtime reads, and write redirects not inheriting scoped `asCell`.

- **Bug Fixes**
  - In `packages/runner/src/builder/pattern.ts`, pass `{ keepStreams: true, keepAsCell: true }` to `sanitizeSchemaForLinks` when serializing alias schemas.
  - In `packages/runner/src/pattern-binding.ts`, introduce `sanitizeAliasSchemaForBinding` that strips `asCell` via `sanitizeSchemaForLinks(..., { keepStreams: true })` and use it when deriving redirect link scopes and computing `sourceSchema` to prevent scope stamping.
  - Tests: add `packages/runner/test/pattern-node-alias-schema.test.ts` (flat, recursive, union, shallow reads) and a new case in `packages/runner/test/pattern-binding.test.ts` ensuring write redirects don’t adopt scoped `asCell`.

<sup>Written for commit 195b656353a230ebc6b844e9ee694c39488c8683. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

