### PR TITLE
fix(telemetry): SigNoz follow-ups from #4401 review (CT-1807)

### DIFF
--- a/packages/background-piece-service/src/main.ts
+++ b/packages/background-piece-service/src/main.ts
@@ -59,14 +59,20 @@ export function shutdown(
   service: Pick<BackgroundPieceService, "stop">,
   exit: typeof Deno.exit = Deno.exit,
 ) {
-  return () => {
+  return () =>
     service.stop()
       // Flush buffered spans before exiting so shutdown telemetry isn't dropped.
       .then(() => shutdownOpenTelemetry())
-      .then(() => {
+      .catch((error) => {
+        // A failed stop()/flush (e.g. the collector is unreachable, which makes
+        // forceFlush reject) must not strand the process. Log and still exit so
+        // the signal handler always terminates cleanly instead of hanging until
+        // the orchestrator SIGKILLs us.
+        console.error("Error during shutdown:", error);
+      })
+      .finally(() => {
         exit(0);
       });
-  };
 }
 
 export async function startBackgroundPieceService(
@@ -83,7 +89,8 @@ export async function startBackgroundPieceService(
 ): Promise<ServiceLike> {
   // Set up tracing before doing any work so spans (incl. runner-library spans)
   // are exported to the local OTel collector -> SigNoz. No-op unless OTEL_ENABLED.
-  await initOpenTelemetry();
+  // Use the injected env so tests/alternate callers control telemetry config.
+  await initOpenTelemetry(dependencies.env);
 
   const workerTimeoutMs = parseWorkerTimeout(args);
   const identity = await dependencies.getIdentity(

--- a/packages/background-piece-service/src/otel.ts
+++ b/packages/background-piece-service/src/otel.ts
@@ -7,8 +7,9 @@ export type OtelConfig = Pick<
   "OTEL_ENABLED" | "OTEL_SERVICE_NAME" | "OTEL_EXPORTER_OTLP_ENDPOINT" | "ENV"
 >;
 
-// Ensure we only register once even during hot-reload.
-let _providerRegistered = false;
+// The single registered provider, or undefined when telemetry is off or has been
+// shut down. init/shutdown guard on this so they stay idempotent and re-init-safe
+// (e.g. across a hot-reload or an init -> shutdown -> init cycle in tests).
 let _provider:
   | import("@opentelemetry/sdk-trace-base").BasicTracerProvider
   | undefined;
@@ -34,12 +35,21 @@ export async function shutdownOpenTelemetry(): Promise<void> {
   // shutdown) is a no-op rather than touching a torn-down provider.
   const provider = _provider;
   _provider = undefined;
-  await provider.forceFlush();
-  await provider.shutdown();
+  try {
+    await provider.forceFlush();
+    await provider.shutdown();
+  } finally {
+    // Reset the global API state too, so a later initOpenTelemetry() can register
+    // a fresh provider + context manager cleanly, and getTracer() falls back to
+    // the API no-op tracer until then. (We don't swallow flush/shutdown errors —
+    // the caller decides; see main.ts's shutdown handler.)
+    trace.disable();
+    context.disable();
+  }
 }
 
 export async function initOpenTelemetry(cfg: OtelConfig = env): Promise<void> {
-  if (_providerRegistered || !cfg.OTEL_ENABLED) {
+  if (_provider || !cfg.OTEL_ENABLED) {
     if (!cfg.OTEL_ENABLED) {
       console.log("OpenTelemetry is disabled via OTEL_ENABLED env var");
     }
@@ -90,7 +100,6 @@ export async function initOpenTelemetry(cfg: OtelConfig = env): Promise<void> {
 
     trace.setGlobalTracerProvider(provider);
     _provider = provider;
-    _providerRegistered = true;
 
     console.log(
       `OpenTelemetry initialized successfully with endpoint: ${cfg.OTEL_EXPORTER_OTLP_ENDPOINT}`,

--- a/packages/background-piece-service/test/env.test.ts
+++ b/packages/background-piece-service/test/env.test.ts
@@ -1,0 +1,21 @@
+import { assertEquals } from "@std/assert";
+import { loadEnv } from "../src/env.ts";
+
+// Regression guard for the z.coerce.boolean() footgun: Boolean("false") === true
+// would silently enable telemetry. loadEnv takes an injectable source so the
+// OTEL_ENABLED transform can be tested without touching the real process env.
+Deno.test("loadEnv: OTEL_ENABLED only enables on 'true'/'1'", () => {
+  const otel = (v: string | undefined) =>
+    loadEnv((key) => (key === "OTEL_ENABLED" ? v : undefined)).OTEL_ENABLED;
+
+  assertEquals(otel("true"), true);
+  assertEquals(otel("1"), true);
+
+  // The cases the old z.coerce.boolean() got wrong:
+  assertEquals(otel("false"), false);
+  assertEquals(otel("0"), false);
+  assertEquals(otel("no"), false);
+
+  // Unset defaults to off.
+  assertEquals(otel(undefined), false);
+});

--- a/packages/background-piece-service/test/otel.test.ts
+++ b/packages/background-piece-service/test/otel.test.ts
@@ -61,4 +61,26 @@ describe("OpenTelemetry setup", () => {
       assertEquals(getTracerProvider(), undefined);
     },
   );
+
+  it(
+    "re-initializes cleanly after shutdown",
+    { sanitizeOps: false, sanitizeResources: false },
+    async () => {
+      await initOpenTelemetry(cfg(true));
+      assert(getTracerProvider() !== undefined, "first init should register");
+      await shutdownOpenTelemetry();
+      assertEquals(getTracerProvider(), undefined);
+
+      // A second init after shutdown must rebuild a working provider. The old
+      // `_providerRegistered` guard was never reset, so this silently no-op'd
+      // and left the service running with no tracing.
+      await initOpenTelemetry(cfg(true));
+      assert(
+        getTracerProvider() !== undefined,
+        "init after shutdown should rebuild the provider",
+      );
+      await shutdownOpenTelemetry();
+      assertEquals(getTracerProvider(), undefined);
+    },
+  );
 });

--- a/packages/background-piece-service/test/service-modules.test.ts
+++ b/packages/background-piece-service/test/service-modules.test.ts
@@ -1285,6 +1285,25 @@ describe("background piece service entry point", () => {
     assertEquals(calls, ["stop", "exit:0"]);
   });
 
+  it("still exits when stop() rejects", async () => {
+    const calls: string[] = [];
+    const callback = shutdown(
+      {
+        stop: () => {
+          calls.push("stop");
+          return Promise.reject(new Error("stop boom"));
+        },
+      },
+      ((code?: number) => {
+        calls.push(`exit:${code}`);
+      }) as typeof Deno.exit,
+    );
+    // A rejected stop()/flush must still reach exit(0) — otherwise the signal
+    // handler hangs until the orchestrator force-kills the process.
+    await callback();
+    assertEquals(calls, ["stop", "exit:0"]);
+  });
+
   it("runs the service entry point only when invoked as main", async () => {
     let calls = 0;
     await runMainIfMain(false, () => {

--- a/packages/toolshed/env.test.ts
+++ b/packages/toolshed/env.test.ts
@@ -1,0 +1,21 @@
+import { assertEquals } from "@std/assert";
+import { EnvSchema } from "@/env.ts";
+
+// Regression guard for the z.coerce.boolean() footgun: Boolean("false") === true,
+// which would silently enable telemetry (and, with the all-span exporter, ship
+// every HTTP request span) when an operator set OTEL_ENABLED=false to disable it.
+Deno.test("OTEL_ENABLED parses strictly: only 'true'/'1' enable telemetry", () => {
+  const otel = (v: string | undefined) =>
+    EnvSchema.parse(v === undefined ? {} : { OTEL_ENABLED: v }).OTEL_ENABLED;
+
+  assertEquals(otel("true"), true);
+  assertEquals(otel("1"), true);
+
+  // The cases the old z.coerce.boolean() got wrong:
+  assertEquals(otel("false"), false);
+  assertEquals(otel("0"), false);
+  assertEquals(otel("no"), false);
+
+  // Unset must default to off.
+  assertEquals(otel(undefined), false);
+});

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -29,7 +29,9 @@ function flagValue() {
 }
 
 // NOTE: This is where we define the environment variable types and defaults.
-const EnvSchema = z.object({
+// Exported so the parsing rules (e.g. OTEL_ENABLED) can be unit-tested without
+// going through the module-level singleton below.
+export const EnvSchema = z.object({
   ENV: z.string().default("development"),
   HOST: z.string().default("0.0.0.0"),
   PORT: z.coerce.number().default(8000),
@@ -48,9 +50,20 @@ const EnvSchema = z.object({
   // ===========================================================================
   // OpenTelemetry Configuration
   // ===========================================================================
-  OTEL_ENABLED: z.coerce.boolean().default(false),
+  // NOT z.coerce.boolean(): Boolean("false") === true, so OTEL_ENABLED=false
+  // would wrongly enable telemetry (and, with the all-span exporter, start
+  // shipping every HTTP request span). Mirror bg-piece-service's strict parse so
+  // only "true"/"1" enable it and "false"/unset disable it.
+  OTEL_ENABLED: z.string().default("false").transform((v) =>
+    v === "true" || v === "1"
+  ),
   OTEL_SERVICE_NAME: z.string().default("toolshed"),
   OTEL_EXPORTER_OTLP_ENDPOINT: z.string().default("http://localhost:4318"),
+  // NOTE: these sampler knobs are currently NOT honored. lib/otel.ts builds the
+  // provider without a Sampler, and the OTel JS SDK does not auto-read
+  // OTEL_TRACES_SAMPLER from the environment under Deno (verified empirically),
+  // so effective sampling is always-on regardless of these values. Left declared
+  // pending a decision to either wire a Sampler from them or drop them.
   OTEL_TRACES_SAMPLER: z.string().default("always_on"),
   OTEL_TRACES_SAMPLER_ARG: z.string().default("1.0"),
   // ===========================================================================

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -4,6 +4,7 @@ import { identity } from "@/lib/identity.ts";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { memory } from "@/routes/storage/memory.ts";
+import { shutdownOpenTelemetry } from "@/lib/otel.ts";
 
 // Create a global runtime instance for the server
 let runtime: Runtime;
@@ -78,6 +79,10 @@ const handleShutdown = async () => {
         } else {
           console.log("Memory system closed successfully");
         }
+
+        // Flush buffered spans so the last batch isn't dropped on exit. No-op
+        // when telemetry is disabled; bounded by the SHUTDOWN_TIMEOUT race above.
+        await shutdownOpenTelemetry();
       })(),
       timeoutPromise,
     ]);

--- a/packages/toolshed/lib/create-app.ts
+++ b/packages/toolshed/lib/create-app.ts
@@ -20,17 +20,13 @@ export default function createApp() {
 
   const app = createRouter();
 
-  // Add OpenTelemetry tracing if enabled
+  // Add OpenTelemetry tracing if enabled.
+  // Note: service.name / service.version are OTel *resource* attributes, already
+  // set on the provider in lib/otel.ts. We intentionally don't re-inject them as
+  // per-span attributes here — doing so duplicated the keys on every span (with a
+  // conflicting default: span-level "toolshed" vs resource-level "toolshed-dev").
   if (env.OTEL_ENABLED) {
-    app.use(
-      "*",
-      otelTracing({
-        additionalAttributes: {
-          "service.name": env.OTEL_SERVICE_NAME || "toolshed",
-          "service.version": "1.0.0",
-        },
-      }),
-    );
+    app.use("*", otelTracing());
   }
 
   app.use(serveEmojiFavicon("🪓"));

--- a/packages/toolshed/lib/otel.test.ts
+++ b/packages/toolshed/lib/otel.test.ts
@@ -1,0 +1,27 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+  getTracerProvider,
+  initOpenTelemetry,
+  shutdownOpenTelemetry,
+} from "@/lib/otel.ts";
+
+Deno.test("shutdownOpenTelemetry is a no-op before init", async () => {
+  assertEquals(getTracerProvider(), undefined);
+  await shutdownOpenTelemetry();
+  assertEquals(getTracerProvider(), undefined);
+});
+
+Deno.test(
+  "registers a provider when enabled, then flushes and tears it down on shutdown",
+  // The batch processor keeps a flush timer until shutdown; we tear it down
+  // below via shutdownOpenTelemetry(), so disable the leak sanitizer here.
+  { sanitizeOps: false, sanitizeResources: false },
+  async () => {
+    initOpenTelemetry(true);
+    assert(getTracerProvider() !== undefined, "provider should be registered");
+
+    // No span was emitted, so forceFlush makes no network call to the collector.
+    await shutdownOpenTelemetry();
+    assertEquals(getTracerProvider(), undefined);
+  },
+);

--- a/packages/toolshed/lib/otel.ts
+++ b/packages/toolshed/lib/otel.ts
@@ -32,7 +32,9 @@ export const provider = new BasicTracerProvider({
 // LLM/OpenInference spans, while its SigNoz pipeline ingests everything. We keep the
 // OpenInferenceBatchSpanProcessor (rather than a plain BatchSpanProcessor) so LLM
 // spans still get OpenInference semantic-convention formatting for Phoenix; a
-// pass-through spanFilter lets non-LLM spans export unchanged for SigNoz.
+// pass-through spanFilter lets non-LLM spans through to SigNoz as well. (The
+// processor tags passed-through spans with an `openinference.span.kind`
+// attribute, so they are not strictly byte-for-byte unchanged.)
 provider.addSpanProcessor(
   new OpenInferenceBatchSpanProcessor({
     exporter: otlpExporter,
@@ -42,6 +44,21 @@ provider.addSpanProcessor(
 
 export function getTracerProvider() {
   return _provider;
+}
+
+/**
+ * Flush and shut down the tracer provider so buffered spans aren't dropped when
+ * the process exits. No-op if telemetry was never initialized. Mirrors the
+ * bg-piece-service shutdown so toolshed doesn't lose its last span batch on
+ * deploy/restart.
+ */
+export async function shutdownOpenTelemetry(): Promise<void> {
+  if (!_provider) return;
+  const p = _provider;
+  _provider = undefined;
+  _providerRegistered = false;
+  await p.forceFlush();
+  await p.shutdown();
 }
 
 // Prefer Deno's built-in context manager when running on Deno ≥2.2.

--- a/packages/toolshed/lib/otel.ts
+++ b/packages/toolshed/lib/otel.ts
@@ -56,9 +56,18 @@ export async function shutdownOpenTelemetry(): Promise<void> {
   if (!_provider) return;
   const p = _provider;
   _provider = undefined;
-  _providerRegistered = false;
-  await p.forceFlush();
-  await p.shutdown();
+  try {
+    await p.forceFlush();
+    await p.shutdown();
+  } finally {
+    // Reset the global API state so getTracer() falls back to the API no-op
+    // after shutdown. We deliberately do NOT reset _providerRegistered: the
+    // `provider` above is a module-level const that init can't rebuild, so a
+    // re-init must stay a guarded no-op rather than re-register a torn-down
+    // instance. Shutdown here is process-exit-only.
+    trace.disable();
+    context.disable();
+  }
 }
 
 // Prefer Deno's built-in context manager when running on Deno ≥2.2.
@@ -81,9 +90,9 @@ const getContextManager = () => {
   return new AsyncHooksContextManager();
 };
 
-export function initOpenTelemetry() {
-  if (_providerRegistered || !env.OTEL_ENABLED) {
-    if (!env.OTEL_ENABLED) {
+export function initOpenTelemetry(enabled: boolean = env.OTEL_ENABLED) {
+  if (_providerRegistered || !enabled) {
+    if (!enabled) {
       console.log("OpenTelemetry is disabled via OTEL_ENABLED env var");
     } else {
       console.log("OpenTelemetry already initialized, skipping");


### PR DESCRIPTION
## What

Follow-up cleanups from a post-merge review of #4401 (toolshed + bg-piece-service → SigNoz telemetry). Tracked in CT-1807. Each change is small and independently reviewable; full verification below.

## The one that matters

**toolshed `OTEL_ENABLED=false` silently *enabled* telemetry.** `env.ts` parsed it with `z.coerce.boolean()`, and `Boolean("false") === true`. Because `create-app.ts` gates *both* `initOpenTelemetry()` and the `app.use("*", otelTracing(...))` middleware on `env.OTEL_ENABLED`, setting it to `false` registered the provider **and** mounted the all-routes tracer — exporting every HTTP span. `.env.example` even ships the literal `OTEL_ENABLED=false`, so copying it backfired. #4401 fixed exactly this footgun in bg-piece-service but left it in toolshed, the service it broadened. Now mirrors bg-piece's strict parse (`"true"`/`"1"` enable; `"false"`/unset disable).

## Changes

**toolshed**
- `env.ts`: strict `OTEL_ENABLED` parse (above); export `EnvSchema` for testing.
- `lib/otel.ts`: add `shutdownOpenTelemetry()` (forceFlush + shutdown); `index.ts` calls it inside the existing timeout-guarded `handleShutdown`, so the last span batch isn't dropped on deploy/restart.
- `lib/create-app.ts`: drop the per-span `service.name`/`service.version` — they're OTel **resource** attributes already set on the provider, and the span-level copy even disagreed by default (`"toolshed"` vs `"toolshed-dev"`).

**bg-piece-service**
- `main.ts`: the SIGINT/SIGTERM handler can no longer strand the process — a rejected `stop()`/flush (e.g. collector unreachable, which makes `forceFlush` reject) now logs and **still** `exit(0)`s instead of hanging until the orchestrator SIGKILLs. (`#4401` made `shutdownOpenTelemetry` propagate errors, so the chain needed a terminal `.catch`/`.finally`.)
- `otel.ts`: init/shutdown are now idempotent and re-init-safe — guard on `_provider` and reset the global API state on shutdown, instead of a `_providerRegistered` flag that was never cleared (which made any init-after-shutdown a silent no-op).
- `main.ts`: `initOpenTelemetry()` now uses the injected `dependencies.env`.

**tests**
- `OTEL_ENABLED` parsing for both services (`"false"`/`"0"`/`"no"`/unset → off; `"true"`/`"1"` → on) — the regression #4401 most needed to pin was previously untested.
- bg-piece: re-init after shutdown (would fail under the old `_providerRegistered` guard), and exit-still-happens-when-`stop()`-rejects.

## Deliberately deferred (flagged, not done here — your call)

- **`OTEL_TRACES_SAMPLER` is dead config under Deno.** Verified empirically: the SDK doesn't read it and the provider passes no `Sampler`, so effective sampling is always-on regardless of the documented knobs. I added a code note rather than wiring a sampler, since the design (default semantics, whether to exempt LLM spans from sampling) is yours to make. Worth doing as a small follow-up given this PR's expanded span volume.
- **High-cardinality span names / malformed `http.route`** in `middlewares/opentelemetry.ts` (`routePath` read inside the `"*"` middleware reflects `*`, not the route template). Pre-existing; touches span-name semantics you verified end-to-end, so it deserves its own change with your input.
- **Sibling `z.coerce.boolean()` flags** (`DISABLE_LOG_REQ_RES`, `PLAID_SYNC_ALL_TRANSACTIONS`) share the same trap, but fixing them changes logging/Plaid behavior — out of scope for a telemetry PR.

## Verification

- `deno fmt --check`, `deno check`, `deno lint` clean on all changed files.
- bg-piece: `deno test test/otel.test.ts test/env.test.ts test/service-modules.test.ts` → 11 passed.
- toolshed: `env.test.ts` + `routes/health/health.test.ts` (app-boot sanity for the `create-app` change) → pass.
- The re-init test fails under the pre-change `_providerRegistered` guard and passes after (red/green).
- Production behavior is unchanged when `OTEL_ENABLED` is unset (off) or `true` (on); only the misparse of explicit `"false"` changes.

Context: review notes on #4401 and the full audit are in CT-1807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes telemetry misconfig and strengthens shutdown in `toolshed` and `bg-piece-service` (CT-1807). Prevents accidental tracing when `OTEL_ENABLED=false`, flushes spans on exit, and makes init/shutdown safe and predictable.

- **Bug Fixes**
  - `toolshed`: Strict `OTEL_ENABLED` parsing ("true"/"1" enable; "false"/unset disable). Flush spans on exit via `shutdownOpenTelemetry()` in `handleShutdown`. Removed duplicate per-span `service.*` attributes.
  - `bg-piece-service`: Signal handler now logs stop/flush errors and still exits. `initOpenTelemetry` now uses injected `env`.

- **Refactors**
  - `bg-piece-service`: Idempotent init/shutdown with `_provider` guard; resets global `trace`/`context` on shutdown; supports clean re-init after shutdown.
  - `toolshed`: `initOpenTelemetry(enabled)` is injectable; `shutdownOpenTelemetry()` resets global API state without clearing `_providerRegistered` (re-init stays a guarded no-op). Tests added for `OTEL_ENABLED` parsing (both services), toolshed init/flush/teardown, bg-piece re-init after shutdown, and exit-on-stop failure.

<sup>Written for commit 59ed90f5e4ae89aa203685c2a614f97ce0b64197. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

