### PR TITLE
ci: cap test/build job wall-clock at 30 minutes

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -24,6 +24,7 @@ jobs:
   check:
     name: "Check"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
@@ -59,6 +60,7 @@ jobs:
   cfcheck:
     name: "CFC Pattern Check (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -83,6 +85,7 @@ jobs:
     name: "Test"
     runs-on:
       group: labs
+    timeout-minutes: 30
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
@@ -129,6 +132,7 @@ jobs:
   runner-test:
     name: "Runner Tests (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -184,6 +188,7 @@ jobs:
     name: "Build Binaries"
     runs-on:
       group: labs
+    timeout-minutes: 30
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
@@ -212,6 +217,7 @@ jobs:
   generated-patterns-integration-test:
     name: "Generated Patterns Integration Tests (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -276,6 +282,7 @@ jobs:
   package-integration-test:
     name: "Package Integration Tests (${{ matrix.suite_name }})"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: ["build-binaries"]
     strategy:
       fail-fast: false
@@ -499,6 +506,7 @@ jobs:
   pattern-integration-test:
     name: "Pattern Integration Tests (${{ matrix.shard }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: ["build-binaries"]
     strategy:
       fail-fast: false
@@ -607,6 +615,7 @@ jobs:
   pattern-reload-integration-test:
     name: "Pattern Reload Integration Tests"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
@@ -660,6 +669,7 @@ jobs:
   pattern-unit-test:
     name: "Pattern Unit Tests (${{ matrix.chunk }}/${{ matrix.total }})"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: ["build-binaries"]
     strategy:
       matrix:
@@ -723,6 +733,7 @@ jobs:
     name: "Performance Check"
     if: (github.event_name == 'pull_request') || (github.ref_name == 'main')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - check
       - test
@@ -790,6 +801,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on:
       group: labs
+    timeout-minutes: 30
     needs:
       [
         "test",
@@ -1121,6 +1133,7 @@ jobs:
     if: false # Disabled - was: github.ref == 'refs/heads/main'
     needs: ["deploy-toolshed"]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: toolshed
     continue-on-error: true # Don't fail the workflow if tests fail
     steps:


### PR DESCRIPTION
The Deno workflow set no per-job timeout on most jobs, so each inherited GitHub Actions' default ceiling of six hours. A test that hangs rather than fails therefore holds a runner for hours instead of surfacing quickly: a wedged process produces no failure signal until the six-hour cap, long after the rest of the matrix has finished.

Add an explicit thirty-minute job-level timeout to every job that lacked one. Thirty minutes sits well above the observed wall-clock of the slowest jobs while still failing a hang in minutes. The CLI integration job keeps its existing per-suite timeouts (ten minutes for the core suites, fifteen for fuse), which are tighter and deliberately tuned.

The three staging deploy jobs are left uncapped: a deploy drives a remote script over SSH whose duration is not bounded by this workflow, and a thirty-minute cap could cancel a legitimately long deploy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 30-minute timeout to CI jobs to fail hangs faster and free runners. Applied `timeout-minutes: 30` to check, test, build, and integration jobs in `.github/workflows/deno.yml`; staging deploy jobs stay uncapped, and the CLI integration job keeps its per-suite limits.

<sup>Written for commit df97a8adaefecfdbed96ad128f30c494c23c264b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

