### PR TITLE
fix(wish): resolve #profile to the default directly instead of the picker

### DIFF
--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -331,7 +331,9 @@ function subscribeProfileName(cell: Cell<unknown>): void {
  * order. Identity is by link equality (`Cell.equals`); there is no synthetic
  * key. Returns [] when no valid profile exists yet.
  */
-function getProfileCandidateCells(ctx: WishContext): Cell<unknown>[] {
+function getProfileCandidateCells(
+  ctx: WishContext,
+): { ordered: Cell<unknown>[]; defaultValid: boolean } {
   const homeSpaceCell = getHomeSpaceCell(ctx);
   const defaultPattern = homeSpaceCell.key("defaultPattern").resolveAsCell();
   const profilesCell = defaultPattern.key("profiles");
@@ -357,7 +359,7 @@ function getProfileCandidateCells(ctx: WishContext): Cell<unknown>[] {
     subscribeProfileName(cell);
     candidates.push(cell);
   }
-  if (candidates.length === 0) return [];
+  if (candidates.length === 0) return { ordered: [], defaultValid: false };
 
   // Ordering inputs: the default link and the MRU list.
   const defaultEntry = defaultPattern.key("defaultProfile");
@@ -390,7 +392,7 @@ function getProfileCandidateCells(ctx: WishContext): Cell<unknown>[] {
     }
     return mruRank(a) - mruRank(b);
   });
-  return ordered;
+  return { ordered, defaultValid };
 }
 
 /**
@@ -399,11 +401,11 @@ function getProfileCandidateCells(ctx: WishContext): Cell<unknown>[] {
  * profile exists yet so callers can fall back to the create surface.
  */
 function getDefaultProfileCell(ctx: WishContext): Cell<unknown> {
-  const candidates = getProfileCandidateCells(ctx);
-  if (candidates.length === 0) {
+  const { ordered } = getProfileCandidateCells(ctx);
+  if (ordered.length === 0) {
     throw new WishError("No profile exists yet");
   }
-  return candidates[0];
+  return ordered[0];
 }
 
 function getProfileSpaceCell(ctx: WishContext): Cell<unknown> {
@@ -806,15 +808,26 @@ function resolveHomeSpaceTarget(
       if (!userDID) {
         throw new WishError("User identity DID not available for #profile");
       }
-      const candidates = getProfileCandidateCells(ctx);
-      if (candidates.length === 0) {
+      const { ordered, defaultValid } = getProfileCandidateCells(ctx);
+      if (ordered.length === 0) {
         // No profile yet — throw so the #profile error path falls back to the
         // create surface (see profileCreateUI).
         throw new WishError("No profile exists yet");
       }
+      // When the viewer has a valid DEFAULT profile, `#profile` resolves to it
+      // directly (single result) — the picker disambiguates *which* profile when
+      // there is no default, it does not re-confirm an explicit default on every
+      // read. Without this short-circuit, any viewer with 2+ profiles gets the
+      // multi-candidate picker and `.result` stays `undefined` until a selection,
+      // dead-locking every pattern that wishes for "the viewer's active profile"
+      // (e.g. profile-group-chat's send guard). Only genuine ambiguity (no
+      // default chosen yet) drives the picker.
+      if (defaultValid) {
+        return [{ cell: ordered[0], pathPrefix: [] }];
+      }
       // Ordered default-first, then by MRU. Headless / single-result callers
-      // take the first (the default); multiple candidates drive the picker.
-      return candidates.map((cell) => ({ cell, pathPrefix: [] }));
+      // take the first; multiple candidates with no default drive the picker.
+      return ordered.map((cell) => ({ cell, pathPrefix: [] }));
     }
 
     case "#profileName": {

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -2564,6 +2564,83 @@ describe("wish built-in", () => {
         .toBe("Ada Lovelace");
     });
 
+    it("#profile resolves to the default directly (no picker) when a default is set among multiple profiles", async () => {
+      // Regression for the profile-picker deadlock: a non-headless `#profile`
+      // wish from a viewer with 2+ profiles used to launch the multi-candidate
+      // picker, leaving `.result` undefined until a selection — dead-locking
+      // every pattern that wishes for "the viewer's active profile" (e.g.
+      // profile-group-chat's send guard). With a default set, `#profile` must
+      // resolve to it directly as a single result.
+      const profileSpaceDid = (await Identity.fromPassphrase(
+        "wish-profile-default-among-many",
+      )).did();
+      const profileA = runtime.getCell(
+        profileSpaceDid,
+        "profile-a",
+        undefined,
+        tx,
+      );
+      profileA.set({
+        name: "Default Della",
+        initialNameApplied: "Default Della",
+        avatar: "della.png",
+        bio: "",
+        elements: [],
+      });
+      const profileB = runtime.getCell(
+        profileSpaceDid,
+        "profile-b",
+        undefined,
+        tx,
+      );
+      profileB.set({
+        name: "Other Otto",
+        initialNameApplied: "Other Otto",
+        avatar: "otto.png",
+        bio: "",
+        elements: [],
+      });
+
+      await tx.commit();
+      await runtime.idle();
+      tx = runtime.edit();
+
+      const homeSpaceCell = runtime.getHomeSpaceCell(tx);
+      const homeDefaultCell = runtime.getCell(
+        userIdentity.did(),
+        "home-default-among-many",
+        undefined,
+        tx,
+      );
+      homeDefaultCell.key("profiles").set([profileA, profileB]);
+      homeDefaultCell.key("defaultProfile").set(profileA);
+      (homeSpaceCell as any).key("defaultPattern").set(homeDefaultCell);
+
+      await tx.commit();
+      await runtime.idle();
+      tx = runtime.edit();
+
+      const wishPattern = pattern(() => {
+        return { profile: wish({ query: "#profile" }) };
+      });
+
+      const resultCell = runtime.getCell<Record<string, any>>(
+        patternSpace.did(),
+        "wish-default-among-many-result",
+        undefined,
+        tx,
+      );
+      const result = runtime.run(tx, wishPattern, {}, resultCell);
+      await tx.commit();
+      tx = runtime.edit();
+
+      await result.pull();
+
+      // Single, direct result — the default — not the picker (which would leave
+      // `.result` undefined until a selection).
+      expect(result.key("profile").get()?.result?.name).toBe("Default Della");
+    });
+
     it("#profileDefault is not a well-known profile target", async () => {
       const profileSpaceDid = (await Identity.fromPassphrase(
         "wish-profile-default-removed-space",


### PR DESCRIPTION
## Problem

A non-headless `wish("#profile")` from a viewer with **2+ profiles** launches the multi-candidate **profile-picker sidecar** (`wish.ts` — `if (isProfilePersonaTarget && !headless && uniqueResultCells.length > 1) sendResult(launchProfilePickerPattern(...))`), leaving `.result` **undefined until a selection is made**. That dead-locks every pattern that wishes for *"the viewer's active profile"*:

- `profile-group-chat`'s **Send button stays disabled forever** — its `hasProfile` guard requires the live `#profile` cell, which never resolves.
- The picker itself must hydrate its cross-space profile list, which is slow (and can stick) under latency.

Single-profile and headless callers were unaffected — which is exactly why this only bit users with **2+ profiles**, and why multi-user demos "work fine" when each test user has a single profile.

This was found while investigating two reports that turned out to be the **same root cause**: (A) the profile picker "renders as if profiles exist but the rows never populate," and (B) `profile-group-chat` flickering/never-settling on staging. Symptom A (picker non-hydration via this sidecar) is upstream of Symptom B.

## Fix

Resolve `#profile` to the **default profile directly** (single result → existing fast path) when a valid default is set. Only drive the picker on **genuine ambiguity** (no default chosen). The picker remains reachable as its own surface for *switching* profiles.

- `getProfileCandidateCells` now returns `{ ordered, defaultValid }`; the two existing callers are updated.
- The `#profile` case short-circuits to `ordered[0]` when `defaultValid`.

## Validation

- **Browser, real 2-profile identity:** send-guard stuck in **4/4 trials → enables in ~2s** after the change; posted a message, room count → 1, message rendered.
- **Unit tests:** `deno test wish.test.ts` → 90 steps, 0 failed; fmt + lint clean.
- **Negative control:** disabling the short-circuit makes *only* the new regression test fail — it genuinely guards the behavior.

## Out of scope (follow-ups)

- **Symptom A latency tail:** even when it resolves, the picker's cross-space profile pulls are a sequential round-trip chain (time-to-settle grows linearly with latency). Worth batching/parallelizing those pulls + deduping the cross-space `resolveLink` kick + latency-aware `pull()`/`settled()` bounds.
- **Design question:** should `wish(...).result` *always* be single (default/first) with the picker living only on `.candidates`/`[UI]`? That would remove this footgun class entirely rather than just the profile instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve `#profile` directly to the viewer’s default profile instead of launching the picker when a default exists. This fixes the deadlock where `.result` stayed undefined for users with 2+ profiles and unblocks flows like group chat send.

- **Bug Fixes**
  - Short-circuit `#profile` to the default when it’s valid; show the picker only when no default is set.
  - `getProfileCandidateCells` now returns `{ ordered, defaultValid }`; updated the two callers.
  - Added a regression test: 2 profiles + default → single direct result (no picker).

<sup>Written for commit d1efd76d6e2368cc79477e66c4f868d335bb774c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

