### PR TITLE
Fix inaccurate comments about build SHA usage in toolshed build-info

### DIFF
--- a/packages/toolshed/lib/build-info.ts
+++ b/packages/toolshed/lib/build-info.ts
@@ -2,8 +2,7 @@
 //
 // `tasks/build-binaries.ts` writes `packages/toolshed/COMPILED` and includes
 // it in the binary via `deno compile --include`. At runtime we read it
-// (synchronously, once) to surface the deployed commit on `/api/meta` and to
-// fingerprint the server-side compilation cache.
+// (synchronously, once) to surface the deployed commit on `/api/meta`.
 //
 // In non-compiled runs (e.g. `deno task production` from a checkout) the
 // file does not exist and `commitSha` is null — `resolveGitSha()` then
@@ -61,17 +60,15 @@ export function resolveGitShaFrom(
 }
 
 /**
- * Canonical git SHA for this server. Used by both `/api/meta` (to surface
- * the deployed commit) and `index.ts` (to fingerprint the compilation
- * cache), so the two stay in lockstep.
+ * Canonical git SHA for this server, surfaced on `/api/meta` to report
+ * the deployed commit.
  *
  * Precedence:
  *   1. `TOOLSHED_GIT_SHA` env var — operator attestation, useful for
  *      hot-patched binaries where you want to declare a different commit
  *      than what was compiled.
  *   2. SHA baked into the binary at build time (read above).
- *   3. `null` — caller decides what to do (the cache falls back to live
- *      git detection; `/api/meta` reports null).
+ *   3. `null` — `/api/meta` reports null.
  *
  * Empty / whitespace-only values at any level are treated as unset.
  */


### PR DESCRIPTION
The comments in `packages/toolshed/lib/build-info.ts` claimed the baked git SHA was used to fingerprint the server-side compilation cache. That is not true: the compile cache's version axis is keyed independently and does not consume `resolveGitSha()` or `buildInfo.commitSha`. The only consumer of `resolveGitSha()` is the `/api/meta` route handler, which surfaces the deployed commit.

This updates three comments to describe the real behavior:

- The file-header comment no longer claims the value is read to fingerprint the compilation cache; it is read only to surface the deployed commit on `/api/meta`.
- The `resolveGitSha()` JSDoc summary drops the `index.ts`/compilation-cache consumer and the "so the two stay in lockstep" clause that depended on it.
- The precedence note for the `null` case no longer mentions the cache falling back to live git detection, since no cache caller exists; it now states only that `/api/meta` reports null.

No code or behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inaccurate comments in `packages/toolshed/lib/build-info.ts` about baked git SHA usage; only `/api/meta` reads it, not the compilation cache. No behavior changes.

- **Refactors**
  - File header: remove cache fingerprint claim.
  - `resolveGitSha()` JSDoc: drop `index.ts`/cache references and the lockstep note.
  - Null precedence: say only `/api/meta` reports null; remove cache fallback note.

<sup>Written for commit 875a2cbb00e588f6b345d83f009e648a1369bc83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

