### PR TITLE
Exclude scripts/ from coverage gating

### DIFF
--- a/docs/development/COVERAGE.md
+++ b/docs/development/COVERAGE.md
@@ -53,9 +53,10 @@ through `cf test`. Setting the variable on such a job has no effect at all.
 
 `tasks/perf-check.ts` downloads every `coverage-profile-*` artifact, joins all
 the LCOV files together, and hands them to `tasks/coverage-metrics.ts`. That
-code walks the tracked source files under `packages`, `tasks`, and `scripts`,
-and for each file counts how many of its lines no test covered. The counts roll
-up into `coverage-debt: <group> uncovered lines` metrics, for example
+code walks the tracked source files under `packages` and `tasks`, and for each
+file counts how many of its lines no test covered. The top-level `scripts`
+directory is excluded from this gate. The counts roll up into
+`coverage-debt: <group> uncovered lines` metrics, for example
 `coverage-debt: packages/patterns uncovered lines`, and the performance check
 gates a pull request on them.
 

--- a/scripts/deno.jsonc
+++ b/scripts/deno.jsonc
@@ -1,4 +1,5 @@
 {
+  // This directory is explicitly excluded from coverage checking.
   "tasks": {
     "test": "deno test -A --permit-no-files"
   }

--- a/tasks/coverage-metrics.test.ts
+++ b/tasks/coverage-metrics.test.ts
@@ -68,6 +68,8 @@ Deno.test("source inventory helpers group tracked files by package", () => {
     shouldTrackSourceFile("packages/vendor-astral/src/page.ts"),
     false,
   );
+  assertEquals(shouldTrackSourceFile("scripts/start-local-dev.sh"), false);
+  assertEquals(shouldTrackSourceFile("scripts/build.ts"), false);
   assertEquals(
     metricGroupFor("packages/runner/src/cell.ts"),
     "packages/runner",
@@ -89,6 +91,7 @@ Deno.test("collectSourceFiles excludes generated and dependency directories", as
     await writeSourceFile("packages/example/node_modules/dep/index.ts");
     await writeSourceFile("packages/example/coverage/report.ts");
     await writeSourceFile("packages/example/src/test/helper.ts");
+    await writeSourceFile("scripts/build.ts");
 
     const files = await collectSourceFiles(rootDir);
     assertEquals(
@@ -170,6 +173,7 @@ Deno.test("collectUncoveredLinesForFiles resolves lines only for requested files
       files: [
         "packages/example/src/covered.ts",
         "packages/example/src/untested.ts",
+        "scripts/build.ts",
         // A test file is not tracked source, so it is skipped.
         "packages/example/src/covered.test.ts",
       ],
@@ -180,6 +184,7 @@ Deno.test("collectUncoveredLinesForFiles resolves lines only for requested files
     // Absent from the report: every tracked line is uncovered.
     assertEquals(uncovered.get("packages/example/src/untested.ts"), [1]);
     // Untracked and unrequested files are absent.
+    assertEquals(uncovered.has("scripts/build.ts"), false);
     assertEquals(uncovered.has("packages/example/src/covered.test.ts"), false);
     assertEquals(uncovered.has("packages/example/src/other.ts"), false);
   } finally {

--- a/tasks/coverage-metrics.ts
+++ b/tasks/coverage-metrics.ts
@@ -5,7 +5,7 @@ export const COVERAGE_PROFILE_ARTIFACT_PREFIX = "coverage-profile-";
 export const COVERAGE_METRIC_PREFIX = "coverage-debt:";
 
 const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx"]);
-const SOURCE_ROOTS = ["packages", "tasks", "scripts"];
+const SOURCE_ROOTS = ["packages", "tasks"];
 const EXCLUDED_PATH_PARTS = new Set([
   ".cache",
   "build",
@@ -188,6 +188,10 @@ export async function collectSourceFiles(
 
 export function shouldTrackSourceFile(relativePath: string): boolean {
   const normalized = toPosix(relativePath);
+  if (normalized === "scripts" || normalized.startsWith("scripts/")) {
+    return false;
+  }
+
   const extension = path.extname(normalized);
   if (!SOURCE_EXTENSIONS.has(extension)) return false;
 

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -736,6 +736,7 @@ Deno.test("coverage debt gating follows changed source groups", () => {
     "packages/patterns/README.md",
     "packages/ui/src/button.test.tsx",
     "tasks/perf-check.ts",
+    "scripts/build.ts",
   ]);
 
   assertEquals([...groups].sort(), ["packages/runner", "packages/ui", "tasks"]);

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -1450,7 +1450,7 @@ export function coverageGroupForChangedFile(filename: string): string | null {
   if (parts[0] === "packages" && parts[1]) {
     return `packages/${parts[1]}`;
   }
-  if (parts[0] === "tasks" || parts[0] === "scripts") {
+  if (parts[0] === "tasks") {
     return parts[0];
   }
   return null;


### PR DESCRIPTION
- Exclude top-level `scripts/` from coverage debt source discovery and changed-file gating
- Document the `scripts/` coverage exclusion

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude top-level `scripts/` from coverage gating and move/own the CLI CPU profiling tools under `packages/cli/support/profiling`, with focused tests and a smoke test. The profiler attach flow is now reliable for short-lived commands.

- **Refactors**
  - Move profiling wrapper, capture script, and helpers to `packages/cli/support/profiling`; extract logic into `cf-profile-lib.ts` and `capture-deno-inspector-profile-lib.ts` with unit tests, plus a smoke test that profiles CLI `--help`. Update the root `cf-profile` task to point to the new path; resolve the capture script relative to the support directory; include support tests via the CLI `test` task; make `scripts/` tests a no-op.

- **Bug Fixes**
  - Exclude `scripts/` from coverage source discovery, uncovered-line checks, and changed-file coverage grouping; add an explicit guard in `shouldTrackSourceFile`; update docs (`docs/development/COVERAGE.md`) and `scripts/deno.jsonc`.
  - Fix attach handshake: run the CLI with `--inspect-wait`, have capture send `Runtime.runIfWaitingForDebugger`, resume on `Debugger.paused` (with retry), prevent double `Profiler.start`, and terminate the CLI if capture fails first.
  - Fix profiling helper test lint by returning explicit resolved promises in test doubles.

<sup>Written for commit da20e1443b7c4872913757364df60ae7c7db05fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

