### PR TITLE
feat(runner): content-addressed action identity (re-root off fn.src)

### DIFF
--- a/docs/specs/action-id-per-instance-decision.md
+++ b/docs/specs/action-id-per-instance-decision.md
@@ -1,0 +1,70 @@
+# Decision note — per-instance action id vs per-symbol fingerprint
+
+**Status:** implemented in this PR (content-addressed action identity), pending
+author confirmation of the durable-key granularity. Companion to
+[`content-addressed-action-identity.md`](./content-addressed-action-identity.md).
+
+## Issue
+
+The content-addressed re-root originally routed **both** the scheduler action id
+and the durable implementation fingerprint through the same per-**symbol** key
+`cf:module/<hash>:<symbol>` (`getSchedulerActionId` returned
+`action.implementationHash`). Only the fingerprint should be per-symbol.
+
+The action id keys two per-instance structures:
+
+- `actionStats` (`scheduler.ts`, `Map<string, ActionStats>`) — drives
+  auto-debounce/throttle (`delays.ts`).
+- the durable scheduler observation (lookup key in `rehydrateActionFromStorage`
+  / `observationMatchesCurrentAction`).
+
+So **N instances of one hoisted op** — one `lift` called twice, a `map` over a
+list, a repeated sub-pattern — collide on a single id. Verified empirically:
+`da = dbl(a); db = dbl(b)` persisted **one** observation (the second overwrote
+the first) where the pre-re-root code persisted **two**. Consequences:
+
+1. **`actionStats` (always-on):** the N instances share one run-count, so
+   auto-debounce trips ~N× early and applies to all of them → update latency for
+   lists. Heuristic only, not a correctness bug.
+2. **Durable observations (`persistentSchedulerState`, off by default):** N
+   instances → 1 surviving observation → on reload all N rehydrate from one
+   instance's reads/writes surface. Latent **correctness** bug for the persistent
+   scheduler-state feature.
+
+No production impact today (the durable path is experimental-off; the stats
+effect is heuristic), but it shouldn't ship as-is.
+
+## What we did
+
+The pre-re-root id (`action.src`) was already per-instance — a hash of
+`{process, reads, writes}` — but it embedded the source location, which the
+cold-load perf work needs off the hot path. We keep the per-instance property
+**without** the source-location dependence:
+
+- **Fingerprint stays per-symbol:** `impl:cf:module/<hash>:<symbol>`
+  (`schedulerImplementationFingerprint`) — identifies the code, for cache/eviction.
+- **Action id becomes per-instance again, source-independent:**
+  `cf:module/<hash>:<symbol>:<instanceKey>`, where `instanceKey =
+  schedulerActionInstanceKey({process, reads, writes})` — a reload-stable hash of
+  the action's links, folding in no source-derived name so it's independent of
+  `fn.src`/the debug annotation.
+
+Guarded by a multi-instance regression test in
+`test/src-garble-identity-invariant.test.ts` (two instances → distinct ids + two
+observations + still byte-identical under `.src` garble).
+
+## For the author (Berni) to confirm / redirect
+
+1. **Is per-instance the intended granularity for the durable observation key?**
+   The spec's stated key (`cf:module/<hash>:line:col`) is per-primitive-*site*
+   and would also collide across instances of the same site — so it
+   under-specifies this. The pre-change code was per-instance (`action.src`),
+   which is what made reload rehydration correct for multi-instance patterns.
+2. **Confirm the fingerprint(per-symbol) / id(per-instance) split** as the
+   intended model.
+3. Any planned instance-keying layer above the observation store that would make
+   a per-symbol durable key acceptable instead?
+
+If (1)/(2) land differently, the change is localized to
+`schedulerActionInstanceKey` + `getSchedulerActionId` + the two setup call sites,
+and easy to adjust.

--- a/docs/specs/content-addressed-action-identity.md
+++ b/docs/specs/content-addressed-action-identity.md
@@ -145,9 +145,26 @@ it badly:
    exists to disambiguate equal `implementationRef`s across loads — a problem
    content addressing dissolves (below).
 
-The scheduler is already migrated: persisted observations key on the
-content-addressed `implementationHash` (`cf:module/<hash>:<line>:<col>`,
-`scheduler/action-run.ts`), with no `implementationRef` dependence.
+The scheduler is migrated to content addressing, with a fingerprint/id split:
+
+- The durable implementation **fingerprint** keys on the per-**symbol** content
+  address `impl:cf:module/<hash>:<symbol>` (`schedulerImplementationFingerprint`,
+  `scheduler/action-run.ts`) — it identifies the implementation *code*, with no
+  `implementationRef` dependence.
+- The action **id** — the durable observation lookup key and the in-session
+  `actionStats` key — must stay per-**instance**, so it appends a
+  source-location-independent instance discriminator:
+  `cf:module/<hash>:<symbol>:<instanceKey>`, where `instanceKey` is a
+  reload-stable hash of the action's `{process, reads, writes}` links
+  (`getSchedulerActionId`/`schedulerActionInstanceKey`, `scheduler/diagnostics.ts`
+  + `runner.ts`). Without the instance key, N instances of one hoisted op (one
+  `lift` called twice, a `map`, a repeated sub-pattern) would collide on a single
+  id and observation.
+
+Persisted-data compatibility: observations written under the previous
+`fn.src`-derived id/fingerprint simply miss the new content-addressed lookup on
+first resume, so the action re-runs once (the safe default) and re-persists under
+the new key — no `SchedulerActionObservation.version` bump or re-key is required.
 
 ## The invariant this design stands on
 

--- a/docs/specs/module-loading-verifier-and-engine-design.md
+++ b/docs/specs/module-loading-verifier-and-engine-design.md
@@ -111,24 +111,40 @@ To reproduce on the ESM path (keep = format-agnostic; replace = AMD-specific):
 | `/${id}` prefix + synthetic `/index.ts` (a workaround for AMD `outFile` prefix-flattening) | **Re-evaluate** — likely unnecessary for a real module graph, but `evaluate`'s prefix-stripping, `collectVerifiedLoadSources`, and identity source normalization all assume it, so any change is consistent across all four sites |
 | CF transformer pipeline (`CommonFabricTransformerPipeline`) | Keep — confirmed module-format-agnostic; feeds ESM emit unchanged |
 
-#### `fn.src` source locations have TWO consumers — both must keep working
+#### `fn.src` source locations: CFC verified-source still depends on them
 
 `annotateFunctionDebugMetadata` → `resolveLocationFromFunctionSource` produces
 `fn.src = "source:line:col"` by `script.indexOf(fn.toString())` against the
-active frame's bundle text, then mapping through the sourcemap. In this worktree
-that feeds **both**:
+active frame's bundle text, then mapping through the sourcemap; the reload-stable
+canonical form is `cf:module/<hash>/<path>:line:col`.
 
-1. `cfc/implementation-identity.ts` `resolveVerifiedImplementationIdentity` — the
-   CFC verified-load trust identity (`isVerifiedSourceInLoad`, `bundleId`, …).
-2. `harness/module-identity.ts` via `Engine.implementationHashForSource` — the
-   merged Phase 1 scheduler implementation fingerprint.
+This **used to** feed two consumers (CFC verified-source and the scheduler
+implementation fingerprint). The scheduler consumer is **gone**: scheduler action
+identity — action ids and the durable implementation fingerprint — was re-rooted
+onto content-addressed `{ identity, symbol }` provenance and no longer reads
+`fn.src`; the `Engine.implementationHashForSource` helper was removed. See
+`docs/specs/content-addressed-action-identity.md`.
 
