### PR TITLE
refactor(runner): replace sanitize cell flags with KeepAsCell enum

### DIFF
--- a/packages/html/src/h.ts
+++ b/packages/html/src/h.ts
@@ -7,7 +7,12 @@ import {
   type UiPromptSlotProps,
   type VNode,
 } from "@commonfabric/api";
-import { getCellOrThrow, isCell, isCellResult } from "@commonfabric/runner";
+import {
+  getCellOrThrow,
+  isCell,
+  isCellResult,
+  KeepAsCell,
+} from "@commonfabric/runner";
 
 /**
  * Fragment element name used for JSX fragments.
@@ -27,7 +32,7 @@ function bindingTargetLink(value: unknown): unknown {
     try {
       return (value as unknown as LinkableCell).getAsLink({
         includeSchema: true,
-        keepAsCell: true,
+        keepAsCell: KeepAsCell.All,
       });
     } catch (error) {
       if (isDeferredLinkContextError(error)) return value;
@@ -38,7 +43,7 @@ function bindingTargetLink(value: unknown): unknown {
     try {
       return (getCellOrThrow(value) as unknown as LinkableCell).getAsLink({
         includeSchema: true,
-        keepAsCell: true,
+        keepAsCell: KeepAsCell.All,
       });
     } catch (error) {
       if (isDeferredLinkContextError(error)) return value;

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -21,6 +21,7 @@ import {
   isCell,
   isStream,
   type JSONSchema,
+  KeepAsCell,
   parseLink,
   type Stream,
   UI,
@@ -2815,7 +2816,7 @@ export class WorkerReconciler {
     return convertCellsToLinks(value, {
       doNotConvertCellResults: true,
       includeSchema: true,
-      keepStreams: true,
+      keepAsCell: KeepAsCell.OnlyStream,
     });
   }
 

--- a/packages/html/test/worker-reconciler-cell-props.test.ts
+++ b/packages/html/test/worker-reconciler-cell-props.test.ts
@@ -5,7 +5,7 @@ import type { WorkerVNode } from "../src/worker/types.ts";
 import type { VDomOp } from "../src/vdom-ops.ts";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { Runtime } from "@commonfabric/runner";
+import { KeepAsCell, Runtime } from "@commonfabric/runner";
 import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import { cfcLabelViewForCell } from "@commonfabric/runner/cfc";
 
@@ -865,7 +865,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
         const propsCell = new MockPropsCell({
           $value: "linked content",
         }, {
-          $value: bindingCell.getAsLink({ keepAsCell: true }),
+          $value: bindingCell.getAsLink({ keepAsCell: KeepAsCell.All }),
         });
         const rootCell = new MockCell({
           type: "vnode",
@@ -991,7 +991,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
           props: {
             $value: bindingCell.getAsLink({
               includeSchema: true,
-              keepAsCell: true,
+              keepAsCell: KeepAsCell.All,
             }),
             author: "alice",
           },
@@ -1075,7 +1075,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
           type: "vnode",
           name: "cf-vstack",
           props: {},
-          children: [linkedChild.getAsLink({ keepAsCell: true })],
+          children: [linkedChild.getAsLink({ keepAsCell: KeepAsCell.All })],
         });
         const commitResult = await tx.commit();
         assertEquals(commitResult.ok !== undefined, true);
@@ -1141,7 +1141,7 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
                 props: { id: "nested-inline-card" },
                 children: ["Nested inline child"],
               },
-              linkedChild.getAsLink({ keepAsCell: true }),
+              linkedChild.getAsLink({ keepAsCell: KeepAsCell.All }),
             ],
           }],
         });

--- a/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
+++ b/packages/html/test/worker-reconciler-cfc-render-policy.test.ts
@@ -1,6 +1,10 @@
 import { assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
-import { isCell as isRuntimeCell, Runtime } from "@commonfabric/runner";
+import {
+  isCell as isRuntimeCell,
+  KeepAsCell,
+  Runtime,
+} from "@commonfabric/runner";
 import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import type { WorkerVNode } from "../src/worker/types.ts";
@@ -2004,18 +2008,18 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           props: {
             $value: message.getAsLink({
               includeSchema: true,
-              keepAsCell: true,
+              keepAsCell: KeepAsCell.All,
             }),
             verifyTextIntegrity: true,
             requiredTextIntegrity: requiredIntegrity.getAsLink({
               includeSchema: true,
-              keepAsCell: true,
+              keepAsCell: KeepAsCell.All,
             }),
           },
           children: [
             message.key("body").getAsLink({
               includeSchema: true,
-              keepAsCell: true,
+              keepAsCell: KeepAsCell.All,
             }),
           ],
         });
@@ -2123,7 +2127,7 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
             verifyTextIntegrity: true,
             requiredTextIntegrity: requiredIntegrity.getAsLink({
               includeSchema: true,
-              keepAsCell: true,
+              keepAsCell: KeepAsCell.All,
             }),
           },
           children: [{
@@ -2229,12 +2233,12 @@ Deno.test("worker reconciler CFC render policy", async (t) => {
           props: {
             $value: messages.key(1).getAsLink({
               includeSchema: true,
-              keepAsCell: true,
+              keepAsCell: KeepAsCell.All,
             }),
             verifyTextIntegrity: true,
             requiredTextIntegrity: requiredIntegrity.getAsLink({
               includeSchema: true,
-              keepAsCell: true,
+              keepAsCell: KeepAsCell.All,
             }),
           },
           children: [{

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -10,6 +10,7 @@ import {
   isLink,
   isStream,
   JSONSchema,
+  KeepAsCell,
   type MemorySpace,
   Module,
   parseLink,
@@ -960,7 +961,7 @@ export class PieceManager {
         linkCell.getAsLink({
           base: targetInputCell,
           includeSchema: true,
-          keepStreams: true,
+          keepAsCell: KeepAsCell.OnlyStream,
         }),
       );
     });

--- a/packages/piece/test/link-reactivity.test.ts
+++ b/packages/piece/test/link-reactivity.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { parseLink, resolveCellPath, Runtime } from "@commonfabric/runner";
+import {
+  KeepAsCell,
+  parseLink,
+  resolveCellPath,
+  Runtime,
+} from "@commonfabric/runner";
 import { taggedHashStringOf } from "@commonfabric/data-model/value-hash";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createSession, Identity } from "@commonfabric/identity";
@@ -105,7 +110,7 @@ describe("PieceManager.link() reactivity", () => {
         source.key("data").getAsLink({
           base: target,
           includeSchema: true,
-          keepStreams: true,
+          keepAsCell: KeepAsCell.OnlyStream,
         }),
       );
     });
@@ -197,7 +202,7 @@ describe("PieceManager.link() reactivity", () => {
         source.getAsLink({
           base: targetArgument,
           includeSchema: true,
-          keepStreams: true,
+          keepAsCell: KeepAsCell.OnlyStream,
         }),
       );
     });

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -39,6 +39,7 @@ import {
 import { traverseValue } from "./traverse-utils.ts";
 import {
   getStableInternalPathSegment,
+  KeepAsCell,
   sanitizeSchemaForLinks,
 } from "../link-utils.ts";
 import { type LegacyAlias } from "../sigil-types.ts";
@@ -422,10 +423,7 @@ function factoryFromPattern<T, R>(
     }
 
     const sanitizedSchema = cellReference.schema !== undefined
-      ? sanitizeSchemaForLinks(cellReference.schema, {
-        keepStreams: true,
-        keepAsCell: true,
-      })
+      ? sanitizeSchemaForLinks(cellReference.schema, KeepAsCell.All)
       : undefined;
     const partialCause = derivedInternalPartialCausesByRoot.get(top);
     if (partialCause !== undefined) {
@@ -486,11 +484,8 @@ function factoryFromPattern<T, R>(
   });
 
   const pattern: Pattern & toJSON = {
-    argumentSchema: sanitizeSchemaForLinks(argumentSchema, {
-      keepStreams: true,
-      keepAsCell: true,
-    }),
-    resultSchema: sanitizeSchemaForLinks(resultSchema, { keepStreams: true }),
+    argumentSchema: sanitizeSchemaForLinks(argumentSchema, KeepAsCell.All),
+    resultSchema: sanitizeSchemaForLinks(resultSchema, KeepAsCell.OnlyStream),
     ...(derivedInternalCells.length > 0 ? { derivedInternalCells } : {}),
     result,
     nodes: serializedNodes,

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -113,10 +113,10 @@ import {
   createSigilLinkFromParsedLink,
   findAndInlineDataURILinks,
   isCellLink,
+  KeepAsCell,
   type NormalizedFullLink,
   type NormalizedLink,
   parseLink,
-  type SanitizeSchemaForLinksOptions,
   toMemorySpaceAddress,
 } from "./link-utils.ts";
 import { isCellScope, normalizeCellScope } from "./scope.ts";
@@ -338,7 +338,8 @@ declare module "@commonfabric/api" {
         base?: Cell<any>;
         baseSpace?: MemorySpace;
         includeSchema?: boolean;
-      } & SanitizeSchemaForLinksOptions,
+        keepAsCell?: KeepAsCell;
+      },
     ): SigilLink;
     getAsWriteRedirectLink(
       options?: {
@@ -2005,7 +2006,8 @@ export class CellImpl<T extends FabricValue>
       base?: Cell<any>;
       baseSpace?: MemorySpace;
       includeSchema?: boolean;
-    } & SanitizeSchemaForLinksOptions,
+      keepAsCell?: KeepAsCell;
+    },
   ): SigilLink {
     return createSigilLinkFromParsedLink(this.link, {
       ...options,
@@ -3041,7 +3043,8 @@ export function convertCellsToLinks(
     includeSchema?: boolean;
     doNotConvertCellResults?: boolean;
     includeCfcLabelView?: boolean;
-  } & SanitizeSchemaForLinksOptions = {},
+    keepAsCell?: KeepAsCell;
+  } = {},
   path: string[] = [],
   seen: Map<any, string[]> = new Map(),
 ): any {

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -76,6 +76,7 @@ export {
   getMetaLink,
   isCellLink as isLink,
   isWriteRedirectLink,
+  KeepAsCell,
   parseLink,
   parseLinkOrThrow,
   parseLLMFriendlyLink,

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -211,7 +211,10 @@ export function createSigilLinkFromParsedLink(
     baseSpace?: MemorySpace;
     includeSchema?: boolean;
     overwrite?: "redirect" | "this"; // default is "this"
-  } & SanitizeSchemaForLinksOptions = {},
+    // Which asCell entries to preserve in the included schema. When omitted,
+    // streams are kept (see below) and all other asCell entries are stripped.
+    keepAsCell?: KeepAsCell;
+  } = {},
 ): SigilLink {
   // Create the base structure
   const sigil: SigilLink = linkRefFrom<CellLinkRefPayload>({
@@ -247,12 +250,11 @@ export function createSigilLinkFromParsedLink(
   // Include schema if requested. Empty `{}` and JSON Schema `true` are
   // permissive and should not turn links into schema-bearing links.
   if (options.includeSchema && link.schema !== undefined) {
-    // If they didn't opt-out of keepStreams, set it to true
-    const extendedOptions = {
-      ...options,
-      keepStreams: options.keepStreams ?? true,
-    };
-    const schema = sanitizeSchemaForLinks(link.schema, extendedOptions);
+    // Default to keeping streams unless a broader mode was requested.
+    const schema = sanitizeSchemaForLinks(
+      link.schema,
+      options.keepAsCell ?? KeepAsCell.OnlyStream,
+    );
     if (isNontrivialSchema(schema)) reference.schema = schema;
   }
 
@@ -313,7 +315,7 @@ export function findAndInlineDataURILinks(value: any): any {
             ...(schema !== undefined && { schema }),
           }, {
             includeSchema: true,
-            keepAsCell: true,
+            keepAsCell: KeepAsCell.All,
           });
           return findAndInlineDataURILinks(newSigilLink);
         }
@@ -384,7 +386,7 @@ export function createDataCellURI(
         const link = parseLink(value, baseLink);
         return createSigilLinkFromParsedLink(link, {
           includeSchema: true,
-          keepAsCell: true,
+          keepAsCell: KeepAsCell.All,
         });
       } else if (Array.isArray(value)) {
         return value.map((item) =>
@@ -408,12 +410,17 @@ export function createDataCellURI(
   return `data:application/json,${encodeURIComponent(json)}` as URI;
 }
 
-export type SanitizeSchemaForLinksOptions = {
-  // Keep the entire asCell entry, which preserves cell, opaque, and stream
-  keepAsCell?: boolean;
-  // Only keep the asCell property if it's a stream
-  keepStreams?: boolean;
-};
+/**
+ * Controls which `asCell` schema entries survive {@link sanitizeSchemaForLinks}.
+ */
+export enum KeepAsCell {
+  // Strip all asCell entries (cell, opaque, and stream).
+  None = "None",
+  // Keep the asCell entry only when it's a stream.
+  OnlyStream = "OnlyStream",
+  // Keep the entire asCell entry (preserves cell, opaque, and stream).
+  All = "All",
+}
 
 /**
  * Traverse schema and remove all asCell flags.
@@ -426,15 +433,15 @@ export type SanitizeSchemaForLinksOptions = {
  */
 export function sanitizeSchemaForLinks(
   schema: JSONSchema,
-  options?: SanitizeSchemaForLinksOptions,
+  keepAsCell?: KeepAsCell,
 ): JSONSchema;
 export function sanitizeSchemaForLinks(
   schema: JSONSchema | undefined,
-  options?: SanitizeSchemaForLinksOptions,
+  keepAsCell?: KeepAsCell,
 ): JSONSchema | undefined;
 export function sanitizeSchemaForLinks(
   schema: JSONSchema | undefined,
-  options?: SanitizeSchemaForLinksOptions,
+  keepAsCell: KeepAsCell = KeepAsCell.None,
 ): JSONSchema | undefined {
   if (schema === undefined || typeof schema === "boolean") {
     return schema;
@@ -458,7 +465,7 @@ export function sanitizeSchemaForLinks(
     defs: {},
     defCounter: 0,
     reservedNames: existingDefNames,
-    options: options ?? {},
+    keepAsCell,
   };
 
   const result = recursiveStripAsCellFromSchema(
@@ -491,8 +498,8 @@ interface SanitizeContext {
   defCounter: number;
   // Reserved def names (from existing $defs in input schema)
   reservedNames: Set<string>;
-  // Options
-  options: SanitizeSchemaForLinksOptions;
+  // Which asCell entries to preserve while stripping.
+  keepAsCell: KeepAsCell;
 }
 
 /**
@@ -552,14 +559,14 @@ function recursiveStripAsCellFromSchema(
   let result;
   // Shallow copy — only top-level keys are deleted/replaced; children are
   // handled by recursive calls that create their own copies.
-  if (context.options.keepAsCell) {
+  if (context.keepAsCell === KeepAsCell.All) {
     result = { ...schema };
   } else {
     const { asCell: _c, ...restSchema } = schema;
     const asCellValues = ContextualFlowControl.getAsCellValues(schema);
     // If we're keeping streams and the outermost is a stream, keep it
     if (
-      context.options.keepStreams &&
+      context.keepAsCell === KeepAsCell.OnlyStream &&
       ContextualFlowControl.getAsCellKind(asCellValues.at(0)) === "stream"
     ) {
       result = { asCell: asCellValues, ...restSchema };
@@ -624,7 +631,7 @@ function recursiveStripAsCellFromSchema(
 
   // Stream properties will be removed if didn't keep streams, so we need to
   // remove them from required if present.
-  if (context.options.keepStreams !== true) {
+  if (context.keepAsCell === KeepAsCell.None) {
     removeStrippedStreamPropertiesFromRequired(schema, result, context);
   }
 
@@ -647,7 +654,9 @@ function schemaLosesStreamCellMarker(
   schema: unknown,
   context: SanitizeContext,
 ): boolean {
-  if (context.options.keepAsCell || !isRecord(schema)) return false;
+  if (context.keepAsCell === KeepAsCell.All || !isRecord(schema)) {
+    return false;
+  }
 
   const asCellValues = ContextualFlowControl.getAsCellValues(schema);
   const hasStreamMarker = asCellValues.some((entry) =>
@@ -656,7 +665,7 @@ function schemaLosesStreamCellMarker(
   if (!hasStreamMarker) return false;
 
   return !(
-    context.options.keepStreams &&
+    context.keepAsCell === KeepAsCell.OnlyStream &&
     ContextualFlowControl.getAsCellKind(asCellValues.at(0)) === "stream"
   );
 }

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -17,6 +17,7 @@ import {
   isCellLink,
   isLegacyAlias,
   isWriteRedirectLink,
+  KeepAsCell,
   type NormalizedFullLink,
   parseLink,
   sanitizeSchemaForLinks,
@@ -48,7 +49,7 @@ type UnwrapOneLevelOptions = {
    * sanitized schema (`sanitizeSchemaForLinks` strips `asCell` entries,
    * taking their scope annotation with them), so a `PerUser<Cell<>>`
    * declaration is invisible on the link by the time aliases are bound. The
-   * authored pattern schema keeps `asCell` (`keepAsCell: true` in
+   * authored pattern schema keeps `asCell` (`keepAsCell: KeepAsCell.All` in
    * builder/pattern.ts) and is the ground truth for what each slot declared.
    * (Internal cells don't need this: each derived internal cell carries its
    * declared scope on its descriptor, realized directly on its link.)
@@ -150,7 +151,7 @@ const sanitizeAliasSchemaForBinding = (schema: JSONSchema): JSONSchema =>
   // Compiled aliases retain asCell for schema fidelity. Live redirects use link
   // schemas without cell wrappers so scoped asCell entries do not stamp the
   // redirect link's own scope and bypass stored argument links.
-  sanitizeSchemaForLinks(schema, { keepStreams: true });
+  sanitizeSchemaForLinks(schema, KeepAsCell.OnlyStream);
 
 const descriptorForPartialCauseAlias = (
   partialCause: JSONValue,

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -826,6 +826,87 @@ describe("link-utils", () => {
       expect(result).toEqual(schema);
     });
 
+    it("respects KeepAsCell modes for mixed cell wrappers", () => {
+      const schema = {
+        type: "object",
+        asCell: ["stream", "cell"],
+        properties: {
+          title: { type: "string" },
+          count: {
+            type: "number",
+            asCell: [{ kind: "cell", scope: "user" }],
+          },
+          submit: {
+            type: "object",
+            asCell: ["stream"],
+            properties: {
+              value: { type: "string", asCell: ["opaque"] },
+            },
+            required: ["value"],
+          },
+          nestedStream: {
+            type: "object",
+            asCell: ["cell", "stream"],
+            properties: {
+              value: { type: "string" },
+            },
+            required: ["value"],
+          },
+        },
+        required: ["title", "count", "submit", "nestedStream"],
+      } as const satisfies JSONSchema;
+
+      expect(sanitizeSchemaForLinks(schema, KeepAsCell.None)).toEqual({
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          count: { type: "number" },
+          submit: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+            required: ["value"],
+          },
+          nestedStream: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+            required: ["value"],
+          },
+        },
+        required: ["title", "count"],
+      });
+
+      expect(sanitizeSchemaForLinks(schema, KeepAsCell.OnlyStream)).toEqual({
+        type: "object",
+        asCell: ["stream", "cell"],
+        properties: {
+          title: { type: "string" },
+          count: { type: "number" },
+          submit: {
+            type: "object",
+            asCell: ["stream"],
+            properties: {
+              value: { type: "string" },
+            },
+            required: ["value"],
+          },
+          nestedStream: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+            required: ["value"],
+          },
+        },
+        required: ["title", "count", "submit", "nestedStream"],
+      });
+
+      expect(sanitizeSchemaForLinks(schema, KeepAsCell.All)).toEqual(schema);
+    });
+
     it("should handle arrays of schemas", () => {
       const schema = {
         type: "object",

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -13,6 +13,7 @@ import {
   isLegacyAlias,
   isSigilLink,
   isWriteRedirectLink,
+  KeepAsCell,
   type NormalizedLink,
   parseLink,
   parseLinkOrThrow,
@@ -651,7 +652,7 @@ describe("link-utils", () => {
         path: [],
         space,
         schema,
-      }, { includeSchema: true, keepStreams: false });
+      }, { includeSchema: true, keepAsCell: KeepAsCell.None });
 
       expect(linkRefPayload(result).schema).toEqual({
         type: "object",
@@ -820,7 +821,7 @@ describe("link-utils", () => {
         required: ["setTitle"],
       } as const satisfies JSONSchema;
 
-      const result = sanitizeSchemaForLinks(schema, { keepStreams: true });
+      const result = sanitizeSchemaForLinks(schema, KeepAsCell.OnlyStream);
 
       expect(result).toEqual(schema);
     });
@@ -1050,14 +1051,14 @@ describe("link-utils", () => {
       expect((result as any).b).not.toHaveProperty("asCell");
     });
 
-    it("should handle keepStreams option with circular schemas", () => {
+    it("should handle OnlyStream option with circular schemas", () => {
       const schema: any = {
         type: "object",
         asCell: ["stream"],
       };
       schema.self = schema;
 
-      const result = sanitizeSchemaForLinks(schema, { keepStreams: true });
+      const result = sanitizeSchemaForLinks(schema, KeepAsCell.OnlyStream);
 
       // Expect the new version of asStream (where it's an entry in asCell)
       expect((result as any).asCell).toEqual(["stream"]);
@@ -1209,8 +1210,8 @@ describe("link-utils", () => {
       const resultDefault = sanitizeSchemaForLinks(schema);
       expect(resultDefault).not.toHaveProperty("asCell");
 
-      // With keepAsCell: true, it should be preserved
-      const resultKept = sanitizeSchemaForLinks(schema, { keepAsCell: true });
+      // With keepAsCell: All, it should be preserved
+      const resultKept = sanitizeSchemaForLinks(schema, KeepAsCell.All);
       expect((resultKept as any).asCell).toEqual(["opaque"]);
     });
   });

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -805,6 +805,41 @@ describe("link-utils", () => {
       });
     });
 
+    it("keeps required entries for boolean property schemas", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          payload: true,
+          submit: {
+            type: "object",
+            asCell: ["stream"],
+            properties: {
+              value: { type: "string" },
+            },
+            required: ["value"],
+          },
+        },
+        required: ["payload", "submit"],
+      } as const satisfies JSONSchema;
+
+      const result = sanitizeSchemaForLinks(schema);
+
+      expect(result).toEqual({
+        type: "object",
+        properties: {
+          payload: true,
+          submit: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+            required: ["value"],
+          },
+        },
+        required: ["payload"],
+      });
+    });
+
     it("should keep required entries for preserved stream properties", () => {
       const schema = {
         type: "object",

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -37,6 +37,7 @@ import { NameSchema, rendererVDOMSchema } from "@commonfabric/runner/schemas";
 import { StorageManager } from "../../runner/src/storage/cache.ts";
 import {
   getMetaLink,
+  KeepAsCell,
   type NormalizedFullLink,
   parseLink,
 } from "../../runner/src/link-utils.ts";
@@ -666,7 +667,7 @@ export class RuntimeProcessor {
     const value = cell.get();
     const converted = convertCellsToLinks(value, {
       includeSchema: true,
-      keepAsCell: true,
+      keepAsCell: KeepAsCell.All,
       doNotConvertCellResults: true,
       includeCfcLabelView: true,
     });
@@ -730,7 +731,7 @@ export class RuntimeProcessor {
       }
       const converted = convertCellsToLinks(value, {
         includeSchema: true,
-        keepAsCell: true,
+        keepAsCell: KeepAsCell.All,
         doNotConvertCellResults: true,
         includeCfcLabelView: true,
       });

--- a/packages/runtime-client/backends/utils.ts
+++ b/packages/runtime-client/backends/utils.ts
@@ -1,4 +1,10 @@
-import { Cell, JSONSchema, parseLink, SigilLink } from "@commonfabric/runner";
+import {
+  Cell,
+  JSONSchema,
+  KeepAsCell,
+  parseLink,
+  SigilLink,
+} from "@commonfabric/runner";
 import { cfcLabelViewForCell } from "@commonfabric/runner/cfc";
 import { CellRef, PageRef } from "../protocol/types.ts";
 import { Runtime } from "@commonfabric/runner";
@@ -44,7 +50,7 @@ export function createCellRef(cell: Cell<unknown>, schema?: unknown): CellRef {
   const link = parseLink(
     cell.getAsLink({
       includeSchema: true,
-      keepAsCell: true,
+      keepAsCell: KeepAsCell.All,
     }),
   );
   // Check before casting to a NormalizedFullLink


### PR DESCRIPTION
## Summary

Cleans up `sanitizeSchemaForLinks`'s option surface, which carried two overlapping booleans (`keepAsCell` + `keepStreams`) — several call sites passed both, where `keepAsCell: true` already implied keeping streams.

- Replaces the two booleans with a single `KeepAsCell` enum: `None` (strip all asCell entries), `OnlyStream` (keep only stream entries), `All` (keep cell, opaque, and stream).
- `sanitizeSchemaForLinks` now takes the enum value directly instead of an options object, defaulting to `KeepAsCell.None`.
- Removes `SanitizeSchemaForLinksOptions`, folding `keepAsCell?: KeepAsCell` directly into the option bags of `createSigilLinkFromParsedLink`, `cell.getAsLink`, and `convertCellsToLinks`.
- Updates all call sites across `runner`, `html`, `piece`, and `runtime-client` (the redundant both-flags sites collapse to `KeepAsCell.All`).

No behavior change — purely a clarification of the API.

## Test plan

- `deno task test` (full workspace suite): all tests passing.
- `deno fmt --check` and `deno lint` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the overlapping keepAsCell/keepStreams flags with a single KeepAsCell enum to simplify link schema handling. Behavior is unchanged; defaults still keep stream markers when including schema.

- **Refactors**
  - Added `KeepAsCell` enum: `None`, `OnlyStream`, `All` (exported from `@commonfabric/runner`).
  - `sanitizeSchemaForLinks` now takes `KeepAsCell` directly and defaults to `KeepAsCell.None`.
  - Folded `keepAsCell?: KeepAsCell` into `createSigilLinkFromParsedLink`, `Cell.getAsLink`, and `convertCellsToLinks` (replacing the old options object). When `includeSchema` is set and no mode is provided, streams are kept by default.
  - Updated call sites across `@commonfabric/runner`, `@commonfabric/html`, `@commonfabric/piece`, and runtime-client.
  - Expanded tests to cover `KeepAsCell` modes, circular schemas, and required handling with boolean property schemas.

- **Migration**
  - Replace `{ keepAsCell: true }` with `keepAsCell: KeepAsCell.All`.
  - Replace `{ keepStreams: true }` with `keepAsCell: KeepAsCell.OnlyStream`.
  - Replace `{ keepStreams: false }` or omissions with `KeepAsCell.None` (or omit; it’s the default).
  - Change `sanitizeSchemaForLinks(schema, opts)` to `sanitizeSchemaForLinks(schema, KeepAsCell....)`.

<sup>Written for commit dad96c301aba48a3058f7babbe1779630e7eb813. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

