### PR TITLE
state-inspector skill: state the scope envelope (can/can't/when)

### DIFF
--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -19,6 +19,43 @@ takes `--json` for machine reading, and a `<space>` is a DID, a unique
 DID-prefix, or a path (local DBs auto-discovered — start with
 `cf inspect spaces`).
 
+## What it can — and can't — answer
+
+It reads ONE durable store, offline and read-only. That single boundary tells
+you when to trust it and when to reach for something else:
+
+**It answers authoritatively** (the same bytes the engine reads): what is
+_stored_ for any entity at any `(branch, seq)`; who/what/when wrote it (per
+commit, wall-clock to the second); how a value got there
+(`history`/`diff`/`timeline`); whether identities _see different values_
+(`overlay`); whether the store is _internally consistent_ (anomalous stale
+reads); whether the same id agrees across spaces (`converge`); and the structure
+of it all (`entities`/`piece`/`graph`).
+
+**It can't — and reaching for it here will mislead you:**
+
+- _Anything client-side_ — optimistic writes, cursor lag, what a browser is
+  actually rendering. "Converged" / "consistent" describes the durable store,
+  not what any client is showing.
+- _A live or production bug from a local snapshot_ — a clean local store does
+  not explain a prod-only misbehaviour; at most it says the local data is
+  healthy, so the cause is concurrency / scale / timing or client-side. To
+  inspect prod you need that space's actual `.sqlite` (no remote mode — copy the
+  file off the box).
+- _How long anything took_ — it has logical order (`seq`) plus
+  second-granularity commit times ("what happened and when"), never latencies or
+  durations.
+- _What was rejected_ — the engine rejects stale reads _before_ they persist, so
+  they are not here. Zero anomalies means consistent, not "no concurrency."
+- _The live reactive graph_ — scheduler dependency tables are usually absent on
+  disk; entity/commit history always works, the reactive graph is opt-in.
+- _Change anything_ — it is read-only; it explains, it never reproduces or
+  fixes.
+
+So **reach for it whenever you would otherwise guess at durable or multiplayer
+state from outside a live runtime**; reach for something else for live
+behaviour, client rendering, performance profiling, or reproducing a bug.
+
 ## The mental model the output assumes
 
 You will misread the tool without these — they are facts about how memory-v2

--- a/skills/state-inspector/SKILL.md
+++ b/skills/state-inspector/SKILL.md
@@ -26,7 +26,7 @@ you when to trust it and when to reach for something else:
 
 **It answers authoritatively** (the same bytes the engine reads): what is
 _stored_ for any entity at any `(branch, seq)`; who/what/when wrote it (per
-commit, wall-clock to the second); how a value got there
+commit, UTC wall-clock to the second); how a value got there
 (`history`/`diff`/`timeline`); whether identities _see different values_
 (`overlay`); whether the store is _internally consistent_ (anomalous stale
 reads); whether the same id agrees across spaces (`converge`); and the structure


### PR DESCRIPTION
## What

Adds a **"What it can — and can't — answer"** section to the `state-inspector` skill, right after the intro.

## Why

From the first real test-drive of the tool: an agent handed the skill needs the tool's *boundary* stated up front, or it over-claims — the sharpest case being using a **clean local store to "explain" a production-only bug**. The skill had per-command honesty (overlay = truth, conflicts = anomaly detector, converge = server-view), but no single statement of the overall envelope.

The new section states:
- **What it answers authoritatively** — stored value at any `(branch, seq)`, who/what/when, divergence (`overlay`), consistency (anomalous stale reads), cross-space agreement (`converge`), structure.
- **What it can't** — anything client-side; a live/prod bug from a local snapshot; latencies/durations (only logical order + second-granularity commit times); rejected commits (the engine rejects stale reads pre-commit); the live reactive graph; and it mutates nothing.
- **When to reach for it vs something else.**

Map + values, principles-framed per `docs/development/skill-authoring.md`; complements rather than duplicates the per-command honesty contract below it. Facts verified against the runtime (commit `created_at` granularity, `validateConfirmedReads`, scheduler-table absence). `check-skill-facts` green.

Follow-up to #4397; sibling to #4398 (resolve spaces by name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a "What it can — and can't — answer" section to the `state-inspector` skill to clearly state its scope, limits, and when to use it. This helps prevent over-claims, like explaining a prod-only bug from a clean local snapshot.

- **New Features**
  - Clarifies what it answers: stored values at any `(branch, seq)`, write provenance (commit times are UTC wall-clock to the second), divergence (`overlay`), consistency anomalies, cross-space agreement (`converge`), and structure.
  - Lists what it can’t: client-side behavior, prod bugs from local snapshots, latencies/durations, rejected commits, live reactive graph, and any mutations.
  - Notes boundaries: reads one durable store, offline and read-only; inspect prod by copying the space’s `.sqlite`.

<sup>Written for commit 98d14df16af2e181437ae33fba83130f82448829. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

