### PR TITLE
state-inspector: Phase 2 — comprehension surface (group/graph/diff/timeline/html)

### DIFF
--- a/docs/plans/2026-06-28-state-inspector-handoff.md
+++ b/docs/plans/2026-06-28-state-inspector-handoff.md
@@ -41,6 +41,7 @@ Each PR's base is the branch below it, so each diff shows only its own delta.
 | 4 | `state-inspector-cf-inspect` | [#4386](https://github.com/commontoolsinc/labs/pull/4386) | #4377 | M3: `cf inspect` + local-DB discovery (usable) | MERGEABLE vs base |
 | 5 | `state-inspector-dogfood` | [#4393](https://github.com/commontoolsinc/labs/pull/4393) | #4386 | dogfood fixes: fvj1 commit decode, `entities`, scheduler/session legibility | MERGEABLE vs base |
 | 6 | `state-inspector-model-unification` | [#4395](https://github.com/commontoolsinc/labs/pull/4395) | #4393 | **Phase 1 model unification** (`model.ts`): whole-document read + path-set classification + lineage; `cf inspect piece`; design + handoff docs | MERGEABLE vs base |
+| 7 | `state-inspector-grouping` | (open when ready) | #4395 | **Phase 2** comprehension surface: `grouping.ts` + `graph.ts` + `timetravel.ts` + `html.ts` → `cf inspect group`/`graph`/`diff`/`timeline`/`html` | MERGEABLE vs base |
 
 All draft. `mergeable` for 2–5 is relative to their *parent branch*; once the base
 rebases onto live main, re-check.
@@ -91,23 +92,41 @@ piece→manifest (`internal`). `cf inspect entities` rewired onto
 `cf inspect piece <id>` shows pattern source + input + result/schema + owned
 cells. Verified on the real notes space; tests + fmt/lint/check green.
 
-## Next phase (Phase 2+) — start here
+## Phase 2: comprehension surface — ✅ DONE (branch `state-inspector-grouping`)
 
-Per `2026-06-28-state-inspector-model-unification.md` roadmap, in order:
-- **Space grouping** — discover + group a user's implicated spaces (home →
-  profiles → main; placeholders marked) via the §3.2 on-disk signals; grouped
-  tree in `cf inspect spaces`.
-- **`graph` command** — emit the real entity graph from the unified model
-  (nodes = pieces/cells/streams/modules; edges = ownership + `patternIdentity` +
-  `argument` + data links).
-- **Time travel** — `diff <entity> --from <a> --to <b>` + a `timeline`. The
-  engine already reconstructs at any seq (`atSeq`); this is surface work.
-- **Visual surface** — self-contained HTML over the existing `--json`.
+Four stacked commits on top of Phase 1 (`c31f856b8` → `4f54f49f1` →
+`426bbf474` → `23b1f79fb`):
+- **Space grouping** (`grouping.ts`, `cf inspect group`) — per-user worlds
+  (home → profiles → main) from on-disk signals (home `profiles[]` cross-space
+  links, `commit.session_id` principal, cross-space links). Placeholder/absent
+  spaces marked. Signals were verified against the real cache before building
+  (137 user groups).
+- **Entity graph** (`graph.ts`, `cf inspect graph`) — nodes + `pattern` /
+  `argument` / `owns` / `link` edges; `--root/--depth` neighborhood, `--dot`.
+- **Time travel** (`timetravel.ts`, `cf inspect diff` / `timeline`) — structural
+  value diff across seqs, entity + space timelines.
+- **Visual surface** (`html.ts`, `cf inspect html`) — one self-contained HTML
+  file (tabs + per-piece graph SVG + growth sparkline), browser-verified.
 
-Open: `value-at` could annotate the entity kind/lineage too (left as-is for now —
-`--doc` already shows the meta paths). Legacy-regime piece classification is
-best-effort (the notes space is fully modern); verify against the 571 MB legacy
-DB when convenient.
+Each has a hermetic test; full suite is 9 files / 41 steps green.
+
+## Next phase (Phase 3+) — candidates
+
+- **Group-aware graph / cross-space graph** — extend `graph` across a grouped
+  user-world (home→profile edges as first-class), or feed the group into `html`.
+- **Legacy-regime verification** — piece classification + lineage are
+  best-effort for the pre-#3522 regime (the notes space is fully modern); verify
+  against the 571 MB legacy DB.
+- **ifc / security-label decoding** from stored schemas; snapshot-base
+  reconstruction (currently replays from seq 0).
+- Open: `value-at` could annotate entity kind/lineage too (left as-is —
+  `--doc` already shows the meta paths).
+
+## Landing note
+
+The chain is now **7 branches** (was 6). Land procedure unchanged (see "How to
+land the chain" above); cascade-rebase #4376→…→`state-inspector-grouping` after
+rebasing the base onto live main.
 
 ## Resume gotchas
 

--- a/docs/plans/2026-06-28-state-inspector-model-unification.md
+++ b/docs/plans/2026-06-28-state-inspector-model-unification.md
@@ -200,19 +200,28 @@ On-disk signals (each verifiable offline):
    not 4); new `cf inspect piece <id>` shows a piece's pattern source, input,
    result/schema keys, and owned cells. Verified end-to-end on the real notes
    space.
-2. **Space grouping.** Discover + group the implicated spaces for a user/session;
-   `cf inspect spaces` shows a grouped tree (home → profiles → main; placeholders
-   marked), recovered via §3.2 signals.
-3. **`graph` command.** Emit the real entity graph using the unified model:
-   nodes = pieces/cells/streams/modules with correct labels; edges = ownership +
-   `patternIdentity` + `argument` + data links. (The mislabeled demo graph from
-   2026-06-27 was blocked exactly by the missing model.)
-4. **Time travel.** `diff <entity> --from <seqA> --to <seqB>` + a `timeline` of how
-   a space/piece grew. The engine already reconstructs at any seq — this is surface
-   work.
-5. **Visual surface.** A self-contained HTML inspector (grouped spaces → entity
-   graph → timeline) consuming the `--json` we already emit, so a teammate opens it
-   in a browser, not a terminal.
+2. **Space grouping.** ✅ **DONE** — `grouping.ts` + `cf inspect group`.
+   Discovers + groups local space DBs into per-user worlds (home → profiles →
+   main) from §3.2 signals (home `profiles[]` cross-space links,
+   `commit.session_id` principal, cross-space links). Placeholder (0-commit) and
+   absent (referenced, no local DB) spaces marked. Compact by default,
+   `--did <prefix>` expands one user. Signals verified against the real cache
+   (137 user groups; clean home→profiles→main trees).
+3. **`graph` command.** ✅ **DONE** — `graph.ts` + `cf inspect graph`. Entity
+   graph from the unified model: nodes = pieces/modules/streams/schemas/cells
+   (fluent labels); edges = `pattern` (patternIdentity→module) + `argument` +
+   `owns` (internal manifest) + `link` (data links, cross-space marked).
+   `--root/--depth` for a neighborhood, `--dot` for Graphviz. Verified on the
+   notes space (147 nodes / 227 edges).
+4. **Time travel.** ✅ **DONE** — `timetravel.ts` + `cf inspect diff` /
+   `timeline`. `diffValues`/`diffEntity` (structural value diff across two seqs;
+   from defaults to birth), `entityTimeline` (write-by-write), `spaceTimeline`
+   (growth: per-commit created/touched + cumulative).
+5. **Visual surface.** ✅ **DONE** — `html.ts` + `cf inspect html`. One
+   self-contained HTML file (Overview / Pieces / Entities / Graph / Timeline)
+   over the same JSON; per-piece graph neighborhood as inline SVG, growth
+   sparkline, entity filter; dark-mode aware, no external resources. Verified in
+   a real browser (Playwright).
 
 Open cross-cutting items: handle legacy + modern regimes everywhere; decode the
 modern `{"/Link@1":…}` envelope as carefully as the legacy sigil; keep every

--- a/docs/plans/2026-06-29-state-inspector-multiplayer.md
+++ b/docs/plans/2026-06-29-state-inspector-multiplayer.md
@@ -1,0 +1,94 @@
+# State Inspector — the Multiplayer Turn (v1 reframe)
+
+> Status: design / latest thinking. Written 2026-06-29. Supersedes the
+> comprehension-surface roadmap's "Phase 3" bullets where they conflict.
+
+## Why this doc
+
+Phases 1–2 made the tool *fluent* about ONE space's `space`-scope state (model,
+grouping, graph, time-travel, the HTML explorer). Dogfooding against real
+multi-user data exposed that this is, in effect, a **single-space DB viewer** —
+and the tool's actual charter (`2026-06-26-runtime-trace-inspector.md`, the
+"Multiplayer State Inspector") is to make **multi-identity, multi-space,
+per-user, async/conflict** behavior inspectable. Owner's steer: build the
+scope-as-identity and cross-space dimensions **together** (they're entwined —
+each identity has a home space, each profile has a space, and per-user/session
+state lives *within* spaces), **CLI-first / agent-first** (`--json`), keeping
+the HTML explorer in step. Conflicts/async are a **second pass**. Don't
+over-invest in the legacy on-disk format (revisit only if old+new coexist in
+practice).
+
+## The grounded scope model (verified on real DBs)
+
+`revision.scope_key` partitions an entity's rows into scopes that **overlap by
+id**:
+
+- `space` — shared / default (PerSpace cells).
+- `user:did:key:<DID>` — per-user state (PerUser cells).
+- `session:did:key:<DID>:<uuid>` — per-session state (PerSession cells).
+
+**Verified (home space z6MkeZZv…):** 633 `space` entities + 16 `user:<DID>`
+entities, and **all 16 user ids also exist in `space`** — i.e. the same cell
+holds a `space` value AND a per-user override, and **the values differ**
+(`space` often a link/default; `user` the concrete state — a `true` toggle, a
+per-user `{children,name,props,type}` VDOM = per-user render state). So:
+
+> **Composition is most-specific-scope-wins: session:X:sid ⊕ user:X ⊕ space.**
+> "View as identity X" overlays X's scopes on top of the shared space. The
+> per-user VDOM divergence is exactly the "looks different for me" multiplayer
+> bug class the tool must show.
+
+The whole package currently hardcodes `scope_key = 'space'`, so it is blind to
+all per-user/session state. That is the #1 gap.
+
+## Identity = a DID, spanning scopes AND spaces
+
+An identity (a DID) implicates:
+- its **home space** (space DID == identity DID),
+- its **profile spaces** (home `profiles[]` → cross-space links),
+- the **main/pattern spaces** it acts in (`commit.session_id` principal == DID),
+- and, *within any of those spaces*, the `user:<DID>` + `session:<DID>:*` scopes.
+
+Grouping (Phase 2) already recovers the space side. The new work adds the scope
+side and unifies them: "show me everything for this user."
+
+## Plan (CLI-first; HTML kept in step)
+
+### 1. Scope primitive — `scopes.ts`
+- `listScopes(space)` → `Scope { raw, kind: space|user|session, principal?,
+  sessionId?, entities, revisions }`.
+- `resolveScopeChain(identity, sessionId?)` → the precedence list
+  `[session:X:sid, user:X, space]`.
+- `valueAsIdentity(space, id, identity, {sessionId, atSeq})` → composed value +
+  which scope it resolved from.
+- `scopeOverlay(space, id)` → the entity's value in EVERY scope it appears in
+  (the per-user/session divergence table for one id).
+
+### 2. CLI (agent-first, `--json`)
+- `cf inspect scopes <space>` — enumerate scopes (who + counts).
+- `cf inspect overlay <space> <entity>` — value across all scopes for one id.
+- `--as <DID>` (and `--session <sid>`) on read commands (`entities`, `piece`,
+  `value-at`) → compose the overlay so "what does user X see" works. `--scope`
+  stays the raw escape hatch.
+
+### 3. Identity world — `cf inspect identity <DID>`
+Unify grouping + scopes: the DID's home/profile/main spaces, and within each the
+`user:<DID>`/`session:<DID>:*` scopes it owns, with per-scope entity counts.
+
+### 4. HTML explorer kept in step
+- A **"view as"** selector (space / each user / each session) that re-renders
+  the detail value from the chosen scope and **flags entities with per-user
+  overrides** (id present in >1 scope with differing values).
+- **Cross-space links navigable** (open the target space / profile), and the
+  home→profiles→main group as a surface to jump between identities.
+
+### 5. (Second pass) Conflicts / async
+`cf inspect conflicts` + per-entity who-wrote/who-lost chain from
+`commit.original` reads vs `resolution`/`findConflictSeq`, and a
+concurrent-writer/contention view over the timeline. The proposal's "killer
+view"; deferred per owner steer.
+
+## Out of scope for v1
+- Legacy on-disk format beyond current best-effort.
+- Client-side correlation overlay (connectionId/eventId) — net-new runtime
+  plumbing, explicitly the proposal's later phase.

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -528,6 +528,10 @@ export const inspect = new Command()
   .option("--branch <branch:string>", "Branch (default: '').")
   .option("--scope <scope:string>", "Scope key (default: space).")
   .option("--out <file:string>", "Write to a file instead of stdout.")
+  .option(
+    "--app-url <url:string>",
+    "Live shell base origin for deep links (e.g. https://host).",
+  )
   .action((options, space) => {
     const s = openSpace(resolveSpacePath(space));
     try {
@@ -535,12 +539,14 @@ export const inspect = new Command()
         branch: options.branch,
         scope: options.scope,
         generatedAt: new Date().toISOString(),
+        liveBase: options.appUrl,
       });
       const html = renderInspectorHtml(bundle);
       if (options.out) {
         Deno.writeTextFileSync(options.out, html);
+        const pieces = bundle.details.filter((d) => d.kind === "piece").length;
         console.error(
-          `wrote ${options.out}  (${bundle.entities.length} entities, ${bundle.pieces.length} pieces)`,
+          `wrote ${options.out}  (${bundle.details.length} entities, ${pieces} pieces)`,
         );
       } else {
         console.log(html);

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -14,6 +14,7 @@ import {
   buildCrossSpaceLinkIndex,
   buildInspectorBundle,
   buildSpaceGraph,
+  contendedEntities,
   convergence,
   type ConvergenceResult,
   convergenceScan,
@@ -21,6 +22,7 @@ import {
   describePiece,
   diffEntity,
   discoverSpaceDbs,
+  entityConflicts,
   entityHistory,
   entityTimeline,
   getValueAt,
@@ -454,6 +456,92 @@ export const inspect = new Command()
             `${r.writes}\twrites\t${r.sessions} sessions\t${r.id}\t(${r.scope})`,
           );
         }
+      });
+    } finally {
+      s.close();
+    }
+  })
+  /* inspect conflicts */
+  .command(
+    "conflicts <space:string> [entity:string]",
+    "Contested entities (≥2 writer sessions); with an entity: stale-read analysis.",
+  )
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .option("--scope <scope:string>", "Scope key (default: space).")
+  .option("--limit <n:number>", "Max contested entities.", { default: 100 })
+  .action((options, space, entity) => {
+    const s = openSpace(resolveSpacePath(space));
+    try {
+      if (entity) {
+        const c = entityConflicts(s, entity, {
+          branch: options.branch,
+          scope: options.scope,
+        });
+        out(!!options.json, c, () => {
+          console.log(
+            `${c.id}\n${c.writers.length} writes by ${c.writerPrincipals} ` +
+              `identit${
+                c.writerPrincipals === 1 ? "y" : "ies"
+              } / ${c.writerSessions} sessions` +
+              (c.multiUser
+                ? "  · MULTI-USER"
+                : "  · single-user (multi-session)") +
+              (c.interleaved ? "  · INTERLEAVED" : ""),
+          );
+          for (const w of c.writers) {
+            console.log(
+              `  seq=${w.seq}\t${w.op}\t${
+                fmtSession(w.session)
+              }\t${w.createdAt}`,
+            );
+          }
+          if (c.staleReads.length) {
+            console.log(`\nstale reads (read an old version, missed a write):`);
+            for (const sr of c.staleReads) {
+              console.log(
+                `  commit #${sr.readerCommitSeq} by ${
+                  fmtSession(sr.readerSession)
+                } ` +
+                  `read @seq ${sr.readAtSeq} but missed write @seq ${sr.missedWriteSeq} ` +
+                  `by ${fmtSession(sr.missedWriteSession)}` +
+                  (sr.readerAlsoWrote
+                    ? "  ⚠ then wrote (lost-update risk)"
+                    : ""),
+              );
+            }
+          } else {
+            console.log("\n(no stale reads detected)");
+          }
+        });
+        return;
+      }
+      const rows = contendedEntities(s, {
+        branch: options.branch,
+        scope: options.scope,
+        limit: options.limit,
+      });
+      out(!!options.json, rows, () => {
+        if (rows.length === 0) {
+          console.log(
+            "(no contested entities — no cell written by ≥2 sessions)",
+          );
+          return;
+        }
+        const mu = rows.filter((r) => r.multiUser).length;
+        console.log(
+          `${rows.length} contested entit${rows.length === 1 ? "y" : "ies"} ` +
+            `(written by ≥2 sessions)  ·  ${mu} MULTI-USER (≥2 identities):`,
+        );
+        for (const r of rows) {
+          console.log(
+            `  ${r.multiUser ? "★" : r.interleaved ? "⇄" : "·"} ${r.id}\t` +
+              `${r.principals} users / ${r.sessions} sessions\t${r.writes} writes` +
+              (r.multiUser ? "  MULTI-USER" : ""),
+          );
+        }
+        console.log(
+          "\ntip: `inspect conflicts <space> <entity>` for the writer timeline + stale reads.",
+        );
       });
     } finally {
       s.close();

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -40,6 +40,7 @@ import {
   type Scope,
   scopeOverlay,
   type SpaceGraph,
+  spaceParticipants,
   type SpaceRef,
   spaceTimeline,
   subgraphAround,
@@ -365,6 +366,42 @@ export const inspect = new Command()
             "     `inspect overlay <space> <id>` shows a cell across all scopes.",
           );
         }
+      });
+    } finally {
+      s.close();
+    }
+  })
+  /* inspect users */
+  .command(
+    "users <space:string>",
+    "Identities that touched this space (committers + per-user/session scopes).",
+  )
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .action((options, space) => {
+    const s = openSpace(resolveSpacePath(space));
+    try {
+      const ps = spaceParticipants(s, { branch: options.branch });
+      out(!!options.json, ps, () => {
+        if (ps.length === 0) {
+          console.log("(no identifiable participants — bare/empty sessions)");
+          return;
+        }
+        console.log(`${ps.length} identit${ps.length === 1 ? "y" : "ies"}:`);
+        for (const p of ps) {
+          console.log(
+            `  ${p.isOwner ? "★" : "·"} ${shortDid(p.did)}` +
+              `\tcommits=${p.commits} sessions=${p.sessions}` +
+              (p.userEntities ? `  user-cells=${p.userEntities}` : "") +
+              (p.sessionEntities
+                ? `  session-cells=${p.sessionEntities}`
+                : "") +
+              (p.isOwner ? "  (owner — this is their home)" : ""),
+          );
+        }
+        console.log(
+          "\ntip: `inspect identity <DID>` opens a user's whole world " +
+            "(home + profiles + the spaces they act in).",
+        );
       });
     } finally {
       s.close();

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -17,8 +17,10 @@ import {
   type ConvergenceResult,
   convergenceScan,
   describePiece,
+  diffEntity,
   discoverSpaceDbs,
   entityHistory,
+  entityTimeline,
   getValueAt,
   graphToDot,
   groupDiscoveredSpaces,
@@ -33,7 +35,9 @@ import {
   resolveSpacePath,
   type SpaceGraph,
   type SpaceRef,
+  spaceTimeline,
   subgraphAround,
+  summarize,
   summarizeSpace,
 } from "@commonfabric/state-inspector";
 
@@ -581,6 +585,105 @@ export const inspect = new Command()
           } else console.log(JSON.stringify(annotate(shown), null, 2));
         },
       );
+    } finally {
+      s.close();
+    }
+  })
+  /* inspect diff */
+  .command(
+    "diff <space:string> <entity:string>",
+    "What changed in an entity between two seqs.",
+  )
+  .option("--from <n:number>", "From seq (default: entity's birth / seq 0).")
+  .option("--to <n:number>", "To seq (default: latest).")
+  .option("--path <path:string>", "Focus inside value, e.g. items/0/title.")
+  .option("--doc", "Diff the whole document, not just value.")
+  .option("--scope <scope:string>", "Scope key (default: space).")
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .action((options, space, entity) => {
+    const s = openSpace(resolveSpacePath(space));
+    try {
+      const d = diffEntity(s, {
+        id: entity,
+        scope: options.scope,
+        branch: options.branch,
+        fromSeq: options.from,
+        toSeq: options.to,
+        path: splitPath(options.path),
+        doc: !!options.doc,
+      });
+      out(!!options.json, d, () => {
+        const range = `${d.fromSeq ?? "birth"} → ${d.toSeq ?? "latest"}`;
+        console.log(`diff ${d.id}  (${range})`);
+        if (!d.fromExists && d.toExists) console.log("  (created in range)");
+        if (d.fromExists && !d.toExists) console.log("  (deleted in range)");
+        if (d.changes.length === 0) {
+          console.log("  (no changes)");
+          return;
+        }
+        for (const c of d.changes) {
+          const at = c.path || "(root)";
+          if (c.kind === "changed") {
+            console.log(
+              `  ~ ${at}: ${summarize(c.before)} → ${summarize(c.after)}`,
+            );
+          } else if (c.kind === "added") {
+            console.log(`  + ${at}: ${summarize(c.after)}`);
+          } else {
+            console.log(`  - ${at}: ${summarize(c.before)}`);
+          }
+        }
+      });
+    } finally {
+      s.close();
+    }
+  })
+  /* inspect timeline */
+  .command(
+    "timeline <space:string> [entity:string]",
+    "How a space grew (no entity), or how one entity evolved (with entity).",
+  )
+  .option("--scope <scope:string>", "Scope key (default: space).")
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .option("--limit <n:number>", "Max rows.", { default: 500 })
+  .action((options, space, entity) => {
+    const s = openSpace(resolveSpacePath(space));
+    try {
+      if (entity) {
+        const steps = entityTimeline(s, {
+          id: entity,
+          scope: options.scope,
+          branch: options.branch,
+          limit: options.limit,
+        });
+        out(!!options.json, steps, () => {
+          console.log(`timeline of ${entity}  (${steps.length} writes)`);
+          for (const st of steps) {
+            console.log(
+              `  seq=${st.seq}\t${st.op}\t${
+                st.changes ? `${st.changes} changes` : "—"
+              }\t${st.summary}\t${fmtSession(st.session)}\t${st.createdAt}`,
+            );
+          }
+        });
+      } else {
+        const entries = spaceTimeline(s, {
+          scope: options.scope,
+          branch: options.branch,
+          limit: options.limit,
+        });
+        out(!!options.json, entries, () => {
+          console.log(`space growth  (${entries.length} commits)`);
+          for (const e of entries) {
+            console.log(
+              `  #${e.commitSeq}\t+${e.created} new\t${e.touched} touched\t` +
+                `Σ${e.cumulativeEntities}\t${
+                  fmtSession(e.session)
+                }\t${e.createdAt}`,
+            );
+          }
+        });
+      }
     } finally {
       s.close();
     }

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -29,18 +29,22 @@ import {
   hotEntities,
   listCommits,
   listEntityModels,
+  listScopes,
   listSqliteFiles,
   openSpace,
   openSpaces,
   quickStats,
   renderInspectorHtml,
   resolveSpacePath,
+  type Scope,
+  scopeOverlay,
   type SpaceGraph,
   type SpaceRef,
   spaceTimeline,
   subgraphAround,
   summarize,
   summarizeSpace,
+  valueAsIdentity,
 } from "@commonfabric/state-inspector";
 
 function humanSize(bytes: number): string {
@@ -63,6 +67,18 @@ function splitPath(p?: string): string[] {
 function shortDid(did: string): string {
   const tail = did.startsWith("did:key:") ? did.slice("did:key:".length) : did;
   return tail.length > 14 ? `${tail.slice(0, 8)}…${tail.slice(-4)}` : tail;
+}
+
+// A scope as a compact, human label: "space", "user z6Mk…", "session z6Mk…/abc".
+function fmtScope(s: Scope): string {
+  if (s.kind === "space") return "space";
+  if (s.kind === "user") return `user ${shortDid(s.principal ?? "?")}`;
+  if (s.kind === "session") {
+    return `session ${shortDid(s.principal ?? "?")}/${
+      (s.sessionId ?? "").slice(0, 8)
+    }`;
+  }
+  return decodeURIComponent(s.raw).slice(0, 40);
 }
 
 // Session ids look like `session:did:key:<space>:<uuid>` (often %-encoded).
@@ -265,6 +281,44 @@ export const inspect = new Command()
               : "tables present, empty (persistentSchedulerState off)"
           }`,
         );
+      });
+    } finally {
+      s.close();
+    }
+  })
+  /* inspect scopes */
+  .command(
+    "scopes <space:string>",
+    "Per-identity scopes in a space: shared/space + per-user + per-session.",
+  )
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .action((options, space) => {
+    const s = openSpace(resolveSpacePath(space));
+    try {
+      const scopes = listScopes(s, { branch: options.branch });
+      out(!!options.json, scopes, () => {
+        const space2 = scopes.find((x) => x.kind === "space");
+        console.log(
+          `${scopes.length} scope(s)` +
+            (space2
+              ? `  ·  shared 'space' has ${space2.entities} entities`
+              : ""),
+        );
+        for (const sc of scopes) {
+          console.log(
+            `  ${
+              fmtScope(sc).padEnd(34)
+            } entities=${sc.entities}\trevs=${sc.revisions}`,
+          );
+        }
+        if (scopes.some((x) => x.kind !== "space")) {
+          console.log(
+            "\ntip: `inspect value-at <space> <id> --as <DID>` reads as that identity;",
+          );
+          console.log(
+            "     `inspect overlay <space> <id>` shows a cell across all scopes.",
+          );
+        }
       });
     } finally {
       s.close();
@@ -595,12 +649,39 @@ export const inspect = new Command()
     "Reconstruct as of this commit seq (default: latest).",
   )
   .option("--path <path:string>", "Navigate into value, e.g. value/count.")
-  .option("--scope <scope:string>", "Scope key (default: space).")
+  .option("--scope <scope:string>", "Raw scope key (default: space).")
+  .option(
+    "--as <did:string>",
+    "Read AS this identity (overlay session⊕user⊕space).",
+  )
+  .option("--session <sid:string>", "With --as: a specific session id.")
   .option("--branch <branch:string>", "Branch (default: '').")
   .option("--doc", "Show the whole document, not just value.")
   .action((options, space, entity) => {
     const s = openSpace(resolveSpacePath(space));
     try {
+      // --as composes the per-identity overlay; otherwise a single raw scope.
+      if (options.as) {
+        const r = valueAsIdentity(s, {
+          id: entity,
+          identity: options.as,
+          sessionId: options.session,
+          branch: options.branch,
+          atSeq: options.seq,
+        });
+        out(!!options.json, r, () => {
+          if (!r.exists) {
+            console.log("(absent for this identity)");
+            return;
+          }
+          console.log(
+            `resolved from: ${r.resolvedKind}` +
+              (r.overrides ? "  (overrides a more-general scope)" : ""),
+          );
+          console.log(JSON.stringify(r.value, null, 2));
+        });
+        return;
+      }
       const res = getValueAt(
         s,
         {
@@ -622,6 +703,46 @@ export const inspect = new Command()
           } else console.log(JSON.stringify(annotate(shown), null, 2));
         },
       );
+    } finally {
+      s.close();
+    }
+  })
+  /* inspect overlay */
+  .command(
+    "overlay <space:string> <entity:string>",
+    "An entity's value across EVERY scope (per-user/session divergence).",
+  )
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .action((options, space, entity) => {
+    const s = openSpace(resolveSpacePath(space));
+    try {
+      const o = scopeOverlay(s, entity, { branch: options.branch });
+      out(!!options.json, o, () => {
+        if (o.variants.length === 0) {
+          console.log("(entity absent)");
+          return;
+        }
+        console.log(
+          `${entity}` +
+            (o.overridden
+              ? o.divergent
+                ? `  —  ${o.variants.length} scopes, DIVERGENT`
+                : `  —  ${o.variants.length} scopes, identical`
+              : "  —  single scope"),
+        );
+        for (const v of o.variants) {
+          const label = v.kind === "space"
+            ? "space"
+            : v.kind === "user"
+            ? `user ${shortDid(v.principal ?? "?")}`
+            : v.kind === "session"
+            ? `session ${shortDid(v.principal ?? "?")}/${
+              (v.sessionId ?? "").slice(0, 8)
+            }`
+            : v.scope;
+          console.log(`  ${label.padEnd(34)} ${v.summary}`);
+        }
+      });
     } finally {
       s.close();
     }

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -12,6 +12,7 @@ import { Table } from "@cliffy/table";
 import {
   annotate,
   buildCrossSpaceLinkIndex,
+  buildSpaceGraph,
   convergence,
   type ConvergenceResult,
   convergenceScan,
@@ -19,6 +20,7 @@ import {
   discoverSpaceDbs,
   entityHistory,
   getValueAt,
+  graphToDot,
   groupDiscoveredSpaces,
   type GroupedSpace,
   hotEntities,
@@ -29,7 +31,9 @@ import {
   openSpaces,
   quickStats,
   resolveSpacePath,
+  type SpaceGraph,
   type SpaceRef,
+  subgraphAround,
   summarizeSpace,
 } from "@commonfabric/state-inspector";
 
@@ -414,6 +418,95 @@ export const inspect = new Command()
         if (piece.pattern?.code) {
           console.log(
             `\n--- ${piece.pattern.filename} ---\n${piece.pattern.code}`,
+          );
+        }
+      });
+    } finally {
+      s.close();
+    }
+  })
+  /* inspect graph */
+  .command(
+    "graph <space:string>",
+    "Entity graph: nodes (pieces/cells/streams/modules) + edges (pattern/argument/owns/link).",
+  )
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .option("--scope <scope:string>", "Scope key (default: space).")
+  .option("--root <entity:string>", "Restrict to one entity's neighborhood.")
+  .option("--depth <n:number>", "Hops around --root.", { default: 2 })
+  .option("--no-links", "Omit data-link edges (keep structural edges only).")
+  .option("--dot", "Emit Graphviz DOT (pipe to: dot -Tsvg).")
+  .option("--limit <n:number>", "Max entities to reconstruct.", {
+    default: 5000,
+  })
+  .action((options, space) => {
+    const s = openSpace(resolveSpacePath(space));
+    try {
+      let g: SpaceGraph = buildSpaceGraph(s, {
+        branch: options.branch,
+        scope: options.scope,
+        limit: options.limit,
+        includeLinks: options.links !== false,
+      });
+      if (options.root) g = subgraphAround(g, options.root, options.depth);
+      if (options.dot) {
+        console.log(graphToDot(g));
+        return;
+      }
+      out(!!options.json, g, () => {
+        console.log(`space: ${g.space}`);
+        console.log(
+          `nodes: ${g.nodes.length}  {${
+            Object.entries(g.stats.nodesByKind)
+              .map(([k, n]) => `${k}=${n}`).join(" ")
+          }}`,
+        );
+        console.log(
+          `edges: ${g.edges.length}  {${
+            Object.entries(g.stats.edgesByKind)
+              .filter(([, n]) => n > 0).map(([k, n]) => `${k}=${n}`).join(" ")
+          }}` + (g.stats.externalEdges
+            ? `  (${g.stats.externalEdges} cross-space)`
+            : ""),
+        );
+        // Adjacency, grouped by source, pieces first (most informative).
+        const labelOf = new Map(g.nodes.map((n) => [n.id, n]));
+        const bySource = new Map<string, typeof g.edges>();
+        for (const e of g.edges) {
+          (bySource.get(e.from) ?? bySource.set(e.from, []).get(e.from)!).push(
+            e,
+          );
+        }
+        const order = [...bySource.keys()].sort((a, b) => {
+          const ka = labelOf.get(a)?.kind === "piece" ? 0 : 1;
+          const kb = labelOf.get(b)?.kind === "piece" ? 0 : 1;
+          return ka - kb;
+        });
+        const arrow = (k: string) =>
+          k === "pattern"
+            ? "⟶pattern"
+            : k === "argument"
+            ? "⟶arg"
+            : k === "owns"
+            ? "⟶owns"
+            : "·link";
+        for (const src of order.slice(0, options.root ? 9999 : 40)) {
+          const n = labelOf.get(src)!;
+          console.log(`\n${n.kind} ${shortDid(src)}  ${n.label}`);
+          for (const e of bySource.get(src)!) {
+            const t = labelOf.get(e.to);
+            console.log(
+              `  ${arrow(e.kind).padEnd(9)} ${
+                t ? `${t.kind} ${t.label}` : "?"
+              }${e.external ? ` @${shortDid(e.to)} [cross-space]` : ""}${
+                e.label ? `  (${e.label})` : ""
+              }`,
+            );
+          }
+        }
+        if (!options.root && order.length > 40) {
+          console.log(
+            `\n… ${order.length - 40} more sources (use --root or --json)`,
           );
         }
       });

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -12,6 +12,7 @@ import { Table } from "@cliffy/table";
 import {
   annotate,
   buildCrossSpaceLinkIndex,
+  buildInspectorBundle,
   buildSpaceGraph,
   convergence,
   type ConvergenceResult,
@@ -32,6 +33,7 @@ import {
   openSpace,
   openSpaces,
   quickStats,
+  renderInspectorHtml,
   resolveSpacePath,
   type SpaceGraph,
   type SpaceRef,
@@ -514,6 +516,35 @@ export const inspect = new Command()
           );
         }
       });
+    } finally {
+      s.close();
+    }
+  })
+  /* inspect html */
+  .command(
+    "html <space:string>",
+    "Emit a self-contained HTML inspector (open in a browser).",
+  )
+  .option("--branch <branch:string>", "Branch (default: '').")
+  .option("--scope <scope:string>", "Scope key (default: space).")
+  .option("--out <file:string>", "Write to a file instead of stdout.")
+  .action((options, space) => {
+    const s = openSpace(resolveSpacePath(space));
+    try {
+      const bundle = buildInspectorBundle(s, {
+        branch: options.branch,
+        scope: options.scope,
+        generatedAt: new Date().toISOString(),
+      });
+      const html = renderInspectorHtml(bundle);
+      if (options.out) {
+        Deno.writeTextFileSync(options.out, html);
+        console.error(
+          `wrote ${options.out}  (${bundle.entities.length} entities, ${bundle.pieces.length} pieces)`,
+        );
+      } else {
+        console.log(html);
+      }
     } finally {
       s.close();
     }

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -17,6 +17,7 @@ import {
   convergence,
   type ConvergenceResult,
   convergenceScan,
+  describeIdentity,
   describePiece,
   diffEntity,
   discoverSpaceDbs,
@@ -238,6 +239,51 @@ export const inspect = new Command()
             `home=${g.homePresent ? "present" : "absent"}  ` +
             `profiles=${c.profile}  main=${c.main}` +
             (c.absent ? `  (+${c.absent} absent)` : ""),
+        );
+      }
+    });
+  })
+  /* inspect identity */
+  .command(
+    "identity <did:string>",
+    "One identity's whole world: its spaces + the scopes it owns in each.",
+  )
+  .option("--dir <dir:string>", "Extra directory to search for *.sqlite files.")
+  .action((options, did) => {
+    const discovered = discoverSpaceDbs(
+      options.dir ? { dirs: [options.dir] } : {},
+    );
+    const w = describeIdentity(discovered, did);
+    out(!!options.json, w, () => {
+      console.log(
+        `● identity ${shortDid(did)}` +
+          (w.homePresent ? "" : "  (home absent/empty locally)"),
+      );
+      console.log(
+        `  ${w.totals.presentSpaces}/${w.totals.spaces} spaces present · ` +
+          `${w.totals.spacesWithScopedState} with per-user/session state · ` +
+          `${w.totals.scopedEntities} scoped entities`,
+      );
+      for (const s of w.spaces) {
+        const head = `  ${s.role.padEnd(7)} ${shortDid(s.did)}` +
+          (s.present
+            ? `  entities=${s.entities ?? 0}`
+            : "  (absent — referenced, no local DB)");
+        console.log(head);
+        for (const sc of s.ownedScopes) {
+          console.log(
+            `      ${sc.kind === "session" ? "session" : "user"}${
+              sc.kind === "session"
+                ? ` /${(sc.sessionId ?? "").slice(0, 8)}`
+                : ""
+            }  entities=${sc.entities} revs=${sc.revisions}`,
+          );
+        }
+      }
+      if (w.totals.scopedEntities > 0) {
+        console.log(
+          "\ntip: `inspect value-at <space> <id> --as " + shortDid(did) +
+            "…` reads a cell as this identity.",
         );
       }
     });

