### PR TITLE
fix(ts-transformers): propagate optionality of destructured captures (CT-1800)

### DIFF
--- a/packages/ts-transformers/src/ast/type-building.ts
+++ b/packages/ts-transformers/src/ast/type-building.ts
@@ -763,6 +763,52 @@ export function buildTypeElementsFromCaptureTree(
         ) {
           questionToken = factory.createToken(ts.SyntaxKind.QuestionToken);
         }
+      } else if (
+        ts.isIdentifier(childNode.expression) &&
+        childNode.expression.getSourceFile()
+      ) {
+        // A bare-identifier capture (e.g. a field destructured from the
+        // pattern's typed parameter). Determine optionality the standard-TS way
+        // — the `?` flag on the SOURCE PROPERTY of the destructured aggregate,
+        // mirroring the intermediate-node branch below. The capture's own symbol
+        // doesn't carry it: a `{ x }` shorthand resolves to a value symbol, and
+        // the destructured binding element doesn't inherit `SymbolFlags.Optional`
+        // from the aggregate's property. So resolve to the binding element, then
+        // read the aggregate property's flag. A field declared `x?: T` is
+        // optional; `x: T | undefined` (no `?`) stays required (a required key
+        // whose value may be undefined), faithful to TS.
+        let symbol = checker.getSymbolAtLocation(childNode.expression);
+        if (
+          symbol?.valueDeclaration &&
+          ts.isShorthandPropertyAssignment(symbol.valueDeclaration)
+        ) {
+          symbol = checker.getShorthandAssignmentValueSymbol(
+            symbol.valueDeclaration,
+          ) ??
+            symbol;
+        }
+        const binding = symbol?.valueDeclaration;
+        if (
+          binding && ts.isBindingElement(binding) &&
+          ts.isObjectBindingPattern(binding.parent)
+        ) {
+          const host = binding.parent.parent;
+          const aggregateType = ts.isParameter(host)
+            ? checker.getTypeAtLocation(host)
+            : ts.isVariableDeclaration(host) && host.initializer
+            ? checker.getTypeAtLocation(host.initializer)
+            : undefined;
+          // For a renamed binding (`{ source: local }`) the optionality lives on
+          // the SOURCE property, not the local capture name.
+          const sourceName =
+            binding.propertyName && ts.isIdentifier(binding.propertyName)
+              ? binding.propertyName.text
+              : propName;
+          const sourceProp = aggregateType?.getProperty(sourceName);
+          if (sourceProp && isOptionalSymbol(sourceProp)) {
+            questionToken = factory.createToken(ts.SyntaxKind.QuestionToken);
+          }
+        }
       }
     } else {
       // Intermediate node - need to get type to check optionality. Every node
@@ -780,8 +826,9 @@ export function buildTypeElementsFromCaptureTree(
           // Get Type for this property to pass to children
           currentType = checker.getTypeOfSymbol(propSymbol);
 
-          // Check optionality using centralized logic
-          // This checks both `?` flag AND `T | undefined` union
+          // Check optionality from the source property's `?` flag
+          // (SymbolFlags.Optional). This is the standard-TS distinction:
+          // `x?: T` is optional; `x: T | undefined` (no `?`) stays required.
           if (isOptionalSymbol(propSymbol)) {
             questionToken = factory.createToken(ts.SyntaxKind.QuestionToken);
           }

--- a/packages/ts-transformers/src/ast/type-building.ts
+++ b/packages/ts-transformers/src/ast/type-building.ts
@@ -799,11 +799,16 @@ export function buildTypeElementsFromCaptureTree(
             ? checker.getTypeAtLocation(host.initializer)
             : undefined;
           // For a renamed binding (`{ source: local }`) the optionality lives on
-          // the SOURCE property, not the local capture name.
-          const sourceName =
-            binding.propertyName && ts.isIdentifier(binding.propertyName)
-              ? binding.propertyName.text
-              : propName;
+          // the SOURCE property, not the local capture name. The source key may
+          // be an identifier, string, or numeric literal (`{ "k": local }`,
+          // `{ 0: local }`); computed keys (`{ [expr]: local }`) aren't
+          // statically resolvable and fall back to the local name.
+          const sourceName = binding.propertyName &&
+              (ts.isIdentifier(binding.propertyName) ||
+                ts.isStringLiteralLike(binding.propertyName) ||
+                ts.isNumericLiteral(binding.propertyName))
+            ? binding.propertyName.text
+            : propName;
           const sourceProp = aggregateType?.getProperty(sourceName);
           if (sourceProp && isOptionalSymbol(sourceProp)) {
             questionToken = factory.createToken(ts.SyntaxKind.QuestionToken);

--- a/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.expected.jsx
@@ -28,17 +28,19 @@ const __cfLift_1 = __cfHelpers.lift<{
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
-    result: any;
+    result?: any;
 }, any>(({ result }) => result?.title ?? "Untitled", {
     type: "object",
     properties: {
         result: true
-    },
-    required: ["result"]
+    }
 } as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-opaque-destructure-temporary-root-names
 // Verifies: destructured opaque temporaries preserve generated root suffixes
 //   const { result } = generateObject(...) uses the synthesized __cf_destructure_* binding consistently
+// NOTE (CT-1800): generateObject's `result` is declared optional, so the captured
+//   `result` is emitted optional (absent from `required`). The lift therefore
+//   fires while pending, keeping the `?? "Untitled"` fallback live.
 export default pattern((__cf_pattern_input) => {
     const messages = __cf_pattern_input.key("messages");
     const preview = __cfLift_1({ messages: messages }).for("preview", true);

--- a/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.input.tsx
@@ -3,6 +3,9 @@ import { computed, generateObject, pattern } from "commonfabric";
 // FIXTURE: pattern-opaque-destructure-temporary-root-names
 // Verifies: destructured opaque temporaries preserve generated root suffixes
 //   const { result } = generateObject(...) uses the synthesized __cf_destructure_* binding consistently
+// NOTE (CT-1800): generateObject's `result` is declared optional, so the captured
+//   `result` is emitted optional (absent from `required`). The lift therefore
+//   fires while pending, keeping the `?? "Untitled"` fallback live.
 export default pattern<{ messages: string[] }>(({ messages }) => {
   const preview = computed(() => messages[0] ?? "");
   const { result } = generateObject({

--- a/packages/ts-transformers/test/fixtures/closures/pattern-optional-destructured-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-optional-destructured-capture.expected.jsx
@@ -1,0 +1,119 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { computed, pattern } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+const __cfLift_1 = __cfHelpers.lift<{
+    req: string;
+    opt?: string;
+    ud: string;
+    renamed?: string;
+}, { renamed?: string | undefined; ud?: string | undefined; opt?: string | undefined; req: string; }>(({ req, opt, ud, renamed }) => ({
+    req: req,
+    ...(opt !== undefined && { opt: opt }),
+    ...(ud !== undefined && { ud: ud }),
+    ...(renamed !== undefined && { renamed: renamed }),
+}), {
+    type: "object",
+    properties: {
+        req: {
+            type: "string"
+        },
+        opt: {
+            type: "string"
+        },
+        ud: {
+            type: "string"
+        },
+        renamed: {
+            type: "string"
+        }
+    },
+    required: ["req", "ud"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        renamed: {
+            type: "string"
+        },
+        ud: {
+            type: "string"
+        },
+        opt: {
+            type: "string"
+        },
+        req: {
+            type: "string"
+        }
+    },
+    required: ["req"]
+} as const satisfies __cfHelpers.JSONSchema);
+// FIXTURE: pattern-optional-destructured-capture
+// Verifies: an optional pattern input (`opt?`) destructured and captured in a
+//   closure is emitted optional in the derived lift's input schema (so it does
+//   not gate the lift), while `ud: T | undefined` (no `?`) stays required, and a
+//   renamed binding (`ren: renamed`) tracks its source property's optionality.
+export default pattern((__cf_pattern_input) => {
+    const req = __cf_pattern_input.key("req");
+    const opt = __cf_pattern_input.key("opt");
+    const ud = __cf_pattern_input.key("ud");
+    const renamed = __cf_pattern_input.key("ren");
+    const body = __cfLift_1({
+        req: req,
+        opt: opt,
+        ud: ud,
+        renamed: renamed
+    }).for("body", true);
+    return <div>{body}</div>;
+}, {
+    type: "object",
+    properties: {
+        req: {
+            type: "string"
+        },
+        opt: {
+            type: "string"
+        },
+        ud: {
+            type: ["string", "undefined"]
+        },
+        ren: {
+            type: "string"
+        }
+    },
+    required: ["req", "ud"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/pattern-optional-destructured-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-optional-destructured-capture.expected.jsx
@@ -16,11 +16,13 @@ const __cfLift_1 = __cfHelpers.lift<{
     opt?: string;
     ud: string;
     renamed?: string;
-}, { renamed?: string | undefined; ud?: string | undefined; opt?: string | undefined; req: string; }>(({ req, opt, ud, renamed }) => ({
+    qOpt?: string;
+}, { qOpt?: string | undefined; renamed?: string | undefined; ud?: string | undefined; opt?: string | undefined; req: string; }>(({ req, opt, ud, renamed, qOpt }) => ({
     req: req,
     ...(opt !== undefined && { opt: opt }),
     ...(ud !== undefined && { ud: ud }),
     ...(renamed !== undefined && { renamed: renamed }),
+    ...(qOpt !== undefined && { qOpt: qOpt }),
 }), {
     type: "object",
     properties: {
@@ -35,12 +37,18 @@ const __cfLift_1 = __cfHelpers.lift<{
         },
         renamed: {
             type: "string"
+        },
+        qOpt: {
+            type: "string"
         }
     },
     required: ["req", "ud"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
+        qOpt: {
+            type: "string"
+        },
         renamed: {
             type: "string"
         },
@@ -59,18 +67,21 @@ const __cfLift_1 = __cfHelpers.lift<{
 // FIXTURE: pattern-optional-destructured-capture
 // Verifies: an optional pattern input (`opt?`) destructured and captured in a
 //   closure is emitted optional in the derived lift's input schema (so it does
-//   not gate the lift), while `ud: T | undefined` (no `?`) stays required, and a
-//   renamed binding (`ren: renamed`) tracks its source property's optionality.
+//   not gate the lift), while `ud: T | undefined` (no `?`) stays required. A
+//   renamed binding tracks its source property's optionality whether the source
+//   key is an identifier (`ren: renamed`) or a string literal (`"q-opt": qOpt`).
 export default pattern((__cf_pattern_input) => {
     const req = __cf_pattern_input.key("req");
     const opt = __cf_pattern_input.key("opt");
     const ud = __cf_pattern_input.key("ud");
     const renamed = __cf_pattern_input.key("ren");
+    const qOpt = __cf_pattern_input.key("q-opt");
     const body = __cfLift_1({
         req: req,
         opt: opt,
         ud: ud,
-        renamed: renamed
+        renamed: renamed,
+        qOpt: qOpt
     }).for("body", true);
     return <div>{body}</div>;
 }, {
@@ -86,6 +97,9 @@ export default pattern((__cf_pattern_input) => {
             type: ["string", "undefined"]
         },
         ren: {
+            type: "string"
+        },
+        "q-opt": {
             type: "string"
         }
     },

--- a/packages/ts-transformers/test/fixtures/closures/pattern-optional-destructured-capture.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-optional-destructured-capture.input.tsx
@@ -1,0 +1,21 @@
+import { computed, pattern } from "commonfabric";
+
+// FIXTURE: pattern-optional-destructured-capture
+// Verifies: an optional pattern input (`opt?`) destructured and captured in a
+//   closure is emitted optional in the derived lift's input schema (so it does
+//   not gate the lift), while `ud: T | undefined` (no `?`) stays required, and a
+//   renamed binding (`ren: renamed`) tracks its source property's optionality.
+export default pattern<{
+  req: string;
+  opt?: string;
+  ud: string | undefined;
+  ren?: string;
+}>(({ req, opt, ud, ren: renamed }) => {
+  const body = computed(() => ({
+    req,
+    ...(opt !== undefined && { opt }),
+    ...(ud !== undefined && { ud }),
+    ...(renamed !== undefined && { renamed }),
+  }));
+  return <div>{body}</div>;
+});

--- a/packages/ts-transformers/test/fixtures/closures/pattern-optional-destructured-capture.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-optional-destructured-capture.input.tsx
@@ -3,19 +3,22 @@ import { computed, pattern } from "commonfabric";
 // FIXTURE: pattern-optional-destructured-capture
 // Verifies: an optional pattern input (`opt?`) destructured and captured in a
 //   closure is emitted optional in the derived lift's input schema (so it does
-//   not gate the lift), while `ud: T | undefined` (no `?`) stays required, and a
-//   renamed binding (`ren: renamed`) tracks its source property's optionality.
+//   not gate the lift), while `ud: T | undefined` (no `?`) stays required. A
+//   renamed binding tracks its source property's optionality whether the source
+//   key is an identifier (`ren: renamed`) or a string literal (`"q-opt": qOpt`).
 export default pattern<{
   req: string;
   opt?: string;
   ud: string | undefined;
   ren?: string;
-}>(({ req, opt, ud, ren: renamed }) => {
+  "q-opt"?: string;
+}>(({ req, opt, ud, ren: renamed, "q-opt": qOpt }) => {
   const body = computed(() => ({
     req,
     ...(opt !== undefined && { opt }),
     ...(ud !== undefined && { ud }),
     ...(renamed !== undefined && { renamed }),
+    ...(qOpt !== undefined && { qOpt }),
   }));
   return <div>{body}</div>;
 });


### PR DESCRIPTION
## Summary

An **optional** pattern input (`field?: T`) destructured and captured in a closure (`computed`/`lift`-applied) was emitted as a **required** field in the derived lift's input schema. The runner only runs a lift once every required input is present, so when the optional field was absent the lift never fired — the reactive node hung. This is the transformer root cause behind the bash-tool empty-body bug worked around in #4385 (the closure→module-lift rewrite); it affects any pattern that conditionally builds a value from optional inputs.

Resolves [CT-1800](https://linear.app/common-tools/issue/CT-1800).

## Root cause

`buildTypeElementsFromCaptureTree` (`packages/ts-transformers/src/ast/type-building.ts`) only set the optional `?` token for `PropertyAccessExpression` captures (via `isOptionalMemberSymbol`); a **bare-identifier** capture (a destructured pattern field) was never checked, so it defaulted to required.

Reading the optionality back is subtle (found by instrumenting the transformer, not by reasoning):
- The capture's use-site type is **flow-narrowed** — captures sit inside an `x !== undefined && { x }` guard, so the use-site type is `T`, not `T | undefined`.
- `getSymbolAtLocation` lands on a **`ShorthandPropertyAssignment`** symbol (`{ x }`).
- The resolved **binding element** does **not** carry `SymbolFlags.Optional` (the pattern parameter type is inferred from `pattern<In>`, not annotated on the binding).
- The `?` flag is reliable only on the **source property** of the destructured aggregate — exactly what the intermediate-node branch already reads.

## Fix

Mirror the intermediate-node branch: resolve a shorthand capture to its value symbol, then read the `?` flag from the source property of the destructured aggregate (handling renamed bindings via `propertyName`). **Purely flag-based, faithful to TS** — `field?: T` is optional; `field: T | undefined` (no `?`) stays **required**. Covers destructured parameters and `const {…} = init`; nested/array/rest fall back conservatively to required. Also corrects the inaccurate `isOptionalSymbol` comment (it is flag-only, not union-aware).

## Blast radius (deliberate)

This propagates TS optionality for **every** destructured optional capture, notably `generateObject`/`generateText` `result` (declared `result?`). One golden changes — `closures/pattern-opaque-destructure-temporary-root-names`: a `result?.title ?? "Untitled"` capture was emitted required, so the `?? "Untitled"` pending-fallback was **dead** (the lift never fired until `result` arrived). It now fires while pending → "Untitled" → title on arrival. The golden was encoding the bug and is updated (with a note).

## Tests

- New `closures/pattern-optional-destructured-capture` fixture locks four behaviors: `req` required, `opt?` optional, `ud: T | undefined` required, renamed `ren: renamed` optional.
- Full `ts-transformers` suite green locally (336 tests / 684 steps; fixtures 360 steps).
- The `generateObject` blast radius reaches all consumers, so the **pattern unit + integration suites validate it here in CI** (impractical to run fully locally).

## Relationship to #4385

#4385 (bash tool) works around this transformer bug at the pattern level (closure → module-level `lift`). With this fix that workaround is no longer necessary, though it remains correct and harmless. Worth a note to @Hixie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes propagation of optionality for destructured pattern inputs captured in closures so derived lifts don’t require optional fields and reactive nodes fire correctly. Resolves CT-1800 by aligning generated input schemas with TS `?` semantics, including renamed keys with quoted/numeric names.

- **Bug Fixes**
  - Read optionality from the source property of the destructured aggregate for bare-identifier captures, including `{ source: local }` and string/numeric literal keys; mirrors the intermediate-node logic.
  - Preserve TS behavior: `field?: T` is optional; `field: T | undefined` (no `?`) stays required. Applies to destructured params and `const { … } = init`.
  - `generateObject`/`generateText` `result` captures are now optional; updates `pattern-opaque-destructure-temporary-root-names` so the `?? "Untitled"` fallback runs while pending. Adds `pattern-optional-destructured-capture` fixture (req/opt/`T | undefined`/renamed/quoted-key) and corrects the `isOptionalSymbol` comment.

<sup>Written for commit 757d0a3f4c207c9d577d4d152e0c09a6bd69e862. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

