### PR TITLE
test(patterns): wait for notebook reload view before click

### DIFF
--- a/packages/patterns/integration/reload/default-app-notebook.test.ts
+++ b/packages/patterns/integration/reload/default-app-notebook.test.ts
@@ -1,4 +1,9 @@
-import { env, Page, waitFor } from "@commonfabric/integration";
+import {
+  awaitViewSettled,
+  env,
+  Page,
+  waitFor,
+} from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { describe, it } from "@std/testing/bdd";
 import { Identity } from "@commonfabric/identity";
@@ -55,10 +60,15 @@ describe("default-app notebook reload integration test", () => {
       return state.isNotebook;
     });
 
-    await waitFor(async () => !!(await clickButtonWithTitle(page, "New Note")));
-    await waitFor(async () =>
-      !!(await findButtonWithText(page, "Create Another"))
+    await waitFor(async () => await awaitViewSettled(page));
+    assert(
+      await clickButtonWithTitle(page, "New Note"),
+      "Expected New Note click to succeed",
     );
+    await waitFor(async () => {
+      await awaitViewSettled(page);
+      return !!(await findButtonWithText(page, "Create Another"));
+    });
     await waitFor(async () => await resetEventInvocationTrace(page));
 
     const noteCreates = 7;


### PR DESCRIPTION
The notebook reload integration test could click the New Note toolbar button as soon as the button appeared in the DOM. On slower browser runs, the rendered view could still be catching up to runtime state, so the click could land before handlers and modal state were ready. The test then waited for the Create Another button and timed out even though the notebook flow itself was healthy.

Wait for the runtime, virtual DOM, and Lit updates to settle before clicking New Note. Then wait for the modal using the same settled-view guard so the test observes the click's rendered effect instead of racing the next DOM poll.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the notebook reload integration test by waiting for the view to settle before interacting with the UI. Prevents races that caused timeouts on slower runs.

- **Bug Fixes**
  - Use `awaitViewSettled` from `@commonfabric/integration` before clicking "New Note" and when waiting for the "Create Another" modal.
  - Replace DOM presence polling with an assert-backed click after a settled-view wait, then wait for the modal with the same guard.

<sup>Written for commit a8765b1b2477fbb0cbd16d77c0451d297e5d7e04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

