### PR TITLE
state-inspector: model unification (fluent entity model + cf inspect piece)

### DIFF
--- a/docs/plans/2026-06-28-state-inspector-handoff.md
+++ b/docs/plans/2026-06-28-state-inspector-handoff.md
@@ -40,7 +40,7 @@ Each PR's base is the branch below it, so each diff shows only its own delta.
 | 3 | `state-inspector-replica-classification` | [#4377](https://github.com/commontoolsinc/labs/pull/4377) | #4376 | M2.5: replica-vs-instance classification | MERGEABLE vs base |
 | 4 | `state-inspector-cf-inspect` | [#4386](https://github.com/commontoolsinc/labs/pull/4386) | #4377 | M3: `cf inspect` + local-DB discovery (usable) | MERGEABLE vs base |
 | 5 | `state-inspector-dogfood` | [#4393](https://github.com/commontoolsinc/labs/pull/4393) | #4386 | dogfood fixes: fvj1 commit decode, `entities`, scheduler/session legibility | MERGEABLE vs base |
-| 6 | `state-inspector-model-unification` | (no PR yet) | #4393 | design doc only so far; **next-phase code lands here** | — |
+| 6 | `state-inspector-model-unification` | [#4395](https://github.com/commontoolsinc/labs/pull/4395) | #4393 | **Phase 1 model unification** (`model.ts`): whole-document read + path-set classification + lineage; `cf inspect piece`; design + handoff docs | MERGEABLE vs base |
 
 All draft. `mergeable` for 2–5 is relative to their *parent branch*; once the base
 rebases onto live main, re-check.
@@ -79,21 +79,35 @@ model unification, so what merges is fluent, not guessing. Alternatively, if the
 team wants `cf inspect` sooner, M1–M3 (#4375–#4386) are independently correct and
 useful; #4393's `entities` is just incomplete, not wrong.
 
-## Next phase: model unification (Phase 1) — start here post-compaction
+## Phase 1: model unification — ✅ DONE (PR #4395, commit `f5046a900`)
 
-Goal: make the tool fluent in the real entity model instead of reading only
-`doc.value`. Per `2026-06-28-state-inspector-model-unification.md`:
+`model.ts` now loads an entity's **whole `is` document** and classifies by
+path-set into **piece / module / stream / schema / owned-cell / free-cell**
+(modern `patternIdentity` + legacy `$TYPE`/`resultRef` regimes), and resolves
+**lineage** — piece→input (`argument`), piece→pattern (`patternIdentity` →
+module entity, matched by `value.identity`), owned-cell→owner (`result`),
+piece→manifest (`internal`). `cf inspect entities` rewired onto
+`listEntityModels` (finds all 7 pieces, not 4); new `describePiece` /
+`cf inspect piece <id>` shows pattern source + input + result/schema + owned
+cells. Verified on the real notes space; tests + fmt/lint/check green.
 
-- New `model.ts`: load an entity's **whole `is` document** (all top-level paths,
-  not just `value`); classify by path-set into **piece / owned-cell / free-cell /
-  stream / module / schema** (handle modern `patternIdentity` AND legacy
-  `$TYPE`/`resultRef` regimes); resolve **lineage** — piece→input (`argument`),
-  piece→pattern (`patternIdentity` → module `code`/`filename`), owned-cell→owner
-  (`result`), piece→manifest (`internal`).
-- Rewire `entities`/`value-at` onto it; add `cf inspect piece <id>` (shows a piece
-  with input, result, owned cells, and pattern source).
-- Then: space grouping → `graph` command → time travel (`diff`/`timeline`) →
-  HTML visual surface. (Time-travel engine already exists via `atSeq`.)
+## Next phase (Phase 2+) — start here
+
+Per `2026-06-28-state-inspector-model-unification.md` roadmap, in order:
+- **Space grouping** — discover + group a user's implicated spaces (home →
+  profiles → main; placeholders marked) via the §3.2 on-disk signals; grouped
+  tree in `cf inspect spaces`.
+- **`graph` command** — emit the real entity graph from the unified model
+  (nodes = pieces/cells/streams/modules; edges = ownership + `patternIdentity` +
+  `argument` + data links).
+- **Time travel** — `diff <entity> --from <a> --to <b>` + a `timeline`. The
+  engine already reconstructs at any seq (`atSeq`); this is surface work.
+- **Visual surface** — self-contained HTML over the existing `--json`.
+
+Open: `value-at` could annotate the entity kind/lineage too (left as-is for now —
+`--doc` already shows the meta paths). Legacy-regime piece classification is
+best-effort (the notes space is fully modern); verify against the 571 MB legacy
+DB when convenient.
 
 ## Resume gotchas
 

--- a/docs/plans/2026-06-28-state-inspector-handoff.md
+++ b/docs/plans/2026-06-28-state-inspector-handoff.md
@@ -1,0 +1,107 @@
+# State Inspector — Handoff & Merge Chain (compaction survival doc)
+
+> Written 2026-06-28 before a context compaction. This is the resume-from-here
+> doc: the stacked-PR chain and how to land it, where everything lives, and the
+> next phase. Companion docs: the proposal
+> `docs/plans/2026-06-26-runtime-trace-inspector.md` and the model design
+> `docs/plans/2026-06-28-state-inspector-model-unification.md`.
+
+## TL;DR
+
+`@commonfabric/state-inspector` (`packages/state-inspector`) is an **offline
+autopsy + comprehension tool** for memory v2 space SQLite stores, surfaced as
+**`cf inspect`**. It's usable today (read-only, no live runtime). It ships as a
+**6-branch stacked chain** of draft PRs, none merged. Next phase = **model
+unification** (read the whole entity document, classify pieces/cells/streams by
+path-set, resolve lineage). The merge of the chain should wait until that lands.
+
+## Where everything lives
+
+- **Worktree:** `/Users/ben/code/labs-state-inspector` (a `git worktree` off
+  `origin/main`). All branches below live here. The current branch is
+  `state-inspector-model-unification`.
+- **Main checkout** `/Users/ben/code/labs` is on a different (merged) branch and
+  contains **stale untracked M1-era copies** of `packages/state-inspector/*` plus
+  the design docs — a `deno fmt` hook keeps re-touching them. Ignore/clean later;
+  they are NOT the real work. Ben's floating `deno.json`/`deno.lock`/`las` edits
+  there must stay untouched.
+- **Real space DBs** for testing: `packages/toolshed/cache/memory/engine-v3/engine-v3/*.sqlite`
+  (gitignored). The freshly-created notes space used for dogfooding:
+  `did:key:z6Mkj75q…` (50 commits, 145 entities, modern regime).
+
+## The stacked PR chain (bottom → top)
+
+Each PR's base is the branch below it, so each diff shows only its own delta.
+
+| Order | Branch | PR | Base | What | Mergeable (2026-06-28) |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `state-inspector-autopsy-core` | [#4375](https://github.com/commontoolsinc/labs/pull/4375) | `main` | M1: db/decode/reconstruct/queries + proposal doc | **CONFLICTING** (main moved) |
+| 2 | `state-inspector-convergence` | [#4376](https://github.com/commontoolsinc/labs/pull/4376) | #4375 | M2: server `applyPatch` reuse + cross-space convergence | MERGEABLE vs base |
+| 3 | `state-inspector-replica-classification` | [#4377](https://github.com/commontoolsinc/labs/pull/4377) | #4376 | M2.5: replica-vs-instance classification | MERGEABLE vs base |
+| 4 | `state-inspector-cf-inspect` | [#4386](https://github.com/commontoolsinc/labs/pull/4386) | #4377 | M3: `cf inspect` + local-DB discovery (usable) | MERGEABLE vs base |
+| 5 | `state-inspector-dogfood` | [#4393](https://github.com/commontoolsinc/labs/pull/4393) | #4386 | dogfood fixes: fvj1 commit decode, `entities`, scheduler/session legibility | MERGEABLE vs base |
+| 6 | `state-inspector-model-unification` | (no PR yet) | #4393 | design doc only so far; **next-phase code lands here** | — |
+
+All draft. `mergeable` for 2–5 is relative to their *parent branch*; once the base
+rebases onto live main, re-check.
+
+## How to land the chain (repo-specific — read before merging)
+
+This repo **squash-merges** and has **instant auto-merge** (no required status
+checks → `gh pr merge --auto` merges immediately, even with CI pending). So:
+
+1. **Don't use `--auto`.** Wait for `gh pr checks <pr>` green, then plain
+   `gh pr merge <pr> --squash`.
+2. **Rebase the chain onto current main first** (base #4375 is CONFLICTING):
+   - In the worktree, `git fetch origin`, then rebase `state-inspector-autopsy-core`
+     onto `origin/main`. **Expected conflicts: `deno.json` (workspace array) and
+     `deno.lock`** from main's churn (e.g. charm→piece renames). Resolve by taking
+     **main's** version and re-adding the one line `"./packages/state-inspector"`
+     to the workspace array + the additive `deno.lock` state-inspector entry.
+   - Cascade-rebase each upper branch onto its rebased parent:
+     `git rebase --onto <new-parent-tip> <old-parent-tip> <branch>` for #4376→…→#4393.
+     Force-push each (`--force-with-lease`). Nothing is stacked above the tip, so
+     force-pushing is safe.
+3. **Squash-merge bottom-up:** merge #4375 (→ main). Then for each next PR, GitHub
+   may auto-retarget to main; if not, rebase it onto main (dropping the
+   now-squash-merged commits — they're squashed, so `drop` in rebase) and merge.
+   Verify each is green first.
+4. **After all merged:** delete the worktree (`git worktree remove`), and clean the
+   stale untracked `packages/state-inspector/*` copies + design-doc copies from the
+   main checkout (they reference a `./packages/state-inspector` workspace member, so
+   if you delete the dir there, also drop that line from that checkout's deno.json —
+   but only after confirming it's not entangled with Ben's floating edits).
+
+**Recommendation:** don't merge piecemeal yet. The dogfood `entities` classifier
+**undercounts pieces** (uses a `$NAME`-string heuristic; finds 4 of 7). Model
+unification (next phase) corrects this. Land the chain as one rebased unit *after*
+model unification, so what merges is fluent, not guessing. Alternatively, if the
+team wants `cf inspect` sooner, M1–M3 (#4375–#4386) are independently correct and
+useful; #4393's `entities` is just incomplete, not wrong.
+
+## Next phase: model unification (Phase 1) — start here post-compaction
+
+Goal: make the tool fluent in the real entity model instead of reading only
+`doc.value`. Per `2026-06-28-state-inspector-model-unification.md`:
+
+- New `model.ts`: load an entity's **whole `is` document** (all top-level paths,
+  not just `value`); classify by path-set into **piece / owned-cell / free-cell /
+  stream / module / schema** (handle modern `patternIdentity` AND legacy
+  `$TYPE`/`resultRef` regimes); resolve **lineage** — piece→input (`argument`),
+  piece→pattern (`patternIdentity` → module `code`/`filename`), owned-cell→owner
+  (`result`), piece→manifest (`internal`).
+- Rewire `entities`/`value-at` onto it; add `cf inspect piece <id>` (shows a piece
+  with input, result, owned cells, and pattern source).
+- Then: space grouping → `graph` command → time travel (`diff`/`timeline`) →
+  HTML visual surface. (Time-travel engine already exists via `atSeq`.)
+
+## Resume gotchas
+
+- Run from the **worktree**; real DBs live in the worktree's toolshed cache or the
+  main checkout's — pass `--dir`/`MEMORY_DIR` or rely on cwd walk-up.
+- `git commit --amend` is **blocked** by a repo hook → make a new commit.
+- A stray **NUL byte** in a TS comment makes git treat the file as binary; `python3`
+  byte-scan to find, replace with space. (Bit us once in `multispace.ts`.)
+- `cf` launcher already grants `--allow-ffi`, so `cf inspect` + sqlite needs no perm
+  change. Registering a Cliffy command in `commands/main.ts` needs
+  `// @ts-ignore for the above type issue` (command-type quirk, like piece/fuse).

--- a/docs/plans/2026-06-28-state-inspector-model-unification.md
+++ b/docs/plans/2026-06-28-state-inspector-model-unification.md
@@ -1,0 +1,232 @@
+# State Inspector — Model Unification (the comprehension turn)
+
+> Status: design doc / latest thinking. Written 2026-06-28 before starting the
+> next phase. Grounded in code investigation (oracle + explore) and direct
+> probing of a real modern space DB. Supersedes the guesswork-level entity model
+> in the M1–M3 code.
+
+## Why this doc
+
+The state-inspector has shipped a usable autopsy + convergence + `cf inspect`
+surface (PRs #4375 → #4376 → #4377 → #4386 → #4393). Dogfooding a real
+freshly-created notes space exposed that our **entity model was guessed, not
+known** — we classified by the shape of `doc.value` and showed raw JSON for
+anything we didn't recognize.
+
+The north star has also sharpened: this is a **comprehension tool to help the
+whole team understand the Common Fabric stack** — what a space is, what pieces /
+patterns / cells / streams are and how they relate, and how state got to where it
+is — **not** a vanity-stats tool. To earn that, the tool must be *fluent* in the
+real model. This doc writes down that model from ground truth, then sequences the
+work to make the tool speak it.
+
+## Part 1 — The reframe
+
+Comprehension over stats. Every feature is judged by: *does it help a teammate
+(or an agent) understand what they're looking at?* That reorders priorities — the
+**unified entity/space model**, the **graph**, **time travel**, and a **visual
+surface** are the spine; counts are supporting detail.
+
+## Part 2 — The entity model (ground truth)
+
+### 2.1 An entity's stored document is a TREE of top-level paths
+
+Memory v2 stores one document (`is`) per entity id. The cell layer addresses
+**paths inside that one document**. The reactive value lives at path `["value"]`;
+the **control plane lives at sibling top-level meta paths** on the *same* entity
+(`packages/runner/src/cell.ts:1833-1859`; `packages/api/index.ts:324-345`
+`MetaField`).
+
+Top-level paths an entity document can carry:
+
+| Path | Meaning |
+| --- | --- |
+| `value` | the reactive value (a cell's contents) |
+| `argument` | SigilLink → the piece's **input cell** |
+| `result` | SigilLink → the **owning piece's result cell** (ownership back-link) |
+| `pattern` | SigilLink → the pattern cell |
+| `patternIdentity` | `{ identity, symbol }` — the **durable piece → pattern(module) pointer** |
+| `internal` | manifest array `[{ partialCause, link }]` of owned child cells |
+| `schema` | the result's JSONSchema |
+| `cfc` | CFC (information-flow) label map + `schemaHash` |
+| `slug` | piece slug metadata |
+
+**The core bug in our current tool:** we only ever read `doc.value`. We are blind
+to the entire control plane — ownership, input cells, and the piece→pattern link.
+To be fluent we must read the **whole `is` document** and classify by *which
+top-level paths exist*.
+
+### 2.2 Entity kinds, by path-set (real counts from one modern space)
+
+Probing the notes space (145 entities, all `scope_key='space'`, modern regime)
+gives the actual distribution of top-level key-combinations:
+
+| Count | Key combination | What it is |
+| --- | --- | --- |
+| 7 | `{argument, internal, patternIdentity, schema, value}` | **Piece** — a running pattern instance (result cell + full lineage) |
+| 72 | `{result, value}` | **Owned cell** — a cell belonging to a piece, with a value |
+| 19 | `{result}` | **Owned cell, value-less** — lineage/ownership node (our old "empty"!) |
+| 38 | `{value}` | **Free cell** — a standalone cell owned by no piece |
+| 9 | `{cfc, value}` | a cell carrying an information-flow label |
+
+Layered on top, by the shape of `value`:
+- `{ $stream: true }` → **stream** (write-only event channel; 20 of them)
+- `{ code, filename, identity, imports, kind }` → **module** (pattern source; 18)
+- `{ ifc, properties, type }` → **schema** stored as a cell value (`ifc` = CFC)
+- `$UI` / `$NAME` / `$TILE_UI` / `$FS` present → a **piece's result** value
+
+So: **cells and streams are the fundamental units. A piece is a result cell with
+lineage meta (`argument`+`patternIdentity`+`internal`+`schema`). Cells/streams may
+be owned by a piece (`result` back-link) or free-floating.**
+
+### 2.3 Piece anatomy
+
+A modern piece is rooted at its **result cell**:
+
+```
+            patternIdentity {identity, symbol}      →  module entity (source code)
+           /
+  PIECE  ─┼─ argument  → input cell
+  (result │
+   cell)  ├─ schema    → result JSONSchema
+           ├─ internal  → [ owned child cells … ]   (each carries result → back here)
+           └─ value     → { $UI, $NAME, …pattern outputs }
+```
+
+- **Input cell** = the `argument` link. **Result cell** = the entity itself (its
+  `value`). **Pattern source** = follow `patternIdentity.identity` to the module
+  entity, whose `code`/`filename` hold the TS source; `symbol` selects the export.
+- Ownership tree: every owned cell's `result` link points back to its piece;
+  `internal` is the piece's manifest of them.
+
+### 2.4 Modules / patterns
+
+Module entities (`packages/runner/src/compilation-cache/cell-cache.ts`):
+- `kind: "source"` → `{ identity, code (TS), filename, imports:[{specifier,link}] }`
+- `kind: "compiled"` → emitted JS + optional sourceMap
+- `identity` = content hash of the module (`computeModuleHashes`, `cf:module/<hash>`),
+  recomputed/verified on read. `imports[].link` → SigilLinks to dependency modules
+  (transitive closure). One `.tsx` → many module entities; one module → many
+  exports, hence `patternIdentity = {identity, symbol}`.
+- There is **no separate "recipe" entity** — "recipe"/"spell"/"charm" are legacy
+  names for pattern/pattern/piece.
+
+### 2.5 Symbols, schemas, envelopes
+
+- `$UI`/`$NAME`/`$TYPE`/`$FS`/`$TILE_UI`/`$CHIP_UI` are **plain string constants**
+  (`builder/types.ts:82-90`), not serialized Symbols. `$stream` is a separate
+  `StreamValue` marker.
+- `ifc` = Information-Flow-Control labels; object cells shaped `{ifc,properties,type}`
+  are **JSONSchemas stored as values**, not data.
+- Two at-rest envelopes (our decoder already routes the first by the `fvj1:` tag):
+  modern codec `{"/Link@1":…}` / `{"/Hash@1":…}` inside `fvj1:`; legacy plain-JSON
+  `{"/":{"link@1":…}}`. Both decode to inert link data offline.
+
+### 2.6 Two regimes — handle both
+
+- **Modern (post-#3522 "Remove Process Cell"):** the layout above. Our notes space
+  is modern (7 pieces all carry `patternIdentity`).
+- **Legacy (pre-#3522):** a separate **process/source cell** whose `value` carries
+  `{ $TYPE: <pattern-id string>, resultRef, argument?, spell?, source? }`; the
+  result cell has a `source` → process cell. The `$TYPE: ba4jcbp…` we saw in older
+  DBs is this legacy pattern-id (a module/pattern hash), **not** a schema hash.
+- The tool must classify pieces in **both** regimes (`patternIdentity` OR
+  legacy `$TYPE`/`resultRef`). `packages/shell/src/lib/debug-utils.ts:269-291`
+  only recognizes the legacy keys today — we should do better.
+
+## Part 3 — The multi-space model
+
+A user's state is spread across **several spaces**, and "understand all implicated
+spaces" means grouping them, not inspecting one DB in isolation.
+
+### 3.1 Space kinds
+
+| Space | DID derivation | Holds |
+| --- | --- | --- |
+| **Home** | = the user's identity DID | registry of the user: `profiles[]` (cross-space links), favorites, default profile, MRU, self-model, `site_table` |
+| **Profile** (per profile) | anonymous `ProfileHome.inSpace()` (frame-cause derived; CT-1650 forbade name-derived) | a profile's name/avatar/bio/elements |
+| **Main / pattern** | arbitrary (e.g. `createSession({spaceName})`) | shared pattern instance data |
+| **PerUser scope** | NOT a separate DB — `scope_key = 'user:<userDID>'` rows **inside** a space DB | `PerUser<T>` cells |
+| **PerSession scope** | NOT a separate DB — `scope_key = 'session:<userDID>:<sessionId>'` rows inside a space DB | `PerSession<T>` cells |
+
+**Correction to an earlier assumption:** PerUser / PerSession are `scope_key`
+**partitions within a space DB**, not separate files. The reactive readers
+(`PerSpace`/`PerUser`/`PerSession`) read only their matching `scope_key` rows
+(`packages/memory/v2/engine.ts:51-79,146-183`). The same cell id can have one row
+per scope in the same DB.
+
+So the 4 SQLite files from creating one space are **4 separate spaces** (the main
+space + placeholder home/profile/session **spaces** pre-created and still empty),
+**not** per-user/per-session partitions.
+
+### 3.2 Recovering the implicated-space group from storage
+
+On-disk signals (each verifiable offline):
+1. **Home `profiles[]` cell** → cross-space links `{id, space, path}` to profile spaces.
+2. **`commit.session_id`** = `session:did:key:<DID>:<uuid>` — the embedded `<DID>`
+   is a related (session/partition) space; we already surface this.
+3. **Cross-space links** anywhere: values whose link carries a `"space"` ≠ self.
+4. **Home `site_table`** → `{did, host}` entries (host hints / known spaces).
+
+### 3.3 Open questions (don't assert — verify before building)
+
+- Exact `session_id` format and whether the embedded DID is always a real space
+  file vs. a principal. (Flagged uncertain by the investigation.)
+- The empty-DB lifecycle: precisely what pre-creates the placeholder space files
+  and what first-write populates them.
+- Profile → home is one-way in storage (no reverse index); recovering the home
+  from a profile DB needs the home DB or an external hint.
+
+## Part 4 — What "fluent" requires of the inspector
+
+1. **Read the whole `is` document**, not just `doc.value`. Expose all top-level
+   paths (value + meta).
+2. **Classify by path-set** (piece / owned-cell / free-cell / stream / module /
+   schema), in both modern and legacy regimes. Retire the `$NAME`-string heuristic
+   that undercounts pieces.
+3. **Resolve lineage**: piece → input (`argument`), piece → pattern
+   (`patternIdentity` → module → `code`/`filename`), owned cell → owner (`result`),
+   piece → manifest (`internal`).
+4. **Render pattern source** for a piece (follow `patternIdentity` to the module).
+5. **Group implicated spaces** across DBs (§3.2), so "a user's world" is one view.
+
+## Part 5 — Roadmap (sequenced; comprehension-first)
+
+1. **Model unification (foundation).** Whole-document read + path-set
+   classification + lineage resolution (ownership tree, `patternIdentity`,
+   `argument`). This corrects `entities`/`value-at` and unblocks everything else.
+2. **Space grouping.** Discover + group the implicated spaces for a user/session;
+   `cf inspect spaces` shows a grouped tree (home → profiles → main; placeholders
+   marked), recovered via §3.2 signals.
+3. **`graph` command.** Emit the real entity graph using the unified model:
+   nodes = pieces/cells/streams/modules with correct labels; edges = ownership +
+   `patternIdentity` + `argument` + data links. (The mislabeled demo graph from
+   2026-06-27 was blocked exactly by the missing model.)
+4. **Time travel.** `diff <entity> --from <seqA> --to <seqB>` + a `timeline` of how
+   a space/piece grew. The engine already reconstructs at any seq — this is surface
+   work.
+5. **Visual surface.** A self-contained HTML inspector (grouped spaces → entity
+   graph → timeline) consuming the `--json` we already emit, so a teammate opens it
+   in a browser, not a terminal.
+
+Open cross-cutting items: handle legacy + modern regimes everywhere; decode the
+modern `{"/Link@1":…}` envelope as carefully as the legacy sigil; keep every
+command `--json` for agents.
+
+## Appendix — evidence
+
+Top-level doc key-combinations in the real modern notes space (145 entities):
+
+```
+ 72  {result, value}                                         owned cells (valued)
+ 38  {value}                                                 free cells
+ 19  {result}                                                owned cells (value-less / lineage)
+  9  {cfc, value}                                            labeled cells
+  7  {argument, internal, patternIdentity, schema, value}    pieces
+```
+
+Key code references: `packages/api/index.ts:324-345` (MetaField), `packages/runner/src/cell.ts:1833-1859`
+(meta paths), `packages/runner/src/runner.ts:~935-987` (argument/internal/patternIdentity/schema writes),
+`packages/runner/src/compilation-cache/cell-cache.ts:286-557` (module docs),
+`packages/runner/src/harness/module-identity.ts:117-182` (module identity hash),
+`packages/memory/v2/engine.ts:51-79` (scope_key), `packages/runner/src/builder/types.ts:82-90` ($-symbol constants).

--- a/docs/plans/2026-06-28-state-inspector-model-unification.md
+++ b/docs/plans/2026-06-28-state-inspector-model-unification.md
@@ -192,9 +192,14 @@ On-disk signals (each verifiable offline):
 
 ## Part 5 — Roadmap (sequenced; comprehension-first)
 
-1. **Model unification (foundation).** Whole-document read + path-set
-   classification + lineage resolution (ownership tree, `patternIdentity`,
-   `argument`). This corrects `entities`/`value-at` and unblocks everything else.
+1. **Model unification (foundation).** ✅ **DONE** — `model.ts`: whole-document
+   read + path-set classification (piece / module / stream / schema / owned-cell
+   / free-cell, modern + legacy regimes) + lineage resolution (`argument` →
+   input, `patternIdentity` → module by `value.identity`, `result` → owner,
+   `internal` → owned cells). `entities` rewired onto it (now finds all 7 pieces,
+   not 4); new `cf inspect piece <id>` shows a piece's pattern source, input,
+   result/schema keys, and owned cells. Verified end-to-end on the real notes
+   space.
 2. **Space grouping.** Discover + group the implicated spaces for a user/session;
    `cf inspect spaces` shows a grouped tree (home → profiles → main; placeholders
    marked), recovered via §3.2 signals.

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -12,15 +12,16 @@ import { Table } from "@cliffy/table";
 import {
   annotate,
   buildCrossSpaceLinkIndex,
-  type ConvergenceResult,
   convergence,
+  type ConvergenceResult,
   convergenceScan,
+  describePiece,
   discoverSpaceDbs,
   entityHistory,
   getValueAt,
   hotEntities,
   listCommits,
-  listEntities,
+  listEntityModels,
   listSqliteFiles,
   openSpace,
   openSpaces,
@@ -134,7 +135,10 @@ export const inspect = new Command()
     });
   })
   /* inspect summary */
-  .command("summary <space:string>", "Space overview: commits, sessions, hot ops.")
+  .command(
+    "summary <space:string>",
+    "Space overview: commits, sessions, hot ops.",
+  )
   .action((options, space) => {
     const s = openSpace(resolveSpacePath(space));
     try {
@@ -150,10 +154,15 @@ export const inspect = new Command()
         console.log(`sessions: ${sum.sessions}`);
         console.log(`entities: ${sum.entities}  revisions: ${sum.revisions}`);
         console.log(
-          `ops: ${Object.entries(sum.ops).map(([k, v]) => `${k}=${v}`).join(" ")}`,
+          `ops: ${
+            Object.entries(sum.ops).map(([k, v]) => `${k}=${v}`).join(" ")
+          }`,
         );
         console.log(
-          `branches: ${sum.branches.map((b) => `${b.name || "(default)"}@${b.head_seq}`).join(" ")}`,
+          `branches: ${
+            sum.branches.map((b) => `${b.name || "(default)"}@${b.head_seq}`)
+              .join(" ")
+          }`,
         );
         console.log(
           `scheduler: ${
@@ -170,17 +179,25 @@ export const inspect = new Command()
     }
   })
   /* inspect commits */
-  .command("commits <space:string>", "Recent commits (who committed, ops, reads).")
+  .command(
+    "commits <space:string>",
+    "Recent commits (who committed, ops, reads).",
+  )
   .option("--session <prefix:string>", "Filter by session id prefix.")
   .option("--limit <n:number>", "Max rows.", { default: 50 })
   .action((options, space) => {
     const s = openSpace(resolveSpacePath(space));
     try {
-      const rows = listCommits(s, { session: options.session, limit: options.limit });
+      const rows = listCommits(s, {
+        session: options.session,
+        limit: options.limit,
+      });
       out(!!options.json, rows, () => {
         for (const r of rows) {
           console.log(
-            `#${r.seq}\t${fmtSession(r.session)}\tlocal=${r.localSeq}\tops=${r.ops}\treads=${r.reads}\t${r.createdAt}`,
+            `#${r.seq}\t${
+              fmtSession(r.session)
+            }\tlocal=${r.localSeq}\tops=${r.ops}\treads=${r.reads}\t${r.createdAt}`,
           );
         }
       });
@@ -189,16 +206,24 @@ export const inspect = new Command()
     }
   })
   /* inspect hot */
-  .command("hot <space:string>", "Entities ranked by write count (contention proxy).")
+  .command(
+    "hot <space:string>",
+    "Entities ranked by write count (contention proxy).",
+  )
   .option("--limit <n:number>", "Max rows.", { default: 20 })
   .option("--branch <branch:string>", "Branch (default: '').")
   .action((options, space) => {
     const s = openSpace(resolveSpacePath(space));
     try {
-      const rows = hotEntities(s, { limit: options.limit, branch: options.branch });
+      const rows = hotEntities(s, {
+        limit: options.limit,
+        branch: options.branch,
+      });
       out(!!options.json, rows, () => {
         for (const r of rows) {
-          console.log(`${r.writes}\twrites\t${r.sessions} sessions\t${r.id}\t(${r.scope})`);
+          console.log(
+            `${r.writes}\twrites\t${r.sessions} sessions\t${r.id}\t(${r.scope})`,
+          );
         }
       });
     } finally {
@@ -206,28 +231,46 @@ export const inspect = new Command()
     }
   })
   /* inspect entities */
-  .command("entities <space:string>", "What's in the space: entities by kind + name.")
-  .option("--kind <kind:string>", "Filter: module | instance | stream | value | empty.")
+  .command(
+    "entities <space:string>",
+    "What's in the space: entities by kind, with lineage.",
+  )
+  .option(
+    "--kind <kind:string>",
+    "Filter: piece | module | stream | schema | owned-cell | free-cell | unknown.",
+  )
   .option("--branch <branch:string>", "Branch (default: '').")
-  .option("--limit <n:number>", "Max entities to reconstruct.", { default: 2000 })
+  .option("--limit <n:number>", "Max entities to reconstruct.", {
+    default: 5000,
+  })
   .action((options, space) => {
     const s = openSpace(resolveSpacePath(space));
     try {
-      let rows = listEntities(s, { limit: options.limit, branch: options.branch });
+      let rows = listEntityModels(s, {
+        limit: options.limit,
+        branch: options.branch,
+      });
       if (options.kind) rows = rows.filter((r) => r.kind === options.kind);
       out(!!options.json, rows, () => {
         if (rows.length === 0) {
           console.log("(no entities)");
           return;
         }
+        // A compact comprehension legend, then the table.
+        const counts = new Map<string, number>();
+        for (const r of rows) counts.set(r.kind, (counts.get(r.kind) ?? 0) + 1);
+        console.log(
+          [...counts.entries()].map(([k, n]) => `${k}=${n}`).join("  "),
+        );
         console.log(
           Table.from([
-            ["KIND", "NAME", "REVS", "LINKS", "ID"],
+            ["KIND", "LABEL", "OWN", "REVS", "LINKS", "ID"],
             ...rows.map((r) => [
               r.kind,
-              r.name.length > 40 ? `${r.name.slice(0, 39)}…` : r.name,
-              String(r.revisions),
-              String(r.links),
+              r.label.length > 34 ? `${r.label.slice(0, 33)}…` : r.label,
+              r.owned ? "↳" : "",
+              String(r.revisions ?? 0),
+              String(r.links ?? 0),
               r.id,
             ]),
           ]).toString(),
@@ -237,8 +280,70 @@ export const inspect = new Command()
       s.close();
     }
   })
+  /* inspect piece */
+  .command(
+    "piece <space:string> <entity:string>",
+    "A piece's pattern, input, result, and owned cells.",
+  )
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .option("--scope <scope:string>", "Scope key (default: space).")
+  .option("--code", "Include the full pattern TS source.")
+  .action((options, space, entity) => {
+    const s = openSpace(resolveSpacePath(space));
+    try {
+      const piece = describePiece(s, entity, {
+        branch: options.branch,
+        scope: options.scope,
+        includeCode: !!options.code,
+      });
+      out(!!options.json, piece, () => {
+        if ("error" in piece) {
+          console.log(`(${piece.error})`);
+          return;
+        }
+        console.log(`piece:   ${piece.name}  [${piece.regime}]`);
+        console.log(`id:      ${piece.id}`);
+        if (piece.pattern) {
+          const p = piece.pattern;
+          console.log(
+            `pattern: ${p.filename ?? "(unresolved)"}` +
+              (p.symbol ? ` · ${p.symbol}` : "") +
+              (p.codeLines ? ` · ${p.codeLines} lines` : "") +
+              (p.id ? `  ${p.id}` : ""),
+          );
+        }
+        if (piece.input) {
+          console.log(`input:   ${piece.input.summary}  ${piece.input.id}`);
+        }
+        console.log(`result:  {${piece.resultKeys.join(", ")}}`);
+        if (piece.schemaKeys.length) {
+          console.log(`schema:  {${piece.schemaKeys.join(", ")}}`);
+        }
+        if (piece.ownedCells.length) {
+          console.log(`owned cells (${piece.ownedCells.length}):`);
+          for (const c of piece.ownedCells) {
+            console.log(
+              `  ${c.kind.padEnd(10)} ${
+                c.summary.length > 40 ? `${c.summary.slice(0, 39)}…` : c.summary
+              }\t${c.id}`,
+            );
+          }
+        }
+        if (piece.pattern?.code) {
+          console.log(
+            `\n--- ${piece.pattern.filename} ---\n${piece.pattern.code}`,
+          );
+        }
+      });
+    } finally {
+      s.close();
+    }
+  })
   /* inspect history */
-  .command("history <space:string> <entity:string>", "Every write that touched an entity.")
+  .command(
+    "history <space:string> <entity:string>",
+    "Every write that touched an entity.",
+  )
   .option("--scope <scope:string>", "Scope key (default: space).")
   .option("--branch <branch:string>", "Branch (default: '').")
   .option("--limit <n:number>", "Max rows.", { default: 200 })
@@ -254,7 +359,9 @@ export const inspect = new Command()
       out(!!options.json, rows, () => {
         for (const r of rows) {
           console.log(
-            `seq=${r.seq}\tcommit=${r.commitSeq}\t${r.op}\t${fmtSession(r.session)}\tlocal=${r.localSeq}\t${r.createdAt}`,
+            `seq=${r.seq}\tcommit=${r.commitSeq}\t${r.op}\t${
+              fmtSession(r.session)
+            }\tlocal=${r.localSeq}\t${r.createdAt}`,
           );
         }
       });
@@ -267,7 +374,10 @@ export const inspect = new Command()
     "value-at <space:string> <entity:string>",
     "Reconstructed value of an entity at a seq.",
   )
-  .option("--seq <n:number>", "Reconstruct as of this commit seq (default: latest).")
+  .option(
+    "--seq <n:number>",
+    "Reconstruct as of this commit seq (default: latest).",
+  )
   .option("--path <path:string>", "Navigate into value, e.g. value/count.")
   .option("--scope <scope:string>", "Scope key (default: space).")
   .option("--branch <branch:string>", "Branch (default: '').")
@@ -277,21 +387,34 @@ export const inspect = new Command()
     try {
       const res = getValueAt(
         s,
-        { id: entity, scope: options.scope, branch: options.branch, atSeq: options.seq },
+        {
+          id: entity,
+          scope: options.scope,
+          branch: options.branch,
+          atSeq: options.seq,
+        },
         splitPath(options.path),
       );
       const shown = options.doc ? res.document : res.value;
-      out(!!options.json, { exists: res.exists, value: annotate(shown) }, () => {
-        if (!res.exists) console.log("(absent at this seq)");
-        else if (shown === undefined) console.log("(entity present, but nothing at that path)");
-        else console.log(JSON.stringify(annotate(shown), null, 2));
-      });
+      out(
+        !!options.json,
+        { exists: res.exists, value: annotate(shown) },
+        () => {
+          if (!res.exists) console.log("(absent at this seq)");
+          else if (shown === undefined) {
+            console.log("(entity present, but nothing at that path)");
+          } else console.log(JSON.stringify(annotate(shown), null, 2));
+        },
+      );
     } finally {
       s.close();
     }
   })
   /* inspect converge */
-  .command("converge <entity:string>", "Compare an entity's value across spaces.")
+  .command(
+    "converge <entity:string>",
+    "Compare an entity's value across spaces.",
+  )
   .option("--all", "Use all discovered spaces.")
   .option("--spaces <list:string>", "Comma-separated DIDs/prefixes/paths.")
   .option("--dir <dir:string>", "Directory of *.sqlite files.")
@@ -307,23 +430,37 @@ export const inspect = new Command()
       });
       const r = convergence(
         refs,
-        { id: entity, scope: options.scope, branch: options.branch, path: splitPath(options.path) },
+        {
+          id: entity,
+          scope: options.scope,
+          branch: options.branch,
+          path: splitPath(options.path),
+        },
         index,
       );
       out(!!options.json, r, () => {
         console.log(
           `verdict: ${r.verdict.toUpperCase()}` +
-            (r.relationship && r.relationship !== "n/a" ? `  [${r.relationship}]` : ""),
+            (r.relationship && r.relationship !== "n/a"
+              ? `  [${r.relationship}]`
+              : ""),
         );
-        console.log(`entity:  ${r.id}` + (r.path.length ? `  path=/${r.path.join("/")}` : ""));
+        console.log(
+          `entity:  ${r.id}` +
+            (r.path.length ? `  path=/${r.path.join("/")}` : ""),
+        );
         for (const v of r.views) {
           if (!v.present) {
             console.log(`  ${v.label}\tABSENT`);
             continue;
           }
-          const cluster = r.clusters.findIndex((c) => c.valueKey === v.valueKey) + 1;
+          const cluster = r.clusters.findIndex((c) =>
+            c.valueKey === v.valueKey
+          ) + 1;
           console.log(
-            `  ${v.label}\thead=${v.headSeq}\trevs=${v.revisions}\tlast=${v.lastSession ? fmtSession(v.lastSession) : "?"}\tcluster#${cluster}`,
+            `  ${v.label}\thead=${v.headSeq}\trevs=${v.revisions}\tlast=${
+              v.lastSession ? fmtSession(v.lastSession) : "?"
+            }\tcluster#${cluster}`,
           );
         }
         console.log(`note: ${r.caveat}`);
@@ -342,7 +479,10 @@ export const inspect = new Command()
   .action((options) => {
     const refs = resolveMultiSpaces(options);
     try {
-      const result = convergenceScan(refs, { limit: options.limit, branch: options.branch });
+      const result = convergenceScan(refs, {
+        limit: options.limit,
+        branch: options.branch,
+      });
       out(!!options.json, result, () => {
         console.log(
           `shared entities (in >=2 spaces): ${result.sharedEntities}  examined: ${result.examined}`,
@@ -356,7 +496,9 @@ export const inspect = new Command()
           const present = f.views.filter((v) => v.present).length;
           const missing = f.views.length - present;
           console.log(
-            `  ${f.verdict.toUpperCase()}\t${relTag(f)}\t${f.id}\tpresent=${present}` +
+            `  ${f.verdict.toUpperCase()}\t${
+              relTag(f)
+            }\t${f.id}\tpresent=${present}` +
               (missing ? `\tmissing=${missing}` : "") +
               `\tclusters=${f.clusters.length}`,
           );

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -8,82 +8,108 @@ recorder.** This package is the lens over it — open a space SQLite file
 read-only, reconstruct state-at-`(branch, seq)`, and answer who/what/when
 questions with no live runtime and no capture step.
 
-## Status: usable (Milestones 1, 2, 2.5, 3)
+## Status: usable (Milestones 1, 2, 2.5, 3 + model unification)
 
 Wired into the `cf` CLI as **`cf inspect`** with local-DB auto-discovery — no
 absolute paths needed. Tested end-to-end against real space DBs (a 571 MB legacy
 DB and a set of modern `fvj1:` DBs).
 
+**Model unification** (`model.ts`) makes the tool _fluent_: instead of guessing
+from the shape of `doc.value`, it reads the **whole entity document** (`value`
+plus the meta paths `argument` / `result` / `patternIdentity` / `internal` /
+`schema` / `cfc`) and classifies by **which top-level paths exist**:
+
+| Kind         | Signal                                                                   |
+| ------------ | ------------------------------------------------------------------------ |
+| `piece`      | `patternIdentity` (modern) or a legacy `$TYPE`/`resultRef` process value |
+| `module`     | value carries `{ code, identity }` (pattern source/compiled)             |
+| `stream`     | `value.$stream === true`                                                 |
+| `schema`     | value is a JSONSchema (`{ type, properties\|$defs }`)                    |
+| `owned-cell` | carries a `result` ownership back-link                                   |
+| `free-cell`  | a bare `value`, owned by no piece                                        |
+
+It also resolves **lineage**: a piece → its input (`argument`), its pattern
+(`patternIdentity` → the module entity, matched by `value.identity`), and its
+owned cells (`internal` manifest); an owned cell → its owner (`result`). This
+corrected `entities` (the old value-shape heuristic undercounted pieces — 4 of 7
+in the notes space; now all 7) and added `cf inspect piece <id>`.
+
 **M3 — usable surface**
+
 - `cf inspect spaces` — discover local space DBs (walks up from cwd through
   `cache/memory/…` and `packages/toolshed/cache/memory/…`, or honors
   `MEMORY_DIR` / `DB_PATH` / `--dir`) and list them with quick stats.
 - All commands take a `<space>` as a **DID, DID-prefix, or path** (resolved via
   discovery), so you go from `spaces` straight to drilling in.
 
-Underlying milestones: 
+Underlying milestones:
 
 **M1 — single-space autopsy core**
+
 - **read-only DB access** (`db.ts`)
 - **value decoder** (`decode.ts`) — recognizes sigil links
   `{ "/": { "link@1": {…} } }`, entity refs `{ "/": "of:…" }`, and streams
   `{ "$stream": true }`; annotates a value into JSON-printable form.
 - **state reconstruction** (`reconstruct.ts`) — replays the append-only
   `revision` log (`set` / `patch` / `delete`) to a target seq. **Patch
-  application reuses the server's `applyPatch`** (`@commonfabric/memory/v2/patch`),
-  not a re-implementation — see fidelity note below.
+  application reuses the server's `applyPatch`**
+  (`@commonfabric/memory/v2/patch`), not a re-implementation — see fidelity note
+  below.
 - **autopsy queries** (`queries.ts`) — `summary`, `commits`, `entityHistory`
   (who wrote this), `hotEntities` (contention proxy).
 
 **M2 — cross-space convergence** (`multispace.ts`)
+
 - `convergence(spaces, {id, path})` — reconstruct an entity's value across N
-  space DBs, cluster equal values, and classify:
-  `converged` / `diverged` / `partial` (present in some, absent in others) /
-  `absent`. Per-space evidence: head seq, revision count, last writer, last
-  write time. Resilient: a decode error in one space is isolated, not fatal.
+  space DBs, cluster equal values, and classify: `converged` / `diverged` /
+  `partial` (present in some, absent in others) / `absent`. Per-space evidence:
+  head seq, revision count, last writer, last write time. Resilient: a decode
+  error in one space is isolated, not fatal.
 - `convergenceScan(spaces)` — find entities present in ≥2 spaces and report
   those that diverge.
 
 **M2.5 — replica vs. instance classification** (`multispace.ts`)
+
 - `buildCrossSpaceLinkIndex(spaces)` — find every link whose `space` names a
-  *different* space than the one holding it (only entities whose stored data
+  _different_ space than the one holding it (only entities whose stored data
   carries an explicit `"space":"did:key:` are reconstructed, so it stays cheap).
 - Each divergence is then labeled `cross-space-linked` (a real replica that
   should converge → **drift bug**) vs `no-cross-space-link` (shared id with no
   cross-space link → **likely independent same-pattern instance**, expected).
   This stops the scan from crying wolf on every same-id divergence.
 
-**CLI** (`cli.ts`) — every command supports `--json` for agents:
-`summary`, `commits`, `hot`, `history`, `value-at`, `converge`, `converge-scan`.
+**CLI** (`cli.ts`) — every command supports `--json` for agents: `summary`,
+`commits`, `hot`, `history`, `value-at`, `converge`, `converge-scan`.
 
 ## Fidelity note (why reconstruction reuses the server applier)
 
 The server's JSON-Patch dialect (`packages/memory/v2/patch.ts`) is **not plain
-RFC 6902**: it has a custom `splice` op (`{index, remove, add}`), creates missing
-object keys on `add`, and is strict about missing array indices. A hand-rolled
-applier silently dropped `splice` and mis-handled `add`. Reconstruction therefore
-calls the real `applyPatch` (offline-safe: pure value ops, no live runtime/cell).
-The hermetic test guards `splice` + missing-key `add` against regressing to a fork.
+RFC 6902**: it has a custom `splice` op (`{index, remove, add}`), creates
+missing object keys on `add`, and is strict about missing array indices. A
+hand-rolled applier silently dropped `splice` and mis-handled `add`.
+Reconstruction therefore calls the real `applyPatch` (offline-safe: pure value
+ops, no live runtime/cell). The hermetic test guards `splice` + missing-key
+`add` against regressing to a fork.
 
 ## Reality checks found while building (feed back into the plan)
 
 1. **Scheduler tables are usually absent.** The 571 MB production-shaped DB had
    only the entity tables. `scheduler_observation` & friends exist only when
-   `persistentSchedulerState` was enabled. ⇒ The autopsy core that works *today*
-   is entity-history only; the scheduler graph is opt-in, so every query degrades
-   gracefully (`hasSchedulerTables`).
+   `persistentSchedulerState` was enabled. ⇒ The autopsy core that works _today_
+   is entity-history only; the scheduler graph is opt-in, so every query
+   degrades gracefully (`hasSchedulerTables`).
 2. **TWO at-rest value formats exist in the wild** — both handled:
    - **modern**: an `fvj1:`-prefixed codec-json envelope (decoded via
      `valueFromJson`; embedded links are `/quote`-escaped literals, so a
-     context-less decode is inert and never reconstructs a live cell).
-     Entity ids: `of:fid1:…`.
+     context-less decode is inert and never reconstructs a live cell). Entity
+     ids: `of:fid1:…`.
    - **legacy**: plain JSON with inline sigil links. Entity ids: `of:baedrei…`.
-   `reconstruct.ts` routes by the `fvj1:` tag. (This corrects an earlier
-   assumption that no `@commonfabric/data-model` dependency was needed.)
+     `reconstruct.ts` routes by the `fvj1:` tag. (This corrects an earlier
+     assumption that no `@commonfabric/data-model` dependency was needed.)
 3. **Same-id divergence is usually NOT replica drift (now classified).** Many
    entities share a content-addressed id across spaces because they're instances
    of the same pattern (e.g. `home.tsx`), not cross-space replicas — so they
-   *legitimately* diverge. M2.5 classifies each divergence via the cross-space
+   _legitimately_ diverge. M2.5 classifies each divergence via the cross-space
    link index. **Real dev DBs frequently contain ZERO cross-space links**, in
    which case every same-id divergence is correctly labeled
    `no-cross-space-link` (likely independent instance). The classifier exists to
@@ -103,8 +129,10 @@ deno task cf inspect spaces
 
 # single space (DID-prefix resolves via discovery)
 deno task cf inspect summary  z6Mkqa41
-deno task cf inspect entities z6Mkqa41           # what's in here: modules/instances/cells
-deno task cf inspect entities z6Mkqa41 --kind instance
+deno task cf inspect entities z6Mkqa41           # what's in here: pieces/modules/streams/cells
+deno task cf inspect entities z6Mkqa41 --kind piece
+deno task cf inspect piece    z6Mkqa41 of:fid1:… # a piece: pattern source, input, owned cells
+deno task cf inspect piece    z6Mkqa41 of:fid1:… --code   # + full pattern TS source
 deno task cf inspect hot      z6Mkqa41 --limit 10
 deno task cf inspect commits  z6Mkqa41 --limit 20
 deno task cf inspect history  z6Mkqa41 of:fid1:…

--- a/packages/state-inspector/mod.ts
+++ b/packages/state-inspector/mod.ts
@@ -8,6 +8,7 @@
 export * from "./db.ts";
 export * from "./decode.ts";
 export * from "./reconstruct.ts";
+export * from "./model.ts";
 export * from "./queries.ts";
 export * from "./multispace.ts";
 export * from "./discover.ts";

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -1,0 +1,616 @@
+// The unified entity model — what makes the inspector *fluent* instead of
+// guessing from `doc.value`.
+//
+// A memory v2 entity stores ONE document (`is`) per id, and that document is a
+// TREE of top-level paths. The reactive value lives at `value`; the control
+// plane lives at sibling meta paths on the SAME entity:
+//
+//   value           the reactive value (a cell's contents)
+//   argument        SigilLink → the piece's INPUT cell
+//   result          SigilLink → the OWNING piece's result cell (ownership back-link)
+//   patternIdentity { identity, symbol } → the durable piece → pattern(module) pointer
+//   internal        manifest [{ partialCause, link }] of the piece's owned child cells
+//   schema          the result's JSONSchema
+//   cfc             information-flow label map
+//   pattern/slug    other piece metadata
+//
+// Classifying by *which top-level paths exist* (plus the shape of `value`) tells
+// us what an entity actually IS. Ground-truthed against a real modern space
+// (145 entities): pieces carry {argument, internal, patternIdentity, schema,
+// value}; owned cells carry {result(, value)}; free cells carry {value}.
+//
+// Two regimes:
+//   modern (post-#3522 "Remove Process Cell") — pieces carry `patternIdentity`.
+//   legacy (pre-#3522) — a separate process cell whose `value` carries
+//     { $TYPE, resultRef, … }; the result cell links to it via `source`.
+// We classify both; modern is the verified path, legacy is best-effort.
+
+import type { SpaceDb } from "./db.ts";
+import { countLinks, parseSigilLink, summarize } from "./decode.ts";
+import { reconstructDocument } from "./reconstruct.ts";
+import type { EntityDocument, ReconstructOptions } from "./reconstruct.ts";
+
+export type EntityKind =
+  | "piece" // a running pattern instance (result cell + lineage meta)
+  | "module" // pattern source/compiled module (value carries code + identity)
+  | "stream" // write-only event channel (value.$stream === true)
+  | "schema" // a JSONSchema stored as a cell value
+  | "owned-cell" // a cell owned by a piece (carries a `result` back-link)
+  | "free-cell" // a standalone cell, owned by no piece
+  | "unknown";
+
+export type Regime = "modern" | "legacy" | "n/a";
+
+export type ValueShape =
+  | "stream"
+  | "module"
+  | "schema"
+  | "piece-result"
+  | "object"
+  | "array"
+  | "scalar"
+  | "absent";
+
+/** Resolved lineage links for an entity (ids only — targets are not followed). */
+export interface Lineage {
+  /** Input cell — a piece's `argument` link target. */
+  argument?: string;
+  /** Pattern pointer + resolved module entity (modern pieces). */
+  pattern?: { identity: string; symbol?: string; moduleId?: string };
+  /** Owning piece — an owned cell's `result` back-link target. */
+  owner?: string;
+  /** Owned child cell ids — a piece's `internal` manifest. */
+  internal?: string[];
+  /** Legacy process/source cell link target. */
+  source?: string;
+}
+
+export interface EntityModel {
+  id: string;
+  scope: string;
+  kind: EntityKind;
+  regime: Regime;
+  /** True when the entity carries a `result` ownership back-link. */
+  owned: boolean;
+  /** Human label: piece $NAME, module:<file>, stream, schema, or value summary. */
+  label: string;
+  /** Top-level paths present in the document (the control plane, sorted). */
+  paths: string[];
+  valueShape: ValueShape;
+  lineage: Lineage;
+  revisions?: number;
+  links?: number;
+}
+
+function isObj(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** The target id of a SigilLink value, if it is one. */
+function linkId(v: unknown): string | undefined {
+  return parseSigilLink(v)?.id ?? undefined;
+}
+
+/** Owned child cell ids from a piece's `internal` manifest. */
+function internalIds(internal: unknown): string[] {
+  if (!Array.isArray(internal)) return [];
+  const out: string[] = [];
+  for (const el of internal) {
+    if (isObj(el) && "link" in el) {
+      const id = linkId(el.link);
+      if (id) out.push(id);
+    }
+  }
+  return out;
+}
+
+function basename(p: string): string {
+  return p.split("/").pop() || p;
+}
+
+/** A value shaped like a module: `{ code, identity, … }`. */
+function isModuleValue(
+  v: unknown,
+): v is { code: string; identity: string; filename?: string; kind?: string } {
+  return isObj(v) && typeof v.code === "string" &&
+    typeof v.identity === "string";
+}
+
+/** A value shaped like a JSONSchema stored as data: `{ type, properties|$defs }`. */
+function isSchemaValue(v: unknown): boolean {
+  if (!isObj(v)) return false;
+  if (typeof v.type !== "string") return false;
+  if (!(isObj(v.properties) || isObj(v.$defs))) return false;
+  // Schemas-as-data don't carry render markers.
+  return !("$UI" in v) && !("$NAME" in v);
+}
+
+function isStreamValue(v: unknown): boolean {
+  return isObj(v) && v.$stream === true;
+}
+
+/** A piece result value: carries render/name markers. */
+function isPieceResultValue(v: unknown): boolean {
+  return isObj(v) && ("$UI" in v || "$NAME" in v || "$TILE_UI" in v);
+}
+
+/** A legacy process cell value: `{ $TYPE, resultRef|spell|source, … }`. */
+function isLegacyProcessValue(
+  v: unknown,
+): v is {
+  $TYPE: string;
+  resultRef?: unknown;
+  argument?: unknown;
+  spell?: unknown;
+  source?: unknown;
+} {
+  return isObj(v) && typeof v.$TYPE === "string" &&
+    ("resultRef" in v || "spell" in v || "source" in v);
+}
+
+function valueShapeOf(v: unknown): ValueShape {
+  if (v === undefined) return "absent";
+  if (isStreamValue(v)) return "stream";
+  if (isModuleValue(v)) return "module";
+  if (isSchemaValue(v)) return "schema";
+  if (isPieceResultValue(v)) return "piece-result";
+  if (Array.isArray(v)) return "array";
+  if (isObj(v)) return "object";
+  return "scalar";
+}
+
+/** Module label, e.g. `module:foo.tsx` or `module:foo.tsx (compiled)`. */
+function moduleLabel(v: { filename?: string; kind?: string }): string {
+  const file = v.filename ? basename(v.filename) : "?";
+  const k = v.kind && v.kind !== "source" ? ` (${v.kind})` : "";
+  return `module:${file}${k}`;
+}
+
+export interface Classification {
+  kind: EntityKind;
+  regime: Regime;
+  owned: boolean;
+  label: string;
+  paths: string[];
+  valueShape: ValueShape;
+  lineage: Lineage;
+}
+
+/**
+ * Classify a reconstructed entity document by its top-level path-set and value
+ * shape. Pure: resolves lineage to link-target ids but does not follow them or
+ * resolve `patternIdentity` to a module (that needs the space-wide module index;
+ * see {@link modelEntity}).
+ */
+export function classifyDocument(doc: EntityDocument): Classification {
+  const paths = Object.keys(doc).sort();
+  const value = doc.value;
+  const owned = "result" in doc;
+  const valueShape = valueShapeOf(value);
+  const lineage: Lineage = {};
+  if (owned) lineage.owner = linkId(doc.result);
+
+  // --- Pieces -------------------------------------------------------------
+  // Modern: the durable piece → pattern pointer is `patternIdentity`.
+  if (isObj(doc.patternIdentity)) {
+    const pi = doc.patternIdentity as { identity?: unknown; symbol?: unknown };
+    lineage.argument = linkId(doc.argument);
+    lineage.internal = internalIds(doc.internal);
+    if (typeof pi.identity === "string") {
+      lineage.pattern = {
+        identity: pi.identity,
+        symbol: typeof pi.symbol === "string" ? pi.symbol : undefined,
+      };
+    }
+    const name = isObj(value) && typeof value.$NAME === "string"
+      ? value.$NAME
+      : undefined;
+    return {
+      kind: "piece",
+      regime: "modern",
+      owned,
+      label: name || "(piece)",
+      paths,
+      valueShape,
+      lineage,
+    };
+  }
+  // Legacy: a process cell carries `{ $TYPE, resultRef, … }`.
+  if (isLegacyProcessValue(value)) {
+    lineage.source = linkId(value.resultRef) ?? linkId(value.source);
+    lineage.argument = linkId(value.argument);
+    return {
+      kind: "piece",
+      regime: "legacy",
+      owned,
+      label: "(piece, legacy process)",
+      paths,
+      valueShape,
+      lineage,
+    };
+  }
+  // Legacy: a result cell links to its process cell via top-level `source`.
+  if ("source" in doc && isPieceResultValue(value)) {
+    lineage.source = linkId(doc.source);
+    const name = isObj(value) && typeof value.$NAME === "string"
+      ? value.$NAME
+      : undefined;
+    return {
+      kind: "piece",
+      regime: "legacy",
+      owned,
+      label: name || "(piece, legacy)",
+      paths,
+      valueShape,
+      lineage,
+    };
+  }
+
+  // --- Cell sub-kinds by value shape -------------------------------------
+  if (isModuleValue(value)) {
+    return {
+      kind: "module",
+      regime: "n/a",
+      owned,
+      label: moduleLabel(value),
+      paths,
+      valueShape,
+      lineage,
+    };
+  }
+  if (isStreamValue(value)) {
+    return {
+      kind: "stream",
+      regime: "n/a",
+      owned,
+      label: "⊙ stream",
+      paths,
+      valueShape,
+      lineage,
+    };
+  }
+  if (isSchemaValue(value)) {
+    const ifc = isObj(value) && "ifc" in value ? "+ifc" : "";
+    return {
+      kind: "schema",
+      regime: "n/a",
+      owned,
+      label: `schema${ifc}`,
+      paths,
+      valueShape,
+      lineage,
+    };
+  }
+
+  // --- Plain cells -------------------------------------------------------
+  if (owned) {
+    const label = value === undefined ? "(lineage)" : summarize(value);
+    return {
+      kind: "owned-cell",
+      regime: "n/a",
+      owned,
+      label,
+      paths,
+      valueShape,
+      lineage,
+    };
+  }
+  if ("value" in doc) {
+    return {
+      kind: "free-cell",
+      regime: "n/a",
+      owned,
+      label: summarize(value),
+      paths,
+      valueShape,
+      lineage,
+    };
+  }
+  return {
+    kind: "unknown",
+    regime: "n/a",
+    owned,
+    label: `{${paths.join(",")}}`,
+    paths,
+    valueShape,
+    lineage,
+  };
+}
+
+export interface ModuleEntry {
+  id: string;
+  filename?: string;
+  kind?: string;
+}
+
+/**
+ * Map a module `identity` (the `patternIdentity.identity` hash) to its module
+ * entity. One `.tsx` yields source + compiled entities sharing an identity; we
+ * prefer the `source` entity (it holds TS code + filename).
+ */
+export function buildModuleIndex(
+  space: SpaceDb,
+  opts: { branch?: string; scope?: string } = {},
+): Map<string, ModuleEntry> {
+  const branch = opts.branch ?? "";
+  const scope = opts.scope ?? "space";
+  const ids = space.db
+    .prepare(
+      `SELECT DISTINCT id FROM revision WHERE branch = ? AND scope_key = ?`,
+    )
+    .all<{ id: string }>(branch, scope)
+    .map((r) => r.id);
+
+  const index = new Map<string, ModuleEntry>();
+  for (const id of ids) {
+    let doc: EntityDocument | undefined;
+    try {
+      doc = reconstructDocument(space, { id, branch, scope });
+    } catch {
+      continue;
+    }
+    const v = doc?.value;
+    if (!isModuleValue(v)) continue;
+    const existing = index.get(v.identity);
+    // First wins, but a `source` entity always supersedes a `compiled` one.
+    if (!existing || v.kind === "source") {
+      index.set(v.identity, { id, filename: v.filename, kind: v.kind });
+    }
+  }
+  return index;
+}
+
+/** Model a single entity: classify + resolve `patternIdentity` → module id. */
+export function modelEntity(
+  space: SpaceDb,
+  address: ReconstructOptions,
+  moduleIndex?: Map<string, ModuleEntry>,
+): EntityModel | undefined {
+  const doc = reconstructDocument(space, address);
+  if (doc === undefined) return undefined;
+  return modelFromDocument(doc, {
+    id: address.id,
+    scope: address.scope ?? "space",
+    moduleIndex,
+  });
+}
+
+/** Build an EntityModel from an already-reconstructed document. */
+export function modelFromDocument(
+  doc: EntityDocument,
+  ctx: { id: string; scope?: string; moduleIndex?: Map<string, ModuleEntry> },
+): EntityModel {
+  const c = classifyDocument(doc);
+  if (c.lineage.pattern && ctx.moduleIndex) {
+    c.lineage.pattern.moduleId = ctx.moduleIndex.get(c.lineage.pattern.identity)
+      ?.id;
+  }
+  return {
+    id: ctx.id,
+    scope: ctx.scope ?? "space",
+    kind: c.kind,
+    regime: c.regime,
+    owned: c.owned,
+    label: c.label,
+    paths: c.paths,
+    valueShape: c.valueShape,
+    lineage: c.lineage,
+  };
+}
+
+const KIND_ORDER: Record<EntityKind, number> = {
+  piece: 0,
+  module: 1,
+  stream: 2,
+  schema: 3,
+  "owned-cell": 4,
+  "free-cell": 5,
+  unknown: 6,
+};
+
+/**
+ * Model every entity in a space — the fluent "what is in here?" view. One
+ * reconstruction pass: collect documents, build the module index from them,
+ * then classify each. Sorted pieces → modules → streams → schemas → cells.
+ * Replaces the old value-shape-only `listEntities` (which undercounted pieces).
+ */
+export function listEntityModels(
+  space: SpaceDb,
+  opts: { branch?: string; scope?: string; limit?: number } = {},
+): EntityModel[] {
+  const branch = opts.branch ?? "";
+  const scope = opts.scope ?? "space";
+  const limit = opts.limit ?? 5000;
+  const rows = space.db
+    .prepare(
+      `SELECT id, count(*) revisions FROM revision
+       WHERE branch = ? AND scope_key = ?
+       GROUP BY id ORDER BY revisions DESC LIMIT ?`,
+    )
+    .all<{ id: string; revisions: number }>(branch, scope, limit);
+
+  // Single reconstruction pass: cache docs + build the module index inline.
+  const docs = new Map<string, EntityDocument | undefined>();
+  const moduleIndex = new Map<string, ModuleEntry>();
+  for (const r of rows) {
+    let doc: EntityDocument | undefined;
+    try {
+      doc = reconstructDocument(space, { id: r.id, branch, scope });
+    } catch {
+      doc = undefined;
+    }
+    docs.set(r.id, doc);
+    const v = doc?.value;
+    if (isModuleValue(v)) {
+      const existing = moduleIndex.get(v.identity);
+      if (!existing || v.kind === "source") {
+        moduleIndex.set(v.identity, {
+          id: r.id,
+          filename: v.filename,
+          kind: v.kind,
+        });
+      }
+    }
+  }
+
+  const out: EntityModel[] = rows.map((r): EntityModel => {
+    const doc = docs.get(r.id);
+    if (doc === undefined) {
+      return {
+        id: r.id,
+        scope,
+        kind: "unknown",
+        regime: "n/a",
+        owned: false,
+        label: "(undecodable)",
+        paths: [],
+        valueShape: "absent",
+        lineage: {},
+        revisions: r.revisions,
+        links: 0,
+      };
+    }
+    const m = modelFromDocument(doc, { id: r.id, scope, moduleIndex });
+    m.revisions = r.revisions;
+    m.links = countLinks(doc.value);
+    return m;
+  });
+
+  return out.sort(
+    (a, b) =>
+      KIND_ORDER[a.kind] - KIND_ORDER[b.kind] ||
+      (b.revisions ?? 0) - (a.revisions ?? 0),
+  );
+}
+
+export interface PieceCellRef {
+  id: string;
+  /** Classified kind of the owned cell (stream / schema / owned-cell / …). */
+  kind: EntityKind;
+  label: string;
+  summary: string;
+}
+
+export interface PieceModel {
+  id: string;
+  regime: Regime;
+  name: string;
+  /** The pattern (module) this piece instantiates, resolved via patternIdentity. */
+  pattern?: {
+    id?: string;
+    identity: string;
+    symbol?: string;
+    filename?: string;
+    codeLines?: number;
+    /** Full TS source — only populated when `includeCode` is set. */
+    code?: string;
+  };
+  /** The piece's input cell (the `argument` link). */
+  input?: { id: string; summary: string };
+  /** Top-level keys of the piece's result value ($UI, $NAME, …pattern outputs). */
+  resultKeys: string[];
+  /** Top-level keys of the result JSONSchema. */
+  schemaKeys: string[];
+  /** The piece's owned child cells (its `internal` manifest, resolved). */
+  ownedCells: PieceCellRef[];
+}
+
+/**
+ * Resolve a piece fully: its pattern source (follow `patternIdentity` → module),
+ * input cell (`argument`), result value + schema, and owned cells (`internal`).
+ * Returns `{ error }` if the entity is absent or is not a piece.
+ */
+export function describePiece(
+  space: SpaceDb,
+  id: string,
+  opts: {
+    branch?: string;
+    scope?: string;
+    includeCode?: boolean;
+    moduleIndex?: Map<string, ModuleEntry>;
+  } = {},
+): PieceModel | { error: string } {
+  const branch = opts.branch ?? "";
+  const scope = opts.scope ?? "space";
+  const doc = reconstructDocument(space, { id, branch, scope });
+  if (doc === undefined) return { error: "entity absent" };
+  const c = classifyDocument(doc);
+  if (c.kind !== "piece") return { error: `not a piece (kind=${c.kind})` };
+
+  const value = doc.value;
+  const name = isObj(value) && typeof value.$NAME === "string"
+    ? value.$NAME
+    : "(unnamed)";
+
+  let pattern: PieceModel["pattern"];
+  if (c.lineage.pattern) {
+    const index = opts.moduleIndex ??
+      buildModuleIndex(space, { branch, scope });
+    const entry = index.get(c.lineage.pattern.identity);
+    let codeLines: number | undefined;
+    let code: string | undefined;
+    if (entry) {
+      const mdoc = reconstructDocument(space, { id: entry.id, branch, scope });
+      const mv = mdoc?.value;
+      if (isModuleValue(mv)) {
+        codeLines = mv.code.split("\n").length;
+        if (opts.includeCode) code = mv.code;
+      }
+    }
+    pattern = {
+      id: entry?.id,
+      identity: c.lineage.pattern.identity,
+      symbol: c.lineage.pattern.symbol,
+      filename: entry?.filename,
+      codeLines,
+      code,
+    };
+  }
+
+  let input: PieceModel["input"];
+  if (c.lineage.argument) {
+    const adoc = reconstructDocument(space, {
+      id: c.lineage.argument,
+      branch,
+      scope,
+    });
+    input = {
+      id: c.lineage.argument,
+      summary: adoc ? summarize(adoc.value) : "(absent)",
+    };
+  }
+
+  const ownedCells: PieceCellRef[] = (c.lineage.internal ?? []).map(
+    (cid): PieceCellRef => {
+      const cdoc = reconstructDocument(space, { id: cid, branch, scope });
+      if (cdoc === undefined) {
+        return {
+          id: cid,
+          kind: "unknown",
+          label: "(absent)",
+          summary: "(absent)",
+        };
+      }
+      const cc = classifyDocument(cdoc);
+      return {
+        id: cid,
+        kind: cc.kind,
+        label: cc.label,
+        summary: cc.valueShape === "absent"
+          ? "(no value)"
+          : summarize(cdoc.value),
+      };
+    },
+  );
+
+  return {
+    id,
+    regime: c.regime,
+    name,
+    pattern,
+    input,
+    resultKeys: isObj(value) ? Object.keys(value) : [],
+    schemaKeys: isObj(doc.schema) ? Object.keys(doc.schema) : [],
+    ownedCells,
+  };
+}

--- a/packages/state-inspector/queries.ts
+++ b/packages/state-inspector/queries.ts
@@ -4,8 +4,7 @@
 
 import type { CommitRow, SpaceDb } from "./db.ts";
 import { hasSchedulerTables } from "./db.ts";
-import { countLinks, decodeStored, summarize } from "./decode.ts";
-import { reconstructDocument } from "./reconstruct.ts";
+import { decodeStored } from "./decode.ts";
 
 export interface SpaceSummary {
   path: string;
@@ -24,9 +23,12 @@ export interface SpaceSummary {
 
 export function summarizeSpace(space: SpaceDb): SpaceSummary {
   const db = space.db;
-  const one = <T extends object>(sql: string): T => db.prepare(sql).get<T>() as T;
+  const one = <T extends object>(sql: string): T =>
+    db.prepare(sql).get<T>() as T;
 
-  const commitAgg = one<{ n: number; lo: number | null; hi: number | null; s: number }>(
+  const commitAgg = one<
+    { n: number; lo: number | null; hi: number | null; s: number }
+  >(
     `SELECT count(*) n, min(seq) lo, max(seq) hi, count(DISTINCT session_id) s FROM "commit"`,
   );
   const revAgg = one<{ n: number; e: number }>(
@@ -60,7 +62,9 @@ export function summarizeSpace(space: SpaceDb): SpaceSummary {
     hasSchedulerTables: hasSched,
     schedulerObservations,
     commits: commitAgg.n,
-    commitSeqRange: commitAgg.lo === null ? null : [commitAgg.lo, commitAgg.hi!],
+    commitSeqRange: commitAgg.lo === null
+      ? null
+      : [commitAgg.lo, commitAgg.hi!],
     sessions: commitAgg.s,
     revisions: revAgg.n,
     entities: revAgg.e,
@@ -203,86 +207,5 @@ export function hotEntities(
     }));
 }
 
-export type EntityKind = "module" | "instance" | "stream" | "value" | "empty";
-
-export interface EntityInfo {
-  id: string;
-  scope: string;
-  kind: EntityKind;
-  /** Human label: module filename, instance $NAME, or a value summary. */
-  name: string;
-  revisions: number;
-  links: number;
-}
-
-function classifyValue(value: unknown): { kind: EntityKind; name: string } {
-  if (value === undefined) return { kind: "empty", name: "(absent)" };
-  if (value && typeof value === "object" && !Array.isArray(value)) {
-    const o = value as Record<string, unknown>;
-    // Module/program entity: carries source + filename.
-    if (typeof o.code === "string" && typeof o.filename === "string") {
-      const file = (o.filename as string).split("/").pop() ?? o.filename;
-      return { kind: "module", name: `module:${file}` };
-    }
-    // Pattern instance: has a resolved $NAME, or instance markers.
-    const named = typeof o.$NAME === "string" ? (o.$NAME as string) : undefined;
-    if (named || "$TYPE" in o || "resultRef" in o || "argument" in o) {
-      return { kind: "instance", name: named ?? "(instance)" };
-    }
-    if ((o as { $stream?: unknown }).$stream === true) {
-      return { kind: "stream", name: "(stream)" };
-    }
-  }
-  return { kind: "value", name: summarize(value) };
-}
-
-/**
- * List the entities in a space with a derived kind + label — the "what is in
- * this space?" view. Reconstructs each entity's head document (cheap for typical
- * spaces; bounded by `limit`). Sorted modules → instances → streams → values.
- */
-export function listEntities(
-  space: SpaceDb,
-  opts: { branch?: string; scope?: string; limit?: number } = {},
-): EntityInfo[] {
-  const branch = opts.branch ?? "";
-  const scope = opts.scope ?? "space";
-  const limit = opts.limit ?? 2000;
-  const rows = space.db
-    .prepare(
-      `SELECT id, count(*) revisions FROM revision
-       WHERE branch = ? AND scope_key = ?
-       GROUP BY id ORDER BY revisions DESC LIMIT ?`,
-    )
-    .all<{ id: string; revisions: number }>(branch, scope, limit);
-
-  const order: Record<EntityKind, number> = {
-    module: 0,
-    instance: 1,
-    stream: 2,
-    value: 3,
-    empty: 4,
-  };
-  return rows
-    .map((r): EntityInfo => {
-      let value: unknown;
-      let name = "(undecodable)";
-      let kind: EntityKind = "value";
-      try {
-        const doc = reconstructDocument(space, { id: r.id, branch, scope });
-        value = doc?.value;
-        ({ kind, name } = classifyValue(value));
-      } catch (e) {
-        name = `(error: ${(e as Error).message.slice(0, 40)})`;
-      }
-      return {
-        id: r.id,
-        scope,
-        kind,
-        name,
-        revisions: r.revisions,
-        links: countLinks(value),
-      };
-    })
-    .sort((a, b) => order[a.kind] - order[b.kind] || b.revisions - a.revisions);
-}
+// Entity classification / listing moved to model.ts (`listEntityModels`),
+// which reads the WHOLE entity document instead of value-shape alone.

--- a/packages/state-inspector/test/entities.test.ts
+++ b/packages/state-inspector/test/entities.test.ts
@@ -1,13 +1,15 @@
-// Hermetic test for entity classification + fvj1 commit decoding (both surfaced
-// by dogfooding a real fvj1 space). Side-effect free.
+// Hermetic test for the unified entity model + fvj1 commit decoding. Seeds a
+// modern piece (patternIdentity → module, argument, internal manifest), an
+// owned cell, a stream, and a free cell, then checks classification + lineage.
+// Side-effect free.
 
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { Database } from "@db/sqlite";
 import { jsonFromValue } from "@commonfabric/data-model/codec-json";
 
 import { openSpace } from "../db.ts";
 import { listCommits } from "../queries.ts";
-import { listEntities } from "../queries.ts";
+import { describePiece, listEntityModels } from "../model.ts";
 
 const SCHEMA = `
 CREATE TABLE "commit" (
@@ -25,6 +27,13 @@ CREATE TABLE revision (
 );
 `;
 
+const MODULE_IDENTITY = "pf1v3J_M5Nep7cq-Uh8EYG0ZQaE217FfDfcjbwGdjVI";
+
+/** A plain-JSON sigil link to an entity id. */
+function link(id: string) {
+  return { "/": { "link@1": { id, path: [] } } };
+}
+
 function seed(path: string) {
   const db = new Database(path, { create: true });
   db.exec(SCHEMA);
@@ -36,6 +45,7 @@ function seed(path: string) {
     `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
      VALUES (?, ?, 0, 'set', ?, ?)`,
   );
+  const session = "session:did:key:zSpaceAAAA:11111111-2222-3333";
 
   // Commit 1: original stored fvj1-encoded with 2 ops and 1 confirmed read.
   const original = jsonFromValue({
@@ -43,43 +53,133 @@ function seed(path: string) {
     operations: [{ op: "set" }, { op: "patch" }],
     reads: { confirmed: [{ id: "x" }], pending: [] },
   });
-  commit.run(1, "session:did:key:zSpaceAAAA:11111111-2222-3333", 1, original);
-  // entities (values stored as plain JSON here; decode handles both)
-  rev.run("of:mod", 1, JSON.stringify({
-    value: { code: "export default 1;", filename: "/api/patterns/foo/bar.tsx", identity: "h" },
-  }), 1);
+  commit.run(1, session, 1, original);
 
-  commit.run(2, "session:did:key:zSpaceAAAA:11111111-2222-3333", 2, "{}");
-  rev.run("of:inst", 2, JSON.stringify({ value: { $NAME: "My Notebook", notes: [] } }), 2);
+  // The pattern module (source).
+  rev.run(
+    "of:mod",
+    1,
+    JSON.stringify({
+      value: {
+        kind: "source",
+        identity: MODULE_IDENTITY,
+        code: "export default () => null;\n",
+        filename: "/api/patterns/notes/notebook.tsx",
+        imports: [],
+      },
+    }),
+    1,
+  );
 
-  commit.run(3, "session:did:key:zSpaceAAAA:11111111-2222-3333", 3, "{}");
-  rev.run("of:val", 3, JSON.stringify({ value: "none" }), 3);
+  // A modern piece: patternIdentity → module, argument → input, internal → owned.
+  commit.run(2, session, 2, "{}");
+  rev.run(
+    "of:piece",
+    2,
+    JSON.stringify({
+      value: { $NAME: "My Notebook", $UI: { type: "vnode" } },
+      argument: link("of:input"),
+      internal: [{ partialCause: "query", link: link("of:owned") }],
+      patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+      schema: { type: "object", properties: {}, $defs: {} },
+    }),
+    2,
+  );
+
+  // The piece's input (argument) cell.
+  commit.run(3, session, 3, "{}");
+  rev.run("of:input", 3, JSON.stringify({ value: { title: "untitled" } }), 3);
+
+  // An owned cell (result back-link to the piece) + a stream + a free cell.
+  commit.run(4, session, 4, "{}");
+  rev.run(
+    "of:owned",
+    4,
+    JSON.stringify({ value: "hello", result: link("of:piece") }),
+    4,
+  );
+
+  commit.run(5, session, 5, "{}");
+  rev.run(
+    "of:stream",
+    5,
+    JSON.stringify({ value: { $stream: true }, result: link("of:piece") }),
+    5,
+  );
+
+  commit.run(6, session, 6, "{}");
+  rev.run("of:free", 6, JSON.stringify({ value: "none" }), 6);
 
   db.close();
 }
 
-Deno.test("entity classification + fvj1 commit decode", async (t) => {
-  const dir = await Deno.makeTempDir({ prefix: "state-inspector-entities-" });
+Deno.test("unified entity model + fvj1 commit decode", async (t) => {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-model-" });
   const dbPath = `${dir}/space.sqlite`;
   try {
     seed(dbPath);
     const space = openSpace(dbPath);
     try {
-      await t.step("listCommits decodes an fvj1 original (ops/reads non-zero)", () => {
-        const rows = listCommits(space);
-        const c1 = rows.find((r) => r.seq === 1)!;
-        assertEquals(c1.ops, 2);
-        assertEquals(c1.reads, 1);
+      await t.step(
+        "listCommits decodes an fvj1 original (ops/reads non-zero)",
+        () => {
+          const rows = listCommits(space);
+          const c1 = rows.find((r) => r.seq === 1)!;
+          assertEquals(c1.ops, 2);
+          assertEquals(c1.reads, 1);
+        },
+      );
+
+      await t.step("entities classify by path-set, not value shape", () => {
+        const ents = listEntityModels(space);
+        const byId = Object.fromEntries(ents.map((e) => [e.id, e]));
+
+        assertEquals(byId["of:mod"].kind, "module");
+        assertEquals(byId["of:mod"].label, "module:notebook.tsx");
+
+        // The piece is a piece because of patternIdentity — NOT because $NAME
+        // is present (the old heuristic would have mislabeled a bare $NAME cell).
+        assertEquals(byId["of:piece"].kind, "piece");
+        assertEquals(byId["of:piece"].label, "My Notebook");
+        assertEquals(byId["of:piece"].regime, "modern");
+        assertEquals(byId["of:piece"].lineage.argument, "of:input");
+        assertEquals(byId["of:piece"].lineage.internal, ["of:owned"]);
+        // patternIdentity resolves to the module entity by matching value.identity.
+        assertEquals(byId["of:piece"].lineage.pattern?.moduleId, "of:mod");
+
+        // A stream beats ownership; an owned cell carries a back-link.
+        assertEquals(byId["of:stream"].kind, "stream");
+        assertEquals(byId["of:owned"].kind, "owned-cell");
+        assertEquals(byId["of:owned"].owned, true);
+        assertEquals(byId["of:owned"].lineage.owner, "of:piece");
+
+        // A bare value cell with no result is free.
+        assertEquals(byId["of:free"].kind, "free-cell");
       });
 
-      await t.step("entities are classified by kind + named", () => {
-        const ents = listEntities(space);
-        const byId = Object.fromEntries(ents.map((e) => [e.id, e]));
-        assertEquals(byId["of:mod"].kind, "module");
-        assertEquals(byId["of:mod"].name, "module:bar.tsx");
-        assertEquals(byId["of:inst"].kind, "instance");
-        assertEquals(byId["of:inst"].name, "My Notebook");
-        assertEquals(byId["of:val"].kind, "value");
+      await t.step(
+        "describePiece resolves pattern, input, and owned cells",
+        () => {
+          const piece = describePiece(space, "of:piece");
+          assert(!("error" in piece));
+          if ("error" in piece) return;
+          assertEquals(piece.name, "My Notebook");
+          assertEquals(piece.pattern?.id, "of:mod");
+          assertEquals(
+            piece.pattern?.filename,
+            "/api/patterns/notes/notebook.tsx",
+          );
+          assertEquals(piece.pattern?.symbol, "default");
+          assertEquals(piece.input?.id, "of:input");
+          assertEquals(piece.ownedCells.length, 1);
+          assertEquals(piece.ownedCells[0].id, "of:owned");
+          assert(piece.resultKeys.includes("$NAME"));
+        },
+      );
+
+      await t.step("describePiece rejects non-pieces", () => {
+        const r = describePiece(space, "of:free");
+        assert("error" in r);
       });
     } finally {
       space.close();


### PR DESCRIPTION
**Stacked PR #6** of the state-inspector chain (base = `state-inspector-dogfood` / #4393).

## What

Makes the inspector *fluent* in the real entity model instead of guessing from the shape of `doc.value`.

A memory v2 entity stores one document (`is`) that is a **tree of top-level paths**: the reactive `value` plus a control plane at sibling meta paths (`argument`, `result`, `patternIdentity`, `internal`, `schema`, `cfc`). The old classifier read only `value`, so it undercounted pieces (**4 of 7** in the notes space) and printed raw JSON for the rest.

New `model.ts` reads the **whole document** and classifies by *which top-level paths exist* (modern + legacy regimes):

| Kind | Signal |
| --- | --- |
| `piece` | `patternIdentity` (modern) / `$TYPE`+`resultRef` (legacy process value) |
| `module` | value carries `{ code, identity }` |
| `stream` | `value.$stream === true` |
| `schema` | value is a JSONSchema (`{ type, properties\|$defs }`) |
| `owned-cell` | carries a `result` ownership back-link |
| `free-cell` | a bare `value`, owned by no piece |

It resolves **lineage**: piece → input (`argument`), piece → pattern (`patternIdentity` → module entity, matched by `value.identity`), piece → owned cells (`internal` manifest), owned cell → owner (`result`).

## Surface

- `cf inspect entities` rewired onto `listEntityModels` — now finds **all 7 pieces**, prints a kind legend + ownership column.
- **new** `cf inspect piece <id>` (`describePiece`) — a piece's resolved pattern **source file** (`--code` for the full TS), input cell, result/schema keys, and owned-cell manifest. Verified on the real notes space:

```
piece:   SummaryIndex  [modern]
pattern: /api/patterns/system/summary-index.tsx · default · 148 lines  of:fid1:6TJe4x…
input:   {}  of:fid1:6b3L0p…
result:  {$NAME, $UI, entries, search}
schema:  {$defs, properties, required, type}
owned cells (7): …
```

## Tests

`packages/state-inspector/test/entities.test.ts` rewritten to seed a real modern piece (patternIdentity → module, argument, internal) and assert classification + lineage resolution + `describePiece`. All 5 suites / 26 steps pass; `deno fmt`/`lint`/`check` clean.

Ground truth + roadmap: `docs/plans/2026-06-28-state-inspector-model-unification.md` (roadmap item 1 ✅). Merge-chain status: `docs/plans/2026-06-28-state-inspector-handoff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the state-inspector’s entity model by reading the whole entity document (value + meta paths) and resolving lineage, replacing the value-only heuristic. This makes `cf inspect` correctly detect pieces and adds a new piece detail view.

- **New Features**
  - Added `model.ts` with path-set classification for `piece | module | stream | schema | owned-cell | free-cell` (modern `patternIdentity` and legacy `$TYPE`/`resultRef`).
  - New `listEntityModels` powers `cf inspect entities` with a kind legend and ownership column; now finds all pieces.
  - New `describePiece` and `cf inspect piece <id>` show the pattern source (optional `--code`), input cell, result/schema keys, and owned cells.

- **Refactors**
  - `cf inspect entities` rewired from `listEntities` to `listEntityModels`; `queries.ts` slimmed (entity listing moved to the model).
  - Exported model API from `packages/state-inspector/mod.ts`; README clarified status and usage.
  - Design and handoff docs added and updated; Phase 1 (model unification) marked done with next-phase guidance.

<sup>Written for commit 45817a18f7d61e5b37ed1ed9cb154f410975090b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

