### PR TITLE
docs(coverage): document the combined LCOV report for IDEs

### DIFF
--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -76,6 +76,35 @@ count drops both because real lines became covered and because the lines the
 instrumentation never names leave the denominator. The second effect is an
 accounting artifact, not new test strength.
 
+## A combined report for IDEs
+
+The same `coverage-profile-*` artifacts feed a second consumer. On `main`, the
+`attest-binaries` job downloads all of them, runs
+`tasks/combine-coverage-lcov.ts` to merge them into one LCOV file, and uploads
+that file to the build-artifacts bucket next to the release tarball. The point
+is to give someone working in an IDE a single file that shows coverage for the
+whole repository, instead of one fragment per CI job.
+
+Two things happen during the merge. The source paths in each fragment are
+absolute paths rooted at whichever runner produced them, so they are rewritten
+to repository-relative paths that an IDE can map onto a local checkout. Records
+for the same source file are then combined into one, with the per-line hit
+counts added together, so a file exercised by several jobs is reported once with
+its combined coverage.
+
+The merged file carries line coverage only. LCOV identifies a function by its
+name, and `deno coverage --lcov` can emit several functions with the same name
+in one file (a free function and a method, for example), so function and branch
+records cannot be merged back together reliably from the fragments alone. Line
+coverage is what an IDE uses to colour the gutter, which is what this file is
+for.
+
+To download the report for a given commit:
+
+```
+gsutil cp gs://commontools-build-artifacts/workspace-artifacts/labs-<commit-sha>.lcov .
+```
+
 ## Which job collects which coverage
 
 | Job | Runtime (V8) coverage | Authored-pattern coverage |


### PR DESCRIPTION
The coverage documentation describes the two coverage mechanisms and how the `coverage-profile-*` artifacts feed the coverage-debt gate, but it does not mention that those same artifacts are also merged into a single repository-wide LCOV file and uploaded for people working in an IDE. That file is produced and uploaded by the attest-binaries job, so a reader of the coverage doc has no pointer to it.

Add a section to COVERAGE.md explaining that the attest-binaries job runs tasks/combine-coverage-lcov.ts to merge every fragment into one report, that the merge rewrites runner-absolute source paths to repository-relative ones and sums per-line hit counts, that the report carries line coverage only (because LCOV keys functions by name and deno can emit duplicate function names in one file), and how to download it for a given commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new section in COVERAGE.md that documents the combined repository-wide LCOV report for IDE use. It explains how `attest-binaries` runs `tasks/combine-coverage-lcov.ts` to merge `coverage-profile-*` fragments (path rewriting, summed per-line hits, line-only coverage) and how to download the report for a specific commit.

<sup>Written for commit 5845753ae124a4076ff244eb4c930b91284c1549. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