--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -19,6 +19,8 @@ import {
   discoverSpaceDbs,
   entityHistory,
   getValueAt,
+  groupDiscoveredSpaces,
+  type GroupedSpace,
   hotEntities,
   listCommits,
   listEntityModels,
@@ -45,6 +47,12 @@ function out(json: boolean, data: unknown, render: () => void): void {
 
 function splitPath(p?: string): string[] {
   return p ? p.split("/").filter(Boolean) : [];
+}
+
+// did:key:z6Mk…wQ2n  ->  z6Mk…wQ2n  (compact, still recognizable)
+function shortDid(did: string): string {
+  const tail = did.startsWith("did:key:") ? did.slice("did:key:".length) : did;
+  return tail.length > 14 ? `${tail.slice(0, 8)}…${tail.slice(-4)}` : tail;
 }
 
 // Session ids look like `session:did:key:<space>:<uuid>` (often %-encoded).
@@ -132,6 +140,80 @@ export const inspect = new Command()
           ]),
         ]).toString(),
       );
+    });
+  })
+  /* inspect group */
+  .command(
+    "group",
+    "Group discovered space DBs into per-user worlds (home → profiles → main).",
+  )
+  .option("--dir <dir:string>", "Extra directory to search for *.sqlite files.")
+  .option(
+    "--did <prefix:string>",
+    "Expand one user's world fully (match the principal DID).",
+  )
+  .action((options) => {
+    const discovered = discoverSpaceDbs(
+      options.dir ? { dirs: [options.dir] } : {},
+    );
+    const result = groupDiscoveredSpaces(discovered);
+    out(!!options.json, result, () => {
+      if (result.groups.length === 0 && result.ungrouped.length === 0) {
+        console.log("no space DBs found.");
+        return;
+      }
+      const roleCounts = (g: { spaces: GroupedSpace[] }) => {
+        const c = { home: 0, profile: 0, main: 0, unknown: 0, absent: 0 };
+        for (const s of g.spaces) {
+          c[s.role]++;
+          if (!s.present) c.absent++;
+        }
+        return c;
+      };
+      const tag = (s: GroupedSpace) =>
+        `${s.role.padEnd(7)} ${shortDid(s.did)}` +
+        (s.present
+          ? `  commits=${s.commits ?? 0} entities=${s.entities ?? 0}` +
+            (s.empty ? "  (placeholder/empty)" : "")
+          : "  (absent — referenced, no local DB)") +
+        (s.evidence.length ? `  · ${s.evidence.join("; ")}` : "");
+
+      // Focused view: expand the matching group(s) fully.
+      if (options.did) {
+        const matches = result.groups.filter((g) =>
+          g.principal.includes(options.did!)
+        );
+        if (matches.length === 0) {
+          console.log(`no group principal matches "${options.did}".`);
+          return;
+        }
+        for (const g of matches) {
+          console.log(
+            `● user ${shortDid(g.principal)}` +
+              (g.homePresent ? "" : "  (home absent/empty locally)"),
+          );
+          for (const s of g.spaces) console.log(`   ${tag(s)}`);
+        }
+        return;
+      }
+
+      // Default: one compact line per group, biggest first.
+      console.log(
+        `${result.groups.length} user group(s)` +
+          (result.ungrouped.length
+            ? `, ${result.ungrouped.length} ungrouped`
+            : "") +
+          `  —  use --did <prefix> to expand one`,
+      );
+      for (const g of result.groups) {
+        const c = roleCounts(g);
+        console.log(
+          `● ${shortDid(g.principal)}  ` +
+            `home=${g.homePresent ? "present" : "absent"}  ` +
+            `profiles=${c.profile}  main=${c.main}` +
+            (c.absent ? `  (+${c.absent} absent)` : ""),
+        );
+      }
     });
   })
   /* inspect summary */

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -26,8 +26,14 @@ DB and a set of modern `fvj1:` DBs).
 - **`diff` / `timeline`** — time travel. `diff` shows what changed in an entity
   between two seqs; `timeline` shows how a space grew (or how one entity
   evolved). The engine already reconstructs at any seq.
