### PR TITLE
docs(state-inspector): mark process-cell legacy support for retirement

### DIFF
--- a/packages/state-inspector/detail.ts
+++ b/packages/state-inspector/detail.ts
@@ -125,7 +125,12 @@ function importSpecifier(v: unknown): string | undefined {
   return undefined;
 }
 
-/** The `resultRef` target of a legacy process cell (`{ $TYPE, resultRef, … }`). */
+/**
+ * The `resultRef` target of a legacy process cell (`{ $TYPE, resultRef, … }`).
+ * LEGACY-PROCESS-CELL: this and `legacyName` (plus their `regime === "legacy"`
+ * callers below) retire with the closed process-cell era — see the retirement
+ * note at the top of model.ts for the full removal checklist.
+ */
 function legacyResultId(v: unknown): string | undefined {
   if (isObj(v) && "$TYPE" in v && "resultRef" in v) {
     return parseSigilLink(v.resultRef)?.id;

--- a/packages/state-inspector/model.ts
+++ b/packages/state-inspector/model.ts
@@ -24,6 +24,32 @@
 //   legacy (pre-#3522) — a separate process cell whose `value` carries
 //     { $TYPE, resultRef, … }; the result cell links to it via `source`.
 // We classify both; modern is the verified path, legacy is best-effort.
+//
+// ┌─ LEGACY-PROCESS-CELL — retirement note (grep this tag to find every site) ─┐
+// The `legacy`/process-cell era (`$TYPE` / `spell` / `resultRef` pieces) is a
+// CLOSED format: it is only emitted by stores written before the spell→
+// patternIdentity flip (#3522, then the runtime cutover ~2026-06; no space mixes
+// the two). Once such stores have aged out of every cache/box we inspect, ALL of
+// this support can be deleted — it is dead weight on a tool that only ever reads
+// fresh data. We keep it now solely to read old DBs faithfully (and label them
+// honestly as "legacy process").
+//
+// To retire it, grep `LEGACY-PROCESS-CELL` and delete each marked site:
+//   • model.ts   — `isLegacyProcessValue`, the two `regime: "legacy"` branches in
+//                  `classifyDocument`, `lineage.source`, and collapse `Regime`
+//                  to `"modern" | "n/a"` (drop the union member + its consumers).
+//   • detail.ts  — `legacyResultId`, `legacyName`, and the `regime === "legacy"`
+//                  branches that call them.
+// That is the WHOLE surface — it is intentionally confined to classification
+// (model.ts) and rendering (detail.ts).
+//
+// Do NOT remove the other two, UNRELATED "legacy" axes when you do this; they
+// retire on their own (different) timelines:
+//   • decode.ts  — at-rest codec routing (`fvj1:` envelope vs plain-JSON sigil
+//                  links). A serialization concern, orthogonal to process cells.
+//   • db.ts / reconstruct.ts — DBs lacking branch/snapshot/scope_key tables
+//                  (`hasTable`, the scope_key shim). A schema-migration concern.
+// └────────────────────────────────────────────────────────────────────────────┘
 
 import type { SpaceDb } from "./db.ts";
 import { countLinks, parseSigilLink, summarize } from "./decode.ts";
@@ -39,6 +65,8 @@ export type EntityKind =
   | "free-cell" // a standalone cell, owned by no piece
   | "unknown";
 
+// LEGACY-PROCESS-CELL: `"legacy"` collapses out when the process-cell era is
+// retired, leaving `"modern" | "n/a"` (see top-of-file retirement note).
 export type Regime = "modern" | "legacy" | "n/a";
 
 export type ValueShape =
@@ -61,7 +89,10 @@ export interface Lineage {
   owner?: string;
   /** Owned child cell ids — a piece's `internal` manifest. */
   internal?: string[];
-  /** Legacy process/source cell link target. */
+  /**
+   * Legacy process/source cell link target.
+   * LEGACY-PROCESS-CELL: removed with the process-cell era (top-of-file note).
+   */
   source?: string;
 }
 
@@ -134,7 +165,11 @@ function isPieceResultValue(v: unknown): boolean {
   return isObj(v) && ("$UI" in v || "$NAME" in v || "$TILE_UI" in v);
 }
 
-/** A legacy process cell value: `{ $TYPE, resultRef|spell|source, … }`. */
+/**
+ * A legacy process cell value: `{ $TYPE, resultRef|spell|source, … }`.
+ * LEGACY-PROCESS-CELL: delete with the closed process-cell era (see top-of-file
+ * retirement note).
+ */
 function isLegacyProcessValue(
   v: unknown,
 ): v is {
@@ -215,6 +250,8 @@ export function classifyDocument(doc: EntityDocument): Classification {
       lineage,
     };
   }
+  // LEGACY-PROCESS-CELL: both `regime: "legacy"` branches below retire together
+  // with the closed process-cell era (see top-of-file retirement note).
   // Legacy: a process cell carries `{ $TYPE, resultRef, … }`.
   if (isLegacyProcessValue(value)) {
     lineage.source = linkId(value.resultRef) ?? linkId(value.source);


### PR DESCRIPTION
## Why

A colleague reviewing a `cf inspect` report noticed everything looked like the *old* organization — `$TYPE`, `spell`, named internals. It was: that space was last written **2026-05-04**, before the `spell`→`patternIdentity` process-cell flip (#3522, runtime cutover ~2026-06). The tool reads it faithfully and labels it "legacy process" — working as intended.

But it surfaced a real point: **this support is temporary.** The process-cell format is a closed era — only pre-flip stores carry it, no space mixes the two. Once those DBs age out of every cache/box we inspect, all of this is dead weight on a tool that only reads fresh data. We should make that future deletion *trivial* and say so next to the code.

## What

Comment-only. No behaviour change.

- **One canonical retirement note** at the top of `model.ts` with the full removal checklist (which symbols/branches go; `Regime` collapses to `"modern" | "n/a"`).
- **A greppable `LEGACY-PROCESS-CELL` tag** on every site so the whole surface is one `grep` away. It is intentionally confined to two files: classification (`model.ts`) and rendering (`detail.ts`).
- **An explicit fence**: the two *unrelated* "legacy" axes — `decode.ts` at-rest codec routing (`fvj1:` vs plain-JSON sigils) and `db.ts`/`reconstruct.ts` schema shims (DBs lacking branch/snapshot/scope_key) — retire on their own timelines and must **not** be ripped out together.

## To retire it later

```
grep -rn LEGACY-PROCESS-CELL packages/state-inspector
```
…then delete each marked site per the checklist in `model.ts`.

Package tests green (21 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks legacy process-cell (`$TYPE`/`spell`/`resultRef`) support in `packages/state-inspector` for future removal with a clear retirement note and greppable tags. No behavior change.

- **Refactors**
  - Add top-of-file retirement note in `model.ts` with the removal checklist and that `Regime` collapses to `"modern" | "n/a"`.
  - Tag all sites with `LEGACY-PROCESS-CELL`; scope limited to `model.ts` (classification) and `detail.ts` (rendering).
  - Fence off unrelated legacy paths in `decode.ts` (codec routing) and `db.ts`/`reconstruct.ts` (schema shims) to avoid accidental removal.

<sup>Written for commit e11c31c35e143215adbcccf4353f81bd9350fe5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

