### PR TITLE
Document CI coverage mechanisms and consolidate the testing docs

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -560,6 +560,10 @@ jobs:
       - name: 🛡️ Disable AppArmor for browser tests
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
+      # These tests run with `deno test`, so they collect V8 runtime coverage
+      # (DENO_COVERAGE_DIR) but not authored-pattern coverage. Pattern coverage
+      # is only collected by `cf test` via CF_PATTERN_COVERAGE_DIR, set on the
+      # pattern-unit-test job. See docs/development/COVERAGE.md.
       - name: 🧩 Run end-to-end patterns integration tests
         working-directory: packages/patterns
         run: |
@@ -616,6 +620,10 @@ jobs:
       - name: 🛡️ Disable AppArmor for browser tests
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
 
+      # These tests run with `deno test`, so they collect V8 runtime coverage
+      # (DENO_COVERAGE_DIR) but not authored-pattern coverage. Pattern coverage
+      # is only collected by `cf test` via CF_PATTERN_COVERAGE_DIR, set on the
+      # pattern-unit-test job. See docs/development/COVERAGE.md.
       - name: 🧩 Run pattern reload integration tests
         run: |
           mkdir -p test-results

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,15 @@ If you are developing runtime code, read the following documentation:
   practices
 - `docs/development/LOCAL_DEV_SERVERS.md` - **CRITICAL**: How to start local dev
   servers correctly (use `dev-local` for shell, not `dev`)
+- `docs/development/TESTING.md` - Running the test suites and the general unit
+  and integration test structure; hub that links the other testing docs
 - `docs/development/CI_PERFORMANCE.md` - When to stop or revisit CI wall-time
   splitting/rebalancing work
+- `docs/development/COVERAGE.md` - The two coverage mechanisms (V8 runtime
+  coverage and transformer-based pattern coverage), which CI job collects which,
+  and why the pattern integration jobs do not set `CF_PATTERN_COVERAGE_DIR`
+- `docs/development/LLM_TESTING.md` - Testing patterns and server routes that
+  call the LLM (test-environment guard, mocks, conversation fixtures)
 - `docs/development/UI_TESTING.md` - How to work with shadow dom in our
   integration tests
 - `docs/development/debugging/` - Runtime errors, type errors, and

