### PR TITLE
packages/ts-transformers tests

### DIFF
--- a/packages/ts-transformers/test/ast/call-kind.test.ts
+++ b/packages/ts-transformers/test/ast/call-kind.test.ts
@@ -11,6 +11,7 @@ import {
   getLiftAppliedInputAndCallback,
   getPatternBuilderCallbackArgument,
 } from "../../src/ast/mod.ts";
+import { getWithPatternHoistablePatternCall } from "../../src/ast/call-kind.ts";
 
 function createProgram(source: string): {
   sourceFile: ts.SourceFile;
@@ -389,4 +390,75 @@ Deno.test("getLiftAppliedInputAndCallback recognizes lift-applied input position
   assertEquals(secondArgs?.input.getText(), "1");
   assertEquals(secondArgs?.callback.parameters[0]?.name.getText(), "value");
   assertEquals(thirdArgs, undefined);
+});
+
+Deno.test("getWithPatternHoistablePatternCall returns the bare pattern call argument", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare const items: any;
+    declare const make: { pattern(body: () => number): number };
+
+    const value = items.mapWithPattern(make.pattern(() => 1), { p: 1 });
+  `);
+
+  const expression = findInitializer(sourceFile, "value");
+  if (!ts.isCallExpression(expression)) {
+    throw new Error("Expected call expression initializer");
+  }
+
+  const hoistable = getWithPatternHoistablePatternCall(expression, checker);
+  assertEquals(hoistable?.getText(), "make.pattern(() => 1)");
+});
+
+Deno.test("getWithPatternHoistablePatternCall ignores a first argument that is not a pattern call", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare const items: any;
+    declare function plain(body: () => number): number;
+
+    const value = items.mapWithPattern(plain(() => 1), { p: 1 });
+  `);
+
+  const expression = findInitializer(sourceFile, "value");
+  if (!ts.isCallExpression(expression)) {
+    throw new Error("Expected call expression initializer");
+  }
+
+  assertEquals(
+    getWithPatternHoistablePatternCall(expression, checker),
+    undefined,
+  );
+});
+
+Deno.test("detectCallKind resolves a pattern builder imported from commonfabric", () => {
+  const { sourceFile, checker } = createProgram(`
+    import { pattern } from "commonfabric";
+
+    const value = pattern(() => 1);
+  `);
+
+  const expression = findInitializer(sourceFile, "value");
+  if (!ts.isCallExpression(expression)) {
+    throw new Error("Expected call expression initializer");
+  }
+
+  const kind = detectCallKind(expression, checker);
+  assertEquals(kind?.kind, "builder");
+  assertEquals(
+    kind?.kind === "builder" ? kind.builderName : undefined,
+    "pattern",
+  );
+});
+
+Deno.test("detectCallKind ignores a builder-named import from a foreign module", () => {
+  const { sourceFile, checker } = createProgram(`
+    import { pattern } from "other-module";
+
+    const value = pattern(() => 1);
+  `);
+
+  const expression = findInitializer(sourceFile, "value");
+  if (!ts.isCallExpression(expression)) {
+    throw new Error("Expected call expression initializer");
+  }
+
+  assertEquals(detectCallKind(expression, checker), undefined);
 });

--- a/packages/ts-transformers/test/ast/dataflow.test.ts
+++ b/packages/ts-transformers/test/ast/dataflow.test.ts
@@ -1,7 +1,19 @@
-import { assertStrictEquals } from "@std/assert";
+import { assert, assertEquals, assertStrictEquals } from "@std/assert";
 import ts from "typescript";
 
 import { createDataFlowAnalyzer } from "../../src/ast/dataflow.ts";