-- **`html`** — a self-contained HTML inspector (Overview / Pieces / Entities /
-  Graph / Timeline) over the same JSON, for opening in a browser.
+- **`html`** — a self-contained HTML **explorer**. Two ways to navigate (a
+  **tree** from pieces down, and a re-rootable **graph** from any node) feeding
+  one detail pane that shows every salient field for the selected entity: value
+  (links clickable), schema, **CFC** information-flow labels, version history,
+  resolved lineage, outgoing links, and module source. Context-aware labels
+  (a stream named by its owner key → `⊙ createProfile`; `{link, specifier}` →
+  `import ./foo.tsx`), click-to-copy ids, and deep links into the live shell
+  (`--app-url`).
 
 **Model unification** (`model.ts`) makes the tool _fluent_: instead of guessing
 from the shape of `doc.value`, it reads the **whole entity document** (`value`
@@ -165,8 +171,9 @@ deno task cf inspect diff     z6Mkqa41 of:fid1:… --from 7 --to 12
 deno task cf inspect timeline z6Mkqa41                       # how the space grew
 deno task cf inspect timeline z6Mkqa41 of:fid1:…             # how one entity evolved
 
-# a self-contained HTML inspector to open in a browser
+# a self-contained HTML explorer to open in a browser (tree + graph + detail)
 deno task cf inspect html     z6Mkqa41 --out /tmp/space.html
+deno task cf inspect html     z6Mkqa41 --app-url https://host --out /tmp/space.html  # + live links
 
 # cross-space convergence (--all discovered, or --spaces a,b, or --dir)
 deno task cf inspect converge      of:fid1:… --all --path value

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -149,6 +149,12 @@ DID-prefix, or a path.
 deno task cf inspect spaces
 deno task cf inspect group                       # per-user worlds (home→profiles→main)
 deno task cf inspect group --did z6MkeZZv        # expand one user's world fully
+deno task cf inspect identity did:key:z6MkeZZv…  # one identity: its spaces + scopes it owns
+
+# the per-identity (multiplayer) dimension — scopes within a space
+deno task cf inspect scopes   z6Mkqa41           # space / per-user / per-session scopes here
+deno task cf inspect overlay  z6Mkqa41 of:fid1:… # a cell's value across EVERY scope (divergence)
+deno task cf inspect value-at z6Mkqa41 of:fid1:… --as did:key:z6MkeZZv…   # read AS an identity
 
 # single space (DID-prefix resolves via discovery)
 deno task cf inspect summary  z6Mkqa41

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -8,11 +8,26 @@ recorder.** This package is the lens over it — open a space SQLite file
 read-only, reconstruct state-at-`(branch, seq)`, and answer who/what/when
 questions with no live runtime and no capture step.
 
-## Status: usable (Milestones 1, 2, 2.5, 3 + model unification)
+## Status: usable (M1–M3 + model unification + comprehension surface)
 
 Wired into the `cf` CLI as **`cf inspect`** with local-DB auto-discovery — no
 absolute paths needed. Tested end-to-end against real space DBs (a 571 MB legacy
 DB and a set of modern `fvj1:` DBs).
+
+**Comprehension surface (Phase 2)** builds on the unified model:
+
+- **`group`** — a user's whole world. Discovers + groups local space DBs into
+  per-user worlds (home → profiles → main) from on-disk signals (home
+  `profiles[]` cross-space links, `commit.session_id` principal, cross-space
+  links). Compact by default; `--did <prefix>` expands one user.
+- **`graph`** — the entity graph. Nodes (pieces/modules/streams/schemas/cells)
+  + edges (`pattern` / `argument` / `owns` / `link`). `--root <entity> --depth`
+  drills into one piece's neighborhood; `--dot` emits Graphviz.
+- **`diff` / `timeline`** — time travel. `diff` shows what changed in an entity
+  between two seqs; `timeline` shows how a space grew (or how one entity
+  evolved). The engine already reconstructs at any seq.
+- **`html`** — a self-contained HTML inspector (Overview / Pieces / Entities /
+  Graph / Timeline) over the same JSON, for opening in a browser.
 
 **Model unification** (`model.ts`) makes the tool _fluent_: instead of guessing
 from the shape of `doc.value`, it reads the **whole entity document** (`value`
@@ -126,6 +141,8 @@ DID-prefix, or a path.
 ```bash
 # discover what's inspectable
 deno task cf inspect spaces
+deno task cf inspect group                       # per-user worlds (home→profiles→main)
+deno task cf inspect group --did z6MkeZZv        # expand one user's world fully
 
 # single space (DID-prefix resolves via discovery)
 deno task cf inspect summary  z6Mkqa41
@@ -137,6 +154,19 @@ deno task cf inspect hot      z6Mkqa41 --limit 10
 deno task cf inspect commits  z6Mkqa41 --limit 20
 deno task cf inspect history  z6Mkqa41 of:fid1:…
 deno task cf inspect value-at z6Mkqa41 of:fid1:… --path value/count
+
+# the entity graph (relationships between pieces/cells/modules)
+deno task cf inspect graph    z6Mkqa41                       # whole-space stats + adjacency
+deno task cf inspect graph    z6Mkqa41 --root of:fid1:… --depth 2   # one piece's neighborhood
+deno task cf inspect graph    z6Mkqa41 --root of:fid1:… --dot | dot -Tsvg > piece.svg
+
+# time travel (the engine reconstructs at any seq)
+deno task cf inspect diff     z6Mkqa41 of:fid1:… --from 7 --to 12
+deno task cf inspect timeline z6Mkqa41                       # how the space grew
+deno task cf inspect timeline z6Mkqa41 of:fid1:…             # how one entity evolved
+
+# a self-contained HTML inspector to open in a browser
+deno task cf inspect html     z6Mkqa41 --out /tmp/space.html
 
 # cross-space convergence (--all discovered, or --spaces a,b, or --dir)
 deno task cf inspect converge      of:fid1:… --all --path value

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -152,6 +152,7 @@ deno task cf inspect group --did z6MkeZZv        # expand one user's world fully
 deno task cf inspect identity did:key:z6MkeZZv…  # one identity: its spaces + scopes it owns
 
 # the per-identity (multiplayer) dimension — scopes within a space
+deno task cf inspect users    z6Mkqa41           # identities that touched this space (browse them)
 deno task cf inspect scopes   z6Mkqa41           # space / per-user / per-session scopes here
 deno task cf inspect overlay  z6Mkqa41 of:fid1:… # a cell's value across EVERY scope (divergence)
 deno task cf inspect value-at z6Mkqa41 of:fid1:… --as did:key:z6MkeZZv…   # read AS an identity

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -21,8 +21,8 @@ DB and a set of modern `fvj1:` DBs).
   `profiles[]` cross-space links, `commit.session_id` principal, cross-space
   links). Compact by default; `--did <prefix>` expands one user.
 - **`graph`** — the entity graph. Nodes (pieces/modules/streams/schemas/cells)
-  + edges (`pattern` / `argument` / `owns` / `link`). `--root <entity> --depth`
-  drills into one piece's neighborhood; `--dot` emits Graphviz.
+  - edges (`pattern` / `argument` / `owns` / `link`). `--root <entity> --depth`
+    drills into one piece's neighborhood; `--dot` emits Graphviz.
 - **`diff` / `timeline`** — time travel. `diff` shows what changed in an entity
   between two seqs; `timeline` shows how a space grew (or how one entity
   evolved). The engine already reconstructs at any seq.
@@ -30,8 +30,8 @@ DB and a set of modern `fvj1:` DBs).
   **tree** from pieces down, and a re-rootable **graph** from any node) feeding
   one detail pane that shows every salient field for the selected entity: value
   (links clickable), schema, **CFC** information-flow labels, version history,
-  resolved lineage, outgoing links, and module source. Context-aware labels
-  (a stream named by its owner key → `⊙ createProfile`; `{link, specifier}` →
+  resolved lineage, outgoing links, and module source. Context-aware labels (a
+  stream named by its owner key → `⊙ createProfile`; `{link, specifier}` →
   `import ./foo.tsx`), click-to-copy ids, and deep links into the live shell
   (`--app-url`).
 
@@ -156,6 +156,10 @@ deno task cf inspect users    z6Mkqa41           # identities that touched this 
 deno task cf inspect scopes   z6Mkqa41           # space / per-user / per-session scopes here
 deno task cf inspect overlay  z6Mkqa41 of:fid1:… # a cell's value across EVERY scope (divergence)
 deno task cf inspect value-at z6Mkqa41 of:fid1:… --as did:key:z6MkeZZv…   # read AS an identity
+
+# conflicts & async — contested cells + lost-update detection
+deno task cf inspect conflicts z6Mkqa41                  # cells written by ≥2 sessions (multi-user flagged)
+deno task cf inspect conflicts z6Mkqa41 of:fid1:…        # writer timeline + stale-read (lost-update) analysis
 
 # single space (DID-prefix resolves via discovery)
 deno task cf inspect summary  z6Mkqa41

--- a/packages/state-inspector/conflicts.ts
+++ b/packages/state-inspector/conflicts.ts
@@ -44,6 +44,8 @@ export interface ContendedEntity {
   writers: Writer[];
   /** Sessions alternate (A→B→A) — concurrent back-and-forth, not a handoff. */
   interleaved: boolean;
+  /** Lost-update reads (attached by the explorer bundle for multi-user cells). */
+  staleReads?: StaleRead[];
 }
 
 /** Distinct writer identities (principals) across a writer list. */

--- a/packages/state-inspector/conflicts.ts
+++ b/packages/state-inspector/conflicts.ts
@@ -1,0 +1,254 @@
+// Conflicts & async — the contested/concurrent dimension of multiplayer state.
+//
+// The durable store records enough to reconstruct who fought over what:
+//   - `revision` — every write, joinable to `commit.session_id` (the writer).
+//   - `commit.original.reads.confirmed[]` — `{ id, path, scope, seq }`: what each
+//     commit READ and at which seq. So a commit declares "I read X@N".
+//
+// Two grounded views:
+//   1. CONTENTION (write-write): entities written by ≥2 distinct sessions, with
+//      the interleaved writer timeline — the back-and-forth of concurrent edits.
+//   2. STALE READS (read-write / lost-update): a commit that wrote X having read
+//      X@N, when a DIFFERENT session wrote X at W with N < W < the writer's commit
+//      — i.e. it never saw W's write. The retroactive "conflict loser" signal.
+//
+// HONESTY: the server serializes the durable log, so what's here is the COMMITTED
+// order. Rejected/retried client commits aren't persisted; we infer contention
+// and stale reads from the successful log, not from rejection records.
+
+import type { SpaceDb } from "./db.ts";
+import { decodeStored } from "./decode.ts";
+import { parseScope } from "./scopes.ts";
+
+export interface Writer {
+  seq: number;
+  commitSeq: number;
+  session: string;
+  /** The writer's identity (principal DID parsed from the session). */
+  principal?: string;
+  op: string;
+  createdAt: string;
+}
+
+export interface ContendedEntity {
+  id: string;
+  /** Distinct writer sessions. */
+  sessions: number;
+  /** Distinct writer IDENTITIES — `>=2` is real cross-user contention vs the
+   * same user editing from multiple tabs/devices. */
+  principals: number;
+  /** True when ≥2 distinct identities wrote it (multi-user, not multi-session). */
+  multiUser: boolean;
+  writes: number;
+  /** Writer timeline, seq-ordered. */
+  writers: Writer[];
+  /** Sessions alternate (A→B→A) — concurrent back-and-forth, not a handoff. */
+  interleaved: boolean;
+}
+
+/** Distinct writer identities (principals) across a writer list. */
+function principalCount(writers: Writer[]): number {
+  return new Set(writers.map((w) => w.principal).filter(Boolean)).size;
+}
+
+/** Number of times the writing session changes across the seq-ordered list. */
+function sessionSwitches(writers: Writer[]): number {
+  let switches = 0;
+  for (let i = 1; i < writers.length; i++) {
+    if (writers[i].session !== writers[i - 1].session) switches++;
+  }
+  return switches;
+}
+
+/**
+ * Entities written by ≥2 distinct sessions — contested cells. Cheap: one join,
+ * then per-contested-entity the writer timeline. `interleaved` flags real
+ * back-and-forth (≥2 session switches) vs a one-time handoff.
+ */
+export function contendedEntities(
+  space: SpaceDb,
+  opts: { branch?: string; scope?: string; limit?: number } = {},
+): ContendedEntity[] {
+  const branch = opts.branch ?? "";
+  const scope = opts.scope ?? "space";
+  const limit = opts.limit ?? 100;
+
+  const ids = space.db
+    .prepare(
+      `SELECT r.id, count(DISTINCT c.session_id) sessions, count(*) writes
+       FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
+       WHERE r.branch = ? AND r.scope_key = ?
+       GROUP BY r.id HAVING sessions >= 2
+       ORDER BY sessions DESC, writes DESC LIMIT ?`,
+    )
+    .all<{ id: string; sessions: number; writes: number }>(
+      branch,
+      scope,
+      limit,
+    );
+
+  const writersStmt = space.db.prepare(
+    `SELECT r.seq, r.commit_seq, r.op, c.session_id, c.created_at
+     FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
+     WHERE r.branch = ? AND r.id = ? AND r.scope_key = ?
+     ORDER BY r.seq ASC, r.op_index ASC`,
+  );
+
+  return ids.map((e) => {
+    const writers: Writer[] = writersStmt
+      .all<{
+        seq: number;
+        commit_seq: number;
+        op: string;
+        session_id: string;
+        created_at: string;
+      }>(branch, e.id, scope)
+      .map((w) => ({
+        seq: w.seq,
+        commitSeq: w.commit_seq,
+        session: w.session_id,
+        principal: parseScope(w.session_id).principal,
+        op: w.op,
+        createdAt: w.created_at,
+      }));
+    const principals = principalCount(writers);
+    return {
+      id: e.id,
+      sessions: e.sessions,
+      principals,
+      multiUser: principals >= 2,
+      writes: e.writes,
+      writers,
+      interleaved: sessionSwitches(writers) >= 2,
+    };
+  }).sort((a, b) =>
+    (b.multiUser ? 1 : 0) - (a.multiUser ? 1 : 0) ||
+    b.principals - a.principals || b.sessions - a.sessions
+  );
+}
+
+export interface StaleRead {
+  /** The commit that read the entity. */
+  readerCommitSeq: number;
+  readerSession: string;
+  /** The seq the reader saw the entity at. */
+  readAtSeq: number;
+  /** A write by a DIFFERENT session the reader never saw (readAtSeq < seq < readerCommitSeq). */
+  missedWriteSeq: number;
+  missedWriteSession: string;
+  /** True when the reader ALSO wrote the entity (a real lost-update risk). */
+  readerAlsoWrote: boolean;
+}
+
+export interface EntityConflicts {
+  id: string;
+  writers: Writer[];
+  writerSessions: number;
+  /** Distinct writer identities — `>=2` is real cross-user contention. */
+  writerPrincipals: number;
+  multiUser: boolean;
+  interleaved: boolean;
+  /** Stale reads: the reader committed without seeing a prior concurrent write. */
+  staleReads: StaleRead[];
+}
+
+interface ReadRef {
+  id: string;
+  seq: number;
+}
+
+/**
+ * Deep per-entity conflict analysis: the writer timeline plus stale-read /
+ * lost-update detection. For each commit that READ this entity at seq N, if a
+ * DIFFERENT session wrote it at W (N < W < the reader's own commit seq), the
+ * reader never saw W — a concurrent-write it missed. Flagged stronger when the
+ * reader also wrote the entity (write-write lost update).
+ */
+export function entityConflicts(
+  space: SpaceDb,
+  id: string,
+  opts: { branch?: string; scope?: string } = {},
+): EntityConflicts {
+  const branch = opts.branch ?? "";
+  const scope = opts.scope ?? "space";
+
+  const writers: Writer[] = space.db
+    .prepare(
+      `SELECT r.seq, r.commit_seq, r.op, c.session_id, c.created_at
+       FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
+       WHERE r.branch = ? AND r.id = ? AND r.scope_key = ?
+       ORDER BY r.seq ASC, r.op_index ASC`,
+    )
+    .all<{
+      seq: number;
+      commit_seq: number;
+      op: string;
+      session_id: string;
+      created_at: string;
+    }>(branch, id, scope)
+    .map((w) => ({
+      seq: w.seq,
+      commitSeq: w.commit_seq,
+      session: w.session_id,
+      principal: parseScope(w.session_id).principal,
+      op: w.op,
+      createdAt: w.created_at,
+    }));
+
+  // Commits that wrote this entity (to flag reader-also-wrote).
+  const wroteByCommit = new Map<number, string>();
+  for (const w of writers) wroteByCommit.set(w.commitSeq, w.session);
+
+  // Candidate reader commits: those whose stored ClientCommit mentions this id.
+  // (Pre-filter by LIKE to avoid decoding every commit in the space.)
+  const candidates = space.db
+    .prepare(
+      `SELECT seq, session_id, original FROM "commit"
+       WHERE original LIKE '%' || ? || '%' ORDER BY seq ASC`,
+    )
+    .all<{ seq: number; session_id: string; original: string }>(id);
+
+  const staleReads: StaleRead[] = [];
+  for (const c of candidates) {
+    let reads: ReadRef[] = [];
+    try {
+      const o = decodeStored(c.original) as {
+        reads?: { confirmed?: ReadRef[] };
+      };
+      reads = (o.reads?.confirmed ?? []).filter((r) => r.id === id);
+    } catch {
+      continue;
+    }
+    for (const rd of reads) {
+      // A write to this entity by ANOTHER session, after what the reader saw but
+      // before the reader committed → the reader missed it.
+      for (const w of writers) {
+        if (
+          w.seq > rd.seq && w.commitSeq < c.seq &&
+          w.session !== c.session_id
+        ) {
+          staleReads.push({
+            readerCommitSeq: c.seq,
+            readerSession: c.session_id,
+            readAtSeq: rd.seq,
+            missedWriteSeq: w.seq,
+            missedWriteSession: w.session,
+            readerAlsoWrote: wroteByCommit.has(c.seq),
+          });
+          break; // one missed write per read is enough to flag it
+        }
+      }
+    }
+  }
+
+  const writerPrincipals = principalCount(writers);
+  return {
+    id,
+    writers,
+    writerSessions: new Set(writers.map((w) => w.session)).size,
+    writerPrincipals,
+    multiUser: writerPrincipals >= 2,
+    interleaved: sessionSwitches(writers) >= 2,
+    staleReads,
+  };
+}

--- a/packages/state-inspector/db.ts
+++ b/packages/state-inspector/db.ts
@@ -48,11 +48,34 @@ export interface SpaceDb {
 /** Open a space DB read-only. Safe against stale (and, best-effort, live) files. */
 export function openSpace(path: string): SpaceDb {
   const db = new Database(path, { readonly: true });
+  shimScopeKey(db);
   return {
     db,
     path,
     close: () => db.close(),
   };
+}
+
+/**
+ * Older space DBs predate the per-scope `scope_key` column on `revision` (added
+ * with PerUser/PerSession scopes). Every scope-aware query in this package
+ * filters `scope_key = 'space'`, so on those DBs we shim the column with a TEMP
+ * VIEW that shadows the table and supplies a constant `'space'` scope. Temp
+ * objects are writable even on a READONLY main DB and take name-resolution
+ * precedence over the real table, so all existing queries work unchanged.
+ */
+function shimScopeKey(db: Database): void {
+  const hasCol = db
+    .prepare(
+      "SELECT 1 FROM pragma_table_info('revision') WHERE name = 'scope_key'",
+    )
+    .get<{ 1: number }>();
+  if (hasCol) return;
+  db.exec(
+    `CREATE TEMP VIEW revision AS
+       SELECT branch, id, 'space' AS scope_key, seq, op_index, op, data, commit_seq
+       FROM main.revision`,
+  );
 }
 
 export function tableNames(db: Database): string[] {

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -98,6 +98,8 @@ export interface EntityDetail {
     argument?: LinkRef;
     internal?: LinkRef[];
     owner?: LinkRef;
+    /** Legacy regime: the result cell a process cell produces (`resultRef`). */
+    result?: LinkRef;
   };
   /** Outgoing data links found in the value, resolved to target labels. */
   outLinks: LinkRef[];
@@ -116,6 +118,27 @@ function importSpecifier(v: unknown): string | undefined {
     Object.keys(v).length === 2
   ) return v.specifier;
   return undefined;
+}
+
+/** The `resultRef` target of a legacy process cell (`{ $TYPE, resultRef, … }`). */
+function legacyResultId(v: unknown): string | undefined {
+  if (isObj(v) && "$TYPE" in v && "resultRef" in v) {
+    return parseSigilLink(v.resultRef)?.id;
+  }
+  return undefined;
+}
+
+/**
+ * A legacy process cell's human name lives on its RESULT cell's `$NAME` (the
+ * process cell itself only carries `$TYPE`/refs). Resolve it through the docs.
+ */
+function legacyName(
+  v: unknown,
+  docs: Map<string, EntityDocument>,
+): string | undefined {
+  const rid = legacyResultId(v);
+  const rv = rid ? docs.get(rid)?.value : undefined;
+  return isObj(rv) && typeof rv.$NAME === "string" ? rv.$NAME : undefined;
 }
 
 /** Render a CFC atom (string sigil, or an object atom) to a short string. */
@@ -210,16 +233,19 @@ function detailFromDoc(
   const named = ctx.nameOf.get(id);
 
   // --- context-aware label + role ----------------------------------------
-  let label = c.label;
+  // Label comes from the shared index (it already folds in import/context/legacy
+  // refinements); role is computed here.
+  let label = ctx.labelOf.get(id)?.label ?? c.label;
   let role: string = c.kind;
   if (spec) {
     label = `import ${spec}`;
     role = "module import";
   } else if (named) {
-    label = c.kind === "stream" ? `⊙ ${named.key}` : named.key;
     role = c.kind === "stream"
       ? `stream · ${named.key}`
       : `cell · ${named.key}`;
+  } else if (c.kind === "piece" && c.regime === "legacy") {
+    role = "piece (legacy process)";
   } else {
     role = roleFor(c.kind, c.owned);
   }
@@ -230,6 +256,16 @@ function detailFromDoc(
     lineage.argument = refTo(c.lineage.argument, ctx);
   }
   if (c.lineage.owner) lineage.owner = refTo(c.lineage.owner, ctx);
+  // Legacy: surface the result cell + the owned-cell manifest from the value.
+  if (c.kind === "piece" && c.regime === "legacy" && isObj(value)) {
+    const rid = legacyResultId(value);
+    if (rid) lineage.result = refTo(rid, ctx);
+    const internalIds = linksWithPaths(value.internal)
+      .map((l) => l.link.id).filter((x): x is string => !!x);
+    if (internalIds.length) {
+      lineage.internal = internalIds.map((cid) => refTo(cid, ctx)!);
+    }
+  }
   if (c.lineage.internal?.length) {
     lineage.internal = c.lineage.internal.map((cid) => refTo(cid, ctx)!);
   }
@@ -372,7 +408,10 @@ export function buildAllDetails(
   const nameOf = new Map<string, { owner: string; key: string }>();
   for (const [id, doc] of docs) {
     const c = classifyDocument(doc);
-    if (c.kind === "piece" && isObj(doc.value)) {
+    // Only MODERN piece result values carry semantic names as keys (createProfile,
+    // profiles, …). A legacy PROCESS cell's top-level keys are control-plane
+    // ($TYPE/resultRef/internal/argument) — naming children by those is noise.
+    if (c.kind === "piece" && c.regime === "modern" && isObj(doc.value)) {
       for (const [key, val] of Object.entries(doc.value)) {
         const tid = parseSigilLink(val)?.id;
         if (tid && !nameOf.has(tid)) nameOf.set(tid, { owner: id, key });
@@ -386,6 +425,9 @@ export function buildAllDetails(
     let label = c.label;
     if (spec) label = `import ${spec}`;
     else if (named) label = c.kind === "stream" ? `⊙ ${named.key}` : named.key;
+    else if (c.kind === "piece" && c.regime === "legacy") {
+      label = legacyName(doc.value, docs) ?? label;
+    }
     labelOf.set(id, { kind: c.kind, label });
   }
 

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -1,0 +1,430 @@
+// Rich per-entity detail — everything a human (or agent) needs to understand
+// ONE entity, with crystal-clear, context-aware labels.
+//
+// The fluent model (model.ts) classifies an entity by kind. This layer goes
+// further: it resolves what each cell/stream actually IS from its CONTEXT and
+// VALUE, so a generic "stream" becomes "⊙ createProfile" (named by the key that
+// points at it in its owner piece) and a bare "{ link, specifier }" becomes
+// "import ./piece-grid.tsx". It also surfaces every salient field: the full
+// value, schema, CFC (information-flow) labels, version history, resolved
+// lineage, outgoing links (with target labels), and module source.
+//
+// Built in one reconstruction pass over the space (buildAllDetails) so link
+// targets and owner→child names resolve against the whole space.
+
+import type { SpaceDb } from "./db.ts";
+import {
+  annotate,
+  type DecodedLink,
+  parseSigilLink,
+  summarize,
+} from "./decode.ts";
+import { reconstructDocument } from "./reconstruct.ts";
+import type { EntityDocument } from "./reconstruct.ts";
+import {
+  classifyDocument,
+  type EntityKind,
+  isModuleValue,
+  type ModuleEntry,
+} from "./model.ts";
+
+/** A resolved reference to another entity (or a cross-space target). */
+export interface LinkRef {
+  id: string;
+  /** Resolved label of the target (if in this space). */
+  label?: string;
+  kind?: EntityKind;
+  /** Cross-space target space DID. */
+  space?: string;
+  path?: string[];
+  /** True when the target is in another space (not resolvable locally). */
+  external?: boolean;
+  /** Where this link sits in the source value (a JSON path), for "links" lists. */
+  at?: string;
+}
+
+export interface VersionRow {
+  seq: number;
+  op: string;
+  session: string;
+  createdAt: string;
+}
+
+/** Parsed, render-ready CFC (information-flow) metadata. */
+export interface CfcSummary {
+  schemaHash?: string;
+  entries: {
+    path: string;
+    confidentiality: string[];
+    integrity: string[];
+    origin?: string;
+  }[];
+}
+
+export interface EntityDetail {
+  id: string;
+  kind: EntityKind;
+  regime: string;
+  owned: boolean;
+  /** Context-aware label (key-name / import specifier / $NAME / module file). */
+  label: string;
+  /** Short human role, e.g. "input cell", "owned stream", "module import". */
+  role: string;
+  /** The key in the owner piece that names this entity, if any. */
+  contextName?: string;
+  /** Top-level document paths present (the control plane). */
+  paths: string[];
+  valueShape: string;
+  /** The annotated value (links/streams normalized; depth-bounded). */
+  value: unknown;
+  valuePreview: string;
+  /** The result JSONSchema (annotated), if the entity carries one. */
+  schema?: unknown;
+  schemaKeys?: string[];
+  /** IFC labels from a schema-as-value entity, if present. */
+  ifc?: unknown;
+  /** Parsed CFC labels from the `cfc` meta path, if present. */
+  cfc?: CfcSummary;
+  revisions: number;
+  headSeq: number | null;
+  firstSeq: number | null;
+  versions: VersionRow[];
+  lineage: {
+    pattern?: LinkRef & {
+      filename?: string;
+      symbol?: string;
+      codeLines?: number;
+    };
+    argument?: LinkRef;
+    internal?: LinkRef[];
+    owner?: LinkRef;
+  };
+  /** Outgoing data links found in the value, resolved to target labels. */
+  outLinks: LinkRef[];
+  /** Module source (only on module entities). */
+  code?: string;
+}
+
+function isObj(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** A `{ link, specifier }` cell is a module-import entry. */
+function importSpecifier(v: unknown): string | undefined {
+  if (
+    isObj(v) && typeof v.specifier === "string" && "link" in v &&
+    Object.keys(v).length === 2
+  ) return v.specifier;
+  return undefined;
+}
+
+/** Render a CFC atom (string sigil, or an object atom) to a short string. */
+function atomLabel(a: unknown): string {
+  if (typeof a === "string") return a;
+  if (isObj(a)) {
+    const t = typeof a.type === "string" ? a.type.split("/").pop() : "atom";
+    const extra = a.name ?? a.subject ?? a.class ?? a.symbol;
+    return extra ? `${t}:${extra}` : String(t);
+  }
+  return String(a);
+}
+
+function parseCfc(cfc: unknown): CfcSummary | undefined {
+  if (!isObj(cfc)) return undefined;
+  const out: CfcSummary = {
+    schemaHash: typeof cfc.schemaHash === "string" ? cfc.schemaHash : undefined,
+    entries: [],
+  };
+  const lm = cfc.labelMap;
+  const entries = isObj(lm) && Array.isArray(lm.entries) ? lm.entries : [];
+  for (const e of entries) {
+    if (!isObj(e)) continue;
+    const label = isObj(e.label) ? e.label : {};
+    out.entries.push({
+      path: Array.isArray(e.path) ? (e.path as string[]).join("/") : "",
+      confidentiality: Array.isArray(label.confidentiality)
+        ? label.confidentiality.map(atomLabel)
+        : [],
+      integrity: Array.isArray(label.integrity)
+        ? label.integrity.map(atomLabel)
+        : [],
+      origin: typeof e.origin === "string" ? e.origin : undefined,
+    });
+  }
+  return out;
+}
+
+/** Collect every sigil link in a value, with its JSON path. */
+function linksWithPaths(
+  v: unknown,
+  base: string[] = [],
+  out: { link: DecodedLink; at: string }[] = [],
+  depth = 10,
+): { link: DecodedLink; at: string }[] {
+  if (depth < 0) return out;
+  const link = parseSigilLink(v);
+  if (link) {
+    out.push({ link, at: base.join("/") });
+    return out;
+  }
+  if (isObj(v)) {
+    for (const [k, val] of Object.entries(v)) {
+      linksWithPaths(val, [...base, k], out, depth - 1);
+    }
+  } else if (Array.isArray(v)) {
+    v.forEach((val, i) =>
+      linksWithPaths(val, [...base, String(i)], out, depth - 1)
+    );
+  }
+  return out;
+}
+
+interface DetailContext {
+  ownDid: string;
+  labelOf: Map<string, { kind: EntityKind; label: string }>;
+  /** entityId → { ownerId, key } naming it in its owner piece's value. */
+  nameOf: Map<string, { owner: string; key: string }>;
+  moduleIndex: Map<string, ModuleEntry>;
+  docs: Map<string, EntityDocument>;
+}
+
+function refTo(
+  id: string | undefined,
+  ctx: DetailContext,
+): LinkRef | undefined {
+  if (!id) return undefined;
+  const info = ctx.labelOf.get(id);
+  return { id, label: info?.label, kind: info?.kind };
+}
+
+/** Build the rich detail for a single (already reconstructed) document. */
+function detailFromDoc(
+  id: string,
+  doc: EntityDocument,
+  ctx: DetailContext,
+  versions: VersionRow[],
+): EntityDetail {
+  const c = classifyDocument(doc);
+  const value = doc.value;
+  const spec = importSpecifier(value);
+  const named = ctx.nameOf.get(id);
+
+  // --- context-aware label + role ----------------------------------------
+  let label = c.label;
+  let role: string = c.kind;
+  if (spec) {
+    label = `import ${spec}`;
+    role = "module import";
+  } else if (named) {
+    label = c.kind === "stream" ? `⊙ ${named.key}` : named.key;
+    role = c.kind === "stream"
+      ? `stream · ${named.key}`
+      : `cell · ${named.key}`;
+  } else {
+    role = roleFor(c.kind, c.owned);
+  }
+
+  // --- lineage, resolved to target labels --------------------------------
+  const lineage: EntityDetail["lineage"] = {};
+  if (c.lineage.argument) {
+    lineage.argument = refTo(c.lineage.argument, ctx);
+  }
+  if (c.lineage.owner) lineage.owner = refTo(c.lineage.owner, ctx);
+  if (c.lineage.internal?.length) {
+    lineage.internal = c.lineage.internal.map((cid) => refTo(cid, ctx)!);
+  }
+  if (c.lineage.pattern) {
+    const mid = ctx.moduleIndex.get(c.lineage.pattern.identity);
+    const ref: EntityDetail["lineage"]["pattern"] = {
+      id: mid?.id ?? c.lineage.pattern.identity,
+      label: mid ? ctx.labelOf.get(mid.id)?.label : undefined,
+      kind: "module",
+      symbol: c.lineage.pattern.symbol,
+      filename: mid?.filename,
+    };
+    if (mid) {
+      const mdoc = ctx.docs.get(mid.id);
+      const mv = mdoc?.value;
+      if (isModuleValue(mv)) ref.codeLines = mv.code.split("\n").length;
+    }
+    lineage.pattern = ref;
+  }
+
+  // --- outgoing links, resolved ------------------------------------------
+  const outLinks: LinkRef[] = linksWithPaths(value).map(({ link, at }) => {
+    const external = !!link.space && link.space !== ctx.ownDid &&
+      link.space !== `did:key:${ctx.ownDid}`;
+    return {
+      id: link.id ?? "?",
+      label: link.id ? ctx.labelOf.get(link.id)?.label : undefined,
+      kind: link.id ? ctx.labelOf.get(link.id)?.kind : undefined,
+      space: link.space,
+      path: link.path ? [...link.path] : undefined,
+      external,
+      at,
+    };
+  });
+
+  // --- module source -----------------------------------------------------
+  let code: string | undefined;
+  if (isModuleValue(value)) code = value.code;
+
+  // --- schema / ifc / cfc ------------------------------------------------
+  const schema = doc.schema !== undefined ? annotate(doc.schema) : undefined;
+  const schemaKeys = isObj(doc.schema) ? Object.keys(doc.schema) : undefined;
+  const ifc = isObj(value) && "ifc" in value ? annotate(value.ifc) : undefined;
+  const cfc = parseCfc(doc.cfc);
+
+  return {
+    id,
+    kind: c.kind,
+    regime: c.regime,
+    owned: c.owned,
+    label,
+    role,
+    contextName: named?.key,
+    paths: c.paths,
+    valueShape: c.valueShape,
+    value: annotate(value),
+    valuePreview: summarize(value),
+    schema,
+    schemaKeys,
+    ifc,
+    cfc,
+    revisions: versions.length,
+    headSeq: versions.length ? versions[versions.length - 1].seq : null,
+    firstSeq: versions.length ? versions[0].seq : null,
+    versions,
+    lineage,
+    outLinks,
+    code,
+  };
+}
+
+function roleFor(kind: EntityKind, owned: boolean): string {
+  switch (kind) {
+    case "piece":
+      return "piece (running pattern)";
+    case "module":
+      return "module (pattern source)";
+    case "stream":
+      return owned ? "owned stream" : "stream";
+    case "schema":
+      return "schema";
+    case "owned-cell":
+      return "owned cell";
+    case "free-cell":
+      return "free cell";
+    default:
+      return "entity";
+  }
+}
+
+/**
+ * Build rich details for every entity in a space — one reconstruction pass,
+ * resolving link-target labels and owner→child context names space-wide.
+ */
+export function buildAllDetails(
+  space: SpaceDb,
+  opts: { branch?: string; scope?: string; limit?: number } = {},
+): EntityDetail[] {
+  const branch = opts.branch ?? "";
+  const scope = opts.scope ?? "space";
+  const limit = opts.limit ?? 5000;
+  const ownDid = (space.path.split("/").pop() ?? "").replace(/\.sqlite$/, "");
+
+  const rows = space.db
+    .prepare(
+      `SELECT id, count(*) revisions FROM revision
+       WHERE branch = ? AND scope_key = ?
+       GROUP BY id ORDER BY revisions DESC LIMIT ?`,
+    )
+    .all<{ id: string; revisions: number }>(branch, scope, limit);
+
+  // Pass 1: reconstruct + module index + base labels.
+  const docs = new Map<string, EntityDocument>();
+  const moduleIndex = new Map<string, ModuleEntry>();
+  const labelOf = new Map<string, { kind: EntityKind; label: string }>();
+  for (const r of rows) {
+    let doc: EntityDocument | undefined;
+    try {
+      doc = reconstructDocument(space, { id: r.id, branch, scope });
+    } catch {
+      doc = undefined;
+    }
+    if (!doc) continue;
+    docs.set(r.id, doc);
+    const v = doc.value;
+    if (isModuleValue(v)) {
+      const existing = moduleIndex.get(v.identity);
+      if (!existing || v.kind === "source") {
+        moduleIndex.set(v.identity, {
+          id: r.id,
+          filename: v.filename,
+          kind: v.kind,
+        });
+      }
+    }
+  }
+
+  // Pass 2: context names (key in a piece's value that points at a child) +
+  // base labels (refined by import specifier / context name).
+  const nameOf = new Map<string, { owner: string; key: string }>();
+  for (const [id, doc] of docs) {
+    const c = classifyDocument(doc);
+    if (c.kind === "piece" && isObj(doc.value)) {
+      for (const [key, val] of Object.entries(doc.value)) {
+        const tid = parseSigilLink(val)?.id;
+        if (tid && !nameOf.has(tid)) nameOf.set(tid, { owner: id, key });
+      }
+    }
+  }
+  for (const [id, doc] of docs) {
+    const c = classifyDocument(doc);
+    const spec = importSpecifier(doc.value);
+    const named = nameOf.get(id);
+    let label = c.label;
+    if (spec) label = `import ${spec}`;
+    else if (named) label = c.kind === "stream" ? `⊙ ${named.key}` : named.key;
+    labelOf.set(id, { kind: c.kind, label });
+  }
+
+  const ctx: DetailContext = { ownDid, labelOf, nameOf, moduleIndex, docs };
+
+  // Pass 3: per-entity detail + version log.
+  const versionStmt = space.db.prepare(
+    `SELECT r.seq, r.op, c.session_id, c.created_at
+     FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
+     WHERE r.branch = ? AND r.id = ? AND r.scope_key = ?
+     ORDER BY r.seq ASC, r.op_index ASC`,
+  );
+  const out: EntityDetail[] = [];
+  for (const [id, doc] of docs) {
+    const versions = versionStmt
+      .all<{ seq: number; op: string; session_id: string; created_at: string }>(
+        branch,
+        id,
+        scope,
+      )
+      .map((v) => ({
+        seq: v.seq,
+        op: v.op,
+        session: v.session_id,
+        createdAt: v.created_at,
+      }));
+    out.push(detailFromDoc(id, doc, ctx, versions));
+  }
+
+  const order: Record<EntityKind, number> = {
+    piece: 0,
+    module: 1,
+    stream: 2,
+    schema: 3,
+    "owned-cell": 4,
+    "free-cell": 5,
+    unknown: 6,
+  };
+  return out.sort(
+    (a, b) => order[a.kind] - order[b.kind] || (b.revisions - a.revisions),
+  );
+}

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -184,31 +184,51 @@ function parseCfc(cfc: unknown): CfcSummary | undefined {
 
 /**
  * A stream / owned cell carries no schema of its own — its DECLARED schema (a
- * stream's event payload, a cell's value type) lives on the OWNER piece's
- * `schema.properties[<key>]` where `<key>` is the name that points at it. Resolve
- * that property, following a `$ref` into the owner's `$defs`.
+ * stream's event payload, a cell's value type) is attached where it is NAMED in
+ * its owner piece, under the key `<key>`. Two sources, link-first:
+ *   1. the inline `schema` on the LINK itself (`value[key]."/"."link@N".schema`)
+ *      — present even when the result schema omits the handler (e.g. addFavorite),
+ *   2. else the owner's `schema.properties[<key>]`, following a `$ref` into `$defs`.
  */
 function declaredSchemaFor(
   ownerDoc: EntityDocument | undefined,
   key: string,
-): { schema: unknown; keys?: string[]; isStream: boolean } | undefined {
-  const osch = ownerDoc?.schema;
-  if (!isObj(osch) || !isObj(osch.properties)) return undefined;
-  const prop = osch.properties[key];
-  if (!isObj(prop)) return undefined;
-  let resolved: Record<string, unknown> = prop;
-  const ref = typeof prop.$ref === "string" ? prop.$ref : undefined;
-  if (ref?.startsWith("#/$defs/") && isObj(osch.$defs)) {
-    const def = osch.$defs[ref.slice("#/$defs/".length)];
-    if (isObj(def)) resolved = def;
+): { schema: unknown; keys?: string[]; via: string } | undefined {
+  // 1. inline schema carried on the naming link.
+  const linkRaw = isObj(ownerDoc?.value)
+    ? (ownerDoc!.value as Record<string, unknown>)[key]
+    : undefined;
+  if (isObj(linkRaw) && isObj(linkRaw["/"])) {
+    const slash = linkRaw["/"] as Record<string, unknown>;
+    const linkKey = Object.keys(slash).find((k) => k.startsWith("link@"));
+    const inner = linkKey ? slash[linkKey] : undefined;
+    if (isObj(inner) && isObj(inner.schema)) {
+      return {
+        schema: annotate(inner.schema),
+        keys: Object.keys(inner.schema),
+        via: "link",
+      };
+    }
   }
-  const isStream = Array.isArray(prop.asCell) &&
-    (prop.asCell as unknown[]).includes("stream");
-  return {
-    schema: annotate(resolved),
-    keys: Object.keys(resolved),
-    isStream,
-  };
+  // 2. fallback: owner's result-schema property ($ref into $defs).
+  const osch = ownerDoc?.schema;
+  if (isObj(osch) && isObj(osch.properties)) {
+    const prop = osch.properties[key];
+    if (isObj(prop)) {
+      let resolved: Record<string, unknown> = prop;
+      const ref = typeof prop.$ref === "string" ? prop.$ref : undefined;
+      if (ref?.startsWith("#/$defs/") && isObj(osch.$defs)) {
+        const def = osch.$defs[ref.slice("#/$defs/".length)];
+        if (isObj(def)) resolved = def;
+      }
+      return {
+        schema: annotate(resolved),
+        keys: Object.keys(resolved),
+        via: "schema",
+      };
+    }
+  }
+  return undefined;
 }
 
 /** Collect every sigil link in a value, with its JSON path. */
@@ -351,8 +371,10 @@ function detailFromDoc(
     if (decl) {
       schema = decl.schema;
       schemaKeys = decl.keys;
-      streamPayload = decl.isStream;
-      schemaSource = `declared in owner · ${named.key}`;
+      streamPayload = c.kind === "stream";
+      schemaSource = decl.via === "link"
+        ? `declared at owner · ${named.key} (link)`
+        : `declared in owner schema · ${named.key}`;
     }
   }
   const ifc = isObj(value) && "ifc" in value ? annotate(value.ifc) : undefined;

--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -78,9 +78,14 @@ export interface EntityDetail {
   /** The annotated value (links/streams normalized; depth-bounded). */
   value: unknown;
   valuePreview: string;
-  /** The result JSONSchema (annotated), if the entity carries one. */
+  /** The result JSONSchema (annotated), if the entity carries one. Streams and
+   * named owned cells get their DECLARED schema resolved from the owner piece. */
   schema?: unknown;
   schemaKeys?: string[];
+  /** Where `schema` came from when it isn't the entity's own (e.g. owner piece). */
+  schemaSource?: string;
+  /** True when the declared schema is a stream payload (`asCell:["stream"]`). */
+  streamPayload?: boolean;
   /** IFC labels from a schema-as-value entity, if present. */
   ifc?: unknown;
   /** Parsed CFC labels from the `cfc` meta path, if present. */
@@ -175,6 +180,35 @@ function parseCfc(cfc: unknown): CfcSummary | undefined {
     });
   }
   return out;
+}
+
+/**
+ * A stream / owned cell carries no schema of its own — its DECLARED schema (a
+ * stream's event payload, a cell's value type) lives on the OWNER piece's
+ * `schema.properties[<key>]` where `<key>` is the name that points at it. Resolve
+ * that property, following a `$ref` into the owner's `$defs`.
+ */
+function declaredSchemaFor(
+  ownerDoc: EntityDocument | undefined,
+  key: string,
+): { schema: unknown; keys?: string[]; isStream: boolean } | undefined {
+  const osch = ownerDoc?.schema;
+  if (!isObj(osch) || !isObj(osch.properties)) return undefined;
+  const prop = osch.properties[key];
+  if (!isObj(prop)) return undefined;
+  let resolved: Record<string, unknown> = prop;
+  const ref = typeof prop.$ref === "string" ? prop.$ref : undefined;
+  if (ref?.startsWith("#/$defs/") && isObj(osch.$defs)) {
+    const def = osch.$defs[ref.slice("#/$defs/".length)];
+    if (isObj(def)) resolved = def;
+  }
+  const isStream = Array.isArray(prop.asCell) &&
+    (prop.asCell as unknown[]).includes("stream");
+  return {
+    schema: annotate(resolved),
+    keys: Object.keys(resolved),
+    isStream,
+  };
 }
 
 /** Collect every sigil link in a value, with its JSON path. */
@@ -306,8 +340,21 @@ function detailFromDoc(
   if (isModuleValue(value)) code = value.code;
 
   // --- schema / ifc / cfc ------------------------------------------------
-  const schema = doc.schema !== undefined ? annotate(doc.schema) : undefined;
-  const schemaKeys = isObj(doc.schema) ? Object.keys(doc.schema) : undefined;
+  let schema = doc.schema !== undefined ? annotate(doc.schema) : undefined;
+  let schemaKeys = isObj(doc.schema) ? Object.keys(doc.schema) : undefined;
+  let schemaSource: string | undefined;
+  let streamPayload: boolean | undefined;
+  // A stream / named owned cell has no own schema — resolve the DECLARED one
+  // from the owner piece that names it.
+  if (schema === undefined && named) {
+    const decl = declaredSchemaFor(ctx.docs.get(named.owner), named.key);
+    if (decl) {
+      schema = decl.schema;
+      schemaKeys = decl.keys;
+      streamPayload = decl.isStream;
+      schemaSource = `declared in owner · ${named.key}`;
+    }
+  }
   const ifc = isObj(value) && "ifc" in value ? annotate(value.ifc) : undefined;
   const cfc = parseCfc(doc.cfc);
 
@@ -325,6 +372,8 @@ function detailFromDoc(
     valuePreview: summarize(value),
     schema,
     schemaKeys,
+    schemaSource,
+    streamPayload,
     ifc,
     cfc,
     revisions: versions.length,

--- a/packages/state-inspector/graph.ts
+++ b/packages/state-inspector/graph.ts
@@ -1,0 +1,322 @@
+// The entity graph — the unified model made relational.
+//
+// Nodes are entities (pieces / modules / streams / schemas / cells) carrying the
+// fluent label from model.ts. Edges are the real relationships:
+//
+//   pattern   piece  → module     (patternIdentity → the pattern source)
+//   argument  piece  → input cell (the `argument` link)
+//   owns      piece  → owned cell (the `internal` manifest)
+//   link      entity → entity     (a data link inside `value`)
+//
+// One reconstruction pass builds everything: collect documents, build the module
+// index inline (so `patternIdentity` resolves to a module node), classify each
+// for its node, then read lineage + value links for edges. Data links may point
+// across spaces; those are kept as `external` edges to a synthesized stub node
+// (present:false) so the home→profile structure shows up here too, bounded.
+
+import type { SpaceDb } from "./db.ts";
+import { collectLinks } from "./decode.ts";
+import { reconstructDocument } from "./reconstruct.ts";
+import type { EntityDocument } from "./reconstruct.ts";
+import {
+  classifyDocument,
+  type EntityKind,
+  isModuleValue,
+  modelFromDocument,
+  type ModuleEntry,
+} from "./model.ts";
+
+export type EdgeKind = "pattern" | "argument" | "owns" | "link";
+
+export interface GraphNode {
+  id: string;
+  kind: EntityKind;
+  label: string;
+  /** False for a synthesized stub (a cross-space link target not in this space). */
+  present: boolean;
+  /** Set on external stubs: the space DID the target lives in. */
+  space?: string;
+}
+
+export interface GraphEdge {
+  from: string;
+  to: string;
+  kind: EdgeKind;
+  /** Optional edge annotation (pattern symbol, link path, …). */
+  label?: string;
+  /** True when `to` lives in another space (a cross-space data link). */
+  external?: boolean;
+}
+
+export interface SpaceGraph {
+  space: string;
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  stats: {
+    nodesByKind: Record<string, number>;
+    edgesByKind: Record<EdgeKind, number>;
+    externalEdges: number;
+  };
+}
+
+function shortPath(p?: readonly string[]): string | undefined {
+  return p && p.length ? p.join("/") : undefined;
+}
+
+/**
+ * Build the entity graph for a space. `includeLinks` (default true) adds data
+ * links found inside each `value`; structural edges (pattern/argument/owns) are
+ * always included.
+ */
+export function buildSpaceGraph(
+  space: SpaceDb,
+  opts: {
+    branch?: string;
+    scope?: string;
+    limit?: number;
+    includeLinks?: boolean;
+  } = {},
+): SpaceGraph {
+  const branch = opts.branch ?? "";
+  const scope = opts.scope ?? "space";
+  const limit = opts.limit ?? 5000;
+  const includeLinks = opts.includeLinks ?? true;
+  const own = (space.path.split("/").pop() ?? "").replace(/\.sqlite$/, "");
+
+  const rows = space.db
+    .prepare(
+      `SELECT id, count(*) revisions FROM revision
+       WHERE branch = ? AND scope_key = ?
+       GROUP BY id ORDER BY revisions DESC LIMIT ?`,
+    )
+    .all<{ id: string; revisions: number }>(branch, scope, limit);
+
+  // Pass 1: reconstruct + build the module index (identity → module entity).
+  const docs = new Map<string, EntityDocument>();
+  const moduleIndex = new Map<string, ModuleEntry>();
+  for (const r of rows) {
+    let doc: EntityDocument | undefined;
+    try {
+      doc = reconstructDocument(space, { id: r.id, branch, scope });
+    } catch {
+      doc = undefined;
+    }
+    if (!doc) continue;
+    docs.set(r.id, doc);
+    const v = doc.value;
+    if (isModuleValue(v)) {
+      const existing = moduleIndex.get(v.identity);
+      if (!existing || v.kind === "source") {
+        moduleIndex.set(v.identity, {
+          id: r.id,
+          filename: v.filename,
+          kind: v.kind,
+        });
+      }
+    }
+  }
+
+  // Pass 2: nodes + edges.
+  const nodes = new Map<string, GraphNode>();
+  const edges: GraphEdge[] = [];
+  const ensureStub = (id: string, space?: string) => {
+    if (!nodes.has(id)) {
+      nodes.set(id, {
+        id,
+        kind: "unknown",
+        label: space ? "(external)" : "(absent)",
+        present: false,
+        space,
+      });
+    }
+  };
+
+  for (const [id, doc] of docs) {
+    const m = modelFromDocument(doc, { id, scope, moduleIndex });
+    nodes.set(id, { id, kind: m.kind, label: m.label, present: true });
+  }
+
+  for (const [id, doc] of docs) {
+    const c = classifyDocument(doc);
+    // pattern: piece → module (resolve patternIdentity via the module index;
+    // classifyDocument leaves moduleId unset — that's modelFromDocument's job).
+    const moduleId = c.lineage.pattern
+      ? moduleIndex.get(c.lineage.pattern.identity)?.id
+      : undefined;
+    if (moduleId) {
+      ensureStub(moduleId);
+      edges.push({
+        from: id,
+        to: moduleId,
+        kind: "pattern",
+        label: c.lineage.pattern!.symbol,
+      });
+    }
+    // argument: piece → input cell
+    if (c.lineage.argument) {
+      ensureStub(c.lineage.argument);
+      edges.push({ from: id, to: c.lineage.argument, kind: "argument" });
+    }
+    // owns: piece → owned cells (internal manifest)
+    for (const child of c.lineage.internal ?? []) {
+      ensureStub(child);
+      edges.push({ from: id, to: child, kind: "owns" });
+    }
+    // link: data links inside the value
+    if (includeLinks) {
+      for (const l of collectLinks(doc.value)) {
+        if (!l.id) continue;
+        const external = !!l.space && l.space !== own &&
+          l.space !== `did:key:${own}`;
+        if (external) ensureStub(l.id, l.space);
+        else ensureStub(l.id);
+        edges.push({
+          from: id,
+          to: l.id,
+          kind: "link",
+          label: shortPath(l.path),
+          ...(external ? { external: true } : {}),
+        });
+      }
+    }
+  }
+
+  // Dedup identical edges (same from/to/kind/label).
+  const seen = new Set<string>();
+  const deduped = edges.filter((e) => {
+    const k = `${e.from}|${e.to}|${e.kind}|${e.label ?? ""}`;
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+
+  const nodesByKind: Record<string, number> = {};
+  for (const n of nodes.values()) {
+    nodesByKind[n.kind] = (nodesByKind[n.kind] ?? 0) + 1;
+  }
+  const edgesByKind: Record<EdgeKind, number> = {
+    pattern: 0,
+    argument: 0,
+    owns: 0,
+    link: 0,
+  };
+  let externalEdges = 0;
+  for (const e of deduped) {
+    edgesByKind[e.kind]++;
+    if (e.external) externalEdges++;
+  }
+
+  return {
+    space: own,
+    nodes: [...nodes.values()],
+    edges: deduped,
+    stats: { nodesByKind, edgesByKind, externalEdges },
+  };
+}
+
+/**
+ * Restrict a graph to the connected neighborhood of `rootId` within `depth`
+ * hops (following edges in both directions). For drilling into one piece.
+ */
+export function subgraphAround(
+  graph: SpaceGraph,
+  rootId: string,
+  depth = 2,
+): SpaceGraph {
+  const adj = new Map<string, Set<string>>();
+  const touch = (a: string, b: string) => {
+    (adj.get(a) ?? adj.set(a, new Set()).get(a)!).add(b);
+  };
+  for (const e of graph.edges) {
+    touch(e.from, e.to);
+    touch(e.to, e.from);
+  }
+  const keep = new Set<string>([rootId]);
+  let frontier = [rootId];
+  for (let d = 0; d < depth; d++) {
+    const next: string[] = [];
+    for (const n of frontier) {
+      for (const m of adj.get(n) ?? []) {
+        if (!keep.has(m)) {
+          keep.add(m);
+          next.push(m);
+        }
+      }
+    }
+    frontier = next;
+  }
+  const nodes = graph.nodes.filter((n) => keep.has(n.id));
+  const edges = graph.edges.filter((e) => keep.has(e.from) && keep.has(e.to));
+  const nodesByKind: Record<string, number> = {};
+  for (const n of nodes) nodesByKind[n.kind] = (nodesByKind[n.kind] ?? 0) + 1;
+  const edgesByKind: Record<EdgeKind, number> = {
+    pattern: 0,
+    argument: 0,
+    owns: 0,
+    link: 0,
+  };
+  let externalEdges = 0;
+  for (const e of edges) {
+    edgesByKind[e.kind]++;
+    if (e.external) externalEdges++;
+  }
+  return {
+    space: graph.space,
+    nodes,
+    edges,
+    stats: { nodesByKind, edgesByKind, externalEdges },
+  };
+}
+
+const DOT_FILL: Record<string, string> = {
+  piece: "#fde68a",
+  module: "#bfdbfe",
+  stream: "#fbcfe8",
+  schema: "#ddd6fe",
+  "owned-cell": "#d1fae5",
+  "free-cell": "#e5e7eb",
+  unknown: "#f3f4f6",
+};
+
+const DOT_EDGE: Record<EdgeKind, string> = {
+  pattern: 'color="#2563eb",style=bold',
+  argument: 'color="#16a34a"',
+  owns: 'color="#6b7280"',
+  link: 'color="#9ca3af",style=dashed',
+};
+
+function dotId(id: string): string {
+  return `"${id.replace(/"/g, "")}"`;
+}
+
+function dotLabel(n: GraphNode): string {
+  const body = n.label.length > 28 ? `${n.label.slice(0, 27)}…` : n.label;
+  const idTail = n.id.length > 12 ? n.id.slice(-8) : n.id;
+  return `${n.kind}\\n${body}\\n${idTail}`.replace(/"/g, "'");
+}
+
+/** Render a graph as Graphviz DOT (pipe to `dot -Tsvg`). */
+export function graphToDot(graph: SpaceGraph): string {
+  const lines: string[] = [
+    `digraph space {`,
+    `  rankdir=LR;`,
+    `  node [shape=box,style="filled,rounded",fontname="monospace",fontsize=9];`,
+    `  edge [fontname="monospace",fontsize=8];`,
+  ];
+  for (const n of graph.nodes) {
+    const fill = DOT_FILL[n.kind] ?? "#f3f4f6";
+    const style = n.present ? "filled,rounded" : "filled,rounded,dashed";
+    lines.push(
+      `  ${dotId(n.id)} [label="${
+        dotLabel(n)
+      }",fillcolor="${fill}",style="${style}"];`,
+    );
+  }
+  for (const e of graph.edges) {
+    const attrs = DOT_EDGE[e.kind];
+    const label = e.label ? `,label="${e.label.replace(/"/g, "'")}"` : "";
+    lines.push(`  ${dotId(e.from)} -> ${dotId(e.to)} [${attrs}${label}];`);
+  }
+  lines.push(`}`);
+  return lines.join("\n");
+}

--- a/packages/state-inspector/grouping.ts
+++ b/packages/state-inspector/grouping.ts
@@ -1,0 +1,340 @@
+// Space grouping — "a user's whole world" from a pile of space DBs.
+//
+// A user's state is spread across SEVERAL spaces; understanding it means
+// grouping them, not inspecting one DB in isolation. We recover the implicated
+// group from on-disk signals, each verified against real DBs:
+//
+//   1. Home `profiles[]`  — a home space holds home-piece instances whose
+//      `profiles` cell is an ARRAY of cross-space links { id, space } where each
+//      `space` is a PROFILE space DID. This is the home → profiles edge.
+//   2. `commit.session_id` = `session:did:key:<DID>:<uuid>` (often %-encoded).
+//      The embedded <DID> is the ACTING PRINCIPAL — the owner whose session
+//      wrote here. For a home space the principal equals the space's own DID
+//      (home DID = user identity DID); for a main/pattern space it points at the
+//      owner's (possibly empty/placeholder) home space.
+//   3. Cross-space links anywhere — any link whose `space` ≠ self names a
+//      related space.
+//
+// Lifecycle note (verified): creating a space pre-creates EMPTY placeholder
+// spaces (e.g. the owner's home), so a referenced space may exist locally with
+// zero commits, or not exist locally at all (remote / not-yet-synced). We mark
+// both: `empty` (present, 0 commits) and `present:false` (referenced, no local
+// DB).
+
+import { openSpace, type SpaceDb } from "./db.ts";
+import { collectLinks } from "./decode.ts";
+import { reconstructDocument } from "./reconstruct.ts";
+import type { DiscoveredSpace } from "./discover.ts";
+
+export type SpaceRole =
+  | "home" // user registry: profiles[], favorites, mru, self-model
+  | "profile" // a profile space (a target of a home's profiles[])
+  | "main" // a pattern/main space (acted on by a principal)
+  | "unknown";
+
+export interface SpaceSignals {
+  did: string;
+  /** A home-piece was found here (result keys include profiles + createProfile). */
+  isHome: boolean;
+  /** Profile space DIDs from this home's `profiles[]` cells (cross-space links). */
+  profileDids: string[];
+  /** Session principal DIDs from `commit.session_id` (owners acting here). */
+  principals: string[];
+  /** Dominant (most frequent) session principal, if any. */
+  principal: string | null;
+  /** All cross-space link target space DIDs (space ≠ self). */
+  crossSpaceDids: string[];
+  commits: number;
+  entities: number;
+}
+
+const SESSION_RE = /^session:(did:key:[^:]+):/i;
+
+/** The acting-principal DID embedded in a `session_id`, if present. */
+export function principalFromSession(sessionId: string): string | null {
+  const m = decodeURIComponent(sessionId).match(SESSION_RE);
+  return m ? m[1] : null;
+}
+
+/** A space DB's own DID, from its file path (basename minus `.sqlite`). */
+function didFromPath(path: string): string {
+  return (path.split("/").pop() ?? path).replace(/\.sqlite$/, "");
+}
+
+/** A home piece's result value carries both `profiles` and `createProfile`. */
+function isHomeResultValue(v: unknown): boolean {
+  return typeof v === "object" && v !== null && !Array.isArray(v) &&
+    "profiles" in v && "createProfile" in v;
+}
+
+/**
+ * Read the grouping signals from a single space DB. Cheap by design: it never
+ * does a full reconstruction pass — it targets home pieces and cross-space
+ * carriers with `data LIKE` candidate queries, then reconstructs only those.
+ */
+export function analyzeSpaceSignals(
+  space: SpaceDb,
+  opts: { branch?: string; scope?: string } = {},
+): SpaceSignals {
+  const branch = opts.branch ?? "";
+  const scope = opts.scope ?? "space";
+  const own = didFromPath(space.path);
+
+  const agg = space.db
+    .prepare(
+      `SELECT (SELECT count(*) FROM "commit") commits,
+              (SELECT count(DISTINCT id) FROM revision) entities`,
+    )
+    .get<{ commits: number; entities: number }>();
+
+  // --- Session principals (owners who wrote here) ------------------------
+  const principalCounts = new Map<string, number>();
+  for (
+    const r of space.db
+      .prepare(
+        `SELECT session_id, count(*) n FROM "commit" GROUP BY session_id`,
+      )
+      .all<{ session_id: string; n: number }>()
+  ) {
+    const p = r.session_id ? principalFromSession(r.session_id) : null;
+    if (p) principalCounts.set(p, (principalCounts.get(p) ?? 0) + r.n);
+  }
+  const principals = [...principalCounts.keys()];
+  let principal: string | null = null;
+  let best = -1;
+  for (const [p, n] of principalCounts) {
+    if (n > best) {
+      best = n;
+      principal = p;
+    }
+  }
+
+  // --- Home detection + profiles[] edges ---------------------------------
+  let isHome = false;
+  const profileDids = new Set<string>();
+  const homeCandidates = space.db
+    .prepare(
+      `SELECT DISTINCT id FROM revision
+       WHERE branch = ? AND scope_key = ?
+         AND data LIKE '%createProfile%' AND data LIKE '%"profiles"%'`,
+    )
+    .all<{ id: string }>(branch, scope);
+  for (const { id } of homeCandidates) {
+    let doc;
+    try {
+      doc = reconstructDocument(space, { id, branch, scope });
+    } catch {
+      continue;
+    }
+    const value = doc?.value;
+    if (!isHomeResultValue(value)) continue;
+    isHome = true;
+    // `profiles` is a link to the profiles cell; follow it and read the array.
+    const profilesField = (value as Record<string, unknown>).profiles;
+    const link = collectLinks(profilesField)[0];
+    if (!link?.id) continue;
+    let pdoc;
+    try {
+      pdoc = reconstructDocument(space, { id: link.id, branch, scope });
+    } catch {
+      continue;
+    }
+    for (const l of collectLinks(pdoc?.value)) {
+      if (l.space && l.space !== own) profileDids.add(l.space);
+    }
+  }
+
+  // --- All cross-space link targets (cheap candidate query) --------------
+  const crossSpaceDids = new Set<string>();
+  for (
+    const { id } of space.db
+      .prepare(
+        `SELECT DISTINCT id FROM revision
+         WHERE branch = ? AND scope_key = ? AND data LIKE '%"space":"did:key:%'`,
+      )
+      .all<{ id: string }>(branch, scope)
+  ) {
+    let doc;
+    try {
+      doc = reconstructDocument(space, { id, branch, scope });
+    } catch {
+      continue;
+    }
+    for (const l of collectLinks(doc)) {
+      if (l.space && l.space !== own) crossSpaceDids.add(l.space);
+    }
+  }
+
+  return {
+    did: own,
+    isHome,
+    profileDids: [...profileDids],
+    principals,
+    principal,
+    crossSpaceDids: [...crossSpaceDids],
+    commits: agg?.commits ?? 0,
+    entities: agg?.entities ?? 0,
+  };
+}
+
+export interface GroupedSpace {
+  did: string;
+  role: SpaceRole;
+  /** A local DB file was found for this DID. */
+  present: boolean;
+  /** Present but with zero commits — a pre-created placeholder. */
+  empty: boolean;
+  commits?: number;
+  entities?: number;
+  /** Why this space is in the group / has this role. */
+  evidence: string[];
+}
+
+export interface SpaceGroup {
+  /** The owner principal / home DID this group centers on. */
+  principal: string;
+  /** A non-empty home space was found locally for the principal. */
+  homePresent: boolean;
+  spaces: GroupedSpace[];
+}
+
+export interface GroupingResult {
+  groups: SpaceGroup[];
+  /** Discovered spaces not attachable to any principal. */
+  ungrouped: GroupedSpace[];
+}
+
+interface Analyzed {
+  disc: DiscoveredSpace;
+  sig: SpaceSignals;
+}
+
+/**
+ * Group discovered space DBs into per-user worlds. Centers each group on a
+ * principal DID (the owner's home) and attaches its home, profile, and main
+ * spaces, plus placeholder nodes for referenced-but-absent spaces.
+ */
+export function groupDiscoveredSpaces(
+  discovered: DiscoveredSpace[],
+  opts: { branch?: string; scope?: string } = {},
+): GroupingResult {
+  const analyzed: Analyzed[] = [];
+  for (const disc of discovered) {
+    let space: SpaceDb | undefined;
+    try {
+      space = openSpace(disc.path);
+      analyzed.push({ disc, sig: analyzeSpaceSignals(space, opts) });
+    } catch {
+      // not a readable v2 space DB — skip
+    } finally {
+      space?.close();
+    }
+  }
+
+  const byDid = new Map<string, Analyzed>();
+  for (const a of analyzed) byDid.set(a.sig.did, a);
+
+  // Each space's owning principal: a home owns itself; everything else is owned
+  // by its dominant session principal (falling back to its own DID).
+  const principalOf = (a: Analyzed): string =>
+    a.sig.isHome ? a.sig.did : (a.sig.principal ?? a.sig.did);
+
+  // profileDid -> the home DID that lists it (for role + evidence).
+  const profileOwner = new Map<string, string>();
+  for (const a of analyzed) {
+    if (a.sig.isHome) {
+      for (const pd of a.sig.profileDids) profileOwner.set(pd, a.sig.did);
+    }
+  }
+
+  // Collect every principal DID we should form a group around: every owner of a
+  // present space, plus every home referenced as a profile-owner or session
+  // principal even if its DB is absent.
+  const principals = new Set<string>();
+  for (const a of analyzed) principals.add(principalOf(a));
+  for (const owner of profileOwner.values()) principals.add(owner);
+
+  const roleOf = (did: string): { role: SpaceRole; evidence: string[] } => {
+    const ev: string[] = [];
+    const a = byDid.get(did);
+    if (profileOwner.has(did)) {
+      ev.push(`listed in profiles[] of ${shortDid(profileOwner.get(did)!)}`);
+      return { role: "profile", evidence: ev };
+    }
+    if (a?.sig.isHome) {
+      ev.push("home pieces (profiles + createProfile)");
+      return { role: "home", evidence: ev };
+    }
+    if (a) {
+      if (a.sig.principal) {
+        ev.push(`written by principal ${shortDid(a.sig.principal)}`);
+      }
+      return { role: "main", evidence: ev };
+    }
+    return { role: "unknown", evidence: ev };
+  };
+
+  const nodeFor = (did: string, extraEvidence: string[] = []): GroupedSpace => {
+    const a = byDid.get(did);
+    const { role, evidence } = roleOf(did);
+    return {
+      did,
+      role: a ? role : (profileOwner.has(did) ? "profile" : role),
+      present: !!a,
+      empty: !!a && a.sig.commits === 0,
+      commits: a?.sig.commits,
+      entities: a?.sig.entities,
+      evidence: [...evidence, ...extraEvidence],
+    };
+  };
+
+  const claimed = new Set<string>();
+  const groups: SpaceGroup[] = [];
+  for (const principal of principals) {
+    const members = new Set<string>();
+    members.add(principal); // the home (may be absent/empty)
+    const homeAnalyzed = byDid.get(principal);
+    // Spaces this principal acts on / owns.
+    for (const a of analyzed) {
+      if (principalOf(a) === principal) members.add(a.sig.did);
+    }
+    // The home's profile spaces.
+    if (homeAnalyzed?.sig.isHome) {
+      for (const pd of homeAnalyzed.sig.profileDids) members.add(pd);
+    }
+    // A group of just an absent principal with nothing attached is noise.
+    const presentMembers = [...members].filter((d) => byDid.has(d));
+    if (presentMembers.length === 0) continue;
+
+    const spaces: GroupedSpace[] = [...members].map((did) => {
+      const extra: string[] = [];
+      if (did === principal) extra.push("group principal (owner home)");
+      return nodeFor(did, extra);
+    });
+    spaces.sort((x, y) => roleRank(x.role) - roleRank(y.role));
+    for (const d of members) claimed.add(d);
+    groups.push({
+      principal,
+      homePresent: !!homeAnalyzed?.sig.isHome &&
+        (homeAnalyzed?.sig.commits ?? 0) > 0,
+      spaces,
+    });
+  }
+
+  groups.sort((a, b) => b.spaces.length - a.spaces.length);
+
+  const ungrouped: GroupedSpace[] = analyzed
+    .filter((a) => !claimed.has(a.sig.did))
+    .map((a) => nodeFor(a.sig.did));
+
+  return { groups, ungrouped };
+}
+
+function roleRank(r: SpaceRole): number {
+  return r === "home" ? 0 : r === "profile" ? 1 : r === "main" ? 2 : 3;
+}
+
+function shortDid(did: string): string {
+  const tail = did.startsWith("did:key:") ? did.slice("did:key:".length) : did;
+  return tail.length > 12 ? `${tail.slice(0, 6)}…${tail.slice(-4)}` : tail;
+}

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -206,7 +206,9 @@ function kindChip(kind){ return el("span",{class:"kind "+kind,style:"background:
 // ---- live shell link --------------------------------------------------
 let LIVE = localStorage.getItem("si-live") || B.liveBase || "";
 function liveUrl(id){ if(!LIVE) return null;
-  const base = LIVE.replace(/\/+$/,""); return base+"/"+B.space+"/"+id; }
+  // The shell navigates by the bare id form (fid1:…); the stored "of:" prefix
+  // makes it parse the segment as raw base64 and throw. Strip it.
+  const base = LIVE.replace(/\/+$/,""); return base+"/"+B.space+"/"+id.replace(/^of:/,""); }
 function liveAnchor(id){ const u = liveUrl(id); return u
   ? el("a",{href:u,target:"_blank",rel:"noopener",text:"open in app ↗",title:u})
   : el("span",{class:"muted",text:"(set app URL ↗ to enable live links)"}); }

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -24,6 +24,11 @@ import {
   scopeOverlay,
   spaceParticipants,
 } from "./scopes.ts";
+import {
+  contendedEntities,
+  type ContendedEntity,
+  entityConflicts,
+} from "./conflicts.ts";
 
 export interface InspectorBundle {
   space: string;
@@ -40,6 +45,8 @@ export interface InspectorBundle {
   overlays: ScopeOverlay[];
   /** Identities that touched this space (committers + per-user/session owners). */
   participants: Participant[];
+  /** Contested entities (≥2 writer sessions); multi-user ones carry stale reads. */
+  conflicts: ContendedEntity[];
 }
 
 /** Assemble everything the explorer needs from one space DB. */
@@ -81,7 +88,25 @@ export function buildInspectorBundle(
     scopes: listScopes(space, { branch }),
     overlays,
     participants: spaceParticipants(space, { branch }),
+    conflicts: buildConflicts(space, branch, scope),
   };
+}
+
+/** Contested entities; attach stale-read analysis to the multi-user ones. */
+function buildConflicts(
+  space: SpaceDb,
+  branch: string,
+  scope: string,
+): ContendedEntity[] {
+  const contended = contendedEntities(space, { branch, scope, limit: 300 });
+  let analyzed = 0;
+  for (const c of contended) {
+    if (c.multiUser && analyzed < 60) {
+      analyzed++;
+      c.staleReads = entityConflicts(space, c.id, { branch, scope }).staleReads;
+    }
+  }
+  return contended;
 }
 
 /** Embed JSON safely inside an HTML <script> block. */
@@ -175,6 +200,7 @@ const KC = { piece:"var(--piece)", module:"var(--module)", stream:"var(--stream)
 const EC = { pattern:"#2563eb", argument:"#16a34a", owns:"#6b7280", link:"#9ca3af" };
 const byId = new Map(B.details.map(d => [d.id, d]));
 const overlayById = new Map((B.overlays||[]).map(o => [o.id, o]));
+const conflictById = new Map((B.conflicts||[]).map(c => [c.id, c]));
 // Per-user/session-only cells aren't in the space-scope details; synthesize
 // lightweight, selectable entries so they're visible + their overlay shows.
 for (const o of (B.overlays||[])) {
@@ -340,6 +366,32 @@ function renderDetail(id){
     host.append(section("Scopes — view as identity"+(ov.divergent?" ⚑":""), true, body));
   }
 
+  // contention / conflicts — who fought over this cell
+  const cf = conflictById.get(id);
+  if (cf){
+    const body=[];
+    body.push(el("div",{class:"muted",text:
+      cf.writes+" writes by "+cf.principals+" identit"+(cf.principals===1?"y":"ies")+" / "+cf.sessions+" sessions"
+      +(cf.multiUser?" · MULTI-USER":" · single-user (multi-session)")+(cf.interleaved?" · interleaved":"")}));
+    for(const w of cf.writers){
+      body.push(el("div",{class:"scopevar",style:"border-color:var(--stream)"},[
+        el("span",{class:"k",text:"seq "+w.seq+"  "+w.op+"  "}),
+        el("span",{class: w.principal&&byId.get(w.principal)?"":"muted",text:fmtSession(w.session)}),
+        el("span",{class:"muted",text:"  "+w.createdAt}),
+      ]));
+    }
+    if(cf.staleReads&&cf.staleReads.length){
+      body.push(el("div",{style:"margin-top:6px;color:var(--stream)",text:"⚠ stale reads (lost-update risk):"}));
+      for(const sr of cf.staleReads){
+        body.push(el("div",{class:"muted",style:"font-size:12px",text:
+          "commit #"+sr.readerCommitSeq+" by "+fmtSession(sr.readerSession)+" read @"+sr.readAtSeq
+          +" but missed write @"+sr.missedWriteSeq+" by "+fmtSession(sr.missedWriteSession)
+          +(sr.readerAlsoWrote?" — then wrote":"")}));
+      }
+    }
+    host.append(section("Contention"+(cf.multiUser?" ⚔ MULTI-USER":"")+(cf.staleReads&&cf.staleReads.length?" · stale reads":""), cf.multiUser, body));
+  }
+
   // schema (a stream's payload schema is resolved from its owner piece)
   if(d.schema!==undefined){
     const title=(d.streamPayload?"Stream payload schema":"Schema")
@@ -394,7 +446,8 @@ function fmtSession(s){ try{ s=decodeURIComponent(s);}catch{} const m=s.match(/^
 // ---- tree view --------------------------------------------------------
 function treeRow(d, childInfo){
   const ov = overlayById.get(d.id);
-  const mark = ov ? (ov.divergent ? " ⚑" : " ◐") : "";
+  const cf = conflictById.get(d.id);
+  const mark = (ov ? (ov.divergent ? " ⚑" : " ◐") : "") + (cf && cf.multiUser ? " ⚔" : "");
   const r = el("div",{class:"row","data-id":d.id, onclick:()=>select(d.id),
     title: ov ? (ov.divergent?"per-identity divergence":"per-identity scope") : ""},[
     el("span",{class:"tw",text:childInfo?"▸":"·"}),
@@ -572,6 +625,12 @@ export function renderInspectorHtml(bundle: InspectorBundle): string {
   const xLine = linkedSpaces.size
     ? ` · links to ${linkedSpaces.size} other space(s)`
     : "";
+  const multiUser = bundle.conflicts.filter((c) => c.multiUser).length;
+  const cfLine = bundle.conflicts.length
+    ? ` · ${bundle.conflicts.length} contested${
+      multiUser ? `, ${multiUser} multi-user ⚔` : ""
+    }`
+    : "";
   return `<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -586,7 +645,7 @@ export function renderInspectorHtml(bundle: InspectorBundle): string {
   <span class="stats">${s.entities} entities · ${s.commits} commits · ${s.sessions} sessions · ops ${opsLine}${
     bundle.generatedAt ? ` · ${bundle.generatedAt.slice(0, 10)}` : ""
   }</span>
-  <span class="stats" style="color:var(--stream)">${idLine}${xLine}</span>
+  <span class="stats" style="color:var(--stream)">${idLine}${xLine}${cfLine}</span>
   <span class="live">app URL <input id="live-input" placeholder="https://host (for live links)" size="22"></span>
 </header>
 <nav>

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -263,6 +263,7 @@ function renderDetail(id){
   if(L.pattern){ lin.push(el("div",{},[el("span",{class:"k muted",text:"pattern  "}),
     linkChip(L.pattern), el("span",{class:"muted",text:" "+(L.pattern.filename||"")+(L.pattern.symbol?" · "+L.pattern.symbol:"")+(L.pattern.codeLines?" · "+L.pattern.codeLines+" lines":"")})])); }
   if(L.argument){ lin.push(el("div",{},[el("span",{class:"k muted",text:"input    "}), linkChip(L.argument)])); }
+  if(L.result){ lin.push(el("div",{},[el("span",{class:"k muted",text:"result   "}), linkChip(L.result)])); }
   if(L.owner){ lin.push(el("div",{},[el("span",{class:"k muted",text:"owner    "}), linkChip(L.owner)])); }
   if(L.internal&&L.internal.length){ const wrap=el("div",{},[el("span",{class:"k muted",text:"owns ("+L.internal.length+")  "})]);
     L.internal.forEach(r=>wrap.append(linkChip(r))); lin.push(wrap); }

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -16,6 +16,12 @@ import { type SpaceSummary, summarizeSpace } from "./queries.ts";
 import { buildSpaceGraph, type SpaceGraph } from "./graph.ts";
 import { spaceTimeline, type SpaceTimelineEntry } from "./timetravel.ts";
 import { buildAllDetails, type EntityDetail } from "./detail.ts";
+import {
+  listScopes,
+  type Scope,
+  type ScopeOverlay,
+  scopeOverlay,
+} from "./scopes.ts";
 
 export interface InspectorBundle {
   space: string;
@@ -26,6 +32,10 @@ export interface InspectorBundle {
   details: EntityDetail[];
   graph: SpaceGraph;
   timeline: SpaceTimelineEntry[];
+  /** Per-identity scopes present (space / user:<DID> / session:<DID>:*). */
+  scopes: Scope[];
+  /** Per-entity scope overlays — only for cells with non-space/multi-scope state. */
+  overlays: ScopeOverlay[];
 }
 
 /** Assemble everything the explorer needs from one space DB. */
@@ -41,6 +51,21 @@ export function buildInspectorBundle(
   const branch = opts.branch ?? "";
   const scope = opts.scope ?? "space";
   const did = (space.path.split("/").pop() ?? "").replace(/\.sqlite$/, "");
+
+  // Entities that carry per-user/session state (in a non-space scope, or in
+  // more than one scope) get a full scope overlay so the explorer can show the
+  // per-identity divergence the space-scope view hides.
+  const overlayIds = space.db
+    .prepare(
+      `SELECT id FROM revision WHERE branch = ?
+       GROUP BY id
+       HAVING count(DISTINCT scope_key) > 1
+           OR sum(CASE WHEN scope_key != 'space' THEN 1 ELSE 0 END) > 0`,
+    )
+    .all<{ id: string }>(branch)
+    .map((r) => r.id);
+  const overlays = overlayIds.map((id) => scopeOverlay(space, id, { branch }));
+
   return {
     space: did,
     generatedAt: opts.generatedAt ?? "",
@@ -49,6 +74,8 @@ export function buildInspectorBundle(
     details: buildAllDetails(space, { branch, scope }),
     graph: buildSpaceGraph(space, { branch, scope }),
     timeline: spaceTimeline(space, { branch, scope }),
+    scopes: listScopes(space, { branch }),
+    overlays,
   };
 }
 
@@ -133,6 +160,7 @@ svg { max-width:100%; border:1px solid var(--line); border-radius:8px; backgroun
 .flash.on { opacity:1; }
 .jlink { color:var(--accent); cursor:pointer; text-decoration:underline; }
 .jstream { color:var(--stream); }
+.scopevar { border-left:2px solid var(--accent); padding-left:8px; margin:6px 0; }
 `;
 
 const APP = String.raw`
@@ -141,6 +169,18 @@ const KC = { piece:"var(--piece)", module:"var(--module)", stream:"var(--stream)
   schema:"var(--schema)", "owned-cell":"var(--owned-cell)", "free-cell":"var(--free-cell)", unknown:"var(--unknown)" };
 const EC = { pattern:"#2563eb", argument:"#16a34a", owns:"#6b7280", link:"#9ca3af" };
 const byId = new Map(B.details.map(d => [d.id, d]));
+const overlayById = new Map((B.overlays||[]).map(o => [o.id, o]));
+// Per-user/session-only cells aren't in the space-scope details; synthesize
+// lightweight, selectable entries so they're visible + their overlay shows.
+for (const o of (B.overlays||[])) {
+  if (byId.has(o.id)) continue;
+  const v = o.variants[0] || {};
+  byId.set(o.id, { id:o.id, kind:"free-cell", label:"⚑ "+(v.summary||"scoped cell"),
+    role:(v.kind||"")+" cell", regime:"n/a", owned:false, paths:["value"],
+    valueShape:"", value:v.value, valuePreview:v.summary, schemaKeys:null,
+    revisions:v.revisions||0, headSeq:null, firstSeq:null, versions:[],
+    lineage:{}, outLinks:[], synthetic:true });
+}
 const $ = (s,r=document) => r.querySelector(s);
 const $$ = (s,r=document) => [...r.querySelectorAll(s)];
 function el(t, props={}, kids=[]) {
@@ -154,6 +194,7 @@ function el(t, props={}, kids=[]) {
   for (const c of [].concat(kids)) if (c!=null && c!=="") n.append(c);
   return n;
 }
+const shortDid = d => { d=(d||"").replace(/^did:key:/,""); return d.length>14?d.slice(0,8)+"…"+d.slice(-4):d; };
 const shortId = id => { const b = id.replace(/^of:/,"").replace(/^cid:/,"cid:");
   return b.length>22 ? b.slice(0,12)+"…"+b.slice(-6) : b; };
 function flash(msg){ const f=$("#flash"); f.textContent=msg; f.classList.add("on");
@@ -272,6 +313,26 @@ function renderDetail(id){
   // value
   host.append(section("Value  ("+d.valueShape+")", d.kind!=="module", [valueDom(d.value)]));
 
+  // scopes (per-identity overlay) — what each identity sees for this cell
+  const ov = overlayById.get(id);
+  if (ov && ov.variants.length) {
+    const body=[];
+    body.push(el("div",{class:"muted",text:
+      ov.overridden ? (ov.divergent ? ov.variants.length+" scopes · DIVERGENT — identities see different values"
+        : ov.variants.length+" scopes · identical") : "single scope"}));
+    for (const v of ov.variants) {
+      const who = v.kind==="space" ? "space (shared)"
+        : v.kind==="user" ? "user "+shortDid(v.principal||"?")
+        : v.kind==="session" ? "session "+shortDid(v.principal||"?")+"/"+(v.sessionId||"").slice(0,8)
+        : v.scope;
+      body.push(el("div",{class:"scopevar"},[
+        el("div",{class:"k",style:"color:var(--accent)",text:who+"  ·  "+v.revisions+" rev"}),
+        valueDom(v.value),
+      ]));
+    }
+    host.append(section("Scopes — view as identity"+(ov.divergent?" ⚑":""), true, body));
+  }
+
   // schema
   if(d.schema!==undefined){
     host.append(section("Schema"+(d.schemaKeys?"  {"+d.schemaKeys.join(", ")+"}":""), false,
@@ -322,10 +383,14 @@ function fmtSession(s){ try{ s=decodeURIComponent(s);}catch{} const m=s.match(/^
 
 // ---- tree view --------------------------------------------------------
 function treeRow(d, childInfo){
-  const r = el("div",{class:"row","data-id":d.id, onclick:()=>select(d.id)},[
+  const ov = overlayById.get(d.id);
+  const mark = ov ? (ov.divergent ? " ⚑" : " ◐") : "";
+  const r = el("div",{class:"row","data-id":d.id, onclick:()=>select(d.id),
+    title: ov ? (ov.divergent?"per-identity divergence":"per-identity scope") : ""},[
     el("span",{class:"tw",text:childInfo?"▸":"·"}),
     el("span",{class:"dot",style:"background:"+(KC[d.kind]||"#999")}),
     el("span",{text:" "+d.label}),
+    mark ? el("span",{style:"color:var(--stream)",text:mark}) : "",
     childInfo ? el("span",{class:"muted",text:" "+childInfo}) : "",
   ]);
   return r;
@@ -463,6 +528,20 @@ if(firstPiece) select(firstPiece.id);
 export function renderInspectorHtml(bundle: InspectorBundle): string {
   const s = bundle.summary;
   const opsLine = Object.entries(s.ops).map(([k, v]) => `${k}=${v}`).join(" ");
+  const identities = bundle.scopes.filter((x) => x.kind !== "space");
+  const idLine = identities.length
+    ? `${identities.length} identity scope(s) · ${bundle.overlays.length} per-user/session cell(s)` +
+      ` · ${bundle.overlays.filter((o) => o.divergent).length} divergent ⚑`
+    : "single-scope (no per-user/session state)";
+  // Distinct other spaces this space links to (cross-space surface).
+  const linkedSpaces = new Set(
+    bundle.graph.edges.filter((e) => e.external && e.to).map((e) =>
+      bundle.graph.nodes.find((n) => n.id === e.to)?.space
+    ).filter(Boolean),
+  );
+  const xLine = linkedSpaces.size
+    ? ` · links to ${linkedSpaces.size} other space(s)`
+    : "";
   return `<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -477,6 +556,7 @@ export function renderInspectorHtml(bundle: InspectorBundle): string {
   <span class="stats">${s.entities} entities · ${s.commits} commits · ${s.sessions} sessions · ops ${opsLine}${
     bundle.generatedAt ? ` · ${bundle.generatedAt.slice(0, 10)}` : ""
   }</span>
+  <span class="stats" style="color:var(--stream)">${idLine}${xLine}</span>
   <span class="live">app URL <input id="live-input" placeholder="https://host (for live links)" size="22"></span>
 </header>
 <nav>

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -18,9 +18,11 @@ import { spaceTimeline, type SpaceTimelineEntry } from "./timetravel.ts";
 import { buildAllDetails, type EntityDetail } from "./detail.ts";
 import {
   listScopes,
+  type Participant,
   type Scope,
   type ScopeOverlay,
   scopeOverlay,
+  spaceParticipants,
 } from "./scopes.ts";
 
 export interface InspectorBundle {
@@ -36,6 +38,8 @@ export interface InspectorBundle {
   scopes: Scope[];
   /** Per-entity scope overlays — only for cells with non-space/multi-scope state. */
   overlays: ScopeOverlay[];
+  /** Identities that touched this space (committers + per-user/session owners). */
+  participants: Participant[];
 }
 
 /** Assemble everything the explorer needs from one space DB. */
@@ -76,6 +80,7 @@ export function buildInspectorBundle(
     timeline: spaceTimeline(space, { branch, scope }),
     scopes: listScopes(space, { branch }),
     overlays,
+    participants: spaceParticipants(space, { branch }),
   };
 }
 
@@ -524,6 +529,26 @@ liveInput.onchange=()=>{ LIVE=liveInput.value.trim(); localStorage.setItem("si-l
   if(cur) renderDetail(cur); flash(LIVE?"live links on":"live links off"); };
 $("#copy-space").onclick=()=>{ navigator.clipboard?.writeText(B.space); flash("copied space DID"); };
 
+// --- identities (users of this space) ---
+function renderIdentities(){
+  const host=$("#idlist"); const ps=B.participants||[];
+  $("#idpanel>summary").textContent="Identities ("+ps.length+")";
+  if(!ps.length){ host.append(el("div",{class:"muted",text:"(no identifiable users — bare sessions)"})); return; }
+  for(const p of ps){
+    const cells=(B.overlays||[]).filter(o=>o.variants.some(v=>v.principal===p.did));
+    host.append(el("div",{style:"margin:5px 0"},[
+      el("div",{},[
+        el("span",{text:(p.isOwner?"★ ":"· ")+shortDid(p.did)}), copyBtn(p.did,"DID"),
+        el("span",{class:"muted",text:" commits="+p.commits+" sessions="+p.sessions+(p.userEntities?" user-cells="+p.userEntities:"")+(p.isOwner?" (owner home)":"")}),
+      ]),
+      ...(cells.length?[el("div",{style:"padding-left:14px"},
+        cells.slice(0,25).map(o=>{ const d=byId.get(o.id);
+          return el("div",{class:"jlink",style:"font-size:12px",text:"• "+(d?d.label:shortId(o.id)),onclick:()=>select(o.id)}); }))]:[]),
+    ]));
+  }
+  host.append(el("div",{class:"muted",style:"margin-top:6px",text:"cross-space (home + profiles): cf inspect identity <DID>"}));
+}
+renderIdentities();
 renderTree();
 const firstPiece=B.details.find(d=>d.kind==="piece")||B.details[0];
 if(firstPiece) select(firstPiece.id);
@@ -571,6 +596,8 @@ export function renderInspectorHtml(bundle: InspectorBundle): string {
 <div id="explore" class="tabwrap active">
   <div class="explore">
     <div class="navi">
+      <details id="idpanel" class="sec" style="margin-bottom:8px"><summary>Identities</summary>
+        <div class="body" id="idlist"></div></details>
       <div class="modebar">
         <button id="mode-tree" class="active">Tree</button>
         <button id="mode-graph">Graph</button>

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -601,7 +601,25 @@ function renderIdentities(){
   }
   host.append(el("div",{class:"muted",style:"margin-top:6px",text:"cross-space (home + profiles): cf inspect identity <DID>"}));
 }
+// --- conflicts (contested cells) ---
+function renderConflicts(){
+  const host=$("#cflist"); const cs=B.conflicts||[];
+  const mu=cs.filter(c=>c.multiUser).length;
+  $("#cfpanel>summary").textContent="Conflicts ("+cs.length+(mu?", "+mu+" ⚔":"")+")";
+  if(!cs.length){ host.append(el("div",{class:"muted",text:"(no contested cells)"})); return; }
+  for(const c of cs.slice(0,150)){
+    const d=byId.get(c.id);
+    const stale=(c.staleReads&&c.staleReads.length)?" · "+c.staleReads.length+" stale":"";
+    host.append(el("div",{class:"row",onclick:()=>select(c.id),style:"white-space:normal"},[
+      el("span",{text:(c.multiUser?"⚔ ":"· ")}),
+      el("span",{class:"jlink",text:d?d.label:shortId(c.id)}),
+      el("span",{class:"muted",text:"  "+c.principals+"u/"+c.sessions+"s · "+c.writes+"w"+(c.multiUser?" MULTI-USER":"")+stale}),
+    ]));
+  }
+  host.append(el("div",{class:"muted",style:"margin-top:6px",text:"⚔ = ≥2 identities (real contention); stale = lost-update risk"}));
+}
 renderIdentities();
+renderConflicts();
 renderTree();
 const firstPiece=B.details.find(d=>d.kind==="piece")||B.details[0];
 if(firstPiece) select(firstPiece.id);
@@ -657,6 +675,8 @@ export function renderInspectorHtml(bundle: InspectorBundle): string {
     <div class="navi">
       <details id="idpanel" class="sec" style="margin-bottom:8px"><summary>Identities</summary>
         <div class="body" id="idlist"></div></details>
+      <details id="cfpanel" class="sec" style="margin-bottom:8px"><summary>Conflicts</summary>
+        <div class="body" id="cflist"></div></details>
       <div class="modebar">
         <button id="mode-tree" class="active">Tree</button>
         <button id="mode-graph">Graph</button>

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -335,9 +335,12 @@ function renderDetail(id){
     host.append(section("Scopes — view as identity"+(ov.divergent?" ⚑":""), true, body));
   }
 
-  // schema
+  // schema (a stream's payload schema is resolved from its owner piece)
   if(d.schema!==undefined){
-    host.append(section("Schema"+(d.schemaKeys?"  {"+d.schemaKeys.join(", ")+"}":""), false,
+    const title=(d.streamPayload?"Stream payload schema":"Schema")
+      +(d.schemaKeys&&d.schemaKeys.length?"  {"+d.schemaKeys.join(", ")+"}":"")
+      +(d.schemaSource?"  ·  "+d.schemaSource:"");
+    host.append(section(title, d.streamPayload||d.kind!=="module",
       [el("pre",{text:JSON.stringify(d.schema,null,2)})]));
   }
   // ifc (schema-as-value)

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -1,0 +1,410 @@
+// The visual surface — a self-contained HTML inspector over the JSON the other
+// commands already emit. No server, no build step, no external deps: one file a
+// teammate opens in a browser. It bundles a space's summary, fluent entity list,
+// resolved pieces, entity graph, and growth timeline, then renders an interactive
+// page (tabs, entity filter, per-piece graph neighborhood, growth sparkline).
+
+import type { SpaceDb } from "./db.ts";
+import { type SpaceSummary, summarizeSpace } from "./queries.ts";
+import {
+  buildModuleIndex,
+  describePiece,
+  type EntityModel,
+  listEntityModels,
+  type PieceModel,
+} from "./model.ts";
+import { buildSpaceGraph, type SpaceGraph } from "./graph.ts";
+import { spaceTimeline, type SpaceTimelineEntry } from "./timetravel.ts";
+
+export interface InspectorBundle {
+  space: string;
+  generatedAt: string;
+  summary: SpaceSummary;
+  entities: EntityModel[];
+  pieces: PieceModel[];
+  graph: SpaceGraph;
+  timeline: SpaceTimelineEntry[];
+}
+
+/** Assemble everything the HTML page needs from one space DB. */
+export function buildInspectorBundle(
+  space: SpaceDb,
+  opts: { branch?: string; scope?: string; generatedAt?: string } = {},
+): InspectorBundle {
+  const branch = opts.branch ?? "";
+  const scope = opts.scope ?? "space";
+  const did = (space.path.split("/").pop() ?? "").replace(/\.sqlite$/, "");
+
+  const summary = summarizeSpace(space);
+  const entities = listEntityModels(space, { branch, scope });
+  const moduleIndex = buildModuleIndex(space, { branch, scope });
+  const pieces = entities
+    .filter((e) => e.kind === "piece")
+    .map((e) => describePiece(space, e.id, { branch, scope, moduleIndex }))
+    .filter((p): p is PieceModel => !("error" in p));
+  const graph = buildSpaceGraph(space, { branch, scope });
+  const timeline = spaceTimeline(space, { branch, scope });
+
+  return {
+    space: did,
+    generatedAt: opts.generatedAt ?? "",
+    summary,
+    entities,
+    pieces,
+    graph,
+    timeline,
+  };
+}
+
+/** Embed JSON safely inside an HTML <script> block. */
+function safeJson(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}
+
+const STYLE = `
+:root {
+  --bg: #ffffff; --fg: #1f2937; --muted: #6b7280; --line: #e5e7eb;
+  --card: #f9fafb; --accent: #2563eb;
+  --piece: #f59e0b; --module: #3b82f6; --stream: #ec4899;
+  --schema: #8b5cf6; --owned: #10b981; --free: #9ca3af; --unknown: #d1d5db;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0b0f17; --fg: #e5e7eb; --muted: #9ca3af; --line: #1f2937;
+    --card: #111827; --accent: #60a5fa;
+  }
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--fg);
+  font: 14px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
+header { padding: 16px 20px; border-bottom: 1px solid var(--line); }
+header h1 { margin: 0 0 4px; font-size: 16px; }
+header .did { color: var(--muted); word-break: break-all; }
+header .stats { margin-top: 8px; color: var(--muted); font-size: 12px; }
+nav { display: flex; gap: 2px; padding: 0 20px; border-bottom: 1px solid var(--line);
+  position: sticky; top: 0; background: var(--bg); z-index: 2; flex-wrap: wrap; }
+nav button { border: 0; background: none; color: var(--muted); padding: 10px 14px;
+  cursor: pointer; font: inherit; border-bottom: 2px solid transparent; }
+nav button.active { color: var(--fg); border-bottom-color: var(--accent); }
+main { padding: 16px 20px; }
+section { display: none; } section.active { display: block; }
+.kind { display: inline-block; padding: 1px 6px; border-radius: 4px; font-size: 11px;
+  color: #fff; }
+.kind.piece { background: var(--piece); } .kind.module { background: var(--module); }
+.kind.stream { background: var(--stream); } .kind.schema { background: var(--schema); }
+.kind.owned-cell { background: var(--owned); } .kind.free-cell { background: var(--free); }
+.kind.unknown { background: var(--unknown); color: #111; }
+table { border-collapse: collapse; width: 100%; font-size: 12px; }
+th, td { text-align: left; padding: 5px 8px; border-bottom: 1px solid var(--line);
+  white-space: nowrap; }
+th { color: var(--muted); cursor: pointer; position: sticky; top: 41px; background: var(--bg); }
+td.id, td.label { font-family: ui-monospace, monospace; }
+td.num { text-align: right; }
+.controls { margin-bottom: 12px; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+input, select { background: var(--card); color: var(--fg); border: 1px solid var(--line);
+  border-radius: 6px; padding: 6px 8px; font: inherit; }
+.card { background: var(--card); border: 1px solid var(--line); border-radius: 8px;
+  padding: 12px 14px; margin-bottom: 10px; }
+.card h3 { margin: 0 0 6px; font-size: 14px; }
+.card .row { display: flex; gap: 8px; margin: 2px 0; }
+.card .k { color: var(--muted); min-width: 72px; }
+.card .v { word-break: break-all; }
+.cells { margin-top: 6px; }
+.cells .cell { font-size: 12px; color: var(--muted); padding: 1px 0; }
+.muted { color: var(--muted); }
+svg { max-width: 100%; border: 1px solid var(--line); border-radius: 8px; background: var(--card); }
+.legend { font-size: 11px; color: var(--muted); margin: 8px 0; display: flex; gap: 14px; flex-wrap: wrap; }
+.legend span::before { content: "●"; margin-right: 4px; }
+pre { background: var(--card); border: 1px solid var(--line); border-radius: 8px;
+  padding: 10px; overflow: auto; font-size: 11px; }
+`;
+
+const APP = String.raw`
+const DATA = JSON.parse(document.getElementById("bundle").textContent);
+const KIND_COLOR = { piece:"var(--piece)", module:"var(--module)", stream:"var(--stream)",
+  schema:"var(--schema)", "owned-cell":"var(--owned)", "free-cell":"var(--free)", unknown:"var(--unknown)" };
+const EDGE_COLOR = { pattern:"#2563eb", argument:"#16a34a", owns:"#6b7280", link:"#9ca3af" };
+const $ = (s, r=document) => r.querySelector(s);
+const el = (t, props={}, kids=[]) => {
+  const n = document.createElement(t);
+  for (const [k,v] of Object.entries(props)) {
+    if (k === "class") n.className = v; else if (k === "text") n.textContent = v; else n.setAttribute(k, v);
+  }
+  for (const c of [].concat(kids)) n.append(c);
+  return n;
+};
+const short = (id) => id && id.length > 16 ? id.slice(0,8)+"…"+id.slice(-6) : id;
+
+// --- tabs ---
+for (const b of document.querySelectorAll("nav button")) {
+  b.onclick = () => {
+    document.querySelectorAll("nav button").forEach(x => x.classList.toggle("active", x===b));
+    document.querySelectorAll("section").forEach(s => s.classList.toggle("active", s.id===b.dataset.tab));
+    if (b.dataset.tab === "graph") drawGraph();
+  };
+}
+
+// --- entities table ---
+function renderEntities() {
+  const kindSel = $("#ent-kind"), q = $("#ent-q"), tbody = $("#ent-body");
+  const draw = () => {
+    const k = kindSel.value, term = q.value.toLowerCase();
+    tbody.innerHTML = "";
+    let rows = DATA.entities;
+    if (k) rows = rows.filter(e => e.kind === k);
+    if (term) rows = rows.filter(e => (e.label+" "+e.id).toLowerCase().includes(term));
+    for (const e of rows.slice(0, 2000)) {
+      tbody.append(el("tr", {}, [
+        el("td", {}, el("span", { class:"kind "+e.kind, text:e.kind })),
+        el("td", { class:"label", text:e.label }),
+        el("td", { text: e.owned ? "↳" : "" }),
+        el("td", { class:"num", text: String(e.revisions ?? 0) }),
+        el("td", { class:"num", text: String(e.links ?? 0) }),
+        el("td", { class:"id muted", text: short(e.id) }),
+      ]));
+    }
+    $("#ent-count").textContent = rows.length + " entities";
+  };
+  kindSel.onchange = draw; q.oninput = draw;
+  draw();
+}
+
+// --- pieces ---
+function renderPieces() {
+  const host = $("#pieces-list");
+  if (!DATA.pieces.length) { host.append(el("p", { class:"muted", text:"(no pieces)" })); return; }
+  for (const p of DATA.pieces) {
+    const rows = [];
+    const add = (k, v) => rows.push(el("div", { class:"row" }, [
+      el("span", { class:"k", text:k }), el("span", { class:"v", text:v }) ]));
+    if (p.pattern) add("pattern", (p.pattern.filename || "(unresolved)") +
+      (p.pattern.symbol ? " · "+p.pattern.symbol : "") +
+      (p.pattern.codeLines ? " · "+p.pattern.codeLines+" lines" : ""));
+    if (p.input) add("input", p.input.summary + "  " + short(p.input.id));
+    add("result", "{" + p.resultKeys.join(", ") + "}");
+    if (p.schemaKeys.length) add("schema", "{" + p.schemaKeys.join(", ") + "}");
+    const cells = el("div", { class:"cells" });
+    for (const c of p.ownedCells) {
+      cells.append(el("div", { class:"cell", text: "• " + c.kind + "  " + c.summary }));
+    }
+    host.append(el("div", { class:"card" }, [
+      el("h3", {}, [ el("span", { class:"kind piece", text:"piece" }),
+        document.createTextNode("  " + p.name) ]),
+      ...rows,
+      p.ownedCells.length ? el("div", { class:"k", text: p.ownedCells.length+" owned cells" }) : "",
+      cells,
+    ]));
+  }
+}
+
+// --- timeline sparkline ---
+function renderTimeline() {
+  const t = DATA.timeline;
+  const host = $("#timeline-body");
+  if (!t.length) { host.append(el("p", { class:"muted", text:"(no commits)" })); return; }
+  const W = 720, H = 160, pad = 24;
+  const maxCum = Math.max(...t.map(e => e.cumulativeEntities), 1);
+  const x = i => pad + (W-2*pad) * (t.length<2?0:i/(t.length-1));
+  const y = v => H-pad - (H-2*pad) * (v/maxCum);
+  let path = "";
+  t.forEach((e,i) => path += (i?" L":"M") + x(i).toFixed(1) + " " + y(e.cumulativeEntities).toFixed(1));
+  const ns = "http://www.w3.org/2000/svg";
+  const svg = document.createElementNS(ns, "svg");
+  svg.setAttribute("viewBox", "0 0 "+W+" "+H); svg.setAttribute("width", W);
+  const mk = (t2, a) => { const n = document.createElementNS(ns, t2);
+    for (const [k,v] of Object.entries(a)) n.setAttribute(k, v); return n; };
+  svg.append(mk("path", { d: path, fill:"none", stroke:"var(--accent)", "stroke-width":"2" }));
+  t.forEach((e,i) => { if (e.created>0) svg.append(mk("circle",
+    { cx:x(i), cy:y(e.cumulativeEntities), r:"2.5", fill:"var(--accent)" })); });
+  host.append(svg);
+  host.append(el("p", { class:"muted", text:
+    t.length+" commits · "+maxCum+" entities at head · peaks mark commits that created entities" }));
+  // recent commits table
+  const tb = el("tbody");
+  for (const e of t.slice(-40).reverse()) {
+    tb.append(el("tr", {}, [
+      el("td", { text: "#"+e.commitSeq }),
+      el("td", { class:"num", text: "+"+e.created }),
+      el("td", { class:"num", text: String(e.touched) }),
+      el("td", { class:"num", text: "Σ"+e.cumulativeEntities }),
+      el("td", { class:"muted", text: e.createdAt }),
+    ]));
+  }
+  host.append(el("table", {}, [ el("thead", {}, el("tr", {}, [
+    el("th",{text:"commit"}), el("th",{text:"new"}), el("th",{text:"touched"}),
+    el("th",{text:"total"}), el("th",{text:"at"}) ])), tb ]));
+}
+
+// --- graph (per-piece neighborhood) ---
+let graphDrawn = false;
+function drawGraph() {
+  if (graphDrawn) return; graphDrawn = true;
+  const sel = $("#graph-root");
+  const pieces = DATA.graph.nodes.filter(n => n.kind === "piece");
+  for (const p of pieces) sel.append(el("option", { value:p.id, text:p.label+" ("+short(p.id)+")" }));
+  sel.onchange = () => layout(sel.value);
+  if (pieces.length) layout(pieces[0].id);
+  else $("#graph-canvas").append(el("p",{class:"muted",text:"(no pieces to root a graph)"}));
+}
+function neighborhood(rootId, depth) {
+  const adj = new Map();
+  for (const e of DATA.graph.edges) {
+    (adj.get(e.from) ?? adj.set(e.from,[]).get(e.from)).push([e.to, e]);
+    (adj.get(e.to) ?? adj.set(e.to,[]).get(e.to)).push([e.from, e]);
+  }
+  const dist = new Map([[rootId,0]]); let frontier=[rootId];
+  for (let d=0; d<depth; d++) { const nx=[];
+    for (const n of frontier) for (const [m] of (adj.get(n)||[]))
+      if (!dist.has(m)) { dist.set(m, d+1); nx.push(m); }
+    frontier = nx; }
+  const nodes = DATA.graph.nodes.filter(n => dist.has(n.id));
+  const edges = DATA.graph.edges.filter(e => dist.has(e.from) && dist.has(e.to));
+  return { nodes, edges, dist };
+}
+function layout(rootId) {
+  const depth = +$("#graph-depth").value;
+  const { nodes, edges, dist } = neighborhood(rootId, depth);
+  const ns = "http://www.w3.org/2000/svg";
+  const byLayer = new Map();
+  for (const n of nodes) { const d = dist.get(n.id);
+    (byLayer.get(d) ?? byLayer.set(d,[]).get(d)).push(n); }
+  const colW = 230, rowH = 56, padX = 20, padY = 30;
+  const pos = new Map();
+  const maxRows = Math.max(...[...byLayer.values()].map(a => a.length), 1);
+  const H = padY*2 + maxRows*rowH, W = padX*2 + (byLayer.size)*colW;
+  for (const [d, arr] of byLayer) arr.forEach((n,i) =>
+    pos.set(n.id, { x: padX + d*colW + 60, y: padY + (i+0.5)*(H-2*padY)/arr.length }));
+  const svg = document.createElementNS(ns,"svg");
+  svg.setAttribute("viewBox", "0 0 "+W+" "+H); svg.setAttribute("width", W);
+  const mk = (t,a,kids=[]) => { const e=document.createElementNS(ns,t);
+    for (const [k,v] of Object.entries(a)) e.setAttribute(k,v);
+    for (const c of [].concat(kids)) e.append(c); return e; };
+  for (const e of edges) {
+    const a = pos.get(e.from), b = pos.get(e.to); if (!a||!b) continue;
+    svg.append(mk("line", { x1:a.x, y1:a.y, x2:b.x, y2:b.y,
+      stroke: EDGE_COLOR[e.kind]||"#999", "stroke-width": e.kind==="pattern"?"2":"1",
+      "stroke-dasharray": e.kind==="link"?"4 3":"" }));
+  }
+  for (const n of nodes) {
+    const p = pos.get(n.id); const isRoot = n.id===rootId;
+    svg.append(mk("circle", { cx:p.x, cy:p.y, r: isRoot?"8":"6",
+      fill: KIND_COLOR[n.kind]||"#999", stroke: isRoot?"var(--fg)":"none", "stroke-width":"2" }));
+    const label = (n.label.length>20?n.label.slice(0,19)+"…":n.label);
+    svg.append(mk("text", { x:p.x+11, y:p.y+4, "font-size":"10", fill:"var(--fg)" },
+      document.createTextNode(label)));
+  }
+  const canvas = $("#graph-canvas"); canvas.innerHTML = ""; canvas.append(svg);
+}
+$("#graph-depth") && ($("#graph-depth").onchange = () => { const s=$("#graph-root"); if (s.value) layout(s.value); });
+
+renderEntities(); renderPieces(); renderTimeline();
+`;
+
+const KINDS = [
+  "piece",
+  "module",
+  "stream",
+  "schema",
+  "owned-cell",
+  "free-cell",
+  "unknown",
+];
+
+/** Render a self-contained HTML inspector for a bundle. */
+export function renderInspectorHtml(bundle: InspectorBundle): string {
+  const s = bundle.summary;
+  const kindOpts = KINDS.map((k) => `<option value="${k}">${k}</option>`).join(
+    "",
+  );
+  const legend = KINDS.map((k) =>
+    `<span style="color:var(--${
+      k === "owned-cell" ? "owned" : k === "free-cell" ? "free" : k
+    })">${k}</span>`
+  ).join("");
+  const opsLine = Object.entries(s.ops).map(([k, v]) => `${k}=${v}`).join(" ");
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>state-inspector · ${bundle.space}</title>
+<style>${STYLE}</style></head>
+<body>
+<header>
+  <h1>state-inspector</h1>
+  <div class="did">${bundle.space}</div>
+  <div class="stats">
+    ${s.entities} entities · ${s.commits} commits · ${s.sessions} sessions ·
+    ops: ${opsLine}${
+    bundle.generatedAt ? ` · generated ${bundle.generatedAt}` : ""
+  }
+  </div>
+</header>
+<nav>
+  <button class="active" data-tab="overview">Overview</button>
+  <button data-tab="pieces">Pieces (${bundle.pieces.length})</button>
+  <button data-tab="entities">Entities (${bundle.entities.length})</button>
+  <button data-tab="graph">Graph</button>
+  <button data-tab="timeline">Timeline</button>
+</nav>
+<main>
+  <section id="overview" class="active">
+    <div class="card">
+      <h3>What's in here</h3>
+      <div class="legend">${legend}</div>
+      <div id="overview-counts"></div>
+    </div>
+    <div class="card">
+      <h3>Reading this</h3>
+      <p class="muted">A <b>piece</b> is a running pattern instance (a result cell
+      with lineage). It owns <b>cells</b> and <b>streams</b>, instantiates a
+      <b>module</b> (pattern source) via patternIdentity, and takes an input cell
+      (argument). Free cells belong to no piece. See the Pieces tab for the
+      resolved anatomy, Graph for relationships, Timeline for how it grew.</p>
+    </div>
+  </section>
+  <section id="pieces"><div id="pieces-list"></div></section>
+  <section id="entities">
+    <div class="controls">
+      <select id="ent-kind"><option value="">all kinds</option>${kindOpts}</select>
+      <input id="ent-q" placeholder="filter by label or id" size="28">
+      <span class="muted" id="ent-count"></span>
+    </div>
+    <table>
+      <thead><tr><th>kind</th><th>label</th><th>own</th><th>revs</th><th>links</th><th>id</th></tr></thead>
+      <tbody id="ent-body"></tbody>
+    </table>
+  </section>
+  <section id="graph">
+    <div class="controls">
+      <label class="muted">root piece</label>
+      <select id="graph-root"></select>
+      <label class="muted">depth</label>
+      <select id="graph-depth"><option>1</option><option selected>2</option><option>3</option></select>
+    </div>
+    <div class="legend">
+      <span style="color:#2563eb">pattern</span>
+      <span style="color:#16a34a">argument</span>
+      <span style="color:#6b7280">owns</span>
+      <span style="color:#9ca3af">link</span>
+    </div>
+    <div id="graph-canvas"></div>
+  </section>
+  <section id="timeline"><div id="timeline-body"></div></section>
+</main>
+<script id="bundle" type="application/json">${safeJson(bundle)}</script>
+<script id="counts" type="application/json">${
+    safeJson(bundle.graph.stats.nodesByKind)
+  }</script>
+<script>
+${APP}
+(function(){
+  const counts = JSON.parse(document.getElementById("counts").textContent);
+  const host = document.getElementById("overview-counts");
+  for (const [k,n] of Object.entries(counts)) {
+    const d = document.createElement("div"); d.className = "row";
+    d.innerHTML = '<span class="kind '+k+'">'+k+'</span> <span style="margin-left:8px">'+n+'</span>';
+    host.append(d);
+  }
+})();
+</script>
+</body></html>`;
+}

--- a/packages/state-inspector/html.ts
+++ b/packages/state-inspector/html.ts
@@ -1,58 +1,54 @@
-// The visual surface — a self-contained HTML inspector over the JSON the other
-// commands already emit. No server, no build step, no external deps: one file a
-// teammate opens in a browser. It bundles a space's summary, fluent entity list,
-// resolved pieces, entity graph, and growth timeline, then renders an interactive
-// page (tabs, entity filter, per-piece graph neighborhood, growth sparkline).
+// The visual surface — a self-contained, interactive HTML explorer over the
+// JSON the other commands emit. No server, no build step, no external resources:
+// one file a teammate opens in a browser.
+//
+// Two ways to navigate, both feeding one detail pane:
+//   - Tree view  — from pieces down (pattern · input · owned cells/streams),
+//     children named by their role.
+//   - Graph view — re-rootable from ANY node; click to select / re-root.
+// The detail pane shows EVERY salient field for the selected entity: value
+// (links clickable), schema, CFC (information-flow) labels, version history,
+// resolved lineage (clickable), outgoing links, and module source. Entity ids
+// are click-to-copy, and each piece/entity has a deep link into the live shell.
 
 import type { SpaceDb } from "./db.ts";
 import { type SpaceSummary, summarizeSpace } from "./queries.ts";
-import {
-  buildModuleIndex,
-  describePiece,
-  type EntityModel,
-  listEntityModels,
-  type PieceModel,
-} from "./model.ts";
 import { buildSpaceGraph, type SpaceGraph } from "./graph.ts";
 import { spaceTimeline, type SpaceTimelineEntry } from "./timetravel.ts";
+import { buildAllDetails, type EntityDetail } from "./detail.ts";
 
 export interface InspectorBundle {
   space: string;
   generatedAt: string;
+  /** Base origin of the live shell, for deep links (`<base>/<space>/<id>`). */
+  liveBase: string;
   summary: SpaceSummary;
-  entities: EntityModel[];
-  pieces: PieceModel[];
+  details: EntityDetail[];
   graph: SpaceGraph;
   timeline: SpaceTimelineEntry[];
 }
 
-/** Assemble everything the HTML page needs from one space DB. */
+/** Assemble everything the explorer needs from one space DB. */
 export function buildInspectorBundle(
   space: SpaceDb,
-  opts: { branch?: string; scope?: string; generatedAt?: string } = {},
+  opts: {
+    branch?: string;
+    scope?: string;
+    generatedAt?: string;
+    liveBase?: string;
+  } = {},
 ): InspectorBundle {
   const branch = opts.branch ?? "";
   const scope = opts.scope ?? "space";
   const did = (space.path.split("/").pop() ?? "").replace(/\.sqlite$/, "");
-
-  const summary = summarizeSpace(space);
-  const entities = listEntityModels(space, { branch, scope });
-  const moduleIndex = buildModuleIndex(space, { branch, scope });
-  const pieces = entities
-    .filter((e) => e.kind === "piece")
-    .map((e) => describePiece(space, e.id, { branch, scope, moduleIndex }))
-    .filter((p): p is PieceModel => !("error" in p));
-  const graph = buildSpaceGraph(space, { branch, scope });
-  const timeline = spaceTimeline(space, { branch, scope });
-
   return {
     space: did,
     generatedAt: opts.generatedAt ?? "",
-    summary,
-    entities,
-    pieces,
-    graph,
-    timeline,
+    liveBase: opts.liveBase ?? "",
+    summary: summarizeSpace(space),
+    details: buildAllDetails(space, { branch, scope }),
+    graph: buildSpaceGraph(space, { branch, scope }),
+    timeline: spaceTimeline(space, { branch, scope }),
   };
 }
 
@@ -63,264 +59,408 @@ function safeJson(data: unknown): string {
 
 const STYLE = `
 :root {
-  --bg: #ffffff; --fg: #1f2937; --muted: #6b7280; --line: #e5e7eb;
-  --card: #f9fafb; --accent: #2563eb;
-  --piece: #f59e0b; --module: #3b82f6; --stream: #ec4899;
-  --schema: #8b5cf6; --owned: #10b981; --free: #9ca3af; --unknown: #d1d5db;
+  --bg:#fff; --fg:#1f2937; --muted:#6b7280; --line:#e5e7eb; --card:#f9fafb;
+  --accent:#2563eb; --hover:#eef2ff;
+  --piece:#f59e0b; --module:#3b82f6; --stream:#ec4899; --schema:#8b5cf6;
+  --owned-cell:#10b981; --free-cell:#9ca3af; --unknown:#d1d5db;
 }
 @media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #0b0f17; --fg: #e5e7eb; --muted: #9ca3af; --line: #1f2937;
-    --card: #111827; --accent: #60a5fa;
-  }
+  :root { --bg:#0b0f17; --fg:#e5e7eb; --muted:#9ca3af; --line:#1f2937;
+    --card:#111827; --accent:#60a5fa; --hover:#1e293b; }
 }
-* { box-sizing: border-box; }
-body { margin: 0; background: var(--bg); color: var(--fg);
-  font: 14px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
-header { padding: 16px 20px; border-bottom: 1px solid var(--line); }
-header h1 { margin: 0 0 4px; font-size: 16px; }
-header .did { color: var(--muted); word-break: break-all; }
-header .stats { margin-top: 8px; color: var(--muted); font-size: 12px; }
-nav { display: flex; gap: 2px; padding: 0 20px; border-bottom: 1px solid var(--line);
-  position: sticky; top: 0; background: var(--bg); z-index: 2; flex-wrap: wrap; }
-nav button { border: 0; background: none; color: var(--muted); padding: 10px 14px;
-  cursor: pointer; font: inherit; border-bottom: 2px solid transparent; }
-nav button.active { color: var(--fg); border-bottom-color: var(--accent); }
-main { padding: 16px 20px; }
-section { display: none; } section.active { display: block; }
-.kind { display: inline-block; padding: 1px 6px; border-radius: 4px; font-size: 11px;
-  color: #fff; }
-.kind.piece { background: var(--piece); } .kind.module { background: var(--module); }
-.kind.stream { background: var(--stream); } .kind.schema { background: var(--schema); }
-.kind.owned-cell { background: var(--owned); } .kind.free-cell { background: var(--free); }
-.kind.unknown { background: var(--unknown); color: #111; }
-table { border-collapse: collapse; width: 100%; font-size: 12px; }
-th, td { text-align: left; padding: 5px 8px; border-bottom: 1px solid var(--line);
-  white-space: nowrap; }
-th { color: var(--muted); cursor: pointer; position: sticky; top: 41px; background: var(--bg); }
-td.id, td.label { font-family: ui-monospace, monospace; }
-td.num { text-align: right; }
-.controls { margin-bottom: 12px; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
-input, select { background: var(--card); color: var(--fg); border: 1px solid var(--line);
-  border-radius: 6px; padding: 6px 8px; font: inherit; }
-.card { background: var(--card); border: 1px solid var(--line); border-radius: 8px;
-  padding: 12px 14px; margin-bottom: 10px; }
-.card h3 { margin: 0 0 6px; font-size: 14px; }
-.card .row { display: flex; gap: 8px; margin: 2px 0; }
-.card .k { color: var(--muted); min-width: 72px; }
-.card .v { word-break: break-all; }
-.cells { margin-top: 6px; }
-.cells .cell { font-size: 12px; color: var(--muted); padding: 1px 0; }
-.muted { color: var(--muted); }
-svg { max-width: 100%; border: 1px solid var(--line); border-radius: 8px; background: var(--card); }
-.legend { font-size: 11px; color: var(--muted); margin: 8px 0; display: flex; gap: 14px; flex-wrap: wrap; }
-.legend span::before { content: "●"; margin-right: 4px; }
-pre { background: var(--card); border: 1px solid var(--line); border-radius: 8px;
-  padding: 10px; overflow: auto; font-size: 11px; }
+* { box-sizing:border-box; }
+body { margin:0; background:var(--bg); color:var(--fg);
+  font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace; }
+a { color:var(--accent); }
+header { padding:12px 16px; border-bottom:1px solid var(--line); display:flex;
+  gap:16px; align-items:baseline; flex-wrap:wrap; }
+header h1 { margin:0; font-size:15px; }
+header .stats { color:var(--muted); font-size:12px; }
+header .live { margin-left:auto; display:flex; gap:6px; align-items:center; font-size:12px; }
+nav { display:flex; gap:2px; padding:0 16px; border-bottom:1px solid var(--line); }
+nav button { border:0; background:none; color:var(--muted); padding:8px 14px;
+  cursor:pointer; font:inherit; border-bottom:2px solid transparent; }
+nav button.active { color:var(--fg); border-bottom-color:var(--accent); }
+.tabwrap { display:none; } .tabwrap.active { display:block; }
+.explore { display:grid; grid-template-columns:minmax(280px,360px) 1fr; height:calc(100vh - 92px); }
+.navi { border-right:1px solid var(--line); overflow:auto; padding:8px; }
+.navi .modebar { display:flex; gap:4px; margin-bottom:8px; }
+.navi .modebar button { flex:1; padding:5px; border:1px solid var(--line);
+  background:var(--card); color:var(--fg); border-radius:6px; cursor:pointer; font:inherit; }
+.navi .modebar button.active { background:var(--accent); color:#fff; border-color:var(--accent); }
+.detail { overflow:auto; padding:14px 18px; }
+input,select { background:var(--card); color:var(--fg); border:1px solid var(--line);
+  border-radius:6px; padding:5px 8px; font:inherit; }
+.kind { display:inline-block; padding:1px 6px; border-radius:4px; font-size:11px; color:#fff; }
+.kind.unknown { color:#111; }
+.tree ul { list-style:none; margin:0; padding-left:14px; }
+.tree li { padding:1px 0; }
+.tree .row { cursor:pointer; padding:2px 4px; border-radius:4px; white-space:nowrap; }
+.tree .row:hover { background:var(--hover); }
+.tree .row.sel { background:var(--accent); color:#fff; }
+.tree .tw { display:inline-block; width:12px; color:var(--muted); }
+.tree .row.sel .tw { color:#fff; }
+.muted { color:var(--muted); }
+.copy { cursor:pointer; border:1px solid var(--line); border-radius:4px; padding:0 5px;
+  background:var(--card); color:var(--muted); font-size:11px; }
+.copy:hover { color:var(--fg); }
+.dh { display:flex; gap:8px; align-items:center; flex-wrap:wrap; margin-bottom:4px; }
+.dh h2 { margin:0; font-size:16px; }
+.idline { color:var(--muted); font-size:12px; display:flex; gap:6px; align-items:center;
+  flex-wrap:wrap; margin-bottom:12px; word-break:break-all; }
+.sec { border:1px solid var(--line); border-radius:8px; margin-bottom:10px; background:var(--card); }
+.sec > summary { cursor:pointer; padding:8px 12px; font-weight:600; user-select:none; }
+.sec > .body { padding:0 12px 12px; }
+.kv { display:grid; grid-template-columns:max-content 1fr; gap:2px 12px; font-size:12px; }
+.kv .k { color:var(--muted); }
+.chip { display:inline-flex; align-items:center; gap:4px; border:1px solid var(--line);
+  border-radius:5px; padding:0 6px; margin:1px; cursor:pointer; background:var(--bg);
+  max-width:100%; }
+.chip:hover { border-color:var(--accent); }
+.chip.ext { cursor:default; border-style:dashed; }
+.chip .ck { font-size:10px; padding:0 3px; border-radius:3px; color:#fff; }
+.dot { width:8px; height:8px; border-radius:50%; display:inline-block; }
+pre { background:var(--bg); border:1px solid var(--line); border-radius:6px; padding:10px;
+  overflow:auto; font-size:12px; margin:6px 0; max-height:420px; }
+table { border-collapse:collapse; width:100%; font-size:12px; }
+th,td { text-align:left; padding:4px 8px; border-bottom:1px solid var(--line); white-space:nowrap; }
+th { color:var(--muted); }
+svg { max-width:100%; border:1px solid var(--line); border-radius:8px; background:var(--card); }
+.legend { font-size:11px; color:var(--muted); margin:6px 0; display:flex; gap:12px; flex-wrap:wrap; }
+.flash { position:fixed; bottom:16px; left:50%; transform:translateX(-50%);
+  background:var(--accent); color:#fff; padding:6px 12px; border-radius:6px; opacity:0;
+  transition:opacity .15s; pointer-events:none; }
+.flash.on { opacity:1; }
+.jlink { color:var(--accent); cursor:pointer; text-decoration:underline; }
+.jstream { color:var(--stream); }
 `;
 
 const APP = String.raw`
-const DATA = JSON.parse(document.getElementById("bundle").textContent);
-const KIND_COLOR = { piece:"var(--piece)", module:"var(--module)", stream:"var(--stream)",
-  schema:"var(--schema)", "owned-cell":"var(--owned)", "free-cell":"var(--free)", unknown:"var(--unknown)" };
-const EDGE_COLOR = { pattern:"#2563eb", argument:"#16a34a", owns:"#6b7280", link:"#9ca3af" };
-const $ = (s, r=document) => r.querySelector(s);
-const el = (t, props={}, kids=[]) => {
+const B = JSON.parse(document.getElementById("bundle").textContent);
+const KC = { piece:"var(--piece)", module:"var(--module)", stream:"var(--stream)",
+  schema:"var(--schema)", "owned-cell":"var(--owned-cell)", "free-cell":"var(--free-cell)", unknown:"var(--unknown)" };
+const EC = { pattern:"#2563eb", argument:"#16a34a", owns:"#6b7280", link:"#9ca3af" };
+const byId = new Map(B.details.map(d => [d.id, d]));
+const $ = (s,r=document) => r.querySelector(s);
+const $$ = (s,r=document) => [...r.querySelectorAll(s)];
+function el(t, props={}, kids=[]) {
   const n = document.createElement(t);
   for (const [k,v] of Object.entries(props)) {
-    if (k === "class") n.className = v; else if (k === "text") n.textContent = v; else n.setAttribute(k, v);
+    if (v==null) continue;
+    if (k==="class") n.className=v; else if (k==="text") n.textContent=v;
+    else if (k==="html") n.innerHTML=v; else if (k[0]==="o"&&k[1]==="n") n[k]=v;
+    else n.setAttribute(k,v);
   }
-  for (const c of [].concat(kids)) n.append(c);
+  for (const c of [].concat(kids)) if (c!=null && c!=="") n.append(c);
   return n;
+}
+const shortId = id => { const b = id.replace(/^of:/,"").replace(/^cid:/,"cid:");
+  return b.length>22 ? b.slice(0,12)+"…"+b.slice(-6) : b; };
+function flash(msg){ const f=$("#flash"); f.textContent=msg; f.classList.add("on");
+  setTimeout(()=>f.classList.remove("on"),900); }
+function copyBtn(text, label){ return el("button",{class:"copy",title:"copy "+text,
+  onclick:e=>{e.stopPropagation(); navigator.clipboard?.writeText(text); flash("copied "+(label||"id"));}}, label||"copy"); }
+function kindChip(kind){ return el("span",{class:"kind "+kind,style:"background:"+(KC[kind]||"#999"),text:kind}); }
+
+// ---- live shell link --------------------------------------------------
+let LIVE = localStorage.getItem("si-live") || B.liveBase || "";
+function liveUrl(id){ if(!LIVE) return null;
+  const base = LIVE.replace(/\/+$/,""); return base+"/"+B.space+"/"+id; }
+function liveAnchor(id){ const u = liveUrl(id); return u
+  ? el("a",{href:u,target:"_blank",rel:"noopener",text:"open in app ↗",title:u})
+  : el("span",{class:"muted",text:"(set app URL ↗ to enable live links)"}); }
+
+// ---- selection + history ----------------------------------------------
+let cur = null; const hist = [];
+function select(id, push=true){
+  if(!byId.has(id)) return;
+  if(push && cur && cur!==id) hist.push(cur);
+  cur = id;
+  renderDetail(id);
+  $$(".tree .row").forEach(r => r.classList.toggle("sel", r.dataset.id===id));
+  const sel = $(".tree .row.sel"); if(sel) sel.scrollIntoView({block:"nearest"});
+  const gsel = $("#graph-root"); if(gsel && gsel.value!==id && byId.get(id)) { /* keep */ }
+}
+function back(){ const id = hist.pop(); if(id){ cur=null; select(id,false); } }
+
+// ---- value renderer (links become clickable chips) --------------------
+function valueDom(v, depth=0){
+  if(v===null) return el("span",{class:"muted",text:"null"});
+  if(typeof v!=="object") return el("span",{text: typeof v==="string" ? JSON.stringify(v) : String(v)});
+  if(v.$link){ return linkInline(v.$link); }
+  if(v.$ref){ return el("span",{class:"jlink",text:"#"+shortId(v.$ref),onclick:()=>select(v.$ref)}); }
+  if(typeof v==="string") return el("span",{text:JSON.stringify(v)});
+  if(Array.isArray(v)){
+    if(!v.length) return el("span",{text:"[]"});
+    if(depth>4) return el("span",{class:"muted",text:"[…"+v.length+"]"});
+    const ul = el("ul",{style:"margin:0;padding-left:16px;list-style:none"});
+    v.slice(0,200).forEach(x => ul.append(el("li",{},valueDom(x,depth+1))));
+    if(v.length>200) ul.append(el("li",{class:"muted",text:"… "+(v.length-200)+" more"}));
+    return ul;
+  }
+  if(v==="$stream"||v===null) return el("span",{class:"jstream",text:"⊙ stream"});
+  const keys = Object.keys(v);
+  if(!keys.length) return el("span",{text:"{}"});
+  if(depth>4) return el("span",{class:"muted",text:"{"+keys.join(", ")+"}"});
+  const ul = el("ul",{style:"margin:0;padding-left:16px;list-style:none"});
+  for(const k of keys){
+    ul.append(el("li",{},[el("span",{class:"muted",text:k+": "}), valueDom(v[k],depth+1)]));
+  }
+  return ul;
+}
+function linkInline(link){
+  const d = link.id && byId.get(link.id);
+  const label = d ? d.label : (link.id ? shortId(link.id) : "link");
+  const span = el("span",{class: d?"jlink":"", text:"🔗 "+label + (link.path&&link.path.length?"/"+link.path.join("/"):"")});
+  if(d) span.onclick = ()=>select(link.id);
+  else if(link.space) span.title = link.id+" @"+link.space;
+  return span;
+}
+function linkChip(ref){
+  const ext = ref.external || !byId.has(ref.id);
+  const c = el("span",{class:"chip"+(ext?" ext":""), title:ref.id+(ref.space?" @"+ref.space:"")},[
+    ref.kind ? el("span",{class:"ck",style:"background:"+(KC[ref.kind]||"#999"),text:ref.kind.replace("-cell","")}) : "",
+    el("span",{text: ref.label || shortId(ref.id)}),
+    ref.at ? el("span",{class:"muted",text:"@"+ref.at}) : "",
+    ext && ref.space ? el("span",{class:"muted",text:"⇗"+shortId(ref.space)}) : "",
+  ]);
+  if(!ext) c.onclick = ()=>select(ref.id);
+  return c;
+}
+
+// ---- detail pane ------------------------------------------------------
+function section(title, openByDefault, bodyNodes){
+  const d = el("details",{class:"sec"}); if(openByDefault) d.setAttribute("open","");
+  d.append(el("summary",{text:title}));
+  d.append(el("div",{class:"body"}, bodyNodes));
+  return d;
+}
+function renderDetail(id){
+  const d = byId.get(id); const host = $("#detail"); host.innerHTML="";
+  if(!d){ host.append(el("p",{class:"muted",text:"select an entity"})); return; }
+  // header
+  host.append(el("div",{class:"dh"},[
+    hist.length ? el("button",{class:"copy",onclick:back,text:"← back"}) : "",
+    kindChip(d.kind),
+    el("h2",{text:d.label}),
+    el("span",{class:"muted",text:d.role}),
+  ]));
+  host.append(el("div",{class:"idline"},[
+    el("span",{text:d.id}), copyBtn(d.id,"id"), el("span",{text:"·"}), liveAnchor(d.id),
+  ]));
+
+  // identity
+  const idkv = el("div",{class:"kv"});
+  const addkv=(k,v)=>{ idkv.append(el("span",{class:"k",text:k})); idkv.append(v.nodeType?v:el("span",{text:String(v)})); };
+  addkv("kind", d.kind+(d.regime!=="n/a"?" ("+d.regime+")":""));
+  addkv("owned", d.owned ? "yes — "+(d.contextName?("as "+d.contextName):"owned by a piece") : "no (free)");
+  addkv("paths", d.paths.join(", "));
+  addkv("version", "rev "+d.revisions+(d.headSeq!=null?" · head seq "+d.headSeq:"")+(d.firstSeq!=null?" · born seq "+d.firstSeq:""));
+  host.append(section("Identity", true, idkv));
+
+  // lineage
+  const L=d.lineage; const lin=[];
+  if(L.pattern){ lin.push(el("div",{},[el("span",{class:"k muted",text:"pattern  "}),
+    linkChip(L.pattern), el("span",{class:"muted",text:" "+(L.pattern.filename||"")+(L.pattern.symbol?" · "+L.pattern.symbol:"")+(L.pattern.codeLines?" · "+L.pattern.codeLines+" lines":"")})])); }
+  if(L.argument){ lin.push(el("div",{},[el("span",{class:"k muted",text:"input    "}), linkChip(L.argument)])); }
+  if(L.owner){ lin.push(el("div",{},[el("span",{class:"k muted",text:"owner    "}), linkChip(L.owner)])); }
+  if(L.internal&&L.internal.length){ const wrap=el("div",{},[el("span",{class:"k muted",text:"owns ("+L.internal.length+")  "})]);
+    L.internal.forEach(r=>wrap.append(linkChip(r))); lin.push(wrap); }
+  if(lin.length) host.append(section("Lineage", true, lin));
+
+  // value
+  host.append(section("Value  ("+d.valueShape+")", d.kind!=="module", [valueDom(d.value)]));
+
+  // schema
+  if(d.schema!==undefined){
+    host.append(section("Schema"+(d.schemaKeys?"  {"+d.schemaKeys.join(", ")+"}":""), false,
+      [el("pre",{text:JSON.stringify(d.schema,null,2)})]));
+  }
+  // ifc (schema-as-value)
+  if(d.ifc!==undefined){
+    host.append(section("IFC (information-flow on this schema)", true,
+      [el("pre",{text:JSON.stringify(d.ifc,null,2)})]));
+  }
+  // cfc
+  if(d.cfc){
+    const body=[];
+    if(d.cfc.schemaHash) body.push(el("div",{class:"muted",text:"schemaHash: "+d.cfc.schemaHash}));
+    if(d.cfc.entries.length){
+      const tb=el("tbody");
+      d.cfc.entries.forEach(e=>tb.append(el("tr",{},[
+        el("td",{text:e.path||"(root)"}),
+        el("td",{text:e.confidentiality.join(", ")||"—"}),
+        el("td",{text:e.integrity.join(", ")||"—"}),
+        el("td",{class:"muted",text:e.origin||""}),
+      ])));
+      body.push(el("table",{},[el("thead",{},el("tr",{},[
+        el("th",{text:"path"}),el("th",{text:"confidentiality"}),el("th",{text:"integrity"}),el("th",{text:"origin"})])),tb]));
+    }
+    host.append(section("CFC (information-flow labels)", true, body));
+  }
+  // outgoing links
+  if(d.outLinks.length){
+    const wrap=el("div",{}); d.outLinks.forEach(r=>wrap.append(linkChip(r)));
+    host.append(section("Links out ("+d.outLinks.length+")", false, wrap));
+  }
+  // module source
+  if(d.code){
+    host.append(section("Source ("+d.code.split("\n").length+" lines)", false,
+      [el("pre",{text:d.code})]));
+  }
+  // version log
+  const vt=el("tbody");
+  d.versions.slice(-60).reverse().forEach(v=>vt.append(el("tr",{},[
+    el("td",{text:"#"+v.seq}), el("td",{text:v.op}),
+    el("td",{class:"muted",text:fmtSession(v.session)}), el("td",{class:"muted",text:v.createdAt})])));
+  host.append(section("Version history ("+d.versions.length+" writes)", false,
+    [el("table",{},[el("thead",{},el("tr",{},[el("th",{text:"seq"}),el("th",{text:"op"}),el("th",{text:"who"}),el("th",{text:"when"})])),vt])]));
+}
+function fmtSession(s){ try{ s=decodeURIComponent(s);}catch{} const m=s.match(/^session:(did:key:)?([^:]+):([0-9a-f-]+)/i);
+  if(m) return (m[2].length>12?m[2].slice(0,6)+"…"+m[2].slice(-4):m[2])+"/"+m[3].slice(0,6); return s.slice(0,18); }
+
+// ---- tree view --------------------------------------------------------
+function treeRow(d, childInfo){
+  const r = el("div",{class:"row","data-id":d.id, onclick:()=>select(d.id)},[
+    el("span",{class:"tw",text:childInfo?"▸":"·"}),
+    el("span",{class:"dot",style:"background:"+(KC[d.kind]||"#999")}),
+    el("span",{text:" "+d.label}),
+    childInfo ? el("span",{class:"muted",text:" "+childInfo}) : "",
+  ]);
+  return r;
+}
+function renderTree(){
+  const host=$("#tree"); host.innerHTML="";
+  const pieces = B.details.filter(d=>d.kind==="piece");
+  const ul = el("ul",{});
+  for(const p of pieces){
+    const li = el("li",{});
+    const kids = el("ul",{style:"display:none"});
+    const childIds = [];
+    if(p.lineage.pattern) childIds.push(["pattern",p.lineage.pattern.id]);
+    if(p.lineage.argument) childIds.push(["input",p.lineage.argument.id]);
+    (p.lineage.internal||[]).forEach(r=>childIds.push(["owns",r.id]));
+    const row = treeRow(p, childIds.length?("("+childIds.length+")"):"");
+    row.querySelector(".tw").onclick=(e)=>{ e.stopPropagation();
+      kids.style.display = kids.style.display==="none"?"block":"none";
+      row.querySelector(".tw").textContent = kids.style.display==="none"?"▸":"▾"; };
+    for(const [role,cid] of childIds){
+      const cd = byId.get(cid); if(!cd) continue;
+      const cr = treeRow(cd, ""); cr.querySelector(".tw").textContent="";
+      cr.prepend(el("span",{class:"muted",text:role+" "}));
+      kids.append(el("li",{},cr));
+    }
+    li.append(row, kids);
+    ul.append(li);
+  }
+  // entities with no piece-root (free cells, orphan modules) under a folder
+  const owned = new Set();
+  for(const p of pieces){ if(p.lineage.pattern)owned.add(p.lineage.pattern.id);
+    if(p.lineage.argument)owned.add(p.lineage.argument.id);
+    (p.lineage.internal||[]).forEach(r=>owned.add(r.id)); owned.add(p.id); }
+  const rest = B.details.filter(d=>!owned.has(d.id));
+  if(rest.length){
+    const li=el("li",{}); const kids=el("ul",{style:"display:none"});
+    const row=treeRow({kind:"unknown",label:"other entities",id:"__rest"}, "("+rest.length+")");
+    row.dataset.id=""; row.onclick=null;
+    row.querySelector(".tw").textContent="▸";
+    row.onclick=()=>{ kids.style.display=kids.style.display==="none"?"block":"none";
+      row.querySelector(".tw").textContent=kids.style.display==="none"?"▸":"▾"; };
+    rest.forEach(d=>{ const cr=treeRow(d,""); cr.querySelector(".tw").textContent=""; kids.append(el("li",{},cr)); });
+    li.append(row,kids); ul.append(li);
+  }
+  host.append(ul);
+}
+
+// ---- graph view -------------------------------------------------------
+function neighborhood(rootId, depth){
+  const adj=new Map();
+  for(const e of B.graph.edges){ (adj.get(e.from)??adj.set(e.from,[]).get(e.from)).push(e.to);
+    (adj.get(e.to)??adj.set(e.to,[]).get(e.to)).push(e.from); }
+  const dist=new Map([[rootId,0]]); let fr=[rootId];
+  for(let i=0;i<depth;i++){ const nx=[]; for(const n of fr) for(const m of (adj.get(n)||[]))
+    if(!dist.has(m)){dist.set(m,i+1);nx.push(m);} fr=nx; }
+  return { nodes:B.graph.nodes.filter(n=>dist.has(n.id)),
+    edges:B.graph.edges.filter(e=>dist.has(e.from)&&dist.has(e.to)), dist };
+}
+function layoutGraph(rootId){
+  const depth=+$("#g-depth").value; const {nodes,edges,dist}=neighborhood(rootId,depth);
+  const ns="http://www.w3.org/2000/svg";
+  const byLayer=new Map(); for(const n of nodes){const d=dist.get(n.id);(byLayer.get(d)??byLayer.set(d,[]).get(d)).push(n);}
+  const colW=240,padX=20,padY=24;
+  const H=Math.max(...[...byLayer.values()].map(a=>a.length),1)*52+padY*2, W=byLayer.size*colW+padX*2;
+  const pos=new Map();
+  for(const [d,arr] of byLayer) arr.forEach((n,i)=>pos.set(n.id,{x:padX+d*colW+60,y:padY+(i+0.5)*(H-2*padY)/arr.length}));
+  const mk=(t,a,k=[])=>{const e=document.createElementNS(ns,t);for(const[k2,v]of Object.entries(a))e.setAttribute(k2,v);for(const c of [].concat(k))e.append(c);return e;};
+  const svg=mk("svg",{viewBox:"0 0 "+W+" "+H,width:W});
+  for(const e of edges){const a=pos.get(e.from),b=pos.get(e.to);if(!a||!b)continue;
+    svg.append(mk("line",{x1:a.x,y1:a.y,x2:b.x,y2:b.y,stroke:EC[e.kind]||"#999",
+      "stroke-width":e.kind==="pattern"?"2":"1","stroke-dasharray":e.kind==="link"?"4 3":""}));}
+  for(const n of nodes){const p=pos.get(n.id);const root=n.id===rootId;
+    const g=mk("g",{style:"cursor:pointer"});
+    g.append(mk("circle",{cx:p.x,cy:p.y,r:root?"8":"6",fill:KC[n.kind]||"#999",
+      stroke:root?"var(--fg)":"none","stroke-width":"2"}));
+    const lab=(n.label.length>22?n.label.slice(0,21)+"…":n.label);
+    g.append(mk("text",{x:p.x+11,y:p.y+4,"font-size":"10",fill:"var(--fg)"},document.createTextNode(lab)));
+    g.onclick=()=>{ select(n.id); if(byId.has(n.id)){ $("#g-root").value=n.id; } };
+    g.ondblclick=()=>{ $("#g-root").value=n.id; layoutGraph(n.id); };
+    svg.append(g);}
+  const c=$("#g-canvas"); c.innerHTML=""; c.append(svg);
+}
+function renderGraph(){
+  const sel=$("#g-root"); if(sel.options.length===0){
+    B.graph.nodes.filter(n=>n.present!==false).forEach(n=>sel.append(el("option",{value:n.id,text:n.kind+": "+n.label})));
+  }
+  if(cur && byId.has(cur)) sel.value=cur;
+  if(sel.value) layoutGraph(sel.value);
+}
+
+// ---- timeline ---------------------------------------------------------
+function renderTimeline(){
+  const t=B.timeline; const host=$("#tl"); host.innerHTML="";
+  if(!t.length){host.append(el("p",{class:"muted",text:"(no commits)"}));return;}
+  const W=820,H=150,pad=24,maxc=Math.max(...t.map(e=>e.cumulativeEntities),1);
+  const x=i=>pad+(W-2*pad)*(t.length<2?0:i/(t.length-1)), y=v=>H-pad-(H-2*pad)*(v/maxc);
+  let p=""; t.forEach((e,i)=>p+=(i?" L":"M")+x(i).toFixed(1)+" "+y(e.cumulativeEntities).toFixed(1));
+  const ns="http://www.w3.org/2000/svg",mk=(t2,a)=>{const n=document.createElementNS(ns,t2);for(const[k,v]of Object.entries(a))n.setAttribute(k,v);return n;};
+  const svg=mk("svg",{viewBox:"0 0 "+W+" "+H,width:W});
+  svg.append(mk("path",{d:p,fill:"none",stroke:"var(--accent)","stroke-width":"2"}));
+  t.forEach((e,i)=>{if(e.created>0)svg.append(mk("circle",{cx:x(i),cy:y(e.cumulativeEntities),r:"2.5",fill:"var(--accent)"}));});
+  host.append(svg, el("p",{class:"muted",text:t.length+" commits · "+maxc+" entities at head"}));
+  const tb=el("tbody");
+  t.slice(-50).reverse().forEach(e=>tb.append(el("tr",{},[
+    el("td",{text:"#"+e.commitSeq}),el("td",{text:"+"+e.created}),el("td",{text:String(e.touched)}),
+    el("td",{text:"Σ"+e.cumulativeEntities}),el("td",{class:"muted",text:fmtSession(e.session)}),el("td",{class:"muted",text:e.createdAt})])));
+  host.append(el("table",{},[el("thead",{},el("tr",{},[el("th",{text:"commit"}),el("th",{text:"new"}),
+    el("th",{text:"touched"}),el("th",{text:"total"}),el("th",{text:"who"}),el("th",{text:"when"})])),tb]));
+}
+
+// ---- wiring -----------------------------------------------------------
+for(const b of $$("nav button")) b.onclick=()=>{
+  $$("nav button").forEach(x=>x.classList.toggle("active",x===b));
+  $$(".tabwrap").forEach(s=>s.classList.toggle("active",s.id===b.dataset.tab));
+  if(b.dataset.tab==="explore"){ if($("#mode-graph").classList.contains("active")) renderGraph(); }
+  if(b.dataset.tab==="timeline") renderTimeline();
 };
-const short = (id) => id && id.length > 16 ? id.slice(0,8)+"…"+id.slice(-6) : id;
+$("#mode-tree").onclick=()=>{ $("#mode-tree").classList.add("active"); $("#mode-graph").classList.remove("active");
+  $("#tree").style.display="block"; $("#gpane").style.display="none"; };
+$("#mode-graph").onclick=()=>{ $("#mode-graph").classList.add("active"); $("#mode-tree").classList.remove("active");
+  $("#tree").style.display="none"; $("#gpane").style.display="block"; renderGraph(); };
+$("#g-root").onchange=e=>{ select(e.target.value); layoutGraph(e.target.value); };
+$("#g-depth").onchange=()=>{ if($("#g-root").value) layoutGraph($("#g-root").value); };
+const liveInput=$("#live-input"); liveInput.value=LIVE;
+liveInput.onchange=()=>{ LIVE=liveInput.value.trim(); localStorage.setItem("si-live",LIVE);
+  if(cur) renderDetail(cur); flash(LIVE?"live links on":"live links off"); };
+$("#copy-space").onclick=()=>{ navigator.clipboard?.writeText(B.space); flash("copied space DID"); };
 
-// --- tabs ---
-for (const b of document.querySelectorAll("nav button")) {
-  b.onclick = () => {
-    document.querySelectorAll("nav button").forEach(x => x.classList.toggle("active", x===b));
-    document.querySelectorAll("section").forEach(s => s.classList.toggle("active", s.id===b.dataset.tab));
-    if (b.dataset.tab === "graph") drawGraph();
-  };
-}
-
-// --- entities table ---
-function renderEntities() {
-  const kindSel = $("#ent-kind"), q = $("#ent-q"), tbody = $("#ent-body");
-  const draw = () => {
-    const k = kindSel.value, term = q.value.toLowerCase();
-    tbody.innerHTML = "";
-    let rows = DATA.entities;
-    if (k) rows = rows.filter(e => e.kind === k);
-    if (term) rows = rows.filter(e => (e.label+" "+e.id).toLowerCase().includes(term));
-    for (const e of rows.slice(0, 2000)) {
-      tbody.append(el("tr", {}, [
-        el("td", {}, el("span", { class:"kind "+e.kind, text:e.kind })),
-        el("td", { class:"label", text:e.label }),
-        el("td", { text: e.owned ? "↳" : "" }),
-        el("td", { class:"num", text: String(e.revisions ?? 0) }),
-        el("td", { class:"num", text: String(e.links ?? 0) }),
-        el("td", { class:"id muted", text: short(e.id) }),
-      ]));
-    }
-    $("#ent-count").textContent = rows.length + " entities";
-  };
-  kindSel.onchange = draw; q.oninput = draw;
-  draw();
-}
-
-// --- pieces ---
-function renderPieces() {
-  const host = $("#pieces-list");
-  if (!DATA.pieces.length) { host.append(el("p", { class:"muted", text:"(no pieces)" })); return; }
-  for (const p of DATA.pieces) {
-    const rows = [];
-    const add = (k, v) => rows.push(el("div", { class:"row" }, [
-      el("span", { class:"k", text:k }), el("span", { class:"v", text:v }) ]));
-    if (p.pattern) add("pattern", (p.pattern.filename || "(unresolved)") +
-      (p.pattern.symbol ? " · "+p.pattern.symbol : "") +
-      (p.pattern.codeLines ? " · "+p.pattern.codeLines+" lines" : ""));
-    if (p.input) add("input", p.input.summary + "  " + short(p.input.id));
-    add("result", "{" + p.resultKeys.join(", ") + "}");
-    if (p.schemaKeys.length) add("schema", "{" + p.schemaKeys.join(", ") + "}");
-    const cells = el("div", { class:"cells" });
-    for (const c of p.ownedCells) {
-      cells.append(el("div", { class:"cell", text: "• " + c.kind + "  " + c.summary }));
-    }
-    host.append(el("div", { class:"card" }, [
-      el("h3", {}, [ el("span", { class:"kind piece", text:"piece" }),
-        document.createTextNode("  " + p.name) ]),
-      ...rows,
-      p.ownedCells.length ? el("div", { class:"k", text: p.ownedCells.length+" owned cells" }) : "",
-      cells,
-    ]));
-  }
-}
-
-// --- timeline sparkline ---
-function renderTimeline() {
-  const t = DATA.timeline;
-  const host = $("#timeline-body");
-  if (!t.length) { host.append(el("p", { class:"muted", text:"(no commits)" })); return; }
-  const W = 720, H = 160, pad = 24;
-  const maxCum = Math.max(...t.map(e => e.cumulativeEntities), 1);
-  const x = i => pad + (W-2*pad) * (t.length<2?0:i/(t.length-1));
-  const y = v => H-pad - (H-2*pad) * (v/maxCum);
-  let path = "";
-  t.forEach((e,i) => path += (i?" L":"M") + x(i).toFixed(1) + " " + y(e.cumulativeEntities).toFixed(1));
-  const ns = "http://www.w3.org/2000/svg";
-  const svg = document.createElementNS(ns, "svg");
-  svg.setAttribute("viewBox", "0 0 "+W+" "+H); svg.setAttribute("width", W);
-  const mk = (t2, a) => { const n = document.createElementNS(ns, t2);
-    for (const [k,v] of Object.entries(a)) n.setAttribute(k, v); return n; };
-  svg.append(mk("path", { d: path, fill:"none", stroke:"var(--accent)", "stroke-width":"2" }));
-  t.forEach((e,i) => { if (e.created>0) svg.append(mk("circle",
-    { cx:x(i), cy:y(e.cumulativeEntities), r:"2.5", fill:"var(--accent)" })); });
-  host.append(svg);
-  host.append(el("p", { class:"muted", text:
-    t.length+" commits · "+maxCum+" entities at head · peaks mark commits that created entities" }));
-  // recent commits table
-  const tb = el("tbody");
-  for (const e of t.slice(-40).reverse()) {
-    tb.append(el("tr", {}, [
-      el("td", { text: "#"+e.commitSeq }),
-      el("td", { class:"num", text: "+"+e.created }),
-      el("td", { class:"num", text: String(e.touched) }),
-      el("td", { class:"num", text: "Σ"+e.cumulativeEntities }),
-      el("td", { class:"muted", text: e.createdAt }),
-    ]));
-  }
-  host.append(el("table", {}, [ el("thead", {}, el("tr", {}, [
-    el("th",{text:"commit"}), el("th",{text:"new"}), el("th",{text:"touched"}),
-    el("th",{text:"total"}), el("th",{text:"at"}) ])), tb ]));
-}
-
-// --- graph (per-piece neighborhood) ---
-let graphDrawn = false;
-function drawGraph() {
-  if (graphDrawn) return; graphDrawn = true;
-  const sel = $("#graph-root");
-  const pieces = DATA.graph.nodes.filter(n => n.kind === "piece");
-  for (const p of pieces) sel.append(el("option", { value:p.id, text:p.label+" ("+short(p.id)+")" }));
-  sel.onchange = () => layout(sel.value);
-  if (pieces.length) layout(pieces[0].id);
-  else $("#graph-canvas").append(el("p",{class:"muted",text:"(no pieces to root a graph)"}));
-}
-function neighborhood(rootId, depth) {
-  const adj = new Map();
-  for (const e of DATA.graph.edges) {
-    (adj.get(e.from) ?? adj.set(e.from,[]).get(e.from)).push([e.to, e]);
-    (adj.get(e.to) ?? adj.set(e.to,[]).get(e.to)).push([e.from, e]);
-  }
-  const dist = new Map([[rootId,0]]); let frontier=[rootId];
-  for (let d=0; d<depth; d++) { const nx=[];
-    for (const n of frontier) for (const [m] of (adj.get(n)||[]))
-      if (!dist.has(m)) { dist.set(m, d+1); nx.push(m); }
-    frontier = nx; }
-  const nodes = DATA.graph.nodes.filter(n => dist.has(n.id));
-  const edges = DATA.graph.edges.filter(e => dist.has(e.from) && dist.has(e.to));
-  return { nodes, edges, dist };
-}
-function layout(rootId) {
-  const depth = +$("#graph-depth").value;
-  const { nodes, edges, dist } = neighborhood(rootId, depth);
-  const ns = "http://www.w3.org/2000/svg";
-  const byLayer = new Map();
-  for (const n of nodes) { const d = dist.get(n.id);
-    (byLayer.get(d) ?? byLayer.set(d,[]).get(d)).push(n); }
-  const colW = 230, rowH = 56, padX = 20, padY = 30;
-  const pos = new Map();
-  const maxRows = Math.max(...[...byLayer.values()].map(a => a.length), 1);
-  const H = padY*2 + maxRows*rowH, W = padX*2 + (byLayer.size)*colW;
-  for (const [d, arr] of byLayer) arr.forEach((n,i) =>
-    pos.set(n.id, { x: padX + d*colW + 60, y: padY + (i+0.5)*(H-2*padY)/arr.length }));
-  const svg = document.createElementNS(ns,"svg");
-  svg.setAttribute("viewBox", "0 0 "+W+" "+H); svg.setAttribute("width", W);
-  const mk = (t,a,kids=[]) => { const e=document.createElementNS(ns,t);
-    for (const [k,v] of Object.entries(a)) e.setAttribute(k,v);
-    for (const c of [].concat(kids)) e.append(c); return e; };
-  for (const e of edges) {
-    const a = pos.get(e.from), b = pos.get(e.to); if (!a||!b) continue;
-    svg.append(mk("line", { x1:a.x, y1:a.y, x2:b.x, y2:b.y,
-      stroke: EDGE_COLOR[e.kind]||"#999", "stroke-width": e.kind==="pattern"?"2":"1",
-      "stroke-dasharray": e.kind==="link"?"4 3":"" }));
-  }
-  for (const n of nodes) {
-    const p = pos.get(n.id); const isRoot = n.id===rootId;
-    svg.append(mk("circle", { cx:p.x, cy:p.y, r: isRoot?"8":"6",
-      fill: KIND_COLOR[n.kind]||"#999", stroke: isRoot?"var(--fg)":"none", "stroke-width":"2" }));
-    const label = (n.label.length>20?n.label.slice(0,19)+"…":n.label);
-    svg.append(mk("text", { x:p.x+11, y:p.y+4, "font-size":"10", fill:"var(--fg)" },
-      document.createTextNode(label)));
-  }
-  const canvas = $("#graph-canvas"); canvas.innerHTML = ""; canvas.append(svg);
-}
-$("#graph-depth") && ($("#graph-depth").onchange = () => { const s=$("#graph-root"); if (s.value) layout(s.value); });
-
-renderEntities(); renderPieces(); renderTimeline();
+renderTree();
+const firstPiece=B.details.find(d=>d.kind==="piece")||B.details[0];
+if(firstPiece) select(firstPiece.id);
 `;
 
-const KINDS = [
-  "piece",
-  "module",
-  "stream",
-  "schema",
-  "owned-cell",
-  "free-cell",
-  "unknown",
-];
-
-/** Render a self-contained HTML inspector for a bundle. */
+/** Render the self-contained HTML explorer for a bundle. */
 export function renderInspectorHtml(bundle: InspectorBundle): string {
   const s = bundle.summary;
-  const kindOpts = KINDS.map((k) => `<option value="${k}">${k}</option>`).join(
-    "",
-  );
-  const legend = KINDS.map((k) =>
-    `<span style="color:var(--${
-      k === "owned-cell" ? "owned" : k === "free-cell" ? "free" : k
-    })">${k}</span>`
-  ).join("");
   const opsLine = Object.entries(s.ops).map(([k, v]) => `${k}=${v}`).join(" ");
   return `<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
@@ -330,81 +470,47 @@ export function renderInspectorHtml(bundle: InspectorBundle): string {
 <body>
 <header>
   <h1>state-inspector</h1>
-  <div class="did">${bundle.space}</div>
-  <div class="stats">
-    ${s.entities} entities · ${s.commits} commits · ${s.sessions} sessions ·
-    ops: ${opsLine}${
-    bundle.generatedAt ? ` · generated ${bundle.generatedAt}` : ""
-  }
-  </div>
+  <span class="stats">${
+    bundle.space.slice(0, 24)
+  }… <button class="copy" id="copy-space">copy DID</button></span>
+  <span class="stats">${s.entities} entities · ${s.commits} commits · ${s.sessions} sessions · ops ${opsLine}${
+    bundle.generatedAt ? ` · ${bundle.generatedAt.slice(0, 10)}` : ""
+  }</span>
+  <span class="live">app URL <input id="live-input" placeholder="https://host (for live links)" size="22"></span>
 </header>
 <nav>
-  <button class="active" data-tab="overview">Overview</button>
-  <button data-tab="pieces">Pieces (${bundle.pieces.length})</button>
-  <button data-tab="entities">Entities (${bundle.entities.length})</button>
-  <button data-tab="graph">Graph</button>
+  <button class="active" data-tab="explore">Explore</button>
   <button data-tab="timeline">Timeline</button>
 </nav>
-<main>
-  <section id="overview" class="active">
-    <div class="card">
-      <h3>What's in here</h3>
-      <div class="legend">${legend}</div>
-      <div id="overview-counts"></div>
+<div id="explore" class="tabwrap active">
+  <div class="explore">
+    <div class="navi">
+      <div class="modebar">
+        <button id="mode-tree" class="active">Tree</button>
+        <button id="mode-graph">Graph</button>
+      </div>
+      <div id="tree" class="tree"></div>
+      <div id="gpane" style="display:none">
+        <div style="display:flex;gap:6px;align-items:center;margin-bottom:6px;flex-wrap:wrap">
+          <label class="muted">root</label>
+          <select id="g-root" style="max-width:180px"></select>
+          <label class="muted">depth</label>
+          <select id="g-depth"><option>1</option><option selected>2</option><option>3</option></select>
+        </div>
+        <div class="legend">
+          <span style="color:#2563eb">●pattern</span><span style="color:#16a34a">●argument</span>
+          <span style="color:#6b7280">●owns</span><span style="color:#9ca3af">●link</span>
+          <span class="muted">click=open · dbl-click=re-root</span>
+        </div>
+        <div id="g-canvas"></div>
+      </div>
     </div>
-    <div class="card">
-      <h3>Reading this</h3>
-      <p class="muted">A <b>piece</b> is a running pattern instance (a result cell
-      with lineage). It owns <b>cells</b> and <b>streams</b>, instantiates a
-      <b>module</b> (pattern source) via patternIdentity, and takes an input cell
-      (argument). Free cells belong to no piece. See the Pieces tab for the
-      resolved anatomy, Graph for relationships, Timeline for how it grew.</p>
-    </div>
-  </section>
-  <section id="pieces"><div id="pieces-list"></div></section>
-  <section id="entities">
-    <div class="controls">
-      <select id="ent-kind"><option value="">all kinds</option>${kindOpts}</select>
-      <input id="ent-q" placeholder="filter by label or id" size="28">
-      <span class="muted" id="ent-count"></span>
-    </div>
-    <table>
-      <thead><tr><th>kind</th><th>label</th><th>own</th><th>revs</th><th>links</th><th>id</th></tr></thead>
-      <tbody id="ent-body"></tbody>
-    </table>
-  </section>
-  <section id="graph">
-    <div class="controls">
-      <label class="muted">root piece</label>
-      <select id="graph-root"></select>
-      <label class="muted">depth</label>
-      <select id="graph-depth"><option>1</option><option selected>2</option><option>3</option></select>
-    </div>
-    <div class="legend">
-      <span style="color:#2563eb">pattern</span>
-      <span style="color:#16a34a">argument</span>
-      <span style="color:#6b7280">owns</span>
-      <span style="color:#9ca3af">link</span>
-    </div>
-    <div id="graph-canvas"></div>
-  </section>
-  <section id="timeline"><div id="timeline-body"></div></section>
-</main>
+    <div id="detail" class="detail"></div>
+  </div>
+</div>
+<div id="timeline" class="tabwrap"><div id="tl" style="padding:14px 18px"></div></div>
+<div id="flash" class="flash"></div>
 <script id="bundle" type="application/json">${safeJson(bundle)}</script>
-<script id="counts" type="application/json">${
-    safeJson(bundle.graph.stats.nodesByKind)
-  }</script>
-<script>
-${APP}
-(function(){
-  const counts = JSON.parse(document.getElementById("counts").textContent);
-  const host = document.getElementById("overview-counts");
-  for (const [k,n] of Object.entries(counts)) {
-    const d = document.createElement("div"); d.className = "row";
-    d.innerHTML = '<span class="kind '+k+'">'+k+'</span> <span style="margin-left:8px">'+n+'</span>';
-    host.append(d);
-  }
-})();
-</script>
+<script>${APP}</script>
 </body></html>`;
 }

--- a/packages/state-inspector/identity.ts
+++ b/packages/state-inspector/identity.ts
@@ -1,0 +1,153 @@
+// Identity world — everything about one DID across the multiplayer surface.
+//
+// An identity (a DID) implicates both SPACES and SCOPES:
+//   - spaces: its home (space DID == identity DID), its profile spaces, and the
+//     main/pattern spaces it acts in (grouping.ts recovers these).
+//   - scopes: within ANY of those spaces, the `user:<DID>` and
+//     `session:<DID>:*` rows that identity owns (scopes.ts reads these).
+//
+// `describeIdentity` joins the two: the DID's spaces, and per space the scopes
+// it owns there with counts — the agent's "show me this user's whole world".
+
+import { openSpace, type SpaceDb } from "./db.ts";
+import type { DiscoveredSpace } from "./discover.ts";
+import {
+  groupDiscoveredSpaces,
+  type GroupedSpace,
+  type SpaceRole,
+} from "./grouping.ts";
+import { listScopes, type Scope } from "./scopes.ts";
+
+export interface IdentitySpace {
+  did: string;
+  role: SpaceRole;
+  present: boolean;
+  empty: boolean;
+  commits?: number;
+  entities?: number;
+  /** Scopes in this space OWNED BY this identity (user:<DID>, session:<DID>:*). */
+  ownedScopes: Scope[];
+  /** Total per-user + per-session entities this identity has here. */
+  scopedEntities: number;
+  evidence: string[];
+}
+
+export interface IdentityWorld {
+  did: string;
+  /** A non-empty home space exists locally for this identity. */
+  homePresent: boolean;
+  spaces: IdentitySpace[];
+  totals: {
+    spaces: number;
+    presentSpaces: number;
+    /** Spaces where this identity has per-user/session state. */
+    spacesWithScopedState: number;
+    scopedEntities: number;
+  };
+}
+
+/** Scopes whose principal is `did` (the per-user + per-session ones it owns). */
+function ownedScopesIn(space: SpaceDb, did: string): Scope[] {
+  return listScopes(space).filter((s) =>
+    (s.kind === "user" || s.kind === "session") && s.principal === did
+  );
+}
+
+/**
+ * Build the identity world for a DID from a set of discovered spaces: its
+ * grouped spaces (home/profiles/mains) plus, per present space, the scopes it
+ * owns there. Falls back to scanning all discovered spaces for owned scopes if
+ * the DID forms no group (e.g. a profile-only or main-only actor).
+ */
+export function describeIdentity(
+  discovered: DiscoveredSpace[],
+  did: string,
+  opts: { branch?: string } = {},
+): IdentityWorld {
+  const { groups } = groupDiscoveredSpaces(discovered, opts);
+  const group = groups.find((g) => g.principal === did);
+
+  const byDidPath = new Map(discovered.map((d) => [d.did, d.path]));
+  const seen = new Map<string, GroupedSpace>();
+  if (group) { for (const s of group.spaces) seen.set(s.did, s); }
+
+  // Also catch present spaces where this DID owns scopes but that aren't in its
+  // group (it acted there without being the dominant principal).
+  for (const d of discovered) {
+    if (seen.has(d.did)) continue;
+    let space: SpaceDb | undefined;
+    try {
+      space = openSpace(d.path);
+      if (ownedScopesIn(space, did).length > 0) {
+        seen.set(d.did, {
+          did: d.did,
+          role: "main",
+          present: true,
+          empty: false,
+          evidence: [`owns scopes for ${shortDid(did)} here`],
+        });
+      }
+    } catch {
+      /* not a v2 DB */
+    } finally {
+      space?.close();
+    }
+  }
+
+  const spaces: IdentitySpace[] = [];
+  for (const s of seen.values()) {
+    const path = byDidPath.get(s.did);
+    let ownedScopes: Scope[] = [];
+    if (path && s.present) {
+      let space: SpaceDb | undefined;
+      try {
+        space = openSpace(path);
+        ownedScopes = ownedScopesIn(space, did);
+      } catch {
+        /* ignore */
+      } finally {
+        space?.close();
+      }
+    }
+    spaces.push({
+      did: s.did,
+      role: s.role,
+      present: s.present,
+      empty: s.empty,
+      commits: s.commits,
+      entities: s.entities,
+      ownedScopes,
+      scopedEntities: ownedScopes.reduce((n, sc) => n + sc.entities, 0),
+      evidence: s.evidence,
+    });
+  }
+
+  // Order: home, profiles, mains; within, those with scoped state first.
+  const rank: Record<SpaceRole, number> = {
+    home: 0,
+    profile: 1,
+    main: 2,
+    unknown: 3,
+  };
+  spaces.sort((a, b) =>
+    rank[a.role] - rank[b.role] || b.scopedEntities - a.scopedEntities
+  );
+
+  const present = spaces.filter((s) => s.present);
+  return {
+    did,
+    homePresent: !!group?.homePresent,
+    spaces,
+    totals: {
+      spaces: spaces.length,
+      presentSpaces: present.length,
+      spacesWithScopedState: spaces.filter((s) => s.scopedEntities > 0).length,
+      scopedEntities: spaces.reduce((n, s) => n + s.scopedEntities, 0),
+    },
+  };
+}
+
+function shortDid(did: string): string {
+  const tail = did.startsWith("did:key:") ? did.slice("did:key:".length) : did;
+  return tail.length > 12 ? `${tail.slice(0, 6)}…${tail.slice(-4)}` : tail;
+}

--- a/packages/state-inspector/mod.ts
+++ b/packages/state-inspector/mod.ts
@@ -16,5 +16,6 @@ export * from "./grouping.ts";
 export * from "./graph.ts";
 export * from "./timetravel.ts";
 export * from "./scopes.ts";
+export * from "./identity.ts";
 export * from "./detail.ts";
 export * from "./html.ts";

--- a/packages/state-inspector/mod.ts
+++ b/packages/state-inspector/mod.ts
@@ -13,3 +13,4 @@ export * from "./queries.ts";
 export * from "./multispace.ts";
 export * from "./discover.ts";
 export * from "./grouping.ts";
+export * from "./graph.ts";

--- a/packages/state-inspector/mod.ts
+++ b/packages/state-inspector/mod.ts
@@ -15,5 +15,6 @@ export * from "./discover.ts";
 export * from "./grouping.ts";
 export * from "./graph.ts";
 export * from "./timetravel.ts";
+export * from "./scopes.ts";
 export * from "./detail.ts";
 export * from "./html.ts";

--- a/packages/state-inspector/mod.ts
+++ b/packages/state-inspector/mod.ts
@@ -15,3 +15,4 @@ export * from "./discover.ts";
 export * from "./grouping.ts";
 export * from "./graph.ts";
 export * from "./timetravel.ts";
+export * from "./html.ts";

--- a/packages/state-inspector/mod.ts
+++ b/packages/state-inspector/mod.ts
@@ -17,5 +17,6 @@ export * from "./graph.ts";
 export * from "./timetravel.ts";
 export * from "./scopes.ts";
 export * from "./identity.ts";
+export * from "./conflicts.ts";
 export * from "./detail.ts";
 export * from "./html.ts";

--- a/packages/state-inspector/mod.ts
+++ b/packages/state-inspector/mod.ts
@@ -15,4 +15,5 @@ export * from "./discover.ts";
 export * from "./grouping.ts";
 export * from "./graph.ts";
 export * from "./timetravel.ts";
+export * from "./detail.ts";
 export * from "./html.ts";

--- a/packages/state-inspector/mod.ts
+++ b/packages/state-inspector/mod.ts
@@ -12,3 +12,4 @@ export * from "./model.ts";
 export * from "./queries.ts";
 export * from "./multispace.ts";
 export * from "./discover.ts";
+export * from "./grouping.ts";

--- a/packages/state-inspector/mod.ts
+++ b/packages/state-inspector/mod.ts
@@ -14,3 +14,4 @@ export * from "./multispace.ts";
 export * from "./discover.ts";
 export * from "./grouping.ts";
 export * from "./graph.ts";
+export * from "./timetravel.ts";

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -109,7 +109,7 @@ function basename(p: string): string {
 }
 
 /** A value shaped like a module: `{ code, identity, … }`. */
-function isModuleValue(
+export function isModuleValue(
   v: unknown,
 ): v is { code: string; identity: string; filename?: string; kind?: string } {
   return isObj(v) && typeof v.code === "string" &&

--- a/packages/state-inspector/scopes.ts
+++ b/packages/state-inspector/scopes.ts
@@ -175,6 +175,79 @@ function encodeScope(scope: string): string {
   return scope.replace(/did:key:/g, "did%3Akey%3A");
 }
 
+export interface Participant {
+  /** The identity (user) DID. */
+  did: string;
+  /** True when this DID owns the space (space DID == did → it's their home). */
+  isOwner: boolean;
+  /** Commits whose session principal is this DID. */
+  commits: number;
+  /** Distinct sessions (browser tabs/devices) this DID acted from. */
+  sessions: number;
+  /** Entities this DID has in a `user:<DID>` scope here. */
+  userEntities: number;
+  /** Entities this DID has in `session:<DID>:*` scopes here. */
+  sessionEntities: number;
+}
+
+/**
+ * The identities (users) that touched a space: everyone who committed (by
+ * session principal) plus everyone with per-user/session scoped state. The
+ * "who is in this space" view — each `did` is browsable via
+ * {@link describeIdentity} (its home + profiles across the discovered DBs).
+ */
+export function spaceParticipants(
+  space: SpaceDb,
+  opts: { branch?: string } = {},
+): Participant[] {
+  const ownDid = (space.path.split("/").pop() ?? "").replace(/\.sqlite$/, "");
+  const acc = new Map<string, Participant>();
+  const get = (did: string): Participant => {
+    let p = acc.get(did);
+    if (!p) {
+      p = {
+        did,
+        isOwner: did === ownDid,
+        commits: 0,
+        sessions: 0,
+        userEntities: 0,
+        sessionEntities: 0,
+      };
+      acc.set(did, p);
+    }
+    return p;
+  };
+
+  // commits + distinct sessions by principal
+  for (
+    const r of space.db
+      .prepare(
+        `SELECT session_id, count(*) n FROM "commit" GROUP BY session_id`,
+      )
+      .all<{ session_id: string; n: number }>()
+  ) {
+    // A commit `session_id` has the same shape as a session scope_key.
+    const did = r.session_id ? parseScope(r.session_id).principal : undefined;
+    if (!did) continue;
+    const p = get(did);
+    p.commits += r.n;
+    p.sessions += 1;
+  }
+
+  // per-user / per-session scoped entities by principal
+  for (const sc of listScopes(space, opts)) {
+    if (sc.kind === "user" && sc.principal) {
+      get(sc.principal).userEntities += sc.entities;
+    } else if (sc.kind === "session" && sc.principal) {
+      get(sc.principal).sessionEntities += sc.entities;
+    }
+  }
+
+  return [...acc.values()].sort((a, b) =>
+    (b.isOwner ? 1 : 0) - (a.isOwner ? 1 : 0) || b.commits - a.commits
+  );
+}
+
 export interface ScopeVariant {
   scope: string;
   kind: ScopeKind;

--- a/packages/state-inspector/scopes.ts
+++ b/packages/state-inspector/scopes.ts
@@ -1,0 +1,234 @@
+// Scope awareness — the per-identity dimension the runtime composes and this
+// tool (until now) ignored.
+//
+// `revision.scope_key` partitions an entity's rows into scopes that OVERLAP by
+// id:
+//   space                              shared / default      (PerSpace cells)
+//   user:did:key:<DID>                 per-user state        (PerUser cells)
+//   session:did:key:<DID>:<uuid>       per-session state     (PerSession cells)
+//
+// The same cell id can hold a `space` value AND a per-user override, and they
+// differ (verified: `space` a link/default; `user` the concrete per-user state,
+// e.g. a per-user VDOM). The runtime resolves what an identity sees as
+// MOST-SPECIFIC-WINS: session:X:sid ⊕ user:X ⊕ space. "View as identity X"
+// overlays X's scopes on top of the shared space — surfacing exactly the
+// per-user divergence ("looks different for me") that multiplayer bugs live in.
+
+import type { SpaceDb } from "./db.ts";
+import { annotate, summarize } from "./decode.ts";
+import { reconstructDocument } from "./reconstruct.ts";
+
+export type ScopeKind = "space" | "user" | "session" | "other";
+
+export interface Scope {
+  /** The raw scope_key as stored (often %-encoded). */
+  raw: string;
+  kind: ScopeKind;
+  /** Owning principal DID (user/session scopes). */
+  principal?: string;
+  /** Session uuid (session scopes). */
+  sessionId?: string;
+  entities: number;
+  revisions: number;
+}
+
+/** Parse a stored scope_key into its kind + principal/session. */
+export function parseScope(raw: string): Scope {
+  const decoded = decodeURIComponent(raw);
+  if (decoded === "space") {
+    return { raw, kind: "space", entities: 0, revisions: 0 };
+  }
+  let m = decoded.match(/^session:(did:key:[^:]+):(.+)$/);
+  if (m) {
+    return {
+      raw,
+      kind: "session",
+      principal: m[1],
+      sessionId: m[2],
+      entities: 0,
+      revisions: 0,
+    };
+  }
+  m = decoded.match(/^user:(did:key:[^:]+)$/);
+  if (m) {
+    return { raw, kind: "user", principal: m[1], entities: 0, revisions: 0 };
+  }
+  return { raw, kind: "other", entities: 0, revisions: 0 };
+}
+
+const KIND_ORDER: Record<ScopeKind, number> = {
+  space: 0,
+  user: 1,
+  session: 2,
+  other: 3,
+};
+
+/** Enumerate the scopes present in a space, with entity/revision counts. */
+export function listScopes(
+  space: SpaceDb,
+  opts: { branch?: string } = {},
+): Scope[] {
+  const branch = opts.branch ?? "";
+  const rows = space.db
+    .prepare(
+      `SELECT scope_key, count(DISTINCT id) ents, count(*) revs
+       FROM revision WHERE branch = ? GROUP BY scope_key`,
+    )
+    .all<{ scope_key: string; ents: number; revs: number }>(branch);
+  return rows
+    .map((r) => ({
+      ...parseScope(r.scope_key),
+      entities: r.ents,
+      revisions: r.revs,
+    }))
+    .sort((a, b) =>
+      KIND_ORDER[a.kind] - KIND_ORDER[b.kind] || b.revisions - a.revisions
+    );
+}
+
+/**
+ * The scope precedence chain for an identity — most specific first. With a
+ * sessionId: `[session:X:sid, user:X, space]`; without: `[user:X, space]`.
+ */
+export function resolveScopeChain(
+  identity: string,
+  sessionId?: string,
+): string[] {
+  const chain: string[] = [];
+  if (sessionId) chain.push(`session:${identity}:${sessionId}`);
+  chain.push(`user:${identity}`);
+  chain.push("space");
+  return chain;
+}
+
+export interface IdentityValue {
+  exists: boolean;
+  /** The scope the value resolved from (the most specific that had the id). */
+  resolvedScope?: string;
+  resolvedKind?: ScopeKind;
+  value?: unknown;
+  /** True if a more-general scope ALSO holds this id (i.e. this is an override). */
+  overrides?: boolean;
+}
+
+/** Does this scope hold any row for `id`? (raw scope_key match.) */
+function scopeHasEntity(
+  space: SpaceDb,
+  id: string,
+  scope: string,
+  branch: string,
+): boolean {
+  const row = space.db
+    .prepare(
+      `SELECT 1 AS one FROM revision
+       WHERE branch = ? AND id = ? AND scope_key = ? LIMIT 1`,
+    )
+    .get<{ one: number }>(branch, id, scope);
+  return !!row;
+}
+
+/**
+ * Read an entity's value AS an identity sees it — walking the precedence chain
+ * (session ⊕ user ⊕ space) and returning the value from the most specific scope
+ * that holds the id, plus whether a more-general scope also holds it (override).
+ */
+export function valueAsIdentity(
+  space: SpaceDb,
+  opts: {
+    id: string;
+    identity: string;
+    sessionId?: string;
+    branch?: string;
+    atSeq?: number;
+  },
+): IdentityValue {
+  const branch = opts.branch ?? "";
+  const chain = resolveScopeChain(opts.identity, opts.sessionId)
+    // The raw stored scope_key is %-encoded for user/session; match that form.
+    .map((s) => (s === "space" ? s : encodeScope(s)));
+  for (let i = 0; i < chain.length; i++) {
+    const scope = chain[i];
+    if (!scopeHasEntity(space, opts.id, scope, branch)) continue;
+    const doc = reconstructDocument(space, {
+      id: opts.id,
+      scope,
+      branch,
+      atSeq: opts.atSeq,
+    });
+    const overrides = chain
+      .slice(i + 1)
+      .some((s) => scopeHasEntity(space, opts.id, s, branch));
+    return {
+      exists: doc !== undefined,
+      resolvedScope: scope,
+      resolvedKind: parseScope(scope).kind,
+      value: doc === undefined ? undefined : annotate(doc.value),
+      overrides,
+    };
+  }
+  return { exists: false };
+}
+
+/** Stored scope_keys %-encode the `did:key:` colons; match that on the way in. */
+function encodeScope(scope: string): string {
+  // session:did:key:<DID>:<uuid>  /  user:did:key:<DID>
+  return scope.replace(/did:key:/g, "did%3Akey%3A");
+}
+
+export interface ScopeVariant {
+  scope: string;
+  kind: ScopeKind;
+  principal?: string;
+  sessionId?: string;
+  value: unknown;
+  summary: string;
+  revisions: number;
+}
+
+export interface ScopeOverlay {
+  id: string;
+  variants: ScopeVariant[];
+  /** True when the id appears in >1 scope (a per-identity override exists). */
+  overridden: boolean;
+  /** True when those scopes hold DIFFERENT values (real divergence). */
+  divergent: boolean;
+}
+
+/**
+ * Every scope an entity appears in, with its value there — the per-user/session
+ * divergence table for one id. The multiplayer "who sees what" view.
+ */
+export function scopeOverlay(
+  space: SpaceDb,
+  id: string,
+  opts: { branch?: string } = {},
+): ScopeOverlay {
+  const branch = opts.branch ?? "";
+  const rows = space.db
+    .prepare(
+      `SELECT scope_key, count(*) revs FROM revision
+       WHERE branch = ? AND id = ? GROUP BY scope_key`,
+    )
+    .all<{ scope_key: string; revs: number }>(branch, id);
+  const variants: ScopeVariant[] = rows.map((r) => {
+    const doc = reconstructDocument(space, { id, scope: r.scope_key, branch });
+    const s = parseScope(r.scope_key);
+    return {
+      scope: r.scope_key,
+      kind: s.kind,
+      principal: s.principal,
+      sessionId: s.sessionId,
+      value: doc === undefined ? undefined : annotate(doc.value),
+      summary: doc === undefined ? "(absent)" : summarize(doc.value),
+      revisions: r.revs,
+    };
+  }).sort((a, b) => KIND_ORDER[a.kind] - KIND_ORDER[b.kind]);
+
+  const keys = new Set(variants.map((v) => JSON.stringify(v.value)));
+  return {
+    id,
+    variants,
+    overridden: variants.length > 1,
+    divergent: keys.size > 1,
+  };
+}

--- a/packages/state-inspector/test/conflicts.test.ts
+++ b/packages/state-inspector/test/conflicts.test.ts
@@ -1,0 +1,108 @@
+// Hermetic test for conflict detection: a cell contested by two identities,
+// with a constructed stale read (lost-update) — Bob reads X@1, Alice writes X@3,
+// Bob commits at @4 having never seen Alice's write. Also checks the multi-user
+// vs multi-session distinction.
+
+import { assert, assertEquals } from "@std/assert";
+import { Database } from "@db/sqlite";
+
+import { openSpace } from "../db.ts";
+import { contendedEntities, entityConflicts } from "../conflicts.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+`;
+
+const SA = "session:did:key:zAlice:s1";
+const SB = "session:did:key:zBob:s2";
+const X = "of:X";
+
+function seed(path: string) {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  const commit = (seq: number, session: string, reads: number[]) =>
+    db.prepare(
+      `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+       VALUES (?, ?, ?, ?, '{"seq":0}')`,
+    ).run(
+      seq,
+      session,
+      seq,
+      JSON.stringify({
+        operations: [{ op: "set" }],
+        reads: {
+          confirmed: reads.map((s) => ({ id: X, path: [], seq: s })),
+          pending: [],
+        },
+      }),
+    );
+  const rev = (seq: number, op: string, commitSeq: number) =>
+    db.prepare(
+      `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+       VALUES (?, ?, 0, ?, ?, ?)`,
+    ).run(X, seq, op, JSON.stringify({ value: seq }), commitSeq);
+
+  // 1: Alice creates X.  2: Bob writes X (saw @1).  3: Alice writes X again.
+  // 4: Bob writes X but still read @1 → missed Alice's @3 (stale, lost update).
+  commit(1, SA, []);
+  rev(1, "set", 1);
+  commit(2, SB, [1]);
+  rev(2, "patch", 2);
+  commit(3, SA, [2]);
+  rev(3, "patch", 3);
+  commit(4, SB, [1]);
+  rev(4, "patch", 4);
+  db.close();
+}
+
+Deno.test("conflicts: contention + stale-read detection", async (t) => {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-conf-" });
+  const dbPath = `${dir}/space.sqlite`;
+  try {
+    seed(dbPath);
+    const space = openSpace(dbPath);
+    try {
+      await t.step("contendedEntities flags multi-user contention", () => {
+        const rows = contendedEntities(space);
+        assertEquals(rows.length, 1);
+        const c = rows[0];
+        assertEquals(c.id, X);
+        assertEquals(c.sessions, 2);
+        assertEquals(c.principals, 2); // Alice + Bob — real cross-user
+        assert(c.multiUser);
+        assert(c.interleaved); // A,B,A,B
+      });
+
+      await t.step(
+        "entityConflicts detects the stale read (lost update)",
+        () => {
+          const c = entityConflicts(space, X);
+          assertEquals(c.writerPrincipals, 2);
+          assert(c.multiUser);
+          assertEquals(c.staleReads.length, 1);
+          const sr = c.staleReads[0];
+          assertEquals(sr.readerCommitSeq, 4); // Bob's stale commit
+          assertEquals(sr.readAtSeq, 1); // read X@1
+          assertEquals(sr.missedWriteSeq, 3); // missed Alice's write @3
+          assert(sr.readerAlsoWrote); // Bob also wrote → lost-update risk
+        },
+      );
+    } finally {
+      space.close();
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/state-inspector/test/db.test.ts
+++ b/packages/state-inspector/test/db.test.ts
@@ -1,0 +1,70 @@
+// Hermetic test for the scope_key compatibility shim. Older space DBs predate
+// the per-scope `scope_key` column on `revision`; openSpace shadows the table
+// with a TEMP VIEW supplying a constant 'space' scope so scope-aware queries
+// (which all filter `scope_key = 'space'`) work unchanged on those DBs.
+
+import { assertEquals } from "@std/assert";
+import { Database } from "@db/sqlite";
+
+import { openSpace } from "../db.ts";
+import { reconstructDocument } from "../reconstruct.ts";
+import { listEntityModels } from "../model.ts";
+
+// NOTE: no `scope_key` column on `revision` — the legacy schema.
+const LEGACY_SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL, seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, seq, op_index)
+);
+`;
+
+function seed(path: string) {
+  const db = new Database(path, { create: true });
+  db.exec(LEGACY_SCHEMA);
+  db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (1, 'session:did:key:zX:u', 1, '{}', '{}')`,
+  ).run();
+  db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES ('of:a', 1, 0, 'set', ?, 1)`,
+  ).run(JSON.stringify({ value: { count: 7 } }));
+  db.close();
+}
+
+Deno.test("scope_key shim: a DB without scope_key still inspects", async () => {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-db-" });
+  const dbPath = `${dir}/legacy.sqlite`;
+  try {
+    seed(dbPath);
+    const space = openSpace(dbPath);
+    try {
+      // The shimmed column resolves to 'space', so the default scope finds it.
+      const has = space.db
+        .prepare(
+          "SELECT scope_key, count(*) n FROM revision GROUP BY scope_key",
+        )
+        .all<{ scope_key: string; n: number }>();
+      assertEquals(has, [{ scope_key: "space", n: 1 }]);
+
+      const doc = reconstructDocument(space, { id: "of:a" });
+      assertEquals((doc?.value as { count: number }).count, 7);
+
+      const models = listEntityModels(space);
+      assertEquals(models.length, 1);
+      assertEquals(models[0].id, "of:a");
+    } finally {
+      space.close();
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/state-inspector/test/graph.test.ts
+++ b/packages/state-inspector/test/graph.test.ts
@@ -1,0 +1,148 @@
+// Hermetic test for the entity graph. Seeds a modern piece (patternIdentity →
+// module, argument → input, internal → owned cell) plus a free cell, then checks
+// nodes, the pattern/argument/owns edges, neighborhood restriction, and DOT.
+
+import { assert, assertEquals } from "@std/assert";
+import { Database } from "@db/sqlite";
+
+import { openSpace } from "../db.ts";
+import { buildSpaceGraph, graphToDot, subgraphAround } from "../graph.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+`;
+
+const MODULE_IDENTITY = "pf1v3J_M5Nep7cq-Uh8EYG0ZQaE217FfDfcjbwGdjVI";
+
+function link(id: string) {
+  return { "/": { "link@1": { id, path: [] } } };
+}
+
+function seed(path: string) {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, 'session:did:key:zX:u', ?, '{}', '{}')`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, 0, 'set', ?, ?)`,
+  );
+
+  commit.run(1, 1);
+  rev.run(
+    "of:mod",
+    1,
+    JSON.stringify({
+      value: {
+        kind: "source",
+        identity: MODULE_IDENTITY,
+        code: "export default () => null;\n",
+        filename: "/api/patterns/notes/notebook.tsx",
+        imports: [],
+      },
+    }),
+    1,
+  );
+
+  commit.run(2, 2);
+  rev.run(
+    "of:piece",
+    2,
+    JSON.stringify({
+      value: { $NAME: "My Notebook", $UI: {}, link: link("of:owned") },
+      argument: link("of:input"),
+      internal: [{ partialCause: "q", link: link("of:owned") }],
+      patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+      schema: { type: "object", properties: {}, $defs: {} },
+    }),
+    2,
+  );
+
+  commit.run(3, 3);
+  rev.run("of:input", 3, JSON.stringify({ value: { title: "t" } }), 3);
+  commit.run(4, 4);
+  rev.run(
+    "of:owned",
+    4,
+    JSON.stringify({ value: "hi", result: link("of:piece") }),
+    4,
+  );
+  commit.run(5, 5);
+  rev.run("of:free", 5, JSON.stringify({ value: "x" }), 5);
+
+  db.close();
+}
+
+Deno.test("entity graph: nodes, edges, neighborhood, dot", async (t) => {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-graph-" });
+  const dbPath = `${dir}/space.sqlite`;
+  try {
+    seed(dbPath);
+    const space = openSpace(dbPath);
+    try {
+      const g = buildSpaceGraph(space);
+
+      await t.step("nodes carry fluent kinds + labels", () => {
+        const byId = Object.fromEntries(g.nodes.map((n) => [n.id, n]));
+        assertEquals(byId["of:piece"].kind, "piece");
+        assertEquals(byId["of:piece"].label, "My Notebook");
+        assertEquals(byId["of:mod"].kind, "module");
+        assertEquals(byId["of:owned"].kind, "owned-cell");
+        assertEquals(byId["of:free"].kind, "free-cell");
+      });
+
+      await t.step("structural edges resolve", () => {
+        const has = (from: string, to: string, kind: string) =>
+          g.edges.some((e) =>
+            e.from === from && e.to === to && e.kind === kind
+          );
+        // patternIdentity → module
+        assert(has("of:piece", "of:mod", "pattern"));
+        // argument → input cell
+        assert(has("of:piece", "of:input", "argument"));
+        // internal manifest → owned cell
+        assert(has("of:piece", "of:owned", "owns"));
+        // a data link in the value → its target
+        assert(has("of:piece", "of:owned", "link"));
+        assertEquals(g.stats.edgesByKind.pattern, 1);
+        assertEquals(g.stats.edgesByKind.argument, 1);
+      });
+
+      await t.step("subgraphAround restricts to a neighborhood", () => {
+        const sub = subgraphAround(g, "of:input", 1);
+        const ids = new Set(sub.nodes.map((n) => n.id));
+        // input is reached only from the piece (argument edge) → both present.
+        assert(ids.has("of:input"));
+        assert(ids.has("of:piece"));
+        // the unrelated free cell is not within 1 hop of the input cell.
+        assert(!ids.has("of:free"));
+      });
+
+      await t.step("graphToDot emits a digraph with the piece node", () => {
+        const dot = graphToDot(g);
+        assert(dot.startsWith("digraph space {"));
+        assert(dot.includes("of:piece"));
+        assert(dot.includes("My Notebook"));
+        assert(dot.trimEnd().endsWith("}"));
+      });
+    } finally {
+      space.close();
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/state-inspector/test/grouping.test.ts
+++ b/packages/state-inspector/test/grouping.test.ts
@@ -1,0 +1,152 @@
+// Hermetic test for space grouping. Seeds a HOME space (a home piece whose
+// profiles[] cell links cross-space to a PROFILE space), a PROFILE space, and a
+// MAIN space written by the home's principal, then checks they group into one
+// user-world with the right roles + a placeholder for an absent referenced space.
+
+import { assert, assertEquals } from "@std/assert";
+import { Database } from "@db/sqlite";
+
+import type { DiscoveredSpace } from "../discover.ts";
+import { groupDiscoveredSpaces, principalFromSession } from "../grouping.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+`;
+
+const HOME = "did:key:zHomeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const PROFILE = "did:key:zProfileBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const MAIN = "did:key:zMainCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+
+/** A plain-JSON sigil link, optionally carrying a cross-space `space`. */
+function link(id: string, space?: string) {
+  return { "/": { "link@1": { id, path: [], ...(space ? { space } : {}) } } };
+}
+
+function newDb(path: string): Database {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  return db;
+}
+
+function setRev(db: Database, id: string, seq: number, value: unknown) {
+  db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, 0, 'set', ?, ?)`,
+  ).run(id, seq, JSON.stringify(value), seq);
+}
+
+function commit(db: Database, seq: number, session: string) {
+  db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, ?, ?, '{}', '{}')`,
+  ).run(seq, session, seq);
+}
+
+function disc(path: string): DiscoveredSpace {
+  const did = (path.split("/").pop() ?? path).replace(/\.sqlite$/, "");
+  return { did, path, sizeBytes: 0, mtimeMs: 0 };
+}
+
+Deno.test("space grouping recovers a user's world", async (t) => {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-group-" });
+  const homePath = `${dir}/${HOME}.sqlite`;
+  const profilePath = `${dir}/${PROFILE}.sqlite`;
+  const mainPath = `${dir}/${MAIN}.sqlite`;
+  // The home's own principal session — for a home, principal == own DID.
+  const homeSession = `session:${HOME}:11111111-2222-3333-4444-555555555555`;
+
+  try {
+    // HOME: a home piece whose `profiles` cell links cross-space to PROFILE,
+    // plus a reference to an ABSENT profile space (no local DB → placeholder).
+    {
+      const db = newDb(homePath);
+      commit(db, 1, homeSession);
+      setRev(db, "of:profilescell", 1, {
+        value: [link("of:prof1", PROFILE), link("of:prof2", `${MAIN}XX`)],
+      });
+      commit(db, 2, homeSession);
+      setRev(db, "of:home", 2, {
+        value: {
+          $NAME: "Home",
+          $UI: {},
+          profiles: link("of:profilescell"),
+          createProfile: { $stream: true },
+          favorites: [],
+          mru: [],
+        },
+        patternIdentity: { identity: "homehash", symbol: "default" },
+      });
+      db.close();
+    }
+
+    // PROFILE: a small profile space (content irrelevant to grouping).
+    {
+      const db = newDb(profilePath);
+      commit(db, 1, `session:${HOME}:aaaa1111-2222-3333-4444-555555555555`);
+      setRev(db, "of:profile", 1, { value: { name: "Ada" } });
+      db.close();
+    }
+
+    // MAIN: a pattern space written by the home's principal (no home pieces).
+    {
+      const db = newDb(mainPath);
+      commit(db, 1, `session:${HOME}:bbbb1111-2222-3333-4444-555555555555`);
+      setRev(db, "of:doc", 1, { value: { count: 1 } });
+      db.close();
+    }
+
+    await t.step("principalFromSession extracts the acting DID", () => {
+      assertEquals(principalFromSession(homeSession), HOME);
+      // URL-encoded form (as stored in real DBs) decodes too.
+      assertEquals(
+        principalFromSession(`session:did%3Akey%3AzX:uuid`),
+        "did:key:zX",
+      );
+      assertEquals(principalFromSession("bare-uuid-no-principal"), null);
+    });
+
+    await t.step("one group: home → profile → main, with a placeholder", () => {
+      const result = groupDiscoveredSpaces([
+        disc(homePath),
+        disc(profilePath),
+        disc(mainPath),
+      ]);
+      assertEquals(result.groups.length, 1);
+      const g = result.groups[0];
+      assertEquals(g.principal, HOME);
+      assert(g.homePresent);
+
+      const byDid = Object.fromEntries(g.spaces.map((s) => [s.did, s]));
+      assertEquals(byDid[HOME].role, "home");
+      assertEquals(byDid[PROFILE].role, "profile");
+      assertEquals(byDid[MAIN].role, "main");
+
+      // The home, profile, and main are all present locally.
+      assert(byDid[HOME].present);
+      assert(byDid[PROFILE].present);
+      assert(byDid[MAIN].present);
+
+      // The second, dangling profile link resolves to an absent placeholder.
+      const absent = `${MAIN}XX`;
+      assert(byDid[absent], "dangling profile ref should appear as a node");
+      assertEquals(byDid[absent].present, false);
+      assertEquals(byDid[absent].role, "profile");
+
+      assertEquals(result.ungrouped.length, 0);
+    });
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/state-inspector/test/html.test.ts
+++ b/packages/state-inspector/test/html.test.ts
@@ -118,6 +118,12 @@ function seed(path: string) {
     JSON.stringify({ value: { link: link("of:mod"), specifier: "./dep.tsx" } }),
     6,
   );
+  // a per-user-scoped cell — the multiplayer dimension the explorer must show.
+  commit.run(7, 7);
+  db.prepare(
+    `INSERT INTO revision (id, scope_key, seq, op_index, op, data, commit_seq)
+     VALUES ('of:pref', 'user:did%3Akey%3AzUser', 7, 0, 'set', ?, 7)`,
+  ).run(JSON.stringify({ value: { theme: "dark" } }));
   db.close();
 }
 
@@ -159,6 +165,16 @@ Deno.test("html explorer: rich bundle + self-contained render", async (t) => {
         const imp = byId("of:imp");
         assertEquals(imp.label, "import ./dep.tsx");
         assertEquals(imp.role, "module import");
+      });
+
+      await t.step("bundle surfaces per-identity scopes + overlays", () => {
+        assert(
+          bundle.scopes.some((s) => s.kind === "user"),
+          "user scope enumerated",
+        );
+        const ov = bundle.overlays.find((o) => o.id === "of:pref");
+        assert(ov, "per-user cell has a scope overlay");
+        assertEquals(ov!.variants[0].kind, "user");
       });
 
       await t.step("CFC labels are parsed", () => {

--- a/packages/state-inspector/test/html.test.ts
+++ b/packages/state-inspector/test/html.test.ts
@@ -90,7 +90,20 @@ function seed(path: string) {
         { partialCause: "q", link: link("of:stream") },
       ],
       patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
-      schema: { type: "object", properties: {}, $defs: {} },
+      schema: {
+        type: "object",
+        properties: {
+          // the `addNote` stream's payload schema lives here on the owner piece
+          addNote: { $ref: "#/$defs/AddNoteEvent", asCell: ["stream"] },
+        },
+        $defs: {
+          AddNoteEvent: {
+            type: "object",
+            properties: { text: { type: "string" } },
+            required: ["text"],
+          },
+        },
+      },
     }),
     2,
   );
@@ -161,6 +174,13 @@ Deno.test("html explorer: rich bundle + self-contained render", async (t) => {
         assertEquals(stream.kind, "stream");
         assertEquals(stream.contextName, "addNote");
         assertEquals(stream.label, "⊙ addNote");
+        // its payload schema is resolved from the owner piece's schema.
+        assert(stream.streamPayload, "stream payload schema resolved");
+        assert(
+          stream.schemaKeys?.includes("properties"),
+          "payload shape present",
+        );
+        assertStringIncludes(stream.schemaSource ?? "", "addNote");
         // A `{ link, specifier }` cell is a module import.
         const imp = byId("of:imp");
         assertEquals(imp.label, "import ./dep.tsx");

--- a/packages/state-inspector/test/html.test.ts
+++ b/packages/state-inspector/test/html.test.ts
@@ -195,6 +195,9 @@ Deno.test("html explorer: rich bundle + self-contained render", async (t) => {
         const ov = bundle.overlays.find((o) => o.id === "of:pref");
         assert(ov, "per-user cell has a scope overlay");
         assertEquals(ov!.variants[0].kind, "user");
+        // conflicts surface is present (single-session seed → none contested)
+        assert(Array.isArray(bundle.conflicts));
+        assert(Array.isArray(bundle.participants));
       });
 
       await t.step("CFC labels are parsed", () => {

--- a/packages/state-inspector/test/html.test.ts
+++ b/packages/state-inspector/test/html.test.ts
@@ -1,12 +1,14 @@
-// Hermetic test for the HTML visual surface: the bundle carries the full model
-// (entities/pieces/graph/timeline) and the rendered page is self-contained with
-// a parseable, `</script>`-safe embedded bundle.
+// Hermetic test for the HTML explorer: the bundle carries rich per-entity
+// details with context-aware labels (named streams, module imports), parsed CFC,
+// and live-base passthrough; the rendered page is self-contained with a
+// parseable, `</script>`-safe embedded bundle.
 
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { Database } from "@db/sqlite";
 
 import { openSpace } from "../db.ts";
 import { buildInspectorBundle, renderInspectorHtml } from "../html.ts";
+import type { EntityDetail } from "../detail.ts";
 
 const SCHEMA = `
 CREATE TABLE "commit" (
@@ -27,7 +29,7 @@ CREATE TABLE branch (
   fork_seq INTEGER, created_seq INTEGER NOT NULL DEFAULT 0,
   head_seq INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'active'
 );
-INSERT INTO branch (name, head_seq, status) VALUES ('', 4, 'active');
+INSERT INTO branch (name, head_seq, status) VALUES ('', 6, 'active');
 `;
 
 const MODULE_IDENTITY = "pf1v3J_M5Nep7cq-Uh8EYG0ZQaE217FfDfcjbwGdjVI";
@@ -47,6 +49,7 @@ function seed(path: string) {
     `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
      VALUES (?, ?, 0, 'set', ?, ?)`,
   );
+  // module — carries CFC integrity, and a `</script>` guard in the source.
   commit.run(1, 1);
   rev.run(
     "of:mod",
@@ -55,22 +58,37 @@ function seed(path: string) {
       value: {
         kind: "source",
         identity: MODULE_IDENTITY,
-        // A value containing the literal `</script>` to exercise escaping.
         code: "// </script> guard\nexport default () => null;\n",
         filename: "/api/patterns/notes/notebook.tsx",
         imports: [],
       },
+      cfc: {
+        version: 1,
+        schemaHash: "fid1:hash",
+        labelMap: {
+          version: 1,
+          entries: [{
+            path: [],
+            label: { integrity: ["cf-compiled-by:cf-compiler"] },
+            origin: "declared",
+          }],
+        },
+      },
     }),
     1,
   );
+  // piece — value names an owned stream by the key `addNote`.
   commit.run(2, 2);
   rev.run(
     "of:piece",
     2,
     JSON.stringify({
-      value: { $NAME: "My Notebook", $UI: {} },
+      value: { $NAME: "My Notebook", $UI: {}, addNote: link("of:stream") },
       argument: link("of:input"),
-      internal: [{ partialCause: "q", link: link("of:owned") }],
+      internal: [
+        { partialCause: "q", link: link("of:owned") },
+        { partialCause: "q", link: link("of:stream") },
+      ],
       patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
       schema: { type: "object", properties: {}, $defs: {} },
     }),
@@ -85,25 +103,72 @@ function seed(path: string) {
     JSON.stringify({ value: "hi", result: link("of:piece") }),
     4,
   );
+  commit.run(5, 5);
+  rev.run(
+    "of:stream",
+    5,
+    JSON.stringify({ value: { $stream: true }, result: link("of:piece") }),
+    5,
+  );
+  // an import cell: { link, specifier }
+  commit.run(6, 6);
+  rev.run(
+    "of:imp",
+    6,
+    JSON.stringify({ value: { link: link("of:mod"), specifier: "./dep.tsx" } }),
+    6,
+  );
   db.close();
 }
 
-Deno.test("html visual surface: bundle + self-contained render", async (t) => {
+Deno.test("html explorer: rich bundle + self-contained render", async (t) => {
   const dir = await Deno.makeTempDir({ prefix: "state-inspector-html-" });
   const dbPath = `${dir}/space.sqlite`;
   try {
     seed(dbPath);
     const space = openSpace(dbPath);
     try {
-      const bundle = buildInspectorBundle(space, { generatedAt: "2026-01-01" });
+      const bundle = buildInspectorBundle(space, {
+        generatedAt: "2026-01-01",
+        liveBase: "https://app.test",
+      });
+      const byId = (id: string): EntityDetail =>
+        bundle.details.find((d) => d.id === id)!;
 
-      await t.step("bundle carries the full model", () => {
-        assert(bundle.entities.length >= 4);
-        assertEquals(bundle.pieces.length, 1);
-        assertEquals(bundle.pieces[0].name, "My Notebook");
-        assert(bundle.graph.nodes.length >= 4);
+      await t.step("bundle carries rich per-entity details", () => {
+        assert(bundle.details.length >= 5);
+        assertEquals(bundle.liveBase, "https://app.test");
         assert(bundle.graph.edges.some((e) => e.kind === "pattern"));
         assert(bundle.timeline.length >= 1);
+
+        const piece = byId("of:piece");
+        assertEquals(piece.kind, "piece");
+        assertEquals(piece.label, "My Notebook");
+        assertEquals(piece.lineage.pattern?.id, "of:mod");
+        assert(piece.schemaKeys?.includes("type"));
+        assert(piece.versions.length >= 1);
+      });
+
+      await t.step("labels are context-aware (no bare stream / link)", () => {
+        // A stream named by the piece's `addNote` key.
+        const stream = byId("of:stream");
+        assertEquals(stream.kind, "stream");
+        assertEquals(stream.contextName, "addNote");
+        assertEquals(stream.label, "⊙ addNote");
+        // A `{ link, specifier }` cell is a module import.
+        const imp = byId("of:imp");
+        assertEquals(imp.label, "import ./dep.tsx");
+        assertEquals(imp.role, "module import");
+      });
+
+      await t.step("CFC labels are parsed", () => {
+        const mod = byId("of:mod");
+        assert(mod.cfc, "module should carry cfc");
+        assertEquals(mod.cfc!.schemaHash, "fid1:hash");
+        assertEquals(mod.cfc!.entries[0].integrity, [
+          "cf-compiled-by:cf-compiler",
+        ]);
+        assert(mod.code, "module should carry source");
       });
 
       await t.step("render is self-contained HTML", () => {
@@ -111,11 +176,10 @@ Deno.test("html visual surface: bundle + self-contained render", async (t) => {
         assertStringIncludes(html, "<!doctype html>");
         assertStringIncludes(html, bundle.space);
         assertStringIncludes(html, "My Notebook");
-        // No external resource references (fully offline).
-        assert(
-          !/src=|href=|@import/.test(html),
-          "should have no external refs",
-        );
+        // No external resources: all `<` in embedded data are escaped, so any
+        // literal tag is ours — and none load a remote resource.
+        assert(!html.includes("<script src"), "no external scripts");
+        assert(!html.includes("<link "), "no external stylesheets");
       });
 
       await t.step("embedded bundle is parseable + script-safe", () => {
@@ -124,14 +188,10 @@ Deno.test("html visual surface: bundle + self-contained render", async (t) => {
           /<script id="bundle" type="application\/json">(.*?)<\/script>/s,
         );
         assert(m, "bundle script block present");
-        // The raw payload must not contain an unescaped </script> closer.
-        assert(
-          !m![1].includes("</script>"),
-          "payload must escape </script>",
-        );
+        assert(!m![1].includes("</script>"), "payload must escape </script>");
         const parsed = JSON.parse(m![1].replaceAll("\\u003c", "<"));
         assertEquals(parsed.space, bundle.space);
-        assertEquals(parsed.pieces.length, 1);
+        assertEquals(parsed.details.length, bundle.details.length);
       });
     } finally {
       space.close();

--- a/packages/state-inspector/test/html.test.ts
+++ b/packages/state-inspector/test/html.test.ts
@@ -1,0 +1,142 @@
+// Hermetic test for the HTML visual surface: the bundle carries the full model
+// (entities/pieces/graph/timeline) and the rendered page is self-contained with
+// a parseable, `</script>`-safe embedded bundle.
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { Database } from "@db/sqlite";
+
+import { openSpace } from "../db.ts";
+import { buildInspectorBundle, renderInspectorHtml } from "../html.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+CREATE TABLE branch (
+  name TEXT NOT NULL PRIMARY KEY DEFAULT '', parent_branch TEXT,
+  fork_seq INTEGER, created_seq INTEGER NOT NULL DEFAULT 0,
+  head_seq INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'active'
+);
+INSERT INTO branch (name, head_seq, status) VALUES ('', 4, 'active');
+`;
+
+const MODULE_IDENTITY = "pf1v3J_M5Nep7cq-Uh8EYG0ZQaE217FfDfcjbwGdjVI";
+
+function link(id: string) {
+  return { "/": { "link@1": { id, path: [] } } };
+}
+
+function seed(path: string) {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, 'session:did:key:zX:u', ?, '{}', '{}')`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, 0, 'set', ?, ?)`,
+  );
+  commit.run(1, 1);
+  rev.run(
+    "of:mod",
+    1,
+    JSON.stringify({
+      value: {
+        kind: "source",
+        identity: MODULE_IDENTITY,
+        // A value containing the literal `</script>` to exercise escaping.
+        code: "// </script> guard\nexport default () => null;\n",
+        filename: "/api/patterns/notes/notebook.tsx",
+        imports: [],
+      },
+    }),
+    1,
+  );
+  commit.run(2, 2);
+  rev.run(
+    "of:piece",
+    2,
+    JSON.stringify({
+      value: { $NAME: "My Notebook", $UI: {} },
+      argument: link("of:input"),
+      internal: [{ partialCause: "q", link: link("of:owned") }],
+      patternIdentity: { identity: MODULE_IDENTITY, symbol: "default" },
+      schema: { type: "object", properties: {}, $defs: {} },
+    }),
+    2,
+  );
+  commit.run(3, 3);
+  rev.run("of:input", 3, JSON.stringify({ value: { title: "t" } }), 3);
+  commit.run(4, 4);
+  rev.run(
+    "of:owned",
+    4,
+    JSON.stringify({ value: "hi", result: link("of:piece") }),
+    4,
+  );
+  db.close();
+}
+
+Deno.test("html visual surface: bundle + self-contained render", async (t) => {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-html-" });
+  const dbPath = `${dir}/space.sqlite`;
+  try {
+    seed(dbPath);
+    const space = openSpace(dbPath);
+    try {
+      const bundle = buildInspectorBundle(space, { generatedAt: "2026-01-01" });
+
+      await t.step("bundle carries the full model", () => {
+        assert(bundle.entities.length >= 4);
+        assertEquals(bundle.pieces.length, 1);
+        assertEquals(bundle.pieces[0].name, "My Notebook");
+        assert(bundle.graph.nodes.length >= 4);
+        assert(bundle.graph.edges.some((e) => e.kind === "pattern"));
+        assert(bundle.timeline.length >= 1);
+      });
+
+      await t.step("render is self-contained HTML", () => {
+        const html = renderInspectorHtml(bundle);
+        assertStringIncludes(html, "<!doctype html>");
+        assertStringIncludes(html, bundle.space);
+        assertStringIncludes(html, "My Notebook");
+        // No external resource references (fully offline).
+        assert(
+          !/src=|href=|@import/.test(html),
+          "should have no external refs",
+        );
+      });
+
+      await t.step("embedded bundle is parseable + script-safe", () => {
+        const html = renderInspectorHtml(bundle);
+        const m = html.match(
+          /<script id="bundle" type="application\/json">(.*?)<\/script>/s,
+        );
+        assert(m, "bundle script block present");
+        // The raw payload must not contain an unescaped </script> closer.
+        assert(
+          !m![1].includes("</script>"),
+          "payload must escape </script>",
+        );
+        const parsed = JSON.parse(m![1].replaceAll("\\u003c", "<"));
+        assertEquals(parsed.space, bundle.space);
+        assertEquals(parsed.pieces.length, 1);
+      });
+    } finally {
+      space.close();
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/state-inspector/test/identity.test.ts
+++ b/packages/state-inspector/test/identity.test.ts
@@ -1,0 +1,111 @@
+// Hermetic test for the identity world: a DID's spaces (home → profile) joined
+// with the per-user/session scopes it owns within them.
+
+import { assert, assertEquals } from "@std/assert";
+import { Database } from "@db/sqlite";
+
+import type { DiscoveredSpace } from "../discover.ts";
+import { describeIdentity } from "../identity.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+`;
+
+const HOME = "did:key:zHomeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const PROFILE = "did:key:zProfileBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const USER = "user:did%3Akey%3AzHomeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+function link(id: string, space?: string) {
+  return { "/": { "link@1": { id, path: [], ...(space ? { space } : {}) } } };
+}
+function db(path: string): Database {
+  const d = new Database(path, { create: true });
+  d.exec(SCHEMA);
+  return d;
+}
+function commit(d: Database, seq: number) {
+  d.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, ?, ?, '{}', '{}')`,
+  ).run(seq, `session:${HOME}:sid`, seq);
+}
+function rev(d: Database, id: string, scope: string, seq: number, v: unknown) {
+  d.prepare(
+    `INSERT INTO revision (id, scope_key, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, ?, 0, 'set', ?, ?)`,
+  ).run(id, scope, seq, JSON.stringify(v), seq);
+}
+function disc(path: string): DiscoveredSpace {
+  const did = (path.split("/").pop() ?? path).replace(/\.sqlite$/, "");
+  return { did, path, sizeBytes: 0, mtimeMs: 0 };
+}
+
+Deno.test("identity world: spaces + owned scopes", async (t) => {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-identity-" });
+  const homePath = `${dir}/${HOME}.sqlite`;
+  const profilePath = `${dir}/${PROFILE}.sqlite`;
+  try {
+    // HOME: a home piece linking to PROFILE, plus a per-user owned cell.
+    {
+      const d = db(homePath);
+      commit(d, 1);
+      rev(d, "of:profilescell", "space", 1, {
+        value: [link("of:prof1", PROFILE)],
+      });
+      commit(d, 2);
+      rev(d, "of:home", "space", 2, {
+        value: {
+          $NAME: "Home",
+          profiles: link("of:profilescell"),
+          createProfile: { $stream: true },
+        },
+      });
+      // a per-user cell OWNED by this identity
+      commit(d, 3);
+      rev(d, "of:userpref", USER, 3, { value: { theme: "dark" } });
+      d.close();
+    }
+    {
+      const d = db(profilePath);
+      commit(d, 1);
+      rev(d, "of:profile", "space", 1, { value: { name: "Ada" } });
+      d.close();
+    }
+
+    const world = describeIdentity([disc(homePath), disc(profilePath)], HOME);
+
+    await t.step("joins spaces with owned scopes", () => {
+      assertEquals(world.did, HOME);
+      const byDid = Object.fromEntries(world.spaces.map((s) => [s.did, s]));
+      assertEquals(byDid[HOME].role, "home");
+      assertEquals(byDid[PROFILE].role, "profile");
+      // the home carries this identity's per-user scope
+      assertEquals(byDid[HOME].ownedScopes.length, 1);
+      assertEquals(byDid[HOME].ownedScopes[0].kind, "user");
+      assertEquals(byDid[HOME].scopedEntities, 1);
+      // the profile has no per-user state for this identity
+      assertEquals(byDid[PROFILE].scopedEntities, 0);
+    });
+
+    await t.step("totals roll up", () => {
+      assertEquals(world.totals.presentSpaces, 2);
+      assertEquals(world.totals.spacesWithScopedState, 1);
+      assertEquals(world.totals.scopedEntities, 1);
+      assert(world.homePresent);
+    });
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/state-inspector/test/scopes.test.ts
+++ b/packages/state-inspector/test/scopes.test.ts
@@ -1,0 +1,135 @@
+// Hermetic test for scope awareness: enumerate space/user/session scopes,
+// compose "view as identity" (session ⊕ user ⊕ space, most-specific wins), and
+// surface the per-scope divergence of one cell. Scope keys are stored %-encoded
+// (as in real DBs) to exercise the encode/decode path.
+
+import { assert, assertEquals } from "@std/assert";
+import { Database } from "@db/sqlite";
+
+import { openSpace } from "../db.ts";
+import {
+  listScopes,
+  parseScope,
+  scopeOverlay,
+  valueAsIdentity,
+} from "../scopes.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+`;
+
+const DID = "did:key:zUser";
+const USER = "user:did%3Akey%3AzUser"; // stored, %-encoded
+const SESS = "session:did%3Akey%3AzUser:sid123";
+
+function seed(path: string) {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  let seq = 0;
+  const put = (id: string, scope: string, value: unknown) => {
+    seq++;
+    db.prepare(
+      `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+       VALUES (?, 'session:did:key:zUser:sid123', ?, '{}', '{}')`,
+    ).run(seq, seq);
+    db.prepare(
+      `INSERT INTO revision (id, scope_key, seq, op_index, op, data, commit_seq)
+       VALUES (?, ?, ?, 0, 'set', ?, ?)`,
+    ).run(id, scope, seq, JSON.stringify({ value }), seq);
+  };
+  // A: space-only.  B: space + user + session (divergent).  C: user-only.
+  put("of:A", "space", "shared-A");
+  put("of:B", "space", "space-B");
+  put("of:B", USER, "user-B");
+  put("of:B", SESS, "session-B");
+  put("of:C", USER, "user-only-C");
+  db.close();
+}
+
+Deno.test("scope awareness: enumerate, compose, diverge", async (t) => {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-scope-" });
+  const dbPath = `${dir}/space.sqlite`;
+  try {
+    seed(dbPath);
+    const space = openSpace(dbPath);
+    try {
+      await t.step("parseScope classifies the three kinds", () => {
+        assertEquals(parseScope("space").kind, "space");
+        assertEquals(parseScope(USER).kind, "user");
+        assertEquals(parseScope(USER).principal, DID);
+        const s = parseScope(SESS);
+        assertEquals(s.kind, "session");
+        assertEquals(s.principal, DID);
+        assertEquals(s.sessionId, "sid123");
+      });
+
+      await t.step("listScopes enumerates with counts", () => {
+        const scopes = listScopes(space);
+        const byKind = Object.fromEntries(scopes.map((s) => [s.kind, s]));
+        assertEquals(byKind.space.entities, 2); // A, B
+        assertEquals(byKind.user.entities, 2); // B, C
+        assertEquals(byKind.session.entities, 1); // B
+      });
+
+      await t.step("valueAsIdentity composes most-specific-wins", () => {
+        // B: session wins over user wins over space.
+        const withSession = valueAsIdentity(space, {
+          id: "of:B",
+          identity: DID,
+          sessionId: "sid123",
+        });
+        assertEquals(withSession.resolvedKind, "session");
+        assertEquals(withSession.value, "session-B");
+        assert(withSession.overrides);
+
+        // B without a session: user wins over space.
+        const userLevel = valueAsIdentity(space, { id: "of:B", identity: DID });
+        assertEquals(userLevel.resolvedKind, "user");
+        assertEquals(userLevel.value, "user-B");
+        assert(userLevel.overrides);
+
+        // A: only space — resolves to space, no override.
+        const spaceOnly = valueAsIdentity(space, { id: "of:A", identity: DID });
+        assertEquals(spaceOnly.resolvedKind, "space");
+        assertEquals(spaceOnly.value, "shared-A");
+        assertEquals(spaceOnly.overrides, false);
+
+        // C: user-only — still visible AS the identity (space would miss it).
+        const userOnly = valueAsIdentity(space, { id: "of:C", identity: DID });
+        assert(userOnly.exists);
+        assertEquals(userOnly.resolvedKind, "user");
+      });
+
+      await t.step("scopeOverlay shows per-scope divergence", () => {
+        const o = scopeOverlay(space, "of:B");
+        assertEquals(o.variants.length, 3);
+        assert(o.overridden);
+        assert(o.divergent);
+        // ordered space → user → session
+        assertEquals(o.variants.map((v) => v.kind), [
+          "space",
+          "user",
+          "session",
+        ]);
+        const single = scopeOverlay(space, "of:A");
+        assertEquals(single.overridden, false);
+      });
+    } finally {
+      space.close();
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/state-inspector/test/scopes.test.ts
+++ b/packages/state-inspector/test/scopes.test.ts
@@ -11,6 +11,7 @@ import {
   listScopes,
   parseScope,
   scopeOverlay,
+  spaceParticipants,
   valueAsIdentity,
 } from "../scopes.ts";
 
@@ -110,6 +111,18 @@ Deno.test("scope awareness: enumerate, compose, diverge", async (t) => {
         const userOnly = valueAsIdentity(space, { id: "of:C", identity: DID });
         assert(userOnly.exists);
         assertEquals(userOnly.resolvedKind, "user");
+      });
+
+      await t.step("spaceParticipants lists the space's identities", () => {
+        const ps = spaceParticipants(space);
+        assertEquals(ps.length, 1);
+        const p = ps[0];
+        assertEquals(p.did, DID);
+        assertEquals(p.commits, 5); // all five commits use zUser's session
+        assertEquals(p.userEntities, 2); // B, C in user scope
+        assertEquals(p.sessionEntities, 1); // B in session scope
+        // the seed space DID isn't zUser, so it's not the owner here
+        assertEquals(p.isOwner, false);
       });
 
       await t.step("scopeOverlay shows per-scope divergence", () => {

--- a/packages/state-inspector/test/timetravel.test.ts
+++ b/packages/state-inspector/test/timetravel.test.ts
@@ -1,0 +1,146 @@
+// Hermetic test for time travel: structural value diff, entity diff across
+// seqs, entity timeline (write-by-write), and space-growth timeline. Seeds an
+// entity edited by a patch and another that is created then deleted.
+
+import { assert, assertEquals } from "@std/assert";
+import { Database } from "@db/sqlite";
+
+import { openSpace } from "../db.ts";
+import {
+  diffEntity,
+  diffValues,
+  entityTimeline,
+  spaceTimeline,
+} from "../timetravel.ts";
+
+const SCHEMA = `
+CREATE TABLE "commit" (
+  seq INTEGER NOT NULL PRIMARY KEY, branch TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL, local_seq INTEGER NOT NULL,
+  invocation_ref TEXT, authorization_ref TEXT,
+  original JSON NOT NULL, resolution JSON NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE revision (
+  branch TEXT NOT NULL DEFAULT '', id TEXT NOT NULL,
+  scope_key TEXT NOT NULL DEFAULT 'space', seq INTEGER NOT NULL,
+  op_index INTEGER NOT NULL, op TEXT NOT NULL, data JSON, commit_seq INTEGER NOT NULL,
+  PRIMARY KEY (branch, id, scope_key, seq, op_index)
+);
+`;
+
+function seed(path: string) {
+  const db = new Database(path, { create: true });
+  db.exec(SCHEMA);
+  const commit = db.prepare(
+    `INSERT INTO "commit" (seq, session_id, local_seq, original, resolution)
+     VALUES (?, ?, ?, '{}', '{}')`,
+  );
+  const rev = db.prepare(
+    `INSERT INTO revision (id, seq, op_index, op, data, commit_seq)
+     VALUES (?, ?, 0, ?, ?, ?)`,
+  );
+
+  // commit 1: create A
+  commit.run(1, "session:did:key:zX:u", 1);
+  rev.run(
+    "of:A",
+    1,
+    "set",
+    JSON.stringify({ value: { count: 0, title: "a" } }),
+    1,
+  );
+  // commit 2: create B
+  commit.run(2, "session:did:key:zX:u", 2);
+  rev.run("of:B", 2, "set", JSON.stringify({ value: { x: 1 } }), 2);
+  // commit 3: patch A.count -> 2
+  commit.run(3, "session:did:key:zX:u", 3);
+  rev.run(
+    "of:A",
+    3,
+    "patch",
+    JSON.stringify([{ op: "replace", path: "/value/count", value: 2 }]),
+    3,
+  );
+  // commit 4: delete B
+  commit.run(4, "session:did:key:zX:u", 4);
+  rev.run("of:B", 4, "delete", null, 4);
+
+  db.close();
+}
+
+Deno.test("time travel: diff + timelines", async (t) => {
+  const dir = await Deno.makeTempDir({ prefix: "state-inspector-tt-" });
+  const dbPath = `${dir}/space.sqlite`;
+  try {
+    seed(dbPath);
+    const space = openSpace(dbPath);
+    try {
+      await t.step("diffValues classifies add/remove/change", () => {
+        const changes = diffValues(
+          { a: 1, b: 2, list: [1, 2] },
+          { a: 1, b: 3, c: 9, list: [1, 5] },
+        );
+        const byPath = Object.fromEntries(changes.map((c) => [c.path, c]));
+        assertEquals(byPath["b"].kind, "changed");
+        assertEquals(byPath["c"].kind, "added");
+        assertEquals(byPath["list/1"].kind, "changed");
+        assert(!("a" in byPath));
+      });
+
+      await t.step("diffEntity across seqs shows the changed leaf", () => {
+        // Default diffs the value; change paths are value-relative ("count").
+        const d = diffEntity(space, { id: "of:A", fromSeq: 1, toSeq: 3 });
+        assert(d.fromExists && d.toExists);
+        const c = d.changes.find((x) => x.path === "count");
+        assert(c, "expected value.count to change");
+        assertEquals(c!.kind, "changed");
+        assertEquals(c!.after, 2);
+        // With --doc, paths are document-relative ("value/count").
+        const dd = diffEntity(space, {
+          id: "of:A",
+          fromSeq: 1,
+          toSeq: 3,
+          doc: true,
+        });
+        assert(dd.changes.some((x) => x.path === "value/count"));
+      });
+
+      await t.step("diffEntity birth→latest reports creation", () => {
+        const d = diffEntity(space, { id: "of:A" });
+        assertEquals(d.fromExists, false);
+        assertEquals(d.toExists, true);
+        assert(d.changes.length > 0);
+      });
+
+      await t.step("diffEntity captures a deletion", () => {
+        const d = diffEntity(space, { id: "of:B", fromSeq: 2, toSeq: 4 });
+        assertEquals(d.fromExists, true);
+        assertEquals(d.toExists, false);
+      });
+
+      await t.step("entityTimeline lists each write with change counts", () => {
+        const steps = entityTimeline(space, { id: "of:A" });
+        assertEquals(steps.length, 2);
+        assertEquals(steps[0].op, "set");
+        assertEquals(steps[1].op, "patch");
+        // the patch changed exactly one path (count)
+        assertEquals(steps[1].changes, 1);
+      });
+
+      await t.step("spaceTimeline tracks created + cumulative growth", () => {
+        const t1 = spaceTimeline(space);
+        assertEquals(t1.length, 4);
+        assertEquals(t1[0].created, 1); // A
+        assertEquals(t1[1].created, 1); // B
+        assertEquals(t1[2].created, 0); // patch A
+        assertEquals(t1[3].created, 0); // delete B
+        assertEquals(t1[3].cumulativeEntities, 2);
+      });
+    } finally {
+      space.close();
+    }
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/state-inspector/timetravel.ts
+++ b/packages/state-inspector/timetravel.ts
@@ -1,0 +1,295 @@
+// Time travel — how state got to where it is.
+//
+// The engine already reconstructs any entity at any seq (reconstruct.ts), so the
+// autopsy can run the clock backwards and forwards. Two views:
+//
+//   diff      — what changed in an entity between two seqs (structural value diff)
+//   timeline  — how an entity grew (per-write value summary + change count), or
+//               how a space grew (commits over time, new vs touched entities)
+//
+// Values are normalized with `annotate` first, so links/streams compare as
+// stable shapes instead of exploding into nested objects.
+
+import type { SpaceDb } from "./db.ts";
+import { annotate, summarize } from "./decode.ts";
+import { getAtPath, reconstructDocument } from "./reconstruct.ts";
+
+export type ChangeKind = "added" | "removed" | "changed";
+
+export interface ValueChange {
+  /** JSON path of the change, e.g. `value/items/0/title`. */
+  path: string;
+  kind: ChangeKind;
+  before?: unknown;
+  after?: unknown;
+}
+
+function isObj(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function canonical(v: unknown): string {
+  const sort = (x: unknown): unknown => {
+    if (Array.isArray(x)) return x.map(sort);
+    if (x && typeof x === "object") {
+      const o = x as Record<string, unknown>;
+      const out: Record<string, unknown> = {};
+      for (const k of Object.keys(o).sort()) out[k] = sort(o[k]);
+      return out;
+    }
+    return x;
+  };
+  return JSON.stringify(sort(v)) ?? "undefined";
+}
+
+/**
+ * Structural diff of two already-annotated values. Recurses through objects and
+ * arrays; leaves compare by canonical JSON. `maxDepth` bounds recursion (deeper
+ * differences collapse to a single `changed` at the boundary).
+ */
+export function diffValues(
+  before: unknown,
+  after: unknown,
+  basePath: string[] = [],
+  maxDepth = 12,
+): ValueChange[] {
+  const out: ValueChange[] = [];
+  const walk = (a: unknown, b: unknown, path: string[], depth: number) => {
+    const here = path.join("/");
+    if (canonical(a) === canonical(b)) return;
+    if (a === undefined) {
+      out.push({ path: here, kind: "added", after: b });
+      return;
+    }
+    if (b === undefined) {
+      out.push({ path: here, kind: "removed", before: a });
+      return;
+    }
+    if (depth <= 0) {
+      out.push({ path: here, kind: "changed", before: a, after: b });
+      return;
+    }
+    if (isObj(a) && isObj(b)) {
+      for (const k of new Set([...Object.keys(a), ...Object.keys(b)])) {
+        walk(a[k], b[k], [...path, k], depth - 1);
+      }
+      return;
+    }
+    if (Array.isArray(a) && Array.isArray(b)) {
+      const n = Math.max(a.length, b.length);
+      for (let i = 0; i < n; i++) {
+        walk(a[i], b[i], [...path, String(i)], depth - 1);
+      }
+      return;
+    }
+    out.push({ path: here, kind: "changed", before: a, after: b });
+  };
+  walk(before, after, basePath, maxDepth);
+  return out;
+}
+
+export interface EntityDiff {
+  id: string;
+  fromSeq: number | null;
+  toSeq: number | null;
+  fromExists: boolean;
+  toExists: boolean;
+  changes: ValueChange[];
+}
+
+/**
+ * Diff an entity between two seqs. By default diffs the whole document (so
+ * lineage/schema changes show too); pass a `path` to focus inside `value`.
+ */
+export function diffEntity(
+  space: SpaceDb,
+  opts: {
+    id: string;
+    scope?: string;
+    branch?: string;
+    fromSeq?: number;
+    toSeq?: number;
+    path?: string[];
+    doc?: boolean;
+  },
+): EntityDiff {
+  const { id } = opts;
+  const scope = opts.scope ?? "space";
+  const branch = opts.branch ?? "";
+  const path = opts.path ?? [];
+  // `from` defaults to birth (seq 0 = empty baseline), NOT latest — omitting
+  // atSeq would reconstruct the head, making a no-`--from` diff always empty.
+  const before = reconstructDocument(space, {
+    id,
+    scope,
+    branch,
+    atSeq: opts.fromSeq ?? 0,
+  });
+  const after = reconstructDocument(space, {
+    id,
+    scope,
+    branch,
+    atSeq: opts.toSeq,
+  });
+  const pick = (doc: typeof before) => {
+    if (doc === undefined) return undefined;
+    if (opts.doc) return annotate(doc);
+    return annotate(getAtPath(doc.value, path));
+  };
+  return {
+    id,
+    fromSeq: opts.fromSeq ?? null,
+    toSeq: opts.toSeq ?? null,
+    fromExists: before !== undefined,
+    toExists: after !== undefined,
+    changes: diffValues(pick(before), pick(after)),
+  };
+}
+
+export interface TimelineStep {
+  seq: number;
+  opIndex: number;
+  op: string;
+  commitSeq: number;
+  session: string;
+  createdAt: string;
+  /** One-line summary of the entity's value after this write. */
+  summary: string;
+  /** Whether the entity exists after this write (false = delete tombstone). */
+  exists: boolean;
+  /** Number of value changes introduced by this write (vs the previous state). */
+  changes: number;
+}
+
+/**
+ * The life of one entity: every write, with the value summary after it and how
+ * many paths changed. Reconstructs incrementally write-by-write.
+ */
+export function entityTimeline(
+  space: SpaceDb,
+  opts: {
+    id: string;
+    scope?: string;
+    branch?: string;
+    limit?: number;
+  },
+): TimelineStep[] {
+  const scope = opts.scope ?? "space";
+  const branch = opts.branch ?? "";
+  const limit = opts.limit ?? 500;
+  const rows = space.db
+    .prepare(
+      `SELECT r.seq, r.op_index, r.op, r.commit_seq,
+              c.session_id, c.created_at
+       FROM revision r JOIN "commit" c ON c.seq = r.commit_seq
+       WHERE r.branch = ? AND r.id = ? AND r.scope_key = ?
+       ORDER BY r.seq ASC, r.op_index ASC LIMIT ?`,
+    )
+    .all<{
+      seq: number;
+      op_index: number;
+      op: string;
+      commit_seq: number;
+      session_id: string;
+      created_at: string;
+    }>(branch, opts.id, scope, limit);
+
+  const steps: TimelineStep[] = [];
+  let prevValue: unknown = undefined;
+  for (const r of rows) {
+    const doc = reconstructDocument(space, {
+      id: opts.id,
+      scope,
+      branch,
+      atSeq: r.seq,
+    });
+    const exists = doc !== undefined;
+    const value = exists ? annotate(doc!.value) : undefined;
+    const changes = diffValues(prevValue, value).length;
+    steps.push({
+      seq: r.seq,
+      opIndex: r.op_index,
+      op: r.op,
+      commitSeq: r.commit_seq,
+      session: r.session_id,
+      createdAt: r.created_at,
+      summary: exists ? summarize(doc!.value) : "(deleted)",
+      exists,
+      changes,
+    });
+    prevValue = value;
+  }
+  return steps;
+}
+
+export interface SpaceTimelineEntry {
+  commitSeq: number;
+  createdAt: string;
+  session: string;
+  /** Entities touched (revisions) in this commit. */
+  touched: number;
+  /** Entities seen here for the first time. */
+  created: number;
+  /** Cumulative distinct entities up to and including this commit. */
+  cumulativeEntities: number;
+}
+
+/** How a space grew: per-commit touched/created counts and a cumulative total. */
+export function spaceTimeline(
+  space: SpaceDb,
+  opts: { branch?: string; scope?: string; limit?: number } = {},
+): SpaceTimelineEntry[] {
+  const branch = opts.branch ?? "";
+  const scope = opts.scope ?? "space";
+  const limit = opts.limit ?? 500;
+
+  // First-seen seq per entity → lets us count "created" per commit.
+  const firstSeen = new Map<string, number>();
+  for (
+    const r of space.db
+      .prepare(
+        `SELECT id, min(commit_seq) firstCommit FROM revision
+         WHERE branch = ? AND scope_key = ? GROUP BY id`,
+      )
+      .all<{ id: string; firstCommit: number }>(branch, scope)
+  ) {
+    firstSeen.set(r.id, r.firstCommit);
+  }
+
+  const commits = space.db
+    .prepare(
+      `SELECT c.seq, c.created_at, c.session_id,
+              count(r.id) touched,
+              sum(CASE WHEN r.op_index = 0 THEN 1 ELSE 0 END) AS distinctish
+       FROM "commit" c
+       LEFT JOIN revision r ON r.commit_seq = c.seq
+         AND r.branch = ? AND r.scope_key = ?
+       GROUP BY c.seq ORDER BY c.seq ASC LIMIT ?`,
+    )
+    .all<{
+      seq: number;
+      created_at: string;
+      session_id: string;
+      touched: number;
+    }>(branch, scope, limit);
+
+  // created-per-commit: count entities whose firstCommit == this commit.
+  const createdByCommit = new Map<number, number>();
+  for (const fc of firstSeen.values()) {
+    createdByCommit.set(fc, (createdByCommit.get(fc) ?? 0) + 1);
+  }
+
+  let cumulative = 0;
+  return commits.map((c) => {
+    const created = createdByCommit.get(c.seq) ?? 0;
+    cumulative += created;
+    return {
+      commitSeq: c.seq,
+      createdAt: c.created_at,
+      session: c.session_id,
+      touched: c.touched,
+      created,
+      cumulativeEntities: cumulative,
+    };
+  });
+}


### PR DESCRIPTION
Phase 2 of the state-inspector (stacked on #4395). Turns the fluent entity
model into a comprehension tool — "a truly useful tool that helps the whole
team understand the stack." Four features, each its own commit + hermetic test.

## Commands added (all keep `--json`)

- **`cf inspect group`** — a user's whole world. Groups discovered space DBs
  into per-user worlds (home → profiles → main) from on-disk signals (home
  `profiles[]` cross-space links, `commit.session_id` principal, cross-space
  links). Placeholder (0-commit) and absent (referenced, no local DB) spaces
  marked. Compact by default; `--did <prefix>` expands one user.
- **`cf inspect graph`** — the entity graph. Nodes (pieces/modules/streams/
  schemas/cells) + edges (`pattern` / `argument` / `owns` / `link`).
  `--root <entity> --depth N` drills into one piece's neighborhood; `--dot`
  emits Graphviz.
- **`cf inspect diff` / `timeline`** — time travel. `diff` shows what changed
  in an entity between two seqs (structural value diff); `timeline` shows how a
  space grew, or how one entity evolved.
- **`cf inspect html`** — a self-contained HTML inspector (Overview / Pieces /
  Entities / Graph / Timeline), per-piece graph as inline SVG + growth
  sparkline, dark-mode aware, no external resources.

## Grounding

The grouping signals were **verified against the real local cache before
building** (137 user groups; clean home→profiles→main trees, a 132-space
test-principal sprawl, cross-home shared profiles). Graph + time-travel verified
on the notes space; the HTML surface was opened in a real browser (Playwright) —
no JS errors, tabs and the graph neighborhood render.

## Tests

New `grouping` / `graph` / `timetravel` / `html` hermetic tests; full package
suite is 9 files / 41 steps green (fmt + lint + check clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Phase 2 comprehension surface to `@commonfabric/state-inspector` and `cf inspect` (group/graph/diff/timeline/html), plus scope-aware views, an identity overview, space participants, and conflict analysis (contention and stale reads) with `cf inspect conflicts`. The HTML explorer now surfaces conflicts with header counts, per-entity markers, a “Contention” section, and a new “Conflicts” panel.

- **New Features**
  - `cf inspect group` — groups space DBs into per-user worlds (home → profiles → main); marks placeholders/absent; `--did <prefix>`, `--json`.
  - `cf inspect graph` — entity graph (pieces/modules/streams/schemas/cells) with edges (`pattern`/`argument`/`owns`/`link`); `--root/--depth`, `--dot`, `--no-links`, `--json`.
  - `cf inspect diff` / `timeline` — structural value diff between seqs; per-entity and per-space timelines.
  - `cf inspect html` — interactive explorer with tree+graph, rich per-entity detail (value/schema/lineage/links/source/history), per-identity scope overlays with divergence flags, identities panel, cross-space link surface, and conflict surface (header counts for contested/multi-user, ⚔ markers, writer timeline + stale reads), plus a “Conflicts (N, M ⚔)” panel listing contested cells; resolves named stream payload schemas (inline link first, then owner); click-to-copy, deep links; `--app-url`; single file.
  - `cf inspect scopes` / `overlay` / `value-at` — view as identity (session ⊕ user ⊕ space): list scopes, show a cell across scopes, or read as a user/session; `--json`.
  - `cf inspect identity <DID>` — joins grouping and scopes for one DID; shows home/profile/main spaces and the `user`/`session` scopes it owns; `--json`.
  - `cf inspect users <space>` — lists identities that touched a space (commits, sessions, per-user/session cells; owner flagged); also shown in the HTML explorer; `--json`.
  - `cf inspect conflicts [entity]` — detects contention (≥2 sessions; flags multi-user vs multi-session and interleaving) and stale reads (lost updates) from the committed log; `--json`.
  - Library exports — `@commonfabric/state-inspector` exports `grouping`, `graph`, `timetravel`, `scopes`, `identity`, `conflicts`, `detail`, `html`, and `isModuleValue`.

- **Bug Fixes**
  - Legacy DBs — shim missing `scope_key` on `revision` via a TEMP VIEW so scope-aware queries work on pre-`scope_key` spaces.
  - Legacy pieces — resolve PROCESS cell labels via `resultRef`; include result + owned-cell lineage in details and the HTML explorer.
  - Stream schemas — read declared payload schema from the naming link when present; fallback to the owner piece property.
  - HTML deep links — strip `of:` prefix from piece ids so “open in app” routes to `<base>/<space>/fid1:…` without errors.

<sup>Written for commit 038bf4ec8a1c670a5e14fa9e8887398e4fc63c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