--- a/docs/common/workflows/pattern-testing.md
+++ b/docs/common/workflows/pattern-testing.md
@@ -307,3 +307,4 @@ const assert_total_correct = computed(() => {
 
 - [Testing Handlers via CLI](./handlers-cli-testing.md) - Manual CLI testing workflow
 - [Pattern Testing Spec](../../specs/PATTERN_TESTING_SPEC.md) - Technical specification
+- [Coverage in CI](../../development/COVERAGE.md) - How the pattern unit tests run here feed the coverage-debt gate

--- a/docs/development/CI_PERFORMANCE.md
+++ b/docs/development/CI_PERFORMANCE.md
@@ -64,10 +64,12 @@ job and step carries `started_at` and `completed_at`.
 
 ## Coverage Debt Baselines
 
-Performance Check also tracks coverage debt as uncovered source lines. Coverage
-debt uses a latest-main ratchet for source groups changed by the PR: any
-increase in a changed group fails unless the PR explicitly accepts it. Debt
-metrics for unchanged groups are still reported, but they do not block the PR.
+Performance Check also tracks coverage debt as uncovered source lines. See
+[COVERAGE.md](COVERAGE.md) for how that coverage is collected and which CI job
+measures which code. Coverage debt uses a latest-main ratchet for source groups
+changed by the PR: any increase in a changed group fails unless the PR
+explicitly accepts it. Debt metrics for unchanged groups are still reported, but
+they do not block the PR.
 
 Use the narrow per-metric form when a PR intentionally increases one coverage
 debt metric:

--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -1,0 +1,147 @@
+# Code coverage in CI
+
+This repository measures code coverage in two different ways, because it runs
+two different kinds of code. Keeping the two apart is the key to reading the
+numbers correctly and to deciding which test job should collect which kind of
+coverage.
+
+## Two kinds of code, two coverage mechanisms
+
+### Runtime and framework code is measured by Deno's V8 coverage
+
+The packages that make up the Common Fabric runtime (api, runner, identity,
+memory, and the rest) are ordinary TypeScript modules. Deno loads and runs them
+directly, so Deno's built-in V8 coverage can record which of their lines ran. A
+CI job turns this on by setting the `DENO_COVERAGE_DIR` environment variable.
+After the tests finish, `tasks/write-coverage-lcov.ts` converts the raw V8
+profile into an LCOV file, and the job uploads it as a `coverage-profile-*`
+artifact. Most test jobs set `DENO_COVERAGE_DIR`, including both pattern
+integration jobs.
+
+### Authored pattern code is measured by transformer instrumentation
+
+Patterns (the user programs under `packages/patterns`) are not loaded the way an
+ordinary module is. Each pattern is compiled through the Common Fabric
+transformer pipeline and then run inside a sandbox. Deno's V8 coverage never
+sees the authored pattern statements execute, so it cannot report which lines of
+a pattern ran.
+
+To measure that, the `cf test` command can turn on a separate mechanism. When
+the `CF_PATTERN_COVERAGE_DIR` environment variable is set (or the
+`--pattern-coverage-dir` flag is passed), the `cf test` runner builds a
+`PatternCoverageCollector`. The transformer then injects a coverage "hit" call
+in front of each authored statement, and the collector writes one
+`*.pattern-coverage.lcov` file per test. The line numbers in that file point
+back at the authored pattern source.
+
+Two properties of this mechanism are worth keeping in mind.
+
+- The counters are statement based. A single statement that spans several lines
+  marks its whole source range as run the moment the statement is reached. The
+  number answers "did this statement run", not "was every line independently
+  exercised".
+- Coverage records that a line ran. It never records that a test checked the
+  result of running that line. A test that drives a pattern through a flow
+  without asserting anything still marks those lines covered.
+
+`CF_PATTERN_COVERAGE_DIR` is read in exactly one place: the `cf test` command in
+`packages/cli/commands/test.ts`. A job that runs patterns through a plain
+`deno test` invocation, or by talking to a running Toolshed server, does not go
+through `cf test`. Setting the variable on such a job has no effect at all.
+
+## How the two feed the coverage gate
+
+`tasks/perf-check.ts` downloads every `coverage-profile-*` artifact, joins all
+the LCOV files together, and hands them to `tasks/coverage-metrics.ts`. That
+code walks the tracked source files under `packages`, `tasks`, and `scripts`,
+and for each file counts how many of its lines no test covered. The counts roll
+up into `coverage-debt: <group> uncovered lines` metrics, for example
+`coverage-debt: packages/patterns uncovered lines`, and the performance check
+gates a pull request on them.
+
+Authored pattern files under `packages/patterns` are tracked source files, so
+their uncovered lines count toward `coverage-debt: packages/patterns`. The only
+job that currently feeds covered-line data for those authored files is
+`pattern-unit-test`, because it is the only job that runs patterns through
+`cf test` with `CF_PATTERN_COVERAGE_DIR` set.
+
+One detail of the gate's accounting matters when reasoning about pattern
+coverage. For a tracked file that has any LCOV record, the gate counts only the
+lines named in that record that were never hit. For a tracked file with no LCOV
+record at all, every tracked line counts as uncovered. Pattern instrumentation
+emits a record line only for statements it could instrument, which is a subset
+of the file's lines. So the first time any test produces a pattern-coverage
+record for a previously unrecorded pattern file, that file's uncovered-line
+count drops both because real lines became covered and because the lines the
+instrumentation never names leave the denominator. The second effect is an
+accounting artifact, not new test strength.
+
+## Which job collects which coverage
+
+| Job | Runtime (V8) coverage | Authored-pattern coverage |
+| --- | --- | --- |
+| `pattern-unit-test` | yes | yes (`cf test` with `CF_PATTERN_COVERAGE_DIR`) |
+| `pattern-integration-test` | yes | no |
+| `pattern-reload-integration-test` | yes | no |
+
+The pattern unit job runs each `packages/patterns/**/*.test.tsx` file through
+`cf test` in-process. The two integration jobs run browser-driven `deno test`
+files against a running Toolshed server.
+
+## Why the two integration jobs do not set `CF_PATTERN_COVERAGE_DIR`
+
+Adding `CF_PATTERN_COVERAGE_DIR` to `pattern-integration-test` or
+`pattern-reload-integration-test` was considered and deliberately not done, for
+four reasons.
+
+1. It would do nothing as written. Both jobs run their tests with `deno test`,
+   not `cf test`, and `CF_PATTERN_COVERAGE_DIR` is read only by `cf test`. The
+   variable would sit in the job's environment unread, which is worse than
+   absent because it suggests coverage is being collected when none is.
+
+2. Making it work would mean crossing a process boundary. These tests run the
+   pattern inside a sandbox in a headless browser that talks to a separate
+   Toolshed server. The "hit" calls happen in that sandbox, with no in-process
+   collector to receive them and write LCOV. Collecting them would require new
+   plumbing to carry hit data back across the browser and server boundaries.
+
+3. It would weaken the pressure the gate puts on test quality. The coverage-debt
+   gate currently rewards focused pattern unit tests, which run in-process,
+   assert on results, and are fast. If broad end-to-end flows counted toward
+   pattern coverage, the gate could be satisfied by incidental execution in an
+   integration test that asserts little, so coverage debt would fall without the
+   matching rise in verification strength.
+
+4. It would distort the gate's numbers through the accounting artifact described
+   above. Crediting integration runs would flip many pattern files from the
+   full-file denominator to the narrower instrumented-statement denominator, so
+   reported debt would drop for reasons unrelated to new testing.
+
+The net effect on metric quality is that crediting integration runs would trade
+a smaller, bounded source of false negatives for a larger source of false
+positives and a less faithful, more gameable gate.
+
+## Known limitations and possible future work
+
+- False negatives exist today. A pattern line that only an integration test
+  exercises is counted as uncovered, because no integration job collects pattern
+  coverage. This understates true coverage for the patterns that are reachable
+  only through end-to-end flows. The trade is deliberate: the alternative above
+  inflates the numbers more than this understates them.
+
+- The record-versus-no-record denominator difference is a pre-existing property
+  of the gate, not specific to integration jobs. If pattern coverage is ever
+  expanded, normalizing the denominator (always scoring a pattern file against
+  the same line set whether or not it has a record) would make the numbers
+  easier to trust.
+
+## Related documentation
+
+- [TESTING.md](TESTING.md) — how to run the test suites whose execution this
+  coverage is measured from.
+- [CI_PERFORMANCE.md](CI_PERFORMANCE.md) — the coverage-debt baseline and ratchet
+  markers (`NEW_PERF_BASELINE` and `NEW_COVERAGE_BASELINE`) that gate a pull
+  request on the metrics described here.
+- [../common/workflows/pattern-testing.md](../common/workflows/pattern-testing.md)
+  — writing the pattern unit tests that the `pattern-unit-test` job runs through
+  `cf test`, which is the only source of authored-pattern coverage.

--- a/docs/development/LLM_TESTING.md
+++ b/docs/development/LLM_TESTING.md
@@ -180,3 +180,10 @@ cd packages/toolshed && deno task test
 # Runner tests (includes smoke tests + fixture tests)
 cd packages/runner && deno task test
 ```
+
+## Related documentation
+
+- [TESTING.md](TESTING.md) — running the suites and the general unit and
+  integration test structure.
+- [COVERAGE.md](COVERAGE.md) — how the runtime coverage these tests produce feeds
+  the coverage-debt gate.

--- a/docs/development/TESTING.md
+++ b/docs/development/TESTING.md
@@ -85,3 +85,19 @@ Deno.exit(0);
 **Adding integration tests:**
 
 When adding runtime features, consider adding integration tests to `packages/runner/integration/` that verify the feature works end-to-end. See existing tests like `basic-persistence.test.ts` or `array_push.test.ts` for examples.
+
+## Related documentation
+
+- [COVERAGE.md](COVERAGE.md) — how CI measures coverage. It explains the two
+  mechanisms (Deno's V8 coverage for runtime code, and transformer-based
+  coverage for authored patterns) and how both feed the coverage-debt gate.
+- [CI_PERFORMANCE.md](CI_PERFORMANCE.md) — the CI wall-time policy, and the
+  coverage-debt baseline and ratchet markers that gate a pull request.
+- [LLM_TESTING.md](LLM_TESTING.md) — testing patterns and server routes that
+  call the LLM, including the test-environment guard and conversation fixtures.
+- [UI_TESTING.md](UI_TESTING.md) — testing shadow DOM components in browser
+  integration tests.
+- [../common/workflows/pattern-testing.md](../common/workflows/pattern-testing.md)
+  — writing and running pattern tests with `cf test`. The agent-oriented version
+  is [../common/ai/pattern-testing-guide.md](../common/ai/pattern-testing-guide.md),
+  and the design reference is [../specs/PATTERN_TESTING_SPEC.md](../specs/PATTERN_TESTING_SPEC.md).

--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -294,3 +294,10 @@ If semantic locators are not finding your element:
 3. **Ensure components are loaded**: wait for the host element before querying
 4. **Fallback to pierce selectors**: use `[data-cf-input]` or
    `[data-cf-button]` with `strategy: "pierce"` for older components
+
+## Related documentation
+
+- [TESTING.md](TESTING.md) — running the suites and the general unit and
+  integration test structure.
+- [COVERAGE.md](COVERAGE.md) — how CI measures coverage and feeds the
+  coverage-debt gate.

--- a/docs/development/debugging/testing.md
+++ b/docs/development/debugging/testing.md
@@ -1,3 +1,0 @@
-# Moved
-
-Merged into [cli-debugging.md](cli-debugging.md) (local checks, deploy, set/inspect/get, and the setsrc workflow).

--- a/docs/specs/pattern-construction/pattern-integration-tests.md
+++ b/docs/specs/pattern-construction/pattern-integration-tests.md
@@ -3,6 +3,13 @@
 > **Status:** Test harness implementation is **COMPLETE**. This spec documents
 > the design for reference.
 >
+> **What shipped:** The `.pattern.test.json` / `.pattern.test.ts` fixture format
+> proposed below was not adopted. Pattern tests are authored as `.test.tsx`
+> patterns and run with `cf test`. For the system as built, see
+> [PATTERN_TESTING_SPEC.md](../PATTERN_TESTING_SPEC.md) and the script-based
+> suites under `packages/runner/integration/`. This document is kept for the
+> design rationale behind that harness.
+>
 > **Terminology update:** What we previously called "patterns" are now referred
 > to as "patterns." The builder API still exports a `pattern(...)` helper, but
 > throughout this document we describe the authored artifacts as patterns.


### PR DESCRIPTION
The recurring question of whether to set CF_PATTERN_COVERAGE_DIR on the pattern-integration-test and pattern-reload-integration-test jobs had no written answer, and the testing and coverage documents had drifted into a set of mostly disconnected pages. Document the coverage model, record the decision about those jobs, and connect the testing docs into a navigable set.

Coverage model and the integration-job decision:

The repository measures coverage two ways. Deno's V8 coverage, enabled with DENO_COVERAGE_DIR, measures the runtime and framework packages because Deno loads and runs them directly. Authored pattern code is compiled through the Common Fabric transformer pipeline and run in a sandbox, so V8 never sees it; a separate transformer-based mechanism, enabled with CF_PATTERN_COVERAGE_DIR, instruments authored patterns. That variable is read only by the cf test command, so only a job that runs patterns through cf test can honor it.

Setting CF_PATTERN_COVERAGE_DIR on the two pattern integration jobs would do nothing: both run their tests with plain deno test driving a headless browser against a Toolshed server, never through cf test, so the variable would be read by nothing. Making it work would require carrying pattern-hit data back across the browser and server boundaries, and crediting end-to-end execution toward pattern coverage would weaken the gate by rewarding incidental execution and by flipping many pattern files onto a narrower denominator. Pattern coverage is therefore left sourced from the focused unit tests that run through cf test.

- Add docs/development/COVERAGE.md describing the two mechanisms, which CI job collects which, how both feed the coverage-debt gate, the statement-based and denominator caveats, the reasons the integration jobs omit the variable, and the known false-negative limitation that choice accepts.
- Add a comment at each of the two integration job steps in the workflow noting that they collect V8 runtime coverage but not authored-pattern coverage.

Testing-doc consolidation:

TESTING.md (how to run the suites) and LLM_TESTING.md were not linked from anywhere, COVERAGE.md and CI_PERFORMANCE.md described the same coverage-debt gate without referencing each other, and docs/development/debugging/testing.md was a three-line "Moved" redirect, its content already merged into cli-debugging.md, with no remaining inbound links.

- Make TESTING.md the hub with a "Related documentation" section linking the other testing and coverage docs, and add reciprocal pointers across the cluster (COVERAGE.md and CI_PERFORMANCE.md to each other; LLM_TESTING.md and UI_TESTING.md back to the hub; the pattern-testing workflow to COVERAGE.md).
- List TESTING.md, COVERAGE.md, and LLM_TESTING.md in the AGENTS.md Runtime Development index, naming TESTING.md as the hub.
- Remove docs/development/debugging/testing.md, the orphaned redirect stub.
- Add a "What shipped" note to the pattern-integration-tests design spec: its proposed .pattern.test.json fixture format was never adopted, so point readers at PATTERN_TESTING_SPEC.md and the packages/runner/integration scripts while keeping the document for its design rationale.

All added links were checked to resolve to existing files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents how CI coverage works, clarifies why `pattern-integration-test` and `pattern-reload-integration-test` do not set `CF_PATTERN_COVERAGE_DIR`, and consolidates testing docs into a simple, linked hub.

- **Refactors**
  - Added `docs/development/COVERAGE.md` explaining V8 runtime coverage (`DENO_COVERAGE_DIR`) vs transformer-based pattern coverage (`CF_PATTERN_COVERAGE_DIR` via `cf test`), which CI jobs collect which, how both feed the coverage-debt gate, and why integration jobs omit the variable.
  - Annotated `.github/workflows/deno.yml` to note integration tests run under `deno test` collect runtime coverage only.
  - Made `docs/development/TESTING.md` the hub and cross-linked related docs; added entries in `AGENTS.md`; connected `CI_PERFORMANCE.md` ↔ `COVERAGE.md`; added “Related documentation” links in `LLM_TESTING.md`, `UI_TESTING.md`, and the pattern-testing workflow.
  - Removed the orphan redirect `docs/development/debugging/testing.md`.
  - Updated the pattern-integration-tests spec with a “What shipped” note pointing to `PATTERN_TESTING_SPEC.md` and the runner integration scripts.

<sup>Written for commit 97aeb4d94ae2b80cc09bb7196b1f93a67feae152. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

