### PR TITLE
state-inspector: dogfooding fixes (accuracy + entities view)

### DIFF
--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -20,6 +20,7 @@ import {
   getValueAt,
   hotEntities,
   listCommits,
+  listEntities,
   listSqliteFiles,
   openSpace,
   openSpaces,
@@ -43,6 +44,19 @@ function out(json: boolean, data: unknown, render: () => void): void {
 
 function splitPath(p?: string): string[] {
   return p ? p.split("/").filter(Boolean) : [];
+}
+
+// Session ids look like `session:did:key:<space>:<uuid>` (often %-encoded).
+// Surface the short space DID + uuid head instead of a uniform truncation.
+function fmtSession(s: string): string {
+  const decoded = decodeURIComponent(s);
+  const m = decoded.match(/^session:(did:key:)?([^:]+):([0-9a-f-]+)/i);
+  if (m) {
+    const did = m[2];
+    const short = did.length > 12 ? `${did.slice(0, 6)}…${did.slice(-4)}` : did;
+    return `${short}/${m[3].slice(0, 8)}`;
+  }
+  return decoded.length > 22 ? `${decoded.slice(0, 21)}…` : decoded;
 }
 
 // Resolve --all / --spaces / --dir into open spaces; caller must close them.
@@ -141,7 +155,15 @@ export const inspect = new Command()
         console.log(
           `branches: ${sum.branches.map((b) => `${b.name || "(default)"}@${b.head_seq}`).join(" ")}`,
         );
-        console.log(`scheduler tables: ${sum.hasSchedulerTables ? "yes" : "no"}`);
+        console.log(
+          `scheduler: ${
+            !sum.hasSchedulerTables
+              ? "absent"
+              : sum.schedulerObservations > 0
+              ? `${sum.schedulerObservations} observations`
+              : "tables present, empty (persistentSchedulerState off)"
+          }`,
+        );
       });
     } finally {
       s.close();
@@ -158,7 +180,7 @@ export const inspect = new Command()
       out(!!options.json, rows, () => {
         for (const r of rows) {
           console.log(
-            `#${r.seq}\t${r.session.slice(0, 14)}\tlocal=${r.localSeq}\tops=${r.ops}\treads=${r.reads}\t${r.createdAt}`,
+            `#${r.seq}\t${fmtSession(r.session)}\tlocal=${r.localSeq}\tops=${r.ops}\treads=${r.reads}\t${r.createdAt}`,
           );
         }
       });
@@ -183,6 +205,38 @@ export const inspect = new Command()
       s.close();
     }
   })
+  /* inspect entities */
+  .command("entities <space:string>", "What's in the space: entities by kind + name.")
+  .option("--kind <kind:string>", "Filter: module | instance | stream | value | empty.")
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .option("--limit <n:number>", "Max entities to reconstruct.", { default: 2000 })
+  .action((options, space) => {
+    const s = openSpace(resolveSpacePath(space));
+    try {
+      let rows = listEntities(s, { limit: options.limit, branch: options.branch });
+      if (options.kind) rows = rows.filter((r) => r.kind === options.kind);
+      out(!!options.json, rows, () => {
+        if (rows.length === 0) {
+          console.log("(no entities)");
+          return;
+        }
+        console.log(
+          Table.from([
+            ["KIND", "NAME", "REVS", "LINKS", "ID"],
+            ...rows.map((r) => [
+              r.kind,
+              r.name.length > 40 ? `${r.name.slice(0, 39)}…` : r.name,
+              String(r.revisions),
+              String(r.links),
+              r.id,
+            ]),
+          ]).toString(),
+        );
+      });
+    } finally {
+      s.close();
+    }
+  })
   /* inspect history */
   .command("history <space:string> <entity:string>", "Every write that touched an entity.")
   .option("--scope <scope:string>", "Scope key (default: space).")
@@ -200,7 +254,7 @@ export const inspect = new Command()
       out(!!options.json, rows, () => {
         for (const r of rows) {
           console.log(
-            `seq=${r.seq}\tcommit=${r.commitSeq}\t${r.op}\t${r.session.slice(0, 14)}\tlocal=${r.localSeq}\t${r.createdAt}`,
+            `seq=${r.seq}\tcommit=${r.commitSeq}\t${r.op}\t${fmtSession(r.session)}\tlocal=${r.localSeq}\t${r.createdAt}`,
           );
         }
       });
