### PR TITLE
state-inspector M2: cross-space convergence + server-applier reconstruction

### DIFF
--- a/packages/memory/deno.json
+++ b/packages/memory/deno.json
@@ -29,6 +29,7 @@
     "./interface": "./interface.ts",
     "./fact": "./fact.ts",
     "./v2": "./v2.ts",
+    "./v2/patch": "./v2/patch.ts",
     "./v2/client": "./v2/client.ts",
     "./v2/engine": "./v2/engine.ts",
     "./v2/server": "./v2/server.ts",

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -8,52 +8,88 @@ recorder.** This package is the lens over it — open a space SQLite file
 read-only, reconstruct state-at-`(branch, seq)`, and answer who/what/when
 questions with no live runtime and no capture step.
 
-## Status: prototype (Milestone 1 core)
+## Status: prototype (Milestones 1 + 2)
 
-Implemented and tested against a hermetic fixture + a real 571 MB space DB:
+Tested against hermetic fixtures + real space DBs (a 571 MB legacy DB and a set
+of modern `fvj1:` DBs):
 
+**M1 — single-space autopsy core**
 - **read-only DB access** (`db.ts`)
-- **value decoder** (`decode.ts`) — recognizes legacy sigil links
+- **value decoder** (`decode.ts`) — recognizes sigil links
   `{ "/": { "link@1": {…} } }`, entity refs `{ "/": "of:…" }`, and streams
   `{ "$stream": true }`; annotates a value into JSON-printable form.
 - **state reconstruction** (`reconstruct.ts`) — replays the append-only
-  `revision` log (`set` / `patch` (RFC 6902) / `delete`) to a target seq.
+  `revision` log (`set` / `patch` / `delete`) to a target seq. **Patch
+  application reuses the server's `applyPatch`** (`@commonfabric/memory/v2/patch`),
+  not a re-implementation — see fidelity note below.
 - **autopsy queries** (`queries.ts`) — `summary`, `commits`, `entityHistory`
   (who wrote this), `hotEntities` (contention proxy).
-- **thin CLI** (`cli.ts`) — every command supports `--json` for agents.
+
+**M2 — cross-space convergence** (`multispace.ts`)
+- `convergence(spaces, {id, path})` — reconstruct an entity's value across N
+  space DBs, cluster equal values, and classify:
+  `converged` / `diverged` / `partial` (present in some, absent in others) /
+  `absent`. Per-space evidence: head seq, revision count, last writer, last
+  write time. Resilient: a decode error in one space is isolated, not fatal.
+- `convergenceScan(spaces)` — find entities present in ≥2 spaces and report
+  those that diverge.
+
+**CLI** (`cli.ts`) — every command supports `--json` for agents:
+`summary`, `commits`, `hot`, `history`, `value-at`, `converge`, `converge-scan`.
+
+## Fidelity note (why reconstruction reuses the server applier)
+
+The server's JSON-Patch dialect (`packages/memory/v2/patch.ts`) is **not plain
+RFC 6902**: it has a custom `splice` op (`{index, remove, add}`), creates missing
+object keys on `add`, and is strict about missing array indices. A hand-rolled
+applier silently dropped `splice` and mis-handled `add`. Reconstruction therefore
+calls the real `applyPatch` (offline-safe: pure value ops, no live runtime/cell).
+The hermetic test guards `splice` + missing-key `add` against regressing to a fork.
 
 ## Reality checks found while building (feed back into the plan)
 
 1. **Scheduler tables are usually absent.** The 571 MB production-shaped DB had
-   only the entity tables (`commit`, `revision`, `head`, `snapshot`, `branch`,
-   `blob_store`, `invocation`, `authorization`). `scheduler_observation` &
-   friends only exist when `persistentSchedulerState` was enabled on the server.
-   ⇒ The autopsy core that works *today* is entity-history only; the scheduler
-   read/write graph is opt-in, so every query must degrade gracefully
-   (`hasSchedulerTables`).
-2. **Stored values are plain JSON with inline sigil links**, not the `fvj1:`
-   codec-json envelope. Decoding current DBs needs no `@commonfabric/data-model`
-   dependency. The modern envelope can be plugged in at the leaves later.
-3. **Entity ids are legacy `of:baedrei…` (CIDv1)** in these DBs; modern cell-rep
-   uses `fid1:…`. The decoder treats both as opaque strings.
+   only the entity tables. `scheduler_observation` & friends exist only when
+   `persistentSchedulerState` was enabled. ⇒ The autopsy core that works *today*
+   is entity-history only; the scheduler graph is opt-in, so every query degrades
+   gracefully (`hasSchedulerTables`).
+2. **TWO at-rest value formats exist in the wild** — both handled:
+   - **modern**: an `fvj1:`-prefixed codec-json envelope (decoded via
+     `valueFromJson`; embedded links are `/quote`-escaped literals, so a
+     context-less decode is inert and never reconstructs a live cell).
+     Entity ids: `of:fid1:…`.
+   - **legacy**: plain JSON with inline sigil links. Entity ids: `of:baedrei…`.
+   `reconstruct.ts` routes by the `fvj1:` tag. (This corrects an earlier
+   assumption that no `@commonfabric/data-model` dependency was needed.)
+3. **Convergence needs link-graph context to interpret.** Many entities share a
+   content-addressed id across spaces because they're instances of the same
+   pattern (e.g. `home.tsx`), not because they're cross-space replicas — so they
+   *legitimately* diverge. Distinguishing "replica that should converge" from
+   "independent instance" requires following cross-space links; that's the M2.5
+   refinement. The scan currently surfaces all same-id divergence as candidates.
 
 ## Usage
 
 ```bash
-# from repo root
-DB="packages/toolshed/cache/memory/engine-v3/engine-v3/<space-did>.sqlite"
+DIR=/abs/path/to/engine-v3   # a directory of <space-did>.sqlite files
+INSPECT="deno run --allow-read --allow-ffi --allow-env cli.ts"
 
-deno task --cwd packages/state-inspector inspect summary  "$DB"
-deno task --cwd packages/state-inspector inspect commits  "$DB" --limit 20
-deno task --cwd packages/state-inspector inspect hot      "$DB" --limit 10
-deno task --cwd packages/state-inspector inspect history  "$DB" of:baedrei… 
-deno task --cwd packages/state-inspector inspect value-at "$DB" of:baedrei… --path value/count
+# single space
+$INSPECT summary  "$DIR/<did>.sqlite"
+$INSPECT hot      "$DIR/<did>.sqlite" --limit 10
+$INSPECT value-at "$DIR/<did>.sqlite" of:fid1:… --path value/count
+
+# cross-space convergence
+$INSPECT converge      of:fid1:… --dir "$DIR" --path value
+$INSPECT converge-scan --dir "$DIR" --limit 20 --json
 ```
 
 ## Not yet built (next milestones)
 
