### PR TITLE
fix(runner): complete S16 filter/flatMap over-taint fix (input read + container reads + structure re-stamp)

### DIFF
--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -39,6 +39,7 @@ import {
 import { resolveOpPattern } from "./op-pattern-ref.ts";
 import { createResumeRepublisher } from "./resume-republish.ts";
 import { createResumeRecovery } from "./resume-recover.ts";
+import { linkResolutionProbe } from "../storage/reactivity-log.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 
 const logger = getLogger("runner.filter", { enabled: true, level: "warn" });
@@ -128,7 +129,12 @@ export function filter(
             if (
               list === undefined || (Array.isArray(list) && list.length === 0)
             ) {
-              result.asSchema(RESULT_PRESENCE_SCHEMA).withTx(settleTx).set([]);
+              settleTx.runWithAmbientReadMeta(
+                linkResolutionProbe,
+                () =>
+                  result!.asSchema(RESULT_PRESENCE_SCHEMA).withTx(settleTx)
+                    .set([]),
+              );
             }
           }).then(({ error }) => {
             if (error) {
@@ -202,6 +208,15 @@ export function filter(
     // every element's taint into the coordinator's per-tx join.
     const resultWithLog = result.asSchema(RESULT_PRESENCE_SCHEMA)
       .withTx(tx);
+    // Container reads/writes run under the link-resolution-probe scope (S16):
+    // the presence probe and set() diffing materialize prior slots for identity
+    // comparison only — per-slot labels ride the link-write machinery, not these
+    // reads. See map.ts. Without it the asCell slot dereference journals a
+    // content read of every prior element, smearing element taint into the
+    // coordinator's per-tx join. The predicate read below stays unprobed: filter
+    // membership genuinely depends on it (D4: "predicate results it read carry").
+    const probeScoped = <T>(fn: () => T): T =>
+      tx.runWithAmbientReadMeta(linkResolutionProbe, fn);
     const createRunInput = (element: Cell<any>, index: number) => ({
       ...(argumentUsage.usesElement ? { element } : {}),
       ...(argumentUsage.usesIndex ? { index } : {}),
@@ -216,7 +231,10 @@ export function filter(
     // against the same absent value until it happens to sync. Pull the
     // container and defer; its arrival re-triggers this reconcile, which then
     // no-ops against the durable value.
-    if (elementAwaitSync && resultWithLog.get() === undefined) {
+    if (
+      elementAwaitSync &&
+      probeScoped(() => resultWithLog.get()) === undefined
+    ) {
       const pending = result.sync();
       // The container's durable value is still streaming in; its arrival
       // re-triggers this reconcile (the read above is journaled). If the
@@ -248,7 +266,7 @@ export function filter(
     // The durable aggregate currently in the container, read links-only
     // (presence schema), so this is a length comparison rather than a content
     // read of every element.
-    const priorSlots = resultWithLog.get();
+    const priorSlots = probeScoped(() => resultWithLog.get());
     const priorLen = Array.isArray(priorSlots) ? priorSlots.length : 0;
 
     // Resume preservation: on a resume reconcile the input list itself may not be
@@ -271,10 +289,10 @@ export function filter(
     // either holds for the still-loading container or sees the durable value, so
     // priorSlots is never undefined here.
     if (priorSlots === undefined) {
-      resultWithLog.set([]);
+      probeScoped(() => resultWithLog.set([]));
     }
     if (list === undefined) {
-      resultWithLog.set([]);
+      probeScoped(() => resultWithLog.set([]));
       for (const entry of elementRuns.values()) {
         runtime.runner.stop(entry.resultCell);
       }
@@ -383,7 +401,7 @@ export function filter(
       awaitPendingThenRepublish(pendingCells);
       return;
     }
-    resultWithLog.set(newArrayValue);
+    probeScoped(() => resultWithLog.set(newArrayValue));
 
     // NOTE: Same as map — elementRuns is not pruned. See map.ts for rationale.
   };

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -40,6 +40,8 @@ import { resolveOpPattern } from "./op-pattern-ref.ts";
 import { createResumeRepublisher } from "./resume-republish.ts";
 import { createResumeRecovery } from "./resume-recover.ts";
 import { linkResolutionProbe } from "../storage/reactivity-log.ts";
+import { resolveLink } from "../link-resolution.ts";
+import { isPrimitiveCellLink, parseLink } from "../link-utils.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 
 const logger = getLogger("runner.filter", { enabled: true, level: "warn" });
@@ -165,8 +167,34 @@ export function filter(
 
   return (tx: IExtendedStorageTransaction) => {
     const elementAwaitSync = resumeBatchAwaitSync;
-    const { list, op } = inputsCell.asSchema(FILTER_INPUT_SCHEMA)
-      .withTx(tx).get();
+    // Identity-only list materialization (mirrors map.ts:163-188): read `op`
+    // through the schema, but build element cells from the raw slot links
+    // WITHOUT dereferencing element content. The previous
+    // `asSchema(FILTER_INPUT_SCHEMA).get()` walked the array as asCell items,
+    // and arrays "dereference one more link" (traverse.ts) — an ordinary content
+    // read of every element doc, joining each element's whole-doc label into the
+    // coordinator's per-tx J and smearing MEMBER content onto the result
+    // container's STRUCTURE label even when membership does not depend on element
+    // content (spec §8.5.6.1, SC-8). Membership taint now rides the
+    // predicate-result reads below + the structure re-stamp (see
+    // recordCfcStructureContainer). resolveLink's probe reads are flow-excluded.
+    const op = inputsCell.asSchema(FILTER_INPUT_SCHEMA).withTx(tx).key("op")
+      .get();
+    const sourceListCell = inputsCell.key("list");
+    const listCell = sourceListCell.withTx(tx).resolveAsCell();
+    const rawList = listCell.withTx(tx).getRaw() as unknown;
+    const listBase = listCell.getAsNormalizedFullLink();
+    const list: Cell<any>[] | undefined = rawList === undefined
+      ? undefined
+      : !Array.isArray(rawList)
+      ? rawList as unknown as Cell<any>[] // non-array: handled by the guard below
+      : rawList.map((slot, i) => {
+        const slotLink: NormalizedFullLink = isPrimitiveCellLink(slot)
+          ? parseLink(slot, listBase)
+          : { ...listBase, path: [...listBase.path, String(i)] };
+        const resolved = resolveLink(runtime, tx, slotLink, "value");
+        return runtime.getCellFromLink(resolved, undefined, tx);
+      });
 
     const opPattern = resolveOpPattern(runtime, op.getRaw(), "filter");
     const argumentUsage = inferListOpArgumentUsage(runtime.cfc, opPattern);
@@ -208,6 +236,15 @@ export function filter(
     // every element's taint into the coordinator's per-tx join.
     const resultWithLog = result.asSchema(RESULT_PRESENCE_SCHEMA)
       .withTx(tx);
+    // (S16) Declare the result container so prepare re-derives its `structure`
+    // label (membership/order, §8.5.6.1) from this tx's J — the selection
+    // criteria the coordinator read (predicate results) — EVERY reconcile,
+    // decoupled from value writes. The membership taint settles on a later pass
+    // than the container's root value write, and incremental changes are
+    // slot/no-op writes that never re-stamp the root, so the taint would
+    // otherwise never land (the dual of the input-read over-taint this fix
+    // removes). Idempotent per reconcile; map deliberately does NOT declare.
+    tx.recordCfcStructureContainer(result.getAsNormalizedFullLink());
     // Container reads/writes run under the link-resolution-probe scope (S16):
     // the presence probe and set() diffing materialize prior slots for identity
     // comparison only — per-slot labels ride the link-write machinery, not these

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -39,6 +39,7 @@ import {
 import { resolveOpPattern } from "./op-pattern-ref.ts";
 import { createResumeRepublisher } from "./resume-republish.ts";
 import { createResumeRecovery } from "./resume-recover.ts";
+import { linkResolutionProbe } from "../storage/reactivity-log.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 
 const logger = getLogger("runner.flatmap", { enabled: true, level: "warn" });
@@ -141,7 +142,12 @@ export function flatMap(
             if (
               list === undefined || (Array.isArray(list) && list.length === 0)
             ) {
-              result.asSchema(RESULT_PRESENCE_SCHEMA).withTx(settleTx).set([]);
+              settleTx.runWithAmbientReadMeta(
+                linkResolutionProbe,
+                () =>
+                  result!.asSchema(RESULT_PRESENCE_SCHEMA).withTx(settleTx)
+                    .set([]),
+              );
             }
           }).then(({ error }) => {
             if (error) {
@@ -204,6 +210,15 @@ export function flatMap(
     // every element's taint into the coordinator's per-tx join.
     const resultWithLog = result.asSchema(RESULT_PRESENCE_SCHEMA)
       .withTx(tx);
+    // Container reads/writes run under the link-resolution-probe scope (S16):
+    // the presence probe and set() diffing materialize prior slots for identity
+    // comparison only — per-slot labels ride the link-write machinery, not these
+    // reads. See map.ts. Without it the asCell slot dereference journals a
+    // content read of every prior element, smearing element taint into the
+    // coordinator's per-tx join. The per-element result read below stays
+    // unprobed: the flattened output genuinely depends on those values.
+    const probeScoped = <T>(fn: () => T): T =>
+      tx.runWithAmbientReadMeta(linkResolutionProbe, fn);
     const createRunInput = (element: Cell<any>, index: number) => ({
       ...(argumentUsage.usesElement ? { element } : {}),
       ...(argumentUsage.usesIndex ? { index } : {}),
@@ -218,7 +233,10 @@ export function flatMap(
     // against the same absent value until it happens to sync. Pull the
     // container and defer; its arrival re-triggers this reconcile, which then
     // no-ops against the durable value.
-    if (elementAwaitSync && resultWithLog.get() === undefined) {
+    if (
+      elementAwaitSync &&
+      probeScoped(() => resultWithLog.get()) === undefined
+    ) {
       const pending = result.sync();
       // The container's durable value is still streaming in; its arrival
       // re-triggers this reconcile (the read above is journaled). If the
@@ -250,7 +268,7 @@ export function flatMap(
     // The durable aggregate currently in the container, read links-only
     // (presence schema), so this is a length comparison rather than a content
     // read of every element.
-    const priorSlots = resultWithLog.get();
+    const priorSlots = probeScoped(() => resultWithLog.get());
     const priorLen = Array.isArray(priorSlots) ? priorSlots.length : 0;
 
     // Resume preservation: on a resume reconcile the input list itself may not be
@@ -273,10 +291,10 @@ export function flatMap(
     // either holds for the still-loading container or sees the durable value, so
     // priorSlots is never undefined here.
     if (priorSlots === undefined) {
-      resultWithLog.set([]);
+      probeScoped(() => resultWithLog.set([]));
     }
     if (list === undefined) {
-      resultWithLog.set([]);
+      probeScoped(() => resultWithLog.set([]));
       for (const entry of elementRuns.values()) {
         runtime.runner.stop(entry.resultCell);
       }
@@ -389,7 +407,7 @@ export function flatMap(
       awaitPendingThenRepublish(pendingCells);
       return;
     }
-    resultWithLog.set(newArrayValue);
+    probeScoped(() => resultWithLog.set(newArrayValue));
 
     // NOTE: Same as map — elementRuns is not pruned. See map.ts for rationale.
   };

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -40,6 +40,8 @@ import { resolveOpPattern } from "./op-pattern-ref.ts";
 import { createResumeRepublisher } from "./resume-republish.ts";
 import { createResumeRecovery } from "./resume-recover.ts";
 import { linkResolutionProbe } from "../storage/reactivity-log.ts";
+import { resolveLink } from "../link-resolution.ts";
+import { isPrimitiveCellLink, parseLink } from "../link-utils.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 
 const logger = getLogger("runner.flatmap", { enabled: true, level: "warn" });
@@ -167,8 +169,33 @@ export function flatMap(
 
   return (tx: IExtendedStorageTransaction) => {
     const elementAwaitSync = resumeBatchAwaitSync;
-    const { list, op } = inputsCell.asSchema(FLATMAP_INPUT_SCHEMA)
-      .withTx(tx).get();
+    // Identity-only list materialization (mirrors map.ts:163-188): read `op`
+    // through the schema, but build element cells from the raw slot links
+    // WITHOUT dereferencing element content. The previous
+    // `asSchema(FLATMAP_INPUT_SCHEMA).get()` walked the array as asCell items,
+    // and arrays "dereference one more link" (traverse.ts) — an ordinary content
+    // read of every element doc, joining each element's whole-doc label into the
+    // coordinator's per-tx J and smearing MEMBER content onto the result
+    // container's STRUCTURE label even when membership does not depend on element
+    // content (spec §8.5.6.1, SC-8). Membership taint now rides the op-result
+    // reads below + the structure re-stamp (see recordCfcStructureContainer).
+    const op = inputsCell.asSchema(FLATMAP_INPUT_SCHEMA).withTx(tx).key("op")
+      .get();
+    const sourceListCell = inputsCell.key("list");
+    const listCell = sourceListCell.withTx(tx).resolveAsCell();
+    const rawList = listCell.withTx(tx).getRaw() as unknown;
+    const listBase = listCell.getAsNormalizedFullLink();
+    const list: Cell<any>[] | undefined = rawList === undefined
+      ? undefined
+      : !Array.isArray(rawList)
+      ? rawList as unknown as Cell<any>[] // non-array: handled by the guard below
+      : rawList.map((slot, i) => {
+        const slotLink: NormalizedFullLink = isPrimitiveCellLink(slot)
+          ? parseLink(slot, listBase)
+          : { ...listBase, path: [...listBase.path, String(i)] };
+        const resolved = resolveLink(runtime, tx, slotLink, "value");
+        return runtime.getCellFromLink(resolved, undefined, tx);
+      });
 
     const opPattern = resolveOpPattern(runtime, op.getRaw(), "flatMap");
     const argumentUsage = inferListOpArgumentUsage(runtime.cfc, opPattern);
@@ -210,6 +237,11 @@ export function flatMap(
     // every element's taint into the coordinator's per-tx join.
     const resultWithLog = result.asSchema(RESULT_PRESENCE_SCHEMA)
       .withTx(tx);
+    // (S16) Declare the result container so prepare re-derives its `structure`
+    // label (membership/order/multiplicity, §8.5.6.1) from this tx's J — the
+    // selection criteria the coordinator read (op results) — EVERY reconcile,
+    // decoupled from value writes. See filter.ts / recordCfcStructureContainer.
+    tx.recordCfcStructureContainer(result.getAsNormalizedFullLink());
     // Container reads/writes run under the link-resolution-probe scope (S16):
     // the presence probe and set() diffing materialize prior slots for identity
     // comparison only — per-slot labels ride the link-write machinery, not these

--- a/packages/runner/src/builtins/resume-republish.ts
+++ b/packages/runner/src/builtins/resume-republish.ts
@@ -3,6 +3,7 @@ import type { Runtime } from "../runtime.ts";
 import type { Logger } from "@commonfabric/utils/logger";
 import type { JSONSchema } from "../builder/types.ts";
 import { cellIdentityKey } from "./scope-policy.ts";
+import { linkResolutionProbe } from "../storage/reactivity-log.ts";
 
 type ElementRuns = Map<
   string,
@@ -115,7 +116,14 @@ export function createResumeRepublisher(
         }
       }
       if (stillPending.length > 0) return stillPending;
-      result.asSchema(resultSchema).withTx(tx).set(out);
+      // The element reads above are real content reads (the aggregate genuinely
+      // depends on them, so they taint J). The container write only diffs prior
+      // slots for identity, so it runs under the link-resolution probe (S16) to
+      // avoid re-journaling prior element content — matching map/filter/flatMap.
+      tx.runWithAmbientReadMeta(
+        linkResolutionProbe,
+        () => result.asSchema(resultSchema).withTx(tx).set(out),
+      );
       return [];
     }).then(({ ok, error }) => {
       if (error) {

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -4013,6 +4013,26 @@ export const prepareBoundaryCommit = (
   if (ingestKey !== undefined) {
     targetKeys.add(ingestKey);
   }
+  // (S16) Result containers a list coordinator (filter/flatMap) declared this
+  // tx: re-derive their `structure` label from J every reconcile, decoupled
+  // from value writes. Membership taint (the predicate-result reads the
+  // coordinator consumed) settles on a later pass than the container's root
+  // value write, and incremental changes are slot/no-op writes that never
+  // re-stamp the root — so without this the taint never lands. Only when there
+  // IS taint (flowHasLabels): a transient empty-J reconcile must NOT clear a
+  // correct prior structure label (resume/loading), so we leave the container
+  // off the persist loop then (fail-safe: keep the existing label).
+  const structureContainerPaths = new Map<string, readonly string[]>();
+  if (flowPersist && flowHasLabels) {
+    for (const addr of tx.getCfcState().structureContainers) {
+      const containerKey = targetKey(addr);
+      structureContainerPaths.set(
+        containerKey,
+        canonicalizeLogicalPath(addr.path),
+      );
+      targetKeys.add(containerKey);
+    }
+  }
   if (flowPersist && flowTargets !== undefined) {
     // Flow targets enter the persist loop when there is taint to attach or
     // stale per-value components (derived/link) to replace under a written
@@ -4526,6 +4546,34 @@ export const prepareBoundaryCommit = (
         });
         return foldedUnique(atoms);
       };
+      // (S16) A declared list-coordinator container re-derives its MEMBERSHIP
+      // stamp (origin structure, observes enumerate — replace-from-criteria,
+      // §8.12.8-normative per #4546) from J this reconcile even with no value
+      // write: drop the carried-forward enumerate entry at the exact container
+      // path and re-stamp it below with the current J. The frozen existence
+      // entry (observes shape) and legacy covering entries are left in place —
+      // deleting the frozen entry would make the stamp loop re-mint it from
+      // the CURRENT join, silently unfreezing it; legacy entries await the
+      // write-path migration absorb.
+      const structureContainerPath = structureContainerPaths.get(key);
+      if (structureContainerPath !== undefined) {
+        const containerPathKey = pathKey(structureContainerPath);
+        for (let i = persistedLabelEntries.length - 1; i >= 0; i--) {
+          const candidateEntry = persistedLabelEntries[i];
+          if (
+            candidateEntry.origin === "structure" &&
+            candidateEntry.observes === "enumerate" &&
+            pathKey(candidateEntry.path) === containerPathKey
+          ) {
+            persistedLabelEntries.splice(i, 1);
+          }
+        }
+        if (
+          !structureStampPaths.some((p) => pathKey(p) === containerPathKey)
+        ) {
+          structureStampPaths.push(structureContainerPath);
+        }
+      }
       for (const path of derivedStampPaths) {
         // Deeper stamped paths are redundant with a stamped ancestor; only
         // collapse against paths that actually receive a covering entry.

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -463,6 +463,16 @@ export type CfcTxState = {
   policyEvaluationMode: CfcPolicyEvaluationMode;
   prepare: CfcPrepareState;
   dereferenceTraces: CfcDereferenceTrace[];
+  // Result containers a list coordinator (filter/flatMap) declares each
+  // reconcile: their `structure` label (membership/order, §8.5.6.1) must be
+  // re-derived from the per-tx join J — the selection criteria the coordinator
+  // read (predicate results) — EVERY reconcile, decoupled from value writes.
+  // The membership taint settles on a later pass than the container's root
+  // value write, and incremental changes are slot/no-op writes that never
+  // re-stamp the root, so without this the taint never lands (S16 over-taint
+  // fix, the dual of the input-read over-taint). map does NOT declare: it is
+  // length-preserving with no membership secret, so its container stays clean.
+  structureContainers: CfcAddress[];
   // Addresses whose invalidating writes scheduled this run (§8.9.2 trigger
   // reads): the decision to run *now* was influenced by their values, so
   // they join the flow-label derivation even when the run never re-reads

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -61,6 +61,7 @@ import {
   type AttemptedWrite,
   canonicalizeLogicalPath,
   CFC_ENFORCING_STRICTNESS,
+  type CfcAddress,
   type CfcDereferenceTrace,
   type CfcEnforcementMode,
   cfcEnforcementStrictness,
@@ -251,6 +252,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     policyEvaluationMode: DEFAULT_CFC_POLICY_EVALUATION_MODE,
     prepare: { status: "unprepared" },
     dereferenceTraces: [],
+    structureContainers: [],
     triggerReads: [],
     writePolicyInputs: [],
     writePolicyInputIdentities: new Map(),
@@ -723,6 +725,13 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.#cfcState.dereferenceTraces.push(deepFreeze(trace));
     if (this.#cfcState.prepare.status === "prepared") {
       this.invalidateCfc("dereference-trace-added");
+    }
+  }
+
+  recordCfcStructureContainer(address: CfcAddress): void {
+    this.#cfcState.structureContainers.push(deepFreeze(address));
+    if (this.#cfcState.prepare.status === "prepared") {
+      this.invalidateCfc("structure-container-added");
     }
   }
 
@@ -1255,6 +1264,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     this.outboxIdempotencyKeys.clear();
     this.#cfcState.prepare = { status: "unprepared" };
     this.#cfcState.dereferenceTraces = [];
+    this.#cfcState.structureContainers = [];
     return this.tx.abort(reason);
   }
 
@@ -1544,6 +1554,10 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
 
   recordCfcDereferenceTrace(trace: CfcDereferenceTrace): void {
     this.wrapped.recordCfcDereferenceTrace(trace);
+  }
+
+  recordCfcStructureContainer(address: CfcAddress): void {
+    this.wrapped.recordCfcStructureContainer(address);
   }
 
   prepareCfc(): string {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -40,6 +40,7 @@ import {
 import { BaseMemoryAddress } from "@commonfabric/runner/traverse";
 import { Cell } from "../cell.ts";
 import type {
+  CfcAddress,
   CfcDereferenceTrace,
   CfcEnforcementMode,
   CfcFlowLabelsMode,
@@ -966,6 +967,15 @@ export interface IExtendedStorageTransaction
    * flows into the digest input is immutable.
    */
   recordCfcDereferenceTrace(trace: CfcDereferenceTrace): void;
+
+  /**
+   * Declares a list-coordinator result container (filter/flatMap) whose
+   * `structure` label must be re-derived from this transaction's flow-join J
+   * (its selection criteria) — independent of whether the container value is
+   * written this tx. See `CfcTxState.structureContainers`. The address is
+   * `deepFreeze()`d on entry.
+   */
+  recordCfcStructureContainer(address: CfcAddress): void;
 
   /**
    * Runs CFC boundary verification for this transaction and records the

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -204,6 +204,11 @@ export interface IStorageManager extends IStorageSubscriptionCapability {
    * observe held, not-yet-loaded state. This is the safe composition of
    * `addCrossSpacePromise` and `removeCrossSpacePromise` — prefer it over
    * wiring the self-removing `finally` by hand at each call site.
+   *
+   * `work` must eventually settle (resolve or reject). A chain that never
+   * settles stays registered and keeps `Cell.pull()`/`idle()` from observing
+   * convergence until the scheduler's convergence bound trips, so a caller that
+   * wraps an external `sync()` should ensure it cannot hang unbounded.
    */
   trackUntilSettled(work: Promise<unknown>): void;
 

--- a/packages/runner/test/cfc-flow-pointwise.test.ts
+++ b/packages/runner/test/cfc-flow-pointwise.test.ts
@@ -13,6 +13,7 @@ type StoredEntry = {
   path: string[];
   label: { confidentiality?: string[]; integrity?: unknown[] };
   origin?: string;
+  observes?: string;
 };
 
 // S16 phase B: pointwise label precision is a structural fact of the
@@ -619,11 +620,15 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
     expect(after).toContainEqual("alice-secret");
     expect(after).toContainEqual("bob-secret");
     expect(after).toContainEqual("carol-secret");
-    // re-stamped, not duplicated: exactly one structure entry at the root
-    const structureEntries = entriesOf(containerId).filter(
-      (e) => e.origin === "structure" && e.path.length === 0,
+    // Re-stamped, not duplicated: exactly one MEMBERSHIP (enumerate) entry
+    // at the root. The frozen existence entry (observes:"shape", #4546)
+    // coexists beside it and is not touched by the re-stamp.
+    const membershipEntries = entriesOf(containerId).filter(
+      (e) =>
+        e.origin === "structure" && e.path.length === 0 &&
+        e.observes === "enumerate",
     );
-    expect(structureEntries.length).toBe(1);
+    expect(membershipEntries.length).toBe(1);
   });
 
   // flatMap gets the same structural-taint treatment as filter: the result
@@ -688,5 +693,110 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
     );
     expect(sc).toContainEqual("alice-secret");
     expect(sc).toContainEqual("bob-secret");
+  });
+
+  // Replace-from-criteria, the narrowing direction (§8.12.8-normative per
+  // #4546): when the selection criteria change on a reconcile with NO value
+  // write (result stays []), the membership (enumerate) entry is re-derived
+  // from the new criteria alone — the departed candidate's atom leaves. The
+  // frozen existence entry (observes "shape") keeps the creation join,
+  // untouched by the re-stamp. This is the coordinator-level pin of the
+  // no-write path; #4546's A3 test covers the persist layer.
+  it("filter: membership replaces from criteria on a no-write re-stamp; frozen existence keeps the creation join", async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+
+    await seedLabeledDoc(runtime, "rp-el-0", { n: 1 }, "dave-secret");
+    await seedLabeledDoc(runtime, "rp-el-1", { n: 2 }, "erin-secret");
+
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, lift } = commonfabric as unknown as {
+      pattern: typeof commonfabric.pattern;
+      lift: (fn: (value: { n: number }) => unknown) => (
+        value: unknown,
+      ) => unknown;
+    };
+    // Reads element content, drops everything: the result stays [] across
+    // membership changes, so the re-stamp rides the declared-container path
+    // (no container value write to piggyback on).
+    const dropAll = lift((value: { n: number }) => value.n < 0);
+
+    const setup = runtime.edit();
+    const d0 = runtime.getCell(space, "rp-el-0", undefined, setup);
+    const d1 = runtime.getCell(space, "rp-el-1", undefined, setup);
+    const listCell = runtime.getCell(
+      space,
+      "rp-list",
+      { type: "array", items: { asCell: ["cell"] } },
+      setup,
+    );
+    listCell.set([d0]);
+    expect((await setup.commit()).ok).toBeDefined();
+
+    const collectionPattern = pattern<{ values: unknown[] }>(({ values }) => {
+      const kept = (values as unknown as {
+        filterWithPattern: (op: unknown, params: unknown) => unknown;
+      }).filterWithPattern(
+        pattern(({ element }: FactoryInput<any>) => dropAll(element)),
+        {},
+      );
+      return { kept };
+    });
+
+    const tx = runtime.edit();
+    const valuesIn = runtime.getCell(space, "rp-list", undefined, tx);
+    const resultCell = runtime.getCell(space, "rp-result", undefined, tx);
+    const result = runtime.run(
+      tx,
+      collectionPattern,
+      { values: valuesIn },
+      resultCell,
+    );
+    await tx.commit();
+    await result.pull();
+    await runtime.idle();
+
+    const containerId = resolvedContainerId(result.key("kept"));
+    const rootEntries = () =>
+      entriesOf(containerId).filter(
+        (e) => e.origin === "structure" && e.path.length === 0,
+      );
+    const membership = () =>
+      rootEntries()
+        .filter((e) => e.observes === "enumerate")
+        .flatMap((e) => e.label.confidentiality ?? []);
+    const frozenShape = () =>
+      rootEntries()
+        .filter((e) => e.observes === "shape")
+        .flatMap((e) => e.label.confidentiality ?? []);
+
+    expect(membership()).toContainEqual("dave-secret");
+    expect(frozenShape()).toContainEqual("dave-secret");
+
+    // Swap the sole candidate: the result stays [] (no container value
+    // write), the predicate now reads erin only.
+    const stx = runtime.edit();
+    const lc = runtime.getCell(
+      space,
+      "rp-list",
+      { type: "array", items: { asCell: ["cell"] } },
+      stx,
+    );
+    lc.set([d1]);
+    expect((await stx.commit()).ok).toBeDefined();
+    await result.pull();
+    await runtime.idle();
+
+    const after = membership();
+    expect(after).toContainEqual("erin-secret");
+    expect(after).not.toContainEqual("dave-secret");
+    // The frozen existence entry is never touched by the re-stamp.
+    expect(frozenShape()).toContainEqual("dave-secret");
+    expect(frozenShape()).not.toContainEqual("erin-secret");
   });
 });

--- a/packages/runner/test/cfc-flow-pointwise.test.ts
+++ b/packages/runner/test/cfc-flow-pointwise.test.ts
@@ -75,6 +75,13 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
       .filter((e) => e.origin === "derived")
       .flatMap((e) => e.label.confidentiality ?? []);
 
+  // confidentiality of the container's STRUCTURE label (origin structure at the
+  // container root) — the membership/order taint (§8.5.6.1).
+  const structureConfidentiality = (id: string): string[] =>
+    entriesOf(id)
+      .filter((e) => e.origin === "structure" && e.path.length === 0)
+      .flatMap((e) => e.label.confidentiality ?? []);
+
   // Element ops run in their own transactions reading only their element,
   // so per-element precision is structural — for elements that arrive in
   // separate reconciles. A batch first-instantiation evaluates all new
@@ -446,5 +453,240 @@ describe("CFC flow labels: pointwise structure (phase B)", () => {
     );
     expect(probeConf).toContainEqual("alice-secret");
     expect(probeConf).toContainEqual("bob-secret");
+  });
+
+  const resolvedContainerId = (keptCell: any): string => {
+    const rtx = runtime!.edit();
+    const id =
+      keptCell.withTx(rtx).resolveAsCell().getAsNormalizedFullLink().id;
+    rtx.commit();
+    return id;
+  };
+
+  // The dual of membership taint: when the predicate decides membership WITHOUT
+  // reading element content (here: by index), the result container's structure
+  // must carry NO member content. This is the over-taint the input-read
+  // identity-only materialization removes — the old asCell `.get()` on the input
+  // list dereferenced every element into the coordinator's J (§8.5.6.1 keeps
+  // member confidentiality separate from structural).
+  it("filter: index-only predicate keeps member content out of the structure label", async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+
+    await seedLabeledDoc(runtime, "ix-el-0", { n: 1 }, "alice-secret");
+    await seedLabeledDoc(runtime, "ix-el-1", { n: 2 }, "bob-secret");
+
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, lift } = commonfabric as unknown as {
+      pattern: typeof commonfabric.pattern;
+      lift: (fn: (value: any) => unknown) => (value: unknown) => unknown;
+    };
+    const keepFirst = lift((i: number) => i < 1);
+    let filteredRef: any;
+
+    const setup = runtime.edit();
+    const el0 = runtime.getCell(space, "ix-el-0", undefined, setup);
+    const el1 = runtime.getCell(space, "ix-el-1", undefined, setup);
+    const listCell = runtime.getCell(
+      space,
+      "ix-list",
+      { type: "array", items: { asCell: ["cell"] } },
+      setup,
+    );
+    listCell.set([el0, el1]);
+    expect((await setup.commit()).ok).toBeDefined();
+
+    const collectionPattern = pattern<{ values: unknown[] }>(({ values }) => {
+      filteredRef = (values as any).filterWithPattern(
+        // reads only `index`, never element content
+        pattern(({ index }: FactoryInput<any>) => keepFirst(index)),
+        {},
+      );
+      return { kept: filteredRef };
+    });
+
+    const tx = runtime.edit();
+    const valuesIn = runtime.getCell(space, "ix-list", undefined, tx);
+    const resultCell = runtime.getCell(
+      space,
+      "ix-filter-result",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(
+      tx,
+      collectionPattern,
+      { values: valuesIn },
+      resultCell,
+    );
+    await tx.commit();
+    await result.pull();
+    await runtime.idle();
+
+    const sc = structureConfidentiality(
+      resolvedContainerId(result.key("kept")),
+    );
+    expect(sc).not.toContainEqual("alice-secret");
+    expect(sc).not.toContainEqual("bob-secret");
+  });
+
+  // The membership taint must RE-STAMP (replace, not duplicate or go stale) when
+  // the list changes across reconciles: the structure label is re-derived from
+  // each reconcile's J, even though the container's root value is not rewritten
+  // (only a slot is appended). Without the re-stamp the late-arriving member's
+  // taint would never reach the container shape.
+  it("filter: structure label re-stamps from J when the list grows", async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+
+    await seedLabeledDoc(runtime, "grow-el-0", { n: 1 }, "alice-secret");
+    await seedLabeledDoc(runtime, "grow-el-1", { n: 2 }, "bob-secret");
+    await seedLabeledDoc(runtime, "grow-el-2", { n: 3 }, "carol-secret");
+
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, lift } = commonfabric as unknown as {
+      pattern: typeof commonfabric.pattern;
+      lift: (fn: (value: any) => unknown) => (value: unknown) => unknown;
+    };
+    const isPositive = lift((value: { n: number }) => value.n > 0);
+    let filteredRef: any;
+
+    const setup = runtime.edit();
+    const el0 = runtime.getCell(space, "grow-el-0", undefined, setup);
+    const el1 = runtime.getCell(space, "grow-el-1", undefined, setup);
+    const el2 = runtime.getCell(space, "grow-el-2", undefined, setup);
+    const listCell = runtime.getCell(
+      space,
+      "grow-list",
+      { type: "array", items: { asCell: ["cell"] } },
+      setup,
+    );
+    listCell.set([el0, el1]);
+    expect((await setup.commit()).ok).toBeDefined();
+
+    const collectionPattern = pattern<{ values: unknown[] }>(({ values }) => {
+      filteredRef = (values as any).filterWithPattern(
+        pattern(({ element }: FactoryInput<any>) => isPositive(element)),
+        {},
+      );
+      return { kept: filteredRef };
+    });
+
+    const tx = runtime.edit();
+    const valuesIn = runtime.getCell(space, "grow-list", undefined, tx);
+    const resultCell = runtime.getCell(space, "grow-result", undefined, tx);
+    const result = runtime.run(
+      tx,
+      collectionPattern,
+      { values: valuesIn },
+      resultCell,
+    );
+    await tx.commit();
+    await result.pull();
+    await runtime.idle();
+
+    const containerId = resolvedContainerId(result.key("kept"));
+    const before = structureConfidentiality(containerId);
+    expect(before).toContainEqual("alice-secret");
+    expect(before).toContainEqual("bob-secret");
+
+    // Grow the list: a re-reconcile re-stamps the container structure from the
+    // new J (now including carol), replacing the prior structure entry rather
+    // than leaving it stale or duplicating it.
+    const gtx = runtime.edit();
+    const lc = runtime.getCell(
+      space,
+      "grow-list",
+      { type: "array", items: { asCell: ["cell"] } },
+      gtx,
+    );
+    lc.set([el0, el1, el2]);
+    expect((await gtx.commit()).ok).toBeDefined();
+    await result.pull();
+    await runtime.idle();
+
+    const after = structureConfidentiality(containerId);
+    expect(after).toContainEqual("alice-secret");
+    expect(after).toContainEqual("bob-secret");
+    expect(after).toContainEqual("carol-secret");
+    // re-stamped, not duplicated: exactly one structure entry at the root
+    const structureEntries = entriesOf(containerId).filter(
+      (e) => e.origin === "structure" && e.path.length === 0,
+    );
+    expect(structureEntries.length).toBe(1);
+  });
+
+  // flatMap gets the same structural-taint treatment as filter: the result
+  // container's structure carries the op outputs' taint (membership/multiplicity
+  // depend on every element the op considered), not via the input deref.
+  it("flatMap: result structure carries the op outputs' taint", async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      cfcFlowLabels: "persist",
+    });
+
+    await seedLabeledDoc(runtime, "fm-el-0", { n: 1 }, "alice-secret");
+    await seedLabeledDoc(runtime, "fm-el-1", { n: 2 }, "bob-secret");
+
+    const { commonfabric } = createTrustedBuilder(runtime);
+    const { pattern, lift } = commonfabric as unknown as {
+      pattern: typeof commonfabric.pattern;
+      lift: (fn: (value: any) => unknown) => (value: unknown) => unknown;
+    };
+    // op reads element content and emits a one-element segment
+    const toSegment = lift((value: { n: number }) => [value.n]);
+    let flattenedRef: any;
+
+    const setup = runtime.edit();
+    const el0 = runtime.getCell(space, "fm-el-0", undefined, setup);
+    const el1 = runtime.getCell(space, "fm-el-1", undefined, setup);
+    const listCell = runtime.getCell(
+      space,
+      "fm-list",
+      { type: "array", items: { asCell: ["cell"] } },
+      setup,
+    );
+    listCell.set([el0, el1]);
+    expect((await setup.commit()).ok).toBeDefined();
+
+    const collectionPattern = pattern<{ values: unknown[] }>(({ values }) => {
+      flattenedRef = (values as any).flatMapWithPattern(
+        pattern(({ element }: FactoryInput<any>) => toSegment(element)),
+        {},
+      );
+      return { flattened: flattenedRef };
+    });
+
+    const tx = runtime.edit();
+    const valuesIn = runtime.getCell(space, "fm-list", undefined, tx);
+    const resultCell = runtime.getCell(space, "fm-result", undefined, tx);
+    const result = runtime.run(
+      tx,
+      collectionPattern,
+      { values: valuesIn },
+      resultCell,
+    );
+    await tx.commit();
+    await result.pull();
+    await runtime.idle();
+
+    const sc = structureConfidentiality(
+      resolvedContainerId(result.key("flattened")),
+    );
+    expect(sc).toContainEqual("alice-secret");
+    expect(sc).toContainEqual("bob-secret");
   });
 });

--- a/packages/runner/test/cfc-structure-container.test.ts
+++ b/packages/runner/test/cfc-structure-container.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { TransactionWrapper } from "../src/storage/extended-storage-transaction.ts";
+import type { CfcAddress } from "../src/cfc/mod.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-structure-container");
+const space = signer.did();
+
+// Unit coverage for the structure-container declaration seam (S16): list
+// coordinators (filter/flatMap) declare their result container so prepare
+// re-derives its `structure` label from J every reconcile. The end-to-end
+// behavior is in cfc-flow-pointwise.test.ts; this pins the tx plumbing.
+describe("CFC structure-container declaration (tx plumbing)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate> | undefined;
+  let runtime: Runtime | undefined;
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+  });
+
+  const addr = (id: string): CfcAddress => ({
+    space,
+    id,
+    scope: "space",
+    path: [],
+  });
+
+  it("records declared structure containers on the tx state", () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcFlowLabels: "persist",
+    });
+    const tx = runtime.edit();
+    tx.recordCfcStructureContainer(addr("of:fid1:container-a"));
+    tx.recordCfcStructureContainer(addr("of:fid1:container-b"));
+    const recorded = tx.getCfcState().structureContainers;
+    expect(recorded.length).toBe(2);
+    expect(recorded[0].id).toBe("of:fid1:container-a");
+    // frozen on entry (owned by the tx, identity-stable)
+    expect(Object.isFrozen(recorded[0])).toBe(true);
+  });
+
+  it("invalidates a prepared digest when recorded after prepare", () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcFlowLabels: "persist",
+    });
+    const tx = runtime.edit();
+    tx.prepareCfc();
+    expect(tx.getCfcState().prepare.status).toBe("prepared");
+    tx.recordCfcStructureContainer(addr("of:fid1:late-container"));
+    expect(tx.getCfcState().prepare.status).toBe("invalidated");
+  });
+
+  it("clears declared structure containers on abort", () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcFlowLabels: "persist",
+    });
+    const tx = runtime.edit();
+    tx.recordCfcStructureContainer(addr("of:fid1:container-c"));
+    expect(tx.getCfcState().structureContainers.length).toBe(1);
+    tx.abort();
+    expect(tx.getCfcState().structureContainers.length).toBe(0);
+  });
+
+  it("TransactionWrapper delegates recordCfcStructureContainer to the wrapped tx", () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcFlowLabels: "persist",
+    });
+    const inner = runtime.edit();
+    const wrapper = new TransactionWrapper(inner);
+    wrapper.recordCfcStructureContainer(addr("of:fid1:wrapped-container"));
+    const recorded = inner.getCfcState().structureContainers;
+    expect(recorded.length).toBe(1);
+    expect(recorded[0].id).toBe("of:fid1:wrapped-container");
+  });
+});

