### PR TITLE
fix(tasks): run name-filtered integration tests as explicit paths

### DIFF
--- a/tasks/integration.test.ts
+++ b/tasks/integration.test.ts
@@ -1,0 +1,269 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import {
+  buildFilteredTestArgs,
+  findIntegrationTestFiles,
+  integrationTestDir,
+  runFilteredIntegration,
+  runPackageIntegration,
+  selectIntegrationTestFiles,
+} from "./integration.ts";
+
+Deno.test("selectIntegrationTestFiles keeps .test.ts files matching the filter", () => {
+  const files = [
+    "home-profile.test.ts",
+    "counter.test.ts",
+    "home-dashboard.test.ts",
+    "README.md",
+  ];
+  assertEquals(selectIntegrationTestFiles(files, "home"), [
+    "home-dashboard.test.ts",
+    "home-profile.test.ts",
+  ]);
+});
+
+Deno.test("selectIntegrationTestFiles matches a single file by name", () => {
+  const files = ["home-profile.test.ts", "counter.test.ts"];
+  assertEquals(selectIntegrationTestFiles(files, "home-profile"), [
+    "home-profile.test.ts",
+  ]);
+});
+
+Deno.test("selectIntegrationTestFiles returns empty when nothing matches", () => {
+  assertEquals(
+    selectIntegrationTestFiles(["counter.test.ts"], "nonexistent"),
+    [],
+  );
+});
+
+Deno.test("selectIntegrationTestFiles ignores non-test files containing the filter", () => {
+  assertEquals(
+    selectIntegrationTestFiles(
+      ["home.ts", "home.test.ts", "home.test.tsx", "home.txt"],
+      "home",
+    ),
+    ["home.test.ts"],
+  );
+});
+
+Deno.test("selectIntegrationTestFiles sorts the results", () => {
+  assertEquals(
+    selectIntegrationTestFiles(["b.test.ts", "a.test.ts"], ".test.ts"),
+    ["a.test.ts", "b.test.ts"],
+  );
+});
+
+Deno.test("integrationTestDir points generated-patterns at its patterns subdir", () => {
+  assertEquals(
+    integrationTestDir("generated-patterns"),
+    "integration/patterns",
+  );
+});
+
+Deno.test("integrationTestDir defaults to the integration directory", () => {
+  assertEquals(integrationTestDir("patterns"), "integration");
+  assertEquals(integrationTestDir("runner"), "integration");
+  assertEquals(integrationTestDir("shell"), "integration");
+});
+
+Deno.test("findIntegrationTestFiles reads one level deep and filters by name", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await Deno.writeTextFile(`${dir}/home-profile.test.ts`, "");
+    await Deno.writeTextFile(`${dir}/counter.test.ts`, "");
+    await Deno.writeTextFile(`${dir}/notes.txt`, "");
+    // A nested directory and the test file inside it are not descended into.
+    await Deno.mkdir(`${dir}/reload`);
+    await Deno.writeTextFile(`${dir}/reload/home-reload.test.ts`, "");
+
+    assertEquals(await findIntegrationTestFiles(dir, "home"), [
+      "home-profile.test.ts",
+    ]);
+    assertEquals(await findIntegrationTestFiles(dir, ""), [
+      "counter.test.ts",
+      "home-profile.test.ts",
+    ]);
+    assertEquals(await findIntegrationTestFiles(dir, "nope"), []);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("findIntegrationTestFiles returns empty for a missing directory", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    assertEquals(await findIntegrationTestFiles(`${dir}/missing`, "home"), []);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("findIntegrationTestFiles rethrows errors other than a missing directory", async () => {
+  const file = await Deno.makeTempFile();
+  try {
+    // Reading a file as a directory raises NotADirectory, not NotFound.
+    await assertRejects(() => findIntegrationTestFiles(file, "home"));
+  } finally {
+    await Deno.remove(file);
+  }
+});
+
+Deno.test("buildFilteredTestArgs passes files as explicit paths under relDir", () => {
+  assertEquals(
+    buildFilteredTestArgs("runner", "integration", ["a.test.ts", "b.test.ts"]),
+    ["test", "-A", "./integration/a.test.ts", "./integration/b.test.ts"],
+  );
+});
+
+Deno.test("buildFilteredTestArgs adds patterns memory and leak flags", () => {
+  assertEquals(
+    buildFilteredTestArgs("patterns", "integration", ["home-profile.test.ts"]),
+    [
+      "test",
+      "-A",
+      "--v8-flags=--max-old-space-size=4096",
+      "--trace-leaks",
+      "./integration/home-profile.test.ts",
+    ],
+  );
+});
+
+Deno.test("buildFilteredTestArgs uses the generated-patterns subdir and flags", () => {
+  assertEquals(
+    buildFilteredTestArgs(
+      "generated-patterns",
+      "integration/patterns",
+      ["simple-counter.test.ts"],
+    ),
+    [
+      "test",
+      "-A",
+      "--trace-leaks",
+      "--parallel",
+      "./integration/patterns/simple-counter.test.ts",
+    ],
+  );
+});
+
+Deno.test("buildFilteredTestArgs adds a junit path when a junit dir is given", () => {
+  assertEquals(
+    buildFilteredTestArgs("shell", "integration", ["a.test.ts"], "out/junit"),
+    [
+      "test",
+      "-A",
+      "--junit-path=out/junit/shell.xml",
+      "./integration/a.test.ts",
+    ],
+  );
+});
+
+Deno.test("runFilteredIntegration fails without running when no file matches", async () => {
+  const pkgDir = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(`${pkgDir}/integration`);
+    await Deno.writeTextFile(`${pkgDir}/integration/counter.test.ts`, "");
+    let ran = false;
+    const result = await runFilteredIntegration(
+      "runner",
+      pkgDir,
+      {},
+      "no-such-test",
+      undefined,
+      () => {
+        ran = true;
+        return Promise.resolve({ success: true, code: 0 });
+      },
+    );
+    assertEquals(result, { success: false, code: 1 });
+    assertEquals(ran, false);
+  } finally {
+    await Deno.remove(pkgDir, { recursive: true });
+  }
+});
+
+Deno.test("runFilteredIntegration runs deno test with the matching explicit paths", async () => {
+  const pkgDir = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(`${pkgDir}/integration`);
+    await Deno.writeTextFile(`${pkgDir}/integration/home-profile.test.ts`, "");
+    await Deno.writeTextFile(`${pkgDir}/integration/counter.test.ts`, "");
+    let captured: { cmd: string[]; cwd?: string } | undefined;
+    const result = await runFilteredIntegration(
+      "patterns",
+      pkgDir,
+      { LOG_LEVEL: "warn" },
+      "home-profile",
+      undefined,
+      (cmd, options) => {
+        captured = { cmd, cwd: options?.cwd };
+        return Promise.resolve({ success: true, code: 0 });
+      },
+    );
+    assertEquals(result, { success: true, code: 0 });
+    assertEquals(captured?.cwd, pkgDir);
+    assertEquals(captured?.cmd, [
+      "deno",
+      "test",
+      "-A",
+      "--v8-flags=--max-old-space-size=4096",
+      "--trace-leaks",
+      "./integration/home-profile.test.ts",
+    ]);
+  } finally {
+    await Deno.remove(pkgDir, { recursive: true });
+  }
+});
+
+Deno.test("runFilteredIntegration uses the generated-patterns subdir", async () => {
+  const pkgDir = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(`${pkgDir}/integration/patterns`, { recursive: true });
+    await Deno.writeTextFile(
+      `${pkgDir}/integration/patterns/simple-counter.test.ts`,
+      "",
+    );
+    let captured: string[] | undefined;
+    await runFilteredIntegration(
+      "generated-patterns",
+      pkgDir,
+      {},
+      "simple-counter",
+      undefined,
+      (cmd) => {
+        captured = cmd;
+        return Promise.resolve({ success: true, code: 0 });
+      },
+    );
+    assertEquals(captured, [
+      "deno",
+      "test",
+      "-A",
+      "--trace-leaks",
+      "--parallel",
+      "./integration/patterns/simple-counter.test.ts",
+    ]);
+  } finally {
+    await Deno.remove(pkgDir, { recursive: true });
+  }
+});
+
+Deno.test("runPackageIntegration returns false when a filtered run matches nothing", async () => {
+  const rootDir = await Deno.makeTempDir();
+  try {
+    await Deno.mkdir(`${rootDir}/packages/runner/integration`, {
+      recursive: true,
+    });
+    await Deno.writeTextFile(
+      `${rootDir}/packages/runner/integration/counter.test.ts`,
+      "",
+    );
+    const ok = await runPackageIntegration(
+      "runner",
+      "",
+      rootDir,
+      "no-such-test",
+    );
+    assertEquals(ok, false);
+  } finally {
+    await Deno.remove(rootDir, { recursive: true });
+  }
+});

