### PR TITLE
Narrow Cell.sync() to Promise<Cell<T>> and drop union-discrimination

### DIFF
--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -118,7 +118,7 @@ export function filter(
     inputListCell: Cell<any>,
   ): void => {
     runtime.storageManager.trackUntilSettled(
-      Promise.resolve(inputListCell.sync())
+      inputListCell.sync()
         .then(() =>
           runtime.editWithRetry((settleTx) => {
             if (!result) return;
@@ -206,10 +206,6 @@ export function filter(
     // no-ops against the durable value.
     if (elementAwaitSync && resultWithLog.get() === undefined) {
       const pending = result.sync();
-      // syncCell is async, so the container pull is always a Promise; the union
-      // on Cell.sync() is a vestigial synchronous fast path the storage manager
-      // no longer takes. Assert it to narrow before awaiting.
-      if (!(pending instanceof Promise)) throw new Error("result.sync()");
       // The container's durable value is still streaming in; its arrival
       // re-triggers this reconcile (the read above is journaled). If the
       // container was never persisted — so nothing will ever stream in to

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -120,7 +120,7 @@ export function flatMap(
   // normal reconcile via its journaled read, so it converges either way.
   const awaitInputThenSettle = (inputListCell: Cell<any>): void => {
     runtime.storageManager.trackUntilSettled(
-      Promise.resolve(inputListCell.sync())
+      inputListCell.sync()
         .then(() =>
           runtime.editWithRetry((settleTx) => {
             if (!result) return;
@@ -208,10 +208,6 @@ export function flatMap(
     // no-ops against the durable value.
     if (elementAwaitSync && resultWithLog.get() === undefined) {
       const pending = result.sync();
-      // syncCell is async, so the container pull is always a Promise; the union
-      // on Cell.sync() is a vestigial synchronous fast path the storage manager
-      // no longer takes. Assert it to narrow before awaiting.
-      if (!(pending instanceof Promise)) throw new Error("result.sync()");
       // The container's durable value is still streaming in; its arrival
       // re-triggers this reconcile (the read above is journaled). If the
       // container was never persisted — so nothing will ever stream in to

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -110,7 +110,7 @@ export function map(
   // either way.
   const awaitInputThenSettle = (inputListCell: Cell<any>): void => {
     runtime.storageManager.trackUntilSettled(
-      Promise.resolve(inputListCell.sync())
+      inputListCell.sync()
         .then(() =>
           runtime.editWithRetry((settleTx) => {
             if (!result) return;
@@ -259,10 +259,6 @@ export function map(
       probeScoped(() => resultWithLog.get()) === undefined
     ) {
       const pending = result.sync();
-      // syncCell is async, so the container pull is always a Promise; the union
-      // on Cell.sync() is a vestigial synchronous fast path the storage manager
-      // no longer takes. Assert it to narrow before awaiting.
-      if (!(pending instanceof Promise)) throw new Error("result.sync()");
       // The container's durable value is still streaming in; its arrival
       // re-triggers this reconcile (the probe read above is journaled). If the
       // container was never persisted — so nothing will ever stream in to

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -325,7 +325,7 @@ declare module "@commonfabric/api" {
       callback: (value: Immutable<FabricValue>) => Cancel | undefined | void,
       options?: SinkOptions,
     ): Cancel;
-    sync(): Promise<Cell<T>> | Cell<T>;
+    sync(): Promise<Cell<T>>;
     pull(): Promise<Readonly<T>>;
     getAsQueryResult<Path extends PropertyKey[]>(
       path?: Readonly<Path>,
@@ -1921,7 +1921,7 @@ export class CellImpl<T extends FabricValue>
     }
   }
 
-  sync(): Promise<Cell<T>> | Cell<T> {
+  sync(): Promise<Cell<T>> {
     this.synced = true;
     logger.info("sync", this.link);
     return this.runtime.storageManager.syncCell<T>(this as unknown as Cell<T>);

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -320,16 +320,14 @@ export function resolveLink(
       // If we're crossing spaces, force fetching data from server, as the
       // original server will not have pushed the data to the client yet.
       if (crossSpace) {
-        const maybePromise = runtime.getCellFromLink(link).sync();
-        if (maybePromise instanceof Promise) {
-          // Swallow sync failures: this kick is best-effort (the read still
-          // resolves from the local replica) and an unhandled rejection here
-          // would otherwise escape the resolution path.
-          const promise = maybePromise.catch(() => {}).finally(() => {
+        // Swallow sync failures: this kick is best-effort (the read still
+        // resolves from the local replica) and an unhandled rejection here
+        // would otherwise escape the resolution path.
+        const promise = runtime.getCellFromLink(link).sync().catch(() => {})
+          .finally(() => {
             runtime.storageManager.removeCrossSpacePromise(promise);
           }) as unknown as Promise<void>;
-          runtime.storageManager.addCrossSpacePromise(promise);
-        }
+        runtime.storageManager.addCrossSpacePromise(promise);
       }
     } else {
       break;

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -323,11 +323,9 @@ export function resolveLink(
         // Swallow sync failures: this kick is best-effort (the read still
         // resolves from the local replica) and an unhandled rejection here
         // would otherwise escape the resolution path.
-        const promise = runtime.getCellFromLink(link).sync().catch(() => {})
-          .finally(() => {
-            runtime.storageManager.removeCrossSpacePromise(promise);
-          }) as unknown as Promise<void>;
-        runtime.storageManager.addCrossSpacePromise(promise);
+        runtime.storageManager.trackUntilSettled(
+          runtime.getCellFromLink(link).sync().catch(() => {}),
+        );
       }
     } else {
       break;

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1353,7 +1353,7 @@ export class Runner {
     // Step 3: Not synced yet? Sync and retry
     // Once getRaw() has a value, all properties including source are synced.
     if (rootCell.getRaw() === undefined) {
-      return Promise.resolve(rootCell.sync()).then(() => {
+      return rootCell.sync().then(() => {
         if (rootCell.getRaw() === undefined) {
           return Promise.reject(new Error("No data at cell"));
         } else {
@@ -1823,8 +1823,7 @@ export class Runner {
       const link = parseLink(value, resultCell);
 
       if (link) {
-        const maybePromise = this.runtime.getCellFromLink(link).sync();
-        if (maybePromise instanceof Promise) promises.add(maybePromise);
+        promises.add(this.runtime.getCellFromLink(link).sync());
       } else if (isRecord(value)) {
         for (const key in value) syncAllMentionedCells(value[key]);
       }
@@ -3246,8 +3245,7 @@ export class Runner {
         const collect = (value: unknown, depth: number): void => {
           if (depth > 16) return;
           if (isCell(value)) {
-            const maybePromise = value.sync();
-            if (maybePromise instanceof Promise) promises.push(maybePromise);
+            promises.push(value.sync());
             return;
           }
           // NOTE: materialized records all carry the back-to-cell symbol, so

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -767,15 +767,12 @@ export class Runtime {
     const key = `${link.space}\0${link.id}`;
     if (this.missingDocLoadKicks.has(key)) return;
     this.missingDocLoadKicks.add(key);
-    const maybePromise = this.getCellFromLink(link).sync();
-    if (maybePromise instanceof Promise) {
-      this.storageManager.trackUntilSettled(
-        maybePromise.catch(() => {
-          // Allow a retry on failure (e.g. transient disconnect).
-          this.missingDocLoadKicks.delete(key);
-        }),
-      );
-    }
+    this.storageManager.trackUntilSettled(
+      this.getCellFromLink(link).sync().catch(() => {
+        // Allow a retry on failure (e.g. transient disconnect).
+        this.missingDocLoadKicks.delete(key);
+      }),
+    );
   }
 
   getCfcStats(): Readonly<CfcRuntimeStats> {


### PR DESCRIPTION
Cell.sync() was declared with the return type Promise<Cell<T>> | Cell<T>, in both the IAnyCell augmentation and the CellImpl implementation signature. That union is stale. The method's body forwards to StorageManager.syncCell, which is an async method typed Promise<Cell<T>>, so sync() now always returns a Promise. The synchronous arm of the union only existed for a fast path that returned the cell directly for self-contained data: links (a "startsWith('data:') return this" branch). That branch was removed when the old Storage/DocumentMap layer was replaced, but the union return type was never narrowed and call sites kept the guards written to cope with it.

Narrow the declared return type to Promise<Cell<T>> in both places in cell.ts, then remove the code that only existed to discriminate the union. Because syncCell is unconditionally async, every one of these guards was always taken, so removing them and always running the body preserves behavior:

- builtins/map.ts, filter.ts, flatmap.ts: drop the `if (!(pending instanceof Promise)) throw` assertion (and its explanatory comment) before awaiting the container pull, and drop the now-redundant Promise.resolve() wrapper around the input-list sync.
- link-resolution.ts: inline the cross-space sync kick, removing the `if (maybePromise instanceof Promise)` wrapper. The `as unknown as Promise<void>` cast stays: catch/finally resolves to Promise<Cell<T> | void>, and addCrossSpacePromise expects Promise<void>, so the cast is payload-driven, not union-driven.
- runtime.ts: inline ensureLinkedDocLoaded's sync kick, removing the instanceof guard.
- runner.ts: drop the instanceof guard on rootCell.sync().then() (and its Promise.resolve wrapper) and on the two collect-mentioned-cells loops that push the sync promise into a pending set.

Stream.sync() is untouched: in this copy Cell and Stream share the single IAnyCell augmentation and the CellImpl implementation, so there is no separate synchronous Stream sync to narrow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrowed `Cell.sync()` to always return `Promise<Cell<T>>`, removed union-discrimination, and switched cross-space sync kicks to `trackUntilSettled` for simpler, safer promise tracking. This simplifies call sites and keeps behavior the same since the storage manager was already async.

- **Refactors**
  - Updated `IAnyCell.sync()` and `CellImpl.sync()` to return `Promise<Cell<T>>`.
  - Removed `instanceof Promise` guards and `Promise.resolve(...)` wrappers in map/filter/flatMap, runner, and runtime.
  - In link resolution, use `storageManager.trackUntilSettled` for the cross-space sync kick and swallow rejections, replacing manual add/remove and casts.
  - No changes to `Stream.sync()`.

- **Migration**
  - Always await `cell.sync()`; it no longer returns a synchronous value.
  - Remove `instanceof Promise` checks and `Promise.resolve(cell.sync())` wrappers.
  - The `IAnyCell.sync()` type in `@commonfabric/api` now returns `Promise<Cell<T>>`.

<sup>Written for commit a15e7ce64dbd09e0029ad145b58c284808bc8a96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

