### PR TITLE
Fix pending patch visibility across branch type changes

### DIFF
--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -134,8 +134,8 @@ const logger = getLogger("storage.v2", {
   level: "error",
 });
 const pendingPatchLogger = getLogger("storage.v2.pending-patch", {
-  enabled: false,
-  level: "info",
+  enabled: true,
+  level: "warn",
   logCountEvery: 0,
 });
 
@@ -449,7 +449,7 @@ const applyPendingVersion = (
         if (hasValueAtPath(pending.value, path)) {
           const setPath = pendingSetPathForBase(next, pending.value, path);
           if (!isSamePath(setPath, path)) {
-            pendingPatchLogger.info("pending-branch-replace", () => [
+            pendingPatchLogger.warn("pending-branch-replace", () => [
               "pending patch visibility replaced data at an existing branch that blocked the nested write",
               {
                 space: logContext.space,

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -133,6 +133,11 @@ const logger = getLogger("storage.v2", {
   enabled: true,
   level: "error",
 });
+const pendingPatchLogger = getLogger("storage.v2.pending-patch", {
+  enabled: false,
+  level: "info",
+  logCountEvery: 0,
+});
 
 function withCommitTiming<T>(
   keys: string[],
@@ -269,6 +274,12 @@ type DocumentRecord = {
   confirmed: ConfirmedVersion;
   pending: PendingVersion[];
   materialized?: PendingMaterializationCache;
+};
+
+type PendingPatchLogContext = {
+  space: MemorySpace;
+  id: URI;
+  scope?: CellScope;
 };
 
 type ConfirmedCommitRead = {
@@ -421,6 +432,7 @@ const compactChangedPaths = (paths: readonly string[][]): string[][] => {
 const applyPendingVersion = (
   base: EntityDocument | undefined,
   pending: PendingVersion,
+  logContext: PendingPatchLogContext,
 ): EntityDocument | undefined => {
   switch (pending.op) {
     case "delete":
@@ -436,6 +448,19 @@ const applyPendingVersion = (
       ) {
         if (hasValueAtPath(pending.value, path)) {
           const setPath = pendingSetPathForBase(next, pending.value, path);
+          if (!isSamePath(setPath, path)) {
+            pendingPatchLogger.info("pending-branch-replace", () => [
+              "pending patch visibility replaced data at an existing branch that blocked the nested write",
+              {
+                space: logContext.space,
+                id: logContext.id,
+                scope: normalizeCellScope(logContext.scope),
+                localSeq: pending.localSeq,
+                path,
+                replacementPath: setPath,
+              },
+            ]);
+          }
           next = cloneWithValueAtPath(
             next,
             setPath,
@@ -469,6 +494,7 @@ const ensurePendingMaterializationCache = (
 
 const materializedVersionThroughPending = (
   record: DocumentRecord,
+  logContext: PendingPatchLogContext,
   pendingCount = record.pending.length,
 ): MaterializedVersion => {
   if (pendingCount <= 0) {
@@ -484,7 +510,7 @@ const materializedVersionThroughPending = (
     const pending = record.pending[nextIndex]!;
     cache.prefixes.push({
       localSeq: pending.localSeq,
-      value: applyPendingVersion(base.value, pending),
+      value: applyPendingVersion(base.value, pending, logContext),
       transactionValue: UNCACHED_TRANSACTION_VALUE,
     });
   }
@@ -2550,6 +2576,7 @@ class SpaceReplica implements ISpaceReplica {
         if (firstPendingIndex === 0) {
           const prefix = materializedVersionThroughPending(
             record,
+            { space: this.#space, id, scope },
             lastPendingIndex + 1,
           );
           const cache = ensurePendingMaterializationCache(record);
@@ -2564,7 +2591,11 @@ class SpaceReplica implements ISpaceReplica {
         } else {
           promoted = confirmedVersion(
             applied.seq,
-            applyPendingVersion(record.confirmed.value, pending),
+            applyPendingVersion(record.confirmed.value, pending, {
+              space: this.#space,
+              id,
+              scope,
+            }),
           );
         }
       }
@@ -2613,7 +2644,11 @@ class SpaceReplica implements ISpaceReplica {
     }
     return {
       record,
-      version: materializedVersionThroughPending(record),
+      version: materializedVersionThroughPending(record, {
+        space: this.#space,
+        id,
+        scope,
+      }),
     };
   }
 

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -368,14 +368,19 @@ const changedPathsForPendingPatch = (
     }
   });
 
-const firstPresentNonTraversablePrefix = (
+// Finds the first existing prefix in `base` that blocks a pending nested write.
+// cloneWithValueAtPath can create missing containers when applying the selected
+// write path.
+const firstExistingPrefixThatBlocksPendingPath = (
   base: EntityDocument | undefined,
   path: readonly string[],
 ): string[] | undefined => {
   for (let length = 1; length < path.length; length += 1) {
     const prefix = path.slice(0, length);
     if (!hasValueAtPath(base, prefix)) {
-      continue;
+      // Once a prefix is missing, by definition everything else in the path
+      // can be written, so nothing is blocking it.
+      return undefined;
     }
     const value = readValueAtPath(base, prefix);
     const nextSegment = path[length]!;
@@ -394,7 +399,7 @@ const pendingSetPathForBase = (
   pendingValue: EntityDocument,
   path: readonly string[],
 ): readonly string[] => {
-  const prefix = firstPresentNonTraversablePrefix(base, path);
+  const prefix = firstExistingPrefixThatBlocksPendingPath(base, path);
   if (!prefix || !hasValueAtPath(pendingValue, prefix)) {
     return path;
   }

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -39,7 +39,11 @@ import {
 import { parentPath, parsePointer } from "../../../memory/v2/path.ts";
 import type { AppliedCommit } from "@commonfabric/memory/v2/engine";
 import { getLogger } from "@commonfabric/utils/logger";
-import { isObject, isRecord } from "@commonfabric/utils/types";
+import {
+  isObject,
+  isPlainContainer,
+  isRecord,
+} from "@commonfabric/utils/types";
 import type { Cell } from "../cell.ts";
 import type { JSONSchema } from "../builder/types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
@@ -104,7 +108,11 @@ const isSamePath = (
 ): boolean =>
   a.length === b.length && a.every((segment, index) => b[index] === segment);
 import { toTransactionDocumentValue } from "./v2-document.ts";
-import { hasValueAtPath, readValueAtPath } from "./v2-path.ts";
+import {
+  hasValueAtPath,
+  isArrayIndexSegment,
+  readValueAtPath,
+} from "./v2-path.ts";
 import {
   compactWatchEntries,
   normalizeSyncEntries,
@@ -360,6 +368,39 @@ const changedPathsForPendingPatch = (
     }
   });
 
+const firstPresentNonTraversablePrefix = (
+  base: EntityDocument | undefined,
+  path: readonly string[],
+): string[] | undefined => {
+  for (let length = 1; length < path.length; length += 1) {
+    const prefix = path.slice(0, length);
+    if (!hasValueAtPath(base, prefix)) {
+      continue;
+    }
+    const value = readValueAtPath(base, prefix);
+    const nextSegment = path[length]!;
+    if (
+      !isPlainContainer(value) ||
+      (Array.isArray(value) && !isArrayIndexSegment(nextSegment))
+    ) {
+      return prefix;
+    }
+  }
+  return undefined;
+};
+
+const pendingSetPathForBase = (
+  base: EntityDocument | undefined,
+  pendingValue: EntityDocument,
+  path: readonly string[],
+): readonly string[] => {
+  const prefix = firstPresentNonTraversablePrefix(base, path);
+  if (!prefix || !hasValueAtPath(pendingValue, prefix)) {
+    return path;
+  }
+  return prefix;
+};
+
 const compactChangedPaths = (paths: readonly string[][]): string[][] => {
   const sorted = [...paths].sort((left, right) => left.length - right.length);
   const retained: string[][] = [];
@@ -389,10 +430,11 @@ const applyPendingVersion = (
         )
       ) {
         if (hasValueAtPath(pending.value, path)) {
+          const setPath = pendingSetPathForBase(next, pending.value, path);
           next = cloneWithValueAtPath(
             next,
-            path,
-            readValueAtPath(pending.value, path),
+            setPath,
+            readValueAtPath(pending.value, setPath),
           ) as EntityDocument;
           continue;
         }

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -89,17 +89,27 @@ type RejectedRecord = {
   error: { name: string; message: string };
 };
 type ScriptedOutcome =
-  | { kind: "accept"; remoteInterleave?: RemoteCommit }
+  | {
+    kind: "accept";
+    remoteInterleave?: RemoteCommit;
+    responseGate?: Promise<void>;
+  }
   | {
     kind: "rejectConflict";
     message?: string;
     remoteInterleave?: RemoteCommit;
+    responseGate?: Promise<void>;
   }
-  | { kind: "dropThenReplayAccept"; remoteInterleave?: RemoteCommit }
+  | {
+    kind: "dropThenReplayAccept";
+    remoteInterleave?: RemoteCommit;
+    responseGate?: Promise<void>;
+  }
   | {
     kind: "dropThenReplayReject";
     message?: string;
     remoteInterleave?: RemoteCommit;
+    responseGate?: Promise<void>;
   };
 type RemoteCommit = {
   label: string;
@@ -408,20 +418,26 @@ class ScriptedModelTransport implements MemoryV2Client.Transport {
         });
         break;
       case "transact": {
+        const responseGate = message.commit
+          ? this.model.scripted.get(message.commit.localSeq)?.responseGate
+          : undefined;
         setTimeout(() => {
-          const commit = message.commit!;
-          const response = this.model.transact(commit);
-          if (response.type === "drop") {
-            this.#closeReceiver(new Error("disconnect"));
-            return;
-          }
-          this.respond({
-            type: "response",
-            requestId: message.requestId!,
-            ...(response.type === "accept"
-              ? { ok: response.applied }
-              : { error: response.error }),
-          });
+          void (async () => {
+            await responseGate;
+            const commit = message.commit!;
+            const response = this.model.transact(commit);
+            if (response.type === "drop") {
+              this.#closeReceiver(new Error("disconnect"));
+              return;
+            }
+            this.respond({
+              type: "response",
+              requestId: message.requestId!,
+              ...(response.type === "accept"
+                ? { ok: response.applied }
+                : { error: response.error }),
+            });
+          })();
         }, 0);
         break;
       }
@@ -1875,6 +1891,81 @@ Deno.test("memory v2 stacked commits: confirming the head pending write promotes
     assertStrictEquals(confirmedDocument, pendingDocument);
     assertStrictEquals(confirmedMaterialized, pendingMaterialized);
   } finally {
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: confirming a later same-doc patch keeps earlier pending overlay", async () => {
+  const harness = await createHarness();
+  const leftResponseGate = Promise.withResolvers<void>();
+  try {
+    await seedAccepted(harness, DOCS.A, {
+      left: 0,
+      right: 0,
+    });
+
+    let leftSettled = false;
+    harness.model.setOutcome(2, {
+      kind: "accept",
+      responseGate: leftResponseGate.promise,
+    });
+    const left = beginPatch(
+      harness,
+      DOCS.A,
+      [{
+        op: "replace",
+        path: "/value/left",
+        value: 1,
+      }],
+      {
+        left: 1,
+        right: 0,
+      },
+    ).finally(() => {
+      leftSettled = true;
+    });
+
+    harness.model.setOutcome(3, { kind: "accept" });
+    const right = beginPatch(
+      harness,
+      DOCS.A,
+      [{
+        op: "replace",
+        path: "/value/right",
+        value: 2,
+      }],
+      {
+        left: 1,
+        right: 2,
+      },
+    );
+
+    expectVisible(harness, {
+      A: {
+        left: 1,
+        right: 2,
+      },
+    });
+
+    await assertResultOk(right);
+    assertEquals(leftSettled, false);
+    expectVisible(harness, {
+      A: {
+        left: 1,
+        right: 2,
+      },
+    });
+
+    leftResponseGate.resolve();
+    await assertResultOk(left);
+    expectVisible(harness, {
+      A: {
+        left: 1,
+        right: 2,
+      },
+    });
+  } finally {
+    leftResponseGate.resolve();
     await harness.close();
   }
 });

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -72,7 +72,7 @@ type TestProvider = IStorageProviderWithReplica & {
   get(uri: URI): EntityDocument | undefined;
 };
 
-type RootValue = Record<string, FabricValue> | undefined;
+type RootValue = FabricValue;
 type DocState = {
   seq: number;
   value: RootValue;
@@ -2170,6 +2170,133 @@ Deno.test("memory v2 stacked commits: pending visibility preserves array move pa
       A: {
         items: ["c", "a", "b"],
       },
+    });
+  } finally {
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: pending visibility can replace a null branch with an object patch", async () => {
+  const harness = await createHarness();
+  try {
+    await seedAccepted(harness, DOCS.A, null);
+
+    harness.model.setOutcome(2, {
+      kind: "rejectConflict",
+      message: "synthetic null-base conflict",
+    });
+    const patch = beginPatch(
+      harness,
+      DOCS.A,
+      [{
+        op: "replace",
+        path: "/value/choice/name",
+        value: "Sushi Place",
+      }],
+      {
+        choice: {
+          name: "Sushi Place",
+        },
+      },
+    );
+
+    expectVisible(harness, {
+      A: {
+        choice: {
+          name: "Sushi Place",
+        },
+      },
+    });
+
+    await assertConflict(patch, "synthetic null-base conflict");
+    expectVisible(harness, {
+      A: null,
+    });
+  } finally {
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: pending visibility can replace a scalar branch with an object patch", async () => {
+  const harness = await createHarness();
+  try {
+    await seedAccepted(harness, DOCS.A, {
+      choice: 1,
+    });
+
+    harness.model.setOutcome(2, {
+      kind: "rejectConflict",
+      message: "synthetic scalar-base conflict",
+    });
+    const patch = beginPatch(
+      harness,
+      DOCS.A,
+      [{
+        op: "replace",
+        path: "/value/choice/name",
+        value: "Sushi Place",
+      }],
+      {
+        choice: {
+          name: "Sushi Place",
+        },
+      },
+    );
+
+    expectVisible(harness, {
+      A: {
+        choice: {
+          name: "Sushi Place",
+        },
+      },
+    });
+
+    await assertConflict(patch, "synthetic scalar-base conflict");
+    expectVisible(harness, {
+      A: {
+        choice: 1,
+      },
+    });
+  } finally {
+    await harness.close();
+  }
+});
+
+Deno.test("memory v2 stacked commits: pending visibility can replace an array branch with an object patch", async () => {
+  const harness = await createHarness();
+  try {
+    await seedAccepted(harness, DOCS.A, []);
+
+    harness.model.setOutcome(2, {
+      kind: "rejectConflict",
+      message: "synthetic array-base conflict",
+    });
+    const patch = beginPatch(
+      harness,
+      DOCS.A,
+      [{
+        op: "replace",
+        path: "/value/choice/name",
+        value: "Sushi Place",
+      }],
+      {
+        choice: {
+          name: "Sushi Place",
+        },
+      },
+    );
+
+    expectVisible(harness, {
+      A: {
+        choice: {
+          name: "Sushi Place",
+        },
+      },
+    });
+
+    await assertConflict(patch, "synthetic array-base conflict");
+    expectVisible(harness, {
+      A: [],
     });
   } finally {
     await harness.close();


### PR DESCRIPTION
When a pending memory v2 patch writes a nested field, the confirmed document can still have null, a primitive, or an array at an ancestor path. The old pending visibility code replayed the nested leaf path directly over that confirmed value. That asked the clone helper to descend through a value that the path reader cannot traverse. In the null case it threw a CloneForMutationError. In the array case it could create a named array property that later reads could not see.

The code now checks each present ancestor before replaying a pending leaf write. If an ancestor cannot be traversed for the next path segment, and the pending value contains that ancestor, the code replaces that ancestor with the pending branch. Normal nested writes still use the exact changed path.

Add runner-level stacked commit tests for null, scalar, and array ancestors. These tests make the browser lunch poll failure reproducible in a deterministic storage test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pending patch visibility across branch type changes and log when a blocked branch is replaced. Prevents crashes and bad reads when replaying nested writes in memory v2, including during non-head confirmations.

- **Bug Fixes**
  - Detect the first existing ancestor that blocks traversal (arrays included) and apply the pending branch at that prefix; otherwise use the exact nested path.
  - Warn on branch replacement via `storage.v2.pending-patch` (`pending-branch-replace`) with space/id/scope/localSeq/path/replacementPath details.
  - Add runner tests for null, scalar, and array ancestors, plus confirming a later same-doc patch while an earlier pending overlay remains visible.

<sup>Written for commit 9addc59506406644c529d69891f2b10e6a5d85c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