--- a/tasks/integration.ts
+++ b/tasks/integration.ts
@@ -347,6 +347,128 @@ function buildPatternTestJUnit(
   return lines.join("\n");
 }
 
+/**
+ * The directory, relative to a package root, that holds its integration test
+ * files. Most packages keep them directly in `integration/`. The
+ * generated-patterns package keeps them in `integration/patterns/`, matching
+ * the glob its own `integration` task runs.
+ */
+export function integrationTestDir(pkg: string): string {
+  return pkg === "generated-patterns" ? "integration/patterns" : "integration";
+}
+
+/**
+ * Select the integration test files whose name matches a filter.
+ *
+ * Keeps the names ending in `.test.ts` whose name contains the filter
+ * substring, sorted so the order is stable.
+ */
+export function selectIntegrationTestFiles(
+  fileNames: string[],
+  filter: string,
+): string[] {
+  return fileNames
+    .filter((name) => name.endsWith(".test.ts") && name.includes(filter))
+    .sort();
+}
+
+/**
+ * List the integration test files in a directory whose name matches a filter.
+ *
+ * Reads the directory one level deep and returns the matching file names. A
+ * missing directory yields an empty list. Nested directories such as
+ * `integration/reload/` are not descended into, matching the single-level set
+ * the package's `integration` task runs.
+ */
+export async function findIntegrationTestFiles(
+  integrationDir: string,
+  filter: string,
+): Promise<string[]> {
+  const fileNames: string[] = [];
+  try {
+    for await (const entry of Deno.readDir(integrationDir)) {
+      if (entry.isFile) {
+        fileNames.push(entry.name);
+      }
+    }
+  } catch (error) {
+    if (!(error instanceof Deno.errors.NotFound)) {
+      throw error;
+    }
+  }
+  return selectIntegrationTestFiles(fileNames, filter);
+}
+
+/**
+ * Build the `deno test` arguments for a name-filtered integration run. The
+ * matching files are passed as explicit paths under `relDir`. Deno does not
+ * filter explicitly-passed paths through a package `test` config's `exclude`,
+ * so they run even where that config drops the `integration/` directory.
+ */
+export function buildFilteredTestArgs(
+  pkg: string,
+  relDir: string,
+  testFiles: string[],
+  junitDir?: string,
+): string[] {
+  const args = ["test", "-A"];
+
+  if (pkg === "patterns") {
+    args.push("--v8-flags=--max-old-space-size=4096", "--trace-leaks");
+  } else if (pkg === "generated-patterns") {
+    args.push("--trace-leaks", "--parallel");
+  }
+
+  if (junitDir) {
+    args.push(`--junit-path=${path.join(junitDir, `${pkg}.xml`)}`);
+  }
+
+  for (const name of testFiles) {
+    args.push(`./${relDir}/${name}`);
+  }
+
+  return args;
+}
+
+/**
+ * Run a package's integration tests filtered by name.
+ *
+ * Enumerates the matching test files and passes them to `deno test` as explicit
+ * paths. A glob string handed to `deno test` is expanded and then filtered
+ * through the package's `test` config; that config's `exclude` drops the
+ * `integration/` directory, leaving no modules to run. Explicit file paths skip
+ * that filtering, so the files are enumerated here instead of passing a glob.
+ * Returns a failing result, without running anything, when no file matches.
+ */
+export async function runFilteredIntegration(
+  pkg: string,
+  packageDir: string,
+  env: Record<string, string>,
+  filter: string,
+  junitDir?: string,
+  run: typeof runCommand = runCommand,
+): Promise<{ success: boolean; code: number }> {
+  const relDir = integrationTestDir(pkg);
+  const testFiles = await findIntegrationTestFiles(
+    path.join(packageDir, relDir),
+    filter,
+  );
+
+  if (testFiles.length === 0) {
+    console.error(
+      `No integration test files in ${pkg} match filter "${filter}".`,
+    );
+    return { success: false, code: 1 };
+  }
+
+  const args = buildFilteredTestArgs(pkg, relDir, testFiles, junitDir);
+  return await run(["deno", ...args], {
+    cwd: packageDir,
+    env,
+    inheritStdio: true,
+  });
+}
+
 /** Recursively walk a directory yielding file paths. */
 async function* walkDir(dir: string): AsyncGenerator<string> {
   for await (const entry of Deno.readDir(dir)) {
@@ -359,7 +481,7 @@ async function* walkDir(dir: string): AsyncGenerator<string> {
   }
 }
 
-async function runPackageIntegration(
+export async function runPackageIntegration(
   pkg: string,
   apiUrl: string,
   rootDir: string,
@@ -445,28 +567,13 @@ async function runPackageIntegration(
       inheritStdio: true,
     });
   } else if (filter) {
-    // Run with filter - find matching test files
-    const globPattern = `./integration/*${filter}*.test.ts`;
-    const args = ["test", "-A"];
-
-    // Add package-specific flags
-    if (pkg === "patterns") {
-      args.push("--v8-flags=--max-old-space-size=4096", "--trace-leaks");
-    } else if (pkg === "generated-patterns") {
-      args.push("--trace-leaks", "--parallel");
-    }
-
-    // Add JUnit output if --junit-dir was specified
-    if (junitDir) {
-      args.push(`--junit-path=${path.join(junitDir, `${pkg}.xml`)}`);
-    }
-
-    args.push(globPattern);
-    result = await runCommand(["deno", ...args], {
-      cwd: packageDir,
+    result = await runFilteredIntegration(
+      pkg,
+      packageDir,
       env,
-      inheritStdio: true,
-    });
+      filter,
+      junitDir,
+    );
   } else {
     // Run the standard integration task
     result = await runCommand(["deno", "task", "integration"], {
@@ -777,7 +884,9 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((error) => {
-  console.error("Integration run failed:", error);
-  Deno.exit(1);
-});
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error("Integration run failed:", error);
+    Deno.exit(1);
+  });
+}


### PR DESCRIPTION
A name-filtered integration run, such as `deno task integration patterns home-profile`, started the dev servers fine and then reported `No test modules found`, never executing the test (Passed: 0/1).

The name-filter branch of the integration runner built a glob string, `./integration/*<filter>*.test.ts`, and passed it as a single argument to `deno test` through Deno.Command. Because Deno.Command runs no shell, Deno itself expanded the glob and then filtered the expanded files through the package's `deno.jsonc` `test` configuration. The patterns package recently gained a `test` config whose `exclude` drops every `integration/` directory (so the workspace `Test` job's plain `.test.ts` unit-test lane does not pick up the browser-driven integration suites). That `exclude` removed all of the glob's matches, leaving zero modules to run.