-So the ESM artifact the compartment evaluates **must** (a) contain each
+The remaining consumer is **CFC verified-implementation identity**
+(`cfc/implementation-identity.ts`, `resolveProvenanceImplementationIdentity`).
+Its anti-spoof proof is the content-addressed provenance WeakMap
+(`harness/verified-provenance.ts`) — an entry exists only for a function
+registered during a verified evaluation, so the lookup itself authenticates.
+`fn.src` is then read as a **fail-closed consistency check**: the canonical
+source must point INTO the provenance module
+(`identityFromCanonicalSource(src) === provenance.identity`), else the identity
+resolves `unsupported` and the gated `writeAuthorizedBy` write is denied. (The
+former `isVerifiedSourceInLoad` / `bundleId` / `verifiedLoadId` registry arm was
+removed with the provenance migration — PR E2.)
+
+So the ESM artifact the compartment evaluates **must** still (a) contain each
 function's source verbatim, in emit order, so `indexOf`/`nextSearchOffset`
 resolves, and (b) carry a sourcemap over the same `filename`, and (c)
-`setVerifiedLoadSources` must include the normalized ESM source paths. This is
-the single most delicate integration constraint and gets its own test
-(`fn.src` resolves identically under both loaders for the same pattern).
+`setVerifiedLoadSources` must include the normalized ESM source paths — because
+CFC's consistency check fail-closes when `fn.src` does not resolve. This remains
+the single most delicate integration constraint and gets its own test (`fn.src`
+resolves to the canonical authored source under the ESM loader, and CFC
+verified-source resolves — `test/esm-source-location.test.ts`).
 
 ## Part A — Verifier classification port
 

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -549,6 +549,26 @@ export function action<T>(_event: (event?: T) => void): Stream<T> {
   );
 }
 
