### PR TITLE
state-inspector: offline autopsy lens over memory v2 space DBs (M1 core)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -35,6 +35,7 @@
     "./packages/leb128",
     "./packages/fuse",
     "./packages/fs-sync-example",
+    "./packages/state-inspector",
     "./tasks",
     "./scripts"
   ],

--- a/deno.lock
+++ b/deno.lock
@@ -2039,6 +2039,12 @@
           "npm:@lit/task@^1.0.2"
         ]
       },
+      "packages/state-inspector": {
+        "dependencies": [
+          "jsr:@db/sqlite@0.12",
+          "jsr:@std/assert@1"
+        ]
+      },
       "packages/static": {
         "dependencies": [
           "npm:typescript@*"

--- a/docs/plans/2026-06-26-runtime-trace-inspector.md
+++ b/docs/plans/2026-06-26-runtime-trace-inspector.md
@@ -1,0 +1,441 @@
+# Multiplayer State Inspector Proposal
+
+> Status: Proposal draft for review (revised 2026-06-26).
+>
+> This document is provisional. It describes a direction and a staged plan for
+> review by runtime, storage, shell, and toolshed owners. It is not a final
+> architecture decision.
+>
+> **Revision note (2026-06-26):** Re-centered from a "capture a trace bundle"
+> design to a "build the lens over the durable store that already exists"
+> design, after auditing the actual surfaces in `runner`, `memory/v2`, `shell`,
+> the multi-runtime harness, and `toolshed`. Two decisions drove the rewrite:
+> the primary goal is **forensic autopsy first** (understand multiplayer bugs
+> after they happen), and the first-class consumer is **agents, with a thin UI
+> layered on top**. The original "trace bundle + client capture + correlation"
+> plan is preserved in spirit but demoted to a later overlay, because the
+> expensive net-new plumbing it required is not where the leverage is.
+
+## Review Metadata
+
+| Field | Value |
+| --- | --- |
+| Proposal date | 2026-06-26 |
+| Primary goal | Make multiplayer, multi-identity, multi-space behavior inspectable from the durable store, retroactively |
+| First-class consumer | Agents (queryable index + query vocabulary); thin UI as a consumer of the same index |
+| Proposed first milestone | Value/link/schema decoder + offline indexer over existing memory v2 SQLite |
+| Review owners | TODO |
+| Runtime reviewers | TODO |
+| Storage reviewers | TODO |
+| Shell/debugger reviewers | TODO |
+| Toolshed/server reviewers | TODO |
+| Test harness reviewers | TODO |
+
+## Summary
+
+The system increasingly depends on behavior that no single client or log stream
+can explain: multiple browser tabs, devices, and identities hold persistent
+subscriptions; optimistic commits, conflict recovery, pending local writes,
+session resume, and server sync interact over time; scheduler actions read and
+write across cells, paths, scopes, spaces, branches, and pattern instances.
+
+The central insight from auditing the codebase is this:
+
+> **The server's memory v2 SQLite store is already a durable, totally-ordered
+> flight recorder.** It records who committed (`session_id`), in what canonical
+> order (`seq`), what each commit read, what conflicted, what sync was emitted,
+> and — behind the `persistentSchedulerState` flag — the scheduler read/write
+> dependency graph. This history is *retroactive* (the bug already happened, no
+> capture needed), *production-shaped* (the real local DBs under `engine-v3/`),
+> and requires *no client cooperation* to inspect.
+
+The gap is not that we fail to record this. The gap is that we have no **lens**:
+no decoder for Fabric values/links/schemas, no index that joins commits to the
+scheduler graph and to per-client subscription state, and no query vocabulary
+that answers concrete multiplayer questions.
+
+This proposal therefore leads with the lens:
+
+1. a reusable **value/link/schema/ifc decoder**,
+2. an **offline indexer** over the existing memory v2 SQLite that reconstructs
+   timelines, state-at-`(branch, seq)`, and the scheduler dependency graph,
+3. a **per-path convergence diagnosis** primitive — the multiplayer-native unit
+   of inspection,
+4. an **agent-first query vocabulary** (stable CLI/SQL surface), and
+5. a **thin UI** that is a consumer of the same index, not the owner of the data
+   model.
+
+Client-side telemetry capture, a portable trace bundle, and harness fault
+injection are real and valuable, but they are *overlays* layered on this
+foundation later, not prerequisites.
+
+## What Changed From The First Draft (and why)
+
+The first draft proposed capturing a normalized `events.ndjson` from every
+client plus SQLite snapshots into a shareable bundle, then indexing that bundle.
+The audit showed two problems with leading there:
+
+1. **The correlation spine the bundle plan assumed mostly does not exist yet.**
+   Of the ~19 identifiers the draft wanted to join on, the only spine that
+   exists is server-side: `(space, sessionId, localSeq) → canonical seq`. On the
+   runtime/client side, `clientId`, `traceId`/`runId`, `batchId`, and `mountId`
+   do not exist; `connectionId` exists only as a server-internal
+   `crypto.randomUUID()` that is never sent to the client
+   (`packages/memory/v2/server.ts:846`); `eventId` is minted but never emitted
+   in telemetry; and runtime telemetry carries no `sessionId`/`connectionId` at
+   all. So "correlation" was net-new plumbing, not joining — the expensive part,
+   front-loaded.
+
+2. **The durable store already answers most autopsy questions with no capture
+   step.** Leading with "start a capture, run the scenario, stop, bundle" misses
+   that the most common real bug is "it already happened in the wild." The
+   server SQLite recorded it. Inspecting the durable store directly is cheaper,
+   retroactive, and needs no hot-path changes.
+
+The reordering: the draft's Milestone 3 (offline indexer over SQLite) becomes
+Milestone 1; the draft's Milestones 1–2 (client capture + correlation) become a
+later, optional overlay; harness fault injection remains a separate, later track
+(it is the *reproduction* product, not the *autopsy* product).
+
+## Goals
+
+- Inspect the durable memory v2 store retroactively, with no capture step and no
+  runtime hot-path changes, to reconstruct a coherent multiplayer timeline.
+- Decode Fabric values, `@link` references, schemas, cell representation, and
+  `ifc`/security labels correctly and reusably.
+- Answer concrete multiplayer questions: who wrote a path, what value held at
+  `(branch, seq)`, which actions read/wrote it, which sessions had it subscribed,
+  why two clients disagree, and why a write was rejected.
+- Make the primary unit of inspection a **per-path convergence diagnosis** that
+  classifies divergence (cursor behind, pending local write, sync integrated but
+  no render, conflict loser), not just a row dump.
+- Expose all of this as a stable, documented query vocabulary that an agent can
+  run cold, with a thin UI as a second consumer.
+
+## Non-goals
+
+- Do not replace memory v2's commit/revision/head/snapshot/branch model.
+- Do not make scheduler observations ordinary user data.
+- Do not require client capture, a portable bundle, or a live visualizer for the
+  first milestone to be useful.
+- Do not add hot-path telemetry overhead to ship the autopsy product.
+- Do not rely on wall-clock timestamps for ordering or causality (see Ordering
+  Model).
+- Do not attempt perfect replay of process-local state never captured (in-flight
+  promises, JS object identity, timers, DOM listener internals).
+- Do not produce a shareable artifact spanning multiple identities without an
+  explicit cross-principal redaction story.
+
+## Core Concepts
+
+### Concept 1: The durable store is the recorder; build the lens
+
+Confirmed by audit (`packages/memory/v2/engine.ts`):
+
+- `commit`: canonical per-space `seq` (PK), keyed `(session_id, local_seq)`
+  UNIQUE (`engine.ts:141`). Stores original payload, reads, resolution.
+- `revision`: append-only entity mutations by `(branch, id, scope_key, seq,
+  op_index)`.
+- `head`, `snapshot`, `branch`, `blob_store`.
+- Scheduler tables (persisted today, gated by `persistentSchedulerState`):
+  `scheduler_observation`, `scheduler_action_snapshot`,
+  `scheduler_observation_replay`, `scheduler_read_index`,
+  `scheduler_write_index`, `scheduler_action_state`.
+- One SQLite file per space under `engine-v3/`, WAL mode.
+
+This is enough to reconstruct, with zero runtime changes: per-space commit
+timelines, who committed each (via `session_id`), conflict/retry chains, sync
+effects, state-at-`(branch, seq)`, and the action read/write dependency graph.
+
+### Concept 2: The per-path convergence diagnosis is the primitive
+
+The multiplayer mental model: each space is a totally-ordered log keyed by `seq`;
+each client is a **cursor** (the `seq` it has integrated) plus a **local pending
+overlay** (un-acked optimistic writes). Divergence between clients is always one
+of a small, classifiable set:
+
+- **cursor behind** — client has not integrated the sync that carries the newer
+  `seq`,
+- **pending local write** — client shows an optimistic value not yet committed
+  (or rejected),
+- **integrated but not rendered** — sync landed, cell did not fire, or VDOM
+  batch did not flush,
+- **conflict loser** — the client's write was rejected by `findConflictSeq` and
+  it has not reconciled.
+
+The killer view, for a given `space/branch/id/scope/path`:
+
+| Source | seq cursor | value | pending ops | last sync integrated | last render |
+| --- | --- | --- | --- | --- | --- |
+| server canonical | — | value@head | — | — | — |
+| session A | … | … | … | … | … |
+| session B | … | … | … | … | … |
+
+…with the mismatch flagged and **classified** into the set above. The
+server-only columns come from SQLite alone (Milestone 1). The client columns
+(render, pending overlay as perceived) come from the optional client overlay
+(later milestone); until then they are shown as "unknown from server view,"
+which is honest and still useful.
+
+### Concept 3: Order by `seq` + causal edges, never timestamps
+
+Within a space, `seq` is the total order — use it. Cross-layer causality is an
+explicit edge chain: `request → accepted commit (seq) → sync (fromSeq..toSeq) →
+client integrate → cell fire → render`. Cross-space causality has no global
+clock; model it as a `(space, seq)` lattice plus explicit causal edges, not by
+comparing wall-clocks across browser/worker/server/Deno-worker processes.
+Timestamps are display-only and never load-bearing for correctness. This
+deletes the draft's hardest open question ("timestamp alignment") by
+construction.
+
+### Concept 4: Agent-first — the index is the product
+
+The deliverable is a stable, documented query vocabulary over a derived
+`index.sqlite`, plus a dozen canned diagnostic queries an agent can run cold.
+The UI is a second consumer of the same index. This matches how the repo is
+actually worked (agent-heavy) and keeps the rot-prone surface (UI) off the
+critical path.
+
+## Existing Surfaces (audited)
+
+### Memory v2 SQLite — the foundation
+
+As above. All claimed tables exist; commits keyed `(session_id, local_seq)` →
+canonical `seq`; scheduler observations persisted behind `persistentSchedulerState`.
+Conflict detection lives in `findConflictSeq` (`engine.ts:3572`); `SessionSync`
+(`fromSeq`/`toSeq`/upserts/removes) and session resume are real protocol
+concepts. **This is the indexer's primary input and needs no changes.**
+
+### Runtime Telemetry — rich, but process-local and uncorrelated
+
+`packages/runner/src/telemetry.ts` defines ~12 marker families (scheduler run /
+invocation / preflight / commit / subscribe / dependencies.update /
+graph.snapshot / non-settling, cell.update, storage push/pull/connection/
+subscription). Reality check for correlation:
+
+- Carries `actionId`/`handlerId`/`reads[]`/`writes[]`.
+- **Does not carry** `sessionId`, `connectionId`, `traceId`, `clientId`,
+  `runId`, `batchId`, `mountId`. `eventId` is minted (`event-identity.ts`) but
+  **never emitted**.
+- Transport is a local `EventTarget`; ephemeral; not persisted across processes.
+- The useful events (`scheduler.run`, `event.commit`, `cell.update`,
+  `subscribe`) are **unconditionally emitted today** — stamping trace context on
+  them has real hot-path cost (see Cost Honesty).
+
+This is the input to the *optional client overlay*, not the autopsy foundation.
+
+### Shell Debugger — useful, but capped and browser-local
+
+`packages/shell/src/lib/debugger-controller.ts` toggles telemetry, stores
+markers (capped at 1000), tracks graph edges, watches cells, runs diagnosis, and
+exports JSON (raw marker array). No session/identity metadata is correlated.
+Confirms UX value; not joined to SQLite.
+
+### Multi-runtime Harness — good base, zero fault injection
+
+`packages/patterns/integration/multi-runtime-harness.ts`: one runtime per Deno
+Worker, shared memory server; models identities↔sessions↔spaces
+(`user:<did>` / `session:<did>:<id>` partitions, `PerSpace` via subscription
+push); emits diagnostics (`getGraphSnapshot`, settle stats, action-run trace).
+**No latency, disconnect, reconnect, or contention injection exists.** This is
+the base for the *reproduction* track (separate product).
+
+### Toolshed OpenTelemetry — HTTP + LLM only
+
+HTTP spans + LLM (Phoenix) + a single `memory.socket.setup` span. **No
+per-message memory tracing**; `requestId` is not propagated into spans; no
+websocket→commit correlation exists today. Relevant only to the later overlay.
+
+### Existing diagnostic to fold in, not reinvent
+
+`packages/runner/src/storage/write-stack-trace.ts` already captures
+`writerActionId` + stack for writes to matched paths. This is the "which code
+wrote this" primitive — the inspector should expose it, not duplicate it.
+
+## Architecture
+
+### 1. Value/Link/Schema/ifc decoder (Milestone 1, deliverable #1)
+
+A single reusable TS library that decodes Fabric values, `@link` references,
+schemas, cell representation, and `ifc`/security labels from SQLite rows into a
+stable, inspectable form. **Everything downstream depends on this** (state-at-seq,
+diffs, the convergence table). It is the reason the whole tool stays in
+TypeScript/Deno — the domain codecs already live there. Treat it as the central
+asset.
+
+### 2. Offline indexer over existing SQLite (Milestone 1)
+
+Reads one or more space SQLite files directly (read-only, snapshot-safe) and
+produces a derived `index.sqlite` (or in-memory model for the first prototype)
+with tables/views including:
+
+- `commit`, `revision`, `entity_head`, `entity_value_at_seq` (keyed by
+  `(branch, seq)`),
+- `scheduler_observation`, `scheduler_read_edge`, `scheduler_write_edge`,
+  `action_state`,
+- `cell_path`, `conflict_summary`, `hot_path_summary`,
+- `subscription_summary` (server-visible portion).
+
+### 3. Query vocabulary (Milestone 1, agent-first)
+
+Canned commands an agent runs cold:
+
+- `cf inspect value-at <space> <branch> <id/scope/path> <seq>`
+- `cf inspect path <space> <id/scope/path>` (all writers, conflicts, readers)
+- `cf inspect commits <space> [--session <id>]`
+- `cf inspect action <space> <actionId>` (reads/writes, dirty/stale state)
+- `cf inspect converge <id/scope/path> --spaces <a,b,…>` (the convergence table)
+- `cf inspect conflicts <space> [--path …]`
+- `cf inspect summary <space>` (hot paths, conflict counts, actors)
+
+### 4. Thin UI (later, a consumer of the index)
+
+Timeline lanes, state browser with value-at-seq + diff, scheduler graph browser,
+commit browser, client browser. All read the derived index; none own the data
+model.
+
+### 5. Minimal client correlation spine (optional overlay, later)
+
+The entire join key between client telemetry and server SQLite is four small
+changes — stated plainly so they don't get lost in a 19-identifier wishlist:
+
+1. expose the server `connectionId` to the client,
+2. stamp `(connectionId, sessionId, localSeq)` into runtime telemetry,
+3. emit the already-minted `eventId`,
+4. attach `requestId` to the memory websocket OTel span.
+
+With these, client-only events (render, optimistic overlay, perceived sync
+timing) join to server commits and complete the convergence table's client
+columns. Until then, the server columns alone are useful.
+
+## Cost Honesty
+
+The autopsy product (Milestones 1–3) requires **no runtime hot-path changes** —
+it reads the durable store offline. The optional client overlay does not: the
+useful telemetry events are emitted unconditionally today, and this repo's
+performance gate has flagged comparable changes before (cross-space
+materialization, seed memoization). The overlay must therefore either gate those
+events (a behavior change) or explicitly budget the overhead. This decision
+belongs to the overlay milestone, not the autopsy foundation.
+
+## Elevated Dimensions (were under-weighted)
+
+- **Branches are core, not optional.** State-at-seq is meaningless without
+  `(branch, seq)`; the schema has fork/merge. Branch awareness is required in
+  the indexer and query vocabulary from Milestone 1.
+- **`ifc`/security labels are top-tier for a multi-identity tool.** "Why was this
+  write rejected / why can't this principal read this" will be a top-3 question
+  as identities multiply. Decode and surface labels in Milestone 1, not as an
+  optional view.
+- **Fold in `write-stack-trace`** as the "which code wrote this" answer.
+
+## Privacy And Redaction
+
+The autopsy tool reads local space DBs for local developer use. The moment any
+derived artifact is shared, note that a multi-identity index is **cross-principal
+data exposure**, not merely "user data." Before sharing: `--redact-values`, path
+allow/denylist, payload truncation, principal anonymization, blob omission by
+default, and a manifest flag recording redaction mode. Open question: redact at
+indexing time, at export time, or both.
+
+## Proposed Milestones
+
+### Milestone 0: Inventory and decode contract
+
+- [ ] Confirm reviewers/owners.
+- [ ] Confirm the value/link/schema/ifc decode contract and stable output shape.
+- [ ] Confirm read-only snapshot method for live WAL SQLite (backup API /
+      `VACUUM INTO` / checkpoint+copy fallback; record method used).
+- [ ] Confirm `(branch, seq)` is the canonical addressing key everywhere.
+- [ ] Pick the first dogfood space (candidate: lunch-poll multi-user contention,
+      or shared-profile roster across identities).
+
+### Milestone 1: Decoder + offline indexer + query vocabulary (autopsy core)
+
+- [ ] Reusable value/link/schema/ifc decoder library.
+- [ ] Read space SQLite read-only; decode commits/revisions/snapshots.
+- [ ] Build state-at-`(branch, seq)` lookup for entities and paths.
+- [ ] Join scheduler observations + read/write indexes into a queryable graph.
+- [ ] Produce derived `index.sqlite`.
+- [ ] Ship the query vocabulary (`value-at`, `path`, `commits`, `action`,
+      `conflicts`, `summary`).
+- [ ] Surface `ifc` labels and `write-stack-trace` origins.
+
+### Milestone 2: Per-path convergence diagnosis (server-view)
+
+- [ ] `cf inspect converge` across multiple space DBs.
+- [ ] Classify divergence into cursor-behind / conflict-loser from server data;
+      mark client-only causes (pending overlay, render) as "unknown from server
+      view" pending the overlay.
+- [ ] Conflict/retry chain reconstruction per `local_seq`.
+
+### Milestone 3: Thin UI over the index
+
+- [ ] Load a derived index.
+- [ ] State browser (value-at-seq + diff), commit browser, scheduler
+      graph/read/write browser, actor timeline lanes.
+- [ ] Render the convergence table.
+
+### Milestone 4 (optional overlay): Client correlation spine
+
+- [ ] Expose `connectionId` to the client.
+- [ ] Stamp `(connectionId, sessionId, localSeq)` + emit `eventId` in runtime
+      telemetry (decide gating vs. overhead budget).
+- [ ] Attach `requestId` to memory websocket OTel span.
+- [ ] Complete the convergence table's client columns (render, pending overlay).
+- [ ] Optional portable bundle format for sharing (with cross-principal
+      redaction).
+
+### Separate track (reproduction product): Harness fault injection
+
+> This is the *reproduction* product, independent of autopsy. Pursue it when the
+> sharper pain is catching multiplayer races in CI rather than autopsying them.
+
+- [ ] Latency / held-response / disconnect-reconnect wrappers on the harness
+      memory transport.
+- [ ] Deterministic contention scenarios.
+- [ ] Emit the same decoded events the indexer consumes, so a reproduced run
+      feeds the same lens.
+
+## Open Questions
+
+- What is the safest portable read-only SQLite snapshot in Deno with
+  `@db/sqlite` for live WAL databases?
+- How should single-file `DB_PATH` mode (vs. one-file-per-space) be represented?
+- Should blobs be copied, omitted, or represented by hash/metadata only?
+- For the overlay: gate the always-on telemetry events, or budget the
+  stamping overhead?
+- Should the derived `index.sqlite` become canonical after indexing, or remain a
+  rebuildable cache of the source space DBs?
+- Redaction at indexing vs. export vs. both.
+
+## Appendix: Example Questions The Autopsy Core Must Answer
+
+### Why did Bob's vote clobber Alice's vote? (server-view, Milestone 1–2)
+
+1. `cf inspect path <space> poll/.../votes` → all writers + conflicts.
+2. Read Bob's commit row: its read set and resolved `seq`.
+3. Compare Alice's prior commit `seq` to Bob's read watermark via
+   `findConflictSeq` semantics.
+4. `cf inspect value-at` before/after each commit.
+
+### Why do two browsers disagree on this value? (convergence, Milestone 2)
+
+1. `cf inspect converge <id/scope/path> --spaces A,B`.
+2. Read the classification: cursor-behind / conflict-loser from server data;
+   client-only causes flagged pending the overlay.
+
+### Which path causes the most contention? (Milestone 1)
+
+1. `cf inspect summary <space>` → `conflict_summary` / `hot_path_summary`.
+2. Drill with `cf inspect path` for writers, readers, and value diff across the
+   conflict window.
+
+## Decision Log
+
+| Date | Decision | Owner | Notes |
+| --- | --- | --- | --- |
+| 2026-06-26 | Lead with autopsy (durable-store lens), not capture bundle | Ben | Forensic pain is sharper; SQLite already records it |
+| 2026-06-26 | Agent-first: index + query vocabulary is the product, UI is a consumer | Ben | Matches repo workflow |
+| 2026-06-26 | Order by `seq` + causal edges, timestamps display-only | — | Deletes timestamp-alignment open question |
+| 2026-06-26 | Reproduction (harness fault injection) is a separate, later track | — | Independent of autopsy |

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -1,0 +1,59 @@
+# @commonfabric/state-inspector
+
+Offline autopsy of Common Fabric memory v2 space DBs. Prototype for the
+[Multiplayer State Inspector proposal](../../docs/plans/2026-06-26-runtime-trace-inspector.md).
+
+The thesis: **the durable store the server already wrote is the flight
+recorder.** This package is the lens over it — open a space SQLite file
+read-only, reconstruct state-at-`(branch, seq)`, and answer who/what/when
+questions with no live runtime and no capture step.
+
+## Status: prototype (Milestone 1 core)
+
+Implemented and tested against a hermetic fixture + a real 571 MB space DB:
+
+- **read-only DB access** (`db.ts`)
+- **value decoder** (`decode.ts`) — recognizes legacy sigil links
+  `{ "/": { "link@1": {…} } }`, entity refs `{ "/": "of:…" }`, and streams
+  `{ "$stream": true }`; annotates a value into JSON-printable form.
+- **state reconstruction** (`reconstruct.ts`) — replays the append-only
+  `revision` log (`set` / `patch` (RFC 6902) / `delete`) to a target seq.
+- **autopsy queries** (`queries.ts`) — `summary`, `commits`, `entityHistory`
+  (who wrote this), `hotEntities` (contention proxy).
+- **thin CLI** (`cli.ts`) — every command supports `--json` for agents.
+
+## Reality checks found while building (feed back into the plan)
+
+1. **Scheduler tables are usually absent.** The 571 MB production-shaped DB had
+   only the entity tables (`commit`, `revision`, `head`, `snapshot`, `branch`,
+   `blob_store`, `invocation`, `authorization`). `scheduler_observation` &
+   friends only exist when `persistentSchedulerState` was enabled on the server.
+   ⇒ The autopsy core that works *today* is entity-history only; the scheduler
+   read/write graph is opt-in, so every query must degrade gracefully
+   (`hasSchedulerTables`).
+2. **Stored values are plain JSON with inline sigil links**, not the `fvj1:`
+   codec-json envelope. Decoding current DBs needs no `@commonfabric/data-model`
+   dependency. The modern envelope can be plugged in at the leaves later.
+3. **Entity ids are legacy `of:baedrei…` (CIDv1)** in these DBs; modern cell-rep
+   uses `fid1:…`. The decoder treats both as opaque strings.
+
+## Usage
+
+```bash
+# from repo root
+DB="packages/toolshed/cache/memory/engine-v3/engine-v3/<space-did>.sqlite"
+
+deno task --cwd packages/state-inspector inspect summary  "$DB"
+deno task --cwd packages/state-inspector inspect commits  "$DB" --limit 20
+deno task --cwd packages/state-inspector inspect hot      "$DB" --limit 10
+deno task --cwd packages/state-inspector inspect history  "$DB" of:baedrei… 
+deno task --cwd packages/state-inspector inspect value-at "$DB" of:baedrei… --path value/count
+```
+
+## Not yet built (next milestones)
+
+- Per-path **convergence diagnosis** across multiple space DBs (M2).
+- `ifc` / security-label decoding from stored schemas.
+- Snapshot-base optimization for reconstruction (currently replays from seq 0).
+- Wiring into `cf inspect` as a first-class subcommand.
+- Client-side correlation overlay (connectionId / eventId).

--- a/packages/state-inspector/cli.ts
+++ b/packages/state-inspector/cli.ts
@@ -1,0 +1,206 @@
+#!/usr/bin/env -S deno run --allow-read --allow-ffi --allow-env
+// Thin CLI over the inspector library. Agent-first: every command also takes
+// --json so a caller can consume structured output. This is a prototype entry
+// point; the intent is to later surface the same commands as `cf inspect …`.
+//
+//   deno task inspect summary  <db>
+//   deno task inspect commits  <db> [--session <prefix>] [--limit <n>]
+//   deno task inspect hot      <db> [--limit <n>] [--branch <b>]
+//   deno task inspect history  <db> <entity-id> [--scope <s>] [--branch <b>]
+//   deno task inspect value-at <db> <entity-id> [--seq <n>] [--path a/b/c]
+//                              [--scope <s>] [--branch <b>] [--doc]
+
+import { openSpace } from "./db.ts";
+import { annotate } from "./decode.ts";
+import {
+  entityHistory,
+  hotEntities,
+  listCommits,
+  summarizeSpace,
+} from "./queries.ts";
+import { getValueAt } from "./reconstruct.ts";
+
+interface Args {
+  positional: string[];
+  flags: Record<string, string | boolean>;
+}
+
+function parseArgs(argv: string[]): Args {
+  const positional: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        flags[key] = next;
+        i++;
+      } else {
+        flags[key] = true;
+      }
+    } else {
+      positional.push(a);
+    }
+  }
+  return { positional, flags };
+}
+
+const str = (v: string | boolean | undefined): string | undefined =>
+  typeof v === "string" ? v : undefined;
+const num = (v: string | boolean | undefined): number | undefined =>
+  typeof v === "string" ? Number(v) : undefined;
+
+function out(json: boolean, data: unknown, render: () => void) {
+  if (json) console.log(JSON.stringify(data, null, 2));
+  else render();
+}
+
+const USAGE = `cf state-inspector (prototype)
+
+  summary  <db>
+  commits  <db> [--session <prefix>] [--limit <n>] [--json]
+  hot      <db> [--limit <n>] [--branch <b>] [--json]
+  history  <db> <entity-id> [--scope <s>] [--branch <b>] [--limit <n>] [--json]
+  value-at <db> <entity-id> [--seq <n>] [--path a/b/c] [--scope <s>]
+                            [--branch <b>] [--doc] [--json]
+`;
+
+function main(argv: string[]): number {
+  const { positional, flags } = parseArgs(argv);
+  const [cmd, dbPath, ...rest] = positional;
+  const json = flags.json === true;
+
+  if (!cmd || cmd === "help" || flags.help) {
+    console.log(USAGE);
+    return cmd ? 0 : 1;
+  }
+  if (!dbPath) {
+    console.error("error: missing <db> path\n");
+    console.log(USAGE);
+    return 1;
+  }
+
+  const space = openSpace(dbPath);
+  try {
+    switch (cmd) {
+      case "summary": {
+        const s = summarizeSpace(space);
+        out(json, s, () => {
+          console.log(`space: ${s.path}`);
+          console.log(
+            `commits: ${s.commits}` +
+              (s.commitSeqRange
+                ? ` (seq ${s.commitSeqRange[0]}–${s.commitSeqRange[1]})`
+                : ""),
+          );
+          console.log(`sessions: ${s.sessions}`);
+          console.log(`entities: ${s.entities}  revisions: ${s.revisions}`);
+          console.log(
+            `ops: ${Object.entries(s.ops).map(([k, v]) => `${k}=${v}`).join(" ")}`,
+          );
+          console.log(
+            `scopes: ${s.scopes.map((sc) => `${sc.scope_key}=${sc.count}`).join(" ")}`,
+          );
+          console.log(
+            `branches: ${s.branches.map((b) => `${b.name || "(default)"}@${b.head_seq}`).join(" ")}`,
+          );
+          console.log(`scheduler tables: ${s.hasSchedulerTables ? "yes" : "no"}`);
+        });
+        return 0;
+      }
+      case "commits": {
+        const rows = listCommits(space, {
+          session: str(flags.session),
+          limit: num(flags.limit),
+        });
+        out(json, rows, () => {
+          for (const r of rows) {
+            console.log(
+              `#${r.seq}\t${r.session.slice(0, 14)}\tlocal=${r.localSeq}\tops=${r.ops}\treads=${r.reads}\t${r.createdAt}`,
+            );
+          }
+        });
+        return 0;
+      }
+      case "hot": {
+        const rows = hotEntities(space, {
+          limit: num(flags.limit),
+          branch: str(flags.branch),
+        });
+        out(json, rows, () => {
+          for (const r of rows) {
+            console.log(
+              `${r.writes}\twrites\t${r.sessions} sessions\t${r.id}\t(${r.scope})`,
+            );
+          }
+        });
+        return 0;
+      }
+      case "history": {
+        const id = rest[0];
+        if (!id) {
+          console.error("error: history needs <entity-id>");
+          return 1;
+        }
+        const rows = entityHistory(space, {
+          id,
+          scope: str(flags.scope),
+          branch: str(flags.branch),
+          limit: num(flags.limit),
+        });
+        out(json, rows, () => {
+          for (const r of rows) {
+            console.log(
+              `seq=${r.seq}\tcommit=${r.commitSeq}\t${r.op}\t${r.session.slice(0, 14)}\tlocal=${r.localSeq}\t${r.createdAt}`,
+            );
+          }
+        });
+        return 0;
+      }
+      case "value-at": {
+        const id = rest[0];
+        if (!id) {
+          console.error("error: value-at needs <entity-id>");
+          return 1;
+        }
+        const path = str(flags.path)
+          ? str(flags.path)!.split("/").filter(Boolean)
+          : [];
+        const res = getValueAt(
+          space,
+          {
+            id,
+            scope: str(flags.scope),
+            branch: str(flags.branch),
+            atSeq: num(flags.seq),
+          },
+          path,
+        );
+        const shown = flags.doc === true ? res.document : res.value;
+        out(json, { exists: res.exists, value: annotate(shown) }, () => {
+          if (!res.exists) {
+            console.log("(absent at this seq)");
+            return;
+          }
+          if (shown === undefined) {
+            console.log("(entity present, but nothing at that path)");
+            return;
+          }
+          console.log(JSON.stringify(annotate(shown), null, 2));
+        });
+        return 0;
+      }
+      default:
+        console.error(`unknown command: ${cmd}\n`);
+        console.log(USAGE);
+        return 1;
+    }
+  } finally {
+    space.close();
+  }
+}
+
+if (import.meta.main) {
+  Deno.exit(main(Deno.args));
+}

