### PR TITLE
feat(telemetry): wire sampler, fix span-route cardinality, strict bool flags

### DIFF
--- a/packages/toolshed/.env.example
+++ b/packages/toolshed/.env.example
@@ -16,7 +16,10 @@ OTEL_ENABLED=false
 OTEL_SERVICE_NAME=toolshed-dev
 # OpenTelemetry collector endpoint (local collector; do not point directly at SigNoz)
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
-# Sampling configuration
+# Sampling configuration. Supported: always_on (default), always_off,
+# traceidratio, parentbased_always_on, parentbased_always_off,
+# parentbased_traceidratio. OTEL_TRACES_SAMPLER_ARG is the ratio (0.0-1.0) for
+# the *ratio variants. A ratio below 1.0 also thins LLM spans sent to Phoenix.
 OTEL_TRACES_SAMPLER=always_on
 OTEL_TRACES_SAMPLER_ARG=1.0
 

--- a/packages/toolshed/env.test.ts
+++ b/packages/toolshed/env.test.ts
@@ -19,3 +19,21 @@ Deno.test("OTEL_ENABLED parses strictly: only 'true'/'1' enable telemetry", () =
   // Unset must default to off.
   assertEquals(otel(undefined), false);
 });
+
+// The sibling boolean flags shared the same z.coerce.boolean() trap and now use
+// the strict boolFlag() parse. Guard them so they can't silently regress.
+Deno.test("DISABLE_LOG_REQ_RES / PLAID_SYNC_ALL_TRANSACTIONS parse strictly", () => {
+  const flag = (key: string, v: string | undefined) =>
+    (EnvSchema.parse(v === undefined ? {} : { [key]: v }) as Record<
+      string,
+      unknown
+    >)[key];
+
+  for (const key of ["DISABLE_LOG_REQ_RES", "PLAID_SYNC_ALL_TRANSACTIONS"]) {
+    assertEquals(flag(key, "true"), true);
+    assertEquals(flag(key, "1"), true);
+    assertEquals(flag(key, "false"), false); // previously coerced to true
+    assertEquals(flag(key, "0"), false);
+    assertEquals(flag(key, undefined), false);
+  }
+});

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -28,6 +28,17 @@ function flagValue() {
   });
 }
 
+/**
+ * Strict boolean env flag: only "true"/"1" enable; "false", unset, or anything
+ * else disable. Avoids z.coerce.boolean()'s footgun where `Boolean("false")` is
+ * `true`, which would turn a flag ON when the operator set it to "false".
+ */
+function boolFlag() {
+  return z.string().default("false").transform((v) =>
+    v === "true" || v === "1"
+  );
+}
+
 // NOTE: This is where we define the environment variable types and defaults.
 // Exported so the parsing rules (e.g. OTEL_ENABLED) can be unit-tested without
 // going through the module-level singleton below.
@@ -44,26 +55,25 @@ export const EnvSchema = z.object({
     "trace",
     "silent",
   ]).default("info"),
-  DISABLE_LOG_REQ_RES: z.coerce.boolean().default(false),
+  // Strict parse (see boolFlag): DISABLE_LOG_REQ_RES=false now means "log req/res",
+  // matching operator intent. Previously z.coerce.boolean() turned "false" into true.
+  DISABLE_LOG_REQ_RES: boolFlag(),
   CACHE_DIR: z.string().default("./cache"),
 
   // ===========================================================================
   // OpenTelemetry Configuration
   // ===========================================================================
-  // NOT z.coerce.boolean(): Boolean("false") === true, so OTEL_ENABLED=false
-  // would wrongly enable telemetry (and, with the all-span exporter, start
-  // shipping every HTTP request span). Mirror bg-piece-service's strict parse so
-  // only "true"/"1" enable it and "false"/unset disable it.
-  OTEL_ENABLED: z.string().default("false").transform((v) =>
-    v === "true" || v === "1"
-  ),
+  // Strict parse (see boolFlag): only "true"/"1" enable telemetry; "false"/unset
+  // disable it. z.coerce.boolean() would wrongly enable on the string "false".
+  OTEL_ENABLED: boolFlag(),
   OTEL_SERVICE_NAME: z.string().default("toolshed"),
   OTEL_EXPORTER_OTLP_ENDPOINT: z.string().default("http://localhost:4318"),