--- a/packages/runner/test/memory-v2-watch-refresh-race.test.ts
+++ b/packages/runner/test/memory-v2-watch-refresh-race.test.ts
@@ -711,6 +711,77 @@ Deno.test("memory v2 runner integrates watch deltas without re-diffing cold watc
   }
 });
 
+Deno.test("memory v2 runner never moves a confirmed doc backwards on a stale watch refresh", async () => {
+  // Watch refreshes can arrive after local confirmations; an upsert whose
+  // seq is below the confirmed base must be skipped (pending replay depends
+  // on monotonic bases). Pins the applySessionSync guard directly — its
+  // only other coverage was an incidental race in unrelated tests.
+  const docA = `of:watch-stale-a-${crypto.randomUUID()}` as URI;
+  const docB = `of:watch-stale-b-${crypto.randomUUID()}` as URI;
+  const transport = new IncrementalEffectTransport(
+    new Map([
+      [docA, { value: { label: docA } }],
+      [docB, { value: { label: docB } }],
+    ]),
+  );
+  const sessionFactory = new SingleSessionFactory(transport);
+  const storageManager = TestStorageManager.create({
+    as: signer,
+    memoryHost: new URL("memory://runner-v2-watch-stale"),
+  }, sessionFactory);
+  const provider = storageManager.open(space) as TestProvider;
+
+  try {
+    await Promise.all([
+      provider.sync(docA, { path: [], schema: false }),
+      provider.sync(docB, { path: [], schema: false }),
+    ]);
+    assertEquals(getObjectValue(provider, docA), { label: docA });
+
+    let integrations = 0;
+    const first = Promise.withResolvers<void>();
+    const second = Promise.withResolvers<void>();
+    const subscription = {
+      next(notification: { type: string }) {
+        if (notification.type === "integrate") {
+          integrations += 1;
+          if (integrations === 1) first.resolve();
+          if (integrations === 2) second.resolve();
+        }
+        return undefined;
+      },
+    };
+    storageManager.subscribe(subscription);
+
+    // Fresh refresh: moves the confirmed base forward.
+    transport.emitSync(fullSync(4, [doc(docA, 4, {
+      value: { label: "updated" },
+    })]));
+    await first.promise;
+    assertEquals(getObjectValue(provider, docA), { label: "updated" });
+
+    // Stale refresh: a newer sync envelope replaying an OLD snapshot of the
+    // doc. The upsert's seq (2) is below the confirmed base (4) — it must
+    // not move the base backwards or resurface the old value. A guard-
+    // skipped sync changes nothing, so it emits no notification of its own;
+    // the follow-up fresh sync on docB is the barrier — syncs apply in
+    // order, so its integrate proves the stale one was fully processed.
+    transport.emitSync(fullSync(5, [doc(docA, 2, {
+      value: { label: "stale" },
+    })]));
+    transport.emitSync(fullSync(6, [doc(docB, 6, {
+      value: { label: "barrier" },
+    })]));
+    await second.promise;
+    storageManager.unsubscribe(subscription);
+
+    assertEquals(getObjectValue(provider, docB), { label: "barrier" });
+    assertEquals(getObjectValue(provider, docA), { label: "updated" });
+  } finally {
+    await storageManager.close();
+  }
+});
+
 Deno.test("memory v2 runner applies watch remove syncs to confirmed docs", async () => {
   const docA = `of:watch-remove-a-${crypto.randomUUID()}` as URI;
   const docB = `of:watch-remove-b-${crypto.randomUUID()}` as URI;

--- a/packages/runner/test/resume-republish-unit.test.ts
+++ b/packages/runner/test/resume-republish-unit.test.ts
@@ -105,7 +105,16 @@ function makeRuntime(options: FakeEditOptions = {}): {
           },
         });
       }
