### PR TITLE
refactor!: remove the OpaqueRef alias + spelling — the break (CT-1756, 3/3)

### DIFF
--- a/docs/check.vocabulary.json
+++ b/docs/check.vocabulary.json
@@ -51,7 +51,6 @@
     "JSONSchema",
     "JSONValue",
     "LinkScope",
-    "OpaqueRef",
     "Pattern",
     "PerAny",
     "PerSession",

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1246,9 +1246,6 @@ export declare const WriteonlyCell: CellTypeConstructor<AsWriteonlyCell>;
  */
 export type Reactive<T> = T;
 
-/** @deprecated Use {@link Reactive}. */
-export type OpaqueRef<T> = Reactive<T>;
-
 // ============================================================================
 // CellLike and FactoryInput - Utility types for accepting cells
 // ============================================================================

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -826,9 +826,9 @@ export class CommonFabricFormatter implements TypeFormatter {
   }
 
   // Detects the "opaque" cell brand, carried by OpaqueCell<T>. Named for the
-  // brand it matches, not the `Reactive`/`OpaqueRef` annotation spelling: those
-  // are an identity alias for T (no runtime wrapper, no brand), so they cannot
-  // be detected structurally here — only OpaqueCell can.
+  // brand it matches, not the `Reactive` annotation spelling: that is an
+  // identity alias for T (no runtime wrapper, no brand), so it cannot be
+  // detected structurally here — only OpaqueCell can.
   private isOpaqueCellType(type: ts.Type, checker: ts.TypeChecker): boolean {
     return isCellBrand(type, checker, "opaque");
   }

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -30,7 +30,6 @@ const CELL_LIKE_WRAPPER_NAMES = spellingsWhere({
   OpaqueCell: false, // split into OPAQUE_WRAPPER_NAMES (see NB above)
   Stream: false, // handled separately at each call site
   SqliteDb: false, // handled separately at each call site
-  OpaqueRef: false,
   Reactive: false,
   CellTypeConstructor: false,
   ScopedCellTypeConstructor: false,
@@ -44,7 +43,6 @@ const OPAQUE_WRAPPER_NAMES = spellingsWhere({
   ComparableCell: false,
   Stream: false,
   SqliteDb: false,
-  OpaqueRef: false,
   Reactive: false,
   CellTypeConstructor: false,
   ScopedCellTypeConstructor: false,
@@ -55,11 +53,10 @@ function getEntityNameText(name: ts.EntityName): string {
   return ts.isIdentifier(name) ? name.text : name.right.text;
 }
 
-// Spellings that participate in node-level wrapper detection. OpaqueRef (and
-// its successor spelling Reactive) is deliberately excluded: wrapperKindForName
-// has never treated it as a node wrapper, and its callers (Default-literal and
-// type-name resolution) must not start unwrapping it — revisit with the
-// OpaqueRef deprecation.
+// Spellings that participate in node-level wrapper detection. Reactive is
+// deliberately excluded: wrapperKindForName has never treated it as a node
+// wrapper, and its callers (Default-literal and type-name resolution) must not
+// start unwrapping it.
 const NODE_WRAPPER_SPELLINGS: Readonly<Record<WrapperSpelling, boolean>> = {
   Cell: true,
   Writable: true,
@@ -69,7 +66,6 @@ const NODE_WRAPPER_SPELLINGS: Readonly<Record<WrapperSpelling, boolean>> = {
   OpaqueCell: true,
   Stream: true,
   SqliteDb: true,
-  OpaqueRef: false,
   Reactive: false,
   CellTypeConstructor: false,
   ScopedCellTypeConstructor: false,
@@ -427,7 +423,7 @@ export function getNamedTypeKey(
   type: ts.Type,
   typeNode?: ts.TypeNode,
 ): string | undefined {
-  // Check if the TypeNode indicates this is a wrapper type (Default/Cell/Stream/OpaqueRef)
+  // Check if the TypeNode indicates this is a wrapper type (Default/Cell/Stream/Reactive)
   // Even if the type symbol says it's the inner type, if it's wrapped we shouldn't hoist it
   if (typeNode && ts.isTypeReferenceNode(typeNode)) {
     const nodeTypeName = getEntityNameText(typeNode.typeName);
@@ -440,12 +436,12 @@ export function getNamedTypeKey(
     }
   }
 
-  // Check if this is a Default/Cell/Stream/OpaqueRef wrapper type via alias
+  // Check if this is a Default/Cell/Stream/Reactive wrapper type via alias
   const aliasName = (type as TypeWithInternals).aliasSymbol?.name;
   if (
     aliasName === "Default" || CELL_LIKE_WRAPPER_NAMES.has(aliasName ?? "") ||
     aliasName === "Stream" || aliasName === "SqliteDb" ||
-    aliasName === "OpaqueRef" || aliasName === "Reactive"
+    aliasName === "Reactive"
   ) {
     return undefined;
   }

--- a/packages/schema-generator/src/typescript/wrapper-names.ts
+++ b/packages/schema-generator/src/typescript/wrapper-names.ts
@@ -26,7 +26,6 @@ export type WrapperSpelling =
   | "OpaqueCell"
   | "Stream"
   | "SqliteDb"
-  | "OpaqueRef"
   | "Reactive"
   | "CellTypeConstructor"
   | "ScopedCellTypeConstructor";
@@ -46,10 +45,6 @@ export const WRAPPER_SPELLING_TO_KIND = {
   OpaqueCell: "OpaqueCell",
   Stream: "Stream",
   SqliteDb: "SqliteDb",
-  // Deprecated spelling of Reactive. The `OpaqueRef` spelling and its api alias
-  // are removed in CT-1756 stage 3; until then it is classified identically to
-  // Reactive so lingering authored references keep resolving.
-  OpaqueRef: "Reactive",
   Reactive: "Reactive",
   // The interface typing the `Cell` constructor/namespace value (api/index.ts).
   CellTypeConstructor: undefined,

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -70,7 +70,6 @@ const CELL_LIKE_CLASSES = spellingsWhere({
   CellTypeConstructor: true,
   ScopedCellTypeConstructor: true,
   SqliteDb: false,
-  OpaqueRef: false,
   Reactive: false,
 });
 

--- a/packages/ts-transformers/src/transformers/cast-validation.ts
+++ b/packages/ts-transformers/src/transformers/cast-validation.ts
@@ -31,7 +31,6 @@ const CELL_LIKE_TYPE_NAMES = spellingsWhere({
   CellTypeConstructor: true,
   ScopedCellTypeConstructor: false,
   SqliteDb: false,
-  OpaqueRef: false, // error, not warning — see FORBIDDEN_CAST_TYPE_NAMES
   Reactive: false, // error, not warning — see FORBIDDEN_CAST_TYPE_NAMES
 });
 
@@ -40,7 +39,6 @@ const CELL_LIKE_TYPE_NAMES = spellingsWhere({
  * Casting to these types is never allowed.
  */
 const FORBIDDEN_CAST_TYPE_NAMES = spellingsWhere({
-  OpaqueRef: true,
   Reactive: true,
   Cell: false,
   Writable: false,

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -697,7 +697,6 @@ const CELL_LIKE_TYPE_NODE_NAMES = spellingsWhere({
   Cell: true,
   Writable: true,
   OpaqueCell: true,
-  OpaqueRef: true,
   Reactive: true,
   ComparableCell: true,
   ReadonlyCell: true,


### PR DESCRIPTION
Stage 3 of 3 for [CT-1756](https://linear.app/common-tools/issue/CT-1756-remove-opaqueref-entirely-complete-the-reactive-rename) — the **breaking change**. **Stacked on #4422** (→ #4420).

⚠️ **Breaking**: external code importing `OpaqueRef` from `@commonfabric/api` must switch to `Reactive` (identity-equivalent since #3153). Shipped as a hard break per the agreed plan — no deprecation window.

## Removed
- **api**: `export type OpaqueRef<T> = Reactive<T>`.
- **schema-generator**: the `"OpaqueRef"` `WrapperSpelling` member + its kind-mapping row; the `OpaqueRef` keys in the `Record<WrapperSpelling>` classification tables (`type-utils.ts`); the dead `aliasName === "OpaqueRef"` branch.
- **ts-transformers**: the `OpaqueRef` keys in the cast-validation / call-kind / type-shrinking tables.
- **docs**: the vocabulary allowlist entry.

The `WrapperSpelling` removal is **type-enforced** — every classification table is a `Record<WrapperSpelling>`, so the compiler enumerated exactly what to drop.

## Intentionally remains
The only `OpaqueRef` left is **forensic history** — the diagnostics probe + README documenting the retired pre-#3153 `OpaqueRefMethods` shape (and the `OPAQUE_REF_OWNER_NAMES` constant it audits). Accurate history, not a live spelling. Retiring that dead constant is a natural follow-up, out of scope here.

## Verified locally
typecheck, fmt, lint, ts-transformers (342), schema-generator (27), runner targeted, generated-patterns integration (145) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the deprecated `OpaqueRef` alias and spelling in favor of `Reactive`, completing CT-1756. Breaking for any `OpaqueRef` imports from `@commonfabric/api`; no runtime change.

- **Migration**
  - Replace all `OpaqueRef<T>` with `Reactive<T>`.
  - Stop importing `OpaqueRef` from `@commonfabric/api`.
  - Types are identity-equivalent.

- **Refactors**
  - Delete the `OpaqueRef` export in the API.
  - Remove `"OpaqueRef"` from `WrapperSpelling`/`WRAPPER_SPELLING_TO_KIND` and from schema-generator/ts-transformers classification tables.
  - Remove the `OpaqueRef` docs vocabulary allowlist entry.

<sup>Written for commit f71219d8bc65e53501cc4c2b152252ff2b7b3230. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

