### PR TITLE
fix(cfc): resolve UI contracts from bound sigil links in event context

### DIFF
--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -9,6 +9,7 @@ import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { getJSONFromDataURI } from "../uri-utils.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import type { CfcAddress } from "./types.ts";
+import { isNormalizedFullLink, type NormalizedLink } from "../link-types.ts";
 
 type UiContractTrustRequirements = {
   trustedPattern?: string;
@@ -545,15 +546,20 @@ const eventEnvelopePayloads = (
   return payloads;
 };
 
-// Binding lowers handler context props one level at a time but preserves the
-// surrounding object/array structure (see `unwrapOneLevelAndBindtoDoc`), so a
+// Helper for the (dormant — see `contractCandidatesFromEventContext`) `$ctx`
+// path. Binding lowers handler context props one level at a time but preserves
+// the surrounding object/array structure (see `unwrapOneLevelAndBindtoDoc`), so a
 // contract-bearing link can sit nested inside a `$ctx` entry (e.g.
 // `myHandler({ config: { savedTitle: state.x } })`) rather than at its top
-// level. Walk plain objects/arrays to collect every reachable bound link,
-// treating a parsed link as a leaf (do not descend into its sigil envelope).
+// level. Walk plain objects/arrays to collect every reachable bound link. A
+// link (sigil or legacy alias) is always a leaf: never descend into its
+// envelope, even when it is rejected below — its internals are not addressable
+// `$ctx` links. Only an absolute (full) link contributes a candidate; parse
+// WITHOUT a base so a relative link stays relative and fails the full-link
+// check, rather than inheriting the write target's id/space/scope (which would
+// make the same-document guard vacuous).
 const collectContextLinks = (
   value: unknown,
-  write: NormalizedFullLink,
   seen: Set<unknown>,
   depth: number,
   out: NormalizedFullLink[],
@@ -561,14 +567,16 @@ const collectContextLinks = (
   if (depth > 16) {
     return;
   }
-  let link: NormalizedFullLink | undefined;
+  let parsedLink: NormalizedLink | undefined;
   try {
-    link = parseLink(value as unknown, write);
+    parsedLink = parseLink(value as unknown);
   } catch {
-    link = undefined;
+    parsedLink = undefined;
   }
-  if (link !== undefined) {
-    out.push(link);
+  if (parsedLink !== undefined) {
+    if (isNormalizedFullLink(parsedLink)) {
+      out.push(parsedLink);
+    }
     return;
   }
   if (!isRecord(value) && !Array.isArray(value)) {
@@ -579,14 +587,28 @@ const collectContextLinks = (
   }
   seen.add(value);
   for (const child of Object.values(value as Record<string, unknown>)) {
-    collectContextLinks(child, write, seen, depth + 1, out);
+    collectContextLinks(child, seen, depth + 1, out);
   }
 };
 
-// A `$ctx` link that addresses the write target carries the schema (and thus
-// any uiContract) for that write. At handler-execution time these are bound
-// sigil links that already address an absolute document, so a link only
-// contributes a contract when it points into the same document as `write`.
+// DORMANT / forward-looking: no production caller currently reaches this.
+// `recordTrustedEventPolicyInputs` is invoked with the bare sent event value
+// (the handler's `$event`), never the `{ $ctx, $event }` argument envelope — the
+// handler's `$ctx` is read separately by the action (see `runner.ts`, the
+// `$ctx`/`$event` split in `invokeJavaScriptImplementation`) and is never handed
+// to enforcement. So `payload.value.$ctx` is empty on every live path, and this
+// function returns no contracts in production; it is exercised only by unit
+// tests that hand-build a context envelope. It is kept as scaffolding for a
+// future path that would feed the argument envelope here (which would let a
+// contract be discovered via a contract-bearing `$ctx` link rather than only via
+// the write's own schema). Until such a caller exists, a UI contract reachable
+// ONLY through `$ctx` is NOT enforced at runtime.
+//
+// The shape it assumes: a `$ctx` link that addresses the write target carries
+// the schema (and thus any uiContract) for that write. At handler-execution time
+// these would be bound sigil links that already address an absolute document, so
+// a link only contributes a contract when it points into the same document as
+// `write`.
 const contractCandidatesFromEventContext = (
   event: unknown,
   write: NormalizedFullLink,
@@ -597,7 +619,7 @@ const contractCandidatesFromEventContext = (
       continue;
     }
     const links: NormalizedFullLink[] = [];
-    collectContextLinks(payload.value.$ctx, write, new Set(), 0, links);
+    collectContextLinks(payload.value.$ctx, new Set(), 0, links);
     for (const link of links) {
       if (
         link.id !== write.id ||

--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -9,7 +9,7 @@ import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { getJSONFromDataURI } from "../uri-utils.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 import type { CfcAddress } from "./types.ts";
-import { isNormalizedFullLink, type NormalizedLink } from "../link-types.ts";
+import { isNormalizedFullLink } from "../link-types.ts";
 
 type UiContractTrustRequirements = {
   trustedPattern?: string;
@@ -567,12 +567,7 @@ const collectContextLinks = (
   if (depth > 16) {
     return;
   }
-  let parsedLink: NormalizedLink | undefined;
-  try {
-    parsedLink = parseLink(value as unknown);
-  } catch {
-    parsedLink = undefined;
-  }
+  const parsedLink = parseLink(value);
   if (parsedLink !== undefined) {
     if (isNormalizedFullLink(parsedLink)) {
       out.push(parsedLink);

--- a/packages/runner/src/cfc/ui-contract.ts
+++ b/packages/runner/src/cfc/ui-contract.ts
@@ -545,6 +545,48 @@ const eventEnvelopePayloads = (
   return payloads;
 };
 
+// Binding lowers handler context props one level at a time but preserves the
+// surrounding object/array structure (see `unwrapOneLevelAndBindtoDoc`), so a
+// contract-bearing link can sit nested inside a `$ctx` entry (e.g.
+// `myHandler({ config: { savedTitle: state.x } })`) rather than at its top
+// level. Walk plain objects/arrays to collect every reachable bound link,
+// treating a parsed link as a leaf (do not descend into its sigil envelope).
+const collectContextLinks = (
+  value: unknown,
+  write: NormalizedFullLink,
+  seen: Set<unknown>,
+  depth: number,
+  out: NormalizedFullLink[],
+): void => {
+  if (depth > 16) {
+    return;
+  }
+  let link: NormalizedFullLink | undefined;
+  try {
+    link = parseLink(value as unknown, write);
+  } catch {
+    link = undefined;
+  }
+  if (link !== undefined) {
+    out.push(link);
+    return;
+  }
+  if (!isRecord(value) && !Array.isArray(value)) {
+    return;
+  }
+  if (seen.has(value)) {
+    return;
+  }
+  seen.add(value);
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    collectContextLinks(child, write, seen, depth + 1, out);
+  }
+};
+
+// A `$ctx` link that addresses the write target carries the schema (and thus
+// any uiContract) for that write. At handler-execution time these are bound
+// sigil links that already address an absolute document, so a link only
+// contributes a contract when it points into the same document as `write`.
 const contractCandidatesFromEventContext = (
   event: unknown,
   write: NormalizedFullLink,
@@ -554,25 +596,19 @@ const contractCandidatesFromEventContext = (
     if (!isRecord(payload.value) || !isRecord(payload.value.$ctx)) {
       continue;
     }
-    for (const value of Object.values(payload.value.$ctx)) {
-      if (!isRecord(value) || !isRecord(value.$alias)) {
-        continue;
-      }
-      const alias = value.$alias;
+    const links: NormalizedFullLink[] = [];
+    collectContextLinks(payload.value.$ctx, write, new Set(), 0, links);
+    for (const link of links) {
       if (
-        !Array.isArray(alias.path) ||
-        !pathHasPrefix(write.path, alias.path)
+        link.id !== write.id ||
+        link.space !== write.space ||
+        (link.scope ?? "space") !== (write.scope ?? "space") ||
+        !pathHasPrefix(write.path, link.path)
       ) {
         continue;
       }
-      const aliasSpace = typeof alias.space === "string"
-        ? alias.space
-        : payload.space;
-      if (aliasSpace !== undefined && aliasSpace !== write.space) {
-        continue;
-      }
-      for (const entry of uiContractsFromSchema(alias.schema as JSONSchema)) {
-        if (pathPatternMatches([...alias.path, ...entry.path], write.path)) {
+      for (const entry of uiContractsFromSchema(link.schema)) {
+        if (pathPatternMatches([...link.path, ...entry.path], write.path)) {
           contracts.push(entry.contract);
         }
       }

--- a/packages/runner/test/cfc-ui-contract.test.ts
+++ b/packages/runner/test/cfc-ui-contract.test.ts
@@ -888,6 +888,168 @@ describe("CFC trusted UI event enforcement", () => {
     ).toBe(true);
   });
 
+  it("ignores an event-context link that addresses a different document", () => {
+    const writeDocumentId = "of:cfc-ui-contract-context-mismatch-write";
+    const otherDocumentId = "of:cfc-ui-contract-context-mismatch-other";
+    const writePolicyInputs: Array<
+      ReturnType<
+        IExtendedStorageTransaction["getCfcState"]
+      >["writePolicyInputs"][number]
+    > = [];
+    const tx = {
+      getCfcState: () => ({ writePolicyInputs }),
+      recordCfcWritePolicyInput: (
+        input: typeof writePolicyInputs[number],
+      ) => {
+        writePolicyInputs.push(input);
+      },
+    };
+    const rawTrustedEvent = {
+      type: "click",
+      provenance: {
+        origin: "dom",
+        trusted: true,
+        ui: {
+          pattern: "TrustedDirectCommandSurface",
+          eventIntegrity: ["TrustedDirectCommandSurface"],
+          uiContractDataset: {
+            uiAction: "SubmitDirectCommand",
+          },
+        },
+      },
+    };
+    // The `$ctx` link is a full, absolute link, but it points at a DIFFERENT
+    // document than the write target, so it must not contribute a contract.
+    const eventEnvelope = {
+      value: {
+        $ctx: {
+          savedTitle: {
+            "/": {
+              [LINK_V1_TAG]: {
+                id: otherDocumentId,
+                path: ["savedTitle"],
+                space,
+                scope: "space",
+                schema: {
+                  $ref: "#/$defs/TrustedAction",
+                  $defs: {
+                    TrustedAction: trustedPatternUiActionSchema,
+                  },
+                },
+              },
+            },
+          },
+        },
+        $event: rawTrustedEvent,
+      },
+    };
+
+    recordTrustedEventPolicyInputs(
+      tx as unknown as IExtendedStorageTransaction,
+      [{
+        space,
+        scope: "space",
+        id: writeDocumentId,
+        path: ["savedTitle"],
+      }],
+      rendererEvent(eventEnvelope),
+    );
+
+    expect(
+      writePolicyInputs.some((input) => input.kind === "trusted-event"),
+    ).toBe(false);
+  });
+
+  it("walks past primitive, shared, and over-deep $ctx entries to the contract link", () => {
+    const documentId = "of:cfc-ui-contract-context-walk-document";
+    const writePolicyInputs: Array<
+      ReturnType<
+        IExtendedStorageTransaction["getCfcState"]
+      >["writePolicyInputs"][number]
+    > = [];
+    const tx = {
+      getCfcState: () => ({ writePolicyInputs }),
+      recordCfcWritePolicyInput: (
+        input: typeof writePolicyInputs[number],
+      ) => {
+        writePolicyInputs.push(input);
+      },
+    };
+    const rawTrustedEvent = {
+      type: "click",
+      provenance: {
+        origin: "dom",
+        trusted: true,
+        ui: {
+          pattern: "TrustedDirectCommandSurface",
+          eventIntegrity: ["TrustedDirectCommandSurface"],
+          uiContractDataset: {
+            uiAction: "SubmitDirectCommand",
+          },
+        },
+      },
+    };
+    const contractLink = {
+      "/": {
+        [LINK_V1_TAG]: {
+          id: documentId,
+          path: ["savedTitle"],
+          space,
+          scope: "space",
+          schema: {
+            $ref: "#/$defs/TrustedAction",
+            $defs: {
+              TrustedAction: trustedPatternUiActionSchema,
+            },
+          },
+        },
+      },
+    };
+    // The walk must tolerate: a primitive entry (a non-record leaf), the same
+    // object reached twice (`seen` guards re-descent — a DAG, not a cycle, so
+    // the surrounding data-URI inliner stays finite), and a nest deeper than the
+    // recursion cap. The contract-bearing link alongside them must still be
+    // found.
+    const shared = { note: "reached twice" };
+    let buried: unknown = { savedTitle: contractLink };
+    for (let index = 0; index < 20; index++) {
+      buried = { nested: buried };
+    }
+    const eventEnvelope = {
+      value: {
+        $ctx: {
+          plain: "not a link",
+          first: shared,
+          second: shared,
+          tooDeep: buried,
+          savedTitle: contractLink,
+        },
+        $event: rawTrustedEvent,
+      },
+    };
+
+    recordTrustedEventPolicyInputs(
+      tx as unknown as IExtendedStorageTransaction,
+      [{
+        space,
+        scope: "space",
+        id: documentId,
+        path: ["savedTitle"],
+      }],
+      rendererEvent(eventEnvelope),
+    );
+
+    expect(
+      writePolicyInputs.some((input) =>
+        input.kind === "trusted-event" &&
+        input.eventId ===
+          `trusted-event:click:${documentId}:savedTitle` &&
+        input.target.id === documentId &&
+        input.target.path.join("/") === "savedTitle"
+      ),
+    ).toBe(true);
+  });
+
   it("uses a single leaf $defs uiContract hint for exact write schemas", () => {
     const writePolicyInputs: Array<
       ReturnType<

--- a/packages/runner/test/cfc-ui-contract.test.ts
+++ b/packages/runner/test/cfc-ui-contract.test.ts
@@ -564,6 +564,10 @@ describe("CFC trusted UI event enforcement", () => {
     ).toBe(true);
   });
 
+  // The one deliberate `data:application/json` example: an event delivered as a
+  // sigil link to a data-URI envelope is the exceptional shape we verify is still
+  // decoded and handled. Other event-context tests use the plain in-memory
+  // envelope so they don't imply the input is always a data-URI link.
   it("records trusted event policy inputs from linked handler event envelopes", () => {
     const writePolicyInputs: Array<
       ReturnType<
@@ -675,37 +679,31 @@ describe("CFC trusted UI event enforcement", () => {
       },
     };
     // At handler-execution time the `$ctx` entry is a bound sigil link that
-    // already addresses the write's document, not a symbolic `$alias`.
-    const eventEnvelopeLink = {
-      "/": {
-        [LINK_V1_TAG]: {
-          id: `data:application/json,${
-            encodeURIComponent(JSON.stringify({
-              value: {
-                $ctx: {
-                  savedTitle: {
-                    "/": {
-                      [LINK_V1_TAG]: {
-                        id: documentId,
-                        path: ["savedTitle"],
-                        space,
-                        schema: {
-                          $ref: "#/$defs/TrustedAction",
-                          $defs: {
-                            TrustedAction: trustedPatternUiActionSchema,
-                          },
-                        },
-                      },
-                    },
+    // already addresses the write's document, not a symbolic `$alias`. The event
+    // value is a plain in-memory envelope here; the `data:`-URI link form is the
+    // exceptional case, covered once by "records trusted event policy inputs from
+    // linked handler event envelopes".
+    const eventEnvelope = {
+      value: {
+        $ctx: {
+          savedTitle: {
+            "/": {
+              [LINK_V1_TAG]: {
+                id: documentId,
+                path: ["savedTitle"],
+                space,
+                scope: "space",
+                schema: {
+                  $ref: "#/$defs/TrustedAction",
+                  $defs: {
+                    TrustedAction: trustedPatternUiActionSchema,
                   },
                 },
-                $event: rawTrustedEvent,
               },
-            }))
-          }`,
-          path: ["$event"],
-          space,
+            },
+          },
         },
+        $event: rawTrustedEvent,
       },
     };
 
@@ -717,7 +715,7 @@ describe("CFC trusted UI event enforcement", () => {
         id: documentId,
         path: ["savedTitle"],
       }],
-      rendererEvent(eventEnvelopeLink),
+      rendererEvent(eventEnvelope),
     );
 
     expect(
@@ -761,39 +759,30 @@ describe("CFC trusted UI event enforcement", () => {
         },
       },
     };
-    const eventEnvelopeLink = {
-      "/": {
-        [LINK_V1_TAG]: {
-          id: `data:application/json,${
-            encodeURIComponent(JSON.stringify({
-              value: {
-                $ctx: {
-                  messages: {
-                    "/": {
-                      [LINK_V1_TAG]: {
-                        id: documentId,
-                        path: ["messages"],
-                        space,
-                        schema: {
-                          type: "array",
-                          items: {
-                            $ref: "#/$defs/TrustedAction",
-                          },
-                          $defs: {
-                            TrustedAction: trustedPatternUiActionSchema,
-                          },
-                        },
-                      },
-                    },
+    const eventEnvelope = {
+      value: {
+        $ctx: {
+          messages: {
+            "/": {
+              [LINK_V1_TAG]: {
+                id: documentId,
+                path: ["messages"],
+                space,
+                scope: "space",
+                schema: {
+                  type: "array",
+                  items: {
+                    $ref: "#/$defs/TrustedAction",
+                  },
+                  $defs: {
+                    TrustedAction: trustedPatternUiActionSchema,
                   },
                 },
-                $event: rawTrustedEvent,
               },
-            }))
-          }`,
-          path: ["$event"],
-          space,
+            },
+          },
         },
+        $event: rawTrustedEvent,
       },
     };
 
@@ -805,7 +794,7 @@ describe("CFC trusted UI event enforcement", () => {
         scope: "space",
         path: ["messages", "0"],
       }],
-      rendererEvent(eventEnvelopeLink),
+      rendererEvent(eventEnvelope),
     );
 
     expect(
@@ -851,38 +840,29 @@ describe("CFC trusted UI event enforcement", () => {
     };
     // Binding preserves nesting, so the contract-bearing sigil link can sit
     // below the top level of a `$ctx` entry (e.g. `{ config: { savedTitle } }`).
-    const eventEnvelopeLink = {
-      "/": {
-        [LINK_V1_TAG]: {
-          id: `data:application/json,${
-            encodeURIComponent(JSON.stringify({
-              value: {
-                $ctx: {
-                  config: {
-                    savedTitle: {
-                      "/": {
-                        [LINK_V1_TAG]: {
-                          id: documentId,
-                          path: ["savedTitle"],
-                          space,
-                          schema: {
-                            $ref: "#/$defs/TrustedAction",
-                            $defs: {
-                              TrustedAction: trustedPatternUiActionSchema,
-                            },
-                          },
-                        },
-                      },
+    const eventEnvelope = {
+      value: {
+        $ctx: {
+          config: {
+            savedTitle: {
+              "/": {
+                [LINK_V1_TAG]: {
+                  id: documentId,
+                  path: ["savedTitle"],
+                  space,
+                  scope: "space",
+                  schema: {
+                    $ref: "#/$defs/TrustedAction",
+                    $defs: {
+                      TrustedAction: trustedPatternUiActionSchema,
                     },
                   },
                 },
-                $event: rawTrustedEvent,
               },
-            }))
-          }`,
-          path: ["$event"],
-          space,
+            },
+          },
         },
+        $event: rawTrustedEvent,
       },
     };
 
@@ -894,7 +874,7 @@ describe("CFC trusted UI event enforcement", () => {
         id: documentId,
         path: ["savedTitle"],
       }],
-      rendererEvent(eventEnvelopeLink),
+      rendererEvent(eventEnvelope),
     );
 
     expect(

--- a/packages/runner/test/cfc-ui-contract.test.ts
+++ b/packages/runner/test/cfc-ui-contract.test.ts
@@ -447,12 +447,7 @@ describe("CFC trusted UI event enforcement", () => {
       schema: {
         type: "object",
         properties: {
-          argument: {
-            type: "object",
-            properties: {
-              savedTitle: { $ref: "#/$defs/TrustedAction" },
-            },
-          },
+          savedTitle: { $ref: "#/$defs/TrustedAction" },
         },
         $defs: {
           TrustedAction: trustedPatternUiActionSchema,
@@ -474,7 +469,7 @@ describe("CFC trusted UI event enforcement", () => {
         space,
         scope: "space",
         id: "of:cfc-ui-contract-nested-document",
-        path: ["argument", "savedTitle"],
+        path: ["savedTitle"],
       }],
       rendererEvent({
         type: "click",
@@ -497,7 +492,7 @@ describe("CFC trusted UI event enforcement", () => {
         input.kind === "trusted-event" &&
         input.target.space === space &&
         input.target.id === "of:cfc-ui-contract-nested-document" &&
-        input.target.path.join("/") === "argument/savedTitle"
+        input.target.path.join("/") === "savedTitle"
       ),
     ).toBe(true);
   });
@@ -585,12 +580,7 @@ describe("CFC trusted UI event enforcement", () => {
       schema: {
         type: "object",
         properties: {
-          argument: {
-            type: "object",
-            properties: {
-              savedTitle: { $ref: "#/$defs/TrustedAction" },
-            },
-          },
+          savedTitle: { $ref: "#/$defs/TrustedAction" },
         },
         $defs: {
           TrustedAction: trustedPatternUiActionSchema,
@@ -639,7 +629,7 @@ describe("CFC trusted UI event enforcement", () => {
         space,
         scope: "space",
         id: "of:cfc-ui-contract-linked-event-document",
-        path: ["argument", "savedTitle"],
+        path: ["savedTitle"],
       }],
       rendererEvent(eventEnvelopeLink),
     );
@@ -648,14 +638,15 @@ describe("CFC trusted UI event enforcement", () => {
       writePolicyInputs.some((input) =>
         input.kind === "trusted-event" &&
         input.eventId ===
-          "trusted-event:click:of:cfc-ui-contract-linked-event-document:argument/savedTitle" &&
+          "trusted-event:click:of:cfc-ui-contract-linked-event-document:savedTitle" &&
         input.target.id === "of:cfc-ui-contract-linked-event-document" &&
-        input.target.path.join("/") === "argument/savedTitle"
+        input.target.path.join("/") === "savedTitle"
       ),
     ).toBe(true);
   });
 
-  it("uses handler event context aliases as UI contract schema hints", () => {
+  it("uses bound sigil-link event context as UI contract schema hints", () => {
+    const documentId = "of:cfc-ui-contract-context-link-document-argument";
     const writePolicyInputs: Array<
       ReturnType<
         IExtendedStorageTransaction["getCfcState"]
@@ -683,6 +674,8 @@ describe("CFC trusted UI event enforcement", () => {
         },
       },
     };
+    // At handler-execution time the `$ctx` entry is a bound sigil link that
+    // already addresses the write's document, not a symbolic `$alias`.
     const eventEnvelopeLink = {
       "/": {
         [LINK_V1_TAG]: {
@@ -691,12 +684,16 @@ describe("CFC trusted UI event enforcement", () => {
               value: {
                 $ctx: {
                   savedTitle: {
-                    $alias: {
-                      path: ["argument", "savedTitle"],
-                      schema: {
-                        $ref: "#/$defs/TrustedAction",
-                        $defs: {
-                          TrustedAction: trustedPatternUiActionSchema,
+                    "/": {
+                      [LINK_V1_TAG]: {
+                        id: documentId,
+                        path: ["savedTitle"],
+                        space,
+                        schema: {
+                          $ref: "#/$defs/TrustedAction",
+                          $defs: {
+                            TrustedAction: trustedPatternUiActionSchema,
+                          },
                         },
                       },
                     },
@@ -717,8 +714,8 @@ describe("CFC trusted UI event enforcement", () => {
       [{
         space,
         scope: "space",
-        id: "of:cfc-ui-contract-context-document",
-        path: ["argument", "savedTitle"],
+        id: documentId,
+        path: ["savedTitle"],
       }],
       rendererEvent(eventEnvelopeLink),
     );
@@ -727,14 +724,16 @@ describe("CFC trusted UI event enforcement", () => {
       writePolicyInputs.some((input) =>
         input.kind === "trusted-event" &&
         input.eventId ===
-          "trusted-event:click:of:cfc-ui-contract-context-document:argument/savedTitle" &&
-        input.target.id === "of:cfc-ui-contract-context-document" &&
-        input.target.path.join("/") === "argument/savedTitle"
+          `trusted-event:click:${documentId}:savedTitle` &&
+        input.target.id === documentId &&
+        input.target.path.join("/") === "savedTitle"
       ),
     ).toBe(true);
   });
 
-  it("uses event context alias item schemas for array item writes", () => {
+  it("uses bound sigil-link event context item schemas for array item writes", () => {
+    const documentId =
+      "of:cfc-ui-contract-context-link-array-document-argument";
     const writePolicyInputs: Array<
       ReturnType<
         IExtendedStorageTransaction["getCfcState"]
@@ -770,15 +769,19 @@ describe("CFC trusted UI event enforcement", () => {
               value: {
                 $ctx: {
                   messages: {
-                    $alias: {
-                      path: ["argument", "messages"],
-                      schema: {
-                        type: "array",
-                        items: {
-                          $ref: "#/$defs/TrustedAction",
-                        },
-                        $defs: {
-                          TrustedAction: trustedPatternUiActionSchema,
+                    "/": {
+                      [LINK_V1_TAG]: {
+                        id: documentId,
+                        path: ["messages"],
+                        space,
+                        schema: {
+                          type: "array",
+                          items: {
+                            $ref: "#/$defs/TrustedAction",
+                          },
+                          $defs: {
+                            TrustedAction: trustedPatternUiActionSchema,
+                          },
                         },
                       },
                     },
@@ -798,9 +801,9 @@ describe("CFC trusted UI event enforcement", () => {
       tx as unknown as IExtendedStorageTransaction,
       [{
         space,
-        id: "of:cfc-ui-contract-context-array-document",
+        id: documentId,
         scope: "space",
-        path: ["argument", "messages", "0"],
+        path: ["messages", "0"],
       }],
       rendererEvent(eventEnvelopeLink),
     );
@@ -809,9 +812,98 @@ describe("CFC trusted UI event enforcement", () => {
       writePolicyInputs.some((input) =>
         input.kind === "trusted-event" &&
         input.eventId ===
-          "trusted-event:click:of:cfc-ui-contract-context-array-document:argument/messages/0" &&
-        input.target.id === "of:cfc-ui-contract-context-array-document" &&
-        input.target.path.join("/") === "argument/messages/0"
+          `trusted-event:click:${documentId}:messages/0` &&
+        input.target.id === documentId &&
+        input.target.path.join("/") === "messages/0"
+      ),
+    ).toBe(true);
+  });
+
+  it("uses sigil links nested inside event context entries as schema hints", () => {
+    const documentId =
+      "of:cfc-ui-contract-context-nested-link-document-argument";
+    const writePolicyInputs: Array<
+      ReturnType<
+        IExtendedStorageTransaction["getCfcState"]
+      >["writePolicyInputs"][number]
+    > = [];
+    const tx = {
+      getCfcState: () => ({ writePolicyInputs }),
+      recordCfcWritePolicyInput: (
+        input: typeof writePolicyInputs[number],
+      ) => {
+        writePolicyInputs.push(input);
+      },
+    };
+    const rawTrustedEvent = {
+      type: "click",
+      provenance: {
+        origin: "dom",
+        trusted: true,
+        ui: {
+          pattern: "TrustedDirectCommandSurface",
+          eventIntegrity: ["TrustedDirectCommandSurface"],
+          uiContractDataset: {
+            uiAction: "SubmitDirectCommand",
+          },
+        },
+      },
+    };
+    // Binding preserves nesting, so the contract-bearing sigil link can sit
+    // below the top level of a `$ctx` entry (e.g. `{ config: { savedTitle } }`).
+    const eventEnvelopeLink = {
+      "/": {
+        [LINK_V1_TAG]: {
+          id: `data:application/json,${
+            encodeURIComponent(JSON.stringify({
+              value: {
+                $ctx: {
+                  config: {
+                    savedTitle: {
+                      "/": {
+                        [LINK_V1_TAG]: {
+                          id: documentId,
+                          path: ["savedTitle"],
+                          space,
+                          schema: {
+                            $ref: "#/$defs/TrustedAction",
+                            $defs: {
+                              TrustedAction: trustedPatternUiActionSchema,
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+                $event: rawTrustedEvent,
+              },
+            }))
+          }`,
+          path: ["$event"],
+          space,
+        },
+      },
+    };
+
+    recordTrustedEventPolicyInputs(
+      tx as unknown as IExtendedStorageTransaction,
+      [{
+        space,
+        scope: "space",
+        id: documentId,
+        path: ["savedTitle"],
+      }],
+      rendererEvent(eventEnvelopeLink),
+    );
+
+    expect(
+      writePolicyInputs.some((input) =>
+        input.kind === "trusted-event" &&
+        input.eventId ===
+          `trusted-event:click:${documentId}:savedTitle` &&
+        input.target.id === documentId &&
+        input.target.path.join("/") === "savedTitle"
       ),
     ).toBe(true);
   });
@@ -827,7 +919,7 @@ describe("CFC trusted UI event enforcement", () => {
         space,
         scope: "space",
         id: "of:cfc-ui-contract-leaf-defs-document",
-        path: ["argument", "savedTitle"],
+        path: ["savedTitle"],
       },
       schema: {
         type: "unknown",
@@ -852,7 +944,7 @@ describe("CFC trusted UI event enforcement", () => {
         space,
         scope: "space",
         id: "of:cfc-ui-contract-leaf-defs-document",
-        path: ["argument", "savedTitle"],
+        path: ["savedTitle"],
       }],
       rendererEvent({
         type: "click",
@@ -874,7 +966,7 @@ describe("CFC trusted UI event enforcement", () => {
       writePolicyInputs.some((input) =>
         input.kind === "trusted-event" &&
         input.target.id === "of:cfc-ui-contract-leaf-defs-document" &&
-        input.target.path.join("/") === "argument/savedTitle"
+        input.target.path.join("/") === "savedTitle"
       ),
     ).toBe(true);
   });
@@ -890,18 +982,13 @@ describe("CFC trusted UI event enforcement", () => {
       target: {
         space,
         scope: "user",
-        id: documentId,
+        id: `${documentId}-argument`,
         path: [],
       },
       schema: {
         type: "object",
         properties: {
-          argument: {
-            type: "object",
-            properties: {
-              savedTitle: { $ref: "#/$defs/TrustedAction" },
-            },
-          },
+          savedTitle: { $ref: "#/$defs/TrustedAction" },
         },
         $defs: {
           TrustedAction: trustedPatternUiActionSchema,
@@ -912,10 +999,10 @@ describe("CFC trusted UI event enforcement", () => {
       target: {
         space,
         scope: "space",
-        id: documentId,
-        path: ["argument", "savedTitle"],
+        id: `${documentId}-argument`,
+        path: ["savedTitle"],
       },
-      eventId: `trusted-event:click:${documentId}:argument/savedTitle`,
+      eventId: `trusted-event:click:${documentId}-argument:savedTitle`,
       provenance: {
         origin: "dom",
         trusted: true,
@@ -942,8 +1029,8 @@ describe("CFC trusted UI event enforcement", () => {
       [{
         space,
         scope: "user",
-        id: documentId,
-        path: ["argument", "savedTitle"],
+        id: `${documentId}-argument`,
+        path: ["savedTitle"],
       }],
       rendererEvent({
         type: "click",
@@ -963,8 +1050,8 @@ describe("CFC trusted UI event enforcement", () => {
 
     const trustedScopes = writePolicyInputs.flatMap((input) =>
       input.kind === "trusted-event" &&
-        input.target.id === documentId &&
-        input.target.path.join("/") === "argument/savedTitle"
+        input.target.id === `${documentId}-argument` &&
+        input.target.path.join("/") === "savedTitle"
         ? [input.target.scope]
         : []
     );


### PR DESCRIPTION
## Summary

`contractCandidatesFromEventContext` resolves UI contracts from contract-bearing sigil links in a handler's event `$ctx`. This PR corrects how those links are parsed, hardens the same-document guard, and — importantly — documents that the whole branch is currently **dormant** in production.

### Dormant-branch finding

Enforcement (`recordTrustedEventPolicyInputs`) is always called with the **bare sent event** (`$event`), never the `{$ctx, $event}` argument envelope. The handler's `$ctx` is split off and consumed separately by the action (`invokeJavaScriptImplementation`), so `payload.value.$ctx` is empty on every live path. This branch is exercised only by unit tests; a UI contract discoverable *only* via `$ctx` is **not enforced at runtime today**. It's retained as forward-looking scaffolding for a future path that would feed the argument envelope into enforcement, and is now annotated as such in the code.

### Parse hardening

At handler-execution time a bound `$ctx` entry is an absolute sigil link, not a symbolic `$alias`. The parse now:

- **Drops the `write` base and requires a full link** (`isNormalizedFullLink`). Previously `parseLink(value, write)` let a *relative* link inherit the write target's `id`/`space`/`scope`, which made the same-document guard vacuous — any relative link whose path prefixed the write path would inject a contract for the write's document. Parsing with no base keeps a relative link relative, so it fails the full-link check and is rejected instead of misattributed.
- **Treats any parsed link as a leaf** — never descends into a link's sigil envelope, even when the link is rejected.

Verified that bound `$ctx` links always carry a concrete scope (the `Cell` constructor defaults scope to `space`; it flows through `getMetaLink` / `scopedLinkForPath` / `createSigilLinkFromParsedLink`), so requiring a concrete scope never rejects a legit link.

## Tests

- Sigil-link fixtures now carry a concrete `scope`, matching real bound links.
- The event-context tests use the **plain in-memory event envelope** (`{ value: { $ctx, $event } }`) rather than a `data:`-URI sigil link, so they no longer imply the enforcement input is always a data-URI link. A **single** `data:application/json` example is kept (the "linked handler event envelopes" test) as the deliberate exceptional shape we verify is still decoded.
- Full `cfc-ui-contract.test.ts` suite green (717 passed).

## Commits

- `69d49249` — resolve UI contracts from bound sigil links in event context
- `65cc67ee` — mark event-context branch dormant; harden link parse; reshape tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)