--- a/packages/state-inspector/db.ts
+++ b/packages/state-inspector/db.ts
@@ -1,0 +1,74 @@
+// Read-only access to a memory v2 space SQLite file.
+//
+// Everything here is offline and side-effect free: we open the durable store
+// the server already wrote and never mutate it. See the proposal in
+// docs/plans/2026-06-26-runtime-trace-inspector.md for why the durable store is
+// treated as the flight recorder.
+
+import { Database } from "@db/sqlite";
+
+export interface CommitRow {
+  seq: number;
+  branch: string;
+  session_id: string;
+  local_seq: number;
+  invocation_ref: string | null;
+  authorization_ref: string | null;
+  original: string;
+  resolution: string;
+  created_at: string;
+}
+
+export interface RevisionRow {
+  branch: string;
+  id: string;
+  scope_key: string;
+  seq: number;
+  op_index: number;
+  op: string;
+  data: string | null;
+  commit_seq: number;
+}
+
+export interface BranchRow {
+  name: string;
+  parent_branch: string | null;
+  fork_seq: number | null;
+  created_seq: number;
+  head_seq: number;
+  status: string;
+}
+
+export interface SpaceDb {
+  readonly db: Database;
+  readonly path: string;
+  close(): void;
+}
+
+/** Open a space DB read-only. Safe against stale (and, best-effort, live) files. */
+export function openSpace(path: string): SpaceDb {
+  const db = new Database(path, { readonly: true });
+  return {
+    db,
+    path,
+    close: () => db.close(),
+  };
+}
+
+export function tableNames(db: Database): string[] {
+  return db
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
+    )
+    .all<{ name: string }>()
+    .map((r) => r.name);
+}
+
+/**
+ * Scheduler persistence tables only exist when `persistentSchedulerState` was
+ * enabled on the server. In practice they are usually absent, so the autopsy
+ * core must degrade gracefully rather than assume the dependency graph is here.
+ */
+export function hasSchedulerTables(db: Database): boolean {
+  return tableNames(db).includes("scheduler_observation");
+}

