### PR TITLE
Upload a combined repo-wide LCOV coverage report from CI

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -798,6 +798,7 @@ jobs:
         "pattern-unit-test",
         "package-integration-test",
         "cli-integration-test",
+        "generated-patterns-integration-test",
       ]
     environment: ci
     permissions:
@@ -814,6 +815,29 @@ jobs:
         with:
           name: common-binaries
           path: common-binaries
+
+      - name: 🦕 Setup Deno
+        uses: ./.github/actions/deno-setup
+
+      # Merge every job's LCOV report into one line-coverage file with
+      # repository-relative paths, so IDE users can download a single artifact
+      # covering the whole repository. Uploaded to Cloud Storage below alongside
+      # the signed binaries. Best-effort: a coverage problem must not block
+      # binary attestation or the deploys that depend on it.
+      - name: 📥 Download coverage reports
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: coverage-profile-*
+          path: coverage-artifacts
+
+      - name: 🧬 Combine coverage LCOV
+        continue-on-error: true
+        run: |
+          deno run --allow-read --allow-write tasks/combine-coverage-lcov.ts \
+            --input-dir=coverage-artifacts \
+            --output=release/labs-${{ github.sha }}.lcov \
+            --repo-name=${{ github.event.repository.name }}
 
       - name: 🔐 Process & sign binaries
         run: |
@@ -978,6 +1002,14 @@ jobs:
           echo "::group::📦 Artifact Links"
           echo "Tarball URL: https://storage.cloud.google.com/commontools-build-artifacts/workspace-artifacts/labs-${{ github.sha }}.tar.gz"
           echo "Hash URL: https://storage.cloud.google.com/commontools-build-artifacts/workspace-artifacts/labs-${{ github.sha }}.hash.txt"
+
+          # The combined coverage report is best-effort; upload it only if the
+          # combine step produced it. To download it for a given commit:
+          #   gsutil cp gs://commontools-build-artifacts/workspace-artifacts/labs-<commit-sha>.lcov .
+          if [ -f release/labs-${{ github.sha }}.lcov ]; then
+            gsutil cp release/labs-${{ github.sha }}.lcov gs://commontools-build-artifacts/workspace-artifacts/
+            echo "Coverage LCOV URL: https://storage.cloud.google.com/commontools-build-artifacts/workspace-artifacts/labs-${{ github.sha }}.lcov"
+          fi
           echo "::endgroup::"
 
   # Automatic deployment to staging (toolshed)

