### PR TITLE
state-inspector M3: cf inspect + local-DB auto-discovery (usable surface)

### DIFF
--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -1,0 +1,314 @@
+// `cf inspect` — offline autopsy of local memory v2 space DBs.
+//
+// Thin CLI surface over @commonfabric/state-inspector. Reads the durable SQLite
+// store the server already wrote (no live runtime, no capture) and answers
+// who/what/when + cross-space convergence questions. Every command takes --json.
+//
+// Space DBs are auto-discovered (no need to pass absolute paths): pass a DID or
+// DID-prefix as <space>, or a file path. `cf inspect spaces` lists what's found.
+
+import { Command } from "@cliffy/command";
+import { Table } from "@cliffy/table";
+import {
+  annotate,
+  buildCrossSpaceLinkIndex,
+  type ConvergenceResult,
+  convergence,
+  convergenceScan,
+  discoverSpaceDbs,
+  entityHistory,
+  getValueAt,
+  hotEntities,
+  listCommits,
+  listSqliteFiles,
+  openSpace,
+  openSpaces,
+  quickStats,
+  resolveSpacePath,
+  type SpaceRef,
+  summarizeSpace,
+} from "@commonfabric/state-inspector";
+
+function humanSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)}K`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)}M`;
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(1)}G`;
+}
+
+function out(json: boolean, data: unknown, render: () => void): void {
+  if (json) console.log(JSON.stringify(data, null, 2));
+  else render();
+}
+
+function splitPath(p?: string): string[] {
+  return p ? p.split("/").filter(Boolean) : [];
+}
+
+// Resolve --all / --spaces / --dir into open spaces; caller must close them.
+function resolveMultiSpaces(opts: {
+  all?: boolean;
+  spaces?: string;
+  dir?: string;
+}): SpaceRef[] {
+  if (opts.dir) return openSpaces(listSqliteFiles(opts.dir));
+  if (opts.all) return openSpaces(discoverSpaceDbs().map((s) => s.path));
+  if (opts.spaces) {
+    const discovered = discoverSpaceDbs();
+    const paths = opts.spaces
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean)
+      .map((t) => resolveSpacePath(t, discovered));
+    return openSpaces(paths);
+  }
+  throw new Error("provide --all, --spaces <a,b,…>, or --dir <dir>");
+}
+
+function relTag(r: ConvergenceResult): string {
+  return r.relationship === "cross-space-linked"
+    ? "DRIFT"
+    : r.relationship === "no-cross-space-link"
+    ? "instance?"
+    : "?";
+}
+
+export const inspect = new Command()
+  .name("inspect")
+  .description(
+    "Offline autopsy of local memory v2 space DBs (state, history, convergence).",
+  )
+  .default("help")
+  .globalOption("--json", "Output machine-readable JSON.")
+  /* inspect spaces */
+  .command("spaces", "List discovered local space DBs with quick stats.")
+  .option("--dir <dir:string>", "Extra directory to search for *.sqlite files.")
+  .action((options) => {
+    const discovered = discoverSpaceDbs(
+      options.dir ? { dirs: [options.dir] } : {},
+    );
+    const rows = discovered.map((s) => {
+      const stats = quickStats(s.path);
+      return {
+        did: s.did,
+        path: s.path,
+        sizeBytes: s.sizeBytes,
+        commits: stats?.commits ?? null,
+        entities: stats?.entities ?? null,
+        lastActivity: stats?.lastActivity ?? null,
+      };
+    });
+    out(!!options.json, rows, () => {
+      if (rows.length === 0) {
+        console.log(
+          "no space DBs found (set MEMORY_DIR, pass --dir, or run from a repo with cache/memory/…).",
+        );
+        return;
+      }
+      console.log(
+        Table.from([
+          ["DID", "SIZE", "COMMITS", "ENTITIES", "LAST ACTIVITY"],
+          ...rows.map((r) => [
+            r.did,
+            humanSize(r.sizeBytes),
+            String(r.commits ?? "?"),
+            String(r.entities ?? "?"),
+            r.lastActivity ?? "?",
+          ]),
+        ]).toString(),
+      );
+    });
+  })
+  /* inspect summary */
+  .command("summary <space:string>", "Space overview: commits, sessions, hot ops.")
+  .action((options, space) => {
+    const s = openSpace(resolveSpacePath(space));
+    try {
+      const sum = summarizeSpace(s);
+      out(!!options.json, sum, () => {
+        console.log(`space: ${sum.path}`);
+        console.log(
+          `commits: ${sum.commits}` +
+            (sum.commitSeqRange
+              ? ` (seq ${sum.commitSeqRange[0]}–${sum.commitSeqRange[1]})`
+              : ""),
+        );
+        console.log(`sessions: ${sum.sessions}`);
+        console.log(`entities: ${sum.entities}  revisions: ${sum.revisions}`);
+        console.log(
+          `ops: ${Object.entries(sum.ops).map(([k, v]) => `${k}=${v}`).join(" ")}`,
+        );
+        console.log(
+          `branches: ${sum.branches.map((b) => `${b.name || "(default)"}@${b.head_seq}`).join(" ")}`,
+        );
+        console.log(`scheduler tables: ${sum.hasSchedulerTables ? "yes" : "no"}`);
+      });
+    } finally {
+      s.close();
+    }
+  })
+  /* inspect commits */
+  .command("commits <space:string>", "Recent commits (who committed, ops, reads).")
+  .option("--session <prefix:string>", "Filter by session id prefix.")
+  .option("--limit <n:number>", "Max rows.", { default: 50 })
+  .action((options, space) => {
+    const s = openSpace(resolveSpacePath(space));
+    try {
+      const rows = listCommits(s, { session: options.session, limit: options.limit });
+      out(!!options.json, rows, () => {
+        for (const r of rows) {
+          console.log(
+            `#${r.seq}\t${r.session.slice(0, 14)}\tlocal=${r.localSeq}\tops=${r.ops}\treads=${r.reads}\t${r.createdAt}`,
+          );
+        }
+      });
+    } finally {
+      s.close();
+    }
+  })
+  /* inspect hot */
+  .command("hot <space:string>", "Entities ranked by write count (contention proxy).")
+  .option("--limit <n:number>", "Max rows.", { default: 20 })
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .action((options, space) => {
+    const s = openSpace(resolveSpacePath(space));
+    try {
+      const rows = hotEntities(s, { limit: options.limit, branch: options.branch });
+      out(!!options.json, rows, () => {
+        for (const r of rows) {
+          console.log(`${r.writes}\twrites\t${r.sessions} sessions\t${r.id}\t(${r.scope})`);
+        }
+      });
+    } finally {
+      s.close();
+    }
+  })
+  /* inspect history */
+  .command("history <space:string> <entity:string>", "Every write that touched an entity.")
+  .option("--scope <scope:string>", "Scope key (default: space).")
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .option("--limit <n:number>", "Max rows.", { default: 200 })
+  .action((options, space, entity) => {
+    const s = openSpace(resolveSpacePath(space));
+    try {
+      const rows = entityHistory(s, {
+        id: entity,
+        scope: options.scope,
+        branch: options.branch,
+        limit: options.limit,
+      });
+      out(!!options.json, rows, () => {
+        for (const r of rows) {
+          console.log(
+            `seq=${r.seq}\tcommit=${r.commitSeq}\t${r.op}\t${r.session.slice(0, 14)}\tlocal=${r.localSeq}\t${r.createdAt}`,
+          );
+        }
+      });
+    } finally {
+      s.close();
+    }
+  })
+  /* inspect value-at */
+  .command(
+    "value-at <space:string> <entity:string>",
+    "Reconstructed value of an entity at a seq.",
+  )
+  .option("--seq <n:number>", "Reconstruct as of this commit seq (default: latest).")
+  .option("--path <path:string>", "Navigate into value, e.g. value/count.")
+  .option("--scope <scope:string>", "Scope key (default: space).")
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .option("--doc", "Show the whole document, not just value.")
+  .action((options, space, entity) => {
+    const s = openSpace(resolveSpacePath(space));
+    try {
+      const res = getValueAt(
+        s,
+        { id: entity, scope: options.scope, branch: options.branch, atSeq: options.seq },
+        splitPath(options.path),
+      );
+      const shown = options.doc ? res.document : res.value;
+      out(!!options.json, { exists: res.exists, value: annotate(shown) }, () => {
+        if (!res.exists) console.log("(absent at this seq)");
+        else if (shown === undefined) console.log("(entity present, but nothing at that path)");
+        else console.log(JSON.stringify(annotate(shown), null, 2));
+      });
+    } finally {
+      s.close();
+    }
+  })
+  /* inspect converge */
+  .command("converge <entity:string>", "Compare an entity's value across spaces.")
+  .option("--all", "Use all discovered spaces.")
+  .option("--spaces <list:string>", "Comma-separated DIDs/prefixes/paths.")
+  .option("--dir <dir:string>", "Directory of *.sqlite files.")
+  .option("--path <path:string>", "Navigate into value, e.g. value/count.")
+  .option("--scope <scope:string>", "Scope key (default: space).")
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .action((options, entity) => {
+    const refs = resolveMultiSpaces(options);
+    try {
+      const index = buildCrossSpaceLinkIndex(refs, {
+        scope: options.scope,
+        branch: options.branch,
+      });
+      const r = convergence(
+        refs,
+        { id: entity, scope: options.scope, branch: options.branch, path: splitPath(options.path) },
+        index,
+      );
+      out(!!options.json, r, () => {
+        console.log(
+          `verdict: ${r.verdict.toUpperCase()}` +
+            (r.relationship && r.relationship !== "n/a" ? `  [${r.relationship}]` : ""),
+        );
+        console.log(`entity:  ${r.id}` + (r.path.length ? `  path=/${r.path.join("/")}` : ""));
+        for (const v of r.views) {
+          if (!v.present) {
+            console.log(`  ${v.label}\tABSENT`);
+            continue;
+          }
+          const cluster = r.clusters.findIndex((c) => c.valueKey === v.valueKey) + 1;
+          console.log(
+            `  ${v.label}\thead=${v.headSeq}\trevs=${v.revisions}\tlast=${(v.lastSession ?? "?").slice(0, 14)}\tcluster#${cluster}`,
+          );
+        }
+        console.log(`note: ${r.caveat}`);
+      });
+    } finally {
+      for (const ref of refs) ref.space.close();
+    }
+  })
+  /* inspect converge-scan */
+  .command("converge-scan", "Find entities present in >=2 spaces that diverge.")
+  .option("--all", "Use all discovered spaces.")
+  .option("--spaces <list:string>", "Comma-separated DIDs/prefixes/paths.")
+  .option("--dir <dir:string>", "Directory of *.sqlite files.")
+  .option("--limit <n:number>", "Max findings.", { default: 50 })
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .action((options) => {
+    const refs = resolveMultiSpaces(options);
+    try {
+      const result = convergenceScan(refs, { limit: options.limit, branch: options.branch });
+      out(!!options.json, result, () => {
+        console.log(
+          `shared entities (in >=2 spaces): ${result.sharedEntities}  examined: ${result.examined}`,
+        );
+        console.log(
+          `cross-space link edges: ${result.crossSpaceLinkEdges}  ` +
+            `(${result.linkedFindings} real-drift / ${result.unlinkedFindings} likely-independent)`,
+        );
+        console.log(`findings (diverged/partial): ${result.findings.length}`);
+        for (const f of result.findings) {
+          const present = f.views.filter((v) => v.present).length;
+          const missing = f.views.length - present;
+          console.log(
+            `  ${f.verdict.toUpperCase()}\t${relTag(f)}\t${f.id}\tpresent=${present}` +
+              (missing ? `\tmissing=${missing}` : "") +
+              `\tclusters=${f.clusters.length}`,
+          );
+        }
+      });
+    } finally {
+      for (const ref of refs) ref.space.close();
+    }
+  });

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -6,6 +6,7 @@ import { deps } from "./deps.ts";
 import { exec } from "./exec.ts";
 import { fuse } from "./fuse.ts";
 import { init } from "./init.ts";