+
+// A minimal branded-cell setup so that `state.*` reads resolve to a reactive
+// (opaque) type under `noLib`, mirroring the reactive harness prelude.
+const REACTIVE_PRELUDE = `
+declare const CELL_BRAND: unique symbol;
+type BrandedCell<T, Brand extends string> = { readonly [CELL_BRAND]: Brand };
+interface OpaqueCell<T> extends BrandedCell<T, "opaque"> {}
+declare const state: {
+  readonly count: OpaqueCell<number>;
+};
+declare function tag(strings: TemplateStringsArray, ...values: unknown[]): string;
+`;
 
 function createProgram(source: string): {
   sourceFile: ts.SourceFile;
@@ -81,4 +93,118 @@ Deno.test("createDataFlowAnalyzer caches repeated analysis for the same node", (
   const second = analyze(expression);
 
   assertStrictEquals(second, first);
+});
+
+Deno.test("property read of a const object spread still resolves through the literal", () => {
+  // The aggregate's only property comes from a spread, so the static-property
+  // lookup short-circuits on the spread assignment and falls back to the
+  // resolved (reactive) property type.
+  const { sourceFile, checker } = createProgram(`
+    ${REACTIVE_PRELUDE}
+    const src = { a: state.count };
+    const agg = { ...src };
+    const value = agg.a;
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  assert(analysis.containsReactive, "spread-sourced reactive prop is reactive");
+});
+
+Deno.test("property read of a const object shorthand follows the shorthand initializer", () => {
+  // The aggregate uses a shorthand property whose name matches the access, so
+  // the lookup returns the shorthand identifier and analyzes it.
+  // `other` is a trailing shorthand that the reverse-order scan visits and
+  // skips before reaching the matching `count` shorthand.
+  const { sourceFile, checker } = createProgram(`
+    ${REACTIVE_PRELUDE}
+    const count = state.count;
+    const other = 1;
+    const agg = { count, other };
+    const value = agg.count;
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  assert(analysis.containsReactive, "shorthand reactive prop is reactive");
+});
+
+Deno.test("property read of a const object missing the key is not reactive", () => {
+  const { sourceFile, checker } = createProgram(`
+    ${REACTIVE_PRELUDE}
+    const agg = { a: 1 };
+    const value = agg.a;
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  assertEquals(analysis.containsReactive, false);
+  assertEquals(analysis.dataFlows.length, 0);
+});
+
+Deno.test("tagged template without substitutions is inert", () => {
+  const { sourceFile, checker } = createProgram(`
+    ${REACTIVE_PRELUDE}
+    const value = tag\`plain text\`;
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  assertEquals(analysis.containsReactive, false);
+  assertEquals(analysis.dataFlows.length, 0);
+});
+
+Deno.test("tagged template with a reactive substitution is reactive", () => {
+  const { sourceFile, checker } = createProgram(`
+    ${REACTIVE_PRELUDE}
+    const value = tag\`count: \${state.count}\`;
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  assert(analysis.containsReactive, "substitution dataflow is reactive");
+});
+
+function createTsxProgram(source: string): {
+  sourceFile: ts.SourceFile;
+  checker: ts.TypeChecker;
+} {
+  const fileName = "/test.tsx";
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    jsx: ts.JsxEmit.Preserve,
+    noLib: true,
+    skipLibCheck: true,
+  };
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    compilerOptions.target!,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const host = ts.createCompilerHost(compilerOptions, true);
+  host.getSourceFile = (name) => name === fileName ? sourceFile : undefined;
+  host.getCurrentDirectory = () => "/";
+  host.getDirectories = () => [];
+  host.fileExists = (name) => name === fileName;
+  host.readFile = (name) => name === fileName ? source : undefined;
+  host.writeFile = () => {};
+  host.useCaseSensitiveFileNames = () => true;
+  host.getCanonicalFileName = (name) => name;
+  host.getNewLine = () => "\n";
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+Deno.test("JSX fragment children carry through reactive dataflow", () => {
+  const { sourceFile, checker } = createTsxProgram(`
+    ${REACTIVE_PRELUDE}
+    const value = <>{state.count}</>;
+  `);
+  const analysis = createDataFlowAnalyzer(checker)(
+    findInitializer(sourceFile, "value"),
+  );
+  assert(analysis.containsReactive, "fragment child dataflow is reactive");
 });

--- a/packages/ts-transformers/test/ast/type-inference.test.ts
+++ b/packages/ts-transformers/test/ast/type-inference.test.ts
@@ -2,6 +2,10 @@ import { assertEquals } from "@std/assert";
 import ts from "typescript";
 
 import { isCollectionType } from "../../src/ast/mod.ts";
+import {
+  inferArrayElementType,
+  unwrapOpaqueLikeType,
+} from "../../src/ast/type-inference.ts";
 
 function createProgram(source: string): {
   sourceFile: ts.SourceFile;
@@ -130,4 +134,118 @@ Deno.test("isCollectionType: scalars, objects, and mixed unions are not collecti
 Deno.test("isCollectionType: an undefined type is not a collection", () => {
   const { checker } = createProgram(SOURCE);
   assertEquals(isCollectionType(undefined, checker), false);
+});
+
+// `inferArrayElementType` operates on the resolved Type, not the syntax, so the
+// declared Array/ReadonlyArray interfaces need a numeric index signature for
+// `getIndexTypeOfType` to return the element type.
+const ARRAY_ELEMENT_SOURCE = `
+  interface Array<T> { length: number; [index: number]: T; }
+  interface ReadonlyArray<T> { length: number; [index: number]: T; }
+  interface Box<T> { value: T; }
+
+  declare const plainArray: string[];
+  declare const unionOfArrays: string[] | number[];
+  declare const optionalArray: string[] | undefined;
+  declare const refIntersection: { tag: number } & string[];
+  declare const plainIntersection: { a: number } & { b: string };
+  declare const boxedArrays: Box<string[]> | number[];
+  declare const boxedScalarMix: Box<string> | number[];
+  declare const scalar: string;
+
+  plainArray;
+  unionOfArrays;
+  optionalArray;
+  refIntersection;
+  plainIntersection;
+  boxedArrays;
+  boxedScalarMix;
+  scalar;
+`;
+
+/** Find the trailing `name;` expression-statement reference by identifier. */
+function findReference(
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.Expression {
+  let found: ts.Expression | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isExpressionStatement(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === name
+    ) {
+      found = node.expression;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error(`Reference ${name} not found`);
+  return found;
+}
+
+function elementTypeText(name: string): string {
+  const { sourceFile, checker } = createProgram(ARRAY_ELEMENT_SOURCE);
+  const result = inferArrayElementType(findReference(sourceFile, name), {
+    checker,
+    factory: ts.factory,
+    sourceFile,
+  });
+  return result.type ? checker.typeToString(result.type) : "<none>";
+}
+
+Deno.test("inferArrayElementType: plain array yields the element type", () => {
+  assertEquals(elementTypeText("plainArray"), "string");
+});
+
+Deno.test("inferArrayElementType: union of distinct arrays yields a union element", () => {
+  // Drives the union fallback (`extractElementFromArrayType` over the union),
+  // de-duplication, and the internal `getUnionType` reconstruction.
+  assertEquals(elementTypeText("unionOfArrays"), "string | number");
+});
+
+Deno.test("inferArrayElementType: array-or-undefined drops the undefined arm", () => {
+  // Drives the single-survivor branch of `combineExtractedElementTypes`.
+  assertEquals(elementTypeText("optionalArray"), "string");
+});
+
+Deno.test("inferArrayElementType: intersection with an array reference unwraps the array", () => {
+  // Drives `findReferenceTypeInIntersection` returning the array member.
+  assertEquals(elementTypeText("refIntersection"), "string");
+});
+
+Deno.test("inferArrayElementType: intersection without an array member is not array-like", () => {
+  // Drives `findReferenceTypeInIntersection` returning undefined and the
+  // empty-result branch of `combineExtractedElementTypes`.
+  assertEquals(elementTypeText("plainIntersection"), "<none>");
+});
+
+Deno.test("inferArrayElementType: union of a wrapped array and a plain array", () => {
+  // Drives the Object/Reference branch of `extractElementFromArrayType` that
+  // recurses into a reference's type argument.
+  assertEquals(elementTypeText("boxedArrays"), "string | number");
+});
+
+Deno.test("inferArrayElementType: a non-array reference member contributes nothing", () => {
+  // `Box<string>` is a reference whose argument is not array-like, so only the
+  // `number[]` arm contributes an element type.
+  assertEquals(elementTypeText("boxedScalarMix"), "number");
+});
+
+Deno.test("inferArrayElementType: a scalar has no element type", () => {
+  assertEquals(elementTypeText("scalar"), "<none>");
+});
+
+Deno.test("unwrapOpaqueLikeType: a plain type is returned unchanged", () => {
+  const { sourceFile, checker } = createProgram(ARRAY_ELEMENT_SOURCE);
+  const scalar = checker.getTypeAtLocation(findReference(sourceFile, "scalar"));
+  assertEquals(
+    checker.typeToString(unwrapOpaqueLikeType(scalar, checker)!),
+    "string",
+  );
+});
+
+Deno.test("unwrapOpaqueLikeType: undefined input returns undefined", () => {
+  const { checker } = createProgram(ARRAY_ELEMENT_SOURCE);
+  assertEquals(unwrapOpaqueLikeType(undefined, checker), undefined);
 });

--- a/packages/ts-transformers/test/ast/utils.test.ts
+++ b/packages/ts-transformers/test/ast/utils.test.ts
@@ -12,6 +12,7 @@ import {
   isMethodCall,
   isOptionalMemberSymbol,
   setParentPointers,
+  visitEachChildWithJsx,
 } from "../../src/ast/utils.ts";
 
 function createProgram(source: string): {
@@ -295,4 +296,41 @@ Deno.test("AST utils set synthetic parent pointers for method-call helpers", () 
     getMethodCallTarget(callee.expression as ts.PropertyAccessExpression),
     undefined,
   );
+});
+
+Deno.test("visitEachChildWithJsx traverses elements, self-closing tags, and fragments", () => {
+  const source =
+    `const elem = <div a={oldName}><span b={oldName} />{oldName}</div>;\n` +
+    `const frag = <>{oldName} trailing</>;`;
+  const sourceFile = ts.createSourceFile(
+    "/test.tsx",
+    source,
+    ts.ScriptTarget.ES2020,
+    true,
+    ts.ScriptKind.TSX,
+  );
+
+  const result = ts.transform(sourceFile, [
+    (context) => (root) => {
+      const visit: ts.Visitor = (visited) => {
+        if (ts.isIdentifier(visited) && visited.text === "oldName") {
+          return ts.factory.createIdentifier("newName");
+        }
+        return visitEachChildWithJsx(visited, visit, context);
+      };
+      return ts.visitNode(root, visit) as ts.SourceFile;
+    },
+  ]);
+
+  const printed = ts.createPrinter().printFile(
+    result.transformed[0] as ts.SourceFile,
+  );
+  result.dispose?.();
+
+  // The rename reached identifiers nested inside the element, the self-closing
+  // child, and the fragment — proving each branch traversed its children.
+  assertEquals(printed.includes("oldName"), false);
+  assert(printed.includes("<div a={newName}>"));
+  assert(printed.includes("<span b={newName}/>"));
+  assert(printed.includes("<>{newName} trailing</>"));
 });

--- a/packages/ts-transformers/test/module-scope-cf-data.test.ts
+++ b/packages/ts-transformers/test/module-scope-cf-data.test.ts
@@ -1,0 +1,76 @@
+import { assert, assertStringIncludes } from "@std/assert";
+import { transformSource } from "./utils.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+// The module-scope cf-data transformer wraps a default-exported callable with
+// `__cfHelpers.__cf_data` when that callable's body may return a call applied to
+// another call result (the `factory()()` shape). These tests drive the decision
+// logic that classifies a callable as such.
+
+const PRELUDE = [
+  'import { pattern } from "commonfabric";',
+  "declare function factory(): () => number;",
+].join("\n");
+
+async function transform(lines: string[]): Promise<string> {
+  return await transformSource([PRELUDE, ...lines].join("\n"), {
+    types: COMMONFABRIC_TYPES,
+  });
+}
+
+Deno.test("module-scope cf-data wraps an arrow callable returning a call-on-call result", async () => {
+  const out = await transform([
+    "const helper = () => factory()();",
+    "export default helper;",
+  ]);
+  assertStringIncludes(out, "export default __cfHelpers.__cf_data(helper)");
+});
+
+Deno.test("module-scope cf-data wraps a block-body callable whose return is a call-on-call result", async () => {
+  const out = await transform([
+    "const helper = () => {",
+    "  const seed = 1;",
+    "  const next = seed + 1;",
+    "  return factory()();",
+    "};",
+    "export default helper;",
+  ]);
+  assertStringIncludes(out, "export default __cfHelpers.__cf_data(helper)");
+});
+
+Deno.test("module-scope cf-data wraps when the call-on-call result is nested in the returned expression", async () => {
+  const out = await transform([
+    "const helper = () => ({ value: factory()() });",
+    "export default helper;",
+  ]);
+  assertStringIncludes(out, "export default __cfHelpers.__cf_data(helper)");
+});
+
+Deno.test("module-scope cf-data ignores a call-on-call result inside a nested function boundary", async () => {
+  const out = await transform([
+    "const helper = () => {",
+    "  const inner = () => factory()();",
+    "  return inner;",
+    "};",
+    "export default helper;",
+  ]);
+  // The call-on-call result lives inside the inner arrow, which is a traversal
+  // boundary, so the outer callable is not treated as returning a call result.
+  assert(
+    !out.includes("__cf_data(helper)"),
+    "expected helper to be left unwrapped",
+  );
+});
+
+Deno.test("module-scope cf-data ignores a callable whose body expression is itself a function", async () => {
+  const out = await transform([
+    "const helper = () => () => factory()();",
+    "export default helper;",
+  ]);
+  // The arrow body is a function expression — a traversal boundary — so the
+  // nested call-on-call result is not attributed to `helper`.
+  assert(
+    !out.includes("__cf_data(helper)"),
+    "expected helper to be left unwrapped",
+  );
+});

--- a/packages/ts-transformers/test/pattern-coverage-transformer.test.ts
+++ b/packages/ts-transformers/test/pattern-coverage-transformer.test.ts
@@ -488,3 +488,31 @@ switch (x) {
   // recorded.
   assertEquals(spans.some((span) => span.startLine === caseOneLine), true);
 });
+
+Deno.test("single-statement control-flow bodies are wrapped and recorded", () => {
+  const source = `const flag = 1;
+if (flag > 0) doThen(); else doElse();
+if (flag > 0) doIfOnly();
+while (flag < 0) doWhile();
+do doDo(); while (flag < 0);
+for (let i = 0; i < 0; i++) doFor();
+`;
+  const { output, spans } = transformWithCoverage(source);
+
+  // Each non-block branch/body is instrumented even without braces.
+  expectSpanContaining(spans, source, "doThen();");
+  expectSpanContaining(spans, source, "doElse();");
+  expectSpanContaining(spans, source, "doWhile();");
+  expectSpanContaining(spans, source, "doDo();");
+  expectSpanContaining(spans, source, "doFor();");
+
+  // The bare statements are lifted into blocks carrying a hit call.
+  assertMatch(
+    output,
+    /if \(flag > 0\)\s*\{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)[\s\S]+doThen\(\);/,
+  );
+  assertMatch(
+    output,
+    /while \(flag < 0\)\s*\{\s+\(globalThis\.__cfPatternCoverage\?\.hit\)[\s\S]+doWhile\(\);/,
+  );
+});

--- a/packages/ts-transformers/test/policy/callback-boundary.test.ts
+++ b/packages/ts-transformers/test/policy/callback-boundary.test.ts
@@ -1,0 +1,138 @@
+import { assertEquals } from "@std/assert";
+import ts from "typescript";
+
+import { classifyCallbackBoundary } from "../../src/policy/callback-boundary.ts";
+
+function createProgramWithFiles(
+  files: Record<string, string>,
+  entryFileName = "/test.tsx",
+): { sourceFile: ts.SourceFile; checker: ts.TypeChecker } {
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.ESNext,
+    strict: true,
+    noLib: true,
+    skipLibCheck: true,
+    jsx: ts.JsxEmit.Preserve,
+  };
+
+  const host: ts.CompilerHost = {
+    fileExists: (name) => files[name] !== undefined,
+    readFile: (name) => files[name],
+    directoryExists: () => true,
+    getDirectories: () => [],
+    getCanonicalFileName: (name) => name,
+    getCurrentDirectory: () => "/",
+    getNewLine: () => "\n",
+    getDefaultLibFileName: () => "lib.d.ts",
+    useCaseSensitiveFileNames: () => true,
+    writeFile: () => {},
+    getSourceFile: (name, languageVersion) =>
+      files[name] !== undefined
+        ? ts.createSourceFile(
+          name,
+          files[name]!,
+          languageVersion,
+          true,
+          name.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+        )
+        : undefined,
+    resolveModuleNames: (moduleNames) =>
+      moduleNames.map((name) => {
+        const directMatch = Object.keys(files).find((fileName) =>
+          fileName === `/${name}.d.ts` || fileName.endsWith(`/${name}.d.ts`)
+        );
+        if (!directMatch) return undefined;
+        return {
+          resolvedFileName: directMatch,
+          extension: ts.Extension.Dts,
+          isExternalLibraryImport: false,
+        };
+      }),
+  };
+
+  const program = ts.createProgram([entryFileName], compilerOptions, host);
+  const sourceFile = program.getSourceFile(entryFileName);
+  if (!sourceFile) throw new Error("Expected entry source file");
+  return { sourceFile, checker: program.getTypeChecker() };
+}
+
+/** Find the second argument arrow of the first `table(cols, (row) => …)` call. */
+function findTableRowCallback(
+  sourceFile: ts.SourceFile,
+): ts.ArrowFunction {
+  let found: ts.ArrowFunction | undefined;
+  const visit = (node: ts.Node): void => {
+    if (
+      !found &&
+      ts.isCallExpression(node) &&
+      node.arguments.length >= 2 &&
+      ts.isArrowFunction(node.arguments[1]!)
+    ) {
+      found = node.arguments[1] as ts.ArrowFunction;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!found) throw new Error("Expected a table row callback");
+  return found;
+}
+
+const SQLITE_TYPINGS = `
+export type SqliteTableFunction = <T>(
+  columns: T,
+  rule: (row: Record<string, unknown>) => unknown,
+) => unknown;
+export declare const table: SqliteTableFunction;
+`;
+
+Deno.test("classifyCallbackBoundary: a SQLite table row rule is a compute-owned supported boundary", () => {
+  const { sourceFile, checker } = createProgramWithFiles({
+    "/commonfabric.d.ts": SQLITE_TYPINGS,
+    "/test.tsx": `
+      import { table } from "commonfabric";
+      const result = table(
+        { id: "id", name: "name" },
+        (row) => ({ display: row.name }),
+      );
+    `,
+  });
+
+  const callback = findTableRowCallback(sourceFile);
+  assertEquals(classifyCallbackBoundary(callback, checker), {
+    kind: "supported",
+    boundaryKind: "sqlite-row-label-rule",
+    bodyContext: {
+      strategy: "explicit",
+      kind: "compute",
+      owner: "unknown",
+    },
+  });
+});
+
+Deno.test("classifyCallbackBoundary: a user-defined table alias does not match the SQLite rule", () => {
+  // The `SqliteTableFunction` alias is declared locally rather than by Common
+  // Fabric's typings, so the declaration-provenance check rejects it.
+  const { sourceFile, checker } = createProgramWithFiles({
+    "/test.tsx": `
+      type SqliteTableFunction = <T>(
+        columns: T,
+        rule: (row: Record<string, unknown>) => unknown,
+      ) => unknown;
+      declare const table: SqliteTableFunction;
+      const result = table(
+        { id: "id" },
+        (row) => ({ display: row.id }),
+      );
+    `,
+  });
+
+  const callback = findTableRowCallback(sourceFile);
+  const decision = classifyCallbackBoundary(callback, checker);
+  assertEquals(
+    decision.kind !== "supported" || decision.boundaryKind !==
+        "sqlite-row-label-rule",
+    true,
+  );
+});

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -2094,3 +2094,42 @@ Deno.test(
     assertEquals(input.readPaths.length, 0);
   },
 );
+
+Deno.test("Capability analysis marks an array-destructured parameter as wildcard", () => {
+  // Unpacking a parameter positionally (`[first, second]`) loses the
+  // field-level precision needed to shrink, so the root is wildcarded.
+  const fn = parseFirstCallback(
+    `const fn = ([first, second]) => first.id + second.value;`,
+  );
+  const summary = analyzeFunctionCapabilities(fn);
+  const param = summary.params[0];
+
+  assert(param, "expected a parameter summary");
+  assertEquals(param.wildcard, true);
+});
+
+Deno.test("Capability analysis skips omitted elements in array destructuring", () => {
+  const fn = parseFirstCallback(
+    `const fn = (input) => {
+      const [, , third] = input.items;
+      return third.name;
+    };`,
+  );
+  const summary = analyzeFunctionCapabilities(fn);
+  const input = getPaths(summary, "input");
+
+  assert(input.readPaths.includes("items"));
+});
+
+Deno.test("Capability analysis tracks reads through a nullish-fallback alias", () => {
+  const fn = parseFirstCallback(
+    `const fn = (a, b) => {
+      const picked = a.user ?? b.user;
+      return picked.name;
+    };`,
+  );
+  const summary = analyzeFunctionCapabilities(fn);
+
+  assert(getPaths(summary, "a").readPaths.includes("user"));
+  assert(getPaths(summary, "b").readPaths.includes("user"));
+});

--- a/packages/ts-transformers/test/schema-injection-scope-and-args.test.ts
+++ b/packages/ts-transformers/test/schema-injection-scope-and-args.test.ts
@@ -1,0 +1,38 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { transformSource } from "./utils.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+// Targeted coverage for schema-injection branches that ran in CI only through
+// patterns: the per-session scope on a `new` cell constructor, and the schema-
+// argument detection that skips injection when two schemas are already present.
+
+Deno.test("schema injection reads the session scope from a `new X.perSession(...)` constructor", async () => {
+  const source = [
+    'import { Writable as WritableConstructor } from "commonfabric";',
+    "export default function Test() {",
+    '  const value = new WritableConstructor.perSession("seed");',
+    "  return { value };",
+    "}",
+  ].join("\n");
+
+  const output = await transformSource(source, { types: COMMONFABRIC_TYPES });
+  assertStringIncludes(output, 'scope: "session"');
+});
+
+Deno.test("schema injection skips a pattern that already supplies input and result schemas", async () => {
+  const source = [
+    'import { pattern } from "commonfabric";',
+    "export default pattern(",
+    "  (state: { count: number }) => ({ doubled: state.count * 2 }),",
+    '  { type: "object" } as const,',
+    '  { type: "object" } as const,',
+    ");",
+  ].join("\n");
+
+  const output = await transformSource(source, { types: COMMONFABRIC_TYPES });
+  // Injection is skipped, so the pattern keeps exactly the two author-supplied
+  // schema literals — no inferred input/result schema is added.
+  const schemaCount =
+    output.split("as const satisfies __cfHelpers.JSONSchema").length - 1;
+  assertEquals(schemaCount, 2);
+});

--- a/packages/ts-transformers/test/schema-shrink-validation.test.ts
+++ b/packages/ts-transformers/test/schema-shrink-validation.test.ts
@@ -1977,6 +1977,72 @@ Deno.test("Schema Shrink Validation", async (t) => {
       assertStringIncludes(result.output, '"bar"');
     },
   );
+
+  await t.step(
+    "errors when an array item access names a property the element type lacks",
+    async () => {
+      // The shrink-coverage check recurses through the array into its element
+      // type to validate item-level property reads.
+      const source = [
+        'import { lift } from "commonfabric";',
+        "const d = lift((items: { id: string }[]) =>",
+        "  items.map((item) => item.missing));",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const shrinkErrors = getErrors(diagnostics).filter(
+        (e) => e.type === "schema:path-not-in-type",
+      );
+      assertGreater(shrinkErrors.length, 0);
+    },
+  );
+
+  await t.step(
+    "errors when a readonly array item access names a missing property",
+    async () => {
+      // Same recursion, but the element type is reached through a readonly
+      // array node.
+      const source = [
+        'import { lift } from "commonfabric";',
+        "const d = lift((items: readonly { id: string }[]) =>",
+        "  items.map((item) => item.missing));",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const shrinkErrors = getErrors(diagnostics).filter(
+        (e) => e.type === "schema:path-not-in-type",
+      );
+      assertGreater(shrinkErrors.length, 0);
+    },
+  );
+
+  await t.step(
+    "validates array item reads alongside an array-root length read",
+    async () => {
+      // Reading both an array-root property (`length`) and item-level fields
+      // exercises the array-root path branch of the coverage check.
+      const source = [
+        'import { lift } from "commonfabric";',
+        "const d = lift((items: { id: string }[]) => {",
+        "  const count = items.length;",
+        "  const ids = items.map((item) => item.missing);",
+        "  return { count, ids };",
+        "});",
+      ].join("\n");
+
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const shrinkErrors = getErrors(diagnostics).filter(
+        (e) => e.type === "schema:path-not-in-type",
+      );
+      assertGreater(shrinkErrors.length, 0);
+    },
+  );
 });
 
 function getShrinkErrors(

--- a/packages/ts-transformers/test/type-shrinking.test.ts
+++ b/packages/ts-transformers/test/type-shrinking.test.ts
@@ -867,6 +867,160 @@ Deno.test("type shrinking helper predicates detect wrapper type nodes", () => {
   assertEquals(preservedWrapperFor(plainNode, undefined, checker), undefined);
 });
 
+Deno.test("applyShrinkAndWrap descends identity paths through named interface references", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare namespace __cfHelpers {
+      export type OpaqueCell<T> = { readonly opaque?: T };
+    }
+    interface Inner { keep: string; drop: number; }
+    interface Outer { inner: Inner; other: string; }
+    type Input = Outer;
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      identityPaths: [["inner", "keep"]],
+      identityCellPaths: [["inner", "keep"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  // The reference resolves to declared members, recurses into `inner`, and
+  // wraps the `keep` leaf. Identity-path application transforms the targeted
+  // leaf in place and leaves the surrounding structure intact.
+  assertStringIncludes(printed, "keep: __cfHelpers.OpaqueCell<unknown>");
+  assertStringIncludes(printed, "drop: number");
+  assertStringIncludes(printed, "other: string");
+});
+
+Deno.test("applyShrinkAndWrap rebuilds inline literals when a nested identity leaf changes", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare namespace __cfHelpers {
+      export type OpaqueCell<T> = { readonly opaque?: T };
+    }
+    type Input = {
+      inner: { keep: string; drop: number };
+      other: string;
+    };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      identityPaths: [["inner", "keep"]],
+      identityCellPaths: [["inner", "keep"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "keep: __cfHelpers.OpaqueCell<unknown>");
+  assertStringIncludes(printed, "drop: number");
+  assertStringIncludes(printed, "other: string");
+});
+
+Deno.test("applyShrinkAndWrap returns an inline literal unchanged when a nested identity path does not resolve", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Input = {
+      a: { x: string };
+      b: string;
+    };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      identityPaths: [["a", "missing"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  // No member changes, so the literal (and its `a` member) is returned as-is.
+  assertStringIncludes(printed, "x: string");
+  assertStringIncludes(printed, "b: string");
+  assertEquals(printed.includes("OpaqueCell"), false);
+});
+
+Deno.test("applyShrinkAndWrap leaves array elements untouched when an identity item path does not resolve", () => {
+  const { sourceFile, checker } = createProgram(`
+    interface Item { keep: string; drop: number; }
+    type Input = Item[];
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      identityPaths: [["0", "missing"]],
+      identityCellPaths: [["0", "missing"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  // The item path names no real member, so the element type (and the whole
+  // array node) is returned unchanged.
+  assertEquals(printed, "Item[]");
+});
+
+Deno.test("applyShrinkAndWrap descends identity item paths through readonly arrays", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare namespace __cfHelpers {
+      export type OpaqueCell<T> = { readonly opaque?: T };
+    }
+    interface Item { keep: string; drop: number; }
+    type Input = readonly Item[];
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      identityPaths: [["0", "keep"]],
+      identityCellPaths: [["0", "keep"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  // The readonly-array node recurses into its element type, resolves the item
+  // interface's members, and wraps the requested leaf in place.
+  assertStringIncludes(printed, "readonly");
+  assertStringIncludes(printed, "keep: __cfHelpers.OpaqueCell<unknown>");
+  assertStringIncludes(printed, "drop: number");
+});
+
 Deno.test("wrapTypeNodeWithCapability emits the expected cell wrappers", () => {
   const { sourceFile } = createProgram(`type Value = string;`);
   const valueNode = findTypeAlias(sourceFile, "Value").type;


### PR DESCRIPTION
Computer-generated test coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds focused unit tests in `packages/ts-transformers` to cover previously untested branches across AST helpers, dataflow, type inference/shrinking, schema injection/validation, pattern coverage, module-scope cf-data wrapping, and policy boundary detection. These tests exercise arrays and unions/intersections, readonly arrays, JSX traversal, tagged templates, `getWithPatternHoistablePatternCall` and builder import resolution, SQLite `table` row callback classification, destructuring and nullish coalescing in capability analysis, session scope via `new X.perSession(...)`, and brace-less control-flow instrumentation.

<sup>Written for commit f7d5df76d1e2e70a2100fd840077e5f36f9e15a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

