### PR TITLE
fix(scheduler): park event handlers on in-flight cross-space state loads (CT-1795)

### DIFF
--- a/packages/runner/src/scheduler/pull-events.ts
+++ b/packages/runner/src/scheduler/pull-events.ts
@@ -11,6 +11,12 @@ const logger = getLogger("scheduler", {
   level: "warn",
 });
 
+// CT-1795: upper bound on how many times one event may park waiting for a
+// cross-space load (kicked by its own handler state) to settle. Each park costs
+// one settle cycle; the common case resolves in 1. The bound guarantees forward
+// progress if loads churn or a value legitimately never resolves.
+const MAX_CROSS_SPACE_LOAD_PARKS = 8;
+
 export async function processPullQueuedEventDuringExecute(
   state: SchedulerEventExecutionState,
   eventBlockingDeps: Set<Action>,
@@ -51,6 +57,15 @@ export async function processPullQueuedEventDuringExecute(
 
   const { handler } = queuedEvent;
   const handlerId = state.getActionId(handler);
+
+  // CT-1795: record the cross-space load count before this event's handler
+  // chain runs, so the park below only fires for loads THIS event kicked (not
+  // pre-existing / unrelated in-flight loads). Set once; preserved across
+  // re-processing while the event stays parked at the queue head.
+  if (queuedEvent.crossSpaceLoadBaseline === undefined) {
+    queuedEvent.crossSpaceLoadBaseline =
+      state.runtime.storageManager.pendingCrossSpacePromiseCount?.() ?? 0;
+  }
 
   // Ensure handler dependencies are computed before running.
   let shouldSkipEvent = false;
@@ -106,6 +121,35 @@ export async function processPullQueuedEventDuringExecute(
   }
 
   if (shouldSkipEvent) return;
+
+  // CT-1795: the preflight above pulled this handler's bound state, but a value
+  // derived from an async cross-space read (e.g. a #profileName wish behind a
+  // plain-value computed arg, read by the handler only) resolves to its
+  // un-loaded default on the first pass: the wish node runs and settles while
+  // its cross-space load is still in flight, so it is not a dirty dependency and
+  // nothing keeps the event parked. If pulling the state pushed the cross-space
+  // load count above this event's baseline, park until those loads settle and
+  // the producing chain re-runs — so the FIRST handler invocation observes the
+  // resolved value instead of the empty default. Bounded and baseline-scoped:
+  // unrelated in-flight loads do not delay this event, and a value that stays
+  // empty still dispatches once the bound is reached.
+  const storage = state.runtime.storageManager;
+  const pendingLoads = storage.pendingCrossSpacePromiseCount?.() ?? 0;
+  const loadBaseline = queuedEvent.crossSpaceLoadBaseline ?? 0;
+  if (
+    pendingLoads > loadBaseline &&
+    (queuedEvent.crossSpaceLoadParks ?? 0) < MAX_CROSS_SPACE_LOAD_PARKS
+  ) {
+    // Only park if we obtain a settle promise to wake on — never park without a
+    // wake (a backend lacking cross-space tracking already reports 0 pending).
+    const settled = storage.crossSpaceSettled?.();
+    if (settled) {
+      queuedEvent.crossSpaceLoadParks = (queuedEvent.crossSpaceLoadParks ?? 0) +
+        1;
+      void settled.then(() => state.queueExecution());
+      return;
+    }
+  }
 
   await dispatchQueuedEvent({
     runtime: state.runtime,

--- a/packages/runner/src/scheduler/pull-events.ts
+++ b/packages/runner/src/scheduler/pull-events.ts
@@ -4,7 +4,7 @@ import {
   preflightQueuedEventDependencies,
   type SchedulerEventExecutionState,
 } from "./events.ts";
-import type { Action } from "./types.ts";
+import type { Action, QueuedEvent } from "./types.ts";
 
 const logger = getLogger("scheduler", {
   enabled: true,
@@ -16,6 +16,20 @@ const logger = getLogger("scheduler", {
 // one settle cycle; the common case resolves in 1. The bound guarantees forward
 // progress if loads churn or a value legitimately never resolves.
 const MAX_CROSS_SPACE_LOAD_PARKS = 8;
+
+// CT-1795: backstop deadline for a single cross-space park. The settle promise
+// normally wakes the event well before this; the deadline only ensures a hung
+// load still dispatches (and that `idle()` has a wake timer to track the wait).
+const CROSS_SPACE_LOAD_BACKSTOP_MS = 2000;
+
+// CT-1795 per-event cross-space park bookkeeping, keyed by the queued event so it
+// survives re-processing and is GC'd with the event. `baseline` is the in-flight
+// cross-space load count captured before the event's handler chain ran (scopes
+// the park to loads THIS event kicked); `parks` counts parks so far (bounded).
+const crossSpaceParkState = new WeakMap<
+  QueuedEvent,
+  { baseline: number; parks: number }
+>();
 
 export async function processPullQueuedEventDuringExecute(
   state: SchedulerEventExecutionState,
@@ -60,11 +74,16 @@ export async function processPullQueuedEventDuringExecute(
 
   // CT-1795: record the cross-space load count before this event's handler
   // chain runs, so the park below only fires for loads THIS event kicked (not
-  // pre-existing / unrelated in-flight loads). Set once; preserved across
+  // pre-existing / unrelated in-flight loads). Captured once; preserved across
   // re-processing while the event stays parked at the queue head.
-  if (queuedEvent.crossSpaceLoadBaseline === undefined) {
-    queuedEvent.crossSpaceLoadBaseline =
-      state.runtime.storageManager.pendingCrossSpacePromiseCount?.() ?? 0;
+  let parkState = crossSpaceParkState.get(queuedEvent);
+  if (parkState === undefined) {
+    parkState = {
+      baseline:
+        state.runtime.storageManager.pendingCrossSpacePromiseCount?.() ?? 0,
+      parks: 0,
+    };
+    crossSpaceParkState.set(queuedEvent, parkState);
   }
 
   // Ensure handler dependencies are computed before running.
@@ -128,25 +147,42 @@ export async function processPullQueuedEventDuringExecute(
   // un-loaded default on the first pass: the wish node runs and settles while
   // its cross-space load is still in flight, so it is not a dirty dependency and
   // nothing keeps the event parked. If pulling the state pushed the cross-space
-  // load count above this event's baseline, park until those loads settle and
-  // the producing chain re-runs — so the FIRST handler invocation observes the
-  // resolved value instead of the empty default. Bounded and baseline-scoped:
-  // unrelated in-flight loads do not delay this event, and a value that stays
-  // empty still dispatches once the bound is reached.
+  // load count above this event's baseline, park the head event until those
+  // loads settle and the producing chain re-runs — so the FIRST handler
+  // invocation observes the resolved value instead of the empty default.
+  // Baseline-scoped (unrelated in-flight loads do not delay this event) and
+  // bounded (a value that stays empty still dispatches once the bound is hit).
   const storage = state.runtime.storageManager;
   const pendingLoads = storage.pendingCrossSpacePromiseCount?.() ?? 0;
-  const loadBaseline = queuedEvent.crossSpaceLoadBaseline ?? 0;
   if (
-    pendingLoads > loadBaseline &&
-    (queuedEvent.crossSpaceLoadParks ?? 0) < MAX_CROSS_SPACE_LOAD_PARKS
+    pendingLoads > parkState.baseline &&
+    parkState.parks < MAX_CROSS_SPACE_LOAD_PARKS
   ) {
     // Only park if we obtain a settle promise to wake on — never park without a
     // wake (a backend lacking cross-space tracking already reports 0 pending).
     const settled = storage.crossSpaceSettled?.();
     if (settled) {
-      queuedEvent.crossSpaceLoadParks = (queuedEvent.crossSpaceLoadParks ?? 0) +
-        1;
-      void settled.then(() => state.queueExecution());
+      parkState.parks += 1;
+      // Genuinely park the head via the queue-wake deadline (the same mechanism
+      // throttled deps use), so `idle()` accounts for the wait and the event is
+      // skipped — not re-preflighted — on every re-entry until it wakes. The
+      // settle promise wakes it early as soon as the cross-space load lands; the
+      // deadline is only a backstop so a hung load still dispatches.
+      const wakeAt = performance.now() + CROSS_SPACE_LOAD_BACKSTOP_MS;
+      queuedEvent.notBefore = wakeAt;
+      state.scheduleEventQueueWake(wakeAt);
+      void settled.then(() => {
+        // Wake as soon as the load settles instead of waiting out the backstop.
+        // Bring the deadline forward (rather than just clearing notBefore) so
+        // scheduleEventQueueWake cancels the backstop timer — leaving it armed
+        // would dangle a 2s timer past the event. Guard on `wakeAt` so a later
+        // re-park's deadline is left intact.
+        if (queuedEvent.notBefore === wakeAt) {
+          const now = performance.now();
+          queuedEvent.notBefore = now;
+          state.scheduleEventQueueWake(now);
+        }
+      });
       return;
     }
   }

--- a/packages/runner/src/scheduler/types.ts
+++ b/packages/runner/src/scheduler/types.ts
@@ -210,6 +210,19 @@ export type QueuedEvent = {
   onCommit?: (tx: IExtendedStorageTransaction) => void;
   notBefore?: number;
   /**
+   * Pending cross-space load count observed when this event first started
+   * processing, before its handler's dependency chain ran. Used to scope the
+   * CT-1795 cross-space park to loads THIS event kicked (vs. pre-existing /
+   * unrelated in-flight loads). Set once, carried across re-processing.
+   */
+  crossSpaceLoadBaseline?: number;
+  /**
+   * Number of times this event has been parked waiting for a cross-space load
+   * kicked by its own state to settle (CT-1795). Bounded so a value that
+   * legitimately stays empty (e.g. the viewer has no profile) still dispatches.
+   */
+  crossSpaceLoadParks?: number;
+  /**
    * Number of transient commit failures this intent has hit. Drives the
    * exponential backoff exponent; carried across backoff retries. Covers every
    * transient commit failure, not only conflicts.

--- a/packages/runner/src/scheduler/types.ts
+++ b/packages/runner/src/scheduler/types.ts
@@ -210,19 +210,6 @@ export type QueuedEvent = {
   onCommit?: (tx: IExtendedStorageTransaction) => void;
   notBefore?: number;
   /**
-   * Pending cross-space load count observed when this event first started
-   * processing, before its handler's dependency chain ran. Used to scope the
-   * CT-1795 cross-space park to loads THIS event kicked (vs. pre-existing /
-   * unrelated in-flight loads). Set once, carried across re-processing.
-   */
-  crossSpaceLoadBaseline?: number;
-  /**
-   * Number of times this event has been parked waiting for a cross-space load
-   * kicked by its own state to settle (CT-1795). Bounded so a value that
-   * legitimately stays empty (e.g. the viewer has no profile) still dispatches.
-   */
-  crossSpaceLoadParks?: number;
-  /**
    * Number of transient commit failures this intent has hit. Drives the
    * exponential backoff exponent; carried across backoff retries. Covers every
    * transient commit failure, not only conflicts.

--- a/packages/runner/test/scheduler-pull-handlers.test.ts
+++ b/packages/runner/test/scheduler-pull-handlers.test.ts
@@ -1156,4 +1156,98 @@ describe("handler dependency pulling", () => {
       "handlerB:lift=10",
     );
   });
+
+  it("parks a handler event on an in-flight cross-space load kicked by its state, then dispatches once it settles (CT-1795)", async () => {
+    // CT-1795: a handler-only-read value derived from an async cross-space wish
+    // resolves to its un-loaded default if the handler runs while the load is
+    // still in flight. The scheduler must park the event until the load settles.
+    // The cold-replica race can't be reproduced with the in-process emulated
+    // backend (it pre-syncs), so we drive the park directly: stub the storage
+    // manager's cross-space tracking so a preflight read "kicks" one in-flight
+    // load whose settle we control, and assert the handler does not run until it
+    // settles — including that unrelated execute passes do not spin the parked
+    // head or burn the park budget.
+    const eventStream = runtime.getCell<number>(
+      space,
+      "crossspace-park-events",
+      undefined,
+      tx,
+    );
+    eventStream.set(0);
+    const result = runtime.getCell<number>(
+      space,
+      "crossspace-park-result",
+      undefined,
+      tx,
+    );
+    result.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    const storage = runtime.storageManager as unknown as {
+      pendingCrossSpacePromiseCount: () => number;
+      crossSpaceSettled: () => Promise<void>;
+    };
+    const origPending = storage.pendingCrossSpacePromiseCount;
+    const origSettled = storage.crossSpaceSettled;
+    let pending = 0;
+    let resolveSettle: () => void = () => {};
+    storage.pendingCrossSpacePromiseCount = () => pending;
+    storage.crossSpaceSettled = () =>
+      new Promise<void>((resolve) => {
+        resolveSettle = resolve;
+      });
+
+    try {
+      let handlerRuns = 0;
+      const eventHandler: EventHandler = (handlerTx, event: number) => {
+        handlerRuns++;
+        result.withTx(handlerTx).send(event);
+      };
+      // The first preflight read kicks one cross-space load (pending 0 -> 1); it
+      // stays in flight until we settle it. Later passes do not re-kick.
+      let kicked = false;
+      const populateDependencies = (depTx: IExtendedStorageTransaction) => {
+        result.withTx(depTx).get();
+        if (!kicked) {
+          kicked = true;
+          pending = 1;
+        }
+      };
+
+      runtime.scheduler.addEventHandler(
+        eventHandler,
+        eventStream.getAsNormalizedFullLink(),
+        populateDependencies,
+      );
+
+      // While parked, the head event is pending work without a runnable wake, so
+      // `idle()` would block; poll with a timer instead (as the throttle-park
+      // test does), then `idle()` once the load settles and it can dispatch.
+      const tick = () => new Promise((resolve) => setTimeout(resolve, 40));
+
+      runtime.scheduler.queueEvent(eventStream.getAsNormalizedFullLink(), 7);
+      await tick();
+
+      // Parked on the in-flight load — the handler must not have run yet.
+      expect(handlerRuns).toBe(0);
+
+      // An unrelated execute pass must not spin the parked head or dispatch it.
+      runtime.scheduler.queueExecution();
+      await tick();
+      expect(handlerRuns).toBe(0);
+
+      // Settle the cross-space load: the wake re-queues the event, which now
+      // dispatches with the resolved state.
+      pending = 0;
+      resolveSettle();
+      await runtime.scheduler.idle();
+
+      expect(handlerRuns).toBe(1);
+      expect(await result.pull()).toBe(7);
+    } finally {
+      storage.pendingCrossSpacePromiseCount = origPending;
+      storage.crossSpaceSettled = origSettled;
+    }
+  });
 });


### PR DESCRIPTION
## Why?
In `lunch-poll`, clicking **Join** with the name box empty no-ops on the first click and only joins on the second (timing-independent); typing a name joins on the first click. The viewer's name comes from a cross-space `#profileName` wish, passed to the join handler as plain-value state.

This isn't just one pattern's quirk. Passing a profile-derived `computed` as plain handler state is the **documented, recommended idiom** (`docs/specs/shared-profile-rosters.md`: *"the CTS transformer auto-unwraps named computed values when used as handler state… do not call `.get()` on them"*). The reference demos (`profile-roster-live-demo`, `shared-profile-roster`) use it and only dodge the bug by *happening* to read the value in a UI label, which eagerly loads it. So the idiom is a silent footgun: whether a join works depends on an unrelated UI read. Fixing it in the runtime makes the idiom reliable everywhere instead of pushing a "remember to also read it in the UI" rule onto every pattern author.

## Root cause (corrects the original triage)
The original analysis blamed the auto-unwrapped computed arg never being registered as a pull dependency. **That's not what happens** — verified by instrumentation: the arg is delivered as a *write-redirect* link, **is** collected by `collectArgumentSchedulerReadLinks`, and its producing computed **is** pulled in preflight. A fix there would have been a no-op.

The real gap is downstream, in the wish's **async cross-space load**:
- The wish is pull-on-demand (`raw(wish, { debounce })`, not `isEffect`), so with no eager reader it first runs during the **first click's preflight**.
- `subscribeProfileName` (`builtins/wish.ts`) kicks a **fire-and-forget** `void cell.pull()` of the cross-space `initialNameApplied`, then reads it **synchronously** → `""` on a cold replica.
- The wish node *runs and settles* (writing `""`) while its load is still in flight, so it's not a dirty dependency — nothing keeps the event parked. The handler dispatches with `""`; the load lands afterward, priming the second click.

## The fix
Realize Berni's "pull the state part with the right schema" via the scheduler's existing **park** machinery. (Pulling the state inline in `presyncInputs` would re-enter `scheduler.idle()` mid-dispatch and **deadlock**.) When an event is about to dispatch, if pulling its handler state pushed the in-flight cross-space load count above this event's baseline, park until `crossSpaceSettled()` and re-process — so the chain re-runs and the **first** invocation sees the resolved value.

- **Baseline-scoped** — pre-existing / unrelated in-flight loads never delay the event.
- **Bounded** (`MAX_CROSS_SPACE_LOAD_PARKS = 8`) — a value that legitimately stays empty (no profile) still dispatches.
- **No re-entrancy** — returns to the execute loop and wakes on settle, like the existing throttle park.

51-line diff: `scheduler/pull-events.ts` + `scheduler/types.ts`.

## For review (scheduler-pull owner — @seefeldb)
These are design calls in your subsystem:
1. **Locus** — park on the load here, vs. modeling an in-flight cross-space load as node dirtiness so the normal dirty-dep park covers it.
2. **Scoping** — the baseline + global `pendingCrossSpacePromiseCount` heuristic (vs. precisely attributing loads to this handler's reads).
3. **Bound** — `MAX_CROSS_SPACE_LOAD_PARKS`.

## Validation
- ✅ **Browser-validated**: empty-box Join flips from two clicks → one (deployed lunch-poll on a local server with the fix; reproduced under real cold-replica latency).
- ✅ Full runner unit suite: 723 files / 3558 steps green. fmt + lint clean.
- ⚠️ **No automated regression test.** The race needs real cold-replica latency; in-process emulated storage pre-syncs cross-space (verified: single- and two-runtime both deliver on the first send). A deterministic test would require storage-latency injection — happy to do that as a follow-up.

Closes CT-1795 — https://linear.app/common-tools/issue/CT-1795

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where handlers read empty cross-space state on first run. Events now park until their own cross-space loads settle, so lunch-poll Join works on the first click. Fixes CT-1795.

- **Bug Fixes**
  - Genuinely park the queue head via `notBefore` with a 2s backstop; wake early on `crossSpaceSettled()` and pull the deadline forward so unrelated executes don’t spin it.
  - Park only when this event’s preflight raised `pendingCrossSpacePromiseCount` above its baseline; no re-entrancy (uses the existing execute loop).
  - Track per-event baseline and park count in a WeakMap keyed by the queued event; cap parks at 8. Added a regression test that stubs cross-space tracking and verifies park/wake and no spinning.

<sup>Written for commit 19fdb0d0369a207e9aff737aa79388519f0af3c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





---

<!-- perf-baseline: Runner Tests (1/5) recalibration -->
**CI note — Perf Check baseline recalibration (approved by Ian / CI owner):** the runner-test shards are split round-robin over the alphabetically-sorted filenames, so adding test files (#4391 + this PR) reshuffled which files land in shard 1/5, moving a heavy file into it. Per-shard on this run: 1/5 +88s, but 2/5–4/5 −120s → **total runner test time is flat (−3%)** — a redistribution, not a slowdown (this PR's own new test runs in 0.7s). The marker below recalibrates shard 1/5's stale per-shard baseline to its new composition. Systemic fix (time-weighted split) is tracked separately.

NEW_PERF_BASELINE: job: Runner Tests (1/5) = 231s