--- a/packages/state-inspector/decode.ts
+++ b/packages/state-inspector/decode.ts
@@ -1,0 +1,148 @@
+// Decoding stored Fabric values into an inspectable form.
+//
+// Reality check (verified against real space DBs, 2026-06-26): today's stored
+// `revision.data` is plain JSON with inline *sigil links* of the legacy form
+//   { "/": { "link@1": { id, space?, path?, scope?, schema? } } }
+// entity references of the form
+//   { "/": "of:baedrei…" }   (or { "/": "fid1:…" } in modern cell-rep)
+// and streams of the form
+//   { "$stream": true }
+//
+// So decoding for current DBs is pure JSON walking + recognition — no live
+// runtime/Cell needed. The modern `fvj1:`-prefixed codec-json envelope
+// (@commonfabric/data-model/codec-json) is NOT what lands in these rows; if we
+// later meet it we can plug `valueFromJson` in at the leaves.
+
+export interface DecodedLink {
+  id?: string;
+  space?: string;
+  path?: readonly string[];
+  scope?: string;
+  hasSchema: boolean;
+}
+
+type Json = unknown;
+
+function isPlainObject(v: Json): v is Record<string, Json> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** A sigil link: `{ "/": { "link@N": {...} } }`. */
+export function parseSigilLink(v: Json): DecodedLink | null {
+  if (!isPlainObject(v)) return null;
+  const keys = Object.keys(v);
+  if (keys.length !== 1 || keys[0] !== "/") return null;
+  const inner = v["/"];
+  if (!isPlainObject(inner)) return null;
+  const linkKey = Object.keys(inner).find((k) => k.startsWith("link@"));
+  if (!linkKey) return null;
+  const payload = inner[linkKey];
+  if (!isPlainObject(payload)) return null;
+  return {
+    id: typeof payload.id === "string" ? payload.id : undefined,
+    space: typeof payload.space === "string" ? payload.space : undefined,
+    path: Array.isArray(payload.path)
+      ? (payload.path as readonly string[])
+      : undefined,
+    scope: typeof payload.scope === "string" ? payload.scope : undefined,
+    hasSchema: payload.schema !== undefined,
+  };
+}
+
+/** An entity reference: `{ "/": "of:…" | "fid1:…" }`. */
+export function parseEntityRef(v: Json): string | null {
+  if (!isPlainObject(v)) return null;
+  const keys = Object.keys(v);
+  if (keys.length !== 1 || keys[0] !== "/") return null;
+  return typeof v["/"] === "string" ? (v["/"] as string) : null;
+}
+
+export function isStream(v: Json): boolean {
+  return isPlainObject(v) && v["$stream"] === true;
+}
+
+function shortDid(did?: string): string | undefined {
+  if (!did) return undefined;
+  // did:key:z6Mk…wQ2n  ->  z6Mk…wQ2n
+  const tail = did.startsWith("did:key:") ? did.slice("did:key:".length) : did;
+  return tail.length > 12 ? `${tail.slice(0, 6)}…${tail.slice(-4)}` : tail;
+}
+
+function shortId(id?: string): string | undefined {
+  if (!id) return undefined;
+  const body = id.startsWith("of:") ? id.slice(3) : id;
+  return body.length > 14 ? `${body.slice(0, 8)}…${body.slice(-4)}` : body;
+}
+
+/** One-line, human-readable summary of a link for tables. */
+export function summarizeLink(link: DecodedLink): string {
+  const id = shortId(link.id) ?? "?";
+  const path = link.path && link.path.length ? `/${link.path.join("/")}` : "";
+  const space = link.space ? ` @${shortDid(link.space)}` : "";
+  const schema = link.hasSchema ? " +schema" : "";
+  return `🔗 ${id}${path}${space}${schema}`;
+}
+
+/**
+ * Recursively transform a stored value into an annotated, JSON-printable form:
+ * links become `{ $link: … }`, entity refs `{ $ref: … }`, streams `"$stream"`.
+ * `maxDepth` guards against deep/cyclic-looking structures.
+ */
+export function annotate(v: Json, maxDepth = 8): Json {
+  if (maxDepth < 0) return "…";
+
+  const link = parseSigilLink(v);
+  if (link) {
+    return {
+      $link: {
+        id: link.id,
+        ...(link.path && link.path.length ? { path: link.path } : {}),
+        ...(link.space ? { space: link.space } : {}),
+        ...(link.scope ? { scope: link.scope } : {}),
+        ...(link.hasSchema ? { schema: true } : {}),
+      },
+    };
+  }
+  if (isStream(v)) return "$stream";
+  const ref = parseEntityRef(v);
+  if (ref !== null) return { $ref: ref };
+
+  if (Array.isArray(v)) return v.map((x) => annotate(x, maxDepth - 1));
+  if (isPlainObject(v)) {
+    const out: Record<string, Json> = {};
+    for (const [k, val] of Object.entries(v)) out[k] = annotate(val, maxDepth - 1);
+    return out;
+  }
+  return v;
+}
+
+/** Compact one-line summary of any value, for table cells. */
+export function summarize(v: Json): string {
+  const link = parseSigilLink(v);
+  if (link) return summarizeLink(link);
+  if (isStream(v)) return "⊙ stream";
+  const ref = parseEntityRef(v);
+  if (ref !== null) return `#${shortId(ref) ?? ref}`;
+  if (v === null) return "null";
+  if (Array.isArray(v)) return `[${v.length}]`;
+  if (isPlainObject(v)) return `{${Object.keys(v).join(", ")}}`;
+  if (typeof v === "string") return v.length > 40 ? `"${v.slice(0, 37)}…"` : `"${v}"`;
+  return String(v);
+}
+
+/** Count links reachable in a value (a cheap fan-out proxy). */
+export function countLinks(v: Json, maxDepth = 8): number {
+  if (maxDepth < 0) return 0;
+  if (parseSigilLink(v)) return 1;
+  if (isStream(v) || parseEntityRef(v) !== null) return 0;
+  if (Array.isArray(v)) {
+    return v.reduce<number>((n, x) => n + countLinks(x, maxDepth - 1), 0);
+  }
+  if (isPlainObject(v)) {
+    return Object.values(v).reduce<number>(
+      (n, x) => n + countLinks(x, maxDepth - 1),
+      0,
+    );
+  }
+  return 0;
+}