-      const ok = fn({});
+      // The republisher wraps its container write in
+      // tx.runWithAmbientReadMeta(linkResolutionProbe, ...) (S16: structure-only
+      // container reads must not journal prior element content). Hand the action
+      // a tx whose ambient-read-meta scope is a pass-through, so the wrapped
+      // write actually runs.
+      const tx = {
+        runWithAmbientReadMeta: <T>(_meta: unknown, action: () => T): T =>
+          action(),
+      };
+      const ok = fn(tx);
       return Promise.resolve({ ok });
     },
     storageManager: {


### PR DESCRIPTION
## Why

Under CFC flow labels, a collection's **membership** confidentiality — *which* elements survived a filter — is a separate dimension from its **members'** content confidentiality (spec §8.5.6.1). `filter`/`flatMap` conflated the two: their input-list read dereferenced **every** element into the coordinator's per-tx join, stamping each member's content onto the result container's membership label — even for elements the predicate never read. Since H2 (#4489) made `persist` the shell default, that over-taint lands in real spaces.

The obvious fix — mirror `map`'s identity-only input read — is a **security regression**: that read was the sole carrier of the legitimate membership taint. The complete fix removes the over-taint AND gives the membership taint its own carrier: re-derive the container's membership label from the coordinator's selection-criteria join on every reconcile, decoupled from value writes.

## Where this now sits (post Epic C / #4546)

The design questions this PR originally posed as "decisions for @seefeldb" have since been **settled against the spec** on the #4525 thread and landed in #4546:

- **Membership stamps are `origin:"structure", observes:"enumerate"` and replace-from-criteria** — §8.12.8 is normative for recomputed membership (this PR's decision 2, confirmed as the spec's position).
- **Container existence is a separate frozen `observes:"shape"` entry** — minted at creation, never grown, never cleared.

What this PR contributes to that settled world is the piece that makes the discipline **live**: on main today, a real filter's membership label is stamped only when the container root happens to be value-written — so it goes stale immediately (departed members stick, late members are never labeled at all; verified with an instrumented probe — main's A-scenario shows a member joining the list and never appearing in the membership label). The re-stamp declaration (`recordCfcStructureContainer`) is what makes replace-from-criteria actually happen each reconcile.