-- Per-path **convergence diagnosis** across multiple space DBs (M2).
+- **M2.5** — follow cross-space links so convergence separates true replicas
+  from same-pattern instances.
 - `ifc` / security-label decoding from stored schemas.
 - Snapshot-base optimization for reconstruction (currently replays from seq 0).
 - Wiring into `cf inspect` as a first-class subcommand.
-- Client-side correlation overlay (connectionId / eventId).
+- Client-side correlation overlay (connectionId / eventId) for the per-session
+  view dimension of convergence.

--- a/packages/state-inspector/cli.ts
+++ b/packages/state-inspector/cli.ts
@@ -3,15 +3,19 @@
 // --json so a caller can consume structured output. This is a prototype entry
 // point; the intent is to later surface the same commands as `cf inspect …`.
 //
-//   deno task inspect summary  <db>
-//   deno task inspect commits  <db> [--session <prefix>] [--limit <n>]
-//   deno task inspect hot      <db> [--limit <n>] [--branch <b>]
-//   deno task inspect history  <db> <entity-id> [--scope <s>] [--branch <b>]
-//   deno task inspect value-at <db> <entity-id> [--seq <n>] [--path a/b/c]
-//                              [--scope <s>] [--branch <b>] [--doc]
+// Single-space:
+//   inspect summary  <db>
+//   inspect commits  <db> [--session <prefix>] [--limit <n>]
+//   inspect hot      <db> [--limit <n>] [--branch <b>]
+//   inspect history  <db> <entity-id> [--scope <s>] [--branch <b>]
+//   inspect value-at <db> <entity-id> [--seq <n>] [--path a/b/c] [--doc]
+// Multi-space (cross-space convergence):
+//   inspect converge      <entity-id> --spaces a.sqlite,b.sqlite [--path a/b/c]
+//   inspect converge      <entity-id> --dir <dir-of-sqlite>
+//   inspect converge-scan --dir <dir> [--limit <n>] [--branch <b>]
 
 import { openSpace } from "./db.ts";