@@ -269,7 +323,7 @@ export const inspect = new Command()
           }
           const cluster = r.clusters.findIndex((c) => c.valueKey === v.valueKey) + 1;
           console.log(
-            `  ${v.label}\thead=${v.headSeq}\trevs=${v.revisions}\tlast=${(v.lastSession ?? "?").slice(0, 14)}\tcluster#${cluster}`,
+            `  ${v.label}\thead=${v.headSeq}\trevs=${v.revisions}\tlast=${v.lastSession ? fmtSession(v.lastSession) : "?"}\tcluster#${cluster}`,
           );
         }
         console.log(`note: ${r.caveat}`);

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -103,6 +103,8 @@ deno task cf inspect spaces
 
 # single space (DID-prefix resolves via discovery)
 deno task cf inspect summary  z6Mkqa41
+deno task cf inspect entities z6Mkqa41           # what's in here: modules/instances/cells
+deno task cf inspect entities z6Mkqa41 --kind instance
 deno task cf inspect hot      z6Mkqa41 --limit 10
 deno task cf inspect commits  z6Mkqa41 --limit 20
 deno task cf inspect history  z6Mkqa41 of:fid1:…

--- a/packages/state-inspector/decode.ts
+++ b/packages/state-inspector/decode.ts
@@ -1,17 +1,23 @@
 // Decoding stored Fabric values into an inspectable form.
 //