## What changed

| Part | Change |
| --- | --- |
| **Input-list read** | `filter`/`flatMap` materialize the input list **identity-only** (read `op` through the schema; build element cells from raw slot links via `getRaw()` + `resolveLink` under the link-resolution probe) — exactly as `map` does. Removes the over-taint and breaks the feedback loop so predicate results become precise. Post-C1, these probes are honestly classified (trace-covered resolution machinery / followRef). |
| **Container / own-output reads** | `probeScoped` wrapping on the presence/diff reads. Load-bearing: without it, a re-reconcile that reads a non-empty prior container re-leaks the kept elements' content (verified via the grow scenario). |
| **Membership re-stamp** | `filter`/`flatMap` declare their result container via `tx.recordCfcStructureContainer`; `prepareBoundaryCommit` re-derives the container's `observes:"enumerate"` entry from the per-tx join **every reconcile, decoupled from value writes**. The splice that replaces the carried entry is scoped to the enumerate class: the frozen existence entry is never touched (deleting it would make the stamp loop re-mint it from the current join — silently unfreezing it), and legacy covering entries await the write-path migration absorb. `map` opts out (length-preserving, no membership secret). |

## Verification

- Over-taint removed: index/sibling-field predicate → membership carries no member content.
- Membership preserved and **now live**: `cfc-flow-pointwise` (membership, shape-only reader, empty result, grow re-stamp) green; #4546's existence-channel + persist-split suites green alongside.
- **Composed with #4556** (stale-slot deletes, the independent bug this work surfaced): the probe's shrink scenario converges — a departed member clears from the membership label at the next membership change (one reconcile of hysteresis: the shrink reconcile's own diff genuinely observes the departing slot's pointer, an SC-8-consistent followRef read). Without #4556, stale per-slot link entries bridge departed members back into the join indefinitely.
- Full CFC sweep on the reconciled branch: 84 files / 506 steps, 0 failed. Full runner suite: see checks.

