### PR TITLE
feat(ui): submit cf-submit-input on Enter via implicit form submission

### DIFF
--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -288,6 +288,33 @@ export async function clickTrustedAction(
   }
 }
 
+/**
+ * Submit a `cf-submit-input` from the keyboard: focus its inner field and press
+ * a real Enter. The field sits inside a `<form>` with a hidden native submit
+ * button, so Enter triggers the browser's implicit form submission, which fires
+ * a trusted click on that button — carrying the typed text to the host exactly
+ * like the visible button's click. The Enter must be a real CDP key press: a
+ * scripted `KeyboardEvent` does not trigger implicit submission, which is why an
+ * earlier dispatched-keydown attempt never reached the create handler.
+ *
+ * The view is settled first so the form is interactive, and the inner input is
+ * resolved by piercing shadow roots (the `inputId` is forwarded to the inner
+ * `<input>`, so the selector matches it directly).
+ */
+export async function submitViaEnter(
+  page: Page,
+  inputSelector: string,
+  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
+) {
+  await settleView(page, { timeout });
+  const input = await page.waitForSelector(inputSelector, {
+    strategy: "pierce",
+    timeout,
+  });
+  await input.focus();
+  await page.keyboard.press("Enter");
+}
+
 export async function clickTrustedActionAndWaitForText(
   page: Page,
   action: string,

--- a/packages/patterns/integration/home-profile.test.ts
+++ b/packages/patterns/integration/home-profile.test.ts
@@ -6,6 +6,7 @@ import {
   clickCfButton,
   clickTrustedAction,
   fillCfInput,
+  submitViaEnter,
   waitForRuntimeIdle,
   waitForRuntimeSynced,
   waitForText,
@@ -62,7 +63,11 @@ async function ensureProfileTabActive(page: any) {
 }
 
 // deno-lint-ignore no-explicit-any
-async function createProfile(page: any, name: string) {
+async function createProfile(
+  page: any,
+  name: string,
+  { viaEnter = false }: { viaEnter?: boolean } = {},
+) {
   await ensureProfileTabActive(page);
   // Each profile lives in its own `inSpace` child space, so appending one is a
   // cross-space commit. `waitForRuntimeIdle` returns once the scheduler queue
@@ -72,7 +77,14 @@ async function createProfile(page: any, name: string) {
   // again after so it reconciles before the caller navigates or appends again.
   await waitForRuntimeSynced(page);
   await fillCfInput(page, "#wish-profile-picker-name-input", name);
-  await clickTrustedAction(page, TRUSTED_PROFILE_CREATE_ACTION);
+  // Submit either by clicking the trusted "Create profile" button or by
+  // pressing Enter in the field. Both ride a trusted gesture that carries the
+  // typed name as event.target.value with the surface's UI integrity.
+  if (viaEnter) {
+    await submitViaEnter(page, "#wish-profile-picker-name-input");
+  } else {
+    await clickTrustedAction(page, TRUSTED_PROFILE_CREATE_ACTION);
+  }
   await waitForRuntimeSynced(page);
 }
 
@@ -140,5 +152,24 @@ describe("home-space profile creation", () => {
     // Both profiles are now listed in the picker.
     await waitForText(page, "#home-profile-summary", "Ada Lovelace");
     await waitForText(page, "#home-profile-summary", "Alan Turing");
+  });
+
+  it("creates a profile by pressing Enter in the field (keyboard submit)", async () => {
+    const page = shell.page();
+
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: { builtin: "home" },
+      identity,
+    });
+
+    await clickCfButton(page, 'cf-tab[value="profile"]');
+
+    // Submitting with Enter (no button click) must create the profile too: the
+    // browser's implicit form submission fires a trusted click on the field's
+    // hidden submit button, carrying the typed name to the create handler.
+    await createProfile(page, "Grace Hopper", { viaEnter: true });
+    await waitForRuntimeIdle(page);
+    await waitForText(page, "#home-profile-summary", "Grace Hopper");
   });
 });