+import { inspect } from "./inspect.ts";
 import { piece } from "./piece.ts";
 import { identity } from "./identity.ts";
 import { test } from "./test.ts";
@@ -73,6 +74,8 @@ export const main = new Command()
   .command("check", check)
   .command("dev", dev)
   .command("deps", deps)
+  // @ts-ignore for the above type issue
+  .command("inspect", inspect)
   .command("exec", exec)
   // @ts-ignore for the above type issue
   .command("fuse", fuse)

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -8,10 +8,20 @@ recorder.** This package is the lens over it — open a space SQLite file
 read-only, reconstruct state-at-`(branch, seq)`, and answer who/what/when
 questions with no live runtime and no capture step.
 
-## Status: prototype (Milestones 1, 2, 2.5)
+## Status: usable (Milestones 1, 2, 2.5, 3)
 
-Tested against hermetic fixtures + real space DBs (a 571 MB legacy DB and a set
-of modern `fvj1:` DBs):
+Wired into the `cf` CLI as **`cf inspect`** with local-DB auto-discovery — no
+absolute paths needed. Tested end-to-end against real space DBs (a 571 MB legacy
+DB and a set of modern `fvj1:` DBs).
+
+**M3 — usable surface**
+- `cf inspect spaces` — discover local space DBs (walks up from cwd through
+  `cache/memory/…` and `packages/toolshed/cache/memory/…`, or honors
+  `MEMORY_DIR` / `DB_PATH` / `--dir`) and list them with quick stats.
+- All commands take a `<space>` as a **DID, DID-prefix, or path** (resolved via
+  discovery), so you go from `spaces` straight to drilling in.
+
+Underlying milestones: 
 
 **M1 — single-space autopsy core**
 - **read-only DB access** (`db.ts`)
