### PR TITLE
Document memory session audience ownership

### DIFF
--- a/docs/specs/memory-v2/04-protocol.md
+++ b/docs/specs/memory-v2/04-protocol.md
@@ -83,6 +83,30 @@ uses its service identity DID. The standalone memory host uses a stable
 deterministic DID. The public memory client rejects a server that omits either
 field.
 
+#### Server Audience Ownership
+
+The audience value identifies the memory server or service that may accept the
+signed `session.open`. It is part of the signed invocation, so changing it
+invalidates signatures made for the old value.
+
+Production toolshed deployments own this value through the toolshed service
+identity. That DID must be stable across restarts and across horizontally scaled
+instances that serve the same logical memory endpoint. All instances behind one
+toolshed memory endpoint must advertise the same audience. Otherwise a client
+can sign for one instance and fail when routing sends it to another instance.
+
+Changing the toolshed service DID is an audience rotation. During rotation,
+clients must discover the new value from `hello.ok` and sign new `session.open`
+requests for it. Existing open sessions can continue only while their
+connection remains alive and keeps using challenges issued by the server that
+accepted them. Reconnects and new sessions must use the new audience. Operators
+should coordinate rotation with deployment routing and client reconnect
+behavior.
+
+Standalone and test memory hosts may use a deterministic local DID, but they
+still need to advertise an audience. The public client treats a missing audience
+as a protocol error.
+
 The challenge is scoped to this WebSocket connection. The current
 implementation generates 32 cryptographically random bytes and encodes them as
 64 hexadecimal characters. The challenge expires at `expiresAt`, in unix


### PR DESCRIPTION
Memory session.open signatures now bind to the audience advertised by the server. Operators need to know who owns that value, how stable it must be, and what it means to rotate it.

Expand the memory v2 protocol chapter with an audience ownership section. It documents that toolshed owns the audience through its service identity DID, that all instances behind one logical memory endpoint must advertise the same value, and that service DID changes are audience rotations that clients pick up through hello.ok on new opens and reconnects.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the memory v2 protocol by documenting server audience ownership for `session.open` signatures. Specifies that toolshed owns the audience via its service DID, all instances of a logical memory endpoint must advertise the same value, and audience rotations (service DID changes) are picked up via `hello.ok` on reconnects and new opens.

<sup>Written for commit bd32e1dd42c64b7f58649276b465ccfa2ac496d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