--- a/packages/ui/src/v2/components/cf-submit-input/cf-submit-input.test.ts
+++ b/packages/ui/src/v2/components/cf-submit-input/cf-submit-input.test.ts
@@ -11,8 +11,9 @@ import { CFSubmitInput } from "./index.ts";
 
 type Internals = {
   _onInput(event: Event): void;
-  _onContainerClick(event: Event): void;
-  _onSubmit(event: Event): void;
+  _onClick(event: Event): void;
+  _onFormSubmit(event: Event): void;
+  _isSubmitGesture(event: Event): boolean;
   _submitting: boolean;
   _seeded: boolean;
   willUpdate(changed: Map<string, unknown>): void;
@@ -23,11 +24,18 @@ function internals(el: CFSubmitInput): Internals {
   return el as unknown as Internals;
 }
 
-// A click event whose composed path optionally runs through a CF-BUTTON, with a
+// How a click reached the form: through the visible cf-button, through the
+// hidden native submit button (the browser's implicit-submission click on
+// Enter), or through neither (a click on the field or surrounding gap).
+type ClickVia = "button" | "submit" | "none";
+
+// A click event with the composed path for the given route, plus a
 // stopPropagation spy.
-function clickEvent(throughButton: boolean): Event & { stopped: boolean } {
-  const path = throughButton
+function clickEvent(via: ClickVia): Event & { stopped: boolean } {
+  const path = via === "button"
     ? [{ tagName: "INPUT" }, { tagName: "CF-BUTTON" }]
+    : via === "submit"
+    ? [{ tagName: "BUTTON", type: "submit" }, { tagName: "FORM" }]
     : [{ tagName: "INPUT" }, { tagName: "DIV" }];
   const event = {
     stopped: false,
@@ -91,36 +99,90 @@ describe("CFSubmitInput", () => {
     expect(el.value).toBe("typed");
   });
 
-  describe("_onContainerClick", () => {
-    it("stops a click that does not run through the submit button", () => {
+  describe("_isSubmitGesture", () => {
+    it("recognizes a click through the visible cf-button", () => {
       const el = new CFSubmitInput();
-      const event = clickEvent(false);
-      internals(el)._onContainerClick(event);
+      expect(internals(el)._isSubmitGesture(clickEvent("button"))).toBe(true);
+    });
+
+    it("recognizes the implicit-submission click on the hidden submit button", () => {
+      const el = new CFSubmitInput();
+      expect(internals(el)._isSubmitGesture(clickEvent("submit"))).toBe(true);
+    });
+
+    it("does not treat a field or gap click as a submit", () => {
+      const el = new CFSubmitInput();
+      expect(internals(el)._isSubmitGesture(clickEvent("none"))).toBe(false);
+    });
+  });
+
+  describe("_onClick gating", () => {
+    it("stops a click that is not a submit gesture", () => {
+      const el = new CFSubmitInput();
+      const event = clickEvent("none");
+      internals(el)._onClick(event);
       expect(event.stopped).toBe(true);
     });
 
-    it("lets a click through the submit button reach the host", () => {
+    it("lets a button-click submit gesture reach the host", () => {
       const el = new CFSubmitInput();
-      const event = clickEvent(true);
-      internals(el)._onContainerClick(event);
+      el.value = "Ada";
+      const event = clickEvent("button");
+      internals(el)._onClick(event);
+      expect(event.stopped).toBe(false);
+    });
+
+    it("lets an Enter-driven submit-button gesture reach the host", () => {
+      const el = new CFSubmitInput();
+      el.value = "Ada";
+      const event = clickEvent("submit");
+      internals(el)._onClick(event);
       expect(event.stopped).toBe(false);
     });
   });
 
-  describe("_onSubmit", () => {
-    it("ignores an empty submit", async () => {
+  describe("_onFormSubmit", () => {
+    it("cancels the form's native submission so the page does not navigate", () => {
+      const el = new CFSubmitInput();
+      let prevented = false;
+      const event = {
+        preventDefault() {
+          prevented = true;
+        },
+      } as unknown as Event;
+      internals(el)._onFormSubmit(event);
+      expect(prevented).toBe(true);
+    });
+  });
+
+  describe("_onClick submit handling", () => {
+    it("ignores an empty submit and stops it reaching the host", async () => {
       const el = new CFSubmitInput();
       el.value = "   ";
-      internals(el)._onSubmit(clickEvent(true));
+      const event = clickEvent("button");
+      internals(el)._onClick(event);
+      // An empty submit fires no create: the flag stays clear, the value is
+      // untouched, and the click is stopped at the shadow boundary so a held
+      // Enter that repeats cannot spin up no-op creates.
       expect(internals(el)._submitting).toBe(false);
+      expect(event.stopped).toBe(true);
       await tick();
       expect(el.value).toBe("   ");
+    });
+
+    it("stops an empty Enter-driven submit reaching the host", () => {
+      const el = new CFSubmitInput();
+      el.value = "";
+      const event = clickEvent("submit");
+      internals(el)._onClick(event);
+      expect(internals(el)._submitting).toBe(false);
+      expect(event.stopped).toBe(true);
     });
 
     it("clears the field after the submit click is handled", async () => {
       const el = new CFSubmitInput();
       el.value = "Ada";
-      internals(el)._onSubmit(clickEvent(true));
+      internals(el)._onClick(clickEvent("button"));
       // In-flight immediately after the click, before the deferred clear.
       expect(internals(el)._submitting).toBe(true);
       expect(el.value).toBe("Ada");
@@ -129,22 +191,48 @@ describe("CFSubmitInput", () => {
       expect(internals(el)._submitting).toBe(false);
     });
 
+    it("clears the field after an Enter-driven submit", async () => {
+      const el = new CFSubmitInput();
+      el.value = "Ada";
+      // Enter fires the browser's implicit-submission click on the hidden
+      // submit button, which routes through the same handler.
+      internals(el)._onClick(clickEvent("submit"));
+      expect(internals(el)._submitting).toBe(true);
+      await tick();
+      expect(el.value).toBe("");
+      expect(internals(el)._submitting).toBe(false);
+    });
+
     it("stops a re-entrant click and does not schedule a second clear", async () => {
       const el = new CFSubmitInput();
       el.value = "Ada";
-      internals(el)._onSubmit(clickEvent(true));
-      const second = clickEvent(true);
-      internals(el)._onSubmit(second);
+      internals(el)._onClick(clickEvent("button"));
+      const second = clickEvent("button");
+      internals(el)._onClick(second);
       expect(second.stopped).toBe(true);
       await tick();
       // The first submit's clear still runs.
       expect(el.value).toBe("");
     });
 
+    it("stops an Enter submit re-entering on a click before the clear (no duplicate create)", async () => {
+      const el = new CFSubmitInput();
+      el.value = "Ada";
+      // Enter submits first...
+      internals(el)._onClick(clickEvent("submit"));
+      // ...then a button click arrives before the deferred clear. It must be
+      // suppressed so the host fires only one create.
+      const second = clickEvent("button");
+      internals(el)._onClick(second);
+      expect(second.stopped).toBe(true);
+      await tick();
+      expect(el.value).toBe("");
+    });
+
     it("does not wipe a value the user retyped before the clear runs", async () => {
       const el = new CFSubmitInput();
       el.value = "Ada";
-      internals(el)._onSubmit(clickEvent(true));
+      internals(el)._onClick(clickEvent("button"));
       // A new name typed before the deferred clear fires must survive.
       el.value = "Alan";
       await tick();
@@ -161,7 +249,7 @@ describe("CFSubmitInput", () => {
         get: () => fakeInput,
       });
       el.value = "Ada";
-      internals(el)._onSubmit(clickEvent(true));
+      internals(el)._onClick(clickEvent("button"));
       await tick();
       expect(el.value).toBe("");
       expect(fakeInput.value).toBe("");

--- a/packages/ui/src/v2/components/cf-submit-input/cf-submit-input.ts
+++ b/packages/ui/src/v2/components/cf-submit-input/cf-submit-input.ts
@@ -18,6 +18,18 @@ import "../cf-button/cf-button.ts";
  * keeps a cross-space create handler stable across retries — the event payload
  * is fixed — with nothing to clobber.
  *
+ * Pressing Enter in the field submits as well. The field sits inside a `<form>`
+ * holding a hidden native submit button, so Enter triggers the browser's
+ * implicit form submission: the user agent fires a trusted click on that submit
+ * button, which bubbles to the host exactly like the visible button's click and
+ * carries the same `event.target.value` and UI integrity. A scripted
+ * `button.click()` would be `isTrusted: false` and carry no integrity, so the
+ * keyboard path relies on the browser's own gesture rather than synthesizing
+ * one. The form's native submission is cancelled so the page does not navigate.
+ * Both the visible button click and the Enter-driven submit click pass through a
+ * single click handler on the form, where the in-flight guard lives, so Enter
+ * and a click cannot fire two creates.
+ *
  * Unlike cf-message-input (which emits a `cf-send` CustomEvent — isTrusted is
  * false for those, so they cannot carry UI integrity to a worker handler), the
  * create here flows from the raw, trusted button click.
@@ -104,12 +116,13 @@ export class CFSubmitInput extends BaseElement {
 
   private _seeded = false;
 
-  // Set while a submit click is in flight, between the click and the deferred
-  // field-clear. A second click that arrives in that window is a duplicate
-  // (the field still holds the submitted text), so its propagation to the host
-  // is stopped to suppress a second create. The flag is reset when the clear
-  // runs, including the case where the clear is skipped because the value
-  // changed, so a later submit is never blocked.
+  // Set while a submit is in flight, between the click and the deferred
+  // field-clear. A second submit that arrives in that window — whether a button
+  // click or an Enter keypress — is a duplicate (the field still holds the
+  // submitted text), so its propagation to the host is stopped to suppress a
+  // second create. The flag is reset when the clear runs, including the case
+  // where the clear is skipped because the value changed, so a later submit is
+  // never blocked.
   private _submitting = false;
 
   // Copy `initialValue` into the editable `value` once, the first time it is
@@ -131,29 +144,44 @@ export class CFSubmitInput extends BaseElement {
     this.value = (event.target as HTMLInputElement).value;
   }
 
-  // Only the submit button click should reach a host-level onClick (the create
-  // gesture). Clicks on the field (to focus/edit) or the surrounding gap compose
-  // out of the shadow root and would otherwise bubble to the host and fire a
-  // spurious create. Let only a click whose path runs through the submit button
-  // continue; stop the rest here.
-  private _onContainerClick(event: Event) {
-    const fromButton = event.composedPath().some(
-      (node) => (node as Element)?.tagName === "CF-BUTTON",
-    );
-    if (!fromButton) event.stopPropagation();
+  // True when a click's composed path runs through a control that means "submit"
+  // — the visible cf-button, or the hidden native submit button the browser
+  // clicks for implicit form submission on Enter. Clicks on the field (to
+  // focus/edit) or the surrounding gap are not submits.
+  private _isSubmitGesture(event: Event): boolean {
+    return event.composedPath().some((node) => {
+      const element = node as Element & { type?: string };
+      return element?.tagName === "CF-BUTTON" ||
+        (element?.tagName === "BUTTON" && element.type === "submit");
+    });
   }
 
-  private _onSubmit(event: Event) {
-    // A second click arriving before the deferred clear runs is a duplicate:
+  // Single click handler for the form. The visible button's click and the
+  // Enter-driven implicit-submission click both bubble through here on their way
+  // to the host, so it is the one place the create gesture is gated and the
+  // in-flight guard is enforced — Enter and a click cannot each fire a create.
+  private _onClick(event: Event) {
+    // Only a submit gesture should reach the host's onClick (the create). Stop
+    // field/gap clicks at the shadow boundary so they fire no spurious create.
+    if (!this._isSubmitGesture(event)) {
+      event.stopPropagation();
+      return;
+    }
+    // A second submit arriving before the deferred clear runs is a duplicate:
     // the field still holds the submitted text, so the host would fire a second
-    // create. Stop this click at the shadow boundary so it never reaches the
-    // host.
+    // create. Stop it at the shadow boundary so it never reaches the host.
     if (this._submitting) {
       event.stopPropagation();
       return;
     }
     const submitted = this.value;
-    if (!submitted.trim()) return;
+    if (!submitted.trim()) {
+      // Nothing to submit. Stop the click here so an empty submit — including a
+      // held Enter key that repeats — never reaches the host to spin up a no-op
+      // create.
+      event.stopPropagation();
+      return;
+    }
     this._submitting = true;
     // Clear the field only after the submit click has been handled — the
     // framework's host-level click listener reads `event.target.value` while
@@ -174,27 +202,37 @@ export class CFSubmitInput extends BaseElement {
     }, 0);
   }
 
+  // Enter in the field triggers implicit form submission. The trusted click on
+  // the hidden submit button is what carries the create to the host; the form's
+  // own navigation is cancelled so the page does not reload.
+  private _onFormSubmit(event: Event) {
+    event.preventDefault();
+  }
+
   override render() {
     return html`
-      <div class="container" @click="${this._onContainerClick}">
-        <input
-          id="${this.inputId}"
-          type="text"
-          .value="${this.value}"
-          placeholder="${this.placeholder}"
-          ?disabled="${this.disabled}"
-          @input="${this._onInput}"
-          part="input"
-        />
-        <cf-button
-          data-cf-button
-          ?disabled="${this.disabled}"
-          @click="${this._onSubmit}"
-          part="button"
-        >
-          ${this.buttonText}
-        </cf-button>
-      </div>
+      <form @submit="${this._onFormSubmit}" @click="${this._onClick}">
+        <div class="container">
+          <input
+            id="${this.inputId}"
+            type="text"
+            .value="${this.value}"
+            placeholder="${this.placeholder}"
+            ?disabled="${this.disabled}"
+            @input="${this._onInput}"
+            part="input"
+          />
+          <cf-button
+            data-cf-button
+            type="button"
+            ?disabled="${this.disabled}"
+            part="button"
+          >
+            ${this.buttonText}
+          </cf-button>
+        </div>
+        <button type="submit" ?disabled="${this.disabled}" hidden></button>
+      </form>
     `;
   }
 }


### PR DESCRIPTION
cf-submit-input previously created only on a click of its submit button. That click is a real, trusted DOM gesture that bubbles to the host, where a pattern's onClick reads the typed text as event.target.value carrying the surrounding surface's UI integrity. Pressing Enter in the field did nothing, so the create surface was not keyboard accessible.

Add Enter-to-submit. The constraint is that the create must ride a genuinely trusted gesture: a scripted button.click() from a keydown handler is isTrusted:false and carries no UI integrity to the worker handler, so it cannot drive the create. Instead, wrap the field and button in a form that also holds a hidden native submit button. Pressing Enter triggers the browser's implicit form submission, where the user agent fires a trusted click on that submit button. That click bubbles out of the shadow root to the host exactly like the visible button's click: event.target retargets to the host, so event.target.value and the composed-path UI integrity (data-ui-action on the host, data-ui-pattern / data-ui-event-integrity on an ancestor) are identical to the button path. The form's native submission is cancelled so the page does not navigate.

The submit button is hidden with the hidden attribute, which removes it from rendering, the accessibility tree, and the tab order. Implicit submission still fires a trusted click on it: the HTML specification fires a click at the form's default button as long as that button is not disabled, with no rendering condition, and this was confirmed against the implicit-submission path.

Route both the visible button click and the Enter-driven submit click through a single click handler on the form. That one chokepoint gates the create gesture and holds the in-flight guard, so Enter and a click cannot fire two creates, and a duplicate submit arriving before the deferred field-clear is stopped at the shadow boundary. The existing clear-on-submit behavior — the deferred setTimeout, the "value unchanged" guard, and the in-flight reset — is preserved. An empty submit is stopped at the boundary too, so a held Enter that repeats does not spin up no-op creates. The visible button is pinned to type="button" so the hidden control stays the sole form-submit target.

Verified with the cf-submit-input unit test (extended to drive the implicit-submit path and the Enter+click duplicate-suppression case) and the home-profile integration test, which creates a profile by pressing a real Enter — a dispatched KeyboardEvent does not trigger implicit submission, so the new submitViaEnter helper uses a real key press. The shared-profile test continues to cover the button path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Enter-to-submit for `cf-submit-input` via the browser’s implicit form submission. Improves keyboard accessibility while preserving trusted click behavior and UI integrity.

- **New Features**
  - Wrap the input and button in a form with a hidden native submit; Enter triggers a trusted click. Cancel the form submit to avoid navigation.
  - Route both button clicks and Enter submits through one form click handler. Stop non-submit clicks, ignore empty submits, and prevent duplicates with an in‑flight guard while preserving deferred clear-on-submit.
  - Keep the visible button `type="button"`. Add a `submitViaEnter` test helper and extend tests (implicit submission, Enter+click duplicate suppression, home profile creation via Enter).

<sup>Written for commit 3548e6b22d6b1f7a625d75d2db7ef8818b23ea7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