--- a/tasks/combine-coverage-lcov.test.ts
+++ b/tasks/combine-coverage-lcov.test.ts
@@ -1,0 +1,197 @@
+import { assertEquals } from "@std/assert";
+import * as path from "@std/path";
+import {
+  combineCoverageLcov,
+  mergeLcovReports,
+  normalizeSourcePath,
+} from "./combine-coverage-lcov.ts";
+
+Deno.test("normalizeSourcePath strips a GitHub-hosted workspace root", () => {
+  assertEquals(
+    normalizeSourcePath(
+      "/home/runner/work/labs/labs/packages/runner/src/mod.ts",
+      "labs",
+    ),
+    "packages/runner/src/mod.ts",
+  );
+});
+
+Deno.test("normalizeSourcePath handles a dotted repository name", () => {
+  assertEquals(
+    normalizeSourcePath(
+      "/home/runner/work/commontoolsinc.labs/commontoolsinc.labs/tasks/x.ts",
+      "commontoolsinc.labs",
+    ),
+    "tasks/x.ts",
+  );
+});
+
+Deno.test("normalizeSourcePath anchors on the checkout, not an earlier repeat", () => {
+  // A self-hosted runner whose work directory itself repeats the repo name must
+  // still anchor on the deepest doubled segment (the checkout root).
+  assertEquals(
+    normalizeSourcePath(
+      "/srv/labs/labs/_work/labs/labs/scripts/build.ts",
+      "labs",
+    ),
+    "scripts/build.ts",
+  );
+});
+
+Deno.test("normalizeSourcePath converts Windows separators to POSIX", () => {
+  assertEquals(
+    normalizeSourcePath(
+      "C:\\actions\\_work\\labs\\labs\\scripts\\build.ts",
+      "labs",
+    ),
+    "scripts/build.ts",
+  );
+});
+
+Deno.test("normalizeSourcePath leaves synthetic pattern paths unchanged", () => {
+  assertEquals(
+    normalizeSourcePath("cf-mount/fid1abc/main.tsx", "labs"),
+    "cf-mount/fid1abc/main.tsx",
+  );
+});
+
+Deno.test("mergeLcovReports sums line coverage for a file seen in two jobs", () => {
+  // The two jobs reach the file under different runner checkout roots and
+  // include the function/branch records deno emits, which the merge drops.
+  const jobA = [
+    "SF:/home/runner/work/labs/labs/packages/a/mod.ts",
+    "FN:1,add",
+    "FNDA:1,add",
+    "FNF:1",
+    "FNH:1",
+    "BRDA:2,0,0,1",
+    "BRF:1",
+    "BRH:1",
+    "DA:1,1",
+    "DA:2,0",
+    "LH:1",
+    "LF:2",
+    "end_of_record",
+  ].join("\n");
+  const jobB = [
+    "SF:/data/_work/labs/labs/packages/a/mod.ts",
+    "DA:1,0",
+    "DA:2,5",
+    "LH:1",
+    "LF:2",
+    "end_of_record",
+  ].join("\n");
+
+  const { lcov, fileCount, rewritten, unchanged } = mergeLcovReports(
+    [jobA, jobB],
+    "labs",
+  );
+
+  assertEquals(fileCount, 1);
+  assertEquals(rewritten, 1);
+  assertEquals(unchanged, 0);
+  assertEquals(
+    lcov,
+    [
+      "SF:packages/a/mod.ts",
+      // line 1: 1 + 0 = 1 (hit); line 2: 0 + 5 = 5 (now hit thanks to job B).
+      "DA:1,1",
+      "DA:2,5",
+      "LF:2",
+      "LH:2",
+      "end_of_record",
+      "",
+    ].join("\n"),
+  );
+});
+
+Deno.test("mergeLcovReports keeps a line uncovered in every job", () => {
+  const report = [
+    "SF:/home/runner/work/labs/labs/packages/a/mod.ts",
+    "DA:5,0",
+    "LH:0",
+    "LF:1",
+    "end_of_record",
+  ].join("\n");
+
+  const { lcov } = mergeLcovReports([report, report], "labs");
+
+  assertEquals(
+    lcov,
+    [
+      "SF:packages/a/mod.ts",
+      "DA:5,0",
+      "LF:1",
+      "LH:0",
+      "end_of_record",
+      "",
+    ].join("\n"),
+  );
+});
+
+Deno.test("combineCoverageLcov tolerates a missing input directory", async () => {
+  const { lcov, fileCount } = await combineCoverageLcov(
+    "/tmp/combine-lcov-does-not-exist-abc123",
+    "labs",
+  );
+  assertEquals(lcov, "");
+  assertEquals(fileCount, 0);
+});
+
+Deno.test("combineCoverageLcov merges reports from a directory tree", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "combine-lcov-" });
+  try {
+    await Deno.writeTextFile(
+      path.join(dir, "workspace.lcov"),
+      [
+        "SF:/home/runner/work/labs/labs/packages/a/mod.ts",
+        "DA:1,1",
+        "LF:1",
+        "LH:1",
+        "end_of_record",
+        "",
+      ].join("\n"),
+    );
+    // A report nested in an artifact subdirectory is still discovered.
+    await Deno.mkdir(path.join(dir, "pattern-runtime", "unit-1"), {
+      recursive: true,
+    });
+    await Deno.writeTextFile(
+      path.join(dir, "pattern-runtime", "unit-1", "subject.lcov"),
+      [
+        "TN:pattern-runtime",
+        "SF:cf-mount/fid/main.tsx",
+        "DA:2,0",
+        "LF:1",
+        "LH:0",
+        "end_of_record",
+        "",
+      ].join("\n"),
+    );
+    // An empty report (no coverage produced) is skipped, not concatenated.
+    await Deno.writeTextFile(path.join(dir, "empty.lcov"), "");
+
+    const { lcov, fileCount, rewritten, unchanged } = await combineCoverageLcov(
+      dir,
+      "labs",
+    );
+
+    assertEquals(fileCount, 2);
+    assertEquals(rewritten, 1);
+    assertEquals(unchanged, 1);
+    // Output is sorted by source path; the synthetic pattern path keeps its TN.
+    assertEquals(
+      lcov.split("\n").filter((line) =>
+        line.startsWith("SF:") || line.startsWith("TN:")
+      ),
+      [
+        "TN:pattern-runtime",
+        "SF:cf-mount/fid/main.tsx",
+        "SF:packages/a/mod.ts",
+      ],
+    );
+    assertEquals(lcov.endsWith("\n"), true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/tasks/combine-coverage-lcov.test.ts
+++ b/tasks/combine-coverage-lcov.test.ts
@@ -1,10 +1,15 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import * as path from "@std/path";
+import { runDenoCommandWithTemporaryLock } from "@commonfabric/test-support/isolated-deno";
 import {
   combineCoverageLcov,
+  main,
   mergeLcovReports,
   normalizeSourcePath,
+  parseArgs,
 } from "./combine-coverage-lcov.ts";
+
+const ROOT = path.join(import.meta.dirname!, "..");
 
 Deno.test("normalizeSourcePath strips a GitHub-hosted workspace root", () => {
   assertEquals(
@@ -191,6 +196,128 @@ Deno.test("combineCoverageLcov merges reports from a directory tree", async () =
       ],
     );
     assertEquals(lcov.endsWith("\n"), true);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("combineCoverageLcov surfaces a non-NotFound read error", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "combine-lcov-" });
+  const file = path.join(dir, "not-a-directory");
+  await Deno.writeTextFile(file, "");
+  try {
+    // Walking a path that is a regular file is not a "no coverage" case; the
+    // error must propagate rather than be swallowed.
+    await assertRejects(() => combineCoverageLcov(file, "labs"));
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("parseArgs reads --key=value flags and ignores other tokens", () => {
+  const parsed = parseArgs(["--input-dir=a", "--repo-name=x=y", "stray", "-z"]);
+  assertEquals(parsed.get("input-dir"), "a");
+  // Everything after the first "=" is the value, so embedded "=" is preserved.
+  assertEquals(parsed.get("repo-name"), "x=y");
+  assertEquals(parsed.has("stray"), false);
+  assertEquals(parsed.size, 2);
+});
+
+Deno.test("main combines reports and writes the output file", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "combine-lcov-main-" });
+  try {
+    const inputDir = path.join(dir, "in");
+    await Deno.mkdir(inputDir);
+    await Deno.writeTextFile(
+      path.join(inputDir, "workspace.lcov"),
+      [
+        "SF:/home/runner/work/labs/labs/packages/a/mod.ts",
+        "DA:1,1",
+        "LF:1",
+        "LH:1",
+        "end_of_record",
+        "",
+      ].join("\n"),
+    );
+    const outputPath = path.join(dir, "nested", "labs-sha.lcov");
+
+    const code = await main([
+      `--input-dir=${inputDir}`,
+      `--output=${outputPath}`,
+      "--repo-name=labs",
+    ]);
+
+    assertEquals(code, 0);
+    assertEquals(
+      await Deno.readTextFile(outputPath),
+      [
+        "SF:packages/a/mod.ts",
+        "DA:1,1",
+        "LF:1",
+        "LH:1",
+        "end_of_record",
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("main returns exit code 2 when a required flag is missing", async () => {
+  assertEquals(await main(["--input-dir=a", "--output=b"]), 2);
+});
+
+// Run the task as its own process so the `import.meta.main` entry point is
+// exercised end to end. Lockfile isolation keeps the real deno.lock untouched,
+// and all inputs and outputs live under temporary directories.
+Deno.test("the CLI entry point runs the task as a process", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "combine-lcov-cli-" });
+  try {
+    const inputDir = path.join(dir, "in");
+    await Deno.mkdir(inputDir);
+    await Deno.writeTextFile(
+      path.join(inputDir, "workspace.lcov"),
+      [
+        "SF:/home/runner/work/labs/labs/packages/a/mod.ts",
+        "DA:1,1",
+        "LF:1",
+        "LH:1",
+        "end_of_record",
+        "",
+      ].join("\n"),
+    );
+    const outputPath = path.join(dir, "labs-sha.lcov");
+
+    const output = await runDenoCommandWithTemporaryLock({
+      root: ROOT,
+      args: (lockPath) => [
+        "run",
+        "--config",
+        path.join(ROOT, "deno.json"),
+        "--lock",
+        lockPath,
+        "--allow-read",
+        "--allow-write",
+        path.join(ROOT, "tasks/combine-coverage-lcov.ts"),
+        `--input-dir=${inputDir}`,
+        `--output=${outputPath}`,
+        "--repo-name=labs",
+      ],
+    });
+
+    assertEquals(output.code, 0);
+    assertEquals(
+      await Deno.readTextFile(outputPath),
+      [
+        "SF:packages/a/mod.ts",
+        "DA:1,1",
+        "LF:1",
+        "LH:1",
+        "end_of_record",
+        "",
+      ].join("\n"),
+    );
   } finally {
     await Deno.remove(dir, { recursive: true });
   }

--- a/tasks/combine-coverage-lcov.ts
+++ b/tasks/combine-coverage-lcov.ts
@@ -1,0 +1,217 @@
+#!/usr/bin/env -S deno run --allow-read --allow-write
+import * as path from "@std/path";
+
+/**
+ * Rewrite an LCOV `SF:` source path to a repository-relative POSIX path.
+ *
+ * `deno coverage --lcov` records each source file by its absolute path on the
+ * machine that ran the tests. Those roots differ between runners: a
+ * GitHub-hosted runner checks the repository out under `/home/runner/work`,
+ * while a self-hosted runner uses its own work directory. The actions runner
+ * always checks out into `<work-dir>/<repo>/<repo>`, so the path that follows
+ * the doubled repository directory is the repository-relative path. Stripping
+ * everything up to and including that doubled directory collapses the differing
+ * absolute roots onto a single relative path an IDE can map back to the
+ * checkout.
+ *
+ * The last occurrence of the doubled directory is used so that a work directory
+ * whose own ancestors happen to repeat the repository name does not anchor too
+ * early. Paths that do not contain the doubled repository directory are
+ * returned unchanged; pattern-runtime coverage uses synthetic paths (for
+ * example `cf-mount/...`) that have no repository file to map to.
+ */
+export function normalizeSourcePath(
+  sourcePath: string,
+  repoName: string,
+): string {
+  const posix = sourcePath.replaceAll("\\", "/");
+  const anchor = `/${repoName}/${repoName}/`;
+  const index = posix.lastIndexOf(anchor);
+  if (index >= 0) return posix.slice(index + anchor.length);
+  return posix;
+}
+
+interface FileCoverage {
+  testName?: string;
+  lineHits: Map<number, number>;
+}
+
+/**
+ * Parse one or more LCOV reports, normalize their source paths, and merge every
+ * record that refers to the same source file into a single line-coverage
+ * record. Per-line execution counts are summed, matching how the repository's
+ * own coverage tooling (tasks/coverage-metrics.ts) accumulates hits, so a file
+ * exercised by several test jobs is reported once with its combined coverage
+ * rather than as repeated records that some LCOV consumers keep only the last
+ * of.
+ *
+ * Only line coverage (`DA`/`LF`/`LH`) is carried through. Function (`FN`) and
+ * branch (`BRDA`) records are dropped: LCOV keys function hits by name, and a
+ * single source file can declare several functions with the same name (for
+ * example a free function and a method), so merging them faithfully is not
+ * possible from the report alone. Line coverage is what IDEs use to colour the
+ * gutter and is the signal the combined report exists to provide.
+ */
+export function mergeLcovReports(
+  reports: string[],
+  repoName: string,
+): { lcov: string; fileCount: number; rewritten: number; unchanged: number } {
+  const files = new Map<string, FileCoverage>();
+  const anchored = new Set<string>();
+
+  for (const report of reports) {
+    let current: FileCoverage | undefined;
+    // An LCOV record opens with an optional `TN:` test-name line before its
+    // `SF:` line, so a test name is held until the source path is known.
+    let pendingTestName: string | undefined;
+    for (const line of report.split(/\r?\n/)) {
+      if (line.startsWith("TN:")) {
+        pendingTestName = line.slice(3) || undefined;
+      } else if (line.startsWith("SF:")) {
+        const original = line.slice(3);
+        const normalized = normalizeSourcePath(original, repoName);
+        current = files.get(normalized);
+        if (!current) {
+          current = { lineHits: new Map() };
+          files.set(normalized, current);
+          if (normalized !== original) anchored.add(normalized);
+        }
+        if (pendingTestName && !current.testName) {
+          current.testName = pendingTestName;
+        }
+        pendingTestName = undefined;
+      } else if (!current) {
+        continue;
+      } else if (line.startsWith("DA:")) {
+        const [lineNumber, hits] = line.slice(3).split(",");
+        const parsedLine = Number(lineNumber);
+        const parsedHits = Number(hits);
+        if (Number.isInteger(parsedLine) && Number.isFinite(parsedHits)) {
+          current.lineHits.set(
+            parsedLine,
+            (current.lineHits.get(parsedLine) ?? 0) + parsedHits,
+          );
+        }
+      } else if (line === "end_of_record") {
+        current = undefined;
+        pendingTestName = undefined;
+      }
+    }
+  }
+
+  const paths = [...files.keys()].sort();
+  const blocks = paths.map((sourcePath) =>
+    serializeFileCoverage(sourcePath, files.get(sourcePath)!)
+  );
+  const lcov = blocks.length === 0 ? "" : `${blocks.join("\n")}\n`;
+
+  return {
+    lcov,
+    fileCount: files.size,
+    rewritten: anchored.size,
+    unchanged: files.size - anchored.size,
+  };
+}
+
+function serializeFileCoverage(
+  sourcePath: string,
+  file: FileCoverage,
+): string {
+  const lines: string[] = [];
+  if (file.testName) lines.push(`TN:${file.testName}`);
+  lines.push(`SF:${sourcePath}`);
+
+  const lineNumbers = [...file.lineHits.keys()].sort((a, b) => a - b);
+  let linesHit = 0;
+  for (const lineNumber of lineNumbers) {
+    const hits = file.lineHits.get(lineNumber)!;
+    if (hits > 0) linesHit++;
+    lines.push(`DA:${lineNumber},${hits}`);
+  }
+  lines.push(`LF:${lineNumbers.length}`);
+  lines.push(`LH:${linesHit}`);
+  lines.push("end_of_record");
+  return lines.join("\n");
+}
+
+async function* collectLcovFiles(dir: string): AsyncGenerator<string> {
+  let entries: Deno.DirEntry[];
+  try {
+    entries = await Array.fromAsync(Deno.readDir(dir));
+  } catch (error) {
+    // A missing input directory (no coverage was downloaded) yields no files.
+    if (error instanceof Deno.errors.NotFound) return;
+    throw error;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory) {
+      yield* collectLcovFiles(full);
+    } else if (entry.name.endsWith(".lcov")) {
+      yield full;
+    }
+  }
+}
+
+/**
+ * Read every LCOV report under `inputDir` and merge them into a single report
+ * with repository-relative source paths.
+ */
+export async function combineCoverageLcov(
+  inputDir: string,
+  repoName: string,
+): Promise<
+  { lcov: string; fileCount: number; rewritten: number; unchanged: number }
+> {
+  const files: string[] = [];
+  for await (const file of collectLcovFiles(inputDir)) files.push(file);
+  files.sort();
+
+  const reports: string[] = [];
+  for (const file of files) {
+    const text = await Deno.readTextFile(file);
+    if (text.trim().length > 0) reports.push(text);
+  }
+
+  return mergeLcovReports(reports, repoName);
+}
+
+function parseArgs(args: string[]): Map<string, string> {
+  const parsed = new Map<string, string>();
+  for (const arg of args) {
+    const match = /^--([^=]+)=(.*)$/.exec(arg);
+    if (match) parsed.set(match[1], match[2]);
+  }
+  return parsed;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(Deno.args);
+  const inputDir = args.get("input-dir");
+  const outputPath = args.get("output");
+  const repoName = args.get("repo-name");
+  if (!inputDir || !outputPath || !repoName) {
+    console.error(
+      "Usage: deno run --allow-read --allow-write tasks/combine-coverage-lcov.ts " +
+        "--input-dir=<dir> --output=<combined.lcov> --repo-name=<repository name>",
+    );
+    Deno.exit(2);
+  }
+
+  const { lcov, fileCount, rewritten, unchanged } = await combineCoverageLcov(
+    inputDir,
+    repoName,
+  );
+
+  await Deno.mkdir(path.dirname(outputPath), { recursive: true });
+  await Deno.writeTextFile(outputPath, lcov);
+
+  console.log(
+    `Merged line coverage for ${fileCount} source file(s) into ${outputPath} ` +
+      `(${rewritten} normalized to repository-relative paths, ${unchanged} left as-is).`,
+  );
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/tasks/combine-coverage-lcov.ts
+++ b/tasks/combine-coverage-lcov.ts
@@ -176,7 +176,7 @@ export async function combineCoverageLcov(
   return mergeLcovReports(reports, repoName);
 }
 
-function parseArgs(args: string[]): Map<string, string> {
+export function parseArgs(args: string[]): Map<string, string> {
   const parsed = new Map<string, string>();
   for (const arg of args) {
     const match = /^--([^=]+)=(.*)$/.exec(arg);
@@ -185,17 +185,18 @@ function parseArgs(args: string[]): Map<string, string> {
   return parsed;
 }
 
-async function main(): Promise<void> {
-  const args = parseArgs(Deno.args);
-  const inputDir = args.get("input-dir");
-  const outputPath = args.get("output");
-  const repoName = args.get("repo-name");
+/** Run the command-line interface; returns the process exit code. */
+export async function main(args: string[]): Promise<number> {
+  const parsed = parseArgs(args);
+  const inputDir = parsed.get("input-dir");
+  const outputPath = parsed.get("output");
+  const repoName = parsed.get("repo-name");
   if (!inputDir || !outputPath || !repoName) {
     console.error(
       "Usage: deno run --allow-read --allow-write tasks/combine-coverage-lcov.ts " +
         "--input-dir=<dir> --output=<combined.lcov> --repo-name=<repository name>",
     );
-    Deno.exit(2);
+    return 2;
   }
 
   const { lcov, fileCount, rewritten, unchanged } = await combineCoverageLcov(
@@ -210,8 +211,7 @@ async function main(): Promise<void> {
     `Merged line coverage for ${fileCount} source file(s) into ${outputPath} ` +
       `(${rewritten} normalized to repository-relative paths, ${unchanged} left as-is).`,
   );
+  return 0;
 }
 
-if (import.meta.main) {
-  await main();
-}
+if (import.meta.main) Deno.exit(await main(Deno.args));


### PR DESCRIPTION
Coverage in CI is produced in fragments. Each test job writes its own `*.lcov` report and uploads it as a `coverage-profile-*` artifact, and the source paths inside those reports are absolute paths rooted at whichever runner produced them (a GitHub-hosted runner checks out under `/home/runner/work`, while the self-hosted `labs` runner uses its own work directory). There is no single artifact an IDE can load to see coverage for the whole repository, and the absolute paths would not map to a local checkout even if there were.

Add `tasks/combine-coverage-lcov.ts`, which merges those fragments into one report:

- Source paths are rewritten to repository-relative POSIX paths by stripping everything up to and including the doubled `<repo>/<repo>` checkout directory the actions runner always creates. The last occurrence is used so a work directory whose own ancestors repeat the repository name does not anchor too early. The repository name is passed in from `github.event.repository.name`, so the same anchor matches both runner layouts. Synthetic pattern-runtime paths (for example `cf-mount/...`) have no such prefix and are left unchanged.

- All records for the same source file are merged into a single record, with per-line execution counts summed. This matches how the repository's own coverage tooling accumulates hits and means a file exercised by several test jobs is reported once with its combined coverage, rather than as repeated records that some LCOV consumers keep only the last of.

- Only line coverage (`DA`/`LF`/`LH`) is carried through. LCOV keys function hits by name, and `deno coverage --lcov` emits several functions with the same name within one file (for example a free function and a same-named method), so function and branch records cannot be merged faithfully from the reports alone. Line coverage is what IDEs use to colour the gutter and is the signal this combined report exists to provide.

The combine and upload run inside the existing `attest-binaries` job rather than a dedicated job. That job already runs on main, on the labs runner group, authenticates to Google Cloud, and copies release artifacts to the build-artifacts bucket, so the only additions are a Deno setup step, the coverage-artifact download, the combine task, and one more `gsutil cp`. The report is uploaded as `labs-<sha>.lcov` alongside the signed binary tarball.

`attest-binaries` already waited on every coverage-producing job except the generated-patterns integration tests, so that one is added to its `needs`. It runs in parallel with the integration-test jobs the attestation already waits for, so it does not extend the critical path, and it makes the deploy gate require the full test suite to have passed.

The coverage download and combine steps are marked `continue-on-error`, and the report is uploaded only if the combine step produced it, so a coverage problem cannot block binary attestation or the deploys that depend on it. The combine task treats a missing input directory as "no coverage" rather than an error, so the best-effort path stays quiet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Combines all CI LCOV fragments into a single repo-wide report and uploads it to Cloud Storage for easy IDE use. Normalizes source paths to repo-relative and merges line hits across jobs.

- **New Features**
  - Added `tasks/combine-coverage-lcov.ts` to rewrite `SF:` paths by stripping the last `<repo>/<repo>` checkout root; synthetic paths are left as-is.
  - Merges per-file line coverage, summing `DA` counts; outputs only `DA`, `LF`, and `LH`.
  - CI updates in `attest-binaries`: download `coverage-profile-*` artifacts, run the combine task, and upload `labs-<sha>.lcov` to the `workspace-artifacts` bucket; marked best-effort with `continue-on-error`.
  - Added `generated-patterns-integration-test` to `needs` so the deploy gate waits for the full test suite.

- **Refactors**
  - Exported `parseArgs` and `main` (now returns an exit code) for testability; the CLI entry point delegates to them.
  - Hardened file discovery: treat a missing input dir as “no coverage,” propagate non-`NotFound` errors; added tests covering the CLI, Windows path normalization, and dotted repo names.

<sup>Written for commit ec1f7a0084f952a20694d918ec7e69e03fa111dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

