### PR TITLE
refactor: migrate OpaqueRef→Reactive symbols (CT-1756, 1/3)

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1249,25 +1249,6 @@ export type Reactive<T> = T;
 /** @deprecated Use {@link Reactive}. */
 export type OpaqueRef<T> = Reactive<T>;
 
-// Helper type for OpaqueRef's inner property/array mapping
-// Handles nullable types by extracting the non-null part for mapping
-type OpaqueRefInner<T> = [T] extends
-  [ArrayBuffer | ArrayBufferView | URL | Date] ? T
-  : [T] extends [Array<infer U>] ? Array<OpaqueRef<U>>
-  : [T] extends [AnyBrandedCell<any>] ? T
-  : [T] extends [object] ? { [K in keyof T]: OpaqueRef<T[K]> }
-  // For nullable types (T | null | undefined), extract and map the non-null part
-  : [NonNullable<T>] extends [never] ? T
-  // Handle nullable branded cells (e.g., (OpaqueRef<X> | undefined) from .find() on proxy arrays)
-  // Use NonNullable<T> instead of T to avoid leaking null/undefined into the
-  // OpaqueCell<T> & OpaqueRefInner<T> intersection, where TypeScript's
-  // intersection simplification would erase them (object & undefined = never).
-  : [NonNullable<T>] extends [AnyBrandedCell<any>] ? NonNullable<T>
-  : [NonNullable<T>] extends [Array<infer U>] ? Array<OpaqueRef<U>>
-  : [NonNullable<T>] extends [object]
-    ? { [K in keyof NonNullable<T>]: OpaqueRef<NonNullable<T>[K]> }
-  : T;
-
 // ============================================================================
 // CellLike and FactoryInput - Utility types for accepting cells
 // ============================================================================
@@ -1358,7 +1339,7 @@ export type FactoryInput<T> =
 
 /**
  * Matches any non-opaque Cell type (Cell, Stream, ComparableCell, etc.) that may be
- * wrapped in any number of OpaqueRef layers. Excludes OpaqueCell and AnyCell (since OpaqueCell extends AnyCell).
+ * wrapped in any number of Reactive layers. Excludes OpaqueCell and AnyCell (since OpaqueCell extends AnyCell).
  */
 /**
  * Recursively unwraps AnyBrandedCell types at any nesting level.
@@ -1424,7 +1405,7 @@ export type Handler<T = any, R = any> = Module & {
 };
 
 export type NodeFactory<T, R> =
-  & ((inputs: FactoryInput<T>) => OpaqueRef<R>)
+  & ((inputs: FactoryInput<T>) => Reactive<R>)
   & (Module | Handler | Pattern)
   & toJSON
   & {
@@ -1432,7 +1413,7 @@ export type NodeFactory<T, R> =
   };
 
 export type PatternFactory<T, R> =
-  & ((inputs: FactoryInput<T>) => OpaqueRef<R>)
+  & ((inputs: FactoryInput<T>) => Reactive<R>)
   & Pattern
   & toJSON
   & {
@@ -1441,7 +1422,7 @@ export type PatternFactory<T, R> =
   };
 
 export type ModuleFactory<T, R> =
-  & ((inputs: FactoryInput<T>) => OpaqueRef<R>)
+  & ((inputs: FactoryInput<T>) => Reactive<R>)
   & Module
   & toJSON
   & {
@@ -1789,7 +1770,7 @@ export type BuiltInLLMTool =
       extraParams?: Record<string, any>;
       useResultSchemaForObservation?: boolean;
     }
-    | { handler: Stream<any> | OpaqueRef<any>; pattern?: never }
+    | { handler: Stream<any> | Reactive<any>; pattern?: never }
   );
 
 /**
@@ -2029,21 +2010,21 @@ export interface PatternFunction {
   // Function-only overload: T and R inferred from function
   <T, R>(
     fn: (
-      input: OpaqueRef<RequireDefaults<T>> & { [SELF]: OpaqueRef<R> },
+      input: Reactive<RequireDefaults<T>> & { [SELF]: Reactive<R> },
     ) => FactoryInput<R>,
   ): PatternFactory<StripCell<T>, R>;
 
   // Function-only overload: T explicit, R inferred
   <T>(
     fn: (
-      input: OpaqueRef<RequireDefaults<T>> & { [SELF]: OpaqueRef<any> },
+      input: Reactive<RequireDefaults<T>> & { [SELF]: Reactive<any> },
     ) => any,
   ): PatternFactory<StripCell<T>, ReturnType<typeof fn>>;
 
   // Function + schema overload: T explicit, R inferred
   <T>(
     fn: (
-      input: OpaqueRef<RequireDefaults<T>> & { [SELF]: OpaqueRef<any> },
+      input: Reactive<RequireDefaults<T>> & { [SELF]: Reactive<any> },
     ) => any,
     argumentSchema: JSONSchema,
     resultSchema?: JSONSchema,
@@ -2052,7 +2033,7 @@ export interface PatternFunction {
   // Function + schema overload: T and R explicit
   <T, R>(
     fn: (
-      input: OpaqueRef<RequireDefaults<T>> & { [SELF]: OpaqueRef<R> },
+      input: Reactive<RequireDefaults<T>> & { [SELF]: Reactive<R> },
     ) => FactoryInput<R>,
     argumentSchema: JSONSchema,
     resultSchema?: JSONSchema,
@@ -2152,45 +2133,45 @@ export type ActionFunction = {
   <T>(fn: (event: T) => void): Stream<T>;
 };
 
-export type ComputedFunction = <T>(fn: () => T) => OpaqueRef<T>;
+export type ComputedFunction = <T>(fn: () => T) => Reactive<T>;
 
 export type StrFunction = (
   strings: TemplateStringsArray,
   ...values: any[]
-) => OpaqueRef<string>;
+) => Reactive<string>;
 
 export type IfElseFunction = <T = any, U = any, V = any>(
   condition: FactoryInput<T>,
   ifTrue: FactoryInput<U>,
   ifFalse: FactoryInput<V>,
-) => OpaqueRef<U | V>;
+) => Reactive<U | V>;
 
 export type WhenFunction = <T = any, U = any>(
   condition: FactoryInput<T>,
   value: FactoryInput<U>,
-) => OpaqueRef<T | U>;
+) => Reactive<T | U>;
 
 export type UnlessFunction = <T = any, U = any>(
   condition: FactoryInput<T>,
   fallback: FactoryInput<U>,
-) => OpaqueRef<T | U>;
+) => Reactive<T | U>;
 
 /** @deprecated Use generateText() or generateObject() instead */
 export type LLMFunction = (
   params: FactoryInput<BuiltInLLMParams>,
-) => OpaqueRef<BuiltInLLMState>;
+) => Reactive<BuiltInLLMState>;
 
 export type LLMDialogFunction = (
   params: FactoryInput<BuiltInLLMParams>,
-) => OpaqueRef<BuiltInLLMDialogState>;
+) => Reactive<BuiltInLLMDialogState>;
 
 export type GenerateObjectFunction = <T = any>(
   params: FactoryInput<BuiltInGenerateObjectParams>,
-) => OpaqueRef<BuiltInLLMGenerateObjectState<T>>;
+) => Reactive<BuiltInLLMGenerateObjectState<T>>;
 
 export type GenerateTextFunction = (
   params: FactoryInput<BuiltInGenerateTextParams>,
-) => OpaqueRef<BuiltInGenerateTextState>;
+) => Reactive<BuiltInGenerateTextState>;
 
 export type FetchOptions = {
   body?: JSONValue;
@@ -2213,11 +2194,11 @@ export type FetchDataFunction = <T>(
     options?: FetchOptions;
     result?: T;
   }>,
-) => OpaqueRef<{ pending: boolean; result: T; error?: any }>;
+) => Reactive<{ pending: boolean; result: T; error?: any }>;
 
 export type FetchProgramFunction = (
   params: FactoryInput<{ url: string }>,
-) => OpaqueRef<{
+) => Reactive<{
   pending: boolean;
   result: {
     files: Array<{ name: string; contents: string }>;
@@ -2232,11 +2213,11 @@ export type StreamDataFunction = <T>(
     options?: FetchOptions;
     result?: T;
   }>,
-) => OpaqueRef<{ pending: boolean; result: T; error?: any }>;
+) => Reactive<{ pending: boolean; result: T; error?: any }>;
 
 export type CompileAndRunFunction = <T = any, S = any>(
   params: FactoryInput<BuiltInCompileAndRunParams<T>>,
-) => OpaqueRef<BuiltInCompileAndRunState<S>>;
+) => Reactive<BuiltInCompileAndRunState<S>>;
 
 // --- SQLite builtins (docs/specs/sqlite-builtin) ---
 
@@ -2271,7 +2252,7 @@ export interface ISqliteQueryable {
       /** `"fail"` (default) | `"skip"` when a row exceeds the ceiling. */
       onExceed?: "fail" | "skip";
     },
-  ): OpaqueRef<{ pending: boolean; result?: Row[]; error?: any }>;
+  ): Reactive<{ pending: boolean; result?: Row[]; error?: any }>;
 }
 
 /**
@@ -2296,7 +2277,7 @@ export type SqliteTableSchemas = Record<string, JSONSchema>;
 /** Non-default database source. Cell-derived (default) needs no source; on-disk
  *  databases are injected as a pattern input, not selected here. */
 export type SqliteDatabaseSource = {
-  vm: OpaqueRef<unknown>;
+  vm: Reactive<unknown>;
   path: string;
 };
 
@@ -2304,7 +2285,7 @@ export type SqliteDatabaseFunction = {
   (
     options?: { tables?: SqliteTableSchemas },
     source?: SqliteDatabaseSource,
-  ): OpaqueRef<SqliteDb>;
+  ): Reactive<SqliteDb>;
   /** Bind the db (and so its on-disk file) to a scope. The transformer lowers
    *  `const db: PerUser<SqliteDb> = sqliteDatabase(...)` to `.asScope("user")`;
    *  call it explicitly for the same effect. */
@@ -2330,7 +2311,7 @@ export type SqliteQueryParams = {
 };
 export type SqliteQueryFunction = <Row = Record<string, unknown>>(
   params: FactoryInput<SqliteQueryParams>,
-) => OpaqueRef<{ pending: boolean; result?: Row[]; error?: any }>;
+) => Reactive<{ pending: boolean; result?: Row[]; error?: any }>;
 
 // Writes are the imperative SqliteDb.exec method (see ISqliteExecutable), which
 // folds a `sqlite` op into the caller's commit (atomic with cell writes). There
@@ -2425,11 +2406,11 @@ export type WishState<T> = {
   [UI]?: VNode;
 };
 