--- a/packages/state-inspector/deno.json
+++ b/packages/state-inspector/deno.json
@@ -1,0 +1,20 @@
+{
+  "name": "@commonfabric/state-inspector",
+  "version": "0.0.1",
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "tasks": {
+    "check": "deno check .",
+    "inspect": "deno run --allow-read --allow-ffi --allow-env ./cli.ts",
+    "just-test": "deno test --allow-read --allow-write --allow-ffi --allow-env",
+    "test": {
+      "description": "Type check & run tests",
+      "dependencies": ["check", "just-test"]
+    }
+  },
+  "imports": {
+    "@db/sqlite": "jsr:@db/sqlite@^0.12.0",
+    "@std/assert": "jsr:@std/assert@^1"
+  }
+}

--- a/packages/state-inspector/mod.ts
+++ b/packages/state-inspector/mod.ts
@@ -1,0 +1,11 @@
+// @commonfabric/state-inspector — offline autopsy of memory v2 space DBs.
+//
+// The durable store the server already wrote IS the flight recorder. This
+// package is the lens over it: open a space SQLite file read-only, reconstruct
+// state-at-(branch, seq), and answer who/what/when questions — no live runtime,
+// no capture step. See docs/plans/2026-06-26-runtime-trace-inspector.md.
+
+export * from "./db.ts";
+export * from "./decode.ts";
+export * from "./reconstruct.ts";
+export * from "./queries.ts";