+/**
+ * TEST-ONLY seam. When set, the registered transform replaces the location
+ * string that {@link annotateFunctionDebugMetadata} writes to the debug
+ * `.src`/`name` annotation. It lets a test deliberately *garble* `.src` to
+ * prove that scheduler action ids and the durable implementation fingerprint
+ * are independent of `.src` (re-rooted onto content-addressed
+ * `{ identity, symbol }` provenance — see
+ * docs/specs/content-addressed-action-identity.md and
+ * test/src-garble-identity-invariant.test.ts). It is also the natural gate for
+ * deferring annotation entirely (the lazy/debug-only `.src` follow-up). Never
+ * set in production.
+ */
+let srcAnnotationTransformForTest: ((location: string) => string) | undefined;
+
+export function __setSrcAnnotationTransformForTest(
+  transform: ((location: string) => string) | undefined,
+): void {
+  srcAnnotationTransformForTest = transform;
+}
+
 function annotateFunctionDebugMetadata(
   fn: (...args: any[]) => unknown,
 ): void {
@@ -558,7 +578,11 @@ function annotateFunctionDebugMetadata(
 
   const { location, sample } = getExternalSourceLocation();
   const fallbackLocation = location ?? resolveLocationFromFunctionSource(fn);
-  const finalLocation = fallbackLocation;
+  // The test-only seam garbles the annotated location (both `.src` and the
+  // `name` mirror below); identity must not move as a result.
+  const finalLocation = fallbackLocation && srcAnnotationTransformForTest
+    ? srcAnnotationTransformForTest(fallbackLocation)
+    : fallbackLocation;
   if (finalLocation) {
     if (location) {
       Object.defineProperty(fn, "name", {

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -1266,22 +1266,6 @@ export class Engine extends EventTarget implements Harness {
         : this.canonicalSourceByPrefixed.get(`/${source}`));
   }
 
-  // Translate a source-location string into a stable content-addressed
-  // implementation identity. See the Harness interface for the contract.
-  implementationHashForSource(sourceLocation: string): string | undefined {
-    const match = sourceLocation.match(/^(.*):(\d+):(\d+)$/);
-    const sourcePath = match ? match[1] : sourceLocation;
-    const suffix = match ? `:${match[2]}:${match[3]}` : "";
-    // `fn.src` is already canonical (`cf:module/<hash>/<path>`); reduce it to the
-    // pure per-module code identity `cf:module/<hash>` for the fingerprint.
-    const canonical = sourcePath.match(/^cf:module\/([^/]+)/);
-    if (canonical) {
-      return `cf:module/${canonical[1]}${suffix}`;
-    }
-    const hash = this.moduleHashByPrefixedSource.get(sourcePath);
-    return hash === undefined ? undefined : `cf:module/${hash}${suffix}`;
-  }
-
   // Map a single position to its original source location.
   // Returns null if no source map is loaded for the filename.
   mapPosition(

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -209,13 +209,6 @@ export interface Harness extends EventTarget {
     options: UnsafeHostTrustOptions,
   ): void;
 
-  // Translate a source-location string (`/<id>/file.tsx:line:col`, as found on
-  // an action's `src`) into a stable, content-addressed implementation hash
-  // (`cf:module/<moduleHash>:line:col`). Returns undefined when the source
-  // location does not correspond to a loaded module, in which case callers fall
-  // back to the raw source location. See docs/specs/module-loading.md.
-  implementationHashForSource?(sourceLocation: string): string | undefined;
-
   // Translate a bundle-prefixed source path (`/<programHash>/<authoredPath>`, as
   // returned by `mapPosition`) into the reload-stable canonical source
   // `cf:module/<moduleHash>/<authoredPath>`, keeping the authored path for

--- a/packages/runner/src/harness/verified-provenance.ts
+++ b/packages/runner/src/harness/verified-provenance.ts
@@ -3,15 +3,18 @@ import { VERIFIED_BINDING_METADATA_FIELD } from "@commonfabric/utils/sandbox-con
 /**
  * Content-addressed provenance for verified implementation functions.
  *
- * An entry exists ONLY for a function object recorded through the single
- * runner-owned registration channel: post-evaluation module indexing
- * (`Engine.recordModuleProvenance`, gated by `isTrustedBuilderArtifact`), which
- * records the implementation function of an exported / `__cfReg`-registered
- * builder artifact with the module's content identity and the artifact's
- * export/`__cfReg` symbol. Builder artifacts minted DURING a running action are
- * NOT recorded — they have no content-addressed identity, and the runner
- * fail-closes on the attempt rather than admitting them (see
- * `Runner.invokeJavaScriptImplementation`).
+ * An entry exists ONLY for a function object that became verified through one
+ * of the runner-owned registration channels:
+ *
+ *  1. post-evaluation module indexing (`PatternManager.indexArtifact`): the
+ *     implementation function of an exported / `__cfReg`-registered builder
+ *     artifact, with the module's content identity and the artifact's
+ *     export/`__cfReg` symbol;
+ *  2. the in-action registrar (`Runner.invokeJavaScriptImplementation`): a
+ *     builder artifact created DURING a verified action's execution, with the
+ *     identity derived from the new function's canonical source location and
+ *     `dynamic: true` (in-session only — such artifacts never resolve across
+ *     a reload, unchanged from the legacy behavior).
  *
  * The WeakMap itself is the anti-spoof proof for CFC: an attacker-supplied
  * function — even with byte-identical source text — was never registered
@@ -23,8 +26,10 @@ import { VERIFIED_BINDING_METADATA_FIELD } from "@commonfabric/utils/sandbox-con
 export type VerifiedProvenance = {
   /** Module content identity (prefix-free `cf:module/<hash>` hash). */
   identity: string;
-  /** Export / `__cfReg` symbol of the registered factory. */
+  /** Export / `__cfReg` symbol of the registered factory (absent: dynamic). */
   symbol?: string;
+  /** Created during a verified action's execution (in-session only). */
+  dynamic?: true;
   /** CT-1665 verified binding identity, when the factory carried one. */
   bindingIdentity?: { sourceFile: string; bindingPath: string[] };
 };

--- a/packages/runner/src/harness/verified-provenance.ts
+++ b/packages/runner/src/harness/verified-provenance.ts
@@ -3,18 +3,16 @@ import { VERIFIED_BINDING_METADATA_FIELD } from "@commonfabric/utils/sandbox-con
 /**
  * Content-addressed provenance for verified implementation functions.
  *
- * An entry exists ONLY for a function object that became verified through one
- * of the runner-owned registration channels:
- *
- *  1. post-evaluation module indexing (`PatternManager.indexArtifact`): the
- *     implementation function of an exported / `__cfReg`-registered builder
- *     artifact, with the module's content identity and the artifact's
- *     export/`__cfReg` symbol;
- *  2. the in-action registrar (`Runner.invokeJavaScriptImplementation`): a
- *     builder artifact created DURING a verified action's execution, with the
- *     identity derived from the new function's canonical source location and
- *     `dynamic: true` (in-session only — such artifacts never resolve across
- *     a reload, unchanged from the legacy behavior).
+ * An entry exists ONLY for a function object recorded through the single
+ * runner-owned registration channel: post-evaluation module indexing
+ * (`Engine.recordModuleProvenance`, gated by `isTrustedBuilderArtifact` and
+ * the defining-module guard), which records the implementation function of an
+ * exported / `__cfReg`-registered builder artifact with the module's content
+ * identity and the artifact's export/`__cfReg` symbol. There is NO in-action
+ * registration channel: a builder artifact minted DURING a running action has
+ * no content-addressed identity, and the runner fails closed at creation time
+ * instead of admitting it (identity E5 — see
+ * `Runner.invokeJavaScriptImplementation` / `builder/action-context.ts`).
  *
  * The WeakMap itself is the anti-spoof proof for CFC: an attacker-supplied
  * function — even with byte-identical source text — was never registered
@@ -28,7 +26,14 @@ export type VerifiedProvenance = {
   identity: string;
   /** Export / `__cfReg` symbol of the registered factory (absent: dynamic). */
   symbol?: string;
-  /** Created during a verified action's execution (in-session only). */
+  /**
+   * Symbol-less dynamic provenance: in-session-only authority — never
+   * serializable to a cross-session `$implRef`. No production writer exists
+   * today (in-action mints fail closed, above); the adversarial suite
+   * (content-addressed-identity-adversarial.test.ts, attack 7) constructs it
+   * directly to pin these semantics, which any future dynamic registrar must
+   * honor.
+   */
   dynamic?: true;
   /** CT-1665 verified binding identity, when the factory carried one. */
   bindingIdentity?: { sourceFile: string; bindingPath: string[] };

--- a/packages/runner/src/harness/verified-provenance.ts
+++ b/packages/runner/src/harness/verified-provenance.ts
@@ -3,18 +3,15 @@ import { VERIFIED_BINDING_METADATA_FIELD } from "@commonfabric/utils/sandbox-con
 /**
  * Content-addressed provenance for verified implementation functions.
  *
- * An entry exists ONLY for a function object that became verified through one
- * of the runner-owned registration channels:
- *
- *  1. post-evaluation module indexing (`PatternManager.indexArtifact`): the
- *     implementation function of an exported / `__cfReg`-registered builder
- *     artifact, with the module's content identity and the artifact's
- *     export/`__cfReg` symbol;
- *  2. the in-action registrar (`Runner.invokeJavaScriptImplementation`): a
- *     builder artifact created DURING a verified action's execution, with the
- *     identity derived from the new function's canonical source location and
- *     `dynamic: true` (in-session only — such artifacts never resolve across
- *     a reload, unchanged from the legacy behavior).
+ * An entry exists ONLY for a function object recorded through the single
+ * runner-owned registration channel: post-evaluation module indexing
+ * (`Engine.recordModuleProvenance`, gated by `isTrustedBuilderArtifact`), which
+ * records the implementation function of an exported / `__cfReg`-registered
+ * builder artifact with the module's content identity and the artifact's
+ * export/`__cfReg` symbol. Builder artifacts minted DURING a running action are
+ * NOT recorded — they have no content-addressed identity, and the runner
+ * fail-closes on the attempt rather than admitting them (see
+ * `Runner.invokeJavaScriptImplementation`).
  *
  * The WeakMap itself is the anti-spoof proof for CFC: an attacker-supplied
  * function — even with byte-identical source text — was never registered
@@ -26,10 +23,8 @@ import { VERIFIED_BINDING_METADATA_FIELD } from "@commonfabric/utils/sandbox-con
 export type VerifiedProvenance = {
   /** Module content identity (prefix-free `cf:module/<hash>` hash). */
   identity: string;
-  /** Export / `__cfReg` symbol of the registered factory (absent: dynamic). */
+  /** Export / `__cfReg` symbol of the registered factory. */
   symbol?: string;
-  /** Created during a verified action's execution (in-session only). */
-  dynamic?: true;
   /** CT-1665 verified binding identity, when the factory carried one. */
   bindingIdentity?: { sourceFile: string; bindingPath: string[] };
 };

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2521,21 +2521,28 @@ export class Runner {
   }
 
   /**
-   * Attach a stable, content-addressed implementation identity to an action,
-   * derived from its bundle-relative source location. No-op when the harness
-   * cannot resolve the location (built-in or unmapped sources); the scheduler
-   * then falls back to the raw source location for its implementation
-   * fingerprint. See docs/specs/module-loading.md.
+   * Attach a stable, content-addressed implementation identity
+   * (`cf:module/<identity>:<symbol>`) to an action, derived from its module
+   * implementation's verified provenance — NOT from the source location. This
+   * keeps action identity / fingerprints independent of `.src` and its (broken)
+   * source-map resolution: the discriminator is the hoisted `__cfReg`/export
+   * `symbol`, not `:line:col`. No-op for implementations with no verified
+   * provenance (host / dynamic / test builders); the scheduler then resolves
+   * `getVerifiedProvenance` live or falls to a generated id.
+   * See docs/specs/content-addressed-action-identity.md.
    */
   private applyImplementationHash(
     action: Action,
-    sourceLocation: string,
+    implementation: unknown,
   ): void {
-    const implementationHash = this.runtime.harness
-      .implementationHashForSource?.(sourceLocation);
-    if (implementationHash) {
+    const provenance = typeof implementation === "function"
+      ? getVerifiedProvenance(implementation)
+      : undefined;
+    if (provenance?.identity) {
       (action as { implementationHash?: string }).implementationHash =
-        implementationHash;
+        provenance.symbol
+          ? `cf:module/${provenance.identity}:${provenance.symbol}`
+          : `cf:module/${provenance.identity}`;
     }
   }
 
@@ -3538,7 +3545,7 @@ export class Runner {
         schedulerJavaScriptActionName(name, processCell, reads, writes),
         { setSrc: true },
       );
-      this.applyImplementationHash(action, name);
+      this.applyImplementationHash(action, module.implementation);
     }
 
     // Writable arguments alone do not make an output-producing action a
@@ -3985,9 +3992,7 @@ export class Runner {
       }
     };
     setRunnableName(action, rawName, { setSrc: true });
-    if (impl.src) {
-      this.applyImplementationHash(action, impl.src);
-    }
+    this.applyImplementationHash(action, impl);
 
     // Seed raw actions with their pattern/module/write metadata so pull-mode
     // scheduling can discover pending computations before their first run.

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3570,7 +3570,12 @@ export class Runner {
         schedulerJavaScriptActionName(name, processCell, reads, writes),
         { setSrc: true },
       );
-      this.applyImplementationHash(action, module.implementation);
+      // Use the RESOLVED implementation `fn` (`resolveByImplRef(module) ?? …`),
+      // not `module.implementation`: an `$implRef`-resolved module (reloaded from
+      // a serialized graph) carries the ref, not the live function, so reading
+      // provenance off `module.implementation` would drop the content-addressed
+      // scheduler identity on reload.
+      this.applyImplementationHash(action, fn);
       (action as { schedulerInstanceKey?: string }).schedulerInstanceKey =
         schedulerActionInstanceKey({
           process: processCell.getAsNormalizedFullLink(),

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -170,6 +170,31 @@ function schedulerActionLinkIdentity(link: NormalizedFullLink) {
   };
 }
 
+/**
+ * A source-location-INDEPENDENT, per-instance discriminator for a scheduler
+ * action: a short hash of the action's `{ process, reads, writes }` cell links.
+ * Two instances of the same hoisted op (e.g. one `lift` called twice) differ in
+ * their reads/writes, so this distinguishes them; the links are reload-stable,
+ * so it is too. Unlike `schedulerJavaScriptActionName`/`schedulerRawActionName`
+ * it folds in NO source-derived name, so it is independent of `fn.src` and the
+ * debug annotation. It is appended to the content-addressed action id
+ * (`cf:module/<hash>:<symbol>:<instanceKey>`, `getSchedulerActionId`) so that the
+ * per-symbol content address stays the implementation *fingerprint* while the
+ * action id — the `actionStats` key and the durable observation key — stays
+ * per-*instance*. Without it, N instances of one symbol collide on a single id.
+ */
+function schedulerActionInstanceKey(parts: {
+  process?: NormalizedFullLink;
+  reads?: readonly NormalizedFullLink[];
+  writes?: readonly NormalizedFullLink[];
+}): string {
+  return hashOf({
+    process: parts.process ? schedulerActionLinkIdentity(parts.process) : null,
+    reads: (parts.reads ?? []).map(schedulerActionLinkIdentity),
+    writes: (parts.writes ?? []).map(schedulerActionLinkIdentity),
+  }).hashString.slice(0, 12);
+}
+
 function schemaCellScope(
   schema: JSONSchema | undefined,
 ): CellScope | undefined {
@@ -3546,6 +3571,12 @@ export class Runner {
         { setSrc: true },
       );
       this.applyImplementationHash(action, module.implementation);
+      (action as { schedulerInstanceKey?: string }).schedulerInstanceKey =
+        schedulerActionInstanceKey({
+          process: processCell.getAsNormalizedFullLink(),
+          reads,
+          writes,
+        });
     }
 
     // Writable arguments alone do not make an output-producing action a
@@ -3993,6 +4024,8 @@ export class Runner {
     };
     setRunnableName(action, rawName, { setSrc: true });
     this.applyImplementationHash(action, impl);
+    (action as { schedulerInstanceKey?: string }).schedulerInstanceKey =
+      schedulerActionInstanceKey({ reads: inputCells, writes: outputCells });
 
     // Seed raw actions with their pattern/module/write metadata so pull-mode
     // scheduling can discover pending computations before their first run.

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -2368,9 +2368,13 @@ export class Scheduler {
   // ============================================================
 
   /**
-   * Gets a stable identifier for an action based on its source location.
-   * Prefers .src (set as backup) over .name, falls back to a generated ID.
-   * This ID is used for stats tracking to persist across action recreation.
+   * A stable, content-addressed, per-INSTANCE identifier for an action:
+   * `cf:module/<hash>:<symbol>:<instanceKey>` — the per-symbol content address
+   * plus a reload-stable hash of the action's reads/writes. It keys
+   * `actionStats` and the durable observation, so it must distinguish two
+   * instances of the same hoisted op (the per-symbol content address alone would
+   * collide them). `.src` is not consulted (debug-only). Falls back to `.name` /
+   * a generated id for actions without provenance.
    */
   private getActionId(action: Action | EventHandler): string {
     return getSchedulerActionId(this.actionIdentityState, action);

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -728,10 +728,13 @@ export function schedulerImplementationFingerprint(
   actionId: string,
   telemetry: SchedulerActionInfo | undefined,
 ): string {
-  // Prefer the per-module content-addressed identity when available: it is
-  // stable across reloads, entry points, and TCB upgrades (see
-  // docs/specs/module-loading.md). The `src` source location is only stable
-  // within a single bundle layout, so it is the fallback.
+  // The implementation FINGERPRINT is the per-module content-addressed identity
+  // `cf:module/<hash>:<symbol>` — stable across reloads, entry points, and TCB
+  // upgrades (see docs/specs/content-addressed-action-identity.md). It is
+  // deliberately per-SYMBOL (it identifies the implementation code), with NO
+  // per-instance key — unlike the action id (`getSchedulerActionId`). `.src` is
+  // no longer consulted (the prior `src:` fallback depended on the source-map
+  // path).
   const implementationHash = (action as { implementationHash?: unknown })
     .implementationHash;
   if (typeof implementationHash === "string" && implementationHash.length > 0) {

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -23,7 +23,10 @@ import {
   runIdempotencyRecheck,
 } from "./diagnosis.ts";
 import { RetryImmediately } from "./retry-immediately.ts";
-import { toActionRunTraceAddress } from "./diagnostics.ts";
+import {
+  contentAddressedActionIdentity,
+  toActionRunTraceAddress,
+} from "./diagnostics.ts";
 import { buildSchedulerActionObservation } from "./persistent-observation.ts";
 import { filterIgnoredAddresses, txToReactivityLog } from "./reactivity.ts";
 import { type ActionTimingState, recordActionTime } from "./timing.ts";
@@ -734,9 +737,12 @@ export function schedulerImplementationFingerprint(
   if (typeof implementationHash === "string" && implementationHash.length > 0) {
     return `impl:${implementationHash}`;
   }
-  const sourceId = (action as { src?: unknown }).src;
-  if (typeof sourceId === "string" && sourceId.length > 0) {
-    return `src:${sourceId}`;
+  // `.src` is no longer consulted for the durable fingerprint; resolve the
+  // content-addressed `{ identity, symbol }` directly (the prior `src:` fallback
+  // depended on the source-map path).
+  const contentId = contentAddressedActionIdentity(action);
+  if (contentId) {
+    return `impl:${contentId}`;
   }
   const telemetryId = schedulerObservationPieceId(actionId, telemetry);
   return `action:${telemetryId}:${actionId}`;

--- a/packages/runner/src/scheduler/diagnostics.ts
+++ b/packages/runner/src/scheduler/diagnostics.ts
@@ -24,18 +24,53 @@ import {
 } from "../sandbox/ses-runtime.ts";
 import type { SchedulerActionInfo } from "../telemetry.ts";
 import { MAX_TRIGGER_TRACE_HISTORY } from "./constants.ts";
+import { getVerifiedProvenance } from "../harness/verified-provenance.ts";
 
 export interface SchedulerActionIdentityState {
   readonly anonymousActionIds: WeakMap<Action | EventHandler, string>;
   anonymousActionCounter: number;
 }
 
+/**
+ * Content-addressed action identity — `cf:module/<identity>:<symbol>` resolved
+ * from the action's module implementation via the verified-provenance index
+ * (populated by `Engine.recordModuleProvenance`). This is `.src`-INDEPENDENT:
+ * it does not read the source-location annotation or its source-map resolution,
+ * so identity is stable regardless of whether `.src` resolves correctly. The
+ * `symbol` (the hoisted `__cfLift_N`/export name) is the within-module
+ * discriminator — see docs/specs/content-addressed-action-identity.md (§3 uses
+ * the same `{ moduleIdentity, symbol }`). Returns undefined for actions with no
+ * verified provenance (host / dynamic / test builders), which fall back to
+ * `.name` / a generated id.
+ */
+export function contentAddressedActionIdentity(
+  action: Action | EventHandler,
+): string | undefined {
+  const impl = (action as { module?: { implementation?: unknown } }).module
+    ?.implementation;
+  const provenance = getVerifiedProvenance(impl);
+  if (!provenance?.identity) return undefined;
+  return provenance.symbol
+    ? `cf:module/${provenance.identity}:${provenance.symbol}`
+    : `cf:module/${provenance.identity}`;
+}
+
 export function getSchedulerActionId(
   state: SchedulerActionIdentityState,
   action: Action | EventHandler,
 ): string {
-  const namedAction = action as Action & { src?: string };
-  if (namedAction.src) return namedAction.src;
+  // Content-addressed identity, consistent with the durable fingerprint
+  // (`schedulerImplementationFingerprint`): a pre-set `implementationHash` (the
+  // spec's stated content key) wins, else `{ identity, symbol }` from provenance.
+  // `.src` is no longer consulted for identity (debug-only; its source-map path
+  // is broken/colliding).
+  const implementationHash =
+    (action as { implementationHash?: unknown }).implementationHash;
+  if (typeof implementationHash === "string" && implementationHash.length > 0) {
+    return implementationHash;
+  }
+  const contentId = contentAddressedActionIdentity(action);
+  if (contentId) return contentId;
   if (action.name && action.name !== "anonymous") return action.name;
 
   const existingId = state.anonymousActionIds.get(action);

--- a/packages/runner/src/scheduler/diagnostics.ts
+++ b/packages/runner/src/scheduler/diagnostics.ts
@@ -64,13 +64,28 @@ export function getSchedulerActionId(
   // spec's stated content key) wins, else `{ identity, symbol }` from provenance.
   // `.src` is no longer consulted for identity (debug-only; its source-map path
   // is broken/colliding).
+  //
+  // The content address is per-SYMBOL — it identifies the implementation, not
+  // the action instance. The action id must stay per-INSTANCE (it keys
+  // `actionStats` and the durable observation), so we append the
+  // source-independent `schedulerInstanceKey` (a hash of the action's
+  // process/reads/writes, set at action creation). Without it, N instances of
+  // one hoisted op (e.g. one `lift` called twice / a `map`) would collide on a
+  // single id. The fingerprint deliberately keeps NO instance key (it is the
+  // per-symbol code identity).
+  const instanceKey = (action as { schedulerInstanceKey?: unknown })
+    .schedulerInstanceKey;
+  const withInstance = (id: string): string =>
+    typeof instanceKey === "string" && instanceKey.length > 0
+      ? `${id}:${instanceKey}`
+      : id;
   const implementationHash =
     (action as { implementationHash?: unknown }).implementationHash;
   if (typeof implementationHash === "string" && implementationHash.length > 0) {
-    return implementationHash;
+    return withInstance(implementationHash);
   }
   const contentId = contentAddressedActionIdentity(action);
-  if (contentId) return contentId;
+  if (contentId) return withInstance(contentId);
   if (action.name && action.name !== "anonymous") return action.name;
 
   const existingId = state.anonymousActionIds.get(action);

--- a/packages/runner/test/action-fingerprint.test.ts
+++ b/packages/runner/test/action-fingerprint.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 
 import { schedulerImplementationFingerprint } from "../src/scheduler/action-run.ts";
 import type { Action } from "../src/scheduler/types.ts";
+import { recordVerifiedProvenance } from "../src/harness/verified-provenance.ts";
 
 function makeAction(props: Record<string, unknown>): Action {
   const fn = (() => {}) as unknown as Action;
@@ -21,20 +22,32 @@ describe("schedulerImplementationFingerprint", () => {
     );
   });
 
-  it("falls back to src when no implementationHash is present", () => {
-    const action = makeAction({ src: "/abc123/pattern.tsx:1:1" });
+  it("derives a content-addressed impl: id from provenance, NOT from src", () => {
+    const impl = (() => {}) as () => void;
+    recordVerifiedProvenance(impl, { identity: "HASH", symbol: "__cfLift_1" });
+    const action = makeAction({
+      src: "/abc123/pattern.tsx:1:1", // present but must be ignored
+      module: { implementation: impl },
+    });
     expect(schedulerImplementationFingerprint(action, "id", undefined)).toBe(
-      "src:/abc123/pattern.tsx:1:1",
+      "impl:cf:module/HASH:__cfLift_1",
     );
   });
 
-  it("ignores a non-string or empty implementationHash and falls back to src", () => {
+  it("does NOT consult src for identity (debug-only); falls to the telemetry id", () => {
+    const action = makeAction({ src: "/abc123/pattern.tsx:1:1" });
+    expect(schedulerImplementationFingerprint(action, "id", undefined)).toBe(
+      "action:action:id:id",
+    );
+  });
+
+  it("ignores an empty implementationHash and still does not consult src", () => {
     const action = makeAction({
       src: "/abc123/pattern.tsx:1:1",
       implementationHash: "",
     });
     expect(schedulerImplementationFingerprint(action, "id", undefined)).toBe(
-      "src:/abc123/pattern.tsx:1:1",
+      "action:action:id:id",
     );
   });
 

--- a/packages/runner/test/esm-source-location.test.ts
+++ b/packages/runner/test/esm-source-location.test.ts
@@ -40,18 +40,9 @@ const program: RuntimeProgram = {
 interface HandlerIdentityProbe {
   src: string | undefined;
   kind: string | undefined;
-  /**
-   * The scheduler's content-addressed implementation hash for this handler,
-   * derived from `fn.src` via `harness.implementationHashForSource`. This is the
-   * SECOND consumer of ESM source-location fidelity (the first is CFC
-   * verified-source above): the scheduler keys reload-stable action identity on
-   * it, so it must resolve under the ESM loader.
-   */
-  implHash: string | undefined;
 }
 
 function probeHandlerIdentity(
-  runtime: Runtime,
   compiled: Pattern,
 ): HandlerIdentityProbe {
   const nodes = (compiled as Pattern & { nodes: { module: Module }[] }).nodes;
@@ -73,13 +64,9 @@ function probeHandlerIdentity(
   const identity = resolvePolicyFacingImplementationIdentity(handlerModule, {
     implementation: fn as never,
   });
-  const implHash = typeof src === "string"
-    ? runtime.harness.implementationHashForSource?.(src)
-    : undefined;
   return {
     src,
     kind: identity?.kind,
-    implHash,
   };
 }
 
@@ -103,7 +90,7 @@ describe("ESM loader: verified-source location resolution", () => {
   it("resolves a handler's src to its original source under the ESM loader", async () => {
     makeRuntime();
     const compiled = await runtime.patternManager.compilePattern(program);
-    const r = probeHandlerIdentity(runtime, compiled);
+    const r = probeHandlerIdentity(compiled);
 
     // src maps back to the authored file, not a `<loadId>.js` / `:esm:` bundle.
     expect(r.src).toMatch(/(?:^|\/)main\.tsx:\d+:\d+$/);
@@ -113,10 +100,5 @@ describe("ESM loader: verified-source location resolution", () => {
     // normalization — they both gain the same leading slash).
     expect(r.src).toMatch(/^cf:module\//);
     expect(r.kind).toBe("verified");
-    // The scheduler's content-addressed implementation hash also resolves:
-    // `fn.src` reduces to the pure per-module code identity
-    // `cf:module/<hash>:line:col` (no `/path` segment). Without it,
-    // reload-stable action identity breaks.
-    expect(r.implHash).toMatch(/^cf:module\/[^/]+:\d+:\d+$/);
   });
 });

--- a/packages/runner/test/module-identity-engine.test.ts
+++ b/packages/runner/test/module-identity-engine.test.ts
@@ -36,18 +36,23 @@ describe("Engine implementation identity", () => {
     await storageManager?.close();
   });
 
+  // The reload-stable, content-addressed MODULE identity is what action
+  // identity now roots on (the scheduler fingerprint was re-rooted off `.src`
+  // onto content-addressed provenance). We assert it via `canonicalModuleSource`
+  // — the live canonicalizer that maps a per-program bundle path onto the
+  // per-module `cf:module/<hash>/<path>` identity. That is exactly the
+  // `moduleHashByPrefixedSource` machinery the (removed) `implementationHashForSource`
+  // reduced, so this preserves the invariant without the dead `.src`-reduction path.
   async function loadAndResolve(
     program: RuntimeProgram,
     modulePath: string,
-  ): Promise<{ id: string; implementationId: string | undefined }> {
+  ): Promise<{ id: string; moduleIdentity: string | undefined }> {
     const { id, graph, mainSpecifier } = await engine.compileToRecordGraph(
       program,
     );
     engine.evaluateRecordGraph(id, graph, mainSpecifier, program.files);
-    const implementationId = engine.implementationHashForSource(
-      `/${id}${modulePath}:1:1`,
-    );
-    return { id, implementationId };
+    const moduleIdentity = engine.canonicalModuleSource(`/${id}${modulePath}`);
+    return { id, moduleIdentity };
   }
 
   it("gives a shared module the same content-addressed identity across entry points", async () => {
@@ -79,10 +84,10 @@ describe("Engine implementation identity", () => {
     // what used to make the implementation fingerprint unstable.
     expect(a.id).not.toBe(b.id);
 
-    // The content-addressed implementation identity is stable.
-    expect(a.implementationId).toBeTruthy();
-    expect(a.implementationId).toBe(b.implementationId);
-    expect(a.implementationId!.startsWith("cf:module/")).toBe(true);
+    // The content-addressed module identity is stable across entry points.
+    expect(a.moduleIdentity).toBeTruthy();
+    expect(a.moduleIdentity).toBe(b.moduleIdentity);
+    expect(a.moduleIdentity!.startsWith("cf:module/")).toBe(true);
   });
 
   it("hashes module identity over PRISTINE authored source, not the helper-injected form (CT-1740)", async () => {
@@ -130,12 +135,10 @@ describe("Engine implementation identity", () => {
       "/shared.ts",
     );
 
-    expect(after.implementationId).not.toBe(before.implementationId);
+    expect(after.moduleIdentity).not.toBe(before.moduleIdentity);
   });
 
-  it("returns undefined for a source location with no loaded module", () => {
-    expect(engine.implementationHashForSource("/unknown/x.tsx:1:1")).toBe(
-      undefined,
-    );
+  it("returns undefined for a source path with no loaded module", () => {
+    expect(engine.canonicalModuleSource("/unknown/x.tsx")).toBe(undefined);
   });
 });

--- a/packages/runner/test/reload-sibling-overdirty.test.ts
+++ b/packages/runner/test/reload-sibling-overdirty.test.ts
@@ -77,8 +77,12 @@ async function mainTsxSnapshots(runtime: Runtime) {
     ownerSpace: space,
     limit: 1000,
   });
+  // Action ids are content-addressed (`cf:module/<hash>:<symbol>`) and path-free
+  // — the source path now lives only in the debug `.src`/`location`. This
+  // isolated runtime persists only this pattern's computeds, so the module
+  // prefix selects exactly them.
   return res.snapshots.filter((s) =>
-    (s.observation.actionId ?? "").includes("main.tsx")
+    (s.observation.actionId ?? "").startsWith("cf:module/")
   );
 }
 

--- a/packages/runner/test/scheduler-observations.test.ts
+++ b/packages/runner/test/scheduler-observations.test.ts
@@ -316,6 +316,9 @@ describe("persistent scheduler observations", () => {
           target.withTx(actionTx).set(runs);
         },
         {
+          // Content-addressed identity (replaces the legacy `.src` key — the
+          // fingerprint keys on this, never on the source location).
+          implementationHash: "cf:module/test-cw:changingWriter",
           writes: [
             firstTarget.getAsNormalizedFullLink(),
             secondTarget.getAsNormalizedFullLink(),
@@ -344,12 +347,12 @@ describe("persistent scheduler observations", () => {
       expect(changedObservation?.currentKnownWrites).toEqual(staticSurface);
 
       const restoredChangingWriter = Object.assign((() => {}) as Action, {
+        implementationHash: "cf:module/test-cw:changingWriter",
         writes: [
           firstTarget.getAsNormalizedFullLink(),
           secondTarget.getAsNormalizedFullLink(),
         ],
       });
-      (restoredChangingWriter as { src?: string }).src = "changingWriter";
       expect(
         runtime.scheduler.rehydrateActionFromObservation(
           restoredChangingWriter,
@@ -407,13 +410,14 @@ describe("persistent scheduler observations", () => {
         toMemorySpaceAddress(target.getAsNormalizedFullLink()),
       ];
       let runs = 0;
-      const logSurfaceWriter = function logSurfaceWriter(
-        actionTx: IExtendedStorageTransaction,
-      ) {
-        runs++;
-        source.withTx(actionTx).get();
-        target.withTx(actionTx).set(runs);
-      } as Action;
+      const logSurfaceWriter = Object.assign(
+        function logSurfaceWriter(actionTx: IExtendedStorageTransaction) {
+          runs++;
+          source.withTx(actionTx).get();
+          target.withTx(actionTx).set(runs);
+        },
+        { implementationHash: "cf:module/test-lsw:logSurfaceWriter" },
+      ) as Action;
 
       runtime.scheduler.subscribe(logSurfaceWriter, {
         reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
@@ -424,8 +428,9 @@ describe("persistent scheduler observations", () => {
       await runtime.scheduler.run(logSurfaceWriter);
       expect(observations.at(-1)?.currentKnownWrites).toEqual(surface);
 
-      const restoredWriter = (() => {}) as Action;
-      (restoredWriter as { src?: string }).src = "logSurfaceWriter";
+      const restoredWriter = Object.assign((() => {}) as Action, {
+        implementationHash: "cf:module/test-lsw:logSurfaceWriter",
+      });
       expect(
         runtime.scheduler.rehydrateActionFromObservation(
           restoredWriter,

--- a/packages/runner/test/src-garble-identity-invariant.test.ts
+++ b/packages/runner/test/src-garble-identity-invariant.test.ts
@@ -209,3 +209,84 @@ Deno.test(
     expect(garbled?.kind).toBe("unsupported");
   },
 );
+
+// Two calls to ONE hoisted lift -> two action INSTANCES of the same symbol. The
+// content address (`cf:module/<hash>:<symbol>`) is per-symbol, so the action id
+// appends a source-independent per-instance key (a hash of reads/writes) to keep
+// instances distinct. This guards that fix: with a per-symbol-only id the two
+// collided onto one durable observation (one silently overwrote the other).
+const MULTI_INSTANCE_PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern, lift } from 'commonfabric';",
+      "const dbl = lift((n: number) => n * 2);",
+      "export default pattern<{ a: number; b: number }>(({ a, b }) => {",
+      "  const da = dbl(a);",
+      "  const db = dbl(b);",
+      "  return { da, db };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+async function runMultiAndCollect(
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+): Promise<{ actionId: string; fingerprint: string }[]> {
+  const runtime = newRuntime(storageManager);
+  try {
+    const compiled = await runtime.patternManager.compilePattern(
+      MULTI_INSTANCE_PROGRAM,
+    );
+    const tx = runtime.edit();
+    const resultCell = runtime.getCell<any>(space, "mi-result", undefined, tx);
+    const handle = runtime.run(tx, compiled, { a: 5, b: 9 }, resultCell);
+    await tx.commit();
+    for (let k = 0; k < 8; k++) {
+      await handle.pull();
+      await runtime.idle();
+    }
+    await runtime.storageManager.synced();
+    expect(resultCell.getAsQueryResult()).toEqual({ da: 10, db: 18 });
+    return await collectIdentities(runtime);
+  } finally {
+    runtime.scheduler.dispose();
+    await runtime.dispose();
+  }
+}
+
+Deno.test(
+  "two instances of one lift get DISTINCT per-instance ids (no collision), .src-independent",
+  async () => {
+    const baseline = await runMultiAndCollect(
+      StorageManager.emulate({ as: signer }),
+    );
+
+    // Two distinct action instances => two distinct durable observations (the
+    // pre-fix per-symbol id collapsed these to one).
+    expect(baseline.length).toBe(2);
+    expect(new Set(baseline.map((b) => b.actionId)).size).toBe(2);
+    // Same symbol (`:dbl`), distinct per-instance suffix; never a `:line:col`.
+    for (const { actionId } of baseline) {
+      expect(actionId).toMatch(/^cf:module\/[^:]+:dbl:[^:]+$/);
+      expect(actionId).not.toMatch(/:\d+:\d+$/);
+    }
+
+    // The per-instance key hashes reads/writes, not `.src`, so garbling `.src`
+    // leaves the ids byte-identical.
+    let counter = 0;
+    __setSrcAnnotationTransformForTest((loc) =>
+      `GARBLED-SRC-${counter++}-len${loc.length}`
+    );
+    let garbled: { actionId: string; fingerprint: string }[];
+    try {
+      garbled = await runMultiAndCollect(
+        StorageManager.emulate({ as: signer }),
+      );
+    } finally {
+      __setSrcAnnotationTransformForTest(undefined);
+    }
+    expect(garbled).toEqual(baseline);
+  },
+);

--- a/packages/runner/test/src-garble-identity-invariant.test.ts
+++ b/packages/runner/test/src-garble-identity-invariant.test.ts
@@ -1,0 +1,211 @@
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import type { Module } from "../src/builder/types.ts";
+import type { HarnessedFunction } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { __setSrcAnnotationTransformForTest } from "../src/builder/module.ts";
+import { recordVerifiedProvenance } from "../src/harness/verified-provenance.ts";
+import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
+
+// `.src`-garbled identity invariant harness (workstream B — content-addressed
+// action identity).
+//
+// THE INVARIANT: scheduler action identity — the persisted action id AND the
+// durable implementation fingerprint — is derived from the content-addressed
+// `{ identity, symbol }` provenance (module hash + hoisted `__cfReg`/export
+// symbol), NOT from `fn.src`. So running a pattern with `.src` deliberately
+// garbled must yield a BYTE-IDENTICAL set of action ids and fingerprints.
+//
+// Why this harness exists: the first cut of B re-rooted only the *consumers* of
+// identity and looked green, while `implementationHash` was still secretly
+// `.src`-derived (applyImplementationHash -> implementationHashForSource(.src)).
+// A consumer-only unit test could not catch that, because the leak was upstream
+// at id *creation*. This harness garbles `.src` at its single write site
+// (annotateFunctionDebugMetadata, via __setSrcAnnotationTransformForTest) so the
+// garble is in effect during module eval + action creation — any `.src` -> id
+// path *anywhere* in the pipeline makes the two runs diverge loudly.
+//
+// THE BOUNDARY (second test): B re-rooted the SCHEDULER action layer only. CFC
+// verified-implementation identity (resolveProvenanceImplementationIdentity,
+// which feeds `writeAuthorizedBy`) STILL consults `.src` as a fail-closed
+// consistency check, so garbling `.src` flips it `verified` -> `unsupported`.
+// That is the remaining `.src` dependency the red-team pass must bless and that
+// the lazy/debug-only `.src` follow-up (workstream C) must re-root before `.src`
+// can be deferred. This test characterizes that boundary so a future "make
+// `.src` lazy" change trips a loud, self-documenting failure here.
+//
+// See docs/specs/content-addressed-action-identity.md and
+// packages/patterns/lunch-poll/perf-seed/B-IDENTITY-REROOT-HANDOFF.md.
+
+const signer = await Identity.fromPassphrase("src-garble identity invariant");
+const space = signer.did();
+
+// A pattern with several distinct reactive primitives (two lifts + three
+// computeds) — five distinct hoisted symbols under one module identity, so the
+// captured identity set exercises both the module hash AND the per-symbol
+// discriminator (and "no collision among distinct symbols").
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern, computed, lift } from 'commonfabric';",
+      "const dbl = lift((n: number) => n * 2);",
+      "const inc = lift((n: number) => n + 1);",
+      "export default pattern<{ value: number }>(({ value }) => {",
+      "  const doubled = dbl(value);",
+      "  const incremented = inc(value);",
+      "  const plusOne = computed(() => (doubled as any) + 1);",
+      "  const sum = computed(() => (doubled as any) + (incremented as any));",
+      "  const label = computed(",
+      "    () => 'v=' + (plusOne as any) + ':' + (sum as any),",
+      "  );",
+      "  return { doubled, incremented, plusOne, sum, label };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+function newRuntime(sm: ReturnType<typeof StorageManager.emulate>) {
+  return new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: sm,
+    experimental: { persistentSchedulerState: true },
+  });
+}
+
+/** The durable identity of every persisted scheduler action for this pattern. */
+async function collectIdentities(
+  runtime: Runtime,
+): Promise<{ actionId: string; fingerprint: string }[]> {
+  const provider = runtime.storageManager.open(space) as {
+    listSchedulerActionSnapshots?: (
+      q: Record<string, unknown>,
+    ) => Promise<{
+      snapshots: {
+        observation: { actionId?: string; implementationFingerprint?: string };
+      }[];
+    }>;
+  };
+  const res = await provider.listSchedulerActionSnapshots!({
+    ownerSpace: space,
+    limit: 1000,
+  });
+  return res.snapshots
+    .filter((s) => (s.observation.actionId ?? "").startsWith("cf:module/"))
+    .map((s) => ({
+      actionId: s.observation.actionId!,
+      fingerprint: s.observation.implementationFingerprint ?? "",
+    }))
+    .sort((a, b) => a.actionId.localeCompare(b.actionId));
+}
+
+/** Run PROGRAM to a settled, persisted state and return its identity set. */
+async function runAndCollect(
+  storageManager: ReturnType<typeof StorageManager.emulate>,
+): Promise<{ actionId: string; fingerprint: string }[]> {
+  const runtime = newRuntime(storageManager);
+  try {
+    const compiled = await runtime.patternManager.compilePattern(PROGRAM);
+    const tx = runtime.edit();
+    const resultCell = runtime.getCell<any>(space, "result", undefined, tx);
+    const handle = runtime.run(tx, compiled, { value: 5 }, resultCell);
+    await tx.commit();
+    for (let k = 0; k < 8; k++) {
+      await handle.pull();
+      await runtime.idle();
+    }
+    await runtime.storageManager.synced();
+    // Sanity: the pattern actually computed (so an empty id set can't masquerade
+    // as "identical").
+    expect(resultCell.getAsQueryResult()).toEqual({
+      doubled: 10,
+      incremented: 6,
+      plusOne: 11,
+      sum: 16,
+      label: "v=11:16",
+    });
+    return await collectIdentities(runtime);
+  } finally {
+    runtime.scheduler.dispose();
+    await runtime.dispose();
+  }
+}
+
+Deno.test(
+  "scheduler action ids + fingerprints are byte-identical with .src garbled",
+  async () => {
+    // Baseline: real `.src`.
+    const baseline = await runAndCollect(
+      StorageManager.emulate({ as: signer }),
+    );
+
+    expect(baseline.length).toBeGreaterThan(0);
+    for (const { actionId, fingerprint } of baseline) {
+      // Content-addressed `cf:module/<hash>:<symbol>` — NOT a `:line:col`
+      // (`.src`-derived) id. A regression to source-location ids ends in
+      // `:<line>:<col>`.
+      expect(actionId).toMatch(/^cf:module\//);
+      expect(actionId).not.toMatch(/:\d+:\d+$/);
+      expect(fingerprint).toMatch(/^impl:cf:module\//);
+      expect(fingerprint).not.toMatch(/:\d+:\d+$/);
+    }
+    // No two distinct primitives collide on an id under real `.src`.
+    expect(new Set(baseline.map((b) => b.actionId)).size).toBe(baseline.length);
+
+    // Garbled run: replace the annotated location with a distinct, NON-canonical
+    // garbage string per primitive (distinct => maximally stresses any `.src`
+    // keying; non-canonical => keeps the recordModuleProvenance `.src` guard a
+    // no-op, exactly the real "source maps broke" failure mode).
+    let counter = 0;
+    __setSrcAnnotationTransformForTest((loc) =>
+      `GARBLED-SRC-${counter++}-len${loc.length}`
+    );
+    let garbled: { actionId: string; fingerprint: string }[];
+    try {
+      garbled = await runAndCollect(StorageManager.emulate({ as: signer }));
+    } finally {
+      __setSrcAnnotationTransformForTest(undefined);
+    }
+
+    // The whole point: identity did not move.
+    expect(garbled).toEqual(baseline);
+    // And the garble introduced no collisions of its own.
+    expect(new Set(garbled.map((g) => g.actionId)).size).toBe(garbled.length);
+  },
+);
+
+Deno.test(
+  "BOUNDARY: CFC verified-implementation identity still fail-closes on .src",
+  () => {
+    // This documents the remaining `.src` dependency B did NOT remove: CFC
+    // verified-source identity (the `writeAuthorizedBy` arm) reads `.src` as a
+    // fail-closed consistency check. It is NOT part of the scheduler-identity
+    // invariant above — and it is the gate workstream C (lazy `.src`) must
+    // re-root first. If a future change makes `.src` lazy without re-rooting
+    // this check, this test trips.
+    const impl = (() => {}) as unknown as HarnessedFunction;
+    recordVerifiedProvenance(impl, { identity: "HASH", symbol: "__cfLift_1" });
+
+    // Canonical `.src` pointing into the provenance module => verified.
+    (impl as { src?: string }).src = "cf:module/HASH/main.tsx:3:20";
+    const verified = resolvePolicyFacingImplementationIdentity(
+      {} as Module,
+      { implementation: impl },
+    );
+    expect(verified?.kind).toBe("verified");
+    expect((verified as { moduleIdentity?: string }).moduleIdentity).toBe(
+      "HASH",
+    );
+
+    // Garbled `.src` => CFC fails closed (NOT byte-identical, by design).
+    (impl as { src?: string }).src = "GARBLED-SRC";
+    const garbled = resolvePolicyFacingImplementationIdentity(
+      {} as Module,
+      { implementation: impl },
+    );
+    expect(garbled?.kind).toBe("unsupported");
+  },
+);


### PR DESCRIPTION
## What this does

Re-roots scheduler action **identity** off `fn.src` (the source-location string,
resolved through the broken/colliding source-map path) onto the content-addressed
`{ identity, symbol }` provenance. `.src` becomes debug-only. This implements the
direction settled with the authors and codified in
[`content-addressed-action-identity.md`](docs/specs/content-addressed-action-identity.md).

Motivation: it's the architectural prerequisite for making the eager
per-primitive `.src` debug annotation (~80–100ms of every piece boot) lazy — see
the cold-load boot-floor work — and it removes a latent id-collision class (the
`:line:col` ids derived from a source-map path that returns the wrong/colliding
location for most primitives).

## The fingerprint/id split (important)

Identity is now **two** things, deliberately at different granularities:

- **Implementation fingerprint** — per-**symbol** `impl:cf:module/<hash>:<symbol>`
  (`schedulerImplementationFingerprint`). Identifies the implementation *code*.
- **Action id** — per-**instance** `cf:module/<hash>:<symbol>:<instanceKey>`
  (`getSchedulerActionId`), where `instanceKey` is a source-independent,
  reload-stable hash of the action's `{process, reads, writes}`. It keys
  `actionStats` and the durable observation, so it must distinguish two instances
  of the same hoisted op (one `lift` called twice, a `map`, a repeated
  sub-pattern). An earlier cut of this change made *both* per-symbol, which
  collided such instances — see
  [`action-id-per-instance-decision.md`](docs/specs/action-id-per-instance-decision.md)
  (**@seefeldb / Berni — this is the one open design question; details there**).

## Commits

1. `feat(runner)` — the identity re-root (`applyImplementationHash` from provenance;
   `getSchedulerActionId` + fingerprint consume it; `.src`/`src:` fallbacks removed).
2. `test(runner)` — a `.src`-garbled invariant harness: runs a pattern with `.src`
   deliberately garbled and asserts action ids + fingerprints are byte-identical.
   Teeth-verified. Plus a boundary test pinning the one surface still on `.src`
   (CFC verified-source fail-closes on it — the lazy-`.src` follow-up must re-root
   it first).
3. `refactor(runner)` — remove the now-dead `implementationHashForSource`, re-root
   its test coverage onto `canonicalModuleSource`, and correct a stale spec section.
4. `fix(runner)` — the per-instance action-id fix above, with a multi-instance
   regression test.
5. `docs` — correct provenance/spec drift; add the decision note.

## Verification

- Full runner suite **723/0**
- `integration pattern-tests` **67/0**, `integration generated-patterns` **147/0**
- fmt / lint / check clean
- Adversarial multi-lens red-team pass (spec-mandated for CFC identity changes):
  no forgery / collision-bug / critical; confirmed findings were doc-drift (fixed
  here) and the action-id collision (fixed here — the substantive one, caught by
  direct verification after the review's collision-lens verifier dropped out).

## Merge caveats

- Base is the point this was developed/tested on; `runner.ts`, `engine.ts`, and
  `builder/module.ts` have since diverged on `main` (the OpaqueRef→Reactive
  rename). **Rebase onto current `main` and re-run the full gate before merge.**
- Merge gate is the red-team review (done) + Berni's nod on the durable-key
  granularity (the decision note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-rooted scheduler action identity off `.src` to content-addressed `{ identity, symbol }` (`cf:module/<hash>:<symbol>`), with action IDs now per-instance and fingerprints per-symbol. `.src` is debug-only; old `.src` keys miss once and re-persist under the new key.

- **New Features**
  - Fingerprint per symbol: `impl:cf:module/<hash>:<symbol>`; `.src` no longer used for identity.
  - Action ID per instance: `cf:module/<hash>:<symbol>:<instanceKey>` where `instanceKey` hashes `{ process, reads, writes }`.
  - Identity resolves from verified provenance (`getVerifiedProvenance`); added `contentAddressedActionIdentity`.
  - Test-only `__setSrcAnnotationTransformForTest` and a new invariant harness prove ids + fingerprints are stable when `.src` is garbled; boundary test documents CFC verified-source still checks `.src`.
  - Removed `Engine.implementationHashForSource` and its Harness hook; tests re-rooted to `canonicalModuleSource`; ESM test no longer asserts an impl hash.
  - Docs updated with the fingerprint(per-symbol)/id(per-instance) split, persisted-data compatibility, and a decision note.

- **Bug Fixes**
  - Prevent ID collisions across multiple instances by appending the instance key.
  - Preserve content-addressed identity across reloads by reading provenance from the resolved implementation function (fixes `$implRef` cases).
  - Retained support for symbol-less dynamic provenance (`VerifiedProvenance.dynamic`) used by the adversarial suite.

<sup>Written for commit 246d3c26431b34d9939962888551751bd3a36602. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

