### PR TITLE
fix(html): value-guard the static-prop path to damp reused-child op churn (CT-1798)

### DIFF
--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -73,6 +73,22 @@ const TEXT_INTEGRITY_PROP_SINKS: ReadonlyMap<string, ReadonlySet<string>> =
   new Map([
     ["cf-chat-message", new Set(["name", "content"])],
   ]);
+// Props whose live DOM value can drift from the authored VDOM value
+// independently of any worker-side change — user input (`value`), or
+// browser / custom-element state (`checked`, `selected`, `selectedIndex`,
+// `indeterminate`, `open`). On the main thread, setPropDefault re-asserts the
+// authored value by comparing against the *live* property, so for these props a
+// repeated set-prop is a drift-repair, not pure churn. The worker-side value
+// guard (updatePropsInPlace) only knows the last *authored* value and cannot
+// see live drift, so it must never skip these — they always re-emit.
+const DOM_LIVE_PROPS: ReadonlySet<string> = new Set([
+  "value",
+  "checked",
+  "selected",
+  "selectedIndex",
+  "indeterminate",
+  "open",
+]);
 const DEFAULT_RENDER_POLICY: RenderPolicy = {
   declassifyConfidentiality: [],
 };
@@ -1584,24 +1600,33 @@ export class WorkerReconciler {
           cancel,
         });
       } else {
-        // Static prop. Skip the worker→main set-prop op when an unchanged
-        // primitive value would be a no-op on the main thread anyway: DOM
+        // Static prop. Skip the worker→main set-prop op when re-asserting the
+        // same authored value would be a true no-op on the main thread: DOM
         // writes are already value-guarded in setPropDefault, but the op and
         // the JSON.stringify it carries are not. This matters because #4366
         // made updateChildrenInPlace always reconcile reused inline-VNode
         // children, so this path now fires on every parent recompute even when
         // captured prop values are identical (CT-1798). Mirrors the Cell<Props>
-        // primitive-prop guard below. Restricted to primitive values (the same
-        // scope as that guard): object/array props compare by reference, which
-        // is unreliable here, so they always re-emit. Text-integrity props are
-        // never skipped either: their transform has policy-dependent side
-        // effects and must re-run.
+        // primitive-prop guard below.
+        //
+        // The skip is sound ONLY when a repeated set-prop is genuinely
+        // redundant, so it is NOT taken when:
+        //   - the value is an object/array — reference equality is unreliable;
+        //   - the prop is a text-integrity sink — its transform has
+        //     policy-dependent side effects and must re-run;
+        //   - the prop's live DOM value can drift independently of the VDOM
+        //     (DOM_LIVE_PROPS) — there the repeated op repairs drift via
+        //     setPropDefault's compare against the *live* value, which the
+        //     worker cannot observe.
+        // This assumes the default value-guarded setProp; a custom setProp with
+        // observable same-value behavior would not be re-invoked on a skip.
         const isPrimitiveValue = value === null ||
           (typeof value !== "object" && typeof value !== "function");
         if (
           isPrimitiveValue && existingState && !existingState.cell &&
           existingState.currentValue === value &&
-          !this.isTextIntegrityProp(state, key)
+          !this.isTextIntegrityProp(state, key) &&
+          !DOM_LIVE_PROPS.has(key)
         ) {
           continue;
         }

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -1584,7 +1584,27 @@ export class WorkerReconciler {
           cancel,
         });
       } else {
-        // Static prop - just set it (cancel any existing subscription)
+        // Static prop. Skip the worker→main set-prop op when an unchanged
+        // primitive value would be a no-op on the main thread anyway: DOM
+        // writes are already value-guarded in setPropDefault, but the op and
+        // the JSON.stringify it carries are not. This matters because #4366
+        // made updateChildrenInPlace always reconcile reused inline-VNode
+        // children, so this path now fires on every parent recompute even when
+        // captured prop values are identical (CT-1798). Mirrors the Cell<Props>
+        // primitive-prop guard below. Restricted to primitive values (the same
+        // scope as that guard): object/array props compare by reference, which
+        // is unreliable here, so they always re-emit. Text-integrity props are
+        // never skipped either: their transform has policy-dependent side
+        // effects and must re-run.
+        const isPrimitiveValue = value === null ||
+          (typeof value !== "object" && typeof value !== "function");
+        if (
+          isPrimitiveValue && existingState && !existingState.cell &&
+          existingState.currentValue === value &&
+          !this.isTextIntegrityProp(state, key)
+        ) {
+          continue;
+        }
         if (existingState) {
           existingState.cancel();
         }
@@ -1598,6 +1618,7 @@ export class WorkerReconciler {
         state.propSubscriptions.set(key, {
           cell: undefined,
           cancel: () => {},
+          currentValue: value,
         });
       }
     }