@@ -81,26 +91,34 @@ The hermetic test guards `splice` + missing-key `add` against regressing to a fo
    replicas appear. (Verified: `converge-scan` over real `fvj1` DBs reports
    `0 cross-space link edges` and labels all 14 findings as instances.)
 
-## Usage
+## Usage (`cf inspect`)
+
+Run from a repo with local space DBs (discovery walks up to find the cache), or
+point at any directory with `--dir` / `MEMORY_DIR`. `<space>` is a DID, a unique
+DID-prefix, or a path.
 
 ```bash
-DIR=/abs/path/to/engine-v3   # a directory of <space-did>.sqlite files
-INSPECT="deno run --allow-read --allow-ffi --allow-env cli.ts"
+# discover what's inspectable
+deno task cf inspect spaces
 
-# single space
-$INSPECT summary  "$DIR/<did>.sqlite"
-$INSPECT hot      "$DIR/<did>.sqlite" --limit 10
-$INSPECT value-at "$DIR/<did>.sqlite" of:fid1:… --path value/count
+# single space (DID-prefix resolves via discovery)
+deno task cf inspect summary  z6Mkqa41
+deno task cf inspect hot      z6Mkqa41 --limit 10
+deno task cf inspect commits  z6Mkqa41 --limit 20
+deno task cf inspect history  z6Mkqa41 of:fid1:…
+deno task cf inspect value-at z6Mkqa41 of:fid1:… --path value/count
 
-# cross-space convergence
-$INSPECT converge      of:fid1:… --dir "$DIR" --path value
-$INSPECT converge-scan --dir "$DIR" --limit 20 --json
+# cross-space convergence (--all discovered, or --spaces a,b, or --dir)
+deno task cf inspect converge      of:fid1:… --all --path value
+deno task cf inspect converge-scan --all --json
 ```
