### PR TITLE
fix(build): restore workspace when a binary build fails

### DIFF
--- a/tasks/build-binaries.ts
+++ b/tasks/build-binaries.ts
@@ -187,9 +187,7 @@ async function buildShell(config: BuildConfig): Promise<void> {
       },
     }).output();
     if (!success) {
-      console.error("Failed to build shell app");
-      Deno.exit(1);
-      return;
+      throw new Error("Failed to build shell app");
     }
 
     // Shell now serves at root path
@@ -238,8 +236,7 @@ async function buildToolshed(config: BuildConfig): Promise<void> {
     stderr: "inherit",
   }).output();
   if (!success) {
-    console.error("Failed to build toolshed binary");
-    Deno.exit(1);
+    throw new Error("Failed to build toolshed binary");
   }
   console.log("Toolshed binary built successfully");
 }
@@ -269,8 +266,7 @@ async function buildBgPieceService(config: BuildConfig): Promise<void> {
     stderr: "inherit",
   }).output();
   if (!success) {
-    console.error("Failed to build background piece service binary");
-    Deno.exit(1);
+    throw new Error("Failed to build background piece service binary");
   }
   console.log("Background piece service binary built successfully");
 }
@@ -337,8 +333,7 @@ async function buildCli(config: BuildConfig): Promise<void> {
     stderr: "inherit",
   }).output();
   if (!success) {
-    console.error("Failed to build CLI binary");
-    Deno.exit(1);
+    throw new Error("Failed to build CLI binary");
   }
   console.log("CLI binary built successfully");
 }


### PR DESCRIPTION
The binary build mutates several tracked files before compiling: prepareWorkspace deletes compilerOptions.types from deno.json, writes the packages/toolshed/COMPILED build marker, and overwrites the compile-cache version constant in
packages/runner/src/compilation-cache/compile-cache-version.ts with a build-time fingerprint. build() wraps the whole sequence in a try/catch and, on any thrown error, calls revertWorkspace before rethrowing so these files are restored and the process still exits non-zero.

The per-binary helpers buildShell, buildToolshed, buildBgPieceService, and buildCli short-circuited a failed deno compile with console.error followed by Deno.exit(1). Deno.exit terminates the process immediately, so it ran neither build()'s catch (and therefore not revertWorkspace) nor the SIGINT handler. A failed compile thus left the mutated files dirty in the working tree, which a developer could accidentally commit.

Make each helper throw an Error on a failed compile instead of calling Deno.exit(1). The error propagates to build()'s try/catch, which already reverts the workspace and rethrows, preserving the non-zero exit while leaving the tree clean. Also remove the now-dead return after the throw in buildShell's loop.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the workspace on failed binary builds by throwing errors instead of calling Deno.exit(1). Errors now bubble to build() so revertWorkspace runs and the process still exits non-zero.

- **Bug Fixes**
  - Replace Deno.exit(1) with thrown errors in buildShell, buildToolshed, buildBgPieceService, and buildCli.
  - Prevents dirty working tree after failed compiles (e.g., deno.json tweaks, COMPILED marker, compile-cache version).
  - Remove unreachable return in buildShell’s loop.

<sup>Written for commit da9d742e5ce87a24319f13dbf7cf9a3af2b44631. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