--- a/packages/state-inspector/queries.ts
+++ b/packages/state-inspector/queries.ts
@@ -1,0 +1,184 @@
+// Autopsy queries over a space DB. These answer the "who/what/when" questions
+// the proposal lists, using only the durable entity tables (no scheduler graph
+// required, since those tables are usually absent).
+
+import type { CommitRow, SpaceDb } from "./db.ts";
+import { hasSchedulerTables } from "./db.ts";
+
+export interface SpaceSummary {
+  path: string;
+  hasSchedulerTables: boolean;
+  commits: number;
+  commitSeqRange: [number, number] | null;
+  sessions: number;
+  revisions: number;
+  entities: number;
+  ops: Record<string, number>;
+  branches: { name: string; head_seq: number; status: string }[];
+  scopes: { scope_key: string; count: number }[];
+}
+
+export function summarizeSpace(space: SpaceDb): SpaceSummary {
+  const db = space.db;
+  const one = <T extends object>(sql: string): T => db.prepare(sql).get<T>() as T;
+
+  const commitAgg = one<{ n: number; lo: number | null; hi: number | null; s: number }>(
+    `SELECT count(*) n, min(seq) lo, max(seq) hi, count(DISTINCT session_id) s FROM "commit"`,
+  );
+  const revAgg = one<{ n: number; e: number }>(
+    `SELECT count(*) n, count(DISTINCT id) e FROM revision`,
+  );
+  const ops = db
+    .prepare(`SELECT op, count(*) c FROM revision GROUP BY op`)
+    .all<{ op: string; c: number }>();
+  const branches = db
+    .prepare(`SELECT name, head_seq, status FROM branch ORDER BY name`)
+    .all<{ name: string; head_seq: number; status: string }>();
+  const scopes = db
+    .prepare(
+      `SELECT scope_key, count(*) count FROM revision GROUP BY scope_key ORDER BY count DESC`,
+    )
+    .all<{ scope_key: string; count: number }>();
+
+  return {
+    path: space.path,
+    hasSchedulerTables: hasSchedulerTables(db),
+    commits: commitAgg.n,
+    commitSeqRange: commitAgg.lo === null ? null : [commitAgg.lo, commitAgg.hi!],
+    sessions: commitAgg.s,
+    revisions: revAgg.n,
+    entities: revAgg.e,
+    ops: Object.fromEntries(ops.map((r) => [r.op, r.c])),
+    branches,
+    scopes,
+  };
+}
+
+export interface CommitInfo {
+  seq: number;
+  branch: string;
+  session: string;
+  localSeq: number;
+  ops: number;
+  reads: number;
+  createdAt: string;
+}
+
+/** List commits, most recent first, optionally filtered by session prefix. */
+export function listCommits(
+  space: SpaceDb,
+  opts: { session?: string; limit?: number } = {},
+): CommitInfo[] {
+  const limit = opts.limit ?? 50;
+  const where = opts.session ? `WHERE session_id LIKE ?` : ``;
+  const params: string[] = opts.session ? [`${opts.session}%`] : [];
+  const rows = space.db
+    .prepare(
+      `SELECT seq, branch, session_id, local_seq, original, created_at
+       FROM "commit" ${where} ORDER BY seq DESC LIMIT ?`,
+    )
+    .all<CommitRow>(...params, limit);
+
+  return rows.map((r) => {
+    let ops = 0;
+    let reads = 0;
+    try {
+      const parsed = JSON.parse(r.original);
+      ops = Array.isArray(parsed.operations) ? parsed.operations.length : 0;
+      reads = (parsed.reads?.confirmed?.length ?? 0) +
+        (parsed.reads?.pending?.length ?? 0);
+    } catch {
+      // leave zeroed if payload is unparseable
+    }
+    return {
+      seq: r.seq,
+      branch: r.branch,
+      session: r.session_id,
+      localSeq: r.local_seq,
+      ops,
+      reads,
+      createdAt: r.created_at,
+    };
+  });
+}
+
+export interface WriteEvent {
+  seq: number;
+  commitSeq: number;
+  opIndex: number;
+  op: string;
+  session: string;
+  localSeq: number;
+  createdAt: string;
+}
+
+/** Every write that touched an entity, in order — the "who wrote this" answer. */
+export function entityHistory(
+  space: SpaceDb,
+  opts: { id: string; scope?: string; branch?: string; limit?: number },
+): WriteEvent[] {
+  const scope = opts.scope ?? "space";
+  const branch = opts.branch ?? "";
+  const limit = opts.limit ?? 200;
+  return space.db
+    .prepare(
+      `SELECT r.seq, r.commit_seq, r.op_index, r.op,
+              c.session_id, c.local_seq, c.created_at
+       FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
+       WHERE r.branch = ? AND r.id = ? AND r.scope_key = ?
+       ORDER BY r.seq ASC, r.op_index ASC LIMIT ?`,
+    )
+    .all<{
+      seq: number;
+      commit_seq: number;
+      op_index: number;
+      op: string;
+      session_id: string;
+      local_seq: number;
+      created_at: string;
+    }>(branch, opts.id, scope, limit)
+    .map((r) => ({
+      seq: r.seq,
+      commitSeq: r.commit_seq,
+      opIndex: r.op_index,
+      op: r.op,
+      session: r.session_id,
+      localSeq: r.local_seq,
+      createdAt: r.created_at,
+    }));
+}
+
+export interface HotEntity {
+  id: string;
+  scope: string;
+  writes: number;
+  sessions: number;
+}
+
+/** Entities ranked by write count — a contention/hot-path proxy. */
+export function hotEntities(
+  space: SpaceDb,
+  opts: { branch?: string; limit?: number } = {},
+): HotEntity[] {
+  const branch = opts.branch ?? "";
+  const limit = opts.limit ?? 20;
+  return space.db
+    .prepare(
+      `SELECT r.id, r.scope_key,
+              count(*) writes, count(DISTINCT c.session_id) sessions
+       FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
+       WHERE r.branch = ?
+       GROUP BY r.id, r.scope_key
+       ORDER BY writes DESC LIMIT ?`,
+    )
+    .all<{ id: string; scope_key: string; writes: number; sessions: number }>(
+      branch,
+      limit,
+    )
+    .map((r) => ({
+      id: r.id,
+      scope: r.scope_key,
+      writes: r.writes,
+      sessions: r.sessions,
+    }));
+}

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -1,0 +1,184 @@
+// State-at-(branch, seq) reconstruction by replaying the append-only revision log.
+//
+// A memory v2 entity document has the shape `{ value: <FabricValue>, source?: … }`.
+// Each `revision` row is one operation on that document:
+//   - op="set"    → data is the whole replacement document
+//   - op="patch"  → data is an RFC 6902 JSON-Patch array applied to the document
+//   - op="delete" → tombstone (document becomes absent)
+//
+// Replaying in (seq, op_index) order up to a target seq yields the document as
+// of that point in the space's total order. This is the autopsy primitive:
+// value-at-seq with no live runtime.
+//
+// NOTE: the JSON-Patch applier here implements standard RFC 6902. The server's
+// own applier (packages/memory/v2/patch.ts) is ground truth; cross-check before
+// trusting reconstruction in anything load-bearing.
+
+import type { SpaceDb } from "./db.ts";
+
+export interface EntityAddress {
+  id: string;
+  scope?: string;
+  branch?: string;
+}
+
+export interface ReconstructOptions extends EntityAddress {
+  /** Replay revisions with seq <= atSeq. Defaults to latest. */
+  atSeq?: number;
+}
+
+export type EntityDocument = { value?: unknown; source?: unknown } & Record<
+  string,
+  unknown
+>;
+
+interface PatchOp {
+  op: "add" | "remove" | "replace" | "move" | "copy" | "test";
+  path: string;
+  from?: string;
+  value?: unknown;
+}
+
+function parsePointer(pointer: string): string[] {
+  if (pointer === "") return [];
+  return pointer
+    .split("/")
+    .slice(1)
+    .map((p) => p.replace(/~1/g, "/").replace(/~0/g, "~"));
+}
+
+function getAt(root: unknown, path: string[]): unknown {
+  let cur: unknown = root;
+  for (const key of path) {
+    if (cur == null) return undefined;
+    if (Array.isArray(cur)) {
+      const idx = key === "-" ? cur.length : Number(key);
+      cur = cur[idx];
+    } else if (typeof cur === "object") {
+      cur = (cur as Record<string, unknown>)[key];
+    } else {
+      return undefined;
+    }
+  }
+  return cur;
+}
+
+function setAt(root: unknown, path: string[], value: unknown, add: boolean): unknown {
+  if (path.length === 0) return value;
+  const parent = getAt(root, path.slice(0, -1));
+  const key = path[path.length - 1];
+  if (parent == null) return root;
+  if (Array.isArray(parent)) {
+    const idx = key === "-" ? parent.length : Number(key);
+    if (add) parent.splice(idx, 0, value);
+    else parent[idx] = value;
+  } else if (typeof parent === "object") {
+    (parent as Record<string, unknown>)[key] = value;
+  }
+  return root;
+}
+
+function removeAt(root: unknown, path: string[]): unknown {
+  if (path.length === 0) return undefined;
+  const parent = getAt(root, path.slice(0, -1));
+  const key = path[path.length - 1];
+  if (parent == null) return root;
+  if (Array.isArray(parent)) {
+    parent.splice(Number(key), 1);
+  } else if (typeof parent === "object") {
+    delete (parent as Record<string, unknown>)[key];
+  }
+  return root;
+}
+
+export function applyJsonPatch(doc: unknown, ops: PatchOp[]): unknown {
+  let root = doc;
+  for (const op of ops) {
+    const path = parsePointer(op.path);
+    switch (op.op) {
+      case "add":
+        root = setAt(root, path, op.value, true);
+        break;
+      case "replace":
+        root = setAt(root, path, op.value, false);
+        break;
+      case "remove":
+        root = removeAt(root, path);
+        break;
+      case "move": {
+        const from = parsePointer(op.from ?? "");
+        const val = getAt(root, from);
+        root = removeAt(root, from);
+        root = setAt(root, path, val, true);
+        break;
+      }
+      case "copy": {
+        const from = parsePointer(op.from ?? "");
+        const val = structuredClone(getAt(root, from));
+        root = setAt(root, path, val, true);
+        break;
+      }
+      case "test":
+        // Verification op; ignored for reconstruction.
+        break;
+    }
+  }
+  return root;
+}
+
+interface RevRow {
+  seq: number;
+  op_index: number;
+  op: string;
+  data: string | null;
+}
+
+/** Replay the revision log to reconstruct an entity document at a seq. */
+export function reconstructDocument(
+  space: SpaceDb,
+  opts: ReconstructOptions,
+): EntityDocument | undefined {
+  const branch = opts.branch ?? "";
+  const scope = opts.scope ?? "space";
+  const atSeq = opts.atSeq ?? Number.MAX_SAFE_INTEGER;
+
+  const rows = space.db
+    .prepare(
+      `SELECT seq, op_index, op, data FROM revision
+       WHERE branch = ? AND id = ? AND scope_key = ? AND seq <= ?
+       ORDER BY seq ASC, op_index ASC`,
+    )
+    .all<RevRow>(branch, opts.id, scope, atSeq);
+
+  let doc: unknown = undefined;
+  for (const row of rows) {
+    if (row.op === "set") {
+      doc = row.data ? JSON.parse(row.data) : undefined;
+    } else if (row.op === "patch") {
+      doc = applyJsonPatch(doc, row.data ? JSON.parse(row.data) : []);
+    } else if (row.op === "delete") {
+      doc = undefined;
+    }
+  }
+  return doc as EntityDocument | undefined;
+}
+
+export interface ValueAtResult {
+  exists: boolean;
+  /** The full reconstructed document (`{ value, source, … }`). */
+  document?: EntityDocument;
+  /** The value navigated to `path` within `document.value`. */
+  value?: unknown;
+}
+
+/** Reconstruct then navigate into `document.value` by path. */
+export function getValueAt(
+  space: SpaceDb,
+  opts: ReconstructOptions,
+  path: string[] = [],
+): ValueAtResult {
+  const document = reconstructDocument(space, opts);
+  if (document === undefined) return { exists: false };
+  const value = getAt(document.value, path);
+  return { exists: true, document, value };
+}