+
+Every command also accepts `--json` for agents. (A standalone `cli.ts` entry
+exists for use outside the `cf` CLI.)
 
 ## Not yet built (next milestones)
 
 - `ifc` / security-label decoding from stored schemas.
 - Snapshot-base optimization for reconstruction (currently replays from seq 0).
-- Wiring into `cf inspect` as a first-class subcommand.
 - Client-side correlation overlay (connectionId / eventId) for the per-session
   view dimension of convergence.

--- a/packages/state-inspector/discover.ts
+++ b/packages/state-inspector/discover.ts
@@ -1,0 +1,155 @@
+// Local space-DB discovery — so callers never have to hand-feed absolute
+// sqlite paths. Finds memory v2 space DBs from env overrides and from the known
+// on-disk cache layouts, walking up from the working directory.
+//
+// On-disk layout (verified): `<root>/{packages/toolshed/,}cache/memory/engine-v3/
+// engine-v3/<did>.sqlite`. The engine-v3 segment is sometimes doubled, so we
+// walk a bounded depth under each cache base rather than assume a fixed path.
+
+import { openSpace } from "./db.ts";
+
+export interface DiscoveredSpace {
+  /** Space DID (DB file basename without `.sqlite`). */
+  did: string;
+  path: string;
+  sizeBytes: number;
+  mtimeMs: number;
+}
+
+function basename(p: string): string {
+  return p.split("/").pop() ?? p;
+}
+function dirname(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i <= 0 ? "" : p.slice(0, i);
+}
+
+function* walkSqlite(dir: string, depth: number): Generator<string> {
+  let entries: Deno.DirEntry[];
+  try {
+    entries = [...Deno.readDirSync(dir)];
+  } catch {
+    return; // missing/unreadable dir
+  }
+  for (const e of entries) {
+    const full = `${dir}/${e.name}`;
+    if (e.isFile && e.name.endsWith(".sqlite")) yield full;
+    else if (e.isDirectory && depth > 0) yield* walkSqlite(full, depth - 1);
+  }
+}
+
+/** Candidate cache directories to search, in priority order. */
+export function candidateRoots(cwd: string = Deno.cwd()): string[] {
+  const roots: string[] = [];
+  const env = Deno.env.get("MEMORY_DIR");
+  if (env) roots.push(env);
+  const dbPath = Deno.env.get("DB_PATH");
+  if (dbPath) roots.push(dbPath.endsWith(".sqlite") ? dirname(dbPath) : dbPath);
+  // Walk up from cwd; check both cache layouts at each level.
+  let dir = cwd;
+  for (let i = 0; i < 8; i++) {
+    roots.push(`${dir}/packages/toolshed/cache/memory`);
+    roots.push(`${dir}/cache/memory`);
+    const parent = dirname(dir);
+    if (!parent || parent === dir) break;
+    dir = parent;
+  }
+  return roots;
+}
+
+/** Discover local space DBs. `dirs` are searched before the default roots. */
+export function discoverSpaceDbs(
+  opts: { dirs?: string[]; cwd?: string } = {},
+): DiscoveredSpace[] {
+  const roots = [...(opts.dirs ?? []), ...candidateRoots(opts.cwd)];
+  const seen = new Set<string>();
+  const out: DiscoveredSpace[] = [];
+  for (const root of roots) {
+    for (const path of walkSqlite(root, 4)) {
+      let real: string;
+      try {
+        real = Deno.realPathSync(path);
+      } catch {
+        real = path;
+      }
+      if (seen.has(real)) continue;
+      seen.add(real);
+      let stat: Deno.FileInfo;
+      try {
+        stat = Deno.statSync(path);
+      } catch {
+        continue;
+      }
+      out.push({
+        did: basename(path).replace(/\.sqlite$/, ""),
+        path,
+        sizeBytes: stat.size,
+        mtimeMs: stat.mtime?.getTime() ?? 0,
+      });
+    }
+  }
+  out.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return out;
+}
+
+/**
+ * Resolve a space token (a DID / DID-prefix, or a path) to a DB file path.
+ * Paths win if they exist; otherwise the token is matched against discovered
+ * DIDs (exact, then substring). Throws on no/ambiguous match.
+ */
+export function resolveSpacePath(
+  token: string,
+  discovered?: DiscoveredSpace[],
+): string {
+  if (token.endsWith(".sqlite") || token.includes("/")) {
+    try {
+      Deno.statSync(token);
+      return token;
+    } catch {
+      // not a real path — fall through to DID matching
+    }
+  }
+  const spaces = discovered ?? discoverSpaceDbs();
+  const exact = spaces.filter((s) => s.did === token);
+  const matches = exact.length ? exact : spaces.filter((s) => s.did.includes(token));
+  if (matches.length === 1) return matches[0].path;
+  if (matches.length === 0) {
+    throw new Error(`no space matches "${token}" (run: inspect spaces)`);
+  }
+  throw new Error(
+    `"${token}" is ambiguous (${matches.length} matches); use a longer prefix or a path`,
+  );
+}
+
+export interface SpaceQuickStats {
+  commits: number;
+  entities: number;
+  lastActivity: string | null;
+}
+
+/** Cheap one-query stats for listing many DBs without a full summary. */
+export function quickStats(path: string): SpaceQuickStats | null {
+  let space;
+  try {
+    space = openSpace(path);
+  } catch {
+    return null;
+  }
+  try {
+    const row = space.db
+      .prepare(
+        `SELECT
+           (SELECT count(*) FROM "commit") AS commits,
+           (SELECT count(DISTINCT id) FROM revision) AS entities,
+           (SELECT max(created_at) FROM "commit") AS lastActivity`,
+      )
+      .get<{ commits: number; entities: number; lastActivity: string | null }>();
+    return row
+      ? { commits: row.commits, entities: row.entities, lastActivity: row.lastActivity }
+      : null;
+  } catch {
+    return null; // not a memory v2 space DB
+  } finally {
+    space.close();
+  }
+}

