### PR TITLE
test(patterns): guard importer prompt Airtable references

### DIFF
--- a/packages/patterns/tools/importer-prompt.test.ts
+++ b/packages/patterns/tools/importer-prompt.test.ts
@@ -11,6 +11,25 @@ function sectionBetween(prompt: string, start: string, end: string): string {
   return endParts[0];
 }
 
+function sourceBlockBetween(
+  prompt: string,
+  heading: string,
+  endMarker: string,
+): string {
+  const startParts = prompt.split(`${heading}\n\n`);
+  assertEquals(startParts.length, 2);
+  const endParts = startParts[1].split(endMarker);
+  assertEquals(endParts.length, 2);
+  return endParts[0];
+}
+
+function commonfabricImports(source: string): string {
+  const matches = source.matchAll(
+    /import\s*\{(?<imports>[\s\S]*?)\}\s*from\s*"commonfabric";/g,
+  );
+  return Array.from(matches, (match) => match.groups?.imports ?? "").join("\n");
+}
+
 const providerConfig: ExtractedProviderConfig = {
   name: "acme",
   authorizationEndpoint: "https://auth.example.com/oauth/authorize",
@@ -143,6 +162,7 @@ Deno.test("generateImporterPrompt includes auth availability and current JSX gui
     instructions,
     'Always use `wish({ query: "#acmeAuth", scope: [".", "~"] })`',
   );
+  assertFalse(instructions.includes("ifElse"));
 
   assertStringIncludes(reference, "## Reference: Airtable Auth Pattern");
   assertStringIncludes(
@@ -152,6 +172,67 @@ Deno.test("generateImporterPrompt includes auth availability and current JSX gui
   assertStringIncludes(reference, "AuthInfo");
   assertStringIncludes(reference, "return `Airtable: ${selectedBaseName}");
   assertFalse(reference.includes("return \\`Airtable:"));
+});
+
+Deno.test("generateImporterPrompt embeds current Airtable source references", async () => {
+  const prompt = generateImporterPrompt({
+    providerName: "acme",
+    brandColor: "#123456",
+    api,
+    providerConfig,
+    primaryListEndpoint: "/v1/widgets",
+    primaryGetEndpoint: "/v1/widgets/{id}",
+  });
+  const references = [
+    {
+      heading: "## Reference: Airtable Auth Pattern (airtable-auth.tsx)",
+      endMarker:
+        "\n\n## Reference: Airtable Auth Manager (airtable-auth-manager.tsx)",
+      source: new URL(
+        "../airtable/core/airtable-auth.tsx",
+        import.meta.url,
+      ),
+    },
+    {
+      heading:
+        "## Reference: Airtable Auth Manager (airtable-auth-manager.tsx)",
+      endMarker: "\n\n## Reference: Airtable API Client (airtable-client.ts)",
+      source: new URL(
+        "../airtable/core/util/airtable-auth-manager.tsx",
+        import.meta.url,
+      ),
+    },
+    {
+      heading: "## Reference: Airtable API Client (airtable-client.ts)",
+      endMarker: "\n\n## Reference: Airtable Importer (airtable-importer.tsx)",
+      source: new URL(
+        "../airtable/core/util/airtable-client.ts",
+        import.meta.url,
+      ),
+    },
+    {
+      heading: "## Reference: Airtable Importer (airtable-importer.tsx)",
+      endMarker: "\n</reference-implementations>",
+      source: new URL("../airtable/airtable-importer.tsx", import.meta.url),
+    },
+  ];
+
+  let importerSource = "";
+  for (const reference of references) {
+    const embedded = sourceBlockBetween(
+      prompt,
+      reference.heading,
+      reference.endMarker,
+    );
+    assertEquals(embedded, await Deno.readTextFile(reference.source));
+
+    if (reference.heading.includes("Importer")) {
+      importerSource = embedded;
+    }
+  }
+
+  assertFalse(/\bifElse\s*\(/.test(importerSource));
+  assertFalse(/\bifElse\b/.test(commonfabricImports(importerSource)));
 });
 
 Deno.test("generateImporterPrompt renders extracted API details", () => {

--- a/packages/patterns/tools/importer-prompt.ts
+++ b/packages/patterns/tools/importer-prompt.ts
@@ -574,24 +574,118 @@ export default pattern<Input, Output>(
             <div
               style={{ display: "flex", flexDirection: "column", gap: "10px" }}
             >
-              {Object.entries(SCOPE_MAP).map(([key, description]) => (
-                <label
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "8px",
-                    cursor: loggedIn ? "not-allowed" : "pointer",
-                    color: loggedIn ? "#9ca3af" : "inherit",
-                  }}
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  cursor: loggedIn ? "not-allowed" : "pointer",
+                  color: loggedIn ? "#9ca3af" : "inherit",
+                }}
+              >
+                <cf-checkbox
+                  $checked={selectedScopes["data.records:read"]}
+                  disabled={checkboxesDisabled}
                 >
-                  <cf-checkbox
-                    $checked={selectedScopes[key as keyof SelectedScopes]}
-                    disabled={checkboxesDisabled}
-                  >
-                    {description}
-                  </cf-checkbox>
-                </label>
-              ))}
+                  {SCOPE_MAP["data.records:read"]}
+                </cf-checkbox>
+              </label>
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  cursor: loggedIn ? "not-allowed" : "pointer",
+                  color: loggedIn ? "#9ca3af" : "inherit",
+                }}
+              >
+                <cf-checkbox
+                  $checked={selectedScopes["data.records:write"]}
+                  disabled={checkboxesDisabled}
+                >
+                  {SCOPE_MAP["data.records:write"]}
+                </cf-checkbox>
+              </label>
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  cursor: loggedIn ? "not-allowed" : "pointer",
+                  color: loggedIn ? "#9ca3af" : "inherit",
+                }}
+              >
+                <cf-checkbox
+                  $checked={selectedScopes["data.recordComments:read"]}
+                  disabled={checkboxesDisabled}
+                >
+                  {SCOPE_MAP["data.recordComments:read"]}
+                </cf-checkbox>
+              </label>
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  cursor: loggedIn ? "not-allowed" : "pointer",
+                  color: loggedIn ? "#9ca3af" : "inherit",
+                }}
+              >
+                <cf-checkbox
+                  $checked={selectedScopes["data.recordComments:write"]}
+                  disabled={checkboxesDisabled}
+                >
+                  {SCOPE_MAP["data.recordComments:write"]}
+                </cf-checkbox>
+              </label>
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  cursor: loggedIn ? "not-allowed" : "pointer",
+                  color: loggedIn ? "#9ca3af" : "inherit",
+                }}
+              >
+                <cf-checkbox
+                  $checked={selectedScopes["schema.bases:read"]}
+                  disabled={checkboxesDisabled}
+                >
+                  {SCOPE_MAP["schema.bases:read"]}
+                </cf-checkbox>
+              </label>
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  cursor: loggedIn ? "not-allowed" : "pointer",
+                  color: loggedIn ? "#9ca3af" : "inherit",
+                }}
+              >
+                <cf-checkbox
+                  $checked={selectedScopes["schema.bases:write"]}
+                  disabled={checkboxesDisabled}
+                >
+                  {SCOPE_MAP["schema.bases:write"]}
+                </cf-checkbox>
+              </label>
+              <label
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  cursor: loggedIn ? "not-allowed" : "pointer",
+                  color: loggedIn ? "#9ca3af" : "inherit",
+                }}
+              >
+                <cf-checkbox
+                  $checked={selectedScopes["webhook:manage"]}
+                  disabled={checkboxesDisabled}
+                >
+                  {SCOPE_MAP["webhook:manage"]}
+                </cf-checkbox>
+              </label>
             </div>
           </div>
 