@@ -2790,7 +2811,13 @@ export class WorkerReconciler {
           key,
           value: propValue,
         }]);
-        state.propSubscriptions.set(key, { cell: undefined, cancel: () => {} });
+        // Record the bound value so a later in-place update can skip the
+        // redundant set-prop op when it is unchanged (CT-1798).
+        state.propSubscriptions.set(key, {
+          cell: undefined,
+          cancel: () => {},
+          currentValue: value,
+        });
       }
     }
 

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -74,13 +74,14 @@ const TEXT_INTEGRITY_PROP_SINKS: ReadonlyMap<string, ReadonlySet<string>> =
     ["cf-chat-message", new Set(["name", "content"])],
   ]);
 // Props whose live DOM value can drift from the authored VDOM value
-// independently of any worker-side change — user input (`value`), or
-// browser / custom-element state (`checked`, `selected`, `selectedIndex`,
-// `indeterminate`, `open`). On the main thread, setPropDefault re-asserts the
-// authored value by comparing against the *live* property, so for these props a
-// repeated set-prop is a drift-repair, not pure churn. The worker-side value
-// guard (updatePropsInPlace) only knows the last *authored* value and cannot
-// see live drift, so it must never skip these — they always re-emit.
+// independently of any worker-side change — user input (`value`), scrolling
+// (`scrollTop`/`scrollLeft`), or browser / custom-element state (`checked`,
+// `selected`, `selectedIndex`, `indeterminate`, `open`). On the main thread,
+// setPropDefault re-asserts the authored value by comparing against the *live*
+// property, so for these props a repeated set-prop is a drift-repair, not pure
+// churn. The worker-side value guard (updatePropsInPlace) only knows the last
+// *authored* value and cannot see live drift, so it must never skip these —
+// they always re-emit.
 const DOM_LIVE_PROPS: ReadonlySet<string> = new Set([
   "value",
   "checked",
@@ -88,6 +89,8 @@ const DOM_LIVE_PROPS: ReadonlySet<string> = new Set([
   "selectedIndex",
   "indeterminate",
   "open",
+  "scrollTop",
+  "scrollLeft",
 ]);
 const DEFAULT_RENDER_POLICY: RenderPolicy = {
   declassifyConfidentiality: [],

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -1310,6 +1310,42 @@ export class WorkerReconciler {
     return TEXT_INTEGRITY_PROP_SINKS.get(state.tagName)?.has(key) ?? false;
   }
 
+  /**
+   * Whether re-asserting a re-supplied static primitive prop can skip its
+   * worker→main set-prop op. Shared by the inline static-prop path
+   * (updatePropsInPlace) and the Cell<Props> primitive path so the two cannot
+   * drift apart (CT-1798 / CT-1803).
+   *
+   * A skip is sound only when a repeated set-prop would be a true no-op on the
+   * main thread: setPropDefault value-guards the DOM write, but the op and the
+   * JSON.stringify it carries are not free. It is taken only for an unchanged
+   * primitive whose prior state was itself a static primitive, and never when:
+   *   - the value is an object/array — reference equality is unreliable;
+   *   - the prop is a text-integrity sink — its transform has policy-dependent
+   *     side effects and must re-run;
+   *   - the prop's live DOM value can drift independently of the VDOM
+   *     (DOM_LIVE_PROPS) — there the repeated op repairs drift via
+   *     setPropDefault's compare against the *live* value, which the worker
+   *     cannot observe.
+   * Assumes the default value-guarded setProp; a custom setProp with observable
+   * same-value behavior would not be re-invoked on a skip.
+   */
+  private canSkipUnchangedStaticProp(
+    state: NodeState,
+    key: string,
+    value: unknown,
+    existingState: PropState | undefined,
+  ): boolean {
+    const isPrimitiveValue = value === null ||
+      (typeof value !== "object" && typeof value !== "function");
+    return isPrimitiveValue &&
+      existingState !== undefined &&
+      existingState.cell === undefined &&
+      existingState.currentValue === value &&
+      !this.isTextIntegrityProp(state, key) &&
+      !DOM_LIVE_PROPS.has(key);
+  }
+
   private transformPropValueForState(
     state: NodeState,
     key: string,
@@ -1603,34 +1639,13 @@ export class WorkerReconciler {
           cancel,
         });
       } else {
-        // Static prop. Skip the worker→main set-prop op when re-asserting the
-        // same authored value would be a true no-op on the main thread: DOM
-        // writes are already value-guarded in setPropDefault, but the op and
-        // the JSON.stringify it carries are not. This matters because #4366
-        // made updateChildrenInPlace always reconcile reused inline-VNode
-        // children, so this path now fires on every parent recompute even when
-        // captured prop values are identical (CT-1798). Mirrors the Cell<Props>
-        // primitive-prop guard below.
-        //
-        // The skip is sound ONLY when a repeated set-prop is genuinely
-        // redundant, so it is NOT taken when:
-        //   - the value is an object/array — reference equality is unreliable;
-        //   - the prop is a text-integrity sink — its transform has
-        //     policy-dependent side effects and must re-run;
-        //   - the prop's live DOM value can drift independently of the VDOM
-        //     (DOM_LIVE_PROPS) — there the repeated op repairs drift via
-        //     setPropDefault's compare against the *live* value, which the
-        //     worker cannot observe.
-        // This assumes the default value-guarded setProp; a custom setProp with
-        // observable same-value behavior would not be re-invoked on a skip.
-        const isPrimitiveValue = value === null ||
-          (typeof value !== "object" && typeof value !== "function");
-        if (
-          isPrimitiveValue && existingState && !existingState.cell &&
-          existingState.currentValue === value &&
-          !this.isTextIntegrityProp(state, key) &&
-          !DOM_LIVE_PROPS.has(key)
-        ) {
+        // Static prop. Skip the redundant worker→main set-prop op for an
+        // unchanged primitive value (see canSkipUnchangedStaticProp). #4366 made
+        // updateChildrenInPlace always reconcile reused inline-VNode children,
+        // so this path now fires on every parent recompute even when captured
+        // values are identical; damping it removes the op + JSON.stringify
+        // churn (CT-1798).
+        if (this.canSkipUnchangedStaticProp(state, key, value, existingState)) {
           continue;
         }
         if (existingState) {
@@ -2039,13 +2054,16 @@ export class WorkerReconciler {
             existingState.cancel();
           }
 
-          // Skip only when a previous primitive value is unchanged. Object/cell
-          // prop states do not track currentValue, so they must still emit a
-          // set-prop when transitioning to a primitive such as undefined.
+          // Skip a redundant op for an unchanged primitive, using the same
+          // predicate as the inline static-prop path so both honor the same
+          // DOM-live / text-integrity exclusions (CT-1803). Object/cell prop
+          // states have cell !== undefined or no currentValue, so transitions
+          // (e.g. to undefined) still emit.
           if (
-            existingState && !existingState.cell &&
-            existingState.currentValue === value
-          ) continue;
+            this.canSkipUnchangedStaticProp(state, key, value, existingState)
+          ) {
+            continue;
+          }
 
           const propValue = this.transformPropValueForState(
             state,

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -245,10 +245,17 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
         onOps: collector.onOps,
       });
 
+      const liveProps = {
+        id: "field",
+        value: "hello",
+        checked: true,
+        scrollTop: 0,
+        scrollLeft: 0,
+      };
       const childCell = new MockCell({
         type: "vnode",
         name: "input",
-        props: { id: "field", value: "hello", checked: true },
+        props: { ...liveProps },
         children: [],
       } as WorkerVNode);
       const rootCell = new MockCell({
@@ -263,12 +270,13 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       collector.clear();
 
       // Reuse the same input VNode with IDENTICAL props. The worker can't see
-      // live DOM drift (a user typing, browser-set checked), so value/checked
-      // must still re-emit to let setPropDefault repair it; inert id stays quiet.
+      // live DOM drift (user typing, browser-set checked, user scrolling), so
+      // the DOM-live props must still re-emit to let setPropDefault repair it;
+      // the inert id stays quiet.
       childCell.set({
         type: "vnode",
         name: "input",
-        props: { id: "field", value: "hello", checked: true },
+        props: { ...liveProps },
         children: [],
       } as WorkerVNode);
       await new Promise((resolve) => setTimeout(resolve, 10));
@@ -276,16 +284,13 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
       const keys = collector.getOpsOfType("set-prop")
         .filter((op) => "key" in op)
         .map((op) => (op as { key: string }).key);
-      assertEquals(
-        keys.includes("value"),
-        true,
-        "DOM-live `value` must re-emit so drift can be repaired",
-      );
-      assertEquals(
-        keys.includes("checked"),
-        true,
-        "DOM-live `checked` must re-emit so drift can be repaired",
-      );
+      for (const liveKey of ["value", "checked", "scrollTop", "scrollLeft"]) {
+        assertEquals(
+          keys.includes(liveKey),
+          true,
+          `DOM-live \`${liveKey}\` must re-emit so drift can be repaired`,
+        );
+      }
       assertEquals(
         keys.includes("id"),
         false,

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -156,6 +156,88 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
   );
 
   await t.step(
+    "does not re-emit set-prop for unchanged static props on a reused child VNode (CT-1798)",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const childCell = new MockCell({
+        type: "vnode",
+        name: "span",
+        props: { id: "tab", "data-role": "tab" },
+        children: ["A"],
+      } as WorkerVNode);
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "div",
+        props: {},
+        children: [childCell as unknown as Cell<WorkerRenderNode>],
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      collector.clear();
+
+      // Re-set the reused child VNode with IDENTICAL props but changed children,
+      // so the reconcile path (updateChildrenInPlace -> updatePropsInPlace) runs
+      // in full. #4366 made this fire on every recompute; unchanged static props
+      // should no longer produce worker->main set-prop ops.
+      childCell.set({
+        type: "vnode",
+        name: "span",
+        props: { id: "tab", "data-role": "tab" },
+        children: ["B"],
+      } as WorkerVNode);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const unchangedPropOps = collector.getOpsOfType("set-prop").filter((op) =>
+        "key" in op && (op.key === "id" || op.key === "data-role")
+      );
+      assertEquals(
+        unchangedPropOps.length,
+        0,
+        "unchanged static props should not re-emit set-prop ops",
+      );
+      // Sanity: the reconcile path actually ran (children changed A -> B).
+      assertEquals(
+        collector.getOps().length > 0,
+        true,
+        "child reconcile should still emit ops for the changed children",
+      );
+
+      // A genuine prop change must still emit, while a still-unchanged sibling
+      // prop stays quiet.
+      collector.clear();
+      childCell.set({
+        type: "vnode",
+        name: "span",
+        props: { id: "tab-2", "data-role": "tab" },
+        children: ["B"],
+      } as WorkerVNode);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const idOps = collector.getOpsOfType("set-prop").filter((op) =>
+        "key" in op && op.key === "id"
+      );
+      assertEquals(idOps.length, 1, "changed static prop should re-emit once");
+      assertEquals(
+        (idOps[0] as any).value,
+        "tab-2",
+        "changed static prop should carry the new value",
+      );
+      assertEquals(
+        collector.getOpsOfType("set-prop").filter((op) =>
+          "key" in op && op.key === "data-role"
+        ).length,
+        0,
+        "still-unchanged static prop should remain quiet",
+      );
+    },
+  );
+
+  await t.step(
     "replaces same-key child Cell when parent supplies a different cell",
     async () => {
       const collector = createOpsCollector();

--- a/packages/html/test/worker-reconciler-cell-child.test.ts
+++ b/packages/html/test/worker-reconciler-cell-child.test.ts
@@ -238,6 +238,171 @@ Deno.test("worker reconciler - cell child optimization", async (t) => {
   );
 
   await t.step(
+    "re-emits DOM-live props (value/checked) on a reused child even when unchanged, so the main thread can repair live-DOM drift (CT-1798 review)",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const childCell = new MockCell({
+        type: "vnode",
+        name: "input",
+        props: { id: "field", value: "hello", checked: true },
+        children: [],
+      } as WorkerVNode);
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "div",
+        props: {},
+        children: [childCell as unknown as Cell<WorkerRenderNode>],
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      collector.clear();
+
+      // Reuse the same input VNode with IDENTICAL props. The worker can't see
+      // live DOM drift (a user typing, browser-set checked), so value/checked
+      // must still re-emit to let setPropDefault repair it; inert id stays quiet.
+      childCell.set({
+        type: "vnode",
+        name: "input",
+        props: { id: "field", value: "hello", checked: true },
+        children: [],
+      } as WorkerVNode);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const keys = collector.getOpsOfType("set-prop")
+        .filter((op) => "key" in op)
+        .map((op) => (op as { key: string }).key);
+      assertEquals(
+        keys.includes("value"),
+        true,
+        "DOM-live `value` must re-emit so drift can be repaired",
+      );
+      assertEquals(
+        keys.includes("checked"),
+        true,
+        "DOM-live `checked` must re-emit so drift can be repaired",
+      );
+      assertEquals(
+        keys.includes("id"),
+        false,
+        "inert `id` should still be skipped when unchanged",
+      );
+    },
+  );
+
+  await t.step(
+    "re-emits object/array static props on a reused child even with a stable reference (CT-1798 review)",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const styleObj = { color: "red" };
+      const childCell = new MockCell({
+        type: "vnode",
+        name: "span",
+        props: { id: "s", style: styleObj },
+        children: ["A"],
+      } as WorkerVNode);
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "div",
+        props: {},
+        children: [childCell as unknown as Cell<WorkerRenderNode>],
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      collector.clear();
+
+      // Same object reference, changed child to force the reconcile. Object
+      // props compare by reference (unreliable), so they must never be skipped.
+      childCell.set({
+        type: "vnode",
+        name: "span",
+        props: { id: "s", style: styleObj },
+        children: ["B"],
+      } as WorkerVNode);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const keys = collector.getOpsOfType("set-prop")
+        .filter((op) => "key" in op)
+        .map((op) => (op as { key: string }).key);
+      assertEquals(
+        keys.includes("style"),
+        true,
+        "object/array props must always re-emit",
+      );
+      assertEquals(
+        keys.includes("id"),
+        false,
+        "inert primitive `id` should still be skipped when unchanged",
+      );
+    },
+  );
+
+  await t.step(
+    "re-emits text-integrity props (cf-chat-message name/content) on a reused child even when unchanged (CT-1798 review)",
+    async () => {
+      const collector = createOpsCollector();
+      const reconciler = new WorkerReconciler({
+        onOps: collector.onOps,
+      });
+
+      const childCell = new MockCell({
+        type: "vnode",
+        name: "cf-chat-message",
+        props: { id: "m1", name: "Alice", content: "hi" },
+        children: [],
+      } as WorkerVNode);
+      const rootCell = new MockCell({
+        type: "vnode",
+        name: "div",
+        props: {},
+        children: [childCell as unknown as Cell<WorkerRenderNode>],
+      });
+
+      reconciler.mount(rootCell as unknown as Cell<WorkerRenderNode>);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      collector.clear();
+
+      // Text-integrity sink props have policy-dependent transforms and must
+      // re-run on every reconcile; only inert id may be skipped.
+      childCell.set({
+        type: "vnode",
+        name: "cf-chat-message",
+        props: { id: "m1", name: "Alice", content: "hi" },
+        children: [],
+      } as WorkerVNode);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const keys = collector.getOpsOfType("set-prop")
+        .filter((op) => "key" in op)
+        .map((op) => (op as { key: string }).key);
+      assertEquals(
+        keys.includes("name"),
+        true,
+        "text-integrity `name` must always re-emit",
+      );
+      assertEquals(
+        keys.includes("content"),
+        true,
+        "text-integrity `content` must always re-emit",
+      );
+      assertEquals(
+        keys.includes("id"),
+        false,
+        "inert `id` should still be skipped when unchanged",
+      );
+    },
+  );
+
+  await t.step(
     "replaces same-key child Cell when parent supplies a different cell",
     async () => {
       const collector = createOpsCollector();

--- a/packages/html/test/worker-reconciler-cell-props.test.ts
+++ b/packages/html/test/worker-reconciler-cell-props.test.ts
@@ -1337,6 +1337,107 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
       },
     );
 
+    await t.step(
+      "Cell<Props> re-emits DOM-live props (value) on an unchanged repeat, parity with inline props (CT-1803)",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+        });
+
+        const propsCell = new MockPropsCell({
+          className: "foo",
+          value: "hello",
+        });
+        const rootCell = new MockCell({
+          type: "vnode",
+          name: "input",
+          props: propsCell,
+          children: [],
+        });
+
+        const cancel = mountReconciler(reconciler, rootCell);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          collector.clear();
+
+          // Re-emit identical values. The worker can't see live DOM drift, so
+          // the DOM-live `value` must re-emit to let setPropDefault repair it;
+          // the inert className stays quiet (parity with the inline static path).
+          propsCell.set({ className: "foo", value: "hello" });
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          const keys = collector.getOpsOfType("set-prop")
+            .map((op: any) => op.key);
+          assertEquals(
+            keys.includes("value"),
+            true,
+            "DOM-live `value` must re-emit so drift can be repaired",
+          );
+          assertEquals(
+            keys.includes("className"),
+            false,
+            "inert className should be skipped when unchanged",
+          );
+        } finally {
+          cancel();
+        }
+      },
+    );
+
+    await t.step(
+      "Cell<Props> re-emits text-integrity props (cf-chat-message name/content) on an unchanged repeat (CT-1803)",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+        });
+
+        const propsCell = new MockPropsCell({
+          id: "m1",
+          name: "Alice",
+          content: "hi",
+        });
+        const rootCell = new MockCell({
+          type: "vnode",
+          name: "cf-chat-message",
+          props: propsCell,
+          children: [],
+        });
+
+        const cancel = mountReconciler(reconciler, rootCell);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          collector.clear();
+
+          // Text-integrity sinks have policy-dependent transforms and must
+          // re-run; only the inert id may be skipped.
+          propsCell.set({ id: "m1", name: "Alice", content: "hi" });
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          const keys = collector.getOpsOfType("set-prop")
+            .map((op: any) => op.key);
+          assertEquals(
+            keys.includes("name"),
+            true,
+            "text-integrity `name` must re-emit",
+          );
+          assertEquals(
+            keys.includes("content"),
+            true,
+            "text-integrity `content` must re-emit",
+          );
+          assertEquals(
+            keys.includes("id"),
+            false,
+            "inert id should be skipped when unchanged",
+          );
+        } finally {
+          cancel();
+        }
+      },
+    );
+
     await t.step("Cell<Props> mixed prop types", async () => {
       const collector = createOpsCollector();
       const reconciler = new WorkerReconciler({


### PR DESCRIPTION
## What

PR #4366 dropped the `areChildrenSame` early-skip on the cell-child path, so `updateChildrenInPlace` now reconciles reused inline-VNode children on every parent recompute. As a result the **static-prop** branch of `updatePropsInPlace` (`packages/html/src/worker/reconciler.ts`) re-emits a worker→main `set-prop` op — and the `JSON.stringify` payload it carries — for every reused inline-VNode child even when the captured value is unchanged.

DOM writes are already value-guarded in `setPropDefault`, so those ops are no-ops on the main thread: pure worker→main op + serialize churn, **no DOM churn**. Resolves CT-1798.

## Change

A value-equality guard on the static-prop path, mirroring the existing **Cell\<Props\>** primitive-prop guard:

- Skip the `set-prop` op when an **unchanged primitive** static prop is re-supplied.
- Record `currentValue` on the **initial render** so the guard engages from the first in-place update (`PropState.currentValue` already existed for exactly this).
- **Never skipped** (always re-emit): text-integrity props (`cf-chat-message` `name`/`content` — the only policy-dependent transforms) and object/array props (referential `===` is unreliable; same scope as the precedent).

## Why it's safe

- `setPropDefault` value-guards every branch (`style`, `data-*`, general property), so a skipped redundant op was already a no-op on the main thread — zero observable DOM difference.
- The only policy-dependent prop transforms are gated behind `isTextIntegrityProp` (`TEXT_INTEGRITY_PROP_SINKS` = `cf-chat-message` `name`/`content`), which the guard excludes. All other props flow through the pure `transformPropValue(key, value)`, so an unchanged raw value ⇒ unchanged output regardless of render policy.

## Testing

- New regression test in `worker-reconciler-cell-child.test.ts` — **negative-control verified**: it fails without the fix (unchanged static props re-emit) and passes with it; a genuinely changed prop still emits.
- Full `packages/html` suite green (38 tests / 268 steps); `deno check` clean.
- Reviewed adversarially across text-integrity/policy, prop-lifecycle, completeness, and main-thread-safety lenses.

## Out of scope

A pre-existing inconsistency — the Cell\<Props\> primitive guard lacks the same `isTextIntegrityProp` exclusion — is tracked separately in CT-1803 (unverified; the two paths have different triggering semantics, so it may not be a live bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents redundant set-prop ops for unchanged static props on reused child VNodes and aligns `Cell<Props>` behavior, reducing worker→main ops and JSON payload churn with no DOM behavior change. Resolves CT-1798; addresses CT-1803.

- **Bug Fixes**
  - Skip set-prop for unchanged primitive static props.
  - Never skip text-integrity, object/array, or DOM-live props (`value`, `checked`, `selected`, `selectedIndex`, `indeterminate`, `open`, `scrollTop`, `scrollLeft`) so the main thread can repair drift or re-run policy transforms.
  - Record `currentValue` on initial render; add `packages/html` tests for inline and `Cell<Props>` paths (skip unchanged, DOM-live re-emit, text-integrity and object/array guardrails).

- **Refactors**
  - Share the skip predicate across inline static and `Cell<Props>` primitive paths; `props={cell}` now re-emits DOM-live and text-integrity props on unchanged repeats for parity.

<sup>Written for commit c9af44dbab6087dd42b83896901f757d68657aa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

