### PR TITLE
fix(patterns): stop optional inputs from gating the bash tool request…

### DIFF
--- a/packages/patterns/system/common-fabric.tsx
+++ b/packages/patterns/system/common-fabric.tsx
@@ -6,6 +6,7 @@ import {
   fetchProgram,
   handler,
   ifElse,
+  lift,
   NAME,
   navigateTo,
   pattern,
@@ -295,19 +296,32 @@ type BashResult = {
   exitCode: number;
 };
 
+// Build the request body. The optional fields are declared optional on the
+// input type, so only command and sandboxId gate the result; each optional
+// field appears in the body only when it is set.
+const buildBashRequestBody = lift((input: {
+  sandboxId: string;
+  command: string;
+  workingDirectory?: string;
+  timeout?: number;
+  environment?: Record<string, string>;
+}) => ({
+  sandboxId: input.sandboxId,
+  command: input.command,
+  ...(input.workingDirectory !== undefined &&
+    { workingDirectory: input.workingDirectory }),
+  ...(input.timeout !== undefined && { timeout: input.timeout }),
+  ...(input.environment !== undefined && { environment: input.environment }),
+}));
+
 export const bash = pattern<BashRequest, BashResult | { error: string }>(
   ({ command, workingDirectory, timeout, environment, sandboxId }) => {
-    // Since some of our input fields should not be included if they are
-    // undefined, we use computed to conditionally construct the body object.
-    const body = computed(() => {
-      return {
-        sandboxId,
-        command,
-        // optional parameters - only include if provided
-        ...(workingDirectory !== undefined && { workingDirectory }),
-        ...(timeout !== undefined && { timeout }),
-        ...(environment !== undefined && { environment }),
-      };
+    const body = buildBashRequestBody({
+      sandboxId,
+      command,
+      workingDirectory,
+      timeout,
+      environment,
     });
     const { result, error } = fetchData<BashResult>({
       url: "/api/sandbox/exec",

--- a/packages/runner/test/bash-tool-request-body.test.ts
+++ b/packages/runner/test/bash-tool-request-body.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { getPatternEnvironment, setPatternEnvironment } from "../src/env.ts";
+import type { PatternEnvironment } from "@commonfabric/api";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("bash tool request body");
+const space = signer.did();
+
+// Read the shipped pattern source so this test exercises the real `bash`
+// pattern through the transformer, not a copy. `common-fabric.tsx`'s only
+// non-builtin import is `./backlinks-index.tsx`, so the two files plus a small
+// default-export shim form a self-contained program.
+const systemDir = new URL("../../patterns/system/", import.meta.url);
+const commonFabricSource = await Deno.readTextFile(
+  new URL("common-fabric.tsx", systemDir),
+);
+const backlinksIndexSource = await Deno.readTextFile(
+  new URL("backlinks-index.tsx", systemDir),
+);
+
+const bashProgram: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        'import { bash } from "./common-fabric.tsx";',
+        "export default bash;",
+      ].join("\n"),
+    },
+    { name: "/common-fabric.tsx", contents: commonFabricSource },
+    { name: "/backlinks-index.tsx", contents: backlinksIndexSource },
+  ],
+};
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// The bash pattern fires `fetchData` to /api/sandbox/exec through the
+// post-commit outbox, so the captured request body lands a tick after the
+// commit. Pull and wait until the exec call shows up.
+async function captureExecRequestBody(
+  fetchCalls: Array<{ url: string; init?: RequestInit }>,
+  result: { pull(): Promise<unknown> },
+): Promise<{ url: string; rawBody: string | undefined }> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    await result.pull();
+    await delay(50);
+    const call = fetchCalls.find((c) => c.url.includes("/api/sandbox/exec"));
+    if (call) {
+      return { url: call.url, rawBody: call.init?.body as string | undefined };
+    }
+  }
+  throw new Error("fetchData never called /api/sandbox/exec");
+}
+
+describe("bash pattern request body", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+  let originalFetch: typeof globalThis.fetch;
+  let originalPatternEnvironment: PatternEnvironment;
+  let fetchCalls: Array<{ url: string; init?: RequestInit }>;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+
+    originalPatternEnvironment = getPatternEnvironment();
+    setPatternEnvironment({
+      apiUrl: new URL("http://mock-test-server.local"),
+    });
+
+    fetchCalls = [];
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+      fetchCalls.push({ url, init });
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ stdout: "", stderr: "", exitCode: 0 }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    };
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    globalThis.fetch = originalFetch;
+    setPatternEnvironment(originalPatternEnvironment);
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("sends a non-empty body with sandboxId and command for a command-only call", async () => {
+    const compiled = await runtime.patternManager.compilePattern(bashProgram);
+    const resultCell = runtime.getCell(
+      space,
+      "bash-command-only",
+      undefined,
+      tx,
+    );
+    // The common case: the model supplies only `command`, the framework
+    // provides `sandboxId`, and the three optional fields are absent.
+    const result = runtime.run(
+      tx,
+      compiled,
+      { command: "echo hello", sandboxId: "sandbox-abc" },
+      resultCell,
+    );
+    await tx.commit();
+    tx = runtime.edit();
+
+    const { rawBody } = await captureExecRequestBody(fetchCalls, result);
+
+    // A non-empty body (the bug sent Content-Length: 0).
+    expect(typeof rawBody).toBe("string");
+    expect(rawBody!.length).toBeGreaterThan(0);
+
+    const body = JSON.parse(rawBody!);
+    expect(body.command).toBe("echo hello");
+    expect(body.sandboxId).toBe("sandbox-abc");
+    // Absent optionals stay out of the body (no `undefined` keys).
+    expect("workingDirectory" in body).toBe(false);
+    expect("timeout" in body).toBe(false);
+    expect("environment" in body).toBe(false);
+  });
+
+  it("includes the optional fields in the body when they are supplied", async () => {
+    const compiled = await runtime.patternManager.compilePattern(bashProgram);
+    const resultCell = runtime.getCell(
+      space,
+      "bash-with-optionals",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(
+      tx,
+      compiled,
+      {
+        command: "ls",
+        sandboxId: "sandbox-xyz",
+        workingDirectory: "/tmp",
+        timeout: 5000,
+        environment: { FOO: "bar" },
+      },
+      resultCell,
+    );
+    await tx.commit();
+    tx = runtime.edit();
+
+    const { rawBody } = await captureExecRequestBody(fetchCalls, result);
+
+    const body = JSON.parse(rawBody!);
+    expect(body.command).toBe("ls");
+    expect(body.sandboxId).toBe("sandbox-xyz");
+    expect(body.workingDirectory).toBe("/tmp");
+    expect(body.timeout).toBe(5000);
+    expect(body.environment).toEqual({ FOO: "bar" });
+  });
+});