-  // NOTE: these sampler knobs are currently NOT honored. lib/otel.ts builds the
-  // provider without a Sampler, and the OTel JS SDK does not auto-read
-  // OTEL_TRACES_SAMPLER from the environment under Deno (verified empirically),
-  // so effective sampling is always-on regardless of these values. Left declared
-  // pending a decision to either wire a Sampler from them or drop them.
+  // Wired into the provider in lib/otel.ts via samplerFromEnv(). The OTel JS SDK
+  // does not auto-read these from the environment under Deno, so we build the
+  // Sampler explicitly. Supported values: always_on (default), always_off,
+  // traceidratio, parentbased_always_on, parentbased_always_off,
+  // parentbased_traceidratio. OTEL_TRACES_SAMPLER_ARG is the ratio for the
+  // *ratio variants. Defaults (always_on / 1.0) keep 100% sampling.
   OTEL_TRACES_SAMPLER: z.string().default("always_on"),
   OTEL_TRACES_SAMPLER_ARG: z.string().default("1.0"),
   // ===========================================================================
@@ -196,7 +206,8 @@ export const EnvSchema = z.object({
   PLAID_PRODUCTS: z.string().default("transactions"),
   PLAID_COUNTRY_CODES: z.string().default("US"),
   PLAID_REDIRECT_URI: z.string().optional(),
-  PLAID_SYNC_ALL_TRANSACTIONS: z.coerce.boolean().default(false),
+  // Strict parse (see boolFlag); previously z.coerce.boolean() turned "false" into true.
+  PLAID_SYNC_ALL_TRANSACTIONS: boolFlag(),
   // ===========================================================================
 
   // URL of the toolshed API, for self-referring requests
@@ -223,10 +234,9 @@ export const EnvSchema = z.object({
 
   // ===========================================================================
   // Experimental feature flags (see ExperimentalOptions in runner)
-  // Note: We intentionally avoid z.coerce.boolean() here. Zod's coerce uses
-  // Boolean(), which treats any non-empty string as truthy -- so setting an
-  // env var to "false" would incorrectly enable the flag. The other boolean
-  // env vars in this file have the same latent bug.
+  // These use flagValue() (tri-state: true/false/undefined) because the runner
+  // distinguishes "unset" from an explicit false. The plain on/off booleans
+  // above use boolFlag(); both avoid z.coerce.boolean()'s Boolean("false") trap.
   // ===========================================================================
   EXPERIMENTAL_MODERN_CELL_REP: flagValue(),
   EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: flagValue(),

--- a/packages/toolshed/lib/otel-sampler.test.ts
+++ b/packages/toolshed/lib/otel-sampler.test.ts
@@ -1,0 +1,51 @@
+import { assertEquals, assertInstanceOf } from "@std/assert";
+import {
+  AlwaysOffSampler,
+  AlwaysOnSampler,
+  ParentBasedSampler,
+  TraceIdRatioBasedSampler,
+} from "@opentelemetry/sdk-trace-base";
+import { samplerFromEnv } from "@/lib/otel-sampler.ts";
+
+Deno.test("samplerFromEnv maps OTEL_TRACES_SAMPLER to the right sampler", () => {
+  assertInstanceOf(samplerFromEnv("always_on", "1.0"), AlwaysOnSampler);
+  assertInstanceOf(samplerFromEnv("always_off", "1.0"), AlwaysOffSampler);
+  assertInstanceOf(
+    samplerFromEnv("traceidratio", "0.25"),
+    TraceIdRatioBasedSampler,
+  );
+  assertInstanceOf(
+    samplerFromEnv("parentbased_traceidratio", "0.1"),
+    ParentBasedSampler,
+  );
+  assertInstanceOf(
+    samplerFromEnv("parentbased_always_off", "1.0"),
+    ParentBasedSampler,
+  );
+
+  // A typo / unknown value falls back to always_on so tracing isn't silently
+  // disabled, and a non-numeric ratio falls back to 1 rather than throwing.
+  assertInstanceOf(samplerFromEnv("totally-bogus", "1.0"), AlwaysOnSampler);
+  assertInstanceOf(
+    samplerFromEnv("traceidratio", "not-a-number"),
+    TraceIdRatioBasedSampler,
+  );
+});
+
+Deno.test("traceidratio reflects the configured ratio", () => {
+  assertEquals(
+    samplerFromEnv("traceidratio", "0.25").toString(),
+    "TraceIdRatioBased{0.25}",
+  );
+
+  // Empty / non-numeric / out-of-range args fall back to 1 (sample everything),
+  // never to 0 -- a malformed OTEL_TRACES_SAMPLER_ARG must not silently drop all
+  // traces. (Number.parseFloat("0x10") would read as 0.)
+  for (const bad of ["", "not-a-number", "0x10", "2", "-0.5"]) {
+    assertEquals(
+      samplerFromEnv("traceidratio", bad).toString(),
+      "TraceIdRatioBased{1}",
+      `arg ${JSON.stringify(bad)} should fall back to ratio 1`,
+    );
+  }
+});

--- a/packages/toolshed/lib/otel-sampler.ts
+++ b/packages/toolshed/lib/otel-sampler.ts
@@ -1,0 +1,48 @@
+import {
+  AlwaysOffSampler,
+  AlwaysOnSampler,
+  ParentBasedSampler,
+  type Sampler,
+  TraceIdRatioBasedSampler,
+} from "@opentelemetry/sdk-trace-base";
+
+/**
+ * Builds a {@link Sampler} from `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG`.
+ *
+ * The OTel JS SDK does *not* auto-read these env vars under Deno (verified: a
+ * `BasicTracerProvider` with no explicit sampler always-samples regardless of
+ * `OTEL_TRACES_SAMPLER`), so toolshed builds the sampler here and passes it to
+ * the provider explicitly (see `lib/otel.ts`).
+ *
+ * Supported names mirror the OTel spec. Unknown names fall back to `always_on`
+ * (the documented default) so a typo never silently disables tracing.
+ * `arg` is the sampling ratio for the `*ratio` variants; an empty, non-numeric,
+ * or out-of-range value falls back to `1` (sample everything) so a malformed
+ * `OTEL_TRACES_SAMPLER_ARG` never silently drops all traces.
+ */
+export function samplerFromEnv(name: string, arg: string): Sampler {
+  // Strict parse: only a clean ratio in [0,1] is honored. (Number.parseFloat is
+  // too lenient -- it reads "0x10" as 0, which would drop every trace.)
+  const trimmed = arg.trim();
+  const parsed = trimmed === "" ? NaN : Number(trimmed);
+  const ratio = Number.isFinite(parsed) && parsed >= 0 && parsed <= 1
+    ? parsed
+    : 1;
+  switch (name) {
+    case "always_off":
+      return new AlwaysOffSampler();
+    case "traceidratio":
+      return new TraceIdRatioBasedSampler(ratio);
+    case "parentbased_always_on":
+      return new ParentBasedSampler({ root: new AlwaysOnSampler() });
+    case "parentbased_always_off":
+      return new ParentBasedSampler({ root: new AlwaysOffSampler() });
+    case "parentbased_traceidratio":
+      return new ParentBasedSampler({
+        root: new TraceIdRatioBasedSampler(ratio),
+      });
+    case "always_on":
+    default:
+      return new AlwaysOnSampler();
+  }
+}

--- a/packages/toolshed/lib/otel.ts
+++ b/packages/toolshed/lib/otel.ts
@@ -5,6 +5,7 @@ import { Resource } from "@opentelemetry/resources";
 import { AsyncHooksContextManager } from "@opentelemetry/context-async-hooks";
 import env from "@/env.ts";
 import { OpenInferenceBatchSpanProcessor } from "@arizeai/openinference-vercel";
+import { samplerFromEnv } from "@/lib/otel-sampler.ts";
 
 // Ensure we only register once even during hot-reload
 let _providerRegistered = false;
@@ -23,6 +24,11 @@ export const provider = new BasicTracerProvider({
     "deployment.environment": env.ENV || "development",
     "openinference.project.name": env.CFTS_AI_LLM_PHOENIX_PROJECT,
   }),
+  // The SDK doesn't read OTEL_TRACES_SAMPLER from the env under Deno, so build
+  // the sampler explicitly. Defaults (always_on / 1.0) keep 100% sampling.
+  // NOTE: head sampling here applies to LLM/OpenInference spans too, so a ratio
+  // below 1.0 also thins the spans the collector forwards to Phoenix.
+  sampler: samplerFromEnv(env.OTEL_TRACES_SAMPLER, env.OTEL_TRACES_SAMPLER_ARG),
 });
 
 // Add span processor after construction (API changed in newer SDK versions)

--- a/packages/toolshed/middlewares/opentelemetry.test.ts
+++ b/packages/toolshed/middlewares/opentelemetry.test.ts
@@ -1,0 +1,44 @@
+import { assertEquals } from "@std/assert";
+import { Hono } from "@hono/hono";
+import { context, trace } from "@opentelemetry/api";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { otelTracing } from "@/middlewares/opentelemetry.ts";
+
+Deno.test("otelTracing tags spans with the low-cardinality route template", async () => {
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider();
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  // The middleware resolves its tracer from the global provider when
+  // getTracerProvider() (lib/otel.ts) is undefined, which it is here.
+  trace.setGlobalTracerProvider(provider);
+
+  try {
+    const app = new Hono();
+    app.use("*", otelTracing());
+    app.get("/api/foo/:id", (c) => c.text("ok"));
+
+    await app.request("/api/foo/123"); // matched route
+    await app.request("/nope"); // unmatched -> 404
+
+    const spans = exporter.getFinishedSpans();
+    assertEquals(spans.length, 2);
+
+    // Matched: template, not the concrete "/api/foo/123" (which would explode
+    // cardinality) and not the old "/api/foo/123/*" concatenation bug.
+    assertEquals(spans[0].name, "GET /api/foo/:id");
+    assertEquals(spans[0].attributes["http.route"], "/api/foo/:id");
+    assertEquals(spans[0].attributes["http.method"], "GET");
+
+    // Unmatched requests collapse to "/*" rather than leaking the raw path.
+    assertEquals(spans[1].name, "GET /*");
+    assertEquals(spans[1].attributes["http.route"], "/*");
+  } finally {
+    trace.disable();
+    context.disable();
+    await provider.shutdown();
+  }
+});

--- a/packages/toolshed/middlewares/opentelemetry.ts
+++ b/packages/toolshed/middlewares/opentelemetry.ts
@@ -39,7 +39,6 @@ export function otelTracing(config: OtelConfig = {}): MiddlewareHandler {
 
     await obtainTracer().startActiveSpan(`${method} ${path}`, async (span) => {
       span.setAttribute("http.method", method);
-      span.setAttribute("http.route", path + c.req.routePath);
       span.setAttribute("http.host", c.req.header("host") || "unknown");
       span.setAttribute(
         "http.user_agent",
@@ -114,6 +113,14 @@ export function otelTracing(config: OtelConfig = {}): MiddlewareHandler {
 
         throw error;
       } finally {
+        // `c.req.routePath` only resolves to the matched route *template* (e.g.
+        // "/api/foo/:id") after `next()` has run; read before, it is this
+        // middleware's own "*", and `path` is the high-cardinality concrete URL.
+        // Set the template now so http.route and the span name aggregate
+        // per-route in the backend instead of exploding cardinality.
+        const route = c.req.routePath || path;
+        span.setAttribute("http.route", route);
+        span.updateName(`${method} ${route}`);
         span.end();
       }
     });


### PR DESCRIPTION
## What

The three follow-ups deferred from #4421 (CT-1807), now that they're worth doing standalone. Toolshed-only, ~190 LOC + 3 new test files. Each was either *pending verification* or *split for scope* — noted per item.

## 1. Wire `OTEL_TRACES_SAMPLER` (was dead config under Deno)

The audit on #4401 left these knobs documented but inert: the OTel JS SDK does **not** auto-read `OTEL_TRACES_SAMPLER` from the environment under Deno (verified — a provider with no explicit sampler always-samples regardless of the env var). New `lib/otel-sampler.ts` builds the sampler explicitly and `lib/otel.ts` passes it to the provider.

- Supports the standard spec values: `always_on` (default), `always_off`, `traceidratio`, `parentbased_always_on`, `parentbased_always_off`, `parentbased_traceidratio`.
- **Defaults (`always_on` / `1.0`) keep 100% sampling — no behavior change** unless an operator opts in.
- Unknown names fall back to `always_on`; malformed/empty/out-of-range ratios fall back to `1` (sample everything) so a typo never silently drops all traces.
- ⚠️ Head sampling applies to LLM/OpenInference spans too, so a ratio < 1.0 also thins the spans the collector forwards to Phoenix. Called out in code + `.env.example`.

*Was split for simplicity* — sampling design was a call I didn't want to make unilaterally in the cleanup PR.

## 2. Fix `http.route` / span-name cardinality

`middlewares/opentelemetry.ts` set `http.route = path + c.req.routePath` **before** `next()`. At that point `routePath` is the middleware's own `*`, and `path` is the concrete URL — so every span got a unique, malformed route like `/api/foo/123/*`, defeating route-level aggregation in SigNoz and inflating cardinality/cost.

Verified under Hono that `c.req.routePath` resolves to the matched **template** (`/api/foo/:id`) once read **after** `next()`. The fix moves it into the `finally` block (covers success and error paths) and sets both `http.route` and the span name from the template; unmatched requests collapse to `/*`.

*Was genuinely pending* — it needed the empirical Hono check before touching span semantics Wilk verified end-to-end. Now locked with an in-memory-exporter test.

## 3. Strict-parse the remaining boolean env flags

#4421 fixed the `z.coerce.boolean()` footgun (`Boolean("false") === true`) only for `OTEL_ENABLED`. This applies a shared `boolFlag()` helper to the two siblings that had the identical bug:

- `DISABLE_LOG_REQ_RES` — `=false` now means "log req/res" (operator intent), not the inverted "disable."
- `PLAID_SYNC_ALL_TRANSACTIONS` — same correction.

Both consumers (`pino-logger.ts`, `plaid-oauth.handlers.ts`) are plain boolean checks and stay correct; the flags remain typed `boolean`. The only behavior change is that an explicit `"false"` now disables (as intended). Updated the stale "the other boolean env vars have the same latent bug" comment.

*Was split for scope discipline* — changing logging/Plaid behavior didn't belong in a telemetry PR.

## Verification

- Empirical probes (under the pinned `@opentelemetry/sdk-trace-base@^1.19`): explicit sampler **does** override the provider default (always_off → 0 spans); `routePath`-after-`next()` resolves the template on both success and thrown-error paths.
- New tests: sampler mapping + malformed-arg fallback (`lib/otel-sampler.test.ts`), route-template span via `InMemorySpanExporter` (`middlewares/opentelemetry.test.ts`), strict parsing for all three flags (`env.test.ts`).
- `deno check` / `lint` / `fmt --check` clean on all touched files + the three consumers; existing `lib/otel.test.ts` + a route-boot test still pass.
- Ran an independent adversarial review of the diff — no substantive bugs; its one low-severity catch (a `parseFloat` leniency that could read `0x10` as 0) is fixed here.

Context: the deferred-items list lives in #4421 and CT-1807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable trace sampling, fixes high-cardinality route spans, and makes boolean env flags strict in `toolshed`. Follow-ups for CT-1807 to reduce noise and give operators real control.

- New Features
  - Respect `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` by building the sampler explicitly. Supports spec values; defaults keep 100% sampling. Malformed ratios fall back to 1.0. Note: head sampling also applies to LLM/OpenInference spans.

- Bug Fixes
  - Set `http.route` and span name from the matched route template after `next()`, so spans aggregate by route; unmatched requests collapse to `/*`.
  - Parse `DISABLE_LOG_REQ_RES` and `PLAID_SYNC_ALL_TRANSACTIONS` strictly (`"true"`/`"1"` only). `"false"` now disables as intended.

<sup>Written for commit 6b4126a1b8019320de4d1864e9edae79d16bf654. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

