### PR TITLE
Fix CLI browser URL construction

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -51,18 +51,15 @@ function hint(message: string, showQuietTip = true) {
   }
 }
 
-export function appRouteUrl(apiUrl: string, ...segments: string[]): string {
-  const parsedBase = new URL(apiUrl);
-  const routeBase = new URL(parsedBase);
-  const basePath = parsedBase.pathname.split("/").filter(Boolean).join("/");
-  routeBase.pathname = basePath ? `/${basePath}/` : "/";
-  routeBase.search = "";
-  routeBase.hash = "";
-  const path = segments
-    .map((segment) => segment.replace(/^\/+|\/+$/g, ""))
-    .filter((segment) => segment.length > 0)
-    .join("/");
-  return new URL(path ? `./${path}` : "./", routeBase).toString();
+export function normalizeApiUrl(apiUrl: string): string {
+  const parsed = new URL(apiUrl);
+  const normalized = new URL(parsed);
+  const basePath = parsed.pathname.split("/").filter(Boolean).join("/");
+  normalized.pathname = basePath ? `/${basePath}` : "/";
+  normalized.search = "";
+  normalized.hash = "";
+  const href = normalized.toString();
+  return basePath ? href : href.slice(0, -1);
 }
 
 function summarizeForDisplay(value: unknown): unknown {
@@ -270,9 +267,7 @@ export const piece = new Command()
     render(pieceId);
     const browserPieceRef = options.slug ?? pieceId;
     hint(cliText(`NEXT STEPS:
-  → Open in browser: ${
-      appRouteUrl(spaceConfig.apiUrl, spaceConfig.space, browserPieceRef)
-    }
+  → Open in browser: ${spaceConfig.apiUrl}/${spaceConfig.space}/${browserPieceRef}
   → Update code:     cf piece setsrc --piece ${pieceId} ${main} ...
   → Test a callable: cf piece call --piece ${pieceId} <callableName> ...
   → Inspect state:   cf piece inspect --piece ${pieceId} ...`));
@@ -314,9 +309,7 @@ export const piece = new Command()
     );
     render(`Set slug ${slug} to ${sourceRef}`);
     hint(cliText(`NEXT STEPS:
-  → Open in browser: ${
-      appRouteUrl(spaceConfig.apiUrl, spaceConfig.space, slug)
-    }`));
+  → Open in browser: ${spaceConfig.apiUrl}/${spaceConfig.space}/${slug}`));
   })
   /* piece step */
   .command("step", "Run a single scheduling step: start → idle → synced → stop")
@@ -393,9 +386,7 @@ export const piece = new Command()
     });
     render(`Updated source for piece ${pieceConfig.piece}`);
     hint(cliText(`NEXT STEPS:
-  → Test in browser: ${
-      appRouteUrl(pieceConfig.apiUrl, pieceConfig.space, pieceConfig.piece)
-    }
+  → Test in browser: ${pieceConfig.apiUrl}/${pieceConfig.space}/${pieceConfig.piece}
   → Test a callable: cf piece call --piece ${pieceConfig.piece} <callableName> ...
   → Check state:     cf piece inspect --piece ${pieceConfig.piece} ...`));
   })
@@ -909,9 +900,7 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
     const pieceId = await recreateSpaceRootPattern(spaceConfig);
     render(pieceId);
     hint(cliText(`NEXT STEPS:
-  → Open space in browser: ${
-      appRouteUrl(spaceConfig.apiUrl, spaceConfig.space, pieceId)
-    }
+  → Open space in browser: ${spaceConfig.apiUrl}/${spaceConfig.space}/${pieceId}
   → Inspect state:         cf piece inspect --piece ${pieceId} ...`));
   })
   /* piece set-home */
@@ -1090,7 +1079,7 @@ export function parseSpaceOptions(
     if (parsedPiece.scope) output.pieceScope = parsedPiece.scope;
   }
 
-  output.apiUrl = input.apiUrl;
+  output.apiUrl = normalizeApiUrl(input.apiUrl);
   output.space = input.space;
 
   if (!input.identity) {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -51,6 +51,20 @@ function hint(message: string, showQuietTip = true) {
   }
 }
 
+export function appRouteUrl(apiUrl: string, ...segments: string[]): string {
+  const parsedBase = new URL(apiUrl);
+  const routeBase = new URL(parsedBase);
+  const basePath = parsedBase.pathname.split("/").filter(Boolean).join("/");
+  routeBase.pathname = basePath ? `/${basePath}/` : "/";
+  routeBase.search = "";
+  routeBase.hash = "";
+  const path = segments
+    .map((segment) => segment.replace(/^\/+|\/+$/g, ""))
+    .filter((segment) => segment.length > 0)
+    .join("/");
+  return new URL(path ? `./${path}` : "./", routeBase).toString();
+}
+
 function summarizeForDisplay(value: unknown): unknown {
   if (value === null || value === undefined) return value;
   if (typeof value !== "object") return value;
@@ -256,7 +270,9 @@ export const piece = new Command()
     render(pieceId);
     const browserPieceRef = options.slug ?? pieceId;
     hint(cliText(`NEXT STEPS:
-  → Open in browser: ${spaceConfig.apiUrl}/${spaceConfig.space}/${browserPieceRef}
+  → Open in browser: ${
+      appRouteUrl(spaceConfig.apiUrl, spaceConfig.space, browserPieceRef)
+    }
   → Update code:     cf piece setsrc --piece ${pieceId} ${main} ...
   → Test a callable: cf piece call --piece ${pieceId} <callableName> ...
   → Inspect state:   cf piece inspect --piece ${pieceId} ...`));
@@ -298,7 +314,9 @@ export const piece = new Command()
     );
     render(`Set slug ${slug} to ${sourceRef}`);
     hint(cliText(`NEXT STEPS:
-  → Open in browser: ${spaceConfig.apiUrl}/${spaceConfig.space}/${slug}`));
+  → Open in browser: ${
+      appRouteUrl(spaceConfig.apiUrl, spaceConfig.space, slug)
+    }`));
   })
   /* piece step */
   .command("step", "Run a single scheduling step: start → idle → synced → stop")
