### PR TITLE
fix(patterns): preserve OCR string errors in extraction

### DIFF
--- a/packages/patterns/record/extraction/error-utils.test.ts
+++ b/packages/patterns/record/extraction/error-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { getOcrErrorText } from "./error-utils.ts";
+
+describe("getOcrErrorText", () => {
+  it("preserves string errors", () => {
+    expect(getOcrErrorText("OCR request failed")).toBe("OCR request failed");
+  });
+
+  it("returns undefined for missing errors", () => {
+    expect(getOcrErrorText(undefined)).toBeUndefined();
+    expect(getOcrErrorText(null)).toBeUndefined();
+    expect(getOcrErrorText("")).toBeUndefined();
+  });
+
+  it("reads a legacy object message", () => {
+    expect(getOcrErrorText({ message: "Vision model timed out" })).toBe(
+      "Vision model timed out",
+    );
+  });
+
+  it("reads Error messages", () => {
+    expect(getOcrErrorText(new Error("Image was too large"))).toBe(
+      "Image was too large",
+    );
+  });
+
+  it("falls back to string conversion", () => {
+    expect(getOcrErrorText({ code: "OCR_FAILED" })).toBe("[object Object]");
+  });
+});

--- a/packages/patterns/record/extraction/error-utils.ts
+++ b/packages/patterns/record/extraction/error-utils.ts
@@ -1,0 +1,18 @@
+export function getOcrErrorText(error: unknown): string | undefined {
+  if (!error) {
+    return undefined;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  if (typeof error === "object" && "message" in error) {
+    const message = error.message;
+    if (message) {
+      return String(message);
+    }
+  }
+
+  return String(error);
+}

--- a/packages/patterns/record/extraction/extractor-module.tsx
+++ b/packages/patterns/record/extraction/extractor-module.tsx
@@ -50,6 +50,7 @@ import { getConfidenceLevel, SOURCE_PRECEDENCE } from "./types.ts";
 import type { JSONSchema } from "./schema-utils.ts";
 import { getResultSchema, getSchemaForType } from "./schema-utils.ts";
 import { getCellValue } from "./schema-utils-pure.ts";
+import { getOcrErrorText } from "./error-utils.ts";
 
 // ===== Types =====
 
@@ -1819,9 +1820,9 @@ export const ExtractorModule = pattern<
       if (!calls || calls.length === 0) return errors;
 
       for (const call of calls) {
-        const error = call.ocr?.error as { message?: string } | undefined;
-        if (error) {
-          errors[call.index] = String(error.message || error);
+        const errorText = getOcrErrorText(call.ocr?.error);
+        if (errorText) {
+          errors[call.index] = errorText;
         }
       }
       return errors;
@@ -1831,6 +1832,12 @@ export const ExtractorModule = pattern<
     const hasOcrErrors = computed(() => {
       const errors = ocrErrors;
       return Object.keys(errors).length > 0;
+    });
+
+    const ocrErrorMessage = computed((): string | null => {
+      const errors = Object.values(ocrErrors);
+      if (errors.length === 0) return null;
+      return errors.join("; ");
     });
 
     // ===== PER-SOURCE EXTRACTION ARCHITECTURE =====
@@ -2655,8 +2662,9 @@ export const ExtractorModule = pattern<
                     >
                       <span style={{ fontSize: "16px" }}>⚠️</span>
                       <span>
-                        OCR failed for some photos. Extraction will continue
-                        with available text.
+                        OCR failed for some photos:{" "}
+                        {ocrErrorMessage}. Extraction will continue with
+                        available text.
                       </span>
                     </div>,
                     null,

--- a/packages/patterns/test/source-coverage/commonfabric-stub.test.ts
+++ b/packages/patterns/test/source-coverage/commonfabric-stub.test.ts
@@ -20,6 +20,15 @@ export const TILE_UI = "__tile_ui";
 export const SELF = "__self";
 
 const wishResults = new Map<string, unknown>();
+let generateTextResult: {
+  pending: boolean;
+  result?: unknown;
+  error?: unknown;
+} = {
+  pending: false,
+  result: "",
+  error: undefined,
+};
 
 export function setWishResult(query: string, result: unknown): void {
   wishResults.set(query, result);
@@ -27,6 +36,22 @@ export function setWishResult(query: string, result: unknown): void {
 
 export function clearWishResults(): void {
   wishResults.clear();
+}
+
+export function setGenerateTextResult(result: {
+  pending: boolean;
+  result?: unknown;
+  error?: unknown;
+}): void {
+  generateTextResult = result;
+}
+
+export function clearGenerateTextResult(): void {
+  generateTextResult = {
+    pending: false,
+    result: "",
+    error: undefined,
+  };
 }
 
 export class Writable<T = unknown> {
@@ -221,6 +246,16 @@ export function generateObject<T>(
   _params: Record<string, unknown>,
 ): { pending: false; result: T; error: undefined } {
   return { pending: false, result: {} as T, error: undefined };
+}
+
+export function generateText<T>(
+  _params: Record<string, unknown>,
+): { pending: boolean; result?: T; error?: unknown } {
+  return generateTextResult as {
+    pending: boolean;
+    result?: T;
+    error?: unknown;
+  };
 }
 
 export function llmDialog<T>(

--- a/packages/patterns/test/source-coverage/fixtures/pattern-source-coverage-child.js
+++ b/packages/patterns/test/source-coverage/fixtures/pattern-source-coverage-child.js
@@ -1,7 +1,9 @@
 import {
+  clearGenerateTextResult,
   clearWishResults,
   findEventHandlers,
   NAME,
+  setGenerateTextResult,
   setWishResult,
   textContent,
   UI,
@@ -127,5 +129,86 @@ if (Deno.env.get("SOURCE_COVERAGE_CHILD") === "1") {
       textContent(uiOf(journal)).includes("Journal subject"),
       "journal renders entries with typed subject cells",
     );
+
+    const { default: ExtractorModule } = await import(
+      "../../../record/extraction/extractor-module.tsx"
+    );
+    setGenerateTextResult({
+      pending: false,
+      result: undefined,
+      error: "OCR request failed",
+    });
+    const extractor = instantiatePattern(ExtractorModule, {
+      parentSubPieces: new Writable([
+        {
+          type: "photo",
+          pinned: false,
+          piece: {
+            image: {
+              data: "data:image/png;base64,AAAA",
+            },
+            label: "Business card",
+          },
+        },
+      ]),
+      parentTrashedSubPieces: new Writable([]),
+      parentTitle: new Writable(""),
+      sourceSelections: new Writable({}),
+      trashSelections: new Writable({}),
+      selections: new Writable({}),
+      extractPhase: new Writable("select"),
+      extractionPrompt: new Writable(""),
+      cleanupNotesEnabled: new Writable(true),
+      notesContentSnapshot: new Writable({}),
+      cleanupApplyStatus: new Writable("pending"),
+      applyInProgress: new Writable(false),
+      errorDetailsExpanded: new Writable(false),
+    });
+    assert(
+      textContent(uiOf(extractor)).includes(
+        "OCR failed for some photos: OCR request failed.",
+      ),
+      "extractor renders OCR string errors",
+    );
+    clearGenerateTextResult();
+
+    setGenerateTextResult({
+      pending: false,
+      result: "Ada prefers tea.",
+      error: undefined,
+    });
+    const extractorWithoutOcrError = instantiatePattern(ExtractorModule, {
+      parentSubPieces: new Writable([
+        {
+          type: "photo",
+          pinned: false,
+          piece: {
+            image: {
+              data: "data:image/png;base64,BBBB",
+            },
+            label: "Tea note",
+          },
+        },
+      ]),
+      parentTrashedSubPieces: new Writable([]),
+      parentTitle: new Writable(""),
+      sourceSelections: new Writable({}),
+      trashSelections: new Writable({}),
+      selections: new Writable({}),
+      extractPhase: new Writable("select"),
+      extractionPrompt: new Writable(""),
+      cleanupNotesEnabled: new Writable(true),
+      notesContentSnapshot: new Writable({}),
+      cleanupApplyStatus: new Writable("pending"),
+      applyInProgress: new Writable(false),
+      errorDetailsExpanded: new Writable(false),
+    });
+    assert(
+      !textContent(uiOf(extractorWithoutOcrError)).includes(
+        "OCR failed for some photos",
+      ),
+      "extractor omits OCR error text when no OCR error is present",
+    );
+    clearGenerateTextResult();
   });
 }


### PR DESCRIPTION
The LLM runner reports generated-text failures as strings. The extractor's OCR error path still treated the value as an object-shaped error before formatting the text, so string-shaped failures could lose the message that should reach the extraction warning.

Add a small OCR error text helper that keeps string errors intact, safely reads legacy message-shaped errors, and ignores missing error values. Use that helper when building the OCR error map, and show the collected OCR message in the existing warning. Cover the helper with focused tests for string, missing, legacy object, Error, and fallback cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves OCR string errors and surfaces them in the extraction warning so users see the actual failure message. Adds a small helper to normalize OCR error values and updates the extractor to join and display messages.

- **Bug Fixes**
  - Keep string OCR errors; read `Error` and legacy `{message}` shapes; ignore missing values.
  - Build the OCR error map with `getOcrErrorText` and join messages in the existing warning; omit the banner when no OCR error is present.
  - Add focused unit tests for the helper; extend the source-coverage stub with configurable `generateText` and instantiate the extractor to cover string-error and no-error paths.

<sup>Written for commit 9cdd50f45d5be25cb362ab1a540366c32af3c5a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