--- a/packages/state-inspector/test/reconstruct.test.ts
+++ b/packages/state-inspector/test/reconstruct.test.ts
@@ -1,0 +1,141 @@
+// Hermetic test: build a tiny space DB in a temp dir matching the memory v2
+// schema, then exercise the read-only inspector against it. Side-effect free —
+// the temp dir is removed in finally.
+
+import { assert, assertEquals } from "@std/assert";
+import { Database } from "@db/sqlite";
+
+import { openSpace } from "../db.ts";
+import { annotate, parseSigilLink } from "../decode.ts";
+import { getValueAt, reconstructDocument } from "../reconstruct.ts";
+import { entityHistory, hotEntities, listCommits, summarizeSpace } from "../queries.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY,
+  branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL,
+  local_seq INTEGER NOT NULL,
+  invocation_ref TEXT,
+  authorization_ref TEXT,
+  original JSON NOT NULL,
+  resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '',
+  id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space',
+  seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL,
+  op TEXT NOT NULL,
+  data JSON,
+  commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+CREATE TABLE branch (
+  name TEXT NOT NULL PRIMARY KEY,
+  parent_branch TEXT,
+  fork_seq INTEGER,
+  created_seq INTEGER NOT NULL DEFAULT 0,
+  head_seq INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'active'
+);
+INSERT INTO branch (name, head_seq) VALUES ('', 4);
+`;
+
+const LINK = {
+  "/": { "link@1": { id: "of:other", space: "did:key:zABC", path: [] } },
+};
+
+function seedDb(path: string) {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, branch, session_id, local_seq, original, resolution)
+     VALUES (?, '', ?, ?, ?, ?)`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (branch, id, scope_key, seq, op_index, op, data, commit_seq)
+     VALUES ('', ?, 'space', ?, 0, ?, ?, ?)`,
+  );
+
+  const mkOriginal = (ops: number) =>
+    JSON.stringify({ localSeq: ops, reads: { confirmed: [], pending: [] }, operations: new Array(ops).fill({}) });
+
+  // seq1: set A
+  commit.run(1, "session-alice", 1, mkOriginal(1), JSON.stringify({ seq: 1 }));
+  rev.run("of:A", 1, "set", JSON.stringify({ value: { count: 1, link: LINK } }), 1);
+  // seq2: set B
+  commit.run(2, "session-bob", 1, mkOriginal(1), JSON.stringify({ seq: 2 }));
+  rev.run("of:B", 2, "set", JSON.stringify({ value: { x: true } }), 2);
+  // seq3: patch A.count -> 2
+  commit.run(3, "session-alice", 2, mkOriginal(1), JSON.stringify({ seq: 3 }));
+  rev.run("of:A", 3, "patch", JSON.stringify([{ op: "replace", path: "/value/count", value: 2 }]), 3);
+  // seq4: delete B
+  commit.run(4, "session-bob", 2, mkOriginal(1), JSON.stringify({ seq: 4 }));
+  rev.run("of:B", 4, "delete", null, 4);
+
+  db.close();
+}
+
+Deno.test("state-inspector autopsy core", async (t) => {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-test-" });
+  const dbPath = `${dir}/space.sqlite`;
+  try {
+    seedDb(dbPath);
+    const space = openSpace(dbPath);
+    try {
+      await t.step("reconstruct at seq replays set then patch", () => {
+        assertEquals(getValueAt(space, { id: "of:A", atSeq: 1 }, ["count"]).value, 1);
+        assertEquals(getValueAt(space, { id: "of:A", atSeq: 2 }, ["count"]).value, 1);
+        assertEquals(getValueAt(space, { id: "of:A", atSeq: 3 }, ["count"]).value, 2);
+        // latest (no seq) sees the patch
+        assertEquals(getValueAt(space, { id: "of:A" }, ["count"]).value, 2);
+      });
+
+      await t.step("delete tombstones the entity", () => {
+        assert(getValueAt(space, { id: "of:B", atSeq: 2 }).exists);
+        assertEquals(getValueAt(space, { id: "of:B", atSeq: 4 }).exists, false);
+      });
+
+      await t.step("links are recognized and annotated", () => {
+        const res = getValueAt(space, { id: "of:A" }, ["link"]);
+        const link = parseSigilLink(res.value);
+        assert(link, "expected a sigil link");
+        assertEquals(link.id, "of:other");
+        assertEquals(link.space, "did:key:zABC");
+        const ann = annotate(res.value) as { $link: { id: string } };
+        assertEquals(ann.$link.id, "of:other");
+      });
+
+      await t.step("absent entity reconstructs to undefined", () => {
+        assertEquals(reconstructDocument(space, { id: "of:missing" }), undefined);
+      });
+
+      await t.step("summary counts match the seed", () => {
+        const s = summarizeSpace(space);
+        assertEquals(s.commits, 4);
+        assertEquals(s.sessions, 2);
+        assertEquals(s.entities, 2);
+        assertEquals(s.revisions, 4);
+        assertEquals(s.ops, { set: 2, patch: 1, delete: 1 });
+        assertEquals(s.hasSchedulerTables, false);
+      });
+
+      await t.step("commits and history list the right rows", () => {
+        assertEquals(listCommits(space).length, 4);
+        assertEquals(listCommits(space, { session: "session-alice" }).length, 2);
+        const histA = entityHistory(space, { id: "of:A" });
+        assertEquals(histA.map((h) => h.op), ["set", "patch"]);
+        const hot = hotEntities(space);
+        assertEquals(hot.find((h) => h.id === "of:A")?.writes, 2);
+      });
+    } finally {
+      space.close();
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## What this is

Base PR (#1 of a stack) for the **Multiplayer State Inspector** — a tool to make multiplayer / multi-identity / multi-space behavior inspectable. Full proposal lands in this PR at `docs/plans/2026-06-26-runtime-trace-inspector.md`.

**Design lane:** autopsy-first (forensic, retroactive) + agent-first (a queryable index/CLI is the product; UI is a thin consumer later). Core thesis: the server's durable memory v2 SQLite store is *already* a totally-ordered flight recorder — so build the **lens** over it rather than a new capture pipeline. Open a space DB read-only, decode stored values, reconstruct state-at-`(branch, seq)`, and answer who/what/when questions with no live runtime and no capture step.

## What's in this PR (Milestone 1 core)

New package `@commonfabric/state-inspector` (`packages/state-inspector`), dependency-light (only `@db/sqlite` + `@std/assert`):

- `db.ts` — read-only space-DB access + `hasSchedulerTables` guard
- `decode.ts` — sigil-link / entity-ref / stream recognition + `annotate()` value rendering
- `reconstruct.ts` — replay the append-only `revision` log (`set` / RFC-6902 `patch` / `delete`) to **value-at-`(branch, seq)`**
- `queries.ts` — `summary`, `commits`, `entityHistory` (who-wrote-this), `hotEntities` (contention proxy)
- `cli.ts` — thin CLI; every command supports `--json` (agent-first)
- hermetic temp-DB test (6 steps)

## Verification

- `deno check` / `deno lint` / `deno task test` all green.
- Run against a real **571 MB** production-shaped space DB: `summary`, `hot`, `commits`, `history`, and `value-at` all work; reconstruction of a 295k-revision entity completes in <1s.

## Findings (folded into the proposal)

1. **Scheduler tables are usually absent on disk.** The big real DB had only the entity tables — `scheduler_observation` & friends exist only when `persistentSchedulerState` was enabled. So the autopsy core that works today is entity-history + state-at-seq; the dependency graph is opt-in. Every query degrades gracefully.
2. **Stored `revision.data` is plain JSON with inline legacy sigil links** (`{"/":{"link@1":{…}}}`), not the `fvj1:` codec envelope — so no `@commonfabric/data-model` dependency is needed for current DBs.

## Reviewer notes

- `reconstruct.ts:applyJsonPatch` is a standalone RFC-6902 implementation. **Before this is trusted in anything load-bearing, cross-check it against the server's `packages/memory/v2/patch.ts`** (ground truth). Flagged in code + README.
- Reconstruction currently replays from seq 0 (no snapshot-base optimization yet).

## Stack (coming as dependent PRs)

- **M2** — per-path convergence diagnosis across N space DBs ("why do these two clients disagree?")
- `ifc` / security-label decode from stored schemas
- snapshot-base reconstruction; wiring into `cf inspect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `@commonfabric/state-inspector`, an offline tool that reads memory v2 SQLite space DBs to reconstruct state-at-`(branch, seq)` and answer who/what/when without a live runtime. Adds a thin CLI and a proposal doc outlining the Multiplayer State Inspector.

- **New Features**
  - New package `@commonfabric/state-inspector` with read-only space DB access and `hasSchedulerTables` detection.
  - Value decoder for legacy sigil links, entity refs, and streams with `annotate()` for JSON-friendly output.
  - State reconstruction by replaying `revision` log (`set`/RFC‑6902 `patch`/`delete`) to compute value-at-seq.
  - Autopsy queries: `summary`, `commits`, `entityHistory`, `hotEntities`.
  - CLI (`inspect`) with `--json` for all commands; proposal at `docs/plans/2026-06-26-runtime-trace-inspector.md`.
  - Hermetic temp-DB test; verified on a 571 MB space DB (e.g., 295k-revision entity <1s). Gracefully handles missing scheduler tables.

- **Dependencies**
  - New workspace package added in root `deno.json`.
  - Adds `@db/sqlite@0.12` and `@std/assert@1` to `packages/state-inspector`.

<sup>Written for commit 0656bd0bab8fd4479f3d57c031bba96fa1314c06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