--- a/packages/state-inspector/mod.ts
+++ b/packages/state-inspector/mod.ts
@@ -10,3 +10,4 @@ export * from "./decode.ts";
 export * from "./reconstruct.ts";
 export * from "./queries.ts";
 export * from "./multispace.ts";
+export * from "./discover.ts";

--- a/packages/state-inspector/test/discover.test.ts
+++ b/packages/state-inspector/test/discover.test.ts
@@ -1,0 +1,88 @@
+// Hermetic test for local DB discovery + space resolution. Builds a fake
+// engine-v3 cache layout in a temp dir and checks discovery, DID resolution,
+// and quick stats. Side-effect free.
+
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { Database } from "@db/sqlite";
+
+import { discoverSpaceDbs, quickStats, resolveSpacePath } from "../discover.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+`;
+
+function makeSpace(path: string, entityCount: number) {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  for (let i = 0; i < entityCount; i++) {
+    db.prepare(
+      `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution, created_at)
+       VALUES (?, 's', 1, '{}', '{}', '2026-06-2${i}')`,
+    ).run(i + 1);
+    db.prepare(
+      `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+       VALUES (?, ?, 0, 'set', '{"value":1}', ?)`,
+    ).run(`of:e${i}`, i + 1, i + 1);
+  }
+  db.close();
+}
+
+const DID_1 = "did:key:zAlphaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const DID_2 = "did:key:zBetaBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+Deno.test("discovery + resolution", async (t) => {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-discover-" });
+  try {
+    // Mimic the doubled engine-v3 cache layout under a "cache/memory" base.
+    const engine = `${dir}/cache/memory/engine-v3/engine-v3`;
+    await Deno.mkdir(engine, { recursive: true });
+    makeSpace(`${engine}/${DID_1}.sqlite`, 2);
+    makeSpace(`${engine}/${DID_2}.sqlite`, 3);
+    // A non-sqlite sibling and a WAL file should be ignored.
+    await Deno.writeTextFile(`${engine}/notes.txt`, "ignore me");
+    await Deno.writeTextFile(`${engine}/${DID_1}.sqlite-wal`, "");
+
+    await t.step("discovers both DBs by walking the cache base", () => {
+      const found = discoverSpaceDbs({ dirs: [`${dir}/cache/memory`] });
+      assertEquals(found.length, 2);
+      assertEquals(new Set(found.map((s) => s.did)), new Set([DID_1, DID_2]));
+      assert(found.every((s) => s.sizeBytes > 0));
+    });
+
+    await t.step("resolveSpacePath matches by DID prefix", () => {
+      const found = discoverSpaceDbs({ dirs: [`${dir}/cache/memory`] });
+      const path = resolveSpacePath("zAlpha", found);
+      assert(path.endsWith(`${DID_1}.sqlite`));
+    });
+
+    await t.step("resolveSpacePath accepts an explicit path", () => {
+      const p = `${engine}/${DID_2}.sqlite`;
+      assertEquals(resolveSpacePath(p), p);
+    });
+
+    await t.step("ambiguous prefix throws", () => {
+      const found = discoverSpaceDbs({ dirs: [`${dir}/cache/memory`] });
+      assertThrows(() => resolveSpacePath("did:key:z", found), Error, "ambiguous");
+    });
+
+    await t.step("quickStats returns counts", () => {
+      const stats = quickStats(`${engine}/${DID_2}.sqlite`);
+      assertEquals(stats?.commits, 3);
+      assertEquals(stats?.entities, 3);
+    });
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
Stacked on #4377 (M2.5). **Base is `state-inspector-replica-classification`**, so the diff is M3-only.

## This is the rung that makes it usable

Until now it was a library + a dev script that needed absolute sqlite paths. M3 turns it into a command you run:

```
$ deno task cf inspect spaces
DID                                                      SIZE COMMITS ENTITIES LAST ACTIVITY
did:key:z6Mkqa41…                                        2.1M 73      89       2026-05-25 06:27:25
…

$ deno task cf inspect summary z6Mkqa41        # DID-prefix resolves via discovery
commits: 73 (seq 1–73)   sessions: 5   entities: 89 …

$ deno task cf inspect converge-scan --all
cross-space link edges: 0  (0 real-drift / N likely-independent)
…
```

## What's in it

- **`discover.ts`** — `discoverSpaceDbs()` walks up from cwd through `cache/memory/…` and `packages/toolshed/cache/memory/…` (and honors `MEMORY_DIR` / `DB_PATH` / explicit `--dir`), returning local space DBs newest-first. `resolveSpacePath()` matches a **DID / DID-prefix / path**. `quickStats()` gives cheap per-DB counts for the listing.
- **`packages/cli/commands/inspect.ts`** — `cf inspect` command group: `spaces`, `summary`, `commits`, `hot`, `history`, `value-at`, `converge`, `converge-scan`. Every command takes `--json`. Registered in `commands/main.ts`.
- The `cf` launcher already grants `--allow-ffi`, so sqlite works with **no permission changes**.
- Hermetic discovery test (cache-layout walk, DID-prefix resolution, ambiguity error, quick stats).

## Verified end-to-end through the real `cf` CLI

Against live `fvj1` DBs: `cf inspect spaces` lists them with stats; `summary z6Mkqa41` resolves a DID prefix; `converge-scan --dir` classifies drift vs instance; `value-at` reconstructs and decodes `fvj1` with `$link`s. `deno check` / `deno lint` / `deno task test` green (state-inspector: 4 test files, 22 steps; cli typechecks). No new deps, no lock change.

## Note for reviewers / merging

Single-space commands (`summary`, `value-at`, …) resolve `<space>` via discovery, so they shine when run from a repo root where the cache is discoverable (real usage). A full path always works too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `cf inspect` with local SQLite space DB auto-discovery, turning `@commonfabric/state-inspector` into a usable CLI for offline state inspection and convergence analysis. No absolute paths or permission changes needed.

- **New Features**
  - New `cf inspect` command group: `spaces`, `summary`, `commits`, `hot`, `history`, `value-at`, `converge`, `converge-scan` (all support `--json`).
  - Auto-discovery: `discoverSpaceDbs()` walks `cache/memory/...` and `packages/toolshed/cache/memory/...`, honoring `MEMORY_DIR`, `DB_PATH`, and `--dir`; `resolveSpacePath()` accepts DID/DID-prefix/path; `quickStats()` for fast listing.
  - Convergence tools: `converge` compares values across spaces; `converge-scan` finds divergent entities and labels drift vs likely-independent instances.
  - Wired into the CLI (`inspect` registered). No new deps; sqlite works with existing `cf` launcher flags.
  - Added hermetic tests for discovery, DID-prefix resolution, ambiguity, and quick stats.

<sup>Written for commit 5e51d2af8e5c626c18fac8fd53c87826b3b461d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