The unfiltered run was unaffected because it delegates to the package's own `integration` task, where `deno task` expands the glob into explicit paths before Deno sees it. Deno does not filter explicitly-passed paths through `exclude`, so those kept running. Only the name-filtered path, which handed a literal glob to `deno test`, was broken.

Stop passing a glob string. Enumerate the matching files directly: read the package's `integration/` directory one level deep, keep the `.test.ts` files whose name contains the filter substring, and pass them as explicit path arguments. This reproduces the single-level file set the package's `integration` task already runs and bypasses the `exclude`, which is how the unfiltered path already succeeds. The matching is a pure, exported `selectIntegrationTestFiles` helper with unit coverage, and `main()` is now guarded by `import.meta.main` so the helper can be imported by a test without launching the runner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes name-filtered integration runs by passing explicit test paths and handling package-specific test dirs and flags. `deno task integration <pkg> <filter>` now reliably runs matching tests, including in `generated-patterns`, even with `test.exclude`.

- **Bug Fixes**
  - Enumerate matching `.test.ts` files one level deep and pass explicit paths; resolve the test dir per package (`integration/` by default, `generated-patterns` uses `integration/patterns/`) to avoid misses and bypass `test.exclude`.
  - Build `deno test` args per package: `patterns` adds `--v8-flags=--max-old-space-size=4096` and `--trace-leaks`; `generated-patterns` adds `--trace-leaks --parallel`; include `--junit-path` when a JUnit dir is given.
  - Extracted helpers with unit tests (dir resolution, discovery incl. missing dir, arg building, no‑match); name-filter branch now delegates; `main()` guarded by `import.meta.main`; empty matches print a clear message.

<sup>Written for commit 7f2ce7ff1ea5d86578ffb74bb80a7cf2a3b57504. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

