### PR TITLE
Reject cell-like casts in the transformer

### DIFF
--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -207,7 +207,7 @@ Validates `as` and angle-bracket assertions:
   - parenthesized/mixed equivalents
 - **Error** `cast-validation:forbidden-cast`
   - casts to `OpaqueRef<...>`
-- **Warning** `cast-validation:cell-cast`
+- **Error** `cast-validation:cell-cast`
   - casts to cell-like types: `Cell`, `OpaqueCell`, `Stream`, `ComparableCell`,
     `ReadonlyCell`, `WriteonlyCell`, `Writable`, `CellTypeConstructor`
 

--- a/packages/generated-patterns/integration/patterns/counter-aggregate.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/counter-aggregate.pattern.ts
@@ -11,7 +11,7 @@ const adjustCounter = handler(
   ) => {
     const index = event?.index ?? 0;
     const amount = typeof event?.amount === "number" ? event.amount : 1;
-    const target = context.counters.key(index) as Cell<number>;
+    const target: Cell<number> = context.counters.key(index);
     const current = target.get() ?? 0;
     target.set(current + amount);
   },

--- a/packages/generated-patterns/integration/patterns/counter-aggregator.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/counter-aggregator.pattern.ts
@@ -53,9 +53,10 @@ const adjustCounter = handler(
       return;
     }
 
-    const entryCell = context.counters.key(index) as Cell<CounterEntry>;
-    const valueCell = entryCell.key("value") as Cell<number>;
-    const current = typeof valueCell.get() === "number" ? valueCell.get() : 0;
+    const entryCell: Cell<CounterEntry> = context.counters.key(index);
+    const valueCell: Cell<number | undefined> = entryCell.key("value");
+    const value = valueCell.get();
+    const current = typeof value === "number" ? value : 0;
     const delta = typeof event.delta === "number" ? event.delta : 0;
     const nextValue = typeof event.set === "number"
       ? event.set

--- a/packages/generated-patterns/integration/patterns/counter-dynamic-handler-list.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/counter-dynamic-handler-list.pattern.ts
@@ -65,7 +65,7 @@ const adjustValue = handler(
     }
 
     const amount = toInteger(event?.amount, 1);
-    const target = context.values.key(requested) as Cell<number>;
+    const target: Cell<number> = context.values.key(requested);
     const current = toInteger(target.get(), 0);
     const nextValue = current + amount;
     target.set(nextValue);

--- a/packages/generated-patterns/integration/patterns/counter-hierarchical-key-path.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/counter-hierarchical-key-path.pattern.ts
@@ -114,16 +114,14 @@ const updateHierarchicalCounter = handler(
     const path = normalizePath(event?.path);
     const amount = typeof event?.amount === "number" ? event.amount : 1;
 
-    let current: Cell<unknown> = context.hierarchy as Cell<unknown>;
+    let current: Cell<any> = context.hierarchy;
     const recordedPath: string[] = [];
     for (const key of path) {
-      current = (current as Cell<Record<PropertyKey, unknown>>).key(
-        key as never,
-      );
+      current = current.key(key as never);
       recordedPath.push(String(key));
     }
 
-    const leaf = current as Cell<number>;
+    const leaf: Cell<number> = current;
     const base = toNumber(leaf.get());
     leaf.set(base + amount);
 

--- a/packages/generated-patterns/integration/patterns/counter-keyed-map.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/counter-keyed-map.pattern.ts
@@ -11,7 +11,7 @@ const adjustKeyedCounter = handler(
   ) => {
     const key = typeof event?.key === "string" ? event.key : "default";
     const amount = typeof event?.amount === "number" ? event.amount : 1;
-    const entry = context.counters.key(key) as Cell<number>;
+    const entry: Cell<number> = context.counters.key(key);
     const current = entry.get() ?? 0;
     entry.set(current + amount);
   },

--- a/packages/generated-patterns/integration/patterns/counter-matrix-state.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/counter-matrix-state.pattern.ts
@@ -125,8 +125,8 @@ const setCellValue = handler(
       return;
     }
 
-    const rowCell = context.matrix.key(row) as Cell<number[]>;
-    const cell = rowCell.key(column) as Cell<number>;
+    const rowCell: Cell<number[]> = context.matrix.key(row);
+    const cell: Cell<number> = rowCell.key(column);
     cell.set(value);
   },
 );
@@ -151,7 +151,7 @@ const setRowValues = handler(
     }
 
     const existingRow = matrixValue[rowIndex];
