### PR TITLE
feat(patterns): run the package's plain Deno unit tests instead of a …

### DIFF
--- a/docs/common/workflows/pattern-testing.md
+++ b/docs/common/workflows/pattern-testing.md
@@ -308,3 +308,4 @@ const assert_total_correct = computed(() => {
 - [Testing Handlers via CLI](./handlers-cli-testing.md) - Manual CLI testing workflow
 - [Pattern Testing Spec](../../specs/PATTERN_TESTING_SPEC.md) - Technical specification
 - [Coverage in CI](../../development/COVERAGE.md) - How the pattern unit tests run here feed the coverage-debt gate
+- [Patterns package test lanes](../../../packages/patterns/deno.jsonc) - Where each kind of test (plain Deno unit test, pattern test, integration test) lives in the patterns package and how each is discovered and run

--- a/packages/patterns/deno.jsonc
+++ b/packages/patterns/deno.jsonc
@@ -1,10 +1,64 @@
 {
   "name": "@commonfabric/patterns",
+  // How to test in this package. A test belongs to exactly one of three lanes.
+  // Pick the lane by what the test needs, drop the file in the matching place,
+  // and the runner for that lane discovers it on its own — there is no list of
+  // files to keep in sync.
+  //
+  // Lane 1 — plain Deno unit test. A `*.test.ts` file of pure logic (helpers,
+  // parsing, schema/string utilities) that runs under `deno test` with no
+  // Common Fabric runtime, shell, toolshed, or browser. Put it anywhere in the
+  // package except an `integration/` directory. The `test` task below picks up
+  // every `**/*.test.ts` outside `integration/`, so adding a unit test is just
+  // adding the file. This is the only lane the root `deno task test` (the
+  // workspace "Test" CI job) runs for this package; it is not sharded.
+  // Examples: vehicles.test.ts, cfc/prompt-injection/prompt.test.ts.
+  //
+  // Lane 2 — pattern test (the testing and coverage docs call these "pattern
+  // unit tests"). A `*.test.tsx` file that `export default`s a pattern (or
+  // `multiUserTest(...)`) which drives a real pattern through `action(...)`
+  // steps and `assert_*` `computed(...)` checks. It is run by `cf test`, which
+  // instantiates it in the runtime; it is not a `deno test`. Colocate it next
+  // to the pattern it exercises. The `.tsx` extension alone routes it here: the
+  // `test` task's `**/*.test.ts` glob never matches `.test.tsx`. CI runs these
+  // in the "Pattern Unit Tests" job, split into chunks by filename (the
+  // `pattern-tests` target in tasks/integration.ts), and they are the only
+  // source of authored-pattern coverage (see docs/development/COVERAGE.md).
+  //
+  // Lane 3 — integration test. A `*.test.ts` file under `integration/` that
+  // needs a running shell/toolshed/browser (PiecesController, ShellIntegration,
+  // end-to-end flows). It is run by `deno task integration`. CI runs these in
+  // the "Pattern Integration Tests" job across four shards; a heavy new file
+  // can be pinned to a shard in tasks/select-pattern-integration-files.ts, and
+  // otherwise falls back to round-robin. Reload-specific cases live in
+  // integration/reload/ and run via `integration:reload`.
+  //
+  // Every workspace member must define a `test` task. The root runner
+  // (tasks/test.ts) calls `deno task test` in each member, and a member with no
+  // such task falls through to the root task and recurses over the whole
+  // workspace. So this lane stays a real task, never an empty stub.
+  //
+  // For how to write each kind of test and how CI measures them, see
+  // docs/development/TESTING.md (the testing hub),
+  // docs/common/workflows/pattern-testing.md (writing pattern tests), and
+  // docs/development/COVERAGE.md (how the lanes feed the coverage-debt gate).
   "tasks": {
     "integration": "LOG_LEVEL=warn deno test --v8-flags=--max-old-space-size=4096 --trace-leaks -A $INTEGRATION_TEST_FLAGS ./integration/*.test.ts",
     "integration:reload": "LOG_LEVEL=warn deno test --v8-flags=--max-old-space-size=4096 --trace-leaks -A $INTEGRATION_TEST_FLAGS ./integration/reload/*.test.ts",
     "integration:all": "TEST_HTTP=1 TEST_LLM=1 LOG_LEVEL=warn deno test --v8-flags=--max-old-space-size=4096 --trace-leaks -A ./integration/*.test.ts",
-    "test": "echo 'No tests defined.'"
+    "test": "deno test -A"
+  },
+  // File discovery for the `test` task (lane 1). `include` keeps only
+  // `.test.ts`, so pattern tests (`.test.tsx`, lane 2) are never collected;
+  // `exclude` drops every `integration/` directory (lane 3, including nested
+  // ones such as google/core/integration), which the `integration` task runs
+  // instead. These globs apply only to bare `deno test` (the `test` task);
+  // the `integration*` tasks pass explicit paths, which Deno does not filter
+  // through `exclude`. The `test` task runs with -A because some unit tests
+  // spawn a hermetic deno/cf subprocess (for example a compiler check).
+  "test": {
+    "include": ["**/*.test.ts"],
+    "exclude": ["**/integration"]
   },
   "exports": {
     ".": "./mod.ts"


### PR DESCRIPTION
…stub

The patterns package colocates a handful of plain Deno unit tests next to the pattern sources they exercise — plate/vehicle helpers, prompt-injection prompt construction, record schema utilities, and a scoped-cell schema check — but the package test task was the stub `echo 'No tests defined.'`. Nothing ran those tests: `cf test` only discovers `.test.tsx` pattern tests, and the integration task only globs `./integration/*.test.ts`, so the four plain `.test.ts` files that live outside `integration/` had no runner and contributed no automated coverage.

Replace the stub with a real `deno test` task driven by a top-level test discovery config. `include` keeps only `.test.ts`, so the `.test.tsx` pattern tests are never collected; `exclude` drops every `integration/` directory, so the shell- and browser-driven integration suites continue to run only under the integration task. Deno does not filter explicitly-passed paths through `exclude`, so the integration tasks, which pass `./integration/*.test.ts` directly, are unaffected.

The new task preserves the stub's original purpose. Every workspace member must define a test task, because the root test runner invokes `deno task test` in each member and a member without one falls through to the root task and recurses over the whole workspace.

Document the three test lanes in the package — plain Deno unit test, pattern test run through `cf test`, and integration test — so future work can tell which lane a new test belongs to and how each lane is discovered and split across CI. The lane comment uses the same "pattern unit tests" term the testing and coverage docs use for the `cf test` lane, links to docs/development/TESTING.md, docs/common/workflows/pattern-testing.md, and docs/development/COVERAGE.md, and the pattern-testing how-to links back to these lanes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run plain Deno unit tests in `@commonfabric/patterns` by replacing the stub with a real `deno test` task and adding discovery rules. This brings existing `.test.ts` files into CI without affecting pattern or integration lanes.

- New Features
  - Added `test` task: `deno test -A` with `include: ["**/*.test.ts"]` and `exclude: ["**/integration"]`; `.test.tsx` pattern tests stay on `cf test`.
  - Integration tasks pass explicit paths and are unaffected; the workspace runner now executes these unit tests. Docs link to the lane guide in `deno.jsonc`.

- Bug Fixes
  - Moved lane docs into `deno.jsonc` (renamed from `deno.json`) so comments are valid and strict JSON parsers don’t fail; updated the doc link.

<sup>Written for commit c77fdb5299d1c7fb117ad0596512cfa23582d986. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

