### PR TITLE
cf inspect: resolve a space by name, not just DID/path

### DIFF
--- a/packages/cli/commands/inspect.ts
+++ b/packages/cli/commands/inspect.ts
@@ -4,8 +4,9 @@
 // store the server already wrote (no live runtime, no capture) and answers
 // who/what/when + cross-space convergence questions. Every command takes --json.
 //
-// Space DBs are auto-discovered (no need to pass absolute paths): pass a DID or
-// DID-prefix as <space>, or a file path. `cf inspect spaces` lists what's found.
+// Space DBs are auto-discovered (no need to pass absolute paths): pass a DID,
+// DID-prefix, a space NAME (resolved the same way the runtime derives it), or a
+// file path as <space>. `cf inspect spaces` lists what's found.
 
 import { Command } from "@cliffy/command";
 import { Table } from "@cliffy/table";
@@ -38,7 +39,7 @@ import {
   openSpaces,
   quickStats,
   renderInspectorHtml,
-  resolveSpacePath,
+  resolveSpace,
   type Scope,
   scopeOverlay,
   type SpaceGraph,
@@ -99,20 +100,22 @@ function fmtSession(s: string): string {
 }
 
 // Resolve --all / --spaces / --dir into open spaces; caller must close them.
-function resolveMultiSpaces(opts: {
+async function resolveMultiSpaces(opts: {
   all?: boolean;
   spaces?: string;
   dir?: string;
-}): SpaceRef[] {
+}): Promise<SpaceRef[]> {
   if (opts.dir) return openSpaces(listSqliteFiles(opts.dir));
   if (opts.all) return openSpaces(discoverSpaceDbs().map((s) => s.path));
   if (opts.spaces) {
     const discovered = discoverSpaceDbs();
-    const paths = opts.spaces
-      .split(",")
-      .map((t) => t.trim())
-      .filter(Boolean)
-      .map((t) => resolveSpacePath(t, discovered));
+    const paths = await Promise.all(
+      opts.spaces
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean)
+        .map((t) => resolveSpace(t, discovered)),
+    );
     return openSpaces(paths);
   }
   throw new Error("provide --all, --spaces <a,b,…>, or --dir <dir>");
@@ -296,8 +299,8 @@ export const inspect = new Command()
     "summary <space:string>",
     "Space overview: commits, sessions, hot ops.",
   )
-  .action((options, space) => {
-    const s = openSpace(resolveSpacePath(space));
+  .action(async (options, space) => {
+    const s = openSpace(await resolveSpace(space));
     try {
       const sum = summarizeSpace(s);
       out(!!options.json, sum, () => {
@@ -341,8 +344,8 @@ export const inspect = new Command()
     "Per-identity scopes in a space: shared/space + per-user + per-session.",
   )
   .option("--branch <branch:string>", "Branch (default: '').")
-  .action((options, space) => {
-    const s = openSpace(resolveSpacePath(space));
+  .action(async (options, space) => {
+    const s = openSpace(await resolveSpace(space));
     try {
       const scopes = listScopes(s, { branch: options.branch });
       out(!!options.json, scopes, () => {
@@ -379,8 +382,8 @@ export const inspect = new Command()
     "Identities that touched this space (committers + per-user/session scopes).",
   )
   .option("--branch <branch:string>", "Branch (default: '').")
-  .action((options, space) => {
-    const s = openSpace(resolveSpacePath(space));
+  .action(async (options, space) => {
+    const s = openSpace(await resolveSpace(space));
     try {
       const ps = spaceParticipants(s, { branch: options.branch });
       out(!!options.json, ps, () => {
@@ -416,8 +419,8 @@ export const inspect = new Command()
   )
   .option("--session <prefix:string>", "Filter by session id prefix.")
   .option("--limit <n:number>", "Max rows.", { default: 50 })
-  .action((options, space) => {
-    const s = openSpace(resolveSpacePath(space));
+  .action(async (options, space) => {
+    const s = openSpace(await resolveSpace(space));
     try {
       const rows = listCommits(s, {
         session: options.session,
@@ -443,8 +446,8 @@ export const inspect = new Command()
   )
   .option("--limit <n:number>", "Max rows.", { default: 20 })
   .option("--branch <branch:string>", "Branch (default: '').")
-  .action((options, space) => {
-    const s = openSpace(resolveSpacePath(space));
+  .action(async (options, space) => {
+    const s = openSpace(await resolveSpace(space));
     try {
       const rows = hotEntities(s, {
         limit: options.limit,
@@ -469,8 +472,8 @@ export const inspect = new Command()
   .option("--branch <branch:string>", "Branch (default: '').")
   .option("--scope <scope:string>", "Scope key (default: space).")
   .option("--limit <n:number>", "Max contested entities.", { default: 100 })
-  .action((options, space, entity) => {
-    const s = openSpace(resolveSpacePath(space));
+  .action(async (options, space, entity) => {
+    const s = openSpace(await resolveSpace(space));
     try {
       if (entity) {
         const c = entityConflicts(s, entity, {
@@ -566,8 +569,8 @@ export const inspect = new Command()
   .option("--limit <n:number>", "Max entities to reconstruct.", {
     default: 5000,
   })
-  .action((options, space) => {
-    const s = openSpace(resolveSpacePath(space));
+  .action(async (options, space) => {
+    const s = openSpace(await resolveSpace(space));
     try {
       let rows = listEntityModels(s, {
         limit: options.limit,
@@ -611,8 +614,8 @@ export const inspect = new Command()
   .option("--branch <branch:string>", "Branch (default: '').")
   .option("--scope <scope:string>", "Scope key (default: space).")
   .option("--code", "Include the full pattern TS source.")
-  .action((options, space, entity) => {
-    const s = openSpace(resolveSpacePath(space));
+  .action(async (options, space, entity) => {
+    const s = openSpace(await resolveSpace(space));
     try {
       const piece = describePiece(s, entity, {
         branch: options.branch,
@@ -676,8 +679,8 @@ export const inspect = new Command()
   .option("--limit <n:number>", "Max entities to reconstruct.", {
     default: 5000,
   })
-  .action((options, space) => {
-    const s = openSpace(resolveSpacePath(space));
+  .action(async (options, space) => {
+    const s = openSpace(await resolveSpace(space));
     try {
       let g: SpaceGraph = buildSpaceGraph(s, {
         branch: options.branch,
@@ -768,8 +771,8 @@ export const inspect = new Command()
     "--app-url <url:string>",
     "Live shell base origin for deep links (e.g. https://host).",
   )
-  .action((options, space) => {
-    const s = openSpace(resolveSpacePath(space));
+  .action(async (options, space) => {
+    const s = openSpace(await resolveSpace(space));
     try {
       const bundle = buildInspectorBundle(s, {
         branch: options.branch,
@@ -799,8 +802,8 @@ export const inspect = new Command()
   .option("--scope <scope:string>", "Scope key (default: space).")
   .option("--branch <branch:string>", "Branch (default: '').")
   .option("--limit <n:number>", "Max rows.", { default: 200 })
-  .action((options, space, entity) => {
-    const s = openSpace(resolveSpacePath(space));
+  .action(async (options, space, entity) => {
+    const s = openSpace(await resolveSpace(space));
     try {
       const rows = entityHistory(s, {
         id: entity,
@@ -840,8 +843,8 @@ export const inspect = new Command()
   .option("--session <sid:string>", "With --as: a specific session id.")
   .option("--branch <branch:string>", "Branch (default: '').")
   .option("--doc", "Show the whole document, not just value.")
-  .action((options, space, entity) => {
-    const s = openSpace(resolveSpacePath(space));
+  .action(async (options, space, entity) => {
+    const s = openSpace(await resolveSpace(space));
     try {
       // --as composes the per-identity overlay; otherwise a single raw scope.
       if (options.as) {
@@ -897,8 +900,8 @@ export const inspect = new Command()
     "An entity's value across EVERY scope (per-user/session divergence).",
   )
   .option("--branch <branch:string>", "Branch (default: '').")
-  .action((options, space, entity) => {
-    const s = openSpace(resolveSpacePath(space));
+  .action(async (options, space, entity) => {
+    const s = openSpace(await resolveSpace(space));
     try {
       const o = scopeOverlay(s, entity, { branch: options.branch });
       out(!!options.json, o, () => {
@@ -942,8 +945,8 @@ export const inspect = new Command()
   .option("--doc", "Diff the whole document, not just value.")
   .option("--scope <scope:string>", "Scope key (default: space).")
   .option("--branch <branch:string>", "Branch (default: '').")
-  .action((options, space, entity) => {
-    const s = openSpace(resolveSpacePath(space));
+  .action(async (options, space, entity) => {
+    const s = openSpace(await resolveSpace(space));
     try {
       const d = diffEntity(s, {
         id: entity,
@@ -988,8 +991,8 @@ export const inspect = new Command()
   .option("--scope <scope:string>", "Scope key (default: space).")
   .option("--branch <branch:string>", "Branch (default: '').")
   .option("--limit <n:number>", "Max rows.", { default: 500 })
-  .action((options, space, entity) => {
-    const s = openSpace(resolveSpacePath(space));
+  .action(async (options, space, entity) => {
+    const s = openSpace(await resolveSpace(space));
     try {
       if (entity) {
         const steps = entityTimeline(s, {
@@ -1041,8 +1044,8 @@ export const inspect = new Command()
   .option("--path <path:string>", "Navigate into value, e.g. value/count.")
   .option("--scope <scope:string>", "Scope key (default: space).")
   .option("--branch <branch:string>", "Branch (default: '').")
-  .action((options, entity) => {
-    const refs = resolveMultiSpaces(options);
+  .action(async (options, entity) => {
+    const refs = await resolveMultiSpaces(options);
     try {
       const index = buildCrossSpaceLinkIndex(refs, {
         scope: options.scope,
@@ -1096,8 +1099,8 @@ export const inspect = new Command()
   .option("--dir <dir:string>", "Directory of *.sqlite files.")
   .option("--limit <n:number>", "Max findings.", { default: 50 })
   .option("--branch <branch:string>", "Branch (default: '').")
-  .action((options) => {
-    const refs = resolveMultiSpaces(options);
+  .action(async (options) => {
+    const refs = await resolveMultiSpaces(options);
     try {
       const result = convergenceScan(refs, {
         limit: options.limit,

--- a/packages/state-inspector/README.md
+++ b/packages/state-inspector/README.md
@@ -90,7 +90,8 @@ is the natural next step.
 
 Run from a repo with local space DBs (discovery walks up to the cache), or point
 at any directory with `--dir` / `MEMORY_DIR` / `DB_PATH`. `<space>` is a DID, a
-unique DID-prefix, or a path. Every command takes `--json` for agents.
+unique DID-prefix, a space **name** (resolved the way the runtime derives it),
+or a path. Every command takes `--json` for agents.
 
 ```bash
 # discover what's inspectable, then drill in

--- a/packages/state-inspector/discover.ts
+++ b/packages/state-inspector/discover.ts
@@ -153,6 +153,11 @@ export function resolveSpacePath(
  * if that finds nothing AND the token looks like a name (not a path, not already
  * `did:`-shaped) does it derive the name's DID via {@link deriveSpaceDid} and
  * match that. Async because the derivation uses the identity keypair.
+ *
+ * Precedence: a path / DID / DID-prefix match always WINS over name derivation,
+ * so a token that is a substring of a discovered DID resolves to that DB and is
+ * never treated as a name. Harmless in practice — space names (e.g.
+ * `2026-06-29-ben`) are never DID-shaped — and a name can never shadow a DID.
  */
 export async function resolveSpace(
   token: string,

--- a/packages/state-inspector/discover.ts
+++ b/packages/state-inspector/discover.ts
@@ -6,7 +6,25 @@
 // engine-v3/<did>.sqlite`. The engine-v3 segment is sometimes doubled, so we
 // walk a bounded depth under each cache base rather than assume a fixed path.
 
+import { Identity } from "@commonfabric/identity";
+
 import { openSpace } from "./db.ts";
+
+// A named space's DID is reproducibly derived by the runtime from its name:
+// `Identity.fromPassphrase("common user").derive(<name>)` (see
+// `packages/identity/src/session.ts` `createSession`). The shell addresses a
+// space by name (`/<space-name>/…`); we mirror that derivation so
+// `cf inspect <name>` resolves the same DB the runtime would, without anyone
+// copying a DID around.
+const SPACE_ROOT_PASSPHRASE = "common user";
+let spaceRoot: Promise<Identity> | undefined;
+
+/** Derive the DID of a NAMED space, the same way the runtime does. */
+export async function deriveSpaceDid(name: string): Promise<string> {
+  spaceRoot ??= Identity.fromPassphrase(SPACE_ROOT_PASSPHRASE);
+  const space = await (await spaceRoot).derive(name);
+  return space.did();
+}
 
 export interface DiscoveredSpace {
   /** Space DID (DB file basename without `.sqlite`). */
@@ -127,6 +145,34 @@ export function resolveSpacePath(
   throw new Error(
     `"${token}" is ambiguous (${matches.length} matches); use a longer prefix or a path`,
   );
+}
+
+/**
+ * Resolve a space token to a DB path, accepting a space NAME in addition to a
+ * DID / DID-prefix / path. Tries the synchronous matcher first (path/DID); only
+ * if that finds nothing AND the token looks like a name (not a path, not already
+ * `did:`-shaped) does it derive the name's DID via {@link deriveSpaceDid} and
+ * match that. Async because the derivation uses the identity keypair.
+ */
+export async function resolveSpace(
+  token: string,
+  discovered?: DiscoveredSpace[],
+): Promise<string> {
+  const spaces = discovered ?? discoverSpaceDbs();
+  try {
+    return resolveSpacePath(token, spaces);
+  } catch (err) {
+    const looksLikeName = !token.includes("/") &&
+      !token.endsWith(".sqlite") && !token.startsWith("did:");
+    if (!looksLikeName) throw err;
+    const did = await deriveSpaceDid(token);
+    const match = spaces.find((s) => s.did === did);
+    if (match) return match.path;
+    throw new Error(
+      `no space matches "${token}" — as a name it derives to ${did}, ` +
+        `but no local DB for that DID was found (run: inspect spaces)`,
+    );
+  }
 }
 
 export interface SpaceQuickStats {

--- a/packages/state-inspector/test/discover.test.ts
+++ b/packages/state-inspector/test/discover.test.ts
@@ -5,7 +5,13 @@
 import { assert, assertEquals, assertThrows } from "@std/assert";
 import { Database } from "@db/sqlite";
 
-import { discoverSpaceDbs, quickStats, resolveSpacePath } from "../discover.ts";
+import {
+  deriveSpaceDid,
+  discoverSpaceDbs,
+  quickStats,
+  resolveSpace,
+  resolveSpacePath,
+} from "../discover.ts";
 
 const SCHEMA = `
 CREATE TABLE "commit" (
@@ -95,6 +101,31 @@ Deno.test("discovery + resolution", async (t) => {
       assertEquals(stats?.commits, 3);
       assertEquals(stats?.entities, 3);
     });
+
+    await t.step(
+      "resolveSpace resolves a space NAME via the runtime derivation",
+      async () => {
+        // The runtime derives a named space's DID; we mirror it, so addressing a
+        // space by the name the shell shows finds the same DB.
+        const name = "state-inspector-test-space";
+        const did = await deriveSpaceDid(name);
+        assert(did.startsWith("did:key:z"), "derives a did:key DID");
+        makeSpace(`${engine}/${did}.sqlite`, 1);
+        const found = discoverSpaceDbs({
+          dirs: [`${dir}/cache/memory`],
+          cwd: dir,
+        });
+
+        const byName = await resolveSpace(name, found);
+        assert(
+          byName.endsWith(`${did}.sqlite`),
+          "a name resolves to its derived DID's DB",
+        );
+        // the same async entry point still honors DID-prefix and path matching
+        const byPrefix = await resolveSpace("zAlpha", found);
+        assert(byPrefix.endsWith(`${DID_1}.sqlite`));
+      },
+    );
   } finally {
     await Deno.remove(dir, { recursive: true });
   }

--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -16,8 +16,8 @@ Full command reference + flags: `packages/state-inspector/README.md`. This skill
 is the **map** — what the tool sees, what to trust, and which question each
 command answers. Run commands with `deno task cf inspect <cmd>`; every command
 takes `--json` for machine reading, and a `<space>` is a DID, a unique
-DID-prefix, or a path (local DBs auto-discovered — start with
-`cf inspect spaces`).
+DID-prefix, a space name (resolved the way the runtime derives it), or a path
+(local DBs auto-discovered — start with `cf inspect spaces`).
 
 ## The mental model the output assumes
 


### PR DESCRIPTION
## What

`cf inspect <space>` now accepts a **space name** (e.g. `2026-06-29-ben`) in addition to a DID / DID-prefix / path. Humans — and the shell URL (`/<space-name>/…`) — address spaces by name, so the tool should too.

## How

A named space's DID is **reproducibly derived by the runtime** from its name: `Identity.fromPassphrase("common user").derive(<name>)` (the exact call in `packages/identity/src/session.ts` `createSession`). The inspector now mirrors that derivation, so `cf inspect <name>` resolves the *same* DB the runtime would — no copying DIDs around.

- `discover.ts`: `deriveSpaceDid(name)` (reuses `@commonfabric/identity`) + async `resolveSpace(token, discovered?)` that tries the existing **sync** DID/path/prefix matcher first and only falls back to name-derivation when the token looks like a name (not a path, not `did:`-shaped). The sync `resolveSpacePath` is unchanged, so existing behaviour is preserved.
- `cli/commands/inspect.ts`: route every `<space>` arg + `--spaces` through the async resolver (the resolver is async because derivation uses the identity keypair).

## Verified

- Hermetic test: derive a name's DID, seed a DB under it, assert the name resolves to that path (DID-prefix + explicit path still work through the same entry point). 21 files / 71 steps green; fmt/lint clean.
- End-to-end against a real dev space: `cf inspect summary 2026-06-29-ben` → resolves to `…/did:key:z6MkoGPB…sqlite` and summarizes it.

## Context

Follow-up to #4397 (state-inspector). One of two discovery/resolution tweaks discussed during the first real test-drive; the other (a "discovery missed the dev cache" report) turned out to be a false alarm — discovery already walks the `engine-v3/engine-v3` nesting — so this is the only change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users pass a space name to `cf inspect`, not just a DID/DID-prefix/path. Name resolution mirrors the runtime so the same DB opens as the app shell; docs now mention name support and clarify precedence.

- **New Features**
  - Added async `resolveSpace()` that tries DID/path first, then derives a name’s DID via `@commonfabric/identity` to match a local DB.
  - Routed all `<space>` args and `--spaces` through the async resolver; kept `resolveSpacePath()` unchanged for sync callers.
  - Updated README and SKILL to document space-name support and that DID/path matching wins over name derivation; added tests confirming name, DID-prefix, and path resolution.

<sup>Written for commit f38bf4b6c08da6ae92622d962ecb499a0502ccc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