## Public surface

New `IExtendedStorageTransaction.recordCfcStructureContainer(address)` + `CfcTxState.structureContainers` (mirrors `recordCfcDereferenceTrace`: deep-frozen, invalidates a prepared digest, reset on abort, wrapper-delegated).

## Known residuals

- One-reconcile hysteresis on shrink (above) — semantically defensible; called out on the #4525 thread.
- ~~The `["length"]` derived value entry doesn't refresh on a subsequent length write~~ — chased: it was the grow-side twin of the shrink elision, fixed in #4556 (second commit).
- The per-child existence-probe under-taint of container-anchored stamps is the spec-recorded residual from #4525's Q1 (per-slot shape encoding, deferred on entry-count cost).

## Investigation trail

Original diagnosis: [`S16-FILTER-FLATMAP-OVERTAINT-HANDOFF.md`](https://github.com/commontoolsinc/labs/blob/gideon/lunch-poll-perf-load/packages/patterns/lunch-poll/perf-seed/S16-FILTER-FLATMAP-OVERTAINT-HANDOFF.md). Discipline settlement: the [#4525 discussion](https://github.com/commontoolsinc/labs/pull/4525#issuecomment-4884100816) and #4546. Echo diagnosis and fix: #4556.

*Reconciliation onto the settled disciplines, probes, and analysis by Claude Fable 5; PR by @mathpirate.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