@@ -954,7 +1048,8 @@ export default pattern<Input, Output>(
       bgUpdater: bgRefreshHandler({ auth, refreshInProgress }),
     };
   },
-);`;
+);
+`;
 
 // Read from: packages/patterns/airtable/core/util/airtable-auth-manager.tsx
 const AIRTABLE_AUTH_MANAGER_SOURCE = `/**
@@ -1109,21 +1204,22 @@ export const AirtableAuthManager = pattern<
   };
 });
 
-export default AirtableAuthManager;`;
+export default AirtableAuthManager;
+`;
 
 // Read from: packages/patterns/airtable/core/util/airtable-client.ts
 const AIRTABLE_CLIENT_SOURCE = `/**
  * Airtable API client with automatic token refresh and retry logic.
  *
  * Usage:
- * \\\`\\\`\\\`typescript
+ * \`\`\`typescript
  * import { AirtableClient } from "./util/airtable-client.ts";
  *
  * const client = AirtableClient(authCell, { debugMode: true });
  * const bases = await client.listBases();
  * const tables = await client.listTables(baseId);
  * const records = await client.listRecords(baseId, tableId);
- * \\\`\\\`\\\`
+ * \`\`\`
  */
 import { getPatternEnvironment, Writable } from "commonfabric";
 