@@ -375,7 +393,9 @@ export const piece = new Command()
     });
     render(`Updated source for piece ${pieceConfig.piece}`);
     hint(cliText(`NEXT STEPS:
-  → Test in browser: ${pieceConfig.apiUrl}/${pieceConfig.space}/${pieceConfig.piece}
+  → Test in browser: ${
+      appRouteUrl(pieceConfig.apiUrl, pieceConfig.space, pieceConfig.piece)
+    }
   → Test a callable: cf piece call --piece ${pieceConfig.piece} <callableName> ...
   → Check state:     cf piece inspect --piece ${pieceConfig.piece} ...`));
   })
@@ -889,7 +909,9 @@ JSON VALUES: Strings need quotes: echo '"hello"' | cf piece set ...`),
     const pieceId = await recreateSpaceRootPattern(spaceConfig);
     render(pieceId);
     hint(cliText(`NEXT STEPS:
-  → Open space in browser: ${spaceConfig.apiUrl}/${spaceConfig.space}/${pieceId}
+  → Open space in browser: ${
+      appRouteUrl(spaceConfig.apiUrl, spaceConfig.space, pieceId)
+    }
   → Inspect state:         cf piece inspect --piece ${pieceId} ...`));
   })
   /* piece set-home */

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/piece.ts";
 import { SlugResolutionError } from "@commonfabric/piece";
 import {
+  appRouteUrl,
   parseLink,
   parsePieceOptions,
   parseSpaceOptions,
@@ -23,6 +24,48 @@ const FULL_URL = `${API_URL}/${SPACE}/${PIECE}`;
 const NO_PIECE_FULL_URL = `${API_URL}/${SPACE}`;
 
 describe("cli piece parsing", () => {
+  it("builds app route URLs without duplicate slashes", () => {
+    expect(appRouteUrl(
+      "https://rapids.saga-castor.ts.net/",
+      "team-lunch",
+      "fid1:abc",
+    )).toBe("https://rapids.saga-castor.ts.net/team-lunch/fid1:abc");
+    expect(appRouteUrl(
+      "https://rapids.saga-castor.ts.net/base/",
+      "/team-lunch/",
+      "/fid1:abc",
+    )).toBe("https://rapids.saga-castor.ts.net/base/team-lunch/fid1:abc");
+    expect(appRouteUrl(
+      "https://rapids.saga-castor.ts.net/base",
+      "team-lunch",
+      "fid1:abc",
+    )).toBe("https://rapids.saga-castor.ts.net/base/team-lunch/fid1:abc");
+    expect(appRouteUrl(
+      "https://rapids.saga-castor.ts.net/?debug=true#top",
+      "team-lunch",
+      "fid1:abc",
+    )).toBe("https://rapids.saga-castor.ts.net/team-lunch/fid1:abc");
+    expect(appRouteUrl(
+      "https://rapids.saga-castor.ts.net/",
+      "did:key:z6MkTest",
+      "fid1:abc",
+    )).toBe("https://rapids.saga-castor.ts.net/did:key:z6MkTest/fid1:abc");
+    expect(appRouteUrl(
+      "https://rapids.saga-castor.ts.net/base/",
+      "fid1:abc",
+    )).toBe("https://rapids.saga-castor.ts.net/base/fid1:abc");
+    expect(appRouteUrl(
+      "https://rapids.saga-castor.ts.net//base",
+      "team-lunch",
+      "fid1:abc",
+    )).toBe("https://rapids.saga-castor.ts.net/base/team-lunch/fid1:abc");
+    expect(appRouteUrl(
+      "https://rapids.saga-castor.ts.net//",
+      "team-lunch",
+      "fid1:abc",
+    )).toBe("https://rapids.saga-castor.ts.net/team-lunch/fid1:abc");
+  });
+
   it("force-closes loadManager storage before disposing failed runtime", async () => {
     let disposeCalls = 0;
     let closeNowCalls = 0;

--- a/packages/cli/test/piece.test.ts
+++ b/packages/cli/test/piece.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../lib/piece.ts";
 import { SlugResolutionError } from "@commonfabric/piece";
 import {
-  appRouteUrl,
+  normalizeApiUrl,
   parseLink,
   parsePieceOptions,
   parseSpaceOptions,
@@ -24,46 +24,31 @@ const FULL_URL = `${API_URL}/${SPACE}/${PIECE}`;
 const NO_PIECE_FULL_URL = `${API_URL}/${SPACE}`;
 
 describe("cli piece parsing", () => {
-  it("builds app route URLs without duplicate slashes", () => {
-    expect(appRouteUrl(
+  it("normalizes API URLs for app route hints", () => {
+    expect(normalizeApiUrl(
       "https://rapids.saga-castor.ts.net/",
-      "team-lunch",
-      "fid1:abc",
-    )).toBe("https://rapids.saga-castor.ts.net/team-lunch/fid1:abc");
-    expect(appRouteUrl(
+    )).toBe("https://rapids.saga-castor.ts.net");
+    expect(normalizeApiUrl(
       "https://rapids.saga-castor.ts.net/base/",
-      "/team-lunch/",
-      "/fid1:abc",
-    )).toBe("https://rapids.saga-castor.ts.net/base/team-lunch/fid1:abc");
-    expect(appRouteUrl(
+    )).toBe("https://rapids.saga-castor.ts.net/base");
+    expect(normalizeApiUrl(
       "https://rapids.saga-castor.ts.net/base",
-      "team-lunch",
-      "fid1:abc",
-    )).toBe("https://rapids.saga-castor.ts.net/base/team-lunch/fid1:abc");
-    expect(appRouteUrl(
+    )).toBe("https://rapids.saga-castor.ts.net/base");
+    expect(normalizeApiUrl(
       "https://rapids.saga-castor.ts.net/?debug=true#top",
-      "team-lunch",
-      "fid1:abc",
-    )).toBe("https://rapids.saga-castor.ts.net/team-lunch/fid1:abc");
-    expect(appRouteUrl(
-      "https://rapids.saga-castor.ts.net/",
-      "did:key:z6MkTest",
-      "fid1:abc",
-    )).toBe("https://rapids.saga-castor.ts.net/did:key:z6MkTest/fid1:abc");
-    expect(appRouteUrl(
-      "https://rapids.saga-castor.ts.net/base/",
-      "fid1:abc",
-    )).toBe("https://rapids.saga-castor.ts.net/base/fid1:abc");
-    expect(appRouteUrl(
+    )).toBe("https://rapids.saga-castor.ts.net");
+    expect(normalizeApiUrl(
       "https://rapids.saga-castor.ts.net//base",
-      "team-lunch",
-      "fid1:abc",
-    )).toBe("https://rapids.saga-castor.ts.net/base/team-lunch/fid1:abc");
-    expect(appRouteUrl(
+    )).toBe("https://rapids.saga-castor.ts.net/base");
+    expect(normalizeApiUrl(
       "https://rapids.saga-castor.ts.net//",
-      "team-lunch",
-      "fid1:abc",
-    )).toBe("https://rapids.saga-castor.ts.net/team-lunch/fid1:abc");
+    )).toBe("https://rapids.saga-castor.ts.net");
+    expect(normalizeApiUrl(
+      "https://user:pass@rapids.saga-castor.ts.net/",
+    )).toBe("https://user:pass@rapids.saga-castor.ts.net");
+    expect(normalizeApiUrl(
+      "https://user:pass@rapids.saga-castor.ts.net/base/",
+    )).toBe("https://user:pass@rapids.saga-castor.ts.net/base");
   });
 
   it("force-closes loadManager storage before disposing failed runtime", async () => {
@@ -134,6 +119,15 @@ describe("cli piece parsing", () => {
       space: SPACE,
       identity: ID,
     })).toMatchObject(expected);
+    const trailingApiUrl = parseSpaceOptions({
+      apiUrl: `${API_URL}/`,
+      space: SPACE,
+      identity: ID,
+    });
+    expect(trailingApiUrl).toMatchObject(expected);
+    expect(`${trailingApiUrl.apiUrl}/${trailingApiUrl.space}/${PIECE}`).toBe(
+      FULL_URL,
+    );
     expect(parseSpaceOptions({
       url: FULL_URL,
       identity: ID,


### PR DESCRIPTION
The piece CLI prints browser links after commands such as piece new, setsrc, set-slug, and recreate-root. Those links were assembled by directly inserting slashes between the configured API URL and route segments. When a user supplied an API URL with a trailing slash, the hint contained a doubled slash before the space name. The shell parses that path as empty, so the link can open the home view instead of the deployed piece.

Add a shared app-route URL builder for those CLI hints. The helper parses the API URL with the URL constructor, clones the parsed URL for the route base, normalizes the parsed pathname on the URL object, clears search and hash data, and creates the final app route with the URL constructor. This keeps the host anchored, avoids doubled route separators, and prevents colon-bearing route segments such as DIDs or piece IDs from being treated as URL schemes.

Update the affected hints to use the helper. Add coverage for trailing slashes, path-prefixed API URLs, query and hash input, DID spaces, piece IDs in the first appended segment, and repeated slashes in the parsed base path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI browser links by normalizing the configured `apiUrl` during option parsing and composing routes safely. Prevents double slashes and bad parsing so links open the correct view.

- **Bug Fixes**
  - Centralized API URL cleanup in `parseSpaceOptions` via `normalizeApiUrl`: removes trailing slashes, collapses repeated “/”, strips query/fragment, and preserves host and credentials.
  - CLI hints in `piece new`, `setsrc`, `set-slug`, and `recreate-root` now rely on the normalized `apiUrl`; tests cover root and path-prefixed URLs, repeated slashes, query/fragment, credentials, and full route strings after parsing a trailing-slash URL.

<sup>Written for commit c320f47d6a9af2bfa342cf8c0ff7f3b7e92152cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

