### PR TITLE
docs(cfc): prioritized runner implementation-gap future-work doc

### DIFF
--- a/docs/specs/cfc-runner-future-work.md
+++ b/docs/specs/cfc-runner-future-work.md
@@ -1,0 +1,378 @@
+# CFC runner future work — prioritized implementation gaps
+
+_Started 2026-07-01. Audit of `~/src/specs/cfc` (the normative CFC prose spec, 18
+chapters + Lean formalization) against the implementation in `packages/runner`
+(primarily `packages/runner/src/cfc/`). Companion to
+[`cfc-spec-changes.md`](./cfc-spec-changes.md) (which tracks edits the **spec**
+needs); this file tracks work the **runner** needs._
+
+This list is ordered **big chunks first**: close the load-bearing structural
+gaps, then fill the small holes. Dependency order matters — several small holes
+and two whole epics collapse into one foundation (Epic A), so building that first
+avoids throwaway work.
+
+## Where the runner stands
+
+The runner soundly implements the **flat "ceiling + required-integrity" fragment**
+of CFC, and enforces all 8 of its own commit-gate invariants (relevant⇒prepared,
+digest-invalidation, verifier-read exclusion, fail-closed on missing
+schema/metadata/unsupported claim, commit-gated side effects, fresh-retry, system-
+controlled metadata, coarse `classification` summary). Its remit — the reactive
+commit boundary — is well covered.
+
+**The organizing theme.** The runtime represents a label as a *flat set* —
+`IFCLabel = { confidentiality?: unknown[]; integrity?: unknown[] }`
+([`label-view-core.ts:5`](../../packages/runner/src/cfc/label-view-core.ts)) — with
+union join and exact-`deepEqual` matching against static allow-lists
+([`prepare.ts:2481`,`:2497`](../../packages/runner/src/cfc/prepare.ts)). The spec's
+algebra is **CNF clauses (AND-of-ORs) + exchange-rule evaluation + pattern-matching
++ trust-closure + observation-class refinement**. Almost every big gap below is a
+facet of that one representational distance. Most of the flat model's narrowness is
+*fail-closed* (it over-restricts — safe), but a few edges are genuine soundness
+holes, called out explicitly.
+
+**Default posture.** Enforcement mode defaults to `disabled`
+([`types.ts:42`](../../packages/runner/src/cfc/types.ts)) and flow-labels to `off`
+([`types.ts:331`](../../packages/runner/src/cfc/types.ts)); hosts opt into
+`enforce-explicit`. So several protections below are *built but dormant* until a
+host turns them on — see Epic H.
+
+---
+
+# Tier 1 — Big chunks (close these first)
+
+Listed in dependency order. **A is the keystone** — B and much of F stand on it.
+
+## Epic A — CNF clause label representation (the shared foundation)
+
+**Size: large. Soundness + expressiveness. The single highest-leverage item.**
+
+Change `IFCLabel.confidentiality` from a flat `unknown[]` to `Clause[]`, where
+`Clause = Atom | { anyOf: Atom[] }` — the 1:1 runtime form of the spec's
+`Clause = Atom | Atom[]`. Generalize join to clause-granular concat+dedup (never
+merge alternatives), and generalize the ceiling-fit check
+(`cfcObservationFitsCeiling`/`atomsOutsideCeiling`,
+[`observation.ts`](../../packages/runner/src/cfc/observation.ts)) from flat subset to
+**clause subsumption** (`∀ clause l ∈ L. ∃ clause c ∈ ceiling. alts(c) ⊆ alts(l)`),
+with a flat/flat fast-path that is byte-for-byte today's check. Then the
+**flat-assumption sweep**: every `for (const atom of confidentiality)` consumer
+(`uniqueCfcAtoms` call sites, `sink-inventory.ts`, `ui-contract.ts`,
+`schema-sanitization.ts`, introspection projections). Ship behind a mixed-version
+fail-closed test.
+
+- **This is exactly the disjunctive-confidentiality proposal's §9 runtime outline**
+  (`~/src/specs/cfc/proposals/author-disjunctive-confidentiality.md:845-899`), which
+  is Adopted (2026-06-09) into the normative spec (§3.1.8, §4.2.1, §8.10.3, §8.17,
+  §18.5). The design + adversarial pass are already written.
+- **Directly delivers:** author-written OR-clauses — "confidential to A **or** B,
+  either can release alone" — which the flat model literally cannot represent (it
+  flattens `[[A∨B]]` to conjunctive `{A,B}`, the *stronger* reading: safe, but the
+  feature is impossible).
+- **Fixes a real soundness hole (the reason this is not merely expressiveness):**
+  §8.10.3 ceiling fit is *unsound* the moment a ceiling is read as a **reader
+  enumeration**. A multi-party value `[User(A), User(B)]` (nobody alone may read)
+  passes a flat `{A, B}` ceiling under the current `∀clause ∃reader` quantifier —
+  and is then shown to A alone, violating B's clause. Clause subsumption
+  (`∀reader ∀clause`) closes it. Deployed conjunctive ceilings must keep their
+  meaning (a list = conjunctive; an `anyOf` entry = reader enumeration).
+- **Depends on:** nothing. **Unblocks:** Epic B (entirely), Epic F (aggregates,
+  read-time clearance), several Tier-2 items.
+- Ref: `cfc-spec-changes.md` SC-1 (components), and the proposal §5.3 (the
+  quantification hole), §9 (runtime outline).
+
+## Epic B — Exchange-rule + policy evaluator (built on Epic A)
+
+**Size: large (a second evaluation engine). Unblocks 5 safety invariants.**
+
+The runner has **no** exchange-rule or policy machinery of any kind — confirmed by
+whole-repo grep (zero hits for `exchangeRule`, `PolicyRecord`, `lookupPolicy`,
+`canAccess`, `trustClosure`, `matchAtomPattern`, `fixpoint`, `fuel`, `HasRole`,
+`declassif`, `EndorsedIntent`). Exchange rules are the guarded, policy-authored
+rewrites that *add an alternative to a clause* — the single mechanism through which
+disjunction, caveat discharge, declassification, and role/space grants all arise.
+Its absence means the runtime **can never release or declassify anything** — it can
+only accumulate taint conjunctively and fail closed.
+
+Decomposes into (dependency order — 1/2/3 can parallelize once A lands):
+
+- **B1 — Atom pattern-matching + variable binding.** `AtomPattern`/`AtomVariable`
+  unification, `substituteVars`/`instantiate`, multi-binding (§4.4.5). Register the
+  ~10 missing atom families (`Space`, `HasRole`, `User`/principal, `Policy`/
+  `Context`, `Concept`, `Role`, `CaveatScreened`, `BoundaryContext`, `Expires`) in
+  [`packages/api/cfc.ts`](../../packages/api/cfc.ts) + spec ch.15. Biggest self-
+  contained algorithmic piece. **This is the "rich matcher" that also fixes the
+  requiredIntegrity soundness edge** — see below.
+- **B2 — Policy-record store + content-addressed lookup.** `PolicyRecord`/
+  `ExchangeRule` types, `lookupPolicy` (fail-closed on hash mismatch),
+  `collectPolicyPrincipals` over the clause-structured label, trusted discovery
+  roots (§4.4.1–4.4.3).
+- **B3 — Trust closure over the acting principal.** The `I ≥_actingUser Concept(C)`
+  resolver under a `trustContext` (§4.4.5, §4.8.9) — feeds concept-valued integrity
+  matches; mints per-user `HasRole` facts. Delivers invariant 11.
+- **B4 — Guarded rewrite + fuelled fixpoint.** `applyExchangeRule` (add-alternative
+  + empty-postcondition drop) + `evaluateExchangeRules` fixpoint with bounded fuel
+  and **hard fail-closed on exhaustion** (§4.4.5); then post-rewrite `canAccess`.
+- **B5 — Boundary hook.** Wire the evaluator into `prepareBoundaryCommit`
+  ([`prepare.ts:3095`](../../packages/runner/src/cfc/prepare.ts)) and the sink/
+  observation path; mint `BoundaryContext` atoms (sink, sinkClass, fieldRole,
+  purpose, intentId); replace the flat `deepEqual` ceiling check with
+  evaluate-to-fixpoint → `canAccess`.
+- **B6 — Prompt-caveat tier profile as data.** Express unscreened→ingress→
+  value-screened tier upgrades and material-risk/influence discharge as ordinary
+  exchange rules (§10.1, §8.10.5), then **retire the hard-coded special-case**: today
+  [`schema-sanitization.ts`](../../packages/runner/src/cfc/schema-sanitization.ts)
+  bulk-strips the four tier kind-strings identically (no transition, no evidence
+  binding, no clause locality) — exactly the "prompt-specific runtime branch"
+  §10.1 says MUST be replaced by exchange rules.
+
+**Delivers safety invariants 3, 5, 6, 10, 11**, all declassification/endorsement
+release paths, and the disjunctive-release semantics ("any alternative releases its
+clause"). **Also fixes a soundness edge inside B1:** the current `requiredIntegrity`
+gate is exact `deepEqual` and lacks §8.10.3's **object-level shared-witness-key
+coherence** — heterogeneous per-leaf integrity can satisfy an object-level
+requirement the spec would reject. That is the one requiredIntegrity narrowing that
+is *not* fail-safe.
+
+- Ref: `cfc-spec-changes.md` SC-15 (class-aware meet), SC-22 (impl identity);
+  invariants §10; §10.1 prompt-caveat profile.
+
+## Epic C — Observation classes / `PathLabelTemplate`
+
+**Size: large. Closes two documented information channels. Independent of A/B.**
+
+Today one label per path is consumed identically by every read *shape*. Implement
+the §4.6.3 observation-class model (`shape` / `value` / `enumerate` / `count` /
+`followRef`) so a read consumes only the label of the observation it actually made.
+
+- **Closes SC-4 existence channel** — overwriting a derived label today also shrinks
+  the *existence* label, leaking "this path was once written" as a public bit
+  (acknowledged in-code at [`prepare.ts:1191`](../../packages/runner/src/cfc/prepare.ts)).
+- **Closes SC-8 pointer-identity-at-a-slot** — which element sits at a slot,
+  observed without dereferencing, is not separately labeled. The `structure`
+  labelMap component is only a partial container-shape mitigation.
+- **Also enables** public reads of low-labeled child fields under a secret parent
+  (today the flat model must take the max), and fixes the sqlite null-origin/
+  computed-column over-labeling.
+- **Depends on:** nothing structurally, but interacts with A (labels become
+  clause-structured per observation class). Ref: SC-4, SC-8; §4.5.2, §4.6.3.
+
+## Epic D — Write-side & agent integrity enforcement (the live soundness cluster)
+
+**Size: medium-large. This is where a flow can actually escape control today.**
+
+Four coupled gaps; the coupling is the point (you cannot fix the last two without
+the middle one):
+
+- **D1 — `requiredIntegrity` write-target floor (§8.12.4.1).** `requiredIntegrity`
+  exists only as a *consume-side* gate; there is no check of the *written value's*
+  integrity against a declared floor. A store path declaring "must be GPS-measured"
+  gets no write-side rejection of untrusted writes. (SC-18 integrity direction,
+  decided but unhomed in §8.10.)
+- **D2 — Per-write data-flow provenance.** Gate each protected write on the reads
+  that *actually fed it*, not the transaction-global consumed set. The enabling
+  machinery for D3, and the reason D3 can't be fixed in isolation (see the in-code
+  TODO at [`prepare.ts:2383`](../../packages/runner/src/cfc/prepare.ts): tightening
+  the vacuous pass without per-write provenance would over-reject). "Potential and
+  Final Write Sets."
+- **D3 — Trusted-agent tool-input `requiredIntegrity` enforced, not decorative.**
+  Today tool-invoke never checks model-supplied input against
+  `inputSchema.ifc.requiredIntegrity`; the only gate is write-target-scoped; and it
+  is **vacuous when the consumed-read set is empty** — a plain model-output literal
+  skips it entirely, so an injected `sendMail` recipient is sent under `enforce`.
+  (`cfc-trusted-agent-tool-integrity.md`.)
+- **D4 — `LlmDerived` / untrust stamping.** Untrust is represented only as
+  *absence* of an integrity atom, so a `requiredIntegrity` gate can fail only on
+  absence — which, combined with D3's vacuous pass, lets model bytes pass silently.
+  Stamp `LlmDerived`/`DerivedFromAdmitted` at `createToolResultMessages` / message
+  append. (§14.2.2 — note this is a "Proposed" spec surface.)
+- **Depends on:** Epic B's matcher for concept-level floors (D1); otherwise
+  standalone. Ref: SC-18; `cfc-trusted-agent-tool-integrity.md`.
+
+## Epic E — Row-set reads, per-row labels & sqlite Phase 3.b/3.c
+
+**Size: medium-large. Mostly unblocked by Epic A.**
+
+The sqlite per-row work surfaced a cluster of general row-set semantics (§8.17) that
+are partly built (skip/fail modes, aggregate integrity meet — verified present in
+`builtins/sqlite/row-label-read.ts`) but blocked on OR-clauses for the rest:
+
+- **Aggregates on rule-bearing tables** (`COUNT`/`SUM`/…) — refused today; sound
+  once the OR-clause **common-alternative property** (§8.17.4) lets `dbOwner()` as an
+  unconditional alternative make `COUNT(*)` readable by the owner with no fallback.
+  **Needs Epic A.**
+- **Read-time clearance / per-user filtered views** (Phase 3.b) — filter rows by
+  who's asking, not by a declared output ceiling. Impractical today. **Needs Epic A.**
+- **Non-attributable writes** — `INSERT…SELECT`, upserts, columnless INSERT, named
+  params, unparseable SQL all fail closed because the runner gate can't verify which
+  columns receive labeled inputs. **Needs Phase 3.c server-side commit-time label
+  re-derivation.**
+- **Cross-table joins over rule-bearing tables** — deferred; rule-input provenance is
+  ambiguous across table boundaries.
+- **Content-derived integrity is forgeable** — `when(matches(auth, /dmarc=pass/)) →
+  authoredBy(sender)` lets any row writer mint provenance unless the `auth` column
+  carries trusted-ingestion integrity. Ties to D2 (per-column input integrity);
+  interim fix is a self-describing `ClaimedAuthoredBy` family.
+- Ref: `docs/specs/sqlite-builtin/06-cfc.md`, `plans/cfc-phase3-per-row.md`,
+  `08-open-questions.md`; §8.17.
+
+## Epic F — Range-scoped integrity for collaborative documents (§14.4.8)
+
+**Size: large but most speculative — least blocking; schedule after the others.**
+
+The flat model carries one label per value; collaborative materialization (OT)
+needs **per-range labels on a single field** — "range [0:100] authored by Alice,
+[100:200] by Bob" — plus witness-bearing materialization and anchors/partial reads.
+Related: `IntegritySummary(semantics="covered-by")` — the runtime can't encode the
+semantic quantifier ("every surviving part is covered by ≥1 signer"), only a flat
+atom set. Expressiveness (over-restricts, safe), and the spec itself marks the full
+collaborative-doc model as a downgraded/future area. Ref: §14.4.8, §3.1.6.
+
+## Epic H — Enforcement & flow activation (smaller than the engines, high leverage)
+
+**Size: medium. Partly just flipping defaults + finishing the ladder — do early.**
+
+Not new machinery so much as turning the system on:
+
+- **Flow-labels default `off` → inv-9 dormant.** The router-attack flow-taint
+  (§10's own worked example) is not stamped by default. Move deployments to
+  propagation `persist`; note trigger-read confidentiality (SC-3) currently never
+  reaches the enforcement side or the egress ceiling even when the dial is on.
+- **Enforcement defaults `disabled`; `enforce-strict` undifferentiated.** The strict
+  rung is rankable but has no additional reject behavior in the commit gate
+  (SC-13). Finish the ladder and pick conforming default deployment states.
+- **Display-ceiling "shell flip."** The render ceiling is built and fail-closed but
+  **no host populates it**, and it admits atoms by raw structural equality rather
+  than §15.2 acting-user shapes (`User`/`PersonalSpace`/`Space`-via-`HasRole`).
+  Atom-shaping needs Epic B's exchange resolution; activation does not. (SC-16;
+  §8.10.6.) Render-boundary *composition + text integrity* itself is owned by
+  `packages/html` (see Out of scope).
+
+---
+
+# Tier 2 — Smaller holes (fill after the big chunks)
+
+Each is bounded and mostly independent. Several are fail-safe today.
+
+- **`addIntegrity` vs spec `addedIntegrity` — naming trap.** The runner honors its
+  own `addIntegrity` spelling; the spec's `addedIntegrity` is in the *unsupported-
+  keys reject list*, so a spec-conformant author is **rejected**, not honored.
+  Reconcile the spelling and honor §8.7.3 boundary-verified transformer-minted
+  semantics. (audit 3.6.)
+- **`propagationClass` registry drift.** Working hand-maintained 12-atom map with a
+  fail-safe `value-bound` default, but it diverges from §15 (`PromptSlotBound`
+  classed value-bound vs spec provenance; `IntegritySummary` absent). Code-generate
+  the map from a shared registry, or add a parity test that fails when §15 gains a
+  hereditary family absent from `CLASS_BY_TYPE`. (SC-10/15/17.)
+- **Atom registry parity.** Register `ExternalIngest` and `UserSurfaceInput` (impl-
+  minted, spec example-only); reconcile the `structure`/`external-ingest`
+  `LabelComponent` enum extensions. (SC-10/20.)
+- **`classification: string[]` shorthand not lowered.** No `classificationToAtoms`
+  anywhere in the runner — a silent no-op if it reaches the runner. Confirm the
+  schema-generator lowers it first, or add the lowering. (§4.2.1, §4.7.1.)
+- **`Caveat.source` redaction is display-only.** The carried-label (cross-space)
+  path is not redacted, so `Caveat.source`, `Origin` URIs, and policy names remain
+  observable to a destination space. Extend redaction to the carried-label path;
+  the `inspectConfLabel` first-layer introspection API (§4.6.4.1) is also unbuilt.
+  (inv-12; SC-14.)
+- **Idempotency ledger / `X-Idempotency-Key`.** Only per-tx `outboxIdempotencyKeys`
+  dedup exists; cross-retry no-double-send is delegated to per-builtin mutex +
+  content-addressed keys. No runtime-level idempotency-key ledger, no HTTP header.
+  (WS10; §6.5.)
+- **`sinkClass` / `BoundaryContext` atom substrate on egress.** The runner owns the
+  sink builtins, but caveat discharge keyed on `sinkClass`/`fieldRole`/`purpose` has
+  no atom substrate on the egress path. (Overlaps Epic B5.)
+- **Destination / audience-release binding at send sinks.** Bind the visible
+  destination context (conversation/channel/public target) into the audience-release
+  evidence. (§8.10.5.2; FUTURE-SPEC destination-binding follow-up.)
+- **§6.5 intent-consumption / attempt-cell contract.** Commit-point single-use
+  intent consumption + bounded-retry attempt-cell ledger (`attemptCellId`/
+  `consumedCellId`). This is runner-remit even though the rest of the Ch.6 refiner
+  chain is not.
+- **Projection binding-scoped atom survival (§8.3).** A value-bound atom should
+  survive a projection only if the runtime verifies the projected value still
+  matches its scope digest. No per-atom conditional survival today (safe: drops or
+  over-keeps). Setup-projection carve-out (audit 3.3) sits here.
+- **Trust-snapshot determinism audit.** `trustSnapshot` is correctly in the prepared
+  digest (invalidates on change), but the *provider* is not audited to be free of
+  ambient mutable state (the anti-TOCTOU property behind inv-7). Verify or harden.
+- **Multi-match integrity subject** (sqlite) — a global regex match over `from` may
+  yield multiple senders; fail closed on >1 for integrity-bearing positions
+  (already the posture) but document.
+- **Stale derived labels (SC-2).** Confirm the "no retroactive relabeling of cold
+  copies" model is documented as intended (policy-layer sweep, not a runtime
+  invariant) — likely a doc note, not code.
+
+---
+
+# Tier 3 — Spec promotion, not runner code
+
+Shipped, security-conscious runner mechanisms with **no normative home**. These are
+`~/src/specs/cfc` edits (and belong in `FUTURE-SPEC-WORK.md`), not runner work — but
+they are load-bearing and an implementer could weaken them with no spec test failing.
+
+- **`ownerPrincipal` / `__ctCurrentPrincipal` write-authority chain** — a fully-built
+  owner-binding-to-acting-principal mechanism with `represents-principal` evidence,
+  zero spec text. (audit 3.5, "confirmed open".)
+- **Schema-merge per-key conflict-direction table** — a monotonicity-defining
+  mechanism (grow confidentiality/requiredIntegrity, narrow maxConfidentiality/
+  integrity ceilings, freeze structural claims) with no §4.2.2.1 counterpart; it even
+  runs *opposite* to §8.15.2 for `writeAuthorizedBy`. (audit 3.10.)
+- **Post-commit sink-release re-verification** — the runner re-checks the frozen
+  request snapshot after commit; §8.10 defines only pre-commit verification. Define
+  the contract (what it re-verifies, whether it re-runs the ceiling). (audit 3.11.)
+- **`ExternalIngest` vouched-ingest provenance mark** — split-mint, module-private
+  trigger, bypasses `gateRuntimeMintedIntegrity`, audience recorded-not-enforced —
+  defined only in a proposal doc.
+
+---
+
+# Out of scope for the runner (owned elsewhere — not runner debt)
+
+Large spec surfaces a different component owns; the runner consumes the *results* of
+policy (store labels + write-authority claims), not these mechanisms.
+
+| Spec surface | Ref | Owner |
+|---|---|---|
+| Render-boundary discharge, text-integrity meet, `sinkClass=display` gating | §8.10.5–6, inv-8/10/13 | `packages/html` reconciler (+ Epic B for atom-shaped ceilings) |
+| Sandbox structured-result contract, caveat clearing, runsc/gVisor mediation, tool-invoke | §14.2.2, §18.2 | `@commonfabric/cf-harness` (runner provides the validator seam only) |
+| Labeled filesystem, subagents, command/CLI exec, `node=CodeHash` identity | §14.2 | cf-harness + sibling gVisor repo |
+| Tool-registry snapshot, agent plan trace, NL-refinement, measured contract | §14.1.3.5, §14.2.2.1 | cf-harness (overlaps the Reactive-Interpreter meta-node effort) |
+| Direct content-addressed storage (label-bearing CAS, miss-indistinguishability) | §17.2–6 | Deferred behind causal-path rollout (WS12) |
+| **Recombination attack** (overlapping declassifiers leak more than either alone) | §14.3.2 | **Explicitly OPEN research problem** in the spec — no owner; note as a known residual |
+| Recursive label-metadata introspection (labels-of-labels) | §14.3.3 | Intentionally out of scope — first-layer `inspectConfLabel` only |
+
+---
+
+# Appendix — suggested critical path
+
+```
+Epic A (CNF clauses)  ──┬──►  Epic B (exchange-rule evaluator)  ──►  B6 retire prompt special-case
+                        │
+                        ├──►  Epic E (row-set / sqlite 3.b)   [3.c is a separate server-side track]
+                        │
+                        └──►  Epic H display-ceiling atom-shaping
+
+Epic C (observation classes)   — independent, start any time
+Epic D (write/agent integrity) — independent (D1 wants B's matcher); highest security urgency
+Epic H activation (flip defaults, finish ladder) — do early, cheap, high leverage
+Epic F (range-scoped integrity) — last of the big epics; most speculative
+```
+
+Rule of thumb: **A unlocks the most** (B, most of E, H's ceiling shaping, and 3–4
+Tier-2 items). **D is the most urgent for security** (live soundness holes) and is
+largely independent. **H is the cheapest leverage** (the system doesn't enforce much
+by default today). Everything in Tier 3 is spec-writing, not runner code.
+
+## Provenance
+
+Findings from an 8-domain adversarial audit (74 raw → 44 verified gaps), a §10
+safety-invariant completeness cross-check, and three focused sweeps
+(docs/specs expressiveness gaps, CFC-spec algebra gaps, exchange-rule epic sizing),
+2026-07-01. Load-bearing claims (vacuous requiredIntegrity gate, flow/enforcement
+defaults, ceiling-fit reader-enumeration hole) were spot-verified against the code.
+Cross-references: `cfc-spec-changes.md` (SC-1..22 + audit queue),
+`~/src/specs/cfc/notes/RUNNER_IMPLEMENTATION_PLAN.md` (12 workstreams),
+`~/src/specs/cfc/notes/FUTURE-SPEC-WORK.md`,
+`~/src/specs/cfc/proposals/author-disjunctive-confidentiality.md` (Adopted; §9 is
+Epic A's runtime outline).
+```

--- a/docs/specs/cfc-runner-future-work.md
+++ b/docs/specs/cfc-runner-future-work.md
@@ -1,10 +1,17 @@
 # CFC runner future work — prioritized implementation gaps
 
-_Started 2026-07-01. Audit of `~/src/specs/cfc` (the normative CFC prose spec, 18
-chapters + Lean formalization) against the implementation in `packages/runner`
-(primarily `packages/runner/src/cfc/`). Companion to
+_Started 2026-07-01. Audit of the normative CFC prose spec (18 chapters + Lean
+formalization) against the implementation in `packages/runner` (primarily
+`packages/runner/src/cfc/`). Companion to
 [`cfc-spec-changes.md`](./cfc-spec-changes.md) (which tracks edits the **spec**
 needs); this file tracks work the **runner** needs._
+
+> **Spec references.** The CFC prose spec + Lean formalization live in the separate
+> [`commontoolsinc/specs`](https://github.com/commontoolsinc/specs) repo under
+> `cfc/`. References below of the form `§3.1.8`, `04-label-representation.md`,
+> `notes/…`, or `proposals/…` are paths within that repo — e.g.
+> [`cfc/proposals/author-disjunctive-confidentiality.md`](https://github.com/commontoolsinc/specs/blob/main/cfc/proposals/author-disjunctive-confidentiality.md).
+> References of the form `packages/…` and `docs/specs/…` are in this repo.
 
 This list is ordered **big chunks first**: close the load-bearing structural
 gaps, then fill the small holes. Dependency order matters — several small holes
@@ -61,9 +68,9 @@ with a flat/flat fast-path that is byte-for-byte today's check. Then the
 fail-closed test.
 
 - **This is exactly the disjunctive-confidentiality proposal's §9 runtime outline**
-  (`~/src/specs/cfc/proposals/author-disjunctive-confidentiality.md:845-899`), which
-  is Adopted (2026-06-09) into the normative spec (§3.1.8, §4.2.1, §8.10.3, §8.17,
-  §18.5). The design + adversarial pass are already written.
+  (`proposals/author-disjunctive-confidentiality.md` §9), which is Adopted
+  (2026-06-09) into the normative spec (§3.1.8, §4.2.1, §8.10.3, §8.17, §18.5). The
+  design + adversarial pass are already written.
 - **Directly delivers:** author-written OR-clauses — "confidential to A **or** B,
   either can release alone" — which the flat model literally cannot represent (it
   flattens `[[A∨B]]` to conjunctive `{A,B}`, the *stronger* reading: safe, but the
@@ -263,9 +270,6 @@ Each is bounded and mostly independent. Several are fail-safe today.
   classed value-bound vs spec provenance; `IntegritySummary` absent). Code-generate
   the map from a shared registry, or add a parity test that fails when §15 gains a
   hereditary family absent from `CLASS_BY_TYPE`. (SC-10/15/17.)
-- **Atom registry parity.** Register `ExternalIngest` and `UserSurfaceInput` (impl-
-  minted, spec example-only); reconcile the `structure`/`external-ingest`
-  `LabelComponent` enum extensions. (SC-10/20.)
 - **`classification: string[]` shorthand not lowered.** No `classificationToAtoms`
   anywhere in the runner — a silent no-op if it reaches the runner. Confirm the
   schema-generator lowers it first, or add the lowering. (§4.2.1, §4.7.1.)
@@ -307,8 +311,9 @@ Each is bounded and mostly independent. Several are fail-safe today.
 # Tier 3 — Spec promotion, not runner code
 
 Shipped, security-conscious runner mechanisms with **no normative home**. These are
-`~/src/specs/cfc` edits (and belong in `FUTURE-SPEC-WORK.md`), not runner work — but
-they are load-bearing and an implementer could weaken them with no spec test failing.
+`commontoolsinc/specs` edits (they belong in `cfc/notes/FUTURE-SPEC-WORK.md`), not
+runner work — but they are load-bearing and an implementer could weaken them with no
+spec test failing.
 
 - **`ownerPrincipal` / `__ctCurrentPrincipal` write-authority chain** — a fully-built
   owner-binding-to-acting-principal mechanism with `represents-principal` evidence,
@@ -323,6 +328,14 @@ they are load-bearing and an implementer could weaken them with no spec test fai
 - **`ExternalIngest` vouched-ingest provenance mark** — split-mint, module-private
   trigger, bypasses `gateRuntimeMintedIntegrity`, audience recorded-not-enforced —
   defined only in a proposal doc.
+- **Atom registry parity (`ExternalIngest` / `UserSurfaceInput`).** Both are
+  *already* registered in the runtime — `CFC_ATOM_TYPE`
+  ([`packages/api/cfc.ts:35`,`:49`](../../packages/api/cfc.ts)) and the propagation
+  map ([`atom-classes.ts:30`,`:34`](../../packages/runner/src/cfc/atom-classes.ts),
+  both `provenance`) — so no runner code is needed. The residual is spec-side:
+  promote them from spec example-only into the §15 atom registry, and reconcile the
+  `structure`/`external-ingest` `LabelComponent` values that extend the spec's
+  3-value enum. (SC-10/20.)
 
 ---
 
@@ -370,9 +383,10 @@ safety-invariant completeness cross-check, and three focused sweeps
 (docs/specs expressiveness gaps, CFC-spec algebra gaps, exchange-rule epic sizing),
 2026-07-01. Load-bearing claims (vacuous requiredIntegrity gate, flow/enforcement
 defaults, ceiling-fit reader-enumeration hole) were spot-verified against the code.
-Cross-references: `cfc-spec-changes.md` (SC-1..22 + audit queue),
-`~/src/specs/cfc/notes/RUNNER_IMPLEMENTATION_PLAN.md` (12 workstreams),
-`~/src/specs/cfc/notes/FUTURE-SPEC-WORK.md`,
-`~/src/specs/cfc/proposals/author-disjunctive-confidentiality.md` (Adopted; §9 is
-Epic A's runtime outline).
+Cross-references: [`cfc-spec-changes.md`](./cfc-spec-changes.md) (SC-1..22 + audit
+queue), and in [`commontoolsinc/specs`](https://github.com/commontoolsinc/specs):
+`cfc/notes/RUNNER_IMPLEMENTATION_PLAN.md` (12 workstreams),
+`cfc/notes/FUTURE-SPEC-WORK.md`, and
+`cfc/proposals/author-disjunctive-confidentiality.md` (Adopted; §9 is Epic A's
+runtime outline).
 ```


### PR DESCRIPTION
## What

Adds `docs/specs/cfc-runner-future-work.md`: a prioritized audit of the normative CFC spec (`~/src/specs/cfc`) against the implementation in `packages/runner`, organized **big chunks first** so we close load-bearing structural gaps before filling small holes.

## Why

We had three gap-tracking docs (`cfc-spec-changes.md` SC-1..22, the runner implementation plan, the open-problems chapter) but no single prioritized "what to build next in the runner" list. This is the companion to `cfc-spec-changes.md` (which tracks edits the *spec* needs); this file tracks work the *runner* needs.

## Key findings

- **Organizing theme:** the runtime represents a label as a flat set (`IFCLabel = { confidentiality?: unknown[]; integrity?: unknown[] }`) where the spec's algebra is CNF clauses + exchange-rule evaluation + pattern-matching + observation-class refinement. Most big gaps are facets of that one representational distance.
- **Epic A (CNF clause representation)** is the keystone — the shared foundation for both author-written disjunctive confidentiality ("confidential to A *or* B, either releases") *and* the exchange-rule/policy evaluator (Epic B). Build once. It also fixes a genuine soundness hole in the §8.10.3 reader-enumeration ceiling check.
- **Epic B (exchange-rule + policy evaluator)** is a big in-runner gap (not out-of-scope): its absence means the runtime can never release or declassify anything. Blocks safety invariants 3, 5, 6, 10, 11.
- **Epic D (write-side + agent integrity)** is the live soundness cluster (write-target integrity floor, vacuous tool-input gate, `LlmDerived` stamping) — most urgent for security, largely independent.
- **Epic H (activation)** — the `disabled`/`off` enforcement + flow defaults leave several built protections dormant; cheapest leverage.

Tiers: big epics (A–F, H) in dependency order → smaller holes → spec-promotion items → out-of-scope surfaces owned by other components. Ends with a critical-path diagram.

## Scope

Docs only — no code changes. Findings from an 8-domain adversarial audit (74 raw → 44 verified gaps), a §10 safety-invariant completeness cross-check, and three focused sweeps; load-bearing claims spot-verified against the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `docs/specs/cfc-runner-future-work.md`: a prioritized audit of the CFC spec against the `packages/runner` implementation. It maps the highest-impact gaps and a critical path, focusing on CNF clause labels, the exchange-rule/policy evaluator, write/agent integrity, and activation defaults; now also uses repo‑relative spec links and clarifies atom-registry parity as spec-side work.

- **New Features**
  - Prioritized gap list with dependency order (Epics A–F, H), plus smaller items, spec-promotion notes, and out-of-scope areas.
  - Doc polish: adds a "Spec references" note with repo-relative links to `commontoolsinc/specs`, and moves `ExternalIngest`/`UserSurfaceInput` atom‑registry parity to Tier 3 (spec promotion). Docs only; no code changes.

<sup>Written for commit e2e358809a56787e919d63b127f24a245a1bf774. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/4437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