-export type NavigateToFunction = (cell: OpaqueRef<any>) => OpaqueRef<boolean>;
+export type NavigateToFunction = (cell: Reactive<any>) => Reactive<boolean>;
 export interface WishFunction {
   <T = unknown>(
     target: FactoryInput<WishParams>,
-  ): OpaqueRef<WishState<T> & UIRenderable>;
+  ): Reactive<WishState<T> & UIRenderable>;
 }
 
 export type CreateNodeFactoryFunction = <T = any, R = any>(
@@ -2603,7 +2584,7 @@ export type RequireDefaults<T> =
   // Use Exclude<T[K], undefined> to strip the `| undefined` that TypeScript
   // adds for optional fields (T[K] of `a?: X` includes `X | undefined`).
   // Without this, the required field's value type would still include
-  // `| undefined`, which propagates through OpaqueRef and makes the field
+  // `| undefined`, which propagates through Reactive and makes the field
   // possibly-undefined in the pattern body despite being required.
   & {
     [K in keyof T as true extends IsDefaultField<T[K]> ? K : never]-?:
@@ -2834,7 +2815,7 @@ export type UIRenderable = {
 export type JSXElement =
   | VNode
   | AnyBrandedCell<UIRenderable>
-  | OpaqueRef<UIRenderable>;
+  | Reactive<UIRenderable>;
 
 /** A "virtual view node", e.g. a virtual DOM element */
 export type VNode = {

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -7,7 +7,7 @@
  * 3. Return { tests: TestStep[] }
  *
  * TestStep is a discriminated union:
- * - { assertion: OpaqueRef<boolean> } from computed(() => condition)
+ * - { assertion: Reactive<boolean> } from computed(() => condition)
  * - { action: Stream<void> } from action(() => sideEffect)
  *
  * The discriminated union avoids TypeScript declaration emit issues
@@ -42,7 +42,7 @@ import type {
   Stream,
 } from "@commonfabric/runner";
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
-import type { OpaqueRef } from "@commonfabric/api";
+import type { Reactive } from "@commonfabric/api";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
@@ -135,7 +135,7 @@ function formatError(error: unknown): string {
  * reads an async-builtin result to keep the read deterministic under load.
  */
 export type TestStep =
-  | { assertion: OpaqueRef<boolean>; skip?: boolean }
+  | { assertion: Reactive<boolean>; skip?: boolean }
   | {
     action: Stream<unknown>;
     event?: unknown;

--- a/packages/fs-sync-example/src/todo-list-pattern.tsx
+++ b/packages/fs-sync-example/src/todo-list-pattern.tsx
@@ -15,8 +15,8 @@ import {
   ifElse,
   NAME,
   nonPrivateRandom,
-  OpaqueRef,
   pattern,
+  Reactive,
   safeDateNow,
   Stream,
   UI,
@@ -105,12 +105,12 @@ interface Output {
   edits: Edit[];
   appliedEdits: Edit[];
   failedEdits: FailedEdit[];
-  create: OpaqueRef<Stream<{ detail: { message: string } }>>;
+  create: Reactive<Stream<{ detail: { message: string } }>>;
   // Per-item actions wrapped in objects (safe from spurious invocation)
   actions: Array<{
-    toggle: OpaqueRef<Stream<unknown>>;
-    delete: OpaqueRef<Stream<unknown>>;
-    update: OpaqueRef<Stream<unknown>>;
+    toggle: Reactive<Stream<unknown>>;
+    delete: Reactive<Stream<unknown>>;
+    update: Reactive<Stream<unknown>>;
   }>;
 }
 

--- a/packages/patterns/dietary-restrictions.tsx
+++ b/packages/patterns/dietary-restrictions.tsx
@@ -1417,7 +1417,7 @@ export const DietaryRestrictionsModule = pattern<
   // VERIFIED: This computed() only runs when restrictions change, not on autocomplete keypress.
   // Console instrumentation confirmed memoization works correctly (Dec 2025).
   const impliedItems = computed(() => {
-    // Access the normalized array - normalizedRestrictions is already a computed OpaqueRef
+    // Access the normalized array - normalizedRestrictions is already a computed Reactive
     const current = (normalizedRestrictions || []) as RestrictionEntry[];
 
     const implied = new Map<

--- a/packages/patterns/examples/cf-picker.tsx
+++ b/packages/patterns/examples/cf-picker.tsx
@@ -12,7 +12,7 @@ export type Result = {
 
 export default pattern<Input, Result>(
   (_) => {
-    // Create counter instances - these are OpaqueRefs to pattern results
+    // Create counter instances - these are Reactives to pattern results
     const counterA = Counter({ value: 10 });
     const counterB = Note({
       content: "This is item B (a Note)",

--- a/packages/patterns/google/extractors/berkeley-library.tsx
+++ b/packages/patterns/google/extractors/berkeley-library.tsx
@@ -798,7 +798,7 @@ export default pattern<PatternInput, PatternOutput>(
     });
 
     // Group active items by due date for checkbox-based bulk returns
-    // Pre-compute ALL derived values here to avoid OpaqueRef issues in UI
+    // Pre-compute ALL derived values here to avoid Reactive issues in UI
     const itemsByDueDate = computed(() => {
       const groups = new Map<string, TrackedItem[]>();
       const items = activeItems || [];
@@ -1239,7 +1239,7 @@ export default pattern<PatternInput, PatternOutput>(
                         {/* Items in this group */}
                         <cf-vstack gap="2">
                           {group.items.map((item) => {
-                            // Extract key before computed to avoid OpaqueRef issues
+                            // Extract key before computed to avoid Reactive issues
                             const itemKey = item.key;
                             const isChecked = computed(() => {
                               const deselected = selectedItems.get() || [];

--- a/packages/patterns/google/extractors/email-notes.tsx
+++ b/packages/patterns/google/extractors/email-notes.tsx
@@ -463,7 +463,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
                 <cf-vstack gap="3">
                   {notes.map((note) => {
                     // Check if this note is being processed
-                    // Extract noteId first to avoid OpaqueRef issues in the projection
+                    // Extract noteId first to avoid Reactive issues in the projection
                     const noteId = note.id;
                     const isProcessing = (processingNotes.get() || []).includes(
                       noteId,

--- a/packages/patterns/record/extraction/extractor-module.tsx
+++ b/packages/patterns/record/extraction/extractor-module.tsx
@@ -1754,7 +1754,7 @@ export const ExtractorModule = pattern<
 
     // Build OCR calls for all selected photos using .map() on computed Cell
     // Each photo gets its own generateText call (framework caches per-item)
-    // .map() on OpaqueRef works reactively - returns another OpaqueRef<Array>
+    // .map() on Reactive works reactively - returns another Reactive<Array>
     const ocrCalls = photoSources.map((photo: ExtractableSource) => {
       // Build prompt for this photo
       const prompt = computed(() => {

--- a/packages/runner/src/builder/built-in.ts
+++ b/packages/runner/src/builder/built-in.ts
@@ -5,8 +5,8 @@ import type {
   FactoryInput,
   JSONSchema,
   NodeFactory,
-  OpaqueRef,
   PatternFactory,
+  Reactive,
   Schema,
 } from "./types.ts";
 import type { Cell as CellType } from "./types.ts";
@@ -101,14 +101,14 @@ export const compileAndRun = createNodeFactory({
   implementation: "compileAndRun",
 }) as <T = any, S = any>(
   params: FactoryInput<BuiltInCompileAndRunParams<T>>,
-) => OpaqueRef<BuiltInCompileAndRunState<S>>;
+) => Reactive<BuiltInCompileAndRunState<S>>;
 
 export const llm = createNodeFactory({
   type: "ref",
   implementation: "llm",
 }) as (
   params: FactoryInput<BuiltInLLMParams>,
-) => OpaqueRef<BuiltInLLMState>;
+) => Reactive<BuiltInLLMState>;
 
 export const llmDialog = createNodeFactory({
   type: "ref",
@@ -117,21 +117,21 @@ export const llmDialog = createNodeFactory({
   propagateInputIfc: false,
 }) as (
   params: FactoryInput<BuiltInLLMParams>,
-) => OpaqueRef<BuiltInLLMDialogState>;
+) => Reactive<BuiltInLLMDialogState>;
 
 export const generateObject = createNodeFactory({
   type: "ref",
   implementation: "generateObject",
 }) as <T = any>(
   params: FactoryInput<BuiltInGenerateObjectParams>,
-) => OpaqueRef<BuiltInLLMGenerateObjectState<T>>;
+) => Reactive<BuiltInLLMGenerateObjectState<T>>;
 
 export const generateText = createNodeFactory({
   type: "ref",
   implementation: "generateText",
 }) as (
   params: FactoryInput<BuiltInGenerateTextParams>,
-) => OpaqueRef<BuiltInGenerateTextState>;
+) => Reactive<BuiltInGenerateTextState>;
 
 export const fetchData = createNodeFactory({
   type: "ref",
@@ -143,14 +143,14 @@ export const fetchData = createNodeFactory({
     options?: FetchOptions;
     result?: T;
   }>,
-) => OpaqueRef<{ pending: boolean; result: T; error?: unknown }>;
+) => Reactive<{ pending: boolean; result: T; error?: unknown }>;
 
 export const fetchProgram = createNodeFactory({
   type: "ref",
   implementation: "fetchProgram",
 }) as (
   params: FactoryInput<{ url: string }>,
-) => OpaqueRef<{
+) => Reactive<{
   pending: boolean;
   result: {
     files: Array<{ name: string; contents: string }>;
@@ -168,7 +168,7 @@ export const streamData = createNodeFactory({
     options?: FetchOptions;
     result?: T;
   }>,
-) => OpaqueRef<{ pending: boolean; result: T; error?: unknown }>;
+) => Reactive<{ pending: boolean; result: T; error?: unknown }>;
 
 export const sqliteDatabase = createNodeFactory({
   type: "ref",
@@ -190,7 +190,7 @@ export function ifElse<T = unknown, U = unknown, V = unknown>(
   condition?: FactoryInput<T>,
   ifTrue?: FactoryInput<U>,
   ifFalse?: FactoryInput<V>,
-): OpaqueRef<U | V> {
+): Reactive<U | V> {
   ifElseFactory ||= createNodeFactory({
     type: "ref",
     implementation: "ifElse",
@@ -205,7 +205,7 @@ export function ifElse<T = unknown, U = unknown, V = unknown>(
       condition,
       ifTrue,
       ifFalse,
-    }) as OpaqueRef<U | V>;
+    }) as Reactive<U | V>;
   }
 
   // Legacy signature: ifElse(cond, ifTrue, ifFalse)
@@ -213,7 +213,7 @@ export function ifElse<T = unknown, U = unknown, V = unknown>(
     condition: conditionSchemaOrCondition,
     ifTrue: ifTrueSchemaOrIfTrue,
     ifFalse: ifFalseSchemaOrIfFalse,
-  }) as OpaqueRef<U | V>;
+  }) as Reactive<U | V>;
 }
 
 let ifElseFactory:
@@ -236,7 +236,7 @@ export function when<T = unknown, U = unknown>(
   resultSchemaOrCondition?: JSONSchema | FactoryInput<T>,
   condition?: FactoryInput<T>,
   value?: FactoryInput<U>,
-): OpaqueRef<T | U> {
+): Reactive<T | U> {
   whenFactory ||= createNodeFactory({
     type: "ref",
     implementation: "when",
@@ -249,14 +249,14 @@ export function when<T = unknown, U = unknown>(
       resultSchema: resultSchemaOrCondition as JSONSchema,
       condition,
       value,
-    }) as OpaqueRef<T | U>;
+    }) as Reactive<T | U>;
   }
 
   // Legacy signature: when(cond, value)
   return whenFactory({
     condition: conditionSchemaOrCondition,
     value: valueSchemaOrValue,
-  }) as OpaqueRef<T | U>;
+  }) as Reactive<T | U>;
 }
 
 let whenFactory:
@@ -277,7 +277,7 @@ export function unless<T = unknown, U = unknown>(
   resultSchemaOrCondition?: JSONSchema | FactoryInput<T>,
   condition?: FactoryInput<T>,
   fallback?: FactoryInput<U>,
-): OpaqueRef<T | U> {
+): Reactive<T | U> {
   unlessFactory ||= createNodeFactory({
     type: "ref",
     implementation: "unless",
@@ -290,14 +290,14 @@ export function unless<T = unknown, U = unknown>(
       resultSchema: resultSchemaOrCondition as JSONSchema,
       condition,
       fallback,
-    }) as OpaqueRef<T | U>;
+    }) as Reactive<T | U>;
   }
 
   // Legacy signature: unless(cond, fallback)
   return unlessFactory({
     condition: conditionSchemaOrCondition,
     fallback: fallbackSchemaOrFallback,
-  }) as OpaqueRef<T | U>;
+  }) as Reactive<T | U>;
 }
 
 let unlessFactory:
@@ -335,19 +335,19 @@ export function uiVariant(
 export const navigateTo = createNodeFactory({
   type: "ref",
   implementation: "navigateTo",
-}) as (cell: OpaqueRef<unknown>) => OpaqueRef<boolean>;
+}) as (cell: Reactive<unknown>) => Reactive<boolean>;
 
 export function wish<T = unknown>(
   target: FactoryInput<WishParams>,
-): OpaqueRef<WishState<T>>;
+): Reactive<WishState<T>>;
 export function wish<T = unknown>(
   target: FactoryInput<WishParams>,
   schema: JSONSchema,
-): OpaqueRef<WishState<T>>;
+): Reactive<WishState<T>>;
 export function wish<T = unknown>(
   target: FactoryInput<WishParams>,
   schema?: JSONSchema,
-): OpaqueRef<WishState<T>> {
+): Reactive<WishState<T>> {
   let param;
   let resultSchema;
 
@@ -378,7 +378,7 @@ export function wish<T = unknown>(
 export function str(
   strings: TemplateStringsArray,
   ...values: unknown[]
-): OpaqueRef<string> {
+): Reactive<string> {
   const interpolatedString = ({
     strings,
     values,

--- a/packages/runner/src/builder/closure-capture-diagnostic.ts
+++ b/packages/runner/src/builder/closure-capture-diagnostic.ts
@@ -3,7 +3,7 @@ import type { CellScope } from "./types.ts";
 /**
  * Both pattern construction paths that detect a reactive cell being captured
  * from an outer frame raise the SAME conceptual violation: a callback (a map /
- * filter / flatMap / computed body) closed over a `Cell`/`OpaqueRef` that
+ * filter / flatMap / computed body) closed over a `Cell`/`Reactive` that
  * belongs to a different frame, instead of receiving it as an explicit
  * reactive input.
  *

--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -12,8 +12,8 @@ import {
   type JSONSchema,
   type JSONValue,
   type Module,
-  type OpaqueRef,
   type Pattern,
+  type Reactive,
   type toJSON,
 } from "./types.ts";
 import { getTopFrame } from "./pattern.ts";
@@ -32,7 +32,7 @@ import {
 import { isCell } from "../cell.ts";
 
 export type CellAliasResolver = (
-  cell: OpaqueRef<any>,
+  cell: Reactive<any>,
   path: readonly PropertyKey[],
   ignoreSelfAliases: boolean,
 ) => LegacyAlias | null | undefined;
@@ -66,7 +66,7 @@ export function toJSONWithLegacyAliases(
     // Otherwise it's an internal reference. Ask the pattern builder how this
     // cell should be represented in the serialized pattern.
     const alias = resolveCellAlias?.(
-      value as OpaqueRef<any>,
+      value as Reactive<any>,
       path,
       ignoreSelfAliases,
     );

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -9,14 +9,14 @@ import type {
   ModuleFactory,
   NodeRef,
   OpaqueCell,
-  OpaqueRef,
+  Reactive,
   Schema,
   SchemaWithoutCell,
   Stream,
   StripCell,
   toJSON,
 } from "./types.ts";
-import { opaqueRef, stream } from "./opaque-ref.ts";
+import { reactive, stream } from "./opaque-ref.ts";
 import {
   applyArgumentIfcToResult,
   connectInputAndOutputs,
@@ -132,8 +132,8 @@ export function createNodeFactory<T = any, R = any>(
     module.argumentSchema,
     module.resultSchema,
   );
-  const factory = Object.assign((inputs: FactoryInput<T>): OpaqueRef<R> => {
-    const outputs = opaqueRef<R>(undefined, module.resultSchema);
+  const factory = Object.assign((inputs: FactoryInput<T>): Reactive<R> => {
+    const outputs = reactive<R>(undefined, module.resultSchema);
     const node: NodeRef = { module, inputs, outputs, frame: getTopFrame() };
 
     connectInputAndOutputs(node);
@@ -502,7 +502,7 @@ export function handler<E, T>(
 // unsafe closures: doesn't need any arguments.
 // Uses argumentSchema: false to signal "takes no input" so the action
 // validation doesn't skip it due to undefined arguments.
-export const computed: <T>(fn: () => T) => OpaqueRef<T> = <T>(fn: () => T) =>
+export const computed: <T>(fn: () => T) => Reactive<T> = <T>(fn: () => T) =>
   createNodeFactory<any, T>({
     type: "javascript",
     implementation: fn,

--- a/packages/runner/src/builder/node-utils.ts
+++ b/packages/runner/src/builder/node-utils.ts
@@ -86,8 +86,8 @@ export function applyInputIfcToOutput<T, R>(
   }
 }
 
-// Attach ifc confidentiality to OpaqueRef objects reachable
-// from the outputs without descending into OpaqueRef objects
+// Attach ifc confidentiality to Reactive objects reachable
+// from the outputs without descending into Reactive objects
 // TODO(@ubik2) Investigate: can we have cycles here?
 function attachCfcToOutputs(
   outputs: unknown,

--- a/packages/runner/src/builder/opaque-ref.ts
+++ b/packages/runner/src/builder/opaque-ref.ts
@@ -3,7 +3,7 @@ import {
   type FactoryInput,
   type JSONSchema,
   type JSONValue,
-  type OpaqueRef,
+  type Reactive,
   type SchemaWithoutCell,
   type Stream,
 } from "./types.ts";
@@ -12,17 +12,17 @@ import { createCell } from "../cell.ts";
 import { ContextualFlowControl } from "../cfc.ts";
 
 /**
- * Implementation of opaqueRef that creates actual Cells.
+ * Implementation of reactive that creates actual Cells.
  * Uses getTopFrame() to access the runtime.
  * @param value - Optional schema default value
  * @param schema - Optional schema
- * @returns An OpaqueRef
+ * @returns An Reactive
  */
-function opaqueRefWithCell<T>(
+function reactiveWithCell<T>(
   value?: FactoryInput<T> | T | undefined,
   schema?: JSONSchema,
   kind?: CellKind,
-): OpaqueRef<T> {
+): Reactive<T> {
   const frame = getTopFrame();
   if (!frame || !frame.runtime) {
     throw new Error(
@@ -52,35 +52,35 @@ function opaqueRefWithCell<T>(
     kind,
   );
 
-  frame.opaqueRefs.add(cell);
+  frame.reactives.add(cell);
 
-  // Use the cell's built-in method to get a proxied OpaqueRef
-  return cell.getAsOpaqueRefProxy();
+  // Use the cell's built-in method to get a proxied Reactive
+  return cell.getAsReactiveProxy();
 }
 
-// Legacy opaqueRef for backward compatibility - creates proxies without Cell
+// Legacy reactive for backward compatibility - creates proxies without Cell
 // This is used during pattern construction before we have a runtime
-export function opaqueRef<S extends JSONSchema>(
+export function reactive<S extends JSONSchema>(
   value: FactoryInput<SchemaWithoutCell<S>> | SchemaWithoutCell<S> | undefined,
   schema: S,
-): OpaqueRef<SchemaWithoutCell<S>>;
-export function opaqueRef<T>(
+): Reactive<SchemaWithoutCell<S>>;
+export function reactive<T>(
   value?: FactoryInput<T> | T | undefined,
   schema?: JSONSchema,
-): OpaqueRef<T>;
+): Reactive<T>;
 
-export function opaqueRef<T>(
+export function reactive<T>(
   value?: FactoryInput<T> | T | undefined,
   schema?: JSONSchema,
-): OpaqueRef<T> {
-  return opaqueRefWithCell<T>(value, schema);
+): Reactive<T> {
+  return reactiveWithCell<T>(value, schema);
 }
 
 export function stream<T>(
   schema?: JSONSchema,
 ): Stream<T> {
-  // The runtime creates a Stream cell, but opaqueRefWithCell is typed to return OpaqueRef
-  return opaqueRefWithCell<T>(undefined, schema, "stream") as unknown as Stream<
+  // The runtime creates a Stream cell, but reactiveWithCell is typed to return Reactive
+  return reactiveWithCell<T>(undefined, schema, "stream") as unknown as Stream<
     T
   >;
 }

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -5,7 +5,7 @@ import {
   type FactoryInput,
   type Frame,
   type ICell,
-  isOpaqueRef,
+  isReactive,
   JSONObject,
   type JSONSchema,
   type JSONValue,
@@ -13,9 +13,9 @@ import {
   type Node,
   type NodeRef,
   type OpaqueCell,
-  type OpaqueRef,
   type Pattern,
   type PatternFactory,
+  type Reactive,
   type RequireDefaults,
   type Schema,
   type SchemaWithoutCell,
@@ -23,7 +23,7 @@ import {
   type toJSON,
   type UnsafeBinding,
 } from "./types.ts";
-import { opaqueRef } from "./opaque-ref.ts";
+import { reactive } from "./opaque-ref.ts";
 import { brandTrustedPattern, noteDerivedCopy } from "./pattern-metadata.ts";
 import {
   applyArgumentIfcToResult,
@@ -71,33 +71,33 @@ import { hardenVerifiedFunction } from "../sandbox/function-hardening.ts";
 // Function-only overloads (most common)
 export function pattern<T>(
   fn: (
-    input: OpaqueRef<RequireDefaults<T>> & { [SELF]: OpaqueRef<any> },
+    input: Reactive<RequireDefaults<T>> & { [SELF]: Reactive<any> },
   ) => any,
 ): PatternFactory<T, ReturnType<typeof fn>>;
 export function pattern<T, R>(
   fn: (
-    input: OpaqueRef<RequireDefaults<T>> & { [SELF]: OpaqueRef<R> },
+    input: Reactive<RequireDefaults<T>> & { [SELF]: Reactive<R> },
   ) => FactoryInput<R>,
 ): PatternFactory<T, R>;
 // Function + schemas overloads
 export function pattern<S extends JSONSchema>(
   fn: (
-    input: OpaqueRef<SchemaWithoutCell<S>> & {
-      [SELF]: OpaqueRef<any>;
+    input: Reactive<SchemaWithoutCell<S>> & {
+      [SELF]: Reactive<any>;
     },
   ) => any,
   argumentSchema: S,
 ): PatternFactory<SchemaWithoutCell<S>, ReturnType<typeof fn>>;
 export function pattern<S extends JSONSchema, R>(
   fn: (
-    input: OpaqueRef<SchemaWithoutCell<S>> & { [SELF]: OpaqueRef<R> },
+    input: Reactive<SchemaWithoutCell<S>> & { [SELF]: Reactive<R> },
   ) => FactoryInput<R>,
   argumentSchema: S,
 ): PatternFactory<SchemaWithoutCell<S>, R>;
 export function pattern<S extends JSONSchema, RS extends JSONSchema>(
   fn: (
-    input: OpaqueRef<SchemaWithoutCell<S>> & {
-      [SELF]: OpaqueRef<Schema<RS>>;
+    input: Reactive<SchemaWithoutCell<S>> & {
+      [SELF]: Reactive<Schema<RS>>;
     },
   ) => FactoryInput<Schema<RS>>,
   argumentSchema: S,
@@ -106,14 +106,14 @@ export function pattern<S extends JSONSchema, RS extends JSONSchema>(
 // Explicit T with optional schemas (e.g. pattern<{ x: number }>(fn, schema))
 export function pattern<T>(
   fn: (
-    input: OpaqueRef<RequireDefaults<T>> & { [SELF]: OpaqueRef<any> },
+    input: Reactive<RequireDefaults<T>> & { [SELF]: Reactive<any> },
   ) => any,
   argumentSchema: JSONSchema,
   resultSchema?: JSONSchema,
 ): PatternFactory<T, ReturnType<typeof fn>>;
 export function pattern<T, R>(
   fn: (
-    input: OpaqueRef<RequireDefaults<T>> & { [SELF]: OpaqueRef<R> },
+    input: Reactive<RequireDefaults<T>> & { [SELF]: Reactive<R> },
   ) => FactoryInput<R>,
   argumentSchema: JSONSchema,
   resultSchema?: JSONSchema,
@@ -121,7 +121,7 @@ export function pattern<T, R>(
 // Implementation signature
 export function pattern<T, R>(
   fn: (
-    input: OpaqueRef<RequireDefaults<T>> & { [SELF]: OpaqueRef<R> },
+    input: Reactive<RequireDefaults<T>> & { [SELF]: Reactive<R> },
   ) => FactoryInput<R>,
   argumentSchema?: JSONSchema,
   resultSchema?: JSONSchema,
@@ -129,17 +129,17 @@ export function pattern<T, R>(
   hardenVerifiedFunction(fn);
 
   // The pattern graph is created by calling `fn` which populates for `inputs`
-  // and `outputs` with Value<> (which containts OpaqueRef<>) and/or default
+  // and `outputs` with Value<> (which containts Reactive<>) and/or default
   // values.
   const frame = pushFrame();
 
-  const inputs = opaqueRef<RequireDefaults<T>>(
+  const inputs = reactive<RequireDefaults<T>>(
     undefined,
     argumentSchema as JSONSchema | undefined,
   );
 
   // Create self reference - will be mapped to resultRef path during serialization
-  const selfRef = opaqueRef<R>(
+  const selfRef = reactive<R>(
     undefined,
     resultSchema as JSONSchema | undefined,
   );
@@ -150,7 +150,7 @@ export function pattern<T, R>(
   let result;
   try {
     const outputs = fn!(
-      inputs as OpaqueRef<RequireDefaults<T>> & { [SELF]: OpaqueRef<R> },
+      inputs as Reactive<RequireDefaults<T>> & { [SELF]: Reactive<R> },
     );
 
     applyInputIfcToOutput(inputs, outputs);
@@ -170,24 +170,24 @@ export function pattern<T, R>(
 // Same as above, but assumes the caller manages the frame
 export function patternFromFrame<T, R>(
   fn: (
-    input: OpaqueRef<RequireDefaults<T>> & { [SELF]: OpaqueRef<R> },
+    input: Reactive<RequireDefaults<T>> & { [SELF]: Reactive<R> },
   ) => FactoryInput<R>,
   argumentSchema?: JSONSchema,
   resultSchema?: JSONSchema,
 ): PatternFactory<T, R> {
-  const inputs = opaqueRef<RequireDefaults<T>>(
+  const inputs = reactive<RequireDefaults<T>>(
     undefined,
     argumentSchema as JSONSchema | undefined,
   );
 
   // Create self reference - will be mapped to resultRef path during serialization
-  const selfRef = opaqueRef<R>(undefined, resultSchema);
+  const selfRef = reactive<R>(undefined, resultSchema);
 
   // Attach SELF to the underlying cell so the proxy can return it
   getCellOrThrow(inputs).setSelfRef(selfRef);
 
   const outputs = fn(
-    inputs as OpaqueRef<RequireDefaults<T>> & { [SELF]: OpaqueRef<R> },
+    inputs as Reactive<RequireDefaults<T>> & { [SELF]: Reactive<R> },
   );
   return factoryFromPattern<T, R>(
     argumentSchema,
@@ -200,13 +200,13 @@ export function patternFromFrame<T, R>(
 function factoryFromPattern<T, R>(
   argumentSchemaArg: JSONSchema | undefined,
   resultSchemaArg: JSONSchema | undefined,
-  inputs: OpaqueRef<RequireDefaults<T>>,
+  inputs: Reactive<RequireDefaults<T>>,
   outputs: FactoryInput<R>,
 ): PatternFactory<T, R> {
-  // Capture selfRef before collectCellsAndNodes transforms inputs from OpaqueRef to Cell
-  // (collectCellsAndNodes replaces OpaqueRef proxies with their underlying Cells,
-  // and SELF access only works through the OpaqueRef proxy)
-  const selfRef = (inputs as unknown as { [SELF]: OpaqueRef<any> })[SELF];
+  // Capture selfRef before collectCellsAndNodes transforms inputs from Reactive to Cell
+  // (collectCellsAndNodes replaces Reactive proxies with their underlying Cells,
+  // and SELF access only works through the Reactive proxy)
+  const selfRef = (inputs as unknown as { [SELF]: Reactive<any> })[SELF];
 
   // Traverse the value, collect all mentioned nodes and cells
   const allCells = new Set<ICell<unknown>>();
@@ -221,7 +221,7 @@ function factoryFromPattern<T, R>(
       if (isCellResultForDereferencing(value)) value = getCellOrThrow(value);
       if (isCell(value) && !allCells.has(value)) {
         const { frame, nodes, path, scope, name } = value.export();
-        if (isOpaqueRef(value) && frame !== getTopFrame()) {
+        if (isReactive(value) && frame !== getTopFrame()) {
           throw new Error(
             closureCaptureErrorMessage({
               capturedCell: { path, scope, name },
@@ -276,7 +276,7 @@ function factoryFromPattern<T, R>(
       if (isRecord(node.inputs)) {
         Object.entries(node.inputs).forEach(([key, input]) => {
           if (
-            isOpaqueRef(input) && input.export().cell === cell &&
+            isReactive(input) && input.export().cell === cell &&
             !cell.export().name && !usedNames.has(key)
           ) {
             cell.for(key, true); // allowIfSet=true to not override existing causes
@@ -289,14 +289,14 @@ function factoryFromPattern<T, R>(
 
   // Also collect otherwise disconnected cells and nodes, e.g. those that are
   // assigned to cells via .set or .push and aren't otherwise connected.
-  getTopFrame()?.opaqueRefs.forEach((ref) => collectCellsAndNodes(ref));
+  getTopFrame()?.reactives.forEach((ref) => collectCellsAndNodes(ref));
 
   const inputCell = isCell(inputs) ? inputs : getCellOrThrow(inputs);
   const selfRefCell = getCellOrThrow(selfRef);
   const inputRootCell = inputCell.export().cell;
   const selfRefRootCell = selfRefCell.export().cell;
   const cellNameForCell = (
-    cell: ICell<unknown> | OpaqueCell<any> | OpaqueRef<any>,
+    cell: ICell<unknown> | OpaqueCell<any> | Reactive<any>,
   ): "argument" | "result" | undefined => {
     const rootCell = cell.export().cell;
     return rootCell === inputRootCell
@@ -339,7 +339,7 @@ function factoryFromPattern<T, R>(
   });
 
   const cellReferenceForCell = (
-    cell: ICell<unknown> | OpaqueCell<any> | OpaqueRef<any>,
+    cell: ICell<unknown> | OpaqueCell<any> | Reactive<any>,
   ): LegacyAlias["$alias"] | undefined => {
     const { cell: top, path, external, scope, schema } = cell.export();
     // If we have an external id, don't bother with all this
@@ -362,7 +362,7 @@ function factoryFromPattern<T, R>(
     }
   };
 
-  const allCellsAndInternalRoots = new Set<ICell<unknown> | OpaqueRef<any>>(
+  const allCellsAndInternalRoots = new Set<ICell<unknown> | Reactive<any>>(
     allCells,
   );
   allCells.forEach((cell) => {
@@ -499,7 +499,7 @@ function factoryFromPattern<T, R>(
     defaultSpace?: string | unknown,
   ): PatternFactory<T, R> => {
     const factory = Object.assign(
-      (inputs: FactoryInput<T>): OpaqueRef<R> => {
+      (inputs: FactoryInput<T>): Reactive<R> => {
         const module: Module & toJSON = {
           type: "pattern",
           implementation: factory,
@@ -509,7 +509,7 @@ function factoryFromPattern<T, R>(
           toJSON: () => moduleToJSON(module),
         };
 
-        const outputs = opaqueRef<R>();
+        const outputs = reactive<R>();
         const frame = getTopFrame();
         if (defaultSpace !== undefined) {
           const targetSpace = resolveInSpaceTargetSpace(defaultSpace, frame);
@@ -660,7 +660,7 @@ export function pushFrame(frame: Partial<Frame> = {}): Frame {
 
   const result = {
     parent,
-    opaqueRefs: new Set(),
+    reactives: new Set(),
     generatedIdCounter: 0,
     ...(parent?.implementationIdentity && {
       implementationIdentity: parent.implementationIdentity,
@@ -701,7 +701,7 @@ export function pushFrameFromCause(
     parent,
     cause,
     generatedIdCounter: 0,
-    opaqueRefs: new Set(),
+    reactives: new Set(),
     ...(parent?.implementationIdentity && {
       implementationIdentity: parent.implementationIdentity,
     }),

--- a/packages/runner/src/builder/traverse-utils.ts
+++ b/packages/runner/src/builder/traverse-utils.ts
@@ -1,5 +1,5 @@
 import { isRecord } from "@commonfabric/utils/types";
-import { type FactoryInput, isOpaqueRef, isPattern } from "./types.ts";
+import { type FactoryInput, isPattern, isReactive } from "./types.ts";
 import { noteDerivedCopy } from "./pattern-metadata.ts";
 import { isCell } from "../cell.ts";
 import { isCellResultForDereferencing } from "../query-result-proxy.ts";
@@ -33,7 +33,7 @@ export function traverseValue(
 
   // Traverse value
   if (
-    !isOpaqueRef(value) &&
+    !isReactive(value) &&
     !isCell(value) &&
     !isCellResultForDereferencing(value) &&
     (isRecord(value) || isPattern(value))

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -41,9 +41,9 @@ import type {
   Module,
   NavigateToFunction,
   NonPrivateRandomFunction,
-  OpaqueRef,
   Pattern,
   PatternToolFunction,
+  Reactive,
   SafeDateNowFunction,
   schema as schemaFunction,
   SELF as SELFSymbol,
@@ -141,11 +141,11 @@ export type {
   ModuleFactory,
   NodeFactory,
   OpaqueCell,
-  OpaqueRef,
   Pattern,
   PatternFactory,
   PatternFunction,
   Props,
+  Reactive,
   RenderNode,
   RequireDefaults,
   SchemaScope,
@@ -163,20 +163,20 @@ export type {
 export type { AsCellEntry } from "@commonfabric/api";
 export type { Schema, SchemaWithoutCell } from "@commonfabric/api/schema";
 
-export const isOpaqueRefMarker = Symbol("isOpaqueRef");
+export const isReactiveMarker = Symbol("isReactive");
 
-export function isOpaqueRef<T = any>(
+export function isReactive<T = any>(
   value: unknown,
-): value is OpaqueRef<T> {
+): value is Reactive<T> {
   return !!value &&
-    typeof (value as { [isOpaqueRefMarker]: true })[isOpaqueRefMarker] ===
+    typeof (value as { [isReactiveMarker]: true })[isReactiveMarker] ===
       "boolean";
 }
 
 export type NodeRef = {
-  module: Module | Pattern | OpaqueRef<Module | Pattern>;
+  module: Module | Pattern | Reactive<Module | Pattern>;
   inputs: FactoryInput<any>;
-  outputs: OpaqueRef<any>;
+  outputs: Reactive<any>;
   frame: Frame | undefined;
 };
 
@@ -288,7 +288,7 @@ export type Frame = {
   tx?: IExtendedStorageTransaction;
   space?: MemorySpace;
   inHandler?: boolean;
-  opaqueRefs: Set<OpaqueRef<any>>;
+  reactives: Set<Reactive<any>>;
   unsafe_binding?: UnsafeBinding;
   sourceLocationContext?: SourceLocationContext;
   /**

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -61,15 +61,15 @@ import {
   type NodeFactory,
   type NodeRef,
   type OpaqueCell,
-  type OpaqueRef,
   type PatternFactory,
+  type Reactive,
   type Schema,
   SELF,
   type Stream,
   type StripDefaultBrand,
 } from "./builder/types.ts";
 import { toCell } from "./back-to-cell.ts";
-import { isOpaqueRefMarker } from "./builder/types.ts";
+import { isReactiveMarker } from "./builder/types.ts";
 import {
   type CellResult,
   createQueryResultProxy,
@@ -180,7 +180,7 @@ let flatMapFactory: NodeFactory<any, any> | undefined;
 
 /**
  * Error thrown by the function-form `.map`/`.filter`/`.flatMap` on an
- * OpaqueRef/Cell. These wrapped the callback in an anonymous inline pattern,
+ * Reactive/Cell. These wrapped the callback in an anonymous inline pattern,
  * which has no stable content-addressed `{ identity, symbol }` and so cannot be
  * passed/persisted by identity (CT-1623). Authored pattern code is always
  * lowered by the TS transformer to the `*WithPattern(pattern(...), params)` form
@@ -190,7 +190,7 @@ let flatMapFactory: NodeFactory<any, any> | undefined;
 function throwOpFunctionFormMessage(
   method: "map" | "filter" | "flatMap",
 ): string {
-  return `OpaqueRef.${method}(fn) is no longer supported: an inline pattern has ` +
+  return `Reactive.${method}(fn) is no longer supported: an inline pattern has ` +
     `no stable identity. Authored \`.${method}(...)\` is lowered by the TS ` +
     `transformer to \`.${method}WithPattern(pattern(...), { params })\`; if you ` +
     `are calling the builder API directly, use \`.${method}WithPattern(op, params)\`.`;
@@ -397,9 +397,9 @@ declare module "@commonfabric/api" {
       name?: unknown;
       external?: unknown;
     };
-    getAsOpaqueRefProxy(
+    getAsReactiveProxy(
       boundTarget?: (...args: unknown[]) => unknown,
-    ): OpaqueRef<T>;
+    ): Reactive<T>;
     toJSON(): SigilLink | null;
     runtime: Runtime;
     tx: IExtendedStorageTransaction | undefined;
@@ -413,7 +413,7 @@ declare module "@commonfabric/api" {
     copyTrap: boolean;
 
     /** Set the self-reference for SELF symbol support in patterns */
-    setSelfRef(selfRef: OpaqueRef<any>): void;
+    setSelfRef(selfRef: Reactive<any>): void;
   }
 
   interface ICreatable<C extends AnyBrandedCell<any>> {
@@ -479,7 +479,7 @@ const cellMethods = new Set<
   "setSchema",
   "connect",
   "export",
-  "getAsOpaqueRefProxy",
+  "getAsReactiveProxy",
   "setSelfRef",
   "exec",
   "query",
@@ -657,7 +657,7 @@ export class CellImpl<T extends FabricValue>
   private _kind: CellKind;
 
   // Self-reference for pattern SELF symbol support
-  private _selfRef?: OpaqueRef<any>;
+  private _selfRef?: Reactive<any>;
   private viewRefHashCache?: {
     link: NormalizedFullLink;
     cfcLabelView: CfcLabelView | undefined;
@@ -2181,7 +2181,7 @@ export class CellImpl<T extends FabricValue>
    */
   connect(node: NodeRef): void {
     // For cells created during pattern construction, we need to track which nodes
-    // they're connected to. Since Cell doesn't have a nodes set like OpaqueRef's store,
+    // they're connected to. Since Cell doesn't have a nodes set like Reactive's store,
     // we'll store this in a WeakMap keyed by the cell instance.
     const top = this._causeContainer.cell;
     if (!cellNodes.has(top)) {
@@ -2191,7 +2191,7 @@ export class CellImpl<T extends FabricValue>
   }
 
   /**
-   * Export cell metadata for introspection, similar to OpaqueRef's export method.
+   * Export cell metadata for introspection, similar to Reactive's export method.
    * If the cell has a link, it's included as 'external'.
    */
   export(): {
@@ -2233,20 +2233,20 @@ export class CellImpl<T extends FabricValue>
    * Set the self-reference for pattern SELF symbol support.
    * This allows patterns to access their own output via the SELF symbol.
    */
-  setSelfRef(selfRef: OpaqueRef<any>): void {
+  setSelfRef(selfRef: Reactive<any>): void {
     this._selfRef = selfRef;
   }
 
   /**
-   * Wrap this cell in a proxy that provides OpaqueRef behavior.
+   * Wrap this cell in a proxy that provides Reactive behavior.
    * The proxy adds Symbol.iterator, Symbol.toPrimitive, and toCell support,
    * and recursively wraps child cells accessed via property access.
    *
-   * @returns A proxied version of this cell with OpaqueRef behavior
+   * @returns A proxied version of this cell with Reactive behavior
    */
-  getAsOpaqueRefProxy(
+  getAsReactiveProxy(
     boundTarget?: (...args: unknown[]) => unknown,
-  ): OpaqueRef<T> {
+  ): Reactive<T> {
     const self = this as unknown as Cell<T>;
     // `query`/`exec` are SqliteDb-only methods whose names are also common data
     // fields (e.g. wish's `query`). Only forward them as methods on a
@@ -2260,7 +2260,7 @@ export class CellImpl<T extends FabricValue>
             let index = 0;
             while (index < 50) { // Limit to 50 items like original
               const itemCell = self.key(index) as Cell<unknown>;
-              yield itemCell.getAsOpaqueRefProxy();
+              yield itemCell.getAsReactiveProxy();
               index++;
             }
           };
@@ -2273,7 +2273,7 @@ export class CellImpl<T extends FabricValue>
         } else if (prop === toCell) {
           // Return a function that returns the unproxied cell
           return () => self;
-        } else if (prop === isOpaqueRefMarker) {
+        } else if (prop === isReactiveMarker) {
           return true;
         } else if (prop === SELF) {
           // Return the self-reference if set (for pattern SELF symbol support)
@@ -2289,7 +2289,7 @@ export class CellImpl<T extends FabricValue>
             cellMethods.has(prop as keyof ICell<T>) &&
             (!isSqliteOnlyMethod || cellKind === "sqlite")
           ) {
-            return nestedCell.getAsOpaqueRefProxy(
+            return nestedCell.getAsReactiveProxy(
               (self as unknown as Record<
                 string,
                 (...args: unknown[]) => unknown
@@ -2297,19 +2297,19 @@ export class CellImpl<T extends FabricValue>
                 .bind(self),
             );
           } else {
-            return nestedCell.getAsOpaqueRefProxy();
+            return nestedCell.getAsReactiveProxy();
           }
         }
         // Delegate everything else to orignal target
         return (target as any)[prop];
       },
     });
-    return proxy as unknown as OpaqueRef<T>;
+    return proxy as unknown as Reactive<T>;
   }
 
   /**
    * Map over an array cell, creating a new derived array.
-   * Similar to Array.prototype.map but works with OpaqueRefs.
+   * Similar to Array.prototype.map but works with Reactives.
    */
   /**
    * SqliteDb reactive read (`db.query<Row>`): builds a `sqliteQuery` node with
@@ -2330,7 +2330,7 @@ export class CellImpl<T extends FabricValue>
       maxConfidentiality?: ReadonlyArray<unknown>;
       onExceed?: "fail" | "skip";
     },
-  ): OpaqueRef<{ pending: boolean; result?: Row[]; error?: unknown }> {
+  ): Reactive<{ pending: boolean; result?: Row[]; error?: unknown }> {
     return sqliteQueryNodeFactory({
       db: this,
       sql,
@@ -2343,16 +2343,16 @@ export class CellImpl<T extends FabricValue>
       // options object) to the node so the builtin can decode `_cf_link`
       // columns. Read loosely — it is not part of the public options type.
       rowSchema: (options as { rowSchema?: unknown } | undefined)?.rowSchema,
-    }) as OpaqueRef<{ pending: boolean; result?: Row[]; error?: unknown }>;
+    }) as Reactive<{ pending: boolean; result?: Row[]; error?: unknown }>;
   }
 
   map<S>(
     _fn: (
-      element: T extends Array<infer U> ? OpaqueRef<U> : OpaqueRef<T>,
-      index: OpaqueRef<number>,
-      array: OpaqueRef<T>,
+      element: T extends Array<infer U> ? Reactive<U> : Reactive<T>,
+      index: Reactive<number>,
+      array: Reactive<T>,
     ) => FactoryInput<S>,
-  ): OpaqueRef<S[]> {
+  ): Reactive<S[]> {
     throw new Error(throwOpFunctionFormMessage("map"));
   }
 
@@ -2364,7 +2364,7 @@ export class CellImpl<T extends FabricValue>
     this: IsThisObject,
     op: PatternFactory<T extends Array<infer U> ? U : T, S>,
     params: Record<string, any>,
-  ): OpaqueRef<S[]> {
+  ): Reactive<S[]> {
     // Create the factory if it doesn't exist
     if (!mapFactory) {
       mapFactory = createNodeFactory({
@@ -2374,7 +2374,7 @@ export class CellImpl<T extends FabricValue>
     }
 
     const result = mapFactory({
-      list: this as unknown as OpaqueRef<T>,
+      list: this as unknown as Reactive<T>,
       op: op,
       params: params,
     });
@@ -2396,11 +2396,11 @@ export class CellImpl<T extends FabricValue>
       array: (T extends Array<infer U> ? U : T)[],
     ) => S,
     initialValue: S,
-  ): OpaqueRef<S> {
+  ): Reactive<S> {
     return lift((list: any[]) => {
       if (!Array.isArray(list)) return initialValue;
       return list.reduce(fn, initialValue);
-    })(this as unknown as OpaqueRef<any>);
+    })(this as unknown as Reactive<any>);
   }
 
   /**
@@ -2417,7 +2417,7 @@ export class CellImpl<T extends FabricValue>
       index: number,
       array: (T extends Array<infer U> ? U : T)[],
     ) => boolean,
-  ): OpaqueRef<number> {
+  ): Reactive<number> {
     // Uses lift rather than a per-element-pattern builtin (like filter/map)
     // because findIndex returns a plain number, not an element reference —
     // there's no benefit to per-element reactive tracking. The lift approach
@@ -2429,21 +2429,21 @@ export class CellImpl<T extends FabricValue>
         throw new TypeError("findIndex called on non-array value");
       }
       return list.findIndex(fn);
-    })(this as unknown as OpaqueRef<any>);
+    })(this as unknown as Reactive<any>);
   }
 
   /**
    * Filter an array cell, creating a new array with only matching elements.
-   * Similar to Array.prototype.filter but works with OpaqueRefs.
+   * Similar to Array.prototype.filter but works with Reactives.
    * Output contains cell references to the original elements.
    */
   filter(
     _fn: (
-      element: T extends Array<infer U> ? OpaqueRef<U> : OpaqueRef<T>,
-      index: OpaqueRef<number>,
-      array: OpaqueRef<T>,
+      element: T extends Array<infer U> ? Reactive<U> : Reactive<T>,
+      index: Reactive<number>,
+      array: Reactive<T>,
     ) => FactoryInput<boolean>,
-  ): OpaqueRef<(T extends Array<infer U> ? U : T)[]> {
+  ): Reactive<(T extends Array<infer U> ? U : T)[]> {
     throw new Error(throwOpFunctionFormMessage("filter"));
   }
 
@@ -2455,7 +2455,7 @@ export class CellImpl<T extends FabricValue>
     this: IsThisObject,
     op: PatternFactory<T extends Array<infer U> ? U : T, S>,
     params: Record<string, any>,
-  ): OpaqueRef<(T extends Array<infer U> ? U : T)[]> {
+  ): Reactive<(T extends Array<infer U> ? U : T)[]> {
     if (!filterFactory) {
       filterFactory = createNodeFactory({
         type: "ref",
@@ -2464,7 +2464,7 @@ export class CellImpl<T extends FabricValue>
     }
 
     const result = filterFactory({
-      list: this as unknown as OpaqueRef<T>,
+      list: this as unknown as Reactive<T>,
       op: op,
       params: params,
     });
@@ -2474,16 +2474,16 @@ export class CellImpl<T extends FabricValue>
 
   /**
    * FlatMap over an array cell, creating a flattened array from per-element arrays.
-   * Similar to Array.prototype.flatMap but works with OpaqueRefs.
+   * Similar to Array.prototype.flatMap but works with Reactives.
    * Each callback should return an array; results are concatenated one level deep.
    */
   flatMap<S>(
     _fn: (
-      element: T extends Array<infer U> ? OpaqueRef<U> : OpaqueRef<T>,
-      index: OpaqueRef<number>,
-      array: OpaqueRef<T>,
+      element: T extends Array<infer U> ? Reactive<U> : Reactive<T>,
+      index: Reactive<number>,
+      array: Reactive<T>,
     ) => FactoryInput<S[]>,
-  ): OpaqueRef<S[]> {
+  ): Reactive<S[]> {
     throw new Error(throwOpFunctionFormMessage("flatMap"));
   }
 
@@ -2495,7 +2495,7 @@ export class CellImpl<T extends FabricValue>
     this: IsThisObject,
     op: PatternFactory<T extends Array<infer U> ? U : T, S[]>,
     params: Record<string, any>,
-  ): OpaqueRef<S[]> {
+  ): Reactive<S[]> {
     if (!flatMapFactory) {
       flatMapFactory = createNodeFactory({
         type: "ref",
@@ -2504,7 +2504,7 @@ export class CellImpl<T extends FabricValue>
     }
 
     const result = flatMapFactory({
-      list: this as unknown as OpaqueRef<T>,
+      list: this as unknown as Reactive<T>,
       op: op,
       params: params,
     });

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -10,7 +10,7 @@ import {
   isEntityRef,
 } from "@commonfabric/data-model/cell-rep";
 import { isRecord } from "@commonfabric/utils/types";
-import { isOpaqueRef } from "./builder/types.ts";
+import { isReactive } from "./builder/types.ts";
 import {
   getCellOrThrow,
   isCellResultForDereferencing,
@@ -41,7 +41,7 @@ export function entityIdFrom(hash: string | FabricHash): EntityId {
 /**
  * Generates an entity ID.
  *
- * Derivation inputs must resolve: a Cell with no entityId or an OpaqueRef with
+ * Derivation inputs must resolve: a Cell with no entityId or a Reactive with
  * no value throws rather than minting a random substitute, so a derived id never
  * silently becomes non-deterministic (audit S14). A missing `cause`, by
  * contrast, deliberately mints a fresh random id.
@@ -102,13 +102,13 @@ export function createRef(
       obj = obj.toJSON() ?? obj;
     }
 
-    if (isOpaqueRef(obj)) {
+    if (isReactive(obj)) {
       const val = obj.export().value;
       if (val == null) {
-        // An OpaqueRef feeding a derived id must carry a value; otherwise the
+        // An Reactive feeding a derived id must carry a value; otherwise the
         // id would silently become non-deterministic (audit S14). Fail closed.
         throw new Error(
-          "[createRef] OpaqueRef has no value; cannot derive a stable id",
+          "[createRef] Reactive has no value; cannot derive a stable id",
         );
       }
       return val;

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -22,9 +22,9 @@ import {
 import ts from "typescript";
 import {
   CommonFabricTransformerPipeline,
-  OpaqueRefErrorTransformer,
   PATTERN_COVERAGE_GLOBAL,
   type PatternCoverageOptions,
+  ReactiveErrorTransformer,
   sourceDisablesCfTransform,
 } from "@commonfabric/ts-transformers";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -366,7 +366,7 @@ export class Engine extends EventTarget implements Harness {
           getTransformedProgram: options.getTransformedProgram
             ? (nextProgram) => options.getTransformedProgram?.(nextProgram)
             : undefined,
-          diagnosticMessageTransformer: new OpaqueRefErrorTransformer({
+          diagnosticMessageTransformer: new ReactiveErrorTransformer({
             verbose: options.verboseErrors,
           }),
           beforeTransformers: (program) => {

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -122,8 +122,8 @@ export {
   ID,
   ID_FIELD,
   isModule,
-  isOpaqueRef as isOpaqueRef,
   isPattern,
+  isReactive,
   isStreamValue,
   type JSONObject,
   type JSONSchema,
@@ -134,10 +134,10 @@ export {
   NAME,
   type NodeFactory,
   OAuth2TokenSchema,
-  type OpaqueRef,
   type Pattern,
   type PatternFactory,
   type Props,
+  type Reactive,
   type RenderNode,
   type Schema,
   schema,
@@ -152,7 +152,7 @@ export {
   WebhookConfigSchema,
 } from "./builder/types.ts";
 export { createNodeFactory } from "./builder/module.ts";
-export { opaqueRef as cell } from "./builder/opaque-ref.ts";
+export { reactive as cell } from "./builder/opaque-ref.ts";
 export {
   CFC_ATOM_TYPE,
   CFC_CONCEPT_KIND,

--- a/packages/runner/src/runner-utils.ts
+++ b/packages/runner/src/runner-utils.ts
@@ -6,7 +6,7 @@ import { linkRefFrom } from "@commonfabric/data-model/cell-rep";
 import { isRecord } from "@commonfabric/utils/types";
 import {
   isModule,
-  isOpaqueRef,
+  isReactive,
   type JSONSchema,
   type Module,
   type Pattern,
@@ -72,22 +72,22 @@ export function describePatternOrModule(
 /**
  * Validates an action result and checks if it contains opaque refs.
  * Throws if result contains invalid types (Map, Set, functions, etc.).
- * Returns true if the result contains any OpaqueRefs.
+ * Returns true if the result contains any Reactives.
  */
-export function validateAndCheckOpaqueRefs(
+export function validateAndCheckReactives(
   value: unknown,
   actionName?: string,
   path: string[] = [],
 ): boolean {
   if (value === null || value === undefined) return false;
-  if (isOpaqueRef(value)) return true;
+  if (isReactive(value)) return true;
   if (isCellLink(value)) return false;
 
   const formatError = (typeName: string, hint?: string) => {
     const pathStr = path.length > 0 ? ` at path "${path.join(".")}"` : "";
     const actionStr = actionName ? `\n  in action: ${actionName}` : "";
     const hintStr = hint ? ` ${hint}` : "";
-    return `Action returned a ${typeName}${pathStr}.${actionStr}\nActions must return JSON-serializable values, OpaqueRefs, or Cells.${hintStr}`;
+    return `Action returned a ${typeName}${pathStr}.${actionStr}\nActions must return JSON-serializable values, Reactives, or Cells.${hintStr}`;
   };
 
   if (typeof value === "function") {
@@ -134,7 +134,7 @@ export function validateAndCheckOpaqueRefs(
 
   if (Array.isArray(obj)) {
     return obj.some((item: unknown, index: number) =>
-      validateAndCheckOpaqueRefs(item, actionName, [...path, `[${index}]`])
+      validateAndCheckReactives(item, actionName, [...path, `[${index}]`])
     );
   }
 
@@ -145,7 +145,7 @@ export function validateAndCheckOpaqueRefs(
   }
 
   return Object.entries(obj as Record<string, unknown>).some(
-    ([key, val]) => validateAndCheckOpaqueRefs(val, actionName, [...path, key]),
+    ([key, val]) => validateAndCheckReactives(val, actionName, [...path, key]),
   );
 }
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -76,7 +76,7 @@ import {
   mergeObjects,
   sanitizeDebugLabel,
   setRunnableName,
-  validateAndCheckOpaqueRefs,
+  validateAndCheckReactives,
 } from "./runner-utils.ts";
 import {
   resolveBuiltinImplementationIdentity,
@@ -95,7 +95,7 @@ import { SigilLink } from "./sigil-types.ts";
 export {
   extractDefaultValues,
   mergeObjects,
-  validateAndCheckOpaqueRefs,
+  validateAndCheckReactives,
 } from "./runner-utils.ts";
 
 const logger = getLogger("runner", { enabled: true, level: "warn" });
@@ -2706,8 +2706,8 @@ export class Runner {
     const receiptsEnabled =
       this.runtime.experimental.commitPreconditions === true;
     if (
-      !validateAndCheckOpaqueRefs(result, name) &&
-      frame.opaqueRefs.size === 0
+      !validateAndCheckReactives(result, name) &&
+      frame.reactives.size === 0
     ) {
       if (receiptsEnabled) {
         // Receipt-only handling (spec scheduler-v2 §7.6): nothing was
@@ -2944,8 +2944,8 @@ export class Runner {
     narrowestReadScope?: CellScope,
   ): any {
     if (
-      !validateAndCheckOpaqueRefs(result, name) &&
-      frame.opaqueRefs.size === 0
+      !validateAndCheckReactives(result, name) &&
+      frame.reactives.size === 0
     ) {
       recordOutputSchemaPolicyInputs(
         tx,

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1080,7 +1080,7 @@ export interface IObjectCreator<T> {
 
   // In the SchemaObjectTraverser system, we don't need to annotate the object
   // or even create a returned value.
-  // In the validateAndTransform system, we may add the toCell and toOpaqueRef
+  // In the validateAndTransform system, we may add the toCell and toReactive
   // functions or actualy create the cell.
   createObject(
     link: NormalizedFullLink,

--- a/packages/runner/test/action-result-validation.test.ts
+++ b/packages/runner/test/action-result-validation.test.ts
@@ -1,39 +1,39 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { validateAndCheckOpaqueRefs } from "../src/runner.ts";
-import { isOpaqueRefMarker } from "../src/builder/types.ts";
+import { validateAndCheckReactives } from "../src/runner.ts";
+import { isReactiveMarker } from "../src/builder/types.ts";
 
-describe("validateAndCheckOpaqueRefs", () => {
+describe("validateAndCheckReactives", () => {
   describe("valid values", () => {
     it("accepts null", () => {
-      expect(validateAndCheckOpaqueRefs(null)).toBe(false);
+      expect(validateAndCheckReactives(null)).toBe(false);
     });
 
     it("accepts undefined", () => {
-      expect(validateAndCheckOpaqueRefs(undefined)).toBe(false);
+      expect(validateAndCheckReactives(undefined)).toBe(false);
     });
 
     it("accepts primitives", () => {
-      expect(validateAndCheckOpaqueRefs("hello")).toBe(false);
-      expect(validateAndCheckOpaqueRefs(42)).toBe(false);
-      expect(validateAndCheckOpaqueRefs(true)).toBe(false);
-      expect(validateAndCheckOpaqueRefs(false)).toBe(false);
+      expect(validateAndCheckReactives("hello")).toBe(false);
+      expect(validateAndCheckReactives(42)).toBe(false);
+      expect(validateAndCheckReactives(true)).toBe(false);
+      expect(validateAndCheckReactives(false)).toBe(false);
     });
 
     it("accepts plain objects", () => {
-      expect(validateAndCheckOpaqueRefs({})).toBe(false);
-      expect(validateAndCheckOpaqueRefs({ a: 1, b: "hello" })).toBe(false);
+      expect(validateAndCheckReactives({})).toBe(false);
+      expect(validateAndCheckReactives({ a: 1, b: "hello" })).toBe(false);
     });
 
     it("accepts arrays", () => {
-      expect(validateAndCheckOpaqueRefs([])).toBe(false);
-      expect(validateAndCheckOpaqueRefs([1, 2, 3])).toBe(false);
-      expect(validateAndCheckOpaqueRefs([{ a: 1 }, { b: 2 }])).toBe(false);
+      expect(validateAndCheckReactives([])).toBe(false);
+      expect(validateAndCheckReactives([1, 2, 3])).toBe(false);
+      expect(validateAndCheckReactives([{ a: 1 }, { b: 2 }])).toBe(false);
     });
 
     it("accepts nested structures", () => {
       expect(
-        validateAndCheckOpaqueRefs({
+        validateAndCheckReactives({
           a: { b: { c: [1, 2, { d: "hello" }] } },
         }),
       ).toBe(false);
@@ -41,98 +41,98 @@ describe("validateAndCheckOpaqueRefs", () => {
 
     it("accepts cell links", () => {
       const cellLink = { "/": { [Symbol.for("cell-link")]: { id: "test" } } };
-      expect(validateAndCheckOpaqueRefs(cellLink)).toBe(false);
+      expect(validateAndCheckReactives(cellLink)).toBe(false);
     });
   });
 
   describe("invalid values", () => {
     it("rejects Map", () => {
-      expect(() => validateAndCheckOpaqueRefs(new Map())).toThrow(
+      expect(() => validateAndCheckReactives(new Map())).toThrow(
         /Action returned a Map[\s\S]*Consider using a plain object/,
       );
     });
 
     it("rejects Set", () => {
-      expect(() => validateAndCheckOpaqueRefs(new Set())).toThrow(
+      expect(() => validateAndCheckReactives(new Set())).toThrow(
         /Action returned a Set[\s\S]*Consider using an array/,
       );
     });
 
     it("rejects functions", () => {
-      expect(() => validateAndCheckOpaqueRefs(() => {})).toThrow(
+      expect(() => validateAndCheckReactives(() => {})).toThrow(
         /Action returned a function/,
       );
     });
 
     it("rejects Date", () => {
-      expect(() => validateAndCheckOpaqueRefs(new Date())).toThrow(
+      expect(() => validateAndCheckReactives(new Date())).toThrow(
         /Action returned a Date/,
       );
     });
 
     it("rejects RegExp", () => {
-      expect(() => validateAndCheckOpaqueRefs(/test/)).toThrow(
+      expect(() => validateAndCheckReactives(/test/)).toThrow(
         /Action returned a RegExp/,
       );
     });
 
     it("rejects NaN", () => {
-      expect(() => validateAndCheckOpaqueRefs(NaN)).toThrow(
+      expect(() => validateAndCheckReactives(NaN)).toThrow(
         /Action returned a NaN[\s\S]*Check your inputs or return null instead/,
       );
     });
 
     it("rejects Infinity", () => {
-      expect(() => validateAndCheckOpaqueRefs(Infinity)).toThrow(
+      expect(() => validateAndCheckReactives(Infinity)).toThrow(
         /Action returned a Infinity[\s\S]*Check your inputs or return null instead/,
       );
     });
 
     it("rejects -Infinity", () => {
-      expect(() => validateAndCheckOpaqueRefs(-Infinity)).toThrow(
+      expect(() => validateAndCheckReactives(-Infinity)).toThrow(
         /Action returned a Infinity[\s\S]*Check your inputs or return null instead/,
       );
     });
 
     it("rejects BigInt", () => {
-      expect(() => validateAndCheckOpaqueRefs(BigInt(123))).toThrow(
+      expect(() => validateAndCheckReactives(BigInt(123))).toThrow(
         /Action returned a BigInt[\s\S]*Consider converting to number or string/,
       );
     });
 
     it("rejects Symbol", () => {
-      expect(() => validateAndCheckOpaqueRefs(Symbol("test"))).toThrow(
+      expect(() => validateAndCheckReactives(Symbol("test"))).toThrow(
         /Action returned a Symbol[\s\S]*Consider removing this property/,
       );
     });
 
     it("rejects NaN nested in object", () => {
-      expect(() => validateAndCheckOpaqueRefs({ value: NaN })).toThrow(
+      expect(() => validateAndCheckReactives({ value: NaN })).toThrow(
         /Action returned a NaN at path "value"/,
       );
     });
 
     it("rejects nested Map with path info", () => {
-      expect(() => validateAndCheckOpaqueRefs({ data: { items: new Map() } }))
+      expect(() => validateAndCheckReactives({ data: { items: new Map() } }))
         .toThrow(/Action returned a Map at path "data\.items"/);
     });
 
     it("rejects Map in array with path info", () => {
-      expect(() => validateAndCheckOpaqueRefs([1, 2, new Map()])).toThrow(
+      expect(() => validateAndCheckReactives([1, 2, new Map()])).toThrow(
         /Action returned a Map at path "\[2\]"/,
       );
     });
 
     it("rejects Set in nested structure with path info", () => {
       expect(() =>
-        validateAndCheckOpaqueRefs({
+        validateAndCheckReactives({
           a: { b: [{ c: new Set() }] },
         })
       ).toThrow(/Action returned a Set at path "a\.b\.\[0\]\.c"/);
     });
 
     it("rejects function in object with path info", () => {
-      expect(() => validateAndCheckOpaqueRefs({ handler: () => {} })).toThrow(
+      expect(() => validateAndCheckReactives({ handler: () => {} })).toThrow(
         /Action returned a function at path "handler"/,
       );
     });
@@ -141,13 +141,13 @@ describe("validateAndCheckOpaqueRefs", () => {
   describe("action name in errors", () => {
     it("includes action name in error message", () => {
       expect(() =>
-        validateAndCheckOpaqueRefs(new Map(), "handleClick (src/app.ts:42)")
+        validateAndCheckReactives(new Map(), "handleClick (src/app.ts:42)")
       ).toThrow(/in action: handleClick \(src\/app\.ts:42\)/);
     });
 
     it("includes action name with nested path", () => {
       expect(() =>
-        validateAndCheckOpaqueRefs(
+        validateAndCheckReactives(
           { data: new Set() },
           "onSubmit (components/Form.tsx:15)",
         )
@@ -157,11 +157,11 @@ describe("validateAndCheckOpaqueRefs", () => {
     });
 
     it("works without action name", () => {
-      expect(() => validateAndCheckOpaqueRefs(new Map())).toThrow(
+      expect(() => validateAndCheckReactives(new Map())).toThrow(
         /Action returned a Map/,
       );
       // Should not include "in action:" when no name provided
-      expect(() => validateAndCheckOpaqueRefs(new Map())).not.toThrow(
+      expect(() => validateAndCheckReactives(new Map())).not.toThrow(
         /in action:/,
       );
     });
@@ -169,22 +169,22 @@ describe("validateAndCheckOpaqueRefs", () => {
 
   describe("opaque ref detection", () => {
     it("returns true for opaque ref at top level", () => {
-      const opaqueRef = { [isOpaqueRefMarker]: true };
-      expect(validateAndCheckOpaqueRefs(opaqueRef)).toBe(true);
+      const reactive = { [isReactiveMarker]: true };
+      expect(validateAndCheckReactives(reactive)).toBe(true);
     });
 
     it("returns true when opaque ref is nested in object", () => {
-      const opaqueRef = { [isOpaqueRefMarker]: true };
-      expect(validateAndCheckOpaqueRefs({ data: opaqueRef })).toBe(true);
+      const reactive = { [isReactiveMarker]: true };
+      expect(validateAndCheckReactives({ data: reactive })).toBe(true);
     });
 
     it("returns true when opaque ref is in array", () => {
-      const opaqueRef = { [isOpaqueRefMarker]: true };
-      expect(validateAndCheckOpaqueRefs([1, opaqueRef, 3])).toBe(true);
+      const reactive = { [isReactiveMarker]: true };
+      expect(validateAndCheckReactives([1, reactive, 3])).toBe(true);
     });
 
     it("returns false when no opaque refs present", () => {
-      expect(validateAndCheckOpaqueRefs({ a: 1, b: "hello" })).toBe(false);
+      expect(validateAndCheckReactives({ a: 1, b: "hello" })).toBe(false);
     });
   });
 });

--- a/packages/runner/test/cell-as-cell.test.ts
+++ b/packages/runner/test/cell-as-cell.test.ts
@@ -1249,7 +1249,7 @@ describe("asCell with schema", () => {
     const frame1 = pushFrame({
       generatedIdCounter: 0,
       cause: "context 1",
-      opaqueRefs: new Set(),
+      reactives: new Set(),
     });
     testCell.set(initialDataCopy);
     popFrame(frame1);
@@ -1274,7 +1274,7 @@ describe("asCell with schema", () => {
     const frame2 = pushFrame({
       generatedIdCounter: 0,
       cause: "context 2",
-      opaqueRefs: new Set(),
+      reactives: new Set(),
     });
     testCell.set(returnedData);
     popFrame(frame2);

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -267,7 +267,7 @@ describe("Cell", () => {
   it("returns a deep-frozen structural copy when recursivelyAddIDIfNeeded has nothing to do (unfrozen input)", () => {
     const frame: Frame = {
       generatedIdCounter: 0,
-      opaqueRefs: new Set(),
+      reactives: new Set(),
     };
     const interests = ["coding", "reading"];
     const value = {
@@ -292,7 +292,7 @@ describe("Cell", () => {
   it("preserves identity when input is already deep-frozen", () => {
     const frame: Frame = {
       generatedIdCounter: 0,
-      opaqueRefs: new Set(),
+      reactives: new Set(),
     };
     // Deep-freeze before passing in. An already-frozen
     // plain Object/Array is a valid `FabricValue` and shallow fabric
@@ -317,7 +317,7 @@ describe("Cell", () => {
   it("adds generated IDs to objects in arrays regardless of clone depth", () => {
     const frame: Frame = {
       generatedIdCounter: 0,
-      opaqueRefs: new Set(),
+      reactives: new Set(),
     };
     const stable = { nested: true };
     const value = {

--- a/packages/runner/test/cell-hooks.test.ts
+++ b/packages/runner/test/cell-hooks.test.ts
@@ -1,4 +1,4 @@
-// toCell and toOpaqueRef hook tests: verifying that objects returned from
+// toCell and toReactive hook tests: verifying that objects returned from
 // cell.get() can be converted back to cells via Symbol hooks.
 
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
@@ -17,7 +17,7 @@ import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
 
-describe("toCell and toOpaqueRef hooks", () => {
+describe("toCell and toReactive hooks", () => {
   let runtime: Runtime;
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let tx: IExtendedStorageTransaction;
@@ -39,7 +39,7 @@ describe("toCell and toOpaqueRef hooks", () => {
   });
 
   describe("Basic hook functionality", () => {
-    it("should add toCell and toOpaqueRef symbols to objects returned from Cell.get()", () => {
+    it("should add toCell and toReactive symbols to objects returned from Cell.get()", () => {
       const schema = {
         type: "object",
         properties: {
@@ -548,7 +548,7 @@ describe("toCell and toOpaqueRef hooks", () => {
 
       // cellProp should be a cell, not have hooks
       expect(isCell(result.cellProp)).toBe(true);
-      // Cells themselves have toOpaqueRef (part of Cell interface) but not toCell
+      // Cells themselves have toReactive (part of Cell interface) but not toCell
       expect(toCell in result.cellProp).toBe(false);
     });
 
@@ -707,7 +707,7 @@ describe("toCell and toOpaqueRef hooks", () => {
   });
 });
 
-describe("toCell and toOpaqueRef hooks: circular references", () => {
+describe("toCell and toReactive hooks: circular references", () => {
   let runtime: Runtime;
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let tx: IExtendedStorageTransaction;

--- a/packages/runner/test/cell-optional-link.test.ts
+++ b/packages/runner/test/cell-optional-link.test.ts
@@ -151,7 +151,7 @@ describe("Cell with Optional Link", () => {
       pushFrame({
         space,
         generatedIdCounter: 0,
-        opaqueRefs: new Set(),
+        reactives: new Set(),
       });
 
       const cell = new CellImpl(runtime, tx);
@@ -175,7 +175,7 @@ describe("Cell with Optional Link", () => {
         cause: { type: "lift-cause" },
         space,
         generatedIdCounter: 0,
-        opaqueRefs: new Set(),
+        reactives: new Set(),
       });
 
       const cell = new CellImpl(runtime, tx);
@@ -196,7 +196,7 @@ describe("Cell with Optional Link", () => {
         space,
         inHandler: true,
         generatedIdCounter: 0,
-        opaqueRefs: new Set(),
+        reactives: new Set(),
       });
 
       try {
@@ -270,7 +270,7 @@ describe("Cell with Optional Link", () => {
       pushFrame({
         space,
         generatedIdCounter: 0,
-        opaqueRefs: new Set(),
+        reactives: new Set(),
       });
 
       try {
@@ -318,7 +318,7 @@ describe("Cell with Optional Link", () => {
         cause: { type: "frame-cause" },
         space,
         generatedIdCounter: 0,
-        opaqueRefs: new Set(),
+        reactives: new Set(),
       });
 
       const cell1 = new CellImpl(runtime, tx);
@@ -347,7 +347,7 @@ describe("Cell with Optional Link", () => {
         cause: { type: "frame-cause" },
         space,
         generatedIdCounter: 0,
-        opaqueRefs: new Set(),
+        reactives: new Set(),
       });
 
       const cell1 = new CellImpl(runtime, tx);
@@ -376,7 +376,7 @@ describe("Cell with Optional Link", () => {
         cause: { type: "frame-cause" },
         space,
         generatedIdCounter: 0,
-        opaqueRefs: new Set(),
+        reactives: new Set(),
       });
 
       const cell1 = new CellImpl(runtime, tx);
@@ -409,7 +409,7 @@ describe("Cell with Optional Link", () => {
         cause: { type: "first-frame" },
         space,
         generatedIdCounter: 0,
-        opaqueRefs: new Set(),
+        reactives: new Set(),
       });
 
       const parent = new CellImpl(runtime, tx);
@@ -420,7 +420,7 @@ describe("Cell with Optional Link", () => {
         cause: { type: "second-frame" },
         space,
         generatedIdCounter: 0,
-        opaqueRefs: new Set(),
+        reactives: new Set(),
       });
 
       const child = parent.key("child");

--- a/packages/runner/test/cell-static-methods.test.ts
+++ b/packages/runner/test/cell-static-methods.test.ts
@@ -233,12 +233,12 @@ describe("Cell Static Methods", () => {
       withinHandlerContext(runtime, space, tx, () => {
         const cell = Cell.of([1, 2, 3]) as any;
 
-        expect(() => cell.map(() => 1)).toThrow("OpaqueRef.map(fn)");
+        expect(() => cell.map(() => 1)).toThrow("Reactive.map(fn)");
         expect(() => cell.filter(() => true)).toThrow(
-          "OpaqueRef.filter(fn)",
+          "Reactive.filter(fn)",
         );
         expect(() => cell.flatMap(() => [1])).toThrow(
-          "OpaqueRef.flatMap(fn)",
+          "Reactive.flatMap(fn)",
         );
       });
     });

--- a/packages/runner/test/computed-error.test.ts
+++ b/packages/runner/test/computed-error.test.ts
@@ -19,7 +19,7 @@ Deno.test("computed throws error", async () => {
   const frame = pushFrame({
     space,
     generatedIdCounter: 0,
-    opaqueRefs: new Set(),
+    reactives: new Set(),
     runtime,
   });
 

--- a/packages/runner/test/create-ref-fail-closed.test.ts
+++ b/packages/runner/test/create-ref-fail-closed.test.ts
@@ -1,21 +1,21 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { createRef } from "../src/create-ref.ts";
-import { isOpaqueRefMarker } from "../src/builder/types.ts";
+import { isReactiveMarker } from "../src/builder/types.ts";
 
 // Regression guard for createRef fail-closed behavior (audit S14).
 //
-// When a derivation input is an OpaqueRef with no value (or a Cell with no
+// When a derivation input is an Reactive with no value (or a Cell with no
 // entityId), the id can no longer be derived from real inputs. The pre-fix code
 // substituted a random UUID, silently producing a non-deterministic id where a
 // stable, content-derived one was expected. createRef must fail closed instead.
 describe("createRef fail-closed", () => {
-  it("throws when an OpaqueRef derivation input has no value", () => {
-    const opaqueRefNoValue = {
-      [isOpaqueRefMarker]: true,
+  it("throws when an Reactive derivation input has no value", () => {
+    const reactiveNoValue = {
+      [isReactiveMarker]: true,
       export: () => ({ value: null }),
     };
-    expect(() => createRef({ ref: opaqueRefNoValue }, "cause")).toThrow(
+    expect(() => createRef({ ref: reactiveNoValue }, "cause")).toThrow(
       /cannot derive a stable id/,
     );
   });

--- a/packages/runner/test/iderivable-type-surface.test.ts
+++ b/packages/runner/test/iderivable-type-surface.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { Cell, OpaqueCell, OpaqueRef } from "@commonfabric/api";
+import type { Cell, OpaqueCell, Reactive } from "@commonfabric/api";
 
 interface Item {
   label: string;
@@ -14,15 +14,15 @@ interface Item {
   tags: string[];
 }
 
-function acceptItems(value: OpaqueRef<Item[]>) {
+function acceptItems(value: Reactive<Item[]>) {
   return value;
 }
 
-function acceptStrings(value: OpaqueRef<string[]>) {
+function acceptStrings(value: Reactive<string[]>) {
   return value;
 }
 
-function acceptNumber(value: OpaqueRef<number>) {
+function acceptNumber(value: Reactive<number>) {
   return value;
 }
 

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -5,12 +5,12 @@ import { Identity } from "@commonfabric/identity";
 import {
   type Frame,
   isModule,
-  isOpaqueRef,
   isPattern,
+  isReactive,
   type JSONSchema,
   type Module,
-  type OpaqueRef as _OpaqueRef,
   type Pattern,
+  type Reactive as _Reactive,
   type Stream,
 } from "../src/builder/types.ts";
 import {
@@ -20,7 +20,7 @@ import {
   parseStackFrame,
   resolveSourceLocationFromStack,
 } from "../src/builder/module.ts";
-import { opaqueRef } from "../src/builder/opaque-ref.ts";
+import { reactive } from "../src/builder/opaque-ref.ts";
 import { pattern, popFrame, pushFrame } from "../src/builder/pattern.ts";
 import { CellImpl } from "../src/cell.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -57,7 +57,7 @@ describe("module", () => {
     frame = pushFrame({
       space,
       generatedIdCounter: 0,
-      opaqueRefs: new Set(),
+      reactives: new Set(),
       runtime,
     });
   });
@@ -76,8 +76,8 @@ describe("module", () => {
 
     it("creates a opaque ref when called", () => {
       const add = lift<{ a: number; b: number }, number>(({ a, b }) => a + b);
-      const result = add({ a: opaqueRef(1), b: opaqueRef(2) });
-      expect(isOpaqueRef(result)).toBe(true);
+      const result = add({ a: reactive(1), b: reactive(2) });
+      expect(isReactive(result)).toBe(true);
     });
 
     it("supports JSON Schema validation", () => {
@@ -159,8 +159,8 @@ describe("module", () => {
         },
         { proxy: true },
       );
-      const stream = clickHandler({ x: opaqueRef(10), y: opaqueRef(20) });
-      expect(isOpaqueRef(stream)).toBe(true);
+      const stream = clickHandler({ x: reactive(10), y: reactive(20) });
+      expect(isReactive(stream)).toBe(true);
       const { value, nodes } = (stream as any).export();
       expect(value).toEqual({ $stream: true });
       expect(nodes.size).toBe(1);
@@ -333,10 +333,10 @@ describe("module", () => {
         },
       );
 
-      const elements = opaqueRef({ button1: true, button2: false });
+      const elements = reactive({ button1: true, button2: false });
       const result = toggleHandler({ elements } as any);
 
-      expect(isOpaqueRef(result)).toBe(true);
+      expect(isReactive(result)).toBe(true);
       const { nodes } = result.export();
       expect(nodes.size).toBe(1);
       const handlerNode = [...nodes][0];
@@ -352,8 +352,8 @@ describe("module", () => {
         },
         { proxy: true },
       );
-      const stream = clickHandler.with({ x: opaqueRef(10), y: opaqueRef(20) });
-      expect(isOpaqueRef(stream)).toBe(true);
+      const stream = clickHandler.with({ x: reactive(10), y: reactive(20) });
+      expect(isReactive(stream)).toBe(true);
       const { value, nodes } = (stream as any).export();
       expect(value).toEqual({ $stream: true });
       expect(nodes.size).toBe(1);
@@ -489,7 +489,7 @@ describe("module", () => {
 
     it("attaches source location through lift", () => {
       const fn = (x: number) => x * 2;
-      lift(fn)(opaqueRef(5));
+      lift(fn)(reactive(5));
 
       // lift should track the original function's source location
       expect(fn.name).toMatch(/module\.test\.ts:\d+:\d+$/);

--- a/packages/runner/test/opaque-ref-schema.test.ts
+++ b/packages/runner/test/opaque-ref-schema.test.ts
@@ -10,7 +10,7 @@ import { isRecord } from "@commonfabric/utils/types";
 
 const signer = await Identity.fromPassphrase("test operator");
 
-describe("OpaqueRef Schema Support", () => {
+describe("Reactive Schema Support", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let pattern: ReturnType<typeof createBuilder>["commonfabric"]["pattern"];

--- a/packages/runner/test/opaque-ref.test.ts
+++ b/packages/runner/test/opaque-ref.test.ts
@@ -1,14 +1,14 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { isOpaqueRef } from "../src/builder/types.ts";
-import { opaqueRef } from "../src/builder/opaque-ref.ts";
+import { isReactive } from "../src/builder/types.ts";
+import { reactive } from "../src/builder/opaque-ref.ts";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Identity } from "@commonfabric/identity";
 
 const signer = await Identity.fromPassphrase("test operator");
 
-describe("opaqueRef function", () => {
+describe("reactive function", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
 
@@ -25,13 +25,13 @@ describe("opaqueRef function", () => {
   });
 
   it("creates an opaque ref", () => {
-    const c = opaqueRef<number>();
-    expect(isOpaqueRef(c)).toBe(true);
+    const c = reactive<number>();
+    expect(isReactive(c)).toBe(true);
   });
 
   it("throws on get", () => {
-    const c = opaqueRef<number>();
-    // Use type assertion since .get() is no longer on OpaqueRef type
+    const c = reactive<number>();
+    // Use type assertion since .get() is no longer on Reactive type
     // but we want to verify runtime still throws
     expect(() => (c as any).get()).toThrow();
   });

--- a/packages/runner/test/opaqueref-intersection.test.ts
+++ b/packages/runner/test/opaqueref-intersection.test.ts
@@ -1,5 +1,5 @@
 /**
- * Regression test for OpaqueRef intersection type handling.
+ * Regression test for Reactive intersection type handling.
  *
  * This is a minimal reproduction of the type error from
  * community-patterns/patterns/jkomoros/components/search-select-prototype.tsx
@@ -10,7 +10,7 @@
  *   Types of property 'group' are incompatible.
  *
  * The fix adds `[NonNullable<T>] extends [AnyBrandedCell<any>]` check to
- * OpaqueRefInner to handle nullable intersection types correctly without
+ * ReactiveInner to handle nullable intersection types correctly without
  * causing distribution over union types (which would lose null/undefined).
  *
  * NOTE: This is a type-level test. The assertions at runtime are trivial;
@@ -18,7 +18,7 @@
  */
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { OpaqueCell, OpaqueRef } from "@commonfabric/api";
+import type { OpaqueCell, Reactive } from "@commonfabric/api";
 
 interface NormalizedItem {
   value: string;
@@ -26,11 +26,11 @@ interface NormalizedItem {
   group?: string;
 }
 
-describe("OpaqueRef intersection type handling", () => {
+describe("Reactive intersection type handling", () => {
   it("should not double-wrap properties that are already intersection types", () => {
     // This reproduces the pattern from search-select-prototype.tsx:
     //
-    // 1. props.items comes from pattern props (already OpaqueRef wrapped)
+    // 1. props.items comes from pattern props (already Reactive wrapped)
     // 2. normalizedItems = computed(() => items.map(item => ({
     //      value: item.value,     // OpaqueCell<string> & string
     //      label: item.label,     // OpaqueCell<string> & string
@@ -38,23 +38,23 @@ describe("OpaqueRef intersection type handling", () => {
     //    })))
     //    The mapped result has properties that ARE ALREADY INTERSECTION TYPES
     //
-    // 3. computed() wraps this with OpaqueRef<MappedItem[]>
+    // 3. computed() wraps this with Reactive<MappedItem[]>
     //
     // 4. itemLookup iterates normalizedItems, assigning items to Record<string, NormalizedItem>
     //
-    // THE BUG: When OpaqueRef processes MappedItem, it wraps the already-wrapped
+    // THE BUG: When Reactive processes MappedItem, it wraps the already-wrapped
     // properties AGAIN, creating nested OpaqueCell types that aren't assignable.
 
-    // Simulate what map() produces when iterating OpaqueRef-wrapped items:
-    // Properties are already intersection types from the source OpaqueRef
+    // Simulate what map() produces when iterating Reactive-wrapped items:
+    // Properties are already intersection types from the source Reactive
     type MappedItem = {
       value: OpaqueCell<string> & string;
       label: OpaqueCell<string | undefined> & string;
       group?: (OpaqueCell<string | undefined> & string) | undefined;
     };
 
-    // computed() wraps the result with OpaqueRef
-    type NormalizedItems = OpaqueRef<MappedItem[]>;
+    // computed() wraps the result with Reactive
+    type NormalizedItems = Reactive<MappedItem[]>;
 
     // When we iterate, we get elements of this type
     type NormalizedElement = NormalizedItems extends Array<infer U> ? U : never;
@@ -80,14 +80,14 @@ describe("OpaqueRef intersection type handling", () => {
   });
 
   it("should allow string methods on intersection type properties", () => {
-    // Same setup: properties are already intersection types from OpaqueRef
+    // Same setup: properties are already intersection types from Reactive
     type MappedItem = {
       value: OpaqueCell<string> & string;
       label: OpaqueCell<string | undefined> & string;
       group?: (OpaqueCell<string | undefined> & string) | undefined;
     };
 
-    type NormalizedItems = OpaqueRef<MappedItem[]>;
+    type NormalizedItems = Reactive<MappedItem[]>;
     type NormalizedElement = NormalizedItems extends Array<infer U> ? U : never;
 
     // THE CRITICAL TYPE TEST: This function signature compiles only if

--- a/packages/runner/test/pattern.test.ts
+++ b/packages/runner/test/pattern.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../src/builder/types.ts";
 import { lift } from "../src/builder/module.ts";
 import { pattern, popFrame, pushFrame } from "../src/builder/pattern.ts";
-import { opaqueRef } from "../src/builder/opaque-ref.ts";
+import { reactive } from "../src/builder/opaque-ref.ts";
 import { Runtime } from "../src/runtime.ts";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Identity } from "@commonfabric/identity";
@@ -36,7 +36,7 @@ describe("pattern", () => {
     frame = pushFrame({
       space,
       generatedIdCounter: 0,
-      opaqueRefs: new Set(),
+      reactives: new Set(),
       runtime,
     });
   });
@@ -65,7 +65,7 @@ describe("pattern", () => {
   it("creates a pattern, with an inner opaque ref", () => {
     const double = lift(({ x }) => x * 2);
     const doublePattern = pattern<{ x: number }>(() => {
-      const x = opaqueRef<number>(1);
+      const x = reactive<number>(1);
       (x as any).for("x");
       return { double: double({ x }) };
     });

--- a/packages/runner/test/patterns-self.test.ts
+++ b/packages/runner/test/patterns-self.test.ts
@@ -11,7 +11,7 @@ import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 
 // Import types from public API for compile-time type tests
-import { type OpaqueRef } from "@commonfabric/api";
+import { type Reactive } from "@commonfabric/api";
 import { Runtime } from "../src/runtime.ts";
 import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
@@ -212,16 +212,16 @@ describe("Pattern Runner - SELF", () => {
     const treePattern = pattern<{ name: string }, TreeNode>(
       ({ name, [SELF]: self }) => {
         // Positive type tests: these assignments SHOULD work
-        const _correctType: OpaqueRef<TreeNode> = self;
-        const _correctChildren: OpaqueRef<TreeNode[]> = self.children;
-        const _correctName: OpaqueRef<string> = self.name;
+        const _correctType: Reactive<TreeNode> = self;
+        const _correctChildren: Reactive<TreeNode[]> = self.children;
+        const _correctName: Reactive<string> = self.name;
 
         // Negative type tests: these should NOT work (verified by @ts-expect-error)
-        // If self were ApiOpaqueRef<any>, these would succeed, making @ts-expect-error unused
-        // @ts-expect-error - self should not be assignable to ApiOpaqueRef<{ wrong: true }>
-        const _wrongType: OpaqueRef<{ wrong: true }> = self;
-        // @ts-expect-error - children should not be assignable to ApiOpaqueRef<string[]>
-        const _wrongChildren: OpaqueRef<string[]> = self.children;
+        // If self were ApiReactive<any>, these would succeed, making @ts-expect-error unused
+        // @ts-expect-error - self should not be assignable to ApiReactive<{ wrong: true }>
+        const _wrongType: Reactive<{ wrong: true }> = self;
+        // @ts-expect-error - children should not be assignable to ApiReactive<string[]>
+        const _wrongChildren: Reactive<string[]> = self.children;
 
         // Use self in the return type
         const children: (typeof self)[] = [];

--- a/packages/runner/test/query-result-proxy-enumeration.test.ts
+++ b/packages/runner/test/query-result-proxy-enumeration.test.ts
@@ -252,7 +252,7 @@ describe("CT-1240: query result proxy enumeration", () => {
       tx,
       generatedIdCounter: 0,
       inHandler: true,
-      opaqueRefs: new Set(),
+      reactives: new Set(),
     };
     pushFrame(frame);
 

--- a/packages/runner/test/schema-to-ts.test.ts
+++ b/packages/runner/test/schema-to-ts.test.ts
@@ -15,7 +15,7 @@ import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import {
   type AnyCellWrapping,
   type JSONSchema,
-  type OpaqueRef,
+  type Reactive,
   Schema,
 } from "../src/builder/types.ts";
 import type { AsCellType, ReadonlyCell } from "@commonfabric/api";
@@ -883,8 +883,8 @@ describe("Schema-to-TS Type Conversion", () => {
     // Verify that the pattern function parameter matches our expected input type
     expectType<InferredInput, ExpectedInput>();
 
-    // The expected output is the output schema wrapped in a single OpaqueRef.
-    type DeepOpaqueOutput = OpaqueRef<Schema<typeof outputSchema>>;
+    // The expected output is the output schema wrapped in a single Reactive.
+    type DeepOpaqueOutput = Reactive<Schema<typeof outputSchema>>;
     expectType<DeepOpaqueOutput, InferredOutput>();
 
     // Uncomment for debugging - shows what the actual structure is

--- a/packages/runner/test/type-utils.test.ts
+++ b/packages/runner/test/type-utils.test.ts
@@ -4,7 +4,7 @@ import {
   type FactoryInput,
   isModule,
   isPattern,
-  type OpaqueRef,
+  type Reactive,
 } from "../src/builder/types.ts";
 import { isWriteRedirectLink } from "../src/link-utils.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
@@ -17,7 +17,7 @@ describe("value type", () => {
     } = {
       foo: "foo",
       bar: "bar",
-    } as OpaqueRef<{
+    } as Reactive<{
       foo: string;
       bar: string;
     }>;

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -54,7 +54,7 @@ const scopeForWrapperName = (
 // structural inner `T` and differ only in read/write capability. The transformer
 // narrows one to another (e.g. `Cell<T>` → `ReadonlyCell<T>`) to reflect usage,
 // so a node-vs-type brand mismatch among these is a capability narrowing, not a
-// structural change. `Stream`/`SqliteDb`/`OpaqueRef` are excluded: they carry a
+// structural change. `Stream`/`SqliteDb`/`Reactive` are excluded: they carry a
 // distinct structural contract, not a read/write variant of a plain cell.
 //
 // Derived as an exhaustive map over `CellWrapperKind` so that adding a new kind
@@ -73,7 +73,7 @@ const CELL_CAPABILITY_KIND_MAP: Readonly<Record<CellWrapperKind, boolean>> = {
   OpaqueCell: true,
   Stream: false,
   SqliteDb: false,
-  OpaqueRef: false,
+  Reactive: false,
 };
 const isCellCapabilityKind = (kind: WrapperKind): boolean =>
   CELL_CAPABILITY_KIND_MAP[kind];
@@ -105,7 +105,7 @@ const applyScopeToAsCellEntry = (
 };
 
 /**
- * Formatter for Common Fabric-specific types (Cell<T>, Stream<T>, OpaqueRef<T>, Default<T,V>)
+ * Formatter for Common Fabric-specific types (Cell<T>, Stream<T>, Reactive<T>, Default<T,V>)
  *
  * TypeScript handles alias resolution automatically and we don't need to
  * manually traverse alias chains.
@@ -160,7 +160,7 @@ export class CommonFabricFormatter implements TypeFormatter {
 
     // Check if union contains wrapper types via node inspection
     // This must come before the blanket union rejection to handle
-    // cases like OpaqueRef<T> | undefined without expanding conditionals
+    // cases like Reactive<T> | undefined without expanding conditionals
     if (this.isWrapperUnion(type, context)) {
       return true; // Take ownership of wrapper unions
     }
@@ -169,7 +169,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       return false;
     }
 
-    // Check if this is a wrapper type (Cell/Stream/OpaqueRef) via type structure
+    // Check if this is a wrapper type (Cell/Stream/Reactive) via type structure
     const wrapperInfo = getCellWrapperInfo(type, context.typeChecker);
     return wrapperInfo !== undefined;
   }
@@ -214,7 +214,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     }
 
     // Handle wrapper unions first (before FactoryInput<T> union check)
-    // This catches cases like OpaqueRef<T> | undefined and processes them
+    // This catches cases like Reactive<T> | undefined and processes them
     // via node inspection to avoid conditional type expansion
     if (
       (type.flags & ts.TypeFlags.Union) !== 0 &&
@@ -341,7 +341,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     }
 
     // If we detected a wrapper syntactically but the current type is wrapped in
-    // additional layers (e.g., FactoryInput<OpaqueRef<...>>), recursively unwrap using
+    // additional layers (e.g., FactoryInput<Reactive<...>>), recursively unwrap using
     // brand information until we reach the underlying wrapper.
     const wrapperKinds: WrapperKind[] = [
       "OpaqueCell",
@@ -843,7 +843,7 @@ export class CommonFabricFormatter implements TypeFormatter {
     const wrapperInfo = getCellWrapperInfo(type, checker);
     if (
       !wrapperInfo ||
-      (wrapperInfo.kind !== "OpaqueRef" && wrapperInfo.kind !== "OpaqueCell")
+      (wrapperInfo.kind !== "Reactive" && wrapperInfo.kind !== "OpaqueCell")
     ) {
       return undefined;
     }
@@ -2081,8 +2081,8 @@ export class CommonFabricFormatter implements TypeFormatter {
   }
 
   /**
-   * Format a union type that contains wrapper types (Cell/OpaqueRef/Stream).
-   * Handles cases like: OpaqueRef<T> | undefined, Cell<T> | null, etc.
+   * Format a union type that contains wrapper types (Cell/Reactive/Stream).
+   * Handles cases like: Reactive<T> | undefined, Cell<T> | null, etc.
    * Uses nodes when available to preserve named type hoisting.
    */
   private formatWrapperUnion(
@@ -2164,7 +2164,7 @@ export class CommonFabricFormatter implements TypeFormatter {
    * Uses type-based detection which handles complex cases like intersection types
    * and conditional type expansions.
    * Returns true ONLY for unions where ALL non-null/undefined members are wrapper types.
-   * Examples that return true: OpaqueRef<T> | undefined, Cell<T> | null, Stream<T> | null | undefined
+   * Examples that return true: Reactive<T> | undefined, Cell<T> | null, Stream<T> | null | undefined
    * Examples that return false: string | Cell | null (mixed union, should use UnionFormatter)
    */
   private isWrapperUnion(type: ts.Type, context: GenerationContext): boolean {

--- a/packages/schema-generator/src/formatters/object-formatter.ts
+++ b/packages/schema-generator/src/formatters/object-formatter.ts
@@ -35,7 +35,7 @@ const logger = getLogger("schema-generator.object", {
 
 /**
  * Check if a callable type (like ModuleFactory or HandlerFactory) returns a wrapper type.
- * ModuleFactory<T, R> when called returns OpaqueRef<R>.
+ * ModuleFactory<T, R> when called returns Reactive<R>.
  * If R is Stream<T>, we should generate { asCell: ["stream"] } instead of skipping.
  * If R is Cell<T>, we should generate { asCell: ["cell"] } instead of skipping.
  *
@@ -51,7 +51,7 @@ function getWrapperSchemaFromCallable(
   // Get the return type of the first call signature
   const callReturnType = callSignatures[0]!.getReturnType();
 
-  // Check if the return type is a wrapper (Stream<T>, Cell<T>, or OpaqueRef<...>)
+  // Check if the return type is a wrapper (Stream<T>, Cell<T>, or Reactive<...>)
   const wrapperInfo = getCellWrapperInfo(callReturnType, checker);
   if (wrapperInfo?.kind === "Stream") {
     return { asCell: ["stream"] };
@@ -61,26 +61,6 @@ function getWrapperSchemaFromCallable(
   }
   if (wrapperInfo?.kind === "SqliteDb") {
     return { asCell: ["sqlite"] };
-  }
-
-  // Also check if it's an OpaqueRef wrapping a Stream or Cell
-  if (wrapperInfo?.kind === "OpaqueRef") {
-    // Get the inner type of OpaqueRef
-    const typeRef = wrapperInfo.typeRef;
-    const typeArgs = checker.getTypeArguments(typeRef);
-    if (typeArgs.length > 0) {
-      const innerType = typeArgs[0]!;
-      const innerWrapperInfo = getCellWrapperInfo(innerType, checker);
-      if (innerWrapperInfo?.kind === "Stream") {
-        return { asCell: ["stream"] };
-      }
-      if (innerWrapperInfo?.kind === "Cell") {
-        return { asCell: ["cell"] };
-      }
-      if (innerWrapperInfo?.kind === "SqliteDb") {
-        return { asCell: ["sqlite"] };
-      }
-    }
   }
 
   return undefined;

--- a/packages/schema-generator/src/typescript/cell-brand.ts
+++ b/packages/schema-generator/src/typescript/cell-brand.ts
@@ -19,7 +19,7 @@ export type CellWrapperKind =
   | "ReadonlyCell"
   | "WriteonlyCell"
   | "SqliteDb"
-  | "OpaqueRef"; // this last one may be obsolete.
+  | "Reactive";
 
 export interface CellWrapperInfo {
   brand: CellBrand;
@@ -173,7 +173,7 @@ export function wrapperKindToBrand(
 ): CellBrand | undefined {
   switch (wrapperKind) {
     case "OpaqueCell":
-    case "OpaqueRef":
+    case "Reactive":
       return "opaque";
     case "Stream":
       return "stream";

--- a/packages/schema-generator/src/typescript/wrapper-names.ts
+++ b/packages/schema-generator/src/typescript/wrapper-names.ts
@@ -46,11 +46,11 @@ export const WRAPPER_SPELLING_TO_KIND = {
   OpaqueCell: "OpaqueCell",
   Stream: "Stream",
   SqliteDb: "SqliteDb",
-  // Deprecation intended — see the note on CellWrapperKind in cell-brand.ts.
-  OpaqueRef: "OpaqueRef",
-  // Successor spelling for OpaqueRef (api will alias OpaqueRef = Reactive);
-  // classified identically everywhere until OpaqueRef is removed.
-  Reactive: "OpaqueRef",
+  // Deprecated spelling of Reactive. The `OpaqueRef` spelling and its api alias
+  // are removed in CT-1756 stage 3; until then it is classified identically to
+  // Reactive so lingering authored references keep resolving.
+  OpaqueRef: "Reactive",
+  Reactive: "Reactive",
   // The interface typing the `Cell` constructor/namespace value (api/index.ts).
   CellTypeConstructor: undefined,
   // The interface typing the scoped-cell factory value (api/index.ts).

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -1124,7 +1124,7 @@ function hasReactiveCollectionProvenanceInternal(
     // That wrap, and the symbol's registration in syntheticReactiveCollectionRegistry,
     // happen in a later pass than the array-method lowering decision, so a nested
     // `.map`/`.filter` over the result's elements would otherwise race the registration
-    // and be emitted raw (-> "OpaqueRef.map(fn) is no longer supported" at runtime).
+    // and be emitted raw (-> "Reactive.map(fn) is no longer supported" at runtime).
     // Recognizing the shape structurally here makes the receiver provably reactive at
     // decision time, exactly as the inline `options.map(...)` form already is.
     //

--- a/packages/ts-transformers/src/ast/dataflow.ts
+++ b/packages/ts-transformers/src/ast/dataflow.ts
@@ -50,7 +50,7 @@ export type RewriteHint =
   | undefined;
 
 export interface DataFlowAnalysis {
-  containsOpaqueRef: boolean;
+  containsReactive: boolean;
   requiresRewrite: boolean;
   dataFlows: ts.Expression[];
   graph: DataFlowGraph;
@@ -66,14 +66,14 @@ interface AnalyzerContext {
 }
 
 interface InternalAnalysis {
-  containsOpaqueRef: boolean;
+  containsReactive: boolean;
   requiresRewrite: boolean;
   dataFlows: ts.Expression[];
   rewriteHint?: RewriteHint;
 }
 
 const emptyAnalysis = (): InternalAnalysis => ({
-  containsOpaqueRef: false,
+  containsReactive: false,
   requiresRewrite: false,
   dataFlows: [],
   rewriteHint: undefined,
@@ -85,12 +85,12 @@ const mergeAnalyses = (...analyses: InternalAnalysis[]): InternalAnalysis => {
   const dataFlows: ts.Expression[] = [];
   for (const analysis of analyses) {
     if (!analysis) continue;
-    contains ||= analysis.containsOpaqueRef;
+    contains ||= analysis.containsReactive;
     requires ||= analysis.requiresRewrite;
     dataFlows.push(...analysis.dataFlows);
   }
   return {
-    containsOpaqueRef: contains,
+    containsReactive: contains,
     requiresRewrite: requires,
     dataFlows,
     rewriteHint: undefined,
@@ -574,7 +574,7 @@ export function createDataFlowAnalyzer(
     // Default: CallExpressions require rewrite if they contain opaque refs
     return {
       ...merged,
-      requiresRewrite: merged.containsOpaqueRef || merged.requiresRewrite,
+      requiresRewrite: merged.containsReactive || merged.requiresRewrite,
       rewriteHint,
     };
   };
@@ -752,7 +752,7 @@ export function createDataFlowAnalyzer(
 
         recordDataFlow(expression, scope, null, true); // Explicit: synthetic opaque parameter
         return {
-          containsOpaqueRef: true,
+          containsReactive: true,
           requiresRewrite: false,
           dataFlows: [expression],
         };
@@ -767,9 +767,9 @@ export function createDataFlowAnalyzer(
         (type && isBrandedCellType(type, checker)) ||
         isReactiveValueExpression(expression, checker)
       ) {
-        recordDataFlow(expression, scope, null, true); // Explicit: direct OpaqueRef
+        recordDataFlow(expression, scope, null, true); // Explicit: direct Reactive
         return {
-          containsOpaqueRef: true,
+          containsReactive: true,
           requiresRewrite: false,
           dataFlows: [expression],
         };
@@ -777,12 +777,12 @@ export function createDataFlowAnalyzer(
       if (isArrayMethodElementBindingReference(expression)) {
         // The synthesized `element` binding of an array-method pattern
         // callback is implicitly opaque, even though its TS type is the plain
-        // user element type. Treat it the same as a direct OpaqueRef so
+        // user element type. Treat it the same as a direct Reactive so
         // `element.foo`-style reads are recorded as reactive dependencies and
         // can drive fine-grained subscriptions in downstream lowering.
         recordDataFlow(expression, scope, null, true);
         return {
-          containsOpaqueRef: true,
+          containsReactive: true,
           requiresRewrite: false,
           dataFlows: [expression],
         };
@@ -790,7 +790,7 @@ export function createDataFlowAnalyzer(
       if (symbolDeclaresCommonFabricDefault(symbol, checker)) {
         recordDataFlow(expression, scope, null, true); // Explicit: Common Fabric default
         return {
-          containsOpaqueRef: true,
+          containsReactive: true,
           requiresRewrite: false,
           dataFlows: [expression],
         };
@@ -806,7 +806,7 @@ export function createDataFlowAnalyzer(
             context,
           );
           if (
-            initializerAnalysis.containsOpaqueRef ||
+            initializerAnalysis.containsReactive ||
             initializerAnalysis.requiresRewrite ||
             initializerAnalysis.dataFlows.length > 0
           ) {
@@ -815,7 +815,7 @@ export function createDataFlowAnalyzer(
             }
             recordDataFlow(expression, scope, null, true);
             return {
-              containsOpaqueRef: initializerAnalysis.containsOpaqueRef ||
+              containsReactive: initializerAnalysis.containsReactive ||
                 initializerAnalysis.requiresRewrite ||
                 initializerAnalysis.dataFlows.length > 0,
               requiresRewrite: initializerAnalysis.requiresRewrite,
@@ -828,7 +828,7 @@ export function createDataFlowAnalyzer(
       }
 
       // Check if this identifier is a parameter to a builder or array-map call (like pattern)
-      // These parameters become implicitly opaque even though their type isn't OpaqueRef
+      // These parameters become implicitly opaque even though their type isn't Reactive
       return emptyAnalysis();
     }
 
@@ -854,7 +854,7 @@ export function createDataFlowAnalyzer(
               context,
             );
             if (
-              propertyAnalysis.containsOpaqueRef ||
+              propertyAnalysis.containsReactive ||
               propertyAnalysis.requiresRewrite ||
               propertyAnalysis.dataFlows.length > 0
             ) {
@@ -862,7 +862,7 @@ export function createDataFlowAnalyzer(
                 context.expressionToNodeId.get(expression.expression) ?? null;
               recordDataFlow(expression, scope, parentId, true);
               return {
-                containsOpaqueRef: true,
+                containsReactive: true,
                 requiresRewrite: false,
                 dataFlows: [expression],
               };
@@ -878,26 +878,26 @@ export function createDataFlowAnalyzer(
         }
         const parentId =
           context.expressionToNodeId.get(expression.expression) ?? null;
-        recordDataFlow(expression, scope, parentId, true); // Explicit: OpaqueRef property
+        recordDataFlow(expression, scope, parentId, true); // Explicit: Reactive property
 
         // If the target is a complex expression requiring rewrite (like ElementAccess),
         // propagate its dataFlows. Otherwise, add this property access as a dataFlow.
         if (target.requiresRewrite && target.dataFlows.length > 0) {
           return {
-            containsOpaqueRef: true,
+            containsReactive: true,
             requiresRewrite: target.requiresRewrite,
             dataFlows: target.dataFlows,
           };
         } else {
           return {
-            containsOpaqueRef: true,
+            containsReactive: true,
             requiresRewrite: target.requiresRewrite,
             dataFlows: [expression],
           };
         }
       }
       // For array-method element bindings, the property access result type is
-      // the plain field type (e.g. `string`), not OpaqueRef. But the read is
+      // the plain field type (e.g. `string`), not Reactive. But the read is
       // still a reactive fine-grained dependency: the runtime can subscribe to
       // `element.key("foo")` specifically. Record the property access (not
       // just the root identifier) as the dataflow so downstream lift-applied
@@ -905,7 +905,7 @@ export function createDataFlowAnalyzer(
       //   { element: { foo: element.key("foo") } }
       // instead of the broader { element: element } whole-binding capture.
       if (
-        target.containsOpaqueRef &&
+        target.containsReactive &&
         leftmostIdentifierIsArrayMethodElementBinding(expression)
       ) {
         if (originatesFromIgnored(expression.expression)) {
@@ -915,7 +915,7 @@ export function createDataFlowAnalyzer(
           context.expressionToNodeId.get(expression.expression) ?? null;
         recordDataFlow(expression, scope, parentId, true);
         return {
-          containsOpaqueRef: true,
+          containsReactive: true,
           requiresRewrite: target.requiresRewrite,
           dataFlows: [expression],
         };
@@ -929,7 +929,7 @@ export function createDataFlowAnalyzer(
           context.expressionToNodeId.get(expression.expression) ?? null;
         recordDataFlow(expression, scope, parentId, true); // Explicit: Common Fabric property
         return {
-          containsOpaqueRef: true,
+          containsReactive: true,
           requiresRewrite: true,
           dataFlows: [expression],
         };
@@ -951,7 +951,7 @@ export function createDataFlowAnalyzer(
           // This is a computed expression - use the dependencies from the target
           recordDataFlow(expression, scope, parentId, false);
           return {
-            containsOpaqueRef: true,
+            containsReactive: true,
             requiresRewrite: true,
             dataFlows: target.dataFlows.length > 0
               ? target.dataFlows
@@ -959,11 +959,11 @@ export function createDataFlowAnalyzer(
           };
         }
 
-        // This is a direct property access on an OpaqueRef (like state.pieces.length)
+        // This is a direct property access on a Reactive (like state.pieces.length)
         // It should be its own explicit dependency
         recordDataFlow(expression, scope, parentId, true);
         return {
-          containsOpaqueRef: true,
+          containsReactive: true,
           requiresRewrite: false,
           dataFlows: [expression],
         };
@@ -977,7 +977,7 @@ export function createDataFlowAnalyzer(
           context.expressionToNodeId.get(expression.expression) ?? null;
         recordDataFlow(expression, scope, parentId, true);
         return {
-          containsOpaqueRef: true,
+          containsReactive: true,
           requiresRewrite: false,
           dataFlows: [expression],
         };
@@ -996,7 +996,7 @@ export function createDataFlowAnalyzer(
                 context.expressionToNodeId.get(expression.expression) ?? null;
               recordDataFlow(expression, scope, parentId, true);
               return {
-                containsOpaqueRef: true,
+                containsReactive: true,
                 requiresRewrite: true,
                 dataFlows: [expression],
               };
@@ -1006,18 +1006,18 @@ export function createDataFlowAnalyzer(
             // Skip __cfHelpers.* property accesses - these are helper functions
             if (root.text === "__cfHelpers") {
               return {
-                containsOpaqueRef: target.containsOpaqueRef,
+                containsReactive: target.containsReactive,
                 requiresRewrite: target.requiresRewrite ||
-                  target.containsOpaqueRef,
+                  target.containsReactive,
                 dataFlows: target.dataFlows,
               };
             }
             // Skip method calls like element.trim()
             if (isMethodCall(expression)) {
               return {
-                containsOpaqueRef: target.containsOpaqueRef,
+                containsReactive: target.containsReactive,
                 requiresRewrite: target.requiresRewrite ||
-                  target.containsOpaqueRef,
+                  target.containsReactive,
                 dataFlows: target.dataFlows,
               };
             }
@@ -1026,7 +1026,7 @@ export function createDataFlowAnalyzer(
               context.expressionToNodeId.get(expression.expression) ?? null;
             recordDataFlow(expression, scope, parentId, true);
             return {
-              containsOpaqueRef: true,
+              containsReactive: true,
               requiresRewrite: true,
               dataFlows: [expression],
             };
@@ -1035,8 +1035,8 @@ export function createDataFlowAnalyzer(
       }
 
       return {
-        containsOpaqueRef: target.containsOpaqueRef,
-        requiresRewrite: target.requiresRewrite || target.containsOpaqueRef,
+        containsReactive: target.containsReactive,
+        requiresRewrite: target.requiresRewrite || target.containsReactive,
         dataFlows: target.dataFlows,
       };
     }
@@ -1068,14 +1068,14 @@ export function createDataFlowAnalyzer(
         // Element access on implicit opaque ref - this is likely an explicit dependency
         recordDataFlow(expression, scope, parentId, true);
         return {
-          containsOpaqueRef: true,
+          containsReactive: true,
           requiresRewrite: true,
           dataFlows: [expression],
         };
       }
       return {
-        containsOpaqueRef: target.containsOpaqueRef ||
-          argument.containsOpaqueRef,
+        containsReactive: target.containsReactive ||
+          argument.containsReactive,
         requiresRewrite: true,
         dataFlows: [...target.dataFlows, ...argument.dataFlows],
       };
@@ -1102,9 +1102,9 @@ export function createDataFlowAnalyzer(
       const whenTrue = analyzeExpression(expression.whenTrue, scope, context);
       const whenFalse = analyzeExpression(expression.whenFalse, scope, context);
       return {
-        containsOpaqueRef: condition.containsOpaqueRef ||
-          whenTrue.containsOpaqueRef ||
-          whenFalse.containsOpaqueRef,
+        containsReactive: condition.containsReactive ||
+          whenTrue.containsReactive ||
+          whenFalse.containsReactive,
         requiresRewrite: true,
         dataFlows: [
           ...condition.dataFlows,
@@ -1120,7 +1120,7 @@ export function createDataFlowAnalyzer(
       const merged = mergeAnalyses(left, right);
       return {
         ...merged,
-        requiresRewrite: left.containsOpaqueRef || right.containsOpaqueRef,
+        requiresRewrite: left.containsReactive || right.containsReactive,
       };
     }
 
@@ -1130,8 +1130,8 @@ export function createDataFlowAnalyzer(
     ) {
       const operand = analyzeExpression(expression.operand, scope, context);
       return {
-        containsOpaqueRef: operand.containsOpaqueRef,
-        requiresRewrite: operand.containsOpaqueRef,
+        containsReactive: operand.containsReactive,
+        requiresRewrite: operand.containsReactive,
         dataFlows: operand.dataFlows,
       };
     }
@@ -1143,7 +1143,7 @@ export function createDataFlowAnalyzer(
       const merged = mergeAnalyses(...parts);
       return {
         ...merged,
-        requiresRewrite: parts.some((part) => part.containsOpaqueRef),
+        requiresRewrite: parts.some((part) => part.containsReactive),
       };
     }
 
@@ -1165,7 +1165,7 @@ export function createDataFlowAnalyzer(
           : null;
         recordDataFlow(expression, scope, parentId, true);
         return {
-          containsOpaqueRef: true,
+          containsReactive: true,
           requiresRewrite: false,
           dataFlows: [expression],
           rewriteHint: undefined,

--- a/packages/ts-transformers/src/ast/type-inference.ts
+++ b/packages/ts-transformers/src/ast/type-inference.ts
@@ -245,7 +245,7 @@ export function typeToTypeNode(
 
 /**
  * Extract the first type argument from a TypeReference or type alias
- * Used to unwrap generic types like OpaqueRef<T> to get T
+ * Used to unwrap generic types like Reactive<T> to get T
  */
 export function getTypeReferenceArgument(type: ts.Type): ts.Type | undefined {
   if ("aliasTypeArguments" in type && type.aliasTypeArguments) {
@@ -303,8 +303,8 @@ export function isCollectionType(
 }
 
 /**
- * Unwrap OpaqueRef-like types to get the underlying type
- * Handles unions, intersections, and nested OpaqueRef types
+ * Unwrap Reactive-like types to get the underlying type
+ * Handles unions, intersections, and nested Reactive types
  * @param seen - Set to track visited types and prevent infinite recursion
  */
 export function unwrapOpaqueLikeType(
@@ -327,13 +327,13 @@ export function unwrapOpaqueLikeType(
   }
 
   if (type.isIntersection()) {
-    // For OpaqueRef<T> = OpaqueCell<T> & OpaqueRefInner<T>, we want to extract T
+    // For Reactive<T> = OpaqueCell<T> & ReactiveInner<T>, we want to extract T
     // Look for an OpaqueCell<T> part and extract its type argument
     for (const part of type.types) {
       if (isBrandedCellType(part, checker)) {
         const inner = getTypeReferenceArgument(part);
         if (inner) {
-          // Recursively unwrap in case T itself contains OpaqueRef types
+          // Recursively unwrap in case T itself contains Reactive types
           return unwrapOpaqueLikeType(inner, checker, seen) ?? inner;
         }
       }
@@ -382,7 +382,7 @@ export function unwrapCellLikeType(
 
 /**
  * Convert a TypeScript type to a TypeNode for schema generation
- * Note: Does NOT unwrap Cell/OpaqueRef types - the schema generator handles those
+ * Note: Does NOT unwrap Cell/Reactive types - the schema generator handles those
  */
 export function typeToSchemaTypeNode(
   type: ts.Type | undefined,
@@ -392,7 +392,7 @@ export function typeToSchemaTypeNode(
   if (!type) {
     return undefined;
   }
-  // Don't unwrap Cell/OpaqueRef types - let the schema generator handle them
+  // Don't unwrap Cell/Reactive types - let the schema generator handle them
   const result = typeToTypeNode(type, checker, location);
   return result;
 }
@@ -806,9 +806,9 @@ function findReferenceTypeInIntersection(
 }
 
 /**
- * Helper to find OpaqueRef type within a union type
+ * Helper to find Reactive type within a union type
  */
-function findOpaqueRefInUnion(
+function findReactiveInUnion(
   unionType: ts.UnionType,
   checker: ts.TypeChecker,
 ): ts.Type | undefined {
@@ -924,12 +924,12 @@ function extractElementFromArrayType(
 }
 
 /**
- * Infer the element type from an array-like expression (e.g., OpaqueRef<T[]> or Array<T>).
+ * Infer the element type from an array-like expression (e.g., Reactive<T[]> or Array<T>).
  * Unwraps one level of array wrapping to get the element type.
  *
  * Handles:
- * - OpaqueRef<T[]> → T[] → T (intersection type case)
- * - FactoryInput<T[]> → OpaqueRef<T[]> → T[] → T (union type case)
+ * - Reactive<T[]> → T[] → T (intersection type case)
+ * - FactoryInput<T[]> → Reactive<T[]> → T[] → T (union type case)
  * - Plain Array<T> → T
  *
  * @param arrayExpr - Expression representing an array or array-like type
@@ -952,10 +952,10 @@ export function inferArrayElementType(
     getTypeAtLocationWithFallback(arrayExpr, checker, typeRegistry) ??
       checker.getTypeAtLocation(arrayExpr);
 
-  // Try to unwrap OpaqueRef<T[]> → T[] → T
+  // Try to unwrap Reactive<T[]> → T[] → T
   let actualType = arrayType;
 
-  // Handle intersections (OpaqueRef case)
+  // Handle intersections (Reactive case)
   if (arrayType.flags & ts.TypeFlags.Intersection) {
     const refType = findReferenceTypeInIntersection(
       arrayType as ts.IntersectionType,
@@ -967,7 +967,7 @@ export function inferArrayElementType(
 
   // Handle unions (FactoryInput<T[]> case)
   if (arrayType.flags & ts.TypeFlags.Union) {
-    const opaqueType = findOpaqueRefInUnion(
+    const opaqueType = findReactiveInUnion(
       arrayType as ts.UnionType,
       checker,
     );
@@ -979,7 +979,7 @@ export function inferArrayElementType(
   // Extract type arguments from the reference type
   let typeArgs: readonly ts.Type[] | undefined;
 
-  // First check if actualType is an intersection (OpaqueRef case)
+  // First check if actualType is an intersection (Reactive case)
   if (actualType.flags & ts.TypeFlags.Intersection) {
     const intersectionType = actualType as ts.IntersectionType;
     // Look for the Reference type member within the intersection
@@ -1138,7 +1138,7 @@ export function hasArrayTypeArgument(
     );
   }
 
-  // Handle object types with type references (e.g., OpaqueRef<T[]>)
+  // Handle object types with type references (e.g., Reactive<T[]>)
   if (type.flags & ts.TypeFlags.Object) {
     const objectType = type as ts.ObjectType;
     if (objectType.objectFlags & ts.ObjectFlags.Reference) {

--- a/packages/ts-transformers/src/closures/strategies/action-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/action-strategy.ts
@@ -164,7 +164,7 @@ function transformActionCall(
   //
   // Note: The action call has type `ModuleFactory<T, Stream<void>>`, but the finalCall
   // is `handler(...)({...})` which CALLS the factory. We need the return type of that call,
-  // which is `OpaqueRef<Stream<void>>`.
+  // which is `Reactive<Stream<void>>`.
   const typeRegistry = context.options.state?.typeRegistry;
   if (typeRegistry) {
     // Get the type of the original action call (ModuleFactory<T, Stream<void>>)
@@ -173,7 +173,7 @@ function transformActionCall(
     const callSignatures = actionType.getCallSignatures();
     if (callSignatures.length > 0) {
       const callReturnType = callSignatures[0]!.getReturnType();
-      // This should be OpaqueRef<Stream<void>> - the type of calling handler(...)({...})
+      // This should be Reactive<Stream<void>> - the type of calling handler(...)({...})
       registerSyntheticCallType(finalCall, callReturnType, typeRegistry);
     }
   }

--- a/packages/ts-transformers/src/closures/strategies/array-method-policy.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-policy.ts
@@ -22,7 +22,7 @@ import { classifyOpaquePathTerminalCall } from "../../transformers/opaque-roots.
  * Detects a fallback-guarded reactive receiver: `(<reactive> ?? fallback)` or
  * `(<reactive> || fallback)`, where `<reactive>` is a reactive value (e.g. a
  * `cell.get()` lowered to a lift-applied call, a `.key(...)` access, or any
- * other OpaqueRef-producing expression).
+ * other Reactive-producing expression).
  *
  * The `?? []` (or `|| []`) guard is the documented defense against a scoped
  * cell reading `undefined` before sync. But it also collapses the receiver's
@@ -56,7 +56,7 @@ function isReactiveFallbackLeft(
   }
   // A `cell.get()` / `cell.key(...)` read isn't reactive-producing on its own
   // (it's a read), but when its receiver is reactive the whole `.get()` result
-  // is still an OpaqueRef at runtime once lowered — so the fallback receiver
+  // is still a Reactive at runtime once lowered — so the fallback receiver
   // needs the WithPattern rewrite. Match `<reactive>.get()` / `.key(...)`.
   if (
     ts.isCallExpression(left) &&
@@ -97,13 +97,13 @@ function hasSharedReactiveCollectionProvenance(
  * Check if an array method call should be transformed to its WithPattern variant.
  *
  * Type-based approach with context awareness (CT-1186 fix):
- * 1. computed()/lift() calls always return OpaqueRef at runtime -> TRANSFORM
- * 2. Inside safe wrappers (computed/lift/etc), OpaqueRef gets auto-unwrapped
- *    to a plain array, so we should NOT transform OpaqueRef method calls there.
+ * 1. computed()/lift() calls always return Reactive at runtime -> TRANSFORM
+ * 2. Inside safe wrappers (computed/lift/etc), Reactive gets auto-unwrapped
+ *    to a plain array, so we should NOT transform Reactive method calls there.
  *    However, Cell and Stream do NOT get auto-unwrapped, so we still transform those.
  * 3. Local aliases created by nested computed()/lift() calls inside the current
  *    compute callback become opaque again and should transform.
- * 4. Outside safe wrappers, transform all cell-like types (OpaqueRef, Cell, Stream).
+ * 4. Outside safe wrappers, transform all cell-like types (Reactive, Cell, Stream).
  */
 export function shouldTransformArrayMethod(
   methodCall: ts.CallExpression,
@@ -165,7 +165,7 @@ export function shouldTransformArrayMethod(
 
   // `(reactive ?? fallback).map(...)`: the fallback guard hides the reactive
   // receiver from the type-based classifier above (it sees a plain array), but
-  // at runtime the receiver is still an OpaqueRef and needs the WithPattern
+  // at runtime the receiver is still a Reactive and needs the WithPattern
   // rewrite. Mirror the lift-applied special-case (CT-1626).
   if (isReactiveFallbackReceiver(mapTarget, context.checker)) {
     return contextInfo.kind === "pattern";

--- a/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
@@ -309,7 +309,7 @@ function createPatternCallWithParams(
 }
 
 /**
- * Transform an array method callback for OpaqueRef arrays.
+ * Transform an array method callback for Reactive arrays.
  * Always transforms to use pattern + the WithPattern variant, even with no
  * captures, to ensure callback parameters become opaque.
  */

--- a/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
@@ -33,7 +33,7 @@ import { SchemaFactory } from "../utils/schema-factory.ts";
  * to see the correct unwrapped types for captured variables.
  *
  * Inside a lift-applied callback:
- * - OpaqueRef<T> captures become T parameters (unwrapped)
+ * - Reactive<T> captures become T parameters (unwrapped)
  * - Cell<T> captures remain Cell<T> (NOT unwrapped)
  *
  * We register this before the visitor runs so decisions are made correctly.
@@ -47,7 +47,7 @@ function preRegisterCaptureTypes(
   if (!typeRegistry) return;
 
   // Build map: capture name -> type to register
-  // Only unwrap OpaqueRef types (kind === "opaque"), not Cell types
+  // Only unwrap Reactive types (kind === "opaque"), not Cell types
   const captureTypes = new Map<string, ts.Type>();
   for (const expr of captureExpressions) {
     if (ts.isIdentifier(expr)) {
@@ -55,7 +55,7 @@ function preRegisterCaptureTypes(
       if (exprType) {
         const kind = getCellKind(exprType, checker);
 
-        // Only unwrap if it's an OpaqueRef (kind === "opaque")
+        // Only unwrap if it's a Reactive (kind === "opaque")
         // Cell and Stream types should NOT be unwrapped
         if (kind === "opaque") {
           const unwrapped = unwrapOpaqueLikeType(exprType, checker);

--- a/packages/ts-transformers/src/diagnostics/error-message-transformer.ts
+++ b/packages/ts-transformers/src/diagnostics/error-message-transformer.ts
@@ -19,9 +19,9 @@ export interface DiagnosticMessageTransformer {
 }
 
 /**
- * Options for the OpaqueRef error transformer.
+ * Options for the Reactive error transformer.
  */
-export interface OpaqueRefErrorTransformerOptions {
+export interface ReactiveErrorTransformerOptions {
   /**
    * When true, appends the original TypeScript error to the transformed message.
    * Useful for debugging.
@@ -30,22 +30,22 @@ export interface OpaqueRefErrorTransformerOptions {
 }
 
 /**
- * Transforms confusing OpaqueRef-related TypeScript errors into clear, actionable messages.
+ * Transforms confusing Reactive-related TypeScript errors into clear, actionable messages.
  *
  * For example, transforms:
  *   "Property 'get' does not exist on type 'OpaqueCell<number> & number'"
  * Into:
  *   "Unnecessary .get() call on a reactive value. This value can be accessed directly..."
  */
-export class OpaqueRefErrorTransformer implements DiagnosticMessageTransformer {
+export class ReactiveErrorTransformer implements DiagnosticMessageTransformer {
   private verbose: boolean;
 
-  constructor(options: OpaqueRefErrorTransformerOptions = {}) {
+  constructor(options: ReactiveErrorTransformerOptions = {}) {
     this.verbose = options.verbose ?? false;
   }
 
   transform(message: string): string | null {
-    // Detect .get() called on OpaqueCell/OpaqueRef types
+    // Detect .get() called on OpaqueCell/Reactive types
     // TypeScript error: "Property 'get' does not exist on type 'OpaqueCell<...> & ...'"
     const match = message.match(
       /^Property 'get' does not exist on type '(OpaqueCell<[^']*>)/,

--- a/packages/ts-transformers/src/diagnostics/mod.ts
+++ b/packages/ts-transformers/src/diagnostics/mod.ts
@@ -1,6 +1,6 @@
 export {
   CompositeDiagnosticTransformer,
   type DiagnosticMessageTransformer,
-  OpaqueRefErrorTransformer,
-  type OpaqueRefErrorTransformerOptions,
+  ReactiveErrorTransformer,
+  type ReactiveErrorTransformerOptions,
 } from "./error-message-transformer.ts";

--- a/packages/ts-transformers/src/mod.ts
+++ b/packages/ts-transformers/src/mod.ts
@@ -36,6 +36,6 @@ export { CommonFabricTransformerPipeline } from "./cf-pipeline.ts";
 export {
   CompositeDiagnosticTransformer,
   type DiagnosticMessageTransformer,
-  OpaqueRefErrorTransformer,
-  type OpaqueRefErrorTransformerOptions,
+  ReactiveErrorTransformer,
+  type ReactiveErrorTransformerOptions,
 } from "./diagnostics/mod.ts";

--- a/packages/ts-transformers/src/transformers/builtins/lift-applied.ts
+++ b/packages/ts-transformers/src/transformers/builtins/lift-applied.ts
@@ -27,11 +27,11 @@ import { registerLiftAppliedCallType } from "../../ast/type-inference.ts";
 import type { TransformationContext } from "../../core/mod.ts";
 
 /**
- * Replace OpaqueRef expressions with parameter identifiers in the callback body.
+ * Replace Reactive expressions with parameter identifiers in the callback body.
  * Also registers the new identifiers with their UNWRAPPED types in the typeRegistry,
  * so that type-based checks inside the lift-applied callback see the correct types.
  */
-function replaceOpaqueRefsWithParams(
+function replaceReactivesWithParams(
   expression: ts.Expression,
   refToParamName: Map<ts.Expression, string>,
   factory: ts.NodeFactory,
@@ -45,7 +45,7 @@ function replaceOpaqueRefsWithParams(
         const newIdentifier = factory.createIdentifier(paramName);
 
         // Register the new identifier with its UNWRAPPED type.
-        // The ref has type OpaqueRef<T>, but inside the lift-applied callback
+        // The ref has type Reactive<T>, but inside the lift-applied callback
         // the parameter has type T (unwrapped).
         if (checker && typeRegistry) {
           const refType = checker.getTypeAtLocation(ref);
@@ -212,7 +212,7 @@ export function createLiftAppliedCall(
     refToParamName,
   );
 
-  const lambdaBody = replaceOpaqueRefsWithParams(
+  const lambdaBody = replaceReactivesWithParams(
     expression,
     refToParamName,
     factory,

--- a/packages/ts-transformers/src/transformers/cast-validation.ts
+++ b/packages/ts-transformers/src/transformers/cast-validation.ts
@@ -3,7 +3,7 @@
  *
  * Validates type assertions (casts) and reports diagnostics for problematic patterns:
  * - `as unknown as X` (double-cast): ERROR - bypasses type safety
- * - `as OpaqueRef<...>`: ERROR - framework handles OpaqueRef wrapping automatically
+ * - `as Reactive<...>`: ERROR - framework handles Reactive wrapping automatically
  * - `as Cell<...>` and other cell-like types: ERROR - prefer proper type annotations
  */
 import ts from "typescript";

--- a/packages/ts-transformers/src/transformers/expression-rewrite/emitters/binary-expression.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/emitters/binary-expression.ts
@@ -101,7 +101,7 @@ export const emitBinaryExpression: Emitter = ({
   // This is important for cases like `computed(() => plainValue) && <JSX>`
   // where the computed() returns a reactive value but doesn't contain reactive
   // refs in its inputs.
-  const leftIsOpaqueRef = isReactiveValueExpression(
+  const leftIsReactive = isReactiveValueExpression(
     expression.left,
     context.checker,
   );
@@ -109,7 +109,7 @@ export const emitBinaryExpression: Emitter = ({
   // Skip if no dataflows AND left side isn't reactive
   if (
     dataFlows.length === 0 &&
-    !leftIsOpaqueRef &&
+    !leftIsReactive &&
     !shouldLowerByContextPolicy
   ) {
     return undefined;

--- a/packages/ts-transformers/src/transformers/expression-rewrite/emitters/call-expression.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/emitters/call-expression.ts
@@ -206,7 +206,7 @@ function shouldFilterNestedLocalsForCallWrapper(
     }
 
     const receiverAnalysis = analyze(callee.expression);
-    return receiverAnalysis.containsOpaqueRef;
+    return receiverAnalysis.containsReactive;
   }
 
   const sinkReceiverChain = classifyArrayMethodResultSinkReceiverChainCall(
@@ -226,7 +226,7 @@ function shouldFilterNestedLocalsForCallWrapper(
   }
 
   const receiverAnalysis = analyze(callee.expression);
-  return receiverAnalysis.containsOpaqueRef;
+  return receiverAnalysis.containsReactive;
 }
 
 function isCellGetTerminalCall(

--- a/packages/ts-transformers/src/transformers/expression-rewrite/emitters/compute-wrap-invariants.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/emitters/compute-wrap-invariants.ts
@@ -220,7 +220,7 @@ export function findPendingComputeWrapCandidate(
     }
 
     const nodeAnalysis = analyze(node);
-    if (!nodeAnalysis.containsOpaqueRef || !nodeAnalysis.requiresRewrite) {
+    if (!nodeAnalysis.containsReactive || !nodeAnalysis.requiresRewrite) {
       ts.forEachChild(node, visit);
       return;
     }

--- a/packages/ts-transformers/src/transformers/expression-rewrite/emitters/helper-owned-expression.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/emitters/helper-owned-expression.ts
@@ -85,7 +85,7 @@ export function rewriteHelperOwnedExpression(
     rewriteChildren,
   } = params;
 
-  // JSX containers can rewrite their dynamic slots locally via OpaqueRefJSX.
+  // JSX containers can rewrite their dynamic slots locally via ReactiveJSX.
   // Wrapping the whole helper-owned branch here would force later passes to
   // disagree about nested collection lowering.
   if (isJsxLocalRewriteContainer(expression)) {

--- a/packages/ts-transformers/src/transformers/expression-rewrite/fallback-array-method-rewrite.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/fallback-array-method-rewrite.ts
@@ -3,7 +3,7 @@ import ts from "typescript";
 import { classifyArrayMethodAccess } from "../../ast/mod.ts";
 import { unwrapExpression } from "../../utils/expression.ts";
 import { isFallbackOperator } from "../../utils/reactive-keys.ts";
-import { isSimpleOpaqueRefAccess } from "../opaque-ref/opaque-ref.ts";
+import { isSimpleReactiveAccess } from "../opaque-ref/opaque-ref.ts";
 
 export function isFallbackMapReceiverExpression(
   expression: ts.BinaryExpression,
@@ -40,5 +40,5 @@ export function shouldDeferFallbackMapReceiverRewrite(
     return false;
   }
 
-  return isSimpleOpaqueRefAccess(unwrapExpression(expression.left), checker);
+  return isSimpleReactiveAccess(unwrapExpression(expression.left), checker);
 }

--- a/packages/ts-transformers/src/transformers/expression-rewrite/mod.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/mod.ts
@@ -1,2 +1,2 @@
 export { rewriteExpression } from "./rewrite-expression.ts";
-export { type OpaqueRefHelperName } from "./types.ts";
+export { type ReactiveHelperName } from "./types.ts";

--- a/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-expression.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-expression.ts
@@ -179,7 +179,7 @@ function rewriteChildExpressions(
       }
 
       const analysis = analyze(child);
-      if (analysis.containsOpaqueRef && analysis.requiresRewrite) {
+      if (analysis.containsReactive && analysis.requiresRewrite) {
         // Skip wrapping if inside a safe callback wrapper (computed/lift/action/etc.)
         // This prevents double-wrapping expressions already in a reactive context
         if (isInsideKnownSafeCallbackWrapper(child, context)) {
@@ -249,7 +249,7 @@ export function rewriteExpression(
       }
 
       const analysis = params.analyze(node);
-      if (analysis.containsOpaqueRef && analysis.requiresRewrite) {
+      if (analysis.containsReactive && analysis.requiresRewrite) {
         return rewriteExpression({
           expression: node,
           analysis,

--- a/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-helpers.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-helpers.ts
@@ -200,7 +200,7 @@ export function createReactiveWrapperForExpression(
  * "!"` declared in the enclosing pattern/map callback) become explicit
  * lift-applied inputs instead of flowing through lexical closure.
  *
- * The dataflow analyzer only surfaces reactive captures (Cell/OpaqueRef).
+ * The dataflow analyzer only surfaces reactive captures (Cell/Reactive).
  * Plain-JS values declared in enclosing scope are invisible to it, so they
  * default to lexical closure when `createLiftAppliedCall` emits the callback.
  * That breaks the self-contained-callback contract that SES sandboxing and

--- a/packages/ts-transformers/src/transformers/expression-rewrite/types.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/types.ts
@@ -5,7 +5,7 @@ import type { ReactiveContextKind } from "../../ast/mod.ts";
 import { TransformationContext } from "../../core/mod.ts";
 import type { ExpressionContainerKind } from "../expression-site-types.ts";
 
-export type OpaqueRefHelperName =
+export type ReactiveHelperName =
   | "lift"
   | "ifElse"
   | "when"

--- a/packages/ts-transformers/src/transformers/expression-site-lowering.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-lowering.ts
@@ -281,7 +281,7 @@ export function rewriteExpressionSite(
   const hasLogicalOps = containsLogicalBinaryOperator(expression);
   const controlFlowNeedsRewrite = containerKind === "jsx-expression" &&
     isControlFlowRewriteExpression(expression) &&
-    analysis.containsOpaqueRef;
+    analysis.containsReactive;
 
   if (!analysis.requiresRewrite && !hasLogicalOps && !controlFlowNeedsRewrite) {
     return undefined;
@@ -292,7 +292,7 @@ export function rewriteExpressionSite(
       context.reportDiagnostic({
         type: "opaque-ref:jsx-expression",
         message:
-          "JSX expression with OpaqueRef computation should use computed()",
+          "JSX expression with Reactive computation should use computed()",
         node: expression,
       });
     }
@@ -369,8 +369,7 @@ export function rewriteOwnedPreClosureJsxExpressionSite(
   if (context.options.mode === "error") {
     context.reportDiagnostic({
       type: "opaque-ref:jsx-expression",
-      message:
-        "JSX expression with OpaqueRef computation should use computed()",
+      message: "JSX expression with Reactive computation should use computed()",
       node: expression,
     });
     return expression;
@@ -791,7 +790,7 @@ export function rewriteArrayMethodCallbackExpressionSites(
     } = {},
   ): ts.Expression | undefined => {
     const analysis = analyze(expression);
-    if (analysis.containsOpaqueRef && analysis.requiresRewrite) {
+    if (analysis.containsReactive && analysis.requiresRewrite) {
       const relevantDataFlows = context.getRelevantDataFlowsFromAnalysis(
         analysis,
       );

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -36,7 +36,7 @@ import type { ExpressionContainerKind } from "./expression-site-types.ts";
 import {
   isPatternFactoryCalleeExpression,
   isStructuralReactiveFactoryExpression,
-  returnsOpaqueRefResult,
+  returnsReactiveResult,
 } from "./structural-reactive-factory.ts";
 
 interface ExpressionSiteCallRootPolicyInfo {
@@ -274,7 +274,7 @@ function classifyCallExpressionRoot(
   const callee = expression.expression;
   if (ts.isIdentifier(callee)) {
     if (
-      returnsOpaqueRefResult(expression, context.checker) ||
+      returnsReactiveResult(expression, context.checker) ||
       isStructuralReactiveFactoryExpression(callee, context.checker)
     ) {
       return "other";
@@ -287,7 +287,7 @@ function classifyCallExpressionRoot(
     ts.isElementAccessExpression(callee)
   ) {
     const receiverAnalysis = analyze(callee.expression);
-    if (receiverAnalysis.containsOpaqueRef) {
+    if (receiverAnalysis.containsReactive) {
       return "receiver-method";
     }
 
@@ -318,7 +318,7 @@ function isSharedJsxLocalHelperCallRoot(
     return false;
   }
 
-  return analyze(expression).containsOpaqueRef;
+  return analyze(expression).containsReactive;
 }
 
 function isSharedPostClosureCallRootKind(
@@ -719,7 +719,7 @@ function isDeferredJsxArrayMethodExpression(
     }
 
     const receiverAnalysis = analyze(current.expression.expression);
-    if (receiverAnalysis.containsOpaqueRef) {
+    if (receiverAnalysis.containsReactive) {
       return true;
     }
   }
@@ -755,7 +755,7 @@ function isOwnedDeferredJsxArrayMethodRoot(
   }
 
   const receiverAnalysis = analyze(callee.expression);
-  return receiverAnalysis.containsOpaqueRef;
+  return receiverAnalysis.containsReactive;
 }
 
 export function isDirectArrayMethodRootExpression(
@@ -788,7 +788,7 @@ function isOwnedDynamicElementAccessRoot(
     return false;
   }
 
-  return analyze(current).containsOpaqueRef;
+  return analyze(current).containsReactive;
 }
 
 function isOwnedObjectLiteralRoot(
@@ -797,7 +797,7 @@ function isOwnedObjectLiteralRoot(
 ): boolean {
   const current = unwrapExpression(expression);
   return ts.isObjectLiteralExpression(current) &&
-    analyze(current).containsOpaqueRef;
+    analyze(current).containsReactive;
 }
 
 function getExpressionSitePolicyInfo(
@@ -868,20 +868,20 @@ function isExpressionSiteLowerable(
     (
       containerKind === "jsx-expression" &&
       siteInfo.controlFlowRewriteRoot &&
-      analysis.containsOpaqueRef
+      analysis.containsReactive
     );
 }
 
 /**
  * The lowerable signal shared by the reactive-boundary value-lift classifiers
  * (helper-owned and array-method-owned): the expression reads a reactive value
- * (`containsOpaqueRef`) and the dataflow analysis says it must be rewritten to
+ * (`containsReactive`) and the dataflow analysis says it must be rewritten to
  * resolve those reads (`requiresRewrite`).
  */
 function hasReactiveComputationToLift(
   analysis: ReturnType<AnalyzeFn>,
 ): boolean {
-  return analysis.containsOpaqueRef && analysis.requiresRewrite;
+  return analysis.containsReactive && analysis.requiresRewrite;
 }
 
 function createSharedExpressionSiteDecision(
@@ -1169,7 +1169,7 @@ export function classifyExpressionSiteHandling(
   // position of a reactive map/filter/flatMap callback (lowered to *WithPattern)
   // must be lifted to operate on RESOLVED values, exactly as the same expression is
   // lifted inside a helper body or a JSX value site. Without this it is emitted raw
-  // on OpaqueRef proxies: a filter predicate `v.optionId === oid` becomes
+  // on Reactive proxies: a filter predicate `v.optionId === oid` becomes
   // proxy-vs-proxy `===` → a constant `false`.
   //
   // Two guards keep COLLECTION-valued expressions out, so they stay structurally
@@ -1395,7 +1395,7 @@ export function classifyRestrictedReactiveComputation(
   }
 
   const analysis = analyze(expression);
-  if (analysis.containsOpaqueRef && analysis.requiresRewrite) {
+  if (analysis.containsReactive && analysis.requiresRewrite) {
     return { kind: "requires-computed" };
   }
 

--- a/packages/ts-transformers/src/transformers/opaque-get-validation.ts
+++ b/packages/ts-transformers/src/transformers/opaque-get-validation.ts
@@ -1,8 +1,8 @@
 /**
- * OpaqueRef .get() Validation Transformer
+ * Reactive .get() Validation Transformer
  *
- * Validates that .get() is not called on OpaqueRef types.
- * OpaqueRef values (from pattern inputs, computed(), lift()) can be accessed
+ * Validates that .get() is not called on Reactive types.
+ * Reactive values (from pattern inputs, computed(), lift()) can be accessed
  * directly without .get(). Only Writable<T> (Cell<T>) requires .get().
  *
  * This transformer provides a clear, actionable error message before TypeScript
@@ -31,7 +31,7 @@ export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
   }
 
   /**
-   * Checks if a call expression is a .get() call on an OpaqueRef type
+   * Checks if a call expression is a .get() call on a Reactive type
    * and reports a helpful error if so.
    */
   private validateGetCall(
@@ -60,7 +60,7 @@ export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
       return;
     }
 
-    // Check if the receiver is an "opaque" cell kind (OpaqueRef/OpaqueCell)
+    // Check if the receiver is an "opaque" cell kind (Reactive/OpaqueCell)
     // These types don't have .get() - values are accessed directly
     const cellKind = getCellKind(receiverType, checker);
 
@@ -91,7 +91,7 @@ export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
   }
 
   /**
-   * Structural fallback for cases where OpaqueRef<T> = T and the brand is gone.
+   * Structural fallback for cases where Reactive<T> = T and the brand is gone.
    *
    * We intentionally only infer reactivity from:
    * - pattern/render callback inputs

--- a/packages/ts-transformers/src/transformers/opaque-ref/opaque-ref.ts
+++ b/packages/ts-transformers/src/transformers/opaque-ref/opaque-ref.ts
@@ -59,7 +59,7 @@ export function getCellKind(
   return utilGetCellKind(type, checker);
 }
 
-export function isSimpleOpaqueRefAccess(
+export function isSimpleReactiveAccess(
   expression: ts.Expression,
   checker: ts.TypeChecker,
 ): boolean {

--- a/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
+++ b/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
@@ -992,7 +992,7 @@ function rewriteTrackedOpaquePatternBody(
 /**
  * Recursively process lift-applied callback bodies (the lowered form of
  * computed() callbacks) to rewrite property accesses on
- * locally-declared OpaqueRef variables (e.g., const foo = computed(...);
+ * locally-declared Reactive variables (e.g., const foo = computed(...);
  * foo.bar → foo.key("bar")).
  *
  * rewriteTrackedOpaquePatternBody stops at function boundaries, so

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -930,7 +930,7 @@ function isAlreadyScopedFactoryCall(node: ts.CallExpression): boolean {
  * an `asScope(scope)` method (the lowering target). This covers the schema-built
  * pattern/node/module factories (which `isPatternFactoryCalleeExpression` also
  * matches) plus opaque builtin factories like `sqliteDatabase`, whose public
- * type is just `(...) => OpaqueRef<...>` with an `asScope` method and so lacks
+ * type is just `(...) => Reactive<...>` with an `asScope` method and so lacks
  * the `argumentSchema`/`resultSchema` shape that check keys on.
  */
 function calleeExposesAsScope(

--- a/packages/ts-transformers/src/transformers/structural-reactive-factory.ts
+++ b/packages/ts-transformers/src/transformers/structural-reactive-factory.ts
@@ -34,7 +34,7 @@ export function isPatternFactoryCalleeExpression(
   }
 }
 
-export function returnsOpaqueRefResult(
+export function returnsReactiveResult(
   expression: ts.CallExpression,
   checker: ts.TypeChecker,
 ): boolean {
@@ -90,7 +90,7 @@ export function isStructuralReactiveFactoryExpression(
         return false;
       }
 
-      if (returnsOpaqueRefResult(target, checker)) {
+      if (returnsReactiveResult(target, checker)) {
         return true;
       }
 

--- a/packages/ts-transformers/src/utils/expression.ts
+++ b/packages/ts-transformers/src/utils/expression.ts
@@ -47,7 +47,7 @@ export function unwrapExpression(
  * binary (`a === b`, `a + b`, `a ?? b`), prefix/postfix unary (`!x`, `-x`,
  * `x++`), and conditional (`a ? b : c`). These are the expressions a reactive
  * boundary (a helper body, or a map/filter/flatMap callback) lifts to value
- * level so they operate on resolved values rather than OpaqueRef proxies.
+ * level so they operate on resolved values rather than Reactive proxies.
  *
  * It is a purely syntactic kind check — it does NOT decide lowerability
  * (reactivity, control-flow routing, and collection-vs-value distinctions are

--- a/packages/ts-transformers/test/diagnostics/probe-element-param-analyzer.ts
+++ b/packages/ts-transformers/test/diagnostics/probe-element-param-analyzer.ts
@@ -4,7 +4,7 @@
  * For each `arr.map((p, ...) => …)` callback in fixture inputs, asks the
  * dataflow analyzer what it currently reports for every read of `p`, `p.x`,
  * `p.x.y`, etc. inside the callback body. This captures the analyzer's
- * blind spot before the Phase 2 fix: any line where `containsOpaqueRef=false`
+ * blind spot before the Phase 2 fix: any line where `containsReactive=false`
  * for a `p.foo`-style access is a place where the analyzer fails to recognize
  * the read as reactive.
  *
@@ -33,7 +33,7 @@ interface Probe {
   inJsx: boolean;
   inMethodCall: boolean;
   typeText: string;
-  containsOpaqueRef: boolean;
+  containsReactive: boolean;
   requiresRewrite: boolean;
   dataFlowsLength: number;
   reactiveMap: boolean;
@@ -301,14 +301,14 @@ async function main() {
           analysis = analyze(acc.expression);
         } catch (_) {
           analysis = {
-            containsOpaqueRef: false,
+            containsReactive: false,
             requiresRewrite: false,
             dataFlows: [],
           };
         }
 
         totalProbes++;
-        const silent = !analysis.containsOpaqueRef &&
+        const silent = !analysis.containsReactive &&
           !analysis.requiresRewrite;
         if (silent) {
           analyzerSilent++;
@@ -331,7 +331,7 @@ async function main() {
             acc.inMethodCall ? "y" : "n",
             accessText,
             typeText,
-            analysis.containsOpaqueRef ? "y" : "n",
+            analysis.containsReactive ? "y" : "n",
             analysis.requiresRewrite ? "y" : "n",
             analysis.dataFlows.length,
             reactiveMap ? "y" : "n",

--- a/packages/ts-transformers/test/error-message-transformer.test.ts
+++ b/packages/ts-transformers/test/error-message-transformer.test.ts
@@ -2,12 +2,12 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   CompositeDiagnosticTransformer,
-  OpaqueRefErrorTransformer,
+  ReactiveErrorTransformer,
 } from "../src/diagnostics/mod.ts";
 
-describe("OpaqueRefErrorTransformer", () => {
+describe("ReactiveErrorTransformer", () => {
   it("transforms .get() on OpaqueCell error to clear message", () => {
-    const transformer = new OpaqueRefErrorTransformer();
+    const transformer = new ReactiveErrorTransformer();
     const originalMessage =
       "Property 'get' does not exist on type 'OpaqueCell<number> & number'.";
 
@@ -20,7 +20,7 @@ describe("OpaqueRefErrorTransformer", () => {
   });
 
   it("includes original error in verbose mode", () => {
-    const transformer = new OpaqueRefErrorTransformer({ verbose: true });
+    const transformer = new ReactiveErrorTransformer({ verbose: true });
     const originalMessage =
       "Property 'get' does not exist on type 'OpaqueCell<number> & number'.";
 
@@ -33,7 +33,7 @@ describe("OpaqueRefErrorTransformer", () => {
   });
 
   it("returns null for unrelated errors", () => {
-    const transformer = new OpaqueRefErrorTransformer();
+    const transformer = new ReactiveErrorTransformer();
     const unrelatedMessage =
       "Type 'string' is not assignable to type 'number'.";
 
@@ -43,7 +43,7 @@ describe("OpaqueRefErrorTransformer", () => {
   });
 
   it("handles complex OpaqueCell types", () => {
-    const transformer = new OpaqueRefErrorTransformer();
+    const transformer = new ReactiveErrorTransformer();
     const complexMessage =
       "Property 'get' does not exist on type 'OpaqueCell<{ items: string[]; count: number }> & { items: string[]; count: number }'.";
 
@@ -56,7 +56,7 @@ describe("OpaqueRefErrorTransformer", () => {
 
 describe("CompositeDiagnosticTransformer", () => {
   it("returns first successful transformation", () => {
-    const transformer1 = new OpaqueRefErrorTransformer();
+    const transformer1 = new ReactiveErrorTransformer();
     const transformer2 = {
       transform: (msg: string) =>
         msg.includes("foo") ? "transformed foo" : null,

--- a/packages/ts-transformers/test/fixture-based.test.ts
+++ b/packages/ts-transformers/test/fixture-based.test.ts
@@ -47,11 +47,11 @@ const configs: FixtureConfig[] = [
     describe: "Schema Transformer",
     formatTestName: (name) => {
       const formatted = name.replace(/-/g, " ");
-      if (name === "with-opaque-ref") return "works with OpaqueRef transformer";
+      if (name === "with-opaque-ref") return "works with Reactive transformer";
       return `transforms ${formatted}`;
     },
     groups: [
-      { pattern: /with-opaque-ref/, name: "OpaqueRef integration" },
+      { pattern: /with-opaque-ref/, name: "Reactive integration" },
     ],
   },
   {

--- a/packages/ts-transformers/test/fixtures/closures/pattern-computed-opaque-ref-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-computed-opaque-ref-map.expected.jsx
@@ -12,7 +12,7 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
-    items: number[] & {} & { [SELF]: OpaqueRef<any>; };
+    items: number[] & {} & { [SELF]: Reactive<any>; };
 }, number[]>(({ items }) => items.map((n) => n * 2), {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/opaque-ref/compute-wrap-invariants.test.ts
+++ b/packages/ts-transformers/test/opaque-ref/compute-wrap-invariants.test.ts
@@ -116,8 +116,8 @@ Deno.test(
       type BrandedCell<T, Brand extends string> = {
         readonly [CELL_BRAND]: Brand;
       };
-      type OpaqueRef<T> = BrandedCell<T, "opaque">;
-      declare const count: OpaqueRef<number>;
+      type Reactive<T> = BrandedCell<T, "opaque">;
+      declare const count: Reactive<number>;
 
       const branch = { label: count + " people" };
     `);
@@ -150,8 +150,8 @@ Deno.test(
       type BrandedCell<T, Brand extends string> = {
         readonly [CELL_BRAND]: Brand;
       };
-      type OpaqueRef<T> = BrandedCell<T, "opaque">;
-      declare const count: OpaqueRef<number>;
+      type Reactive<T> = BrandedCell<T, "opaque">;
+      declare const count: Reactive<number>;
 
       const branch = {
         label: count + " people",
@@ -184,8 +184,8 @@ Deno.test(
       type BrandedCell<T, Brand extends string> = {
         readonly [CELL_BRAND]: Brand;
       };
-      type OpaqueRef<T> = BrandedCell<T, "opaque">;
-      declare const count: OpaqueRef<number>;
+      type Reactive<T> = BrandedCell<T, "opaque">;
+      declare const count: Reactive<number>;
       declare const collection: {
         map<T>(fn: (item: number) => T): T[];
       };

--- a/packages/ts-transformers/test/opaque-ref/normalize.test.ts
+++ b/packages/ts-transformers/test/opaque-ref/normalize.test.ts
@@ -79,7 +79,7 @@ describe("normalizeDataFlows", () => {
     } as const;
 
     const relevant = getRelevantDataFlows({
-      containsOpaqueRef: true,
+      containsReactive: true,
       requiresRewrite: true,
       dataFlows: [syntheticElement, ignoredUse],
       graph: {

--- a/packages/ts-transformers/test/opaque-ref/runtime-style.test.ts
+++ b/packages/ts-transformers/test/opaque-ref/runtime-style.test.ts
@@ -7,7 +7,7 @@ import { transformSource, validateSource } from "../utils.ts";
 const staticCache = new StaticCacheFS();
 const commonfabric = await staticCache.getText("types/commonfabric.d.ts");
 
-describe("OpaqueRef transformer (runtime-style API)", () => {
+describe("Reactive transformer (runtime-style API)", () => {
   const types = { "commonfabric.d.ts": commonfabric };
 
   describe("error mode", () => {
@@ -25,7 +25,7 @@ export default pattern<{ count: number }>((state) => {
       expect(diagnostics.length).toBeGreaterThan(0);
       expect(
         diagnostics.some((d) =>
-          d.message.includes("OpaqueRef computation should use computed()")
+          d.message.includes("Reactive computation should use computed()")
         ),
       ).toBe(true);
     });

--- a/packages/ts-transformers/test/policy/expression-site-lowering.test.ts
+++ b/packages/ts-transformers/test/policy/expression-site-lowering.test.ts
@@ -785,7 +785,7 @@ Deno.test(
     const analyze = (_expression: ts.Expression) => {
       analyzeCalls++;
       return {
-        containsOpaqueRef: false,
+        containsReactive: false,
         requiresRewrite: false,
         dataFlows: [],
         graph: {

--- a/packages/ts-transformers/test/utils.ts
+++ b/packages/ts-transformers/test/utils.ts
@@ -522,7 +522,7 @@ export async function transformFiles(
           "1. Update the input fixture to use valid Common Fabric patterns",
         );
         errors.push(
-          "   (e.g., use Cell<T> for mutable state, OpaqueRef<T> for references)",
+          "   (e.g., use Cell<T> for mutable state, Reactive<T> for references)",
         );
         errors.push(
           "2. Run with SKIP_INPUT_CHECK=1 to skip validation temporarily",

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -61,11 +61,11 @@ const casted = {} as Cell<number>;
 Deno.test("Cast Validation", async (t) => {
   await t.step("errors on double cast 'as unknown as'", async () => {
     const source = `
-      import { OpaqueRef } from "commonfabric";
+      import { Reactive } from "commonfabric";
 
       interface Item { name: string; }
       const data = { name: "test" };
-      const ref = data as unknown as OpaqueRef<Item>;
+      const ref = data as unknown as Reactive<Item>;
     `;
     const { diagnostics } = await validateSource(source, {
       types: COMMONFABRIC_TYPES,
@@ -75,13 +75,13 @@ Deno.test("Cast Validation", async (t) => {
     assertHasErrorType(errors, "cast-validation:double-unknown");
   });
 
-  await t.step("errors on 'as OpaqueRef<>'", async () => {
+  await t.step("errors on 'as Reactive<>'", async () => {
     const source = `
-      import { OpaqueRef } from "commonfabric";
+      import { Reactive } from "commonfabric";
 
       interface Item { name: string; }
       const data: any = { name: "test" };
-      const ref = data as OpaqueRef<Item>;
+      const ref = data as Reactive<Item>;
     `;
     const { diagnostics } = await validateSource(source, {
       types: COMMONFABRIC_TYPES,
@@ -530,7 +530,7 @@ Deno.test("Pattern Context Validation - Restricted Contexts", async (t) => {
       assertEquals(
         errors.length,
         0,
-        "Optional chaining inside JSX should be allowed (OpaqueRefJSXTransformer handles it)",
+        "Optional chaining inside JSX should be allowed (ReactiveJSXTransformer handles it)",
       );
     },
   );
@@ -1896,9 +1896,9 @@ Deno.test("Computed local reactive alias validation", async (t) => {
 Deno.test("Diagnostic output format", async (t) => {
   await t.step("includes source location information", async () => {
     const source = `
-      import { OpaqueRef } from "commonfabric";
+      import { Reactive } from "commonfabric";
 
-      const data = {} as unknown as OpaqueRef<any>;
+      const data = {} as unknown as Reactive<any>;
     `;
     const { diagnostics } = await validateSource(source, {
       types: COMMONFABRIC_TYPES,
@@ -2042,11 +2042,11 @@ Deno.test("Pattern Context Validation - Function Creation", async (t) => {
   });
 
   await t.step("allows map callback inside JSX", async () => {
-    const source = `      import { pattern, h, OpaqueRef } from "commonfabric";
+    const source = `      import { pattern, h, Reactive } from "commonfabric";
 
       interface Item { name: string; }
 
-      export default pattern<{ items: OpaqueRef<Item[]> }>(({ items }) => {
+      export default pattern<{ items: Reactive<Item[]> }>(({ items }) => {
         return <div>{items.map(item => <span>{item.name}</span>)}</div>;
       });
     `;
@@ -2093,12 +2093,12 @@ Deno.test("Pattern Context Validation - Function Creation", async (t) => {
   });
 
   await t.step("allows map callback outside JSX in pattern body", async () => {
-    const source = `      import { pattern, OpaqueRef } from "commonfabric";
+    const source = `      import { pattern, Reactive } from "commonfabric";
 
       interface Item { name: string; }
 
       const listItems = pattern<
-        { items: OpaqueRef<Item[]> },
+        { items: Reactive<Item[]> },
         { result: Array<{ label: string }> }
       >(({ items }) => {
         const result = items.map((item) => ({
@@ -2504,11 +2504,11 @@ Deno.test("Pattern Context Validation - Object Members", async (t) => {
 
   await t.step("allows a JSX array-method render callback", async () => {
     const { diagnostics } = await validateSource(
-      `      import { pattern, h, OpaqueRef } from "commonfabric";
+      `      import { pattern, h, Reactive } from "commonfabric";
 
       interface Item { name: string; }
 
-      export default pattern<{ items: OpaqueRef<Item[]> }>(({ items }) => {
+      export default pattern<{ items: Reactive<Item[]> }>(({ items }) => {
         return <div>{items.map((item) => <span>{item.name}</span>)}</div>;
       });
     `,
@@ -3072,7 +3072,7 @@ Deno.test("Pattern Context Validation - Builder Placement", async (t) => {
   });
 });
 
-Deno.test("OpaqueRef .get() Validation", async (t) => {
+Deno.test("Reactive .get() Validation", async (t) => {
   await t.step(
     "errors on .get() called on computed result",
     async () => {


### PR DESCRIPTION
Stage 1 of 3 for [CT-1756](https://linear.app/common-tools/issue/CT-1756-remove-opaqueref-entirely-complete-the-reactive-rename) — completing the `OpaqueRef → Reactive` rename by removing the deprecated `OpaqueRef` spelling.

**Scope of "breaking":** this PR keeps the documented external surface — the `OpaqueRef` *type* alias (`export type OpaqueRef<T> = Reactive<T>`) stays until stage 3. It does rename **internal value exports** in place, without deprecated aliases — `isOpaqueRef` → `isReactive`, `OpaqueRefErrorTransformer` → `ReactiveErrorTransformer`, the builder `opaqueRef()` → `reactive()`. Those have no in-repo consumers remaining and aren't part of the documented authoring API, so per the agreed "ship the rename" plan they're renamed rather than aliased. The actual external break (deleting the type alias) lands in stage 3.

`OpaqueRef` has been an identity alias (`= T`) since #3153, so this is a rename of a name, not a type migration.

## What changed
- **api**: ~40 factory/builtin signatures → `Reactive`; deleted the dead, unused `OpaqueRefInner` helper; the `OpaqueRef` *type* alias is kept (removed in stage 3).
- **runner**: runtime guard `isOpaqueRef` → `isReactive` (+ `isReactiveMarker`); internal builder identifiers (`opaqueRef()` → `reactive()`, `getAsOpaqueRefProxy` → `getAsReactiveProxy`, `frame.opaqueRefs` → `reactives`, `opaqueRefWithCell` → `reactiveWithCell`); re-exports `Reactive`.
- **schema-generator**: `CellWrapperKind "OpaqueRef"` → `"Reactive"`. Kept `"OpaqueRef"` as a recognized `WrapperSpelling` (removed in stage 3) so authored `OpaqueRef` still classifies as reactive — output-neutral. Also removes a **pre-existing dead `kind === "OpaqueRef"` branch** in `object-formatter.ts` that the rename surfaced (`getCellWrapperInfo` is brand-based and never returns that kind — dead since #3153).
- **ts-transformers**: predicates/identifiers (`containsOpaqueRef` → `containsReactive`, `OpaqueRefErrorTransformer` → `ReactiveErrorTransformer`, …); preserved the spelling-axis `WrapperSpelling` tables and the historical `OpaqueRefMethods` test models.
- **consumers** (patterns, fs-sync-example, cli): type annotations.

One synthesized fixture output updated (the pattern self-type now emits `[SELF]: Reactive<any>`, forced by the api signature rename).

## Staging
- **This PR (1/3)** — symbol migration; the `OpaqueRef` *type* alias kept.
- **2/3** ([#4422](https://github.com/commontoolsinc/labs/pull/4422)) — file/dir/fixture renames + docs.
- **3/3** ([#4424](https://github.com/commontoolsinc/labs/pull/4424)) — delete the `OpaqueRef` type alias + `WrapperSpelling` → the actual external break.

## Verified locally
typecheck (api/runner/schema-generator/ts-transformers/consumers), `fmt --check`, `lint`, ts-transformers (342), schema-generator (27), runner targeted, generated-patterns integration (145) — all green.

> Stacked 1/3 — please don't merge until the full stack is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)