### PR TITLE
Split runner tests across five CI shards

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -132,8 +132,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
-        total: [4]
+        shard: [1, 2, 3, 4, 5]
+        total: [5]
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -610,7 +610,7 @@ const EXCLUDED_METRIC_PATTERNS = [
 
 const EXPECTED_COVERAGE_ARTIFACT_NAMES = [
   "coverage-profile-workspace",
-  ...[1, 2, 3, 4].map((shard) => `coverage-profile-runner-${shard}`),
+  ...[1, 2, 3, 4, 5].map((shard) => `coverage-profile-runner-${shard}`),
   ...[1, 2, 3, 4].map((shard) =>
     `coverage-profile-generated-patterns-${shard}`
   ),

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -364,7 +364,7 @@ Deno.test("extractMetrics aggregates runner test matrix shards", () => {
   const metrics = extractMetrics(makeRun(), [
     makeJob(
       1,
-      "Runner Tests (1/4)",
+      "Runner Tests (1/5)",
       "2026-01-01T00:00:00Z",
       "2026-01-01T00:01:40Z",
       [
@@ -377,7 +377,7 @@ Deno.test("extractMetrics aggregates runner test matrix shards", () => {
     ),
     makeJob(
       2,
-      "Runner Tests (2/4)",
+      "Runner Tests (2/5)",
       "2026-01-01T00:00:00Z",
       "2026-01-01T00:01:10Z",
       [
@@ -391,11 +391,11 @@ Deno.test("extractMetrics aggregates runner test matrix shards", () => {
   ]);
 
   assertEquals(
-    metrics.get("job: Runner Tests (1/4)")?.durationSeconds,
+    metrics.get("job: Runner Tests (1/5)")?.durationSeconds,
     100,
   );
   assertEquals(
-    metrics.get("job: Runner Tests (2/4)")?.durationSeconds,
+    metrics.get("job: Runner Tests (2/5)")?.durationSeconds,
     70,
   );
   assertEquals(metrics.get("job: Runner Tests")?.durationSeconds, 100);
@@ -522,7 +522,7 @@ Deno.test("computeCiWallTimeRevisitSignals stays quiet for balanced CI", () => {
     ),
     makeJob(
       5,
-      "Runner Tests (1/4)",
+      "Runner Tests (1/5)",
       "2026-01-01T00:00:00Z",
       "2026-01-01T00:01:35Z",
       [],
@@ -564,7 +564,7 @@ Deno.test("computeCiWallTimeRevisitSignals flags slow and imbalanced jobs", () =
     ),
     makeJob(
       5,
-      "Runner Tests (1/4)",
+      "Runner Tests (1/5)",
       "2026-01-01T00:00:00Z",
       "2026-01-01T00:01:25Z",
       [],

--- a/tasks/select-runner-test-files.test.ts
+++ b/tasks/select-runner-test-files.test.ts
@@ -5,20 +5,20 @@ import {
 } from "./select-runner-test-files.ts";
 import { parseShard } from "./shard-utils.ts";
 
-const TOTAL_SHARDS = 4;
+const TOTAL_SHARDS = 5;
 
 Deno.test("parseShard parses shard notation", () => {
-  assertEquals(parseShard("2/4"), { index: 2, total: 4 });
+  assertEquals(parseShard("2/5"), { index: 2, total: 5 });
 });
 
 Deno.test("parseShard rejects invalid shard notation", () => {
   try {
-    parseShard("5/4");
+    parseShard("6/5");
     throw new Error("expected parseShard to throw");
   } catch (error) {
     assertEquals(
       (error as Error).message,
-      "Shard index 5 exceeds total shard count 4",
+      "Shard index 6 exceeds total shard count 5",
     );
   }
 });
@@ -27,7 +27,7 @@ Deno.test("runner test round-robin keeps shard counts even", () => {
   const files = Array.from({ length: 30 }, (_, i) => ({
     name: `t${String(i).padStart(2, "0")}.test.ts`,
   }));
-  const counts = [1, 2, 3, 4].map((index) =>
+  const counts = [1, 2, 3, 4, 5].map((index) =>
     selectRunnerTestFiles(files, { index, total: TOTAL_SHARDS }).length
   );
   assertEquals(


### PR DESCRIPTION
The runner test job has outgrown the four-way split, so the CI matrix now fans the runner suite out across five shards. This keeps the existing selection mechanism and only changes the shard count used by the workflow.

The performance gate expects one coverage artifact per runner shard. Update that expected artifact list so the new fifth runner job is treated as required coverage input instead of being ignored or reported as missing from the wrong side of the check.

Update the runner shard selector tests and timing helper fixtures to use the five-shard runner job shape. These tests keep the real runner test file list covered exactly once and keep performance metric examples aligned with the workflow names.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split runner tests into five CI shards to keep runtimes balanced and shorten individual jobs. Updated coverage artifact expectations and test fixtures to match the five-shard layout so the performance gate stays accurate.

- **Refactors**
  - CI matrix: set `shard: [1, 2, 3, 4, 5]` and `total: [5]` in `.github/workflows/deno.yml`.
  - Performance gate: require `coverage-profile-runner-1..5` artifacts in `tasks/perf-check.ts`.
  - Tests: update runner job names to "(x/5)", shard parsing, and round-robin counts in `tasks/perf-lib.test.ts` and `tasks/select-runner-test-files.test.ts`.

<sup>Written for commit 3a252fe8d2c43d8c5161a12a8a06f38a5f4f1442. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