-import { annotate } from "./decode.ts";
+import { annotate, summarize } from "./decode.ts";
 import {
   entityHistory,
   hotEntities,
@@ -19,6 +23,13 @@ import {
   summarizeSpace,
 } from "./queries.ts";
 import { getValueAt } from "./reconstruct.ts";
+import {
+  convergence,
+  convergenceScan,
+  listSqliteFiles,
+  openSpaces,
+  type SpaceRef,
+} from "./multispace.ts";
 
 interface Args {
   positional: string[];
@@ -50,6 +61,8 @@ const str = (v: string | boolean | undefined): string | undefined =>
   typeof v === "string" ? v : undefined;
 const num = (v: string | boolean | undefined): number | undefined =>
   typeof v === "string" ? Number(v) : undefined;
+const splitPath = (v: string | boolean | undefined): string[] =>
+  str(v) ? str(v)!.split("/").filter(Boolean) : [];
 
 function out(json: boolean, data: unknown, render: () => void) {
   if (json) console.log(JSON.stringify(data, null, 2));
@@ -58,23 +71,123 @@ function out(json: boolean, data: unknown, render: () => void) {
 
 const USAGE = `cf state-inspector (prototype)
 
+single-space:
   summary  <db>
   commits  <db> [--session <prefix>] [--limit <n>] [--json]
   hot      <db> [--limit <n>] [--branch <b>] [--json]
   history  <db> <entity-id> [--scope <s>] [--branch <b>] [--limit <n>] [--json]
   value-at <db> <entity-id> [--seq <n>] [--path a/b/c] [--scope <s>]
                             [--branch <b>] [--doc] [--json]
+
+cross-space convergence:
+  converge      <entity-id> (--spaces a,b,… | --dir <dir>) [--path a/b/c]
+                            [--scope <s>] [--branch <b>] [--json]
+  converge-scan (--spaces a,b,… | --dir <dir>) [--limit <n>] [--scope <s>]
+                            [--branch <b>] [--json]
 `;
+
+function resolveSpaces(flags: Record<string, string | boolean>): SpaceRef[] {
+  const dir = str(flags.dir);
+  const spaces = str(flags.spaces);
+  if (dir) return openSpaces(listSqliteFiles(dir));
+  if (spaces) return openSpaces(spaces.split(",").map((s) => s.trim()).filter(Boolean));
+  throw new Error("provide --spaces a,b,… or --dir <dir>");
+}
+
+function runMultiSpace(cmd: string, rest: string[], flags: Record<string, string | boolean>, json: boolean): number {
+  let refs: SpaceRef[];
+  try {
+    refs = resolveSpaces(flags);
+  } catch (e) {
+    console.error(`error: ${(e as Error).message}`);
+    return 1;
+  }
+  if (refs.length === 0) {
+    console.error("error: no space DBs resolved");
+    return 1;
+  }
+  try {
+    if (cmd === "converge") {
+      const id = rest[0];
+      if (!id) {
+        console.error("error: converge needs <entity-id>");
+        return 1;
+      }
+      const result = convergence(refs, {
+        id,
+        scope: str(flags.scope),
+        branch: str(flags.branch),
+        path: splitPath(flags.path),
+      });
+      out(json, result, () => {
+        console.log(`verdict: ${result.verdict.toUpperCase()}`);
+        console.log(`entity:  ${result.id}  scope=${result.scope}  branch=${result.branch || "(default)"}` +
+          (result.path.length ? `  path=/${result.path.join("/")}` : ""));
+        for (const v of result.views) {
+          if (!v.present) {
+            console.log(`  ${v.label}\tABSENT`);
+            continue;
+          }
+          const cluster = result.clusters.findIndex((c) => c.valueKey === v.valueKey) + 1;
+          console.log(
+            `  ${v.label}\thead=${v.headSeq}\trevs=${v.revisions}\tlast=${(v.lastSession ?? "?").slice(0, 14)}@${v.lastWriteAt ?? "?"}\tcluster#${cluster}`,
+          );
+        }
+        if (result.clusters.length > 1) {
+          console.log("clusters:");
+          result.clusters.forEach((c, i) =>
+            console.log(`  #${i + 1} [${c.labels.length}]\t${summarize(c.value)}`)
+          );
+        }
+        console.log(`note: ${result.caveat}`);
+      });
+      return 0;
+    }
+    if (cmd === "converge-scan") {
+      const result = convergenceScan(refs, {
+        scope: str(flags.scope),
+        branch: str(flags.branch),
+        limit: num(flags.limit),
+      });
+      out(json, result, () => {
+        console.log(`shared entities (in >=2 spaces): ${result.sharedEntities}  examined: ${result.examined}`);
+        console.log(`findings (diverged/partial): ${result.findings.length}`);
+        for (const f of result.findings) {
+          const present = f.views.filter((v) => v.present).map((v) => v.label);
+          const absent = f.views.filter((v) => !v.present).map((v) => v.label);
+          console.log(
+            `  ${f.verdict.toUpperCase()}\t${f.id}\tpresent=[${present.join(",")}]` +
+              (absent.length ? `\tmissing=[${absent.join(",")}]` : "") +
+              `\tclusters=${f.clusters.length}`,
+          );
+        }
+      });
+      return 0;
+    }
+    console.error(`unknown command: ${cmd}`);
+    return 1;
+  } finally {
+    for (const r of refs) r.space.close();
+  }
+}
 
 function main(argv: string[]): number {
   const { positional, flags } = parseArgs(argv);
-  const [cmd, dbPath, ...rest] = positional;
+  const [cmd, ...rest] = positional;
   const json = flags.json === true;
 
   if (!cmd || cmd === "help" || flags.help) {
     console.log(USAGE);
     return cmd ? 0 : 1;
   }
+
+  if (cmd === "converge" || cmd === "converge-scan") {
+    return runMultiSpace(cmd, rest, flags, json);
+  }
+
+  // Single-space commands take <db> as the first positional.
+  const dbPath = rest[0];
+  const tail = rest.slice(1);
   if (!dbPath) {
     console.error("error: missing <db> path\n");
     console.log(USAGE);
@@ -138,7 +251,7 @@ function main(argv: string[]): number {
         return 0;
       }
       case "history": {
-        const id = rest[0];
+        const id = tail[0];
         if (!id) {
           console.error("error: history needs <entity-id>");
           return 1;
@@ -159,14 +272,11 @@ function main(argv: string[]): number {
         return 0;
       }
       case "value-at": {
-        const id = rest[0];
+        const id = tail[0];
         if (!id) {
           console.error("error: value-at needs <entity-id>");
           return 1;
         }
-        const path = str(flags.path)
-          ? str(flags.path)!.split("/").filter(Boolean)
-          : [];
         const res = getValueAt(
           space,
           {
@@ -175,7 +285,7 @@ function main(argv: string[]): number {
             branch: str(flags.branch),
             atSeq: num(flags.seq),
           },
-          path,
+          splitPath(flags.path),
         );
         const shown = flags.doc === true ? res.document : res.value;
         out(json, { exists: res.exists, value: annotate(shown) }, () => {

--- a/packages/state-inspector/mod.ts
+++ b/packages/state-inspector/mod.ts
@@ -9,3 +9,4 @@ export * from "./db.ts";
 export * from "./decode.ts";
 export * from "./reconstruct.ts";
 export * from "./queries.ts";
+export * from "./multispace.ts";

--- a/packages/state-inspector/multispace.ts
+++ b/packages/state-inspector/multispace.ts
@@ -1,0 +1,262 @@
+// Cross-space convergence diagnosis — the multiplayer-native autopsy primitive.
+//
+// The same logical entity (same id) is often materialized into several spaces:
+// a cross-space link from space A to `space B / entity X` makes A hold a replica
+// of X. When two clients/identities disagree about a value, the durable cause is
+// frequently that these replicas have diverged. This module compares an entity's
+// reconstructed value across N space DBs and classifies the result.
+//
+// HONESTY (server-view only): this sees durable committed state, not client
+// state. A "converged" verdict means the stored values agree — NOT that every
+// client is displaying them. Client cursor lag, pending optimistic writes, and
+// render/VDOM state require the (future) client-correlation overlay. Likewise
+// `seq` is per-space and is NOT comparable across spaces; divergence is judged
+// by value equality, with per-space write metadata offered as evidence.
+
+import { openSpace, type SpaceDb } from "./db.ts";
+import { annotate } from "./decode.ts";
+import { getValueAt } from "./reconstruct.ts";
+
+export interface SpaceRef {
+  /** Display label — usually the space DID (DB file basename). */
+  label: string;
+  space: SpaceDb;
+}
+
+export interface SpaceEntityView {
+  label: string;
+  present: boolean;
+  headSeq: number | null;
+  revisions: number;
+  lastSession: string | null;
+  lastWriteAt: string | null;
+  /** Annotated value at the requested path (links/streams normalized). */
+  value?: unknown;
+  /** Canonical key used for clustering equal values. */
+  valueKey?: string;
+  /** Set if reconstruction/decode threw for this space (entity still counts as present). */
+  error?: string;
+}
+
+export type ConvergenceVerdict =
+  | "converged"
+  | "diverged"
+  | "partial"
+  | "absent";
+
+export interface ValueCluster {
+  valueKey: string;
+  value: unknown;
+  labels: string[];
+}
+
+export interface ConvergenceResult {
+  id: string;
+  scope: string;
+  branch: string;
+  path: string[];
+  verdict: ConvergenceVerdict;
+  views: SpaceEntityView[];
+  clusters: ValueCluster[];
+  caveat: string;
+}
+
+const CAVEAT =
+  "Server-view only: durable values compared. Client cursor lag, pending " +
+  "optimistic writes, and render state are not visible here — 'converged' " +
+  "means the stored values agree, not that every client is displaying them.";
+
+/** Stable, key-sorted JSON so clustering ignores object key order. */
+function canonical(v: unknown): string {
+  const sort = (x: unknown): unknown => {
+    if (Array.isArray(x)) return x.map(sort);
+    if (x && typeof x === "object") {
+      const o = x as Record<string, unknown>;
+      const out: Record<string, unknown> = {};
+      for (const k of Object.keys(o).sort()) out[k] = sort(o[k]);
+      return out;
+    }
+    return x;
+  };
+  return JSON.stringify(sort(v)) ?? "undefined";
+}
+
+interface MetaRow {
+  headSeq: number | null;
+  revisions: number;
+}
+interface LastRow {
+  session_id: string;
+  created_at: string;
+}
+
+function entityMeta(
+  space: SpaceDb,
+  id: string,
+  scope: string,
+  branch: string,
+): SpaceEntityView {
+  const meta = space.db
+    .prepare(
+      `SELECT max(seq) headSeq, count(*) revisions FROM revision
+       WHERE branch = ? AND id = ? AND scope_key = ?`,
+    )
+    .get<MetaRow>(branch, id, scope);
+  const present = !!meta && meta.revisions > 0;
+  if (!present) {
+    return {
+      label: "",
+      present: false,
+      headSeq: null,
+      revisions: 0,
+      lastSession: null,
+      lastWriteAt: null,
+    };
+  }
+  const last = space.db
+    .prepare(
+      `SELECT c.session_id, c.created_at FROM revision r
+       JOIN "commit" c ON c.seq = r.commit_seq
+       WHERE r.branch = ? AND r.id = ? AND r.scope_key = ?
+       ORDER BY r.seq DESC, r.op_index DESC LIMIT 1`,
+    )
+    .get<LastRow>(branch, id, scope);
+  return {
+    label: "",
+    present: true,
+    headSeq: meta!.headSeq,
+    revisions: meta!.revisions,
+    lastSession: last?.session_id ?? null,
+    lastWriteAt: last?.created_at ?? null,
+  };
+}
+
+export interface ConvergenceOptions {
+  id: string;
+  scope?: string;
+  branch?: string;
+  path?: string[];
+}
+
+/** Compare one entity's value across the given spaces and classify. */
+export function convergence(
+  spaces: SpaceRef[],
+  opts: ConvergenceOptions,
+): ConvergenceResult {
+  const scope = opts.scope ?? "space";
+  const branch = opts.branch ?? "";
+  const path = opts.path ?? [];
+
+  const views: SpaceEntityView[] = spaces.map(({ label, space }) => {
+    const view = entityMeta(space, opts.id, scope, branch);
+    view.label = label;
+    if (view.present) {
+      // Decode can throw (e.g. an fvj1 payload referencing a live cell). Keep the
+      // entity counted as present but isolate the failure so one bad row doesn't
+      // abort a whole scan; errored spaces cluster together by a distinct key.
+      try {
+        const res = getValueAt(space, { id: opts.id, scope, branch }, path);
+        view.value = annotate(res.value);
+        view.valueKey = canonical(view.value);
+      } catch (e) {
+        view.error = (e as Error).message;
+        view.valueKey = "«decode-error»";
+      }
+    }
+    return view;
+  });
+
+  const present = views.filter((v) => v.present);
+  const clusterMap = new Map<string, ValueCluster>();
+  for (const v of present) {
+    const key = v.valueKey!;
+    const c = clusterMap.get(key);
+    if (c) c.labels.push(v.label);
+    else clusterMap.set(key, { valueKey: key, value: v.value, labels: [v.label] });
+  }
+  const clusters = [...clusterMap.values()];
+
+  let verdict: ConvergenceVerdict;
+  if (present.length === 0) verdict = "absent";
+  else if (clusters.length > 1) verdict = "diverged";
+  else if (present.length < views.length) verdict = "partial";
+  else verdict = "converged";
+
+  return { id: opts.id, scope, branch, path, verdict, views, clusters, caveat: CAVEAT };
+}
+
+export interface ScanOptions {
+  scope?: string;
+  branch?: string;
+  /** Max diverged/partial findings to return. */
+  limit?: number;
+  /** Max shared entities to reconstruct (cost guard). */
+  examineCap?: number;
+}
+
+export interface ScanResult {
+  /** Entity ids present in >= 2 spaces. */
+  sharedEntities: number;
+  examined: number;
+  examineCapped: boolean;
+  findings: ConvergenceResult[];
+}
+
+/** Find entities present in >=2 spaces and report those that diverge. */
+export function convergenceScan(
+  spaces: SpaceRef[],
+  opts: ScanOptions = {},
+): ScanResult {
+  const scope = opts.scope ?? "space";
+  const branch = opts.branch ?? "";
+  const limit = opts.limit ?? 50;
+  const examineCap = opts.examineCap ?? 1000;
+
+  // id -> how many spaces hold it
+  const counts = new Map<string, number>();
+  for (const { space } of spaces) {
+    const ids = space.db
+      .prepare(
+        `SELECT DISTINCT id FROM revision WHERE branch = ? AND scope_key = ?`,
+      )
+      .all<{ id: string }>(branch, scope);
+    for (const { id } of ids) counts.set(id, (counts.get(id) ?? 0) + 1);
+  }
+  const shared = [...counts.entries()].filter(([, n]) => n >= 2).map(([id]) => id);
+
+  const findings: ConvergenceResult[] = [];
+  let examined = 0;
+  for (const id of shared) {
+    if (examined >= examineCap) break;
+    examined++;
+    const result = convergence(spaces, { id, scope, branch });
+    if (result.verdict === "diverged" || result.verdict === "partial") {
+      findings.push(result);
+      if (findings.length >= limit) break;
+    }
+  }
+
+  return {
+    sharedEntities: shared.length,
+    examined,
+    examineCapped: examined >= examineCap && shared.length > examineCap,
+    findings,
+  };
+}
+
+/** Open spaces from explicit file paths, labeling each by its basename. */
+export function openSpaces(paths: string[]): SpaceRef[] {
+  return paths.map((p) => ({
+    label: p.split("/").pop() ?? p,
+    space: openSpace(p),
+  }));
+}
+
+/** List `*.sqlite` files in a directory (non-recursive). */
+export function listSqliteFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of Deno.readDirSync(dir)) {
+    if (entry.isFile && entry.name.endsWith(".sqlite")) out.push(`${dir}/${entry.name}`);
+  }
+  return out.sort();
+}

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -3,18 +3,36 @@
 // A memory v2 entity document has the shape `{ value: <FabricValue>, source?: … }`.
 // Each `revision` row is one operation on that document:
 //   - op="set"    → data is the whole replacement document
-//   - op="patch"  → data is an RFC 6902 JSON-Patch array applied to the document
+//   - op="patch"  → data is a JSON-Patch array applied to the document
 //   - op="delete" → tombstone (document becomes absent)
 //
 // Replaying in (seq, op_index) order up to a target seq yields the document as
 // of that point in the space's total order. This is the autopsy primitive:
 // value-at-seq with no live runtime.
 //
-// NOTE: the JSON-Patch applier here implements standard RFC 6902. The server's
-// own applier (packages/memory/v2/patch.ts) is ground truth; cross-check before
-// trusting reconstruction in anything load-bearing.
+// Patch application reuses the SERVER's applier (`@commonfabric/memory/v2/patch`)
+// rather than a re-implementation. That matters for fidelity: the server's
+// JSON-Patch dialect includes a custom `splice` op and has specific add/remove
+// strictness and missing-key creation semantics that a hand-rolled RFC-6902
+// applier would get subtly wrong. `applyPatch` is offline-safe (pure value ops;
+// no live runtime/cell). See packages/memory/v2/patch.ts.
+
+import { applyPatch } from "@commonfabric/memory/v2/patch";
+import type { PatchOp } from "@commonfabric/memory/v2";
+import type { FabricValue } from "@commonfabric/api";
+import { valueFromJson } from "@commonfabric/data-model/codec-json";
 
 import type { SpaceDb } from "./db.ts";
+
+// Stored values come in TWO at-rest formats, both seen in real DBs:
+//   - modern: an `fvj1:`-prefixed codec-json envelope (decode via valueFromJson;
+//     embedded links are `/quote`-escaped literals, so a context-less decode is
+//     inert and does not try to reconstruct live cells)
+//   - legacy: plain JSON with inline sigil links
+// Route by the format tag.
+function decodeStored(data: string): unknown {
+  return data.startsWith("fvj1:") ? valueFromJson(data) : JSON.parse(data);
+}
 
 export interface EntityAddress {
   id: string;
@@ -32,28 +50,13 @@ export type EntityDocument = { value?: unknown; source?: unknown } & Record<
   unknown
 >;
 
-interface PatchOp {
-  op: "add" | "remove" | "replace" | "move" | "copy" | "test";
-  path: string;
-  from?: string;
-  value?: unknown;
-}
-
-function parsePointer(pointer: string): string[] {
-  if (pointer === "") return [];
-  return pointer
-    .split("/")
-    .slice(1)
-    .map((p) => p.replace(/~1/g, "/").replace(/~0/g, "~"));
-}
-
-function getAt(root: unknown, path: string[]): unknown {
+/** Navigate into a value by a JSON path (array of keys). Display-only. */
+export function getAtPath(root: unknown, path: string[]): unknown {
   let cur: unknown = root;
   for (const key of path) {
     if (cur == null) return undefined;
     if (Array.isArray(cur)) {
-      const idx = key === "-" ? cur.length : Number(key);
-      cur = cur[idx];
+      cur = cur[key === "-" ? cur.length : Number(key)];
     } else if (typeof cur === "object") {
       cur = (cur as Record<string, unknown>)[key];
     } else {
@@ -61,69 +64,6 @@ function getAt(root: unknown, path: string[]): unknown {
     }
   }
   return cur;
-}
-
-function setAt(root: unknown, path: string[], value: unknown, add: boolean): unknown {
-  if (path.length === 0) return value;
-  const parent = getAt(root, path.slice(0, -1));
-  const key = path[path.length - 1];
-  if (parent == null) return root;
-  if (Array.isArray(parent)) {
-    const idx = key === "-" ? parent.length : Number(key);
-    if (add) parent.splice(idx, 0, value);
-    else parent[idx] = value;
-  } else if (typeof parent === "object") {
-    (parent as Record<string, unknown>)[key] = value;
-  }
-  return root;
-}
-
-function removeAt(root: unknown, path: string[]): unknown {
-  if (path.length === 0) return undefined;
-  const parent = getAt(root, path.slice(0, -1));
-  const key = path[path.length - 1];
-  if (parent == null) return root;
-  if (Array.isArray(parent)) {
-    parent.splice(Number(key), 1);
-  } else if (typeof parent === "object") {
-    delete (parent as Record<string, unknown>)[key];
-  }
-  return root;
-}
-
-export function applyJsonPatch(doc: unknown, ops: PatchOp[]): unknown {
-  let root = doc;
-  for (const op of ops) {
-    const path = parsePointer(op.path);
-    switch (op.op) {
-      case "add":
-        root = setAt(root, path, op.value, true);
-        break;
-      case "replace":
-        root = setAt(root, path, op.value, false);
-        break;
-      case "remove":
-        root = removeAt(root, path);
-        break;
-      case "move": {
-        const from = parsePointer(op.from ?? "");
-        const val = getAt(root, from);
-        root = removeAt(root, from);
-        root = setAt(root, path, val, true);
-        break;
-      }
-      case "copy": {
-        const from = parsePointer(op.from ?? "");
-        const val = structuredClone(getAt(root, from));
-        root = setAt(root, path, val, true);
-        break;
-      }
-      case "test":
-        // Verification op; ignored for reconstruction.
-        break;
-    }
-  }
-  return root;
 }
 
 interface RevRow {
@@ -150,12 +90,16 @@ export function reconstructDocument(
     )
     .all<RevRow>(branch, opts.id, scope, atSeq);
 
-  let doc: unknown = undefined;
+  let doc: FabricValue | undefined = undefined;
   for (const row of rows) {
     if (row.op === "set") {
-      doc = row.data ? JSON.parse(row.data) : undefined;
+      doc = row.data ? (decodeStored(row.data) as FabricValue) : undefined;
     } else if (row.op === "patch") {
-      doc = applyJsonPatch(doc, row.data ? JSON.parse(row.data) : []);
+      // A patch with no prior document is anomalous (the server always lays a
+      // set first); skip rather than feed `undefined` to the applier.
+      if (doc === undefined) continue;
+      const ops = row.data ? (decodeStored(row.data) as PatchOp[]) : [];
+      doc = applyPatch(doc, ops);
     } else if (row.op === "delete") {
       doc = undefined;
     }
@@ -179,6 +123,6 @@ export function getValueAt(
 ): ValueAtResult {
   const document = reconstructDocument(space, opts);
   if (document === undefined) return { exists: false };
-  const value = getAt(document.value, path);
+  const value = getAtPath(document.value, path);
   return { exists: true, document, value };
 }

--- a/packages/state-inspector/test/convergence.test.ts
+++ b/packages/state-inspector/test/convergence.test.ts
@@ -1,0 +1,106 @@
+// Hermetic test for cross-space convergence. Builds several tiny space DBs in a
+// temp dir holding the SAME entity id with converged / diverged / partial state,
+// then checks the verdicts. Side-effect free.
+
+import { assert, assertEquals } from "@std/assert";
+import { Database } from "@db/sqlite";
+
+import { convergence, convergenceScan, openSpaces } from "../multispace.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+`;
+
+// Write a single set of an entity's value into a fresh space DB.
+function makeSpace(path: string, entries: { id: string; value: unknown }[]) {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, ?, ?, '{}', ?)`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, 0, 'set', ?, ?)`,
+  );
+  entries.forEach((e, i) => {
+    const seq = i + 1;
+    commit.run(seq, `session-${i}`, 1, JSON.stringify({ seq }));
+    rev.run(e.id, seq, JSON.stringify({ value: e.value }), seq);
+  });
+  db.close();
+}
+
+Deno.test("cross-space convergence", async (t) => {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-converge-" });
+  try {
+    // X agrees in A & B, disagrees in C; Y is present only in A & B (partial); Z only in A.
+    makeSpace(`${dir}/A.sqlite`, [
+      { id: "of:X", value: { n: 1 } },
+      { id: "of:Y", value: { ok: true } },
+      { id: "of:Z", value: { solo: 1 } },
+    ]);
+    makeSpace(`${dir}/B.sqlite`, [
+      { id: "of:X", value: { n: 1 } },
+      { id: "of:Y", value: { ok: true } },
+    ]);
+    makeSpace(`${dir}/C.sqlite`, [
+      { id: "of:X", value: { n: 999 } },
+    ]);
+
+    const refs = openSpaces([`${dir}/A.sqlite`, `${dir}/B.sqlite`, `${dir}/C.sqlite`]);
+    try {
+      await t.step("diverged: X differs in C", () => {
+        const r = convergence(refs, { id: "of:X" });
+        assertEquals(r.verdict, "diverged");
+        assertEquals(r.clusters.length, 2);
+        // the {n:1} cluster holds A and B
+        const big = r.clusters.find((c) => c.labels.length === 2);
+        assertEquals(big?.labels.sort(), ["A.sqlite", "B.sqlite"]);
+      });
+
+      await t.step("partial: Y present in A,B but absent in C", () => {
+        const r = convergence(refs, { id: "of:Y" });
+        assertEquals(r.verdict, "partial");
+        assertEquals(r.views.filter((v) => v.present).length, 2);
+        assertEquals(r.views.find((v) => v.label === "C.sqlite")?.present, false);
+      });
+
+      await t.step("absent: unknown entity", () => {
+        assertEquals(convergence(refs, { id: "of:nope" }).verdict, "absent");
+      });
+
+      await t.step("path-scoped convergence", () => {
+        // X.n converges to 1 across A,B; C diverges at 999
+        const r = convergence(refs, { id: "of:X", path: ["n"] });
+        assertEquals(r.verdict, "diverged");
+        const c = r.views.find((v) => v.label === "C.sqlite");
+        assertEquals(c?.value, 999);
+      });
+
+      await t.step("scan surfaces X (diverged) and Y (partial), not Z", () => {
+        const scan = convergenceScan(refs);
+        const ids = scan.findings.map((f) => f.id).sort();
+        assertEquals(ids, ["of:X", "of:Y"]);
+        // Z is solo (present in only one space) → not a shared entity
+        assert(!ids.includes("of:Z"));
+      });
+    } finally {
+      for (const r of refs) r.space.close();
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/state-inspector/test/reconstruct.test.ts
+++ b/packages/state-inspector/test/reconstruct.test.ts
@@ -1,6 +1,12 @@
 // Hermetic test: build a tiny space DB in a temp dir matching the memory v2
 // schema, then exercise the read-only inspector against it. Side-effect free —
 // the temp dir is removed in finally.
+//
+// Patch coverage intentionally includes the server dialect's `splice` op and
+// `add`-creates-missing-key semantics, since reconstruction reuses the server's
+// applier (`@commonfabric/memory/v2/patch`). A naive RFC-6902 applier would drop
+// the splice and fail the nested add — these steps guard against regressing to
+// a hand-rolled fork.
 
 import { assert, assertEquals } from "@std/assert";
 import { Database } from "@db/sqlite";
@@ -41,7 +47,7 @@ CREATE TABLE branch (
   head_seq INTEGER NOT NULL DEFAULT 0,
   status TEXT NOT NULL DEFAULT 'active'
 );
-INSERT INTO branch (name, head_seq) VALUES ('', 4);
+INSERT INTO branch (name, head_seq) VALUES ('', 8);
 `;
 
 const LINK = {
@@ -76,6 +82,18 @@ function seedDb(path: string) {
   // seq4: delete B
   commit.run(4, "session-bob", 2, mkOriginal(1), JSON.stringify({ seq: 4 }));
   rev.run("of:B", 4, "delete", null, 4);
+  // seq5: set C with an array
+  commit.run(5, "session-carol", 1, mkOriginal(1), JSON.stringify({ seq: 5 }));
+  rev.run("of:C", 5, "set", JSON.stringify({ value: { list: [10, 20, 30] } }), 5);
+  // seq6: splice C.list at index 1, remove 1, add [99, 98]  ->  [10, 99, 98, 30]
+  commit.run(6, "session-carol", 2, mkOriginal(1), JSON.stringify({ seq: 6 }));
+  rev.run("of:C", 6, "patch", JSON.stringify([{ op: "splice", path: "/value/list", index: 1, remove: 1, add: [99, 98] }]), 6);
+  // seq7: set D empty value
+  commit.run(7, "session-carol", 3, mkOriginal(1), JSON.stringify({ seq: 7 }));
+  rev.run("of:D", 7, "set", JSON.stringify({ value: {} }), 7);
+  // seq8: add D.profile (creates the missing key)
+  commit.run(8, "session-carol", 4, mkOriginal(1), JSON.stringify({ seq: 8 }));
+  rev.run("of:D", 8, "patch", JSON.stringify([{ op: "add", path: "/value/profile", value: { name: "x" } }]), 8);
 
   db.close();
 }
@@ -100,6 +118,16 @@ Deno.test("state-inspector autopsy core", async (t) => {
         assertEquals(getValueAt(space, { id: "of:B", atSeq: 4 }).exists, false);
       });
 
+      await t.step("server splice op is applied (not dropped)", () => {
+        assertEquals(getValueAt(space, { id: "of:C", atSeq: 5 }, ["list"]).value, [10, 20, 30]);
+        assertEquals(getValueAt(space, { id: "of:C" }, ["list"]).value, [10, 99, 98, 30]);
+      });
+
+      await t.step("add creates a missing object key", () => {
+        assertEquals(getValueAt(space, { id: "of:D", atSeq: 7 }, ["profile"]).value, undefined);
+        assertEquals(getValueAt(space, { id: "of:D" }, ["profile", "name"]).value, "x");
+      });
+
       await t.step("links are recognized and annotated", () => {
         const res = getValueAt(space, { id: "of:A" }, ["link"]);
         const link = parseSigilLink(res.value);
@@ -116,16 +144,16 @@ Deno.test("state-inspector autopsy core", async (t) => {
 
       await t.step("summary counts match the seed", () => {
         const s = summarizeSpace(space);
-        assertEquals(s.commits, 4);
-        assertEquals(s.sessions, 2);
-        assertEquals(s.entities, 2);
-        assertEquals(s.revisions, 4);
-        assertEquals(s.ops, { set: 2, patch: 1, delete: 1 });
+        assertEquals(s.commits, 8);
+        assertEquals(s.sessions, 3);
+        assertEquals(s.entities, 4);
+        assertEquals(s.revisions, 8);
+        assertEquals(s.ops, { set: 4, patch: 3, delete: 1 });
         assertEquals(s.hasSchedulerTables, false);
       });
 
       await t.step("commits and history list the right rows", () => {
-        assertEquals(listCommits(space).length, 4);
+        assertEquals(listCommits(space).length, 8);
         assertEquals(listCommits(space, { session: "session-alice" }).length, 2);
         const histA = entityHistory(space, { id: "of:A" });
         assertEquals(histA.map((h) => h.op), ["set", "patch"]);


### PR DESCRIPTION
Stacked on #4375 (M1 autopsy core). **Base of this PR is `state-inspector-autopsy-core`**, so the diff shows only the M2 delta.

## 1. Reconstruction fidelity — the `applyJsonPatch` ground-truth cross-check

The M1 prototype carried a hand-rolled RFC-6902 applier. Cross-checking against the server's `packages/memory/v2/patch.ts` found real divergences: the server dialect has a **custom `splice` op** (`{index, remove, add}`) and **creates missing object keys on `add`** — my fork silently dropped `splice` and mishandled `add`.

Fix: reconstruction now calls the **server's `applyPatch`** directly (newly exported as `@commonfabric/memory/v2/patch`; offline-safe — pure value ops, no live runtime/cell). Hermetic tests added for `splice` and missing-key `add` so we can't regress to a fork.

## 2. Both at-rest value formats

Real DBs use **two** encodings — both now decoded:
- **modern**: `fvj1:`-prefixed codec-json envelope → `valueFromJson` (embedded links are `/quote`-escaped literals, so a context-less decode is inert; ids `of:fid1:…`)
- **legacy**: plain JSON with inline sigil links (ids `of:baedrei…`)

(This corrects the M1 claim that no `@commonfabric/data-model` dependency was needed.)

## 3. Cross-space convergence (`multispace.ts`) — the multiplayer primitive

- `convergence(spaces, {id, path})` — reconstruct an entity across N space DBs, cluster equal values, classify **converged / diverged / partial / absent**, with per-space evidence (head seq, revisions, last writer/time). Per-space decode errors are isolated, not fatal.
- `convergenceScan(spaces)` — find entities present in ≥2 spaces that diverge.
- CLI: `converge` / `converge-scan` (`--spaces` / `--dir`, `--json`).

## Verification

- `deno check` / `deno lint` / `deno task test` green (2 test files, 13 steps).
- Ran `converge-scan --dir` over real `fvj1` space DBs: surfaced 14 cross-space shared entities and their value clusters in ~0.15s.

## Honest caveat (drives M2.5)

Many entities share a content-addressed id across spaces because they're **instances of the same pattern** (e.g. `home.tsx`), not cross-space replicas — so they legitimately diverge. Separating "replica that should converge" from "independent instance" needs to follow the cross-space link graph. That's the next refinement; the scan currently surfaces all same-id divergence as candidates.

## Memory package change

Additive only: one new export `"./v2/patch": "./v2/patch.ts"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cross-space convergence diagnosis and switches reconstruction to the server’s patch applier for accurate replays. New CLI commands help find and inspect divergence across multiple space DBs, with support for both legacy JSON and modern `fvj1:` values.

- **New Features**
  - Cross-space convergence (`multispace.ts`): `convergence(spaces, {id, path})` clusters values and classifies `converged` / `diverged` / `partial` / `absent`, with per-space evidence (head seq, revisions, last writer/time).
  - Scan for divergence: `convergenceScan(spaces)` finds entities present in ≥2 spaces that disagree.
  - CLI: `converge` and `converge-scan` with `--spaces` or `--dir`, optional `--path`, and `--json` output.

- **Refactors**
  - Reconstruction now uses `applyPatch` from `@commonfabric/memory/v2/patch` (supports server `splice` and missing-key `add`) instead of a custom RFC-6902 applier.
  - Decoding handles both at-rest formats: modern `fvj1:` via `@commonfabric/data-model` `valueFromJson`, and legacy plain JSON with sigil links.
  - Added `./v2/patch` export in `packages/memory` to enable importing `@commonfabric/memory/v2/patch`.

<sup>Written for commit e7e58a484cbdad5cfdff9e2916b168d96f2442c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