-    const rowCell = context.matrix.key(rowIndex) as Cell<number[]>;
+    const rowCell: Cell<number[]> = context.matrix.key(rowIndex);
     const targetLength = Array.isArray(existingRow) ? existingRow.length : 0;
     if (targetLength === 0) {
       return;
@@ -203,8 +203,8 @@ const setColumnValues = handler(
         return;
       }
 
-      const rowCell = context.matrix.key(rowIndex) as Cell<number[]>;
-      const cell = rowCell.key(columnIndex) as Cell<number>;
+      const rowCell: Cell<number[]> = context.matrix.key(rowIndex);
+      const cell: Cell<number> = rowCell.key(columnIndex);
       const candidate = valuesArray && valuesArray[rowIndex];
       if (typeof candidate === "number" && Number.isFinite(candidate)) {
         cell.set(candidate);

--- a/packages/generated-patterns/integration/patterns/counter-nested-array-objects.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/counter-nested-array-objects.pattern.ts
@@ -56,26 +56,26 @@ const updateNestedEntry = handler(
     if (!Array.isArray(groupsValue)) return;
     if (groupIndex < 0 || groupIndex >= groupsValue.length) return;
 
-    const groupCell = context.groups.key(groupIndex) as Cell<NestedGroup>;
-    const entriesCell = groupCell.key("entries") as Cell<NestedEntry[]>;
+    const groupCell: Cell<NestedGroup> = context.groups.key(groupIndex);
+    const entriesCell: Cell<NestedEntry[]> = groupCell.key("entries");
     const entriesValue = entriesCell.get();
     if (!Array.isArray(entriesValue)) return;
     if (entryIndex < 0 || entryIndex >= entriesValue.length) return;
 
-    const entryCell = entriesCell.key(entryIndex) as Cell<NestedEntry>;
-    const valueCell = entryCell.key("value") as Cell<number>;
+    const entryCell: Cell<NestedEntry> = entriesCell.key(entryIndex);
+    const valueCell: Cell<number> = entryCell.key("value");
     const currentValue = valueCell.get() ?? 0;
     const delta = typeof event.delta === "number" ? event.delta : 1;
     valueCell.set(currentValue + delta);
 
     if (typeof event.label === "string") {
-      const labelCell = entryCell.key("label") as Cell<string>;
+      const labelCell: Cell<string> = entryCell.key("label");
       labelCell.set(event.label);
     }
 
     if (typeof event.note === "string") {
-      const detailsCell = entryCell.key("details") as Cell<EntryDetails>;
-      const noteCell = detailsCell.key("note") as Cell<string>;
+      const detailsCell: Cell<EntryDetails> = entryCell.key("details");
+      const noteCell: Cell<string> = detailsCell.key("note");
       noteCell.set(event.note);
     }
   },
@@ -93,8 +93,8 @@ const appendNestedEntry = handler(
     const groupsArray = Array.isArray(groupsValue) ? groupsValue : [];
     if (groupIndex < 0 || groupIndex >= groupsArray.length) return;
 
-    const groupCell = context.groups.key(groupIndex) as Cell<NestedGroup>;
-    const entriesCell = groupCell.key("entries") as Cell<NestedEntry[]>;
+    const groupCell: Cell<NestedGroup> = context.groups.key(groupIndex);
+    const entriesCell: Cell<NestedEntry[]> = groupCell.key("entries");
     const entriesValue = entriesCell.get();
     const length = Array.isArray(entriesValue) ? entriesValue.length : 0;
 

--- a/packages/generated-patterns/integration/patterns/counter-nested-computed-percentages.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/counter-nested-computed-percentages.pattern.ts
@@ -106,9 +106,9 @@ const recordContribution = handler(
       return;
     }
 
-    const groupCell = context.groups.key(groupIndex) as Cell<
-      ContributionGroupSeed
-    >;
+    const groupCell: Cell<ContributionGroupSeed> = context.groups.key(
+      groupIndex,
+    );
     if (typeof event.groupLabel === "string") {
       groupCell.key("label").set(event.groupLabel.trim());
     }
@@ -117,7 +117,9 @@ const recordContribution = handler(
       return;
     }
 
-    const itemsCell = groupCell.key("items") as Cell<ContributionItemSeed[]>;
+    const itemsCell: Cell<ContributionItemSeed[] | undefined> = groupCell.key(
+      "items",
+    );
     const current = itemsCell.get();
     const items = Array.isArray(current) ? [...current] : [];
 

--- a/packages/generated-patterns/integration/patterns/counter-nested-computed-totals.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/counter-nested-computed-totals.pattern.ts
@@ -185,8 +185,8 @@ const appendToGroup = handler(
       return;
     }
 
-    const groupCell = context.groups.key(index) as Cell<SubtotalGroupSeed>;
-    const valuesCell = groupCell.key("values") as Cell<number[]>;
+    const groupCell: Cell<SubtotalGroupSeed> = context.groups.key(index);
+    const valuesCell: Cell<number[] | undefined> = groupCell.key("values");
     const current = sanitizeValues(valuesCell.get());
     const amount = sanitizeNumber(event.value);
     valuesCell.set([...current, amount]);

--- a/packages/generated-patterns/integration/patterns/counter-opaque-ref-map.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/counter-opaque-ref-map.pattern.ts
@@ -39,7 +39,7 @@ const rewriteHistoryEntry = handler(
     if (!Array.isArray(values)) return;
     if (targetIndex < 0 || targetIndex >= values.length) return;
 
-    const entryCell = context.history.key(targetIndex) as Cell<number>;
+    const entryCell: Cell<number> = context.history.key(targetIndex);
     entryCell.set(event.value);
   },
 );

--- a/packages/generated-patterns/integration/patterns/counter-parent-child-bubble.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/counter-parent-child-bubble.pattern.ts
@@ -25,8 +25,8 @@ type BubbleRecord = {
 };
 
 const asIncrementStream = (
-  ref: unknown,
-): Stream<{ amount?: number }> => ref as Stream<{ amount?: number }>;
+  ref: Stream<{ amount?: number }>,
+): Stream<{ amount?: number }> => ref;
 
 const sanitizeAmount = (value: unknown): number => {
   return typeof value === "number" && Number.isFinite(value) ? value : 1;

--- a/packages/generated-patterns/integration/patterns/counter-replicator.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/counter-replicator.pattern.ts
@@ -29,7 +29,7 @@ const adjustReplica = handler(
     if (requested < 0 || requested >= list.length) return;
 
     const amount = typeof event?.amount === "number" ? event.amount : 1;
-    const target = context.values.key(requested) as Cell<number>;
+    const target: Cell<number> = context.values.key(requested);
     const current = target.get() ?? 0;
     target.set(current + amount);
   },

--- a/packages/generated-patterns/integration/patterns/list-manager.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/list-manager.pattern.ts
@@ -38,7 +38,7 @@ const incrementItem = handler(
   ) => {
     const index = event?.index ?? 0;
     const amount = typeof event?.amount === "number" ? event.amount : 1;
-    const target = context.items.key(index) as Cell<Item>;
+    const target: Cell<Item> = context.items.key(index);
     const countCell = target.key("count");
     const current = countCell.get() ?? 0;
     countCell.set(current + amount);

--- a/packages/patterns/cfc-group-chat-demo/main.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.tsx
@@ -260,15 +260,15 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
     roomDraft,
   }: GroupChatDemoInput,
 ): GroupChatDemoOutput => {
-  const myProfileCell = myProfile as MyProfileCell;
-  const profilesCell = profiles as SharedProfilesCell;
-  const messagesCell = messages as SharedMessagesCell;
-  const roomsCell = rooms as SharedRoomsCell;
-  const adminRegistryCell = adminRegistry as ChatAdminRegistryCell;
-  const profileDraftCell = profileDraft as DraftCell;
-  const messageDraftCell = messageDraft as DraftCell;
-  const hostMessageDraftCell = hostMessageDraft as DraftCell;
-  const roomDraftCell = roomDraft as RoomDraftCell;
+  const myProfileCell: MyProfileCell = myProfile!;
+  const profilesCell: SharedProfilesCell = profiles!;
+  const messagesCell: SharedMessagesCell = messages!;
+  const roomsCell: SharedRoomsCell = rooms!;
+  const adminRegistryCell: ChatAdminRegistryCell = adminRegistry!;
+  const profileDraftCell: DraftCell = profileDraft!;
+  const messageDraftCell: DraftCell = messageDraft!;
+  const hostMessageDraftCell: DraftCell = hostMessageDraft!;
+  const roomDraftCell: RoomDraftCell = roomDraft!;
   const trustedProfileSave = TrustedProfileSaveSurface({
     myProfile: myProfileCell,
     profiles: profilesCell,

--- a/packages/patterns/cfc-group-chat-demo/multi-user.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/multi-user.test.tsx
@@ -22,8 +22,6 @@ import {
 import {
   messagesValue,
   profilesValue,
-  type SharedMessagesCell,
-  type SharedProfilesCell,
   TRUSTED_GROUP_CHAT_ADMIN_SURFACE,
   TRUSTED_GROUP_CHAT_PROFILE_SURFACE,
   TRUSTED_GROUP_CHAT_SAVE_PROFILE_ACTION,

--- a/packages/patterns/cfc-group-chat-demo/multi-user.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/multi-user.test.tsx
@@ -60,13 +60,13 @@ export const setup = pattern(() => ({
 }));
 
 const profileNames = (chat: GroupChatDemoOutput): string[] =>
-  profilesValue(chat.profiles as SharedProfilesCell)
+  profilesValue(chat.profiles)
     .map((profile) => profile.get()?.name ?? "")
     .filter((name) => name.length > 0)
     .toSorted();
 
 const messageBodies = (chat: GroupChatDemoOutput): string[] =>
-  messagesValue(chat.messages as SharedMessagesCell).map((m) => m.body);
+  messagesValue(chat.messages).map((m) => m.body);
 
 export const alice = pattern<{ setup: Setup }>(({ setup }) => {
   const chat = setup.chat;
@@ -135,9 +135,8 @@ export const bob = pattern<{ setup: Setup }>(({ setup }) => {
   });
 
   // PerUser draft: Alice's typing must never show up in Bob's runtime.
-  const assert_draft_empty = computed(() =>
-    ((chat.profileDraft as Writable<string | Default<"">>).get() ?? "") === ""
-  );
+  const profileDraft: Writable<string | Default<"">> = chat.profileDraft;
+  const assert_draft_empty = computed(() => (profileDraft.get() ?? "") === "");
   const assert_unnamed = computed(() =>
     chat.currentProfileName === "Name not set"
   );

--- a/packages/patterns/cfc-group-chat-demo/trusted.tsx
+++ b/packages/patterns/cfc-group-chat-demo/trusted.tsx
@@ -235,10 +235,13 @@ export const chatAdminRolesValue = (
   if (bootstrapAdmin === undefined) {
     return [];
   }
+  const subject: ProfileCell = adminRegistry.key("bootstrapAdmin").key(
+    "subject",
+  )
+    .resolveAsCell();
   return [{
     ...bootstrapAdmin,
-    subject: adminRegistry.key("bootstrapAdmin").key("subject")
-      .resolveAsCell() as ProfileCell,
+    subject,
   } as ChatAdminRole];
 };
 

--- a/packages/patterns/cfc/prompt-injection/prompt.test.ts
+++ b/packages/patterns/cfc/prompt-injection/prompt.test.ts
@@ -35,3 +35,11 @@ Deno.test("parseResultSchemaInput fails closed for malformed schema strings", ()
     type: "object",
   });
 });
+
+Deno.test("parseResultSchemaInput accepts direct schemas and rejects other values", () => {
+  const schema = { type: "object", properties: {} } as const;
+  assertEquals(parseResultSchemaInput(true), true);
+  assertEquals(parseResultSchemaInput(schema), schema);
+  assertEquals(parseResultSchemaInput(["not-a-schema-object"]), false);
+  assertEquals(parseResultSchemaInput(null), false);
+});

--- a/packages/patterns/experimental/email-task-engine.tsx
+++ b/packages/patterns/experimental/email-task-engine.tsx
@@ -20,11 +20,11 @@
 import {
   computed,
   Default,
-  type FactoryInput,
   generateObject,
   handler,
   NAME,
   pattern,
+  schema,
   Stream,
   TILE_UI,
   UI,
@@ -385,7 +385,7 @@ const dismissTask = handler<
 // =============================================================================
 
 // Simpler flat schema that works better with the framework's type system
-const SUGGESTION_SCHEMA = {
+const SUGGESTION_SCHEMA = schema({
   type: "object" as const,
   description:
     "Suggested action for this email. Use actionType to indicate what kind of action.",
@@ -430,7 +430,7 @@ const SUGGESTION_SCHEMA = {
     },
   },
   required: ["actionType", "confidence"],
-};
+});
 
 // =============================================================================
 // PATTERN
@@ -547,18 +547,17 @@ export default pattern<PatternInput, PatternOutput>(({ overrideAuth }) => {
 
   // Analyze each task email with LLM
   const analyses = taskEmails.map((email: TaskEmail) => {
-    const prompt = computed(() => {
-      if (!email?.subject) return undefined;
+    const llmAnalysis = generateObject<SuggestionResult>({
+      prompt: computed(() => {
+        // Build notes context directly from availableNotes
+        const notes = availableNotes || [];
+        const notesContext = notes.length === 0
+          ? "No existing notes found."
+          : notes.map((n: { title: string; contentPreview: string }) =>
+            `- "${n.title}": ${n.contentPreview}`
+          ).join("\n");
 
-      // Build notes context directly from availableNotes
-      const notes = availableNotes || [];
-      const notesContext = notes.length === 0
-        ? "No existing notes found."
-        : notes.map((n: { title: string; contentPreview: string }) =>
-          `- "${n.title}": ${n.contentPreview}`
-        ).join("\n");
-
-      return `You are analyzing an email to suggest an action. The email has been labeled "task-current" indicating the user wants to take action on it.
+        return `You are analyzing an email to suggest an action. The email has been labeled "task-current" indicating the user wants to take action on it.
 
 AVAILABLE NOTES:
 ${notesContext}
@@ -583,10 +582,7 @@ Consider:
 - Use low confidence (<0.5) when unsure
 
 Respond with the most appropriate action.`;
-    });
-
-    const llmAnalysis = generateObject<SuggestionResult>({
-      prompt: prompt as FactoryInput<string>,
+      }),
       schema: SUGGESTION_SCHEMA,
       model: "anthropic:claude-sonnet-4-5",
     });

--- a/packages/patterns/experimental/folksonomy-tags.tsx
+++ b/packages/patterns/experimental/folksonomy-tags.tsx
@@ -293,7 +293,7 @@ export const FolksonomyTags = pattern<
     const aggregator = injectedAggregator ?? aggregatorWish.result ?? null;
 
     // Get the aggregator's postEvent stream for telemetry
-    const aggregatorStream = (aggregator?.postEvent as Stream<TagEvent>) ??
+    const aggregatorStream: Stream<TagEvent> | null = aggregator?.postEvent ??
       null;
 
     // Track previous tags for change detection

--- a/packages/patterns/factory-outputs/lot-watch/main.tsx
+++ b/packages/patterns/factory-outputs/lot-watch/main.tsx
@@ -475,8 +475,8 @@ export default pattern<LotWatchInput, LotWatchOutput>(
     >(
       {} as LotWatchAdminRegistryValue,
     );
-    const adminRegistry =
-      (inputAdminRegistry ?? defaultAdminRegistry) as LotWatchAdminRegistryCell;
+    const adminRegistry: LotWatchAdminRegistryCell = inputAdminRegistry ??
+      defaultAdminRegistry;
     const adminManagerCredential = new Writable.perUser<
       LotWatchAdminManagerCredential | null
     >(null);

--- a/packages/patterns/factory-outputs/parking-coordinator/main.tsx
+++ b/packages/patterns/factory-outputs/parking-coordinator/main.tsx
@@ -425,8 +425,8 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
     >(
       {} as ParkingAdminRegistryValue,
     );
-    const adminRegistry =
-      (inputAdminRegistry ?? defaultAdminRegistry) as ParkingAdminRegistryCell;
+    const adminRegistry: ParkingAdminRegistryCell = inputAdminRegistry ??
+      defaultAdminRegistry;
     const adminManagerCredential = new Writable.perUser<
       ParkingAdminManagerCredential | null
     >(null);

--- a/packages/patterns/google/WIP/google-docs-importer.tsx
+++ b/packages/patterns/google/WIP/google-docs-importer.tsx
@@ -24,6 +24,7 @@ import {
 
 // Import Google Docs client
 import {
+  type Auth,
   extractFileId,
   type GoogleComment,
   GoogleDocsClient,
@@ -81,7 +82,7 @@ const importDocument = handler<
   unknown,
   {
     docUrl: Cell<string>;
-    auth: Cell<unknown>;
+    auth: Cell<Auth>;
     markdown: Cell<string>;
     docTitle: Cell<string>;
     isFetching: Cell<boolean>;
@@ -115,7 +116,7 @@ const importDocument = handler<
       return;
     }
 
-    const authData = auth.get() as { token?: string } | null;
+    const authData = auth.get();
     const token = authData?.token;
     if (!token) {
       lastError.set("Please authenticate with Google first");
@@ -127,7 +128,7 @@ const importDocument = handler<
 
     try {
       // Create client with auth Cell for automatic token refresh
-      const client = new GoogleDocsClient(auth as Cell<any>, {
+      const client = new GoogleDocsClient(auth, {
         debugMode: true,
       });
 

--- a/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
+++ b/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
@@ -2341,9 +2341,7 @@ Be conservative: when in doubt, recommend "do_not_share".`,
         recommendation: "share" | "share_with_edits" | "do_not_share";
       };
 
-      const pendingWritable = pendingSubmissions as Writable<
-        PendingSubmission[]
-      >;
+      const pendingWritable: Writable<PendingSubmission[]> = pendingSubmissions;
       const submissions = (pendingWritable.get() || []).filter((
         s: PendingSubmission | null,
       ): s is PendingSubmission => s != null);
@@ -2363,18 +2361,24 @@ Be conservative: when in doubt, recommend "do_not_share".`,
 
       // Update the submission with screening results using .key().key().set()
       const itemCell = pendingWritable.key(idx);
-      (itemCell.key("sanitizedQuery") as Writable<string>).set(
+      const sanitizedQueryCell: Writable<string> = itemCell.key(
+        "sanitizedQuery",
+      );
+      const piiWarningsCell: Writable<string[]> = itemCell.key("piiWarnings");
+      const generalizabilityIssuesCell: Writable<string[]> = itemCell.key(
+        "generalizabilityIssues",
+      );
+      const recommendationCell: Writable<
+        "share" | "share_with_edits" | "do_not_share" | "pending"
+      > = itemCell.key("recommendation");
+      sanitizedQueryCell.set(
         screeningData.sanitizedQuery || submission.originalQuery,
       );
-      (itemCell.key("piiWarnings") as Writable<string[]>).set(
-        screeningData.piiFound || [],
-      );
-      (itemCell.key("generalizabilityIssues") as Writable<string[]>).set(
+      piiWarningsCell.set(screeningData.piiFound || []);
+      generalizabilityIssuesCell.set(
         screeningData.generalizabilityIssues || [],
       );
-      (itemCell.key("recommendation") as Writable<
-        "share" | "share_with_edits" | "do_not_share" | "pending"
-      >).set(screeningData.recommendation);
+      recommendationCell.set(screeningData.recommendation);
     });
 
     // Note: approvePendingSubmissionHandler, rejectPendingSubmissionHandler, updateSanitizedQueryHandler
@@ -2568,18 +2572,19 @@ Be conservative: when in doubt, recommend "do_not_share".`,
                             value={submission.sanitizedQuery}
                             onChange={(e: any) => {
                               const newValue = e.target.value;
-                              const pendingWritable =
-                                pendingSubmissions as Writable<
-                                  PendingSubmission[]
-                                >;
+                              const pendingWritable: Writable<
+                                PendingSubmission[]
+                              > = pendingSubmissions;
                               const subs = pendingWritable.get() || [];
                               const idx = subs.findIndex((
                                 s: PendingSubmission,
                               ) => s.localQueryId === submission.localQueryId);
                               if (idx >= 0) {
-                                (pendingWritable.key(idx).key(
-                                  "sanitizedQuery",
-                                ) as Writable<string>).set(newValue);
+                                const sanitizedQueryCell: Writable<string> =
+                                  pendingWritable.key(idx).key(
+                                    "sanitizedQuery",
+                                  );
+                                sanitizedQueryCell.set(newValue);
                               }
                             }}
                             style={{
@@ -2604,13 +2609,12 @@ Be conservative: when in doubt, recommend "do_not_share".`,
                           <cf-button
                             onClick={() => {
                               // Reject
-                              const pendingWritable =
-                                pendingSubmissions as Writable<
-                                  PendingSubmission[]
-                                >;
-                              const localWritable = localQueries as Writable<
+                              const pendingWritable: Writable<
+                                PendingSubmission[]
+                              > = pendingSubmissions;
+                              const localWritable: Writable<
                                 LocalQuery[]
-                              >;
+                              > = localQueries;
                               const subs = pendingWritable.get() || [];
                               pendingWritable.set(
                                 subs.filter((s: PendingSubmission) =>
@@ -2623,11 +2627,12 @@ Be conservative: when in doubt, recommend "do_not_share".`,
                                 q: LocalQuery,
                               ) => q.id === submission.localQueryId);
                               if (idx >= 0) {
-                                (localWritable.key(idx).key(
-                                  "shareStatus",
-                                ) as Writable<
+                                const shareStatusCell: Writable<
                                   "private" | "pending_review" | "submitted"
-                                >).set("private");
+                                > = localWritable.key(idx).key(
+                                  "shareStatus",
+                                );
+                                shareStatusCell.set("private");
                               }
                             }}
                             variant="ghost"
@@ -2639,18 +2644,19 @@ Be conservative: when in doubt, recommend "do_not_share".`,
                           <cf-button
                             onClick={() => {
                               // Approve
-                              const pendingWritable =
-                                pendingSubmissions as Writable<
-                                  PendingSubmission[]
-                                >;
+                              const pendingWritable: Writable<
+                                PendingSubmission[]
+                              > = pendingSubmissions;
                               const subs = pendingWritable.get() || [];
                               const idx = subs.findIndex((
                                 s: PendingSubmission,
                               ) => s.localQueryId === submission.localQueryId);
                               if (idx >= 0) {
-                                (pendingWritable.key(idx).key(
-                                  "userApproved",
-                                ) as Writable<boolean>).set(true);
+                                const userApprovedCell: Writable<boolean> =
+                                  pendingWritable.key(idx).key(
+                                    "userApproved",
+                                  );
+                                userApprovedCell.set(true);
                               }
                             }}
                             variant={submission.userApproved
@@ -2699,13 +2705,12 @@ Be conservative: when in doubt, recommend "do_not_share".`,
                                 );
                                 const submitHandler = registry?.result
                                   ?.submitQuery;
-                                const pendingWritable =
-                                  pendingSubmissions as Writable<
-                                    PendingSubmission[]
-                                  >;
-                                const localWritable = localQueries as Writable<
+                                const pendingWritable: Writable<
+                                  PendingSubmission[]
+                                > = pendingSubmissions;
+                                const localWritable: Writable<
                                   LocalQuery[]
-                                >;
+                                > = localQueries;
 
                                 // Submit each approved query
                                 approved.forEach(
@@ -2727,10 +2732,12 @@ Be conservative: when in doubt, recommend "do_not_share".`,
                                         submission.localQueryId
                                     );
                                     if (idx >= 0) {
-                                      (pendingWritable.key(idx).key(
+                                      const submittedAtCell: Writable<
+                                        number | undefined
+                                      > = pendingWritable.key(idx).key(
                                         "submittedAt",
-                                      ) as Writable<number | undefined>)
-                                        .set(safeDateNow());
+                                      );
+                                      submittedAtCell.set(safeDateNow());
                                     }
 
                                     // Update local query status to submitted
@@ -2740,13 +2747,14 @@ Be conservative: when in doubt, recommend "do_not_share".`,
                                       q: LocalQuery,
                                     ) => q.id === submission.localQueryId);
                                     if (qIdx >= 0) {
-                                      (localWritable.key(qIdx).key(
-                                        "shareStatus",
-                                      ) as Writable<
+                                      const shareStatusCell: Writable<
                                         | "private"
                                         | "pending_review"
                                         | "submitted"
-                                      >).set("submitted");
+                                      > = localWritable.key(qIdx).key(
+                                        "shareStatus",
+                                      );
+                                      shareStatusCell.set("submitted");
                                     }
                                   },
                                 );

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -170,7 +170,7 @@ const handlers: Record<
     await target.pull();
     let cell = target;
     for (const segment of (path ?? []) as (string | number)[]) {
-      cell = cell.key(segment as never) as Cell<any>;
+      cell = cell.key(segment as never);
     }
     return sanitizeForTransfer(cell.get());
   },
@@ -185,7 +185,7 @@ const handlers: Record<
     await target.pull();
     let cell = target;
     for (const segment of (path ?? []) as (string | number)[]) {
-      cell = cell.key(segment as never) as Cell<any>;
+      cell = cell.key(segment as never);
     }
     const resolved = cell.resolveAsCell();
     const link = resolved.getAsNormalizedFullLink();

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -225,7 +225,8 @@ const voteKey = (voterName: string, optionId: string): string =>
 // would then see that stale content and treat the absent vote as present.
 // Removing a vote always pairs the link removal with this clear.
 const clearVoteEntity = (votes: VotesCell, key: string): void => {
-  (votes.elementById(key) as Writable<Vote | undefined>).set(undefined);
+  const vote: Writable<Vote | undefined> = votes.elementById(key);
+  vote.set(undefined);
 };
 
 const getInitials = (name: string): string => {

--- a/packages/patterns/notes/notebook.tsx
+++ b/packages/patterns/notes/notebook.tsx
@@ -333,7 +333,8 @@ const addSelectedToNotebook = handler<
   const selected = selectedNoteIndices.get();
   const notesList = notes.get();
   const targetNotebookCell = notebooks.key(nbIndex);
-  const targetNotebookNotes = targetNotebookCell.key("notes");
+  const targetNotebookNotes: Writable<NotePiece[] | undefined> =
+    targetNotebookCell.key("notes");
 
   // Collect notes first, then batch push (reduces N reactive cycles to 1)
   const notesToAdd: NotePiece[] = [];
@@ -341,9 +342,7 @@ const addSelectedToNotebook = handler<
     const note = notesList[idx];
     if (note) notesToAdd.push(note);
   }
-  (targetNotebookNotes as Writable<NotePiece[] | undefined>).push(
-    ...notesToAdd,
-  );
+  targetNotebookNotes.push(...notesToAdd);
 
   selectedNoteIndices.set([]);
   selectedAddNotebook.set("");

--- a/packages/patterns/record/extraction/extractor-module.tsx
+++ b/packages/patterns/record/extraction/extractor-module.tsx
@@ -1071,9 +1071,7 @@ const startExtraction = handler<
       if (source.type === "notes") {
         // Access piece content via .get() first to resolve links, then access properties
         // Cell.key() navigation doesn't work through link boundaries - piece is stored as a link
-        const entry = (parentSubPiecesCell as Writable<SubPieceEntry[]>)
-          .key(source.index)
-          .get();
+        const entry = parentSubPiecesCell.key(source.index).get();
         const piece = entry?.piece as Record<string, unknown>;
         const liveContent = getCellValue<unknown>(piece?.content);
         const content = typeof liveContent === "string" ? liveContent : "";
@@ -1133,9 +1131,8 @@ function applyFieldToModule(
 
   try {
     // Only write if validation passed
-    // Cast needed: Cell.key() navigation loses type info for dynamic nested paths
-    // Use actualFieldName to write to the correct field (handles aliases)
-    (parentSubPiecesCell as Writable<SubPieceEntry[]>)
+    // Use actualFieldName to write to the correct field.
+    parentSubPiecesCell
       .key(existingIndex)
       .key("piece")
       .key(actualFieldName)
@@ -1296,8 +1293,7 @@ function applyNotesCleanup(params: NotesCleanupParams): boolean {
     // Approach 2: Fallback to Cell key navigation
     if (!thisCleanupSucceeded) {
       try {
-        // Cast needed: Writable.key() navigation loses type info for dynamic nested paths
-        (parentSubPiecesCell as Writable<SubPieceEntry[]>)
+        parentSubPiecesCell
           .key(notesIndex)
           .key("piece")
           .key("content")

--- a/packages/patterns/system/backlinks-index.tsx
+++ b/packages/patterns/system/backlinks-index.tsx
@@ -156,14 +156,14 @@ const EntryRow = pattern<Entry, { [UI]: VNode }>(({ piece, backlinks }) => {
 });
 
 const BacklinksIndex = pattern<Input, Output>(({ allPieces }) => {
-  const allPieceCells = allPieces as MentionableCell[];
+  const allPieceCells: MentionableCell[] = allPieces;
 
   computeIndex({ allPieces: allPieceCells });
 
   // Compute mentionable list from allPieces reactively
-  const mentionable = computeMentionable({
+  const mentionable: MentionableCell[] = computeMentionable({
     allPieces: allPieceCells,
-  }) as MentionableCell[];
+  });
 
   const query = new Writable("");
 

--- a/packages/patterns/system/home-ben.tsx
+++ b/packages/patterns/system/home-ben.tsx
@@ -49,7 +49,7 @@ type SpaceEntry = {
  * Uses schema to properly resolve nested cell references.
  */
 function captureSnapshot(
-  cell: Writable<{ [NAME]?: string }>,
+  cell: Writable<unknown>,
   schemaTag?: string,
 ): JournalSnapshot {
   let name = "";
@@ -58,7 +58,8 @@ function captureSnapshot(
   try {
     const value = cell.get();
     if (value && typeof value === "object" && NAME in value) {
-      name = value[NAME] || "";
+      const valueName = value[NAME];
+      name = typeof valueName === "string" ? valueName : "";
     }
   } catch {
     // Ignore errors - name is optional
@@ -134,10 +135,7 @@ const removeFavorite = handler<
     const hashTags = (favorite.tags ?? []).map((t) => `#${t}`);
 
     // Capture snapshot before removing
-    const snapshot = captureSnapshot(
-      piece as Writable<{ [NAME]?: string }>,
-      hashTags.join(" "),
-    );
+    const snapshot = captureSnapshot(piece, hashTags.join(" "));
 
     favorites.remove(favorite);
 
@@ -145,7 +143,7 @@ const removeFavorite = handler<
     journal.push({
       timestamp: safeDateNow(),
       eventType: "piece:unfavorited",
-      subject: piece as any,
+      subject: piece,
       snapshot,
       narrative: "",
       narrativePending: true,

--- a/packages/patterns/system/knowledge-graph.tsx
+++ b/packages/patterns/system/knowledge-graph.tsx
@@ -183,12 +183,14 @@ const KnowledgeGraph = pattern<Input>(() => {
       if (!piece) continue;
       const pieceName = (piece.get()[NAME] ?? "").toString();
       const mentioned = piece.key("mentioned").get() ?? [];
-      for (const mentionedItem of mentioned) {
+      for (let index = 0; index < mentioned.length; index++) {
+        const mentionedItem = mentioned[index];
         if (!mentionedItem) continue;
+        const mentionedCell = piece.key("mentioned").key(index);
         const mentionedName = (mentionedItem[NAME] ?? "").toString();
         result.push({
           from: piece,
-          to: mentionedItem as Writable<MentionablePiece>,
+          to: mentionedCell,
           fromName: pieceName,
           toName: mentionedName,
           description: "mentions",
@@ -293,12 +295,10 @@ Use exact piece names from the piece list above for fromName/toName/pieceNames.`
     return groups.map(
       (group: { name: string; pieceNames: string[]; summary: string }) => ({
         [NAME]: group.name,
-        linkedPieces: (group.pieceNames ?? [])
-          .map((name: string) =>
-            entryList.find((e: any) => e.name === name)
-              ?.piece
-          )
-          .filter(Boolean) as Writable<MentionablePiece>[],
+        linkedPieces: (group.pieceNames ?? []).flatMap((name: string) => {
+          const piece = entryList.find((e: any) => e.name === name)?.piece;
+          return piece ? [piece] : [];
+        }),
         summary: group.summary,
       }),
     );

--- a/packages/runner/test/security.test.ts
+++ b/packages/runner/test/security.test.ts
@@ -255,7 +255,7 @@ describe("SES security regressions", () => {
             "    event: { amount?: number } | undefined,",
             "    context: { values: Cell<number[]> },",
             "  ) => {",
-            "    const target = context.values.key(0) as Cell<number>;",
+            "    const target: Cell<number> = context.values.key(0);",
             "    target.set(toInteger(target.get()) + toInteger(event?.amount));",
             "  },",
             ");",

--- a/packages/ts-transformers/src/core/common-fabric-symbols.ts
+++ b/packages/ts-transformers/src/core/common-fabric-symbols.ts
@@ -1,23 +1,66 @@
 import ts from "typescript";
 
-// Constant for identifying Common Fabric declarations
 const COMMONFABRIC_DECLARATION = "commonfabric.d.ts";
+const COMMONFABRIC_MODULE_NAME = "commonfabric";
+const COMMONFABRIC_PACKAGE_PREFIX = "@commonfabric/";
+
+export function isCommonFabricModuleName(moduleName: string): boolean {
+  return moduleName === COMMONFABRIC_MODULE_NAME ||
+    moduleName.startsWith(COMMONFABRIC_PACKAGE_PREFIX);
+}
+
+export function getImportTypeModuleName(
+  typeNode: ts.ImportTypeNode,
+): string | undefined {
+  const argument = typeNode.argument;
+  if (!ts.isLiteralTypeNode(argument)) return undefined;
+  return ts.isStringLiteral(argument.literal)
+    ? argument.literal.text
+    : undefined;
+}
+
+export function isCommonFabricDeclaration(
+  declaration: ts.Declaration,
+): boolean {
+  if (
+    isCommonFabricDeclarationSourceFile(
+      declaration.getSourceFile().fileName,
+    )
+  ) {
+    return true;
+  }
+
+  let current: ts.Node | undefined = declaration;
+  while (current) {
+    if (
+      ts.isModuleDeclaration(current) &&
+      ts.isStringLiteral(current.name) &&
+      isCommonFabricModuleName(current.name.text)
+    ) {
+      return true;
+    }
+    current = current.parent;
+  }
+
+  return false;
+}
+
+function isCommonFabricDeclarationSourceFile(fileName: string): boolean {
+  const normalized = fileName.replace(/\\/g, "/");
+  return normalized === COMMONFABRIC_DECLARATION ||
+    normalized.endsWith(`/${COMMONFABRIC_DECLARATION}`) ||
+    normalized.endsWith("/packages/api/index.ts") ||
+    normalized.includes("/@commonfabric/api/") ||
+    normalized.includes("/packages/runner/src/");
+}
 
 /**
- * Checks if a declaration comes from the Common Fabric library
+ * Checks if a symbol comes from the Common Fabric library
  */
 export function isCommonFabricSymbol(
   symbol: ts.Symbol,
 ): boolean {
-  const declarations = symbol.getDeclarations();
-  if (
-    declarations && declarations[0]
-  ) {
-    const source = declarations[0].getSourceFile();
-    const fileName = source.fileName.replace(/\\/g, "/");
-    return fileName.endsWith(COMMONFABRIC_DECLARATION);
-  }
-  return false;
+  return (symbol.getDeclarations() ?? []).some(isCommonFabricDeclaration);
 }
 
 /**

--- a/packages/ts-transformers/src/transformers/cast-validation.ts
+++ b/packages/ts-transformers/src/transformers/cast-validation.ts
@@ -4,14 +4,14 @@
  * Validates type assertions (casts) and reports diagnostics for problematic patterns:
  * - `as unknown as X` (double-cast): ERROR - bypasses type safety
  * - `as OpaqueRef<...>`: ERROR - framework handles OpaqueRef wrapping automatically
- * - `as Cell<...>` and other cell-like types: WARNING - prefer proper type annotations
+ * - `as Cell<...>` and other cell-like types: ERROR - prefer proper type annotations
  */
 import ts from "typescript";
 import { spellingsWhere } from "@commonfabric/schema-generator/wrapper-names";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 
 /**
- * Cell-like types that should trigger a warning when cast to.
+ * Cell-like types that should trigger an error when cast to.
  * These types have special reactive semantics that casts can bypass.
  */
 const CELL_LIKE_TYPE_NAMES = spellingsWhere({
@@ -47,6 +47,10 @@ const FORBIDDEN_CAST_TYPE_NAMES = spellingsWhere({
   CellTypeConstructor: false,
   ScopedCellTypeConstructor: false,
 });
+
+type CastTargetClassification =
+  | { kind: "forbidden"; typeName: string }
+  | { kind: "cellLike"; typeName: string };
 
 export class CastValidationTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
@@ -186,48 +190,249 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
     castNode: ts.Node,
     context: TransformationContext,
   ): void {
-    const typeName = this.extractTypeName(typeNode);
-    if (!typeName) return;
+    const typeNames = this.extractTypeNames(typeNode, context);
+    const classification = this.classifyCastTarget(typeNames);
+    if (!classification) return;
 
-    // Check for forbidden cast targets (ERROR)
-    if (FORBIDDEN_CAST_TYPE_NAMES.has(typeName)) {
+    if (classification.kind === "forbidden") {
       context.reportDiagnostic({
         severity: "error",
         type: "cast-validation:forbidden-cast",
-        message: `Casting to '${typeName}<>' is not allowed. ` +
+        message: `Casting to '${classification.typeName}<>' is not allowed. ` +
           "The framework handles this type conversion automatically.",
         node: castNode,
       });
       return;
     }
 
-    // Check for cell-like cast targets (WARNING)
-    if (CELL_LIKE_TYPE_NAMES.has(typeName)) {
-      context.reportDiagnostic({
-        severity: "warning",
-        type: "cast-validation:cell-cast",
-        message: `Casting to '${typeName}<>' is discouraged. ` +
-          "Consider using proper type annotations instead.",
-        node: castNode,
-      });
+    context.reportDiagnostic({
+      severity: "error",
+      type: "cast-validation:cell-cast",
+      message: `Casting to '${classification.typeName}<>' is not allowed. ` +
+        "Use a type annotation instead.",
+      node: castNode,
+    });
+  }
+
+  private classifyCastTarget(
+    typeNames: readonly string[],
+  ): CastTargetClassification | undefined {
+    const forbiddenTypeName = typeNames.find((typeName) =>
+      FORBIDDEN_CAST_TYPE_NAMES.has(typeName)
+    );
+    if (forbiddenTypeName) {
+      return { kind: "forbidden", typeName: forbiddenTypeName };
     }
+
+    const cellLikeTypeName = typeNames.find((typeName) =>
+      CELL_LIKE_TYPE_NAMES.has(typeName)
+    );
+    if (cellLikeTypeName) {
+      return { kind: "cellLike", typeName: cellLikeTypeName };
+    }
+
+    return undefined;
   }
 
   /**
-   * Extracts the base type name from a type node.
-   * For example, `Cell<number>` returns "Cell", `OpaqueRef<Foo>` returns "OpaqueRef".
+   * Extracts wrapper names from a cast target.
+   * For example, `Cell<number>` returns "Cell".
+   * A nested type like `Cell<number> | undefined` returns "Cell".
    */
-  private extractTypeName(typeNode: ts.TypeNode): string | undefined {
+  private extractTypeNames(
+    typeNode: ts.TypeNode,
+    context: TransformationContext,
+    seenSymbols = new Set<ts.Symbol>(),
+  ): string[] {
+    const names = new Set<string>();
+
+    const visit = (node: ts.TypeNode): void => {
+      if (ts.isParenthesizedTypeNode(node)) {
+        visit(node.type);
+        return;
+      }
+      if (ts.isUnionTypeNode(node) || ts.isIntersectionTypeNode(node)) {
+        for (const child of node.types) visit(child);
+        return;
+      }
+      const name = this.extractTypeReferenceName(
+        node,
+        context,
+        seenSymbols,
+      );
+      if (name) names.add(name);
+    };
+
+    visit(typeNode);
+    return [...names];
+  }
+
+  private extractTypeReferenceName(
+    typeNode: ts.TypeNode,
+    context: TransformationContext,
+    seenSymbols: Set<ts.Symbol>,
+  ): string | undefined {
     if (ts.isTypeReferenceNode(typeNode)) {
-      const typeName = typeNode.typeName;
-      if (ts.isIdentifier(typeName)) {
-        return typeName.text;
-      }
-      // Handle qualified names like `Foo.Bar`
-      if (ts.isQualifiedName(typeName)) {
-        return typeName.right.text;
-      }
+      return this.resolveWrapperTypeName(
+        typeNode.typeName,
+        context,
+        seenSymbols,
+      );
+    }
+    if (ts.isImportTypeNode(typeNode)) {
+      return this.resolveImportTypeName(typeNode);
     }
     return undefined;
+  }
+
+  private resolveImportTypeName(
+    typeNode: ts.ImportTypeNode,
+  ): string | undefined {
+    const qualifier = typeNode.qualifier;
+    if (!qualifier || !this.importTypeReferencesFramework(typeNode)) {
+      return undefined;
+    }
+    const typeName = ts.isIdentifier(qualifier)
+      ? qualifier.text
+      : qualifier.right.text;
+    return this.isWrapperTypeName(typeName) ? typeName : undefined;
+  }
+
+  private importTypeReferencesFramework(typeNode: ts.ImportTypeNode): boolean {
+    const argument = typeNode.argument;
+    return ts.isLiteralTypeNode(argument) &&
+      ts.isStringLiteral(argument.literal) &&
+      this.isFrameworkModuleName(argument.literal.text);
+  }
+
+  private resolveWrapperTypeName(
+    typeName: ts.EntityName,
+    context: TransformationContext,
+    seenSymbols: Set<ts.Symbol>,
+  ): string | undefined {
+    const symbol = context.checker.getSymbolAtLocation(typeName);
+    if (!symbol) return undefined;
+    return this.resolveWrapperSymbolName(symbol, context, seenSymbols);
+  }
+
+  private resolveWrapperSymbolName(
+    symbol: ts.Symbol,
+    context: TransformationContext,
+    seenSymbols: Set<ts.Symbol>,
+  ): string | undefined {
+    if (seenSymbols.has(symbol)) return undefined;
+    seenSymbols.add(symbol);
+
+    if (symbol.flags & ts.SymbolFlags.Alias) {
+      const aliasedSymbol = context.checker.getAliasedSymbol(symbol);
+      const aliasedName = this.resolveWrapperSymbolName(
+        aliasedSymbol,
+        context,
+        seenSymbols,
+      );
+      if (aliasedName) return aliasedName;
+    }
+
+    const symbolName = symbol.getName();
+    if (
+      this.isWrapperTypeName(symbolName) &&
+      this.hasFrameworkDeclaration(symbol)
+    ) {
+      return symbolName;
+    }
+
+    for (const declaration of symbol.declarations ?? []) {
+      if (ts.isTypeAliasDeclaration(declaration)) {
+        const typeNames = this.extractTypeNames(
+          declaration.type,
+          context,
+          seenSymbols,
+        );
+        const wrapperName = typeNames.find((name) =>
+          this.isWrapperTypeName(name)
+        );
+        if (wrapperName) return wrapperName;
+      }
+
+      if (ts.isInterfaceDeclaration(declaration)) {
+        const wrapperName = this.resolveInterfaceHeritageWrapperName(
+          declaration,
+          context,
+          seenSymbols,
+        );
+        if (wrapperName) return wrapperName;
+      }
+    }
+
+    return undefined;
+  }
+
+  private resolveInterfaceHeritageWrapperName(
+    declaration: ts.InterfaceDeclaration,
+    context: TransformationContext,
+    seenSymbols: Set<ts.Symbol>,
+  ): string | undefined {
+    for (const clause of declaration.heritageClauses ?? []) {
+      if (clause.token !== ts.SyntaxKind.ExtendsKeyword) continue;
+      for (const heritageType of clause.types) {
+        const symbol = context.checker.getSymbolAtLocation(
+          heritageType.expression,
+        );
+        if (!symbol) continue;
+        const wrapperName = this.resolveWrapperSymbolName(
+          symbol,
+          context,
+          seenSymbols,
+        );
+        if (wrapperName) return wrapperName;
+      }
+    }
+
+    return undefined;
+  }
+
+  private isWrapperTypeName(typeName: string): boolean {
+    return FORBIDDEN_CAST_TYPE_NAMES.has(typeName) ||
+      CELL_LIKE_TYPE_NAMES.has(typeName);
+  }
+
+  private hasFrameworkDeclaration(symbol: ts.Symbol): boolean {
+    return (symbol.declarations ?? []).some((declaration) =>
+      this.isFrameworkDeclaration(declaration)
+    );
+  }
+
+  private isFrameworkDeclaration(declaration: ts.Declaration): boolean {
+    const sourceFileName = declaration.getSourceFile().fileName.replaceAll(
+      "\\",
+      "/",
+    );
+    if (
+      sourceFileName === "commonfabric.d.ts" ||
+      sourceFileName.endsWith("/commonfabric.d.ts") ||
+      sourceFileName.endsWith("/packages/api/index.ts") ||
+      sourceFileName.includes("/packages/runner/src/")
+    ) {
+      return true;
+    }
+
+    let current: ts.Node | undefined = declaration;
+    while (current) {
+      if (
+        ts.isModuleDeclaration(current) &&
+        ts.isStringLiteral(current.name) &&
+        this.isFrameworkModuleName(current.name.text)
+      ) {
+        return true;
+      }
+      current = current.parent;
+    }
+
+    return false;
+  }
+
+  private isFrameworkModuleName(moduleName: string): boolean {
+    return moduleName === "commonfabric" ||
+      moduleName.startsWith("@commonfabric/");
   }
 }

--- a/packages/ts-transformers/src/transformers/cast-validation.ts
+++ b/packages/ts-transformers/src/transformers/cast-validation.ts
@@ -311,8 +311,8 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
     seenSymbols: Set<ts.Symbol>,
   ): string | undefined {
     const symbol = context.checker.getSymbolAtLocation(typeName);
-    if (!symbol) return undefined;
-    return this.resolveWrapperSymbolName(symbol, context, seenSymbols);
+    return symbol &&
+      this.resolveWrapperSymbolName(symbol, context, seenSymbols);
   }
 
   private resolveWrapperSymbolName(
@@ -373,7 +373,6 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
     seenSymbols: Set<ts.Symbol>,
   ): string | undefined {
     for (const clause of declaration.heritageClauses ?? []) {
-      if (clause.token !== ts.SyntaxKind.ExtendsKeyword) continue;
       for (const heritageType of clause.types) {
         const symbol = context.checker.getSymbolAtLocation(
           heritageType.expression,

--- a/packages/ts-transformers/src/transformers/cast-validation.ts
+++ b/packages/ts-transformers/src/transformers/cast-validation.ts
@@ -8,7 +8,13 @@
  */
 import ts from "typescript";
 import { spellingsWhere } from "@commonfabric/schema-generator/wrapper-names";
-import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
+import {
+  getImportTypeModuleName,
+  HelpersOnlyTransformer,
+  isCommonFabricDeclaration,
+  isCommonFabricModuleName,
+  TransformationContext,
+} from "../core/mod.ts";
 
 /**
  * Cell-like types that should trigger an error when cast to.
@@ -289,20 +295,18 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
     typeNode: ts.ImportTypeNode,
   ): string | undefined {
     const qualifier = typeNode.qualifier;
-    if (!qualifier || !this.importTypeReferencesFramework(typeNode)) {
+    const moduleName = getImportTypeModuleName(typeNode);
+    if (
+      !qualifier ||
+      !moduleName ||
+      !isCommonFabricModuleName(moduleName)
+    ) {
       return undefined;
     }
     const typeName = ts.isIdentifier(qualifier)
       ? qualifier.text
       : qualifier.right.text;
     return this.isWrapperTypeName(typeName) ? typeName : undefined;
-  }
-
-  private importTypeReferencesFramework(typeNode: ts.ImportTypeNode): boolean {
-    const argument = typeNode.argument;
-    return ts.isLiteralTypeNode(argument) &&
-      ts.isStringLiteral(argument.literal) &&
-      this.isFrameworkModuleName(argument.literal.text);
   }
 
   private resolveWrapperTypeName(
@@ -336,7 +340,7 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
     const symbolName = symbol.getName();
     if (
       this.isWrapperTypeName(symbolName) &&
-      this.hasFrameworkDeclaration(symbol)
+      this.hasCommonFabricDeclaration(symbol)
     ) {
       return symbolName;
     }
@@ -395,43 +399,9 @@ export class CastValidationTransformer extends HelpersOnlyTransformer {
       CELL_LIKE_TYPE_NAMES.has(typeName);
   }
 
-  private hasFrameworkDeclaration(symbol: ts.Symbol): boolean {
+  private hasCommonFabricDeclaration(symbol: ts.Symbol): boolean {
     return (symbol.declarations ?? []).some((declaration) =>
-      this.isFrameworkDeclaration(declaration)
+      isCommonFabricDeclaration(declaration)
     );
-  }
-
-  private isFrameworkDeclaration(declaration: ts.Declaration): boolean {
-    const sourceFileName = declaration.getSourceFile().fileName.replaceAll(
-      "\\",
-      "/",
-    );
-    if (
-      sourceFileName === "commonfabric.d.ts" ||
-      sourceFileName.endsWith("/commonfabric.d.ts") ||
-      sourceFileName.endsWith("/packages/api/index.ts") ||
-      sourceFileName.includes("/packages/runner/src/")
-    ) {
-      return true;
-    }
-
-    let current: ts.Node | undefined = declaration;
-    while (current) {
-      if (
-        ts.isModuleDeclaration(current) &&
-        ts.isStringLiteral(current.name) &&
-        this.isFrameworkModuleName(current.name.text)
-      ) {
-        return true;
-      }
-      current = current.parent;
-    }
-
-    return false;
-  }
-
-  private isFrameworkModuleName(moduleName: string): boolean {
-    return moduleName === "commonfabric" ||
-      moduleName.startsWith("@commonfabric/");
   }
 }

--- a/packages/ts-transformers/test/core/common-fabric-symbols.test.ts
+++ b/packages/ts-transformers/test/core/common-fabric-symbols.test.ts
@@ -1,15 +1,20 @@
 /**
  * Unit tests for symbolDeclaresCommonFabricDefault.
  *
- * The function is meant to return true ONLY for properties whose declared type
- * is the Common Fabric Default<T,V> from `@commonfabric/api` (identified by the
- * source file being named "commonfabric.d.ts").  A user who happens to name
- * their own generic type "Default" must NOT trigger the same special handling.
+ * The function returns true for properties whose declared type is the Common
+ * Fabric Default<T,V> from `@commonfabric/api`. A user type named "Default"
+ * does not trigger the same special handling.
  */
 import ts from "typescript";
 import { describe, it } from "@std/testing/bdd";
-import { assert, assertFalse } from "@std/assert";
-import { symbolDeclaresCommonFabricDefault } from "../../src/core/common-fabric-symbols.ts";
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import {
+  getImportTypeModuleName,
+  isCommonFabricDeclaration,
+  isCommonFabricModuleName,
+  isCommonFabricSymbol,
+  symbolDeclaresCommonFabricDefault,
+} from "../../src/core/common-fabric-symbols.ts";
 
 // ---------------------------------------------------------------------------
 // Test infrastructure
@@ -78,9 +83,186 @@ function getPropertySymbol(
   return found;
 }
 
+function getInterfaceSymbol(
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  interfaceName: string,
+): ts.Symbol | undefined {
+  let found: ts.Symbol | undefined;
+  ts.forEachChild(sourceFile, (node) => {
+    if (ts.isInterfaceDeclaration(node) && node.name.text === interfaceName) {
+      found = checker.getSymbolAtLocation(node.name);
+    }
+  });
+  return found;
+}
+
+function findFirstNode<T extends ts.Node>(
+  sourceFile: ts.SourceFile,
+  predicate: (node: ts.Node) => node is T,
+): T | undefined {
+  let found: T | undefined;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (predicate(node)) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe("isCommonFabricModuleName", () => {
+  it("matches Common Fabric module names", () => {
+    assert(isCommonFabricModuleName("commonfabric"));
+    assert(isCommonFabricModuleName("@commonfabric/api"));
+    assert(isCommonFabricModuleName("@commonfabric/common"));
+  });
+
+  it("rejects unrelated module names", () => {
+    assertFalse(isCommonFabricModuleName("not-commonfabric"));
+    assertFalse(isCommonFabricModuleName("@notcommonfabric/api"));
+  });
+});
+
+describe("getImportTypeModuleName", () => {
+  it("reads the module name from an import type node", () => {
+    const sourceFile = ts.createSourceFile(
+      "/test.ts",
+      `type Ref = import("@commonfabric/api").Cell<number>;`,
+      ts.ScriptTarget.ES2020,
+      true,
+      ts.ScriptKind.TS,
+    );
+
+    const typeNode = findFirstNode(sourceFile, ts.isImportTypeNode);
+
+    assert(typeNode);
+    assertEquals(getImportTypeModuleName(typeNode), "@commonfabric/api");
+  });
+});
+
+describe("isCommonFabricDeclaration", () => {
+  it("matches declarations from Common Fabric source files", () => {
+    const sourceFile = ts.createSourceFile(
+      "/repo/packages/api/index.ts",
+      `export interface Cell<T> { value: T }`,
+      ts.ScriptTarget.ES2020,
+      true,
+      ts.ScriptKind.TS,
+    );
+
+    const declaration = findFirstNode(sourceFile, ts.isInterfaceDeclaration);
+
+    assert(declaration);
+    assert(isCommonFabricDeclaration(declaration));
+  });
+
+  it("matches declarations from installed Common Fabric package files", () => {
+    const sourceFile = ts.createSourceFile(
+      "/repo/node_modules/@commonfabric/api/index.d.ts",
+      `export interface Cell<T> { value: T }`,
+      ts.ScriptTarget.ES2020,
+      true,
+      ts.ScriptKind.TS,
+    );
+
+    const declaration = findFirstNode(sourceFile, ts.isInterfaceDeclaration);
+
+    assert(declaration);
+    assert(isCommonFabricDeclaration(declaration));
+  });
+
+  it("matches declarations inside Common Fabric ambient modules", () => {
+    const sourceFile = ts.createSourceFile(
+      "/types.d.ts",
+      `declare module "@commonfabric/api" {
+        export interface Cell<T> { value: T }
+      }`,
+      ts.ScriptTarget.ES2020,
+      true,
+      ts.ScriptKind.TS,
+    );
+
+    const declaration = findFirstNode(sourceFile, ts.isInterfaceDeclaration);
+
+    assert(declaration);
+    assert(isCommonFabricDeclaration(declaration));
+  });
+
+  it("rejects user declarations with matching names", () => {
+    const sourceFile = ts.createSourceFile(
+      "/test.ts",
+      `interface Cell<T> { value: T }`,
+      ts.ScriptTarget.ES2020,
+      true,
+      ts.ScriptKind.TS,
+    );
+
+    const declaration = findFirstNode(sourceFile, ts.isInterfaceDeclaration);
+
+    assert(declaration);
+    assertFalse(isCommonFabricDeclaration(declaration));
+  });
+});
+
+describe("isCommonFabricSymbol", () => {
+  it("matches symbols from Common Fabric source files", () => {
+    const { program, checker } = createProgram({
+      "/repo/packages/api/index.ts": `
+        export interface Cell<T> {
+          get(): T;
+        }
+      `,
+    });
+
+    const sf = program.getSourceFile("/repo/packages/api/index.ts")!;
+    const symbol = getInterfaceSymbol(checker, sf, "Cell");
+
+    assert(symbol);
+    assert(isCommonFabricSymbol(symbol));
+  });
+
+  it("matches symbols from installed Common Fabric package files", () => {
+    const { program, checker } = createProgram({
+      "/repo/node_modules/@commonfabric/api/index.d.ts": `
+        export interface Cell<T> {
+          get(): T;
+        }
+      `,
+    });
+
+    const sf = program.getSourceFile(
+      "/repo/node_modules/@commonfabric/api/index.d.ts",
+    )!;
+    const symbol = getInterfaceSymbol(checker, sf, "Cell");
+
+    assert(symbol);
+    assert(isCommonFabricSymbol(symbol));
+  });
+
+  it("rejects user symbols with Common Fabric names", () => {
+    const { program, checker } = createProgram({
+      "/test.ts": `
+        interface Cell<T> {
+          get(): T;
+        }
+      `,
+    });
+
+    const sf = program.getSourceFile("/test.ts")!;
+    const symbol = getInterfaceSymbol(checker, sf, "Cell");
+
+    assert(symbol);
+    assertFalse(isCommonFabricSymbol(symbol));
+  });
+});
 
 describe("symbolDeclaresCommonFabricDefault", () => {
   describe("user-defined Default type (should return false)", () => {
@@ -153,9 +335,6 @@ describe("symbolDeclaresCommonFabricDefault", () => {
 
   describe("Common Fabric Default from commonfabric.d.ts (should return true)", () => {
     it("returns true when the property type references Default declared in commonfabric.d.ts", () => {
-      // isCommonFabricSymbol checks fileName.endsWith("commonfabric.d.ts").
-      // Declaring Default globally in commonfabric.d.ts and including it as a
-      // root file makes it the canonical Common Fabric Default.
       const { program, checker } = createProgram({
         "commonfabric.d.ts": `
           declare const DEFAULT_MARKER: unique symbol;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
@@ -57,10 +57,8 @@ const createCellRef = lift(({ isInitialized, storedCellRef }) => {
             items: true
         } as const satisfies __cfHelpers.JSONSchema);
         newCellRef.set([]);
-        // Local cast: the schema types storedCellRef as a cell of a generic object,
-        // but this fixture stores an array cell into it; the schema accuracy isn't
-        // what this transformer fixture exercises.
-        (storedCellRef as Cell<unknown>).set(newCellRef);
+        const storedCellValue: Cell<unknown> = storedCellRef;
+        storedCellValue.set(newCellRef);
         isInitialized.set(true);
         return {
             cellRef: newCellRef,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.input.tsx
@@ -23,10 +23,8 @@ const createCellRef = lift(
       console.log("Creating cellRef - first time");
       const newCellRef = Cell.for<any[]>("piecesArray");
       newCellRef.set([]);
-      // Local cast: the schema types storedCellRef as a cell of a generic object,
-      // but this fixture stores an array cell into it; the schema accuracy isn't
-      // what this transformer fixture exercises.
-      (storedCellRef as Cell<unknown>).set(newCellRef);
+      const storedCellValue: Cell<unknown> = storedCellRef;
+      storedCellValue.set(newCellRef);
       isInitialized.set(true);
       return {
         cellRef: newCellRef,

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
@@ -28,10 +28,10 @@ const liftOptional = lift((input: Writable<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema);
-const deriveInput = __cfHelpers.__cf_data({} as Writable<{
+const deriveInput: Writable<{
     foo: string;
     bar: string;
-}>);
+}> = __cfHelpers.__cf_data({} as never);
 const __cfLift_1 = __cfHelpers.lift(() => deriveInput.key("foo").get(), false);
 const computedObserved = __cfHelpers.__cf_data(__cfLift_1().for("computedObserved", true));
 const handlerObserved = handler(false as const satisfies __cfHelpers.JSONSchema, {

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.input.tsx
@@ -8,7 +8,7 @@ const liftOptional = lift((input: Writable<{ foo: string | undefined; bar: strin
   input.key("foo").get()
 );
 
-const deriveInput = {} as Writable<{ foo: string; bar: string }>;
+const deriveInput: Writable<{ foo: string; bar: string }> = {} as never;
 const computedObserved = computed(() => deriveInput.key("foo").get());
 
 const handlerObserved = handler(

--- a/packages/ts-transformers/test/schema-shrink-validation.test.ts
+++ b/packages/ts-transformers/test/schema-shrink-validation.test.ts
@@ -1734,7 +1734,7 @@ Deno.test("Schema Shrink Validation", async (t) => {
       const source = [
         "/// <cts-enable />",
         'import { lift, type Writable } from "commonfabric";',
-        "const value = {} as Writable<number>;",
+        "declare const value: Writable<number>;",
         "const doubled = lift((v) => v.get() * 2)(value);",
       ].join("\n");
 
@@ -1762,7 +1762,7 @@ Deno.test("Schema Shrink Validation", async (t) => {
       const source = [
         "/// <cts-enable />",
         'import { lift, type Writable } from "commonfabric";',
-        "const value = {} as Writable<number>;",
+        "declare const value: Writable<number>;",
         "const copy = lift((v) => v.get())(value);",
       ].join("\n");
 
@@ -1895,7 +1895,7 @@ Deno.test("Schema Shrink Validation", async (t) => {
       const source = [
         "/// <cts-enable />",
         'import { lift, equals, type Writable } from "commonfabric";',
-        "const state = {} as (Writable<number> | undefined);",
+        "declare const state: Writable<number> | undefined;",
         "const same = lift((state) => equals(state, state))(state);",
       ].join("\n");
 
@@ -1922,7 +1922,7 @@ Deno.test("Schema Shrink Validation", async (t) => {
     async () => {
       const source = [
         'import { lift, type Writable } from "commonfabric";',
-        "const input = {} as Writable<{ foo: string; bar: string }>;",
+        "declare const input: Writable<{ foo: string; bar: string }>;",
         "const d = lift((v: Writable<{ foo: string; bar: string }>) => {",
         '  const foo = v.key("foo").get();',
         "  Object.keys(v.get());",

--- a/packages/ts-transformers/test/transform-guards.test.ts
+++ b/packages/ts-transformers/test/transform-guards.test.ts
@@ -374,8 +374,8 @@ Deno.test(
       `import { Cell, Default, handler, pattern, type Stream } from "commonfabric";
 
 const asIncrementStream = (
-  ref: unknown,
-): Stream<{ amount?: number }> => ref as Stream<{ amount?: number }>;
+  ref: Stream<{ amount?: number }>,
+): Stream<{ amount?: number }> => ref;
 
 const childIncrement = handler(
   (_event: { amount?: number } | undefined, _context: { value: Cell<number> }) => {},

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -7,10 +7,6 @@ function getErrors(diagnostics: readonly TransformationDiagnostic[]) {
   return diagnostics.filter((d) => d.severity === "error");
 }
 
-function getWarnings(diagnostics: readonly TransformationDiagnostic[]) {
-  return diagnostics.filter((d) => d.severity === "warning");
-}
-
 function getEmptyArrayErrors(diagnostics: readonly TransformationDiagnostic[]) {
   return diagnostics.filter((d) =>
     d.type === "cell-factory:empty-array" && d.severity === "error"
@@ -95,7 +91,7 @@ Deno.test("Cast Validation", async (t) => {
     assertHasErrorType(errors, "cast-validation:forbidden-cast");
   });
 
-  await t.step("warns on 'as Cell<>'", async () => {
+  await t.step("errors on 'as Cell<>'", async () => {
     const source = `
       import { Cell } from "commonfabric";
 
@@ -105,12 +101,12 @@ Deno.test("Cast Validation", async (t) => {
     const { diagnostics } = await validateSource(source, {
       types: COMMONFABRIC_TYPES,
     });
-    const warnings = getWarnings(diagnostics);
-    assertGreater(warnings.length, 0, "Expected at least one warning");
-    assertEquals(warnings[0]!.type, "cast-validation:cell-cast");
+    const errors = getErrors(diagnostics);
+    assertGreater(errors.length, 0, "Expected at least one error");
+    assertEquals(errors[0]!.type, "cast-validation:cell-cast");
   });
 
-  await t.step("warns on 'as OpaqueCell<>'", async () => {
+  await t.step("errors on 'as OpaqueCell<>'", async () => {
     const source = `
       import { OpaqueCell } from "commonfabric";
 
@@ -120,12 +116,12 @@ Deno.test("Cast Validation", async (t) => {
     const { diagnostics } = await validateSource(source, {
       types: COMMONFABRIC_TYPES,
     });
-    const warnings = getWarnings(diagnostics);
-    assertGreater(warnings.length, 0, "Expected at least one warning");
-    assertEquals(warnings[0]!.type, "cast-validation:cell-cast");
+    const errors = getErrors(diagnostics);
+    assertGreater(errors.length, 0, "Expected at least one error");
+    assertEquals(errors[0]!.type, "cast-validation:cell-cast");
   });
 
-  await t.step("warns on 'as Writable<>'", async () => {
+  await t.step("errors on 'as Writable<>'", async () => {
     const source = `
       import { Writable } from "commonfabric";
 
@@ -135,9 +131,98 @@ Deno.test("Cast Validation", async (t) => {
     const { diagnostics } = await validateSource(source, {
       types: COMMONFABRIC_TYPES,
     });
-    const warnings = getWarnings(diagnostics);
-    assertGreater(warnings.length, 0, "Expected at least one warning");
-    assertEquals(warnings[0]!.type, "cast-validation:cell-cast");
+    const errors = getErrors(diagnostics);
+    assertGreater(errors.length, 0, "Expected at least one error");
+    assertEquals(errors[0]!.type, "cast-validation:cell-cast");
+  });
+
+  await t.step("errors on union casts containing 'Writable<>'", async () => {
+    const source = `
+      import { Writable } from "commonfabric";
+
+      const data: any = { value: 42 };
+      const cell = data as (Writable<number> | undefined);
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getErrors(diagnostics);
+    assertGreater(errors.length, 0, "Expected at least one error");
+    assertEquals(errors[0]!.type, "cast-validation:cell-cast");
+  });
+
+  await t.step("errors on renamed imports of 'Cell<>'", async () => {
+    const source = `
+      import { Cell as C } from "commonfabric";
+
+      const data: any = { value: 42 };
+      const cell = data as C<number>;
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getErrors(diagnostics);
+    assertGreater(errors.length, 0, "Expected at least one error");
+    assertEquals(errors[0]!.type, "cast-validation:cell-cast");
+  });
+
+  await t.step("errors on type aliases to 'Cell<>'", async () => {
+    const source = `
+      import { Cell } from "commonfabric";
+
+      type MyCell = Cell<number>;
+      const data: any = { value: 42 };
+      const cell = data as MyCell;
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getErrors(diagnostics);
+    assertGreater(errors.length, 0, "Expected at least one error");
+    assertEquals(errors[0]!.type, "cast-validation:cell-cast");
+  });
+
+  await t.step("errors on import type casts to 'Cell<>'", async () => {
+    const source = `
+      const data: any = { value: 42 };
+      const cell = data as import("commonfabric").Cell<number>;
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getErrors(diagnostics);
+    assertGreater(errors.length, 0, "Expected at least one error");
+    assertEquals(errors[0]!.type, "cast-validation:cell-cast");
+  });
+
+  await t.step("errors on interfaces extending 'Cell<>'", async () => {
+    const source = `
+      import { Cell } from "commonfabric";
+
+      interface MyCell extends Cell<number> {}
+      const data: any = { value: 42 };
+      const cell = data as MyCell;
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getErrors(diagnostics);
+    assertGreater(errors.length, 0, "Expected at least one error");
+    assertEquals(errors[0]!.type, "cast-validation:cell-cast");
+  });
+
+  await t.step("allows unrelated local types named 'Cell'", async () => {
+    const source = `
+      type Cell<T> = { value: T };
+
+      const data: any = { value: 42 };
+      const cell = data as Cell<number>;
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getErrors(diagnostics);
+    assertEquals(errors.length, 0, "Should not produce any errors");
   });
 
   await t.step("allows valid type assertions", async () => {
@@ -3562,7 +3647,7 @@ Deno.test("Standalone Function Validation", async (t) => {
     async () => {
       const source = `      import { computed, Cell } from "commonfabric";
 
-      const count = {} as Cell<number>;
+      declare const count: Cell<number>;
 
       const helper = () => {
         return computed(() => count.get() * 2);
@@ -3667,7 +3752,7 @@ Deno.test("Standalone Function Validation", async (t) => {
       const source =
         `      import { pattern, patternTool, computed, Cell } from "commonfabric";
 
-      const multiplier = {} as Cell<number>;
+      declare const multiplier: Cell<number>;
 
       const tool = patternTool(pattern(({ query }: { query: string }) => {
         return computed(() => query.length * multiplier.get());
@@ -3691,7 +3776,7 @@ Deno.test("Standalone Function Validation", async (t) => {
       const source =
         `      import { patternTool, computed, Cell } from "commonfabric";
 
-      const multiplier = {} as Cell<number>;
+      declare const multiplier: Cell<number>;
 
       const tool = patternTool(({ query }: { query: string }) => {
         return computed(() => query.length * multiplier.get());
@@ -3820,7 +3905,7 @@ Deno.test("Standalone Function Validation", async (t) => {
     async () => {
       const source = `      import { computed, Cell } from "commonfabric";
 
-      const count = {} as Cell<number>;
+      declare const count: Cell<number>;
 
       const outer = () => {
         // Nested function uses computed() — error should be on inner,

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -303,6 +303,58 @@ Deno.test("Cast Validation", async (t) => {
     },
   );
 
+  await t.step("allows unresolved type references", async () => {
+    const source = `
+      const data: any = { value: 42 };
+      const cell = data as MissingCell<number>;
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getErrors(diagnostics);
+    assertEquals(errors.length, 0, "Should not produce any errors");
+  });
+
+  await t.step("allows unresolved qualified type references", async () => {
+    const source = `
+      const data: any = { value: 42 };
+      const cell = data as MissingNamespace.MissingCell<number>;
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getErrors(diagnostics);
+    assertEquals(errors.length, 0, "Should not produce any errors");
+  });
+
+  await t.step("allows recursive local type aliases", async () => {
+    const source = `
+      type LocalCell<T> = LocalCell<T>;
+
+      const data: any = { value: 42 };
+      const cell = data as LocalCell<number>;
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getErrors(diagnostics);
+    assertEquals(errors.length, 0, "Should not produce any errors");
+  });
+
+  await t.step("allows interfaces extending unresolved types", async () => {
+    const source = `
+      interface LocalCell<T> extends MissingCell<T> {}
+
+      const data: any = { value: 42 };
+      const cell = data as LocalCell<number>;
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getErrors(diagnostics);
+    assertEquals(errors.length, 0, "Should not produce any errors");
+  });
+
   await t.step("allows unrelated local types named 'Cell'", async () => {
     const source = `
       type Cell<T> = { value: T };

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -211,6 +211,98 @@ Deno.test("Cast Validation", async (t) => {
     assertEquals(errors[0]!.type, "cast-validation:cell-cast");
   });
 
+  await t.step(
+    "errors on wrappers from framework module declarations",
+    async () => {
+      const source = `
+        import { Cell } from "@commonfabric/local-test";
+
+        const data: any = { value: 42 };
+        const cell = data as Cell<number>;
+      `;
+      const { diagnostics } = await validateSource(source, {
+        types: {
+          ...COMMONFABRIC_TYPES,
+          "local-commonfabric.d.ts": `
+            declare module "@commonfabric/local-test" {
+              export interface Cell<T> {
+                get(): T;
+              }
+            }
+          `,
+        },
+      });
+      const errors = getErrors(diagnostics);
+      assertGreater(errors.length, 0, "Expected at least one error");
+      assertEquals(errors[0]!.type, "cast-validation:cell-cast");
+    },
+  );
+
+  await t.step("errors on qualified framework import types", async () => {
+    const source = `
+      declare module "@commonfabric/local-test" {
+        export namespace wrappers {
+          export interface Cell<T> {
+            get(): T;
+          }
+        }
+      }
+
+      const data: any = { value: 42 };
+      const cell = data as import("@commonfabric/local-test").wrappers.Cell<number>;
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getErrors(diagnostics);
+    assertGreater(errors.length, 0, "Expected at least one error");
+    assertEquals(errors[0]!.type, "cast-validation:cell-cast");
+  });
+
+  await t.step("allows import types from non-framework modules", async () => {
+    const source = `
+      declare module "not-commonfabric" {
+        export interface Cell<T> {
+          get(): T;
+        }
+      }
+
+      const data: any = { value: 42 };
+      const cell = data as import("not-commonfabric").Cell<number>;
+    `;
+    const { diagnostics } = await validateSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+    const errors = getErrors(diagnostics);
+    assertEquals(errors.length, 0, "Should not produce any errors");
+  });
+
+  await t.step(
+    "allows imports from non-framework module declarations",
+    async () => {
+      const source = `
+      import { Cell } from "not-commonfabric";
+
+      const data: any = { value: 42 };
+      const cell = data as Cell<number>;
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: {
+          ...COMMONFABRIC_TYPES,
+          "not-commonfabric.d.ts": `
+          declare module "not-commonfabric" {
+            export interface Cell<T> {
+              get(): T;
+            }
+          }
+        `,
+        },
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(errors.length, 0, "Should not produce any errors");
+    },
+  );
+
   await t.step("allows unrelated local types named 'Cell'", async () => {
     const source = `
       type Cell<T> = { value: T };


### PR DESCRIPTION
This changes the cast validation diagnostic for cell-like wrapper types from a warning into an error.

Casting to `Cell`, `Writable`, `Stream`, and related wrapper types can hide whether a value is actually a reactive cell. The transformer now rejects those casts and points callers toward type annotations instead.

The change also migrates existing pattern and test code away from those casts. It replaces them with typed locals, typed helper parameters, and typed child-cell variables.

Validation now covers direct casts, renamed imports, local type aliases, import type syntax, interfaces extending cell wrappers, and unrelated local types named `Cell`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject casts to cell-like wrappers with an error and expand detection to renamed imports, type aliases, unions/intersections, import types (including qualified), and interfaces. Centralize Common Fabric module/import/declaration checks and migrate patterns and tests to type annotations; keep Gmail utilities SES-safe.

- **Refactors**
  - Promote `cast-validation:cell-cast` to error; resolver now handles parenthesized/union/intersection forms, renamed imports, local aliases, import types (qualified and unqualified), and interfaces extending wrappers; only flags framework-owned `Cell`/`Writable`/`Stream` types. Simplify interface/symbol resolution fallbacks and share Common Fabric module/import/declaration predicates in `common-fabric-symbols`; use them in cast validation. Update docs and add tests for helper predicates, framework module declarations, qualified import types, non-framework exemptions, unresolved/qualified references, and recursive aliases.
  - Replace `as Cell<>`/`as Writable<>`/`as Stream<>` with typed locals/params across authored patterns, generated fixtures, and CI tests; preserve optional child types with `T | undefined`. Email task engine: pass the computed prompt directly and wrap the suggestion schema with `schema()`.

- **Migration**
  - Replace `value as Cell<T>` with `const valueCell: Cell<T> = value;` and annotate variables/params directly; import-type and alias casts are blocked. Use `T | undefined` where children may be absent.

<sup>Written for commit 71de232041e1006caa77fa41446f229f7a3a7aed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