@@ -1238,7 +1334,7 @@ export function AirtableClient(
         const response = await fetch(url, {
           ...options,
           headers: {
-            Authorization: \\\`Bearer \\\${token}\\\`,
+            Authorization: \`Bearer \${token}\`,
             "Content-Type": "application/json",
             ...options.headers,
           },
@@ -1252,12 +1348,11 @@ export function AirtableClient(
 
         if (response.status === 429) {
           const retryAfter = response.headers.get("Retry-After");
-          const waitMs = retryAfter
-            ? parseInt(retryAfter) * 1000
-            : delay * (attempt + 1);
+          const parsed = retryAfter ? parseInt(retryAfter, 10) : NaN;
+          const waitMs = !isNaN(parsed) ? parsed * 1000 : delay * (attempt + 1);
           debugLog(
             debugMode,
-            \\\`Rate limited, waiting \\\${waitMs}ms...\\\`,
+            \`Rate limited, waiting \${waitMs}ms...\`,
           );
           await sleep(waitMs);
           continue;
@@ -1266,7 +1361,7 @@ export function AirtableClient(
         if (!response.ok) {
           const errorBody = await response.text();
           throw new Error(
-            \\\`Airtable API error \\\${response.status}: \\\${errorBody}\\\`,
+            \`Airtable API error \${response.status}: \${errorBody}\`,
           );
         }
 
@@ -1276,7 +1371,7 @@ export function AirtableClient(
         if (attempt < retries) {
           debugLog(
             debugMode,
-            \\\`Request failed (attempt \\\${attempt + 1}/\\\${retries + 1}):\\\`,
+            \`Request failed (attempt \${attempt + 1}/\${retries + 1}):\`,
             lastError.message,
           );
           await sleep(delay);
@@ -1313,7 +1408,7 @@ export function AirtableClient(
     );
 
     if (!res.ok) {
-      throw new Error(\\\`Token refresh failed: \\\${res.status}\\\`);
+      throw new Error(\`Token refresh failed: \${res.status}\`);
     }
 
     const json = await res.json();
@@ -1343,7 +1438,7 @@ export function AirtableClient(
     let offset: string | undefined;
 
     do {
-      const url = new URL(\\\`\\\${AIRTABLE_META_BASE}/bases\\\`);
+      const url = new URL(\`\${AIRTABLE_META_BASE}/bases\`);
       if (offset) url.searchParams.set("offset", offset);
 
       const response = await request<{
@@ -1355,7 +1450,7 @@ export function AirtableClient(
       offset = response.offset;
     } while (offset);
 
-    debugLog(debugMode, \\\`Found \\\${bases.length} bases\\\`);
+    debugLog(debugMode, \`Found \${bases.length} bases\`);
     return bases;
   }
 
@@ -1365,13 +1460,13 @@ export function AirtableClient(
   async function listTables(
     baseId: string,
   ): Promise<AirtableTable[]> {
-    debugLog(debugMode, \\\`Listing tables for base \\\${baseId}...\\\`);
+    debugLog(debugMode, \`Listing tables for base \${baseId}...\`);
 
     const response = await request<{ tables: AirtableTable[] }>(
-      \\\`\\\${AIRTABLE_META_BASE}/bases/\\\${baseId}/tables\\\`,
+      \`\${AIRTABLE_META_BASE}/bases/\${baseId}/tables\`,
     );
 
-    debugLog(debugMode, \\\`Found \\\${response.tables.length} tables\\\`);
+    debugLog(debugMode, \`Found \${response.tables.length} tables\`);
     return response.tables;
   }
 
@@ -1385,7 +1480,7 @@ export function AirtableClient(
   ): Promise<AirtableRecord[]> {
     debugLog(
       debugMode,
-      \\\`Listing records from \\\${baseId}/\\\${tableIdOrName}...\\\`,
+      \`Listing records from \${baseId}/\${tableIdOrName}...\`,
     );
 
     const records: AirtableRecord[] = [];
@@ -1394,7 +1489,7 @@ export function AirtableClient(
 
     do {
       const url = new URL(
-        \\\`\\\${AIRTABLE_API_BASE}/\\\${baseId}/\\\${encodeURIComponent(tableIdOrName)}\\\`,
+        \`\${AIRTABLE_API_BASE}/\${baseId}/\${encodeURIComponent(tableIdOrName)}\`,
       );
 
       if (options.pageSize) {
@@ -1415,10 +1510,10 @@ export function AirtableClient(
       }
       if (options.sort) {
         for (let i = 0; i < options.sort.length; i++) {
-          url.searchParams.set(\\\`sort[\\\${i}][field]\\\`, options.sort[i].field);
+          url.searchParams.set(\`sort[\${i}][field]\`, options.sort[i].field);
           if (options.sort[i].direction) {
             url.searchParams.set(
-              \\\`sort[\\\${i}][direction]\\\`,
+              \`sort[\${i}][direction]\`,
               options.sort[i].direction!,
             );
           }
@@ -1439,7 +1534,7 @@ export function AirtableClient(
     } while (offset);
 
     const result = records.slice(0, maxRecords);
-    debugLog(debugMode, \\\`Fetched \\\${result.length} records\\\`);
+    debugLog(debugMode, \`Fetched \${result.length} records\`);
     return result;
   }
 
@@ -1455,6 +1550,7 @@ const AIRTABLE_IMPORTER_SOURCE = `import {
   NAME,
   pattern,
   UI,
+  type VNode,
   Writable,
 } from "commonfabric";
 
@@ -1486,6 +1582,7 @@ interface Input {
 
 /** Import records from an Airtable base. #airtableImporter */
 export interface Output {
+  [UI]: VNode;
   records: readonly AirtableRecordData[];
   bases: readonly BaseInfo[];
   tables: readonly TableInfo[];
@@ -2141,7 +2238,8 @@ function formatCellValue(value: unknown): string {
     return JSON.stringify(value);
   }
   return String(value);
-}`;
+}
+`;
 
 // ---------------------------------------------------------------------------
 // Prompt generation


### PR DESCRIPTION
The importer prompt carries copied Airtable source as embedded template literals. Those copies can drift from the reference patterns, and stale escaping can leave generated prompts with malformed snippets. The prompt also now guides generated importers toward JSX ternaries, so stale ifElse import guidance should be caught by tests before review.

Refresh the embedded Airtable auth, auth manager, client, and importer snippets from the source files. Add a unit test that renders the prompt, slices each Airtable reference block by its heading, and compares it with the source file text after template literal escaping has been evaluated. The test also rejects stale ifElse guidance and verifies the embedded importer source does not import ifElse when it does not use ifElse.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the importer prompt with the latest Airtable source and adds stricter tests to prevent drift. Fixes malformed snippets from stale escaping and blocks outdated `ifElse` guidance to steer generators toward JSX ternaries.

- **Bug Fixes**
  - Refreshed embedded Airtable Auth, Auth Manager, API Client, and Importer snippets to match source, including the importer’s new `[UI]: VNode` typing.
  - Fixed template-literal escaping in the API client so headers, URLs, and logs render correctly.
  - Added a strict test that slices each reference block by heading/end markers, compares exact source text, and fails on any `ifElse` usage or import.

<sup>Written for commit 8bd5180b3655020bf80e056712ec4c39553d1168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