### PR DESCRIPTION
… body

The bash sandbox tool pattern POSTed an empty HTTP body to /api/sandbox/exec whenever it was invoked without the optional workingDirectory, timeout, and environment fields. That is the normal case: the tool is exposed to the model as patternTool(bash), the model calls it with just { command }, the framework supplies sandboxId, and the three optional fields are omitted. With an empty body the toolshed exec route rejects the request as malformed JSON, the sandbox never runs, and the caller waits on a result that never arrives.

The body was built with a zero-argument computed() closure that captured all five inputs. The transformer compiles such a closure into a lift, and it derived that lift's input schema by treating every captured plain identifier as required, so the schema required all five fields even though three of them are declared optional on BashRequest. The runner only runs a lift once every required input is present, so when the optional fields were absent the body lift never fired and fetchData sent nothing.

Replace the closure with a module-level lift whose parameter type declares workingDirectory, timeout, and environment as optional. The transformer honors explicit optionality, so the emitted input schema now requires only sandboxId and command. The body is produced as soon as those two are available, and each optional field is still included only when it is set, so absent fields stay out of the JSON.

Add a runner test that compiles the shipped pattern from source and asserts the captured /api/sandbox/exec request body: a command-only call sends a non-empty body carrying sandboxId and command and omitting the optional fields, and supplying the optional fields includes them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bash sandbox tool so optional inputs no longer block the request body. Calls now POST JSON with `sandboxId` and `command`, preventing hangs and malformed JSON errors on /api/sandbox/exec.

- **Bug Fixes**
  - Replaced closure-based body builder with a module-level `lift` that treats `workingDirectory`, `timeout`, and `environment` as optional, so the body emits when `sandboxId` and `command` are present and only includes optionals when set.
  - Added a runner test (`packages/runner/test/bash-tool-request-body.test.ts`) that verifies command-only sends a non-empty body with `sandboxId` and `command`, and that provided optionals are included.

<sup>Written for commit ae2a86ce5d8f91c87d88120a3ef08314f3e05ff8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