-// Reality check (verified against real space DBs, 2026-06-26): today's stored
-// `revision.data` is plain JSON with inline *sigil links* of the legacy form
-//   { "/": { "link@1": { id, space?, path?, scope?, schema? } } }
-// entity references of the form
-//   { "/": "of:baedrei…" }   (or { "/": "fid1:…" } in modern cell-rep)
-// and streams of the form
-//   { "$stream": true }
-//
-// So decoding for current DBs is pure JSON walking + recognition — no live
-// runtime/Cell needed. The modern `fvj1:`-prefixed codec-json envelope
-// (@commonfabric/data-model/codec-json) is NOT what lands in these rows; if we
-// later meet it we can plug `valueFromJson` in at the leaves.
+// Stored payloads (`revision.data`, `commit.original`, …) come in TWO at-rest
+// formats, BOTH seen in real DBs:
+//   - modern: an `fvj1:`-prefixed codec-json envelope (decode via valueFromJson)
+//   - legacy: plain JSON
+// In both, links/refs/streams appear as plain-data sigils:
+//   link   { "/": { "link@1": { id, space?, path?, scope?, schema? } } }
+//   ref    { "/": "of:…" | "fid1:…" }
+//   stream { "$stream": true }
+// `decodeStored()` routes by the `fvj1:` tag; everything else here is pure JSON
+// walking + recognition (no live runtime/Cell needed). In the fvj1 form embedded
+// links are `/quote`-escaped literals, so a context-less decode is inert.
+
+import { valueFromJson } from "@commonfabric/data-model/codec-json";
+
+/** Decode a stored payload string, routing the `fvj1:` codec envelope. */
+export function decodeStored(data: string): unknown {
+  return data.startsWith("fvj1:") ? valueFromJson(data) : JSON.parse(data);
+}
 
 export interface DecodedLink {
   id?: string;

--- a/packages/state-inspector/queries.ts
+++ b/packages/state-inspector/queries.ts
@@ -4,10 +4,14 @@
 
 import type { CommitRow, SpaceDb } from "./db.ts";
 import { hasSchedulerTables } from "./db.ts";
+import { countLinks, decodeStored, summarize } from "./decode.ts";
+import { reconstructDocument } from "./reconstruct.ts";
 
 export interface SpaceSummary {
   path: string;
   hasSchedulerTables: boolean;
+  /** Persisted scheduler observation rows (0 even when the tables exist empty). */
+  schedulerObservations: number;
   commits: number;
   commitSeqRange: [number, number] | null;
   sessions: number;
@@ -40,9 +44,21 @@ export function summarizeSpace(space: SpaceDb): SpaceSummary {
     )
     .all<{ scope_key: string; count: number }>();
 
+  const hasSched = hasSchedulerTables(db);
+  let schedulerObservations = 0;
+  if (hasSched) {
+    try {
+      schedulerObservations =
+        one<{ n: number }>(`SELECT count(*) n FROM scheduler_observation`).n;
+    } catch {
+      schedulerObservations = 0;
+    }
+  }
+
   return {
     path: space.path,
-    hasSchedulerTables: hasSchedulerTables(db),
+    hasSchedulerTables: hasSched,
+    schedulerObservations,
     commits: commitAgg.n,
     commitSeqRange: commitAgg.lo === null ? null : [commitAgg.lo, commitAgg.hi!],
     sessions: commitAgg.s,
@@ -83,7 +99,11 @@ export function listCommits(
     let ops = 0;
     let reads = 0;
     try {
-      const parsed = JSON.parse(r.original);
+      // `original` is a ClientCommit, stored either fvj1-encoded or as plain JSON.
+      const parsed = decodeStored(r.original) as {
+        operations?: unknown[];
+        reads?: { confirmed?: unknown[]; pending?: unknown[] };
+      };
       ops = Array.isArray(parsed.operations) ? parsed.operations.length : 0;
       reads = (parsed.reads?.confirmed?.length ?? 0) +
         (parsed.reads?.pending?.length ?? 0);
@@ -181,4 +201,88 @@ export function hotEntities(
       writes: r.writes,
       sessions: r.sessions,
     }));
+}
+
+export type EntityKind = "module" | "instance" | "stream" | "value" | "empty";
+
+export interface EntityInfo {
+  id: string;
+  scope: string;
+  kind: EntityKind;
+  /** Human label: module filename, instance $NAME, or a value summary. */
+  name: string;
+  revisions: number;
+  links: number;
+}
+
+function classifyValue(value: unknown): { kind: EntityKind; name: string } {
+  if (value === undefined) return { kind: "empty", name: "(absent)" };
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const o = value as Record<string, unknown>;
+    // Module/program entity: carries source + filename.
+    if (typeof o.code === "string" && typeof o.filename === "string") {
+      const file = (o.filename as string).split("/").pop() ?? o.filename;
+      return { kind: "module", name: `module:${file}` };
+    }
+    // Pattern instance: has a resolved $NAME, or instance markers.
+    const named = typeof o.$NAME === "string" ? (o.$NAME as string) : undefined;
+    if (named || "$TYPE" in o || "resultRef" in o || "argument" in o) {
+      return { kind: "instance", name: named ?? "(instance)" };
+    }
+    if ((o as { $stream?: unknown }).$stream === true) {
+      return { kind: "stream", name: "(stream)" };
+    }
+  }
+  return { kind: "value", name: summarize(value) };
+}
+
+/**
+ * List the entities in a space with a derived kind + label — the "what is in
+ * this space?" view. Reconstructs each entity's head document (cheap for typical
+ * spaces; bounded by `limit`). Sorted modules → instances → streams → values.
+ */
+export function listEntities(
+  space: SpaceDb,
+  opts: { branch?: string; scope?: string; limit?: number } = {},
+): EntityInfo[] {
+  const branch = opts.branch ?? "";
+  const scope = opts.scope ?? "space";
+  const limit = opts.limit ?? 2000;
+  const rows = space.db
+    .prepare(
+      `SELECT id, count(*) revisions FROM revision
+       WHERE branch = ? AND scope_key = ?
+       GROUP BY id ORDER BY revisions DESC LIMIT ?`,
+    )
+    .all<{ id: string; revisions: number }>(branch, scope, limit);
+
+  const order: Record<EntityKind, number> = {
+    module: 0,
+    instance: 1,
+    stream: 2,
+    value: 3,
+    empty: 4,
+  };
+  return rows
+    .map((r): EntityInfo => {
+      let value: unknown;
+      let name = "(undecodable)";
+      let kind: EntityKind = "value";
+      try {
+        const doc = reconstructDocument(space, { id: r.id, branch, scope });
+        value = doc?.value;
+        ({ kind, name } = classifyValue(value));
+      } catch (e) {
+        name = `(error: ${(e as Error).message.slice(0, 40)})`;
+      }
+      return {
+        id: r.id,
+        scope,
+        kind,
+        name,
+        revisions: r.revisions,
+        links: countLinks(value),
+      };
+    })
+    .sort((a, b) => order[a.kind] - order[b.kind] || b.revisions - a.revisions);
 }

--- a/packages/state-inspector/reconstruct.ts
+++ b/packages/state-inspector/reconstruct.ts
@@ -20,19 +20,9 @@
 import { applyPatch } from "@commonfabric/memory/v2/patch";
 import type { PatchOp } from "@commonfabric/memory/v2";
 import type { FabricValue } from "@commonfabric/api";
-import { valueFromJson } from "@commonfabric/data-model/codec-json";
 
 import type { SpaceDb } from "./db.ts";
-
-// Stored values come in TWO at-rest formats, both seen in real DBs:
-//   - modern: an `fvj1:`-prefixed codec-json envelope (decode via valueFromJson;
-//     embedded links are `/quote`-escaped literals, so a context-less decode is
-//     inert and does not try to reconstruct live cells)
-//   - legacy: plain JSON with inline sigil links
-// Route by the format tag.
-function decodeStored(data: string): unknown {
-  return data.startsWith("fvj1:") ? valueFromJson(data) : JSON.parse(data);
-}
+import { decodeStored } from "./decode.ts";
 
 export interface EntityAddress {
   id: string;

--- a/packages/state-inspector/test/discover.test.ts
+++ b/packages/state-inspector/test/discover.test.ts
@@ -55,14 +55,14 @@ Deno.test("discovery + resolution", async (t) => {
     await Deno.writeTextFile(`${engine}/${DID_1}.sqlite-wal`, "");
 
     await t.step("discovers both DBs by walking the cache base", () => {
-      const found = discoverSpaceDbs({ dirs: [`${dir}/cache/memory`] });
+      const found = discoverSpaceDbs({ dirs: [`${dir}/cache/memory`], cwd: dir });
       assertEquals(found.length, 2);
       assertEquals(new Set(found.map((s) => s.did)), new Set([DID_1, DID_2]));
       assert(found.every((s) => s.sizeBytes > 0));
     });
 
     await t.step("resolveSpacePath matches by DID prefix", () => {
-      const found = discoverSpaceDbs({ dirs: [`${dir}/cache/memory`] });
+      const found = discoverSpaceDbs({ dirs: [`${dir}/cache/memory`], cwd: dir });
       const path = resolveSpacePath("zAlpha", found);
       assert(path.endsWith(`${DID_1}.sqlite`));
     });
@@ -73,7 +73,7 @@ Deno.test("discovery + resolution", async (t) => {
     });
 
     await t.step("ambiguous prefix throws", () => {
-      const found = discoverSpaceDbs({ dirs: [`${dir}/cache/memory`] });
+      const found = discoverSpaceDbs({ dirs: [`${dir}/cache/memory`], cwd: dir });
       assertThrows(() => resolveSpacePath("did:key:z", found), Error, "ambiguous");
     });
 

--- a/packages/state-inspector/test/entities.test.ts
+++ b/packages/state-inspector/test/entities.test.ts
@@ -1,0 +1,90 @@
+// Hermetic test for entity classification + fvj1 commit decoding (both surfaced
+// by dogfooding a real fvj1 space). Side-effect free.
+
+import { assertEquals } from "@std/assert";
+import { Database } from "@db/sqlite";
+import { jsonFromValue } from "@commonfabric/data-model/codec-json";
+
+import { openSpace } from "../db.ts";
+import { listCommits } from "../queries.ts";
+import { listEntities } from "../queries.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+`;
+
+function seed(path: string) {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, ?, ?, ?, '{}')`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, 0, 'set', ?, ?)`,
+  );
+
+  // Commit 1: original stored fvj1-encoded with 2 ops and 1 confirmed read.
+  const original = jsonFromValue({
+    localSeq: 1,
+    operations: [{ op: "set" }, { op: "patch" }],
+    reads: { confirmed: [{ id: "x" }], pending: [] },
+  });
+  commit.run(1, "session:did:key:zSpaceAAAA:11111111-2222-3333", 1, original);
+  // entities (values stored as plain JSON here; decode handles both)
+  rev.run("of:mod", 1, JSON.stringify({
+    value: { code: "export default 1;", filename: "/api/patterns/foo/bar.tsx", identity: "h" },
+  }), 1);
+
+  commit.run(2, "session:did:key:zSpaceAAAA:11111111-2222-3333", 2, "{}");
+  rev.run("of:inst", 2, JSON.stringify({ value: { $NAME: "My Notebook", notes: [] } }), 2);
+
+  commit.run(3, "session:did:key:zSpaceAAAA:11111111-2222-3333", 3, "{}");
+  rev.run("of:val", 3, JSON.stringify({ value: "none" }), 3);
+
+  db.close();
+}
+
+Deno.test("entity classification + fvj1 commit decode", async (t) => {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-entities-" });
+  const dbPath = `${dir}/space.sqlite`;
+  try {
+    seed(dbPath);
+    const space = openSpace(dbPath);
+    try {
+      await t.step("listCommits decodes an fvj1 original (ops/reads non-zero)", () => {
+        const rows = listCommits(space);
+        const c1 = rows.find((r) => r.seq === 1)!;
+        assertEquals(c1.ops, 2);
+        assertEquals(c1.reads, 1);
+      });
+
+      await t.step("entities are classified by kind + named", () => {
+        const ents = listEntities(space);
+        const byId = Object.fromEntries(ents.map((e) => [e.id, e]));
+        assertEquals(byId["of:mod"].kind, "module");
+        assertEquals(byId["of:mod"].name, "module:bar.tsx");
+        assertEquals(byId["of:inst"].kind, "instance");
+        assertEquals(byId["of:inst"].name, "My Notebook");
+        assertEquals(byId["of:val"].kind, "value");
+      });
+    } finally {
+      space.close();
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
Stacked on #4386 (M3). Found by probing a freshly-created notes/pieces space from an agent's POV — does the output make sense / useful / accurate?

## Accuracy bugs fixed

- **`commits` showed `ops=0 reads=0` for every commit.** `commit.original` is `fvj1`-encoded; `listCommits`' `JSON.parse` threw and was caught → zeros. Now decoded via a shared `decodeStored()` (extracted to `decode.ts`; `reconstruct.ts` reuses it). Real DB now shows real op/read counts.
- **`summary` "scheduler tables: yes" was misleading** — the tables exist but are empty. Now: `absent` / `N observations` / `tables present, empty (persistentSchedulerState off)`.

## Usefulness: new `cf inspect entities <space>`

The "what's in this space?" view I was missing. Reconstructs each entity's head, classifies it (`module` / `instance` / `stream` / `value`), and labels it (module filename, instance `$NAME`, or a value summary) with revs + link count. Turns 146 opaque `of:fid1:…` ids into a legible map:

```
KIND     NAME              REVS LINKS
module   module:default-app.tsx  1   6
module   module:note.tsx         1   2
instance BacklinksIndex          1   5
instance SummaryIndex            1   5
value    "📝 COol Note"          3   0     ← the note I'd created
…
```
`--kind` filters; `--json` for agents.

## Legibility

Session ids (`session:did:key:<space>:<uuid>`) were truncated to a uniform `session:did%3A`; now `<short-space-did>/<uuid8>` — which also surfaces that the session-space DID is one of the otherwise-empty placeholder spaces.

## Verification

`deno check` / `deno lint` / `deno task test` green (state-inspector: 5 files, 24 steps incl. new fvj1-commit-decode + entity-classification tests; cli typechecks). Re-probed the real space end-to-end through `cf inspect`. No new deps / no lock change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inaccurate commit stats and scheduler summary in state-inspector, and adds a new `cf inspect entities` view to make space contents easy to scan.

- **New Features**
  - Added `cf inspect entities <space>`: classifies each entity (`module`/`instance`/`stream`/`value`), labels it (module filename, instance `$NAME`, or value summary), and shows revisions + link count. Supports `--kind` and `--json`.
  - Improved session ID formatting in CLI output to `<short-space-did>/<uuid8>` for readability.

- **Bug Fixes**
  - Corrected commit ops/reads by decoding `commit.original` when `fvj1`-encoded via a shared `decodeStored()` (also reused in reconstruction).
  - Made `summary` scheduler reporting precise: "absent", "N observations", or "tables present, empty (persistentSchedulerState off)".

<sup>Written for commit 3419f80fdd37d96e117e6fbb26ed23d45d3c72e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

